### PR TITLE
fix: stop shell sidebar skeleton covering logo

### DIFF
--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -1,9 +1,12 @@
 import { FullPageError } from "@/components/full-page-error";
 import { GramLogo } from "@/components/gram-logo";
 import { PageHeader } from "@/components/page-header";
+import { SidebarNavSkeleton } from "@/components/sidebar-nav-skeleton";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
   SidebarInset,
   SidebarProvider,
 } from "@/components/ui/sidebar";
@@ -281,69 +284,38 @@ export const ProjectProvider = ({
   );
 };
 
-/** Skeleton nav group matching the new collapsible sidebar style. */
-const SkeletonNavItem = ({ width = "w-20" }: { width?: string }) => (
-  <div className="flex items-center gap-2 px-2 py-2">
-    <Skeleton className="h-4 w-4 shrink-0 rounded" />
-    <Skeleton className={`h-3.5 ${width}`} />
-  </div>
-);
-
-const SkeletonNavGroup = () => (
-  <div className="border-border mt-1 ml-4 border-l pl-2">
-    <div className="flex flex-col gap-0.5 py-0.5">
-      <Skeleton className="mx-2 my-1.5 h-3 w-16" />
-      <Skeleton className="mx-2 my-1.5 h-3 w-20" />
-      <Skeleton className="mx-2 my-1.5 h-3 w-14" />
-    </div>
-  </div>
-);
-
 /**
  * Lightweight shell that mirrors the real AppLayout structure,
  * shown while the auth session is still loading so the user
  * sees the app chrome immediately instead of a blank screen.
+ *
+ * Keep the structure in sync with AppLayout/AppSidebar: the logo belongs
+ * inside SidebarHeader, not a sibling header. The sidebar renders as a
+ * `fixed inset-y-0 z-10` container, so a sibling header would sit under it.
  */
 const AppLoadingShell = () => (
   <SidebarProvider
-    style={{ "--sidebar-width": "14rem" } as React.CSSProperties}
+    style={{ "--sidebar-width": "16rem" } as React.CSSProperties}
   >
     <div className="flex h-screen w-full flex-col">
-      {/* Header */}
-      <header className="dark:bg-background flex h-14 shrink-0 items-center border-b bg-white pr-4 pl-5">
-        <div className="flex items-center gap-3">
-          <GramLogo className="w-28" />
-          <span className="text-muted-foreground/50 text-xl select-none">
-            /
-          </span>
-          <Skeleton className="h-5 w-24" />
-          <span className="text-muted-foreground/50 text-xl select-none">
-            /
-          </span>
-          <Skeleton className="h-5 w-20" />
-        </div>
-        <div className="ml-auto flex items-center gap-4">
-          <Skeleton className="h-8 w-8 rounded-full" />
-        </div>
-      </header>
-      {/* Body */}
-      <div className="flex w-full flex-1 overflow-hidden pt-2">
-        <Sidebar collapsible="offcanvas" variant="inset">
-          <SidebarContent className="pt-5">
-            <div className="flex flex-col gap-1 px-2">
-              {/* Home */}
-              <SkeletonNavItem width="w-16" />
-              {/* Connect group */}
-              <SkeletonNavItem width="w-20" />
-              <SkeletonNavGroup />
-              {/* Build group */}
-              <SkeletonNavItem width="w-14" />
-              {/* Observe group */}
-              <SkeletonNavItem width="w-20" />
-              {/* Security group */}
-              <SkeletonNavItem width="w-18" />
+      <div className="flex w-full flex-1 overflow-hidden">
+        <Sidebar collapsible="icon" variant="inset">
+          <SidebarHeader className="gap-3 pb-3">
+            <div className="flex h-(--header-height) items-center px-1">
+              <GramLogo className="w-28" />
             </div>
+            {/* Workspace switcher */}
+            <Skeleton className="h-8 w-full" />
+          </SidebarHeader>
+          <SidebarContent className="pt-2">
+            <SidebarNavSkeleton />
           </SidebarContent>
+          <SidebarFooter className="border-t">
+            <div className="flex items-center gap-2 py-2">
+              <Skeleton className="size-8 shrink-0 rounded-full" />
+              <Skeleton className="h-3.5 w-24" />
+            </div>
+          </SidebarFooter>
         </Sidebar>
         <SidebarInset>
           <PageHeader>


### PR DESCRIPTION
## What

While the auth session is loading, the app shell's skeleton sidebar painted over the Gram logo. You now get the logo, then the skeleton nav.

## Why

`AppLoadingShell` rendered `GramLogo` inside a sibling `<header className="h-14">`, but `Sidebar` paints itself through a `fixed top-(--header-offset) bottom-0 z-10` container (`ui/sidebar.tsx:210`). `--header-offset` defaults to `0px` — it exists only to clear the impersonation banner, not to track a header — so the sidebar started at the viewport top and covered the header. The header had no `z-index` and created no stacking context, so the sidebar won.

The real `AppLayout` never hits this: it has no top header at all, and the logo lives inside `SidebarHeader` (`app-sidebar.tsx:341-352`).

## How

Rather than bumping a `z-index`, `AppLoadingShell` now mirrors the structure it already claimed to mirror:

- Logo moves into `SidebarHeader`; the sibling `<header>` is gone.
- Nav placeholder reuses `SidebarNavSkeleton` instead of duplicating skeleton nav markup locally.
- Matches the real sidebar's `16rem` width and `collapsible="icon"` (was `14rem` / `offcanvas`), so the chrome no longer shifts when auth resolves.

Net: 24 insertions, 52 deletions.

## Testing

`pnpm -F dashboard type-check` passes. Verified in the browser by stalling the `auth.info` RPC to hold the loading shell open — see the before/after below.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the loading shell so the sidebar skeleton no longer covers the Gram logo. The shell now matches the real app sidebar to keep the layout stable while auth loads.

- **Bug Fixes**
  - Moved `GramLogo` into `SidebarHeader`; removed the sibling header that sat under the fixed `Sidebar`.
  - Replaced local skeleton markup with `SidebarNavSkeleton`.
  - Matched real sidebar settings: `--sidebar-width: 16rem` and `collapsible="icon"` to prevent chrome shift.

<sup>Written for commit 2c196a9e69eb3eb48f8d5a66c43e5d32e9545539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

