### PR TITLE
feat: persist company-credential AI accounts keyed on employee or session email

### DIFF
--- a/.changeset/company-credential-user-accounts.md
+++ b/.changeset/company-credential-user-accounts.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Persist company-credential AI accounts in `user_accounts`. Claude sessions authenticated by an API key, bearer-token gateway, Bedrock, or Vertex carry no `user.account_uuid`, so attribution previously classified them (`account_type=team`) but never persisted an account entity — leaving no chat→account links and no billing-mode resolution for the whole population. Such sessions now upsert an entity keyed on the resolved employee — so all of an employee's sessions (different reported emails, device-bridge attribution, or no email at all) converge on one account — falling back to the normalized session email while no employee has resolved; an email-keyed row is promoted to the employee key in place when its email later resolves. Company-credential accounts run the billing-mode cascade like OAuth accounts, and a chat linked to one upgrades to the OAuth account if the session's `user.account_uuid` arrives in a later batch.

--- a/server/database/sqlc.yaml
+++ b/server/database/sqlc.yaml
@@ -15,12 +15,6 @@ overrides:
           import: "github.com/google/uuid"
           type: "NullUUID"
         nullable: true
-      # Temporary pin while user_accounts.external_account_uuid transitions to
-      # nullable (DNO-555): keeps the generated type `string` so the migration
-      # ships without Go changes. The follow-up feature PR removes this pin and
-      # adapts call sites to pgtype.Text. No NULLs exist until that PR writes them.
-      - column: user_accounts.external_account_uuid
-        go_type: string
       - column: http_tool_definitions.response_filter
         go_type:
           import: github.com/speakeasy-api/gram/server/internal/tools/repo/models

