### PR TITLE
chore(server): bump hooksGeneratorVersion to 17 + re-pin hooks@0.2.0

### DIFF
--- a/.changeset/hooks-generator-v17.md
+++ b/.changeset/hooks-generator-v17.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Bump hooksGeneratorVersion to 17 so the next hooks rollout republishes every connected plugin. Ships the pinned-bootstrapper generation to orgs still on older script generations, and is the vehicle for distributing the hooks@0.2.0 binary (fail-open cache + offline spool) once hooksBinaryVersion is re-pinned to the published release.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -344,7 +344,7 @@ const mcpGeneratorVersion = "9"
 //
 // The Plugin Generate Check CI workflow requires the relevant one of these two
 // constants to change whenever generate.go does.
-const hooksGeneratorVersion = "16"
+const hooksGeneratorVersion = "17"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits


### PR DESCRIPTION
## Summary

Per the [Hooks Rollout Procedure](https://app.notion.com/p/speakeasyapi/Hooks-Rollout-Procedure-39c726c497cc8010875cd54623bc5cc4): bumps `hooksGeneratorVersion` 16 → 17 so the plugin-generator-rollout schedule republishes every connected plugin.

**Draft until the hooks@0.2.0 release exists.** The point of this rollout is distributing the new binary (fail-open cache + offline spool, DNO-497/498); merging the bump alone would republish plugins that still bootstrap 0.1.1 and burn the version number.

## Remaining steps before marking ready

1. Merge the version-packages PR #4227 → release workflow tags `hooks@0.2.0` and publishes artifacts.
2. Add the re-pin commit here: `hooksBinaryVersion = "0.2.0"` + the six SHA-256s from the release checksums in `server/internal/plugins/hooks_bootstrap.go`.
3. Merge + deploy. `speakeasy-team` (canary) republishes within ~5 min.
4. Raise the [FlagHooksRollout PostHog payload](https://us.posthog.com/project/10122/feature_flags/755549) to `{"version": 17}` with whatever phased release conditions we want for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)