### PR TITLE
fix: removes excessive querying for listPolicies

### DIFF
--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -29,10 +29,11 @@ WHERE organization_id = @organization_id
   )
 ORDER BY principal_urn;
 
--- name: ListPrincipalGrantsByScope :many
--- Returns grant rows for every resource of one kind under a scope in an org.
--- Batched form of ListPrincipalGrantsByResource: callers group the results by
--- the selector's resource_id to avoid a per-resource round trip.
+-- name: ListPrincipalGrantsByResourceIDs :many
+-- Returns grant rows for a set of resources under one scope in an org. Batched
+-- form of ListPrincipalGrantsByResource that stays scoped to the caller's
+-- resource ids, so listing one project's resources never loads the whole org.
+-- Callers group the results by the selector's resource_id.
 SELECT principal_urn, scope, effect, selectors
 FROM principal_grants
 WHERE organization_id = @organization_id
@@ -40,6 +41,7 @@ WHERE organization_id = @organization_id
   AND selectors @> jsonb_build_object(
     'resource_kind', sqlc.arg(resource_kind)::text
   )
+  AND selectors->>'resource_id' = ANY(@resource_ids::text[])
 ORDER BY principal_urn;
 
 -- name: UpsertPrincipalGrant :one

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -29,6 +29,19 @@ WHERE organization_id = @organization_id
   )
 ORDER BY principal_urn;
 
+-- name: ListPrincipalGrantsByScope :many
+-- Returns grant rows for every resource of one kind under a scope in an org.
+-- Batched form of ListPrincipalGrantsByResource: callers group the results by
+-- the selector's resource_id to avoid a per-resource round trip.
+SELECT principal_urn, scope, effect, selectors
+FROM principal_grants
+WHERE organization_id = @organization_id
+  AND scope = @scope
+  AND selectors @> jsonb_build_object(
+    'resource_kind', sqlc.arg(resource_kind)::text
+  )
+ORDER BY principal_urn;
+
 -- name: UpsertPrincipalGrant :one
 -- Creates or updates a single grant row. On conflict (same org/principal/scope/effect/selectors),
 -- the updated_at is refreshed. Uses COALESCE to match the functional unique index.

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -1400,7 +1400,7 @@ func (q *Queries) ListPrincipalGrantsByResource(ctx context.Context, arg ListPri
 	return items, nil
 }
 
-const listPrincipalGrantsByScope = `-- name: ListPrincipalGrantsByScope :many
+const listPrincipalGrantsByResourceIDs = `-- name: ListPrincipalGrantsByResourceIDs :many
 SELECT principal_urn, scope, effect, selectors
 FROM principal_grants
 WHERE organization_id = $1
@@ -1408,34 +1408,42 @@ WHERE organization_id = $1
   AND selectors @> jsonb_build_object(
     'resource_kind', $3::text
   )
