### PR TITLE
fix: fix orghome projects wrapper

### DIFF
--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -1,0 +1,137 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/page-layout", () => {
+  function Page({ children }: { children: ReactNode }) {
+    return <>{children}</>;
+  }
+  function Header({ children }: { children?: ReactNode }) {
+    return <>{children}</>;
+  }
+  Header.Breadcrumbs = () => null;
+  Page.Header = Header;
+  Page.Body = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+  return { Page };
+});
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/project-menu", () => ({
+  ProjectAvatar: () => <span />,
+}));
+vi.mock("@/components/member-facepile", () => ({
+  MemberFacepile: () => <span />,
+}));
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  ContextMenuContent: () => null,
+  ContextMenuItem: () => null,
+  ContextMenuSeparator: () => null,
+}));
+vi.mock("@/components/auditlogs/feed", () => ({
+  ActionBadge: () => null,
+  ActionDot: () => null,
+}));
+vi.mock("@/pages/access/ChallengesTab", () => ({
+  ChallengesEmptyState: () => null,
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({
+    id: "org-1",
+    name: "Acme",
+    slug: "acme",
+    projects: [{ id: "project-1", name: "Project One", slug: "project-one" }],
+  }),
+}));
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({ projects: { create: vi.fn() } }),
+  useSlugs: () => ({ orgSlug: "acme" }),
+}));
+vi.mock("@/contexts/Telemetry", () => ({
+  useTelemetry: () => ({ isFeatureEnabled: () => false }),
+}));
+vi.mock("@/hooks/useLocalStorageState", () => ({
+  useLocalStorageState: () => ["list", vi.fn()],
+}));
+vi.mock("@/hooks/useProjectFavorites", () => ({
+  useProjectFavorites: () => ({
+    favoriteSet: new Set<string>(),
+    isFavorite: () => false,
+    toggleFavorite: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useRBAC", () => ({
+  useRBAC: () => ({ hasScope: () => true }),
+}));
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({
+    access: {
+      challenges: {
+        Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+      },
+      roles: { goTo: vi.fn() },
+    },
+    auditLogs: {
+      Link: ({ children }: { children: ReactNode }) => <>{children}</>,
+    },
+    team: { goTo: vi.fn() },
+  }),
+}));
+
+vi.mock("@gram/client/react-query/_context.js", () => ({
+  useGramContext: () => ({}),
+}));
+vi.mock("@gram/client/react-query/auditLogs.js", () => ({
+  useAuditLogs: () => ({ data: { result: { logs: [] } } }),
+}));
+vi.mock("@gram/client/react-query/challengeBuckets.js", () => ({
+  useChallengeBuckets: () => ({ data: { buckets: [] }, isLoading: false }),
+}));
+vi.mock("@gram/client/react-query/members.js", () => ({
+  useMembers: () => ({ data: { members: [] } }),
+}));
+vi.mock("@gram/client/react-query/productFeatures.js", () => ({
+  useProductFeatures: () => ({ data: { logsEnabled: false } }),
+}));
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQueryClient: () => ({ prefetchQuery: vi.fn() }),
+}));
+vi.mock("react-router", () => ({
+  Link: ({ children, ...props }: React.ComponentProps<"a">) => (
+    <a {...props}>{children}</a>
+  ),
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("@speakeasy-api/moonshine", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@speakeasy-api/moonshine")>()),
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  Icon: () => null,
+}));
+
+import OrgHome from "./OrgHome";
+
+afterEach(cleanup);
+
+describe("OrgHome", () => {
+  it("does not wrap project list rows in a full-height element", () => {
+    render(<OrgHome />);
+
+    const projectName = screen.getByText("Project One");
+    expect(projectName.closest(".h-full")).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_DATE_RANGE_PRESET } from "@/components/observe/useDateRangeFilt
 import { buildProjectOverviewQuery } from "@/components/project/projectOverviewQuery";
 import { RequireScope } from "@/components/require-scope";
 import { CardContextMenu } from "@/components/card-context-menu";
+import { TableRowContextMenu } from "@/components/table-row-context-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Heading } from "@/components/ui/heading";
@@ -547,9 +548,7 @@ function ProjectRow({
   const actions = useProjectActions(project, { isFavorite, onToggleFavorite });
 
   return (
-    <CardContextMenu actions={actions}>
-      {/* The row div keeps `relative`, so the Link overlay below still fills
-          the row rather than the context-menu wrapper. */}
+    <TableRowContextMenu actions={actions}>
       <div className="group hover:bg-muted/40 relative flex items-center gap-4 px-4 py-3 transition-colors">
         {/* Decorative content: pointer-events-none routes clicks through to the
             Link overlay below, while the actions region opts back in. */}
@@ -603,7 +602,7 @@ function ProjectRow({
           className="absolute inset-0"
         />
       </div>
-    </CardContextMenu>
+    </TableRowContextMenu>
   );
 }
 


### PR DESCRIPTION
Fixes an issue with the project row wrapper

<img width="1074" height="578" alt="image" src="https://github.com/user-attachments/assets/fe8135bb-900b-4d18-9653-b395bd4f7cd8" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Org Home project row wrapper so rows are no longer wrapped by a full-height element, restoring correct click targets and hover behavior.

- **Bug Fixes**
  - Replaced `CardContextMenu` with `TableRowContextMenu` to keep the row as the positioned element and limit the link overlay to the row.
  - Added a regression test (`OrgHome.test.tsx`) to ensure project rows aren’t inside an `.h-full` wrapper.

<sup>Written for commit 3753d0d4aa7320cff40963ae92a870e89675dce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

