### PR TITLE
fix(agent): scope device-agent marketplaces to default project + assigned (DNO-538)

### DIFF
--- a/.changeset/device-agent-marketplace-scoping.md
+++ b/.changeset/device-agent-marketplace-scoping.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Scope the device agent's managed marketplaces to the org's default project plus any project the caller has an assignment in. `agent.getPlugins` previously returned every published marketplace in the org — each synthesizing its always-on observability plugin independent of assignments — so an org with many published projects flooded the device agent with one `speakeasy-observability` per project. The default project still always surfaces as the org-wide baseline; a non-default project now appears only when the caller has a matching plugin assignment there.

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -147,13 +147,13 @@ func TestGetPlugins_MultiProjectDistinctByDefault(t *testing.T) {
 
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
-	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
-	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+	beta := seedProject(t, ctx, ti.conn, ti.orgID, "beta")
+	publishMarketplace(t, ctx, ti.conn, beta, "beta-token")
 	// A wildcard-assigned plugin makes the non-default project surface for the
 	// caller (a non-default project with no assignment is intentionally hidden).
-	adamTool := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-tool")
-	assignPlugin(t, ctx, ti.conn, adamTool, ti.orgID, "*")
-	wantAdam := naming.MarketplaceName(mockidp.MockOrgName, "adam", false) // local-dev-org-adam-speakeasy
+	betaTool := seedPlugin(t, ctx, ti.conn, ti.orgID, beta, "beta-tool")
+	assignPlugin(t, ctx, ti.conn, betaTool, ti.orgID, "*")
+	wantBeta := naming.MarketplaceName(mockidp.MockOrgName, "beta", false) // local-dev-org-beta-speakeasy
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -164,9 +164,9 @@ func TestGetPlugins_MultiProjectDistinctByDefault(t *testing.T) {
 		byName[m.Name] = m.URL
 	}
 	require.Contains(t, byName, wantMarketplace, "default project keeps the bare org name")
-	require.Contains(t, byName, wantAdam, "non-default project is scoped by slug")
+	require.Contains(t, byName, wantBeta, "non-default project is scoped by slug")
 	require.Contains(t, byName[wantMarketplace], "default-token")
-	require.Contains(t, byName[wantAdam], "adam-token")
+	require.Contains(t, byName[wantBeta], "beta-token")
 }
 
 // TestGetPlugins_CollidingNamesPreferDefault pins the DNO-228 tiebreak that still
@@ -180,15 +180,15 @@ func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
 
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
-	// "adam" sorts before the default project's "test-<hex>" slug, but overrides
+	// "beta" sorts before the default project's "test-<hex>" slug, but overrides
 	// its name to collide with the default's bare org name. Its plugin — assigned
 	// to the caller so scoping would otherwise deliver it — must NOT leak onto the
