### PR TITLE
feat(dashboard): add search to plugin detail page

### DIFF
--- a/.changeset/plugin-detail-search.md
+++ b/.changeset/plugin-detail-search.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a search bar to the plugin detail page that filters the plugin's MCP servers, assignments, and skills, with distinct empty states for "nothing added yet" vs "no search matches".

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -62,8 +62,9 @@ import { InstallInstructionsDialog } from "./InstallInstructionsDialog";
 import { PluginAssignmentsSheet } from "./PluginAssignmentsSheet";
 import { PluginSkillsSection } from "./PluginSkillsSection";
 import { PluginAssignmentsList } from "./PluginAssignmentsList";
-import { memberMapByUrn, roleMapByUrn } from "./principals";
+import { describePrincipal, memberMapByUrn, roleMapByUrn } from "./principals";
 import { PublishDialog } from "./PublishDialog";
+import { SectionEmptyState } from "./SectionEmptyState";
 
 // A selectable server for a plugin, sourced from either a toolset (Hosted) or
 // a Remote MCP-backed mcp_server. The kind determines whether it is submitted
@@ -92,6 +93,7 @@ export default function PluginDetail(): JSX.Element | null {
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isAssignmentsOpen, setIsAssignmentsOpen] = useState(false);
+  const [search, setSearch] = useState("");
 
   const { data: plugin } = usePluginSuspense({ id: pluginId! });
   // Polled so the publish-freshness badges/banner pick up the Temporal
@@ -384,6 +386,84 @@ export default function PluginDetail(): JSX.Element | null {
       : !addedMcpServerIds.has(o.id),
   );
 
