### PR TITLE
fix: return per-user and project TotalCost from metrics summaries (DNO-553)

### DIFF
--- a/.changeset/user-metrics-total-cost.md
+++ b/.changeset/user-metrics-total-cost.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix `TotalCost` (and cache token counts) always returning 0 from `telemetry.getUserMetricsSummary` and `telemetry.getProjectMetricsSummary` — the summary queries never selected the `total_cost`, `cache_read_input_tokens`, and `cache_creation_input_tokens` columns even though cost is attributed on every usage row. Also surface ClickHouse execution errors from the summary queries instead of silently returning an all-zero summary when a query fails mid-stream, which made transient failures look like "no activity" for the requested window.

--- a/server/internal/telemetry/get_metrics_summary_test.go
+++ b/server/internal/telemetry/get_metrics_summary_test.go
@@ -53,6 +53,43 @@ func TestGetProjectMetricsSummary_Empty(t *testing.T) {
 	require.Equal(t, int64(0), result.Metrics.TotalToolCalls)
 }
 
+func TestGetProjectMetricsSummary_CostAndCacheTokens(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userID := "project-cost-user-" + uuid.New().String()
+
+	insertChatCompletionLogWithCost(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, 100, 50, 1.5, 400, 80)
+	insertChatCompletionLogWithCost(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), userID, 200, 100, 2.25, 600, 120)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetProjectMetricsSummary(ctx, &gen.GetProjectMetricsSummaryPayload{
+			From: from,
+			To:   to,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+
+		m := res.Metrics
+		assert.InDelta(c, 3.75, m.TotalCost, 1e-9)              // 1.5 + 2.25
+		assert.Equal(c, int64(1000), m.CacheReadInputTokens)    // 400 + 600
+		assert.Equal(c, int64(200), m.CacheCreationInputTokens) // 80 + 120
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
 func TestGetProjectMetricsSummary(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/telemetry/get_user_metrics_summary_test.go
+++ b/server/internal/telemetry/get_user_metrics_summary_test.go
@@ -395,6 +395,89 @@ func TestGetUserMetricsSummary_OnlyChatCompletions(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
+func TestGetUserMetricsSummary_CostAndCacheTokens(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userID := "cost-user-" + uuid.New().String()
+	otherUserID := "other-cost-user-" + uuid.New().String()
+
+	insertChatCompletionLogWithCost(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), userID, 100, 50, 1.5, 400, 80)
+	insertChatCompletionLogWithCost(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), userID, 200, 100, 2.25, 600, 120)
+
+	// Another user's cost must not leak into the target user's summary
+	insertChatCompletionLogWithCost(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), otherUserID, 500, 250, 9.75, 1000, 200)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.GetUserMetricsSummary(ctx, &gen.GetUserMetricsSummaryPayload{
+			From:   from,
+			To:     to,
+			UserID: &userID,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) || !assert.NotNil(c, res.Metrics) {
+			return
+		}
+
+		m := res.Metrics
+		assert.InDelta(c, 3.75, m.TotalCost, 1e-9)              // 1.5 + 2.25
+		assert.Equal(c, int64(1000), m.CacheReadInputTokens)    // 400 + 600
+		assert.Equal(c, int64(200), m.CacheCreationInputTokens) // 80 + 120
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+// insertChatCompletionLogWithCost inserts a chat completion log carrying cost and
+// cache token usage attributes for a user.
+func insertChatCompletionLogWithCost(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID string, inputTokens, outputTokens int, costUSD float64, cacheReadTokens, cacheCreationTokens int) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gen_ai.conversation.id":                   uuid.New().String(),
+		"gen_ai.response.id":                       uuid.New().String(),
+		"gen_ai.usage.input_tokens":                inputTokens,
+		"gen_ai.usage.output_tokens":               outputTokens,
+		"gen_ai.usage.total_tokens":                inputTokens + outputTokens,
+		"gen_ai.usage.cost":                        costUSD,
+		"gen_ai.usage.cache_read.input_tokens":     cacheReadTokens,
+		"gen_ai.usage.cache_creation.input_tokens": cacheCreationTokens,
+		"gen_ai.response.model":                    "gpt-4",
+		"gen_ai.provider.name":                     "openai",
+		"gram.resource.urn":                        "chat:completion",
+		"user.id":                                  userID,
+	}
+
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_deployment_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, deploymentID, "chat:completion", "gram-server")
+	require.NoError(t, err)
+}
+
 // insertChatCompletionLogWithUser inserts a chat completion log with user identification attributes.
 func insertChatCompletionLogWithUser(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, chatID string, inputTokens, outputTokens, totalTokens int, durationSec float64, finishReason, model, provider, userID, externalUserID string) {
 	t.Helper()

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1458,7 +1458,12 @@ func (q *Queries) GetMetricsSummary(ctx context.Context, arg GetMetricsSummaryPa
 		"sumIfMerge(total_input_tokens) AS total_input_tokens",
 		"sumIfMerge(total_output_tokens) AS total_output_tokens",
 		"sumIfMerge(total_tokens) AS total_tokens",
+		"sumIfMerge(cache_read_input_tokens) AS cache_read_input_tokens",
+		"sumIfMerge(cache_creation_input_tokens) AS cache_creation_input_tokens",
 		"avgIfMerge(avg_tokens_per_request) AS avg_tokens_per_request",
+
+		// Cost metrics
+		"sumIfMerge(total_cost) AS total_cost",
 
 		// Chat request metrics
 		"countIfMerge(total_chat_requests) AS total_chat_requests",
@@ -1506,6 +1511,13 @@ func (q *Queries) GetMetricsSummary(ctx context.Context, arg GetMetricsSummaryPa
 	defer rows.Close()
 
 	if !rows.Next() {
+		// A summary aggregate with no GROUP BY always yields one row on success,
+		// so a missing row means the query failed mid-stream (e.g. under
+		// ClickHouse concurrency or memory pressure) — surface that instead of
+		// silently reporting an all-zero summary.
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("reading metrics summary row: %w", err)
+		}
 		// Return empty metrics if no rows
 		return &MetricsSummaryRow{
 			FirstSeenUnixNano:        0,
@@ -1823,6 +1835,11 @@ func (q *Queries) GetOverviewSummary(ctx context.Context, arg GetOverviewSummary
 	defer rows.Close()
 
 	if !rows.Next() {
+		// Distinguish "no data" from a query that failed mid-stream; without
+		// this an execution error is reported as an all-zero overview.
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("reading overview summary row: %w", err)
+		}
 		return &OverviewSummary{
 			TotalChats:               0,
 			ResolvedChats:            0,
@@ -2523,7 +2540,12 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') AS total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') AS total_output_tokens",
 		totalTokensExpr+" AS total_tokens",
+		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens)), toString(attributes.gen_ai.usage.cache_read.input_tokens) != '') AS cache_read_input_tokens",
+		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens)), toString(attributes.gen_ai.usage.cache_creation.input_tokens) != '') AS cache_creation_input_tokens",
 		"avgIf(toFloat64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS avg_tokens_per_request",