-	// winning marketplace, since adam's repo isn't the one served under that name.
-	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
-	setMarketplaceOverride(t, ctx, ti.conn, adam, wantMarketplace)
-	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
-	adamTool := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-only-tool")
-	assignPlugin(t, ctx, ti.conn, adamTool, ti.orgID, "*")
+	// winning marketplace, since beta's repo isn't the one served under that name.
+	beta := seedProject(t, ctx, ti.conn, ti.orgID, "beta")
+	setMarketplaceOverride(t, ctx, ti.conn, beta, wantMarketplace)
+	publishMarketplace(t, ctx, ti.conn, beta, "beta-token")
+	betaTool := seedPlugin(t, ctx, ti.conn, ti.orgID, beta, "beta-only-tool")
+	assignPlugin(t, ctx, ti.conn, betaTool, ti.orgID, "*")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -197,8 +197,8 @@ func TestGetPlugins_CollidingNamesPreferDefault(t *testing.T) {
 	require.Equal(t, wantMarketplace, res.Marketplaces[0].Name)
 	require.Contains(t, res.Marketplaces[0].URL, "default-token",
 		"the default project's token must win the collision, not the alphabetically-first one")
-	require.NotContains(t, res.Marketplaces[0].URL, "adam-token")
-	require.NotContains(t, pluginSlugs(res), "adam-only-tool",
+	require.NotContains(t, res.Marketplaces[0].URL, "beta-token")
+	require.NotContains(t, pluginSlugs(res), "beta-only-tool",
 		"the collapsed project's plugin must not be attached to the winning marketplace")
 }
 
@@ -217,11 +217,11 @@ func TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces(t *testing.T) {
 	// A second project published under a distinct override name, with a
 	// wildcard-assigned plugin so it surfaces under the default-plus-assigned
 	// scoping (a non-default project with no assignment is hidden).
-	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
-	setMarketplaceOverride(t, ctx, ti.conn, adam, "team-adam")
-	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
-	adamTool := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-tool")
-	assignPlugin(t, ctx, ti.conn, adamTool, ti.orgID, "*")
+	beta := seedProject(t, ctx, ti.conn, ti.orgID, "beta")
+	setMarketplaceOverride(t, ctx, ti.conn, beta, "team-beta")
+	publishMarketplace(t, ctx, ti.conn, beta, "beta-token")
+	betaTool := seedPlugin(t, ctx, ti.conn, ti.orgID, beta, "beta-tool")
+	assignPlugin(t, ctx, ti.conn, betaTool, ti.orgID, "*")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -233,9 +233,9 @@ func TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces(t *testing.T) {
 		byName[m.Name] = m.URL
 	}
 	require.Contains(t, byName, wantMarketplace, "default project keeps the org-derived name")
-	require.Contains(t, byName, "team-adam", "override project surfaces under its published name")
+	require.Contains(t, byName, "team-beta", "override project surfaces under its published name")
 	require.Contains(t, byName[wantMarketplace], "default-token")
-	require.Contains(t, byName["team-adam"], "adam-token")
+	require.Contains(t, byName["team-beta"], "beta-token")
 }
 
 // TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden pins the
@@ -250,9 +250,9 @@ func TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden(t *testing.T) {
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
 	// A published non-default project with no assignment for the caller.
-	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
-	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
-	wantAdam := naming.MarketplaceName(mockidp.MockOrgName, "adam", false)
+	beta := seedProject(t, ctx, ti.conn, ti.orgID, "beta")
+	publishMarketplace(t, ctx, ti.conn, beta, "beta-token")
+	wantBeta := naming.MarketplaceName(mockidp.MockOrgName, "beta", false)
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -263,9 +263,9 @@ func TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden(t *testing.T) {
 	for _, m := range res.Marketplaces {
 		names = append(names, m.Name)
 	}
-	require.NotContains(t, names, wantAdam, "an unassigned non-default project is hidden")
+	require.NotContains(t, names, wantBeta, "an unassigned non-default project is hidden")
 	require.Equal(t, []string{wantObservability}, pluginSlugs(res),
-		"only the default project's observability ships, not adam's")
+		"only the default project's observability ships, not beta's")
 }
 
 func TestGetPlugins_CrossOrgIsolation(t *testing.T) {

--- a/server/internal/agent/getplugins_test.go
+++ b/server/internal/agent/getplugins_test.go
@@ -139,7 +139,8 @@ func TestGetPlugins_UnpublishedProjectExcluded(t *testing.T) {
 // org with multiple published projects surfaces each as its own marketplace. The
 // default project (from InitAuthContext, the org's oldest) keeps the bare
 // org-derived name; a non-default project is scoped by its slug. Both are
-// returned, each with its own token.
+// returned, each with its own token. The non-default project has an assignment
+// for the caller so it surfaces at all under the default-plus-assigned scoping.
 func TestGetPlugins_MultiProjectDistinctByDefault(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
@@ -148,6 +149,10 @@ func TestGetPlugins_MultiProjectDistinctByDefault(t *testing.T) {
 
 	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
 	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+	// A wildcard-assigned plugin makes the non-default project surface for the
+	// caller (a non-default project with no assignment is intentionally hidden).
+	adamTool := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-tool")
+	assignPlugin(t, ctx, ti.conn, adamTool, ti.orgID, "*")
 	wantAdam := naming.MarketplaceName(mockidp.MockOrgName, "adam", false) // local-dev-org-adam-speakeasy
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
@@ -209,10 +214,14 @@ func TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces(t *testing.T) {
 	// Default project keeps the org-derived name.
 	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
 
-	// A second project published under a distinct override name.
+	// A second project published under a distinct override name, with a
+	// wildcard-assigned plugin so it surfaces under the default-plus-assigned
+	// scoping (a non-default project with no assignment is hidden).
 	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
 	setMarketplaceOverride(t, ctx, ti.conn, adam, "team-adam")
 	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+	adamTool := seedPlugin(t, ctx, ti.conn, ti.orgID, adam, "adam-tool")
+	assignPlugin(t, ctx, ti.conn, adamTool, ti.orgID, "*")
 
 	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
 	require.NoError(t, err)
@@ -227,6 +236,36 @@ func TestGetPlugins_DistinctOverridesYieldSeparateMarketplaces(t *testing.T) {
 	require.Contains(t, byName, "team-adam", "override project surfaces under its published name")
 	require.Contains(t, byName[wantMarketplace], "default-token")
 	require.Contains(t, byName["team-adam"], "adam-token")
+}
+
+// TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden pins the
+// default-plus-assigned scoping: a published non-default project the caller has
+// no assignment in is omitted entirely — its marketplace and always-on
+// observability plugin would otherwise flood the device agent — while the
+// default project still surfaces as the org-wide baseline.
+func TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+
+	publishMarketplace(t, ctx, ti.conn, ti.projectID, "default-token")
+
+	// A published non-default project with no assignment for the caller.
+	adam := seedProject(t, ctx, ti.conn, ti.orgID, "adam")
+	publishMarketplace(t, ctx, ti.conn, adam, "adam-token")
+	wantAdam := naming.MarketplaceName(mockidp.MockOrgName, "adam", false)
+
+	res, err := ti.service.GetPlugins(ctx, &gen.GetPluginsPayload{Email: mockidp.MockUserEmail})
+	require.NoError(t, err)
+
+	require.Len(t, res.Marketplaces, 1, "only the default project surfaces")
+	require.Equal(t, wantMarketplace, res.Marketplaces[0].Name)
+	names := make([]string, 0, len(res.Marketplaces))
+	for _, m := range res.Marketplaces {
+		names = append(names, m.Name)
+	}
+	require.NotContains(t, names, wantAdam, "an unassigned non-default project is hidden")
+	require.Equal(t, []string{wantObservability}, pluginSlugs(res),
+		"only the default project's observability ships, not adam's")
 }
 
 func TestGetPlugins_CrossOrgIsolation(t *testing.T) {

--- a/server/internal/agent/queries.sql
+++ b/server/internal/agent/queries.sql
@@ -1,14 +1,15 @@
 -- name: GetAgentPluginSet :many
 -- Returns the device agent's full plugin set for an org, marketplace-first.
 --
--- The base is every *published* marketplace in the org (a
--- plugin_github_connections row with a marketplace_token), so a marketplace —
--- and its always-required observability plugin, synthesized in the view layer —
--- is returned even when the caller has no explicit assignments. Plugins whose
--- assignment principal_urn matches the caller's resolved principal set (email,
--- user:<id>, user:all, role:<...>, or the org wildcard) are LEFT JOINed on top;
--- projects with no matching assignment still yield one row with null plugin
--- columns.
+-- The base is the org's *published* marketplaces (plugin_github_connections rows
+-- with a marketplace_token), scoped so the device agent isn't flooded with every
+-- project: the org's default project always appears (marketplace + its
+-- always-required observability plugin, synthesized in the view layer) as the
+-- org-wide baseline, while a non-default project appears only when the caller has
+-- a matching assignment there. Plugins whose assignment principal_urn matches the
+-- caller's resolved principal set (email, user:<id>, user:all, role:<...>, or the
+-- org wildcard) are LEFT JOINed on top; the default project still yields one row
+-- with null plugin columns when the caller has no assignment there.
 --
 -- Each project resolves to a marketplace name the way the publish path does:
 -- the per-project override (project_marketplace_settings.marketplace_name) when
@@ -70,6 +71,24 @@ LEFT JOIN plugins p
   )
 WHERE pr.organization_id = @organization_id
   AND pgc.marketplace_token IS NOT NULL
+  AND (
+    -- The org's default project (oldest, by id ASC) is the org-wide baseline:
+    -- always surface its marketplace + observability, even when the caller has no
+    -- assignment there. Pinned to @organization_id (uncorrelated) so Postgres
+    -- evaluates it once; the same subquery backs the is_default_project column.
+    pr.id = (
+      SELECT p2.id
+      FROM projects p2
+      WHERE p2.organization_id = @organization_id
+        AND p2.deleted IS FALSE
+      ORDER BY p2.id ASC
+      LIMIT 1
+    )
+    -- A non-default project surfaces only when the caller has a matching assigned
+    -- plugin there (the LEFT JOIN produced a non-null plugin row); otherwise its
+    -- marketplace and observability plugin are just noise for this user.
+    OR p.id IS NOT NULL
+  )
 ORDER BY pr.id, p.slug;
 
 -- name: UpsertDeviceAgentSync :exec

--- a/server/internal/agent/repo/queries.sql.go
+++ b/server/internal/agent/repo/queries.sql.go
@@ -63,6 +63,24 @@ LEFT JOIN plugins p
   )
 WHERE pr.organization_id = $1
   AND pgc.marketplace_token IS NOT NULL
