### PR TITLE
feat: label unset user cost bucket as "Team-wide account"

### DIFF
--- a/.changeset/team-wide-account-label.md
+++ b/.changeset/team-wide-account-label.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Label the empty user bucket on cost breakdowns as "Team-wide account" instead of "(unset)". Claude Code sessions authenticated with a company API key or gateway emit no user identity, so their pooled spend is the shared team account's usage, not a data gap. The label applies everywhere the user dimension renders — the cost table, the Top spenders widget (which now includes the bucket instead of hiding it), the drill-in profile, breadcrumbs, and the billing token-usage breakdown — while other dimensions keep "(unset)".

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -3559,13 +3559,26 @@ async function seedObservabilityData(init: {
         BigInt(dayStartMs + Math.floor((8 + r() * 10) * 3_600_000)) *
         BigInt(1_000_000);
 
+      // A slice of sessions comes from devices without an enrolled identity
+      // (no user.email / directory attributes — only the consuming surface):
+      // the company-credential population, since Claude Code on an API
+      // key/gateway emits no user identity (POC-282). Heavier than an
+      // attributed session on average so the pooled bucket — rendered as
+      // "Team-wide account" on the user breakdown, and feeding the "tokens
+      // without user attribution" metric — ranks among the top spenders,
+      // mirroring how a gateway-authenticated org looks in production.
+      const anonymous = r() < 0.12;
+      const anonBoost = anonymous ? 4 : 1;
+
       // Cache-heavy token mix (agent sessions replay large cached prompts);
       // ~15% are light API-style calls with little cache traffic.
       const cacheDiv = r() < 0.15 ? 10 : 1;
-      const inputTokens = 800 + Math.floor(r() * 7_000);
-      const outputTokens = 300 + Math.floor(r() * 3_500);
-      const cacheReadTokens = Math.floor((8_000 + r() * 80_000) / cacheDiv);
-      const cacheCreationTokens = Math.floor((1_500 + r() * 18_000) / cacheDiv);
+      const inputTokens = (800 + Math.floor(r() * 7_000)) * anonBoost;
+      const outputTokens = (300 + Math.floor(r() * 3_500)) * anonBoost;
+      const cacheReadTokens =
+        Math.floor((8_000 + r() * 80_000) / cacheDiv) * anonBoost;
+      const cacheCreationTokens =
+        Math.floor((1_500 + r() * 18_000) / cacheDiv) * anonBoost;
       const totalTokens =
         inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
       const [pIn, pOut, pRead, pWrite] = HISTORY_PRICING[model] ?? [
@@ -3579,10 +3592,6 @@ async function seedObservabilityData(init: {
         1_000_000
       ).toFixed(6);
 
-      // A small slice of sessions comes from devices without an enrolled
-      // identity (no user.email / directory attributes — only the consuming
-      // surface), populating the "tokens without user attribution" metric.
-      const anonymous = r() < 0.06;
       const uaFrag = anonymous
         ? `"gram.hook.source": "${hookSource}"`
         : userAttrsJSONFragment(userIndex, hookSource);

--- a/client/dashboard/src/components/billing/breakdown-options.ts
+++ b/client/dashboard/src/components/billing/breakdown-options.ts
@@ -1,3 +1,4 @@
+import { unsetLabel } from "@/components/observe/account-display-utils";
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
 import {
   BadgeCheck,
@@ -133,14 +134,15 @@ export function breakdownLabel(value: string): string {
 }
 
 // Display label for one breakdown row value: "" is observed traffic that
-// lacks the attribute, and project_id values are UUIDs mapped to project
-// names (a deleted project falls back to its raw id).
+// lacks the attribute ("(unset)", or "Team-wide account" on the user
+// dimension — see unsetLabel), and project_id values are UUIDs mapped to
+// project names (a deleted project falls back to its raw id).
 export function breakdownValueLabel(
   dimension: string,
   value: string,
   projectNames: Map<string, string>,
 ): string {
-  if (value === "") return "(unset)";
+  if (value === "") return unsetLabel(dimension as Dimension);
   if (dimension === Dimension.ProjectId) {
     return projectNames.get(value) ?? value;
   }

--- a/client/dashboard/src/components/observe/account-display-utils.ts
+++ b/client/dashboard/src/components/observe/account-display-utils.ts
@@ -3,6 +3,8 @@
 // "only-export-components" rule) and these can be shared with non-component
 // modules like the cost taxonomy.
 
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+
 // A single linked AI account in display shape. Identity is (provider, email):
 // the same email on two providers is two distinct accounts, so provider is
 // always shown alongside the email.
@@ -26,6 +28,18 @@ export function providerLabel(provider: string): string {
   const known = PROVIDER_LABELS[provider.toLowerCase()];
   if (known) return known;
   return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+// Label for a breakdown dimension's empty-value bucket. For the user (email)
+// dimension the pooled empty bucket IS the company credential's usage — Claude
+// Code authenticated with an API key/gateway emits no user identity at all, so
+// this spend belongs to the shared team account rather than any individual —
+// and it gets a real name (POC-282). Other dimensions keep the neutral
+// "(unset)": their empty buckets mix identity-less traffic with attributed
+// users who merely lack the attribute (e.g. no department in the directory),
+// so no single semantic label is honest there.
+export function unsetLabel(dim: Dimension): string {
+  return dim === Dimension.Email ? "Team-wide account" : "(unset)";
 }
 
 // The email to display for a session produced by a personal AI account (e.g. a

--- a/client/dashboard/src/pages/costs/CostTable.tsx
+++ b/client/dashboard/src/pages/costs/CostTable.tsx
@@ -24,7 +24,7 @@ import {
   ESTIMATED_COST_TOOLTIP,
   isMeteredBilling,
 } from "@/components/estimated-cost-utils";
-import { isAttributionDim } from "./taxonomy";
+import { isAttributionDim, unsetLabel } from "./taxonomy";
 
 function formatCost(value: number): string {
   return `$${value.toLocaleString(undefined, {
@@ -102,8 +102,8 @@ const GREEN = "#10b981";
 const RED = "#f43f5e";
 const GREY = "#94a3b8";
 
-function displayValue(groupValue: string): string {
-  return groupValue === "" ? "(unset)" : groupValue;
+function displayValue(groupBy: Dimension, groupValue: string): string {
+  return groupValue === "" ? unsetLabel(groupBy) : groupValue;
 }
 
 // "" is the "(unset)" bucket — a real slice (everyone missing this attribute),
@@ -158,11 +158,12 @@ type Sort = { key: SortKey; dir: SortDir };
 function sortValue(
   row: QueryRow,
   key: SortKey,
+  groupBy: Dimension,
   seriesByGroup: Map<string, number[]>,
 ): number | string {
   switch (key) {
     case "name":
-      return displayValue(row.groupValue).toLowerCase();
+      return displayValue(groupBy, row.groupValue).toLowerCase();
     case "cost":
     // Share is cost ÷ a constant total, so it sorts identically to cost.
     case "share":
@@ -259,8 +260,8 @@ export function CostTable({
     const main = rows.filter((r) => r.groupValue !== "Other");
     const other = rows.filter((r) => r.groupValue === "Other");
     main.sort((a, b) => {
-      const av = sortValue(a, sort.key, seriesByGroup);
-      const bv = sortValue(b, sort.key, seriesByGroup);
+      const av = sortValue(a, sort.key, groupBy, seriesByGroup);
+      const bv = sortValue(b, sort.key, groupBy, seriesByGroup);
       const cmp =
         typeof av === "string"
           ? av.localeCompare(bv as string)
@@ -268,7 +269,7 @@ export function CostTable({
       return sort.dir === "asc" ? cmp : -cmp;
     });
     return [...main, ...other];
-  }, [rows, sort, seriesByGroup]);
+  }, [rows, sort, groupBy, seriesByGroup]);
 
   if (isLoading) return <SkeletonTable />;
 
@@ -448,7 +449,7 @@ export function CostTable({
                   />
                 )}
                 <span className="truncate font-medium">
-                  {displayValue(row.groupValue)}
+                  {displayValue(groupBy, row.groupValue)}
                 </span>
                 {drillable && (
                   <ChevronRight className="text-muted-foreground size-4 shrink-0" />

--- a/client/dashboard/src/pages/costs/CostWidgets.tsx
+++ b/client/dashboard/src/pages/costs/CostWidgets.tsx
@@ -1,5 +1,5 @@
 import type { Dimension } from "@gram/client/models/components/queryfilter.js";
-import type { Measures } from "./taxonomy";
+import { type Measures, unsetLabel } from "./taxonomy";
 import { Sparkline } from "./Sparkline";
 import { movingAverage, resample, smoothPath } from "./sparkline-math";
 import { EstimatedCostIndicator } from "@/components/estimated-cost";
@@ -327,7 +327,7 @@ function MixCard({
             return (
               <MixRowItem
                 key={r.label}
-                label={r.label}
+                label={r.label === "" ? unsetLabel(dim) : r.label}
                 cost={r.cost}
                 barPct={(r.cost / max) * 100}
                 barColor={gradeColor(t)}

--- a/client/dashboard/src/pages/costs/CostsExplorer.tsx
+++ b/client/dashboard/src/pages/costs/CostsExplorer.tsx
@@ -716,11 +716,14 @@ export function CostsExplorer(): JSX.Element {
     const out: CardSpec[] = [];
     // Mix cards are compact "spend by X" rankings, so drop the "" bucket
     // entirely — an "(unset)" row is noise here (e.g. the $0 tool-row model
-    // bucket). The full breakdown table still surfaces it for non-attribution
-    // dims where "unset" is a real, drillable slice.
-    const toRows = (t: QueryRow[]) =>
+    // bucket). The user dimension is the exception: its "" bucket is the
+    // Team-wide account (company-credential sessions carry no user identity),
+    // a real ranked spender the card must show. The full breakdown table
+    // still surfaces "" for non-attribution dims where it is a real,
+    // drillable slice.
+    const toRows = (t: QueryRow[], dim: Dimension) =>
       t
-        .filter((r) => r.groupValue !== "")
+        .filter((r) => r.groupValue !== "" || dim === Dimension.Email)
         .map((r) => ({ label: r.groupValue, cost: r.measures.totalCost ?? 0 }));
     const cardTitle = (dim: Dimension) =>
       dim === Dimension.Email
@@ -742,7 +745,7 @@ export function CostsExplorer(): JSX.Element {
         title: "Top spenders",
         dim: Dimension.Email,
         drillable: drillableDim(Dimension.Email),
-        rows: toRows(userRows),
+        rows: toRows(userRows, Dimension.Email),
         loading: loadingSlice,
       });
     }
@@ -752,7 +755,7 @@ export function CostsExplorer(): JSX.Element {
         title: cardTitle(mixDimA),
         dim: mixDimA,
         drillable: drillableDim(mixDimA),
-        rows: toRows(mixDataA?.table ?? []),
+        rows: toRows(mixDataA?.table ?? [], mixDimA),
         loading: mixLoadingA,
       });
     }
@@ -762,7 +765,7 @@ export function CostsExplorer(): JSX.Element {
         title: cardTitle(mixDimB),
         dim: mixDimB,
         drillable: drillableDim(mixDimB),
-        rows: toRows(mixDataB?.table ?? []),
+        rows: toRows(mixDataB?.table ?? [], mixDimB),
         loading: mixLoadingB,
       });
     }

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -25,6 +25,7 @@ import {
   LABELS,
   type Measures,
   pluralLabel,
+  unsetLabel,
 } from "./taxonomy";
 
 // ── Formatting helpers ──────────────────────────────────────────────────────
@@ -36,8 +37,8 @@ function formatCost(value: number): string {
   })}`;
 }
 
-function displayValue(groupValue: string): string {
-  return groupValue === "" ? "(unset)" : groupValue;
+function displayValue(dim: Dimension, groupValue: string): string {
+  return groupValue === "" ? unsetLabel(dim) : groupValue;
 }
 
 // ── CSV export ──────────────────────────────────────────────────────────────
@@ -65,7 +66,7 @@ function buildCostCsv(
     const cost = r.measures.totalCost ?? 0;
     const chats = r.measures.totalChats ?? 0;
     return [
-      displayValue(r.groupValue),
+      displayValue(groupBy, r.groupValue),
       cost.toFixed(2),
       total > 0 ? ((cost / total) * 100).toFixed(1) : "0.0",
       chats > 0 ? (cost / chats).toFixed(2) : "0.00",
@@ -295,6 +296,15 @@ export function EntityProfile({
     groupCount: isError ? 0 : rows.length,
   });
 
+  // The "Back to …" label names the immediate parent with its own dimension's
+  // labeling (the parent crumb is second-to-last on the path; the last crumb is
+  // the entity in view), falling back to the project at the root.
+  const parentDim = path[path.length - 2]?.dim;
+  const backLabel =
+    parentValue !== null && parentDim !== undefined
+      ? displayValue(parentDim, parentValue)
+      : projectName || "All costs";
+
   // Whichever table is on screen owns the export: the dimension rows by default,
   // the override's rows (sessions) when it has supplied a builder. The control
   // renders either way and only disables on an empty table, so switching the
@@ -393,9 +403,7 @@ export function EntityProfile({
               <span className="max-w-[220px] truncate">
                 Back to{" "}
                 <span className="text-foreground font-semibold">
-                  {parentValue
-                    ? displayValue(parentValue)
-                    : projectName || "All costs"}
+                  {backLabel}
                 </span>
               </span>
             </button>

--- a/client/dashboard/src/pages/costs/breakdownCopy.test.ts
+++ b/client/dashboard/src/pages/costs/breakdownCopy.test.ts
@@ -72,6 +72,15 @@ describe("scopePhrase", () => {
       "(unset)'s spend",
     );
   });
+
+  // The empty user bucket is the company credential's spend (Claude Code on an
+  // API key/gateway emits no user identity), so it reads as the shared team
+  // account rather than "(unset)".
+  it("names the unset user bucket the team-wide account", () => {
+    expect(scopePhrase([at(Dimension.Email, "")], "spend")).toBe(
+      "Team-wide account's spend",
+    );
+  });
 });
 
 // ── Title + caption, per breakdown axis ─────────────────────────────────────

--- a/client/dashboard/src/pages/costs/taxonomy.ts
+++ b/client/dashboard/src/pages/costs/taxonomy.ts
@@ -1,5 +1,10 @@
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
-import { providerLabel } from "@/components/observe/account-display-utils";
+import {
+  providerLabel,
+  unsetLabel,
+} from "@/components/observe/account-display-utils";
+
+export { unsetLabel };
 
 // Shared cost-taxonomy config + helpers, used by both the CostsExplorer
 // controller and the EntityProfile view. Kept in a non-component module so the
@@ -402,7 +407,7 @@ export function datasetDefaultGroupBy(
 // title-cased form belongs to the hero, which pairs it with the address anyway
 // (see prettyName in EntityProfile).
 export function displayName(dim: Dimension, value: string): string {
-  if (value === "") return "(unset)";
+  if (value === "") return unsetLabel(dim);
   if (dim === Dimension.Provider) return providerLabel(value);
   if (dim === Dimension.AccountType) {
     return value.charAt(0).toUpperCase() + value.slice(1);


### PR DESCRIPTION
## What

Renames the empty-user bucket on cost breakdowns from "(unset)" to **"Team-wide account"** — on the user dimension only. All other dimensions keep "(unset)".

## Why

Claude Code sessions authenticated with a company API key or gateway emit no user identity at all (per Claude's monitoring docs, only a random installation `user.id` and `session.id` are populated — no `user.email`, no `account_uuid`). All of that spend pools into one empty-email bucket, which rendered as "(unset)" and looked like a data bug — often as the org's single biggest "user". It is actually the shared company credential's usage, so it now says so. Context and root-cause investigation: POC-282.

Other dimensions are deliberately unchanged: their empty buckets mix identity-less traffic with attributed users who merely lack the attribute (e.g. no department in the directory), so no single semantic label would be honest there.

## Changes

- `unsetLabel(dim)` in `account-display-utils` is the single source of the label; the cost taxonomy re-exports it.
- Applied on every surface the user dimension renders: the breakdown table, the drill-in profile (hero, breadcrumb, "Back to …" control, CSV export), prose captions ("Team-wide account's spend"), and the billing token-usage breakdown.
- The **Top spenders** widget previously dropped the "" bucket as noise; for the user dimension it now includes it — hiding the literal top spender there while the table shows it was misleading.
- Seed: the identity-less session slice is bigger and cost-heavier so the bucket ranks as a top spender locally, mirroring how a gateway-authenticated org looks in production.
- Test: `scopePhrase` case for the new label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the empty user bucket on cost breakdowns to "Team-wide account" to reflect shared company-credential usage. This clarifies the top spenders view and addresses POC-282 where "(unset)" appeared as the highest "user".

- **Bug Fixes**
  - Centralized empty-bucket labeling with a single helper; other dimensions still show "(unset)".
  - Applied across all user-dimension surfaces: cost table, drill-in profile (hero, breadcrumb, Back to), CSV export, and billing token-usage.
  - Top spenders now includes the empty user bucket for the user dimension; non-user dimensions still filter it out.
  - Seed data updated so identity-less sessions are heavier and rank locally; added a test for "Team-wide account's spend".

<sup>Written for commit 38160ce908364e9ccc8668094bc0cb474b61671b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

