### PR TITLE
feat: clarify MCP permission denial errors

### DIFF
--- a/.changeset/mcp-permission-guidance.md
+++ b/.changeset/mcp-permission-guidance.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Show actionable permission errors when an organization's access policy blocks an MCP server or tool.

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -645,14 +645,6 @@ func validateInput(c Check) error {
 func (e *Engine) mapError(ctx context.Context, err error) error {
 	switch {
 	case errors.Is(err, ErrDenied):
-		if denied, ok := errors.AsType[*DeniedError](err); ok && denied.Scope == ScopeMCPConnect {
-			if denied.Selector[SelectorKeyTool] != "" {
-				return oops.E(oops.CodeForbidden, nil, "you do not have permission to use this MCP tool. Contact your organization's administrator to request access.")
-			}
-
-			return oops.E(oops.CodeForbidden, nil, "you do not have permission to use this MCP server. Contact your organization's administrator to request access.")
-		}
-
 		return oops.C(oops.CodeForbidden)
 	case errors.Is(err, ErrMissingGrants):
 		return oops.E(oops.CodeUnexpected, err, "authz grants missing from prepared context").LogError(ctx, e.logger)

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -645,6 +645,14 @@ func validateInput(c Check) error {
 func (e *Engine) mapError(ctx context.Context, err error) error {
 	switch {
 	case errors.Is(err, ErrDenied):
+		if denied, ok := errors.AsType[*DeniedError](err); ok && denied.Scope == ScopeMCPConnect {
+			if denied.Selector[SelectorKeyTool] != "" {
+				return oops.E(oops.CodeForbidden, nil, "you do not have permission to use this MCP tool. Contact your organization's administrator to request access.")
+			}
+
+			return oops.E(oops.CodeForbidden, nil, "you do not have permission to use this MCP server. Contact your organization's administrator to request access.")
+		}
+
 		return oops.C(oops.CodeForbidden)
 	case errors.Is(err, ErrMissingGrants):
 		return oops.E(oops.CodeUnexpected, err, "authz grants missing from prepared context").LogError(ctx, e.logger)

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -73,40 +73,6 @@ func TestEngineRequire_mapsDeniedToForbidden(t *testing.T) {
 	require.Equal(t, "permission denied", oopsErr.Error())
 }
 
-func TestEngineRequire_mapsMCPServerDenialToActionableForbidden(t *testing.T) {
-	t.Parallel()
-
-	chConn, err := newClickhouseClient(t)
-	require.NoError(t, err)
-	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(true), staticChallengeLogging(true), workos.NewStubClient())
-	ctx := GrantsToContext(enterpriseSessionCtx(t), nil)
-
-	err = engine.Require(ctx, MCPCheck(ScopeMCPConnect, "server_123", "project_123"))
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
-	require.Equal(t, "you do not have permission to use this MCP server. Contact your organization's administrator to request access.", oopsErr.Error())
-}
-
-func TestEngineRequire_mapsMCPToolDenialToActionableForbidden(t *testing.T) {
-	t.Parallel()
-
-	chConn, err := newClickhouseClient(t)
-	require.NoError(t, err)
-	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(true), staticChallengeLogging(true), workos.NewStubClient())
-	ctx := GrantsToContext(enterpriseSessionCtx(t), nil)
-
-	err = engine.Require(ctx, MCPToolCallCheck("server_123", MCPToolCallDimensions{
-		Tool:        "delete_ticket",
-		Disposition: "",
-		ProjectID:   "project_123",
-	}))
-	var oopsErr *oops.ShareableError
-	require.ErrorAs(t, err, &oopsErr)
-	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
-	require.Equal(t, "you do not have permission to use this MCP tool. Contact your organization's administrator to request access.", oopsErr.Error())
-}
-
 func TestEngineRequire_mapsMissingGrantsToUnexpected(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -70,6 +70,41 @@ func TestEngineRequire_mapsDeniedToForbidden(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Equal(t, "permission denied", oopsErr.Error())
+}
+
+func TestEngineRequire_mapsMCPServerDenialToActionableForbidden(t *testing.T) {
+	t.Parallel()
+
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(true), staticChallengeLogging(true), workos.NewStubClient())
+	ctx := GrantsToContext(enterpriseSessionCtx(t), nil)
+
+	err = engine.Require(ctx, MCPCheck(ScopeMCPConnect, "server_123", "project_123"))
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Equal(t, "you do not have permission to use this MCP server. Contact your organization's administrator to request access.", oopsErr.Error())
+}
+
+func TestEngineRequire_mapsMCPToolDenialToActionableForbidden(t *testing.T) {
+	t.Parallel()
+
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(true), staticChallengeLogging(true), workos.NewStubClient())
+	ctx := GrantsToContext(enterpriseSessionCtx(t), nil)
+
+	err = engine.Require(ctx, MCPToolCallCheck("server_123", MCPToolCallDimensions{
+		Tool:        "delete_ticket",
+		Disposition: "",
+		ProjectID:   "project_123",
+	}))
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Equal(t, "you do not have permission to use this MCP tool. Contact your organization's administrator to request access.", oopsErr.Error())
 }
 
 func TestEngineRequire_mapsMissingGrantsToUnexpected(t *testing.T) {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -54,6 +54,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
@@ -769,7 +770,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").LogError(ctx, s.logger)
 			}
 			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
-				return err
+				return mcpaccess.ServerPermissionDenied(err)
 			}
 		}
 

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -770,7 +770,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").LogError(ctx, s.logger)
 			}
 			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
