### PR TITLE
mig(security): creates an index on risk results to improve loading times

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3762,6 +3762,13 @@ CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE AND excluded_at IS NULL AND false_positive_at IS NULL;
 
+-- Serves the risk overview window scan (GetRiskOverviewCounts): counts every
+-- scanned message in a project's created_at window regardless of found state,
+-- so the partial _project_found_idx cannot help. Range-scans just the window;
+-- trailing chat_message_id enables an index-only distinct for messages_scanned.
+CREATE INDEX IF NOT EXISTS risk_results_project_created_msg_idx
+ON risk_results (project_id, created_at, chat_message_id);
+
 -- Narrows the exclusion sweeps (exact/rule_id/source) by project + policy +
 -- rule. The verbatim match column is intentionally NOT indexed: it can exceed
 -- the btree row-size limit (2704 bytes), and the sweep queries apply

--- a/server/migrations/20260717084803_risk-results-add-overview-window-index.sql
+++ b/server/migrations/20260717084803_risk-results-add-overview-window-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "risk_results_project_created_msg_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_created_msg_idx" ON "risk_results" ("project_id", "created_at", "chat_message_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hND/K8br7uGFYnbLuujL0QrEULAklK3FV6ytwPK7mYo=
+h1:1goEIG9x3JGasRSyHn3TSkbTcFkA9wf4ZFySAnDURwk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -271,3 +271,4 @@ h1:hND/K8br7uGFYnbLuujL0QrEULAklK3FV6ytwPK7mYo=
 20260716202303_chat-messages-transcript-order-index.sql h1:BZjNPN0tP9rnbNWcScIajjv+EvdAsTnYKVN9SqSZ4po=
 20260716213928_skill-distributions-sync-receipts.sql h1:iW9LlmEmqcXaWE5ny7fk9ohcbbt1pVS3kFdcvgQvFeY=
 20260717080213_tunneled-mcp-server-headers.sql h1:3X8LqBrSIcgHrOxK/QkKrWnEv11/Q2ZQCOO3MjKxqV0=
+20260717084803_risk-results-add-overview-window-index.sql h1:BGSMZeD4ym5mRiZYyzsnHG63R0+A1ztbrt3EqGokbvQ=


### PR DESCRIPTION
Query:
```
SELECT
    COUNT(DISTINCT rr.chat_message_id)::BIGINT AS messages_scanned
  , (COUNT(*) FILTER (
      WHERE rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
    ))::BIGINT AS findings
  , (COUNT(DISTINCT cm.chat_id) FILTER (
      WHERE rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
        AND cm.chat_id IS NOT NULL
    ))::BIGINT AS flagged_sessions
  , (
      SELECT COUNT(*)::BIGINT
      FROM risk_policies active_rp
      WHERE active_rp.project_id = $1 AND enabled IS TRUE AND deleted IS FALSE
    ) AS active_policies
FROM risk_results rr
JOIN chat_messages cm ON cm.id = rr.chat_message_id
WHERE rr.project_id = $1
  AND rr.created_at >= $2
  AND rr.created_at < $3;
  ```
often takes 5+ seconds to execute.

`messages_scanned` counts every scanned message (found OR not), so the partial _project_found_idx cannot be used. No (project_id, created_at) index covers the full row set, planner falls to seq/bitmap scan over all of the project's risk_results, filtering created_at on the heap.

Then it JOINs chat_messages (PK lookup) for every scanned row just to read chat_id, plus two COUNT(DISTINCT) (sort/hash). Multiple policies scan the same message, many risk_results rows per message, so the join amplifies. Cost scales with total project history.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `risk_results_project_created_msg_idx` on `(project_id, created_at, chat_message_id)` to speed up Risk Overview counts. It enables windowed range scans and index-only DISTINCT for `messages_scanned`; created concurrently with no app changes.

<sup>Written for commit 683fad4cec7708417cd11425ad3836e949efb125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

