### PR TITLE
feat(hooks): detect Cursor skill activations

### DIFF
--- a/.changeset/curly-cursors-read.md
+++ b/.changeset/curly-cursors-read.md
@@ -1,0 +1,5 @@
+---
+"hooks": minor
+---
+
+Detect Cursor skill activations from skill manifest reads.

--- a/.mise-tasks/hooks/e2e.js
+++ b/.mise-tasks/hooks/e2e.js
@@ -1563,7 +1563,7 @@ function featureChecks(provider, evidence, chats, opts = {}) {
         ? "provider rows load in one chat generation"
         : `chat rows split across generations: ${splitGenerationChats.join("; ")}`,
   });
-  if (provider === "claude" || provider === "codex") {
+  if (["claude", "cursor", "codex"].includes(provider)) {
     const skillName = opts.skillName;
     const skillActivated = evidence.some(
       (r) =>
@@ -1825,6 +1825,13 @@ function skillPrompt(runId, skillName, provider, skillDir) {
       `Then reply with exactly: GRAM_HOOKS_E2E_OK ${runId} codex skill`,
     ].join(" ");
   }
+  if (provider === "cursor") {
+    return [
+      `Gram hooks E2E skill run ${runId} for cursor.`,
+      `Use the ${skillName} skill and follow its instructions.`,
+      `Then reply with exactly: GRAM_HOOKS_E2E_OK ${runId} cursor skill`,
+    ].join(" ");
+  }
   return [
     `Gram hooks E2E skill run ${runId} for claude.`,
     `Run the Gram hooks E2E skill probe by invoking the Skill tool with skill "${skillName}".`,
@@ -1854,6 +1861,29 @@ async function runSkillScenario(args) {
       { cwd: args.workdir, env: args.env, timeoutMs: args.timeoutMs },
     );
     res.provider = "codex";
+    return res;
+  }
+  if (args.provider === "cursor") {
+    await prepareCursorProjectHooks(args.pluginDir, args.workdir);
+    const res = await runProcess(
+      "cursor",
+      [
+        "agent",
+        "--print",
+        "--output-format",
+        "stream-json",
+        "--trust",
+        "--force",
+        "--approve-mcps",
+        "--plugin-dir",
+        args.pluginDir,
+        "--workspace",
+        args.workdir,
+        prompt,
+      ],
+      { cwd: args.workdir, timeoutMs: args.timeoutMs },
+    );
+    res.provider = "cursor";
     return res;
   }
   const sessionId = crypto.randomUUID();
@@ -2002,14 +2032,18 @@ async function runCaptureSuite(args) {
         }
       }
     }
