### PR TITLE
fix: Prefill company field in demo booking flow

### DIFF
--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -2,12 +2,16 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { CAL_DEMO_LINK } from "./demo-booking";
 
-type MockSession = { user: { email: string; displayName?: string } } | null;
+type MockSession = {
+  user: { email: string; displayName?: string };
+  organization?: { name: string };
+} | null;
 const { captureMock, sessionHolder } = vi.hoisted(() => ({
   captureMock: vi.fn(),
   sessionHolder: {
     current: {
       user: { email: "jane@acme.com", displayName: "Jane Smith" },
+      organization: { name: "Acme Inc" },
     } as MockSession,
   },
 }));
@@ -19,13 +23,14 @@ vi.mock("@calcom/embed-react", () => ({
     config,
   }: {
     calLink: string;
-    config?: { name?: string; email?: string };
+    config?: { name?: string; email?: string; company?: string };
   }) => (
     <div
       data-testid="cal-embed"
       data-cal-link={calLink}
       data-cal-name={config?.name ?? ""}
       data-cal-email={config?.email ?? ""}
+      data-cal-company={config?.company ?? ""}
     />
   ),
 }));
@@ -44,6 +49,7 @@ beforeEach(() => {
   captureMock.mockClear();
   sessionHolder.current = {
     user: { email: "jane@acme.com", displayName: "Jane Smith" },
+    organization: { name: "Acme Inc" },
   };
 });
 
@@ -56,11 +62,12 @@ describe("DemoBookingFlow", () => {
     expect(embed.getAttribute("data-cal-link")).toBe(CAL_DEMO_LINK);
   });
 
-  it("prefills name and email from the session", () => {
+  it("prefills name, email, and company from the session", () => {
     render(<DemoBookingFlow />);
     const embed = screen.getByTestId("cal-embed");
     expect(embed.getAttribute("data-cal-name")).toBe("Jane Smith");
     expect(embed.getAttribute("data-cal-email")).toBe("jane@acme.com");
+    expect(embed.getAttribute("data-cal-company")).toBe("Acme Inc");
   });
 
   it("renders the embed even before the session resolves", () => {
@@ -70,6 +77,7 @@ describe("DemoBookingFlow", () => {
     expect(embed.getAttribute("data-cal-link")).toBe(CAL_DEMO_LINK);
     expect(embed.getAttribute("data-cal-name")).toBe("");
     expect(embed.getAttribute("data-cal-email")).toBe("");
+    expect(embed.getAttribute("data-cal-company")).toBe("");
   });
 
   it("fires booked_demo on a Cal bookingSuccessful message", () => {

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -17,6 +17,9 @@ export function DemoBookingFlow(): JSX.Element {
   const email = session?.user.email ?? "";
   const { firstName, lastName } = splitDisplayName(session?.user.displayName);
   const name = [firstName, lastName].filter(Boolean).join(" ");
+  // The org is created from the company name entered during sign-up, so it
+  // doubles as the answer to the Cal form's company question.
+  const companyName = session?.organization?.name ?? "";
 
   useEffect(() => {
     const handler = (e: MessageEvent) => {
@@ -62,6 +65,9 @@ export function DemoBookingFlow(): JSX.Element {
             hideEventTypeDetails: "true",
             name,
             email,
+            // Prefill key must match the booking question's identifier on the
+            // Cal event (see CAL_DEMO_LINK).
+            company: companyName,
             cssVarsPerTheme: JSON.stringify({
               light: { "cal-bg": "transparent" },
               dark: { "cal-bg": "transparent" },


### PR DESCRIPTION
## Summary
Add support for prefilling the company field in the Cal booking embed by extracting the organization name from the session and passing it to the Cal form configuration.

## Changes
- Extended `MockSession` type to include optional `organization` field with a `name` property
- Updated the Cal embed mock to accept a `company` config parameter and render it as a data attribute
- Added logic to extract `companyName` from `session?.organization?.name` in `DemoBookingFlow`
- Pass the `company` field to the Cal embed config to prefill the company question on the booking form
- Updated test cases to verify the company field is correctly prefilled from the session organization and rendered as an empty string before the session resolves

## Implementation Details
The organization name (created from the company name entered during sign-up) is reused as the answer to the Cal form's company question. This eliminates the need for users to re-enter their company information during the booking flow.

https://claude.ai/code/session_01HLT1gMYEof3UpG5rRTfYFK