### PR TITLE
mig(aiintegrations): expand AI integration sync schedule schema

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -2898,6 +2898,12 @@ CREATE TABLE IF NOT EXISTS ai_integration_syncs (
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   ai_integration_config_id uuid NOT NULL,
+  -- Expand-phase discriminator for the sync pipeline. Nullable until all
+  -- existing rows are backfilled and old writers have drained.
+  schedule TEXT,
+  -- Expand-phase checkpoint kind ('cursor' or 'time'). Nullable until the
+  -- application backfill completes.
+  kind TEXT,
   poll_watermark_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   last_cursor_id TEXT,
   next_poll_after timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -2912,6 +2918,9 @@ CREATE TABLE IF NOT EXISTS ai_integration_syncs (
 
 CREATE UNIQUE INDEX IF NOT EXISTS ai_integration_syncs_config_id_key
   ON ai_integration_syncs (ai_integration_config_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ai_integration_syncs_config_id_schedule_key
+  ON ai_integration_syncs (ai_integration_config_id, schedule);
 
 CREATE TABLE IF NOT EXISTS principal_grants (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/aiintegrations/repo/queries.sql.go
+++ b/server/internal/aiintegrations/repo/queries.sql.go
@@ -56,12 +56,12 @@ WITH inserted AS (
     $1
   )
   ON CONFLICT (ai_integration_config_id) DO NOTHING
-  RETURNING created_at, updated_at, ai_integration_config_id, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+  RETURNING created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
 )
-SELECT created_at, updated_at, ai_integration_config_id, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
 FROM inserted
 UNION ALL
-SELECT created_at, updated_at, ai_integration_config_id, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
 FROM ai_integration_syncs
 WHERE ai_integration_config_id = $1
 LIMIT 1
@@ -71,6 +71,8 @@ type EnsureSyncRow struct {
 	CreatedAt             pgtype.Timestamptz
 	UpdatedAt             pgtype.Timestamptz
 	AiIntegrationConfigID uuid.UUID
+	Schedule              pgtype.Text
+	Kind                  pgtype.Text
 	PollWatermarkAt       pgtype.Timestamptz
 	LastCursorID          pgtype.Text
 	NextPollAfter         pgtype.Timestamptz
@@ -88,6 +90,8 @@ func (q *Queries) EnsureSync(ctx context.Context, aiIntegrationConfigID uuid.UUI
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.AiIntegrationConfigID,
+		&i.Schedule,
+		&i.Kind,
 		&i.PollWatermarkAt,
 		&i.LastCursorID,
 		&i.NextPollAfter,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -53,6 +53,8 @@ type AiIntegrationSync struct {
 	CreatedAt             pgtype.Timestamptz
 	UpdatedAt             pgtype.Timestamptz
 	AiIntegrationConfigID uuid.UUID
+	Schedule              pgtype.Text
+	Kind                  pgtype.Text
 	PollWatermarkAt       pgtype.Timestamptz
 	LastCursorID          pgtype.Text
 	NextPollAfter         pgtype.Timestamptz

--- a/server/migrations/20260717034451_ai-integration-sync-schedule-expand.sql
+++ b/server/migrations/20260717034451_ai-integration-sync-schedule-expand.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "ai_integration_syncs" table
+ALTER TABLE "ai_integration_syncs" ADD COLUMN "schedule" text NULL, ADD COLUMN "kind" text NULL;
+-- Create index "ai_integration_syncs_config_id_schedule_key" to table: "ai_integration_syncs"
+CREATE UNIQUE INDEX CONCURRENTLY "ai_integration_syncs_config_id_schedule_key" ON "ai_integration_syncs" ("ai_integration_config_id", "schedule");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hd8rd/HEEWepFxEgJM74N61wASR7kkcOKwpOd9YjIN4=
+h1:FLjJqjmCguE2UbId8ka5q6eCI+2veo79qOuIch8tGtg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -270,3 +270,4 @@ h1:hd8rd/HEEWepFxEgJM74N61wASR7kkcOKwpOd9YjIN4=
 20260715234644_skill_versions_ordering_index.sql h1:VrJFF+sNk9bil82fYMMgHmSQKABV3qmvJDcTUFVEw6s=
 20260716202303_chat-messages-transcript-order-index.sql h1:BZjNPN0tP9rnbNWcScIajjv+EvdAsTnYKVN9SqSZ4po=
 20260716213928_skill-distributions-sync-receipts.sql h1:iW9LlmEmqcXaWE5ny7fk9ohcbbt1pVS3kFdcvgQvFeY=
+20260717034451_ai-integration-sync-schedule-expand.sql h1:frkSTAfN29DxZoDAyXJOY5dSxMSRFcU1IjIALgyxL4k=


### PR DESCRIPTION
## Summary
- add nullable `schedule` and `kind` columns for the expand phase
- add the composite config/schedule unique index while retaining the legacy config-only index
- regenerate SQLc models without changing existing writer behavior

## Rollout
- prerequisite for the compatible writer and primary-row backfill phase
- safe to deploy before old application instances drain

## Test plan
- [x] `go test ./server/internal/aiintegrations`
- [x] `mise lint:server`
- [x] migration ordering and concurrent-index checks
- [x] `atlas migrate lint` against a temporary clean database

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the `ai_integration_syncs` schema to support per-schedule syncs. Adds nullable `schedule` and `kind` fields and a composite unique index; updates generated models and the EnsureSync query to return these fields.

- **Migration**
  - Adds `schedule` and `kind` columns; creates `ai_integration_config_id + schedule` unique index concurrently while keeping the legacy config-only index.
  - Backward compatible and safe to deploy before draining old app instances; backfill and writer updates will follow.

<sup>Written for commit 8df44b472c4cbda7ca96775fb3cc3cea52cb5c35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