+  AND (
+    -- The org's default project (oldest, by id ASC) is the org-wide baseline:
+    -- always surface its marketplace + observability, even when the caller has no
+    -- assignment there. Pinned to @organization_id (uncorrelated) so Postgres
+    -- evaluates it once; the same subquery backs the is_default_project column.
+    pr.id = (
+      SELECT p2.id
+      FROM projects p2
+      WHERE p2.organization_id = $1
+        AND p2.deleted IS FALSE
+      ORDER BY p2.id ASC
+      LIMIT 1
+    )
+    -- A non-default project surfaces only when the caller has a matching assigned
+    -- plugin there (the LEFT JOIN produced a non-null plugin row); otherwise its
+    -- marketplace and observability plugin are just noise for this user.
+    OR p.id IS NOT NULL
+  )
 ORDER BY pr.id, p.slug
 `
 
@@ -88,14 +106,15 @@ type GetAgentPluginSetRow struct {
 
 // Returns the device agent's full plugin set for an org, marketplace-first.
 //
-// The base is every *published* marketplace in the org (a
-// plugin_github_connections row with a marketplace_token), so a marketplace —
-// and its always-required observability plugin, synthesized in the view layer —
-// is returned even when the caller has no explicit assignments. Plugins whose
-// assignment principal_urn matches the caller's resolved principal set (email,
-// user:<id>, user:all, role:<...>, or the org wildcard) are LEFT JOINed on top;
-// projects with no matching assignment still yield one row with null plugin
-// columns.
+// The base is the org's *published* marketplaces (plugin_github_connections rows
+// with a marketplace_token), scoped so the device agent isn't flooded with every
+// project: the org's default project always appears (marketplace + its
+// always-required observability plugin, synthesized in the view layer) as the
+// org-wide baseline, while a non-default project appears only when the caller has
+// a matching assignment there. Plugins whose assignment principal_urn matches the
+// caller's resolved principal set (email, user:<id>, user:all, role:<...>, or the
+// org wildcard) are LEFT JOINed on top; the default project still yields one row
+// with null plugin columns when the caller has no assignment there.
 //
 // Each project resolves to a marketplace name the way the publish path does:
 // the per-project override (project_marketplace_settings.marketplace_name) when

--- a/server/internal/mv/agent.go
+++ b/server/internal/mv/agent.go
@@ -18,11 +18,14 @@ import (
 // agent.GetAgentPluginSet into the tool-agnostic marketplaces + plugins view
 // the agent endpoint returns.
 //
-// For every published marketplace in the org it emits the marketplace and its
+// For every marketplace the query returns it emits the marketplace and its
 // always-required observability plugin, then layers on the user's assigned
-// plugins (the non-null plugin rows). Rows arrive grouped by project
-// (`ORDER BY pr.id, p.slug`), one row per project even when the user has no
-// assignment there (null plugin columns).
+// plugins (the non-null plugin rows). The query already scopes which projects
+// appear — the org's default project always, non-default projects only where the
+// caller has a matching assignment — so this builder emits a marketplace for
+// every row it receives. Rows arrive grouped by project (`ORDER BY pr.id,
+// p.slug`); the default project can still yield one row with null plugin columns
+// when the caller has no assignment there.
 //
 // Each project's marketplace name is resolved the same way the publish path
 // resolves it: the per-project override (project_marketplace_settings) when set,