--- a/server/internal/background/activities/risk_analysis/scan_account_identity_test.go
+++ b/server/internal/background/activities/risk_analysis/scan_account_identity_test.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/sdk/testsuite"
 
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -73,7 +74,7 @@ func seedAccountChatWithAccount(t *testing.T, conn *pgxpool.Pool, td testData, a
 	account, err := hooksrepo.New(conn).UpsertUserAccount(ctx, hooksrepo.UpsertUserAccountParams{
 		OrganizationID:      td.orgID,
 		Provider:            "anthropic",
-		ExternalAccountUuid: externalAccountUUID,
+		ExternalAccountUuid: conv.ToPGText(externalAccountUUID),
 		UserID:              pgtype.Text{},
 		ExternalOrgID:       pgtype.Text{},
 		ExternalAccountID:   pgtype.Text{},
@@ -104,7 +105,7 @@ func setAccountEmail(t *testing.T, conn *pgxpool.Pool, td testData, externalAcco
 	_, err := hooksrepo.New(conn).UpsertUserAccount(t.Context(), hooksrepo.UpsertUserAccountParams{
 		OrganizationID:      td.orgID,
 		Provider:            "anthropic",
-		ExternalAccountUuid: externalAccountUUID,
+		ExternalAccountUuid: conv.ToPGText(externalAccountUUID),
 		UserID:              pgtype.Text{},
 		ExternalOrgID:       pgtype.Text{},
 		ExternalAccountID:   pgtype.Text{},

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1952,7 +1952,7 @@ type UserAccount struct {
 	UserID              pgtype.Text
 	Provider            string
 	ExternalOrgID       pgtype.Text
-	ExternalAccountUuid string
+	ExternalAccountUuid pgtype.Text
 	ExternalAccountID   pgtype.Text
 	Email               pgtype.Text
 	AccountType         pgtype.Text

--- a/server/internal/hooks/account_attribution.go
+++ b/server/internal/hooks/account_attribution.go
@@ -56,9 +56,12 @@ func classifyAccountType(emailResolvedUserID string) string {
 // bridge (keyed on the per-device id) is taught/consulted whenever a DeviceID
 // is present — both including sessions that carry no provider account UUID (a
 // company-credential session — see classifyAccount). The user_accounts entity
-// and billing mode, however, key on that UUID, so they are skipped when it is
-// absent: there is no account entity to persist. All failures are returned to
-// the caller, which logs and continues: account attribution must never block
+// keys on that UUID for OAuth sessions; for company-credential ones it keys on
+// the resolved employee, falling back to the normalized session email until
+// one resolves (see upsertCompanyCredentialAccount). Only a session with no
+// identity at all (no UUID, no resolved employee, no email) has nothing to
+// persist an entity under, and skips it. All failures are returned to the
+// caller, which logs and continues: account attribution must never block
 // session capture or enforcement.
 func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) error {
 	// Classify before consulting the device bridge: meta.UserID at this point
@@ -93,38 +96,122 @@ func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) e
 		}
 	}
 
-	// The user_accounts entity and its billing mode key on the provider account
-	// UUID (user_accounts.external_account_uuid is NOT NULL and is the entity
-	// key). A session authenticated by company credentials (an API key, a
-	// gateway/proxy, Bedrock, or Vertex) carries no such UUID, so there is no
-	// account entity to persist — the account_type stamped above is the signal
-	// the cost surfaces consume. Stop here for these sessions.
-	if meta.ExternalAccountUUID == "" {
-		return nil
+	// Persist the account entity. An OAuth-authenticated session keys it on the
+	// provider account UUID; a company-credential session (an API key, a
+	// gateway/proxy, Bedrock, or Vertex) carries no UUID and keys on the
+	// resolved employee or, until one resolves, the session email. A session
+	// with no identity on any of those axes persists nothing — the account_type
+	// stamped above is then the only signal the cost surfaces consume.
+	var accountID string
+	var billingOverride string
+	if meta.ExternalAccountUUID != "" {
+		account, err := s.repo.UpsertUserAccount(ctx, repo.UpsertUserAccountParams{
+			OrganizationID:      meta.GramOrgID,
+			Provider:            meta.Provider,
+			ExternalAccountUuid: conv.ToPGText(meta.ExternalAccountUUID),
+			UserID:              conv.ToPGTextEmpty(meta.UserID),
+			ExternalOrgID:       conv.ToPGTextEmpty(meta.ExternalOrgID),
+			ExternalAccountID:   conv.ToPGTextEmpty(meta.ExternalAccountID),
+			Email:               conv.ToPGTextEmpty(meta.UserEmail),
+			AccountType:         conv.ToPGTextEmpty(meta.AccountType),
+		})
+		if err != nil {
+			return fmt.Errorf("upsert user account: %w", err)
+		}
+		accountID = account.ID.String()
+		billingOverride = conv.FromPGTextOrEmpty[string](account.BillingMode)
+	} else {
+		var err error
+		accountID, billingOverride, err = s.upsertCompanyCredentialAccount(ctx, meta)
+		if err != nil {
+			return err
+		}
+		if accountID == "" {
+			return nil
+		}
 	}
+	meta.UserAccountID = accountID
 
-	account, err := s.repo.UpsertUserAccount(ctx, repo.UpsertUserAccountParams{
-		OrganizationID:      meta.GramOrgID,
-		Provider:            meta.Provider,
-		ExternalAccountUuid: meta.ExternalAccountUUID,
-		UserID:              conv.ToPGTextEmpty(meta.UserID),
-		ExternalOrgID:       conv.ToPGTextEmpty(meta.ExternalOrgID),
-		ExternalAccountID:   conv.ToPGTextEmpty(meta.ExternalAccountID),
-		Email:               conv.ToPGTextEmpty(meta.UserEmail),
-		AccountType:         conv.ToPGTextEmpty(meta.AccountType),
-	})
-	if err != nil {
-		return fmt.Errorf("upsert user account: %w", err)
-	}
-	meta.UserAccountID = account.ID.String()
-
-	billingMode, err := s.resolveBillingMode(ctx, meta, conv.FromPGTextOrEmpty[string](account.BillingMode))
+	billingMode, err := s.resolveBillingMode(ctx, meta, billingOverride)
 	if err != nil {
 		return fmt.Errorf("resolve billing mode: %w", err)
 	}
 	meta.BillingMode = billingMode
 
 	return nil
+}
+
+// upsertCompanyCredentialAccount persists the account entity for a
+// company-credential session on its dual key: the resolved employee
+// (user_accounts_org_provider_company_user_key) so every session of an
+// employee — whatever email it reports, or with none at all when the device
+// bridge supplied the owner — lands on ONE account; or the normalized session
+// email (user_accounts_org_provider_email_key) while no employee has
+// resolved. An email-keyed row is promoted to the employee key in place when
+// its employee later resolves, so the row id and any chat links survive.
+// Returns an empty accountID (and no error) when the session has neither a
+// resolved employee nor an email — there is no identity to persist.
+func (s *Service) upsertCompanyCredentialAccount(ctx context.Context, meta *SessionMetadata) (accountID string, billingOverride string, err error) {
+	email := conv.NormalizeEmail(meta.UserEmail)
+
+	if meta.UserID == "" {
+		if email == "" {
+			return "", "", nil
+		}
+		adopted, err := s.repo.AdoptCompanyCredentialUserAccountByEmail(ctx, repo.AdoptCompanyCredentialUserAccountByEmailParams{
+			OrganizationID: meta.GramOrgID,
+			Provider:       meta.Provider,
+			Email:          conv.ToPGText(email),
+			AccountType:    conv.ToPGTextEmpty(meta.AccountType),
+		})
+		if err == nil {
+			return adopted.ID.String(), conv.FromPGTextOrEmpty[string](adopted.BillingMode), nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return "", "", fmt.Errorf("adopt company-credential user account: %w", err)
+		}
+		inserted, err := s.repo.InsertCompanyCredentialUserAccountByEmail(ctx, repo.InsertCompanyCredentialUserAccountByEmailParams{
+			OrganizationID: meta.GramOrgID,
+			Provider:       meta.Provider,
+			Email:          conv.ToPGText(email),
+			AccountType:    conv.ToPGTextEmpty(meta.AccountType),
+		})
+		if err != nil {
+			return "", "", fmt.Errorf("insert company-credential user account: %w", err)
+		}
+		return inserted.ID.String(), conv.FromPGTextOrEmpty[string](inserted.BillingMode), nil
+	}
+
+	// Resolved employee: first promote an email-keyed row persisted before the
+	// employee resolved (preserving its id and chat links); when none exists —
+	// or the employee already has their resolved account — upsert on the
+	// employee key.
+	if email != "" {
+		claimed, err := s.repo.ClaimCompanyCredentialUserAccount(ctx, repo.ClaimCompanyCredentialUserAccountParams{
+			OrganizationID: meta.GramOrgID,
+			Provider:       meta.Provider,
+			UserID:         conv.ToPGText(meta.UserID),
+			Email:          conv.ToPGText(email),
+			AccountType:    conv.ToPGTextEmpty(meta.AccountType),
+		})
+		if err == nil {
+			return claimed.ID.String(), conv.FromPGTextOrEmpty[string](claimed.BillingMode), nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return "", "", fmt.Errorf("claim company-credential user account: %w", err)
+		}
+	}
+	account, err := s.repo.UpsertCompanyCredentialUserAccountByUser(ctx, repo.UpsertCompanyCredentialUserAccountByUserParams{
+		OrganizationID: meta.GramOrgID,
+		Provider:       meta.Provider,
+		UserID:         conv.ToPGText(meta.UserID),
+		Email:          conv.ToPGTextEmpty(email),
+		AccountType:    conv.ToPGTextEmpty(meta.AccountType),
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("upsert company-credential user account: %w", err)
+	}
+	return account.ID.String(), conv.FromPGTextOrEmpty[string](account.BillingMode), nil
 }
 
 // providerBillingConfigProvider maps a session's provider tag to the provider
@@ -211,7 +298,13 @@ func (s *Service) classifyAccount(ctx context.Context, meta *SessionMetadata) (s
 	// user.account_uuid at all is classified team for personal sessions too.
 	// Accepted: both slices are small and the prior behavior — an entire
 	// company-credential org parked under an unclassified account type — was the
-	// far larger distortion.
+	// far larger distortion. If that UUID-less first batch also carried the
+	// email, it persists an email-keyed company-credential entity
+	// (attributeSession) that the re-attribution does not remove — the chat link
+	// upgrades to the OAuth account (LinkChatUserAccount) but the stale team row
+	// lingers with a frozen last_seen_at. Also accepted: email and UUID ride the
+	// same user.* log attributes, so an email-without-UUID batch for an OAuth
+	// session is the rare sub-slice of an already-small slice.
 	if meta.ExternalAccountUUID == "" {
 		return accountTypeTeam, nil
 	}

--- a/server/internal/hooks/account_attribution_test.go
+++ b/server/internal/hooks/account_attribution_test.go
@@ -75,7 +75,7 @@ func TestLogs_AttributesTeamAndPersonalAccountsViaDeviceBridge(t *testing.T) {
 	teamAccount, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
 		OrganizationID:      orgID,
 		Provider:            providerAnthropic,
-		ExternalAccountUuid: teamAccountUUID,
+		ExternalAccountUuid: conv.ToPGText(teamAccountUUID),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypeTeam, teamAccount.AccountType.String)
@@ -114,7 +114,7 @@ func TestLogs_AttributesTeamAndPersonalAccountsViaDeviceBridge(t *testing.T) {
 	personalAccount, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
 		OrganizationID:      orgID,
 		Provider:            providerAnthropic,
-		ExternalAccountUuid: persAccountUUID,
+		ExternalAccountUuid: conv.ToPGText(persAccountUUID),
 	})
 	require.NoError(t, err)
 	// Classified personal (email did not resolve) but attributed to the employee
@@ -172,7 +172,7 @@ func TestLogs_DowngradesPersonalAccountOnWorkEmail(t *testing.T) {
 
 	// Employee A's enterprise account is team.
 	entA, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-ent-a",
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText("acct-ent-a"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypeTeam, entA.AccountType.String)
@@ -183,7 +183,7 @@ func TestLogs_DowngradesPersonalAccountOnWorkEmail(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "max-a", emailA, "max-org-solo", "acct-max-a", "device-max-a", now.Add(time.Minute))
 
 	maxA, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-max-a",
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText("acct-max-a"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, maxA.AccountType.String)
@@ -208,7 +208,7 @@ func TestLogs_SingleAccountEnterpriseStaysTeam(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "solo-session", email, "solo-enterprise-org", "acct-solo", "device-solo", now)
 
 	acct, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-solo",
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText("acct-solo"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypeTeam, acct.AccountType.String)
@@ -248,7 +248,7 @@ func TestLogs_PromotesUnresolvedAccountUnderSharedEnterpriseOrg(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "promote-ent-c", "unprovisioned@example.com", enterpriseOrg, "acct-promote-c", "device-promote-c", now.Add(2*time.Minute))
 
 	acct, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-promote-c",
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText("acct-promote-c"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypeTeam, acct.AccountType.String, "unresolved account under a shared enterprise org is team")
@@ -273,7 +273,7 @@ func TestLogs_AttributesOncePerSession(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "repeat-session", email, "some-org", "acct-repeat", "device-repeat", now)
 
 	first, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-repeat",
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText("acct-repeat"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, first.AccountType.String)
@@ -286,7 +286,7 @@ func TestLogs_AttributesOncePerSession(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "repeat-session", email, "some-org", "acct-repeat", "device-repeat", now.Add(time.Minute))
 
 	second, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: "acct-repeat",
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText("acct-repeat"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, second.AccountType.String)
@@ -334,7 +334,7 @@ func TestLogs_EnrichesAttributionWhenIdentityArrivesAcrossBatches(t *testing.T) 
 	require.NoError(t, err)
 
 	first, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: accountUUID,
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText(accountUUID),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, first.AccountType.String)
@@ -360,7 +360,7 @@ func TestLogs_EnrichesAttributionWhenIdentityArrivesAcrossBatches(t *testing.T) 
 	require.NoError(t, err)
 
 	enriched, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: accountUUID,
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText(accountUUID),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypeTeam, enriched.AccountType.String)
@@ -488,7 +488,7 @@ func TestLogs_BackfillsChatAccountLinkOnExistingChat(t *testing.T) {
 	account, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
 		OrganizationID:      authCtx.ActiveOrganizationID,
 		Provider:            providerAnthropic,
-		ExternalAccountUuid: accountUUID,
+		ExternalAccountUuid: conv.ToPGText(accountUUID),
 	})
 	require.NoError(t, err)
 
@@ -499,7 +499,8 @@ func TestLogs_BackfillsChatAccountLinkOnExistingChat(t *testing.T) {
 }
 
 // TestLogs_NoAccountIdentityDoesNotCreateUserAccount confirms attribution is a
-// no-op for sessions that carry no provider account id (older clients): no
+// no-op for a session with no persistable account identity at all — no provider
+// account UUID and no session email. There is nothing to key an entity on, so no
 // user_accounts row is created and ingest still succeeds.
 func TestLogs_NoAccountIdentityDoesNotCreateUserAccount(t *testing.T) {
 	t.Parallel()
@@ -516,30 +517,27 @@ func TestLogs_NoAccountIdentityDoesNotCreateUserAccount(t *testing.T) {
 			TimeUnixNano: new(nanoString(now)),
 			Body:         &gen.OTELLogBody{StringValue: new("api request")},
 			Attributes: []*gen.OTELAttribute{
-				strAttr("session.id", "identityless-session"),
-				strAttr("user.email", "someone@example.com"),
+				strAttr("session.id", "identityless-"+uuid.NewString()),
 			},
 		},
 	))
 	require.NoError(t, err)
 
-	_, err = repo.New(ti.conn).GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID:      authCtx.ActiveOrganizationID,
-		Provider:            providerAnthropic,
-		ExternalAccountUuid: "",
-	})
-	require.Error(t, err)
+	count, err := repo.New(ti.conn).CountUserAccountsByOrg(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Zero(t, count)
 }
 
 // TestLogs_ClassifiesCompanyCredentialSessionAsTeam covers a Claude session
 // authenticated by company credentials (an API key / gateway / Bedrock / Vertex):
 // it emits user.email and user.id but no user.account_uuid or organization.id, so
-// no personal account is behind it. Attribution must classify it team and stamp
-// account_type onto the telemetry — even though no user_accounts entity can be
-// persisted (that entity keys on the absent UUID) — so the cost breakdown does
-// not park the whole org's spend under "(unset)". The email is deliberately NOT
+// no personal account is behind it. Attribution must classify it team, stamp
+// account_type onto the telemetry — so the cost breakdown does not park the whole
+// org's spend under "(unset)" — and persist the account entity keyed on the
+// session email (the UUID entity key is absent). The email is deliberately NOT
 // provisioned in Gram: this is the corporate-gateway population that an email- or
-// provider-org-based signal alone would miss.
+// provider-org-based signal alone would miss, so the entity persists with no
+// owning user_id.
 func TestLogs_ClassifiesCompanyCredentialSessionAsTeam(t *testing.T) {
 	t.Parallel()
 
@@ -556,8 +554,8 @@ func TestLogs_ClassifiesCompanyCredentialSessionAsTeam(t *testing.T) {
 			TimeUnixNano: new(nanoString(now)),
 			Body:         &gen.OTELLogBody{StringValue: new("api request")},
 			Attributes: []*gen.OTELAttribute{
-				strAttr("session.id", "gateway-session"),
-				strAttr("user.email", "gateway-user@example.com"),
+				strAttr("session.id", "gateway-"+uuid.NewString()),
+				strAttr("user.email", "Gateway-User@example.com"),
 				strAttr("user.id", "gateway-device"),
 			},
 		},
@@ -567,14 +565,17 @@ func TestLogs_ClassifiesCompanyCredentialSessionAsTeam(t *testing.T) {
 	logs := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), claudeOTELLogsURN, now, 1)
 	require.Contains(t, logs[0].Attributes, accountTypeTeam)
 
-	// No account entity is persisted: the user_accounts key (external_account_uuid)
-	// is absent for a company-credential session.
-	_, err = repo.New(ti.conn).GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID:      orgID,
-		Provider:            providerAnthropic,
-		ExternalAccountUuid: "",
+	// The account entity is persisted keyed on the normalized session email,
+	// with no provider account UUID and no resolved owner.
+	account, err := repo.New(ti.conn).GetCompanyCredentialUserAccount(ctx, repo.GetCompanyCredentialUserAccountParams{
+		OrganizationID: orgID,
+		Provider:       providerAnthropic,
+		Email:          conv.ToPGText("gateway-user@example.com"),
 	})
-	require.Error(t, err)
+	require.NoError(t, err)
+	require.Equal(t, accountTypeTeam, account.AccountType.String)
+	require.False(t, account.ExternalAccountUuid.Valid)
+	require.False(t, account.UserID.Valid)
 }
 
 // TestLogs_CompanyCredentialSessionTeachesDeviceBridge covers the bridge at a