-    if (provider === "claude" || provider === "codex") {
+    if (["claude", "cursor", "codex"].includes(provider)) {
       // Codex validates $name mentions against the skill roots on disk;
       // CODEX_HOME/skills is the only root the isolated env controls
       // regardless of the hook process cwd.
       const skillsRoot =
         provider === "codex"
           ? path.join(args.codexEnv.CODEX_HOME, "skills")
-          : path.join(args.workdir, ".claude", "skills");
+          : path.join(
+              args.workdir,
+              provider === "cursor" ? ".cursor" : ".claude",
+              "skills",
+            );
       const skill = await prepareSkillFixture(skillsRoot, args.runId, provider);
       skillNamesByProvider.set(provider, skill.skillName);
       log.info(`${provider}: running capture skill-activation scenario`);

--- a/hooks/relay/envelope.go
+++ b/hooks/relay/envelope.go
@@ -259,11 +259,16 @@ func applyToolCall(data *components.HookIngestData, base *agenthooks.Event, tool
 			return components.TypeSkillActivated
 		}
 	}
-	// Codex skill activations are inferred from ordinary tool payloads, so the
-	// event keeps its true type: only pre-tool events count (completions must
-	// not re-report, permission previews may be denied).
+	// Codex and Cursor skill activations are inferred from ordinary tool
+	// payloads, so the event keeps its true type: only pre-tool events count
+	// (completions must not re-report, permission previews may be denied).
 	if base.Provider == agenthooks.ProviderCodex && base.Kind == agenthooks.KindToolPre {
 		if name := codexToolSkillName(tool); name != "" {
+			data.Skill = &components.HookSkillData{Name: name, Source: nil}
+		}
+	}
+	if base.Provider == agenthooks.ProviderCursor && base.Kind == agenthooks.KindToolPre {
+		if name := cursorToolSkillName(tool); name != "" {
 			data.Skill = &components.HookSkillData{Name: name, Source: nil}
 		}
 	}

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -809,6 +809,86 @@ func TestEnvelopeCodexSkillInference(t *testing.T) {
 	require.Equal(t, "imagegen", skillOf(got), "reads of .system skill paths must infer the bare skill name")
 }
 
+func TestEnvelopeCursorSkillInference(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	sequence := 0
+	payload := func(nativeName, toolName string, toolInput any) []byte {
+		t.Helper()
+		sequence++
+		input := map[string]any{
+			"conversation_id": "cursor-skill-" + strconv.Itoa(sequence),
+			"hook_event_name": nativeName,
+			"tool_name":       toolName,
+			"tool_input":      toolInput,
+			"tool_use_id":     "call-" + strconv.Itoa(sequence),
+		}
+		if nativeName == "beforeReadFile" {
+			input["file_path"] = toolInput
+			delete(input, "tool_name")
+			delete(input, "tool_input")
+		}
+		if nativeName == "postToolUse" {
+			input["tool_response"] = map[string]any{"output": "ok"}
+		}
+		b, err := json.Marshal(input)
+		require.NoError(t, err)
+		return b
+	}
+	envelope := func(input []byte) components.IngestRequestBody {
+		t.Helper()
+		runner := agenthooks.New(agenthooks.WithDedupDir(t.TempDir()), agenthooks.WithoutBackfill())
+		var got components.IngestRequestBody
+		runner.OnToolPre(func(_ context.Context, e *agenthooks.ToolPreEvent) (agenthooks.ToolPreDecision, error) {
+			got = buildEnvelope(e, "test-host")
+			return agenthooks.NoDecision(), nil
+		})
+		runner.OnToolPost(func(_ context.Context, e *agenthooks.ToolPostEvent) (agenthooks.ToolPostDecision, error) {
+			got = buildEnvelope(e, "test-host")
+			return agenthooks.Observed(), nil
+		})
+		res := agenthookstest.Invoke(t, runner, agenthooks.ProviderCursor, input, "--variant=cli")
+		require.Equal(t, 0, res.ExitCode)
+		require.Equal(t, schemaVersion, got.SchemaVersion, "the payload must reach a tool handler")
+		return got
+	}
+	skillOf := func(got components.IngestRequestBody) string {
+		if got.Data == nil || got.Data.Skill == nil {
+			return ""
+		}
+		return got.Data.Skill.Name
+	}
+
+	workspacePath := filepath.Join(t.TempDir(), ".cursor", "skills", "workspace-skill", "SKILL.md")
+	got := envelope(payload("preToolUse", "Read", map[string]any{"file_path": workspacePath}))
+	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	require.Equal(t, "workspace-skill", skillOf(got))
+
+	pluginPath := filepath.Join(t.TempDir(), "arbitrary", "plugin", "skills", "plugin-skill", "SKILL.md")
+	got = envelope(payload("preToolUse", "Read", map[string]any{"file_path": pluginPath}))
+	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	require.Equal(t, "plugin-skill", skillOf(got))
+
+	got = envelope(payload("preToolUse", "Read", map[string]any{"path": workspacePath}))
+	require.Equal(t, "workspace-skill", skillOf(got), "legacy Cursor payloads use path instead of file_path")
+
+	got = envelope(payload("beforeReadFile", "", workspacePath))
+	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	require.Equal(t, "ReadFile", *got.Data.ToolCall.Name)
+	require.Empty(t, skillOf(got), "the duplicate beforeReadFile is normalized to ReadFile")
+
+	got = envelope(payload("postToolUse", "Read", map[string]any{"file_path": workspacePath}))
+	require.Equal(t, components.TypeToolCompleted, got.Event.Type)
+	require.Empty(t, skillOf(got), "completions must not re-report the activation")
+
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Bash", map[string]any{"file_path": workspacePath}))))
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(filepath.Dir(workspacePath), "README.md")}))))
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", "{"))))
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{}))))
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": "SKILL.md"}))))
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "not-a-skill", "SKILL.md")}))))
+	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "plugin", "skills", "SKILL.md")}))))
+}
+
 // TestRedactCommandMasksSeparatedHeaderValue pins the tokenized-header shape:
 // quote stripping splits `--header "X-API-Key: abc"` into a bare header token
 // and its value, and the value must not survive redaction.

