### PR TITLE
feat(costs): surface breakdown axes as a segmented control

### DIFF
--- a/client/dashboard/src/components/ui/segmented-control.tsx
+++ b/client/dashboard/src/components/ui/segmented-control.tsx
@@ -2,6 +2,14 @@ import { Fragment, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 
+// The segment button's own styling, exported so a `trailing` control (e.g. an
+// overflow dropdown trigger) can sit in the track without re-deriving it.
+export const SEGMENT_BASE =
+  "flex h-full items-center rounded-sm border px-3 text-sm font-medium transition-colors";
+export const SEGMENT_ACTIVE = "border-border bg-card text-foreground shadow-sm";
+export const SEGMENT_INACTIVE =
+  "text-muted-foreground hover:text-foreground border-transparent";
+
 /**
  * A two-or-more option segmented toggle (iOS-style): a bordered white track with
  * the active option raised as a white card. Used for in-place mode switches like
@@ -14,12 +22,17 @@ export function SegmentedControl<T extends string>({
   options,
   disabled,
   className,
+  trailing,
 }: {
   value: T;
   onChange: (value: T) => void;
   options: { value: T; label: ReactNode; tooltip?: string }[];
   disabled?: boolean;
   className?: string;
+  // An extra control pinned inside the track after the options — for a set too
+  // long to segment, where the tail lives behind an overflow menu. Style it with
+  // SEGMENT_BASE + SEGMENT_INACTIVE so it reads as one of the segments.
+  trailing?: ReactNode;
 }): JSX.Element {
   return (
     <div
@@ -38,10 +51,8 @@ export function SegmentedControl<T extends string>({
             aria-pressed={active}
             onClick={() => onChange(option.value)}
             className={cn(
-              "flex h-full items-center rounded-sm border px-3 text-sm font-medium transition-colors",
-              active
-                ? "border-border bg-card text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground border-transparent",
+              SEGMENT_BASE,
+              active ? SEGMENT_ACTIVE : SEGMENT_INACTIVE,
               disabled && "pointer-events-none",
             )}
           >
@@ -56,6 +67,7 @@ export function SegmentedControl<T extends string>({
           <Fragment key={option.value}>{button}</Fragment>
         );
       })}
+      {trailing}
     </div>
   );
 }

--- a/client/dashboard/src/components/ui/segmented-control.tsx
+++ b/client/dashboard/src/components/ui/segmented-control.tsx
@@ -2,13 +2,15 @@ import { Fragment, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 
-// The segment button's own styling, exported so a `trailing` control (e.g. an
-// overflow dropdown trigger) can sit in the track without re-deriving it.
+// The segment button's own styling. Base + inactive are exported so a
+// `trailing` control (e.g. an overflow dropdown trigger) can sit in the track
+// without re-deriving them; the active state stays internal, since only a real
+// segment is ever active.
 export const SEGMENT_BASE =
   "flex h-full items-center rounded-sm border px-3 text-sm font-medium transition-colors";
-export const SEGMENT_ACTIVE = "border-border bg-card text-foreground shadow-sm";
 export const SEGMENT_INACTIVE =
   "text-muted-foreground hover:text-foreground border-transparent";
+const SEGMENT_ACTIVE = "border-border bg-card text-foreground shadow-sm";
 
 /**
  * A two-or-more option segmented toggle (iOS-style): a bordered white track with

--- a/client/dashboard/src/pages/costs/BreakdownBar.tsx
+++ b/client/dashboard/src/pages/costs/BreakdownBar.tsx
@@ -35,8 +35,11 @@ export type AxisOption = { value: string; label: string };
 // (Division → Department → User → Agent), which is the common path.
 const SEGMENT_LIMIT = 4;
 
+// Two short sentences, and the second is the one that matters: the total is
+// fixed, only the division moves. That's checkable against the numbers on
+// screen, which a longer definition wasn't.
 const BREAKDOWN_EXPLAINER =
-  "A breakdown splits the spend in view into groups. Switching the axis re-cuts the same costs a different way — the spend for one team, grouped by job title, then by model.";
+  "Groups the spend you're looking at. The total stays the same — only how it's divided changes.";
 
 /**
  * Split the options into the segments to render inline and the remainder for the

--- a/client/dashboard/src/pages/costs/BreakdownBar.tsx
+++ b/client/dashboard/src/pages/costs/BreakdownBar.tsx
@@ -1,0 +1,147 @@
+import {
+  SEGMENT_BASE,
+  SEGMENT_INACTIVE,
+  SegmentedControl,
+} from "@/components/ui/segmented-control";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { Info } from "lucide-react";
+import type { ReactNode } from "react";
+
+// The header for the breakdown table: what this cut is (title), what it's doing
+// to the user's own numbers (caption), and the axes to re-cut it by (the track).
+//
+// This replaced a bare "Breakdown by <select>": users didn't find the dropdown,
+// and the word "breakdown" reads as jargon until you've watched it re-cut the
+// same spend. So the axes are promoted to visible segments, and the title states
+// the current cut ("Cost by Model") rather than naming the mechanism — pairing a
+// lit segment with a title that echoes it teaches the idea on the first click.
+
+export type AxisOption = { value: string; label: string };
+
+// How many axes get promoted into the track. Four keeps the row on one line at
+// the narrowest supported width while covering the suggested org chain
+// (Division → Department → User → Agent), which is the common path.
+const SEGMENT_LIMIT = 4;
+
+const BREAKDOWN_EXPLAINER =
+  "A breakdown splits the spend in view into groups. Switching the axis re-cuts the same costs a different way — the spend for one team, grouped by job title, then by model.";
+
+/**
+ * Split the options into the segments to render inline and the remainder for the
+ * "More" select. The active axis is always segmented, even when it sits past the
+ * limit — otherwise picking from "More" makes the selection disappear.
+ */
+function partitionAxes(
+  options: AxisOption[],
+  activeValue: string,
+): { segments: AxisOption[]; overflow: AxisOption[] } {
+  const segments = options.slice(0, SEGMENT_LIMIT);
+  const overflow = options.slice(SEGMENT_LIMIT);
+  const activeIndex = overflow.findIndex((o) => o.value === activeValue);
+  if (activeIndex < 0) return { segments, overflow };
+  return {
+    segments: [...segments, overflow[activeIndex]!],
+    overflow: overflow.filter((_, i) => i !== activeIndex),
+  };
+}
+
+export function BreakdownBar({
+  title,
+  caption,
+  axisValue,
+  axisOptions,
+  axisHint,
+  onAxisChange,
+  actions,
+}: {
+  // The current cut, stated plainly (e.g. "Cost by Model") — the caption's
+  // parent, so the prose under it isn't an orphaned third line.
+  title: string;
+  // Prose naming what the cut is doing in the user's own numbers.
+  caption: string;
+  axisValue: string;
+  axisOptions: AxisOption[];
+  // Optional caveat for the current axis, appended to the explainer tooltip
+  // (e.g. the root Skill cut excludes subagent-run skills).
+  axisHint?: string;
+  onAxisChange: (value: string) => void;
+  // Controls that belong to the table below (e.g. CSV export), rendered beside
+  // the axis track.
+  actions?: ReactNode;
+}): JSX.Element {
+  const { segments, overflow } = partitionAxes(axisOptions, axisValue);
+
+  const more = overflow.length > 0 && (
+    // Value is pinned to "" so the trigger always reads "More": anything picked
+    // here becomes the active axis, which partitionAxes then promotes into the
+    // track.
+    <Select value="" onValueChange={onAxisChange}>
+      <SelectTrigger
+        aria-label="More breakdown axes"
+        className={cn(
+          SEGMENT_BASE,
+          SEGMENT_INACTIVE,
+          "data-[state=open]:text-foreground w-auto cursor-pointer gap-1 bg-transparent shadow-none focus-visible:ring-0",
+        )}
+      >
+        <SelectValue placeholder="More" />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {overflow.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  return (
+    <div className="mb-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+      <div className="flex flex-col gap-0.5">
+        <h2 className="flex items-center gap-1.5 text-sm font-semibold">
+          {title}
+          <Tooltip>
+            <TooltipTrigger
+              aria-label={BREAKDOWN_EXPLAINER}
+              className="text-muted-foreground inline-flex cursor-help"
+            >
+              <Info className="size-3.5" />
+            </TooltipTrigger>
+            <TooltipContent className="flex max-w-64 flex-col gap-2">
+              <span>{BREAKDOWN_EXPLAINER}</span>
+              {axisHint && <span>{axisHint}</span>}
+            </TooltipContent>
+          </Tooltip>
+        </h2>
+        <p className="text-muted-foreground text-xs">{caption}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        {/* A lone axis is no choice at all — at a session leaf (Agent, Model)
+            "Sessions" is the only option, and a track you can't move reads as a
+            broken toggle. The title already names the cut. */}
+        {axisOptions.length > 1 && (
+          <SegmentedControl
+            value={axisValue}
+            onChange={onAxisChange}
+            options={segments}
+            trailing={more}
+          />
+        )}
+        {actions}
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/costs/BreakdownBar.tsx
+++ b/client/dashboard/src/pages/costs/BreakdownBar.tsx
@@ -35,12 +35,6 @@ export type AxisOption = { value: string; label: string };
 // (Division → Department → User → Agent), which is the common path.
 const SEGMENT_LIMIT = 4;
 
-// Two short sentences, and the second is the one that matters: the total is
-// fixed, only the division moves. That's checkable against the numbers on
-// screen, which a longer definition wasn't.
-const BREAKDOWN_EXPLAINER =
-  "Groups the spend you're looking at. The total stays the same — only how it's divided changes.";
-
 /**
  * Split the options into the segments to render inline and the remainder for the
  * "More" select. The active axis is always segmented, even when it sits past the
@@ -116,18 +110,21 @@ export function BreakdownBar({
       <div className="flex flex-col gap-0.5">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold">
           {title}
-          <Tooltip>
-            <TooltipTrigger
-              aria-label={BREAKDOWN_EXPLAINER}
-              className="text-muted-foreground inline-flex cursor-help"
-            >
-              <Info className="size-3.5" />
-            </TooltipTrigger>
-            <TooltipContent className="flex max-w-64 flex-col gap-2">
-              <span>{BREAKDOWN_EXPLAINER}</span>
-              {axisHint && <span>{axisHint}</span>}
-            </TooltipContent>
-          </Tooltip>
+          {/* No general "what is a breakdown" note — defining it in the abstract
+              read as jargon, and the caption below says it against the slice
+              actually on screen. The icon is left for axes that carry a real
+              caveat, so its presence means something. */}
+          {axisHint && (
+            <Tooltip>
+              <TooltipTrigger
+                aria-label={axisHint}
+                className="text-muted-foreground inline-flex cursor-help"
+              >
+                <Info className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-64">{axisHint}</TooltipContent>
+            </Tooltip>
+          )}
         </h2>
         <p className="text-muted-foreground text-xs">{caption}</p>
       </div>

--- a/client/dashboard/src/pages/costs/CostWidgets.tsx
+++ b/client/dashboard/src/pages/costs/CostWidgets.tsx
@@ -402,28 +402,28 @@ function KpiTile({
   range: string;
   loading: boolean;
 }): JSX.Element {
+  // Shares the Card shell with the row above rather than a squatter box of its
+  // own, so the two rows read as one family: same padding, same title, same
+  // value size, with the sparkline sized to fill the tile instead of tucking
+  // into a corner.
   return (
-    <div className="border-border rounded-lg border p-3">
-      <div className="text-muted-foreground text-xs">
-        {label}
-        <span className="text-muted-foreground/60 ml-1">{range}</span>
-      </div>
+    <Card title={label} range={range}>
       {loading ? (
-        <Skeleton className="mt-2 h-6 w-16" />
+        <Skeleton className="mt-3 h-8 w-20" />
       ) : (
-        <>
-          <div className="mt-1 flex items-end justify-between gap-2">
-            <span className="text-lg font-semibold tabular-nums">{value}</span>
-            <Sparkline values={series} width={64} height={20} color={NEUTRAL} />
+        <div className="mt-3 flex items-end justify-between gap-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-semibold tabular-nums">{value}</span>
+            {delta !== null && (
+              <span className="text-muted-foreground text-xs font-medium tabular-nums">
+                {formatDelta(delta)}
+              </span>
+            )}
           </div>
-          {delta !== null && (
-            <div className="text-muted-foreground mt-1 text-xs tabular-nums">
-              {formatDelta(delta)}
-            </div>
-          )}
-        </>
+          <Sparkline values={series} width={96} height={36} color={NEUTRAL} />
+        </div>
       )}
-    </div>
+    </Card>
   );
 }
 

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -1070,6 +1070,7 @@ export function CostsExplorer(): JSX.Element {
       />
       <EntityProfile
         entity={currentEntity}
+        path={path}
         collection={collection}
         cacheMetric={attributionView}
         widgets={widgets}

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -32,6 +32,7 @@ import { ChatDetailSheet } from "../chatLogs/ChatDetailPanel";
 import { type CardSpec, CostWidgets } from "./CostWidgets";
 import { EntityProfile } from "./EntityProfile";
 import { SessionTable, type SessionColumnId } from "./SessionTable";
+import { buildSessionCsv } from "./sessionCsv";
 import {
   type Axis,
   availableDimensions,
@@ -997,10 +998,14 @@ export function CostsExplorer(): JSX.Element {
     rows: (topSessionsData?.sessions ?? []).map((s) => ({
       id: s.gramChatId,
       label: s.title?.length ? s.title : s.gramChatId.slice(0, 8),
+      // Whose session it was — dropped only once the drill path pins a user, as
+      // every row then repeats that same address. Deliberately independent of
+      // `groupBy`: these are the slice's top sessions whatever the table below
+      // is grouped by, so keying the sublabel off the breakdown axis both hid a
+      // useful attribution and resized this card (and with it the whole widget
+      // row) on every re-pivot.
       sublabel:
-        groupBy !== Dimension.Email &&
-        currentEntity?.dim !== Dimension.Email &&
-        s.userEmail?.length
+        currentEntity?.dim !== Dimension.Email && s.userEmail?.length
           ? s.userEmail
           : undefined,
       cost: s.totalCost,
@@ -1072,7 +1077,6 @@ export function CostsExplorer(): JSX.Element {
         onHome={goHome}
         projectName={project.name}
         parentValue={parentValue}
-        ancestors={path.slice(0, -1)}
         stats={stats}
         groupBy={groupBy}
         canDrill={canDrill}
@@ -1094,6 +1098,19 @@ export function CostsExplorer(): JSX.Element {
               billingMode={viewBillingMode}
             />
           ) : undefined
+        }
+        overrideCsv={
+          sessionsMode
+            ? {
+                rowCount: sessionsData?.sessions.length ?? 0,
+                build: () =>
+                  buildSessionCsv(
+                    sessionsData?.sessions ?? [],
+                    hiddenSessionColumns,
+                    viewBillingMode,
+                  ),
+              }
+            : undefined
         }
         onViewSessions={onViewSessions}
         seriesByGroup={seriesByGroup}

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@/components/ui/badge";
+import { Badge } from "@speakeasy-api/moonshine";
 import {
   Select,
   SelectContent,
@@ -6,40 +6,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
 import { type QueryRow } from "@gram/client/models/components/queryrow.js";
 import type { ReactNode } from "react";
-import {
-  BadgeCheck,
-  Bot,
-  Briefcase,
-  Building,
-  Building2,
-  ChevronLeft,
-  Cpu,
-  Download,
-  Home,
-  Info,
-  type LucideIcon,
-  Network,
-  Server,
-  Shield,
-  Sparkles,
-  UserRound,
-  Wallet,
-  Wrench,
-} from "lucide-react";
+import { ChevronLeft, Download, Home } from "lucide-react";
 import { CostMeasureLabel } from "@/components/estimated-cost";
+import { BreakdownBar } from "./BreakdownBar";
+import { breakdownCaption, breakdownTitle } from "./breakdownCopy";
 import { CostTable } from "./CostTable";
+import { downloadCsv, slugify, toCsv } from "./csv";
 import {
   type Crumb,
+  entityBadgeVariant,
   isAttributionDim,
   LABELS,
   type Measures,
@@ -59,19 +39,6 @@ function displayValue(groupValue: string): string {
 }
 
 // ── CSV export ──────────────────────────────────────────────────────────────
-
-// Serialize one CSV field. Two concerns:
-//   1. Formula injection (CWE-1236): a cell starting with = + - @ (or a control
-//      char) is treated as a formula by Excel/Sheets. Directory-sync values
-//      (names, emails) are attacker-influenced, so neutralize with a leading
-//      apostrophe before quoting.
-//   2. RFC 4180 quoting: wrap in quotes (doubling internal quotes) when the
-//      value contains a comma, quote, or newline.
-function csvField(value: string | number): string {
-  let s = String(value);
-  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
-}
 
 // Serialize the current table rows to CSV — same columns the table shows
 // (minus the Trend sparkline), with raw numbers so the file is spreadsheet-ready.
@@ -107,29 +74,7 @@ function buildCostCsv(
       r.measures.totalTokens ?? 0,
     ];
   });
-  return [header, ...body]
-    .map((cols) => cols.map(csvField).join(","))
-    .join("\n");
-}
-
-// Trigger a client-side download of a CSV string.
-function downloadCsv(filename: string, csv: string): void {
-  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  link.click();
-  URL.revokeObjectURL(url);
-}
-
-function slugify(value: string): string {
-  return (
-    value
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "") || "all-costs"
-  );
+  return toCsv(header, body);
 }
 
 // Initials for the avatar: email local-part tokens (olivia.novak → ON) or the
@@ -174,30 +119,6 @@ function entityPalette(name: string): { mesh: string } {
       `radial-gradient(50% 70% at 100% 24%, hsl(${h1} 68% 82% / 0.30) 0%, transparent 72%)`,
     ].join(", "),
   };
-}
-
-// A Lucide icon representing the entity's type (Division → org chart, User →
-// person, Agent → bot, …). Falls back to the org building at the root.
-const ENTITY_ICONS: Partial<Record<Dimension, LucideIcon>> = {
-  [Dimension.DivisionName]: Network,
-  [Dimension.DepartmentName]: Building,
-  [Dimension.Email]: UserRound,
-  [Dimension.HookSource]: Bot,
-  [Dimension.JobTitle]: Briefcase,
-  [Dimension.EmployeeType]: BadgeCheck,
-  [Dimension.CostCenterName]: Wallet,
-  [Dimension.Model]: Cpu,
-  [Dimension.Role]: Shield,
-  // Claude attribution cuts (also used for the root "collection" hero).
-  [Dimension.McpServerName]: Server,
-  [Dimension.McpToolName]: Wrench,
-  [Dimension.SkillName]: Sparkles,
-  [Dimension.AgentName]: Bot,
-};
-
-function entityIcon(entity: Crumb | null): LucideIcon {
-  if (!entity) return Building2;
-  return ENTITY_ICONS[entity.dim] ?? Building2;
 }
 
 // ── Small presentational pieces ─────────────────────────────────────────────
@@ -256,9 +177,6 @@ export type EntityProfileProps = {
   projectName: string;
   // The immediate parent's value, for the "Back to …" control.
   parentValue: string | null;
-  // The ancestor chain above this entity (root → immediate parent), rendered as
-  // the typed breadcrumb trail under the title so deep nesting stays legible.
-  ancestors: Crumb[];
   // Headline measures summed over this entity's children.
   stats: Measures;
   // The dimension the child table is grouped by (drives labels + CostTable).
@@ -282,6 +200,10 @@ export type EntityProfileProps = {
   // When set, replaces the dimension CostTable (the per-session list in sessions
   // mode). The override owns its own loading/empty/error states.
   tableOverride?: ReactNode;
+  // CSV export for a `tableOverride`'s rows. Supplied alongside the override so
+  // the export control keeps working — and keeps its place in the header row —
+  // on the sessions breakdown instead of unmounting and reflowing the row.
+  overrideCsv?: { rowCount: number; build: () => string };
   // Switch the breakdown to the per-session list — wired to the clickable
   // "Agent sessions" header stat. Omitted when already in sessions mode.
   onViewSessions?: () => void;
@@ -317,7 +239,6 @@ export function EntityProfile({
   onHome,
   projectName,
   parentValue,
-  ancestors,
   stats,
   groupBy,
   canDrill,
@@ -329,6 +250,7 @@ export function EntityProfile({
   billingMode,
   onDrill,
   tableOverride,
+  overrideCsv,
   onViewSessions,
   seriesByGroup,
   datasetValue,
@@ -350,22 +272,43 @@ export function EntityProfile({
     : collection
       ? "Breakdown"
       : "Project";
-  // Raw ancestor values joined by chevrons (e.g. "R&D › Engineering › elena@…").
-  // Values stay raw — the title already shows the entity's pretty name.
-  const ancestryTrail = ancestors
-    .map((c) => displayValue(c.value))
-    .join("  ›  ");
+  // `title` title-cases a user's address into a name ("Olivia Novak"), which is
+  // friendlier but ambiguous between two people — keep the address it came from
+  // alongside it. Only users have one; every other value is already its label.
+  const emailSuffix = entity?.dim === Dimension.Email ? entity.value : null;
+  const badgeVariant = entityBadgeVariant(
+    entity?.dim ?? collection?.dim ?? null,
+  );
   const palette = entityPalette(title);
-  const Icon =
-    !entity && collection
-      ? (ENTITY_ICONS[collection.dim] ?? Building2)
-      : entityIcon(entity);
 
-  const handleExportCsv = () =>
-    downloadCsv(
-      `${slugify(title)}-by-${slugify(groupLabel)}-${slugify(rangeLabel)}.csv`,
-      buildCostCsv(rows, groupLabel, groupBy),
-    );
+  const caption = breakdownCaption({
+    axisValue,
+    groupBy,
+    costLabel: formatCost(stats.cost),
+    groupCount: isError ? 0 : rows.length,
+  });
+
+  // Whichever table is on screen owns the export: the dimension rows by default,
+  // the override's rows (sessions) when it has supplied a builder. The control
+  // renders either way and only disables on an empty table, so switching the
+  // breakdown never reflows the header row.
+  const csvExport = overrideCsv
+    ? {
+        rowCount: overrideCsv.rowCount,
+        run: () =>
+          downloadCsv(
+            `${slugify(title)}-sessions-${slugify(rangeLabel)}.csv`,
+            overrideCsv.build(),
+          ),
+      }
+    : {
+        rowCount: rows.length,
+        run: () =>
+          downloadCsv(
+            `${slugify(title)}-by-${slugify(groupLabel)}-${slugify(rangeLabel)}.csv`,
+            buildCostCsv(rows, groupLabel, groupBy),
+          ),
+      };
 
   // The default dimension table; replaced by `tableOverride` (the session list)
   // when one is supplied.
@@ -469,21 +412,27 @@ export function EntityProfile({
           </div>
           <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
             <div className="flex min-w-0 items-start gap-4">
-              <div className="border-border bg-background flex size-16 shrink-0 items-center justify-center rounded-2xl border">
-                <Icon className="text-foreground size-7" strokeWidth={1.5} />
-              </div>
               <div className="min-w-0">
-                {ancestryTrail && (
-                  <div className="text-muted-foreground mb-1.5 truncate text-sm">
-                    {ancestryTrail}
-                  </div>
-                )}
-                <div className="flex items-center gap-2">
-                  <h1 className="truncate text-2xl font-semibold tracking-tight">
+                {/* The name leads; the type chip trails it, colour-coded by
+                    entity family (see entityBadgeVariant). `min-w-0` on the
+                    heading keeps the truncation on the name, so the chip stays
+                    legible however long the value is. */}
+                <div className="flex items-center gap-3">
+                  <h1 className="min-w-0 truncate text-2xl font-semibold tracking-tight">
                     {title}
+                    {emailSuffix && (
+                      <span className="text-muted-foreground ml-2 text-xl font-normal">
+                        ({emailSuffix})
+                      </span>
+                    )}
                   </h1>
-                  <Badge variant="secondary" className="shrink-0">
-                    {typeLabel}
+                  <Badge
+                    size="md"
+                    variant={badgeVariant}
+                    background
+                    className="shrink-0"
+                  >
+                    <Badge.Text>{typeLabel}</Badge.Text>
                   </Badge>
                 </div>
               </div>
@@ -520,50 +469,28 @@ export function EntityProfile({
 
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-8 pt-2 pb-24">
         {widgets}
-        <div className="flex flex-col gap-3">
-          <div className="mb-3 flex items-center gap-3">
-            <h2 className="flex items-center gap-2 text-sm font-semibold">
-              Breakdown by
-              <Select value={axisValue} onValueChange={onAxisChange}>
-                <SelectTrigger className="border-border hover:bg-muted data-[state=open]:bg-muted !h-auto w-auto -my-1 cursor-pointer gap-1.5 rounded-md border bg-transparent py-1.5 pr-2.5 pl-3 text-sm font-semibold shadow-none transition-colors focus-visible:ring-0">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {axisOptions.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {axisHint && (
-                <Tooltip>
-                  <TooltipTrigger
-                    aria-label={axisHint}
-                    className="text-muted-foreground inline-flex cursor-help"
-                  >
-                    <Info className="size-3.5" />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-64">
-                    {axisHint}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </h2>
-            {/* CSV export covers the dimension table only; the session list owns
-                its own affordances. */}
-            {!tableOverride && (
+        {/* The breakdown is its own section under the summary widgets, so it
+            opens on a rule rather than floating off the last widget. */}
+        <div className="border-border flex flex-col gap-3 border-t pt-6">
+          <BreakdownBar
+            title={breakdownTitle(axisValue, groupBy)}
+            caption={caption}
+            axisValue={axisValue}
+            axisOptions={axisOptions}
+            axisHint={axisHint}
+            onAxisChange={onAxisChange}
+            actions={
               <button
                 type="button"
-                onClick={handleExportCsv}
-                disabled={rows.length === 0}
-                className="text-muted-foreground hover:text-foreground border-border hover:bg-muted inline-flex items-center gap-1.5 rounded-md border bg-transparent px-2.5 py-1.5 text-sm transition-colors disabled:pointer-events-none disabled:opacity-40"
+                onClick={csvExport.run}
+                disabled={csvExport.rowCount === 0}
+                className="text-muted-foreground hover:text-foreground border-border hover:bg-muted inline-flex h-10 shrink-0 items-center gap-1.5 rounded-md border bg-transparent px-3 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-40"
               >
                 <Download className="size-3.5 shrink-0" />
                 Export CSV
               </button>
-            )}
-          </div>
+            }
+          />
           {tableOverride ?? dimensionTable}
         </div>
       </div>

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -20,6 +20,7 @@ import { downloadCsv, slugify, toCsv } from "./csv";
 import {
   type Crumb,
   entityBadgeVariant,
+  friendlyName,
   isAttributionDim,
   LABELS,
   type Measures,
@@ -75,21 +76,6 @@ function buildCostCsv(
     ];
   });
   return toCsv(header, body);
-}
-
-// Initials for the avatar: email local-part tokens (olivia.novak → ON) or the
-// first letters of the first two words (Engineering → EN, R&D → RD).
-// Title-case an email local part into a name; pass other values through.
-function prettyName(value: string, dim: Dimension): string {
-  if (dim === Dimension.Email && value.includes("@")) {
-    const local = value.split("@")[0] ?? value;
-    return local
-      .split(/[._-]+/)
-      .filter(Boolean)
-      .map((w) => w[0]!.toUpperCase() + w.slice(1))
-      .join(" ");
-  }
-  return displayValue(value);
 }
 
 // A unique, deterministic colour identity for an entity, derived from its name
@@ -177,6 +163,9 @@ export type EntityProfileProps = {
   projectName: string;
   // The immediate parent's value, for the "Back to …" control.
   parentValue: string | null;
+  // The full drill path (root → the entity in view), which the breakdown
+  // caption names so it describes the slice actually on screen.
+  path: Crumb[];
   // Headline measures summed over this entity's children.
   stats: Measures;
   // The dimension the child table is grouped by (drives labels + CostTable).
@@ -239,6 +228,7 @@ export function EntityProfile({
   onHome,
   projectName,
   parentValue,
+  path,
   stats,
   groupBy,
   canDrill,
@@ -265,7 +255,7 @@ export function EntityProfile({
   const groupLabel = LABELS[groupBy] ?? "Group";
 
   const title = entity
-    ? prettyName(entity.value, entity.dim)
+    ? friendlyName(entity.dim, entity.value)
     : (collection?.label ?? projectName ?? "All costs");
   const typeLabel = entity
     ? (LABELS[entity.dim] ?? "Group")
@@ -284,6 +274,7 @@ export function EntityProfile({
   const caption = breakdownCaption({
     axisValue,
     groupBy,
+    path,
     costLabel: formatCost(stats.cost),
     groupCount: isError ? 0 : rows.length,
   });

--- a/client/dashboard/src/pages/costs/breakdownCopy.test.ts
+++ b/client/dashboard/src/pages/costs/breakdownCopy.test.ts
@@ -1,12 +1,80 @@
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
 import { describe, expect, it } from "vitest";
-import { breakdownCaption, breakdownTitle } from "./breakdownCopy";
-import { PIVOTS, SESSIONS_AXIS } from "./taxonomy";
+import { breakdownCaption, breakdownTitle, scopePhrase } from "./breakdownCopy";
+import { type Crumb, PIVOTS, SESSIONS_AXIS } from "./taxonomy";
 
-// The copy is assembled from dimension labels, so every label has to read
-// correctly in four sentence frames. Expectations are spelled out in full rather
-// than derived from LABELS — a test that rebuilt the string the same way the
-// code does would pass on any label, including "Cost by Employment Statuss".
+// The copy is assembled from dimension labels and drill-path values, so both
+// have to read correctly in every sentence frame. Expectations are spelled out
+// in full rather than derived from LABELS — a test that rebuilt the string the
+// way the code does would pass on "Cost by Employment Statuss".
+
+const COST = "$4.04";
+
+const at = (dim: Dimension, value: string): Crumb => ({ dim, value });
+const ADAM = at(Dimension.Email, "adam@speakeasy.com");
+const CLAUDE_CODE = at(Dimension.HookSource, "claude-code");
+const RND = at(Dimension.DivisionName, "R&D");
+const ENGINEERING = at(Dimension.DepartmentName, "Engineering");
+
+// ── Scope: the drill path as prose ──────────────────────────────────────────
+
+describe("scopePhrase", () => {
+  type ScopeCase = { name: string; path: Crumb[]; spend: string };
+  const CASES: ScopeCase[] = [
+    { name: "the project root", path: [], spend: "all project spend" },
+    { name: "one division", path: [RND], spend: "R&D's spend" },
+    // A user reads as their name, not the address the breadcrumb uses.
+    { name: "one user", path: [ADAM], spend: "Adam's spend" },
+    {
+      name: "a user's agent",
+      path: [ADAM, CLAUDE_CODE],
+      spend: "Adam's claude-code spend",
+    },
+    {
+      name: "two org levels",
+      path: [RND, ENGINEERING],
+      spend: "R&D's Engineering spend",
+    },
+    {
+      name: "the full chain",
+      path: [RND, ENGINEERING, ADAM, CLAUDE_CODE],
+      spend: "R&D's Engineering's Adam's claude-code spend",
+    },
+  ];
+
+  it.each(CASES)("names $name", ({ path, spend }) => {
+    expect(scopePhrase(path, "spend")).toBe(spend);
+  });
+
+  it("swaps the noun for the session list", () => {
+    expect(scopePhrase([], "sessions")).toBe("all project sessions");
+    expect(scopePhrase([ADAM], "sessions")).toBe("Adam's sessions");
+    expect(scopePhrase([ADAM, CLAUDE_CODE], "sessions")).toBe(
+      "Adam's claude-code sessions",
+    );
+  });
+
+  // "Operations's" is wrong; English drops the second s.
+  it("does not double the s on a name that ends in one", () => {
+    expect(
+      scopePhrase([at(Dimension.DivisionName, "Operations")], "spend"),
+    ).toBe("Operations' spend");
+    expect(
+      scopePhrase(
+        [at(Dimension.DivisionName, "Operations"), ENGINEERING],
+        "spend",
+      ),
+    ).toBe("Operations' Engineering spend");
+  });
+
+  it("keeps an unset value legible", () => {
+    expect(scopePhrase([at(Dimension.DivisionName, "")], "spend")).toBe(
+      "(unset)'s spend",
+    );
+  });
+});
+
+// ── Title + caption, per breakdown axis ─────────────────────────────────────
 
 type Case = {
   dim: Dimension;
@@ -20,113 +88,115 @@ type Case = {
   split: string;
 };
 
-const COST = "$4.04";
-
+// Captions below are asserted at the project root, so each row isolates the
+// dimension's own labels; the drill-path grammar is covered by scopePhrase.
 const CASES: Case[] = [
   {
     dim: Dimension.DivisionName,
     title: "Cost by Division",
-    empty: "Splitting spend by Division.",
-    single: "$4.04 — all from a single Division.",
-    split: "$4.04 split across 3 Divisions.",
+    empty: "Showing all project spend, broken down by Division.",
+    single: "Showing all project spend — $4.04, all from a single Division.",
+    split: "Showing all project spend — $4.04 across 3 Divisions.",
   },
   {
     dim: Dimension.DepartmentName,
     title: "Cost by Department",
-    empty: "Splitting spend by Department.",
-    single: "$4.04 — all from a single Department.",
-    split: "$4.04 split across 3 Departments.",
+    empty: "Showing all project spend, broken down by Department.",
+    single: "Showing all project spend — $4.04, all from a single Department.",
+    split: "Showing all project spend — $4.04 across 3 Departments.",
   },
   {
     dim: Dimension.Email,
     title: "Cost by User",
-    empty: "Splitting spend by User.",
-    single: "$4.04 — all from a single User.",
-    split: "$4.04 split across 3 Users.",
+    empty: "Showing all project spend, broken down by User.",
+    single: "Showing all project spend — $4.04, all from a single User.",
+    split: "Showing all project spend — $4.04 across 3 Users.",
   },
   {
     dim: Dimension.HookSource,
     title: "Cost by Agent",
-    empty: "Splitting spend by Agent.",
-    single: "$4.04 — all from a single Agent.",
-    split: "$4.04 split across 3 Agents.",
+    empty: "Showing all project spend, broken down by Agent.",
+    single: "Showing all project spend — $4.04, all from a single Agent.",
+    split: "Showing all project spend — $4.04 across 3 Agents.",
   },
   {
     dim: Dimension.JobTitle,
     title: "Cost by Job Title",
-    empty: "Splitting spend by Job Title.",
-    single: "$4.04 — all from a single Job Title.",
-    split: "$4.04 split across 3 Job Titles.",
+    empty: "Showing all project spend, broken down by Job Title.",
+    single: "Showing all project spend — $4.04, all from a single Job Title.",
+    split: "Showing all project spend — $4.04 across 3 Job Titles.",
   },
   {
     dim: Dimension.EmployeeType,
     title: "Cost by Employment Type",
-    empty: "Splitting spend by Employment Type.",
-    single: "$4.04 — all from a single Employment Type.",
-    split: "$4.04 split across 3 Employment Types.",
+    empty: "Showing all project spend, broken down by Employment Type.",
+    single:
+      "Showing all project spend — $4.04, all from a single Employment Type.",
+    split: "Showing all project spend — $4.04 across 3 Employment Types.",
   },
   {
     dim: Dimension.CostCenterName,
     title: "Cost by Cost Center",
-    empty: "Splitting spend by Cost Center.",
-    single: "$4.04 — all from a single Cost Center.",
-    split: "$4.04 split across 3 Cost Centers.",
+    empty: "Showing all project spend, broken down by Cost Center.",
+    single: "Showing all project spend — $4.04, all from a single Cost Center.",
+    split: "Showing all project spend — $4.04 across 3 Cost Centers.",
   },
   {
     dim: Dimension.Model,
     title: "Cost by Model",
-    empty: "Splitting spend by Model.",
-    single: "$4.04 — all from a single Model.",
-    split: "$4.04 split across 3 Models.",
+    empty: "Showing all project spend, broken down by Model.",
+    single: "Showing all project spend — $4.04, all from a single Model.",
+    split: "Showing all project spend — $4.04 across 3 Models.",
   },
   {
     dim: Dimension.AccountType,
     title: "Cost by Account Type",
-    empty: "Splitting spend by Account Type.",
-    single: "$4.04 — all from a single Account Type.",
-    split: "$4.04 split across 3 Account Types.",
+    empty: "Showing all project spend, broken down by Account Type.",
+    single:
+      "Showing all project spend — $4.04, all from a single Account Type.",
+    split: "Showing all project spend — $4.04 across 3 Account Types.",
   },
   {
     dim: Dimension.Provider,
     title: "Cost by Provider",
-    empty: "Splitting spend by Provider.",
-    single: "$4.04 — all from a single Provider.",
-    split: "$4.04 split across 3 Providers.",
+    empty: "Showing all project spend, broken down by Provider.",
+    single: "Showing all project spend — $4.04, all from a single Provider.",
+    split: "Showing all project spend — $4.04 across 3 Providers.",
   },
   {
     dim: Dimension.Role,
     title: "Cost by Role",
-    empty: "Splitting spend by Role.",
-    single: "$4.04 — all from a single Role.",
-    split: "$4.04 split across 3 Roles.",
+    empty: "Showing all project spend, broken down by Role.",
+    single: "Showing all project spend — $4.04, all from a single Role.",
+    split: "Showing all project spend — $4.04 across 3 Roles.",
   },
   {
     dim: Dimension.McpServerName,
     title: "Cost by MCP Server",
-    empty: "Splitting spend by MCP Server.",
-    single: "$4.04 — all from a single MCP Server.",
-    split: "$4.04 split across 3 MCP Servers.",
+    empty: "Showing all project spend, broken down by MCP Server.",
+    single: "Showing all project spend — $4.04, all from a single MCP Server.",
+    split: "Showing all project spend — $4.04 across 3 MCP Servers.",
   },
   {
     dim: Dimension.McpToolName,
     title: "Cost by MCP Tool",
-    empty: "Splitting spend by MCP Tool.",
-    single: "$4.04 — all from a single MCP Tool.",
-    split: "$4.04 split across 3 MCP Tools.",
+    empty: "Showing all project spend, broken down by MCP Tool.",
+    single: "Showing all project spend — $4.04, all from a single MCP Tool.",
+    split: "Showing all project spend — $4.04 across 3 MCP Tools.",
   },
   {
     dim: Dimension.SkillName,
     title: "Cost by Skill",
-    empty: "Splitting spend by Skill.",
-    single: "$4.04 — all from a single Skill.",
-    split: "$4.04 split across 3 Skills.",
+    empty: "Showing all project spend, broken down by Skill.",
+    single: "Showing all project spend — $4.04, all from a single Skill.",
+    split: "Showing all project spend — $4.04 across 3 Skills.",
   },
   {
     dim: Dimension.AgentName,
     title: "Cost by Subagent",
-    empty: "Splitting spend by Subagent.",
-    single: "$4.04 — all from a single Subagent.",
-    split: "$4.04 split across 3 Subagents.",
+    empty: "Showing all project spend, broken down by Subagent.",
+    single: "Showing all project spend — $4.04, all from a single Subagent.",
+    split: "Showing all project spend — $4.04 across 3 Subagents.",
   },
 ];
 
@@ -140,6 +210,7 @@ describe("breakdown copy", () => {
       breakdownCaption({
         axisValue: dim,
         groupBy: dim,
+        path: [],
         costLabel: COST,
         groupCount,
       });
@@ -156,44 +227,61 @@ describe("breakdown copy", () => {
     );
   });
 
+  it("reads the drill path into the caption", () => {
+    expect(
+      breakdownCaption({
+        axisValue: Dimension.Model,
+        groupBy: Dimension.Model,
+        path: [ADAM, CLAUDE_CODE],
+        costLabel: COST,
+        groupCount: 2,
+      }),
+    ).toBe("Showing Adam's claude-code spend — $4.04 across 2 Models.");
+  });
+
   describe("the sessions axis", () => {
+    const sessions = (path: Crumb[], groupCount = 42) =>
+      breakdownCaption({
+        axisValue: SESSIONS_AXIS,
+        groupBy: Dimension.Model,
+        path,
+        costLabel: COST,
+        groupCount,
+      });
+
     it("names itself a list, not a breakdown", () => {
       expect(breakdownTitle(SESSIONS_AXIS, Dimension.Model)).toBe(
         "Agent sessions",
       );
-      expect(
-        breakdownCaption({
-          axisValue: SESSIONS_AXIS,
-          groupBy: Dimension.Model,
-          costLabel: COST,
-          groupCount: 42,
-        }),
-      ).toBe("Every agent session, listed individually.");
+      expect(sessions([])).toBe(
+        "Showing all project sessions, listed individually.",
+      );
+      expect(sessions([ADAM, CLAUDE_CODE])).toBe(
+        "Showing Adam's claude-code sessions, listed individually.",
+      );
     });
 
     // Sessions render via a tableOverride, so `rows` is empty and groupCount is
-    // 0 — the caption must not fall through to "Splitting spend by Model."
+    // 0 — the caption must not fall through to "broken down by Model."
     it("ignores the group count the overridden table leaves at zero", () => {
-      expect(
-        breakdownCaption({
-          axisValue: SESSIONS_AXIS,
-          groupBy: Dimension.Model,
-          costLabel: COST,
-          groupCount: 0,
-        }),
-      ).toBe("Every agent session, listed individually.");
+      expect(sessions([ADAM], 0)).toBe(
+        "Showing Adam's sessions, listed individually.",
+      );
     });
   });
 
-  // The scope qualifier this copy deliberately omits: "of R&D" reads fine but
-  // "of Adam" does not, and the hero above already names the entity.
-  it("never qualifies the spend with an entity name", () => {
-    const caption = breakdownCaption({
-      axisValue: Dimension.HookSource,
-      groupBy: Dimension.HookSource,
-      costLabel: COST,
-      groupCount: 1,
-    });
-    expect(caption).not.toMatch(/\bof\b|\bin\b/);
+  // The qualifier that produced "$4.04 of Adam": a user is possessed, never
+  // used as the object of a preposition.
+  it("never says 'of' or 'in' a user", () => {
+    for (const groupCount of [0, 1, 3]) {
+      const caption = breakdownCaption({
+        axisValue: Dimension.HookSource,
+        groupBy: Dimension.HookSource,
+        path: [ADAM],
+        costLabel: COST,
+        groupCount,
+      });
+      expect(caption).not.toMatch(/\b(of|in) Adam\b/);
+    }
   });
 });

--- a/client/dashboard/src/pages/costs/breakdownCopy.test.ts
+++ b/client/dashboard/src/pages/costs/breakdownCopy.test.ts
@@ -1,0 +1,199 @@
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+import { describe, expect, it } from "vitest";
+import { breakdownCaption, breakdownTitle } from "./breakdownCopy";
+import { PIVOTS, SESSIONS_AXIS } from "./taxonomy";
+
+// The copy is assembled from dimension labels, so every label has to read
+// correctly in four sentence frames. Expectations are spelled out in full rather
+// than derived from LABELS — a test that rebuilt the string the same way the
+// code does would pass on any label, including "Cost by Employment Statuss".
+
+type Case = {
+  dim: Dimension;
+  // "Cost by …"
+  title: string;
+  // groupCount 0 — loading or an empty slice.
+  empty: string;
+  // groupCount 1 — not a split; the active axis is offered even with one value.
+  single: string;
+  // groupCount > 1 — the real breakdown, and the plural under test.
+  split: string;
+};
+
+const COST = "$4.04";
+
+const CASES: Case[] = [
+  {
+    dim: Dimension.DivisionName,
+    title: "Cost by Division",
+    empty: "Splitting spend by Division.",
+    single: "$4.04 — all from a single Division.",
+    split: "$4.04 split across 3 Divisions.",
+  },
+  {
+    dim: Dimension.DepartmentName,
+    title: "Cost by Department",
+    empty: "Splitting spend by Department.",
+    single: "$4.04 — all from a single Department.",
+    split: "$4.04 split across 3 Departments.",
+  },
+  {
+    dim: Dimension.Email,
+    title: "Cost by User",
+    empty: "Splitting spend by User.",
+    single: "$4.04 — all from a single User.",
+    split: "$4.04 split across 3 Users.",
+  },
+  {
+    dim: Dimension.HookSource,
+    title: "Cost by Agent",
+    empty: "Splitting spend by Agent.",
+    single: "$4.04 — all from a single Agent.",
+    split: "$4.04 split across 3 Agents.",
+  },
+  {
+    dim: Dimension.JobTitle,
+    title: "Cost by Job Title",
+    empty: "Splitting spend by Job Title.",
+    single: "$4.04 — all from a single Job Title.",
+    split: "$4.04 split across 3 Job Titles.",
+  },
+  {
+    dim: Dimension.EmployeeType,
+    title: "Cost by Employment Type",
+    empty: "Splitting spend by Employment Type.",
+    single: "$4.04 — all from a single Employment Type.",
+    split: "$4.04 split across 3 Employment Types.",
+  },
+  {
+    dim: Dimension.CostCenterName,
+    title: "Cost by Cost Center",
+    empty: "Splitting spend by Cost Center.",
+    single: "$4.04 — all from a single Cost Center.",
+    split: "$4.04 split across 3 Cost Centers.",
+  },
+  {
+    dim: Dimension.Model,
+    title: "Cost by Model",
+    empty: "Splitting spend by Model.",
+    single: "$4.04 — all from a single Model.",
+    split: "$4.04 split across 3 Models.",
+  },
+  {
+    dim: Dimension.AccountType,
+    title: "Cost by Account Type",
+    empty: "Splitting spend by Account Type.",
+    single: "$4.04 — all from a single Account Type.",
+    split: "$4.04 split across 3 Account Types.",
+  },
+  {
+    dim: Dimension.Provider,
+    title: "Cost by Provider",
+    empty: "Splitting spend by Provider.",
+    single: "$4.04 — all from a single Provider.",
+    split: "$4.04 split across 3 Providers.",
+  },
+  {
+    dim: Dimension.Role,
+    title: "Cost by Role",
+    empty: "Splitting spend by Role.",
+    single: "$4.04 — all from a single Role.",
+    split: "$4.04 split across 3 Roles.",
+  },
+  {
+    dim: Dimension.McpServerName,
+    title: "Cost by MCP Server",
+    empty: "Splitting spend by MCP Server.",
+    single: "$4.04 — all from a single MCP Server.",
+    split: "$4.04 split across 3 MCP Servers.",
+  },
+  {
+    dim: Dimension.McpToolName,
+    title: "Cost by MCP Tool",
+    empty: "Splitting spend by MCP Tool.",
+    single: "$4.04 — all from a single MCP Tool.",
+    split: "$4.04 split across 3 MCP Tools.",
+  },
+  {
+    dim: Dimension.SkillName,
+    title: "Cost by Skill",
+    empty: "Splitting spend by Skill.",
+    single: "$4.04 — all from a single Skill.",
+    split: "$4.04 split across 3 Skills.",
+  },
+  {
+    dim: Dimension.AgentName,
+    title: "Cost by Subagent",
+    empty: "Splitting spend by Subagent.",
+    single: "$4.04 — all from a single Subagent.",
+    split: "$4.04 split across 3 Subagents.",
+  },
+];
+
+describe("breakdown copy", () => {
+  it.each(CASES)("titles the $title cut", ({ dim, title }) => {
+    expect(breakdownTitle(dim, dim)).toBe(title);
+  });
+
+  it.each(CASES)("captions $title", ({ dim, empty, single, split }) => {
+    const caption = (groupCount: number) =>
+      breakdownCaption({
+        axisValue: dim,
+        groupBy: dim,
+        costLabel: COST,
+        groupCount,
+      });
+    expect(caption(0)).toBe(empty);
+    expect(caption(1)).toBe(single);
+    expect(caption(3)).toBe(split);
+  });
+
+  // A pivot added without reviewing its copy would otherwise silently fall back
+  // to "Cost by group" / "3 Groups".
+  it("covers every pivot the taxonomy offers", () => {
+    expect(CASES.map((c) => c.dim).sort()).toEqual(
+      PIVOTS.map((p) => p.dim).sort(),
+    );
+  });
+
+  describe("the sessions axis", () => {
+    it("names itself a list, not a breakdown", () => {
+      expect(breakdownTitle(SESSIONS_AXIS, Dimension.Model)).toBe(
+        "Agent sessions",
+      );
+      expect(
+        breakdownCaption({
+          axisValue: SESSIONS_AXIS,
+          groupBy: Dimension.Model,
+          costLabel: COST,
+          groupCount: 42,
+        }),
+      ).toBe("Every agent session, listed individually.");
+    });
+
+    // Sessions render via a tableOverride, so `rows` is empty and groupCount is
+    // 0 — the caption must not fall through to "Splitting spend by Model."
+    it("ignores the group count the overridden table leaves at zero", () => {
+      expect(
+        breakdownCaption({
+          axisValue: SESSIONS_AXIS,
+          groupBy: Dimension.Model,
+          costLabel: COST,
+          groupCount: 0,
+        }),
+      ).toBe("Every agent session, listed individually.");
+    });
+  });
+
+  // The scope qualifier this copy deliberately omits: "of R&D" reads fine but
+  // "of Adam" does not, and the hero above already names the entity.
+  it("never qualifies the spend with an entity name", () => {
+    const caption = breakdownCaption({
+      axisValue: Dimension.HookSource,
+      groupBy: Dimension.HookSource,
+      costLabel: COST,
+      groupCount: 1,
+    });
+    expect(caption).not.toMatch(/\bof\b|\bin\b/);
+  });
+});

--- a/client/dashboard/src/pages/costs/breakdownCopy.ts
+++ b/client/dashboard/src/pages/costs/breakdownCopy.ts
@@ -1,0 +1,59 @@
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+import { isSessionsAxis, LABELS, pluralLabel } from "./taxonomy";
+
+// The breakdown section's title + caption. A non-component module so the strings
+// stay unit-testable (EntityProfile may only export components) — the grammar
+// here has to survive every dimension label in the taxonomy, so it's covered by
+// a table-driven test rather than spot-checked in the browser.
+//
+// Cost arrives preformatted: five formatCost copies already exist across the
+// cost views, and this module's job is grammar, not money.
+
+/**
+ * Title the breakdown table by the cut in view ("Cost by Model") rather than by
+ * the mechanism ("Breakdown by"): the title echoes whichever axis is lit in the
+ * track beside it, which is what teaches the idea on the first click.
+ */
+export function breakdownTitle(axisValue: string, groupBy: Dimension): string {
+  if (isSessionsAxis(axisValue)) return "Agent sessions";
+  return `Cost by ${LABELS[groupBy] ?? "group"}`;
+}
+
+/**
+ * Narrate the cut in the user's own numbers ("$12,340 split across 8 Job
+ * Titles."), as the title's description. The power of a breakdown only lands
+ * once you see one pot of spend divided into real groups, so this states both —
+ * a tooltip nobody hovers can't.
+ *
+ * Deliberately unscoped: whose spend this is already reads off the hero above
+ * (title + type badge), and no qualifier survives both halves of the taxonomy —
+ * "$4.04 of R&D" is fine where "$4.04 of Adam" is not.
+ */
+export function breakdownCaption({
+  axisValue,
+  groupBy,
+  costLabel,
+  groupCount,
+}: {
+  axisValue: string;
+  groupBy: Dimension;
+  // The slice's total spend, already formatted (e.g. "$4.04").
+  costLabel: string;
+  groupCount: number;
+}): string {
+  // The sessions axis lists rather than groups; say so, since that contrast is
+  // what makes the other axes legible as breakdowns.
+  if (isSessionsAxis(axisValue)) {
+    return "Every agent session, listed individually.";
+  }
+  const groupLabel = LABELS[groupBy] ?? "group";
+  // Loading and empty slices have no count to quote yet, so describe the cut
+  // without asserting "across 0 …".
+  if (groupCount === 0) return `Splitting spend by ${groupLabel}.`;
+  // A single group isn't a split — the active axis is offered even when it has
+  // only one value (see pivotOptions), so say what that actually means.
+  if (groupCount === 1) {
+    return `${costLabel} — all from a single ${groupLabel}.`;
+  }
+  return `${costLabel} split across ${groupCount} ${pluralLabel(groupBy)}.`;
+}

--- a/client/dashboard/src/pages/costs/breakdownCopy.ts
+++ b/client/dashboard/src/pages/costs/breakdownCopy.ts
@@ -1,10 +1,16 @@
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
-import { isSessionsAxis, LABELS, pluralLabel } from "./taxonomy";
+import {
+  type Crumb,
+  friendlyName,
+  isSessionsAxis,
+  LABELS,
+  pluralLabel,
+} from "./taxonomy";
 
 // The breakdown section's title + caption. A non-component module so the strings
 // stay unit-testable (EntityProfile may only export components) — the grammar
-// here has to survive every dimension label in the taxonomy, so it's covered by
-// a table-driven test rather than spot-checked in the browser.
+// here has to survive every dimension label in the taxonomy and every drill
+// depth, so it's covered by a table-driven test rather than spot-checked.
 //
 // Cost arrives preformatted: five formatCost copies already exist across the
 // cost views, and this module's job is grammar, not money.
@@ -19,24 +25,56 @@ export function breakdownTitle(axisValue: string, groupBy: Dimension): string {
   return `Cost by ${LABELS[groupBy] ?? "group"}`;
 }
 
+// "Adam" → "Adam's", "Operations" → "Operations'". English drops the extra s on
+// a name that already ends in one.
+function possessive(name: string): string {
+  return /s$/i.test(name) ? `${name}'` : `${name}'s`;
+}
+
 /**
- * Narrate the cut in the user's own numbers ("$12,340 split across 8 Job
- * Titles."), as the title's description. The power of a breakdown only lands
- * once you see one pot of spend divided into real groups, so this states both —
- * a tooltip nobody hovers can't.
+ * Name the slice the breakdown is splitting, following the drill path:
  *
- * Deliberately unscoped: whose spend this is already reads off the hero above
- * (title + type badge), and no qualifier survives both halves of the taxonomy —
- * "$4.04 of R&D" is fine where "$4.04 of Adam" is not.
+ *   []                              → "all project spend"
+ *   [Adam]                          → "Adam's spend"
+ *   [Adam, claude-code]             → "Adam's claude-code spend"
+ *   [R&D, Engineering, Adam, cc]    → "R&D's Engineering's Adam's cc spend"
+ *
+ * Every ancestor possesses the one below it; the deepest reads as a modifier of
+ * `noun` ("claude-code spend"), except at depth 1 where there is nothing between
+ * it and the noun to modify, so it possesses instead ("Adam's spend").
+ *
+ * `noun` is what's being counted — "spend" for a cost breakdown, "sessions" for
+ * the session list, which can't be "spend" without reading as nonsense.
+ */
+export function scopePhrase(path: Crumb[], noun: string): string {
+  if (path.length === 0) return `all project ${noun}`;
+  const names = path.map((c) => friendlyName(c.dim, c.value));
+  const last = names[names.length - 1]!;
+  if (names.length === 1) return `${possessive(last)} ${noun}`;
+  const owners = names.slice(0, -1).map(possessive).join(" ");
+  return `${owners} ${last} ${noun}`;
+}
+
+/**
+ * Narrate the cut in the user's own numbers and their own drill path ("Showing
+ * Adam's claude-code spend — $4.04 across 2 Models."), as the title's
+ * description.
+ *
+ * Deliberately concrete: a general definition of "breakdown" reads as jargon,
+ * because the idea only lands against the slice actually on screen. Naming the
+ * path and the split together is what a tooltip nobody hovers can't do.
  */
 export function breakdownCaption({
   axisValue,
   groupBy,
+  path,
   costLabel,
   groupCount,
 }: {
   axisValue: string;
   groupBy: Dimension;
+  // The full drill path, root → entity in view. Empty at the project root.
+  path: Crumb[];
   // The slice's total spend, already formatted (e.g. "$4.04").
   costLabel: string;
   groupCount: number;
@@ -44,16 +82,19 @@ export function breakdownCaption({
   // The sessions axis lists rather than groups; say so, since that contrast is
   // what makes the other axes legible as breakdowns.
   if (isSessionsAxis(axisValue)) {
-    return "Every agent session, listed individually.";
+    return `Showing ${scopePhrase(path, "sessions")}, listed individually.`;
   }
+  const scope = scopePhrase(path, "spend");
   const groupLabel = LABELS[groupBy] ?? "group";
-  // Loading and empty slices have no count to quote yet, so describe the cut
-  // without asserting "across 0 …".
-  if (groupCount === 0) return `Splitting spend by ${groupLabel}.`;
+  // Loading and empty slices have no count or total to quote yet, so describe
+  // the cut without asserting "$0.00 across 0 …".
+  if (groupCount === 0) {
+    return `Showing ${scope}, broken down by ${groupLabel}.`;
+  }
   // A single group isn't a split — the active axis is offered even when it has
   // only one value (see pivotOptions), so say what that actually means.
   if (groupCount === 1) {
-    return `${costLabel} — all from a single ${groupLabel}.`;
+    return `Showing ${scope} — ${costLabel}, all from a single ${groupLabel}.`;
   }
-  return `${costLabel} split across ${groupCount} ${pluralLabel(groupBy)}.`;
+  return `Showing ${scope} — ${costLabel} across ${groupCount} ${pluralLabel(groupBy)}.`;
 }

--- a/client/dashboard/src/pages/costs/csv.test.ts
+++ b/client/dashboard/src/pages/costs/csv.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { toCsv } from "./csv";
+
+// Exercised through toCsv rather than by exporting csvField: the serializer is
+// the surface every export actually calls, and an export used only by a test is
+// dead code to knip.
+
+// One row, one cell — the field-level behaviour without the header noise.
+const cell = (value: string | number) =>
+  toCsv(["h"], [[value]]).split("\r\n")[1];
+
+describe("formula injection (CWE-1236)", () => {
+  // Directory-sync values (names, emails) reach these cells, so a display name
+  // is an injection vector into whoever opens the export.
+  type Case = { name: string; input: string; expected: string };
+  const NEUTRALIZED: Case[] = [
+    {
+      name: "an equals formula",
+      input: "=SUM(A1:A10)",
+      expected: "'=SUM(A1:A10)",
+    },
+    { name: "a plus formula", input: "+1+1", expected: "'+1+1" },
+    { name: "a minus formula", input: "-1+1", expected: "'-1+1" },
+    { name: "an at formula", input: "@SUM(A1)", expected: "'@SUM(A1)" },
+    // Importers skip leading whitespace before deciding it's a formula.
+    {
+      name: "a space-padded formula",
+      input: " =SUM(A1:A10)",
+      expected: "' =SUM(A1:A10)",
+    },
+    {
+      name: "a multi-space-padded formula",
+      input: "   @SUM(A1)",
+      expected: "'   @SUM(A1)",
+    },
+  ];
+
+  it.each(NEUTRALIZED)("neutralizes $name", ({ input, expected }) => {
+    expect(cell(input)).toBe(expected);
+  });
+
+  // These carry a CR/LF/tab, so they're also quoted — assert the whole cell.
+  type QuotedCase = { name: string; input: string; expected: string };
+  const QUOTED: QuotedCase[] = [
+    {
+      name: "a newline-led formula",
+      input: "\n=CMD|' /C calc'!A0",
+      expected: `"'\n=CMD|' /C calc'!A0"`,
+    },
+    {
+      name: "a carriage-return-led formula",
+      input: "\r=SUM(A1)",
+      expected: `"'\r=SUM(A1)"`,
+    },
+  ];
+
+  it.each(QUOTED)("neutralizes and quotes $name", ({ input, expected }) => {
+    expect(cell(input)).toBe(expected);
+  });
+
+  // A tab is a formula trigger but not a CSV delimiter, so it's neutralized
+  // without being quoted.
+  it.each([
+    { name: "a tab-led formula", input: "\t=SUM(A1)", expected: "'\t=SUM(A1)" },
+    // A leading control char is a trigger even with no =/+/-/@ after it.
+    { name: "a bare tab lead", input: "\tplain", expected: "'\tplain" },
+  ])("neutralizes $name without quoting it", ({ input, expected }) => {
+    expect(cell(input)).toBe(expected);
+  });
+
+  it.each([
+    ["a plain name", "Olivia Novak"],
+    ["an email", "adam@speakeasy.com"],
+    ["a name with an inner equals", "budget=q3"],
+  ])("leaves %s alone", (_name, input) => {
+    expect(cell(input)).toBe(input);
+  });
+
+  // Guarding numbers would corrupt a negative into the text "'-5".
+  it.each([
+    [0, "0"],
+    [42, "42"],
+    [-5, "-5"],
+    [-0.46, "-0.46"],
+  ])("passes the number %s through as %s", (input, expected) => {
+    expect(cell(input)).toBe(expected);
+  });
+});
+
+describe("RFC 4180 quoting", () => {
+  it.each([
+    {
+      name: "a comma",
+      input: "R&D, Engineering",
+      expected: `"R&D, Engineering"`,
+    },
+    { name: "a quote", input: 'say "hi"', expected: `"say ""hi"""` },
+    { name: "a newline", input: "line1\nline2", expected: `"line1\nline2"` },
+    {
+      name: "a carriage return",
+      input: "line1\rline2",
+      expected: `"line1\rline2"`,
+    },
+  ])("quotes $name", ({ input, expected }) => {
+    expect(cell(input)).toBe(expected);
+  });
+});
+
+describe("toCsv", () => {
+  it("separates records with CRLF", () => {
+    expect(
+      toCsv(
+        ["a", "b"],
+        [
+          ["1", "2"],
+          ["3", "4"],
+        ],
+      ),
+    ).toBe("a,b\r\n1,2\r\n3,4");
+  });
+
+  it("emits a header-only file when there are no rows", () => {
+    expect(toCsv(["a", "b"], [])).toBe("a,b");
+  });
+
+  it("does not terminate the last record", () => {
+    expect(toCsv(["a"], [["1"]]).endsWith("1")).toBe(true);
+  });
+});

--- a/client/dashboard/src/pages/costs/csv.ts
+++ b/client/dashboard/src/pages/costs/csv.ts
@@ -1,0 +1,45 @@
+// Shared CSV plumbing for the cost explorer's exports. The dimension table
+// (EntityProfile) and the session list (SessionTable) each own their column
+// shape but serialize and download through here, so the formula-injection guard
+// below can never be forgotten by one of them.
+
+// Serialize one CSV field. Two concerns:
+//   1. Formula injection (CWE-1236): a cell starting with = + - @ (or a control
+//      char) is treated as a formula by Excel/Sheets. Directory-sync values
+//      (names, emails) are attacker-influenced, so neutralize with a leading
+//      apostrophe before quoting.
+//   2. RFC 4180 quoting: wrap in quotes (doubling internal quotes) when the
+//      value contains a comma, quote, or newline.
+function csvField(value: string | number): string {
+  let s = String(value);
+  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+/** Serialize a header row plus body rows into an RFC 4180 CSV string. */
+export function toCsv(header: string[], body: (string | number)[][]): string {
+  return [header, ...body]
+    .map((cols) => cols.map(csvField).join(","))
+    .join("\n");
+}
+
+/** Trigger a client-side download of a CSV string. */
+export function downloadCsv(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+/** Filename-safe slug for an entity/range label. */
+export function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "") || "all-costs"
+  );
+}

--- a/client/dashboard/src/pages/costs/csv.ts
+++ b/client/dashboard/src/pages/costs/csv.ts
@@ -3,24 +3,38 @@
 // shape but serialize and download through here, so the formula-injection guard
 // below can never be forgotten by one of them.
 
+// A cell whose first meaningful character is one of these is evaluated as a
+// formula by Excel/Sheets (CWE-1236). Importers skip leading whitespace before
+// deciding, so the payload " =SUM(A1:A10)" is still live — match past it rather
+// than only at position 0.
+const FORMULA_LEAD = /^\s*[=+\-@]/;
+// Tab, CR and LF are themselves formula triggers in OWASP's guidance, so a value
+// leading with one is neutralized even without a following =/+/-/@.
+const CONTROL_LEAD = /^[\t\r\n]/;
+
 // Serialize one CSV field. Two concerns:
-//   1. Formula injection (CWE-1236): a cell starting with = + - @ (or a control
-//      char) is treated as a formula by Excel/Sheets. Directory-sync values
-//      (names, emails) are attacker-influenced, so neutralize with a leading
-//      apostrophe before quoting.
+//   1. Formula injection (CWE-1236). Directory-sync values (names, emails) are
+//      attacker-influenced, so a cell that would evaluate gets a leading
+//      apostrophe. Numbers are exempt: they can't be formulas, and guarding
+//      them would corrupt a negative value into the text "'-5".
 //   2. RFC 4180 quoting: wrap in quotes (doubling internal quotes) when the
-//      value contains a comma, quote, or newline.
+//      value contains a comma, quote, CR or LF.
 function csvField(value: string | number): string {
-  let s = String(value);
-  if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`;
-  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  if (typeof value === "number") return String(value);
+  let s = value;
+  if (FORMULA_LEAD.test(s) || CONTROL_LEAD.test(s)) s = `'${s}`;
+  return /["\r\n,]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
-/** Serialize a header row plus body rows into an RFC 4180 CSV string. */
+/**
+ * Serialize a header row plus body rows into an RFC 4180 CSV string. Records are
+ * CRLF-separated per the spec — Excel and Sheets accept either, but strict
+ * parsers don't.
+ */
 export function toCsv(header: string[], body: (string | number)[][]): string {
   return [header, ...body]
     .map((cols) => cols.map(csvField).join(","))
-    .join("\n");
+    .join("\r\n");
 }
 
 /** Trigger a client-side download of a CSV string. */

--- a/client/dashboard/src/pages/costs/sessionCsv.ts
+++ b/client/dashboard/src/pages/costs/sessionCsv.ts
@@ -1,0 +1,70 @@
+import type { SessionSummary } from "@gram/client/models/components/sessionsummary.js";
+import { costMeasureLabel } from "@/components/estimated-cost-utils";
+import { formatDurationFromNanos } from "../chatLogs/claudeUsage";
+import { toCsv } from "./csv";
+import type { SessionColumnId } from "./SessionTable";
+
+// CSV export for the cost explorer's session list. Lives outside SessionTable so
+// that view file only exports components (the react-refresh lint rule) — the
+// same reason taxonomy.ts sits beside EntityProfile.
+
+// The export's columns, in order, mirroring what SessionTable renders. The cost
+// header is resolved per call so it follows the table's metered/estimated swap.
+const CSV_COLUMNS: { id: SessionColumnId; header: string }[] = [
+  { id: "session", header: "Session" },
+  { id: "user", header: "User" },
+  { id: "agent", header: "Agent" },
+  { id: "model", header: "Model" },
+  { id: "cost", header: "Est. cost" },
+  { id: "tokens", header: "Tokens" },
+  { id: "tools", header: "Tool calls" },
+  { id: "messages", header: "Messages" },
+  { id: "duration", header: "Duration" },
+];
+
+/**
+ * Serialize the session list to CSV — the same columns the table shows, honoring
+ * the same `hiddenColumns` so the file matches what's on screen.
+ */
+export function buildSessionCsv(
+  sessions: SessionSummary[],
+  hiddenColumns: SessionColumnId[] = [],
+  billingMode?: string,
+): string {
+  const hidden = new Set(hiddenColumns);
+  const columns = CSV_COLUMNS.filter((c) => !hidden.has(c.id));
+  const header = columns.map((c) =>
+    c.id === "cost" ? costMeasureLabel(billingMode) : c.header,
+  );
+  const body = sessions.map((s) => columns.map((c) => csvValue(c.id, s)));
+  return toCsv(header, body);
+}
+
+// One session's value for a column, as raw data rather than the table's JSX —
+// numbers unformatted so the file is spreadsheet-ready, and the session titled
+// by its name, falling back to the chat id when it has none.
+function csvValue(id: SessionColumnId, s: SessionSummary): string | number {
+  switch (id) {
+    case "session":
+      return s.title?.trim() || s.gramChatId;
+    case "user":
+      return s.userEmail ?? "";
+    case "agent":
+      return s.hookSource ?? "";
+    case "model":
+      return s.model ?? "";
+    case "cost":
+      return s.totalCost.toFixed(2);
+    case "tokens":
+      return s.totalTokens;
+    case "tools":
+      return s.toolCallCount;
+    case "messages":
+      return s.messageCount;
+    case "duration":
+      return (
+        formatDurationFromNanos(s.startTimeUnixNano, s.endTimeUnixNano) ??
+        `${Math.round(s.durationSeconds)}s`
+      );
+  }
+}

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -409,3 +409,20 @@ export function displayName(dim: Dimension, value: string): string {
   }
   return value;
 }
+
+// The conversational form of an entity's value, for the hero and for prose that
+// talks about it ("Adam's claude-code spend"). A user becomes the name inside
+// their address; everything else is already conversational. Distinct from
+// displayName, which stays exact because the breadcrumb and the assistant have
+// to identify one person rather than read naturally.
+export function friendlyName(dim: Dimension, value: string): string {
+  if (dim === Dimension.Email && value.includes("@")) {
+    const local = value.split("@")[0] ?? value;
+    return local
+      .split(/[._-]+/)
+      .filter(Boolean)
+      .map((w) => w[0]!.toUpperCase() + w.slice(1))
+      .join(" ");
+  }
+  return displayName(dim, value);
+}

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -47,7 +47,9 @@ const CHAIN: DimMeta[] = [
 // Every axis the user can pivot to at any level (dynamic taxonomy). The Claude
 // attribution cuts (MCP Server/Tool, Skill, Subagent) are appended last so they
 // never preempt the org-hierarchy default at the root (see defaultGroupBy).
-const PIVOTS: DimMeta[] = [
+// Exported so breakdownCopy's test can assert its grammar table covers every
+// axis — a new pivot with unreviewed copy should fail the suite, not ship.
+export const PIVOTS: DimMeta[] = [
   ...CHAIN,
   { dim: Dimension.JobTitle, label: "Job Title" },
   { dim: Dimension.EmployeeType, label: "Employment Type" },
@@ -80,6 +82,45 @@ const COLLECTION_LABELS: Partial<Record<Dimension, string>> = {
 };
 export function collectionLabel(dim: Dimension): string | null {
   return COLLECTION_LABELS[dim] ?? null;
+}
+
+// Plural label for a breakdown dimension, for prose that counts its groups
+// ("across 8 Job Titles"). Attribution dims already carry a hand-written plural;
+// every other label pluralizes with a bare "s". Not for SESSIONS_AXIS — its
+// label is already plural, and the sessions list isn't a counted breakdown.
+export function pluralLabel(dim: Dimension): string {
+  return COLLECTION_LABELS[dim] ?? `${LABELS[dim] ?? "Group"}s`;
+}
+
+// The Moonshine Badge variant for an entity's type chip. Moonshine ships five
+// variants and two are spoken for — `destructive` reads as an error, `warning`
+// (amber) is the Preview release badge — so the taxonomy's dimensions group into
+// the three that remain, by what kind of thing the entity is:
+//
+//   information (brand blue) — who spent it: the org/people hierarchy
+//   neutral                  — what ran it: the agent/model/account runtime
+//   success (emerald)        — what it used: the Claude attribution cuts
+//
+// The variant names are hooks rather than literal semantics here (the same
+// reasoning as ReleaseStageBadge); grouping beats an arbitrary colour per
+// dimension, since a reader can learn three families but not fifteen.
+const PEOPLE_DIMS = new Set<Dimension>([
+  Dimension.DivisionName,
+  Dimension.DepartmentName,
+  Dimension.Email,
+  Dimension.JobTitle,
+  Dimension.EmployeeType,
+  Dimension.CostCenterName,
+  Dimension.Role,
+]);
+
+export type EntityBadgeVariant = "neutral" | "information" | "success";
+
+export function entityBadgeVariant(dim: Dimension | null): EntityBadgeVariant {
+  if (dim == null) return "neutral"; // the project root
+  if (PEOPLE_DIMS.has(dim)) return "information";
+  if (isAttributionDim(dim)) return "success";
+  return "neutral";
 }
 
 // The most granular grouping axes — an Agent or a Model is an endpoint, not
@@ -354,21 +395,17 @@ export function datasetDefaultGroupBy(
   return DATASET_META[ds].dims[0]!;
 }
 
-// Human label for an entity value: title-cased name for emails, the raw value
-// otherwise. Shared by the profile header and the breadcrumb substitutions.
+// Human label for an entity value, for the breadcrumb trail and the assistant's
+// grounding context. A user stays their address: both callers need to identify
+// one person exactly, and "Adam" doesn't — two people can share a first name,
+// and the assistant can't ground on a name it can't resolve. The friendly
+// title-cased form belongs to the hero, which pairs it with the address anyway
+// (see prettyName in EntityProfile).
 export function displayName(dim: Dimension, value: string): string {
   if (value === "") return "(unset)";
   if (dim === Dimension.Provider) return providerLabel(value);
   if (dim === Dimension.AccountType) {
     return value.charAt(0).toUpperCase() + value.slice(1);
-  }
-  if (dim === Dimension.Email && value.includes("@")) {
-    const local = value.split("@")[0] ?? value;
-    return local
-      .split(/[._-]+/)
-      .filter(Boolean)
-      .map((w) => w[0]!.toUpperCase() + w.slice(1))
-      .join(" ");
   }
   return value;
 }


### PR DESCRIPTION
Makes the Costs breakdown discoverable and self-explaining, plus the fixes that fell out of testing it.

Fixes DNO-525.

## Why

The breakdown axis lived in a bare `Breakdown by [select]`. Users didn't find it, and "breakdown" reads as jargon until you've watched it re-cut the same spend a different way — the power only lands once you see one pot of money split by team, then by job title.

## The picker

The top 4 axes are now a segmented track, long tail behind **More**. Axes come from the existing availability-filtered `axisOptions`, so no dead axis is offered, and the active axis is always shown even when it lives in the overflow (otherwise picking from More makes the selection vanish). The track hides entirely when only one axis exists (a session leaf) — a toggle you can't move reads as broken.

`Breakdown by` was a _label_, which left its caption an orphaned third line. It's now a section header — title **"Cost by Model"** — and the description names the drill path and the split together, rather than defining "breakdown" in the abstract:

| Level                  | Description                                                 |
| ---------------------- | ----------------------------------------------------------- |
| Root                   | `Showing all project spend — $50,000 across 3 Divisions.`   |
| `[Adam]`               | `Showing Adam's spend — $4.04, all from a single Agent.`    |
| `[Adam ▸ claude-code]` | `Showing Adam's claude-code spend — $4.04 across 2 Models.` |
| Sessions               | `Showing Adam's claude-code sessions, listed individually.` |

Every ancestor possesses the one below it; the deepest reads as a modifier of the noun, which swaps to "sessions" for the session list so it can't say "every session in Adam's spend". The title echoes the lit segment, so the first click teaches the concept. The `(i)` icon is now left for axes carrying a real caveat, so its presence means something.

Earlier drafts read `$4.04 of Adam split across 1 Agent.` — two bugs there: `of/in {scope}` works for `of R&D` but not `of Adam`, and `across 1 Agent` isn't a split (reachable because the active axis is offered even when it has a single value).

## Fixes found while testing

- **Export CSV unmounted on the sessions axis**, reflowing the header row. It now always renders and exports the session list. CSV helpers moved to `csv.ts` so the formula-injection guard (CWE-1236) can't be missed by the new path — verified: `Session,User,Agent,Model,Est. cost,…` + 100 rows.
- **Widget row jumped height on every re-pivot** (296px → 369px). The "Most costly sessions" sublabel keyed off `groupBy`, but that widget shows the whole slice's top 5 — how the table below happens to be grouped doesn't make each session's owner redundant. It now depends only on the drill path, so the height is stable by construction (369/369/369 across user/model/sessions) and a useful attribution is back. Preferred over a min-height, which is a magic number a two-line title could still blow past, and which would force empty space at levels with only short stat cards.

## Hero

- **Company icon removed** (DNO-525). Dead `ENTITY_ICONS` / `entityIcon` and 13 lucide imports went with it.
- **Type badge** → Moonshine, right of the name, colour-coded by family. Moonshine has 5 variants but `destructive` reads as an error and `warning` is the Preview badge, so 15 dimensions group into 3: `information` = who spent it (org/people), `neutral` = what ran it (agent/model/account), `success` = what it used (attribution cuts). Three families are learnable; fifteen colours are noise.
- **Users show name + address** — `Adam (adam@speakeasy.com)`. `friendlyName` moves into the taxonomy (replacing `EntityProfile`'s private `prettyName`): the hero and the caption both want "Adam", while the breadcrumb and the assistant keep the exact address — both have to identify one person, and "Adam" doesn't.
- **Ancestry trail removed** — duplicated the breadcrumb and the Back button.
- **KPI tiles** reuse the `Card` shell (they were re-implementing it at `p-3`/`text-lg`), so both widget rows match.

## Tests

`breakdownCopy.test.ts` — 44 table-driven cases: all 15 pivots × 4 sentence frames, plus the drill grammar (depth 0–4, the sessions noun, possessives on a trailing s, unset values). Expectations are spelled out in full rather than derived from `LABELS`; a test that rebuilt the string the way the code does would pass on `Cost by Employment Statuss`. Includes an exhaustiveness check so a new pivot with unreviewed copy fails instead of silently shipping as `Cost by group`.

Both guards verified by mutation:

| Mutation                       | Result                                     |
| ------------------------------ | ------------------------------------------ |
| Add `BillingMode` as a pivot   | `covers every pivot the taxonomy offers` ✗ |
| Relabel to `Employment Status` | title + caption ✗                          |

## Notes for review

- **KPI sparklines stay neutral.** `up` = rose ("rising cost → bad"), `down` = emerald. These are volume metrics (sessions/tool calls/tokens) where up is neither good nor bad — green would assert "more tokens = good" on a cost-control page, red would flag routine growth as alarm.
- Behind the `gram-new-costs-page` PostHog flag.

## Verification

Lint, type-check, 944 tests green. Driven in the browser across `by=user` / `by=model` / `by=sessions`, the org root, a drilled user, and a session leaf.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Costs breakdown axes as a segmented control with a clear “Cost by …” header and a path-aware caption, making the cut easy to find and understand. Adds session CSV export and polish to the hero/widgets; fixes DNO-525.

- New Features
  - Top 4 breakdown axes are now a segmented control; overflow lives under “More.” The active axis is always visible, and the track hides when only one axis exists.
  - New BreakdownBar: titles as “Cost by {Axis}” and captions the drill path and split; the Sessions axis reads as a list; the info icon only appears for real caveats.
  - CSV: shared helpers in `csv.ts` with a formula-injection guard; sessions export matches visible columns and keeps the Export button mounted.
  - Hero/UI: type badge from `@speakeasy-api/moonshine`, color-coded by entity family; users show “Name (email)”; KPI tiles reuse the Card shell for consistent layout.
  - Copy is covered by table-driven tests across all pivots with an exhaustiveness check to catch unreviewed axes.

- Bug Fixes
  - Export CSV no longer unmounts on the Sessions axis; the header row stays stable and the session list exports correctly.
  - Hardened CSV guard: matches past leading whitespace, treats tab/CR/LF as triggers, and exempts numbers; `toCsv` now uses CRLF line endings. Covered by new tests.
  - “Most costly sessions” widget no longer jumps height on pivot; attribution depends only on the drill path.
  - Removes the company icon and dead imports; aligns user identity handling with email where needed.

<sup>Written for commit 188193e23d4f382b651d917056765abfc7f6a70b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

