### PR TITLE
fix(hooks): queue events behind the offline spool so replays keep conversation order

### DIFF
--- a/.changeset/hooks-ordered-send-queue.md
+++ b/.changeset/hooks-ordered-send-queue.md
@@ -1,0 +1,5 @@
+---
+"hooks": patch
+---
+
+Preserve conversation order across offline-spool recovery (DNO-536). Previously the first live event after an outage was persisted before the spooled backlog it triggered draining of, so the newest message sorted ahead of older ones in chat_messages. The spool now doubles as an ordered send queue: observe-only events arriving while backlog exists append behind it (and kick the drain) instead of overtaking it, and gating events flush the backlog synchronously under a small budget before their live verdict send. Enforcement is unaffected — gating events always send live for the authoritative verdict, the budget keeps a slow backlog from stalling the user, and a drain already holding the lock is never waited on. The drain also re-lists after productive passes so entries queued mid-flush deliver in the same run.

--- a/hooks/relay/codextools.go
+++ b/hooks/relay/codextools.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,10 +112,16 @@ func withFileLock(path string, fn func()) {
 	fn()
 }
 
+// errLockHeld is tryLockFile's contention sentinel: the lock exists and
+// another process holds it. Any other tryLockFile error means the lock
+// machinery itself is unavailable.
+var errLockHeld = errors.New("file lock held by another process")
+
 // withFileTryLock is withFileLock's non-blocking variant: it reports false
