### PR TITLE
fix(dashboard): make plugin assignments dropdown scrollable

### DIFF
--- a/.changeset/dno-549-assignments-dropdown-scroll.md
+++ b/.changeset/dno-549-assignments-dropdown-scroll.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the plugin assignments dropdown not scrolling when it contains many users/roles. The multi-select popover is portaled inside the modal assignments sheet, so make its popover modal to restore mouse-wheel scrolling of the options list.

--- a/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
+++ b/client/dashboard/src/pages/plugins/PluginAssignmentsSheet.tsx
@@ -189,6 +189,7 @@ function AssignmentsEditor({
           creatable
           searchable
           hideSelectAll
+          modalPopover
           maxCount={20}
         />
         <Type muted small className="mt-2">


### PR DESCRIPTION
## What

The plugin **Manage assignments** dropdown (roles / users / emails multi-select) could not be scrolled with the mouse wheel, so with a long list it was impossible to reach and select options below the fold.

## Root cause

The assignments editor renders a `MultiSelect` inside a `Sheet` (a Radix Dialog, which is modal by default). A modal Radix dialog engages `react-remove-scroll`, which blocks wheel scrolling everywhere except inside the dialog's own content subtree. The `MultiSelect` popover, however, is portaled to `document.body` — outside that subtree — so its options list fell outside the scroll-lock allowlist and the wheel did nothing over it. (Keyboard arrow navigation still scrolled, a classic tell for this interaction.)

## Fix

Pass `modalPopover` to the `MultiSelect` in `PluginAssignmentsSheet.tsx`. This makes the popover mount its own `react-remove-scroll` instance that allowlists the popover content, restoring wheel/trackpad scrolling of the options list. One-line, scoped to this component.

## Testing

- The added prop is already part of the `MultiSelect` API (`modalPopover` → Radix Popover `modal`), so it's type-safe and low risk.
- Manual check: open **Plugins → a plugin → Manage assignments**, add enough roles/users to overflow the list, and confirm the dropdown now scrolls with the wheel.

Fixes DNO-549

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix scrolling in the plugin Manage assignments dropdown when there are many users/roles. Set `modalPopover` on the `MultiSelect` in `PluginAssignmentsSheet.tsx` so its popover lives inside the modal `Sheet`, restoring wheel/trackpad scrolling (DNO-549).

<sup>Written for commit df4e3948628d8f12b2c973a588e40e948a226467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

