### PR TITLE
chore: fix release transitive skip

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2007,8 +2007,26 @@ jobs:
 
   dispatch-release:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [ci-gate]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      [
+        ci-gate,
+        docker-build-server,
+        assistant-runtime-image,
+        svix-sync-webhooks,
+      ]
+    # ci-gate's transitive needs include path-filtered jobs, and a skipped job
+    # anywhere in the needs chain skips dependents under the default success()
+    # condition even when every direct need succeeded. !cancelled() opts out of
+    # that propagation, so each need's result must be checked explicitly: ci-gate
+    # green gates the release, and the image/sync jobs succeeding (not skipped)
+    # keeps docs-only pushes from dispatching one.
+    if: >-
+      !cancelled() &&
+      needs.ci-gate.result == 'success' &&
+      needs.docker-build-server.result == 'success' &&
+      needs.assistant-runtime-image.result == 'success' &&
+      needs.svix-sync-webhooks.result == 'success' &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Generate GitHub App Token
         id: generate-token


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the release workflow so it doesn’t get skipped when upstream path-filtered jobs are skipped. Only dispatches a release on main when all build and sync jobs actually succeed; docs-only pushes won’t trigger a release.

- **Bug Fixes**
  - Expanded `dispatch-release` needs to include `ci-gate`, `docker-build-server`, `assistant-runtime-image`, and `svix-sync-webhooks`.
  - Replaced default success checks with `!cancelled()` and explicit `needs.*.result == 'success'`.
  - Still runs only on `push` to `main`; avoids releases when image/sync jobs are skipped (e.g., docs-only changes).

<sup>Written for commit 6a477792e34853ebbabe91bde1948778429cb38e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

