### PR TITLE
mig: add risk policy idempotency storage

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3557,6 +3557,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,
   organization_id TEXT NOT NULL,
+  idempotency_key TEXT,
 
   enabled BOOLEAN NOT NULL DEFAULT TRUE,
   name TEXT NOT NULL,
@@ -3614,6 +3615,10 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   CONSTRAINT risk_policies_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
   CONSTRAINT risk_policies_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS risk_policies_project_id_idempotency_key_idx
+ON risk_policies (project_id, idempotency_key)
+WHERE idempotency_key IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS risk_policies_project_id_idx
 ON risk_policies (project_id)

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3618,7 +3618,7 @@ CREATE TABLE IF NOT EXISTS risk_policies (
 
 CREATE UNIQUE INDEX IF NOT EXISTS risk_policies_project_id_idempotency_key_idx
 ON risk_policies (project_id, idempotency_key)
-WHERE idempotency_key IS NOT NULL;
+WHERE idempotency_key IS NOT NULL AND deleted IS FALSE;
 
 CREATE INDEX IF NOT EXISTS risk_policies_project_id_idx
 ON risk_policies (project_id)

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1515,6 +1515,7 @@ type RiskPolicy struct {
 	ID                   uuid.UUID
 	ProjectID            uuid.UUID
 	OrganizationID       string
+	IdempotencyKey       pgtype.Text
 	Enabled              bool
 	Name                 string
 	PolicyType           string

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -46,6 +46,7 @@ type RiskPolicy struct {
 	ID                   uuid.UUID
 	ProjectID            uuid.UUID
 	OrganizationID       string
+	IdempotencyKey       pgtype.Text
 	Enabled              bool
 	Name                 string
 	PolicyType           string

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -257,7 +257,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -272,6 +272,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.ID,
 		&i.ProjectID,
 		&i.OrganizationID,
+		&i.IdempotencyKey,
 		&i.Enabled,
 		&i.Name,
 		&i.PolicyType,
@@ -622,7 +623,7 @@ VALUES (
   , COALESCE($22::double precision, 5.0)
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -680,6 +681,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.ID,
 		&i.ProjectID,
 		&i.OrganizationID,
+		&i.IdempotencyKey,
 		&i.Enabled,
 		&i.Name,
 		&i.PolicyType,
@@ -1291,7 +1293,7 @@ func (q *Queries) GetRiskOverviewScanCounts(ctx context.Context, arg GetRiskOver
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1310,6 +1312,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.ID,
 		&i.ProjectID,
 		&i.OrganizationID,
+		&i.IdempotencyKey,
 		&i.Enabled,
 		&i.Name,
 		&i.PolicyType,
@@ -1379,7 +1382,7 @@ func (q *Queries) GetRiskPolicyBypassRequest(ctx context.Context, arg GetRiskPol
 }
 
 const getRiskPolicyForUpdate = `-- name: GetRiskPolicyForUpdate :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1399,6 +1402,7 @@ func (q *Queries) GetRiskPolicyForUpdate(ctx context.Context, arg GetRiskPolicyF
 		&i.ID,
 		&i.ProjectID,
 		&i.OrganizationID,
+		&i.IdempotencyKey,
 		&i.Enabled,
 		&i.Name,
 		&i.PolicyType,
@@ -1629,7 +1633,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1652,6 +1656,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.ID,
 			&i.ProjectID,
 			&i.OrganizationID,
+			&i.IdempotencyKey,
 			&i.Enabled,
 			&i.Name,
 			&i.PolicyType,
@@ -1739,7 +1744,7 @@ func (q *Queries) ListEnabledExclusionsForPolicy(ctx context.Context, arg ListEn
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1759,6 +1764,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.ID,
 			&i.ProjectID,
 			&i.OrganizationID,
+			&i.IdempotencyKey,
 			&i.Enabled,
 			&i.Name,
 			&i.PolicyType,
@@ -1795,7 +1801,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1817,6 +1823,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.ID,
 			&i.ProjectID,
 			&i.OrganizationID,
+			&i.IdempotencyKey,
 			&i.Enabled,
 			&i.Name,
 			&i.PolicyType,
@@ -1853,7 +1860,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1878,6 +1885,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.ID,
 			&i.ProjectID,
 			&i.OrganizationID,
+			&i.IdempotencyKey,
 			&i.Enabled,
 			&i.Name,
 			&i.PolicyType,
@@ -2198,7 +2206,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -2218,6 +2226,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.ID,
 			&i.ProjectID,
 			&i.OrganizationID,
+			&i.IdempotencyKey,
 			&i.Enabled,
 			&i.Name,
 			&i.PolicyType,
@@ -3693,7 +3702,7 @@ SET name = $1
 WHERE id = $19
   AND project_id = $20
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, idempotency_key, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -3747,6 +3756,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.ID,
 		&i.ProjectID,
 		&i.OrganizationID,
+		&i.IdempotencyKey,
 		&i.Enabled,
 		&i.Name,
 		&i.PolicyType,

--- a/server/migrations/20260716162437_risk-policies-idempotency-key.sql
+++ b/server/migrations/20260716162437_risk-policies-idempotency-key.sql
@@ -1,6 +1,0 @@
--- atlas:txmode none
-
--- Modify "risk_policies" table
-ALTER TABLE "risk_policies" ADD COLUMN "idempotency_key" text NULL;
--- Create index "risk_policies_project_id_idempotency_key_idx" to table: "risk_policies"
-CREATE UNIQUE INDEX CONCURRENTLY "risk_policies_project_id_idempotency_key_idx" ON "risk_policies" ("project_id", "idempotency_key") WHERE (idempotency_key IS NOT NULL);

--- a/server/migrations/20260716162437_risk-policies-idempotency-key.sql
+++ b/server/migrations/20260716162437_risk-policies-idempotency-key.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "idempotency_key" text NULL;
+-- Create index "risk_policies_project_id_idempotency_key_idx" to table: "risk_policies"
+CREATE UNIQUE INDEX CONCURRENTLY "risk_policies_project_id_idempotency_key_idx" ON "risk_policies" ("project_id", "idempotency_key") WHERE (idempotency_key IS NOT NULL);

--- a/server/migrations/20260717210611_risk-policies-idempotency-key.sql
+++ b/server/migrations/20260717210611_risk-policies-idempotency-key.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "idempotency_key" text NULL;
+-- Create index "risk_policies_project_id_idempotency_key_idx" to table: "risk_policies"
+CREATE UNIQUE INDEX CONCURRENTLY "risk_policies_project_id_idempotency_key_idx" ON "risk_policies" ("project_id", "idempotency_key") WHERE ((idempotency_key IS NOT NULL) AND (deleted IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:1goEIG9x3JGasRSyHn3TSkbTcFkA9wf4ZFySAnDURwk=
+h1:Kp8133iN9S5byDYZ1ItWuWsRWyYUGAbCG9GCri7p58k=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -272,3 +272,4 @@ h1:1goEIG9x3JGasRSyHn3TSkbTcFkA9wf4ZFySAnDURwk=
 20260716213928_skill-distributions-sync-receipts.sql h1:iW9LlmEmqcXaWE5ny7fk9ohcbbt1pVS3kFdcvgQvFeY=
 20260717080213_tunneled-mcp-server-headers.sql h1:3X8LqBrSIcgHrOxK/QkKrWnEv11/Q2ZQCOO3MjKxqV0=
 20260717084803_risk-results-add-overview-window-index.sql h1:BGSMZeD4ym5mRiZYyzsnHG63R0+A1ztbrt3EqGokbvQ=
+20260717210611_risk-policies-idempotency-key.sql h1:PLEdvjjuQy+XG0uNN/feFt5wy976jBGqF9H0OPUjyOw=


### PR DESCRIPTION
## What this accomplishes

Adds the database support needed to make risk policy creation idempotent, so retries can resolve to one policy instead of creating duplicates. This migration ships separately so the schema is available before the application behavior rolls out.

## Major changes

- Adds a nullable `idempotency_key` to `risk_policies` for a backward-compatible rollout.
- Adds a project-scoped partial unique index for non-null idempotency keys.
- Creates the index concurrently to avoid blocking policy writes during deployment.

## Test plan

- `mise run lint:migrations --no-atlas`
- `atlas migrate lint` against an isolated Postgres 17 dev database
- `git diff --check origin/main...alexm/dno-367-risk-policy-idempotency`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds idempotency storage for risk policy creation by adding an optional `idempotency_key` and a project-scoped unique index that only applies to active (non-deleted) policies. Supports DNO-367’s idempotent setup flow and ensures deleted policies release their keys.

- **Migration**
  - Add nullable `idempotency_key` to `risk_policies`.
  - Add partial unique index on `(project_id, idempotency_key)` where key is not null and `deleted` is false; created concurrently.
  - Ship column and index in a single migration.

- **Refactors**
  - Regenerate models and SQLc queries to include `idempotency_key` in SELECT/RETURNING results.

<sup>Written for commit ac9d9d4a8b83a5e69dcdee2801c3461661b704c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

