### PR TITLE
fix(dashboard): resolve React and browser warnings

### DIFF
--- a/.changeset/quiet-react-warnings.md
+++ b/.changeset/quiet-react-warnings.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix dashboard React warnings caused by nested log controls, duplicate risk-rule keys, command-palette focus restoration, and unsupported Moonshine button children.

--- a/client/dashboard/src/components/OpenApiSourceInput.tsx
+++ b/client/dashboard/src/components/OpenApiSourceInput.tsx
@@ -125,8 +125,14 @@ export function OpenApiSourceInput({
               disabled={!url.trim() || fetchMutation.isPending}
               className="w-full"
             >
-              {fetchMutation.isPending && <Spinner className="mr-2 size-4" />}
-              {fetchMutation.isPending ? "Loading..." : "Load OpenAPI Spec"}
+              {fetchMutation.isPending && (
+                <Button.LeftIcon>
+                  <Spinner className="size-4" />
+                </Button.LeftIcon>
+              )}
+              <Button.Text>
+                {fetchMutation.isPending ? "Loading..." : "Load OpenAPI Spec"}
+              </Button.Text>
             </Button>
           </Stack>
         </form>

--- a/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
+++ b/client/dashboard/src/components/access/ApprovalRequestsContent.tsx
@@ -1109,16 +1109,14 @@ export function ApprovalRequestsContent({
               }}
               disabled={revokeRequest.isPending}
             >
-              {revokeRequest.isPending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Revoking</Button.Text>
-                </>
-              ) : (
-                <Button.Text>Revoke</Button.Text>
+              {revokeRequest.isPending && (
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
               )}
+              <Button.Text>
+                {revokeRequest.isPending ? "Revoking" : "Revoke"}
+              </Button.Text>
             </Button>
           </Dialog.Footer>
         </Dialog.Content>

--- a/client/dashboard/src/components/command-palette/CommandPaletteTrigger.tsx
+++ b/client/dashboard/src/components/command-palette/CommandPaletteTrigger.tsx
@@ -33,6 +33,7 @@ export function CommandPaletteTrigger({
       <TooltipTrigger asChild>
         <button
           type="button"
+          data-slot="command-palette-trigger"
           onClick={open}
           aria-label="Search (Command palette)"
           className={cn(

--- a/client/dashboard/src/components/mcp-tool-filtering-section.tsx
+++ b/client/dashboard/src/components/mcp-tool-filtering-section.tsx
@@ -151,16 +151,14 @@ export function MCPToolFilteringSection({
             disabled={isSaving || groupsQuery.isLoading}
             onClick={() => createGroup.mutate({})}
           >
-            {createGroup.isPending ? (
-              <>
-                <Button.LeftIcon>
-                  <Loader2 className="size-4 animate-spin" />
-                </Button.LeftIcon>
-                <Button.Text>Enabling</Button.Text>
-              </>
-            ) : (
-              <Button.Text>Enable</Button.Text>
+            {createGroup.isPending && (
+              <Button.LeftIcon>
+                <Loader2 className="size-4 animate-spin" />
+              </Button.LeftIcon>
             )}
+            <Button.Text>
+              {createGroup.isPending ? "Enabling" : "Enable"}
+            </Button.Text>
           </Button>
         </RequireScope>
       ) : (

--- a/client/dashboard/src/components/server-enable-dialog.tsx
+++ b/client/dashboard/src/components/server-enable-dialog.tsx
@@ -83,8 +83,10 @@ export function ServerEnableDialog({
           </Button>
           {!canEnable ? (
             <Button onClick={handleUpgrade} className="gap-2">
-              <CreditCard className="h-4 w-4" />
-              Upgrade Plan
+              <Button.LeftIcon>
+                <CreditCard className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>Upgrade Plan</Button.Text>
             </Button>
           ) : (
             <Button

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryActions.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryActions.tsx
@@ -171,7 +171,9 @@ export function ShadowMCPInventoryActionMenu({
           size="xs"
           variant="tertiary"
         >
-          <Icon name="ellipsis" />
+          <Button.Icon>
+            <Icon name="ellipsis" />
+          </Button.Icon>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.test.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.test.tsx
@@ -114,6 +114,7 @@ vi.mock("@speakeasy-api/moonshine", () => ({
       </button>
     ),
     {
+      Icon: ({ children }: { children: ReactNode }) => <span>{children}</span>,
       LeftIcon: ({ children }: { children: ReactNode }) => (
         <span>{children}</span>
       ),

--- a/client/dashboard/src/components/sources/RemoveMcpSourceDialogContent.tsx
+++ b/client/dashboard/src/components/sources/RemoveMcpSourceDialogContent.tsx
@@ -115,16 +115,12 @@ export function RemoveMcpSourceDialogContent({
           disabled={!inputMatches || isPending}
           onClick={() => void handleConfirm()}
         >
-          {isPending ? (
-            <>
-              <Button.LeftIcon>
-                <Loader2 className="size-4 animate-spin" />
-              </Button.LeftIcon>
-              <Button.Text>Deleting</Button.Text>
-            </>
-          ) : (
-            <Button.Text>Delete</Button.Text>
+          {isPending && (
+            <Button.LeftIcon>
+              <Loader2 className="size-4 animate-spin" />
+            </Button.LeftIcon>
           )}
+          <Button.Text>{isPending ? "Deleting" : "Delete"}</Button.Text>
         </Button>
       </Dialog.Footer>
     </>

--- a/client/dashboard/src/components/sources/SourcesEmptyState.tsx
+++ b/client/dashboard/src/components/sources/SourcesEmptyState.tsx
@@ -90,7 +90,9 @@ export function SourcesEmptyState({
                       <Plus className="h-4 w-4" />
                     </Button.LeftIcon>
                     <Button.Text>Add Source</Button.Text>
-                    <ChevronDown className="ml-1 h-4 w-4" />
+                    <Button.RightIcon>
+                      <ChevronDown className="h-4 w-4" />
+                    </Button.RightIcon>
                   </Button>
                 </DropdownMenuTrigger>
                 {!disabled && (

--- a/client/dashboard/src/components/sources/UploadOpenApiDialogContent.tsx
+++ b/client/dashboard/src/components/sources/UploadOpenApiDialogContent.tsx
@@ -78,8 +78,12 @@ export function UploadOpenApiDialogContent({
           onClick={() => void deploySpecUpdate()}
           disabled={!file || isDeploying || !documentSlug}
         >
-          {isDeploying && <Spinner />}
-          {isDeploying ? "Deploying..." : "Deploy"}
+          {isDeploying && (
+            <Button.LeftIcon>
+              <Spinner />
+            </Button.LeftIcon>
+          )}
+          <Button.Text>{isDeploying ? "Deploying..." : "Deploy"}</Button.Text>
         </Button>
       </Dialog.Footer>
     </>

--- a/client/dashboard/src/contexts/CommandPaletteProvider.test.tsx
+++ b/client/dashboard/src/contexts/CommandPaletteProvider.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { CSSProperties } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCommandPalette } from "./CommandPalette";
+import { CommandPaletteProvider } from "./CommandPaletteProvider";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function PaletteControls({ hiddenStyle }: { hiddenStyle: CSSProperties }) {
+  const { open, close } = useCommandPalette();
+
+  return (
+    <>
+      <div style={hiddenStyle}>
+        <button type="button" onClick={open}>
+          Hidden opener
+        </button>
+      </div>
+      <button type="button" data-slot="command-palette-trigger">
+        Visible trigger
+      </button>
+      <button type="button" onClick={close}>
+        Close palette
+      </button>
+    </>
+  );
+}
+
+describe("CommandPaletteProvider focus restoration", () => {
+  const hiddenAncestorStyles = [
+    ["opacity", { opacity: 0 }],
+    ["content visibility", { contentVisibility: "hidden" }],
+  ] satisfies ReadonlyArray<readonly [string, CSSProperties]>;
+
+  it.each(hiddenAncestorStyles)(
+    "uses the visible fallback for an opener hidden by ancestor %s",
+    (_, hiddenStyle) => {
+      vi.spyOn(HTMLElement.prototype, "getClientRects").mockReturnValue([
+        {} as DOMRect,
+      ] as unknown as DOMRectList);
+      vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+        (callback) => {
+          callback(0);
+          return 1;
+        },
+      );
+
+      render(
+        <CommandPaletteProvider>
+          <PaletteControls hiddenStyle={hiddenStyle} />
+        </CommandPaletteProvider>,
+      );
+
+      const opener = screen.getByRole("button", { name: "Hidden opener" });
+      const fallback = screen.getByRole("button", { name: "Visible trigger" });
+      opener.focus();
+      fireEvent.click(opener);
+      fireEvent.click(screen.getByRole("button", { name: "Close palette" }));
+
+      expect(document.activeElement).toBe(fallback);
+    },
+  );
+});

--- a/client/dashboard/src/contexts/CommandPaletteProvider.tsx
+++ b/client/dashboard/src/contexts/CommandPaletteProvider.tsx
@@ -4,9 +4,42 @@ import {
   useEffect,
   useCallback,
   useMemo,
+  useRef,
 } from "react";
 import { CommandPaletteContext } from "./CommandPalette";
 import type { CommandAction } from "./CommandPalette";
+
+const MAX_FOCUS_RESTORE_FRAMES = 60;
+
+function isVisiblyRendered(element: HTMLElement): boolean {
+  const style = window.getComputedStyle(element);
+
+  return (
+    style.display !== "none" &&
+    style.visibility !== "hidden" &&
+    style.visibility !== "collapse" &&
+    element.getClientRects().length > 0
+  );
+}
+
+function isUsableFocusTarget(
+  element: HTMLElement | null,
+): element is HTMLElement {
+  if (!element?.isConnected) return false;
+
+  return (
+    !element.closest(
+      ':disabled, [disabled], [aria-disabled="true"], [hidden], [inert], [aria-hidden="true"]',
+    ) && isVisiblyRendered(element)
+  );
+}
+
+function focusIfUsable(element: HTMLElement | null): boolean {
+  if (!isUsableFocusTarget(element)) return false;
+
+  element.focus();
+  return document.activeElement === element;
+}
 
 export function CommandPaletteProvider({
   children,
@@ -16,10 +49,55 @@ export function CommandPaletteProvider({
   const [isOpen, setIsOpen] = useState(false);
   const [actions, setActionsState] = useState<CommandAction[]>([]);
   const [contextBadge, setContextBadgeState] = useState<string | null>(null);
+  const openerRef = useRef<HTMLElement | null>(null);
 
-  const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
-  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+  const open = useCallback(() => {
+    const activeElement = document.activeElement;
+    openerRef.current =
+      activeElement instanceof HTMLElement && activeElement !== document.body
+        ? activeElement
+        : null;
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    const opener = openerRef.current;
+
+    const restoreFocus = (frame: number) => {
+      if (openerRef.current !== opener) return;
+
+      if (!focusIfUsable(opener)) {
+        const fallback = Array.from(
+          document.querySelectorAll<HTMLElement>(
+            '[data-slot="command-palette-trigger"]',
+          ),
+        ).find(isUsableFocusTarget);
+
+        if (focusIfUsable(fallback ?? null)) {
+          openerRef.current = null;
+          return;
+        }
+
+        if (frame < MAX_FOCUS_RESTORE_FRAMES) {
+          requestAnimationFrame(() => restoreFocus(frame + 1));
+          return;
+        }
+      }
+
+      openerRef.current = null;
+    };
+
+    requestAnimationFrame(() => restoreFocus(0));
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }, [close, isOpen, open]);
 
   const setContextBadge = useCallback((badge: string | null) => {
     setContextBadgeState(badge);

--- a/client/dashboard/src/contexts/CommandPaletteProvider.tsx
+++ b/client/dashboard/src/contexts/CommandPaletteProvider.tsx
@@ -12,14 +12,24 @@ import type { CommandAction } from "./CommandPalette";
 const MAX_FOCUS_RESTORE_FRAMES = 60;
 
 function isVisiblyRendered(element: HTMLElement): boolean {
-  const style = window.getComputedStyle(element);
+  let current: HTMLElement | null = element;
 
-  return (
-    style.display !== "none" &&
-    style.visibility !== "hidden" &&
-    style.visibility !== "collapse" &&
-    element.getClientRects().length > 0
-  );
+  while (current) {
+    const style = window.getComputedStyle(current);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.visibility === "collapse" ||
+      Number.parseFloat(style.opacity) === 0 ||
+      style.contentVisibility === "hidden"
+    ) {
+      return false;
+    }
+
+    current = current.parentElement;
+  }
+
+  return element.getClientRects().length > 0;
 }
 
 function isUsableFocusTarget(

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -284,27 +284,32 @@ export default function CatalogDetail(): JSX.Element {
                           }
                           disabled={removeServerMutation.isPending}
                         >
-                          {removeServerMutation.isPending ? (
-                            <>
+                          <Button.LeftIcon>
+                            {removeServerMutation.isPending ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
-                              <Button.Text>Removing...</Button.Text>
-                            </>
-                          ) : (
-                            <>
+                            ) : (
                               <Minus className="h-4 w-4" />
-                              <Button.Text>Remove</Button.Text>
-                            </>
-                          )}
+                            )}
+                          </Button.LeftIcon>
+                          <Button.Text>
+                            {removeServerMutation.isPending
+                              ? "Removing..."
+                              : "Remove"}
+                          </Button.Text>
                         </Button>
                       )}
                       <Button size="md" onClick={() => setShowAddDialog(true)}>
-                        <Plus className="h-4 w-4" />
+                        <Button.LeftIcon>
+                          <Plus className="h-4 w-4" />
+                        </Button.LeftIcon>
                         <Button.Text>Add another</Button.Text>
                       </Button>
                     </Stack>
                   ) : (
                     <Button size="md" onClick={() => setShowAddDialog(true)}>
-                      <Plus className="h-4 w-4" />
+                      <Button.LeftIcon>
+                        <Plus className="h-4 w-4" />
+                      </Button.LeftIcon>
                       <Button.Text>Add</Button.Text>
                     </Button>
                   )}

--- a/client/dashboard/src/pages/deployments/deployment/FailedSourcesSection.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/FailedSourcesSection.tsx
@@ -293,18 +293,16 @@ export function FailedSourcesSection({
                 onClick={handleRemoveClick}
                 disabled={pending || selected.size === 0}
               >
-                {pending ? (
-                  <>
-                    <Button.LeftIcon>
-                      <Loader2 className="size-4 animate-spin" />
-                    </Button.LeftIcon>
-                    <Button.Text>Removing...</Button.Text>
-                  </>
-                ) : (
-                  <Button.Text>
-                    {`Remove ${selected.size > 0 ? selected.size : ""} source${selected.size !== 1 ? "s" : ""}`}
-                  </Button.Text>
+                {pending && (
+                  <Button.LeftIcon>
+                    <Loader2 className="size-4 animate-spin" />
+                  </Button.LeftIcon>
                 )}
+                <Button.Text>
+                  {pending
+                    ? "Removing..."
+                    : `Remove ${selected.size > 0 ? selected.size : ""} source${selected.size !== 1 ? "s" : ""}`}
+                </Button.Text>
               </Button>
             </RequireScope>
           </div>

--- a/client/dashboard/src/pages/environments/Environment.tsx
+++ b/client/dashboard/src/pages/environments/Environment.tsx
@@ -452,8 +452,10 @@ function EnvironmentPageInner() {
                   {canWrite && (
                     <div className="mt-4 flex flex-col items-center gap-2">
                       <Button onClick={() => setVariableDialog({ open: true })}>
-                        <Plus className="mr-2 h-4 w-4" />
-                        ADD YOUR FIRST VARIABLE
+                        <Button.LeftIcon>
+                          <Plus className="h-4 w-4" />
+                        </Button.LeftIcon>
+                        <Button.Text>ADD YOUR FIRST VARIABLE</Button.Text>
                       </Button>
                       <Button
                         variant="secondary"

--- a/client/dashboard/src/pages/integrations/Integrations.tsx
+++ b/client/dashboard/src/pages/integrations/Integrations.tsx
@@ -306,14 +306,12 @@ function IntegrationCard({
           </Button>
         ) : (
           <Button variant="secondary" onClick={() => void toggleEnabled()}>
-            {isEnabled ? (
-              <>
+            {isEnabled && (
+              <Button.LeftIcon>
                 <CheckIcon className="h-4 w-4" />
-                Enabled
-              </>
-            ) : (
-              "Enable"
+              </Button.LeftIcon>
             )}
+            <Button.Text>{isEnabled ? "Enabled" : "Enable"}</Button.Text>
           </Button>
         )}
       </Card.Header>

--- a/client/dashboard/src/pages/logs/LogDetailSheet.tsx
+++ b/client/dashboard/src/pages/logs/LogDetailSheet.tsx
@@ -12,7 +12,7 @@ import {
   Icon,
 } from "@speakeasy-api/moonshine";
 import { ChevronDown, Copy } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { formatNanoTimestamp, getSeverityColorClass } from "./utils";
 
 interface LogDetailSheetProps {
@@ -367,6 +367,7 @@ function CollapsibleBodySection({
   defaultOpen?: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const contentId = useId();
 
   // Try to pretty-print JSON content
   let displayContent = content;
@@ -378,34 +379,38 @@ function CollapsibleBodySection({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="relative flex flex-col gap-2">
       <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="group flex items-center justify-between"
+        type="button"
+        aria-controls={contentId}
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((open) => !open)}
+        className="group flex min-h-7 items-center justify-between pr-12"
       >
-        <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+        <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
           {title}
-        </div>
-        <div className="flex items-center gap-1">
-          <button
-            className="hover:bg-muted rounded p-1.5"
-            onClick={(e) => {
-              e.stopPropagation();
-              void navigator.clipboard.writeText(content);
-            }}
-          >
-            <Copy className="size-4" />
-          </button>
-          <ChevronDown
-            className={cn(
-              "text-muted-foreground size-4 transition-transform",
-              !isOpen && "-rotate-90",
-            )}
-          />
-        </div>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "text-muted-foreground absolute top-1.5 right-0 size-4 transition-transform",
+            !isOpen && "-rotate-90",
+          )}
+        />
+      </button>
+      <button
+        type="button"
+        aria-label={`Copy ${title}`}
+        className="hover:bg-muted absolute top-0 right-5 z-10 rounded p-1.5"
+        onClick={() => void navigator.clipboard.writeText(content)}
+      >
+        <Copy aria-hidden="true" className="size-4" />
       </button>
       {isOpen && (
-        <div className="bg-muted/40 border-border max-h-96 overflow-y-auto rounded-lg border p-4">
+        <div
+          id={contentId}
+          className="bg-muted/40 border-border max-h-96 overflow-y-auto rounded-lg border p-4"
+        >
           <pre className="font-mono text-sm break-words whitespace-pre-wrap">
             {displayContent}
           </pre>

--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -1826,8 +1826,10 @@ export function OAuthDetailsModal({
                         onEditRequest();
                       }}
                     >
-                      <Pencil className="mr-2 h-4 w-4" />
-                      Edit
+                      <Button.LeftIcon>
+                        <Pencil aria-hidden="true" className="h-4 w-4" />
+                      </Button.LeftIcon>
+                      <Button.Text>Edit</Button.Text>
                     </Button>
                     <Button
                       variant="tertiary"
@@ -1841,8 +1843,10 @@ export function OAuthDetailsModal({
                         })
                       }
                     >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Unlink
+                      <Button.LeftIcon>
+                        <Trash2 aria-hidden="true" className="h-4 w-4" />
+                      </Button.LeftIcon>
+                      <Button.Text>Unlink</Button.Text>
                     </Button>
                   </div>
                 </div>
@@ -2014,8 +2018,10 @@ export function OAuthDetailsModal({
                 })
               }
             >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Unlink
+              <Button.LeftIcon>
+                <Trash2 aria-hidden="true" className="h-4 w-4" />
+              </Button.LeftIcon>
+              <Button.Text>Unlink</Button.Text>
             </Button>
           </Dialog.Footer>
         )}

--- a/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
+++ b/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
@@ -222,6 +222,10 @@ export function PluginStatusBanner({
     }
   };
 
+  let saveButtonText = "Publish";
+  if (isPublished) saveButtonText = "Update";
+  if (isSaving) saveButtonText = "Publishing";
+
   return (
     <div className="border border-border/70 relative overflow-hidden rounded-xl shadow-sm">
       <div
@@ -317,15 +321,12 @@ export function PluginStatusBanner({
                   disabled={!hasChanges || isSaving}
                   onClick={() => void handleSave()}
                 >
-                  {isSaving ? (
-                    <>
-                      <Spinner /> Publishing
-                    </>
-                  ) : isPublished ? (
-                    "Update"
-                  ) : (
-                    "Publish"
+                  {isSaving && (
+                    <Button.LeftIcon>
+                      <Spinner />
+                    </Button.LeftIcon>
                   )}
+                  <Button.Text>{saveButtonText}</Button.Text>
                 </Button>
               </div>
             )}

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/SettingsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/SettingsSection.tsx
@@ -4,7 +4,7 @@ import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
 import { Button } from "@speakeasy-api/moonshine";
 import { Loader2, SaveIcon } from "lucide-react";
-import { createContext, use } from "react";
+import { createContext, type ComponentProps, use } from "react";
 
 type SettingsSectionTone = "default" | "danger";
 type SettingsSectionContextValue = {
@@ -180,48 +180,24 @@ export const DangerSettingsSection = Object.assign(
   settingsSectionSlots,
 );
 
-export function FooterSaveButtonContent({
-  pending,
-}: {
+type FooterSaveButtonProps = Omit<ComponentProps<typeof Button>, "children"> & {
   pending: boolean;
-}): JSX.Element {
-  if (pending) {
-    return (
-      <>
-        <Button.LeftIcon>
-          <Loader2 className="size-4 animate-spin" />
-        </Button.LeftIcon>
-        <Button.Text>Saving</Button.Text>
-      </>
-    );
-  }
+};
 
-  return (
-    <>
-      <Button.LeftIcon>
-        <SaveIcon className="size-4" />
-      </Button.LeftIcon>
-      <Button.Text>Save</Button.Text>
-    </>
-  );
-}
-
-export function RowSaveButtonContent({
+export function FooterSaveButton({
   pending,
-}: {
-  pending: boolean;
-}): JSX.Element {
-  if (pending) {
-    return (
-      <Button.LeftIcon>
-        <Loader2 className="size-4 animate-spin" />
-      </Button.LeftIcon>
-    );
-  }
-
+  ...buttonProps
+}: FooterSaveButtonProps): JSX.Element {
   return (
-    <Button.LeftIcon>
-      <SaveIcon className="size-4" />
-    </Button.LeftIcon>
+    <Button variant="primary" size="md" {...buttonProps}>
+      <Button.LeftIcon>
+        {pending ? (
+          <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+        ) : (
+          <SaveIcon aria-hidden="true" className="size-4" />
+        )}
+      </Button.LeftIcon>
+      <Button.Text>{pending ? "Saving" : "Save"}</Button.Text>
+    </Button>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/BrandingSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/BrandingSection.tsx
@@ -12,12 +12,11 @@ import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import { invalidateAllGetMcpServer } from "@gram/client/react-query/getMcpServer.js";
 import { invalidateAllMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { useUpdateMcpServerMutation } from "@gram/client/react-query/updateMcpServer.js";
-import { Button } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
-import { FooterSaveButtonContent, SettingsSection } from "../SettingsSection";
+import { FooterSaveButton, SettingsSection } from "../SettingsSection";
 
 // The display name shares the mcp_servers.name column, whose CHECK caps length
 // at 40 (see schema.sql / MCP_SERVER_NAME_MAX_LENGTH on the legacy page).
@@ -124,14 +123,11 @@ export function BrandingSection({
           </SettingsSection.FooterHint>
           <SettingsSection.FooterActions>
             <RequireScope scope="mcp:write" level="component">
-              <Button
-                variant="primary"
-                size="md"
+              <FooterSaveButton
+                pending={update.isPending}
                 disabled={saveDisabled}
                 onClick={() => void handleSave()}
-              >
-                <FooterSaveButtonContent pending={update.isPending} />
-              </Button>
+              />
             </RequireScope>
           </SettingsSection.FooterActions>
         </SettingsSection.Footer>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/DangerZoneSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/DangerZoneSection.tsx
@@ -272,16 +272,12 @@ function ServerAvailabilityDialog({
             disabled={isLoading}
             onClick={onConfirm}
           >
-            {isLoading ? (
-              <>
-                <Button.LeftIcon>
-                  <Loader2 className="size-4 animate-spin" />
-                </Button.LeftIcon>
-                <Button.Text>Saving</Button.Text>
-              </>
-            ) : (
-              <Button.Text>Continue</Button.Text>
+            {isLoading && (
+              <Button.LeftIcon>
+                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+              </Button.LeftIcon>
             )}
+            <Button.Text>{isLoading ? "Saving" : "Continue"}</Button.Text>
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/HeadersSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/HeadersSection.tsx
@@ -551,16 +551,15 @@ export function HeadersSection({
                   disabled={saveDisabled}
                   onClick={() => void handleSave()}
                 >
-                  {saving ? (
-                    <>
-                      <Button.LeftIcon>
-                        <Loader2 className="size-4 animate-spin" />
-                      </Button.LeftIcon>
-                      <Button.Text>Saving</Button.Text>
-                    </>
-                  ) : (
-                    <Button.Text>Save</Button.Text>
+                  {saving && (
+                    <Button.LeftIcon>
+                      <Loader2
+                        aria-hidden="true"
+                        className="size-4 animate-spin"
+                      />
+                    </Button.LeftIcon>
                   )}
+                  <Button.Text>{saving ? "Saving" : "Save"}</Button.Text>
                 </Button>
               </RequireScope>
             </Stack>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/PublishingSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/PublishingSection.tsx
@@ -5,7 +5,7 @@ import { usePublishing } from "@/pages/mcp/usePublishing";
 import type { McpEndpoint } from "@gram/client/models/components/mcpendpoint.js";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import { Button, Stack } from "@speakeasy-api/moonshine";
-import { FooterSaveButtonContent, SettingsSection } from "../SettingsSection";
+import { FooterSaveButton, SettingsSection } from "../SettingsSection";
 
 export function PublishingSection({
   mcpServer,
@@ -118,14 +118,11 @@ export function PublishingSection({
                 >
                   <Button.Text>Discard</Button.Text>
                 </Button>
-                <Button
-                  variant="primary"
-                  size="md"
+                <FooterSaveButton
+                  pending={isSaving}
                   disabled={isSaving}
                   onClick={() => void handleSave()}
-                >
-                  <FooterSaveButtonContent pending={isSaving} />
-                </Button>
+                />
               </SettingsSection.FooterActions>
             )}
           </SettingsSection.Footer>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ServerUrlSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ServerUrlSection.tsx
@@ -25,12 +25,12 @@ import { invalidateAllMcpEndpoints } from "@gram/client/react-query/mcpEndpoints
 import { useUpdateMcpEndpointMutation } from "@gram/client/react-query/updateMcpEndpoint.js";
 import { Button, Dialog, Stack } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { Loader2, Plus, Trash2, XIcon } from "lucide-react";
+import { Loader2, Plus, SaveIcon, Trash2, XIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useMcpEndpointSlugValidation } from "../../../useMcpEndpointSlugValidation";
 import { SettingsInlineEmptyState } from "../SettingsInlineEmptyState";
-import { RowSaveButtonContent, SettingsSection } from "../SettingsSection";
+import { SettingsSection } from "../SettingsSection";
 
 const ADDRESS_INPUT_GROUP_CLASSNAME = "rounded-md";
 const ADDRESS_SLUG_INPUT_CLASSNAME = "font-mono pl-0! font-bold";
@@ -326,8 +326,15 @@ function AddressRow({
             variant="primary"
             disabled={!dirty || !!slugError || update.isPending}
             onClick={handleSave}
+            aria-label={update.isPending ? "Saving address" : "Save address"}
           >
-            <RowSaveButtonContent pending={update.isPending} />
+            <Button.Icon>
+              {update.isPending ? (
+                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+              ) : (
+                <SaveIcon aria-hidden="true" className="size-4" />
+              )}
+            </Button.Icon>
           </Button>
           <Button
             variant="destructive-secondary"
@@ -393,16 +400,14 @@ function RemoveLastAddressDialog({
             disabled={isLoading}
             onClick={onConfirm}
           >
-            {isLoading ? (
-              <>
-                <Button.LeftIcon>
-                  <Loader2 className="size-4 animate-spin" />
-                </Button.LeftIcon>
-                <Button.Text>Removing</Button.Text>
-              </>
-            ) : (
-              <Button.Text>Remove address</Button.Text>
+            {isLoading && (
+              <Button.LeftIcon>
+                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+              </Button.LeftIcon>
             )}
+            <Button.Text>
+              {isLoading ? "Removing" : "Remove address"}
+            </Button.Text>
           </Button>
         </Dialog.Footer>
       </Dialog.Content>
@@ -476,8 +481,15 @@ function NewPlatformAddressRow({
           variant="primary"
           disabled={!suffix.trim() || !!slugError || submitting}
           onClick={() => void handleCreate()}
+          aria-label={submitting ? "Adding address" : "Add address"}
         >
-          <RowSaveButtonContent pending={submitting} />
+          <Button.Icon>
+            {submitting ? (
+              <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+            ) : (
+              <SaveIcon aria-hidden="true" className="size-4" />
+            )}
+          </Button.Icon>
         </Button>
         <Button
           size="md"
@@ -565,8 +577,15 @@ function NewCustomAddressRow({
           variant="primary"
           disabled={!slug.trim() || !domainId || !!slugError || submitting}
           onClick={() => void handleCreate()}
+          aria-label={submitting ? "Adding address" : "Add address"}
         >
-          <RowSaveButtonContent pending={submitting} />
+          <Button.Icon>
+            {submitting ? (
+              <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+            ) : (
+              <SaveIcon aria-hidden="true" className="size-4" />
+            )}
+          </Button.Icon>
         </Button>
         <Button
           size="md"

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ToolFilteringSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/ToolFilteringSection.tsx
@@ -22,7 +22,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { FooterSaveButtonContent, SettingsSection } from "../SettingsSection";
+import { FooterSaveButton, SettingsSection } from "../SettingsSection";
 
 // Radix Select disallows an empty-string value, so the "Disabled" option needs
 // a sentinel that maps back to null (filtering off) when persisted.
@@ -101,17 +101,6 @@ export function ToolFilteringSection({
   const isSaving = updateMcpServer.isPending || createGroup.isPending;
   const dirty = draft !== currentValue;
   const hasGroups = groups.length > 0;
-  let enableButtonContent = <Button.Text>Enable</Button.Text>;
-  if (createGroup.isPending) {
-    enableButtonContent = (
-      <>
-        <Button.LeftIcon>
-          <Loader2 className="size-4 animate-spin" />
-        </Button.LeftIcon>
-        <Button.Text>Enabling</Button.Text>
-      </>
-    );
-  }
 
   return (
     <SettingsSection>
@@ -160,7 +149,14 @@ export function ToolFilteringSection({
                   disabled={isSaving || groupsQuery.isLoading}
                   onClick={() => createGroup.mutate({})}
                 >
-                  {enableButtonContent}
+                  {createGroup.isPending && (
+                    <Button.LeftIcon>
+                      <Loader2 className="size-4 animate-spin" />
+                    </Button.LeftIcon>
+                  )}
+                  <Button.Text>
+                    {createGroup.isPending ? "Enabling" : "Enable"}
+                  </Button.Text>
                 </Button>
               </RequireScope>
             )}
@@ -173,18 +169,13 @@ export function ToolFilteringSection({
           {hasGroups && (
             <SettingsSection.FooterActions>
               <RequireScope scope="mcp:write" level="component">
-                <Button
-                  variant="primary"
-                  size="md"
+                <FooterSaveButton
+                  pending={updateMcpServer.isPending}
                   disabled={!dirty || isSaving}
                   onClick={() =>
                     applyGroup(draft === DISABLED_VALUE ? null : draft)
                   }
-                >
-                  <FooterSaveButtonContent
-                    pending={updateMcpServer.isPending}
-                  />
-                </Button>
+                />
               </RequireScope>
             </SettingsSection.FooterActions>
           )}

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/DeleteRemoteIdentityProviderDialog.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/DeleteRemoteIdentityProviderDialog.tsx
@@ -157,16 +157,12 @@ function DeleteRemoteIdentityProviderDialogBody({
           disabled={!inputMatches || submitting}
           onClick={() => void handleConfirm()}
         >
-          {submitting ? (
-            <>
-              <Button.LeftIcon>
-                <Loader2 className="size-4 animate-spin" />
-              </Button.LeftIcon>
-              <Button.Text>Removing</Button.Text>
-            </>
-          ) : (
-            <Button.Text>Remove</Button.Text>
+          {submitting && (
+            <Button.LeftIcon>
+              <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+            </Button.LeftIcon>
           )}
+          <Button.Text>{submitting ? "Removing" : "Remove"}</Button.Text>
         </Button>
       </Dialog.Footer>
     </>

--- a/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
+++ b/client/dashboard/src/pages/onboarding/UploadOpenAPI.tsx
@@ -110,8 +110,10 @@ function FooterActions() {
     case "completed":
       return (
         <Button variant="primary" onClick={() => routes.mcp.goTo()}>
-          Continue
-          <ArrowRightIcon className="size-4" />
+          <Button.Text>Continue</Button.Text>
+          <Button.RightIcon>
+            <ArrowRightIcon className="size-4" />
+          </Button.RightIcon>
         </Button>
       );
     case "error":
@@ -119,8 +121,10 @@ function FooterActions() {
         // This should never happen, but just in case
         return (
           <Button variant="primary" onClick={stepper.reset}>
-            <RefreshCcwIcon className="size-4" />
-            Try Again
+            <Button.LeftIcon>
+              <RefreshCcwIcon className="size-4" />
+            </Button.LeftIcon>
+            <Button.Text>Try Again</Button.Text>
           </Button>
         );
       }
@@ -131,8 +135,10 @@ function FooterActions() {
             variant="primary"
             onClick={() => routes.deployments.deployment.goTo(deploymentId)}
           >
-            View Logs
-            <ArrowRightIcon className="size-4" />
+            <Button.Text>View Logs</Button.Text>
+            <Button.RightIcon>
+              <ArrowRightIcon className="size-4" />
+            </Button.RightIcon>
           </Button>
         </>
       );

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -261,16 +261,19 @@ function OrgApiKeysInner() {
               <div className="bg-muted flex items-center space-x-2 rounded-md p-3">
                 <code className="flex-1 break-all">{newlyCreatedKey.key}</code>
                 <Button
+                  aria-label={isCopied ? "API key copied" : "Copy API key"}
                   variant="tertiary"
                   size="sm"
                   onClick={() => void handleCopyToken()}
                   className="shrink-0"
                 >
-                  {isCopied ? (
-                    <CheckCircle2 className="h-4 w-4 text-green-500" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
+                  <Button.Icon>
+                    {isCopied ? (
+                      <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button.Icon>
                 </Button>
               </div>
               <div className="flex justify-end">

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -163,7 +163,9 @@ function IPAllowlistEditor({
               onClick={() => handleRemove(row.id)}
               aria-label="Remove entry"
             >
-              <X className="h-4 w-4" />
+              <Button.Icon>
+                <X className="h-4 w-4" />
+              </Button.Icon>
             </Button>
           </div>
           {row.error && (
@@ -414,13 +416,16 @@ function OrgDomainsInner() {
                   </Button>
                 )}
                 <Button
+                  aria-label="Delete custom domain"
                   variant="tertiary"
                   size="sm"
                   onClick={() => setIsDeleteDomainDialogOpen(true)}
                   className="hover:text-destructive"
                   disabled={deleteDomainMutation.isPending}
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Button.Icon>
+                    <Trash2 className="h-4 w-4" />
+                  </Button.Icon>
                 </Button>
               </Stack>
             </RequireScope>
@@ -595,16 +600,21 @@ function OrgDomainsInner() {
               <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
                 <code className="flex-1 break-all">{CNAME_VALUE}</code>
                 <Button
+                  aria-label={
+                    isCnameCopied ? "CNAME value copied" : "Copy CNAME value"
+                  }
                   variant="tertiary"
                   size="sm"
                   onClick={() => void handleCopyCname()}
                   className="shrink-0"
                 >
-                  {isCnameCopied ? (
-                    <CheckCircle2 className="h-4 w-4 text-green-500" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
+                  <Button.Icon>
+                    {isCnameCopied ? (
+                      <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button.Icon>
                 </Button>
               </div>
             </div>
@@ -623,16 +633,21 @@ function OrgDomainsInner() {
               <div className="bg-muted mt-2 flex items-center space-x-2 rounded-md p-3">
                 <code className="flex-1 break-all">{txtValue}</code>
                 <Button
+                  aria-label={
+                    isTxtCopied ? "TXT value copied" : "Copy TXT value"
+                  }
                   variant="tertiary"
                   size="sm"
                   onClick={() => void handleCopyTxt()}
                   className="shrink-0"
                 >
-                  {isTxtCopied ? (
-                    <CheckCircle2 className="h-4 w-4 text-green-500" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
+                  <Button.Icon>
+                    {isTxtCopied ? (
+                      <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button.Icon>
                 </Button>
               </div>
             </div>

--- a/client/dashboard/src/pages/playground/EditToolDialog.tsx
+++ b/client/dashboard/src/pages/playground/EditToolDialog.tsx
@@ -363,9 +363,11 @@ export function EditToolDialog({
               onClick={() => void handleSave()}
               disabled={!hasChanges || saving}
             >
-              {saving ? "Saving..." : "Save"}
+              <Button.Text>{saving ? "Saving..." : "Save"}</Button.Text>
               {hasChanges && !saving && (
-                <span className="ml-2 text-xs opacity-60">⌘⏎</span>
+                <Button.RightIcon>
+                  <span className="text-xs opacity-60">⌘⏎</span>
+                </Button.RightIcon>
               )}
             </Button>
           </div>

--- a/client/dashboard/src/pages/plugins/PluginCard.tsx
+++ b/client/dashboard/src/pages/plugins/PluginCard.tsx
@@ -24,6 +24,7 @@ import { toast } from "sonner";
 import { DEFAULT_PLUGIN_DESCRIPTION } from "./default-plugin";
 import { downloadPluginPackage } from "./downloadPluginPackage";
 import { InstallInstructionsDialog } from "./InstallInstructionsDialog";
+import { PluginInstallButton } from "./PluginInstallButton";
 
 export function PluginCard({
   plugin,
@@ -200,13 +201,7 @@ export function PluginCard({
                   onOpenChange={setIsDownloadMenuOpen}
                 >
                   <DropdownMenuTrigger asChild>
-                    <Button variant="primary" size="sm">
-                      <Button.Text>Install</Button.Text>
-                      <span className="bg-primary-foreground/25 mx-1 h-4 w-px self-center" />
-                      <Button.RightIcon>
-                        <Icon name="chevron-down" className="h-4 w-4" />
-                      </Button.RightIcon>
-                    </Button>
+                    <PluginInstallButton size="sm" />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     {installActions.map((action) => (

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -59,6 +59,7 @@ import { toast } from "sonner";
 import { DEFAULT_PLUGIN_DESCRIPTION } from "./default-plugin";
 import { downloadPluginPackage } from "./downloadPluginPackage";
 import { InstallInstructionsDialog } from "./InstallInstructionsDialog";
+import { PluginInstallButton } from "./PluginInstallButton";
 import { PluginAssignmentsSheet } from "./PluginAssignmentsSheet";
 import { PluginSkillsSection } from "./PluginSkillsSection";
 import { PluginAssignmentsList } from "./PluginAssignmentsList";
@@ -431,13 +432,7 @@ export default function PluginDetail(): JSX.Element | null {
                 onOpenChange={setIsDownloadMenuOpen}
               >
                 <DropdownMenuTrigger asChild>
-                  <Button variant="primary">
-                    <Button.Text>Install</Button.Text>
-                    <span className="bg-primary-foreground/25 mx-1 h-4 w-px self-center" />
-                    <Button.RightIcon>
-                      <Icon name="chevron-down" className="h-4 w-4" />
-                    </Button.RightIcon>
-                  </Button>
+                  <PluginInstallButton />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem

--- a/client/dashboard/src/pages/plugins/PluginInstallButton.tsx
+++ b/client/dashboard/src/pages/plugins/PluginInstallButton.tsx
@@ -1,0 +1,22 @@
+import { Button, Icon, type ButtonProps } from "@speakeasy-api/moonshine";
+import { forwardRef } from "react";
+
+type PluginInstallButtonProps = Omit<ButtonProps, "children" | "variant">;
+
+export const PluginInstallButton = forwardRef<
+  HTMLButtonElement,
+  PluginInstallButtonProps
+>(function PluginInstallButton(buttonProps, ref) {
+  return (
+    <Button ref={ref} variant="primary" {...buttonProps}>
+      <Button.Text>Install</Button.Text>
+      <Button.Icon
+        aria-hidden="true"
+        className="bg-primary-foreground/25 h-4 w-px self-center"
+      />
+      <Button.RightIcon>
+        <Icon aria-hidden="true" name="chevron-down" className="h-4 w-4" />
+      </Button.RightIcon>
+    </Button>
+  );
+});

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -32,7 +32,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Icon,
   Stack,
 } from "@speakeasy-api/moonshine";
 import { Activity } from "lucide-react";
@@ -46,6 +45,7 @@ import {
   UninitializedMarketplaceCard,
 } from "./MarketplaceCard";
 import { PluginCard } from "./PluginCard";
+import { PluginInstallButton } from "./PluginInstallButton";
 import {
   matchesPluginFilters,
   PLUGINS_FILTERS,
@@ -591,13 +591,7 @@ function ObservabilityPluginCard({
           onOpenChange={onDownloadMenuOpenChange}
         >
           <DropdownMenuTrigger asChild>
-            <Button variant="primary" size="sm">
-              <Button.Text>Install</Button.Text>
-              <span className="bg-primary-foreground/25 mx-1 h-4 w-px self-center" />
-              <Button.RightIcon>
-                <Icon name="chevron-down" className="h-4 w-4" />
-              </Button.RightIcon>
-            </Button>
+            <PluginInstallButton size="sm" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem

--- a/client/dashboard/src/pages/prompts/PromptEditor.tsx
+++ b/client/dashboard/src/pages/prompts/PromptEditor.tsx
@@ -184,10 +184,12 @@ export function PromptEditor({
                     className="absolute top-4 right-4"
                     type="button"
                     variant="tertiary"
+                    aria-label="Exit full screen"
                     onClick={() => setFullScreenEditor(false)}
                   >
-                    <span className="sr-only">Exit full screen</span>
-                    <X className="h-4 w-4" />
+                    <Button.Icon>
+                      <X aria-hidden="true" className="h-4 w-4" />
+                    </Button.Icon>
                   </Button>
                 ) : null}
                 {!fullScreenEditor ? (
@@ -195,13 +197,15 @@ export function PromptEditor({
                     className="absolute right-4 bottom-4"
                     type="button"
                     variant="tertiary"
+                    aria-label="Enter full screen"
                     onClick={() => {
                       setFullScreenEditor(true);
                       document.querySelector("textarea")?.focus();
                     }}
                   >
-                    <span className="sr-only">Enter full screen</span>
-                    <Fullscreen className="h-4 w-4" />
+                    <Button.Icon>
+                      <Fullscreen aria-hidden="true" className="h-4 w-4" />
+                    </Button.Icon>
                   </Button>
                 ) : null}
               </div>
@@ -249,9 +253,11 @@ export function PromptEditor({
           ) : null}
           <Button type="submit" disabled={isPending} size="md">
             {isPending ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Button.LeftIcon>
+                <Loader2 className="h-4 w-4 animate-spin" />
+              </Button.LeftIcon>
             ) : null}
-            {isPending ? "Saving..." : "Save Prompt"}
+            <Button.Text>{isPending ? "Saving..." : "Save Prompt"}</Button.Text>
           </Button>
         </div>
       </form>

--- a/client/dashboard/src/pages/security/RiskOverviewRulesIndex.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewRulesIndex.tsx
@@ -11,6 +11,7 @@ import { useRiskOverview } from "@gram/client/react-query/riskOverview.js";
 import { Icon } from "@speakeasy-api/moonshine";
 import { useMemo } from "react";
 import { Link, useLocation } from "react-router";
+import { riskRuleKey } from "./riskRuleKey";
 import { getRuleTitleFallback } from "./risk-utils";
 
 const RISK_OVERVIEW_PRESETS: DateRangePreset[] = [
@@ -153,7 +154,7 @@ function RiskOverviewRulesIndexContent() {
                 </div>
               );
               return (
-                <li key={r.ruleId || `__none_${i}`}>
+                <li key={riskRuleKey(r.source, r.ruleId)}>
                   {href ? (
                     <Link to={href} className="hover:bg-muted/40 block">
                       {body}

--- a/client/dashboard/src/pages/security/SecurityOverview.test.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SecurityOverview from "./SecurityOverview";
+
+const mocks = vi.hoisted(() => ({
+  useRiskOverview: vi.fn(),
+}));
+
+vi.mock("@/components/chart/ChartCard", () => ({
+  ChartCard: () => null,
+}));
+
+vi.mock("@/components/chart/MetricCard", () => ({
+  MetricCard: () => null,
+}));
+
+vi.mock("@/components/insights-dock", () => ({
+  InsightsConfig: () => null,
+}));
+
+vi.mock("@/components/page-layout", async () => {
+  const { createElement } = await import("react");
+
+  function Container({ children }: { children?: ReactNode }) {
+    return createElement("div", null, children);
+  }
+
+  const Header = Object.assign(Container, { Breadcrumbs: () => null });
+  const Section = Object.assign(Container, {
+    Title: Container,
+    Description: Container,
+    CTA: Container,
+    Body: Container,
+  });
+
+  return {
+    Page: Object.assign(Container, {
+      Header,
+      Body: Container,
+      Section,
+    }),
+  };
+});
+
+vi.mock("@/components/require-scope", async () => {
+  const { createElement, Fragment } = await import("react");
+
+  return {
+    RequireScope: ({ children }: { children: ReactNode }) =>
+      createElement(Fragment, null, children),
+  };
+});
+
+vi.mock("@/components/ui/dashboard-card", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    DashboardCard: ({ children }: { children: ReactNode }) =>
+      createElement("div", null, children),
+  };
+});
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => null,
+}));
+
+vi.mock("@/components/DashboardTimeRangePicker", () => ({
+  TimeRangePicker: () => null,
+}));
+
+vi.mock("@/components/observe/useDateRangeFilter", () => ({
+  formatDateRangeLabel: () => "the selected range",
+  useDateRangeFilter: () => ({
+    dateRange: "7d",
+    customRange: null,
+    customRangeLabel: "",
+    from: undefined,
+    to: undefined,
+    setDateRangeParam: vi.fn(),
+    setCustomRangeParam: vi.fn(),
+    clearCustomRange: vi.fn(),
+  }),
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    agentSessions: { href: () => "/sessions" },
+    policyCenter: { href: () => "/policies" },
+    riskEvents: { href: () => "/risk-events" },
+    riskOverview: {
+      categoriesIndex: { href: () => "/risk/categories" },
+      rulesIndex: { href: () => "/risk/rules" },
+      usersIndex: { href: () => "/risk/users" },
+    },
+  }),
+}));
+
+vi.mock("@gram/client/react-query/riskOverview.js", () => ({
+  useRiskOverview: mocks.useRiskOverview,
+}));
+
+vi.mock("@speakeasy-api/moonshine", async () => {
+  const { createElement } = await import("react");
+
+  function Container({ children }: { children?: ReactNode }) {
+    return createElement("span", null, children);
+  }
+
+  return {
+    Button: Object.assign(Container, {
+      LeftIcon: Container,
+      RightIcon: Container,
+      Text: Container,
+    }),
+    Icon: ({ name }: { name: string }) => createElement("span", null, name),
+  };
+});
+
+vi.mock("chart.js", () => ({
+  CategoryScale: {},
+  Chart: { register: vi.fn() },
+  Filler: {},
+  Legend: {},
+  LinearScale: {},
+  LineElement: {},
+  PointElement: {},
+  Tooltip: {},
+}));
+
+vi.mock("chartjs-plugin-zoom", () => ({ default: {} }));
+vi.mock("react-chartjs-2", () => ({ Line: () => null }));
+
+vi.mock("react-router", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    Link: ({ children, to }: { children: ReactNode; to: string }) =>
+      createElement("a", { href: to }, children),
+    Outlet: () => null,
+    useLocation: () => ({ search: "" }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("SecurityOverview rule identity", () => {
+  it.each([
+    ["non-empty", "seed.history_risk"],
+    ["empty", ""],
+  ])("keeps %s rule IDs from different sources distinct", (_, ruleId) => {
+    mocks.useRiskOverview.mockReturnValue({
+      data: {
+        activePolicies: 1,
+        findings: 3,
+        flaggedSessions: 1,
+        from: new Date().toISOString(),
+        messagesScanned: 10,
+        timeSeriesFindings: [],
+        to: new Date().toISOString(),
+        topCategories: [],
+        topRules: [
+          { source: "catalog", ruleId, findings: 2 },
+          { source: "custom", ruleId, findings: 1 },
+        ],
+        topUsers: [],
+      },
+      error: null,
+      isLoading: false,
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(<SecurityOverview />);
+
+    const errors = consoleError.mock.calls.flat().join(" ");
+    expect(errors).not.toContain("same key");
+  });
+});

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -25,6 +25,7 @@ import {
   useDateRangeFilter,
 } from "@/components/observe/useDateRangeFilter";
 import { RULE_CATEGORY_META, type RuleCategory } from "./policy-data";
+import { riskRuleKey } from "./riskRuleKey";
 import { getRuleTitleFallback } from "./risk-utils";
 import {
   CategoryScale,
@@ -254,7 +255,7 @@ function SecurityOverviewContent() {
           : "";
       const href = r.ruleId ? `${riskEventsHref}${search}` : undefined;
       return {
-        key: r.ruleId || "__none",
+        key: riskRuleKey(r.source, r.ruleId),
         label,
         value: Number(r.findings),
         href,

--- a/client/dashboard/src/pages/security/riskRuleKey.test.ts
+++ b/client/dashboard/src/pages/security/riskRuleKey.test.ts
@@ -1,0 +1,138 @@
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import RiskOverviewRulesIndex from "./RiskOverviewRulesIndex";
+import { riskRuleKey } from "./riskRuleKey";
+
+const mocks = vi.hoisted(() => ({
+  useRiskOverview: vi.fn(),
+}));
+
+vi.mock("@/components/page-layout", async () => {
+  const { createElement } = await import("react");
+
+  function Container({ children }: { children?: ReactNode }) {
+    return createElement("div", null, children);
+  }
+
+  const Header = Object.assign(Container, { Breadcrumbs: () => null });
+  const Section = Object.assign(Container, {
+    Title: Container,
+    Description: Container,
+    CTA: Container,
+    Body: Container,
+  });
+
+  return {
+    Page: Object.assign(Container, {
+      Header,
+      Body: Container,
+      Section,
+    }),
+  };
+});
+
+vi.mock("@/components/require-scope", async () => {
+  const { createElement, Fragment } = await import("react");
+
+  return {
+    RequireScope: ({ children }: { children: ReactNode }) =>
+      createElement(Fragment, null, children),
+  };
+});
+
+vi.mock("@/components/DashboardTimeRangePicker", () => ({
+  TimeRangePicker: () => null,
+}));
+
+vi.mock("@/components/observe/useDateRangeFilter", () => ({
+  formatDateRangeLabel: () => "",
+  useDateRangeFilter: () => ({
+    dateRange: "7d",
+    customRange: null,
+    customRangeLabel: "",
+    from: undefined,
+    to: undefined,
+    setDateRangeParam: vi.fn(),
+    setCustomRangeParam: vi.fn(),
+    clearCustomRange: vi.fn(),
+  }),
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({
+    riskEvents: { href: () => "/risk-events" },
+  }),
+}));
+
+vi.mock("@gram/client/react-query/riskOverview.js", () => ({
+  useRiskOverview: mocks.useRiskOverview,
+}));
+
+vi.mock("@speakeasy-api/moonshine", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    Icon: ({ name }: { name: string }) => createElement("span", null, name),
+  };
+});
+
+vi.mock("react-router", async () => {
+  const { createElement } = await import("react");
+
+  return {
+    Link: ({ children, to }: { children: ReactNode; to: string }) =>
+      createElement("a", { href: to }, children),
+    useLocation: () => ({ search: "" }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("risk rule row identity", () => {
+  it.each([
+    ["non-empty", "seed.history_risk"],
+    ["empty", ""],
+  ])("keeps %s rule IDs from different sources distinct", (_, ruleId) => {
+    mocks.useRiskOverview.mockReturnValue({
+      data: {
+        topRules: [
+          { source: "catalog", ruleId, findings: 2 },
+          { source: "custom", ruleId, findings: 1 },
+        ],
+      },
+      isLoading: false,
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(RiskOverviewRulesIndex());
+
+    const errors = consoleError.mock.calls.flat().join(" ");
+    expect(errors).not.toContain("same key");
+  });
+});
+
+describe("riskRuleKey", () => {
+  it("distinguishes the same rule ID from different sources", () => {
+    expect(riskRuleKey("catalog", "seed.history_risk")).not.toBe(
+      riskRuleKey("custom", "seed.history_risk"),
+    );
+  });
+
+  it("uses a stable sentinel for an empty rule ID", () => {
+    expect(riskRuleKey("catalog", "")).toBe(riskRuleKey("catalog", ""));
+    expect(riskRuleKey("catalog", "")).not.toBe(riskRuleKey("custom", ""));
+  });
+
+  it("distinguishes an empty rule ID from the sentinel text", () => {
+    expect(riskRuleKey("catalog", "")).not.toBe(
+      riskRuleKey("catalog", "__none"),
+    );
+  });
+});

--- a/client/dashboard/src/pages/security/riskRuleKey.ts
+++ b/client/dashboard/src/pages/security/riskRuleKey.ts
@@ -1,0 +1,5 @@
+const EMPTY_RULE_ID = "__none";
+
+export function riskRuleKey(source: string, ruleId: string): string {
+  return `${source}\u0000${ruleId ? `value:${ruleId}` : `empty:${EMPTY_RULE_ID}`}`;
+}

--- a/client/dashboard/src/pages/settings/RegistryCacheSection.tsx
+++ b/client/dashboard/src/pages/settings/RegistryCacheSection.tsx
@@ -78,9 +78,11 @@ export function RegistryCacheSection(): JSX.Element {
                   }}
                 >
                   {isClearing && (
-                    <Loader2 className="mr-2 h-3 w-3 animate-spin" />
+                    <Button.LeftIcon>
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    </Button.LeftIcon>
                   )}
-                  Clear Cache
+                  <Button.Text>Clear Cache</Button.Text>
                 </Button>
               </Stack>
             );

--- a/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
+++ b/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
@@ -50,6 +50,12 @@ function describeSaveResult(addedCount: number, removedCount: number): string {
     : "Distributed to plugin";
 }
 
+function saveButtonLabel(isSaving: boolean, isDistributed: boolean): string {
+  if (isSaving) return "Saving";
+  if (isDistributed) return "Update";
+  return "Distribute";
+}
+
 /**
  * The distribution status banner at the top of the skill detail page:
  * summarizes which plugins carry this skill and lets writers stage and save
@@ -271,15 +277,14 @@ export function SkillPluginBanner({
                   disabled={!hasChanges || isSaving}
                   onClick={() => void handleSave()}
                 >
-                  {isSaving ? (
-                    <>
-                      <Spinner /> Saving
-                    </>
-                  ) : isDistributed ? (
-                    "Update"
-                  ) : (
-                    "Distribute"
+                  {isSaving && (
+                    <Button.LeftIcon>
+                      <Spinner />
+                    </Button.LeftIcon>
                   )}
+                  <Button.Text>
+                    {saveButtonLabel(isSaving, isDistributed)}
+                  </Button.Text>
                 </Button>
               </div>
             </RequireScope>

--- a/client/dashboard/src/pages/sources/remote-mcp/CreateRemoteMcp.tsx
+++ b/client/dashboard/src/pages/sources/remote-mcp/CreateRemoteMcp.tsx
@@ -195,15 +195,13 @@ function CreateRemoteMcpForm() {
             />
             <Button type="submit" variant="primary" disabled={submitDisabled}>
               {createSource.isPending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Adding</Button.Text>
-                </>
-              ) : (
-                <Button.Text>Add server</Button.Text>
-              )}
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
+              ) : null}
+              <Button.Text>
+                {createSource.isPending ? "Adding" : "Add server"}
+              </Button.Text>
             </Button>
             <Button
               type="button"

--- a/client/dashboard/src/pages/sources/remote-mcp/RemoteMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/remote-mcp/RemoteMCPDetails.tsx
@@ -603,15 +603,11 @@ function NameSection({
               onClick={() => void handleSave()}
             >
               {update.isPending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Saving</Button.Text>
-                </>
-              ) : (
-                <Button.Text>Save</Button.Text>
-              )}
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
+              ) : null}
+              <Button.Text>{update.isPending ? "Saving" : "Save"}</Button.Text>
             </Button>
           </RequireScope>
         </Stack>
@@ -744,15 +740,11 @@ function UrlSection({
               onClick={() => void handleSave()}
             >
               {update.isPending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Saving</Button.Text>
-                </>
-              ) : (
-                <Button.Text>Save</Button.Text>
-              )}
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
+              ) : null}
+              <Button.Text>{update.isPending ? "Saving" : "Save"}</Button.Text>
             </Button>
           </RequireScope>
         </Stack>

--- a/client/dashboard/src/pages/sources/remote-mcp/VerifyRemoteMcpUrlButton.tsx
+++ b/client/dashboard/src/pages/sources/remote-mcp/VerifyRemoteMcpUrlButton.tsx
@@ -22,21 +22,16 @@ export function VerifyRemoteMcpUrlButton({
         void state.trigger();
       }}
     >
-      {state.isPending ? (
-        <>
-          <Button.LeftIcon>
-            <Loader2 className="size-4 animate-spin" />
-          </Button.LeftIcon>
-          <Button.Text>Verifying</Button.Text>
-        </>
-      ) : (
-        <>
-          <Button.LeftIcon>
-            <Plug className="size-4" />
-          </Button.LeftIcon>
-          <Button.Text>Verify MCP Connectivity</Button.Text>
-        </>
-      )}
+      <Button.LeftIcon>
+        {state.isPending ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Plug className="size-4" />
+        )}
+      </Button.LeftIcon>
+      <Button.Text>
+        {state.isPending ? "Verifying" : "Verify MCP Connectivity"}
+      </Button.Text>
     </Button>
   );
 }

--- a/client/dashboard/src/pages/sources/tunneled-mcp/CreateTunneledMcp.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/CreateTunneledMcp.tsx
@@ -224,15 +224,13 @@ function CreateTunneledMcpForm() {
           <Stack direction="horizontal" gap={2}>
             <Button type="submit" variant="primary" disabled={submitDisabled}>
               {createSource.isPending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Adding</Button.Text>
-                </>
-              ) : (
-                <Button.Text>Add server</Button.Text>
-              )}
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
+              ) : null}
+              <Button.Text>
+                {createSource.isPending ? "Adding" : "Add server"}
+              </Button.Text>
             </Button>
             <Button
               type="button"

--- a/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx
+++ b/client/dashboard/src/pages/sources/tunneled-mcp/TunneledMCPDetails.tsx
@@ -724,15 +724,11 @@ function NameSection({
               onClick={() => void handleSave()}
             >
               {update.isPending ? (
-                <>
-                  <Button.LeftIcon>
-                    <Loader2 className="size-4 animate-spin" />
-                  </Button.LeftIcon>
-                  <Button.Text>Saving</Button.Text>
-                </>
-              ) : (
-                <Button.Text>Save</Button.Text>
-              )}
+                <Button.LeftIcon>
+                  <Loader2 className="size-4 animate-spin" />
+                </Button.LeftIcon>
+              ) : null}
+              <Button.Text>{update.isPending ? "Saving" : "Save"}</Button.Text>
             </Button>
           </RequireScope>
         </Stack>
@@ -868,15 +864,13 @@ function TunnelKeySection({
                   disabled={rotate.isPending}
                 >
                   {rotate.isPending ? (
-                    <>
-                      <Button.LeftIcon>
-                        <Loader2 className="size-4 animate-spin" />
-                      </Button.LeftIcon>
-                      <Button.Text>Rotating</Button.Text>
-                    </>
-                  ) : (
-                    <Button.Text>Rotate</Button.Text>
-                  )}
+                    <Button.LeftIcon>
+                      <Loader2 className="size-4 animate-spin" />
+                    </Button.LeftIcon>
+                  ) : null}
+                  <Button.Text>
+                    {rotate.isPending ? "Rotating" : "Rotate"}
+                  </Button.Text>
                 </Button>
               </Dialog.Footer>
             </>

--- a/client/dashboard/src/pages/toolBuilder/Toolify.tsx
+++ b/client/dashboard/src/pages/toolBuilder/Toolify.tsx
@@ -187,8 +187,14 @@ export const ToolifyDialog = ({
               onClick={() => void onSubmit()}
               disabled={!purpose || inProgress}
             >
-              {inProgress && <Spinner />}
-              {inProgress ? "Generating..." : "Toolify"}
+              {inProgress && (
+                <Button.LeftIcon>
+                  <Spinner />
+                </Button.LeftIcon>
+              )}
+              <Button.Text>
+                {inProgress ? "Generating..." : "Toolify"}
+              </Button.Text>
             </Button>
           </div>
         </Dialog.Footer>


### PR DESCRIPTION
## Summary

This cleans up four classes of React/browser warnings found across the dashboard:

### Log detail hydration error
The collapsible log body rendered a copy button inside the button used to expand the section, producing invalid nested interactive markup and a hydration failure. The controls are now sibling buttons with the same visual layout, plus explicit `aria-expanded` and `aria-controls` wiring.

### Duplicate risk-rule keys
Risk rules from different sources can share the same rule ID, so keying rows by `ruleId` alone caused React collisions such as `seed.history_risk`. Keys now include both the source and rule ID, with a stable representation for empty IDs. Regression coverage exercises both overview renderers and the key helper.

### Command-palette focus warning
Closing the command palette could leave focus inside the modal while Radix was applying `aria-hidden` to its surrounding content. The provider now remembers the opener and restores focus after modal teardown. It validates that the target is still connected, enabled, visible, and outside hidden or inert content, then falls back to a visible command-palette trigger when needed.

### Moonshine button child warnings
Moonshine buttons only accept raw text or their supported text/icon slots, but several dashboard buttons passed arbitrary elements and fragments. The affected buttons now use `Button.Text`, `Button.LeftIcon`, `Button.RightIcon`, or `Button.Icon` as appropriate. Repeated footer-save and plugin-install patterns were consolidated while preserving existing spacing and layout.

## Verification
- `pnpm -F dashboard test` — 981 tests passed
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:oxlint`
- `pnpm -F dashboard lint:format`