@@ -622,6 +623,17 @@ func TestLogs_CompanyCredentialSessionTeachesDeviceBridge(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, userID, owner.LinkedUserID.String)
 
+	// The company-credential account entity persists keyed on the work email,
+	// owned by the resolved employee.
+	companyAccount, err := queries.GetCompanyCredentialUserAccount(ctx, repo.GetCompanyCredentialUserAccountParams{
+		OrganizationID: orgID,
+		Provider:       providerAnthropic,
+		Email:          conv.ToPGText(workEmail),
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountTypeTeam, companyAccount.AccountType.String)
+	require.Equal(t, userID, companyAccount.UserID.String)
+
 	// A personal session on the same device (UUID present, gmail does not
 	// resolve) adopts the learned employee through the bridge.
 	claudeAccountSession(t, ctx, ti, "gateway-pers-session", "gateway-person@gmail.com", "gateway-max-org", "acct-gateway-personal", deviceID, now.Add(time.Minute))
@@ -629,11 +641,224 @@ func TestLogs_CompanyCredentialSessionTeachesDeviceBridge(t *testing.T) {
 	personalAccount, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
 		OrganizationID:      orgID,
 		Provider:            providerAnthropic,
-		ExternalAccountUuid: "acct-gateway-personal",
+		ExternalAccountUuid: conv.ToPGText("acct-gateway-personal"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, personalAccount.AccountType.String)
 	require.Equal(t, userID, personalAccount.UserID.String)
+}
+
+// claudeCompanyCredentialSession POSTs a single-record Claude OTEL logs payload
+// with the identity shape a company-credential session emits: a session email
+// and per-device id, but no user.account_uuid or organization.id.
+func claudeCompanyCredentialSession(t *testing.T, ctx context.Context, ti *testInstance, sessionID, email, deviceID string, ts time.Time) {
+	t.Helper()
+	err := ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		nil,
+		&gen.OTELLogRecord{
+			TimeUnixNano: new(nanoString(ts)),
+			Body:         &gen.OTELLogBody{StringValue: new("api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("user.email", email),
+				strAttr("user.id", deviceID),
+			},
+		},
+	))
+	require.NoError(t, err)
+}
+
+// TestLogs_CompanyCredentialAccountSharedAcrossSessions covers the entity key:
+// company-credential sessions with the same email share ONE user_accounts row
+// across sessions, and a later session whose email has become resolvable fills
+// in the owning employee (COALESCE keeps learned fields).
+func TestLogs_CompanyCredentialAccountSharedAcrossSessions(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	orgID := authCtx.ActiveOrganizationID
+	queries := repo.New(ti.conn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	email := "shared-credential@example.com"
+
+	// First session: the email is not provisioned in Gram yet, so the entity
+	// persists unowned.
+	claudeCompanyCredentialSession(t, ctx, ti, "cc-shared-1-"+uuid.NewString(), email, "cc-device-1", now)
+
+	first, err := queries.GetCompanyCredentialUserAccount(ctx, repo.GetCompanyCredentialUserAccountParams{
+		OrganizationID: orgID,
+		Provider:       providerAnthropic,
+		Email:          conv.ToPGText(email),
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountTypeTeam, first.AccountType.String)
+	require.False(t, first.UserID.Valid)
+
+	// The employee is provisioned; a later session resolves and fills the owner
+	// on the SAME entity instead of creating a second row.
+	userID := "cc-shared-employee"
+	seedHookUser(t, ctx, ti.conn, orgID, userID, email)
+	claudeCompanyCredentialSession(t, ctx, ti, "cc-shared-2-"+uuid.NewString(), email, "cc-device-2", now.Add(time.Minute))
+
+	second, err := queries.GetCompanyCredentialUserAccount(ctx, repo.GetCompanyCredentialUserAccountParams{
+		OrganizationID: orgID,
+		Provider:       providerAnthropic,
+		Email:          conv.ToPGText(email),
+	})
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, userID, second.UserID.String)
+
+	count, err := queries.CountUserAccountsByOrg(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+// TestLogs_CompanyCredentialSessionsConvergeOnEmployeeAccount covers the
+// resolved entity key: sessions of ONE employee reporting different emails —
+// one that resolves directly, one alias attributed through the device bridge —
+// land on a single employee-keyed account instead of one row per email.
+func TestLogs_CompanyCredentialSessionsConvergeOnEmployeeAccount(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	orgID := authCtx.ActiveOrganizationID
+	queries := repo.New(ti.conn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	userID, workEmail := "cc-converge-employee", "cc-converge@example.com"
+	seedHookUser(t, ctx, ti.conn, orgID, userID, workEmail)
+	const deviceID = "cc-converge-device"
+
+	// Work email resolves directly; the session also teaches the bridge.
+	claudeCompanyCredentialSession(t, ctx, ti, "cc-converge-1-"+uuid.NewString(), workEmail, deviceID, now)
+
+	// An alias that does NOT resolve, on the same device: the bridge supplies
+	// the employee, so this session must join the SAME account.
+	claudeCompanyCredentialSession(t, ctx, ti, "cc-converge-2-"+uuid.NewString(), "cc-converge-alias@example.com", deviceID, now.Add(time.Minute))
+
+	count, err := queries.CountUserAccountsByOrg(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+// TestLogs_PersistsCompanyCredentialAccountForBridgedNoEmailSession covers the
+// no-email residual: a company-credential session reporting no email at all
+// still persists (onto the employee-keyed account) when the device bridge
+// knows the device's owner. Only a session with no identity on any axis — no
+// UUID, no email, no bridged owner — persists nothing.
+func TestLogs_PersistsCompanyCredentialAccountForBridgedNoEmailSession(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	orgID := authCtx.ActiveOrganizationID
+	queries := repo.New(ti.conn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	userID, workEmail := "cc-noemail-employee", "cc-noemail@example.com"
+	seedHookUser(t, ctx, ti.conn, orgID, userID, workEmail)
+	const deviceID = "cc-noemail-device"
+
+	// Teach the bridge (and create the employee's account).
+	claudeCompanyCredentialSession(t, ctx, ti, "cc-noemail-1-"+uuid.NewString(), workEmail, deviceID, now)
+
+	// A later session on the same device with NO email: the bridge resolves the
+	// owner, and the session joins the same employee-keyed account.
+	err := ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		nil,
+		&gen.OTELLogRecord{
+			TimeUnixNano: new(nanoString(now.Add(time.Minute))),
+			Body:         &gen.OTELLogBody{StringValue: new("api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", "cc-noemail-2-"+uuid.NewString()),
+				strAttr("user.id", deviceID),
+			},
+		},
+	))
+	require.NoError(t, err)
+
+	count, err := queries.CountUserAccountsByOrg(ctx, orgID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	account, err := queries.GetCompanyCredentialUserAccount(ctx, repo.GetCompanyCredentialUserAccountParams{
+		OrganizationID: orgID,
+		Provider:       providerAnthropic,
+		Email:          conv.ToPGText(workEmail),
+	})
+	require.NoError(t, err)
+	require.Equal(t, userID, account.UserID.String)
+}
+
+// TestLogs_UpgradesChatLinkWhenAccountUUIDArrivesLate covers the healing path
+// for a session whose first OTEL batch carried the email but not the (late)
+// user.account_uuid: the batch persists an email-keyed company-credential
+// entity and links the chat to it; when the UUID arrives, re-attribution
+// persists the real OAuth account and the chat link upgrades to it. The stale
+// email-keyed row is a documented leftover (its last_seen_at freezes).
+func TestLogs_UpgradesChatLinkWhenAccountUUIDArrivesLate(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	orgID := authCtx.ActiveOrganizationID
+	queries := repo.New(ti.conn)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	sessionID := "cc-upgrade-" + uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+	email := "late-uuid-person@gmail.com"
+
+	// The chat already exists, unlinked — first prompt beat the first OTEL export.
+	_, err := queries.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             chatID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: orgID,
+		UserID:         conv.ToPGTextEmpty(""),
+		ExternalUserID: conv.ToPGTextEmpty(email),
+		UserAccountID:  conv.StringToNullUUID(""),
+		Title:          conv.ToPGText("late-uuid chat"),
+	})
+	require.NoError(t, err)
+
+	// First batch: email but no UUID. The chat links to the email-keyed entity.
+	claudeCompanyCredentialSession(t, ctx, ti, sessionID, email, "cc-upgrade-device", now)
+
+	companyAccount, err := queries.GetCompanyCredentialUserAccount(ctx, repo.GetCompanyCredentialUserAccountParams{
+		OrganizationID: orgID,
+		Provider:       providerAnthropic,
+		Email:          conv.ToPGText(email),
+	})
+	require.NoError(t, err)
+
+	chat, err := chatRepo.New(ti.conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.True(t, chat.UserAccountID.Valid)
+	require.Equal(t, companyAccount.ID, chat.UserAccountID.UUID)
+
+	// Second batch: the UUID arrives. Re-attribution persists the OAuth account
+	// and the chat link upgrades from the email-keyed entity to it.
+	accountUUID := "acct-" + sessionID
+	claudeAccountSession(t, ctx, ti, sessionID, email, "org-"+sessionID, accountUUID, "cc-upgrade-device", now.Add(time.Minute))
+
+	oauthAccount, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
+		OrganizationID:      orgID,
+		Provider:            providerAnthropic,
+		ExternalAccountUuid: conv.ToPGText(accountUUID),
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountTypePersonal, oauthAccount.AccountType.String)
+
+	chat, err = chatRepo.New(ti.conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.True(t, chat.UserAccountID.Valid)
+	require.Equal(t, oauthAccount.ID, chat.UserAccountID.UUID)
 }
 
 // TestLogs_LateBridgeBackfillsPersonalAccount covers the "late linking" ordering:
@@ -667,7 +892,7 @@ func TestLogs_LateBridgeBackfillsPersonalAccount(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "late-pers-1", "late-person@gmail.com", persOrg, persAcct, deviceID, now)
 
 	pers1, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: persAcct,
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText(persAcct),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, pers1.AccountType.String)
@@ -688,7 +913,7 @@ func TestLogs_LateBridgeBackfillsPersonalAccount(t *testing.T) {
 	claudeAccountSession(t, ctx, ti, "late-pers-2", "late-person@gmail.com", persOrg, persAcct, deviceID, now.Add(2*time.Minute))
 
 	pers2, err := queries.GetUserAccount(ctx, repo.GetUserAccountParams{
-		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: persAcct,
+		OrganizationID: orgID, Provider: providerAnthropic, ExternalAccountUuid: conv.ToPGText(persAcct),
 	})
 	require.NoError(t, err)
 	require.Equal(t, accountTypePersonal, pers2.AccountType.String, "stays personal")

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -82,18 +82,21 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		// as personal and never persist the late-arriving email / external_org_id
 		// or teach the device bridge (DNO-360).
 		//
-		// A company-credential session (no provider account UUID) never gets a
-		// UserAccountID — there is no account entity to persist — so for those
-		// sessions the fast path keys on the resolved AccountType instead, or they
-		// would re-attribute on every batch for their lifetime. A UUID-bearing
-		// session must still present a persisted UserAccountID: attribution stamps
-		// AccountType before the user_accounts upsert, so keying on AccountType
-		// alone would freeze a session whose entity persistence transiently failed
-		// (classified but never persisted, linked, or billing-resolved) instead of
-		// retrying on the next batch.
+		// A session with an account entity to persist — a provider account UUID
+		// (OAuth) or a session email (company credentials, entity keyed on the
+		// resolved employee or the email) — must present a persisted
+		// UserAccountID before it may take the
+		// fast path: attribution stamps AccountType before the user_accounts
+		// upsert, so keying on AccountType alone would freeze a session whose
+		// entity persistence transiently failed (classified but never persisted,
+		// linked, or billing-resolved) instead of retrying on the next batch.
+		// Only a session with neither identity (no UUID and no email — nothing to
+		// key an entity on) fast-paths on the resolved AccountType, or it would
+		// re-attribute on every batch for its lifetime.
 		var cached SessionMetadata
 		if err := s.cache.Get(ctx, sessionCacheKey(session.SessionID), &cached); err == nil &&
-			(cached.UserAccountID != "" || (cached.AccountType != "" && cached.ExternalAccountUUID == "")) &&
+			(cached.UserAccountID != "" ||
+				(cached.AccountType != "" && cached.ExternalAccountUUID == "" && cached.UserEmail == "")) &&
 			!sessionEnrichesAttribution(session, cached) {
 			attributionBySession[session.SessionID] = cached
 			continue
@@ -177,8 +180,8 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		}
 
 		// Cache only after the backfill: the once-per-session fast path above
-		// keys on the cached UserAccountID (or, for a company-credential session
-		// with no account entity, the resolved AccountType), so caching an
+		// keys on the cached UserAccountID (or, for a session with no persistable
+		// account identity, the resolved AccountType), so caching an
 		// attribution whose backfill just failed would freeze the chat unlinked
 		// forever. Skipping
 		// the write keeps this batch's row stamping (attributionBySession) and

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -51,19 +51,42 @@ UPDATE chats SET updated_at = NOW() WHERE id = @id AND project_id = @project_id;
 -- created before account attribution landed. A chat is created once, on the
 -- session's first persisted message, so a first prompt that beats the first
 -- OTEL export would otherwise leave the chat unlinked forever (and the
--- account-identity risk rules blind to it). Fill-once: never overwrites a
--- link that chat creation or an earlier backfill already set.
+-- account-identity risk rules blind to it). Fill-once, with one exception: a
+-- link to a company-credential account (no provider account UUID) may be
+-- upgraded to a UUID-bearing account. That heals the session whose first OTEL
+-- batch carried the email but not the late-arriving user.account_uuid — the
+-- UUID proves the session was an OAuth account all along, so the UUID-keyed
+-- entity is strictly more precise. Never the reverse: a UUID-bearing link is
+-- final.
 UPDATE chats
 SET user_account_id = @user_account_id
   , updated_at = NOW()
-WHERE id = @id
-  AND project_id = @project_id
-  AND user_account_id IS NULL
-  AND deleted IS FALSE;
+WHERE chats.id = @id
+  AND chats.project_id = @project_id
+  AND chats.deleted IS FALSE
+  AND (
+    chats.user_account_id IS NULL
+    OR (
+      EXISTS (
+        SELECT 1 FROM user_accounts new_ua
+        WHERE new_ua.id = @user_account_id
+          AND new_ua.organization_id = chats.organization_id
+          AND new_ua.external_account_uuid IS NOT NULL
+      )
+      AND EXISTS (
+        SELECT 1 FROM user_accounts cur_ua
+        WHERE cur_ua.id = chats.user_account_id
+          AND cur_ua.organization_id = chats.organization_id
+          AND cur_ua.external_account_uuid IS NULL
+      )
+    )
+  );
 
 -- name: UpsertUserAccount :one
--- Records the external AI provider account observed for a session, keyed by the
--- provider's stable per-account id. COALESCE on conflict keeps a previously
+-- Records the external AI provider account observed for an OAuth-authenticated
+-- session, keyed by the provider's stable per-account id (a company-credential
+-- session has none — see UpsertCompanyCredentialUserAccount). COALESCE on
+-- conflict keeps a previously
 -- learned owner/email/account_id rather than clobbering it with a null from a
 -- later session that lacked that field. The conflict target carries the partial
 -- index predicate so it matches user_accounts_org_provider_external_account_uuid_key.
@@ -98,6 +121,120 @@ DO UPDATE SET
 -- billing_mode is intentionally not written here: it is an admin/out-of-band
 -- override, never set by ingest. Returning it lets attribution resolve the
 -- account-level tier of the billing-mode cascade without a second round trip.
+RETURNING id, billing_mode;
+
+-- Company-credential accounts (an API key, a gateway/proxy, Bedrock, or
+-- Vertex) carry no provider account UUID, so their entity keys on the resolved
+-- employee (user_accounts_org_provider_company_user_key) — one account per
+-- employee per provider, so device-bridge attribution and email aliases
+-- converge on a single account — falling back to the normalized session email
+-- (user_accounts_org_provider_email_key) while no employee has resolved. The
+-- four queries below implement that dual key; external_org_id /
+-- external_account_id are never present on this path, so none of them write
+-- those. As with UpsertUserAccount, billing_mode is admin/out-of-band only —
+-- never written by ingest, returned so attribution can resolve the
+-- account-level tier of the billing-mode cascade without a second round trip.
+
+-- name: ClaimCompanyCredentialUserAccount :one
+-- Promotes an email-keyed row persisted before its employee resolved to the
+-- now-resolved employee, in place — the row id (and any chat links) survive
+-- the transition. Guarded so an employee never gains a second resolved row:
+-- when one already exists this matches nothing (ErrNoRows) and the caller
+-- falls through to the by-user upsert.
+UPDATE user_accounts SET
+    user_id      = @user_id
+  , account_type = @account_type
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+WHERE user_accounts.organization_id = @organization_id
+  AND user_accounts.provider = @provider
+  AND user_accounts.external_account_uuid IS NULL
+  AND user_accounts.deleted_at IS NULL
+  AND user_accounts.user_id IS NULL
+  AND user_accounts.email = @email
+  AND NOT EXISTS (
+    SELECT 1 FROM user_accounts resolved
+    WHERE resolved.organization_id = @organization_id
+      AND resolved.provider = @provider
+      AND resolved.external_account_uuid IS NULL
+      AND resolved.deleted_at IS NULL
+      AND resolved.user_id = @user_id::text
+  )
+RETURNING id, billing_mode;
+
+-- name: UpsertCompanyCredentialUserAccountByUser :one
+-- The resolved-employee entity upsert. email may be NULL: a session with no
+-- email at all still persists here when the device bridge resolved its owner.
+-- COALESCE keeps a previously learned email rather than clobbering it.
+INSERT INTO user_accounts (
+    organization_id
+  , provider
+  , external_account_uuid
+  , user_id
+  , email
+  , account_type
+) VALUES (
+    @organization_id
+  , @provider
+  , NULL
+  , @user_id
+  , sqlc.narg(email)
+  , @account_type
+)
+ON CONFLICT (organization_id, provider, user_id) WHERE external_account_uuid IS NULL AND deleted_at IS NULL
+DO UPDATE SET
+    email        = COALESCE(EXCLUDED.email, user_accounts.email)
+  , account_type = EXCLUDED.account_type
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+RETURNING id, billing_mode;
+
+-- name: AdoptCompanyCredentialUserAccountByEmail :one
+-- For a session whose employee did NOT resolve: joins the company-credential
+-- account already known for this email, preferring an employee-resolved row —
+-- so a session that stops resolving (e.g. the employee was deprovisioned)
+-- rejoins the same account instead of forking a second row. ErrNoRows when
+-- the email has no account yet (caller inserts).
+UPDATE user_accounts SET
+    account_type = @account_type
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+WHERE id = (
+    SELECT candidate.id FROM user_accounts candidate
+    WHERE candidate.organization_id = @organization_id
+      AND candidate.provider = @provider
+      AND candidate.external_account_uuid IS NULL
+      AND candidate.deleted_at IS NULL
+      AND candidate.email = @email
+    ORDER BY (candidate.user_id IS NOT NULL) DESC, candidate.created_at
+    LIMIT 1
+  )
+RETURNING id, billing_mode;
+
+-- name: InsertCompanyCredentialUserAccountByEmail :one
+-- First sight of an unresolved company-credential email: create the
+-- email-keyed row. ON CONFLICT covers the concurrent-first-sight race between
+-- two sessions of the same email.
+INSERT INTO user_accounts (
+    organization_id
+  , provider
+  , external_account_uuid
+  , user_id
+  , email
+  , account_type
+) VALUES (
+    @organization_id
+  , @provider
+  , NULL
+  , NULL
+  , @email
+  , @account_type
+)
+ON CONFLICT (organization_id, provider, email) WHERE external_account_uuid IS NULL AND user_id IS NULL AND deleted_at IS NULL
+DO UPDATE SET
+    account_type = EXCLUDED.account_type
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
 RETURNING id, billing_mode;
 
 -- name: CountEmployeesForExternalOrg :one
@@ -144,6 +281,28 @@ SELECT * FROM user_accounts
 WHERE organization_id = @organization_id
   AND provider = @provider
   AND external_account_uuid = @external_account_uuid
+  AND deleted_at IS NULL;
+
+-- name: GetCompanyCredentialUserAccount :one
+-- Looks up a company-credential account by session email, preferring the
+-- employee-resolved row when an orphaned unresolved row with the same email
+-- also exists (see ClaimCompanyCredentialUserAccount's guard).
+SELECT * FROM user_accounts
+WHERE id = (
+    SELECT candidate.id FROM user_accounts candidate
+    WHERE candidate.organization_id = @organization_id
+      AND candidate.provider = @provider
+      AND candidate.email = @email
+      AND candidate.external_account_uuid IS NULL
+      AND candidate.deleted_at IS NULL
+    ORDER BY (candidate.user_id IS NOT NULL) DESC, candidate.created_at
+    LIMIT 1
+  );
+
+-- name: CountUserAccountsByOrg :one
+-- Test fixture: asserts how many live account entities an org has.
+SELECT COUNT(*)::bigint FROM user_accounts
+WHERE organization_id = @organization_id
   AND deleted_at IS NULL;
 
 -- name: ListUserAccountsByUsers :many

--- a/server/internal/hooks/repo/models.go
+++ b/server/internal/hooks/repo/models.go
@@ -38,7 +38,7 @@ type UserAccount struct {
 	UserID              pgtype.Text
 	Provider            string
 	ExternalOrgID       pgtype.Text
-	ExternalAccountUuid string
+	ExternalAccountUuid pgtype.Text
 	ExternalAccountID   pgtype.Text
 	Email               pgtype.Text
 	AccountType         pgtype.Text

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -12,6 +12,53 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const adoptCompanyCredentialUserAccountByEmail = `-- name: AdoptCompanyCredentialUserAccountByEmail :one
+UPDATE user_accounts SET
+    account_type = $1
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+WHERE id = (
+    SELECT candidate.id FROM user_accounts candidate
+    WHERE candidate.organization_id = $2
+      AND candidate.provider = $3
+      AND candidate.external_account_uuid IS NULL
+      AND candidate.deleted_at IS NULL
+      AND candidate.email = $4
+    ORDER BY (candidate.user_id IS NOT NULL) DESC, candidate.created_at
+    LIMIT 1
+  )
+RETURNING id, billing_mode
+`
+
+type AdoptCompanyCredentialUserAccountByEmailParams struct {
+	AccountType    pgtype.Text
+	OrganizationID string
+	Provider       string
+	Email          pgtype.Text
+}
+
+type AdoptCompanyCredentialUserAccountByEmailRow struct {
+	ID          uuid.UUID
+	BillingMode pgtype.Text
+}
+
+// For a session whose employee did NOT resolve: joins the company-credential
+// account already known for this email, preferring an employee-resolved row —
+// so a session that stops resolving (e.g. the employee was deprovisioned)
+// rejoins the same account instead of forking a second row. ErrNoRows when
+// the email has no account yet (caller inserts).
+func (q *Queries) AdoptCompanyCredentialUserAccountByEmail(ctx context.Context, arg AdoptCompanyCredentialUserAccountByEmailParams) (AdoptCompanyCredentialUserAccountByEmailRow, error) {
+	row := q.db.QueryRow(ctx, adoptCompanyCredentialUserAccountByEmail,
+		arg.AccountType,
+		arg.OrganizationID,
+		arg.Provider,
+		arg.Email,
+	)
+	var i AdoptCompanyCredentialUserAccountByEmailRow
+	err := row.Scan(&i.ID, &i.BillingMode)
+	return i, err
+}
+
 const backfillLatestClaudeUserMessagePromptID = `-- name: BackfillLatestClaudeUserMessagePromptID :execrows
 WITH latest_user_message AS (
   SELECT chat_messages.id
@@ -43,6 +90,72 @@ func (q *Queries) BackfillLatestClaudeUserMessagePromptID(ctx context.Context, a
 	return result.RowsAffected(), nil
 }
 
+const claimCompanyCredentialUserAccount = `-- name: ClaimCompanyCredentialUserAccount :one
+
+UPDATE user_accounts SET
+    user_id      = $1
+  , account_type = $2
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+WHERE user_accounts.organization_id = $3
+  AND user_accounts.provider = $4
+  AND user_accounts.external_account_uuid IS NULL
+  AND user_accounts.deleted_at IS NULL
+  AND user_accounts.user_id IS NULL
+  AND user_accounts.email = $5
+  AND NOT EXISTS (
+    SELECT 1 FROM user_accounts resolved
+    WHERE resolved.organization_id = $3
+      AND resolved.provider = $4
+      AND resolved.external_account_uuid IS NULL
+      AND resolved.deleted_at IS NULL
+      AND resolved.user_id = $1::text
+  )
+RETURNING id, billing_mode
+`
+
+type ClaimCompanyCredentialUserAccountParams struct {
+	UserID         pgtype.Text
+	AccountType    pgtype.Text
+	OrganizationID string
+	Provider       string
+	Email          pgtype.Text
+}
+
+type ClaimCompanyCredentialUserAccountRow struct {
+	ID          uuid.UUID
+	BillingMode pgtype.Text
+}
+
+// Company-credential accounts (an API key, a gateway/proxy, Bedrock, or
+// Vertex) carry no provider account UUID, so their entity keys on the resolved
+// employee (user_accounts_org_provider_company_user_key) — one account per
+// employee per provider, so device-bridge attribution and email aliases
+// converge on a single account — falling back to the normalized session email
+// (user_accounts_org_provider_email_key) while no employee has resolved. The
+// four queries below implement that dual key; external_org_id /
+// external_account_id are never present on this path, so none of them write
+// those. As with UpsertUserAccount, billing_mode is admin/out-of-band only —
+// never written by ingest, returned so attribution can resolve the
+// account-level tier of the billing-mode cascade without a second round trip.
+// Promotes an email-keyed row persisted before its employee resolved to the
+// now-resolved employee, in place — the row id (and any chat links) survive
+// the transition. Guarded so an employee never gains a second resolved row:
+// when one already exists this matches nothing (ErrNoRows) and the caller
+// falls through to the by-user upsert.
+func (q *Queries) ClaimCompanyCredentialUserAccount(ctx context.Context, arg ClaimCompanyCredentialUserAccountParams) (ClaimCompanyCredentialUserAccountRow, error) {
+	row := q.db.QueryRow(ctx, claimCompanyCredentialUserAccount,
+		arg.UserID,
+		arg.AccountType,
+		arg.OrganizationID,
+		arg.Provider,
+		arg.Email,
+	)
+	var i ClaimCompanyCredentialUserAccountRow
+	err := row.Scan(&i.ID, &i.BillingMode)
+	return i, err
+}
+
 const countEmployeesForExternalOrg = `-- name: CountEmployeesForExternalOrg :one
 SELECT COUNT(DISTINCT user_id)::bigint
 FROM user_accounts
@@ -66,6 +179,20 @@ type CountEmployeesForExternalOrgParams struct {
 // email under a solo org is checked against the work-email guard instead.
 func (q *Queries) CountEmployeesForExternalOrg(ctx context.Context, arg CountEmployeesForExternalOrgParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countEmployeesForExternalOrg, arg.OrganizationID, arg.Provider, arg.ExternalOrgID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const countUserAccountsByOrg = `-- name: CountUserAccountsByOrg :one
+SELECT COUNT(*)::bigint FROM user_accounts
+WHERE organization_id = $1
+  AND deleted_at IS NULL
+`
+
+// Test fixture: asserts how many live account entities an org has.
+func (q *Queries) CountUserAccountsByOrg(ctx context.Context, organizationID string) (int64, error) {
+	row := q.db.QueryRow(ctx, countUserAccountsByOrg, organizationID)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
@@ -160,6 +287,54 @@ func (q *Queries) FindAssistantToolCallMessageID(ctx context.Context, arg FindAs
 	return id, err
 }
 
+const getCompanyCredentialUserAccount = `-- name: GetCompanyCredentialUserAccount :one
+SELECT id, organization_id, user_id, provider, external_org_id, external_account_uuid, external_account_id, email, account_type, billing_mode, plan_type, first_seen_at, last_seen_at, created_at, updated_at, deleted_at, deleted FROM user_accounts
+WHERE id = (
+    SELECT candidate.id FROM user_accounts candidate
+    WHERE candidate.organization_id = $1
+      AND candidate.provider = $2
+      AND candidate.email = $3
+      AND candidate.external_account_uuid IS NULL
+      AND candidate.deleted_at IS NULL
+    ORDER BY (candidate.user_id IS NOT NULL) DESC, candidate.created_at
+    LIMIT 1
+  )
+`
+
+type GetCompanyCredentialUserAccountParams struct {
+	OrganizationID string
+	Provider       string
+	Email          pgtype.Text
+}
+
+// Looks up a company-credential account by session email, preferring the
+// employee-resolved row when an orphaned unresolved row with the same email
+// also exists (see ClaimCompanyCredentialUserAccount's guard).
+func (q *Queries) GetCompanyCredentialUserAccount(ctx context.Context, arg GetCompanyCredentialUserAccountParams) (UserAccount, error) {
+	row := q.db.QueryRow(ctx, getCompanyCredentialUserAccount, arg.OrganizationID, arg.Provider, arg.Email)
+	var i UserAccount
+	err := row.Scan(
+		&i.ID,
+		&i.OrganizationID,
+		&i.UserID,
+		&i.Provider,
+		&i.ExternalOrgID,
+		&i.ExternalAccountUuid,
+		&i.ExternalAccountID,
+		&i.Email,
+		&i.AccountType,
+		&i.BillingMode,
+		&i.PlanType,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getDeviceOwner = `-- name: GetDeviceOwner :one
 SELECT id, organization_id, provider, device_id, linked_user_id, first_seen_at, last_seen_at, created_at, updated_at, deleted_at, deleted FROM device_owners
 WHERE organization_id = $1
@@ -243,7 +418,7 @@ WHERE organization_id = $1
 type GetUserAccountParams struct {
 	OrganizationID      string
 	Provider            string
-	ExternalAccountUuid string
+	ExternalAccountUuid pgtype.Text
 }
 
 func (q *Queries) GetUserAccount(ctx context.Context, arg GetUserAccountParams) (UserAccount, error) {
@@ -268,6 +443,57 @@ func (q *Queries) GetUserAccount(ctx context.Context, arg GetUserAccountParams) 
 		&i.DeletedAt,
 		&i.Deleted,
 	)
+	return i, err
+}
+
+const insertCompanyCredentialUserAccountByEmail = `-- name: InsertCompanyCredentialUserAccountByEmail :one
+INSERT INTO user_accounts (
+    organization_id
+  , provider
+  , external_account_uuid
+  , user_id
+  , email
+  , account_type
+) VALUES (
+    $1
+  , $2
+  , NULL
+  , NULL
+  , $3
+  , $4
+)
+ON CONFLICT (organization_id, provider, email) WHERE external_account_uuid IS NULL AND user_id IS NULL AND deleted_at IS NULL
+DO UPDATE SET
+    account_type = EXCLUDED.account_type
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+RETURNING id, billing_mode
+`
+
+type InsertCompanyCredentialUserAccountByEmailParams struct {
+	OrganizationID string
+	Provider       string
+	Email          pgtype.Text
+	AccountType    pgtype.Text
+}
+
+type InsertCompanyCredentialUserAccountByEmailRow struct {
+	ID          uuid.UUID
+	BillingMode pgtype.Text
+}
+
+// First sight of an unresolved company-credential email: create the
+// email-keyed row. ON CONFLICT covers the concurrent-first-sight race between
+// two sessions of the same email.
+func (q *Queries) InsertCompanyCredentialUserAccountByEmail(ctx context.Context, arg InsertCompanyCredentialUserAccountByEmailParams) (InsertCompanyCredentialUserAccountByEmailRow, error) {
+	row := q.db.QueryRow(ctx, insertCompanyCredentialUserAccountByEmail,
+		arg.OrganizationID,
+		arg.Provider,
+		arg.Email,
+		arg.AccountType,
+	)
+	var i InsertCompanyCredentialUserAccountByEmailRow
+	err := row.Scan(&i.ID, &i.BillingMode)
 	return i, err
 }
 
@@ -397,10 +623,26 @@ const linkChatUserAccount = `-- name: LinkChatUserAccount :execrows
 UPDATE chats
 SET user_account_id = $1
   , updated_at = NOW()
-WHERE id = $2
-  AND project_id = $3
-  AND user_account_id IS NULL
-  AND deleted IS FALSE
+WHERE chats.id = $2
+  AND chats.project_id = $3
+  AND chats.deleted IS FALSE
+  AND (
+    chats.user_account_id IS NULL
+    OR (
+      EXISTS (
+        SELECT 1 FROM user_accounts new_ua
+        WHERE new_ua.id = $1
+          AND new_ua.organization_id = chats.organization_id
+          AND new_ua.external_account_uuid IS NOT NULL
+      )
+      AND EXISTS (
+        SELECT 1 FROM user_accounts cur_ua
+        WHERE cur_ua.id = chats.user_account_id
+          AND cur_ua.organization_id = chats.organization_id
+          AND cur_ua.external_account_uuid IS NULL
+      )
+    )
+  )
 `
 
 type LinkChatUserAccountParams struct {
@@ -413,8 +655,13 @@ type LinkChatUserAccountParams struct {
 // created before account attribution landed. A chat is created once, on the
 // session's first persisted message, so a first prompt that beats the first
 // OTEL export would otherwise leave the chat unlinked forever (and the
-// account-identity risk rules blind to it). Fill-once: never overwrites a
-// link that chat creation or an earlier backfill already set.
+// account-identity risk rules blind to it). Fill-once, with one exception: a
+// link to a company-credential account (no provider account UUID) may be
+// upgraded to a UUID-bearing account. That heals the session whose first OTEL
+// batch carried the email but not the late-arriving user.account_uuid — the
+// UUID proves the session was an OAuth account all along, so the UUID-keyed
+// entity is strictly more precise. Never the reverse: a UUID-bearing link is
+// final.
 func (q *Queries) LinkChatUserAccount(ctx context.Context, arg LinkChatUserAccountParams) (int64, error) {
 	result, err := q.db.Exec(ctx, linkChatUserAccount, arg.UserAccountID, arg.ID, arg.ProjectID)
 	if err != nil {
@@ -588,6 +835,60 @@ func (q *Queries) UpsertClaudeCodeSession(ctx context.Context, arg UpsertClaudeC
 	return id, err
 }
 
+const upsertCompanyCredentialUserAccountByUser = `-- name: UpsertCompanyCredentialUserAccountByUser :one
+INSERT INTO user_accounts (
+    organization_id
+  , provider
+  , external_account_uuid
+  , user_id
+  , email
+  , account_type
+) VALUES (
+    $1
+  , $2
+  , NULL
+  , $3
+  , $4
+  , $5
+)
+ON CONFLICT (organization_id, provider, user_id) WHERE external_account_uuid IS NULL AND deleted_at IS NULL
+DO UPDATE SET
+    email        = COALESCE(EXCLUDED.email, user_accounts.email)
+  , account_type = EXCLUDED.account_type
+  , last_seen_at = clock_timestamp()
+  , updated_at   = clock_timestamp()
+RETURNING id, billing_mode
+`
+
+type UpsertCompanyCredentialUserAccountByUserParams struct {
+	OrganizationID string
+	Provider       string
+	UserID         pgtype.Text
+	Email          pgtype.Text
+	AccountType    pgtype.Text
+}
+
+type UpsertCompanyCredentialUserAccountByUserRow struct {
+	ID          uuid.UUID
+	BillingMode pgtype.Text
+}
+
+// The resolved-employee entity upsert. email may be NULL: a session with no
+// email at all still persists here when the device bridge resolved its owner.
+// COALESCE keeps a previously learned email rather than clobbering it.
+func (q *Queries) UpsertCompanyCredentialUserAccountByUser(ctx context.Context, arg UpsertCompanyCredentialUserAccountByUserParams) (UpsertCompanyCredentialUserAccountByUserRow, error) {
+	row := q.db.QueryRow(ctx, upsertCompanyCredentialUserAccountByUser,
+		arg.OrganizationID,
+		arg.Provider,
+		arg.UserID,
+		arg.Email,
+		arg.AccountType,
+	)
+	var i UpsertCompanyCredentialUserAccountByUserRow
+	err := row.Scan(&i.ID, &i.BillingMode)
+	return i, err
+}
+
 const upsertDeviceOwner = `-- name: UpsertDeviceOwner :one
 INSERT INTO device_owners (
     organization_id
@@ -694,7 +995,7 @@ RETURNING id, billing_mode
 type UpsertUserAccountParams struct {
 	OrganizationID      string
 	Provider            string
-	ExternalAccountUuid string
+	ExternalAccountUuid pgtype.Text
 	UserID              pgtype.Text
 	ExternalOrgID       pgtype.Text
 	ExternalAccountID   pgtype.Text
@@ -707,8 +1008,10 @@ type UpsertUserAccountRow struct {
 	BillingMode pgtype.Text
 }
 
-// Records the external AI provider account observed for a session, keyed by the
-// provider's stable per-account id. COALESCE on conflict keeps a previously
+// Records the external AI provider account observed for an OAuth-authenticated
+// session, keyed by the provider's stable per-account id (a company-credential
+// session has none — see UpsertCompanyCredentialUserAccount). COALESCE on
+// conflict keeps a previously
 // learned owner/email/account_id rather than clobbering it with a null from a
 // later session that lacked that field. The conflict target carries the partial
 // index predicate so it matches user_accounts_org_provider_external_account_uuid_key.

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -471,7 +471,7 @@ func TestSearchUsers_AttachesAccountsToEmailKeyedSummary(t *testing.T) {
 	_, err := hooksQueries.UpsertUserAccount(ctx, hooksRepo.UpsertUserAccountParams{
 		OrganizationID:      authCtx.ActiveOrganizationID,
 		Provider:            "anthropic",
-		ExternalAccountUuid: uuid.New().String(),
+		ExternalAccountUuid: conv.ToPGText(uuid.New().String()),
 		UserID:              conv.ToPGTextEmpty(userID),
 		ExternalOrgID:       conv.ToPGTextEmpty("ext-org-" + uuid.New().String()),
 		ExternalAccountID:   conv.ToPGTextEmpty(""),
@@ -543,7 +543,7 @@ func TestSearchUsers_ForeignRawUserIDsDoNotStealAccounts(t *testing.T) {
 		_, err := hooksQueries.UpsertUserAccount(ctx, hooksRepo.UpsertUserAccountParams{
 			OrganizationID:      authCtx.ActiveOrganizationID,
 			Provider:            "anthropic",
-			ExternalAccountUuid: uuid.New().String(),
+			ExternalAccountUuid: conv.ToPGText(uuid.New().String()),
 			UserID:              conv.ToPGTextEmpty(owner),
 			ExternalOrgID:       conv.ToPGTextEmpty("ext-org-" + uuid.New().String()),
 			ExternalAccountID:   conv.ToPGTextEmpty(""),
@@ -622,7 +622,7 @@ func TestSearchUsers_PersonalAccountAttachesToOwnerSummary(t *testing.T) {
 		_, err := hooksQueries.UpsertUserAccount(ctx, hooksRepo.UpsertUserAccountParams{
 			OrganizationID:      authCtx.ActiveOrganizationID,
 			Provider:            "anthropic",
-			ExternalAccountUuid: uuid.New().String(),
+			ExternalAccountUuid: conv.ToPGText(uuid.New().String()),
 			UserID:              conv.ToPGTextEmpty(userID),
 			ExternalOrgID:       conv.ToPGTextEmpty("ext-org-" + uuid.New().String()),
 			ExternalAccountID:   conv.ToPGTextEmpty(""),


### PR DESCRIPTION
## Summary

Stacked on #4325 (merge that first). Fixes DNO-555: Claude accounts authenticated with company credentials (an API key, a bearer-token gateway, Bedrock, or Vertex) emit no `user.account_uuid`, so attribution classified them `team` (since #4259) but never persisted a `user_accounts` entity. At a gateway-only org the entire team population had no account rows, no chat→account links, and no billing-mode resolution — only the handful of personal OAuth logins appeared.

With this change, UUID-less sessions persist an account entity on a **dual key**:

- **Resolved employee** (`user_accounts_org_provider_company_user_key`): one company-credential account per employee per provider. All of an employee's sessions converge on it — whichever email they report (aliases, device-bridge attribution) and even sessions reporting **no email at all** when the device bridge knows the owner.
- **Normalized session email** (`user_accounts_org_provider_email_key`) as the fallback while no employee has resolved — this is what covers the ~45% of the affected population with no linked Gram user. When the email later resolves, ingest **promotes the row to the employee key in place** (`ClaimCompanyCredentialUserAccount`) so the row id and any chat links survive the transition; the claim is guarded so an employee never gains a second resolved row.

Only a session with no identity on any axis (no UUID, no resolved employee, no email) persists nothing. Company-credential accounts run the same billing-mode cascade as OAuth accounts.

Keying resolved rows on the employee (rather than email alone) was reworked from the first draft after review flagged per-email fragmentation; keying _solely_ on `user_id` was rejected because ~45% of the population has no Gram user to key on (numbers in DNO-555).

## Edge cases handled

- **Late-arriving OAuth UUID**: an OAuth session whose first OTEL batch carries the email but not the UUID would link its chat to a spurious company-credential entity. `LinkChatUserAccount` now upgrades a chat's link from a UUID-less entity to a UUID-bearing account when the UUID arrives (never the reverse; subqueries org-scoped for defense-in-depth). The stale row itself lingers with a frozen `last_seen_at` — accepted and documented in `classifyAccount` (email and UUID ride the same `user.*` log attributes, so this batch shape is rare).
- **Fast-path freeze**: the once-per-session short-circuit in `otel.go` previously treated "no UUID + classified" as terminal. It now only freezes on `AccountType` when the session has no persistable identity at all, so a transiently failed upsert retries on the next batch — the same hazard #4259's review caught for the UUID path.
- **Deprovisioned employee**: a session whose email stops resolving rejoins the existing resolved account (adopt-by-email prefers the resolved row) instead of forking a new one.
- **Classification queries unaffected**: company-credential rows have NULL `external_org_id`, so `CountEmployeesForExternalOrg` / `EmployeeHasSharedExternalOrg` never see them.

## Visible behavior changes

- Company-credential chats move from the "unattributed" dashboard filter bucket to "team", and the account-identity risk scanner sees them as team accounts.
- Org-level `billing_mode` declarations on `ai_integration_configs` now apply to gateway sessions.
- The employees page's per-user account breakdown includes company-credential accounts for resolved users.

Codex and Cursor are unaffected (they never run account attribution).

## Testing

New coverage: entity persisted for an unprovisioned gateway email; entity shared across sessions with in-place promotion when the employee resolves; sessions with alias emails / no email converging on one employee account via the device bridge; chat-link upgrade on late UUID; no entity when no identity at all. Full `hooks`, `risk_analysis`, `telemetry`, and `chat` suites pass; `mise lint:server` clean.

Refs DNO-555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