+  AND selectors->>'resource_id' = ANY($4::text[])
 ORDER BY principal_urn
 `
 
-type ListPrincipalGrantsByScopeParams struct {
+type ListPrincipalGrantsByResourceIDsParams struct {
 	OrganizationID string
 	Scope          string
 	ResourceKind   string
+	ResourceIds    []string
 }
 
-type ListPrincipalGrantsByScopeRow struct {
+type ListPrincipalGrantsByResourceIDsRow struct {
 	PrincipalUrn urn.Principal
 	Scope        string
 	Effect       pgtype.Text
 	Selectors    []byte
 }
 
-// Returns grant rows for every resource of one kind under a scope in an org.
-// Batched form of ListPrincipalGrantsByResource: callers group the results by
-// the selector's resource_id to avoid a per-resource round trip.
-func (q *Queries) ListPrincipalGrantsByScope(ctx context.Context, arg ListPrincipalGrantsByScopeParams) ([]ListPrincipalGrantsByScopeRow, error) {
-	rows, err := q.db.Query(ctx, listPrincipalGrantsByScope, arg.OrganizationID, arg.Scope, arg.ResourceKind)
+// Returns grant rows for a set of resources under one scope in an org. Batched
+// form of ListPrincipalGrantsByResource that stays scoped to the caller's
+// resource ids, so listing one project's resources never loads the whole org.
+// Callers group the results by the selector's resource_id.
+func (q *Queries) ListPrincipalGrantsByResourceIDs(ctx context.Context, arg ListPrincipalGrantsByResourceIDsParams) ([]ListPrincipalGrantsByResourceIDsRow, error) {
+	rows, err := q.db.Query(ctx, listPrincipalGrantsByResourceIDs,
+		arg.OrganizationID,
+		arg.Scope,
+		arg.ResourceKind,
+		arg.ResourceIds,
+	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []ListPrincipalGrantsByScopeRow
+	var items []ListPrincipalGrantsByResourceIDsRow
 	for rows.Next() {
-		var i ListPrincipalGrantsByScopeRow
+		var i ListPrincipalGrantsByResourceIDsRow
 		if err := rows.Scan(
 			&i.PrincipalUrn,
 			&i.Scope,

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -1400,6 +1400,58 @@ func (q *Queries) ListPrincipalGrantsByResource(ctx context.Context, arg ListPri
 	return items, nil
 }
 
+const listPrincipalGrantsByScope = `-- name: ListPrincipalGrantsByScope :many
+SELECT principal_urn, scope, effect, selectors
+FROM principal_grants
+WHERE organization_id = $1
+  AND scope = $2
+  AND selectors @> jsonb_build_object(
+    'resource_kind', $3::text
+  )
+ORDER BY principal_urn
+`
+
+type ListPrincipalGrantsByScopeParams struct {
+	OrganizationID string
+	Scope          string
+	ResourceKind   string
+}
+
+type ListPrincipalGrantsByScopeRow struct {
+	PrincipalUrn urn.Principal
+	Scope        string
+	Effect       pgtype.Text
+	Selectors    []byte
+}
+
+// Returns grant rows for every resource of one kind under a scope in an org.
+// Batched form of ListPrincipalGrantsByResource: callers group the results by
+// the selector's resource_id to avoid a per-resource round trip.
+func (q *Queries) ListPrincipalGrantsByScope(ctx context.Context, arg ListPrincipalGrantsByScopeParams) ([]ListPrincipalGrantsByScopeRow, error) {
+	rows, err := q.db.Query(ctx, listPrincipalGrantsByScope, arg.OrganizationID, arg.Scope, arg.ResourceKind)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPrincipalGrantsByScopeRow
+	for rows.Next() {
+		var i ListPrincipalGrantsByScopeRow
+		if err := rows.Scan(
+			&i.PrincipalUrn,
+			&i.Scope,
+			&i.Effect,
+			&i.Selectors,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markGlobalRoleDeleted = `-- name: MarkGlobalRoleDeleted :execrows
 UPDATE global_roles
 SET workos_deleted_at = $1,

--- a/server/internal/authz/resource_grants.go
+++ b/server/internal/authz/resource_grants.go
@@ -279,3 +279,44 @@ func ListGrantsForResource(ctx context.Context, db repo.DBTX, resource Resource)
 
 	return grants, nil
 }
+
+// ListGrantsForScopeKind loads every grant for a scope in an org, batching what
+// ListGrantsForResource does for a single resource. Callers group the returned
+// grants by Selector.ResourceID() to attribute each grant to its resource.
+func ListGrantsForScopeKind(ctx context.Context, db repo.DBTX, organizationID string, scope Scope) ([]Grant, error) {
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization id is required")
+	}
+	if scope == "" {
+		return nil, fmt.Errorf("scope is required")
+	}
+	resourceKind := ResourceKindForScope(scope)
+	if resourceKind == WildcardResource {
+		return nil, fmt.Errorf("scope %q does not map to a resource kind", scope)
+	}
+
+	rows, err := repo.New(db).ListPrincipalGrantsByScope(ctx, repo.ListPrincipalGrantsByScopeParams{
+		OrganizationID: organizationID,
+		Scope:          string(scope),
+		ResourceKind:   resourceKind,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list scope grants: %w", err)
+	}
+
+	grants := make([]Grant, 0, len(rows))
+	for _, row := range rows {
+		selector, err := SelectorFromRow(row.Selectors)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, Grant{
+			PrincipalUrn: row.PrincipalUrn.String(),
+			Scope:        Scope(row.Scope),
+			Effect:       policyEffectFromText(row.Effect),
+			Selector:     selector,
+		})
+	}
+
+	return grants, nil
+}

