### PR TITLE
chore: drop stale fork requirement from PR skill

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,29 +7,19 @@ description: Create a Pull Request for the current changes and/or branch
 Create a Pull Request for the current changes and/or branch:
 
 1. Ask user what the scope of the changes is for context
-2. **Ensure repository is forked**: Check if the user has forked the repository. If not, create a fork using `gh repo fork` and set up the remote properly
-3. Use the current branch or create a new branch if on main
-4. **Validate conventional commit prefix**: Ensure PR title and any commits use proper conventional commit prefixes:
+2. Use the current branch or create a new branch if on main
+3. **Validate conventional commit prefix**: Ensure PR title and any commits use proper conventional commit prefixes:
    - `chore:` - for maintenance tasks, configuration changes, tooling updates
    - `feat:` - for new features or functionality additions
    - `fix:` - for bug fixes and error corrections
    - `mig:` - for database migrations and schema changes
    - Ask user to clarify the change type if unclear, and enforce one of these four prefixes
-5. If there are uncommitted changes, create a single line conventional commit summarizing the changes eg. `feat: add new feature`
-6. Ensure the branch is up-to-date with remote
-7. Push the branch to the user's fork (origin remote)
-8. Create a short but well-structured PR description in a temporary file (with a unique file name) in the /tmp directory for reviewers
-9. Create PR with the description file using GitHub CLI, ensuring the title starts with `chore:`, `feat:`, `fix:`, or `mig:` and targets the upstream repository
-10. Add appropriate labels based on change type (enhancement, bug, documentation, etc.). Ensure to query for the available labels beforehand.
-11. Provide a clickable link to the PR in the output
+4. If there are uncommitted changes, create a single line conventional commit summarizing the changes eg. `feat: add new feature`
+5. Ensure the branch is up-to-date with `origin/main`
+6. Push the branch to `origin`
+7. Create a short but well-structured PR description in a temporary file (with a unique file name) in the /tmp directory for reviewers
+8. Create PR with the description file using GitHub CLI, ensuring the title starts with `chore:`, `feat:`, `fix:`, or `mig:` and targets `main`
+9. Add appropriate labels based on change type (enhancement, bug, documentation, etc.). Ensure to query for the available labels beforehand.
+10. Provide a clickable link to the PR in the output
 
 Follow conventional commit standards and keep PR descriptions concise but informative. **IMPORTANT**: All PR titles MUST start with one of the four prefixes: `chore:`, `feat:`, `fix:`, or `mig:`.
-
-## Fork Requirements
-
-All pull requests must be submitted from a personal fork of the repository. The command should:
-
-- Check if a fork exists using `gh repo view --json parent` to determine if current repo is a fork
-- If not a fork, create one with `gh repo fork --clone=false`
-- Set up remotes properly: `origin` should point to the user's fork, `upstream` to the original repository
-- Push changes to the fork and create the PR targeting the upstream repository


### PR DESCRIPTION
Follow-up to #4305.

The `/pr` skill required every PR to come from a personal fork. Nobody does this: `gh repo view --json parent` returns null, and every recent merged PR heads from a branch on `speakeasy-api/gram` directly. The instructions described a workflow that doesn't exist and pointed the skill at an `upstream` remote that isn't configured.

Removed the fork step, the "Fork Requirements" section, and the `upstream` references. Steps 5, 6, and 8 now name `origin` and `main` directly, which is what they always meant in practice.

No replacement section — the numbered steps already say where to push and what to target, so a "Branching" heading restating it would just be another thing to go stale.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated personal fork requirement from the `/pr` skill and defaulted pushes/PRs to `origin/main`. This matches our workflow of opening PRs from branches on `speakeasy-api/gram` and prevents issues with a missing `upstream` remote.

- **Refactors**
  - Deleted the “Fork Requirements” section and fork checks (`gh repo view --json parent`, `gh repo fork`).
  - Updated steps to sync with `origin/main`, push to `origin`, and open the PR against `main`.
  - Kept conventional commit guidance; reordered steps accordingly.

<sup>Written for commit 7d6832091084fcad9b6c29f6ebe4aaa528ef049f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

