### PR TITLE
fix: support dotenv paste for MCP variables

### DIFF
--- a/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
@@ -16,7 +16,7 @@ import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Button } from "@speakeasy-api/moonshine";
 import { AlertCircle, ChevronDown, Plus, X } from "lucide-react";
 import { type ClipboardEvent, useCallback, useState } from "react";
-import { parseDotEnv } from "./dotEnvUtils";
+import { parseDotEnvPaste } from "./dotEnvUtils";
 import { EnvVarState } from "./environmentVariableUtils";
 
 interface Environment {
@@ -123,20 +123,22 @@ export function AddVariableSheet({
     index: number,
     event: ClipboardEvent<HTMLInputElement>,
   ) => {
-    const parsed = parseDotEnv(event.clipboardData.getData("text"));
-    if (parsed.entries.length === 0) return;
+    const parsed = parseDotEnvPaste(event.clipboardData.getData("text"));
+    if (!parsed) return;
 
     event.preventDefault();
-    const importedEntries = parsed.entries.map(({ key, value }) => ({
-      key: key.toUpperCase(),
-      value,
-      isSecret: true,
-    }));
-    setEntries((prev) => [
-      ...prev.slice(0, index),
-      ...importedEntries,
-      ...prev.slice(index + 1),
-    ]);
+    if (parsed.entries.length > 0) {
+      const importedEntries = parsed.entries.map(({ key, value }) => ({
+        key: key.toUpperCase(),
+        value,
+        isSecret: true,
+      }));
+      setEntries((prev) => [
+        ...prev.slice(0, index),
+        ...importedEntries,
+        ...prev.slice(index + 1),
+      ]);
+    }
 
     if (parsed.invalidLineNumbers.length > 0) {
       const lineLabel =

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
@@ -15,7 +15,8 @@ import { Switch } from "@/components/ui/switch";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Button } from "@speakeasy-api/moonshine";
 import { AlertCircle, ChevronDown, Plus, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import { type ClipboardEvent, useCallback, useState } from "react";
+import { parseDotEnv } from "./dotEnvUtils";
 import { EnvVarState } from "./environmentVariableUtils";
 
 interface Environment {
@@ -30,6 +31,14 @@ interface VariableEntry {
   state: EnvVarState;
   isSecret: boolean;
 }
+
+type DraftVariableEntry = Omit<VariableEntry, "state">;
+
+const EMPTY_ENTRY: DraftVariableEntry = {
+  key: "",
+  value: "",
+  isSecret: true,
+};
 
 interface AddVariableSheetProps {
   open: boolean;
@@ -50,12 +59,13 @@ export function AddVariableSheet({
 }: AddVariableSheetProps): JSX.Element {
   // Secret is on by default so an unattended value is never stored in the clear
   // by accident. This matches the server's default for new entries.
-  const emptyEntry = { key: "", value: "", isSecret: true };
-  const [entries, setEntries] = useState([{ ...emptyEntry }]);
+  const [entries, setEntries] = useState<DraftVariableEntry[]>([
+    { ...EMPTY_ENTRY },
+  ]);
   const [error, setError] = useState<string | null>(null);
 
   const resetForm = useCallback(() => {
-    setEntries([{ key: "", value: "", isSecret: true }]);
+    setEntries([{ ...EMPTY_ENTRY }]);
     setError(null);
   }, []);
 
@@ -106,7 +116,37 @@ export function AddVariableSheet({
   };
 
   const addEntry = () => {
-    setEntries((prev) => [...prev, { ...emptyEntry }]);
+    setEntries((prev) => [...prev, { ...EMPTY_ENTRY }]);
+  };
+
+  const handleDotEnvPaste = (
+    index: number,
+    event: ClipboardEvent<HTMLInputElement>,
+  ) => {
+    const parsed = parseDotEnv(event.clipboardData.getData("text"));
+    if (parsed.entries.length === 0) return;
+
+    event.preventDefault();
+    const importedEntries = parsed.entries.map(({ key, value }) => ({
+      key: key.toUpperCase(),
+      value,
+      isSecret: true,
+    }));
+    setEntries((prev) => [
+      ...prev.slice(0, index),
+      ...importedEntries,
+      ...prev.slice(index + 1),
+    ]);
+
+    if (parsed.invalidLineNumbers.length > 0) {
+      const lineLabel =
+        parsed.invalidLineNumbers.length === 1 ? "line" : "lines";
+      setError(
+        `Ignored invalid .env ${lineLabel}: ${parsed.invalidLineNumbers.join(", ")}.`,
+      );
+    } else {
+      setError(null);
+    }
   };
 
   const removeEntry = (index: number) => {
@@ -202,6 +242,7 @@ export function AddVariableSheet({
                   type="text"
                   value={entry.key}
                   onChange={(e) => updateEntry(index, "key", e.target.value)}
+                  onPaste={(e) => handleDotEnvPaste(index, e)}
                   placeholder="CLIENT_KEY..."
                   className="border-input bg-background placeholder:text-muted-foreground focus:ring-ring h-10 w-full rounded-md border px-3 font-mono text-sm focus:ring-2 focus:outline-none"
                 />

--- a/client/dashboard/src/pages/mcp/dotEnvUtils.test.ts
+++ b/client/dashboard/src/pages/mcp/dotEnvUtils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseDotEnv } from "./dotEnvUtils";
+
+describe("parseDotEnv", () => {
+  it("parses dotenv assignments while ignoring comments and blank lines", () => {
+    expect(
+      parseDotEnv(`
+# API credentials
+API_KEY=secret-value
+BASE_URL = https://example.test/path?a=b
+
+export EMPTY_VALUE=
+`),
+    ).toEqual({
+      entries: [
+        { key: "API_KEY", value: "secret-value" },
+        { key: "BASE_URL", value: "https://example.test/path?a=b" },
+        { key: "EMPTY_VALUE", value: "" },
+      ],
+      invalidLineNumbers: [],
+    });
+  });
+
+  it("handles quoted values and inline comments", () => {
+    expect(
+      parseDotEnv(`
+HASH_VALUE="value # kept"
+SINGLE_QUOTED='also # kept'
+COMMENTED=value # removed
+MULTILINE="first\\nsecond"
+`),
+    ).toEqual({
+      entries: [
+        { key: "HASH_VALUE", value: "value # kept" },
+        { key: "SINGLE_QUOTED", value: "also # kept" },
+        { key: "COMMENTED", value: "value" },
+        { key: "MULTILINE", value: "first\nsecond" },
+      ],
+      invalidLineNumbers: [],
+    });
+  });
+
+  it("reports malformed lines without discarding valid assignments", () => {
+    expect(
+      parseDotEnv('VALID=value\nnot an assignment\nUNCLOSED="value'),
+    ).toEqual({
+      entries: [{ key: "VALID", value: "value" }],
+      invalidLineNumbers: [2, 3],
+    });
+  });
+
+  it("does not mistake a plain key for dotenv content", () => {
+    expect(parseDotEnv("API_KEY")).toEqual({
+      entries: [],
+      invalidLineNumbers: [1],
+    });
+  });
+});

--- a/client/dashboard/src/pages/mcp/dotEnvUtils.test.ts
+++ b/client/dashboard/src/pages/mcp/dotEnvUtils.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseDotEnv } from "./dotEnvUtils";
+import { parseDotEnvPaste } from "./dotEnvUtils";
 
-describe("parseDotEnv", () => {
+describe("parseDotEnvPaste", () => {
   it("parses dotenv assignments while ignoring comments and blank lines", () => {
     expect(
-      parseDotEnv(`
+      parseDotEnvPaste(`
 # API credentials
 API_KEY=secret-value
 BASE_URL = https://example.test/path?a=b
@@ -23,7 +23,7 @@ export EMPTY_VALUE=
 
   it("handles quoted values and inline comments", () => {
     expect(
-      parseDotEnv(`
+      parseDotEnvPaste(`
 HASH_VALUE="value # kept"
 SINGLE_QUOTED='also # kept'
 COMMENTED=value # removed
@@ -42,17 +42,21 @@ MULTILINE="first\\nsecond"
 
   it("reports malformed lines without discarding valid assignments", () => {
     expect(
-      parseDotEnv('VALID=value\nnot an assignment\nUNCLOSED="value'),
+      parseDotEnvPaste('VALID=value\nnot an assignment\nUNCLOSED="value'),
     ).toEqual({
       entries: [{ key: "VALID", value: "value" }],
       invalidLineNumbers: [2, 3],
     });
   });
 
-  it("does not mistake a plain key for dotenv content", () => {
-    expect(parseDotEnv("API_KEY")).toEqual({
+  it("reports malformed-only dotenv content", () => {
+    expect(parseDotEnvPaste('not an assignment\nUNCLOSED="value')).toEqual({
       entries: [],
-      invalidLineNumbers: [1],
+      invalidLineNumbers: [1, 2],
     });
+  });
+
+  it("does not mistake a plain key for dotenv content", () => {
+    expect(parseDotEnvPaste("API_KEY")).toBeNull();
   });
 });

--- a/client/dashboard/src/pages/mcp/dotEnvUtils.ts
+++ b/client/dashboard/src/pages/mcp/dotEnvUtils.ts
@@ -1,0 +1,62 @@
+export interface DotEnvEntry {
+  key: string;
+  value: string;
+}
+
+export interface DotEnvParseResult {
+  entries: DotEnvEntry[];
+  invalidLineNumbers: number[];
+}
+
+const DOT_ENV_ASSIGNMENT =
+  /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_.-]*)\s*=\s*(.*)$/;
+const QUOTED_VALUE = /^(["'])(.*)\1(?:\s*#.*)?$/;
+
+/**
+ * Parses the common, single-line subset of dotenv files used for environment
+ * variable forms. Comments and blank lines are ignored; malformed lines are
+ * reported so callers do not silently drop pasted content.
+ */
+export function parseDotEnv(contents: string): DotEnvParseResult {
+  const entries: DotEnvEntry[] = [];
+  const invalidLineNumbers: number[] = [];
+
+  for (const [index, originalLine] of contents.split(/\r?\n/).entries()) {
+    const line = originalLine.replace(/^\uFEFF/, "").trim();
+    if (line === "" || line.startsWith("#")) continue;
+
+    const assignment = line.match(DOT_ENV_ASSIGNMENT);
+    if (!assignment) {
+      invalidLineNumbers.push(index + 1);
+      continue;
+    }
+
+    const [, key, rawValue] = assignment;
+    const value = parseDotEnvValue(rawValue);
+    if (value === null) {
+      invalidLineNumbers.push(index + 1);
+      continue;
+    }
+
+    entries.push({ key, value });
+  }
+
+  return { entries, invalidLineNumbers };
+}
+
+function parseDotEnvValue(rawValue: string): string | null {
+  const trimmed = rawValue.trim();
+  if (trimmed === "") return "";
+
+  if (trimmed.startsWith('"') || trimmed.startsWith("'")) {
+    const quoted = trimmed.match(QUOTED_VALUE);
+    if (!quoted) return null;
+
+    const [, quote, value] = quoted;
+    return quote === '"'
+      ? value.replaceAll("\\n", "\n").replaceAll("\\r", "\r")
+      : value;
+  }
+
+  return trimmed.replace(/\s+#.*$/, "").trim();
+}

--- a/client/dashboard/src/pages/mcp/dotEnvUtils.ts
+++ b/client/dashboard/src/pages/mcp/dotEnvUtils.ts
@@ -1,9 +1,9 @@
-export interface DotEnvEntry {
+interface DotEnvEntry {
   key: string;
   value: string;
 }
 
-export interface DotEnvParseResult {
+interface DotEnvParseResult {
   entries: DotEnvEntry[];
   invalidLineNumbers: number[];
 }

--- a/client/dashboard/src/pages/mcp/dotEnvUtils.ts
+++ b/client/dashboard/src/pages/mcp/dotEnvUtils.ts
@@ -31,7 +31,13 @@ export function parseDotEnv(contents: string): DotEnvParseResult {
       continue;
     }
 
-    const [, key, rawValue] = assignment;
+    const key = assignment[1];
+    const rawValue = assignment[2];
+    if (key === undefined || rawValue === undefined) {
+      invalidLineNumbers.push(index + 1);
+      continue;
+    }
+
     const value = parseDotEnvValue(rawValue);
     if (value === null) {
       invalidLineNumbers.push(index + 1);
@@ -52,7 +58,10 @@ function parseDotEnvValue(rawValue: string): string | null {
     const quoted = trimmed.match(QUOTED_VALUE);
     if (!quoted) return null;
 
-    const [, quote, value] = quoted;
+    const quote = quoted[1];
+    const value = quoted[2];
+    if (quote === undefined || value === undefined) return null;
+
     return quote === '"'
       ? value.replaceAll("\\n", "\n").replaceAll("\\r", "\r")
       : value;

--- a/client/dashboard/src/pages/mcp/dotEnvUtils.ts
+++ b/client/dashboard/src/pages/mcp/dotEnvUtils.ts
@@ -17,7 +17,17 @@ const QUOTED_VALUE = /^(["'])(.*)\1(?:\s*#.*)?$/;
  * variable forms. Comments and blank lines are ignored; malformed lines are
  * reported so callers do not silently drop pasted content.
  */
-export function parseDotEnv(contents: string): DotEnvParseResult {
+export function parseDotEnvPaste(contents: string): DotEnvParseResult | null {
+  const parsed = parseDotEnv(contents);
+  if (parsed.entries.length > 0) return parsed;
+
+  const looksLikeDotEnv = /[\r\n=]/.test(contents);
+  return parsed.invalidLineNumbers.length > 0 && looksLikeDotEnv
+    ? parsed
+    : null;
+}
+
+function parseDotEnv(contents: string): DotEnvParseResult {
   const entries: DotEnvEntry[] = [];
   const invalidLineNumbers: number[] = [];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- parse dotenv-formatted clipboard content pasted into an MCP environment variable key field
- populate one form row per assignment while keeping imported values secret by default
- block malformed dotenv-only pastes and report their invalid line numbers without inserting raw text
- preserve normal single-key clipboard pastes such as `API_KEY`
- keep parser-only types module-private so the client Knip gate passes
- cover comments, exports, quoted values, malformed-only input, inline comments, and embedded equals signs with unit tests

## Testing
- `pnpm -F dashboard knip`
- `pnpm -F dashboard lint`
- `pnpm -F dashboard test src/pages/mcp/dotEnvUtils.test.ts` (5 focused tests passed)
- manually verified valid dotenv paste creates and saves masked variables
- manually verified malformed dotenv paste keeps the Key empty and reports invalid lines 1 and 2

## Demo
Valid dotenv paste:
<a href="https://cursor.com/agents/bc-a1d741e4-7f14-4a2a-baf6-533121a87842/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_dotenv_paste_demo.mp4"><img src="https://cursor.com/artifacts/c/art-710618e3-d92b-4cbf-9357-ffbe9b59e328" alt="mcp_dotenv_paste_demo.mp4" /></a>

Malformed dotenv rejection:
<a href="https://cursor.com/agents/bc-a1d741e4-7f14-4a2a-baf6-533121a87842/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_invalid_dotenv_paste_review_fix.mp4"><img src="https://cursor.com/artifacts/c/art-26beea67-8129-4d3f-bd10-1252b151a87d" alt="mcp_invalid_dotenv_paste_review_fix.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-262](https://linear.app/speakeasy/issue/AIS-262/bug-copypasting-env-doesnt-work-for-adding-env-variables-to-mcp)

<div><a href="https://cursor.com/agents/bc-a1d741e4-7f14-4a2a-baf6-533121a87842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1d741e4-7f14-4a2a-baf6-533121a87842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable pasting dotenv content into the MCP Add Variable form. Values default to secret, keys are uppercased, malformed lines are reported, and plain key pastes are left alone; also fixes the client `knip` export check (AIS-262).

- **Bug Fixes**
  - Parse `.env` text on paste in the key field; create rows per assignment; default values to secret; uppercase keys.
  - Support `export`, quoted values, inline comments, embedded equals, and escaped newlines; ignore comments and blank lines.
  - Treat paste as dotenv only when it looks like `.env` (e.g., contains “=” or newlines); ignore plain key pastes.
  - Show errors with invalid line numbers while keeping valid entries; stricter validation for unmatched quotes and partial assignments.
  - Add unit tests for the parser; fix client `knip` export check.

<sup>Written for commit cb2906d67a2c147eda2248c4fb4701cc547df33a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