-// without running fn when another process already holds the lock. Lock
-// *setup* failures degrade to running unlocked, same as withFileLock — only
-// a genuinely held lock skips.
+// without running fn when another process already holds the lock. Every
+// other failure — open error, unsupported/interrupted lock operation —
+// degrades to running unlocked, same as withFileLock; only genuine
+// contention skips.
 func withFileTryLock(path string, fn func()) bool {
 	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
@@ -122,8 +129,12 @@ func withFileTryLock(path string, fn func()) bool {
 		return true
 	}
 	defer func() { _ = f.Close() }()
-	if err := tryLockFile(f); err != nil {
+	switch err := tryLockFile(f); {
+	case errors.Is(err, errLockHeld):
 		return false
+	case err != nil:
+		fn()
+		return true
 	}
 	defer unlockFile(f)
 	fn()

--- a/hooks/relay/codextools.go
+++ b/hooks/relay/codextools.go
@@ -111,6 +111,25 @@ func withFileLock(path string, fn func()) {
 	fn()
 }
 
+// withFileTryLock is withFileLock's non-blocking variant: it reports false
+// without running fn when another process already holds the lock. Lock
+// *setup* failures degrade to running unlocked, same as withFileLock — only
+// a genuinely held lock skips.
+func withFileTryLock(path string, fn func()) bool {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		fn()
+		return true
+	}
+	defer func() { _ = f.Close() }()
+	if err := tryLockFile(f); err != nil {
+		return false
+	}
+	defer unlockFile(f)
+	fn()
+	return true
+}
+
 func readCodexToolQueue(path string) []string {
 	b, err := os.ReadFile(path)
 	if err != nil {

--- a/hooks/relay/codextools_lock_unix.go
+++ b/hooks/relay/codextools_lock_unix.go
@@ -3,6 +3,7 @@
 package relay
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
@@ -11,10 +12,16 @@ func lockFile(f *os.File) error {
 	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
 }
 
-// tryLockFile acquires the lock without blocking, erroring when another
-// process already holds it.
+// tryLockFile acquires the lock without blocking, returning errLockHeld for
+// contention. Other errnos (interrupted, unsupported filesystem) pass
+// through so the caller can distinguish "someone holds it" from "locking is
+// unavailable here".
 func tryLockFile(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+		return errLockHeld
+	}
+	return err
 }
 
 func unlockFile(f *os.File) {

--- a/hooks/relay/codextools_lock_unix.go
+++ b/hooks/relay/codextools_lock_unix.go
@@ -11,6 +11,12 @@ func lockFile(f *os.File) error {
 	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
 }
 
+// tryLockFile acquires the lock without blocking, erroring when another
+// process already holds it.
+func tryLockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
 func unlockFile(f *os.File) {
 	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }

--- a/hooks/relay/codextools_lock_windows.go
+++ b/hooks/relay/codextools_lock_windows.go
@@ -9,4 +9,6 @@ import "os"
 // and the queue self-heals as entries drain.
 func lockFile(*os.File) error { return nil }
 
+func tryLockFile(*os.File) error { return nil }
+
 func unlockFile(*os.File) {}

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -77,9 +77,65 @@ func Drain(ctx context.Context) DrainSummary {
 		return s
 	}
 	withFileLock(filepath.Join(dir, "drain"), func() {
-		s = drainSpool(ctx, dir)
+		s = drainUntilDry(ctx, dir)
 	})
 	return s
+}
+
+// drainUntilDry re-runs drainSpool while passes make progress. Each pass
+// works from a snapshot of the directory, so entries appended mid-pass —
+// non-gating hooks queue behind a non-empty spool to preserve conversation
+// order — would otherwise strand until the next drain trigger. A pass that
+// only skips (no credential, newer schema) ends the run: retrying cannot
+// deliver those until the machine's state changes.
+func drainUntilDry(ctx context.Context, dir string) DrainSummary {
+	var total DrainSummary
+	for {
+		s := drainSpool(ctx, dir)
+		total.Replayed += s.Replayed
+		total.Dropped += s.Dropped
+		total.Expired += s.Expired
+		// Skipped and Remaining describe the directory now, not a running
+		// tally: a re-skipped entry must not count twice.
+		total.Skipped = s.Skipped
+		total.Remaining = s.Remaining
+		total.Aborted = s.Aborted
+		if s.Aborted || s.Remaining == 0 || s.Replayed+s.Dropped+s.Expired == 0 {
+			return total
+		}
+	}
+}
+
+// gatingDrainBudget bounds the synchronous backlog flush a gating event runs
+// before requesting its verdict. Backlogs are typically small — a budget's
+// worth of draining covers them with room to spare — and a gating hook must
+// answer well inside the provider's ~60s hook kill. Var rather than const so
+// budget-expiry tests don't have to wait out real seconds.
+var gatingDrainBudget = 2 * time.Second
+
+// drainBeforeVerdict synchronously flushes the spool before a gating event's
+// live send so outage backlog persists ahead of it in conversation order.
+// Best-effort by design: it returns immediately when the spool is empty,
+// skips when another drain already holds the lock (waiting on it could burn
+// the whole budget without changing what that drain delivers), and gives up
+// at the budget — enforcement needs the live verdict, so a rare oversized
+// backlog costs row ordering for this one event rather than blocking the
+// user.
+func (r *Relay) drainBeforeVerdict(ctx context.Context) {
+	dir := spoolDirPath()
+	if dir == "" || len(listSpoolEntries(dir)) == 0 {
+		return
+	}
+	dctx, cancel := context.WithTimeout(ctx, gatingDrainBudget)
+	defer cancel()
+	ran := withFileTryLock(filepath.Join(dir, "drain"), func() {
+		s := drainUntilDry(dctx, dir)
+		r.debugf("spool: pre-verdict drain replayed=%d dropped=%d expired=%d skipped=%d remaining=%d aborted=%t",
+			s.Replayed, s.Dropped, s.Expired, s.Skipped, s.Remaining, s.Aborted)
+	})
+	if !ran {
+		r.debugf("spool: pre-verdict drain skipped; another drain holds the lock")
+	}
 }
 
 func drainSpool(ctx context.Context, dir string) DrainSummary {

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -91,7 +91,7 @@ func Drain(ctx context.Context) DrainSummary {
 func drainUntilDry(ctx context.Context, dir string) DrainSummary {
 	var total DrainSummary
 	for {
-		s := drainSpool(ctx, dir)
+		s, undrainable := drainSpool(ctx, dir)
 		total.Replayed += s.Replayed
 		total.Dropped += s.Dropped
 		total.Expired += s.Expired
@@ -101,6 +101,13 @@ func drainUntilDry(ctx context.Context, dir string) DrainSummary {
 		total.Remaining = s.Remaining
 		total.Aborted = s.Aborted
 		if s.Aborted || s.Remaining == 0 || s.Replayed+s.Dropped+s.Expired == 0 {
+			// A non-aborted final pass walked every entry, so its
+			// undrainable set is complete for the directory as it stands;
+			// persist it so spoolHasBacklog stops counting poison entries.
+			// An aborted pass saw only a prefix — keep the previous marker.
+			if !s.Aborted {
+				writeUndrainable(dir, undrainable)
+			}
 			return total
 		}
 	}
@@ -122,10 +129,10 @@ var gatingDrainBudget = 2 * time.Second
 // backlog costs row ordering for this one event rather than blocking the
 // user.
 func (r *Relay) drainBeforeVerdict(ctx context.Context) {
-	dir := spoolDirPath()
-	if dir == "" || len(listSpoolEntries(dir)) == 0 {
+	if !spoolHasBacklog() {
 		return
 	}
+	dir := spoolDirPath()
 	dctx, cancel := context.WithTimeout(ctx, gatingDrainBudget)
 	defer cancel()
 	ran := withFileTryLock(filepath.Join(dir, "drain"), func() {
@@ -138,8 +145,13 @@ func (r *Relay) drainBeforeVerdict(ctx context.Context) {
 	}
 }
 
-func drainSpool(ctx context.Context, dir string) DrainSummary {
+// drainSpool runs one pass over the directory snapshot. Alongside the
+// summary it returns the entry names this binary can never deliver
+// (undecodable, newer schema) so drainUntilDry can persist them for
+// spoolHasBacklog — a per-binary-deterministic set, unlike credential skips.
+func drainSpool(ctx context.Context, dir string) (DrainSummary, []string) {
 	var s DrainSummary
+	var undrainable []string
 	cutoff := time.Now().Add(-spoolMaxAge).UnixNano()
 	clients := make(map[string]*client)
 	auths := make(map[string]drainAuth)
@@ -174,11 +186,13 @@ func drainSpool(ctx context.Context, dir string) DrainSummary {
 			// delete what we couldn't read — leave it for a newer binary, or
 			// the age cap.
 			s.Skipped++
+			undrainable = append(undrainable, name)
 			continue
 		}
 		if entry.V != spoolEntryVersion {
 			// A newer binary wrote it — not this one's to interpret or delete.
 			s.Skipped++
+			undrainable = append(undrainable, name)
 			continue
 		}
 		key := drainAuthKey(entry)
@@ -236,7 +250,7 @@ func drainSpool(ctx context.Context, dir string) DrainSummary {
 		}
 	}
 	s.Remaining = len(listSpoolEntries(dir))
-	return s
+	return s, undrainable
 }
 
 // decodeSpoolEntry unmarshals an entry, restoring every any-typed envelope
@@ -406,10 +420,15 @@ var startDrainProcess = func() error {
 // recovery trigger (which covers idle machines). Best-effort and debounced;
 // never blocks the hook.
 func (r *Relay) maybeSpawnDrain() {
-	dir := spoolDirPath()
-	if dir == "" || len(listSpoolEntries(dir)) == 0 {
+	// spoolHasBacklog (not a raw entry count) so a lingering poison entry —
+	// which no drain run can ever deliver — doesn't spawn a useless drain
+	// every debounce window for two weeks. Credential-skipped entries are
+	// not in the undrainable set, so they still trigger spawns and deliver
+	// once a re-login restores access.
+	if !spoolHasBacklog() {
 		return
 	}
+	dir := spoolDirPath()
 	marker := filepath.Join(dir, "last-spawn")
 	if info, err := os.Stat(marker); err == nil && time.Since(info.ModTime()) < spawnDrainDebounce {
 		return

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -79,6 +79,14 @@ func Drain(ctx context.Context) DrainSummary {
 	withFileLock(filepath.Join(dir, "drain"), func() {
 		s = drainUntilDry(ctx, dir)
 	})
+	if s.Aborted {
+		// The queue path spawns drains while the control plane may still be
+		// down (unlike the accepted-send trigger, which proves it is up).
+		// Clear the spawn debounce after a failed run so the next queued
+		// event re-triggers immediately at recovery instead of waiting out
+		// the window.
+		_ = os.Remove(filepath.Join(dir, "last-spawn"))
+	}
 	return s
 }
 

--- a/hooks/relay/drain_test.go
+++ b/hooks/relay/drain_test.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"bytes"
 	"encoding/json"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -229,21 +230,42 @@ func TestMaybeSpawnDrainAfterRecovery(t *testing.T) {
 	startDrainProcess = func() error { spawns++; return nil }
 	t.Cleanup(func() { startDrainProcess = orig })
 
+	// One deployment address across outage and recovery, like a real outage:
+	// bind a port to learn the address, keep it closed during the outage,
+	// then serve on the same address.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
 	// Outage: the payload spools, and no drain spawns off a failed send.
-	cfg := authedConfig(t, closedPortURL(t))
+	cfg := authedConfig(t, "http://"+addr)
 	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
 	require.Len(t, spoolFiles(t), 1)
 	require.Zero(t, spawns, "a failed send must not spawn a drain")
 
-	// Recovery: a successful send with a non-empty spool spawns the drain.
-	fs := newFakeServer(t, nil)
-	cfg.ServerURL = fs.URL
-	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
-	require.Equal(t, 1, spawns, "the first healthy send after an outage must flush the backlog")
+	// Recovery via a gating event: the backlog now flushes synchronously
+	// before the verdict send (drainBeforeVerdict), so the queue empties in
+	// conversation order with no detached spawn needed.
+	var requests int
+	ln2, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"decision":"allow"}`))
+	}), ReadHeaderTimeout: time.Second}
+	go func() { _ = srv.Serve(ln2) }()
+	t.Cleanup(func() { _ = srv.Close() })
 
-	// Burst: the debounce marker suppresses a second spawn.
 	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
-	require.Equal(t, 1, spawns, "a burst of healthy sends must not stack drains")
+	require.Zero(t, spawns, "an inline pre-verdict flush must not also spawn a detached drain")
+	require.Empty(t, spoolFiles(t), "the first healthy gating event after an outage must flush the backlog")
+	require.Equal(t, 2, requests, "the spooled entry must replay ahead of the live event")
+
+	// Steady state: healthy sends with an empty spool never pay a spawn.
+	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	require.Zero(t, spawns)
 }
 
 // TestMaybeSpawnDrainSkipsEmptySpool: healthy sends on a machine with no

--- a/hooks/relay/drain_test.go
+++ b/hooks/relay/drain_test.go
@@ -220,15 +220,14 @@ func TestDrainUsesConfigOrgKeyFallback(t *testing.T) {
 }
 
 // TestMaybeSpawnDrainAfterRecovery drives the real provider path: sends fail
-// against a dead server (payloads spool), the server comes back, and the
-// next successful send spawns exactly one detached drain — debounced across
-// a burst.
+// against a dead server (payloads spool), the server comes back on the same
+// address, and the next gating event flushes the backlog synchronously
+// (drainBeforeVerdict) with no detached spawn. Spawn debounce across a burst
+// of queued observe events is pinned separately in
+// TestQueueSpawnDebouncedAcrossBurst.
 func TestMaybeSpawnDrainAfterRecovery(t *testing.T) {
 	setSpoolStateHome(t)
-	spawns := 0
-	orig := startDrainProcess
-	startDrainProcess = func() error { spawns++; return nil }
-	t.Cleanup(func() { startDrainProcess = orig })
+	spawns := stubDrainSpawn(t)
 
 	// One deployment address across outage and recovery, like a real outage:
 	// bind a port to learn the address, keep it closed during the outage,
@@ -242,7 +241,7 @@ func TestMaybeSpawnDrainAfterRecovery(t *testing.T) {
 	cfg := authedConfig(t, "http://"+addr)
 	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
 	require.Len(t, spoolFiles(t), 1)
-	require.Zero(t, spawns, "a failed send must not spawn a drain")
+	require.Zero(t, *spawns, "a failed send must not spawn a drain")
 
 	// Recovery via a gating event: the backlog now flushes synchronously
 	// before the verdict send (drainBeforeVerdict), so the queue empties in
@@ -259,27 +258,24 @@ func TestMaybeSpawnDrainAfterRecovery(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Close() })
 
 	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
-	require.Zero(t, spawns, "an inline pre-verdict flush must not also spawn a detached drain")
+	require.Zero(t, *spawns, "an inline pre-verdict flush must not also spawn a detached drain")
 	require.Empty(t, spoolFiles(t), "the first healthy gating event after an outage must flush the backlog")
 	require.Equal(t, 2, requests, "the spooled entry must replay ahead of the live event")
 
 	// Steady state: healthy sends with an empty spool never pay a spawn.
 	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
-	require.Zero(t, spawns)
+	require.Zero(t, *spawns)
 }
 
 // TestMaybeSpawnDrainSkipsEmptySpool: healthy sends on a machine with no
 // backlog never pay the spawn cost.
 func TestMaybeSpawnDrainSkipsEmptySpool(t *testing.T) {
 	setSpoolStateHome(t)
-	spawns := 0
-	orig := startDrainProcess
-	startDrainProcess = func() error { spawns++; return nil }
-	t.Cleanup(func() { startDrainProcess = orig })
+	spawns := stubDrainSpawn(t)
 
 	fs := newFakeServer(t, nil)
 	invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
-	require.Zero(t, spawns)
+	require.Zero(t, *spawns)
 }
 
 // TestRunDrainExitCodes: 0 when the spool ends empty, 1 when work remains.

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -498,6 +498,9 @@ func TestCachedAuthUsesConfigProject(t *testing.T) {
 // emit afterAgentResponse): the assistant message text and token usage must
 // reach the server as assistant.responded.
 func TestCursorModelResponseRelaysMessage(t *testing.T) {
+	// Isolate the spool: a non-empty backlog makes observe events queue
+	// behind it instead of sending live, which is not under test here.
+	setSpoolStateHome(t)
 	fs := newFakeServer(t, nil)
 	cfg := authedConfig(t, fs.URL)
 	payload := []byte(`{"hook_event_name":"afterAgentResponse","conversation_id":"sess-cursor-1","text":"final answer","input_tokens":10,"output_tokens":5}`)
@@ -591,6 +594,9 @@ func TestWritePluginMatchesPublishedEventSets(t *testing.T) {
 }
 
 func TestClaudeConfigChangeIsRelayed(t *testing.T) {
+	// Isolate the spool: a non-empty backlog makes observe events queue
+	// behind it instead of sending live, which is not under test here.
+	setSpoolStateHome(t)
 	fs := newFakeServer(t, nil)
 	cfg := authedConfig(t, fs.URL)
 	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "speakeasy-hooks-test-missing-device-agent")
@@ -624,6 +630,9 @@ func TestParseClaudeMCPInventory(t *testing.T) {
 }
 
 func TestClaudeSessionStartRelaysRedactedMCPInventory(t *testing.T) {
+	// Isolate the spool: a non-empty backlog makes observe events queue
+	// behind it instead of sending live, which is not under test here.
+	setSpoolStateHome(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("fake claude executable uses a POSIX shell")
 	}
@@ -661,6 +670,9 @@ func TestClaudeSessionStartRelaysRedactedMCPInventory(t *testing.T) {
 }
 
 func TestClaudeConfigChangeCollectsFreshMCPInventory(t *testing.T) {
+	// Isolate the spool: a non-empty backlog makes observe events queue
+	// behind it instead of sending live, which is not under test here.
+	setSpoolStateHome(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("fake claude executable uses a POSIX shell")
 	}

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -186,11 +186,17 @@ func (r *Relay) deliver(ctx context.Context, typed any, queueBehind bool) (inges
 		// The spool still holds outage backlog: sending this event live would
 		// persist it ahead of older messages. Queue it behind the backlog and
 		// let the (spawned) drain deliver everything oldest-first — the spool
-		// doubles as an ordered send queue until it runs dry.
-		r.spoolUnsent(idemKey, payload)
-		r.maybeSpawnDrain()
-		r.debugf("event=%s type=%s queued behind spool backlog", base.NativeName, payload.Event.Type)
-		return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil}, stateReady
+		// doubles as an ordered send queue until it runs dry. When the queue
+		// is at capacity, fall through to a live send instead: evicting
+		// backlog to admit a newer event would discard the very rows ordering
+		// protects, and dropping the event loses data the reachable server
+		// could store.
+		if r.spoolBehindBacklog(idemKey, payload) {
+			r.maybeSpawnDrain()
+			r.debugf("event=%s type=%s queued behind spool backlog", base.NativeName, payload.Event.Type)
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil}, stateReady
+		}
+		r.debugf("event=%s type=%s queue full or unavailable; sending live", base.NativeName, payload.Event.Type)
 	}
 	res := r.send(ctx, c, payload, idemKey)
 	r.debugf("event=%s type=%s server=%s authfile=%s status=%d denied=%t", agenthooks.EventOf(typed).NativeName, payload.Event.Type, r.cfg.ServerURL, authFilePath(), res.statusCode, res.decision.denied())

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -121,7 +121,13 @@ const envKeyRejectedMessage = "Speakeasy hooks rejected the API key configured i
 // deliver relays one event to the server, returning the result and the
 // credential posture. It performs no work when the machine holds no credential
 // so an unauthenticated install never leaks events.
-func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState) {
+//
+// queueBehind marks observe-only events, which may queue behind a non-empty
+// spool instead of sending live: an event that overtakes the outage backlog
+// persists ahead of messages that happened before it. Gating events pass
+// false — their verdict IS the send, so they always go live (after
+// evaluate's bounded pre-verdict drain).
+func (r *Relay) deliver(ctx context.Context, typed any, queueBehind bool) (ingestResult, authState) {
 	// An unreadable speakeasy.json means the deployment identity is unknown:
 	// the default server plus a cached key would route this workspace's events
 	// to whatever project the cache was minted for. Skip the network with the
@@ -176,6 +182,16 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	// the spooled copy a later drain replays. The server stores at most one
 	// event per key, so every redelivery path is safe.
 	idemKey := newIdempotencyToken()
+	if queueBehind && spoolHasBacklog() {
+		// The spool still holds outage backlog: sending this event live would
+		// persist it ahead of older messages. Queue it behind the backlog and
+		// let the (spawned) drain deliver everything oldest-first — the spool
+		// doubles as an ordered send queue until it runs dry.
+		r.spoolUnsent(idemKey, payload)
+		r.maybeSpawnDrain()
+		r.debugf("event=%s type=%s queued behind spool backlog", base.NativeName, payload.Event.Type)
+		return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil}, stateReady
+	}
 	res := r.send(ctx, c, payload, idemKey)
 	r.debugf("event=%s type=%s server=%s authfile=%s status=%d denied=%t", agenthooks.EventOf(typed).NativeName, payload.Event.Type, r.cfg.ServerURL, authFilePath(), res.statusCode, res.decision.denied())
 	if res.authRejected && c.Source == credEnv {
@@ -236,7 +252,11 @@ func (r *Relay) send(ctx context.Context, c creds, payload components.IngestRequ
 // evaluate delivers a gating event and resolves the block decision under the
 // ratchet and the org's fail-open posture.
 func (r *Relay) evaluate(ctx context.Context, typed any) verdict {
-	res, state := r.deliver(ctx, typed)
+	// Flush any outage backlog first (bounded) so this event's row lands
+	// after the messages that preceded it; the live send below then carries
+	// the authoritative verdict.
+	r.drainBeforeVerdict(ctx)
+	res, state := r.deliver(ctx, typed, false)
 	switch state {
 	case stateNeverAuthed:
 		// A broken config suppresses the nudge: sign-in cannot recover an
@@ -359,7 +379,7 @@ func (r *Relay) onToolPost(ctx context.Context, e *agenthooks.ToolPostEvent) (ag
 	if cursorMCPEcho(&e.Event, e.Tool.Name) {
 		return agenthooks.Observed(), nil
 	}
-	r.deliver(ctx, e)
+	r.deliver(ctx, e, true)
 	return agenthooks.Observed(), nil
 }
 
@@ -380,7 +400,7 @@ func cursorMCPEcho(base *agenthooks.Event, toolName string) bool {
 }
 
 func (r *Relay) onStop(ctx context.Context, e *agenthooks.StopEvent) (agenthooks.StopDecision, error) {
-	r.deliver(ctx, e)
+	r.deliver(ctx, e, true)
 	return agenthooks.Finish(), nil
 }
 
@@ -394,12 +414,12 @@ func (r *Relay) onSessionStart(ctx context.Context, e *agenthooks.SessionStartEv
 	if r.cfg.BrowserLogin && strings.TrimSpace(os.Getenv("GRAM_HOOKS_API_KEY")) == "" && !cached {
 		r.login.tryInteractive(ctx)
 	}
-	r.deliver(ctx, e)
+	r.deliver(ctx, e, true)
 	return agenthooks.ContinueSession(), nil
 }
 
 func (r *Relay) onObserve(ctx context.Context, typed any) error {
-	r.deliver(ctx, typed)
+	r.deliver(ctx, typed, true)
 	return nil
 }
 

--- a/hooks/relay/sendqueue_test.go
+++ b/hooks/relay/sendqueue_test.go
@@ -1,0 +1,208 @@
+package relay
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/speakeasy-api/agenthooks"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
+)
+
+// These tests pin the ordered send-queue behavior (DNO-536): while the spool
+// holds outage backlog, observe-only events queue behind it instead of
+// overtaking it, and gating events flush the backlog (bounded) before their
+// live verdict send — so replayed messages land in conversation order, not
+// drain order.
+
+func stubDrainSpawn(t *testing.T) *int {
+	t.Helper()
+	spawns := 0
+	orig := startDrainProcess
+	startDrainProcess = func() error { spawns++; return nil }
+	t.Cleanup(func() { startDrainProcess = orig })
+	return &spawns
+}
+
+// TestObserveEventQueuesBehindBacklog: an observe-only event arriving while
+// the spool is non-empty must not send live (it would persist ahead of older
+// messages); it appends to the spool and kicks the drain.
+func TestObserveEventQueuesBehindBacklog(t *testing.T) {
+	drainEnv(t)
+	spawns := stubDrainSpawn(t)
+	fs := newFakeServer(t, nil)
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-backlog")
+	cfg := authedConfig(t, fs.URL)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Zero(t, fs.count(), "a queued observe event must not reach the server live")
+	require.Len(t, spoolFiles(t), 2, "the event must append behind the existing backlog")
+	require.Equal(t, 1, *spawns, "queueing must kick the drain so the queue empties while the server is up")
+}
+
+// TestObserveEventSendsLiveWhenSpoolEmpty: the queue path only engages while
+// backlog exists — the everyday case stays a direct live send with nothing
+// written to disk.
+func TestObserveEventSendsLiveWhenSpoolEmpty(t *testing.T) {
+	drainEnv(t)
+	fs := newFakeServer(t, nil)
+	cfg := authedConfig(t, fs.URL)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, 1, fs.count())
+	require.Empty(t, spoolFiles(t))
+}
+
+// TestObserveEventWithBacklogAndNoCredentialsDoesNotQueue: an
+// unauthenticated install never leaks events — not to the network, and not
+// into another deployment's backlog either.
+func TestObserveEventWithBacklogAndNoCredentialsDoesNotQueue(t *testing.T) {
+	setSpoolStateHome(t)
+	t.Setenv("GRAM_HOOKS_AUTH_FILE", filepath.Join(t.TempDir(), "hooks-auth.env"))
+	t.Setenv("GRAM_HOOKS_API_KEY", "")
+	fs := newFakeServer(t, nil)
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-backlog")
+	cfg := Config{ServerURL: fs.URL, ProjectSlug: "default", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Zero(t, fs.count())
+	require.Len(t, spoolFiles(t), 1, "no-credential machines must not append to the queue")
+}
+
+// TestGatingEventDrainsBacklogBeforeVerdict pins the DNO-536 repro: the
+// first live event after an outage must not persist ahead of the spooled
+// messages that happened before it. The gating event flushes the backlog
+// synchronously, then sends live — the server sees oldest, newer, live, in
+// that order, with only the replays carrying the marker.
+func TestGatingEventDrainsBacklogBeforeVerdict(t *testing.T) {
+	drainEnv(t)
+	stubDrainSpawn(t)
+	fs := newFakeServer(t, nil)
+	seedSpoolEntry(t, fs.URL, 2*time.Hour, "sess-old")
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-new")
+	cfg := authedConfig(t, fs.URL)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Empty(t, spoolFiles(t), "the backlog must be flushed before the verdict send")
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	require.Len(t, fs.requests, 3, "two replays then the live gating event")
+	require.Equal(t, "sess-old", *fs.requests[0].Session.ID)
+	require.Equal(t, "sess-new", *fs.requests[1].Session.ID)
+	for i := range 2 {
+		marker, err := strconv.ParseBool(fs.headers[i].Get("X-Gram-Replayed"))
+		require.NoError(t, err)
+		require.True(t, marker, "backlog replays must carry the replay marker")
+	}
+	require.Equal(t, components.TypeToolRequested, fs.requests[2].Event.Type)
+	require.Empty(t, fs.headers[2].Get("X-Gram-Replayed"), "the live event is not a replay")
+}
+
+// TestGatingEventProceedsWhenDrainLockHeld: a drain already in flight must
+// not stall the verdict — the gating event skips the flush and sends live.
+func TestGatingEventProceedsWhenDrainLockHeld(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the drain lock is a no-op on Windows")
+	}
+	drainEnv(t)
+	stubDrainSpawn(t)
+	fs := newFakeServer(t, nil)
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-backlog")
+	cfg := authedConfig(t, fs.URL)
+
+	lockPath := filepath.Join(os.Getenv("XDG_STATE_HOME"), "gram", "hooks", "spool", "drain.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	require.NoError(t, lockFile(f))
+	defer unlockFile(f)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, 1, fs.count(), "the live verdict send must proceed without the flush")
+	require.Equal(t, components.TypeToolRequested, fs.last().Event.Type)
+	require.Len(t, spoolFiles(t), 1, "the held lock leaves the backlog to the drain that owns it")
+}
+
+// TestGatingEventBudgetExpiryStillSendsLive: a backlog too slow for the
+// budget must not block the user — the flush aborts at the budget and the
+// live verdict send proceeds; the unsent entry stays for a later drain.
+func TestGatingEventBudgetExpiryStillSendsLive(t *testing.T) {
+	drainEnv(t)
+	stubDrainSpawn(t)
+	origBudget := gatingDrainBudget
+	gatingDrainBudget = 50 * time.Millisecond
+	t.Cleanup(func() { gatingDrainBudget = origBudget })
+
+	fs := newFakeServer(t, func(p components.IngestRequestBody) (int, decision) {
+		if p.Session != nil && p.Session.ID != nil && *p.Session.ID == "sess-slow" {
+			time.Sleep(300 * time.Millisecond) // outlives the budget; the replay send is canceled
+		}
+		return http.StatusOK, decision{Decision: "allow", Reason: "", Message: ""}
+	})
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-slow")
+	cfg := authedConfig(t, fs.URL)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Contains(t, string(res.Stdout), "{}", "the verdict must resolve despite the slow backlog")
+	require.Len(t, spoolFiles(t), 1, "the undelivered entry must survive for a later drain")
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	var liveSeen bool
+	for _, p := range fs.requests {
+		if p.Session == nil || p.Session.ID == nil || *p.Session.ID != "sess-slow" {
+			liveSeen = true
+		}
+	}
+	require.True(t, liveSeen, "the live gating event must still reach the server for its verdict")
+}
+
+// TestDrainPicksUpEntriesAppendedMidPass: drainUntilDry re-lists after a
+// productive pass, so an event queued while the drain was already running —
+// a hook racing the flush — is delivered by the same run instead of
+// stranding until the next trigger.
+func TestDrainPicksUpEntriesAppendedMidPass(t *testing.T) {
+	drainEnv(t)
+	appended := false
+	var fs *fakeServer
+	fs = newFakeServer(t, func(p components.IngestRequestBody) (int, decision) {
+		if !appended && p.Session != nil && p.Session.ID != nil && *p.Session.ID == "sess-a" {
+			appended = true
+			seedSpoolEntry(t, fs.URL, 0, "sess-b")
+		}
+		return http.StatusOK, decision{Decision: "allow", Reason: "", Message: ""}
+	})
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-a")
+
+	s := Drain(t.Context())
+
+	require.Equal(t, 2, s.Replayed, "the mid-pass append must drain in the same run")
+	require.Zero(t, s.Remaining)
+	require.False(t, s.Aborted)
+	require.Empty(t, spoolFiles(t))
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	require.Len(t, fs.requests, 2)
+	require.Equal(t, "sess-a", *fs.requests[0].Session.ID)
+	require.Equal(t, "sess-b", *fs.requests[1].Session.ID, "the appended entry must replay after the backlog")
+}

--- a/hooks/relay/sendqueue_test.go
+++ b/hooks/relay/sendqueue_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -174,6 +175,86 @@ func TestGatingEventBudgetExpiryStillSendsLive(t *testing.T) {
 		}
 	}
 	require.True(t, liveSeen, "the live gating event must still reach the server for its verdict")
+}
+
+// seedPoisonSpoolEntry writes an entry with a newer schema version — one this
+// binary can never deliver, only skip.
+func seedPoisonSpoolEntry(t *testing.T, serverURL string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("XDG_STATE_HOME"), "gram", "hooks", "spool")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	entry := map[string]any{
+		"v":               spoolEntryVersion + 1,
+		"idempotency_key": newIdempotencyToken(),
+		"server_url":      serverURL,
+	}
+	b, err := json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, spoolFileName(time.Now().Add(-time.Hour))), b, 0o600))
+}
+
+// TestObserveEventIgnoresUndrainableOnlyBacklog: a poison entry (newer schema
+// version) is skipped forever and lingers until the 14-day expiry. Once a
+// drain run has proved it undrainable, it must stop counting as backlog —
+// otherwise every observe event queues behind it for two weeks.
+func TestObserveEventIgnoresUndrainableOnlyBacklog(t *testing.T) {
+	drainEnv(t)
+	stubDrainSpawn(t)
+	fs := newFakeServer(t, nil)
+	seedPoisonSpoolEntry(t, fs.URL)
+	cfg := authedConfig(t, fs.URL)
+
+	// A drain run walks the spool, skips the poison entry, and records it as
+	// undrainable for this binary.
+	s := Drain(t.Context())
+	require.Equal(t, 1, s.Skipped)
+	require.Equal(t, 1, s.Remaining)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, 1, fs.count(), "an undrainable-only spool must not reroute observe events through the queue")
+	require.Len(t, spoolFiles(t), 1, "the poison entry stays for a newer binary or the age cap")
+}
+
+// TestQueueFullFallsBackToLiveSend: when queueing would evict older backlog
+// at the caps, the observe event sends live instead — dropping the oldest
+// conversation rows to admit a newer event would invert the ordering goal,
+// and dropping the event loses data the reachable server could store.
+func TestQueueFullFallsBackToLiveSend(t *testing.T) {
+	drainEnv(t)
+	stubDrainSpawn(t)
+	origCap := spoolEntryCap
+	spoolEntryCap = 1
+	t.Cleanup(func() { spoolEntryCap = origCap })
+
+	fs := newFakeServer(t, nil)
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-oldest")
+	before := spoolFiles(t)
+	cfg := authedConfig(t, fs.URL)
+
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, 1, fs.count(), "the event must send live when the queue is at capacity")
+	require.Equal(t, before, spoolFiles(t), "the oldest backlog entry must never be evicted to admit a newer event")
+}
+
+// TestQueueSpawnDebouncedAcrossBurst: a burst of queued observe events must
+// not stack detached drain processes — the last-spawn marker debounces to
+// one useful run.
+func TestQueueSpawnDebouncedAcrossBurst(t *testing.T) {
+	drainEnv(t)
+	spawns := stubDrainSpawn(t)
+	fs := newFakeServer(t, nil)
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-backlog")
+	cfg := authedConfig(t, fs.URL)
+
+	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+	invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/post_tool_use.json")
+
+	require.Equal(t, 1, *spawns, "a burst of queued events must spawn one drain, not one per event")
+	require.Len(t, spoolFiles(t), 3, "both burst events still queue behind the backlog")
 }
 
 // TestDrainPicksUpEntriesAppendedMidPass: drainUntilDry re-lists after a

--- a/hooks/relay/spool.go
+++ b/hooks/relay/spool.go
@@ -277,25 +277,40 @@ func writeUndrainable(dir string, names []string) {
 // guard. Entries the last drain run marked undrainable don't count: a
 // poison entry (newer schema) lingers until the 14-day expiry, and counting
 // it would reroute every observe event through the spool for two weeks.
+// It answers a boolean, so it probes the directory in batches and returns on
+// the first live entry instead of materializing and sorting the full listing
+// the way listSpoolEntries does — this runs on every observe event.
 func spoolHasBacklog() bool {
 	dir := spoolDirPath()
 	if dir == "" {
 		return false
 	}
-	names := listSpoolEntries(dir)
-	if len(names) == 0 {
+	f, err := os.Open(dir)
+	if err != nil {
 		return false
 	}
-	und := readUndrainable(dir)
-	if len(und) == 0 {
-		return true
-	}
-	for _, name := range names {
-		if !und[name] {
-			return true
+	defer func() { _ = f.Close() }()
+	var und map[string]bool
+	undLoaded := false
+	for {
+		names, err := f.Readdirnames(64)
+		for _, name := range names {
+			if _, ok := spoolNanos(name); !ok {
+				continue
+			}
+			// Lazy: the marker is only worth reading once an entry exists.
+			if !undLoaded {
+				und = readUndrainable(dir)
+				undLoaded = true
+			}
+			if !und[name] {
+				return true
+			}
+		}
+		if err != nil {
+			return false
 		}
 	}
-	return false
 }
 
 // spoolDirPath resolves the spool directory without creating it, or "" when

--- a/hooks/relay/spool.go
+++ b/hooks/relay/spool.go
@@ -137,6 +137,88 @@ func (r *Relay) spoolUnsent(idemKey string, payload components.IngestRequestBody
 	r.debugf("spool: stored event=%s bytes=%d", payload.Event.Type, len(data))
 }
 
+// spoolBehindBacklog is spoolUnsent's non-evicting variant for the ordered
+// send-queue path: it appends the event behind the existing backlog, but
+// refuses (returning false) when doing so would evict older entries at the
+// caps — dropping the oldest conversation rows to admit a newer event would
+// invert the very ordering the queue exists to preserve. The caller falls
+// back to a live send: at the cap, delivering beats both dropping backlog
+// and dropping the event.
+func (r *Relay) spoolBehindBacklog(idemKey string, payload components.IngestRequestBody) bool {
+	dir := spoolDir()
+	if dir == "" {
+		r.debugf("spool: no writable state dir; queue-behind unavailable")
+		return false
+	}
+	entry := spoolEntry{
+		V:              spoolEntryVersion,
+		IdempotencyKey: idemKey,
+		ServerURL:      r.cfg.ServerURL,
+		OrgID:          r.cfg.OrgID,
+		ProjectSlug:    r.cfg.ProjectSlug,
+		ConfigPath:     r.cfg.ConfigPath,
+		SpooledAt:      time.Now().UTC(),
+		Envelope:       payload,
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		r.debugf("spool: marshal failed: %v", err)
+		return false
+	}
+	if len(data) > maxSpoolEntryBytes {
+		entry.Envelope.Raw = nil
+		if data, err = json.Marshal(entry); err != nil {
+			r.debugf("spool: marshal failed: %v", err)
+			return false
+		}
+		if len(data) > maxSpoolEntryBytes {
+			return false
+		}
+		r.debugf("spool: raw echo stripped from oversize entry")
+	}
+	if spoolOverCap(dir, len(data)) {
+		return false
+	}
+	var commitErr error
+	for range 2 {
+		if commitErr = commitSpoolEntry(dir, data); commitErr == nil {
+			break
+		}
+	}
+	if commitErr != nil {
+		r.debugf("spool: commit failed: %v", commitErr)
+		return false
+	}
+	r.debugf("spool: queued event=%s bytes=%d behind backlog", payload.Event.Type, len(data))
+	return true
+}
+
+// spoolOverCap reports whether admitting one more entry of incomingBytes
+// would exceed either spool cap.
+func spoolOverCap(dir string, incomingBytes int) bool {
+	des, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	var count int
+	var total int64
+	for _, de := range des {
+		if de.IsDir() {
+			continue
+		}
+		if _, ok := spoolNanos(de.Name()); !ok {
+			continue
+		}
+		info, err := de.Info()
+		if err != nil {
+			continue
+		}
+		count++
+		total += info.Size()
+	}
+	return count+1 > spoolEntryCap || total+int64(incomingBytes) > int64(spoolBytesCap)
+}
+
 // commitSpoolEntry writes one entry under a fresh chronological name via the
 // same-directory temp+rename idiom.
 func commitSpoolEntry(dir string, data []byte) error {
@@ -152,12 +234,68 @@ func commitSpoolEntry(dir string, data []byte) error {
 	return nil
 }
 
+// undrainableMarkerName is the spool-dir sidecar listing entries a completed
+// drain run proved THIS binary can never deliver (newer schema version,
+// undecodable) — a determination that is per-binary deterministic, so the
+// marker cannot go stale while the same binary runs. Credential-related
+// skips are deliberately excluded: those become deliverable after a
+// re-login, so ordering behind them still matters. The name doesn't match
+// the entry shape, so listSpoolEntries and the caps never count it.
+const undrainableMarkerName = "undrainable"
+
+// readUndrainable loads the marker as a set. Missing or torn reads yield an
+// empty set — the conservative direction (entries count as backlog).
+func readUndrainable(dir string) map[string]bool {
+	b, err := os.ReadFile(filepath.Join(dir, undrainableMarkerName))
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]bool)
+	for name := range strings.SplitSeq(strings.TrimSpace(string(b)), "\n") {
+		if name = strings.TrimSpace(name); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// writeUndrainable persists the set, or removes the marker when empty.
+// Callers hold the drain lock; failures are swallowed — a missing marker
+// only means observe events keep queueing behind a poison entry.
+func writeUndrainable(dir string, names []string) {
+	path := filepath.Join(dir, undrainableMarkerName)
+	if len(names) == 0 {
+		_ = os.Remove(path)
+		return
+	}
+	_ = os.WriteFile(path, []byte(strings.Join(names, "\n")+"\n"), 0o600)
+}
+
 // spoolHasBacklog reports whether undelivered entries are waiting on disk.
 // deliver consults it so observe-only events queue behind an outage backlog
-// instead of overtaking it.
+// instead of overtaking it, and the drain paths use it as their emptiness
+// guard. Entries the last drain run marked undrainable don't count: a
+// poison entry (newer schema) lingers until the 14-day expiry, and counting
+// it would reroute every observe event through the spool for two weeks.
 func spoolHasBacklog() bool {
 	dir := spoolDirPath()
-	return dir != "" && len(listSpoolEntries(dir)) > 0
+	if dir == "" {
+		return false
+	}
+	names := listSpoolEntries(dir)
+	if len(names) == 0 {
+		return false
+	}
+	und := readUndrainable(dir)
+	if len(und) == 0 {
+		return true
+	}
+	for _, name := range names {
+		if !und[name] {
+			return true
+		}
+	}
+	return false
 }
 
 // spoolDirPath resolves the spool directory without creating it, or "" when

--- a/hooks/relay/spool.go
+++ b/hooks/relay/spool.go
@@ -152,6 +152,14 @@ func commitSpoolEntry(dir string, data []byte) error {
 	return nil
 }
 
+// spoolHasBacklog reports whether undelivered entries are waiting on disk.
+// deliver consults it so observe-only events queue behind an outage backlog
+// instead of overtaking it.
+func spoolHasBacklog() bool {
+	dir := spoolDirPath()
+	return dir != "" && len(listSpoolEntries(dir)) > 0
+}
+
 // spoolDirPath resolves the spool directory without creating it, or "" when
 // no state home exists. Readers (drain, the spawn check) use this so an
 // install that never spooled doesn't grow an empty directory.


### PR DESCRIPTION
## Summary

Fixes the out-of-order transcript rows after an offline-spool recovery (DNO-536). Repro: kill the server mid-session, send a message (spools), bring the server back, send another message — the second message lands in `chat_messages` _before_ the first, because the live event that proves the control plane is back necessarily reaches the server ahead of the backlog it triggers draining of, and rows are stamped at insert time.

## Approach: the spool doubles as an ordered send queue

- **Observe-only events** (PostToolUse, Stop, session lifecycle, model responses): when the spool holds backlog, they append behind it and kick the drain instead of sending live — they never overtake older messages, and nobody is waiting on them.
- **Gating events** (PreToolUse, prompt submit): flush the backlog synchronously under a 2s budget (`drainBeforeVerdict`), then always send live for the authoritative verdict. ***In normal operation this costs effectively nothing***: the spool is empty, so the pre-verdict flush is a single directory listing that returns immediately — the budget only comes into play in the seconds right after an outage ends, while backlog exists. Enforcement never degrades: the budget keeps a slow backlog from stalling the user's tool call, and a drain already holding the lock is skipped (non-blocking try-lock), not waited on. A rare over-budget backlog costs row ordering for that one event — the deliberate trade-off.
- **`drainUntilDry`**: the drain re-lists the spool after each productive pass, so events queued behind the backlog while a drain is running deliver in the same run instead of stranding until the next trigger.

Verdict semantics, the fail-open guard, and the 401 credential ratchet are untouched.

## Tests

New `sendqueue_test.go` pins: the DNO-536 repro end-to-end (backlog replays oldest-first with the replay marker, live event last), observe events queueing behind backlog / sending live when empty, no queueing for unauthenticated installs, live verdict proceeding when the drain lock is held, budget expiry still resolving the verdict while preserving the undelivered entry, and mid-drain appends delivering in the same run. `TestMaybeSpawnDrainAfterRecovery` was updated for the new recovery flow (and now simulates the outage on one server address, as real outages do) — plus four existing tests gained spool isolation they were silently missing.

## Notes

- During a _continued_ outage, a gating event pays up to one extra failed replay attempt (bounded by the 2s budget) before its own send fails — posture handling is unchanged.
- Replayed rows still carry drain-time `created_at`; this PR fixes order, not displayed timestamps (server-side `occurred_at` persistence was considered and deliberately deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
