### PR TITLE
chore(docs): add contributors facepile to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and detailed cont
 - [OpenRouter](https://openrouter.ai/) — LLM gateway.
 - [Speakeasy](https://www.speakeasy.com/) — generated SDKs. Spec hosted [here](https://app.getgram.ai/openapi.yaml).
 
+## Contributors
+
+Thanks to everyone who has contributed to Gram!
+
+<a href="https://github.com/speakeasy-api/gram/graphs/contributors">
+  <img alt="Gram contributors" src="https://contrib.rocks/image?repo=speakeasy-api/gram" />
+</a>
+
 <hr />
 <br />
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and detailed cont
 
 ## Contributors
 
-Thanks to everyone who has contributed to Gram!
-
 <a href="https://github.com/speakeasy-api/gram/graphs/contributors">
   <img alt="Gram contributors" src="https://contrib.rocks/image?repo=speakeasy-api/gram" />
 </a>


### PR DESCRIPTION
## Summary

Adds a **Contributors** section to the bottom of the README, just above the "Built by Speakeasy" badge. It uses [contrib.rocks](https://contrib.rocks) to render an auto-updating facepile of every GitHub contributor's avatar, linked to the repo's contributors graph — no hardcoded list to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9dyw4e8jsPLjfvkhCwycK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Contributors section to the README with an auto-updating facepile from contrib.rocks that links to the repo’s contributors graph. Kept it minimal (no subtext) and placed it above the “Built by Speakeasy” badge to avoid maintaining a manual list.

<sup>Written for commit 338c462c9094f5027256537351337c77c9bae59a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

