### PR TITLE
feat(assistants): expose skill data to project assistant

### DIFF
--- a/.changeset/project-assistant-skill-tools.md
+++ b/.changeset/project-assistant-skill-tools.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Give the Project Assistant read-only platform tools to list project skills, inspect the latest skill content, review version history, and inspect plugin distributions.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -769,7 +769,7 @@ func newStartCommand() *cli.Command {
 			memoryTools := platformtoolsruntime.MemoryExternalTools(memorySvc)
 			triggerTools := platformtoolsruntime.TriggerExternalTools(db, triggerApp, auditLogger)
 			// mcpService captures this map by reference now; the remaining
-			// insights tools (chat/orgs/risk/deployments) are merged in once
+			// insights tools (chat/orgs/risk/deployments/skills) are merged in once
 			// their backing services exist further down.
 			managedInsightsTools := append([]platformtools.ExternalTool{}, platformtoolsruntime.ManagedAssistantLogsTools(telemSvc)...)
 			platformToolsets := map[string]platformtools.Toolset{}
@@ -1125,7 +1125,8 @@ func newStartCommand() *cli.Command {
 			pluginsSvc := plugins.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, pluginsGitHub, c.String("environment"), c.String("server-url"), featureFlags)
 			plugins.Attach(mux, pluginsSvc)
 			productfeatures.Attach(mux, productfeatures.NewService(logger, tracerProvider, db, sessionManager, redisClient, authzEngine, auditLogger))
-			skills.Attach(mux, skills.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger))
+			skillsService := skills.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger)
+			skills.Attach(mux, skillsService)
 			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil)
 			toolsets.Attach(mux, toolsetsSvc)
 			integrations.Attach(mux, integrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
@@ -1203,6 +1204,7 @@ func newStartCommand() *cli.Command {
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantUsersTools(organizationsService)...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantRiskTools(riskService)...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantDeploymentsTools(deploymentsService)...)
+			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantSkillsTools(skillsService)...)
 			maps.Copy(platformToolsets, platformtools.BuildToolsets(platformtools.ToolsetDependencies{
 				AssistantMemoryTools:          memoryTools,
 				AssistantTriggerTools:         triggerTools,

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -23,6 +23,7 @@ import (
 	platformlogs "github.com/speakeasy-api/gram/server/internal/platformtools/logs"
 	platformmemory "github.com/speakeasy-api/gram/server/internal/platformtools/memory"
 	platformrisk "github.com/speakeasy-api/gram/server/internal/platformtools/risk"
+	platformskills "github.com/speakeasy-api/gram/server/internal/platformtools/skills"
 	platformtriggers "github.com/speakeasy-api/gram/server/internal/platformtools/triggers"
 	platformusers "github.com/speakeasy-api/gram/server/internal/platformtools/users"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
@@ -177,6 +178,17 @@ func ManagedAssistantRiskTools(riskSvc platformrisk.RiskService) []platformtools
 func ManagedAssistantDeploymentsTools(deploymentsSvc platformdeployments.DeploymentsService) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
 		{Executor: platformdeployments.NewGetDeploymentLogsTool(deploymentsSvc), RequiredFeature: ""},
+	}
+}
+
+// ManagedAssistantSkillsTools returns read-only skill management tools for the
+// project's managed assistant.
+func ManagedAssistantSkillsTools(skillsSvc platformskills.SkillsService) []platformtools.ExternalTool {
+	return []platformtools.ExternalTool{
+		{Executor: platformskills.NewListTool(skillsSvc), RequiredFeature: ""},
+		{Executor: platformskills.NewGetTool(skillsSvc), RequiredFeature: ""},
+		{Executor: platformskills.NewListVersionsTool(skillsSvc), RequiredFeature: ""},
+		{Executor: platformskills.NewListDistributionsTool(skillsSvc), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -185,10 +185,10 @@ func ManagedAssistantDeploymentsTools(deploymentsSvc platformdeployments.Deploym
 // project's managed assistant.
 func ManagedAssistantSkillsTools(skillsSvc platformskills.SkillsService) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
-		{Executor: platformskills.NewListTool(skillsSvc), RequiredFeature: ""},
-		{Executor: platformskills.NewGetTool(skillsSvc), RequiredFeature: ""},
-		{Executor: platformskills.NewListVersionsTool(skillsSvc), RequiredFeature: ""},
-		{Executor: platformskills.NewListDistributionsTool(skillsSvc), RequiredFeature: ""},
+		{Executor: platformskills.NewListTool(skillsSvc), RequiredFeature: "skills"},
+		{Executor: platformskills.NewGetTool(skillsSvc), RequiredFeature: "skills"},
+		{Executor: platformskills.NewListVersionsTool(skillsSvc), RequiredFeature: "skills"},
+		{Executor: platformskills.NewListDistributionsTool(skillsSvc), RequiredFeature: "skills"},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -104,13 +104,16 @@ func TestManagedAssistantDeploymentsToolsExposesCatalog(t *testing.T) {
 func TestManagedAssistantSkillsToolsExposesCatalog(t *testing.T) {
 	t.Parallel()
 
-	got := toolNames(ManagedAssistantSkillsTools(nil))
+	tools := ManagedAssistantSkillsTools(nil)
 	require.ElementsMatch(t, []string{
 		"platform_list_skills",
 		"platform_get_skill",
 		"platform_list_skill_versions",
 		"platform_list_skill_distributions",
-	}, got)
+	}, toolNames(tools))
+	for _, tool := range tools {
+		require.Equal(t, "skills", tool.RequiredFeature)
+	}
 }
 
 func toolNames(tools []platformtools.ExternalTool) []string {

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -101,6 +101,18 @@ func TestManagedAssistantDeploymentsToolsExposesCatalog(t *testing.T) {
 	}, got)
 }
 
+func TestManagedAssistantSkillsToolsExposesCatalog(t *testing.T) {
+	t.Parallel()
+
+	got := toolNames(ManagedAssistantSkillsTools(nil))
+	require.ElementsMatch(t, []string{
+		"platform_list_skills",
+		"platform_get_skill",
+		"platform_list_skill_versions",
+		"platform_list_skill_distributions",
+	}, got)
+}
+
 func toolNames(tools []platformtools.ExternalTool) []string {
 	out := make([]string, 0, len(tools))
 	for _, tool := range tools {

--- a/server/internal/platformtools/skills/shared.go
+++ b/server/internal/platformtools/skills/shared.go
@@ -1,0 +1,16 @@
+package skills
+
+import (
+	"context"
+
+	genskills "github.com/speakeasy-api/gram/server/gen/skills"
+)
+
+// SkillsService is the read-only subset of the skills management service used
+// by the project's managed assistant.
+type SkillsService interface {
+	List(context.Context, *genskills.ListPayload) (*genskills.ListSkillsResult, error)
+	Get(context.Context, *genskills.GetPayload) (*genskills.GetSkillResult, error)
+	ListVersions(context.Context, *genskills.ListVersionsPayload) (*genskills.ListSkillVersionsResult, error)
+	ListDistributions(context.Context, *genskills.ListDistributionsPayload) (*genskills.ListSkillDistributionsResult, error)
+}

--- a/server/internal/platformtools/skills/tools.go
+++ b/server/internal/platformtools/skills/tools.go
@@ -1,0 +1,231 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	genskills "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type List struct{ skills SkillsService }
+
+type listInput struct {
+	Cursor *string `json:"cursor,omitempty" jsonschema:"Cursor for the next page of skills."`
+	Limit  int     `json:"limit,omitempty" jsonschema:"Number of skills to return (1-200)."`
+}
+
+func NewListTool(svc SkillsService) *List { return &List{skills: svc} }
+
+func (t *List) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "skills",
+		HandlerName: "list_skills",
+		Name:        "platform_list_skills",
+		Description: "List active skills in the current project, including names, summaries, classifications, latest version IDs, and version counts.",
+		InputSchema: core.BuildInputSchema[listInput](core.WithPropertyNumberRange("limit", 1, 200)),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *List) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.skills == nil {
+		return fmt.Errorf("skills service not configured")
+	}
+
+	input := listInput{Cursor: nil, Limit: 50}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.Limit == 0 {
+		input.Limit = 50
+	}
+
+	result, err := t.skills.List(ctx, &genskills.ListPayload{
+		Cursor:           input.Cursor,
+		Limit:            input.Limit,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("list skills: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}
+
+type Get struct{ skills SkillsService }
+
+type getInput struct {
+	ID string `json:"id" jsonschema:"The skill ID."`
+}
+
+func NewGetTool(svc SkillsService) *Get { return &Get{skills: svc} }
+
+func (t *Get) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "skills",
+		HandlerName: "get_skill",
+		Name:        "platform_get_skill",
+		Description: "Get an active skill and its latest immutable version, including the exact SKILL.md content, metadata, and validation status.",
+		InputSchema: core.BuildInputSchema[getInput](core.WithPropertyFormat("id", "uuid")),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *Get) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.skills == nil {
+		return fmt.Errorf("skills service not configured")
+	}
+
+	input := getInput{ID: ""}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+
+	result, err := t.skills.Get(ctx, &genskills.GetPayload{
+		ID:               input.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("get skill: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}
+
+type ListVersions struct{ skills SkillsService }
+
+type listVersionsInput struct {
+	ID     string  `json:"id" jsonschema:"The skill ID."`
+	Cursor *string `json:"cursor,omitempty" jsonschema:"Cursor for the next page of versions."`
+	Limit  int     `json:"limit,omitempty" jsonschema:"Number of versions to return (1-50)."`
+}
+
+func NewListVersionsTool(svc SkillsService) *ListVersions { return &ListVersions{skills: svc} }
+
+func (t *ListVersions) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "skills",
+		HandlerName: "list_skill_versions",
+		Name:        "platform_list_skill_versions",
+		Description: "List immutable versions of an active skill, newest first, including exact SKILL.md content and validation status.",
+		InputSchema: core.BuildInputSchema[listVersionsInput](
+			core.WithPropertyFormat("id", "uuid"),
+			core.WithPropertyNumberRange("limit", 1, 50),
+		),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *ListVersions) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.skills == nil {
+		return fmt.Errorf("skills service not configured")
+	}
+
+	input := listVersionsInput{ID: "", Cursor: nil, Limit: 20}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+	if input.Limit == 0 {
+		input.Limit = 20
+	}
+
+	result, err := t.skills.ListVersions(ctx, &genskills.ListVersionsPayload{
+		ID:               input.ID,
+		Cursor:           input.Cursor,
+		Limit:            input.Limit,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("list skill versions: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}
+
+type ListDistributions struct{ skills SkillsService }
+
+type listDistributionsInput struct {
+	SkillID  *string `json:"skill_id,omitempty" jsonschema:"Only return distributions of this skill ID."`
+	PluginID *string `json:"plugin_id,omitempty" jsonschema:"Only return distributions carried by this plugin ID."`
+	Cursor   *string `json:"cursor,omitempty" jsonschema:"Cursor for the next page of distributions."`
+	Limit    int     `json:"limit,omitempty" jsonschema:"Number of distributions to return (1-50)."`
+}
+
+func NewListDistributionsTool(svc SkillsService) *ListDistributions {
+	return &ListDistributions{skills: svc}
+}
+
+func (t *ListDistributions) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "skills",
+		HandlerName: "list_skill_distributions",
+		Name:        "platform_list_skill_distributions",
+		Description: "List active distributions of project skills to plugins, optionally filtered by skill or plugin.",
+		InputSchema: core.BuildInputSchema[listDistributionsInput](
+			core.WithPropertyFormat("skill_id", "uuid"),
+			core.WithPropertyFormat("plugin_id", "uuid"),
+			core.WithPropertyNumberRange("limit", 1, 50),
+		),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *ListDistributions) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.skills == nil {
+		return fmt.Errorf("skills service not configured")
+	}
+
+	input := listDistributionsInput{SkillID: nil, PluginID: nil, Cursor: nil, Limit: 20}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.Limit == 0 {
+		input.Limit = 20
+	}
+
+	result, err := t.skills.ListDistributions(ctx, &genskills.ListDistributionsPayload{
+		SkillID:          input.SkillID,
+		PluginID:         input.PluginID,
+		Cursor:           input.Cursor,
+		Limit:            input.Limit,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("list skill distributions: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}

--- a/server/internal/platformtools/skills/tools.go
+++ b/server/internal/platformtools/skills/tools.go
@@ -46,6 +46,9 @@ func (t *List) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Re
 	if input.Limit == 0 {
 		input.Limit = 50
 	}
+	if input.Limit < 1 || input.Limit > 200 {
+		return fmt.Errorf("limit must be between 1 and 200")
+	}
 
 	result, err := t.skills.List(ctx, &genskills.ListPayload{
 		Cursor:           input.Cursor,
@@ -153,6 +156,9 @@ func (t *ListVersions) Call(ctx context.Context, _ toolconfig.ToolCallEnv, paylo
 	if input.Limit == 0 {
 		input.Limit = 20
 	}
+	if input.Limit < 1 || input.Limit > 50 {
+		return fmt.Errorf("limit must be between 1 and 50")
+	}
 
 	result, err := t.skills.ListVersions(ctx, &genskills.ListVersionsPayload{
 		ID:               input.ID,
@@ -212,6 +218,9 @@ func (t *ListDistributions) Call(ctx context.Context, _ toolconfig.ToolCallEnv, 
 	}
 	if input.Limit == 0 {
 		input.Limit = 20
+	}
+	if input.Limit < 1 || input.Limit > 50 {
+		return fmt.Errorf("limit must be between 1 and 50")
 	}
 
 	result, err := t.skills.ListDistributions(ctx, &genskills.ListDistributionsPayload{

--- a/server/internal/platformtools/skills/tools_test.go
+++ b/server/internal/platformtools/skills/tools_test.go
@@ -84,3 +84,28 @@ func TestToolsForwardReadFiltersWithoutAuthOverrides(t *testing.T) {
 	require.Nil(t, svc.listDistributionsPayload.ApikeyToken)
 	require.Nil(t, svc.listDistributionsPayload.ProjectSlugInput)
 }
+
+func TestToolsRejectInvalidLimits(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubSkillsService{}
+	env := toolconfig.ToolCallEnv{
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+	}
+	var out bytes.Buffer
+
+	err := NewListTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"limit":-1}`), &out)
+	require.ErrorContains(t, err, "limit must be between 1 and 200")
+	require.Nil(t, svc.listPayload)
+
+	err = NewListVersionsTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"id":"skill-id","limit":-1}`), &out)
+	require.ErrorContains(t, err, "limit must be between 1 and 50")
+	require.Nil(t, svc.listVersionsPayload)
+
+	err = NewListDistributionsTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"limit":-1}`), &out)
+	require.ErrorContains(t, err, "limit must be between 1 and 50")
+	require.Nil(t, svc.listDistributionsPayload)
+}

--- a/server/internal/platformtools/skills/tools_test.go
+++ b/server/internal/platformtools/skills/tools_test.go
@@ -1,0 +1,86 @@
+package skills
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	genskills "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type stubSkillsService struct {
+	listPayload              *genskills.ListPayload
+	getPayload               *genskills.GetPayload
+	listVersionsPayload      *genskills.ListVersionsPayload
+	listDistributionsPayload *genskills.ListDistributionsPayload
+}
+
+func (s *stubSkillsService) List(_ context.Context, payload *genskills.ListPayload) (*genskills.ListSkillsResult, error) {
+	s.listPayload = payload
+	return &genskills.ListSkillsResult{Skills: nil, NextCursor: nil}, nil
+}
+
+func (s *stubSkillsService) Get(_ context.Context, payload *genskills.GetPayload) (*genskills.GetSkillResult, error) {
+	s.getPayload = payload
+	return &genskills.GetSkillResult{Skill: nil, LatestVersion: nil}, nil
+}
+
+func (s *stubSkillsService) ListVersions(_ context.Context, payload *genskills.ListVersionsPayload) (*genskills.ListSkillVersionsResult, error) {
+	s.listVersionsPayload = payload
+	return &genskills.ListSkillVersionsResult{Versions: nil, NextCursor: nil}, nil
+}
+
+func (s *stubSkillsService) ListDistributions(_ context.Context, payload *genskills.ListDistributionsPayload) (*genskills.ListSkillDistributionsResult, error) {
+	s.listDistributionsPayload = payload
+	return &genskills.ListSkillDistributionsResult{Distributions: nil, NextCursor: nil}, nil
+}
+
+func TestToolsForwardReadFiltersWithoutAuthOverrides(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubSkillsService{}
+	env := toolconfig.ToolCallEnv{
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+	}
+	var out bytes.Buffer
+
+	err := NewListTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"cursor":"next"}`), &out)
+	require.NoError(t, err)
+	require.Equal(t, 50, svc.listPayload.Limit)
+	require.Equal(t, "next", *svc.listPayload.Cursor)
+	require.Nil(t, svc.listPayload.SessionToken)
+	require.Nil(t, svc.listPayload.ApikeyToken)
+	require.Nil(t, svc.listPayload.ProjectSlugInput)
+
+	out.Reset()
+	err = NewGetTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"id":"skill-id"}`), &out)
+	require.NoError(t, err)
+	require.Equal(t, "skill-id", svc.getPayload.ID)
+	require.Nil(t, svc.getPayload.SessionToken)
+	require.Nil(t, svc.getPayload.ApikeyToken)
+	require.Nil(t, svc.getPayload.ProjectSlugInput)
+
+	out.Reset()
+	err = NewListVersionsTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"id":"skill-id","limit":7}`), &out)
+	require.NoError(t, err)
+	require.Equal(t, "skill-id", svc.listVersionsPayload.ID)
+	require.Equal(t, 7, svc.listVersionsPayload.Limit)
+	require.Nil(t, svc.listVersionsPayload.SessionToken)
+	require.Nil(t, svc.listVersionsPayload.ApikeyToken)
+	require.Nil(t, svc.listVersionsPayload.ProjectSlugInput)
+
+	out.Reset()
+	err = NewListDistributionsTool(svc).Call(t.Context(), env, bytes.NewBufferString(`{"plugin_id":"plugin-id"}`), &out)
+	require.NoError(t, err)
+	require.Equal(t, 20, svc.listDistributionsPayload.Limit)
+	require.Equal(t, "plugin-id", *svc.listDistributionsPayload.PluginID)
+	require.Nil(t, svc.listDistributionsPayload.SessionToken)
+	require.Nil(t, svc.listDistributionsPayload.ApikeyToken)
+	require.Nil(t, svc.listDistributionsPayload.ProjectSlugInput)
+}


### PR DESCRIPTION
## Summary
- add read-only platform tools for listing skills, loading latest skill content, reviewing version history, and listing plugin distributions
- expose the tools only through the managed Project Assistant toolset
- add catalog and request-forwarding coverage

## Validation
- `go test ./server/internal/platformtools/skills ./server/internal/platformtools/runtime ./server/cmd/gram`
- `mise lint:server`
- `mise exec -- hk fix`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose read-only project skill data to the Project Assistant and add tools to browse skills, versions, and distributions with strict input limit validation. Tools are only available to the managed assistant and are gated by the skills feature.

- **New Features**
  - Added tools: `platform_list_skills`, `platform_get_skill`, `platform_list_skill_versions`, `platform_list_skill_distributions`.
  - Wired via `platformtoolsruntime.ManagedAssistantSkillsTools`; server start attaches the skills service and adds these tools to the managed toolset.

- **Bug Fixes**
  - Enforced limit validation and schema ranges: list (1–200, default 50), versions and distributions (1–50, default 20); reject invalid limits.
  - Tests cover catalog exposure, request forwarding without auth overrides, and limit validation.

<sup>Written for commit 0d716a13dd4d255cb5168511c7933bd202a79155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

