### PR TITLE
mig(clickhouse): add inserted_at, excluded_at, exclusion_id to risk_findings

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `risk_findings` DROP COLUMN `exclusion_id`;
-ALTER TABLE `risk_findings` DROP COLUMN `excluded_at`;
-ALTER TABLE `risk_findings` DROP COLUMN `inserted_at`;
+ALTER TABLE `risk_findings` DROP COLUMN IF EXISTS `exclusion_id`;
+ALTER TABLE `risk_findings` DROP COLUMN IF EXISTS `excluded_at`;
+ALTER TABLE `risk_findings` DROP COLUMN IF EXISTS `inserted_at`;

--- a/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `risk_findings` DROP COLUMN `exclusion_id`;
+ALTER TABLE `risk_findings` DROP COLUMN `excluded_at`;
+ALTER TABLE `risk_findings` DROP COLUMN `inserted_at`;

--- a/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `risk_findings` ADD COLUMN `inserted_at` DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `excluded_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `exclusion_id` Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD(1));

--- a/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260717083846_add-risk-findings-exclusion-fields.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `risk_findings` ADD COLUMN `inserted_at` DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD(1));
-ALTER TABLE `risk_findings` ADD COLUMN `excluded_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD(1));
-ALTER TABLE `risk_findings` ADD COLUMN `exclusion_id` Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN IF NOT EXISTS `inserted_at` DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN IF NOT EXISTS `excluded_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN IF NOT EXISTS `exclusion_id` Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD(1));

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:1oUXFuuh6w4ZIBiGeO3VJu0bpace40EpFHDxtLfaYTQ=
+h1:fAqeVJmr9blNigWPP9I6rKA+7K8EZ8pouMQU+CKyTpc=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -63,4 +63,4 @@ h1:1oUXFuuh6w4ZIBiGeO3VJu0bpace40EpFHDxtLfaYTQ=
 20260714173525_drop-tum-breakdown-summaries.up.sql h1:bN2z1+CUm9cttkIMubc0en+gp7viCi4ojcCACI8rhtU=
 20260714200951_shadow-mcp-server-name-override.up.sql h1:O6ZXprNwT+7pVXUmO6pkPoy+SFpCh4+zSH3E61ODGnQ=
 20260714200952_add-risk-findings.up.sql h1:RBBGniqX3KuAlZdyXFC/x/PPrVj8gUWqTBMGWKytQhA=
-20260717083846_add-risk-findings-exclusion-fields.up.sql h1:rW+JDFWFgP/pahwcGvOa+Zgydh3MrsgASM0coqL85gM=
+20260717083846_add-risk-findings-exclusion-fields.up.sql h1:9PmfgWmscSsydpGzc13/NZQiFfoaitotBAvoKRhUuLg=

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:hC+lQ42fJHlAyTseEkH1UjTtHOJYW4yiT0XQ15BTwHE=
+h1:1oUXFuuh6w4ZIBiGeO3VJu0bpace40EpFHDxtLfaYTQ=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -63,3 +63,4 @@ h1:hC+lQ42fJHlAyTseEkH1UjTtHOJYW4yiT0XQ15BTwHE=
 20260714173525_drop-tum-breakdown-summaries.up.sql h1:bN2z1+CUm9cttkIMubc0en+gp7viCi4ojcCACI8rhtU=
 20260714200951_shadow-mcp-server-name-override.up.sql h1:O6ZXprNwT+7pVXUmO6pkPoy+SFpCh4+zSH3E61ODGnQ=
 20260714200952_add-risk-findings.up.sql h1:RBBGniqX3KuAlZdyXFC/x/PPrVj8gUWqTBMGWKytQhA=
+20260717083846_add-risk-findings-exclusion-fields.up.sql h1:rW+JDFWFgP/pahwcGvOa+Zgydh3MrsgASM0coqL85gM=

--- a/server/clickhouse/migrations/20260717083841_add-risk-findings-exclusion-fields.sql
+++ b/server/clickhouse/migrations/20260717083841_add-risk-findings-exclusion-fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `risk_findings` ADD COLUMN `inserted_at` DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `excluded_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `exclusion_id` Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD(1));

--- a/server/clickhouse/migrations/20260717083841_add-risk-findings-exclusion-fields.sql
+++ b/server/clickhouse/migrations/20260717083841_add-risk-findings-exclusion-fields.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `risk_findings` ADD COLUMN `inserted_at` DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD(1));
-ALTER TABLE `risk_findings` ADD COLUMN `excluded_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD(1));
-ALTER TABLE `risk_findings` ADD COLUMN `exclusion_id` Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN IF NOT EXISTS `inserted_at` DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN IF NOT EXISTS `excluded_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN IF NOT EXISTS `exclusion_id` Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD(1));

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8Xb2+zzpfdEI9R48YhZc6CprI0Y6Dx60e8ztAXHBz3c=
+h1:zrFzrdDXLUTetam6kapo1aJSYoV/dlGG6t2jzYtyR2c=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -68,3 +68,4 @@ h1:8Xb2+zzpfdEI9R48YhZc6CprI0Y6Dx60e8ztAXHBz3c=
 20260714173521_drop-tum-breakdown-summaries.sql h1:La2w4JzKmjNoWbI1cZXtZKwXYCbFSkNUHwgVACpS0IY=
 20260714200946_shadow-mcp-server-name-override.sql h1:FjftHYJ4Mqv4G1R1n0LoyA4M5pVgXcRwhz6ZUiebLd8=
 20260714200947_add-risk-findings.sql h1:b+Neqb/8G5TEVbAaoxOke+CNZq5sYm2UYjFUIJ+Id3I=
