### PR TITLE
feat(dashboard): move tool call bytes into a Meta section

### DIFF
--- a/client/dashboard/src/elements/components/ui/tool-ui.tsx
+++ b/client/dashboard/src/elements/components/ui/tool-ui.tsx
@@ -102,6 +102,12 @@ interface SectionHighlight {
   activeOccurrence?: number | null;
 }
 
+/** One row in the tool's "Meta" section (e.g. payload size, cost). */
+interface ToolUIMetaRow {
+  label: string;
+  value: React.ReactNode;
+}
+
 interface ToolUIProps {
   /** Display name of the tool */
   name: string;
@@ -121,6 +127,9 @@ interface ToolUIProps {
   requestHighlight?: SectionHighlight;
   /** Flag matches inside the output (risk review). */
   resultHighlight?: SectionHighlight;
+  /** Extra facts about the call (payload size, cost) shown in a collapsible
+   * "Meta" section beneath Arguments and Output. */
+  meta?: ToolUIMetaRow[];
   /** When set, highlight occurrences of this query (case-insensitive) in the
    * tool name — e.g. a thread search for "customer" lights up `get_customer`. */
   nameQuery?: string;
@@ -656,6 +665,80 @@ function StructuredResultContent({
  * ToolUISection - Expandable section for Request/Result
  * -------------------------------------------------------------------------- */
 
+function SectionDisclosureHeader({
+  title,
+  indicator,
+  actions,
+  isExpanded,
+  onToggle,
+}: {
+  title: string;
+  indicator?: React.ReactNode;
+  actions?: React.ReactNode;
+  isExpanded: boolean;
+  onToggle: () => void;
+}): React.JSX.Element {
+  return (
+    <button
+      onClick={onToggle}
+      className="flex w-full cursor-pointer items-center justify-between px-5 py-2.5 text-left transition-colors hover:bg-accent/50"
+    >
+      <span className="flex items-center gap-2 text-sm text-muted-foreground">
+        {title}
+        {indicator}
+      </span>
+      <div className="flex items-center gap-1">
+        {actions}
+        <ChevronRightIcon
+          className={cn(
+            "size-4 text-muted-foreground transition-transform duration-200",
+            isExpanded && "rotate-90",
+          )}
+        />
+      </div>
+    </button>
+  );
+}
+
+/* -----------------------------------------------------------------------------
+ * ToolUIMetaSection - Expandable detail list of call facts (size, cost)
+ * -------------------------------------------------------------------------- */
+
+function ToolUIMetaSection({
+  rows,
+  defaultExpanded = false,
+}: {
+  rows: ToolUIMetaRow[];
+  defaultExpanded?: boolean;
+}): React.JSX.Element {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div data-slot="tool-ui-meta-section" className="border-t border-border">
+      <SectionDisclosureHeader
+        title="Meta"
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded(!isExpanded)}
+      />
+      {isExpanded && (
+        <dl className="divide-y divide-border border-t border-border">
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className="flex items-start justify-between gap-3 px-5 py-2 text-xs"
+            >
+              <dt className="text-muted-foreground">{row.label}</dt>
+              <dd className="text-right font-medium tabular-nums">
+                {row.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}
+
 function ToolUISection({
   title,
   content,
@@ -688,24 +771,13 @@ function ToolUISection({
 
   return (
     <div data-slot="tool-ui-section" className="border-t border-border">
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="flex w-full cursor-pointer items-center justify-between px-5 py-2.5 text-left transition-colors hover:bg-accent/50"
-      >
-        <span className="flex items-center gap-2 text-sm text-muted-foreground">
-          {title}
-          {headerIndicator}
-        </span>
-        <div className="flex items-center gap-1">
-          <CopyButton content={contentString} />
-          <ChevronRightIcon
-            className={cn(
-              "size-4 text-muted-foreground transition-transform duration-200",
-              isExpanded && "rotate-90",
-            )}
-          />
-        </div>
-      </button>
+      <SectionDisclosureHeader
+        title={title}
+        indicator={headerIndicator}
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded(!isExpanded)}
+        actions={<CopyButton content={contentString} />}
+      />
       {isExpanded && (
         <div className="border-t border-border">
           {matchCount > 0 ? (
@@ -787,6 +859,7 @@ function ToolUI({
   defaultExpanded = false,
   requestHighlight,
   resultHighlight,
+  meta,
   nameQuery,
   nameActiveOccurrence = null,
   className,
@@ -803,7 +876,8 @@ function ToolUI({
     onDeny !== undefined;
   // Auto-expand when approval is pending, collapse when approved
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
-  const hasContent = request !== undefined || result !== undefined;
+  const hasMeta = (meta?.length ?? 0) > 0;
+  const hasContent = request !== undefined || result !== undefined || hasMeta;
 
   // Track approval mode: 'one-time' or 'for-session'
   const [approvalMode, setApprovalMode] = useState<ApprovalMode>("one-time");
@@ -911,6 +985,7 @@ function ToolUI({
               defaultExpanded={(resultHighlight?.matches?.length ?? 0) > 0}
             />
           )}
+          {hasMeta && <ToolUIMetaSection rows={meta!} />}
         </div>
       )}
 
@@ -1169,6 +1244,7 @@ export {
 };
 export type {
   ToolUIProps,
+  ToolUIMetaRow,
   ToolUISectionProps,
   ToolUIGroupProps,
   ToolStatus,

--- a/client/dashboard/src/elements/index.ts
+++ b/client/dashboard/src/elements/index.ts
@@ -33,6 +33,7 @@ export {
 } from "@/elements/components/ui/tool-ui";
 export type {
   ToolUIProps,
+  ToolUIMetaRow,
   ToolUIGroupProps,
   ToolUISectionProps,
   ToolStatus,

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -86,6 +86,7 @@ import {
 import { cn } from "@/lib/utils";
 import {
   buildClaudeToolUsageByToolUseId,
+  buildClaudeTurnByPromptId,
   buildClaudeUsageByMessageId,
   formatTokenCount,
   formatUsageCost,
@@ -929,6 +930,13 @@ function ChatDetailPanel({
         : [];
     return buildClaudeToolUsageByToolUseId(tools);
   }, [chat?.agentUsage]);
+  const claudeTurnByPromptId = useMemo(() => {
+    const turns =
+      chat?.agentUsage?.type === "claude"
+        ? (chat.agentUsage.claude?.turns ?? [])
+        : [];
+    return buildClaudeTurnByPromptId(turns);
+  }, [chat?.agentUsage]);
 
   const transcriptRows = useMemo(
     () => buildTranscript(chatMessages),
@@ -1115,6 +1123,7 @@ function ChatDetailPanel({
       riskResultsByMessage,
       claudeUsageByMessage,
       claudeToolUsageByToolUseId,
+      claudeTurnByPromptId,
       dimNonRisk,
       searchQuery: searchActive ? searchQuery : undefined,
       userLabel: chat?.externalUserId,
@@ -1124,6 +1133,7 @@ function ChatDetailPanel({
       riskResultsByMessage,
       claudeUsageByMessage,
       claudeToolUsageByToolUseId,
+      claudeTurnByPromptId,
       dimNonRisk,
       searchActive,
       searchQuery,

--- a/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
@@ -25,7 +25,6 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import {
-  Badge,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -37,8 +36,10 @@ import {
   type SectionMatch,
   ToolUI,
   ToolUIGroup,
+  type ToolUIMetaRow,
 } from "@/elements";
 import type { ClaudeToolUsage } from "@gram/client/models/components/claudetoolusage.js";
+import type { ClaudeTurnUsage } from "@gram/client/models/components/claudeturnusage.js";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import {
   Popover,
@@ -86,6 +87,9 @@ interface RowContext {
   riskResultsByMessage?: Map<string, RiskResult[]>;
   claudeUsageByMessage?: Map<string, ClaudeUsageMatch>;
   claudeToolUsageByToolUseId?: Map<string, ClaudeToolUsage>;
+  /** Turn usage keyed by prompt id — a tool row joins to its turn's cost
+   * through `ClaudeToolUsage.promptId`. */
+  claudeTurnByPromptId?: Map<string, ClaudeTurnUsage>;
   rowDecoration?: (messageIds: string[]) => RowDecoration | null;
   /** When the session has findings, non-flagged rows are dimmed to spotlight
    * the risky ones. */
@@ -108,6 +112,7 @@ type ResolvedRowContext = Required<
     | "riskResultsByMessage"
     | "claudeUsageByMessage"
     | "claudeToolUsageByToolUseId"
+    | "claudeTurnByPromptId"
   >
 > &
   RowContext;
@@ -115,6 +120,7 @@ type ResolvedRowContext = Required<
 const EMPTY_RISK_RESULTS = new Map<string, RiskResult[]>();
 const EMPTY_CLAUDE_USAGE = new Map<string, ClaudeUsageMatch>();
 const EMPTY_CLAUDE_TOOL_USAGE = new Map<string, ClaudeToolUsage>();
+const EMPTY_CLAUDE_TURNS = new Map<string, ClaudeTurnUsage>();
 
 function applyRowContextDefaults(ctx: RowContext): ResolvedRowContext {
   return {
@@ -123,6 +129,7 @@ function applyRowContextDefaults(ctx: RowContext): ResolvedRowContext {
     claudeUsageByMessage: ctx.claudeUsageByMessage ?? EMPTY_CLAUDE_USAGE,
     claudeToolUsageByToolUseId:
       ctx.claudeToolUsageByToolUseId ?? EMPTY_CLAUDE_TOOL_USAGE,
+    claudeTurnByPromptId: ctx.claudeTurnByPromptId ?? EMPTY_CLAUDE_TURNS,
   };
 }
 
@@ -208,13 +215,29 @@ function CostBadge({ usage }: { usage: ClaudeUsageMatch }) {
   );
 }
 
-function ToolByteBadge({ bytes }: { bytes: number }) {
-  if (bytes <= 0) return null;
-  return (
-    <Badge variant="neutral" className="shrink-0 text-[10px]">
-      <Badge.Text>{formatByteCount(bytes)}</Badge.Text>
-    </Badge>
-  );
+// The API reports payload size per tool call but cost only per turn (a turn
+// covers every tool it called), so the cost row is labelled accordingly.
+function toolMetaRows({
+  usage,
+  turn,
+}: {
+  usage: ClaudeToolUsage | undefined;
+  turn: ClaudeTurnUsage | undefined;
+}): ToolUIMetaRow[] {
+  if (!usage) return [];
+  const total = usage.inputSizeBytes + usage.resultSizeBytes;
+  const rows: ToolUIMetaRow[] = [];
+  if (total > 0) {
+    rows.push(
+      { label: "Arguments size", value: formatByteCount(usage.inputSizeBytes) },
+      { label: "Output size", value: formatByteCount(usage.resultSizeBytes) },
+      { label: "Total size", value: formatByteCount(total) },
+    );
+  }
+  if (turn) {
+    rows.push({ label: "Turn cost", value: formatUsageCost(turn.costUsd) });
+  }
+  return rows;
 }
 
 // Two letters for the avatar fallback: the first two name parts of an email
@@ -738,8 +761,8 @@ function ToolRowView({
 
   const toolUseId = row.toolCall?.id ?? row.resultMessage?.toolCallId ?? "";
   const usage = ctx.claudeToolUsageByToolUseId.get(toolUseId);
-  const inputBytes = usage?.inputSizeBytes ?? 0;
-  const outputBytes = usage?.resultSizeBytes ?? 0;
+  const turn = usage ? ctx.claudeTurnByPromptId.get(usage.promptId) : undefined;
+  const meta = toolMetaRows({ usage, turn });
   const decoration = ctx.rowDecoration?.(messageIdsForRow(row)) ?? null;
 
   return (
@@ -749,11 +772,6 @@ function ToolRowView({
         dimClass(ctx.dimNonRisk && !flagged),
       )}
     >
-      {inputBytes + outputBytes > 0 && (
-        <div className="mb-1.5 flex items-center gap-2 pl-1">
-          <ToolByteBadge bytes={inputBytes + outputBytes} />
-        </div>
-      )}
       <ToolUI
         // ToolUI expansion is uncontrolled, so key on `toolActive` to remount it:
         // landing on this tool's match opens it; moving to the next match
@@ -767,6 +785,7 @@ function ToolRowView({
         defaultExpanded={flagged || toolActive}
         requestHighlight={requestHighlight}
         resultHighlight={resultHighlight}
+        meta={meta}
         nameQuery={ctx.searchQuery}
         nameActiveOccurrence={activeNameOccurrence}
         className={bare ? "rounded-none border-0" : undefined}

--- a/client/dashboard/src/pages/chatLogs/claudeUsage.ts
+++ b/client/dashboard/src/pages/chatLogs/claudeUsage.ts
@@ -91,6 +91,12 @@ export function buildClaudeUsageByMessageId({
   return result;
 }
 
+export function buildClaudeTurnByPromptId(
+  turns: ClaudeTurnUsage[],
+): Map<string, ClaudeTurnUsage> {
+  return new Map(turns.map((turn) => [turn.promptId, turn]));
+}
+
 export function buildClaudeToolUsageByToolUseId(
   tools: ClaudeToolUsage[],
 ): Map<string, ClaudeToolUsage> {


### PR DESCRIPTION
Tool calls in the chat detail sheet showed payload size as a floating `N BYTES` badge above each tool card. It sat outside the card it described, and it was the only place per-call telemetry surfaced.

This moves that number into a **Meta** section — a third collapsible section on the tool card, below Arguments and Output, in the same disclosure style — and adds cost alongside it.

## Rows

| Row            | Source                                           |
| -------------- | ------------------------------------------------ |
| Arguments size | `ClaudeToolUsage.inputSizeBytes`                 |
| Output size    | `ClaudeToolUsage.resultSizeBytes`                |
| Total size     | sum of the two                                   |
| Turn cost      | `ClaudeTurnUsage.costUsd`, joined via `promptId` |

Size rows are omitted when the call has no size telemetry; the cost row is omitted when the turn has no cost. A tool with neither keeps its old behaviour of no Meta section at all.

## Notes for reviewers

- **`meta` is a generic prop.** `ToolUI` lives in `elements/`, which the standalone chat widget also consumes, so it takes `meta?: ToolUIMetaRow[]` (label/value rows) rather than anything bytes- or cost-specific. The domain formatting stays in `ChatTranscript`.
- **"Turn cost", not "Cost".** The API has no per-tool cost: `ClaudeToolUsage` (`server/design/chat/design.go:455`) carries only the two byte counts, `tool_use_id`, `prompt_id`, and `tool_name`. Cost exists only per turn, and a turn covers every tool it called — so this value is shared across sibling tool cards. Labelling it "Cost" inside one tool card would read as that call's cost and overstate it on multi-tool turns. Happy to drop the row instead if that's still too easy to misread.
- **Shared section header.** Arguments, Output, and Meta now render their header through one `SectionDisclosureHeader` so the three can't drift. Meta passes no copy button — there's no blob to copy.

## Verification

Drove the dashboard against a local stack with seeded telemetry. The Meta section renders under Arguments/Output and expands to all four rows (47 BYTES / 111 BYTES / 158 BYTES / $0.0075), and the floating badges are gone.

Seeding this needed local-only fixture work that isn't in this PR: `seed:chat-detail` never emitted the `claude_code.tool_result` rows that carry `tool_input_size_bytes` / `tool_result_size_bytes`, so no seeded chat had size telemetry at all. That seed script is git-excluded locally, so anyone verifying from a fresh seed will see the size rows absent (the cost row still renders). Worth upstreaming separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved per-tool payload size into a collapsible Meta section on each tool card and added turn cost. Removes the floating BYTES badge and makes telemetry easier to read.

- **New Features**
  - Added a "Meta" section under Arguments and Output for each tool card.
  - Shows Arguments size, Output size, Total size, and Turn cost (cost is per turn, shared across tools).
  - Automatically hides missing rows; omits the Meta section when no size or cost is available.

- **Refactors**
  - `ToolUI` now accepts a generic `meta` prop typed as `ToolUIMetaRow[]`; Meta has no copy button.
  - Introduced a shared `SectionDisclosureHeader` used by Arguments, Output, and Meta.
  - Joined turn cost via `buildClaudeTurnByPromptId` in the dashboard and removed floating BYTES badges.

<sup>Written for commit 55918fa397f8a4fc1657b6367538307883342f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

