### PR TITLE
mig: index chat_messages (chat_id, generation, created_at, seq) for transcript order

### DIFF
--- a/.changeset/chat-messages-transcript-order-index.md
+++ b/.changeset/chat-messages-transcript-order-index.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add a (chat_id, generation, created_at, seq) index on chat_messages so the DNO-536 transcript ordering — (created_at, seq) within a generation — is served by an ordered index scan and keyset pagination keeps its LIMIT early-stop instead of sorting the generation's full row set per page.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1642,6 +1642,13 @@ CREATE TABLE IF NOT EXISTS chat_messages (
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_seq_idx ON chat_messages (chat_id, generation, seq);
 
+-- Transcript readers and keyset pages order by (created_at, seq) within a
+-- generation (DNO-536: hook rows carry the event's occurred_at, so seq alone
+-- no longer matches display order). This index serves that filter+sort with
+-- an ordered scan and restores keyset LIMIT early-stop.
+CREATE INDEX IF NOT EXISTS chat_messages_chat_id_generation_created_at_seq_idx
+ON chat_messages (chat_id, generation, created_at, seq);
+
 -- Chat listings derive each chat's message count and last-message time per
 -- request; this lets those be per-chat index-only probes instead of an
 -- aggregate over the chat's full message history.

--- a/server/migrations/20260716202303_chat-messages-transcript-order-index.sql
+++ b/server/migrations/20260716202303_chat-messages-transcript-order-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "chat_messages_chat_id_generation_created_at_seq_idx" to table: "chat_messages"
+CREATE INDEX CONCURRENTLY "chat_messages_chat_id_generation_created_at_seq_idx" ON "chat_messages" ("chat_id", "generation", "created_at", "seq");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:2+E98Kae62hPW7nUsXZkUWG7JUiBC6xKYwOLwDSZTdc=
+h1:0DRVwzYAAShSX3v0ZXxTXoUP1Xp+KUhJTsx5KaP1HrQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -268,3 +268,4 @@ h1:2+E98Kae62hPW7nUsXZkUWG7JUiBC6xKYwOLwDSZTdc=
 20260715174418_observability-mode-to-hooks-fail-open.sql h1:LdG61RUE0xWhm7f/V+KWMdYVPC20yR9U5Q0jY+bj6N8=
 20260715203754_chat-messages-add-replayed.sql h1:xieBGqLsKZ4ZST5QAfn/Hq8aSaTCWM4sknr0bmMhHa0=
 20260715234644_skill_versions_ordering_index.sql h1:VrJFF+sNk9bil82fYMMgHmSQKABV3qmvJDcTUFVEw6s=
+20260716202303_chat-messages-transcript-order-index.sql h1:BZjNPN0tP9rnbNWcScIajjv+EvdAsTnYKVN9SqSZ4po=


### PR DESCRIPTION
## Summary

Migration-only PR: adds a concurrent index on `chat_messages (chat_id, generation, created_at, seq)` so the DNO-536 transcript ordering — `(created_at, seq)` within a generation (#4277) — is served by an ordered index scan, and keyset pagination keeps its `LIMIT` early-stop instead of sorting the generation's full row set per page.

Safe to merge independently of #4277 in either order: the index is harmless without the query changes, and the queries are correct (just slower on large chats) without the index.

Generated with `mise db:diff`; applied and verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a concurrent index on `chat_messages (chat_id, generation, created_at, seq)` to serve transcript ordering by `(created_at, seq)` within a generation. Improves transcript read speed and keeps keyset pagination fast, supporting DNO-536 when messages arrive out of order.

- **Migration**
  - Adds `chat_messages_chat_id_generation_created_at_seq_idx` via `CREATE INDEX CONCURRENTLY`; no other schema changes and safe to merge independently of query updates.

<sup>Written for commit fd115542724d8b6cbef75c5a87a8d8985c1c8f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

