### PR TITLE
perf(dashboard): serve project homepage metrics from attribute_metrics_summaries

### DIFF
--- a/.changeset/homepage-attribute-metrics-summaries.md
+++ b/.changeset/homepage-attribute-metrics-summaries.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Serve the project homepage's hook/agent-view metrics (Total Spend, Sessions, Top Users, Most Agent Sessions by User, Most Used Agents) from the pre-aggregated `attribute_metrics_summaries` table via `telemetry.query` instead of paginating every user through `telemetry.searchUsers` (which scanned raw `telemetry_logs`). This is the same source the Costs page uses, so the homepage and Costs figures now agree. The MCP-hosting fallback view is unchanged.

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -5,13 +5,18 @@ import { Page } from "@/components/page-layout";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { DashboardCard } from "@/components/ui/dashboard-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useProject } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
 import { useOrgRoutes, useRoutes } from "@/routes";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useAuditLogs } from "@gram/client/react-query/auditLogs.js";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import { telemetryQuery } from "@gram/client/funcs/telemetryQuery";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+import { GroupBy } from "@gram/client/models/components/querypayload.js";
+import type { QueryMeasures } from "@gram/client/models/components/querymeasures.js";
 import type { SearchUsersFilter } from "@gram/client/models/components/searchusersfilter.js";
 import type { UserSummary } from "@gram/client/models/components/usersummary.js";
 import { unwrapAsync } from "@gram/client/types/fp";
