### PR TITLE
feat(server): record hooks.event.duration on ingest and tag hook metrics with decision verdict

### DIFF
--- a/.changeset/hooks-metric-decision-ingest.md
+++ b/.changeset/hooks-metric-decision-ingest.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Expand the `hooks.event.duration` metric for DNO-539 dashboard coverage: the unified `/rpc/hooks.ingest` endpoint now records it (it previously emitted no duration/throughput metric at all, leaving the plugin ingest path invisible to the hooks monitors), and every hooks endpoint now tags the metric with a `gram.hook.decision` attribute (allow/deny/ask, or none when the endpoint errored before producing a verdict) so allow/deny rates can be charted independently of the processing outcome. Ingest also distinguishes a new `unauthenticated` outcome (keyless requests acknowledged without processing) from the hard-401 `unauthorized` one.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -329,6 +329,10 @@ const (
 	VisibilityKey                     = attribute.Key("gram.visibility")
 
 	// Hooks
+	// HookDecisionKey carries the policy verdict the hook endpoint returned to
+	// the agent (allow/deny) on hook metrics, independent of the processing
+	// outcome (accepted/failure/unauthorized) in OutcomeKey.
+	HookDecisionKey             = attribute.Key("gram.hook.decision")
 	HookEventKey                = attribute.Key("gram.hook.event")
 	HookErrorKey                = attribute.Key("gram.hook.error")
 	HookIsInterruptKey          = attribute.Key("gram.hook.is_interrupt")
@@ -579,6 +583,8 @@ func HookServerNameOverrideID(v string) attribute.KeyValue {
 func SlogHookServerNameOverrideID(v string) slog.Attr {
 	return slog.String(string(HookServerNameOverrideIDKey), v)
 }
+
+func HookDecision(v string) attribute.KeyValue { return HookDecisionKey.String(v) }
 
 func HookEvent(v string) attribute.KeyValue { return HookEventKey.String(v) }
 func SlogHookEvent(v string) slog.Attr      { return slog.String(string(HookEventKey), v) }

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -258,7 +258,7 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (res *
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
-		s.metrics.RecordHookEventDuration(ctx, "claude", hookEventName, outcome, orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, "claude", hookEventName, outcome, claudeHookDecision(res), orgSlug, time.Since(start))
 	}()
 
 	if hasPluginAuth {

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -34,7 +34,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *ge
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
-		s.metrics.RecordHookEventDuration(ctx, "codex", hookEventName, outcome, orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, "codex", hookEventName, outcome, codexHookDecision(res), orgSlug, time.Since(start))
 	}()
 
 	logger := s.logger.With(

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -39,7 +39,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (res *
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
-		s.metrics.RecordHookEventDuration(ctx, "cursor", logHookEventName, outcome, orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, "cursor", logHookEventName, outcome, cursorHookDecision(res), orgSlug, time.Since(start))
 	}()
 
 	logger := s.logger.With(

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -47,30 +47,49 @@ func isExplicitSkillActivation(payload *gen.IngestPayload) bool {
 // identity is the publishing admin, not the developer at the keyboard —
 // falling back to the token owner for personal keys and senders without a
 // device agent.
-func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (*gen.IngestHookResult, error) {
+func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *gen.IngestHookResult, err error) {
+	start := time.Now()
+	source := ""
+	eventType := ""
+	orgSlug := ""
+	outcome := hookMetricOutcomeAccepted
+	defer func() {
+		if err != nil && outcome == hookMetricOutcomeAccepted {
+			outcome = hookMetricOutcomeFailure
+		}
+		decision := hookMetricDecisionNone
+		if res != nil {
+			decision = res.Decision
+		}
+		s.metrics.RecordHookEventDuration(ctx, source, eventType, outcome, decision, orgSlug, time.Since(start))
+	}()
+
 	if err := validateCanonicalIngestPayload(payload); err != nil {
 		return nil, err
 	}
+	source = strings.TrimSpace(payload.Source.Adapter)
+	eventType = strings.TrimSpace(payload.Event.Type)
 	if apikey := strings.TrimSpace(conv.PtrValOr(payload.ApikeyToken, "")); apikey != "" {
 		authedCtx, err := s.authorizePluginRequest(ctx, apikey, strings.TrimSpace(conv.PtrValOr(payload.ProjectSlugInput, "")))
 		if err != nil {
+			outcome = hookMetricOutcomeUnauthorized
 			return nil, oops.E(oops.CodeUnauthorized, err, "unauthorized")
 		}
 		ctx = authedCtx
 	}
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		outcome = hookMetricOutcomeUnauthenticated
 		s.logger.InfoContext(ctx, "unauthenticated hook acknowledged without processing",
 			attr.SlogEvent("hooks_ingest_unauthenticated"),
-			attr.SlogHookSource(strings.TrimSpace(payload.Source.Adapter)),
-			attr.SlogHookEvent(strings.TrimSpace(payload.Event.Type)),
+			attr.SlogHookSource(source),
+			attr.SlogHookEvent(eventType),
 		)
 		return canonicalAllowResult(), nil
 	}
+	orgSlug = authCtx.OrganizationSlug
 	actor := s.resolveCanonicalActor(ctx, payload, authCtx)
 
-	eventType := strings.TrimSpace(payload.Event.Type)
-	source := strings.TrimSpace(payload.Source.Adapter)
 	sessionID := canonicalSessionID(payload)
 	timestamp := canonicalEventTime(payload)
 

--- a/server/internal/hooks/metrics.go
+++ b/server/internal/hooks/metrics.go
@@ -8,15 +8,26 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 )
 
 const (
 	meterHooksEventDuration = "hooks.event.duration"
 
-	hookMetricOutcomeAccepted     = "accepted"
-	hookMetricOutcomeFailure      = "failure"
-	hookMetricOutcomeUnauthorized = "unauthorized"
+	hookMetricOutcomeAccepted        = "accepted"
+	hookMetricOutcomeFailure         = "failure"
+	hookMetricOutcomeUnauthorized    = "unauthorized"
+	hookMetricOutcomeUnauthenticated = "unauthenticated"
+
+	hookMetricDecisionAllow = "allow"
+	hookMetricDecisionDeny  = "deny"
+	// hookMetricDecisionNone marks responses that carried no verdict at all —
+	// the endpoint errored before producing a result. Client behavior then
+	// depends on the org's fail open/closed setting, so neither allow nor deny
+	// would be truthful.
+	hookMetricDecisionNone = "none"
 )
 
 type metrics struct {
@@ -42,19 +53,56 @@ func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metric
 	}
 }
 
-func (m *metrics) RecordHookEventDuration(ctx context.Context, source string, eventName string, outcome string, orgSlug string, duration time.Duration) {
+func (m *metrics) RecordHookEventDuration(ctx context.Context, source string, eventName string, outcome string, decision string, orgSlug string, duration time.Duration) {
 	if m == nil || m.eventDuration == nil {
 		return
 	}
 
-	m.eventDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(hookEventMetricAttributes(source, eventName, outcome, orgSlug)...))
+	m.eventDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(hookEventMetricAttributes(source, eventName, outcome, decision, orgSlug)...))
 }
 
-func hookEventMetricAttributes(source string, eventName string, outcome string, orgSlug string) []attribute.KeyValue {
+// claudeHookDecision maps a Claude hook response to the verdict dimension on
+// hook metrics: a top-level block or a nested permissionDecision of deny/ask
+// wins; anything else — including responses with no decision field, which
+// Claude Code treats as pass-through — counts as allow.
+func claudeHookDecision(res *gen.ClaudeHookResult) string {
+	if res == nil {
+		return hookMetricDecisionNone
+	}
+	if conv.PtrValOr(res.Decision, "") == "block" {
+		return hookMetricDecisionDeny
+	}
+	if output, ok := res.HookSpecificOutput.(*HookSpecificOutput); ok && output != nil {
+		if decision := conv.PtrValOr(output.PermissionDecision, ""); decision != "" {
+			return decision
+		}
+	}
+	return hookMetricDecisionAllow
+}
+
+// cursorHookDecision and codexHookDecision pass the response verdict through
+// (allow / deny / ask for Cursor), defaulting absent fields to allow to match
+// how the client interprets them.
+func cursorHookDecision(res *gen.CursorHookResult) string {
+	if res == nil {
+		return hookMetricDecisionNone
+	}
+	return conv.Default(conv.PtrValOr(res.Permission, ""), hookMetricDecisionAllow)
+}
+
+func codexHookDecision(res *gen.CodexHookResult) string {
+	if res == nil {
+		return hookMetricDecisionNone
+	}
+	return conv.Default(conv.PtrValOr(res.Decision, ""), hookMetricDecisionAllow)
+}
+
+func hookEventMetricAttributes(source string, eventName string, outcome string, decision string, orgSlug string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attr.HookSource(source),
 		attr.HookEvent(eventName),
 		attr.Outcome(outcome),
+		attr.HookDecision(decision),
 	}
 	if orgSlug != "" {
 		attrs = append(attrs, attr.OrganizationSlug(orgSlug))

--- a/server/internal/hooks/metrics_test.go
+++ b/server/internal/hooks/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -20,7 +21,7 @@ func TestMetrics_RecordHookEventDuration(t *testing.T) {
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	metrics := newMetrics(meterProvider, testenv.NewLogger(t))
 
-	metrics.RecordHookEventDuration(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, "acme", 150*time.Millisecond)
+	metrics.RecordHookEventDuration(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, hookMetricDecisionDeny, "acme", 150*time.Millisecond)
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
@@ -41,9 +42,62 @@ func TestMetrics_RecordHookEventDuration(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, hookMetricOutcomeAccepted, value.AsString())
 
+	value, ok = histogramPoint.Attributes.Value(attr.HookDecisionKey)
+	require.True(t, ok)
+	require.Equal(t, hookMetricDecisionDeny, value.AsString())
+
 	value, ok = histogramPoint.Attributes.Value(attr.OrganizationSlugKey)
 	require.True(t, ok)
 	require.Equal(t, "acme", value.AsString())
+}
+
+func TestClaudeHookDecision(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, hookMetricDecisionNone, claudeHookDecision(nil))
+	require.Equal(t, hookMetricDecisionAllow, claudeHookDecision(makeHookResult("Stop")))
+	require.Equal(t, hookMetricDecisionAllow, claudeHookDecision(makeHookResult("PreToolUse")))
+	require.Equal(t, hookMetricDecisionDeny, claudeHookDecision(constructBlockResponse("UserPromptSubmit", "blocked")))
+	require.Equal(t, hookMetricDecisionDeny, claudeHookDecision(constructBlockResponse("PreToolUse", "blocked")))
+	require.Equal(t, hookMetricDecisionDeny, claudeHookDecision(constructWarnChallengeResponse("PreToolUse", "agent", "user")))
+}
+
+func TestCursorHookDecision(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, hookMetricDecisionNone, cursorHookDecision(nil))
+	require.Equal(t, hookMetricDecisionAllow, cursorHookDecision(&gen.CursorHookResult{
+		Permission:        nil,
+		UserMessage:       nil,
+		AdditionalContext: nil,
+		AgentMessage:      nil,
+	}))
+	require.Equal(t, hookMetricDecisionDeny, cursorHookDecision(&gen.CursorHookResult{
+		Permission:        new("deny"),
+		UserMessage:       nil,
+		AdditionalContext: nil,
+		AgentMessage:      nil,
+	}))
+	require.Equal(t, "ask", cursorHookDecision(&gen.CursorHookResult{
+		Permission:        new("ask"),
+		UserMessage:       nil,
+		AdditionalContext: nil,
+		AgentMessage:      nil,
+	}))
+}
+
+func TestCodexHookDecision(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, hookMetricDecisionNone, codexHookDecision(nil))
+	require.Equal(t, hookMetricDecisionAllow, codexHookDecision(&gen.CodexHookResult{
+		Decision: nil,
+		Reason:   nil,
+	}))
+	require.Equal(t, hookMetricDecisionDeny, codexHookDecision(&gen.CodexHookResult{
+		Decision: new("deny"),
+		Reason:   nil,
+	}))
 }
 
 func findHookEventDurationPoint(t *testing.T, rm metricdata.ResourceMetrics) metricdata.HistogramDataPoint[float64] {


### PR DESCRIPTION
Server-side metric coverage for [DNO-539](https://linear.app/speakeasy/issue/DNO-539/dcpd-hooks-metrics-dashboard-coverage-for-throughput-and-sync-hook) — the companion to the [Hooks & OTEL ingestion dashboard](https://app.datadoghq.com/dashboard/7bz-6ab-j52) revamp (new throughput, sync-gating-latency, and monitor-status groups, already live).

## What changed

- **`/rpc/hooks.ingest` now records `hooks.event.duration`.** The unified ingest endpoint — the path the new hook plugin and the DD gating synthetic use — previously emitted no duration/throughput metric at all, so it was invisible to the hooks latency monitor and every dashboard widget. It now records the same histogram as the per-provider endpoints (source = `source.adapter`, event = `event.type`, org slug from auth context).
- **New `gram.hook.decision` attribute on all four hook endpoints** (`claude`, `cursor`, `codex`, `ingest`): the verdict returned to the agent — `allow` / `deny` / `ask`, or `none` when the endpoint errored before producing a result (client behavior then depends on the org's fail open/closed setting). This is orthogonal to the existing `gram.outcome` processing dimension and unlocks allow/deny-rate charting (the deny-rate widget is already on the dashboard waiting for this to deploy).
- **New `unauthenticated` outcome on ingest** for keyless requests acknowledged without processing, distinct from the hard-401 `unauthorized` — a spike in these means devices are losing auth, which the old lumping would have hidden.

## Notes

- Decision derivation is centralized in `metrics.go` helpers that read the response shapes (`decision: block` / `permissionDecision` for Claude, `permission` for Cursor, `decision` for Codex, `blockReason` for ingest), with unit tests covering block, warn-challenge, ask, and pass-through responses.
- Follow-up after deploy: widen the [gating-latency monitor](https://app.datadoghq.com/monitors/305139582) to also cover the canonical gating events (`prompt.submitted`, `tool.requested`); the dashboard's gating widgets already include them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds metric coverage for the hooks ingest path to complete DNO-539: `/rpc/hooks.ingest` now records `hooks.event.duration`, and all hook endpoints tag metrics with a `gram.hook.decision` verdict to enable throughput and allow/deny charts.

- **New Features**
  - Record `hooks.event.duration` on `/rpc/hooks.ingest` with `source.adapter`, `event.type`, and `org_slug` tags (same histogram as per-provider endpoints).
  - Add `gram.hook.decision` (`allow`/`deny`/`ask`/`none`) on `claude`, `cursor`, `codex`, and `ingest` metrics for verdict-rate charts.
  - Add `unauthenticated` `gram.outcome` on ingest for keyless acknowledgements, distinct from `unauthorized`.
  - Centralize verdict mapping across endpoints with unit tests for block/warn-challenge/ask/allow.

<sup>Written for commit 5bf166925fa6d15a2ae96a3c326f47712e7ec7a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