+20260717083841_add-risk-findings-exclusion-fields.sql h1:MNvPLJC/fEexs/4te14GQCp2u6VWsEvZPQZUWnSf1bM=

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zrFzrdDXLUTetam6kapo1aJSYoV/dlGG6t2jzYtyR2c=
+h1:VLTgVRaZxHkCE6eSUF3uBq8QXej45DqLFdteTbKiMyc=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -68,4 +68,4 @@ h1:zrFzrdDXLUTetam6kapo1aJSYoV/dlGG6t2jzYtyR2c=
 20260714173521_drop-tum-breakdown-summaries.sql h1:La2w4JzKmjNoWbI1cZXtZKwXYCbFSkNUHwgVACpS0IY=
 20260714200946_shadow-mcp-server-name-override.sql h1:FjftHYJ4Mqv4G1R1n0LoyA4M5pVgXcRwhz6ZUiebLd8=
 20260714200947_add-risk-findings.sql h1:b+Neqb/8G5TEVbAaoxOke+CNZq5sYm2UYjFUIJ+Id3I=
-20260717083841_add-risk-findings-exclusion-fields.sql h1:MNvPLJC/fEexs/4te14GQCp2u6VWsEvZPQZUWnSf1bM=
+20260717083841_add-risk-findings-exclusion-fields.sql h1:DwX9lBE63B6RDvG7QFhAqkQg1y/cy+zWkjSDIYn3kMM=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -841,6 +841,7 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     -- Identity
     id UUID COMMENT 'Finding UUIDv7, supplied by the scanner that produced it.',
     created_at DateTime64(9) COMMENT 'Time the finding was produced.' CODEC(DoubleDelta, ZSTD),
+    inserted_at DateTime64(9) DEFAULT now64(9) COMMENT 'Server-side ingestion time, stamped on insert. Used for ingestion-lag diagnostics and to tie-break redelivered rows sharing the same id.' CODEC(DoubleDelta, ZSTD),
 
     -- Tenancy
     organization_id String COMMENT 'Organization the finding belongs to (HKDF salt for the tenant fingerprint).' CODEC(ZSTD),
@@ -873,7 +874,13 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     -- One-way fingerprints (base64url of HMAC-SHA256). See internal/risk/fingerprint.go.
     fingerprint_pepper_version String DEFAULT '' COMMENT 'Pepper keyring version used to compute the fingerprints.',
     fingerprint_global_hs256 String DEFAULT '' COMMENT 'Global fingerprint: base64url HMAC-SHA256 of the match under the current pepper. Stable across tenants.' CODEC(ZSTD),
-    fingerprint_tenant_hs256 String DEFAULT '' COMMENT 'Tenant-qualified fingerprint: base64url HMAC-SHA256 under a per-org HKDF key. Used to dedupe unique matches within an org.' CODEC(ZSTD)
+    fingerprint_tenant_hs256 String DEFAULT '' COMMENT 'Tenant-qualified fingerprint: base64url HMAC-SHA256 under a per-org HKDF key. Used to dedupe unique matches within an org.' CODEC(ZSTD),
+
+    -- Exclusion annotation. When a going-forward exclusion suppresses a finding
+    -- it is recorded here rather than dropped, so excluded findings remain
+    -- auditable and can be filtered in or out at read time.
+    excluded_at Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD),
+    exclusion_id Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD)
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(created_at)
 ORDER BY (organization_id, project_id, created_at, id)


### PR DESCRIPTION
## What

Adds three columns to the ClickHouse `risk_findings` table:

- **`inserted_at`** `DateTime64(9) DEFAULT now64(9)` — server-stamped ingestion time. Powers ingestion-lag diagnostics and tie-breaks redelivered rows sharing the same `id` (Pub/Sub is at-least-once; the table is plain `MergeTree`, so redeliveries land as duplicate rows).
- **`excluded_at`** `Nullable(DateTime64(9))` — when a going-forward exclusion suppressed the finding (null = not excluded).
- **`exclusion_id`** `Nullable(UUID)` — which `risk_exclusions` row suppressed it.

`excluded_at`/`exclusion_id` let the `risk_findings` writer **annotate** excluded findings instead of dropping them, so they stay auditable and can be filtered in/out at read time.

## Why a standalone migration PR

Schema-only, decoupled from the larger `FindingCHWriter` feature branch so the migration can land and provision independently. All three are additive `ALTER TABLE ADD COLUMN`s — no rewrite, backfill, or read-path impact.

## Notes

- Both migration flavors (Atlas + golang-migrate) generated via `mise clickhouse:diff`; `atlas.sum` regenerated. Verified `mise clickhouse:migrate` replays clean.
- The writer changes that populate these columns land in the feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `inserted_at`, `excluded_at`, and `exclusion_id` to the ClickHouse `risk_findings` table to improve ingestion observability and keep excluded findings auditable. Exclusions are now annotated instead of dropped, and `inserted_at` stamps server ingest time to tie-break duplicate deliveries.

- **Migration**
  - Additive `ALTER TABLE` with IF (NOT) EXISTS; idempotent up/down; no rewrite, backfill, or read-path changes.
  - Migrations included for Atlas and `golang-migrate`; run ClickHouse migrations to apply.

<sup>Written for commit b23a2121f4ab4cdd9993d61c30f49b61b7aa8d63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