-				return mcpaccess.ServerPermissionDenied(err)
+				return fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err))
 			}
 		}
 

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -227,7 +227,7 @@ func handleToolsCall(
 			Disposition: disposition,
 			ProjectID:   payload.projectID.String(),
 		})); err != nil {
-			return nil, mcpaccess.ToolPermissionDenied(err)
+			return nil, fmt.Errorf("authorize MCP tool call: %w", mcpaccess.ToolPermissionDenied(err))
 		}
 	}
 

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -32,6 +32,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	mcpmetadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -226,7 +227,7 @@ func handleToolsCall(
 			Disposition: disposition,
 			ProjectID:   payload.projectID.String(),
 		})); err != nil {
-			return nil, err
+			return nil, mcpaccess.ToolPermissionDenied(err)
 		}
 	}
 

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
@@ -513,7 +514,7 @@ func (s *Service) prepareProxyBackendContext(
 
 		// mcp:connect covers non-tool proxy methods; tool interceptors still enforce per-tool scopes.
 		if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, mcpServer.ID.String(), endpoint.ProjectID.String())); err != nil {
-			return nil, err
+			return nil, mcpaccess.ServerPermissionDenied(err)
 		}
 	case mcpservers.VisibilityPublic:
 		// Public, no OAuth: optionally probe Gram identity if the

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -514,7 +514,7 @@ func (s *Service) prepareProxyBackendContext(
 
 		// mcp:connect covers non-tool proxy methods; tool interceptors still enforce per-tool scopes.
 		if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, mcpServer.ID.String(), endpoint.ProjectID.String())); err != nil {
-			return nil, mcpaccess.ServerPermissionDenied(err)
+			return nil, fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err))
 		}
 	case mcpservers.VisibilityPublic:
 		// Public, no OAuth: optionally probe Gram identity if the

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -764,6 +764,7 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_RequiresC
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Equal(t, "you do not have permission to use this MCP server. Contact your organization's administrator to request access.", oopsErr.Error())
 
 	select {
 	case <-upstreamHit:

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -764,7 +765,7 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_RequiresC
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
-	require.Equal(t, "you do not have permission to use this MCP server. Contact your organization's administrator to request access.", oopsErr.Error())
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, oopsErr.Error())
 
 	select {
 	case <-upstreamHit:

--- a/server/internal/mcpaccess/errors.go
+++ b/server/internal/mcpaccess/errors.go
@@ -1,0 +1,34 @@
+package mcpaccess
+
+import (
+	"errors"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// ServerPermissionDeniedMessage is the user-facing MCP server access denial.
+const ServerPermissionDeniedMessage = "you do not have permission to use this MCP server. Contact your organization's administrator to request access."
+
+// ToolPermissionDeniedMessage is the user-facing MCP tool access denial.
+const ToolPermissionDeniedMessage = "you do not have permission to use this MCP tool. Contact your organization's administrator to request access."
+
+// ServerPermissionDenied replaces a generic forbidden error at an MCP server
+// access boundary while preserving all other errors.
+func ServerPermissionDenied(err error) error {
+	return permissionDenied(err, ServerPermissionDeniedMessage)
+}
+
+// ToolPermissionDenied replaces a generic forbidden error at an MCP tool-call
+// boundary while preserving all other errors.
+func ToolPermissionDenied(err error) error {
+	return permissionDenied(err, ToolPermissionDeniedMessage)
+}
+
+func permissionDenied(err error, message string) error {
+	var shareableErr *oops.ShareableError
+	if !errors.As(err, &shareableErr) || shareableErr.Code != oops.CodeForbidden {
+		return err
+	}
+
+	return oops.E(oops.CodeForbidden, err, message)
+}

--- a/server/internal/mcpaccess/errors.go
+++ b/server/internal/mcpaccess/errors.go
@@ -30,5 +30,5 @@ func permissionDenied(err error, message string) error {
 		return err
 	}
 
-	return oops.E(oops.CodeForbidden, err, message)
+	return oops.E(oops.CodeForbidden, err, "%s", message)
 }

--- a/server/internal/mcpaccess/errors_test.go
+++ b/server/internal/mcpaccess/errors_test.go
@@ -1,0 +1,46 @@
+package mcpaccess_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestServerPermissionDeniedRewritesForbiddenError(t *testing.T) {
+	t.Parallel()
+
+	cause := oops.C(oops.CodeForbidden)
+	err := mcpaccess.ServerPermissionDenied(cause)
+
+	var shareableErr *oops.ShareableError
+	require.ErrorAs(t, err, &shareableErr)
+	require.Equal(t, oops.CodeForbidden, shareableErr.Code)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, shareableErr.Error())
+	require.ErrorIs(t, err, cause)
+}
+
+func TestToolPermissionDeniedRewritesForbiddenError(t *testing.T) {
+	t.Parallel()
+
+	cause := oops.C(oops.CodeForbidden)
+	err := mcpaccess.ToolPermissionDenied(cause)
+
+	var shareableErr *oops.ShareableError
+	require.ErrorAs(t, err, &shareableErr)
+	require.Equal(t, oops.CodeForbidden, shareableErr.Code)
+	require.Equal(t, mcpaccess.ToolPermissionDeniedMessage, shareableErr.Error())
+	require.ErrorIs(t, err, cause)
+}
+
+func TestPermissionDeniedPreservesNonForbiddenError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("temporary failure")
+
+	require.ErrorIs(t, mcpaccess.ServerPermissionDenied(cause), cause)
+	require.ErrorIs(t, mcpaccess.ToolPermissionDenied(cause), cause)
+}

