### PR TITLE
chore(agents): forbid customer-identifying data in anything committed or pushed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,18 @@ This document provides an overview of the key directories in the Gram project to
 If you've just cloned this repository, then consider running `./zero --agent` to get your development environment set up.
 </tip>
 
+## Customer Data Is Confidential
+
+<important>
+
+Never include customer-identifying information in anything that gets committed or pushed: customer names, organization ids, project ids, external account ids, emails, or revenue/spend figures. This applies to EVERY surface that leaves the machine — branch names, commit messages, PR titles and bodies, file contents, file NAMES, changesets, test fixtures, and code comments. This repository is public, and pushed data propagates to surfaces that cannot be scrubbed afterwards: pull request refs outlive branch deletion, CI logs embed PR titles, and review bots ingest full diffs.
+
+- Use placeholders (`<PROJECT_ID>`, `<ORG_ID>`, "the customer") in runbooks, migrations, docs, and tests — even when hardcoding a real value would be more convenient. Keep concrete values in internal systems (e.g. Linear) and fill them in at execution time.
+- Ticket ids (e.g. ABC-123) are fine; ticket URLs whose slugs embed a customer name are not.
+- Before committing or pushing, check every surface: branch name, commit message, changed file contents and names, changeset text, PR title/body.
+
+</important>
+
 ## Key Directories
 
 <structure>


### PR DESCRIPTION
## Summary

Adds a "Customer Data Is Confidential" section to the agent guide (`CLAUDE.md`, surfaced to all agents via the `AGENTS.md` symlink), placed at the top so it is read before any work starts.

It forbids customer-identifying information — names, org/project/account ids, emails, revenue/spend figures — in anything committed or pushed, and enumerates every surface that leaves the machine: branch names, commit messages, PR titles/bodies, file contents, file **names**, changesets, test fixtures, and comments. It explains why this is unrecoverable once pushed (public repo; pull request refs outlive branch deletion, CI logs embed PR titles, review bots ingest full diffs) and prescribes the safe pattern: placeholders like `<PROJECT_ID>` in repo artifacts, concrete values kept in internal systems and filled in at execution time, plus a pre-push checklist.

## Context

A recent PR had to be closed and scrubbed because it carried customer identifiers across several of these surfaces, some of which cannot be removed after the fact. This makes the policy explicit for every agent working in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Customer Data Is Confidential" policy to `CLAUDE.md` (surfaced via `AGENTS.md`) that forbids customer-identifying info in anything committed or pushed. Includes safe patterns (placeholders like `<PROJECT_ID>`) and a pre-push checklist covering branch names, commits, PR titles/bodies, file contents, file names, fixtures, and comments.

<sup>Written for commit 40bdbae01d1f744e8c9ff10fdb2f7fa9f4d784ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