+  // Client-side search across the page's entry lists. Servers match on their
+  // displayed name; assignments match on the resolved principal label (role
+  // name, member name, email, "Everyone") plus the member's email. Skills are
+  // filtered inside PluginSkillsSection with the same query.
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredServers = normalizedSearch
+    ? servers.filter((s) =>
+        s.displayName.toLowerCase().includes(normalizedSearch),
+      )
+    : servers;
+  const filteredAssignments = normalizedSearch
+    ? assignments.filter((a) => {
+        const { label } = describePrincipal(
+          a.principalUrn,
+          roleByUrn,
+          memberByUrn,
+        );
+        const email = memberByUrn.get(a.principalUrn)?.email ?? "";
+        return (
+          label.toLowerCase().includes(normalizedSearch) ||
+          email.toLowerCase().includes(normalizedSearch)
+        );
+      })
+    : assignments;
+
+  // Precomputed section bodies keep the JSX below free of nested ternaries
+  // while distinguishing "nothing added yet" from "no search matches".
+  let serversContent: JSX.Element;
+  if (servers.length === 0) {
+    serversContent = <SectionEmptyState title="No servers added yet" />;
+  } else if (filteredServers.length === 0) {
+    serversContent = <SectionEmptyState title="No servers match your search" />;
+  } else {
+    serversContent = (
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        {filteredServers.map((server) => (
+          <PluginServerCard
+            key={server.id}
+            server={server}
+            toolset={
+              server.toolsetId ? toolsetById.get(server.toolsetId) : undefined
+            }
+            mcpServer={
+              server.mcpServerId
+                ? mcpServerById.get(server.mcpServerId)
+                : undefined
+            }
+            isLoading={isLoadingServers}
+            onRemove={() => handleRemoveServer(server)}
+            lastPublishedAt={publishStatus?.lastPublishedAt}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  let assignmentsContent: JSX.Element;
+  if (assignments.length === 0) {
+    assignmentsContent = (
+      <SectionEmptyState
+        title="Not assigned to anyone yet"
+        subtitle="Assign this plugin to roles, users, or emails to deliver it to their devices."
+      />
+    );
+  } else if (filteredAssignments.length === 0) {
+    assignmentsContent = (
+      <SectionEmptyState title="No assignments match your search" />
+    );
+  } else {
+    assignmentsContent = (
+      <PluginAssignmentsList
+        assignments={filteredAssignments}
+        roleByUrn={roleByUrn}
+        memberByUrn={memberByUrn}
+      />
+    );
+  }
+
   return (
     <Page>
       <Page.Header>
@@ -544,6 +624,16 @@ export default function PluginDetail(): JSX.Element | null {
         {/* Everything below the hero re-centers in the max-w-7xl column that
             Page.Body would normally provide (disabled here via fullWidth). */}
         <div className="mx-auto w-full max-w-7xl px-8 pb-24">
+          {/* One search box narrows every entry list on the page (servers,
+            assignments, skills) rather than a per-section input. */}
+          <Page.Toolbar className="mb-8">
+            <Page.Toolbar.Search
+              value={search}
+              onChange={setSearch}
+              placeholder="Search servers, skills, and assignments"
+            />
+          </Page.Toolbar>
+
           {/* Servers section */}
           <div className="mb-3 flex items-center gap-3">
             <div className="border-border flex-1 border-t" />
@@ -568,42 +658,7 @@ export default function PluginDetail(): JSX.Element | null {
               <Button.Text>Add Server</Button.Text>
             </Button>
           </div>
-          <div className="mb-8">
-            {servers.length === 0 ? (
-              <Stack
-                gap={2}
-                className="border-border rounded-xl border py-8"
-                align="center"
-                justify="center"
-              >
-                <Type variant="body" muted>
-                  No servers added yet
-                </Type>
-              </Stack>
-            ) : (
-              <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {servers.map((server) => (
-                  <PluginServerCard
-                    key={server.id}
-                    server={server}
-                    toolset={
-                      server.toolsetId
-                        ? toolsetById.get(server.toolsetId)
-                        : undefined
-                    }
-                    mcpServer={
-                      server.mcpServerId
-                        ? mcpServerById.get(server.mcpServerId)
-                        : undefined
-                    }
-                    isLoading={isLoadingServers}
-                    onRemove={() => handleRemoveServer(server)}
-                    lastPublishedAt={publishStatus?.lastPublishedAt}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+          <div className="mb-8">{serversContent}</div>
 
           {/* Assignments only affect device-agent delivery, so the section is
             hidden for marketplace-only orgs (see showAssignments). */}
@@ -644,30 +699,7 @@ export default function PluginDetail(): JSX.Element | null {
                   <Button.Text>Manage assignments</Button.Text>
                 </Button>
               </div>
-              <div className="mb-8">
-                {assignments.length === 0 ? (
-                  <Stack
-                    gap={2}
-                    className="border-border rounded-xl border py-8"
-                    align="center"
-                    justify="center"
-                  >
-                    <Type variant="body" muted>
-                      Not assigned to anyone yet
-                    </Type>
-                    <Type small muted>
-                      Assign this plugin to roles, users, or emails to deliver
-                      it to their devices.
-                    </Type>
-                  </Stack>
-                ) : (
-                  <PluginAssignmentsList
-                    assignments={assignments}
-                    roleByUrn={roleByUrn}
-                    memberByUrn={memberByUrn}
-                  />
-                )}
-              </div>
+              <div className="mb-8">{assignmentsContent}</div>
             </>
           )}
 
@@ -681,6 +713,7 @@ export default function PluginDetail(): JSX.Element | null {
             >
               <PluginSkillsSection
                 pluginId={pluginId!}
+                searchQuery={search}
                 onMutated={(message) => offerPublish(message)}
               />
             </RequireScope>

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -47,7 +47,14 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Network, Puzzle, Sparkles, Trash2 } from "lucide-react";
-import { Fragment, useCallback, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useParams } from "react-router";
 import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import type { PluginServer } from "@gram/client/models/components/pluginserver.js";
@@ -94,6 +101,9 @@ export default function PluginDetail(): JSX.Element | null {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isAssignmentsOpen, setIsAssignmentsOpen] = useState(false);
   const [search, setSearch] = useState("");
+  // The component stays mounted when only :pluginId changes, so a stale query
+  // from a previous plugin would filter the new plugin's lists.
+  useEffect(() => setSearch(""), [pluginId]);
 
   const { data: plugin } = usePluginSuspense({ id: pluginId! });
   // Polled so the publish-freshness badges/banner pick up the Temporal

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -16,12 +16,13 @@ import {
 } from "@gram/client/react-query/skillDistributions.js";
 import { useSkillsInfinite } from "@gram/client/react-query/skills.js";
 import { useUndistributeSkillMutation } from "@gram/client/react-query/undistributeSkill.js";
-import { Badge, Button, Icon, Stack } from "@speakeasy-api/moonshine";
+import { Badge, Button, Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Sparkles, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
+import { SectionEmptyState } from "./SectionEmptyState";
 
 /**
  * The Skills section of the plugin detail page: lists the skills this plugin
@@ -30,9 +31,12 @@ import { toast } from "sonner";
  */
 export function PluginSkillsSection({
   pluginId,
+  searchQuery,
   onMutated,
 }: {
   pluginId: string;
+  /** Page-level search query; narrows the listed skill distributions. */
+  searchQuery: string;
   /** Invoked after a successful change, e.g. to offer a marketplace publish. */
   onMutated: (message: string) => void;
 }): JSX.Element {
@@ -57,6 +61,18 @@ export function PluginSkillsSection({
       ) ?? [],
     [distributionsQuery.data?.pages],
   );
+
+  // Case-insensitive match on the card's visible labels: the skill display
+  // name and its mono slug-style name.
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+  const filteredDistributions = useMemo(() => {
+    if (!normalizedSearch) return distributions;
+    return distributions.filter(
+      (d) =>
+        d.skillDisplayName.toLowerCase().includes(normalizedSearch) ||
+        d.skillName.toLowerCase().includes(normalizedSearch),
+    );
+  }, [distributions, normalizedSearch]);
 
   const skillsQuery = useSkillsInfinite({ limit: 200 }, undefined, {
     throwOnError: false,
@@ -117,6 +133,42 @@ export function PluginSkillsSection({
     );
   };
 
+  // Precomputed list body keeps the JSX below free of nested ternaries while
+  // distinguishing "nothing distributed yet" from "no search matches".
+  let listContent: JSX.Element;
+  if (distributionsQuery.error && !distributionsQuery.data) {
+    listContent = (
+      <ErrorAlert
+        title="Unable to load distributed skills"
+        error={distributionsQuery.error}
+      />
+    );
+  } else if (!isMembershipLoaded) {
+    listContent = <Skeleton className="h-24 w-full rounded-xl" />;
+  } else if (distributions.length === 0) {
+    listContent = (
+      <SectionEmptyState
+        title="No skills distributed yet"
+        subtitle="Add project skills to bundle them with this plugin."
+      />
+    );
+  } else if (filteredDistributions.length === 0) {
+    listContent = <SectionEmptyState title="No skills match your search" />;
+  } else {
+    listContent = (
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        {filteredDistributions.map((distribution) => (
+          <PluginSkillCard
+            key={distribution.id}
+            distribution={distribution}
+            isRemoving={undistribute.isPending}
+            onRemove={() => handleRemoveSkill(distribution)}
+          />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <>
       <div className="mb-3 flex items-center gap-3">
@@ -160,41 +212,7 @@ export function PluginSkillsSection({
           </Button>
         </RequireScope>
       </div>
-      <div className="mb-8">
-        {distributionsQuery.error && !distributionsQuery.data ? (
-          <ErrorAlert
-            title="Unable to load distributed skills"
-            error={distributionsQuery.error}
-          />
-        ) : !isMembershipLoaded ? (
-          <Skeleton className="h-24 w-full rounded-xl" />
-        ) : distributions.length === 0 ? (
-          <Stack
-            gap={2}
-            className="border-border rounded-xl border py-8"
-            align="center"
-            justify="center"
-          >
-            <Type variant="body" muted>
-              No skills distributed yet
-            </Type>
-            <Type small muted>
-              Add project skills to bundle them with this plugin.
-            </Type>
-          </Stack>
-        ) : (
-          <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-            {distributions.map((distribution) => (
-              <PluginSkillCard
-                key={distribution.id}
-                distribution={distribution}
-                isRemoving={undistribute.isPending}
-                onRemove={() => handleRemoveSkill(distribution)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      <div className="mb-8">{listContent}</div>
 
       {/* Add Skill Dialog */}
       <Dialog open={isAddSkillOpen} onOpenChange={setIsAddSkillOpen}>

--- a/client/dashboard/src/pages/plugins/SectionEmptyState.tsx
+++ b/client/dashboard/src/pages/plugins/SectionEmptyState.tsx
@@ -1,0 +1,33 @@
+import { Type } from "@/components/ui/type";
+import { Stack } from "@speakeasy-api/moonshine";
+
+/**
+ * Bordered empty-state card shared by the plugin detail page sections
+ * (servers, assignments, skills), covering both "nothing here yet" and
+ * "no search matches" so the two states stay visually consistent.
+ */
+export function SectionEmptyState({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle?: string;
+}): JSX.Element {
+  return (
+    <Stack
+      gap={2}
+      className="border-border rounded-xl border py-8"
+      align="center"
+      justify="center"
+    >
+      <Type variant="body" muted>
+        {title}
+      </Type>
+      {subtitle && (
+        <Type small muted>
+          {subtitle}
+        </Type>
+      )}
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary

The plugin detail/overview page listed the plugin's MCP servers, assignments, and skills with no way to search them (the parent plugins list page already has search). This adds the standard `Page.Toolbar` search bar at the top of the content column, filtering all three entry lists client-side:

- **MCP Servers** — case-insensitive match on the server's display name
- **Assignments** — match on the resolved principal label (role name, member name, email, "Everyone"/"All users") and the member's email
- **Skills** — match on the skill display name and its slug-style name (`PluginSkillsSection` receives the page-level query)

Each section now distinguishes its "nothing added yet" empty state from a "no search matches" state. The three near-identical bordered empty-state blocks that already existed across `PluginDetail.tsx` and `PluginSkillsSection.tsx` are extracted into a shared `SectionEmptyState` component, and the section bodies are precomputed via if/else chains instead of nested ternaries per the frontend guidelines.

No existing controls were removed — the hero actions (Install/Sync/overflow), Add Server, Manage assignments, and Add Skill buttons are untouched.

## Verification

- `cd client/dashboard && ./node_modules/.bin/tsc -b --noEmit --force` — clean
- `pnpm -F dashboard lint` — exit 0 (only pre-existing generated-SDK warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCzAkxRzt66dfNnf23A97p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a single search bar to the plugin detail page that filters MCP servers, assignments, and skills. The search now resets when switching plugins to avoid stale filters.

- New Features
  - Page-level search filters all sections client-side.
  - MCP Servers: case-insensitive match on display name.
  - Assignments: match on principal label and member email.
  - Skills: match on display name and slug.
  - Clear empty states for “nothing added” vs “no matches”. Existing actions unchanged.

- Bug Fixes
  - Reset the search when `:pluginId` changes to prevent empty states caused by a stale query.

<sup>Written for commit 0b07a23ede36c6f0dee5b48bf831e0e3f79e7d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

