### PR TITLE
feat(dashboard): animate brand gradient

### DIFF
--- a/client/dashboard/src/App.css
+++ b/client/dashboard/src/App.css
@@ -256,6 +256,47 @@
   }
 }
 
+@keyframes brand-gradient-color-drift {
+  0% {
+    transform: translateX(-14%);
+    opacity: 0;
+  }
+  5%,
+  95% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(30%);
+    opacity: 0;
+  }
+}
+
+.brand-gradient-line {
+  position: relative;
+  overflow: hidden;
+}
+
+.brand-gradient-line::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: -18%;
+  width: 130%;
+  background: linear-gradient(
+    90deg,
+    var(--gradient-brand-primary-colors)
+  );
+  filter: brightness(1.08) saturate(1.02);
+  animation: brand-gradient-color-drift 750ms ease-in-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .brand-gradient-line::after {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 .nav-shimmer {
   background: linear-gradient(
     90deg,

--- a/client/dashboard/src/components/brand-gradient-line.test.tsx
+++ b/client/dashboard/src/components/brand-gradient-line.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BrandGradientLine } from "./brand-gradient-line";
+
+describe("BrandGradientLine", () => {
+  it("renders the shared mount-animation class without changing its decorative contract", () => {
+    const { container } = render(<BrandGradientLine className="test-class" />);
+    const line = container.firstElementChild;
+
+    expect(line?.getAttribute("aria-hidden")).toBe("true");
+    expect(line?.classList.contains("brand-gradient-line")).toBe(true);
+    expect(line?.classList.contains("test-class")).toBe(true);
+    expect((line as HTMLElement).style.background).toBe(
+      "linear-gradient(90deg, var(--gradient-brand-primary-colors))",
+    );
+  });
+});

--- a/client/dashboard/src/components/brand-gradient-line.tsx
+++ b/client/dashboard/src/components/brand-gradient-line.tsx
@@ -15,7 +15,7 @@ export function BrandGradientLine({
   return (
     <div
       aria-hidden
-      className={cn("h-[3px] w-full shrink-0", className)}
+      className={cn("brand-gradient-line h-[3px] w-full shrink-0", className)}
       style={{
         background:
           "linear-gradient(90deg, var(--gradient-brand-primary-colors))",


### PR DESCRIPTION
## Summary

Adds a one-shot 750ms color drift to the shared 3px rainbow line below dashboard breadcrumbs. When the line mounts, a slightly brighter, widened copy of the gradient fades in, travels left-to-right over the fixed base gradient, then fades out to leave the original line unchanged.

The animation lives in `BrandGradientLine`, so every dashboard page gets the same page-entry treatment automatically. It is intentionally not tied to query or loading state, so refetches and ordinary content updates do not replay it. Reduced-motion users continue to see the static gradient.

## Demo

https://github.com/user-attachments/assets/32057537-1d68-40e5-8f6c-e48406d4f614

## Verification

* `pnpm -F dashboard test`: 101 files, 887 tests passed
* `pnpm -F dashboard lint`
* `git diff --check`