--- a/server/internal/authz/resource_grants.go
+++ b/server/internal/authz/resource_grants.go
@@ -280,25 +280,30 @@ func ListGrantsForResource(ctx context.Context, db repo.DBTX, resource Resource)
 	return grants, nil
 }
 
-// ListGrantsForScopeKind loads every grant for a scope in an org, batching what
-// ListGrantsForResource does for a single resource. Callers group the returned
-// grants by Selector.ResourceID() to attribute each grant to its resource.
-func ListGrantsForScopeKind(ctx context.Context, db repo.DBTX, organizationID string, scope Scope) ([]Grant, error) {
+// ListGrantsForResourceIDs loads grants for a set of resources under one scope
+// in an org in a single query, batching what ListGrantsForResource does for a
+// single resource while staying scoped to the given ids. Callers group the
+// returned grants by Selector.ResourceID() to attribute each grant.
+func ListGrantsForResourceIDs(ctx context.Context, db repo.DBTX, organizationID string, scope Scope, resourceIDs []string) ([]Grant, error) {
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization id is required")
 	}
 	if scope == "" {
 		return nil, fmt.Errorf("scope is required")
 	}
+	if len(resourceIDs) == 0 {
+		return nil, nil
+	}
 	resourceKind := ResourceKindForScope(scope)
 	if resourceKind == WildcardResource {
 		return nil, fmt.Errorf("scope %q does not map to a resource kind", scope)
 	}
 
-	rows, err := repo.New(db).ListPrincipalGrantsByScope(ctx, repo.ListPrincipalGrantsByScopeParams{
+	rows, err := repo.New(db).ListPrincipalGrantsByResourceIDs(ctx, repo.ListPrincipalGrantsByResourceIDsParams{
 		OrganizationID: organizationID,
 		Scope:          string(scope),
 		ResourceKind:   resourceKind,
+		ResourceIds:    resourceIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list scope grants: %w", err)

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -470,16 +470,47 @@ func (s *Service) ListRiskPolicies(ctx context.Context, payload *gen.ListRiskPol
 		return nil, oops.E(oops.CodeUnexpected, err, "list risk policies").LogError(ctx, s.logger)
 	}
 
+	if len(rows) == 0 {
+		return &gen.ListRiskPoliciesResult{Policies: []*types.RiskPolicy{}}, nil
+	}
+
+	// Enrichment is resolved once for the whole set rather than per policy (the
+	// old N+1). totalMessages is project-wide and identical for every policy;
+	// analyzed counts and audience grants are batched into one query each and
+	// looked up per row below.
+	totalMessages, err := s.repo.CountTotalMessages(ctx, uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true})
+	if err != nil {
+		totalMessages = 0
+	}
+
+	analyzedRows, err := s.repo.CountAnalyzedMessagesByProject(ctx, *authCtx.ProjectID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "count analyzed messages").LogError(ctx, s.logger)
+	}
+	analyzedByPolicy := make(map[analyzedMessagesKey]int64, len(analyzedRows))
+	for _, r := range analyzedRows {
+		analyzedByPolicy[analyzedMessagesKey{policyID: r.RiskPolicyID, version: r.RiskPolicyVersion}] = r.AnalyzedMessages
+	}
+
+	audienceByPolicy, err := riskPolicyAudienceURNsByPolicy(ctx, s.db, authCtx.ActiveOrganizationID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "load risk policy audiences").LogError(ctx, s.logger)
+	}
+
 	policies := make([]*types.RiskPolicy, 0, len(rows))
 	for _, row := range rows {
-		p, err := s.policyToType(ctx, row)
-		if err != nil {
-			return nil, err
-		}
-		policies = append(policies, p)
+		analyzedMessages := analyzedByPolicy[analyzedMessagesKey{policyID: row.ID, version: row.Version}]
+		policies = append(policies, buildRiskPolicyType(row, totalMessages, analyzedMessages, audienceByPolicy[row.ID.String()]))
 	}
 
 	return &gen.ListRiskPoliciesResult{Policies: policies}, nil
+}
+
+// analyzedMessagesKey keys the batched analyzed-message counts by the
+// (policy, version) pair they were aggregated on.
+type analyzedMessagesKey struct {
+	policyID uuid.UUID
+	version  int64
 }
 
 // ListBuiltinExclusions returns the built-in exclusion library grouped by
@@ -3078,12 +3109,21 @@ func (s *Service) policyToType(ctx context.Context, row repo.RiskPolicy) (*types
 	if err != nil {
 		analyzedMessages = 0
 	}
-	pendingMessages := max(totalMessages-analyzedMessages, 0)
 
 	audiencePrincipalURNs, err := riskPolicyAudiencePrincipalURNs(ctx, s.db, row.OrganizationID, row.ID.String())
 	if err != nil {
 		return nil, fmt.Errorf("load risk policy audience: %w", err)
 	}
+
+	return buildRiskPolicyType(row, totalMessages, analyzedMessages, audiencePrincipalURNs), nil
+}
+
+// buildRiskPolicyType assembles the API type from a policy row and its already
+// resolved message counts and audience. The enrichment queries are the caller's
+// responsibility so batched paths (ListRiskPolicies) can resolve them once for
+// the whole set instead of per policy.
+func buildRiskPolicyType(row repo.RiskPolicy, totalMessages, analyzedMessages int64, audiencePrincipalURNs []string) *types.RiskPolicy {
+	pendingMessages := max(totalMessages-analyzedMessages, 0)
 
 	return &types.RiskPolicy{
 		ID:                     row.ID.String(),
@@ -3114,7 +3154,7 @@ func (s *Service) policyToType(ctx context.Context, row repo.RiskPolicy) (*types
 		UpdatedAt:              row.UpdatedAt.Time.Format(time.RFC3339),
 		PendingMessages:        pendingMessages,
 		TotalMessages:          totalMessages,
-	}, nil
+	}
 }
 
 func policyRowSnapshotWithAudience(row repo.RiskPolicy, audiencePrincipalURNs []string) *types.RiskPolicy {

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -483,16 +483,24 @@ func (s *Service) ListRiskPolicies(ctx context.Context, payload *gen.ListRiskPol
 		totalMessages = 0
 	}
 
-	analyzedRows, err := s.repo.CountAnalyzedMessagesByProject(ctx, *authCtx.ProjectID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "count analyzed messages").LogError(ctx, s.logger)
-	}
-	analyzedByPolicy := make(map[analyzedMessagesKey]int64, len(analyzedRows))
-	for _, r := range analyzedRows {
-		analyzedByPolicy[analyzedMessagesKey{policyID: r.RiskPolicyID, version: r.RiskPolicyVersion}] = r.AnalyzedMessages
+	// Analyzed counts are optional status enrichment, so a failure degrades to
+	// zero (pending = total) rather than failing the whole list — matching the
+	// tolerance of the single-policy CountAnalyzedMessages path.
+	analyzedByPolicy := map[analyzedMessagesKey]int64{}
+	if analyzedRows, err := s.repo.CountAnalyzedMessagesByProject(ctx, *authCtx.ProjectID); err != nil {
+		s.logger.WarnContext(ctx, "count analyzed messages for risk policy list failed", attr.SlogError(err))
+	} else {
+		analyzedByPolicy = make(map[analyzedMessagesKey]int64, len(analyzedRows))
+		for _, r := range analyzedRows {
+			analyzedByPolicy[analyzedMessagesKey{policyID: r.RiskPolicyID, version: r.RiskPolicyVersion}] = r.AnalyzedMessages
+		}
 	}
 
-	audienceByPolicy, err := riskPolicyAudienceURNsByPolicy(ctx, s.db, authCtx.ActiveOrganizationID)
+	policyIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		policyIDs = append(policyIDs, row.ID.String())
+	}
+	audienceByPolicy, err := riskPolicyAudienceURNsByPolicy(ctx, s.db, authCtx.ActiveOrganizationID, policyIDs)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load risk policy audiences").LogError(ctx, s.logger)
 	}

