### PR TITLE
fix(dashboard): resolve compliance chat owners

### DIFF
--- a/.changeset/resolve-compliance-chat-owner.md
+++ b/.changeset/resolve-compliance-chat-owner.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Resolve chat session owners from organization members instead of displaying opaque external user IDs.

--- a/client/dashboard/src/lib/chat-owner.test.ts
+++ b/client/dashboard/src/lib/chat-owner.test.ts
@@ -1,6 +1,6 @@
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import { describe, expect, it } from "vitest";
-import { resolveChatOwner } from "./chat-owner";
+import { chatOwnerLabel, resolveChatOwner } from "./chat-owner";
 
 function member(overrides: Partial<AccessMember>): AccessMember {
   return {
@@ -18,6 +18,7 @@ const members = [
   member({ id: "gram-1", email: "ada@example.com", name: "Ada" }),
   member({ id: "gram-2", email: "grace@example.com", name: "Grace" }),
 ];
+const currentUser = { id: "gram-2", email: "grace@example.com" };
 
 describe("resolveChatOwner", () => {
   it("matches a compliance chat using its resolved Gram user ID", () => {
@@ -47,5 +48,44 @@ describe("resolveChatOwner", () => {
 
   it("returns undefined before members load", () => {
     expect(resolveChatOwner(undefined, { userId: "gram-1" })).toBeUndefined();
+  });
+});
+
+describe("chatOwnerLabel", () => {
+  it("prefers a personal account email", () => {
+    expect(
+      chatOwnerLabel(
+        members,
+        { userId: "gram-2", externalUserId: "user_opaque" },
+        currentUser,
+        "personal@example.com",
+      ),
+    ).toBe("personal@example.com");
+  });
+
+  it("labels the current user as You before using their member name", () => {
+    expect(
+      chatOwnerLabel(
+        members,
+        { userId: "gram-2", externalUserId: "user_opaque" },
+        currentUser,
+      ),
+    ).toBe("You");
+  });
+
+  it("uses another member's name", () => {
+    expect(
+      chatOwnerLabel(
+        members,
+        { userId: "gram-1", externalUserId: "user_opaque" },
+        currentUser,
+      ),
+    ).toBe("Ada");
+  });
+
+  it("falls back to an unresolved external user ID", () => {
+    expect(
+      chatOwnerLabel(members, { externalUserId: "user_opaque" }, currentUser),
+    ).toBe("user_opaque");
   });
 });

--- a/client/dashboard/src/lib/chat-owner.test.ts
+++ b/client/dashboard/src/lib/chat-owner.test.ts
@@ -1,0 +1,51 @@
+import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import { describe, expect, it } from "vitest";
+import { resolveChatOwner } from "./chat-owner";
+
+function member(overrides: Partial<AccessMember>): AccessMember {
+  return {
+    id: "gram-user-id",
+    email: "member@example.com",
+    name: "Example Member",
+    joinedAt: new Date(0),
+    principalUrn: "principal:user:gram-user-id",
+    roleIds: [],
+    ...overrides,
+  };
+}
+
+const members = [
+  member({ id: "gram-1", email: "ada@example.com", name: "Ada" }),
+  member({ id: "gram-2", email: "grace@example.com", name: "Grace" }),
+];
+
+describe("resolveChatOwner", () => {
+  it("matches a compliance chat using its resolved Gram user ID", () => {
+    const owner = resolveChatOwner(members, {
+      userId: "gram-2",
+      externalUserId: "user_01HXXXXXXXXXXXXXXXXXXXXXXX",
+    });
+
+    expect(owner?.name).toBe("Grace");
+  });
+
+  it("matches dashboard chats using the external email", () => {
+    const owner = resolveChatOwner(members, {
+      externalUserId: "ada@example.com",
+    });
+
+    expect(owner?.name).toBe("Ada");
+  });
+
+  it("does not match an unresolved opaque external user ID", () => {
+    expect(
+      resolveChatOwner(members, {
+        externalUserId: "user_01HXXXXXXXXXXXXXXXXXXXXXXX",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined before members load", () => {
+    expect(resolveChatOwner(undefined, { userId: "gram-1" })).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/lib/chat-owner.ts
+++ b/client/dashboard/src/lib/chat-owner.ts
@@ -1,8 +1,13 @@
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 
+type ChatIdentity = {
+  userId?: string;
+  externalUserId?: string;
+};
+
 export function resolveChatOwner(
   members: AccessMember[] | undefined,
-  chat: { userId?: string; externalUserId?: string },
+  chat: ChatIdentity,
 ): AccessMember | undefined {
   if (!members) return undefined;
 
@@ -11,4 +16,23 @@ export function resolveChatOwner(
       (!!chat.userId && member.id === chat.userId) ||
       (!!chat.externalUserId && member.email === chat.externalUserId),
   );
+}
+
+export function chatOwnerLabel(
+  members: AccessMember[] | undefined,
+  chat: ChatIdentity,
+  currentUser: { id: string; email: string },
+  accountEmail?: string,
+): string {
+  if (accountEmail) return accountEmail;
+
+  const isCurrentUser =
+    (!!chat.userId && chat.userId === currentUser.id) ||
+    (!!chat.externalUserId && chat.externalUserId === currentUser.email);
+  if (isCurrentUser) return "You";
+
+  const member = resolveChatOwner(members, chat);
+  if (member) return member.name || member.email;
+
+  return chat.externalUserId || "anonymous";
 }

--- a/client/dashboard/src/lib/chat-owner.ts
+++ b/client/dashboard/src/lib/chat-owner.ts
@@ -1,0 +1,14 @@
+import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+
+export function resolveChatOwner(
+  members: AccessMember[] | undefined,
+  chat: { userId?: string; externalUserId?: string },
+): AccessMember | undefined {
+  if (!members) return undefined;
+
+  return members.find(
+    (member) =>
+      (!!chat.userId && member.id === chat.userId) ||
+      (!!chat.externalUserId && member.email === chat.externalUserId),
+  );
+}

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -34,6 +34,7 @@ import {
 } from "@speakeasy-api/moonshine";
 import type { ChatOverview } from "@gram/client/models/components/chatoverview.js";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
+import { useMembers } from "@gram/client/react-query/members.js";
 import { useSearchLogsMutation } from "@gram/client/react-query/searchLogs.js";
 import { useRiskListResults } from "@gram/client/react-query/riskListResults.js";
 import { QueryErrorResetBoundary, useQueryClient } from "@tanstack/react-query";
@@ -58,6 +59,7 @@ import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useIsPlatformAdmin } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { resolveChatOwner } from "@/lib/chat-owner";
 import { handleError, toError } from "@/lib/errors";
 import {
   ExclusionEditor,
@@ -240,6 +242,7 @@ function MetaRow({ label, children }: { label: string; children: ReactNode }) {
 
 function SessionSummary({
   chat,
+  userLabel,
   messageCount,
   toolCount,
   compact = false,
@@ -257,6 +260,7 @@ function SessionSummary({
     lastMessageTimestamp?: Date;
     updatedAt: Date;
   };
+  userLabel: string;
   messageCount: number;
   toolCount: number;
   compact?: boolean;
@@ -311,7 +315,7 @@ function SessionSummary({
         <div className="space-y-1">
           <div className="mb-1 text-sm font-semibold">Session details</div>
           <div className="divide-border divide-y">
-            <MetaRow label="User">{chat.externalUserId || "anonymous"}</MetaRow>
+            <MetaRow label="User">{userLabel}</MetaRow>
             {accountEmail && (
               <MetaRow label="Account">
                 <span className="inline-flex flex-wrap items-center justify-end gap-1.5">
@@ -614,6 +618,7 @@ function ThreadSearchBar({
 function ChatDetailHeader({
   chatId,
   chat,
+  userLabel,
   messageCount,
   toolCount,
   canManageChat,
@@ -632,6 +637,7 @@ function ChatDetailHeader({
 }: {
   chatId: string;
   chat: Parameters<typeof SessionSummary>[0]["chat"] & { title?: string };
+  userLabel: string;
   messageCount: number;
   toolCount: number;
   canManageChat: boolean;
@@ -682,6 +688,7 @@ function ChatDetailHeader({
         <div className="flex shrink-0 items-center gap-1">
           <SessionSummary
             chat={chat}
+            userLabel={userLabel}
             messageCount={messageCount}
             toolCount={toolCount}
             compact={compactMetadata}
@@ -852,6 +859,10 @@ function ChatDetailPanel({
   // resolved (otherwise the panel would show "Not found" despite having data).
   const chat = transcript.chat ?? active.chat;
   const chatMessages = active.messages;
+  const { data: membersData } = useMembers();
+  const owner = chat ? resolveChatOwner(membersData?.members, chat) : undefined;
+  const resolvedUserLabel = owner ? owner.name || owner.email : undefined;
+  const userLabel = resolvedUserLabel ?? chat?.externalUserId ?? "anonymous";
   // Only the primary (or risk) initial load blanks the whole panel; a search
   // re-fetch updates the transcript in place — its loading shows in the search
   // bar and as a "Searching…" empty state instead.
@@ -1113,10 +1124,12 @@ function ChatDetailPanel({
     else transcript.loadRest();
   }, [windowed, transcript]);
 
-  // Personal-account sessions label the user's turns with the account's own
-  // email (mirrors the sessions list) instead of the attributed employee's
-  // work email carried on the messages.
-  const userLabelOverride = chat ? personalAccountEmail(chat) : undefined;
+  // Personal-account sessions label turns with the account's own email.
+  // Otherwise use the resolved organization member instead of an opaque
+  // external provider identifier.
+  const userLabelOverride = chat
+    ? (personalAccountEmail(chat) ?? resolvedUserLabel)
+    : undefined;
 
   const rowCtx = useMemo<RowContext>(
     () => ({
@@ -1226,6 +1239,7 @@ function ChatDetailPanel({
       <ChatDetailHeader
         chatId={chatId}
         chat={chat}
+        userLabel={userLabel}
         messageCount={chat.numMessages}
         toolCount={toolLogs.length}
         canManageChat={canManageChat}

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -57,9 +57,9 @@ import { AccountTypeBadge } from "@/components/account-type-badge";
 import { personalAccountEmail } from "@/components/observe/account-display-utils";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useRBAC } from "@/hooks/useRBAC";
-import { useIsPlatformAdmin } from "@/contexts/Auth";
+import { useIsPlatformAdmin, useSession } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
-import { resolveChatOwner } from "@/lib/chat-owner";
+import { chatOwnerLabel } from "@/lib/chat-owner";
 import { handleError, toError } from "@/lib/errors";
 import {
   ExclusionEditor,
@@ -781,6 +781,7 @@ function ChatDetailPanel({
   dimNonRisk: dimNonRiskProp = false,
 }: ChatDetailPanelProps) {
   const client = useSdkClient();
+  const { user } = useSession();
   const isPlatformAdmin = useIsPlatformAdmin();
   const { hasScope } = useRBAC();
   const canManageChat = isPlatformAdmin || hasScope("org:admin");
@@ -860,9 +861,14 @@ function ChatDetailPanel({
   const chat = transcript.chat ?? active.chat;
   const chatMessages = active.messages;
   const { data: membersData } = useMembers();
-  const owner = chat ? resolveChatOwner(membersData?.members, chat) : undefined;
-  const resolvedUserLabel = owner ? owner.name || owner.email : undefined;
-  const userLabel = resolvedUserLabel ?? chat?.externalUserId ?? "anonymous";
+  const userLabel = chat
+    ? chatOwnerLabel(
+        membersData?.members,
+        chat,
+        user,
+        personalAccountEmail(chat),
+      )
+    : "anonymous";
   // Only the primary (or risk) initial load blanks the whole panel; a search
   // re-fetch updates the transcript in place — its loading shows in the search
   // bar and as a "Searching…" empty state instead.
@@ -1124,12 +1130,7 @@ function ChatDetailPanel({
     else transcript.loadRest();
   }, [windowed, transcript]);
 
-  // Personal-account sessions label turns with the account's own email.
-  // Otherwise use the resolved organization member instead of an opaque
-  // external provider identifier.
-  const userLabelOverride = chat
-    ? (personalAccountEmail(chat) ?? resolvedUserLabel)
-    : undefined;
+  const userLabelOverride = chat ? userLabel : undefined;
 
   const rowCtx = useMemo<RowContext>(
     () => ({

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.test.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.test.tsx
@@ -19,6 +19,20 @@ vi.mock("@/components/ui/tooltip", () => ({
   SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("@gram/client/react-query/members.js", () => ({
+  useMembers: () => ({
+    data: {
+      members: [
+        {
+          id: "gram-user-1",
+          email: "ada@example.com",
+          name: "Ada Lovelace",
+        },
+      ],
+    },
+  }),
+}));
+
 function makeChat(id: string): ChatOverview {
   const createdAt = new Date("2026-01-01T12:00:00Z");
 
@@ -82,5 +96,30 @@ describe("ChatLogsTable", () => {
 
     expect(screen.getByText(/^Created Jan 1, \d{2}:00$/)).toBeTruthy();
     expect(screen.getByText(/^Last activity Jan 1, \d{2}:03$/)).toBeTruthy();
+  });
+
+  it("shows a resolved member name for a compliance chat", () => {
+    render(
+      <ChatLogsTable
+        chats={[
+          {
+            ...makeChat("chat_01HXQ1P84WV3S9J7Z52DKVE7NE"),
+            userId: "gram-user-1",
+            externalUserId: "user_01HXXXXXXXXXXXXXXXXXXXXXXX",
+          },
+        ]}
+        onDeleteChat={() => {
+          /* test stub */
+        }}
+        onSelectChat={() => {
+          /* test stub */
+        }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    expect(screen.getByText("Ada Lovelace")).toBeTruthy();
+    expect(screen.queryByText("user_01HXXXXXXXXXXXXXXXXXXXXXXX")).toBeNull();
   });
 });

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -3,40 +3,15 @@ import { personalAccountEmail } from "@/components/observe/account-display-utils
 import { TableRowContextMenu } from "@/components/table-row-context-menu";
 import { Dialog } from "@/components/ui/dialog";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { resolveChatOwner } from "@/lib/chat-owner";
+import { chatOwnerLabel } from "@/lib/chat-owner";
 import { cn } from "@/lib/utils";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useSession } from "@/contexts/Auth";
-import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { ChatOverview } from "@gram/client/models/components/chatoverview.js";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import { format } from "date-fns";
 import { useCallback, useState } from "react";
-
-// Label for a session's owner. Personal-account sessions show the account's own
-// email (the session's user fields carry the attributed employee's WORK email,
-// which hides which account was actually used — the adjacent AccountTypeIcon
-// marks it personal). Otherwise the caller's own sessions show "You" (matched by
-// internal user id, or by external user id when it equals their email —
-// seeded/dashboard chats carry the email there). For other users, resolve the
-// chat's internal user id against the org members loaded by access.listMembers.
-// Unresolved external users fall back to their external id or "anonymous".
-function ownerLabel(
-  chat: ChatOverview,
-  user: { id: string; email: string },
-  members: AccessMember[] | undefined,
-): string {
-  const accountEmail = personalAccountEmail(chat);
-  if (accountEmail) return accountEmail;
-  const isMe =
-    (!!chat.userId && chat.userId === user.id) ||
-    (!!chat.externalUserId && chat.externalUserId === user.email);
-  if (isMe) return "You";
-  const member = resolveChatOwner(members, chat);
-  if (member) return member.name || member.email;
-  return chat.externalUserId || "anonymous";
-}
 
 interface ChatLogsTableProps {
   chats: ChatOverview[];
@@ -275,7 +250,12 @@ export function ChatLogsTable({
                       <span className="flex items-center gap-1.5">
                         <AccountTypeIcon accountType={chat.accountType} />
                         <span className="max-w-[120px] truncate">
-                          {ownerLabel(chat, user, membersData?.members)}
+                          {chatOwnerLabel(
+                            membersData?.members,
+                            chat,
+                            user,
+                            personalAccountEmail(chat),
+                          )}
                         </span>
                       </span>
                       {source && (

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -3,10 +3,13 @@ import { personalAccountEmail } from "@/components/observe/account-display-utils
 import { TableRowContextMenu } from "@/components/table-row-context-menu";
 import { Dialog } from "@/components/ui/dialog";
 import { SimpleTooltip } from "@/components/ui/tooltip";
+import { resolveChatOwner } from "@/lib/chat-owner";
 import { cn } from "@/lib/utils";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useSession } from "@/contexts/Auth";
+import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { ChatOverview } from "@gram/client/models/components/chatoverview.js";
+import { useMembers } from "@gram/client/react-query/members.js";
 import { Button, Icon } from "@speakeasy-api/moonshine";
 import { format } from "date-fns";
 import { useCallback, useState } from "react";
@@ -16,11 +19,13 @@ import { useCallback, useState } from "react";
 // which hides which account was actually used — the adjacent AccountTypeIcon
 // marks it personal). Otherwise the caller's own sessions show "You" (matched by
 // internal user id, or by external user id when it equals their email —
-// seeded/dashboard chats carry the email there). Everyone else falls back to the
-// external user id, or "anonymous" when there is none.
+// seeded/dashboard chats carry the email there). For other users, resolve the
+// chat's internal user id against the org members loaded by access.listMembers.
+// Unresolved external users fall back to their external id or "anonymous".
 function ownerLabel(
   chat: ChatOverview,
   user: { id: string; email: string },
+  members: AccessMember[] | undefined,
 ): string {
   const accountEmail = personalAccountEmail(chat);
   if (accountEmail) return accountEmail;
@@ -28,6 +33,8 @@ function ownerLabel(
     (!!chat.userId && chat.userId === user.id) ||
     (!!chat.externalUserId && chat.externalUserId === user.email);
   if (isMe) return "You";
+  const member = resolveChatOwner(members, chat);
+  if (member) return member.name || member.email;
   return chat.externalUserId || "anonymous";
 }
 
@@ -148,6 +155,7 @@ export function ChatLogsTable({
   error,
 }: ChatLogsTableProps): JSX.Element {
   const { user } = useSession();
+  const { data: membersData } = useMembers();
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   if (isLoading && chats.length === 0) {
     return (
@@ -267,7 +275,7 @@ export function ChatLogsTable({
                       <span className="flex items-center gap-1.5">
                         <AccountTypeIcon accountType={chat.accountType} />
                         <span className="max-w-[120px] truncate">
-                          {ownerLabel(chat, user)}
+                          {ownerLabel(chat, user, membersData?.members)}
                         </span>
                       </span>
                       {source && (


### PR DESCRIPTION
## Summary
- resolve chat session owners against organization members using the internal user ID
- show the resolved name or email in session lists, details, and transcript labels while retaining external-ID fallbacks
- add focused owner-resolution coverage and a dashboard changeset

Fixes DNO-451.

## Test plan
- [x] `pnpm -F dashboard test`
- [x] `pnpm -F dashboard lint`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve chat session owners against organization members so the dashboard shows names/emails instead of opaque external IDs in session lists, details, and transcript author labels. Fixes DNO-451.

- **Bug Fixes**
  - Added `resolveChatOwner` and `chatOwnerLabel` (match by `userId` or email) and used them in `ChatLogsTable` and `ChatDetailPanel`.
  - Preserved label precedence: personal account email → "You" (current user) → member name/email → `externalUserId` or "anonymous".
  - Added unit tests for resolution/labeling, updated `ChatLogsTable` test, and a dashboard changeset.

<sup>Written for commit 2952c447e26a0d20c13cb3bce75c372b998cae0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

