### PR TITLE
feat(playground): make tunneled MCP servers available in the Playground

### DIFF
--- a/.changeset/tunneled-mcp-playground.md
+++ b/.changeset/tunneled-mcp-playground.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Playground: tunneled MCP servers can now be selected and chatted with (behind the `gram-tunneled-mcp` flag).

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ __pycache__/
 
 .playwright-mcp
 .playwright-cli
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/client/dashboard/src/components/mcp-server-x-sidebar-nav.tsx
+++ b/client/dashboard/src/components/mcp-server-x-sidebar-nav.tsx
@@ -285,7 +285,11 @@ export function McpServerXSidebarNav(): React.JSX.Element | null {
         )}
         <div className="bg-border w-px self-stretch" />
         <routes.playground.Link
-          queryParams={isRemoteBacked ? { mcpServer: mcpServer.id } : undefined}
+          queryParams={
+            isRemoteBacked || isTunneledBacked
+              ? { mcpServer: mcpServer.id }
+              : undefined
+          }
           className="flex flex-1 items-center justify-center hover:no-underline"
         >
           <span className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs font-semibold transition-colors">

--- a/client/dashboard/src/hooks/useProxiedMcpTools.ts
+++ b/client/dashboard/src/hooks/useProxiedMcpTools.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
  * `tools/list` response). All fields are advisory and may be absent; malformed
  * hint values are dropped (`.catch`) rather than failing the whole decode.
  */
