### PR TITLE
fix: splits query to improve performance

### DIFF
--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1377,13 +1377,22 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 	}
 
 	window := riskOverviewWindowParams(from, to)
-	counts, err := s.repo.GetRiskOverviewCounts(ctx, repo.GetRiskOverviewCountsParams{
+	scanCounts, err := s.repo.GetRiskOverviewScanCounts(ctx, repo.GetRiskOverviewScanCountsParams{
 		ProjectID: *authCtx.ProjectID,
 		FromTime:  window.from,
 		ToTime:    window.to,
 	})
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview counts").LogError(ctx, s.logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview scan counts").LogError(ctx, s.logger)
+	}
+
+	findingCounts, err := s.repo.GetRiskOverviewFindingCounts(ctx, repo.GetRiskOverviewFindingCountsParams{
+		ProjectID: *authCtx.ProjectID,
+		FromTime:  window.from,
+		ToTime:    window.to,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview finding counts").LogError(ctx, s.logger)
 	}
 
 	userRows, err := s.repo.ListRiskOverviewTopUsers(ctx, repo.ListRiskOverviewTopUsersParams{
@@ -1453,10 +1462,10 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 	return &gen.RiskOverviewResult{
 		From:               from.UTC().Format(time.RFC3339),
 		To:                 to.UTC().Format(time.RFC3339),
-		MessagesScanned:    counts.MessagesScanned,
-		Findings:           counts.Findings,
-		FlaggedSessions:    counts.FlaggedSessions,
-		ActivePolicies:     counts.ActivePolicies,
+		MessagesScanned:    scanCounts.MessagesScanned,
+		Findings:           findingCounts.Findings,
+		FlaggedSessions:    findingCounts.FlaggedSessions,
+		ActivePolicies:     scanCounts.ActivePolicies,
 		TopCategories:      topCategories,
 		TopUsers:           topUsers,
 		TopRules:           topRules,

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -514,16 +514,14 @@ WHERE rr.project_id = @project_id
   AND rr.risk_policy_id = @risk_policy_id
   AND rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL;
 
--- name: GetRiskOverviewCounts :one
+-- name: GetRiskOverviewScanCounts :one
+-- messages_scanned counts every scanned message in the window regardless of
+-- found state. chat_message_id is NOT NULL with a FK to chat_messages, so the
+-- old JOIN was lossless — dropping it lets this be an index-only distinct on
+-- risk_results_project_created_msg_idx (project_id, created_at, chat_message_id).
+-- active_policies is a cheap scalar subquery, folded in here to save a round trip.
 SELECT
     COUNT(DISTINCT rr.chat_message_id)::BIGINT AS messages_scanned
-  , (COUNT(*) FILTER (
-      WHERE rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
-    ))::BIGINT AS findings
-  , (COUNT(DISTINCT cm.chat_id) FILTER (
-      WHERE rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
-        AND cm.chat_id IS NOT NULL
-    ))::BIGINT AS flagged_sessions
   , (
       SELECT COUNT(*)::BIGINT
       FROM risk_policies active_rp
@@ -532,10 +530,26 @@ SELECT
         AND deleted IS FALSE
     ) AS active_policies
 FROM risk_results rr
-JOIN chat_messages cm ON cm.id = rr.chat_message_id
 WHERE rr.project_id = @project_id
   AND rr.created_at >= @from_time
   AND rr.created_at < @to_time;
+
+-- name: GetRiskOverviewFindingCounts :one
+-- findings + flagged_sessions over the live-found subset. Pushing the found
+-- predicate into WHERE lets the partial risk_results_project_found_idx serve the
+-- scan, so the JOIN to chat_messages only touches found rows instead of every
+-- scanned row. COUNT(DISTINCT cm.chat_id) already skips NULL chat_ids.
+SELECT
+    COUNT(*)::BIGINT AS findings
+  , COUNT(DISTINCT cm.chat_id)::BIGINT AS flagged_sessions
+FROM risk_results rr
+JOIN chat_messages cm ON cm.id = rr.chat_message_id
+WHERE rr.project_id = @project_id
+  AND rr.created_at >= @from_time
+  AND rr.created_at < @to_time
+  AND rr.found IS TRUE
+  AND rr.excluded_at IS NULL
+  AND rr.false_positive_at IS NULL;
 
 -- name: ListRiskOverviewTopRules :many
 -- Project-wide finding counts grouped by rule_id within a window.

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1215,16 +1215,45 @@ func (q *Queries) GetRiskExclusionForReconcile(ctx context.Context, arg GetRiskE
 	return i, err
 }
 
-const getRiskOverviewCounts = `-- name: GetRiskOverviewCounts :one
+const getRiskOverviewFindingCounts = `-- name: GetRiskOverviewFindingCounts :one
+SELECT
+    COUNT(*)::BIGINT AS findings
+  , COUNT(DISTINCT cm.chat_id)::BIGINT AS flagged_sessions
+FROM risk_results rr
+JOIN chat_messages cm ON cm.id = rr.chat_message_id
+WHERE rr.project_id = $1
+  AND rr.created_at >= $2
+  AND rr.created_at < $3
+  AND rr.found IS TRUE
+  AND rr.excluded_at IS NULL
+  AND rr.false_positive_at IS NULL
+`
+
+type GetRiskOverviewFindingCountsParams struct {
+	ProjectID uuid.UUID
+	FromTime  pgtype.Timestamptz
+	ToTime    pgtype.Timestamptz
+}
+
+type GetRiskOverviewFindingCountsRow struct {
+	Findings        int64
+	FlaggedSessions int64
+}
+
+// findings + flagged_sessions over the live-found subset. Pushing the found
+// predicate into WHERE lets the partial risk_results_project_found_idx serve the
+// scan, so the JOIN to chat_messages only touches found rows instead of every
+// scanned row. COUNT(DISTINCT cm.chat_id) already skips NULL chat_ids.
+func (q *Queries) GetRiskOverviewFindingCounts(ctx context.Context, arg GetRiskOverviewFindingCountsParams) (GetRiskOverviewFindingCountsRow, error) {
+	row := q.db.QueryRow(ctx, getRiskOverviewFindingCounts, arg.ProjectID, arg.FromTime, arg.ToTime)
+	var i GetRiskOverviewFindingCountsRow
+	err := row.Scan(&i.Findings, &i.FlaggedSessions)
+	return i, err
+}
+
+const getRiskOverviewScanCounts = `-- name: GetRiskOverviewScanCounts :one
 SELECT
     COUNT(DISTINCT rr.chat_message_id)::BIGINT AS messages_scanned
-  , (COUNT(*) FILTER (
-      WHERE rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
-    ))::BIGINT AS findings
-  , (COUNT(DISTINCT cm.chat_id) FILTER (
-      WHERE rr.found IS TRUE AND rr.excluded_at IS NULL AND rr.false_positive_at IS NULL
-        AND cm.chat_id IS NOT NULL
-    ))::BIGINT AS flagged_sessions
   , (
       SELECT COUNT(*)::BIGINT
       FROM risk_policies active_rp
@@ -1233,34 +1262,31 @@ SELECT
         AND deleted IS FALSE
     ) AS active_policies
 FROM risk_results rr
-JOIN chat_messages cm ON cm.id = rr.chat_message_id
 WHERE rr.project_id = $1
   AND rr.created_at >= $2
   AND rr.created_at < $3
 `
 
-type GetRiskOverviewCountsParams struct {
+type GetRiskOverviewScanCountsParams struct {
 	ProjectID uuid.UUID
 	FromTime  pgtype.Timestamptz
 	ToTime    pgtype.Timestamptz
 }
 
-type GetRiskOverviewCountsRow struct {
+type GetRiskOverviewScanCountsRow struct {
 	MessagesScanned int64
-	Findings        int64
-	FlaggedSessions int64
 	ActivePolicies  int64
 }
 
-func (q *Queries) GetRiskOverviewCounts(ctx context.Context, arg GetRiskOverviewCountsParams) (GetRiskOverviewCountsRow, error) {
-	row := q.db.QueryRow(ctx, getRiskOverviewCounts, arg.ProjectID, arg.FromTime, arg.ToTime)
-	var i GetRiskOverviewCountsRow
-	err := row.Scan(
-		&i.MessagesScanned,
-		&i.Findings,
-		&i.FlaggedSessions,
-		&i.ActivePolicies,
-	)
+// messages_scanned counts every scanned message in the window regardless of
+// found state. chat_message_id is NOT NULL with a FK to chat_messages, so the
+// old JOIN was lossless — dropping it lets this be an index-only distinct on
+// risk_results_project_created_msg_idx (project_id, created_at, chat_message_id).
+// active_policies is a cheap scalar subquery, folded in here to save a round trip.
+func (q *Queries) GetRiskOverviewScanCounts(ctx context.Context, arg GetRiskOverviewScanCountsParams) (GetRiskOverviewScanCountsRow, error) {
+	row := q.db.QueryRow(ctx, getRiskOverviewScanCounts, arg.ProjectID, arg.FromTime, arg.ToTime)
+	var i GetRiskOverviewScanCountsRow
+	err := row.Scan(&i.MessagesScanned, &i.ActivePolicies)
 	return i, err
 }
 


### PR DESCRIPTION
messages_scanned — over all rows, uses the new index, no join to chat_messages.

findings + flagged_sessions — push found IS TRUE AND excluded_at IS NULL AND false_positive_at IS NULL to the scan level so it uses the existing partial _project_found_idx; 

the join to chat_messages then touches only the small found subset instead of every scanned row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the Risk Overview counts into two optimized queries to reduce scans and joins, speeding up the endpoint. Messages scanned now use an index-only path; findings and flagged sessions touch only found rows.

- **Performance**
  - Introduced `GetRiskOverviewScanCounts` (index-only DISTINCT on risk_results_project_created_msg_idx) and `GetRiskOverviewFindingCounts` (filters in WHERE to use risk_results_project_found_idx).
  - Removed the `chat_messages` join for messages_scanned; join runs only for found rows.
  - Inlined active policy count in the scan query to save a round trip.

<sup>Written for commit d30da2ef6389852885d6f6cab7e7db36495edfdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

