### PR TITLE
feat(dashboard): prepare static assets for CDN serving

### DIFF
--- a/client/dashboard/Dockerfile
+++ b/client/dashboard/Dockerfile
@@ -3,8 +3,14 @@ FROM nginxinc/nginx-unprivileged:alpine
 # Copy the build output to nginx
 COPY dist /usr/share/nginx/html
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# nginx.conf is an envsubst template: the image entrypoint renders it to
+# /etc/nginx/conf.d/default.conf at startup, substituting ${GRAM_CDN_URL}.
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+
+# Default: no CDN rewrite. Must always be defined — envsubst only substitutes
+# variables present in the environment, and an unsubstituted ${GRAM_CDN_URL}
+# would be parsed by nginx as an (undefined) nginx variable and fail startup.
+ENV GRAM_CDN_URL=""
 
 EXPOSE 3000
 

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -5,6 +5,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # When GRAM_CDN_URL is set (e.g. https://cdn.dev.getgram.ai), rewrite
+    # asset URLs in HTML responses so browsers fetch static assets through
+    # the CDN. This file ships as an envsubst template (see Dockerfile): the
+    # nginx entrypoint substitutes ${GRAM_CDN_URL} at container start, and
+    # with it empty the rewrite is a no-op and assets stay same-origin. Only
+    # HTML is rewritten (sub_filter_types defaults to text/html); JS and CSS
+    # reference their sub-resources relative to their own URL, so they follow
+    # automatically (see renderBuiltUrl in vite.config.ts).
+    sub_filter_once off;
+    sub_filter '"/assets/' '"${GRAM_CDN_URL}/assets/';
+
     # Serve JS under /external with CORS enabled
     location ~* ^/external/.+\.js$ {
         expires max;
@@ -12,10 +23,15 @@ server {
         add_header Access-Control-Allow-Origin "*";
     }
 
-    # Serve static assets with an efficient cache policy
+    # Serve static assets with an efficient cache policy. CORS is required
+    # here: Vite emits <script type="module" crossorigin> and stylesheet
+    # links, so when assets are served via the CDN host the app origin
+    # fetches them in CORS mode. The CDN passes origin headers through and
+    # deliberately adds none of its own (see cdn.tf in gram-infra).
     location ~* \.(js|css)$ {
         expires max;
         add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header Access-Control-Allow-Origin "*";
     }
     location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf)$ {
         expires max;

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -152,6 +152,39 @@ export default defineConfig(({ command }) => {
   //                               playground.
 
   return {
+    experimental: {
+      // Static assets can be served through a CDN.
+      // The CDN hostname may be env-specific but this build is env-agnostic
+      // (one image is promoted dev -> prod), so instead of baking a CDN origin
+      // in via `base`, the dashboard's nginx rewrites the /assets/ URLs in
+      // index.html to the CDN host at serve time (see nginx.conf) and every
+      // other URL follows from the module that references it:
+      //
+      //   - html: keep the default root-absolute /assets/... URLs so the
+      //     nginx sub_filter can match and rewrite them.
+      //   - js/css: emit URLs relative to import.meta.url so chunk imports,
+      //     lazy-load preloads, and fonts/images referenced from CSS resolve
+      //     against whatever origin the module graph was loaded from — the
+      //     CDN when enabled, same-origin otherwise.
+      //   - workers: keep the default root-absolute URLs. Browsers reject
+      //     cross-origin new Worker(), so worker scripts must load from the
+      //     app origin even when everything else is on the CDN (CSP's
+      //     worker-src 'self' also depends on this). Detected by filename:
+      //     every worker entry (monaco's *.worker, @pierre/diffs' worker.js)
+      //     has "worker" in its emitted basename — keep it that way when
+      //     adding new workers.
+      renderBuiltUrl(filename, { hostType, type }) {
+        const isWorkerAsset = /(^|\/)[^/]*worker[^/]*\.js$/.test(filename);
+        if (
+          type === "asset" &&
+          !isWorkerAsset &&
+          (hostType === "js" || hostType === "css")
+        ) {
+          return { relative: true };
+        }
+        return undefined;
+      },
+    },
     define: {
       __GRAM_SERVER_URL__: JSON.stringify(serverUrl),
       __PLAYGROUND_PROXY_URL__: JSON.stringify(isDev ? siteUrl : undefined),

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -176,7 +176,7 @@ export default defineConfig(({ command }) => {
       renderBuiltUrl(filename, { hostType, type }) {
         const isWorkerAsset = /(^|\/)[^/]*worker[^/]*\.js$/.test(filename);
         if (
-          type === "asset" &&
+          (type === "asset" || type === "public") &&
           !isWorkerAsset &&
           (hostType === "js" || hostType === "css")
         ) {

--- a/mise.toml
+++ b/mise.toml
@@ -205,6 +205,13 @@ GRAM_LOG_PRETTY = { default = "1" }
 ## used by the CLI to point to the correct Gram API server
 GRAM_API_URL = "{{env.GRAM_SERVER_URL}}"
 VITE_DEV_HOSTNAMES = "localhost"
+## Base URL of the CDN serving the dashboard's static assets (e.g.
+## https://cdn.dev.getgram.ai). Not a build-time setting: the dashboard
+## container's nginx reads it at runtime to rewrite /assets/ URLs in
+## index.html to the CDN host (see client/dashboard/nginx.conf and the
+## renderBuiltUrl comment in client/dashboard/vite.config.ts). Unset locally
+## and by default in production — assets are then served same-origin.
+# GRAM_CDN_URL = "https://cdn.dev.getgram.ai"
 TEMPORAL_WEB_PORT = "8233"
 ## If you want to enable/disable certain feature flags during local development,
 ## copy the following line to mise.local.toml and point to a CSV file containing


### PR DESCRIPTION
## Summary

Prepares the dashboard to serve its static assets through a CDN, controlled at runtime by a single `GRAM_CDN_URL` environment variable. With the variable unset (the default everywhere today), behavior is unchanged — assets remain same-origin.

## Why runtime, not build time

The dashboard image is built once and promoted dev → prod, so an env-specific CDN origin can't be baked in via Vite's `base`. Instead:

- **nginx** (`nginx.conf`, now an envsubst template rendered at container start) rewrites `"/assets/` URLs in HTML responses to `${GRAM_CDN_URL}/assets/`. When the variable is empty the rewrite is a no-op.
- **Vite** (`renderBuiltUrl`) emits asset URLs in JS/CSS relative to `import.meta.url`, so chunk imports, preloads, and CSS-referenced fonts/images resolve against whatever origin the module graph was loaded from — the CDN when enabled, same-origin otherwise.
- **Workers** keep root-absolute URLs: browsers reject cross-origin `new Worker()`, so worker scripts must always load from the app origin (matched by `worker` in the emitted basename).
- **CORS**: `Access-Control-Allow-Origin: *` added for JS/CSS since Vite emits `crossorigin` script/link tags, which fetch in CORS mode when served from the CDN host.

## Config

- `GRAM_CDN_URL` documented in `mise.toml` (commented out — unset locally and in production by default).
- `Dockerfile` sets `GRAM_CDN_URL=""` so an unsubstituted `${GRAM_CDN_URL}` never reaches nginx (which would parse it as an undefined nginx variable and fail startup).

## Testing

- No-op path: with `GRAM_CDN_URL` unset, rendered nginx config contains an empty substitution and asset URLs are unchanged.
- CDN infra lands separately; this PR is inert until the variable is set on the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the dashboard to serve static assets via a CDN at runtime using `GRAM_CDN_URL`. Unset by default, so behavior stays same-origin until enabled.

- **New Features**
  - Runtime CDN toggle via `GRAM_CDN_URL`; `nginx.conf` is an envsubst template rendered at startup that rewrites `"/assets/"` in HTML to `${GRAM_CDN_URL}/assets/` (no-op when empty).
  - `Vite` `experimental.renderBuiltUrl` emits relative URLs in JS/CSS so chunks and CSS assets follow the host; worker scripts stay root-absolute (matched by filenames containing “worker”).
  - Adds `Access-Control-Allow-Origin: *` for JS/CSS to support CORS when assets are on the CDN.
  - `Dockerfile` sets `GRAM_CDN_URL=""` and installs the template at `/etc/nginx/templates/default.conf.template`; `mise.toml` documents the variable.

- **Migration**
  - Optionally set `GRAM_CDN_URL` (e.g. `https://cdn.dev.getgram.ai`) on the deployment.
  - No changes needed if unset; CDN infrastructure is provisioned separately.

<sup>Written for commit f162eb1fe0de641aca7e95680c84b07fc21cc98e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