--- a/server/internal/risk/policy_audience.go
+++ b/server/internal/risk/policy_audience.go
@@ -135,3 +135,35 @@ func riskPolicyAudiencePrincipalURNs(ctx context.Context, db repo.DBTX, organiza
 
 	return principalURNs, nil
 }
+
+// riskPolicyAudienceURNsByPolicy batch-loads audience principal URNs for every
+// risk policy in an org in a single query, keyed by policy id. Batched form of
+// riskPolicyAudiencePrincipalURNs used by ListRiskPolicies to avoid a per-policy
+// round trip. Policies with no audience grants are simply absent from the map.
+func riskPolicyAudienceURNsByPolicy(ctx context.Context, db repo.DBTX, organizationID string) (map[string][]string, error) {
+	grants, err := authz.ListGrantsForScopeKind(ctx, db, organizationID, authz.ScopeRiskPolicyEvaluate)
+	if err != nil {
+		return nil, fmt.Errorf("list risk policy audience grants: %w", err)
+	}
+
+	byPolicy := make(map[string][]string)
+	for _, grant := range grants {
+		if grant.Effect != authz.PolicyEffectAllow {
+			continue
+		}
+		// Attribute the grant to its policy via the selector's resource_id, then
+		// re-check against the canonical selector so grants carrying extra keys
+		// (or wildcards) are excluded exactly as the single-policy path does.
+		policyID := grant.Selector.ResourceID()
+		if !maps.Equal(grant.Selector, authz.NewSelector(authz.ScopeRiskPolicyEvaluate, policyID)) {
+			continue
+		}
+		byPolicy[policyID] = append(byPolicy[policyID], grant.PrincipalUrn)
+	}
+	for policyID, principalURNs := range byPolicy {
+		slices.Sort(principalURNs)
+		byPolicy[policyID] = slices.Compact(principalURNs)
+	}
+
+	return byPolicy, nil
+}