+
+		// Cost metrics (per-request cost attributed on each usage row)
+		"sumIf(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') AS total_cost",
 
 		// Chat request metrics
 		"uniqExactIf(toString(attributes.gen_ai.response.id), toString(attributes.gen_ai.response.id) != '') AS total_chat_requests",
@@ -2588,6 +2610,13 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 	defer rows.Close()
 
 	if !rows.Next() {
+		// A summary aggregate with no GROUP BY always yields one row on success,
+		// so a missing row means the query failed mid-stream (e.g. under
+		// ClickHouse concurrency or memory pressure) — surface that instead of
+		// silently reporting an all-zero summary.
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("reading metrics summary row: %w", err)
+		}
 		// Return empty metrics if no rows
 		return &MetricsSummaryRow{
 			FirstSeenUnixNano:        0,
@@ -2632,7 +2661,10 @@ func (q *Queries) GetUserMetricsSummary(ctx context.Context, arg GetUserMetricsS
 		&metrics.TotalInputTokens,
 		&metrics.TotalOutputTokens,
 		&metrics.TotalTokens,
+		&metrics.CacheReadInputTokens,
+		&metrics.CacheCreationInputTokens,
 		&metrics.AvgTokensPerReq,
+		&metrics.TotalCost,
 		&metrics.TotalChatRequests,
 		&metrics.AvgChatDurationMs,
 		&metrics.FinishReasonStop,


### PR DESCRIPTION
Fixes the two data-quality issues reported in [DNO-553](https://linear.app/speakeasy/issue/DNO-553/bug-per-user-metrics-totalcost-always-0-bounded-time-window-returns).

## Issue 1 — `TotalCost` always 0

The `GetUserMetricsSummary` ClickHouse query hand-builds its SELECT list and simply never selected `total_cost`, `cache_read_input_tokens`, or `cache_creation_input_tokens` — the positional `rows.Scan` skipped those struct fields, so they stayed at their Go zero values for every user and every window. Cost **is** attributed per usage row (`attributes.gen_ai.usage.cost`); the sibling `searchUsers` and overview queries already sum it from the same rows.

The project-level `GetMetricsSummary` had the same gap: it reads the `metrics_summaries` MV, which already carries `total_cost` / cache-token aggregate states, but never merged them.

- Per-user query now selects all three columns (same `sumIf` expressions as `searchUsers`).
- Project query now merges all three MV states (same `sumIfMerge` as the overview).

## Issue 2 — bounded windows silently returning zeros

The `if !rows.Next()` branches of the summary queries returned an all-zero summary without checking `rows.Err()`. A grouped-aggregate query with no `GROUP BY` always yields exactly one row on success, so a missing row means the query **failed mid-stream** (ClickHouse concurrency/memory pressure — e.g. the 15s upstream timeouts visible in Datadog for this endpoint). Those failures surfaced as "all zeros", easy to misread as no activity. They now propagate as errors (user summary, project summary, and observability overview).

Note on the reported "from-only → 500": production logs at `2026-07-17T15:08:43Z` show the actual failure was `'from' time must be before 'to' time` — the assistant passed a `from` at/after the defaulted `to=now`, so that part is request-side rather than a server bug. The error-swallowing fix above ensures any genuine query failure is no longer disguised as an empty result.

## Testing

- New `TestGetUserMetricsSummary_CostAndCacheTokens` (red before the fix: `TotalCost` 0 vs expected 3.75) and `TestGetProjectMetricsSummary_CostAndCacheTokens` (exercises the full MV path), both asserting cost and cache-token sums and cross-user isolation.
- Full `internal/telemetry` package passes; server builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-user and project metrics to return correct TotalCost and cache token counts, and surfaces ClickHouse errors instead of returning all-zero summaries for bounded windows. Addresses Linear DNO-553.

- **Bug Fixes**
  - `GetUserMetricsSummary`: now selects `total_cost`, `cache_read_input_tokens`, and `cache_creation_input_tokens` (same `sumIf` as `searchUsers`) and scans them into the result.
  - `GetMetricsSummary`: now merges `total_cost`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from the `metrics_summaries` MV (same `sumIfMerge` as the overview).
  - Error handling: `GetUserMetricsSummary`, `GetMetricsSummary`, and `GetOverviewSummary` now check `rows.Err()` when `!rows.Next()` and return an error instead of an all-zero summary.

<sup>Written for commit 284aa28356a7b0b9b539a0d3582141bf44575b08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