@@ -36,6 +41,8 @@ import { buildProjectOverviewQuery } from "./projectOverviewQuery";
 
 export function ProjectDashboard(): JSX.Element {
   const { orgSlug, projectSlug } = useSlugs();
+  const project = useProject();
+  const projectId = project.id;
   const routes = useRoutes();
   const orgRoutes = useOrgRoutes();
 
@@ -90,109 +97,167 @@ export function ProjectDashboard(): JSX.Element {
 
   const { data: membersData, isPending: isMembersPending } = useMembers();
   const members = useMemo(() => membersData?.members ?? [], [membersData]);
-  const memberById = useMemo(
-    () => new Map(members.map((m) => [m.id, m])),
+  const memberByEmail = useMemo(
+    () => new Map(members.map((m) => [m.email, m])),
     [members],
   );
 
-  const { data: topUsersSearchData, isPending: isTopUsersPending } = useQuery({
-    queryKey: ["project", "topUsers", from.toISOString(), to.toISOString()],
-    queryFn: () =>
-      fetchAllUsers(client, { from, to, eventSource: "hook" }, "internal"),
-    enabled: logsEnabled,
-    placeholderData: keepPreviousData,
-  });
+  // Hook/agent-view metrics read the pre-aggregated attribute_metrics_summaries
+  // table through the org-scoped telemetry.query endpoint, filtered to this
+  // project (project_id is an allowlisted dimension) — the same source as the
+  // Costs page, so the numbers agree. This replaces paginating every user
+  // through telemetry.searchUsers, which scanned raw telemetry_logs. The
+  // generated useTelemetryQuery hook keys its cache on gramSession only
+  // (ignores the body), so drive useQuery directly. throwOnError is off so a
+  // member without org:read degrades to the MCP view instead of crashing the
+  // page on the app-wide error boundary.
+  const projectFilter = useMemo(
+    () => [{ dimension: Dimension.ProjectId, values: [projectId] }],
+    [projectId],
+  );
 
-  // Mode detection: a project that only hosts MCP servers produces no hook
-  // telemetry, so the hook-filtered fetch above is empty. Once it has loaded we
-  // know which view to render — prefer the hook/agent view whenever any hook
-  // data exists, else fall back to the MCP-hosting view.
-  const hookDataLoaded = topUsersSearchData !== undefined;
-  const hasHookData = (topUsersSearchData?.length ?? 0) > 0;
+  const {
+    data: usageByUserData,
+    isPending: isUsageByUserPending,
+    isError: isUsageByUserError,
+  } = useQuery({
+    queryKey: [
+      "project",
+      "usageByUser",
+      projectId,
+      from.toISOString(),
+      to.toISOString(),
+    ],
+    queryFn: () =>
+      unwrapAsync(
+        telemetryQuery(client, {
+          queryPayload: {
+            from,
+            to,
+            groupBy: GroupBy.Email,
+            sortBy: "total_tokens",
+            topN: 100,
+            filters: projectFilter,
+          },
+        }),
+      ),
+    enabled: logsEnabled && !!projectId,
+    placeholderData: keepPreviousData,
+    throwOnError: false,
+  });
+  const usageByUserRows = usageByUserData?.table;
+
+  // Mode detection: attribute_metrics_summaries only admits agent-surface
+  // telemetry (Claude/Codex/Cursor), so any row with usage means the project
+  // has hook data. A project that only hosts MCP servers produces none, and
+  // falls back to the MCP-hosting view.
+  const hookDataLoaded = usageByUserRows !== undefined || isUsageByUserError;
+  const hasHookData = (usageByUserRows ?? []).some((r) => hasUsage(r.measures));
+
+  // Per-user rows suitable for ranking: drop the unattributed '' bucket and
+  // the synthetic "Other" rollup. Both still count toward the totals below.
+  const rankableUserRows = useMemo(
+    () =>
+      (usageByUserRows ?? []).filter(
+        (r) => r.groupValue !== "" && r.groupValue !== "Other",
+      ),
+    [usageByUserRows],
+  );
 
   const topUsersByTokens = useMemo(() => {
-    if (!topUsersSearchData) return [];
-    return [...topUsersSearchData]
-      .sort(
-        (a, b) =>
-          b.totalInputTokens +
-          b.totalOutputTokens -
-          (a.totalInputTokens + a.totalOutputTokens),
-      )
+    return [...rankableUserRows]
+      .sort((a, b) => b.measures.totalTokens - a.measures.totalTokens)
       .slice(0, 5)
-      .map((u) => ({
-        key: u.userId,
-        label: memberById.get(u.userId)?.name ?? u.userId,
-        value: u.totalInputTokens + u.totalOutputTokens,
+      .filter((r) => r.measures.totalTokens > 0)
+      .map((r) => ({
+        key: r.groupValue,
+        label: memberByEmail.get(r.groupValue)?.name ?? r.groupValue,
+        value: r.measures.totalTokens,
       }));
-  }, [topUsersSearchData, memberById]);
+  }, [rankableUserRows, memberByEmail]);
 
-  // Most Agent Sessions by User reads from the same trusted telemetrySearchUsers
-  // data as Top Users (rather than overview.summary.topUsers), ranking by the
-  // number of distinct agent sessions (totalChats = unique gen_ai.conversation.id,
-  // which every hook source stamps with its session id). Names resolve via the
-  // shared memberById map; internal users only, so raw auth IDs no longer leak.
+  // Most Agent Sessions by User ranks the same per-email rows by distinct
+  // agent sessions (total_chats = unique gen_ai.conversation.id). Names
+  // resolve via the members list; group keys are emails, so raw auth IDs
+  // never surface.
   const topUsersBySessions = useMemo(() => {
-    if (!topUsersSearchData) return [];
-    return [...topUsersSearchData]
-      .filter((u) => u.totalChats > 0)
-      .sort((a, b) => b.totalChats - a.totalChats)
+    return [...rankableUserRows]
+      .filter((r) => r.measures.totalChats > 0)
+      .sort((a, b) => b.measures.totalChats - a.measures.totalChats)
       .slice(0, 5)
-      .map((u) => {
-        const member = memberById.get(u.userId);
+      .map((r) => {
+        const member = memberByEmail.get(r.groupValue);
         return {
-          userId: u.userId,
-          name: member?.name ?? u.userId,
-          initialsSource: member?.email ?? member?.name ?? u.userId,
-          sessions: u.totalChats,
+          userId: r.groupValue,
+          name: member?.name ?? r.groupValue,
+          initialsSource: r.groupValue,
+          sessions: r.measures.totalChats,
         };
       });
-  }, [topUsersSearchData, memberById]);
+  }, [rankableUserRows, memberByEmail]);
 
-  // Total agent sessions = sum of per-user distinct hook sessions (totalChats).
-  // Each session id (gen_ai.conversation.id) belongs to a single user, so summing
-  // per-user counts gives the project-wide distinct-session total.
-  const totalSessions = (topUsersSearchData ?? []).reduce(
-    (sum, u) => sum + u.totalChats,
+  // Total agent sessions = sum of per-user distinct sessions. Each session id
+  // (gen_ai.conversation.id) belongs to a single user, so summing per-user
+  // counts gives the project-wide distinct-session total. Includes the
+  // unattributed '' bucket and the "Other" rollup.
+  const totalSessions = (usageByUserRows ?? []).reduce(
+    (sum, r) => sum + r.measures.totalChats,
     0,
   );
 
-  // Most Used Agents: aggregate per-user hook-source breakdowns (hookSources)
-  // across all users, ranking agents (claude-code, cursor, ...) by total events.
-  // Replaces overview.summary.llmClientBreakdown, whose tool-call-only count
-  // reads 0 for hook events (they carry no `tools:` URN).
+  // Total Spend sums per-user cost across every row (including '' and
+  // "Other"), matching the Costs page's figure for this project since both
+  // read the same aggregate.
+  const totalSpend = (usageByUserRows ?? []).reduce(
+    (sum, r) => sum + r.measures.totalCost,
+    0,
+  );
+
+  // Most Used Agents: one grouped-by-hook_source read, ranked by token volume.
+  // Only fetched in the hook/agent view.
+  const { data: usageByAgentData, isPending: isUsageByAgentPending } = useQuery(
+    {
+      queryKey: [
+        "project",
+        "usageByAgent",
+        projectId,
+        from.toISOString(),
+        to.toISOString(),
+      ],
+      queryFn: () =>
+        unwrapAsync(
+          telemetryQuery(client, {
+            queryPayload: {
+              from,
+              to,
+              groupBy: GroupBy.HookSource,
+              sortBy: "total_tokens",
+              topN: 10,
+              filters: projectFilter,
+            },
+          }),
+        ),
+      enabled: logsEnabled && !!projectId && hasHookData,
+      placeholderData: keepPreviousData,
+      throwOnError: false,
+    },
+  );
+
   const mostUsedAgents = useMemo(() => {
-    const bySource = new Map<string, number>();
-    for (const u of topUsersSearchData ?? []) {
-      for (const h of u.hookSources) {
-        bySource.set(h.source, (bySource.get(h.source) ?? 0) + h.eventCount);
-      }
-    }
-    return [...bySource.entries()]
-      .sort((a, b) => b[1] - a[1])
+    return (usageByAgentData?.table ?? [])
+      .filter(
+        (r) =>
+          r.groupValue !== "" &&
+          r.groupValue !== "Other" &&
+          r.measures.totalTokens > 0,
+      )
       .slice(0, 5)
-      .map(([source, eventCount]) => ({
-        key: source,
-        label: source,
-        value: eventCount,
+      .map((r) => ({
+        key: r.groupValue,
+        label: r.groupValue,
+        value: r.measures.totalTokens,
       }));
-  }, [topUsersSearchData]);
-
-  // Total Spend mirrors the Employees ("cost") page exactly: internal users,
-  // all event sources (no eventSource filter), summing per-user totalCost — so
-  // this card shows the same figure as that page.
-  const { data: allUsersSpendData, isPending: isSpendPending } = useQuery({
-    queryKey: ["project", "totalSpend", from.toISOString(), to.toISOString()],
-    queryFn: () => fetchAllUsers(client, { from, to }, "internal"),
-    // Spend is only shown in the hook/agent view.
-    enabled: logsEnabled && hasHookData,
-    placeholderData: keepPreviousData,
-  });
-
-  const totalSpend = (allUsersSpendData ?? []).reduce(
-    (sum, u) => sum + u.totalCost,
-    0,
-  );
+  }, [usageByAgentData]);
 
   // MCP-hosting fallback: external end-users (customer-supplied IDs) and their
   // tool-call activity. Fetched only when the project has no hook data. No
@@ -280,12 +345,14 @@ export function ProjectDashboard(): JSX.Element {
   const endUsersCount = externalUsersData?.length ?? 0;
 
   const isTopUsersLoading =
-    logsEnabled && (isTopUsersPending || isMembersPending);
+    logsEnabled &&
+    ((isUsageByUserPending && !isUsageByUserError) || isMembersPending);
 
-  // Mode is unknown until the hook fetch + members settle.
+  // Mode is unknown until the per-user usage fetch + members settle.
   const modePending = isTopUsersLoading;
-  // Spend (hook view) / external users (MCP view) still loading after mode known.
-  const isSpendLoading = hasHookData && (isSpendPending || !allUsersSpendData);
+  // Agent breakdown (hook view) / external users (MCP view) still loading
+  // after mode is known.
+  const isAgentsLoading = hasHookData && isUsageByAgentPending;
   const mcpUsersPending = !hasHookData && externalUsersData === undefined;
 
   const featuresSettled = !isFeaturesPending || isFeaturesError;
@@ -416,8 +483,7 @@ export function ProjectDashboard(): JSX.Element {
                     tooltip="Total tool invocations recorded across all servers and sources in the selected period."
                   />
                 )}
-                {modePending ||
-                (hasHookData ? isSpendLoading : mcpUsersPending) ? (
+                {modePending || (!hasHookData && mcpUsersPending) ? (
                   <Skeleton className="h-[100px] rounded-lg" />
                 ) : hasHookData ? (
                   <MetricCard
@@ -425,7 +491,7 @@ export function ProjectDashboard(): JSX.Element {
                     value={totalSpend}
                     format="currency"
                     icon="dollar-sign"
-                    tooltip="Total LLM spend by project members in the selected period, summed from per-user cost. Matches the figure on the Employees page."
+                    tooltip="Total LLM spend recorded for this project in the selected period. Matches the figure on the Costs page."
                   />
                 ) : (
                   <MetricCard
@@ -461,7 +527,7 @@ export function ProjectDashboard(): JSX.Element {
                   title={hasHookData ? "Top Users" : "Top End Users"}
                   tooltip={
                     hasHookData
-                      ? "Employees ranked by total token consumption (input + output tokens) in the selected period."
+                      ? "Employees ranked by total token consumption in the selected period."
                       : "External end users ranked by MCP tool calls in the selected period."
                   }
                   action={
@@ -614,7 +680,7 @@ export function ProjectDashboard(): JSX.Element {
 
                     <DashboardCard
                       title="Most Used Agents"
-                      tooltip="Agents (e.g. Claude, Cursor, Codex) ranked by activity volume in the selected period, identified from client metadata sent with each call."
+                      tooltip="Agents (e.g. Claude, Cursor, Codex) ranked by token volume in the selected period, identified from client metadata sent with each call."
                       action={
                         <CardActions>
                           <ExploreWithAIButton
@@ -635,7 +701,7 @@ export function ProjectDashboard(): JSX.Element {
                         </CardActions>
                       }
                     >
-                      {isTopUsersLoading ? (
+                      {modePending || isAgentsLoading ? (
                         <SkeletonList />
                       ) : mostUsedAgents.length === 0 ? (
                         <EmptyState message="No agent activity recorded" />
@@ -781,8 +847,22 @@ function avatarColor(index: number): string {
   return AVATAR_COLORS[index % AVATAR_COLORS.length]!;
 }
 
+// A row "has usage" when any measure is nonzero — used to detect whether the
+// project has agent (hook) telemetry at all, since attribute_metrics_summaries
+// only admits agent-surface rows.
+function hasUsage(m: QueryMeasures): boolean {
+  return (
+    m.totalTokens > 0 ||
+    m.totalCost > 0 ||
+    m.totalChats > 0 ||
+    m.totalToolCalls > 0
+  );
+}
+
 // Fetch every page of telemetrySearchUsers for the given filter, following the
-// pagination cursor. Shared by the overview's hook / spend / external queries.
+// pagination cursor. Used by the MCP-hosting fallback view's external-user
+// query only — the hook/agent view reads pre-aggregated data via
+// telemetry.query instead.
 async function fetchAllUsers(
   client: Parameters<typeof telemetrySearchUsers>[0],
   filter: SearchUsersFilter,


### PR DESCRIPTION
## Summary

- The project homepage's hook/agent-view cards — **Total Spend**, **Sessions**, **Top Users**, **Most Agent Sessions by User**, and **Most Used Agents** — previously paginated every user through `telemetry.searchUsers`, which scans raw `telemetry_logs` (with per-row JSON attribute extraction) up to twice per page load.
- They now read the pre-aggregated `attribute_metrics_summaries` table via `telemetry.query`, filtered to the current project through the `project_id` dimension. This is the **same source the Costs page uses**, so the homepage and Costs figures now agree (verified locally: both show $10.03 for the same 7-day window on the seeded `ecommerce-api` project).
- **Most Used Agents** is now ranked by token volume (grouped by `hook_source`) instead of raw hook-event counts; tooltip updated to match. The **Total Spend** tooltip now references the Costs page rather than the Employees page.
- Mode detection (hook/agent view vs. MCP-hosting view) derives from whether the per-user query returns rows with usage. Since `telemetry.query` is org-scoped, its query opts out of the error boundary — a member without `org:read` degrades to the MCP view instead of crashing the page.

### Out of scope (intentionally unchanged)
- The **MCP-hosting fallback view** (End Users, Most Used Tools, Top Tools by Failure Rate) keeps its `telemetrySearchUsers` path: `attribute_metrics_summaries_mv` deliberately excludes external-user MCP tool-call telemetry (provenance-first admission), and per-tool URN breakdowns aren't a dimension.
- The `getProjectOverview`-backed KPIs (Active Servers, Tool Calls, Failed Tool Calls) and Top Servers are unchanged.

### Behavioral note
Users whose telemetry rows carry no directory email now roll into the unattributed (`''`) bucket — counted in the Total Spend / Sessions totals, hidden from the top-5 lists — whereas `searchUsers` had a self-join that could recover them by user id. This matches how the Costs page already behaves.

## Test plan

- [x] `pnpm -F dashboard type-check`
- [x] `pnpm -F dashboard lint`
- [x] Local stack + seed: `ecommerce-api` renders the hook/agent view with real per-email token/session/spend numbers; Total Spend matches the Costs page for the same range
- [x] A project with no agent telemetry (`default`) still falls back to the MCP-hosting view
- [x] No console errors from the new queries

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serves project homepage metrics from the pre-aggregated `attribute_metrics_summaries` via `telemetry.query`, replacing raw log scans. This speeds up the dashboard and makes totals match the Costs page.

- **Refactors**
  - Switched homepage hook/agent metrics to `telemetry.query` over `attribute_metrics_summaries`, filtered by `project_id`; removed `telemetry.searchUsers` pagination.
  - Updated cards: Total Spend, Sessions, Top Users, Most Agent Sessions by User, and Most Used Agents now use the aggregate; Total Spend matches the Costs page.
  - Most Used Agents now ranks by token volume grouped by `hook_source`; tooltips updated.
  - Mode detection checks for any usage rows; without `org:read`, the page falls back to the MCP view instead of erroring.
  - Unattributed (`''`) and "Other" buckets are hidden from top lists but included in totals; MCP-hosting fallback stays on `telemetry.searchUsers`.

- **Dependencies**
  - Added changeset for `dashboard` patch.

<sup>Written for commit 0b1b3449b8d1cc8ec31b2930016ed9a65379ccd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