--- a/server/internal/risk/policy_audience.go
+++ b/server/internal/risk/policy_audience.go
@@ -136,12 +136,13 @@ func riskPolicyAudiencePrincipalURNs(ctx context.Context, db repo.DBTX, organiza
 	return principalURNs, nil
 }
 
-// riskPolicyAudienceURNsByPolicy batch-loads audience principal URNs for every
-// risk policy in an org in a single query, keyed by policy id. Batched form of
+// riskPolicyAudienceURNsByPolicy batch-loads audience principal URNs for the
+// given risk policies in a single query, keyed by policy id. Batched form of
 // riskPolicyAudiencePrincipalURNs used by ListRiskPolicies to avoid a per-policy
-// round trip. Policies with no audience grants are simply absent from the map.
-func riskPolicyAudienceURNsByPolicy(ctx context.Context, db repo.DBTX, organizationID string) (map[string][]string, error) {
-	grants, err := authz.ListGrantsForScopeKind(ctx, db, organizationID, authz.ScopeRiskPolicyEvaluate)
+// round trip. Scoped to policyIDs so it never loads the whole org. Policies with
+// no audience grants are simply absent from the map.
+func riskPolicyAudienceURNsByPolicy(ctx context.Context, db repo.DBTX, organizationID string, policyIDs []string) (map[string][]string, error) {
+	grants, err := authz.ListGrantsForResourceIDs(ctx, db, organizationID, authz.ScopeRiskPolicyEvaluate, policyIDs)
 	if err != nil {
 		return nil, fmt.Errorf("list risk policy audience grants: %w", err)
 	}

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -486,6 +486,18 @@ WHERE rr.project_id = @project_id
   AND rr.risk_policy_id = @risk_policy_id
   AND rr.risk_policy_version = @risk_policy_version;
 
+-- name: CountAnalyzedMessagesByProject :many
+-- Batched form of CountAnalyzedMessages: the analyzed-message count for every
+-- (policy, version) in a project in one query, so ListRiskPolicies avoids a
+-- per-policy round trip.
+SELECT
+    rr.risk_policy_id
+  , rr.risk_policy_version
+  , COUNT(DISTINCT rr.chat_message_id)::BIGINT AS analyzed_messages
+FROM risk_results rr
+WHERE rr.project_id = @project_id
+GROUP BY rr.risk_policy_id, rr.risk_policy_version;
+
 -- name: CountFindingsByPolicy :one
 SELECT COUNT(*)::BIGINT
 FROM risk_results

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -336,6 +336,45 @@ func (q *Queries) CountAnalyzedMessages(ctx context.Context, arg CountAnalyzedMe
 	return column_1, err
 }
 
+const countAnalyzedMessagesByProject = `-- name: CountAnalyzedMessagesByProject :many
+SELECT
+    rr.risk_policy_id
+  , rr.risk_policy_version
+  , COUNT(DISTINCT rr.chat_message_id)::BIGINT AS analyzed_messages
+FROM risk_results rr
+WHERE rr.project_id = $1
+GROUP BY rr.risk_policy_id, rr.risk_policy_version
+`
+
+type CountAnalyzedMessagesByProjectRow struct {
+	RiskPolicyID      uuid.UUID
+	RiskPolicyVersion int64
+	AnalyzedMessages  int64
+}
+
+// Batched form of CountAnalyzedMessages: the analyzed-message count for every
+// (policy, version) in a project in one query, so ListRiskPolicies avoids a
+// per-policy round trip.
+func (q *Queries) CountAnalyzedMessagesByProject(ctx context.Context, projectID uuid.UUID) ([]CountAnalyzedMessagesByProjectRow, error) {
+	rows, err := q.db.Query(ctx, countAnalyzedMessagesByProject, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountAnalyzedMessagesByProjectRow
+	for rows.Next() {
+		var i CountAnalyzedMessagesByProjectRow
+		if err := rows.Scan(&i.RiskPolicyID, &i.RiskPolicyVersion, &i.AnalyzedMessages); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countEnabledRegexExclusionsInScope = `-- name: CountEnabledRegexExclusionsInScope :one
 SELECT COUNT(*)::BIGINT
 FROM risk_exclusions


### PR DESCRIPTION
Fix #1 — hoist CountTotalMessages (impl.go)
Project-wide count now computed once in ListRiskPolicies, not per policy. Kills the repeated identical chat_messages full-count you flagged.

Fix #2 — batch principal_grants
- New SQL ListPrincipalGrantsByScope (access/queries.sql) — all grants for scope+kind in org, one query.
- New authz.ListGrantsForScopeKind (resource_grants.go).
- New riskPolicyAudienceURNsByPolicy (policy_audience.go) — groups by selector resource_id, re-checks canonical selector so semantics match single-policy path. N→1.

Fix #3 — batch CountAnalyzedMessages
- New SQL CountAnalyzedMessagesByProject (risk/queries.sql) — GROUP BY (policy_id, version), one query. Looked up via analyzedMessagesKey. N→1.

Refactor: extracted pure buildRiskPolicyType(row, total, analyzed, audience). policyToType (single-row callers: GetRiskPolicy, Update, Create) unchanged behavior — runs 3 queries then delegates to builder. ListRiskPolicies resolves enrichment in bulk then builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes N+1 queries in `ListRiskPolicies` by batching analyzed counts and audience grants, and by hoisting the project-wide total message count. This reduces redundant DB round trips and speeds up listing policies.

- **Performance**
  - Hoisted project-wide `CountTotalMessages` in `ListRiskPolicies` (compute once).
  - Added `CountAnalyzedMessagesByProject` (grouped by policy/version) and used in the list path.
  - Batched audience grants via `ListPrincipalGrantsByResourceIDs` and `authz.ListGrantsForResourceIDs`; built per-policy audiences with `riskPolicyAudienceURNsByPolicy` while preserving canonical selector semantics.

- **Refactors**
  - Extracted `buildRiskPolicyType(row, total, analyzed, audience)`; `policyToType` behavior unchanged for single-policy callers, while the list path uses bulk-enriched data.

<sup>Written for commit ac317cb8ee726818590232893c3d1aacac46796d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