--- a/server/internal/remotemcp/tools_call_authz_interceptor.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor.go
@@ -2,6 +2,7 @@ package remotemcp
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -77,9 +78,14 @@ func (i *ToolsCallAuthzInterceptor) InterceptToolsCallRequest(ctx context.Contex
 		return nil
 	}
 
-	return mcpaccess.ToolPermissionDenied(i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
+	err := i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
 		Tool:        call.Params.Name,
 		Disposition: "",
 		ProjectID:   i.projectID,
-	})))
+	}))
+	if err != nil {
+		return fmt.Errorf("authorize remote MCP tool call: %w", mcpaccess.ToolPermissionDenied(err))
+	}
+
+	return nil
 }

--- a/server/internal/remotemcp/tools_call_authz_interceptor.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 )
 
@@ -76,9 +77,9 @@ func (i *ToolsCallAuthzInterceptor) InterceptToolsCallRequest(ctx context.Contex
 		return nil
 	}
 
-	return i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
+	return mcpaccess.ToolPermissionDenied(i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
 		Tool:        call.Params.Name,
 		Disposition: "",
 		ProjectID:   i.projectID,
-	}))
+	})))
 }

--- a/server/internal/remotemcp/tools_call_authz_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
@@ -112,7 +113,7 @@ func TestToolsCallAuthzInterceptor_GrantsRejectNonMatchingTool(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
-	require.Equal(t, "you do not have permission to use this MCP tool. Contact your organization's administrator to request access.", oopsErr.Error())
+	require.Equal(t, mcpaccess.ToolPermissionDeniedMessage, oopsErr.Error())
 }
 
 func TestToolsCallAuthzInterceptor_NoGrantsRejects(t *testing.T) {

--- a/server/internal/remotemcp/tools_call_authz_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor_test.go
@@ -112,6 +112,7 @@ func TestToolsCallAuthzInterceptor_GrantsRejectNonMatchingTool(t *testing.T) {
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Equal(t, "you do not have permission to use this MCP tool. Contact your organization's administrator to request access.", oopsErr.Error())
 }
 
 func TestToolsCallAuthzInterceptor_NoGrantsRejects(t *testing.T) {

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -98,7 +98,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	// Authorization mirrors the runtime gate: minting a bearer grants runtime
 	// access, so the endpoint requires the same mcp:connect permission.
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, target.resourceID, authCtx.ProjectID.String())); err != nil {
-		return nil, mcpaccess.ServerPermissionDenied(err)
+		return nil, fmt.Errorf("authorize MCP session mint: %w", mcpaccess.ServerPermissionDenied(err))
 	}
 
 	issuer, err := repo.New(s.db).GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -97,7 +98,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	// Authorization mirrors the runtime gate: minting a bearer grants runtime
 	// access, so the endpoint requires the same mcp:connect permission.
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, target.resourceID, authCtx.ProjectID.String())); err != nil {
-		return nil, err
+		return nil, mcpaccess.ServerPermissionDenied(err)
 	}
 
 	issuer, err := repo.New(s.db).GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{

--- a/server/internal/usersessions/minthandler_server_test.go
+++ b/server/internal/usersessions/minthandler_server_test.go
@@ -48,7 +48,9 @@ func TestMintUserSessionForServerRequiresMCPConnect(t *testing.T) {
 		ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
-	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, err.Error())
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, oopsErr.Error())
 }
 
 func TestMintUserSessionForServerAllowsMCPConnect(t *testing.T) {

--- a/server/internal/usersessions/minthandler_server_test.go
+++ b/server/internal/usersessions/minthandler_server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -47,6 +48,7 @@ func TestMintUserSessionForServerRequiresMCPConnect(t *testing.T) {
 		ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, err.Error())
 }
 
 func TestMintUserSessionForServerAllowsMCPConnect(t *testing.T) {

--- a/server/internal/usersessions/minthandler_test.go
+++ b/server/internal/usersessions/minthandler_test.go
@@ -13,6 +13,7 @@ import (
 	sessionsgen "github.com/speakeasy-api/gram/server/gen/user_sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -45,6 +46,7 @@ func TestMintUserSessionRequiresMCPConnect(t *testing.T) {
 		ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, err.Error())
 }
 
 func TestMintUserSessionAllowsMCPConnect(t *testing.T) {

--- a/server/internal/usersessions/minthandler_test.go
+++ b/server/internal/usersessions/minthandler_test.go
@@ -46,7 +46,9 @@ func TestMintUserSessionRequiresMCPConnect(t *testing.T) {
 		ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
-	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, err.Error())
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, oopsErr.Error())
 }
 
 func TestMintUserSessionAllowsMCPConnect(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- return actionable permission-denial copy for MCP server and tool access
- apply MCP-specific copy at runtime gateways and session-mint enforcement boundaries while keeping the shared authorization engine resource-agnostic
- preserve non-forbidden failures and retain contextual error wrapping for diagnostics
- add a server patch changeset

## Testing
- validation in progress
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-179](https://linear.app/speakeasy/issue/AIS-179/feat-display-more-specific-permission-denial-error-for-mcp-server)

<div><a href="https://cursor.com/agents/bc-5faf4ddd-a598-4681-9aa3-e9a8388f02bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5faf4ddd-a598-4681-9aa3-e9a8388f02bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies MCP permission-denial errors with clear messages for server vs tool denials. Now wraps authorization errors at MCP boundaries with context while keeping diagnostics; non‑MCP auth still returns the generic “permission denied” (AIS‑179).

- **New Features**
  - MCP server denial: “you do not have permission to use this MCP server. Contact your organization's administrator to request access.”
  - MCP tool denial: “you do not have permission to use this MCP tool. Contact your organization's administrator to request access.”

- **Refactors**
  - Added `server/internal/mcpaccess` with constants and wrappers that only rewrite `oops.CodeForbidden`; errors are wrapped with boundary context and applied at proxy backend, RPC tools_call, remote tool-call interceptor, toolset resolution, and user-session minting.

<sup>Written for commit fc3a9379020162d021d39c4a52f7554f6b3157c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

