### PR TITLE
mig: add assistant skill distribution targets

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -347,39 +347,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS plugins_project_id_is_default_key
 
 COMMENT ON COLUMN plugins.is_default IS 'Marks the fallback plugin new servers land in when not explicitly routed to a named plugin. At most one true per project (see plugins_project_id_is_default_key).';
 
-CREATE TABLE IF NOT EXISTS skill_distributions (
-  id uuid NOT NULL DEFAULT generate_uuidv7(),
-  project_id uuid NOT NULL,
-  skill_id uuid NOT NULL,
-  pinned_version_id uuid,
-  plugin_id uuid,
-
-  channel TEXT NOT NULL,
-  created_by_user_id TEXT NOT NULL,
-  revoked_at timestamptz,
-
-  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
-
-  CONSTRAINT skill_distributions_pkey PRIMARY KEY (id),
-  CONSTRAINT skill_distributions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
-  CONSTRAINT skill_distributions_project_id_skill_id_fkey FOREIGN KEY (project_id, skill_id) REFERENCES skills (project_id, id) ON DELETE CASCADE,
-  CONSTRAINT skill_distributions_skill_id_pinned_version_id_fkey FOREIGN KEY (skill_id, pinned_version_id) REFERENCES skill_versions (skill_id, id),
-  -- NULL plugin_id targets the whole project; otherwise targeting is delegated
-  -- to the plugin's own assignment mechanism.
-  CONSTRAINT skill_distributions_project_id_plugin_id_fkey FOREIGN KEY (project_id, plugin_id) REFERENCES plugins (project_id, id)
-);
-
--- NULLS NOT DISTINCT so at most one active direct (plugin_id IS NULL)
--- distribution exists per skill and channel alongside per-plugin ones.
-CREATE UNIQUE INDEX IF NOT EXISTS skill_distributions_project_id_skill_id_channel_plugin_id_key
-ON skill_distributions (project_id, skill_id, channel, plugin_id) NULLS NOT DISTINCT
-WHERE revoked_at IS NULL;
-
-CREATE INDEX IF NOT EXISTS skill_distributions_project_id_idx ON skill_distributions (project_id);
-CREATE INDEX IF NOT EXISTS skill_distributions_skill_id_pinned_version_id_idx ON skill_distributions (skill_id, pinned_version_id);
-CREATE INDEX IF NOT EXISTS skill_distributions_plugin_id_idx ON skill_distributions (plugin_id);
-
 CREATE TABLE IF NOT EXISTS skill_sync_receipts (
   project_id uuid NOT NULL,
   skill_id uuid NOT NULL,
@@ -1491,6 +1458,42 @@ CREATE UNIQUE INDEX IF NOT EXISTS assistants_project_id_name_key
 ON assistants (project_id, name)
 WHERE deleted IS FALSE;
 
+CREATE UNIQUE INDEX IF NOT EXISTS assistants_project_id_id_key ON assistants (project_id, id);
+
+CREATE TABLE IF NOT EXISTS skill_distributions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  skill_id uuid NOT NULL,
+  pinned_version_id uuid,
+  plugin_id uuid,
+  assistant_id uuid,
+
+  channel TEXT NOT NULL,
+  created_by_user_id TEXT NOT NULL,
+  revoked_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skill_distributions_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_distributions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT skill_distributions_project_id_skill_id_fkey FOREIGN KEY (project_id, skill_id) REFERENCES skills (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT skill_distributions_skill_id_pinned_version_id_fkey FOREIGN KEY (skill_id, pinned_version_id) REFERENCES skill_versions (skill_id, id),
+  CONSTRAINT skill_distributions_project_id_plugin_id_fkey FOREIGN KEY (project_id, plugin_id) REFERENCES plugins (project_id, id),
+  CONSTRAINT skill_distributions_project_id_assistant_id_fkey FOREIGN KEY (project_id, assistant_id) REFERENCES assistants (project_id, id)
+);
+
+-- Active distributions target either a plugin or an assistant. NULLS NOT
+-- DISTINCT preserves one active row per complete target tuple.
+CREATE UNIQUE INDEX IF NOT EXISTS skill_distributions_active_target_key
+ON skill_distributions (project_id, skill_id, channel, plugin_id, assistant_id) NULLS NOT DISTINCT
+WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS skill_distributions_project_id_idx ON skill_distributions (project_id);
+CREATE INDEX IF NOT EXISTS skill_distributions_skill_id_pinned_version_id_idx ON skill_distributions (skill_id, pinned_version_id);
+CREATE INDEX IF NOT EXISTS skill_distributions_plugin_id_idx ON skill_distributions (plugin_id);
+CREATE INDEX IF NOT EXISTS skill_distributions_assistant_id_idx ON skill_distributions (assistant_id);
+
 -- project_managed_assistants maps a project to its single platform-managed
 -- assistant (the one powering the AI Insights sidebar). Kept in its own table
 -- rather than a flag on assistants/projects so the relation has an explicit
@@ -1568,6 +1571,8 @@ CREATE TABLE IF NOT EXISTS assistant_threads (
   chat_id uuid NOT NULL,
   source_kind TEXT NOT NULL CHECK (source_kind <> '' AND CHAR_LENGTH(source_kind) <= 50),
   source_ref_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- Versioned delivered skill-set document. NULL means no delivered baseline.
+  skill_set_snapshot JSONB,
   last_event_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -173,18 +173,19 @@ type AssistantRuntime struct {
 }
 
 type AssistantThread struct {
-	ID            uuid.UUID
-	AssistantID   uuid.UUID
-	ProjectID     uuid.UUID
-	CorrelationID string
-	ChatID        uuid.UUID
-	SourceKind    string
-	SourceRefJson []byte
-	LastEventAt   pgtype.Timestamptz
-	CreatedAt     pgtype.Timestamptz
-	UpdatedAt     pgtype.Timestamptz
-	DeletedAt     pgtype.Timestamptz
-	Deleted       bool
+	ID               uuid.UUID
+	AssistantID      uuid.UUID
+	ProjectID        uuid.UUID
+	CorrelationID    string
+	ChatID           uuid.UUID
+	SourceKind       string
+	SourceRefJson    []byte
+	SkillSetSnapshot []byte
+	LastEventAt      pgtype.Timestamptz
+	CreatedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
+	DeletedAt        pgtype.Timestamptz
+	Deleted          bool
 }
 
 type AssistantThreadEvent struct {
@@ -1648,6 +1649,7 @@ type SkillDistribution struct {
 	SkillID         uuid.UUID
 	PinnedVersionID uuid.NullUUID
 	PluginID        uuid.NullUUID
+	AssistantID     uuid.NullUUID
 	Channel         string
 	CreatedByUserID string
 	RevokedAt       pgtype.Timestamptz

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -1247,7 +1247,7 @@ WHERE prev.id = sd.id
   AND sd.project_id = $1
   AND sd.plugin_id = $2
   AND sd.revoked_at IS NULL
-RETURNING sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at, prev.updated_at AS previous_updated_at, resolved.id AS resolved_version_id, s.name AS skill_name, s.display_name AS skill_display_name
+RETURNING sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.assistant_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at, prev.updated_at AS previous_updated_at, resolved.id AS resolved_version_id, s.name AS skill_name, s.display_name AS skill_display_name
 `
 
 type RevokeSkillDistributionsByPluginParams struct {
@@ -1261,6 +1261,7 @@ type RevokeSkillDistributionsByPluginRow struct {
 	SkillID           uuid.UUID
 	PinnedVersionID   uuid.NullUUID
 	PluginID          uuid.NullUUID
+	AssistantID       uuid.NullUUID
 	Channel           string
 	CreatedByUserID   string
 	RevokedAt         pgtype.Timestamptz
@@ -1290,6 +1291,7 @@ func (q *Queries) RevokeSkillDistributionsByPlugin(ctx context.Context, arg Revo
 			&i.SkillID,
 			&i.PinnedVersionID,
 			&i.PluginID,
+			&i.AssistantID,
 			&i.Channel,
 			&i.CreatedByUserID,
 			&i.RevokedAt,

--- a/server/internal/skills/repo/models.go
+++ b/server/internal/skills/repo/models.go
@@ -28,6 +28,7 @@ type SkillDistribution struct {
 	SkillID         uuid.UUID
 	PinnedVersionID uuid.NullUUID
 	PluginID        uuid.NullUUID
+	AssistantID     uuid.NullUUID
 	Channel         string
 	CreatedByUserID string
 	RevokedAt       pgtype.Timestamptz

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -116,7 +116,7 @@ FROM skills s
 WHERE s.project_id = $4
   AND s.id = $5
   AND s.archived_at IS NULL
-RETURNING id, project_id, skill_id, pinned_version_id, plugin_id, channel, created_by_user_id, revoked_at, created_at, updated_at
+RETURNING id, project_id, skill_id, pinned_version_id, plugin_id, assistant_id, channel, created_by_user_id, revoked_at, created_at, updated_at
 `
 
 type CreateSkillDistributionParams struct {
@@ -142,6 +142,7 @@ func (q *Queries) CreateSkillDistribution(ctx context.Context, arg CreateSkillDi
 		&i.SkillID,
 		&i.PinnedVersionID,
 		&i.PluginID,
+		&i.AssistantID,
 		&i.Channel,
 		&i.CreatedByUserID,
 		&i.RevokedAt,
@@ -227,7 +228,7 @@ func (q *Queries) CreateSkillVersion(ctx context.Context, arg CreateSkillVersion
 
 const getActiveSkillDistributionRecord = `-- name: GetActiveSkillDistributionRecord :one
 SELECT
-  sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at,
+  sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.assistant_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at,
   resolved.id AS resolved_version_id
 FROM skill_distributions sd
 JOIN LATERAL (
@@ -267,6 +268,7 @@ func (q *Queries) GetActiveSkillDistributionRecord(ctx context.Context, arg GetA
 		&i.SkillDistribution.SkillID,
 		&i.SkillDistribution.PinnedVersionID,
 		&i.SkillDistribution.PluginID,
+		&i.SkillDistribution.AssistantID,
 		&i.SkillDistribution.Channel,
 		&i.SkillDistribution.CreatedByUserID,
 		&i.SkillDistribution.RevokedAt,
@@ -605,7 +607,7 @@ func (q *Queries) GetValidSkillVersion(ctx context.Context, arg GetValidSkillVer
 
 const listActiveSkillDistributions = `-- name: ListActiveSkillDistributions :many
 SELECT
-  sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at,
+  sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.assistant_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at,
   s.name AS skill_name,
   s.display_name AS skill_display_name,
   pl.name AS plugin_name,
@@ -680,6 +682,7 @@ func (q *Queries) ListActiveSkillDistributions(ctx context.Context, arg ListActi
 			&i.SkillDistribution.SkillID,
 			&i.SkillDistribution.PinnedVersionID,
 			&i.SkillDistribution.PluginID,
+			&i.SkillDistribution.AssistantID,
 			&i.SkillDistribution.Channel,
 			&i.SkillDistribution.CreatedByUserID,
 			&i.SkillDistribution.RevokedAt,
@@ -857,7 +860,7 @@ WHERE project_id = $1
   AND plugin_id = $3
   AND channel = 'plugin'
   AND revoked_at IS NULL
-RETURNING id, project_id, skill_id, pinned_version_id, plugin_id, channel, created_by_user_id, revoked_at, created_at, updated_at
+RETURNING id, project_id, skill_id, pinned_version_id, plugin_id, assistant_id, channel, created_by_user_id, revoked_at, created_at, updated_at
 `
 
 type RevokeActiveSkillDistributionParams struct {
@@ -875,6 +878,7 @@ func (q *Queries) RevokeActiveSkillDistribution(ctx context.Context, arg RevokeA
 		&i.SkillID,
 		&i.PinnedVersionID,
 		&i.PluginID,
+		&i.AssistantID,
 		&i.Channel,
 		&i.CreatedByUserID,
 		&i.RevokedAt,
@@ -902,7 +906,7 @@ WHERE prev.id = sd.id
   AND sd.project_id = $1
   AND sd.skill_id = $2
   AND sd.revoked_at IS NULL
-RETURNING sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at, prev.updated_at AS previous_updated_at, resolved.id AS resolved_version_id
+RETURNING sd.id, sd.project_id, sd.skill_id, sd.pinned_version_id, sd.plugin_id, sd.assistant_id, sd.channel, sd.created_by_user_id, sd.revoked_at, sd.created_at, sd.updated_at, prev.updated_at AS previous_updated_at, resolved.id AS resolved_version_id
 `
 
 type RevokeAllSkillDistributionsBySkillParams struct {
@@ -932,6 +936,7 @@ func (q *Queries) RevokeAllSkillDistributionsBySkill(ctx context.Context, arg Re
 			&i.SkillDistribution.SkillID,
 			&i.SkillDistribution.PinnedVersionID,
 			&i.SkillDistribution.PluginID,
+			&i.SkillDistribution.AssistantID,
 			&i.SkillDistribution.Channel,
 			&i.SkillDistribution.CreatedByUserID,
 			&i.SkillDistribution.RevokedAt,
@@ -1000,7 +1005,7 @@ WHERE project_id = $2
   AND plugin_id = $4
   AND channel = 'plugin'
   AND revoked_at IS NULL
-RETURNING id, project_id, skill_id, pinned_version_id, plugin_id, channel, created_by_user_id, revoked_at, created_at, updated_at
+RETURNING id, project_id, skill_id, pinned_version_id, plugin_id, assistant_id, channel, created_by_user_id, revoked_at, created_at, updated_at
 `
 
 type UpdateSkillDistributionParams struct {
@@ -1024,6 +1029,7 @@ func (q *Queries) UpdateSkillDistribution(ctx context.Context, arg UpdateSkillDi
 		&i.SkillID,
 		&i.PinnedVersionID,
 		&i.PluginID,
+		&i.AssistantID,
 		&i.Channel,
 		&i.CreatedByUserID,
 		&i.RevokedAt,

--- a/server/migrations/20260718133346_assistant-skill-distributions-additive.sql
+++ b/server/migrations/20260718133346_assistant-skill-distributions-additive.sql
@@ -1,0 +1,12 @@
+-- atlas:txmode none
+
+-- Modify "assistant_threads" table
+ALTER TABLE "assistant_threads" ADD COLUMN "skill_set_snapshot" jsonb NULL;
+-- Create index "assistants_project_id_id_key" to table: "assistants"
+CREATE UNIQUE INDEX CONCURRENTLY "assistants_project_id_id_key" ON "assistants" ("project_id", "id");
+-- Modify "skill_distributions" table
+ALTER TABLE "skill_distributions" ADD COLUMN "assistant_id" uuid NULL, ADD CONSTRAINT "skill_distributions_project_id_assistant_id_fkey" FOREIGN KEY ("project_id", "assistant_id") REFERENCES "assistants" ("project_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- Create index "skill_distributions_active_target_key" to table: "skill_distributions"
+CREATE UNIQUE INDEX CONCURRENTLY "skill_distributions_active_target_key" ON "skill_distributions" ("project_id", "skill_id", "channel", "plugin_id", "assistant_id") NULLS NOT DISTINCT WHERE (revoked_at IS NULL);
+-- Create index "skill_distributions_assistant_id_idx" to table: "skill_distributions"
+CREATE INDEX CONCURRENTLY "skill_distributions_assistant_id_idx" ON "skill_distributions" ("assistant_id");

--- a/server/migrations/20260718133423_assistant-skill-distributions-drop-old-index.sql
+++ b/server/migrations/20260718133423_assistant-skill-distributions-drop-old-index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Drop index "skill_distributions_project_id_skill_id_channel_plugin_id_key" from table: "skill_distributions"
+DROP INDEX CONCURRENTLY "skill_distributions_project_id_skill_id_channel_plugin_id_key";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:1goEIG9x3JGasRSyHn3TSkbTcFkA9wf4ZFySAnDURwk=
+h1:IXZ+z42xWfVbO+ylU4ZXHDxhz9ZTqC2ZPDEZAjS/Vkg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -272,3 +272,5 @@ h1:1goEIG9x3JGasRSyHn3TSkbTcFkA9wf4ZFySAnDURwk=
 20260716213928_skill-distributions-sync-receipts.sql h1:iW9LlmEmqcXaWE5ny7fk9ohcbbt1pVS3kFdcvgQvFeY=
 20260717080213_tunneled-mcp-server-headers.sql h1:3X8LqBrSIcgHrOxK/QkKrWnEv11/Q2ZQCOO3MjKxqV0=
 20260717084803_risk-results-add-overview-window-index.sql h1:BGSMZeD4ym5mRiZYyzsnHG63R0+A1ztbrt3EqGokbvQ=
+20260718133346_assistant-skill-distributions-additive.sql h1:O8xELra+jvEYo4FcZeD5nZ2Bm4jGk9TvGQZ9qS7N7mI=
+20260718133423_assistant-skill-distributions-drop-old-index.sql h1:uXeDfnAwbzpH7GZglJYBhjBzwCzOj4MbX4cS04AZWFw=


### PR DESCRIPTION
## Summary
- add project-scoped assistant targets to skill distributions
- persist per-thread skill-set snapshots for runtime change detection
- replace active-target uniqueness without a migration-time guard gap

Linear: https://linear.app/speakeasy/issue/DNO-433

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-assistant skill distributions by adding `assistant_id` to `skill_distributions`, enabling skills to target individual assistants. Also store a per-thread `skill_set_snapshot` to detect runtime changes. Implements DNO-433.

- **New Features**
  - Assistant targeting: nullable `assistant_id` FK on `skill_distributions` (scoped by `project_id`).
  - Enforced uniqueness for active targets via `(project_id, skill_id, channel, plugin_id, assistant_id) NULLS NOT DISTINCT`.
  - Thread snapshots: `skill_set_snapshot` JSONB on `assistant_threads`.
  - Indexes: unique `(project_id, id)` on `assistants`; index on `skill_distributions.assistant_id`.
  - Updated Go models and queries to read/write `AssistantID`.

- **Migration**
  - Online rollout: add columns and new index concurrently, then drop the old index; no uniqueness gap.
  - No backfill needed; existing plugin-targeted rows are unchanged.
  - App invariant per DNO-433: `channel = 'assistant'` ⇒ `assistant_id` set and `plugin_id` NULL; `channel = 'plugin'` ⇒ `plugin_id` set and `assistant_id` NULL.

<sup>Written for commit 9f33685ef9589ef87d95857d96fa87a9242dd81b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

