### PR TITLE
chore: stop pitchfork daemons in nuke task

### DIFF
--- a/.mise-tasks/nuke.sh
+++ b/.mise-tasks/nuke.sh
@@ -4,6 +4,13 @@
 
 set -e
 
+# Best-effort: stop this worktree's pitchfork daemons and prune stopped
+# entries from `pitchfork list` (clean is global across worktrees)
+if pitchfork supervisor status &> /dev/null; then
+    pitchfork stop --all-local || true
+    pitchfork clean || true
+fi
+
 docker compose --profile "*" down --volumes --remove-orphans
 
 # dev-idp's SQLite database lives outside docker -- nuke it too so a


### PR DESCRIPTION
# Summary

- `mise run nuke` now stops the current worktree's pitchfork daemons (`pitchfork stop --all-local`) and prunes stopped entries from `pitchfork list` (`pitchfork clean`) before tearing down docker infra.
- Guarded by `pitchfork supervisor status` so nuke still works when the supervisor (or the pitchfork binary) is absent; each call is best-effort (`|| true`) so a pitchfork hiccup can't abort the docker teardown or the `git:workclean` loop.

# Root cause

`mise run git:workclean` nukes each selected worktree before removing it, but nuke only tore down docker resources. Pitchfork daemons are namespaced per worktree directory, so the removed worktree's daemons kept running and left stale entries in `pitchfork list`. Placing the cleanup in `nuke.sh` (rather than `workclean.sh`) also covers standalone `mise run nuke` usage.

# Test plan

- [ ] `mise run nuke` in a worktree stops that worktree's daemons and prunes them from `pitchfork list`
- [ ] `mise run nuke` succeeds when the pitchfork supervisor is not running
- [ ] `mise run git:workclean` removes worktrees without leaving daemons behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `mise run nuke` to stop this worktree’s `pitchfork` daemons and prune stale entries before tearing down Docker. Guarded by `pitchfork supervisor status` and best-effort calls so it works even if `pitchfork` isn’t running and prevents leftover daemons after `mise run git:workclean`.

<sup>Written for commit ca1225c606660bef7538eafde38bce27be282190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

