### PR TITLE
chore(hooks): cut binary release with fail-open cache and offline spool

### DIFF
--- a/.changeset/hooks-release-fail-open-spool.md
+++ b/.changeset/hooks-release-fail-open-spool.md
@@ -1,0 +1,5 @@
+---
+"hooks": minor
+---
+
+Cut a speakeasy-hooks release containing the DNO-497/DNO-498 client work that merged after hooks@0.1.1 was tagged and therefore never shipped: the org-settings fail-open cache (the binary mirrors the server-confirmed `fail_open` posture next to its credential cache and consults it when no verdict is obtainable, so fail-open orgs actually fail open during control-plane outages), the offline payload spool + drain (unsent events buffer locally and replay on recovery), and the typed replay marker header. Without this release the pinned 0.1.1 binary fails closed for every org during an outage and spools nothing. After the release is published, `hooksBinaryVersion` and the embedded archive checksums in `server/internal/plugins/hooks_bootstrap.go` must be re-pinned in a follow-up.

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -4453,9 +4453,11 @@ async function seed() {
     const dbUser = process.env.DB_USER || "gram";
     const dbName = process.env.DB_NAME || "gram";
     const redisPassword = process.env.GRAM_REDIS_CACHE_PASSWORD || "xi9XILbY";
-    await $`docker compose exec gram-db psql -U ${dbUser} -d ${dbName} -c "INSERT INTO organization_features (organization_id, feature_name) VALUES ('${activeOrgID}', 'logs'), ('${activeOrgID}', 'tool_io_logs') ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE DO NOTHING;"`.quiet();
-    await $`docker compose exec gram-cache redis-cli -p 35299 -a ${redisPassword} DEL feature:${activeOrgID}:logs: feature:${activeOrgID}:tool_io_logs:`.quiet();
-    log.info("Enabled local logs and tool_io_logs features");
+    // session_capture gates Claude hook chat persistence; without it,
+    // hooks.ingest accepts events but silently skips writing chat_messages.
+    await $`docker compose exec gram-db psql -U ${dbUser} -d ${dbName} -c "INSERT INTO organization_features (organization_id, feature_name) VALUES ('${activeOrgID}', 'logs'), ('${activeOrgID}', 'tool_io_logs'), ('${activeOrgID}', 'session_capture') ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE DO NOTHING;"`.quiet();
+    await $`docker compose exec gram-cache redis-cli -p 35299 -a ${redisPassword} DEL feature:${activeOrgID}:logs: feature:${activeOrgID}:tool_io_logs: feature:${activeOrgID}:session_capture:`.quiet();
+    log.info("Enabled local logs, tool_io_logs, and session_capture features");
   } catch (e: unknown) {
     const err = e as { stderr?: string; message?: string };
     log.stepFailed(


### PR DESCRIPTION
## Summary

The DNO-497/DNO-498 client work never shipped: `hooks@0.1.1` was tagged on Jul 14 (#4175), and the org-settings fail-open cache (#4204), the offline payload spool + drain (#4232), and the typed replay marker (#4247) all merged the next day — none of their changesets bumped the `hooks` package, so changesets never cut a new release and #4191 pinned the bootstrapper to the old `0.1.1` binary.

Field effect (reproduced live on a dev box today): the org has `hooks_fail_open` enabled and every ingest response carries `effects.org_settings.fail_open: true`, but the installed binary never writes the org-settings cache and hard-blocks every tool call with `Speakeasy hook returned HTTP 0` during a control-plane outage. It also spools nothing, so buffered replay can't be exercised in the field.

## Changes

- Add a `hooks` minor changeset so version-packages cuts the release that actually contains the fail-open cache, spool/drain, and replay marker.
- Seed the `session_capture` product feature in the local dev seed (alongside `logs` / `tool_io_logs`, with the matching Redis feature-cache flush). Without it, `hooks.ingest` accepts events but silently skips writing `chat_messages`, which cost a debugging session today after a re-seed.

## Follow-up (not in this PR)

After the release workflow publishes the new artifacts, re-pin `hooksBinaryVersion` and the embedded archive SHA-256s in `server/internal/plugins/hooks_bootstrap.go` (and regenerate plugins) so the bootstrapper distributes the new binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut a minor `hooks` release that ships the DNO-497/DNO-498 client work to fix fail-closed behavior during control‑plane outages. Also seeds `session_capture` in local dev so `hooks.ingest` persists chat messages after a reseed.

- **New Features**
  - Release includes: fail-open org-settings cache; offline spool/drain; typed replay marker.
  - Local dev: seed `session_capture` and flush Redis feature cache so `hooks.ingest` writes `chat_messages`.

- **Migration**
  - After artifacts publish, re-pin `hooksBinaryVersion` and embedded checksums in `server/internal/plugins/hooks_bootstrap.go`, then regenerate plugins.

<sup>Written for commit e5190ce49a98315b79ae6ebe0e7ebefd46b33488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

