### PR TITLE
feat(chat): add platform changelog suggestion to chat landing and slash commands

### DIFF
--- a/.changeset/changelog-chat-suggestion.md
+++ b/.changeset/changelog-chat-suggestion.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a "What's shipped this week on the platform?" suggestion to the chat landing page and the project assistant's slash-command menu. Picking it starts a session that asks the assistant to check the changelog for the week's platform releases.

--- a/client/dashboard/src/lib/insights-suggestions.ts
+++ b/client/dashboard/src/lib/insights-suggestions.ts
@@ -141,11 +141,17 @@ export const CHAT_LANDING_SUGGESTIONS: InsightsSuggestion[] = [
     prompt:
       "Which tools have the worst p95 latency, and which ones have regressed the most this week compared to last? Flag anything that looks like it's degrading.",
   },
+  {
+    title: "What's shipped this week on the platform?",
+    label: "Platform changelog",
+    icon: "rocket",
+    prompt: "What's shipped this week on the platform? Check the changelog.",
+  },
 ];
 
 /**
  * The full command palette shown when the user types `/` in the "Ask anything"
- * composer. A superset of the landing chips — the seven headline prompts plus a
+ * composer. A superset of the landing chips — the headline prompts plus a
  * deeper bench — so the slash menu speaks the same vocabulary as the chips while
  * surfacing the long tail of questions the assistant can answer.
  */


### PR DESCRIPTION
## Summary

Adds a **"What's shipped this week on the platform?"** suggestion to the project assistant, on both surfaces that read from `insights-suggestions.ts`:

- **/chat landing page** — new chip in `CHAT_LANDING_SUGGESTIONS` (rocket icon, "Platform changelog" label)
- **Slash-command menu** — appears automatically in the `/` command palette, since `SLASH_COMMANDS` spreads the landing suggestions in

Selecting it kicks off a session with the prompt: *"What's shipped this week on the platform? Check the changelog."* — nudging the assistant toward the changelog tooling.

Also fixes the now-stale "seven headline prompts" count in the `SLASH_COMMANDS` doc comment.

## Verification

- `pnpm -F dashboard type-check` — clean
- `pnpm -F dashboard lint` — no new findings (only pre-existing warnings in generated SDK files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVaH1osWAmv2Pt5t5h9yVs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Platform changelog" suggestion to the assistant on the /chat landing page and in the slash-command menu; selecting it starts a session with "What's shipped this week on the platform? Check the changelog." Also updates a stale doc comment in `SLASH_COMMANDS` to remove the hardcoded count.

<sup>Written for commit 8eb16eb6a60aeb6cdce9c814c2a1e8718ec104e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

