### PR TITLE
feat(dashboard): add search to costs breakdown table

### DIFF
--- a/.changeset/costs-breakdown-search.md
+++ b/.changeset/costs-breakdown-search.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add the standard toolbar search box to the costs breakdown section, filtering the visible breakdown rows (or sessions) client-side while keeping the preset breakdown-axis controls in place.

--- a/client/dashboard/src/pages/costs/BreakdownBar.tsx
+++ b/client/dashboard/src/pages/costs/BreakdownBar.tsx
@@ -1,3 +1,4 @@
+import { Page } from "@/components/page-layout";
 import {
   SEGMENT_BASE,
   SEGMENT_INACTIVE,
@@ -61,6 +62,9 @@ export function BreakdownBar({
   axisOptions,
   axisHint,
   onAxisChange,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder,
   actions,
 }: {
   // The current cut, stated plainly (e.g. "Cost by Model") — the caption's
@@ -74,6 +78,11 @@ export function BreakdownBar({
   // (e.g. the root Skill cut excludes subagent-run skills).
   axisHint?: string;
   onAxisChange: (value: string) => void;
+  // Free-text filter over the table's rows, rendered as the standard toolbar
+  // search box. Client-side: it narrows the already-loaded rows, never the query.
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  searchPlaceholder: string;
   // Controls that belong to the table below (e.g. CSV export), rendered beside
   // the axis track.
   actions?: ReactNode;
@@ -106,7 +115,7 @@ export function BreakdownBar({
   );
 
   return (
-    <div className="mb-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+    <div className="mb-3 flex flex-col gap-3">
       <div className="flex flex-col gap-0.5">
         <h2 className="flex items-center gap-1.5 text-sm font-semibold">
           {title}
@@ -128,20 +137,30 @@ export function BreakdownBar({
         </h2>
         <p className="text-muted-foreground text-xs">{caption}</p>
       </div>
-      <div className="flex items-center gap-2">
-        {/* A lone axis is no choice at all — at a session leaf (Agent, Model)
-            "Sessions" is the only option, and a track you can't move reads as a
-            broken toggle. The title already names the cut. */}
-        {axisOptions.length > 1 && (
-          <SegmentedControl
-            value={axisValue}
-            onChange={onAxisChange}
-            options={segments}
-            trailing={more}
-          />
-        )}
-        {actions}
-      </div>
+      {/* The standard list-page control strip: search narrows the rows on the
+          left; the preset axis track (re-cut, not narrow) and table actions
+          keep their place on the right. */}
+      <Page.Toolbar>
+        <Page.Toolbar.Search
+          value={searchValue}
+          onChange={onSearchChange}
+          placeholder={searchPlaceholder}
+        />
+        <Page.Toolbar.Actions>
+          {/* A lone axis is no choice at all — at a session leaf (Agent, Model)
+              "Sessions" is the only option, and a track you can't move reads as
+              a broken toggle. The title already names the cut. */}
+          {axisOptions.length > 1 && (
+            <SegmentedControl
+              value={axisValue}
+              onChange={onAxisChange}
+              options={segments}
+              trailing={more}
+            />
+          )}
+          {actions}
+        </Page.Toolbar.Actions>
+      </Page.Toolbar>
     </div>
   );
 }

--- a/client/dashboard/src/pages/costs/CostTable.tsx
+++ b/client/dashboard/src/pages/costs/CostTable.tsx
@@ -221,6 +221,9 @@ export type CostTableProps = {
   // The view's resolved billing mode; "metered" shows real cost rather than the
   // API-rate estimate on the cost headers.
   billingMode?: string;
+  // Zero-row copy override — e.g. an active search should read "no matches",
+  // not "no data".
+  emptyMessage?: string;
 };
 
 export function CostTable({
@@ -232,6 +235,7 @@ export function CostTable({
   seriesByGroup,
   isLoading,
   billingMode,
+  emptyMessage,
 }: CostTableProps): JSX.Element {
   const [sort, setSort] = useState<Sort>({ key: "cost", dir: "desc" });
   const [page, setPage] = useState(0);
@@ -404,7 +408,7 @@ export function CostTable({
           style={{ gridColumn: "1 / -1" }}
         >
           <Type className="text-muted-foreground">
-            No cost data for this slice.
+            {emptyMessage ?? "No cost data for this slice."}
           </Type>
         </div>
       ) : (

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -62,6 +62,10 @@ import {
   showsTopSessionsWidget,
 } from "./taxonomy";
 
+// Server-side cap on the per-session list (ranked by cost). SessionTable's
+// truncation footer and the search zero-match copy both key off it.
+const SESSION_LIMIT = 100;
+
 const EMPTY_MEASURES: Measures = {
   cost: 0,
   sessions: 0,
@@ -478,7 +482,7 @@ export function CostsExplorer(): JSX.Element {
             from,
             to,
             sortBy: "total_cost",
-            limit: 100,
+            limit: SESSION_LIMIT,
             filters: filters.length ? filters : undefined,
           },
         }),
@@ -940,6 +944,16 @@ export function CostsExplorer(): JSX.Element {
         ),
       )
     : allSessions;
+
+  // Zero-match copy for the session search. Over a capped slice, scope the
+  // claim to what was actually searched — lower-ranked sessions may still match.
+  let sessionsEmptyMessage: string | undefined;
+  if (normalizedSearch) {
+    sessionsEmptyMessage = "No matches for your search.";
+    if (allSessions.length >= SESSION_LIMIT) {
+      sessionsEmptyMessage = `No matches in the ${SESSION_LIMIT} most expensive sessions.`;
+    }
+  }
   const onViewSessions =
     sessionsMode || !sliceScoped
       ? undefined
@@ -1134,9 +1148,8 @@ export function CostsExplorer(): JSX.Element {
               onOpen={setOpenChatId}
               hiddenColumns={hiddenSessionColumns}
               billingMode={viewBillingMode}
-              emptyMessage={
-                normalizedSearch ? "No matches for your search." : undefined
-              }
+              emptyMessage={sessionsEmptyMessage}
+              sourceCount={allSessions.length}
             />
           ) : undefined
         }

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -12,7 +12,7 @@ import { useChatDeleteMutation } from "@gram/client/react-query/chatDelete.js";
 import { invalidateAllListChats } from "@gram/client/react-query/listChats.js";
 import { unwrapAsync } from "@gram/client/types/fp";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { TimeRangePicker } from "@/components/DashboardTimeRangePicker";
 import { resolveScopeBillingMode } from "@/components/estimated-cost-utils";
@@ -139,6 +139,10 @@ export function CostsExplorer(): JSX.Element {
   // Which session's detail overlay is open (ephemeral UI, not drill state — so
   // it lives in component state rather than the URL).
   const [openChatId, setOpenChatId] = useState<string | null>(null);
+  // Free-text filter over the visible table rows (ephemeral view state, like
+  // openChatId). Client-side only: the table already holds the server-ranked
+  // top-N slice, so search narrows what's shown without touching the queries.
+  const [breakdownSearch, setBreakdownSearch] = useState("");
 
   // Drill state is the URL. The filter `path` is encoded as pathname segments
   // (so the breadcrumb tracks it and the view is shareable/refresh-safe); the
@@ -525,6 +529,20 @@ export function CostsExplorer(): JSX.Element {
     ? rows.filter((r) => r.groupValue !== "")
     : rows;
 
+  // Search narrows the table only — headline stats, widgets, and CSV-adjacent
+  // aggregates stay slice totals. Rows match on both the raw group value and
+  // its display name (a user's email matches their prettified name too).
+  const normalizedSearch = breakdownSearch.trim().toLowerCase();
+  const searchedRows = normalizedSearch
+    ? visibleRows.filter(
+        (r) =>
+          r.groupValue.toLowerCase().includes(normalizedSearch) ||
+          displayName(groupBy, r.groupValue)
+            .toLowerCase()
+            .includes(normalizedSearch),
+      )
+    : visibleRows;
+
   // At the root, an attribution breakdown is presented as a "collection" (e.g.
   // "MCP Servers") rather than the project — and its headline stats then sum
   // only the attributed rows, so the hero reconciles with the residual-hidden
@@ -905,6 +923,23 @@ export function CostsExplorer(): JSX.Element {
       : []),
   ];
   const axisValue: string = sessionsMode ? SESSIONS_AXIS : groupBy;
+
+  // A search typed against one cut is meaningless against another — clear it
+  // when the drill path or the breakdown axis changes.
+  useEffect(() => {
+    setBreakdownSearch("");
+  }, [location.pathname, axisValue]);
+
+  // The session list matches on everything its rows display: title, chat id,
+  // user, agent, and model.
+  const allSessions = sessionsData?.sessions ?? [];
+  const searchedSessions = normalizedSearch
+    ? allSessions.filter((s) =>
+        [s.title, s.gramChatId, s.userEmail, s.hookSource, s.model].some(
+          (field) => field?.toLowerCase().includes(normalizedSearch),
+        ),
+      )
+    : allSessions;
   const onViewSessions =
     sessionsMode || !sliceScoped
       ? undefined
@@ -1085,28 +1120,33 @@ export function CostsExplorer(): JSX.Element {
         axisOptions={axisOptions}
         axisHint={axisHint}
         onAxisChange={(value) => changeGroupBy(value as Axis)}
-        rows={visibleRows}
+        searchValue={breakdownSearch}
+        onSearchChange={setBreakdownSearch}
+        rows={searchedRows}
         billingMode={viewBillingMode}
         onDrill={drillInto}
         tableOverride={
           sessionsMode ? (
             <SessionTable
-              sessions={sessionsData?.sessions ?? []}
+              sessions={searchedSessions}
               isLoading={sessionsFetching && !sessionsData}
               isError={sessionsError}
               onOpen={setOpenChatId}
               hiddenColumns={hiddenSessionColumns}
               billingMode={viewBillingMode}
+              emptyMessage={
+                normalizedSearch ? "No matches for your search." : undefined
+              }
             />
           ) : undefined
         }
         overrideCsv={
           sessionsMode
             ? {
-                rowCount: sessionsData?.sessions.length ?? 0,
+                rowCount: searchedSessions.length,
                 build: () =>
                   buildSessionCsv(
-                    sessionsData?.sessions ?? [],
+                    searchedSessions,
                     hiddenSessionColumns,
                     viewBillingMode,
                   ),

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -24,6 +24,7 @@ import {
   isAttributionDim,
   LABELS,
   type Measures,
+  pluralLabel,
 } from "./taxonomy";
 
 // ── Formatting helpers ──────────────────────────────────────────────────────
@@ -76,6 +77,15 @@ function buildCostCsv(
     ];
   });
   return toCsv(header, body);
+}
+
+// The search placeholder's noun: the axis plural sentence-cased — words
+// lowercase except acronyms ("Users" → "users", "MCP Servers" → "MCP servers").
+function searchNoun(label: string): string {
+  return label
+    .split(" ")
+    .map((word) => (word === word.toUpperCase() ? word : word.toLowerCase()))
+    .join(" ");
 }
 
 // A unique, deterministic colour identity for an entity, derived from its name
@@ -180,6 +190,10 @@ export type EntityProfileProps = {
   // beside the select (e.g. the root Skill cut excludes subagent-run skills).
   axisHint?: string;
   onAxisChange: (value: string) => void;
+  // Free-text filter over the visible table rows (dimension rows or sessions),
+  // owned by the explorer so it can filter both row sources consistently.
+  searchValue: string;
+  onSearchChange: (value: string) => void;
   // The child rows + drill handler.
   rows: QueryRow[];
   // The view's resolved billing mode; "metered" shows real cost instead of the
@@ -236,6 +250,8 @@ export function EntityProfile({
   axisOptions,
   axisHint,
   onAxisChange,
+  searchValue,
+  onSearchChange,
   rows,
   billingMode,
   onDrill,
@@ -301,6 +317,13 @@ export function EntityProfile({
           ),
       };
 
+  // Placeholder names what the search box narrows: the sessions list when the
+  // override table is on screen, otherwise the current axis's plural.
+  const searchPlaceholder = tableOverride
+    ? "Search sessions..."
+    : `Search ${searchNoun(pluralLabel(groupBy))}...`;
+  const searchActive = searchValue.trim().length > 0;
+
   // The default dimension table; replaced by `tableOverride` (the session list)
   // when one is supplied.
   const dimensionTable = isError ? (
@@ -315,6 +338,7 @@ export function EntityProfile({
       seriesByGroup={seriesByGroup}
       isLoading={isLoading}
       billingMode={billingMode}
+      emptyMessage={searchActive ? "No matches for your search." : undefined}
     />
   );
 
@@ -470,6 +494,9 @@ export function EntityProfile({
             axisOptions={axisOptions}
             axisHint={axisHint}
             onAxisChange={onAxisChange}
+            searchValue={searchValue}
+            onSearchChange={onSearchChange}
+            searchPlaceholder={searchPlaceholder}
             actions={
               <button
                 type="button"

--- a/client/dashboard/src/pages/costs/SessionTable.tsx
+++ b/client/dashboard/src/pages/costs/SessionTable.tsx
@@ -234,6 +234,9 @@ export type SessionTableProps = {
   // The view's resolved billing mode; "metered" shows real cost ("Cost") rather
   // than the API-rate estimate ("Est. cost") on the cost column.
   billingMode?: string;
+  // Zero-row copy override — e.g. an active search should read "no matches",
+  // not "no sessions".
+  emptyMessage?: string;
 };
 
 /**
@@ -253,6 +256,7 @@ export function SessionTable({
   onOpen,
   hiddenColumns,
   billingMode,
+  emptyMessage,
 }: SessionTableProps): JSX.Element {
   // Server already ranks by cost; mirror that as the default header indicator.
   const [sort, setSort] = useState<Sort>({ key: "cost", dir: "desc" });
@@ -348,7 +352,7 @@ export function SessionTable({
           style={{ gridColumn: "1 / -1" }}
         >
           <Type className="text-muted-foreground">
-            No sessions in this slice.
+            {emptyMessage ?? "No sessions in this slice."}
           </Type>
         </div>
       ) : (

--- a/client/dashboard/src/pages/costs/SessionTable.tsx
+++ b/client/dashboard/src/pages/costs/SessionTable.tsx
@@ -237,6 +237,10 @@ export type SessionTableProps = {
   // Zero-row copy override — e.g. an active search should read "no matches",
   // not "no sessions".
   emptyMessage?: string;
+  // The unfiltered slice size, when the caller narrows `sessions` client-side
+  // (search). Keeps the truncation footer honest: a filtered list must still
+  // disclose that only the capped top slice was searched.
+  sourceCount?: number;
 };
 
 /**
@@ -257,6 +261,7 @@ export function SessionTable({
   hiddenColumns,
   billingMode,
   emptyMessage,
+  sourceCount,
 }: SessionTableProps): JSX.Element {
   // Server already ranks by cost; mirror that as the default header indicator.
   const [sort, setSort] = useState<Sort>({ key: "cost", dir: "desc" });
@@ -300,6 +305,16 @@ export function SessionTable({
     safePage * PAGE_SIZE,
     (safePage + 1) * PAGE_SIZE,
   );
+
+  // Truncation disclosure keys off the *unfiltered* slice size — a client-side
+  // search that narrows a capped list must not read as exhaustive, since only
+  // the top slice was searched. The copy shifts to name that scope.
+  const sliceCount = sourceCount ?? sessions.length;
+  const sliceTruncated = sliceCount >= DEFAULT_LIMIT;
+  let truncationNote = `Showing the ${DEFAULT_LIMIT} most expensive sessions in this slice.`;
+  if (sessions.length < sliceCount) {
+    truncationNote = `Matches within the ${DEFAULT_LIMIT} most expensive sessions in this slice.`;
+  }
 
   if (isLoading) return <SkeletonTable />;
   if (isError) {
@@ -376,10 +391,10 @@ export function SessionTable({
         ))
       )}
 
-      {sessions.length >= DEFAULT_LIMIT && (
+      {sliceTruncated && (
         <div className="px-5 py-3" style={{ gridColumn: "1 / -1" }}>
           <Type small className="text-muted-foreground">
-            Showing the {DEFAULT_LIMIT} most expensive sessions in this slice.
+            {truncationNote}
           </Type>
         </div>
       )}


### PR DESCRIPTION
## Summary

The second half of the costs page (the breakdown table) had only the preset breakdown-axis segments — no way to find a specific row. This brings in the standard `Page.Toolbar` search bar while keeping the presets exactly where they were:

- `BreakdownBar` now renders the standard `Page.Toolbar`: the shared search box on the left, the existing breakdown-axis segmented control (+ "More" overflow) and Export CSV in `Toolbar.Actions` on the right — all uniform 40px controls in the standard grey bar.
- Search is client-side over the already-loaded top-100 rows (no new queries, no raw-log scan path):
  - dimension breakdowns match the group value and its display name (searching part of an email also matches the prettified user name);
  - the per-session list matches title, chat id, user, agent, and model.
- The search clears automatically on drill or re-pivot, since a query typed against one cut is meaningless against another.
- CSV export narrows to the filtered rows so the file matches the visible table.
- Zero matches show "No matches for your search." instead of the misleading no-data copy.
- Headline stats, hero numbers, and widgets deliberately stay slice totals — search narrows the table view, not the data.

## Testing

- `tsc -b --noEmit --force` clean
- `pnpm lint` (oxlint + format + knip + tsc) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCzAkxRzt66dfNnf23A97p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added search to the costs breakdown using the standard toolbar to quickly filter visible rows or sessions without new queries. CSV export and empty states respect the filter, and the session truncation notice stays accurate while searching.

- **New Features**
  - Added `Page.Toolbar` search to the breakdown: search on the left; axis segmented control and Export CSV on the right.
  - Client-side filtering over the loaded top-N rows:
    - Dimensions match group value and display name.
    - Sessions match title, chat id, user, agent, and model.
  - Search clears on drill or when changing the breakdown axis.
  - CSV export includes only the filtered rows/sessions.
  - Empty states show “No matches for your search.”; headline totals and widgets remain slice totals.

- **Bug Fixes**
  - Kept the session truncation disclosure visible under search and scoped its copy to “Matches within the 100 most expensive sessions.” Zero-match copy names the same scope.

<sup>Written for commit 3c54ab8741683866a306f58a750d307b11b53879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

