### PR TITLE
feat: post tool metadata UI

### DIFF
--- a/.changeset/lucky-areas-wear.md
+++ b/.changeset/lucky-areas-wear.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+automatically publish tool metadata from dashboard

--- a/client/dashboard/src/components/mcp-server-x-sidebar-nav.tsx
+++ b/client/dashboard/src/components/mcp-server-x-sidebar-nav.tsx
@@ -179,11 +179,11 @@ export function McpServerXSidebarNav(): React.JSX.Element | null {
       active: activeTab === "overview",
     },
     {
-      key: "tools",
-      title: "Tools",
+      key: "inspect",
+      title: "Inspect",
       Icon: Wrench,
-      href: mcpServerTabHref(routes, idOrSlug, "tools"),
-      active: activeTab === "tools",
+      href: mcpServerTabHref(routes, idOrSlug, "inspect"),
+      active: activeTab === "inspect",
     },
     ...(isRbacEnabled
       ? [

--- a/client/dashboard/src/components/tool-list/AnnotationBadges.tsx
+++ b/client/dashboard/src/components/tool-list/AnnotationBadges.tsx
@@ -1,7 +1,7 @@
 import { toolSupportsAnnotations, type Tool } from "@/lib/toolTypes";
 import { Badge } from "@speakeasy-api/moonshine";
 
-export interface ResolvedToolAnnotations {
+interface ResolvedToolAnnotations {
   readOnly: boolean;
   destructive: boolean;
   idempotent: boolean;
@@ -37,14 +37,13 @@ export function AnnotationBadges({ tool }: { tool: Tool }): JSX.Element | null {
 
 /**
  * Presentational annotation-hint labels, decoupled from the Gram `Tool` model so
- * other tool sources (e.g. remote MCP servers) can render the same badges from
- * their own resolved hints. Returns null when no hint is set.
+ * they render from already-resolved hints. Returns null when no hint is set.
  *
  * Renders the same text labels and variants as the Connect → Catalog → MCP tool
  * cards (`CatalogDetail`), so the permission labels read identically wherever a
  * tool is surfaced — including Distribute → MCP → Tools.
  */
-export function AnnotationBadgeIcons({
+function AnnotationBadgeIcons({
   readOnly,
   destructive,
   idempotent,

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetails.tsx
@@ -35,14 +35,15 @@ import {
   activeTabFromPath,
   initialTabFromHash,
   isLegacyAuthenticationTabPath,
+  isLegacyToolsTabPath,
   mcpServerTabHref,
 } from "./MCPServerDetailsRouting";
 import { MCPOverviewTab } from "@/pages/mcp/overview/MCPOverviewTab";
-import { ToolsTab } from "./tabs/ToolsTab";
+import { InspectTab } from "./tabs/InspectTab";
 import { MCP_AUTHENTICATION_SECTION_ID } from "./tabs/settings/sections/authentication/AuthenticationSection";
 import { SettingsTab } from "./tabs/settings/SettingsTab";
 
-const MCP_X_TAB_URLS = ["overview", "tools", "team-access", "settings"];
+const MCP_X_TAB_URLS = ["overview", "inspect", "team-access", "settings"];
 
 export default function MCPServerDetails(): JSX.Element {
   const { mcpServerSlug } = useParams<{ mcpServerSlug: string }>();
@@ -56,6 +57,7 @@ export default function MCPServerDetails(): JSX.Element {
     location.pathname,
     idOrSlug,
   );
+  const legacyToolsPath = isLegacyToolsTabPath(location.pathname, idOrSlug);
 
   const {
     data: mcpServer,
@@ -85,6 +87,11 @@ export default function MCPServerDetails(): JSX.Element {
         to={`${mcpServerTabHref(routes, idOrSlug, "settings")}#${MCP_AUTHENTICATION_SECTION_ID}`}
         replace
       />
+    );
+  }
+  if (legacyToolsPath) {
+    return (
+      <Navigate to={mcpServerTabHref(routes, idOrSlug, "inspect")} replace />
     );
   }
   if (!activeTab) {
@@ -123,10 +130,10 @@ export default function MCPServerDetails(): JSX.Element {
             />
           )
         );
-      case "tools":
+      case "inspect":
         return (
           mcpServer && (
-            <ToolsTab
+            <InspectTab
               mcpServer={mcpServer}
               endpoints={endpoints}
               isLoadingEndpoints={isLoadingEndpoints}

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.test.ts
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.test.ts
@@ -3,6 +3,7 @@ import {
   activeTabFromPath,
   initialTabFromHash,
   isLegacyAuthenticationTabPath,
+  isLegacyToolsTabPath,
 } from "./MCPServerDetailsRouting";
 
 describe("activeTabFromPath", () => {
@@ -12,7 +13,7 @@ describe("activeTabFromPath", () => {
     ).toBeUndefined();
   });
 
-  it.each(["overview", "team-access", "settings"] as const)(
+  it.each(["overview", "inspect", "team-access", "settings"] as const)(
     "reads the %s tab when the server slug has the same value",
     (tab) => {
       expect(
@@ -63,6 +64,33 @@ describe("activeTabFromPath", () => {
     ).toBe(true);
   });
 
+  it("does not treat the legacy tools path as an active tab", () => {
+    expect(
+      activeTabFromPath(
+        "/acme/projects/default/mcp/x/my-server/tools",
+        "my-server",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("detects the legacy tools path for redirects", () => {
+    expect(
+      isLegacyToolsTabPath(
+        "/acme/projects/default/mcp/x/my-server/tools",
+        "my-server",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not confuse the inspect tab with the legacy tools path", () => {
+    expect(
+      isLegacyToolsTabPath(
+        "/acme/projects/default/mcp/x/my-server/inspect",
+        "my-server",
+      ),
+    ).toBe(false);
+  });
+
   it("matches decoded server slug segments", () => {
     expect(
       activeTabFromPath(
@@ -85,6 +113,10 @@ describe("activeTabFromPath", () => {
 describe("initialTabFromHash", () => {
   it("maps the legacy authentication hash to settings", () => {
     expect(initialTabFromHash("#authentication", true)).toBe("settings");
+  });
+
+  it("maps the legacy tools hash to inspect", () => {
+    expect(initialTabFromHash("#tools", true)).toBe("inspect");
   });
 
   it("keeps team access behind the RBAC feature flag", () => {

--- a/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.ts
+++ b/client/dashboard/src/pages/mcp/x/MCPServerDetailsRouting.ts
@@ -1,7 +1,8 @@
 import type { useRoutes } from "@/routes";
 
-const VALID_TABS = ["overview", "tools", "team-access", "settings"] as const;
+const VALID_TABS = ["overview", "inspect", "team-access", "settings"] as const;
 const LEGACY_AUTHENTICATION_TAB = "authentication";
+const LEGACY_TOOLS_TAB = "tools";
 
 export type TabValue = (typeof VALID_TABS)[number];
 
@@ -57,12 +58,21 @@ export function isLegacyAuthenticationTabPath(
   );
 }
 
+/** The Inspect tab was called Tools until AGE-2876; keep old links working. */
+export function isLegacyToolsTabPath(
+  pathname: string,
+  mcpServerSlug: string,
+): boolean {
+  return tabSegmentFromPath(pathname, mcpServerSlug) === LEGACY_TOOLS_TAB;
+}
+
 export function initialTabFromHash(
   hash: string,
   isRbacEnabled: boolean,
 ): TabValue {
   const hashValue = hash.replace("#", "");
   if (hashValue === LEGACY_AUTHENTICATION_TAB) return "settings";
+  if (hashValue === LEGACY_TOOLS_TAB) return "inspect";
   if (!isValidTab(hashValue)) return "overview";
   if (hashValue === "team-access" && !isRbacEnabled) return "overview";
   return hashValue;
@@ -76,8 +86,8 @@ export function mcpServerTabHref(
   switch (tab) {
     case "overview":
       return routes.mcp.x.overview.href(mcpServerSlug);
-    case "tools":
-      return routes.mcp.x.tools.href(mcpServerSlug);
+    case "inspect":
+      return routes.mcp.x.inspect.href(mcpServerSlug);
     case "team-access":
       return routes.mcp.x.teamAccess.href(mcpServerSlug);
     case "settings":

--- a/client/dashboard/src/pages/mcp/x/tabs/InspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/InspectTab.tsx
@@ -5,17 +5,17 @@ import type { McpServer } from "@gram/client/models/components/mcpserver.js";
 import { RemoteMcpToolsSection } from "./RemoteMcpToolsSection";
 import { MCP_AUTHENTICATION_SECTION_ID } from "./settings/sections/authentication/AuthenticationSection";
 
-type ToolsTabProps = {
+type InspectTabProps = {
   mcpServer: McpServer;
   endpoints: McpEndpoint[];
   isLoadingEndpoints: boolean;
 };
 
-export function ToolsTab({
+export function InspectTab({
   mcpServer,
   endpoints,
   isLoadingEndpoints,
-}: ToolsTabProps): JSX.Element {
+}: InspectTabProps): JSX.Element {
   const routes = useRoutes();
   const { mcpUrl, loading } = useResolvedMcpServerUrl(
     endpoints,

--- a/client/dashboard/src/pages/mcp/x/tabs/InspectTab.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/InspectTab.tsx
@@ -35,6 +35,7 @@ export function InspectTab({
         isResolvingUrl={loading}
         mcpServerId={mcpServer.id}
         userSessionIssuerId={mcpServer.userSessionIssuerId}
+        remoteMcpServerId={mcpServer.remoteMcpServerId ?? undefined}
         isDisabled={mcpServer.visibility === "disabled"}
         authSettingsHref={authSettingsHref}
       />

--- a/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
@@ -20,6 +20,8 @@ import {
 import { useUserSessionToken } from "@/hooks/useUserSessionToken";
 import { handleError, toError } from "@/lib/errors";
 import { cn, firstPartyConnectUrl, mcpConnectionUrl } from "@/lib/utils";
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { useToolMetadata, type ToolMetadataByName } from "./useToolMetadata";
 import { Badge, Button } from "@speakeasy-api/moonshine";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { PlugZap } from "lucide-react";
@@ -40,6 +42,11 @@ type RemoteMcpToolsSectionProps = {
    * different issuer discards the token bound to the old one.
    */
   userSessionIssuerId: string | undefined;
+  /**
+   * The backing remote_mcp_server id, when there is one. Only remote-backed
+   * servers carry tool metadata — the API rejects toolset-backed ones.
+   */
+  remoteMcpServerId?: string;
   /** Disabled servers cannot serve MCP requests. */
   isDisabled: boolean;
   /**
@@ -160,6 +167,7 @@ function RemoteMcpToolsSectionInner({
   isResolvingUrl,
   mcpServerId,
   userSessionIssuerId,
+  remoteMcpServerId,
 }: RemoteMcpToolsSectionProps): JSX.Element {
   const isIssuerGated = !!userSessionIssuerId;
 
@@ -167,6 +175,13 @@ function RemoteMcpToolsSectionInner({
     target: { kind: "mcpServer", id: mcpServerId },
     userSessionIssuerId,
   });
+
+  // Gram's stored annotation overrides for this server's tools. Toolset-backed
+  // servers don't carry any, so skip the request entirely for them.
+  const { metadataByTool, isLoading: isMetadataLoading } = useToolMetadata(
+    mcpServerId,
+    { enabled: !!remoteMcpServerId },
+  );
 
   // Issuer-gated servers must wait for the JWT before connecting, otherwise the
   // unauthenticated request 401s and caches a spurious `needsAuth`.
@@ -209,7 +224,8 @@ function RemoteMcpToolsSectionInner({
     if (authUrl) window.open(authUrl, "_blank", "noopener,noreferrer");
   };
 
-  const loading = isResolvingUrl || isTokenLoading || isLoading;
+  const loading =
+    isResolvingUrl || isTokenLoading || isLoading || isMetadataLoading;
 
   return (
     <ToolsSectionShell>
@@ -218,6 +234,7 @@ function RemoteMcpToolsSectionInner({
         needsAuth={needsAuth}
         isError={isError}
         toolEntries={toolEntries}
+        metadataByTool={metadataByTool}
         onRetry={refetch}
         onConnect={authUrl ? handleConnect : undefined}
       />
@@ -230,6 +247,7 @@ function RemoteMcpToolsBody({
   needsAuth,
   isError,
   toolEntries,
+  metadataByTool,
   onRetry,
   onConnect,
 }: {
@@ -237,6 +255,7 @@ function RemoteMcpToolsBody({
   needsAuth: boolean;
   isError: boolean;
   toolEntries: Array<[string, ProxiedMcpTool]>;
+  metadataByTool: ToolMetadataByName;
   onRetry: () => void;
   onConnect?: () => void;
 }): JSX.Element {
@@ -261,7 +280,12 @@ function RemoteMcpToolsBody({
     return <EmptyState message="This server didn't advertise any tools." />;
   }
 
-  return <RemoteMcpToolsList toolEntries={toolEntries} />;
+  return (
+    <RemoteMcpToolsList
+      toolEntries={toolEntries}
+      metadataByTool={metadataByTool}
+    />
+  );
 }
 
 /**
@@ -271,8 +295,10 @@ function RemoteMcpToolsBody({
  */
 function RemoteMcpToolsList({
   toolEntries,
+  metadataByTool,
 }: {
   toolEntries: Array<[string, ProxiedMcpTool]>;
+  metadataByTool: ToolMetadataByName;
 }): JSX.Element {
   const [selectedName, setSelectedName] = useState<string | null>(null);
 
@@ -292,6 +318,7 @@ function RemoteMcpToolsList({
             name={name}
             description={tool.description}
             annotations={tool.annotations}
+            stored={metadataByTool[name]}
             selected={name === selectedName}
             onSelect={() => setSelectedName(name)}
           />
@@ -306,7 +333,11 @@ function RemoteMcpToolsList({
       >
         <SheetContent className="w-full gap-0 sm:max-w-md">
           {selected && (
-            <RemoteToolDetails name={selected[0]} tool={selected[1]} />
+            <RemoteToolDetails
+              name={selected[0]}
+              tool={selected[1]}
+              stored={metadataByTool[selected[0]]}
+            />
           )}
         </SheetContent>
       </Sheet>
@@ -325,12 +356,14 @@ function RemoteToolRow({
   name,
   description,
   annotations,
+  stored,
   selected,
   onSelect,
 }: {
   name: string;
   description?: string;
   annotations?: ProxiedMcpToolAnnotations;
+  stored?: ToolMetadata;
   selected: boolean;
   onSelect: () => void;
 }): JSX.Element {
@@ -354,7 +387,7 @@ function RemoteToolRow({
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="flex min-w-0 items-center gap-2">
           <p className="text-foreground truncate text-sm leading-6">{name}</p>
-          <AnnotationBadgeIcons {...resolveAnnotations(annotations)} />
+          <AnnotationBadgeIcons {...resolveAnnotations(annotations, stored)} />
         </div>
         <p className="text-muted-foreground truncate text-sm leading-6">
           {description || "No description"}
@@ -368,9 +401,11 @@ function RemoteToolRow({
 function RemoteToolDetails({
   name,
   tool,
+  stored,
 }: {
   name: string;
   tool: ProxiedMcpTool;
+  stored?: ToolMetadata;
 }): JSX.Element {
   const parameters = useMemo(() => extractParameters(tool), [tool]);
 
@@ -381,11 +416,13 @@ function RemoteToolDetails({
           <SheetTitle className="font-mono text-sm break-all">
             {name}
           </SheetTitle>
-          <AnnotationBadgeIcons {...resolveAnnotations(tool.annotations)} />
+          <AnnotationBadgeIcons
+            {...resolveAnnotations(tool.annotations, stored)}
+          />
         </div>
-        {tool.annotations?.title ? (
+        {stored?.title ?? tool.annotations?.title ? (
           <Type muted small as="p">
-            {tool.annotations.title}
+            {stored?.title ?? tool.annotations?.title}
           </Type>
         ) : null}
         <SheetDescription className="whitespace-pre-line">
@@ -514,15 +551,24 @@ function RemoteMcpToolsConnectPrompt({
   );
 }
 
-/** Map raw MCP annotation hints to the booleans AnnotationBadgeIcons renders. */
+/**
+ * Resolve the hints to display for a tool: Gram's stored metadata wins over
+ * whatever the server advertised, and an unset stored hint falls through to the
+ * advertised value. Same `override ?? base` precedence AnnotationBadges applies
+ * to tool variations — stored hints are tri-state, so `false` is a real
+ * override and only `undefined` falls through.
+ */
 function resolveAnnotations(
   annotations: ProxiedMcpToolAnnotations | undefined,
+  stored?: ToolMetadata,
 ): ResolvedToolAnnotations {
   return {
-    readOnly: Boolean(annotations?.readOnlyHint),
-    destructive: Boolean(annotations?.destructiveHint),
-    idempotent: Boolean(annotations?.idempotentHint),
-    openWorld: Boolean(annotations?.openWorldHint),
+    readOnly: Boolean(stored?.readOnlyHint ?? annotations?.readOnlyHint),
+    destructive: Boolean(
+      stored?.destructiveHint ?? annotations?.destructiveHint,
+    ),
+    idempotent: Boolean(stored?.idempotentHint ?? annotations?.idempotentHint),
+    openWorld: Boolean(stored?.openWorldHint ?? annotations?.openWorldHint),
   };
 }
 

--- a/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
@@ -21,6 +21,9 @@ import { useUserSessionToken } from "@/hooks/useUserSessionToken";
 import { handleError, toError } from "@/lib/errors";
 import { cn, firstPartyConnectUrl, mcpConnectionUrl } from "@/lib/utils";
 import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { ToolMetadataDriftPanel } from "./ToolMetadataDriftPanel";
+import { computeDrift } from "./toolMetadataSync";
+import { useSyncToolMetadata } from "./useSyncToolMetadata";
 import { useToolMetadata, type ToolMetadataByName } from "./useToolMetadata";
 import { Badge, Button } from "@speakeasy-api/moonshine";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
@@ -176,7 +179,7 @@ function RemoteMcpToolsSectionInner({
     userSessionIssuerId,
   });
 
-  // Gram's stored annotation overrides for this server's tools. Toolset-backed
+  // Speakeasy's stored annotation overrides for this server's tools. Toolset-backed
   // servers don't carry any, so skip the request entirely for them.
   const { metadataByTool, isLoading: isMetadataLoading } = useToolMetadata(
     mcpServerId,
@@ -227,8 +230,31 @@ function RemoteMcpToolsSectionInner({
   const loading =
     isResolvingUrl || isTokenLoading || isLoading || isMetadataLoading;
 
+  // Only remote-backed servers carry tool metadata, and there is nothing to
+  // reconcile until both the session and the stored set have loaded.
+  const tracksMetadata = !!remoteMcpServerId;
+  const { sync, isSyncing } = useSyncToolMetadata({
+    mcpServerId,
+    live: tools,
+    stored: metadataByTool,
+    enabled: tracksMetadata && !loading && !!tools,
+  });
+
+  const drift = useMemo(
+    () => (tracksMetadata && tools ? computeDrift(tools, metadataByTool) : []),
+    [tracksMetadata, tools, metadataByTool],
+  );
+
   return (
     <ToolsSectionShell>
+      {!loading && drift.length > 0 ? (
+        <ToolMetadataDriftPanel
+          drift={drift}
+          mcpServerId={mcpServerId}
+          onSync={sync}
+          isSyncing={isSyncing}
+        />
+      ) : null}
       <RemoteMcpToolsBody
         loading={loading}
         needsAuth={needsAuth}
@@ -420,7 +446,7 @@ function RemoteToolDetails({
             {...resolveAnnotations(tool.annotations, stored)}
           />
         </div>
-        {stored?.title ?? tool.annotations?.title ? (
+        {(stored?.title ?? tool.annotations?.title) ? (
           <Type muted small as="p">
             {stored?.title ?? tool.annotations?.title}
           </Type>
@@ -552,7 +578,7 @@ function RemoteMcpToolsConnectPrompt({
 }
 
 /**
- * Resolve the hints to display for a tool: Gram's stored metadata wins over
+ * Resolve the hints to display for a tool: Speakeasy's stored metadata wins over
  * whatever the server advertised, and an unset stored hint falls through to the
  * advertised value. Same `override ?? base` precedence AnnotationBadges applies
  * to tool variations — stored hints are tri-state, so `false` is a real

--- a/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
@@ -1,7 +1,3 @@
-import {
-  AnnotationBadgeIcons,
-  type ResolvedToolAnnotations,
-} from "@/components/tool-list/AnnotationBadges";
 import { Heading } from "@/components/ui/heading";
 import {
   Sheet,
@@ -21,6 +17,7 @@ import { useUserSessionToken } from "@/hooks/useUserSessionToken";
 import { handleError, toError } from "@/lib/errors";
 import { cn, firstPartyConnectUrl, mcpConnectionUrl } from "@/lib/utils";
 import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { ToolAnnotationIndicators } from "./ToolAnnotationIndicators";
 import { ToolMetadataDriftPanel } from "./ToolMetadataDriftPanel";
 import { computeDrift } from "./toolMetadataSync";
 import { useSyncToolMetadata } from "./useSyncToolMetadata";
@@ -413,7 +410,7 @@ function RemoteToolRow({
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="flex min-w-0 items-center gap-2">
           <p className="text-foreground truncate text-sm leading-6">{name}</p>
-          <AnnotationBadgeIcons {...resolveAnnotations(annotations, stored)} />
+          <ToolAnnotationIndicators annotations={annotations} stored={stored} />
         </div>
         <p className="text-muted-foreground truncate text-sm leading-6">
           {description || "No description"}
@@ -442,8 +439,9 @@ function RemoteToolDetails({
           <SheetTitle className="font-mono text-sm break-all">
             {name}
           </SheetTitle>
-          <AnnotationBadgeIcons
-            {...resolveAnnotations(tool.annotations, stored)}
+          <ToolAnnotationIndicators
+            annotations={tool.annotations}
+            stored={stored}
           />
         </div>
         {(stored?.title ?? tool.annotations?.title) ? (
@@ -575,27 +573,6 @@ function RemoteMcpToolsConnectPrompt({
       ) : null}
     </div>
   );
-}
-
-/**
- * Resolve the hints to display for a tool: Speakeasy's stored metadata wins over
- * whatever the server advertised, and an unset stored hint falls through to the
- * advertised value. Same `override ?? base` precedence AnnotationBadges applies
- * to tool variations — stored hints are tri-state, so `false` is a real
- * override and only `undefined` falls through.
- */
-function resolveAnnotations(
-  annotations: ProxiedMcpToolAnnotations | undefined,
-  stored?: ToolMetadata,
-): ResolvedToolAnnotations {
-  return {
-    readOnly: Boolean(stored?.readOnlyHint ?? annotations?.readOnlyHint),
-    destructive: Boolean(
-      stored?.destructiveHint ?? annotations?.destructiveHint,
-    ),
-    idempotent: Boolean(stored?.idempotentHint ?? annotations?.idempotentHint),
-    openWorld: Boolean(stored?.openWorldHint ?? annotations?.openWorldHint),
-  };
 }
 
 type ToolParameter = {

--- a/client/dashboard/src/pages/mcp/x/tabs/ToolAnnotationIndicators.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/ToolAnnotationIndicators.tsx
@@ -1,0 +1,76 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ProxiedMcpToolAnnotations } from "@/hooks/useProxiedMcpTools";
+import { cn } from "@/lib/utils";
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { AlertTriangle, Eye, Globe, Repeat } from "lucide-react";
+
+const ANNOTATIONS = [
+  { key: "readOnlyHint", label: "Read-only", Icon: Eye },
+  { key: "destructiveHint", label: "Destructive", Icon: AlertTriangle },
+  { key: "idempotentHint", label: "Idempotent", Icon: Repeat },
+  { key: "openWorldHint", label: "Open world", Icon: Globe },
+] as const;
+
+/**
+ * The MCP annotation hints a tool actually asserts, one icon each.
+ *
+ * Unlike the shared AnnotationBadgeIcons — which shows only the most salient
+ * hint and drops open-world entirely to keep dense tool lists readable — every
+ * hint the tool states is rendered here, in a stable order.
+ *
+ * Hints are tri-state and the distinction is load-bearing on this tab: `false`
+ * is the server asserting something, whereas unset is it declining to say. An
+ * unset hint is omitted so the row only carries claims that were actually made,
+ * and the remaining two states are drawn differently (solid / muted) with the
+ * value named in the tooltip, since that difference is too fine to carry on
+ * styling alone.
+ */
+export function ToolAnnotationIndicators({
+  annotations,
+  stored,
+}: {
+  annotations?: ProxiedMcpToolAnnotations;
+  /** Stored metadata wins over what the session advertises, when present. */
+  stored?: ToolMetadata;
+}): JSX.Element | null {
+  const asserted = ANNOTATIONS.map((annotation) => ({
+    ...annotation,
+    // Stored metadata wins, and only `undefined` falls through — a stored
+    // `false` is an assertion in its own right.
+    value: stored?.[annotation.key] ?? annotations?.[annotation.key],
+  })).filter((annotation) => annotation.value !== undefined);
+
+  if (asserted.length === 0) return null;
+
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {asserted.map(({ key, label, Icon, value }) => {
+        const description = `${label}: ${String(value)}`;
+
+        return (
+          <Tooltip key={key}>
+            <TooltipTrigger asChild>
+              <span aria-label={description} className="flex">
+                <Icon
+                  aria-hidden
+                  strokeWidth={value === true ? 2.5 : 1.5}
+                  className={cn(
+                    "size-3.5",
+                    value === true
+                      ? "text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{description}</TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </span>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/ToolMetadataDriftPanel.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/ToolMetadataDriftPanel.tsx
@@ -1,0 +1,231 @@
+import { RequireScope } from "@/components/require-scope";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Type } from "@/components/ui/type";
+import { cn } from "@/lib/utils";
+import { Badge, Button } from "@speakeasy-api/moonshine";
+import { Loader2, RefreshCw } from "lucide-react";
+import {
+  type FieldChange,
+  type MetadataField,
+  type ToolDrift,
+} from "./toolMetadataSync";
+
+const FIELD_LABELS: Record<MetadataField, string> = {
+  title: "Title",
+  readOnlyHint: "Read-only",
+  destructiveHint: "Destructive",
+  idempotentHint: "Idempotent",
+  openWorldHint: "Open world",
+};
+
+/**
+ * Diff colours, as explicit palette values rather than the semantic tokens.
+ * Moonshine defines --success and --warning as BACKGROUND tokens (green-100 /
+ * orange-100 in light mode, with separate -foreground counterparts), so
+ * `text-success` paints near-white text; only --destructive is text-weight.
+ * Using the palette directly keeps the before/after pair legible and balanced
+ * in both themes.
+ */
+/**
+ * The leading marker for each row: one character, coloured by drift kind.
+ *
+ * Mind which token is the text colour — `--success` and `--warning` are
+ * BACKGROUND tokens (green-100 / orange-100 in light mode) whose readable
+ * counterpart is `-foreground`, while `--destructive` is itself text-weight and
+ * its `-foreground` is the pale colour for text sitting ON destructive fill.
+ * Hence the asymmetry below; both halves are design-system tokens.
+ */
+const DRIFT_MARKERS: Record<
+  ToolDrift["kind"],
+  { symbol: string; label: string; className: string }
+> = {
+  new: { symbol: "+", label: "New", className: "text-success-foreground" },
+  changed: {
+    symbol: "~",
+    label: "Changed",
+    className: "text-warning-foreground",
+  },
+  removed: { symbol: "−", label: "Removed", className: "text-destructive" },
+};
+
+/** Render an unset hint as an em dash so it reads differently from `false`. */
+function formatValue(value: string | boolean | undefined): string {
+  if (value === undefined) return "—";
+  if (typeof value === "boolean") return String(value);
+  return value;
+}
+
+/**
+ * Shows how Speakeasy's stored tool metadata differs from what the live MCP session
+ * advertises, and offers to reconcile it.
+ *
+ * The session is authoritative, so every row reads as "what syncing would do".
+ * Newly advertised tools are recorded automatically and never appear here; what
+ * is left is the destructive half — overwriting hints that changed upstream and
+ * removing tools the session stopped advertising — which only happens when the
+ * user asks for it.
+ */
+export function ToolMetadataDriftPanel({
+  drift,
+  mcpServerId,
+  onSync,
+  isSyncing,
+}: {
+  drift: ToolDrift[];
+  mcpServerId: string | undefined;
+  onSync: () => void;
+  isSyncing: boolean;
+}): JSX.Element | null {
+  if (drift.length === 0) return null;
+
+  const removing = drift.filter((d) => d.kind === "removed").length;
+
+  return (
+    <div className="border-border mb-5 rounded-lg border">
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 border-b px-4 py-2">
+        <Type small as="p" className="text-muted-foreground">
+          <span className="text-foreground font-medium">
+            {drift.length} {drift.length === 1 ? "tool" : "tools"}
+          </span>{" "}
+          {drift.length === 1 ? "differs" : "differ"} from what this server
+          advertises
+          {removing > 0 ? (
+            <>
+              {" · "}
+              <span className="text-destructive">
+                syncing removes {removing}
+              </span>
+            </>
+          ) : null}
+        </Type>
+        <RequireScope
+          scope="mcp:write"
+          resourceId={mcpServerId}
+          level="component"
+          reason="You need write access to this MCP server to sync tool metadata."
+        >
+          {({ disabled }) => (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  className="p-2"
+                  disabled={disabled || isSyncing}
+                  onClick={onSync}
+                >
+                  <Button.LeftIcon>
+                    {isSyncing ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="size-4" />
+                    )}
+                  </Button.LeftIcon>
+                  {/* The panel header already explains what syncing does, so
+                      the label is for screen readers and the tooltip. */}
+                  <Button.Text className="sr-only">
+                    {isSyncing ? "Syncing annotations" : "Sync annotations"}
+                  </Button.Text>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Sync annotations</TooltipContent>
+            </Tooltip>
+          )}
+        </RequireScope>
+      </div>
+
+      <ul className="divide-border divide-y">
+        {drift.map((entry) => (
+          <DriftRow key={entry.toolName} entry={entry} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * One tool per line: marker, name, then what syncing changes. The three columns
+ * use the same track sizes on every row so they read as a table, and the detail
+ * column scrolls rather than wrapping so a tool with several changed hints
+ * still occupies a single line.
+ */
+function DriftRow({ entry }: { entry: ToolDrift }): JSX.Element {
+  return (
+    <li className="hover:bg-muted/50 grid grid-cols-[0.75rem_minmax(0,14rem)_minmax(0,1fr)] items-baseline gap-x-3 px-4 py-1.5 transition-colors">
+      <DriftMarker kind={entry.kind} />
+      <Type
+        mono
+        small
+        as="span"
+        className={cn(
+          "truncate",
+          // The name itself is struck through when the tool is going away, so
+          // the row reads as a deletion without needing to spell it out.
+          entry.kind === "removed" && "text-muted-foreground line-through",
+        )}
+        title={entry.toolName}
+      >
+        {entry.toolName}
+      </Type>
+
+      {entry.kind === "changed" ? (
+        <span className="flex gap-x-3 overflow-x-auto whitespace-nowrap">
+          {entry.changes.map((change) => (
+            <ChangeChip key={change.field} change={change} />
+          ))}
+        </span>
+      ) : entry.kind === "new" ? (
+        // Worth saying, because it already happened without the user asking.
+        // A removal needs no gloss — the marker is the whole story.
+        <Type muted small as="span" className="truncate">
+          recorded automatically
+        </Type>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * `field old new` — the superseded value struck through and untinted so it
+ * recedes, the incoming value filled so the outcome is what catches the eye.
+ */
+function ChangeChip({ change }: { change: FieldChange }): JSX.Element {
+  return (
+    <span className="flex shrink-0 items-baseline gap-1 text-xs">
+      <span className="text-muted-foreground">
+        {FIELD_LABELS[change.field]}
+      </span>
+      <Badge variant="destructive" size="sm">
+        <Badge.Text className="font-mono line-through">
+          {formatValue(change.stored)}
+        </Badge.Text>
+      </Badge>
+      <Badge variant="success" size="sm" background>
+        <Badge.Text className="font-mono">
+          {formatValue(change.advertised)}
+        </Badge.Text>
+      </Badge>
+    </span>
+  );
+}
+
+function DriftMarker({ kind }: { kind: ToolDrift["kind"] }): JSX.Element {
+  const { symbol, label, className } = DRIFT_MARKERS[kind];
+
+  return (
+    <span
+      aria-label={label}
+      title={label}
+      className={cn(
+        "shrink-0 text-center font-mono text-sm font-medium",
+        className,
+      )}
+    >
+      {symbol}
+    </span>
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.test.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.test.ts
@@ -71,6 +71,20 @@ describe("computeDrift", () => {
     ]);
   });
 
+  it("reports a stored tool named after an Object.prototype member as removed", () => {
+    // Tool names are remote input. `"toString" in live` is true on any plain
+    // object, so an inherited member must not make an absent tool look present.
+    expect(computeDrift(live(), byName(stored("toString")))).toEqual([
+      { kind: "removed", toolName: "toString" },
+    ]);
+  });
+
+  it("treats a tool named after an Object.prototype member as new", () => {
+    expect(computeDrift(live(["toString", {}]), byName())).toEqual([
+      { kind: "new", toolName: "toString", advertised: {} },
+    ]);
+  });
+
   it("treats an unset hint as different from an explicit false", () => {
     // The runtime distinguishes the two, so a sync has to be able to move a
     // stored `false` back to unset when the server stops asserting it.
@@ -118,6 +132,13 @@ describe("newToolsBatch", () => {
         openWorldHint: undefined,
       },
     ]);
+  });
+
+  it("records a tool named after an Object.prototype member", () => {
+    // `stored["toString"]` resolves to an inherited function on a plain object,
+    // which would make this tool look already-recorded and skip it forever.
+    const batch = newToolsBatch(live(["toString", {}]), byName());
+    expect(batch?.map((f) => f.toolName)).toEqual(["toString"]);
   });
 
   it("never carries a stored tool the session no longer advertises", () => {

--- a/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.test.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.test.ts
@@ -1,0 +1,156 @@
+import type { ProxiedMcpTool } from "@/hooks/useProxiedMcpTools";
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { describe, expect, it } from "vitest";
+import { computeDrift, fullSyncBatch, newToolsBatch } from "./toolMetadataSync";
+import type { ToolMetadataByName } from "./useToolMetadata";
+
+function live(
+  ...tools: Array<[string, ProxiedMcpTool["annotations"]]>
+): Record<string, ProxiedMcpTool> {
+  return Object.fromEntries(
+    tools.map(([name, annotations]) => [name, { annotations }]),
+  );
+}
+
+function stored(
+  toolName: string,
+  overrides: Partial<ToolMetadata> = {},
+): ToolMetadata {
+  return {
+    mcpServerId: "server-1",
+    toolName,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function byName(...entries: ToolMetadata[]): ToolMetadataByName {
+  return Object.fromEntries(entries.map((e) => [e.toolName, e]));
+}
+
+describe("computeDrift", () => {
+  it("reports nothing when the stored set already mirrors the session", () => {
+    const drift = computeDrift(
+      live(["alpha", { readOnlyHint: true }]),
+      byName(stored("alpha", { readOnlyHint: true })),
+    );
+    expect(drift).toEqual([]);
+  });
+
+  it("flags a tool the session advertises but Speakeasy has never stored", () => {
+    const drift = computeDrift(
+      live(["alpha", { readOnlyHint: true }]),
+      byName(),
+    );
+    expect(drift).toEqual([
+      { kind: "new", toolName: "alpha", advertised: { readOnlyHint: true } },
+    ]);
+  });
+
+  it("flags a tool the session stopped advertising", () => {
+    const drift = computeDrift(live(), byName(stored("gone")));
+    expect(drift).toEqual([{ kind: "removed", toolName: "gone" }]);
+  });
+
+  it("reports the fields that disagree, stored value first", () => {
+    const drift = computeDrift(
+      live(["alpha", { destructiveHint: true, title: "Alpha" }]),
+      byName(stored("alpha", { destructiveHint: false })),
+    );
+
+    expect(drift).toEqual([
+      {
+        kind: "changed",
+        toolName: "alpha",
+        changes: [
+          { field: "title", stored: undefined, advertised: "Alpha" },
+          { field: "destructiveHint", stored: false, advertised: true },
+        ],
+      },
+    ]);
+  });
+
+  it("treats an unset hint as different from an explicit false", () => {
+    // The runtime distinguishes the two, so a sync has to be able to move a
+    // stored `false` back to unset when the server stops asserting it.
+    const drift = computeDrift(
+      live(["alpha", {}]),
+      byName(stored("alpha", { readOnlyHint: false })),
+    );
+    expect(drift).toEqual([
+      {
+        kind: "changed",
+        toolName: "alpha",
+        changes: [
+          { field: "readOnlyHint", stored: false, advertised: undefined },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("newToolsBatch", () => {
+  it("is null when every advertised tool is already stored", () => {
+    expect(
+      newToolsBatch(live(["alpha", {}]), byName(stored("alpha"))),
+    ).toBeNull();
+  });
+
+  it("sends only the tools with no stored entry", () => {
+    // addToolMetadataBatch is a strict insert — naming a tool that already has
+    // an entry fails the whole batch with a 409.
+    const batch = newToolsBatch(
+      live(
+        ["alpha", { readOnlyHint: false }],
+        ["beta", { readOnlyHint: true }],
+      ),
+      byName(stored("alpha", { readOnlyHint: true })),
+    );
+
+    expect(batch).toEqual([
+      {
+        toolName: "beta",
+        title: undefined,
+        readOnlyHint: true,
+        destructiveHint: undefined,
+        idempotentHint: undefined,
+        openWorldHint: undefined,
+      },
+    ]);
+  });
+
+  it("never carries a stored tool the session no longer advertises", () => {
+    // The additive pass cannot delete anything, and a stored entry is not ours
+    // to resend — only an explicit sync touches those.
+    const batch = newToolsBatch(
+      live(["beta", {}]),
+      byName(stored("vanished", { readOnlyHint: true })),
+    );
+
+    expect(batch?.map((f) => f.toolName)).toEqual(["beta"]);
+  });
+});
+
+describe("fullSyncBatch", () => {
+  it("sends only live tools, so stored-but-unadvertised ones remove", () => {
+    const batch = fullSyncBatch(
+      live(["alpha", { readOnlyHint: true, title: "Alpha" }]),
+    );
+
+    expect(batch).toEqual([
+      {
+        toolName: "alpha",
+        title: "Alpha",
+        readOnlyHint: true,
+        destructiveHint: undefined,
+        idempotentHint: undefined,
+        openWorldHint: undefined,
+      },
+    ]);
+  });
+
+  it("is empty when the session advertises nothing, removing the whole set", () => {
+    expect(fullSyncBatch(live())).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.ts
@@ -50,6 +50,21 @@ function storedField(
 }
 
 /**
+ * Own-property lookup for a tool name.
+ *
+ * Tool names come from the remote server, so plain member access can't be
+ * trusted: on any object carrying Object.prototype, `stored["toString"]`
+ * resolves to an inherited function and a tool that has no stored entry looks
+ * like it has one. `in` has the same problem, hence Object.hasOwn throughout.
+ */
+function storedEntry(
+  stored: ToolMetadataByName,
+  toolName: string,
+): ToolMetadata | undefined {
+  return Object.hasOwn(stored, toolName) ? stored[toolName] : undefined;
+}
+
+/**
  * Compare Speakeasy's stored metadata against what the live MCP session advertises.
  *
  * The session is the source of truth: this is what a sync would change, in the
@@ -63,7 +78,7 @@ export function computeDrift(
   const drift: ToolDrift[] = [];
 
   for (const [toolName, tool] of Object.entries(live)) {
-    const entry = stored[toolName];
+    const entry = storedEntry(stored, toolName);
     if (!entry) {
       drift.push({
         kind: "new",
@@ -85,7 +100,7 @@ export function computeDrift(
   }
 
   for (const toolName of Object.keys(stored)) {
-    if (!(toolName in live)) {
+    if (!Object.hasOwn(live, toolName)) {
       drift.push({ kind: "removed", toolName });
     }
   }
@@ -125,7 +140,9 @@ export function newToolsBatch(
   live: LiveTools,
   stored: ToolMetadataByName,
 ): ToolMetadataForm[] | null {
-  const missing = Object.entries(live).filter(([name]) => !stored[name]);
+  const missing = Object.entries(live).filter(
+    ([name]) => !storedEntry(stored, name),
+  );
   if (missing.length === 0) return null;
 
   return sortForms(missing.map(([name, tool]) => advertisedToForm(name, tool)));

--- a/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.ts
@@ -1,0 +1,145 @@
+import type {
+  ProxiedMcpTool,
+  ProxiedMcpToolAnnotations,
+} from "@/hooks/useProxiedMcpTools";
+import type { ToolMetadataForm } from "@gram/client/models/components/toolmetadataform.js";
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import type { ToolMetadataByName } from "./useToolMetadata";
+
+/** The annotation fields Speakeasy mirrors from a tool's MCP `annotations` object. */
+const METADATA_FIELDS = [
+  "title",
+  "readOnlyHint",
+  "destructiveHint",
+  "idempotentHint",
+  "openWorldHint",
+] as const;
+
+export type MetadataField = (typeof METADATA_FIELDS)[number];
+
+export type FieldChange = {
+  field: MetadataField;
+  /** What Speakeasy has stored. Undefined means the hint is unset. */
+  stored: string | boolean | undefined;
+  /** What the live session advertises. Undefined means the hint is unset. */
+  advertised: string | boolean | undefined;
+};
+
+export type ToolDrift =
+  /** Advertised by the session with nothing stored for it yet. */
+  | { kind: "new"; toolName: string; advertised: ProxiedMcpToolAnnotations }
+  /** Stored, still advertised, but the two disagree on at least one field. */
+  | { kind: "changed"; toolName: string; changes: FieldChange[] }
+  /** Stored but no longer advertised by the session. */
+  | { kind: "removed"; toolName: string };
+
+type LiveTools = Record<string, ProxiedMcpTool>;
+
+function advertisedField(
+  annotations: ProxiedMcpToolAnnotations | undefined,
+  field: MetadataField,
+): string | boolean | undefined {
+  return annotations?.[field];
+}
+
+function storedField(
+  stored: ToolMetadata,
+  field: MetadataField,
+): string | boolean | undefined {
+  return stored[field];
+}
+
+/**
+ * Compare Speakeasy's stored metadata against what the live MCP session advertises.
+ *
+ * The session is the source of truth: this is what a sync would change, in the
+ * order the Inspect tab lists it. An empty result means the table already
+ * mirrors the session.
+ */
+export function computeDrift(
+  live: LiveTools,
+  stored: ToolMetadataByName,
+): ToolDrift[] {
+  const drift: ToolDrift[] = [];
+
+  for (const [toolName, tool] of Object.entries(live)) {
+    const entry = stored[toolName];
+    if (!entry) {
+      drift.push({
+        kind: "new",
+        toolName,
+        advertised: tool.annotations ?? {},
+      });
+      continue;
+    }
+
+    const changes = METADATA_FIELDS.flatMap((field) => {
+      const a = advertisedField(tool.annotations, field);
+      const s = storedField(entry, field);
+      return a === s ? [] : [{ field, stored: s, advertised: a }];
+    });
+
+    if (changes.length > 0) {
+      drift.push({ kind: "changed", toolName, changes });
+    }
+  }
+
+  for (const toolName of Object.keys(stored)) {
+    if (!(toolName in live)) {
+      drift.push({ kind: "removed", toolName });
+    }
+  }
+
+  return drift.sort((a, b) => a.toolName.localeCompare(b.toolName));
+}
+
+function advertisedToForm(
+  toolName: string,
+  tool: ProxiedMcpTool,
+): ToolMetadataForm {
+  const annotations = tool.annotations;
+  return {
+    toolName,
+    title: annotations?.title,
+    readOnlyHint: annotations?.readOnlyHint,
+    destructiveHint: annotations?.destructiveHint,
+    idempotentHint: annotations?.idempotentHint,
+    openWorldHint: annotations?.openWorldHint,
+  };
+}
+
+function sortForms(forms: ToolMetadataForm[]): ToolMetadataForm[] {
+  return forms.sort((a, b) => a.toolName.localeCompare(b.toolName));
+}
+
+/**
+ * The payload for addToolMetadataBatch: only tools the session advertises that
+ * Speakeasy has never stored. Returns null when there are none.
+ *
+ * A tool appearing for the first time has no stored value to disagree with, so
+ * recording it needs no confirmation. That endpoint is strictly additive and
+ * rejects a tool that already has an entry, so this sends nothing else — a
+ * conflict means our view of stored state was stale and we should reload it.
+ */
+export function newToolsBatch(
+  live: LiveTools,
+  stored: ToolMetadataByName,
+): ToolMetadataForm[] | null {
+  const missing = Object.entries(live).filter(([name]) => !stored[name]);
+  if (missing.length === 0) return null;
+
+  return sortForms(missing.map(([name, tool]) => advertisedToForm(name, tool)));
+}
+
+/**
+ * The payload that makes the stored set mirror the session exactly.
+ *
+ * Only live tools are sent, so anything stored that the session no longer
+ * advertises is removed by omission — the destructive half of a sync, which is
+ * why this one is never run without the user asking for it.
+ */
+export function fullSyncBatch(live: LiveTools): ToolMetadataForm[] {
+  return sortForms(
+    Object.entries(live).map(([name, tool]) => advertisedToForm(name, tool)),
+  );
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/useSyncToolMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/useSyncToolMetadata.ts
@@ -1,0 +1,115 @@
+import { useRBAC } from "@/hooks/useRBAC";
+import type { ProxiedMcpTool } from "@/hooks/useProxiedMcpTools";
+import { handleAPIError } from "@/lib/errors";
+import { useAddMcpServerToolMetadataBatchMutation } from "@gram/client/react-query/addMcpServerToolMetadataBatch.js";
+import { invalidateAllListMcpServerToolMetadata } from "@gram/client/react-query/listMcpServerToolMetadata.js";
+import { useSetMcpServerToolMetadataBatchMutation } from "@gram/client/react-query/setMcpServerToolMetadataBatch.js";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { fullSyncBatch, newToolsBatch } from "./toolMetadataSync";
+import type { ToolMetadataByName } from "./useToolMetadata";
+
+export interface UseSyncToolMetadataResult {
+  /** Make the stored set mirror the session, removing tools it dropped. */
+  sync: () => void;
+  isSyncing: boolean;
+}
+
+/**
+ * Keeps Speakeasy's stored tool metadata in step with the live MCP session.
+ *
+ * The session is only the source the annotations are read FROM — what gets
+ * written is persisted against the MCP server for the whole project, so a sync
+ * changes what every caller of that server sees, not just this viewer.
+ *
+ * Tools the session advertises for the first time are recorded automatically —
+ * there is no stored value to disagree with, so nothing needs confirming.
+ * Everything else (a tool whose advertised hints changed, or one the session
+ * stopped advertising and so would be removed) waits for an explicit sync,
+ * because those overwrite or remove records an operator may be relying on.
+ */
+export function useSyncToolMetadata({
+  mcpServerId,
+  live,
+  stored,
+  enabled,
+}: {
+  mcpServerId: string | undefined;
+  live: Record<string, ProxiedMcpTool> | undefined;
+  stored: ToolMetadataByName;
+  /** False until both sides have loaded, and for servers without metadata. */
+  enabled: boolean;
+}): UseSyncToolMetadataResult {
+  const queryClient = useQueryClient();
+  const { hasAnyScope } = useRBAC();
+
+  // Writing is gated on mcp:write like any other mutation; a read-only viewer
+  // must not have a page visit silently write on their behalf.
+  const canWrite = hasAnyScope(["mcp:write"], mcpServerId);
+
+  const refresh = () =>
+    invalidateAllListMcpServerToolMetadata(queryClient, {
+      refetchType: "all",
+    });
+
+  // Records tools with no stored entry. Strictly additive: it rejects the whole
+  // batch if any tool already has one, so a 409 means our stored snapshot was
+  // stale rather than that anything went wrong. This pass is invisible, so that
+  // case just reloads the list instead of surfacing an error.
+  const add = useAddMcpServerToolMetadataBatchMutation({
+    onSuccess: refresh,
+    onError: async (error) => {
+      if (error instanceof GramError && error.statusCode === 409) {
+        await refresh();
+        return;
+      }
+      handleAPIError(error, "Failed to record new tool metadata");
+    },
+  });
+
+  // Makes the stored set mirror the session, deleting tools it dropped.
+  const set = useSetMcpServerToolMetadataBatchMutation({
+    onSuccess: async () => {
+      await refresh();
+      toast.success("Annotations synced");
+    },
+    onError: (error) => handleAPIError(error, "Failed to sync tool metadata"),
+  });
+
+  // Guard the automatic pass so a re-render (or the refetch the write itself
+  // triggers) can't fire it twice for the same server.
+  const autoWrittenFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !canWrite || !mcpServerId || !live) return;
+    if (autoWrittenFor.current === mcpServerId) return;
+
+    const tools = newToolsBatch(live, stored);
+    autoWrittenFor.current = mcpServerId;
+    if (!tools) return;
+
+    add.mutate({
+      request: {
+        setToolMetadataBatchRequestBody: { mcpServerId, tools },
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, canWrite, mcpServerId, live, stored]);
+
+  return {
+    sync: () => {
+      if (!live || !mcpServerId) return;
+      set.mutate({
+        request: {
+          setToolMetadataBatchRequestBody: {
+            mcpServerId,
+            tools: fullSyncBatch(live),
+          },
+        },
+      });
+    },
+    isSyncing: set.isPending,
+  };
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/useSyncToolMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/useSyncToolMetadata.ts
@@ -54,6 +54,12 @@ export function useSyncToolMetadata({
       refetchType: "all",
     });
 
+  // Guard the automatic pass so a re-render (or the refetch the write itself
+  // triggers) can't fire it twice for the same server. Released whenever the
+  // write fails, so a transient error doesn't leave the tools unrecorded until
+  // the page is remounted — the next refetch gets to try again.
+  const autoWrittenFor = useRef<string | null>(null);
+
   // Records tools with no stored entry. Strictly additive: it rejects the whole
   // batch if any tool already has one, so a 409 means our stored snapshot was
   // stale rather than that anything went wrong. This pass is invisible, so that
@@ -61,6 +67,7 @@ export function useSyncToolMetadata({
   const add = useAddMcpServerToolMetadataBatchMutation({
     onSuccess: refresh,
     onError: async (error) => {
+      autoWrittenFor.current = null;
       if (error instanceof GramError && error.statusCode === 409) {
         await refresh();
         return;
@@ -77,10 +84,6 @@ export function useSyncToolMetadata({
     },
     onError: (error) => handleAPIError(error, "Failed to sync tool metadata"),
   });
-
-  // Guard the automatic pass so a re-render (or the refetch the write itself
-  // triggers) can't fire it twice for the same server.
-  const autoWrittenFor = useRef<string | null>(null);
 
   useEffect(() => {
     if (!enabled || !canWrite || !mcpServerId || !live) return;

--- a/client/dashboard/src/pages/mcp/x/tabs/useToolMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/useToolMetadata.ts
@@ -41,7 +41,10 @@ export function useToolMetadata(
   );
 
   const metadataByTool = useMemo(() => {
-    const byName: ToolMetadataByName = {};
+    // Null-prototype: tool names come from the remote server, so a tool called
+    // `__proto__` or `constructor` would otherwise either fail to become an own
+    // property or make an absent tool look present, and drift would miss it.
+    const byName = Object.create(null) as ToolMetadataByName;
     for (const entry of data?.tools ?? []) {
       byName[entry.toolName] = entry;
     }

--- a/client/dashboard/src/pages/mcp/x/tabs/useToolMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/useToolMetadata.ts
@@ -1,0 +1,57 @@
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { useListMcpServerToolMetadata } from "@gram/client/react-query/listMcpServerToolMetadata.js";
+import { useMemo } from "react";
+
+/** Stored tool metadata keyed by tool name, for O(1) lookup per rendered row. */
+export type ToolMetadataByName = Record<string, ToolMetadata>;
+
+export interface UseToolMetadataResult {
+  metadataByTool: ToolMetadataByName;
+  isLoading: boolean;
+}
+
+/**
+ * Loads Gram's stored annotation metadata for an MCP server's tools.
+ *
+ * This is the admin-authoritative side of the Inspect tab: the remote server
+ * advertises its own annotation hints over the live MCP session, and these
+ * stored entries are what Gram asserts on top of them (read by the runtime
+ * proxy to fill the disposition dimension of RBAC checks).
+ *
+ * Only servers backed by a remote MCP server carry tool metadata — the API
+ * rejects toolset-backed ones, which persist hints on their tool-definition
+ * tables instead. Callers gate on that via `enabled`.
+ */
+export function useToolMetadata(
+  mcpServerId: string | undefined,
+  options?: { enabled?: boolean },
+): UseToolMetadataResult {
+  const enabled = (options?.enabled ?? true) && !!mcpServerId;
+
+  const { data, isLoading, fetchStatus } = useListMcpServerToolMetadata(
+    { mcpServerId: mcpServerId ?? "" },
+    undefined,
+    {
+      enabled,
+      // Stored metadata is supplementary to the live tool listing. A failure
+      // here shouldn't take down the tools list, so keep it inline — the rows
+      // simply fall back to the annotations the server advertised.
+      throwOnError: false,
+    },
+  );
+
+  const metadataByTool = useMemo(() => {
+    const byName: ToolMetadataByName = {};
+    for (const entry of data?.tools ?? []) {
+      byName[entry.toolName] = entry;
+    }
+    return byName;
+  }, [data]);
+
+  return {
+    metadataByTool,
+    // `isLoading` stays true for a disabled query; pair it with fetchStatus so
+    // a gated server doesn't hold the section in a permanent skeleton.
+    isLoading: isLoading && fetchStatus !== "idle",
+  };
+}

--- a/client/dashboard/src/pages/mcp/x/tabs/useToolMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/useToolMetadata.ts
@@ -11,11 +11,11 @@ export interface UseToolMetadataResult {
 }
 
 /**
- * Loads Gram's stored annotation metadata for an MCP server's tools.
+ * Loads Speakeasy's stored annotation metadata for an MCP server's tools.
  *
  * This is the admin-authoritative side of the Inspect tab: the remote server
  * advertises its own annotation hints over the live MCP session, and these
- * stored entries are what Gram asserts on top of them (read by the runtime
+ * stored entries are what Speakeasy asserts on top of them (read by the runtime
  * proxy to fill the disposition dimension of RBAC checks).
  *
  * Only servers backed by a remote MCP server carry tool metadata — the API

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -392,16 +392,20 @@ const ROUTE_STRUCTURE = {
             title: "MCP Server Overview",
             url: "overview",
           },
-          tools: {
-            title: "MCP Server Tools",
-            url: "tools",
+          inspect: {
+            title: "MCP Server Inspect",
+            url: "inspect",
           },
-          // Legacy route. MCPServerDetails redirects this to
+          // Legacy routes. MCPServerDetails redirects `authentication` to
           // settings#authentication now that authentication lives under
-          // Settings.
+          // Settings, and `tools` to `inspect`.
           authentication: {
             title: "MCP Server Authentication",
             url: "authentication",
+          },
+          tools: {
+            title: "MCP Server Tools",
+            url: "tools",
           },
           teamAccess: {
             title: "MCP Server Team Access",


### PR DESCRIPTION
This changeset adds UI functionality to publish MCP tool metadata from admins. It is intended to be invisible automatic synchronization upon connect with explicit confirmation of changes via diff UI when modified metadata (or removed tools are detected). Granular change management is left out of scope (and likely requires a new domain concept of an explicit override which is not treated with in this PR)




https://github.com/user-attachments/assets/a7aeccb8-d521-436f-9674-77ffac4dadca


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Inspect tab for MCP servers that reconciles stored tool metadata (title + hints) with what the live MCP session advertises and lets admins sync differences. New tools are recorded automatically; changed/removed tools are shown in a drift panel with a “Sync annotations” action, gated by RBAC (AGE-2876).

- **New Features**
  - Renamed Tools → Inspect; legacy `tools` and `authentication` routes and `#tools` hash redirect.
  - Render stored vs advertised metadata (title + four hints) with tri‑state indicators; stored wins, `undefined` falls back; show every asserted hint.
  - Auto-record new tools via `@gram/client` `addMcpServerToolMetadataBatch` (strict insert; 409 refreshes); only for remote-backed servers; automatic writes require `mcp:write`.
  - Drift panel lists changed/removed tools; sync via `@gram/client` `setMcpServerToolMetadataBatch`; writes require `mcp:write`.

- **Bug Fixes**
  - Use null‑prototype maps and `Object.hasOwn` so tool names like `toString` don’t collide with `Object.prototype`.
  - Retry automatic recording after failures; release guard and refresh on 409 to avoid getting stuck.

<sup>Written for commit ee6374ab5b3a88a5ce61ad20a08591cbc5572e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

