### PR TITLE
fix(dashboard): never inline fonts as base64

### DIFF
--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -195,6 +195,16 @@ export default defineConfig(({ command }) => {
     },
     build: {
       sourcemap: true,
+      // Fonts must stay as standalone asset files — inlining them as base64
+      // bloats the CSS bundle and defeats CDN caching of the font files.
+      // Returning undefined keeps Vite's default inlining behavior for
+      // everything else.
+      assetsInlineLimit(filePath) {
+        if (/\.(?:woff2?|ttf|otf|eot)$/i.test(filePath)) {
+          return false;
+        }
+        return undefined;
+      },
       rolldownOptions: {
         input: {
           main: path.resolve(__dirname, "index.html"),


### PR DESCRIPTION
## What

Adds a `build.assetsInlineLimit` callback to the dashboard vite config that opts all font files (`.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`) out of base64 inlining, so they are always emitted as standalone assets. All other asset types keep Vite's default 4KB inline threshold.

## Why

Small fonts fell under the default threshold — e.g. `speakeasy-ascii.woff2` (~2KB) was base64-inlined into the CSS bundle. That:

- violates our CSP, whose `font-src` does not allow `data:` URLs — inlined fonts would be blocked by the browser
- defeats CDN caching of font files (follow-up to #4303)
- bloats the stylesheet

## Verification

Ran a full production build: all fonts (ABC Diatype, speakeasy-ascii, KaTeX, codicon) are emitted as files under `dist/assets/`, the built CSS references them by relative URL, and no `data:` font URIs remain in any emitted CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update dashboard `vite` build to never base64-inline fonts (`.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`), always emitting them as files. This fixes CSP `font-src` violations, enables CDN caching, and avoids CSS bloat; other assets keep `vite`’s default inline limit.

<sup>Written for commit 6b662e97dbba31165769f08499342d1f80198acb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