--- a/hooks/relay/skills.go
+++ b/hooks/relay/skills.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,8 +20,8 @@ import (
 // classification on top instead.
 
 var (
-	codexSkillPathRE  = regexp.MustCompile(`skills/(?:\.system/)?([A-Za-z0-9][A-Za-z0-9._-]*)/SKILL\.md`)
-	codexSkillTokenRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	codexSkillPathRE = regexp.MustCompile(`skills/(?:\.system/)?([A-Za-z0-9][A-Za-z0-9._-]*)/SKILL\.md`)
+	skillTokenRE     = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 )
 
 // codexToolSkillName infers an implicit activation from a reader tool opening
@@ -39,6 +40,33 @@ func codexToolSkillName(tool *agenthooks.ToolCall) string {
 	// The bash senders' greedy sed match resolved the last occurrence; keep
 	// that so both channels report the same skill for one command.
 	return matches[len(matches)-1][1]
+}
+
+func cursorToolSkillName(tool *agenthooks.ToolCall) string {
+	// Cursor also emits beforeReadFile as ReadFile for the same activation.
+	if tool.Name != "Read" {
+		return ""
+	}
+	var input struct {
+		FilePath string `json:"file_path"`
+		Path     string `json:"path"`
+	}
+	if json.Unmarshal(tool.Input, &input) != nil {
+		return ""
+	}
+	path := input.FilePath
+	if path == "" {
+		path = input.Path
+	}
+	manifestDir := filepath.Dir(path)
+	if filepath.Base(path) != "SKILL.md" || filepath.Base(filepath.Dir(manifestDir)) != "skills" {
+		return ""
+	}
+	name := filepath.Base(manifestDir)
+	if !skillTokenRE.MatchString(name) {
+		return ""
+	}
+	return name
 }
 
 // codexPromptSkillName infers an explicit activation from a $skill-name
@@ -64,7 +92,7 @@ func codexPromptSkillName(prompt, cwd string) string {
 	names := []string{}
 	for _, f := range fields {
 		name, ok := strings.CutPrefix(f, "$")
-		if !ok || !codexSkillTokenRE.MatchString(name) {
+		if !ok || !skillTokenRE.MatchString(name) {
 			continue
 		}
 		// Sentence-final punctuation survives tokenization ("use $foo.").


### PR DESCRIPTION
## Summary
- infer Cursor skill activation from `preToolUse` `Read` events for `skills/<name>/SKILL.md`
- preserve the truthful `tool.requested` event and attach `data.skill` for server-side derived telemetry
- cover current `file_path`, legacy `path`, duplicate-event negatives, workspace/plugin paths, and Cursor skill E2E verification

Linear: DNO-575

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect Cursor skill activations by inferring from pre-tool Read of skills/<name>/SKILL.md. We attach `data.skill` to `tool.requested` and let ingest derive `skill.activated`, bringing telemetry parity with Codex and Claude (Linear DNO-575).

- **New Features**
  - Infer Cursor skill from `preToolUse` + `Read` when `file_path` or legacy `path` ends with `skills/<name>/SKILL.md` (supports workspace `.cursor/skills/...` and plugin `.../skills/...`).
  - Only pre-tool events count; ignore `beforeReadFile` duplicates and do not re-report on `postToolUse`.
  - Preserve the true event type (`tool.requested`), attach `data.skill`, and rely on server ingest to emit `skill.activated`.
  - Add unit and E2E coverage (enable Cursor in the capture suite; normalize `beforeReadFile` to `ReadFile`), generalize the skill token regex, and include a changeset for a minor `hooks` release.

<sup>Written for commit b5ee090ff9ca56f301c067a51bf0511bedeb76dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