-const remoteMcpToolAnnotationsSchema = z.object({
+const proxiedMcpToolAnnotationsSchema = z.object({
   /** Human-friendly display name for the tool. */
   title: z.string().optional(),
   readOnlyHint: z.boolean().optional().catch(undefined),
@@ -17,36 +17,36 @@ const remoteMcpToolAnnotationsSchema = z.object({
 });
 
 /** A single tool from the `tools/list` response (extra fields are ignored). */
-const remoteMcpToolSchema = z.object({
+const proxiedMcpToolSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   // Raw JSON Schema for the tool's input; kept opaque and parsed lazily in the
   // UI when rendering parameters.
   inputSchema: z.unknown().optional(),
-  annotations: remoteMcpToolAnnotationsSchema.optional(),
+  annotations: proxiedMcpToolAnnotationsSchema.optional(),
 });
 
 /** The decoded shape of an MCP `tools/list` result. */
 const listToolsResultSchema = z.object({
-  tools: z.array(remoteMcpToolSchema),
+  tools: z.array(proxiedMcpToolSchema),
 });
 
-export type RemoteMcpToolAnnotations = z.infer<
-  typeof remoteMcpToolAnnotationsSchema
+export type ProxiedMcpToolAnnotations = z.infer<
+  typeof proxiedMcpToolAnnotationsSchema
 >;
 
 /** The slice of an MCP tool we surface for the dashboard listing. */
-export interface RemoteMcpTool {
+export interface ProxiedMcpTool {
   description?: string;
   inputSchema?: unknown;
-  annotations?: RemoteMcpToolAnnotations;
+  annotations?: ProxiedMcpToolAnnotations;
 }
 
 /** A record of tools keyed by tool name, mirroring the `tools/list` response. */
-type RemoteMcpToolSet = Record<string, RemoteMcpTool>;
+type ProxiedMcpToolSet = Record<string, ProxiedMcpTool>;
 
-export interface UseRemoteMcpToolsResult {
-  tools: RemoteMcpToolSet | undefined;
+export interface UseProxiedMcpToolsResult {
+  tools: ProxiedMcpToolSet | undefined;
   isLoading: boolean;
   isError: boolean;
   /**
@@ -59,7 +59,7 @@ export interface UseRemoteMcpToolsResult {
   refetch: () => void;
 }
 
-export interface UseRemoteMcpToolsOptions {
+export interface UseProxiedMcpToolsOptions {
   /**
    * Extra request headers for the MCP connection — e.g. the user-session JWT
    * (`Authorization: Bearer …`) the runtime gateway uses to resolve the
@@ -82,16 +82,16 @@ export interface UseRemoteMcpToolsOptions {
 }
 
 /**
- * Connects to a Gram-proxied remote MCP endpoint and lists its tools.
+ * Connects to a Gram-proxied MCP endpoint and lists its tools.
  *
  * Issuer-gated servers need a user-session JWT passed via `options.headers`
- * (minted by useRemoteMcpUserSessionToken); without it they surface as
+ * (minted by useProxiedMcpUserSessionToken); without it they surface as
  * `needsAuth`.
  */
-export function useRemoteMcpTools(
+export function useProxiedMcpTools(
   mcpUrl: string | undefined,
-  options?: UseRemoteMcpToolsOptions,
-): UseRemoteMcpToolsResult {
+  options?: UseProxiedMcpToolsOptions,
+): UseProxiedMcpToolsResult {
   const { headers, enabled = true, throwOnError } = options ?? {};
 
   // Key on the header values so the query refetches once the JWT arrives or
@@ -102,14 +102,14 @@ export function useRemoteMcpTools(
         .sort()
     : [];
 
-  const query: UseQueryResult<RemoteMcpToolSet, Error> = useQuery({
-    queryKey: ["remoteMcpTools", mcpUrl, headersKey],
+  const query: UseQueryResult<ProxiedMcpToolSet, Error> = useQuery({
+    queryKey: ["proxiedMcpTools", mcpUrl, headersKey],
     queryFn: async () => {
       // `enabled` guards against an undefined URL, but narrow for the type.
       if (!mcpUrl) throw new Error("No MCP URL configured");
 
       const client = await createMCPClient({
-        name: "gram-dashboard-remote-mcp-client",
+        name: "gram-dashboard-proxied-mcp-client",
         transport: {
           type: "http",
           url: mcpUrl,
@@ -136,7 +136,7 @@ export function useRemoteMcpTools(
         ).listTools();
         const { tools } = listToolsResultSchema.parse(raw);
 
-        const toolSet: RemoteMcpToolSet = {};
+        const toolSet: ProxiedMcpToolSet = {};
         for (const tool of tools) {
           toolSet[tool.name] = {
             description: tool.description,

--- a/client/dashboard/src/hooks/useProxiedMcpUserSessionToken.ts
+++ b/client/dashboard/src/hooks/useProxiedMcpUserSessionToken.ts
@@ -2,16 +2,16 @@ import { useProject, useSession } from "@/contexts/Auth";
 import { useMintUserSessionMutation } from "@gram/client/react-query/mintUserSession.js";
 import { useQuery } from "@tanstack/react-query";
 
-export interface UseRemoteMcpUserSessionTokenResult {
+export interface UseProxiedMcpUserSessionTokenResult {
   /** The minted user-session JWT, or undefined while loading / not gated. */
   accessToken: string | undefined;
   isLoading: boolean;
 }
 
 /**
- * Mints a user-session JWT scoped to a remote MCP server, mirroring the
+ * Mints a user-session JWT scoped to a proxied MCP server, mirroring the
  * playground (see PlaygroundElements.tsx) but passing `mcpServerId` to the
- * unified mint: remote MCP servers are mcp_servers-backed and carry no toolset,
+ * unified mint: proxied MCP servers are mcp_servers-backed and carry no toolset,
  * so the JWT audience binds to the server's user_session_issuer (the /x/mcp
  * convention).
  * The minted token matches what /x/mcp/{slug}/token would emit after an OAuth
@@ -21,13 +21,13 @@ export interface UseRemoteMcpUserSessionTokenResult {
  * Only issuer-gated servers get a token; the mint RPC 400s for the rest, so we
  * leave `accessToken` undefined and let the connection proceed unauthenticated.
  */
-export function useRemoteMcpUserSessionToken({
+export function useProxiedMcpUserSessionToken({
   mcpServerId,
   isIssuerGated,
 }: {
   mcpServerId: string | undefined;
   isIssuerGated: boolean;
-}): UseRemoteMcpUserSessionTokenResult {
+}): UseProxiedMcpUserSessionTokenResult {
   const session = useSession();
   const project = useProject();
   const mintMutation = useMintUserSessionMutation();
@@ -36,7 +36,7 @@ export function useRemoteMcpUserSessionToken({
 
   const query = useQuery({
     queryKey: [
-      "remoteMcpUserSessionToken",
+      "proxiedMcpUserSessionToken",
       project.id,
       mcpServerId,
       session.user.id,

--- a/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
@@ -13,11 +13,11 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import {
-  useRemoteMcpTools,
-  type RemoteMcpTool,
-  type RemoteMcpToolAnnotations,
-} from "@/hooks/useRemoteMcpTools";
-import { useRemoteMcpUserSessionToken } from "@/hooks/useRemoteMcpUserSessionToken";
+  useProxiedMcpTools,
+  type ProxiedMcpTool,
+  type ProxiedMcpToolAnnotations,
+} from "@/hooks/useProxiedMcpTools";
+import { useProxiedMcpUserSessionToken } from "@/hooks/useProxiedMcpUserSessionToken";
 import { handleError, toError } from "@/lib/errors";
 import { cn, firstPartyConnectUrl, mcpConnectionUrl } from "@/lib/utils";
 import { Badge, Button } from "@speakeasy-api/moonshine";
@@ -158,7 +158,7 @@ function RemoteMcpToolsSectionInner({
   isIssuerGated,
 }: RemoteMcpToolsSectionProps): JSX.Element {
   const { accessToken, isLoading: isTokenLoading } =
-    useRemoteMcpUserSessionToken({ mcpServerId, isIssuerGated });
+    useProxiedMcpUserSessionToken({ mcpServerId, isIssuerGated });
 
   // Issuer-gated servers must wait for the JWT before connecting, otherwise the
   // unauthenticated request 401s and caches a spurious `needsAuth`.
@@ -174,7 +174,7 @@ function RemoteMcpToolsSectionInner({
   // isn't dropped on a cross-origin hop. No-op in prod / for custom domains.
   const connectUrl = useMemo(() => mcpConnectionUrl(mcpUrl), [mcpUrl]);
 
-  const { tools, isLoading, needsAuth, isError, refetch } = useRemoteMcpTools(
+  const { tools, isLoading, needsAuth, isError, refetch } = useProxiedMcpTools(
     connectUrl,
     { headers, enabled: connectionEnabled },
   );
@@ -228,7 +228,7 @@ function RemoteMcpToolsBody({
   loading: boolean;
   needsAuth: boolean;
   isError: boolean;
-  toolEntries: Array<[string, RemoteMcpTool]>;
+  toolEntries: Array<[string, ProxiedMcpTool]>;
   onRetry: () => void;
   onConnect?: () => void;
 }): JSX.Element {
@@ -264,7 +264,7 @@ function RemoteMcpToolsBody({
 function RemoteMcpToolsList({
   toolEntries,
 }: {
-  toolEntries: Array<[string, RemoteMcpTool]>;
+  toolEntries: Array<[string, ProxiedMcpTool]>;
 }): JSX.Element {
   const [selectedName, setSelectedName] = useState<string | null>(null);
 
@@ -322,7 +322,7 @@ function RemoteToolRow({
 }: {
   name: string;
   description?: string;
-  annotations?: RemoteMcpToolAnnotations;
+  annotations?: ProxiedMcpToolAnnotations;
   selected: boolean;
   onSelect: () => void;
 }): JSX.Element {
@@ -362,7 +362,7 @@ function RemoteToolDetails({
   tool,
 }: {
   name: string;
-  tool: RemoteMcpTool;
+  tool: ProxiedMcpTool;
 }): JSX.Element {
   const parameters = useMemo(() => extractParameters(tool), [tool]);
 
@@ -508,7 +508,7 @@ function RemoteMcpToolsConnectPrompt({
 
 /** Map raw MCP annotation hints to the booleans AnnotationBadgeIcons renders. */
 function resolveAnnotations(
-  annotations: RemoteMcpToolAnnotations | undefined,
+  annotations: ProxiedMcpToolAnnotations | undefined,
 ): ResolvedToolAnnotations {
   return {
     readOnly: Boolean(annotations?.readOnlyHint),
@@ -526,7 +526,7 @@ type ToolParameter = {
 };
 
 /** Flatten a tool's JSON Schema into a flat list of named parameters. */
-function extractParameters(tool: RemoteMcpTool): ToolParameter[] {
+function extractParameters(tool: ProxiedMcpTool): ToolParameter[] {
   const schema = readJsonSchema(tool.inputSchema);
   if (!schema) return [];
 

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -43,9 +43,9 @@ import { PlaygroundAuth } from "./PlaygroundAuth";
 import { PlaygroundConfigPanel } from "./PlaygroundConfigPanel";
 import { PlaygroundElements } from "./PlaygroundElements";
 import { PlaygroundLogsPanel } from "./PlaygroundLogsPanel";
-import { PlaygroundRemoteChat } from "./PlaygroundRemoteChat";
+import { PlaygroundProxiedChat } from "./PlaygroundProxiedChat";
 import { ShareChatButton } from "./ShareChatButton";
-import { useRemoteMcpConnection } from "./useRemoteMcpConnection";
+import { useProxiedMcpConnection } from "./useProxiedMcpConnection";
 
 // A single selectable server in the playground. Toolset-backed and
 // remote-MCP-backed servers share one flat picker; the `kind` discriminant only
@@ -61,7 +61,7 @@ type PlaygroundServerRef =
     };
 
 const toolsetServerKey = (slug: string) => `toolset:${slug}`;
-const remoteServerKey = (mcpServerId: string) => `remote:${mcpServerId}`;
+const mcpServerKey = (mcpServerId: string) => `remote:${mcpServerId}`;
 
 // Merges toolset-backed servers (from listToolsets) with remote-MCP-backed
 // servers (the remoteMcpServerId subset of mcpServers) into one sorted list.
@@ -91,7 +91,7 @@ function usePlaygroundServers(): {
       .filter((server) => !!server.remoteMcpServerId)
       .map((server) => ({
         kind: "remote",
-        key: remoteServerKey(server.id),
+        key: mcpServerKey(server.id),
         name: server.name ?? server.slug ?? "Remote MCP server",
         mcpServerId: server.id,
         isIssuerGated: !!server.userSessionIssuerId,
@@ -147,7 +147,7 @@ export default function Playground(): JSX.Element {
 /** Resolve the initially-selected server key from URL params. */
 function initialServerKey(searchParams: URLSearchParams): string | null {
   const mcpServer = searchParams.get("mcpServer");
-  if (mcpServer) return remoteServerKey(mcpServer);
+  if (mcpServer) return mcpServerKey(mcpServer);
   const toolset = searchParams.get("toolset");
   if (toolset) return toolsetServerKey(toolset);
   return null;
@@ -278,7 +278,7 @@ function PlaygroundInner() {
               />
             )}
             {selectedServer?.kind === "remote" && (
-              <RemoteServerPanel
+              <ProxiedServerPanel
                 mcpServerId={selectedServer.mcpServerId}
                 isIssuerGated={selectedServer.isIssuerGated}
                 serverSelector={serverSelector}
@@ -308,7 +308,7 @@ function PlaygroundInner() {
                 />
               )}
               {selectedServer?.kind === "remote" && (
-                <PlaygroundRemoteChat
+                <PlaygroundProxiedChat
                   mcpServerId={selectedServer.mcpServerId}
                   isIssuerGated={selectedServer.isIssuerGated}
                   environmentSlug={selectedEnvironment}
@@ -599,11 +599,11 @@ function ToolsetPanel({
 }
 
 /**
- * Left panel for a remote-MCP-backed server: the shared selector, a read-only
+ * Left panel for a proxied-MCP-backed server: the shared selector, a read-only
  * live tool list, and model settings. Tool curation, auth, and env config are
  * absent — those affordances don't apply to a proxied upstream.
  */
-function RemoteServerPanel({
+function ProxiedServerPanel({
   mcpServerId,
   isIssuerGated,
   serverSelector,
@@ -617,7 +617,7 @@ function RemoteServerPanel({
   mcpServerId: string;
   isIssuerGated: boolean;
 }) {
-  const { tools } = useRemoteMcpConnection(mcpServerId, isIssuerGated);
+  const { tools } = useProxiedMcpConnection(mcpServerId, isIssuerGated);
 
   const remoteTools = useMemo(
     () =>

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -13,9 +13,11 @@ import { useSdkClient } from "@/contexts/Sdk";
 import {
   useRegisterEnvironmentTelemetry,
   useRegisterToolsetTelemetry,
+  useTelemetry,
 } from "@/contexts/Telemetry";
 import { useLatestDeployment, useToolset } from "@/hooks/toolTypes";
 import { DEFAULT_MODEL } from "@/lib/models";
+import { TUNNELED_MCP_FEATURE_FLAG } from "@/lib/tunneledMcp";
 import { Tool } from "@/lib/toolTypes";
 import { useRoutes } from "@/routes";
 import { useHideInsightsDock } from "@/components/insights-context";
@@ -48,8 +50,11 @@ import { ShareChatButton } from "./ShareChatButton";
 import { useProxiedMcpConnection } from "./useProxiedMcpConnection";
 
 // A single selectable server in the playground. Toolset-backed and
-// remote-MCP-backed servers share one flat picker; the `kind` discriminant only
-// drives how we connect (and which controls appear), never how it's labeled.
+// proxied-MCP-backed servers (remote or tunneled) share one flat picker; the
+// `kind` discriminant only drives how we connect (and which controls appear),
+// never how it's labeled. `remote` and `tunneled` carry identical fields and
+// route to the same proxied connection path — the distinct variant keeps the
+// discriminant honest and leaves room for tunneled-only affordances later.
 type PlaygroundServerRef =
   | { kind: "toolset"; key: string; name: string; toolsetSlug: string }
   | {
@@ -58,10 +63,17 @@ type PlaygroundServerRef =
       name: string;
       mcpServerId: string;
       isIssuerGated: boolean;
+    }
+  | {
+      kind: "tunneled";
+      key: string;
+      name: string;
+      mcpServerId: string;
+      isIssuerGated: boolean;
     };
 
 const toolsetServerKey = (slug: string) => `toolset:${slug}`;
-const mcpServerKey = (mcpServerId: string) => `remote:${mcpServerId}`;
+const mcpServerKey = (mcpServerId: string) => `mcp:${mcpServerId}`;
 
 // Merges toolset-backed servers (from listToolsets) with remote-MCP-backed
 // servers (the remoteMcpServerId subset of mcpServers) into one sorted list.
@@ -74,6 +86,10 @@ function usePlaygroundServers(): {
     useListToolsets();
   const { data: mcpServersData, isLoading: isLoadingMcpServers } =
     useMcpServers();
+
+  const telemetry = useTelemetry();
+  const tunneledEnabled =
+    telemetry.isFeatureEnabled(TUNNELED_MCP_FEATURE_FLAG) === true;
 
   const servers = useMemo<PlaygroundServerRef[]>(() => {
     const toolsetServers: PlaygroundServerRef[] = (
@@ -97,10 +113,24 @@ function usePlaygroundServers(): {
         isIssuerGated: !!server.userSessionIssuerId,
       }));
 
-    return [...toolsetServers, ...remoteServers].sort((a, b) =>
-      a.name.localeCompare(b.name),
+    // Tunneled servers serve at the same /mcp/<slug> path and are the same
+    // McpServer view as remote; they only reach the picker when the flag is on.
+    const tunneledServers: PlaygroundServerRef[] = tunneledEnabled
+      ? (mcpServersData?.mcpServers ?? [])
+          .filter((server) => !!server.tunneledMcpServerId)
+          .map((server) => ({
+            kind: "tunneled",
+            key: mcpServerKey(server.id),
+            name: server.name ?? server.slug ?? "Tunneled MCP server",
+            mcpServerId: server.id,
+            isIssuerGated: !!server.userSessionIssuerId,
+          }))
+      : [];
+
+    return [...toolsetServers, ...remoteServers, ...tunneledServers].sort(
+      (a, b) => a.name.localeCompare(b.name),
     );
-  }, [toolsetsData, mcpServersData]);
+  }, [toolsetsData, mcpServersData, tunneledEnabled]);
 
   return { servers, isLoading: isLoadingToolsets || isLoadingMcpServers };
 }
@@ -277,7 +307,8 @@ function PlaygroundInner() {
                 onPlaygroundEnvironmentSlug={setPlaygroundEnvironmentSlug}
               />
             )}
-            {selectedServer?.kind === "remote" && (
+            {(selectedServer?.kind === "remote" ||
+              selectedServer?.kind === "tunneled") && (
               <ProxiedServerPanel
                 mcpServerId={selectedServer.mcpServerId}
                 isIssuerGated={selectedServer.isIssuerGated}
@@ -307,7 +338,8 @@ function PlaygroundInner() {
                   additionalActions={additionalActions}
                 />
               )}
-              {selectedServer?.kind === "remote" && (
+              {(selectedServer?.kind === "remote" ||
+                selectedServer?.kind === "tunneled") && (
                 <PlaygroundProxiedChat
                   mcpServerId={selectedServer.mcpServerId}
                   isIssuerGated={selectedServer.isIssuerGated}

--- a/client/dashboard/src/pages/playground/PlaygroundProxiedChat.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundProxiedChat.tsx
@@ -3,9 +3,9 @@ import { Type } from "@/components/ui/type";
 import { PlugZap } from "lucide-react";
 import { useEffect } from "react";
 import { PlaygroundChat } from "./PlaygroundChat";
-import { useRemoteMcpConnection } from "./useRemoteMcpConnection";
+import { useProxiedMcpConnection } from "./useProxiedMcpConnection";
 
-interface PlaygroundRemoteChatProps {
+interface PlaygroundProxiedChatProps {
   mcpServerId: string;
   isIssuerGated: boolean;
   environmentSlug: string | null;
@@ -14,18 +14,18 @@ interface PlaygroundRemoteChatProps {
 }
 
 /**
- * The remote-MCP-backed playground variant: resolves the server's proxied
+ * The proxied-MCP-backed playground variant: resolves the server's proxied
  * `/mcp/<slug>` URL and issuer-gated token, prompts for an upstream connect
  * when needed, then renders the shared {@link PlaygroundChat}. Environment and
- * MCP-App registration don't apply to remote servers, so both are omitted.
+ * MCP-App registration don't apply to proxied servers, so both are omitted.
  */
-export function PlaygroundRemoteChat({
+export function PlaygroundProxiedChat({
   mcpServerId,
   isIssuerGated,
   environmentSlug,
   model,
   additionalActions,
-}: PlaygroundRemoteChatProps): JSX.Element {
+}: PlaygroundProxiedChatProps): JSX.Element {
   const {
     mcpUrl,
     gatewayToken,
@@ -35,7 +35,7 @@ export function PlaygroundRemoteChat({
     refetch,
     isLoading,
     connectionReady,
-  } = useRemoteMcpConnection(mcpServerId, isIssuerGated);
+  } = useProxiedMcpConnection(mcpServerId, isIssuerGated);
 
   // When the user comes back from the connect tab, re-attempt the connection so
   // a freshly linked session surfaces without a manual refresh.
@@ -47,16 +47,16 @@ export function PlaygroundRemoteChat({
   }, [needsAuth, refetch]);
 
   if (needsAuth) {
-    return <RemoteConnectPrompt connectUrl={connectUrl} />;
+    return <ProxiedConnectPrompt connectUrl={connectUrl} />;
   }
 
   if (isError) {
     return (
-      <RemoteStatusNotice message="Couldn't connect to this MCP server to list its tools.">
+      <ProxiedStatusNotice message="Couldn't connect to this MCP server to list its tools.">
         <Button variant="secondary" onClick={refetch}>
           Try again
         </Button>
-      </RemoteStatusNotice>
+      </ProxiedStatusNotice>
     );
   }
 
@@ -72,7 +72,7 @@ export function PlaygroundRemoteChat({
   // open an unauthenticated chat that would 401 on every request.
   if (!connectionReady) {
     return (
-      <RemoteStatusNotice message="Couldn't authenticate with this MCP server. Check the server's identity provider configuration." />
+      <ProxiedStatusNotice message="Couldn't authenticate with this MCP server. Check the server's identity provider configuration." />
     );
   }
 
@@ -87,7 +87,7 @@ export function PlaygroundRemoteChat({
   );
 }
 
-function RemoteStatusNotice({
+function ProxiedStatusNotice({
   message,
   children,
 }: {
@@ -107,7 +107,7 @@ function RemoteStatusNotice({
   );
 }
 
-function RemoteConnectPrompt({
+function ProxiedConnectPrompt({
   connectUrl,
 }: {
   connectUrl: string | undefined;

--- a/client/dashboard/src/pages/playground/useProxiedMcpConnection.ts
+++ b/client/dashboard/src/pages/playground/useProxiedMcpConnection.ts
@@ -1,8 +1,8 @@
 import {
-  useRemoteMcpTools,
-  type RemoteMcpTool,
-} from "@/hooks/useRemoteMcpTools";
-import { useRemoteMcpUserSessionToken } from "@/hooks/useRemoteMcpUserSessionToken";
+  useProxiedMcpTools,
+  type ProxiedMcpTool,
+} from "@/hooks/useProxiedMcpTools";
+import { useProxiedMcpUserSessionToken } from "@/hooks/useProxiedMcpUserSessionToken";
 import {
   firstPartyConnectUrl,
   getServerURL,
@@ -11,7 +11,7 @@ import {
 import { useMcpEndpoints } from "@gram/client/react-query/mcpEndpoints.js";
 import { useMemo } from "react";
 
-export interface RemoteMcpConnection {
+export interface ProxiedMcpConnection {
   /**
    * The Gram-origin display MCP URL (`/mcp/<slug>`) handed to the elements
    * chat, which manages its own transport (mirrors the toolset path).
@@ -28,7 +28,7 @@ export interface RemoteMcpConnection {
   /** Re-attempt the tools listing (e.g. after returning from the connect tab). */
   refetch: () => void;
   /** The tools advertised by the upstream, keyed by name. */
-  tools: Record<string, RemoteMcpTool> | undefined;
+  tools: Record<string, ProxiedMcpTool> | undefined;
   isLoading: boolean;
   /**
    * True once we can safely open the chat: a non-gated server is always ready,
@@ -40,15 +40,15 @@ export interface RemoteMcpConnection {
 }
 
 /**
- * Resolves everything needed to chat with a remote-MCP-backed server: its
+ * Resolves everything needed to chat with a proxied-MCP-backed server: its
  * proxied `/mcp/<slug>` URL, the issuer-gated JWT, the live tools listing, and
  * the needs-connect state. Mirrors the plumbing in RemoteMcpToolsSection so the
  * playground connects through the exact path a real MCP client would.
  */
-export function useRemoteMcpConnection(
+export function useProxiedMcpConnection(
   mcpServerId: string | undefined,
   isIssuerGated: boolean,
-): RemoteMcpConnection {
+): ProxiedMcpConnection {
   const { data: endpointsData, isLoading: isLoadingEndpoints } =
     useMcpEndpoints({ mcpServerId: mcpServerId ?? "" }, undefined, {
       enabled: !!mcpServerId,
@@ -69,7 +69,7 @@ export function useRemoteMcpConnection(
   }, [endpointsData]);
 
   const { accessToken, isLoading: isTokenLoading } =
-    useRemoteMcpUserSessionToken({ mcpServerId, isIssuerGated });
+    useProxiedMcpUserSessionToken({ mcpServerId, isIssuerGated });
 
   const headers = useMemo(
     () =>
@@ -87,7 +87,7 @@ export function useRemoteMcpConnection(
 
   // No error boundary wraps the playground panels, so keep every failure inline
   // (isError) rather than throwing a non-401 to the nearest boundary.
-  const { tools, needsAuth, isError, isLoading, refetch } = useRemoteMcpTools(
+  const { tools, needsAuth, isError, isLoading, refetch } = useProxiedMcpTools(
     connectUrl,
     { headers, enabled: connectionReady, throwOnError: false },
   );


### PR DESCRIPTION
[AIS-329](https://linear.app/speakeasy/issue/AIS-329/make-tunneled-mcps-available-in-playground) | [Artifacts](<https://cloud.humanlayer.com/tasks/019f71e1-2d24-7292-94e0-fb658aef8725/artifacts>) | [Task](<https://cloud.humanlayer.com/deep/tasks/019f71e1-2d24-7292-94e0-fb658aef8725>)

## What problems was I solving

Tunneled MCP servers already serve at the same `/mcp/<slug>` path as remote ones and are backed by the same `McpServer` view — they were simply filtered out of the Playground picker, so there was no way to try one interactively. This PR surfaces tunneled servers in the Playground (behind the `gram-tunneled-mcp` flag) so they can be selected, connected, and chatted with through the exact same proxied path a real MCP client uses.

Frontend-only, no backend changes. Success = a flagged user sees their tunneled server in the picker, "Test in Playground" pre-selects it, and chat/tool-listing work identically to remote.

## What user-facing changes did I ship

* [client/dashboard/src/pages/playground/Playground.tsx](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-c0c2d728127e47b5e3fdcc605fd464a2cbc28d7fb5f3d2823cbf3a2eede0edd0>) - Adds a flag-gated `tunneled` server variant to the Playground picker; selecting it drives the same proxied connect/chat path as remote.
* [client/dashboard/src/components/mcp-server-x-sidebar-nav.tsx](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-f080d8561c150f597ed5856527d190757aa3afd1eef3377682d53b191456c595>) - "Test in Playground" now pre-selects tunneled servers via `?mcpServer=<id>`, not just remote ones.

## How I implemented it

Two commits: a mechanical rename (Phase 1) so the shared connection layer is honestly named, then the feature (Phase 2).

### Phase 1 — rename `remote*` → `proxied*` (no behavior change)

The connection machinery is source-agnostic (it just talks to a proxied `/mcp/<slug>` endpoint), so it was renamed from `remote*` to `proxied*` first, isolating the rename noise from the feature diff:

* [client/dashboard/src/hooks/useProxiedMcpTools.ts](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-0d0b3fafecec177afb401d550b794e90abdf6e2788a2f7c412594b23e4912fcc>) - `useRemoteMcpTools` → `useProxiedMcpTools` (+ schemas/types/query key).
* [client/dashboard/src/hooks/useProxiedMcpUserSessionToken.ts](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-a79966a2b1e4ef4f98db6ffbd0c30d5ca4a7c71e7026c846141f1fa9fb69d8dc>) - `useRemoteMcpUserSessionToken` → `useProxiedMcpUserSessionToken`.
* [client/dashboard/src/pages/playground/useProxiedMcpConnection.ts](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-85656adb36a5e323d139cf6342435201210a775c6c34f72230665e3744b232df>) - `useRemoteMcpConnection` → `useProxiedMcpConnection`.
* [client/dashboard/src/pages/playground/PlaygroundProxiedChat.tsx](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-237007d67afc1a258776b302638876eaaf4e04c5f6121c9c62d4138bf9260304>) - `PlaygroundRemoteChat` → `PlaygroundProxiedChat` (+ internal `Remote*` helpers → `Proxied*`).
* [client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-4341b0e54a5d9c8af3916b4d8d97fbe1c2a3df851215e4db34cb66d435adfc5c>) - Consumer updated to the new `proxied*` imports/types (file name kept).

### Phase 2 — flag-gated `tunneled` picker variant

* [Playground.tsx](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-c0c2d728127e47b5e3fdcc605fd464a2cbc28d7fb5f3d2823cbf3a2eede0edd0>) - New `tunneled` arm on the `PlaygroundServerRef` discriminant (identical fields to `remote`). `usePlaygroundServers` reads `useTelemetry().isFeatureEnabled(TUNNELED_MCP_FEATURE_FLAG)` and, when on, maps the `tunneledMcpServerId` subset of `mcpServers` into picker entries. The panel/chat render guards widen to `kind === "remote" || kind === "tunneled"`, both routing to `ProxiedServerPanel` / `PlaygroundProxiedChat`. The remote-only server key `remote:<id>` was generalized to `mcp:<id>` so URL pre-selection works for either source.
* [mcp-server-x-sidebar-nav.tsx](<https://github.com/speakeasy-api/gram/pull/4329/files#diff-f080d8561c150f597ed5856527d190757aa3afd1eef3377682d53b191456c595>) - "Test in Playground" link passes `?mcpServer=<id>` for `isRemoteBacked || isTunneledBacked`.

The distinct `tunneled` variant carries the same fields as `remote` and routes to the same path — kept separate to keep the discriminant honest and leave room for tunneled-only affordances later.

## Deviations from the plan

No plan file found (an approved structure outline exists and was followed). Compared against `04-structure-outline-tunneled-mcps-playground.md`:

### Implemented as planned

* Phase 1 mechanical `remote*` → `proxied*` rename with no behavior change.
* Phase 2 flag-gated `tunneled` picker variant reusing the proxied path.
* Sidebar "Test in Playground" pre-selection extended to tunneled servers.
* No backend changes.

### Deviations/surprises

* None of substance.

### Additions not in plan

* None.

### Items planned but not implemented

* None.

## How to verify it

```bash
git fetch origin poc-308-make-tunneled-mcps-available-in-playground
git worktree add ../gram-poc-308 poc-308-make-tunneled-mcps-available-in-playground
cd ../gram-poc-308 && pnpm -F dashboard type-check
```

### Manual Testing

- [ ] With `gram-tunneled-mcp` **off**: tunneled servers do **not** appear in the Playground picker (unchanged behavior).
- [ ] With the flag **on**: a tunneled MCP server appears in the picker; selecting it lists tools and drives chat.
- [ ] Issuer-gated tunneled server prompts to connect, then chats after minting the user-session JWT.
- [ ] "Test in Playground" on a tunneled server deep-links to the Playground with it pre-selected (`?mcpServer=<id>`).
- [ ] Remote-MCP Playground behavior is unchanged after the rename.

### Automated Tests

```bash
pnpm -F dashboard type-check
```

## Description for the changelog

Playground: tunneled MCP servers can now be selected and chatted with (behind the `gram-tunneled-mcp` flag).