### PR DESCRIPTION
Fixes DNO-538.

## Problem

The device agent surfaces far too many plugins — one `speakeasy-observability` per published project in the org. A real org showed **17 marketplaces / 18 plugins**, 17 of them `speakeasy-observability` from distinct projects.

## Root cause

`agent.getPlugins` (`GetAgentPluginSet`) uses **every published marketplace in the org** as its base, and `mv.BuildAgentPluginsView` synthesizes the always-on observability plugin for each marketplace **independent of assignments** (`mv/agent.go`: "Observability is required on every published marketplace"). So every published project contributes a marketplace + its observability plugin regardless of whether the polling user has anything assigned there.

## Fix

Scope the marketplace base in `GetAgentPluginSet` so a project surfaces only when:

- it is the org's **default project** (oldest by `id ASC`) — always, as the org-wide baseline; **or**
- the caller has a **matching assignment** in it.

A non-default project the caller has no assignment in is dropped entirely (its marketplace and observability plugin). Assignment-gated real plugins are unchanged. Chosen over "strict default-project only" so explicit cross-project assignments still deliver to the device agent.

For the example org, the device agent now returns a single marketplace (`speakeasy-speakeasy`) with `kitchen-sink` + one `speakeasy-observability`.

## Tests

- New `TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden` pins the drop.
- Updated the two multi-project naming/collapse tests (`MultiProjectDistinctByDefault`, `DistinctOverridesYieldSeparateMarketplaces`) to give the non-default project an assignment so they still exercise distinct-marketplace logic under the new scoping.
- Full `getPlugins` + `mv` suites pass, full server build OK, custom `glint` 0 issues, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes device-agent marketplaces to the org’s default project plus projects where the caller has an assignment, reducing duplicate `speakeasy-observability` entries. Addresses DNO-538 by keeping a single baseline marketplace and only surfacing cross-project marketplaces when relevant.

- **Bug Fixes**
  - Scoped `GetAgentPluginSet` base: always include the default project; include non-default projects only when a matching assignment exists.
  - Kept assignment-gated real plugins unchanged; observability remains synthesized per surfaced marketplace.
  - Added `TestGetPlugins_NonDefaultProjectWithoutAssignmentHidden`; updated multi-project tests to include an assignment and renamed the secondary test project to a neutral name.

- **Dependencies**
  - Added changeset to publish a patch for `server` documenting the marketplace scoping.

<sup>Written for commit 4897a990336a0c63e54cdc732e9c17f53354bd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



