### PR TITLE
fix(dashboard): give logo svgs an intrinsic size so Safari renders them

### DIFF
--- a/client/dashboard/src/components/gram-logo/variants/horizontal.tsx
+++ b/client/dashboard/src/components/gram-logo/variants/horizontal.tsx
@@ -1,6 +1,16 @@
 export const GramLogoHorizontal = (): JSX.Element => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 1000 160">
+    // Explicit width/height + h-auto: Safari collapses an unsized svg in an
+    // auto-height flex parent to 0px tall instead of deriving the aspect
+    // ratio from the viewBox alone.
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 1000 160"
+      width="1000"
+      height="160"
+      className="h-auto w-full"
+    >
       <path
         d="M983.132 33.08L958.201 101.302L932.453 33.08H915.584L949.69 120.736L945.46 130.657C944.264 133.599 943.222 135.684 942.395 136.828L942.323 136.93C941.649 138.095 940.76 138.892 939.605 139.362C938.389 139.873 936.479 140.128 933.924 140.128H920.601V154.821H938.144C942.231 154.821 945.562 154.157 948.065 152.849C950.579 151.531 952.704 149.477 954.359 146.739C955.953 144.113 957.802 140.149 959.836 134.948L1000 33.0698H983.121L983.132 33.08Z"
         fill="#232323"

--- a/client/dashboard/src/components/gram-logo/variants/icon.tsx
+++ b/client/dashboard/src/components/gram-logo/variants/icon.tsx
@@ -1,6 +1,16 @@
 export const GramIcon = (): JSX.Element => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 97">
+    // Explicit width/height + h-auto: Safari collapses an unsized svg in an
+    // auto-height flex parent to 0px tall instead of deriving the aspect
+    // ratio from the viewBox alone.
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 100 97"
+      width="100"
+      height="97"
+      className="h-auto w-full"
+    >
       <path
         d="M70.9355 91.3402L5.05057 81.9787L0 86.3592L70.9355 96.4351L100 71.2201L94.9557 70.5059L70.9355 91.3402Z"
         fill="#232323"


### PR DESCRIPTION
## Summary

The Speakeasy logo in the dashboard sidebar rendered as an invisible 0×0 box in Safari (macOS and iOS), while Chrome and Firefox displayed it correctly.

The logo SVGs (`GramLogoHorizontal`, `GramIcon`) had only a `viewBox` — no `width`/`height` attributes. Safari resolves an unsized svg's auto height against its auto-height flex wrapper (`<div class="flex items-center w-28">`), which circularly resolves to 0px. Chrome and Firefox instead derive the aspect ratio from the viewBox, which is why the bug was Safari-only.

## Fix

Give each logo svg an intrinsic size (`width`/`height` attributes matching the viewBox) plus `className="h-auto w-full"` so it scales to whatever width the wrapper sets. All call sites (app sidebar, org sidebar, login, onboarding, error pages) keep their existing wrapper-based sizing. The `vertical` variant re-exports `GramLogoHorizontal`, so the two edited files cover all three variants.

## Verification

Drove the local dashboard in Playwright WebKit (Safari's engine) and measured the logo svg's bounding box:

| Markup                                   | Rendered size in WebKit             |
| ---------------------------------------- | ----------------------------------- |
| Before (viewBox only)                    | 0 × 0 (invisible)                   |
| After (intrinsic size + `w-full h-auto`) | 112 × 17.9 (correct 1000:160 ratio) |

Also confirmed visually via WebKit screenshot. `pnpm -F dashboard lint` and `type-check` pass.

## Before

<img width="560" height="400" alt="before-safari-crop" src="https://github.com/user-attachments/assets/61e4a1c6-9659-49d2-84f3-b7b2f9ae19a7" />

## After

<img width="560" height="400" alt="after-safari-crop" src="https://github.com/user-attachments/assets/8a4cee84-ee2f-4807-8912-e703c68813ba" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Safari rendering of the dashboard logos by giving the SVGs intrinsic width/height and responsive sizing. This resolves the 0×0 logo issue on macOS and iOS while keeping existing wrapper-based sizing.

- **Bug Fixes**
  - Set width/height to match the viewBox and added className="h-auto w-full" on `GramLogoHorizontal` and `GramIcon`.
  - Verified in WebKit; no changes needed at call sites and other browsers remain unchanged.

<sup>Written for commit 0b1a8e58b476d23e68666dde8b9f07ebcad2e381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

