### PR TITLE
chore(ci): sync dashboard build assets to CDN origin bucket

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1448,6 +1448,16 @@ jobs:
           NODE_ENV: production
         run: mise exec --env viteprod -- pnpm build
 
+      # Published for upload-dashboard-assets so the CDN bucket receives the
+      # exact assets this image ships with (a rebuild there could hash
+      # differently, e.g. GRAM_GIT_SHA is only set in this job).
+      - name: Upload built assets artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dashboard-assets
+          path: client/dashboard/dist/assets
+          retention-days: 2
+
       - name: Upload source maps to DataDog
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
@@ -1495,6 +1505,62 @@ jobs:
       - name: Prune PNPM store
         if: success()
         run: pnpm store prune
+
+  upload-dashboard-assets:
+    name: Upload dashboard assets to CDN bucket (${{ matrix.environment }})
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: [docker-build-client]
+    # Syncs the dist/assets the dashboard image was built from (via artifact,
+    # not a rebuild) into the private GCS buckets that will become the CDN
+    # origins (gram-infra: infra/terraform/k8s/cdn-bucket.tf). Runs on PRs too
+    # so preview images' hashed assets are already in the buckets before any
+    # deploy references them. Forks and dependabot are skipped: their runs
+    # cannot mint the OIDC token needed for workload identity auth.
+    if: |
+      !cancelled() &&
+      needs.docker-build-client.result == 'success' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !github.event.pull_request.head.repo.fork
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: dev
+            bucket_secret: ASSET_BUCKET_DEV
+            workload_identity_provider_secret: GCP_WORKLOAD_IDENTITY_PROVIDER_DEV
+            service_account_secret: ASSET_BUCKET_SERVICE_ACCOUNT_DEV
+          - environment: prod
+            bucket_secret: ASSET_BUCKET_PROD
+            workload_identity_provider_secret: GCP_WORKLOAD_IDENTITY_PROVIDER_PROD
+            service_account_secret: ASSET_BUCKET_SERVICE_ACCOUNT_PROD
+    steps:
+      - name: Download built assets artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dashboard-assets
+          path: dist/assets
+
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets[matrix.workload_identity_provider_secret] }}
+          service_account: ${{ secrets[matrix.service_account_secret] }}
+
+      - name: Upload assets to bucket
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
+        with:
+          path: dist/assets
+          destination: ${{ secrets[matrix.bucket_secret] }}/assets
+          parent: false
+          # The CDN compresses at the edge (compression_mode AUTOMATIC) and
+          # skips responses that are already content-encoded, so objects must
+          # be stored uncompressed.
+          gzip: false
+          process_gcloudignore: false
+          # Filenames are content-hashed, so they are safe to cache forever.
+          headers: |-
+            cache-control: public, max-age=31536000, immutable
 
   client-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -1941,6 +2007,7 @@ jobs:
       - server-test
       - docker-build-server
       - docker-build-client
+      - upload-dashboard-assets
       - docker-build-pystreams
       - client-build-lint
       - client-test


### PR DESCRIPTION
The dashboard will start serving its static assets from a CDN backed by a private GCS bucket. For that to work, the exact assets baked into each client image must already exist in the bucket before any deploy references them — a rebuild in a separate job could hash differently (e.g. GRAM_GIT_SHA is only set during the image build), so the built dist/assets are passed from the docker-build-client job via artifact rather than rebuilt.

The job runs on PRs too so preview images' hashed assets are in place ahead of preview deploys. Objects are stored uncompressed because the CDN compresses at the edge and skips already-encoded responses, and they are cached as immutable since filenames are content-hashed. Forks and dependabot are skipped as they cannot mint the OIDC token required for workload identity auth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI job to sync the dashboard’s built `dist/assets` to private GCS CDN origin buckets (dev/prod) so deploys reference assets that already exist. Uses the exact files from the image build via artifact to avoid hash mismatches.

- **New Features**
  - Publishes built assets from `docker-build-client` via artifact (no rebuilds).
  - Uploads to env-specific buckets at `/assets` with `cache-control: public, max-age=31536000, immutable`.
  - Stores objects uncompressed; CDN performs edge compression.
  - Runs on PRs for previews; skips forks and `dependabot[bot]` (OIDC required).
  - Adds a dependency so downstream jobs wait for the asset upload.

<sup>Written for commit 54eefbc038a81cc182618c0bb271d0ce88ae6baf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

