### PR TITLE
feat(dashboard): add configurable headers UI to tunneled MCP sources

### DIFF
--- a/client/dashboard/src/pages/sources/tunneled-mcp/HeadersSection.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/HeadersSection.tsx
@@ -1,0 +1,75 @@
+import {
+  HeadersEditor,
+  type EditableHeader,
+  type HeaderWriteFields,
+  type HeadersEditorAdapter,
+} from "@/components/headers-editor";
+import { useCreateTunneledMcpServerHeaderMutation } from "@gram/client/react-query/createTunneledMcpServerHeader.js";
+import { useDeleteTunneledMcpServerHeaderMutation } from "@gram/client/react-query/deleteTunneledMcpServerHeader.js";
+import {
+  invalidateAllTunneledMcpServerHeaders,
+  useTunneledMcpServerHeaders,
+} from "@gram/client/react-query/tunneledMcpServerHeaders.js";
+import { useUpdateTunneledMcpServerHeaderMutation } from "@gram/client/react-query/updateTunneledMcpServerHeader.js";
+import { useQueryClient } from "@tanstack/react-query";
+
+export function HeadersSection({
+  tunneledMcpServerId,
+}: {
+  tunneledMcpServerId: string;
+}): JSX.Element {
+  const headersQuery = useTunneledMcpServerHeaders(
+    { tunneledMcpServerId },
+    undefined,
+    { enabled: tunneledMcpServerId !== "" },
+  );
+
+  const queryClient = useQueryClient();
+  const createHeader = useCreateTunneledMcpServerHeaderMutation();
+  const updateHeader = useUpdateTunneledMcpServerHeaderMutation();
+  const deleteHeader = useDeleteTunneledMcpServerHeaderMutation();
+
+  const adapter: HeadersEditorAdapter = {
+    headers: headersQuery.data?.headers,
+    isLoading: headersQuery.isLoading,
+    isSaving:
+      createHeader.isPending ||
+      updateHeader.isPending ||
+      deleteHeader.isPending,
+    mutationError:
+      createHeader.error ?? updateHeader.error ?? deleteHeader.error,
+    createHeader: async (fields: HeaderWriteFields) => {
+      await createHeader.mutateAsync({
+        request: {
+          createTunneledMcpServerHeaderForm: { tunneledMcpServerId, ...fields },
+        },
+      });
+    },
+    updateHeader: async (id: string, fields: HeaderWriteFields) => {
+      await updateHeader.mutateAsync({
+        request: { updateTunneledMcpServerHeaderForm: { id, ...fields } },
+      });
+    },
+    deleteHeader: async (id: string) => {
+      await deleteHeader.mutateAsync({ request: { id } });
+    },
+    refetch: async (): Promise<EditableHeader[] | null> => {
+      const refreshed = await headersQuery.refetch();
+      if (refreshed.isError || !refreshed.data) return null;
+      return refreshed.data.headers ?? [];
+    },
+    invalidate: async () => {
+      await invalidateAllTunneledMcpServerHeaders(queryClient, {
+        refetchType: "all",
+      });
+    },
+  };
+
+  return (
+    <HeadersEditor
+      adapter={adapter}
+      title="Upstream Headers"
+      description="Headers sent through the tunnel to your MCP server."
+    />
+  );
+}

--- a/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx
@@ -57,6 +57,7 @@ import {
   useRotateTunneledMcpServerKey,
   type RotateTunneledMcpServerKeyData,
 } from "./hooks";
+import { HeadersSection } from "./HeadersSection";
 import { RemoveTunneledMcpDialogContent } from "./RemoveTunneledMcpDialog";
 import { TunneledMcpSetupTabs } from "./TunneledMcpSetupTabs";
 
@@ -648,6 +649,7 @@ function SettingsTab({
     <div className="mx-auto w-full max-w-[1270px] space-y-8 px-8 py-8">
       <NameSection tunneledMcpServer={tunneledMcpServer} />
       <TunnelKeySection tunneledMcpServer={tunneledMcpServer} />
+      <HeadersSection tunneledMcpServerId={tunneledMcpServer.id} />
       <DangerZoneSection
         tunneledMcpServer={tunneledMcpServer}
         linkedMcpServers={linkedMcpServers}


### PR DESCRIPTION
**Stacked PR 4 of 4** — tunneled MCP header support. Base: PR3. Depends on PR2 (SDK hooks/types) and PR3 (shared component).

Mounts the shared `headers-editor.tsx` on tunneled MCP source pages. Only adds new files / new render — no changes to remote MCP or the shared component.

## Files
- `client/dashboard/src/pages/sources/tunneled-mcp/HeadersSection.tsx` — new; wires the tunneled SDK hooks (`useTunneledMcpServerHeaders` + create/update/delete mutations from PR2) into the shared editor, catalog suggestions passed empty
- `client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx` — mount the new `HeadersSection`

## Verify
- `pnpm -F dashboard type-check`, `pnpm -F dashboard build`
- Manual (`gram-playwright-cli`): on a tunneled MCP source, add a static header, a request-pass-through header, and a secret header; save; reload → persistence + secret masked as `***`; delete one; then exercise the tunnel and confirm the header reaches upstream