### PR TITLE
chore: remove cost / spend UI from assistants page

### DIFF
--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -1,4 +1,3 @@
-import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
 import { Page } from "@/components/page-layout";
 import { getGradientColors } from "@/components/gradient-colors";
 import { RequireScope } from "@/components/require-scope";
@@ -10,17 +9,14 @@ import { Badge } from "@/components/ui/badge";
 import { DotCard } from "@/components/ui/dot-card";
 import { Action, MoreActions } from "@/components/ui/more-actions";
 import { SearchBar } from "@/components/ui/search-bar";
-import { Skeleton } from "@/components/ui/skeleton";
 import {
   PageTabsTrigger,
   Tabs,
   TabsContent,
   TabsList,
 } from "@/components/ui/tabs";
-import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { UpdatedAt } from "@/components/updated-at";
-import { useProductTier } from "@/hooks/useProductTier";
 import { useRoutes } from "@/routes";
 import { Assistant } from "@gram/client/models/components/assistant.js";
 import { useAssistantsDeleteMutation } from "@gram/client/react-query/assistantsDelete.js";
@@ -28,10 +24,9 @@ import {
   invalidateAllAssistantsList,
   useAssistantsList,
 } from "@gram/client/react-query/assistantsList.js";
-import { useGetPeriodUsage } from "@gram/client/react-query/getPeriodUsage.js";
 import { Button, Icon, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { Bot, Boxes, Cpu, Info, Plus } from "lucide-react";
+import { Bot, Boxes, Cpu, Plus } from "lucide-react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { MouseEvent, useMemo, useState } from "react";
 import { Outlet } from "react-router";
@@ -186,7 +181,6 @@ export default function AssistantsIndex(): JSX.Element {
             className="mt-6 flex w-full flex-col gap-4"
           >
             {content}
-            <UsageSection />
           </TabsContent>
           <TabsContent value="triggers" className="mt-6 w-full">
             <TriggersPanel />
@@ -238,52 +232,6 @@ function AssistantsBody({
         <AssistantCard key={assistant.id} assistant={assistant} />
       ))}
     </div>
-  );
-}
-
-function UsageSection() {
-  const productTier = useProductTier();
-  const { data: periodUsage, isError } = useGetPeriodUsage(
-    undefined,
-    undefined,
-    { throwOnError: false },
-  );
-
-  if (isError) return null;
-
-  return (
-    <Page.Section>
-      <Page.Section.Title>Assistant Credits</Page.Section.Title>
-      <Page.Section.Description>
-        Credits consumed by assistant runs this billing period. Each turn debits
-        credits based on the underlying model's cost.
-      </Page.Section.Description>
-      <RequireScope scope="org:admin" level="section">
-        <TopUpCTA />
-      </RequireScope>
-      <Page.Section.Body>
-        <Stack gap={3} className="mb-6">
-          <Stack direction="horizontal" align="center" gap={1}>
-            <Type variant="body" className="font-medium">
-              Credits
-            </Type>
-            <SimpleTooltip tooltip="Credits track model usage across assistants and chat. 1 credit ≈ $1 of model cost.">
-              <Info className="text-muted-foreground h-4 w-4" />
-            </SimpleTooltip>
-          </Stack>
-          {periodUsage ? (
-            <UsageProgress
-              value={periodUsage.credits}
-              included={periodUsage.includedCredits || 1}
-              overageIncrement={periodUsage.includedCredits || 1}
-              noMax={productTier === "enterprise"}
-            />
-          ) : (
-            <Skeleton className="h-4 w-full" />
-          )}
-        </Stack>
-      </Page.Section.Body>
-    </Page.Section>
   );
 }
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/DNO-522/chore-remove-cost-spend-ui-from-assistants-page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the cost/spend UI from the Assistants page per DNO-522. The page no longer shows Assistant Credits, usage progress, or top-up controls.

- **Refactors**
  - Removed the Assistant Credits section and admin-only top-up CTA.
  - Dropped usage fetching and progress UI (period usage query, product tier check, tooltip, skeleton).
  - Cleaned up related imports and icons.

<sup>Written for commit f907738399008945728c9d4b10059697937436af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

