### PR TITLE
chore(ci): gate dispatch-release on ci-gate

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1960,6 +1960,7 @@ jobs:
       - atlas-push
       - webhooks-catalog-breaking-changes
       - tunnel-agent
+      - svix-sync-webhooks
     steps:
       - name: Check results
         env:
@@ -2006,11 +2007,7 @@ jobs:
 
   dispatch-release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs:
-      - ci-gate
-      - docker-build-server
-      - assistant-runtime-image
-      - svix-sync-webhooks
+    needs: [ci-gate]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2006,7 +2006,11 @@ jobs:
 
   dispatch-release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [docker-build-server, assistant-runtime-image, svix-sync-webhooks]
+    needs:
+      - ci-gate
+      - docker-build-server
+      - assistant-runtime-image
+      - svix-sync-webhooks
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Generate GitHub App Token


### PR DESCRIPTION
`dispatch-release` did not depend on `ci-gate`. It teed off `docker-build-server`, `assistant-runtime-image` and `svix-sync-webhooks` only, so a push to `main` could dispatch **Prepare Release** to `gram-infra` while `server-test`, `client-build-lint`, `atlas-lint` or any other check was still red.

This adds `ci-gate` to its `needs`, making the gate the final node that release tees off.

## Why the other needs stay

`needs: [ci-gate]` on its own would have been a behaviour change. `ci-gate` is `if: always()` and computes pass/fail itself, deliberately treating **skipped** jobs as passing — so it succeeds on every green run, including docs-only commits where no image was built.

`needs:` defaults to `success()`, and a skipped need does not satisfy it. Today `dispatch-release` inherits its skip from `docker-build-server` (`if: needs.changes.outputs.server == 'true'`), which is what stops docs-only pushes from cutting a release. Keeping the image jobs preserves that skip; adding `ci-gate` adds the gating.

## Verification

Parsed the workflow and walked the job graph: no cycles, all needs resolve.

## Follow-up (not in this PR)

`svix-sync-webhooks` is a release dependency but is not among `ci-gate`'s needs, so it sits outside the required status check. Worth adding if we want `ci-gate` to be the single source of truth for "is `main` healthy".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `dispatch-release` solely on `ci-gate` so releases only dispatch after CI is green. Also add `svix-sync-webhooks` to `ci-gate` so it’s included in the gate.

- **Bug Fixes**
  - Set `dispatch-release.needs` to [`ci-gate`] only.
  - Added `svix-sync-webhooks` to `ci-gate.needs`.

<sup>Written for commit bae1208fa5e30bc06cf47a0b12a6cd9dafa2e973. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

