### PR TITLE
feat: add table view for plugin detail entries

### DIFF
--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -7,8 +7,10 @@ import { Button as UiButton } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Dialog } from "@/components/ui/dialog";
 import { DotCard } from "@/components/ui/dot-card";
+import { DotTable } from "@/components/ui/dot-table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import { useViewMode } from "@/components/ui/use-view-mode";
 import { cn } from "@/lib/utils";
 import { mcpServerRouteParam } from "@/lib/sources";
 import { useRoutes } from "@/routes";
@@ -69,6 +71,7 @@ import { InstallInstructionsDialog } from "./InstallInstructionsDialog";
 import { PluginAssignmentsSheet } from "./PluginAssignmentsSheet";
 import { PluginSkillsSection } from "./PluginSkillsSection";
 import { PluginAssignmentsList } from "./PluginAssignmentsList";
+import { PluginServerTableRow } from "./PluginServerTableRow";
 import { describePrincipal, memberMapByUrn, roleMapByUrn } from "./principals";
 import { PublishDialog } from "./PublishDialog";
 import { SectionEmptyState } from "./SectionEmptyState";
@@ -101,6 +104,7 @@ export default function PluginDetail(): JSX.Element | null {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [isAssignmentsOpen, setIsAssignmentsOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useViewMode();
   // The component stays mounted when only :pluginId changes, so a stale query
   // from a previous plugin would filter the new plugin's lists.
   useEffect(() => setSearch(""), [pluginId]);
@@ -428,6 +432,36 @@ export default function PluginDetail(): JSX.Element | null {
     serversContent = <SectionEmptyState title="No servers added yet" />;
   } else if (filteredServers.length === 0) {
     serversContent = <SectionEmptyState title="No servers match your search" />;
+  } else if (viewMode === "table") {
+    serversContent = (
+      <DotTable
+        headers={[
+          { label: "Name" },
+          { label: "Publish status" },
+          { label: "Type" },
+          { label: "Visibility" },
+          { label: "", className: "text-right" },
+        ]}
+      >
+        {filteredServers.map((server) => (
+          <PluginServerTableRow
+            key={server.id}
+            server={server}
+            toolset={
+              server.toolsetId ? toolsetById.get(server.toolsetId) : undefined
+            }
+            mcpServer={
+              server.mcpServerId
+                ? mcpServerById.get(server.mcpServerId)
+                : undefined
+            }
+            isLoading={isLoadingServers}
+            onRemove={() => handleRemoveServer(server)}
+            lastPublishedAt={publishStatus?.lastPublishedAt}
+          />
+        ))}
+      </DotTable>
+    );
   } else {
     serversContent = (
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
@@ -642,6 +676,7 @@ export default function PluginDetail(): JSX.Element | null {
               onChange={setSearch}
               placeholder="Search servers, skills, and assignments"
             />
+            <Page.Toolbar.ViewAs value={viewMode} onChange={setViewMode} />
           </Page.Toolbar>
 
           {/* Servers section */}
@@ -724,6 +759,7 @@ export default function PluginDetail(): JSX.Element | null {
               <PluginSkillsSection
                 pluginId={pluginId!}
                 searchQuery={search}
+                viewMode={viewMode}
                 onMutated={(message) => offerPublish(message)}
               />
             </RequireScope>

--- a/client/dashboard/src/pages/plugins/PluginServerTableRow.tsx
+++ b/client/dashboard/src/pages/plugins/PluginServerTableRow.tsx
@@ -1,0 +1,130 @@
+import { MCPStatusIndicator } from "@/components/mcp/MCPStatusIndicator";
+import { ToolCollectionBadge } from "@/components/tool-collection-badge";
+import { Button } from "@/components/ui/button";
+import { DotRow } from "@/components/ui/dot-row";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Type } from "@/components/ui/type";
+import { mcpServerRouteParam } from "@/lib/sources";
+import { useRoutes } from "@/routes";
+import type { McpServer } from "@gram/client/models/components/mcpserver.js";
+import type { PluginServer } from "@gram/client/models/components/pluginserver.js";
+import type { ToolsetEntry } from "@gram/client/models/components/toolsetentry.js";
+import { Badge } from "@speakeasy-api/moonshine";
+import { Network, Trash2 } from "lucide-react";
+
+export function PluginServerTableRow({
+  server,
+  toolset,
+  mcpServer,
+  isLoading,
+  onRemove,
+  lastPublishedAt,
+}: {
+  server: PluginServer;
+  toolset: ToolsetEntry | undefined;
+  mcpServer: McpServer | undefined;
+  isLoading: boolean;
+  onRemove: () => void;
+  lastPublishedAt: Date | undefined;
+}): JSX.Element {
+  const routes = useRoutes();
+  const isRemote = !!server.mcpServerId;
+  const notYetPublished =
+    !lastPublishedAt || server.createdAt > lastPublishedAt;
+
+  let href: string | undefined;
+  if (isRemote && mcpServer) {
+    href = routes.mcp.x.overview.href(mcpServerRouteParam(mcpServer));
+  } else if (toolset) {
+    href = routes.mcp.details.href(toolset.slug);
+  }
+
+  let typeContent: JSX.Element;
+  if (isRemote) {
+    typeContent = <Badge variant="neutral">Remote MCP</Badge>;
+  } else if (toolset) {
+    typeContent = (
+      <ToolCollectionBadge toolNames={toolset.tools.map((tool) => tool.name)} />
+    );
+  } else if (isLoading) {
+    typeContent = <Skeleton className="h-5 w-16" />;
+  } else {
+    typeContent = <Badge variant="destructive">Toolset missing</Badge>;
+  }
+
+  let visibilityContent: JSX.Element;
+  if (isRemote) {
+    visibilityContent = (
+      <Type small muted>
+        —
+      </Type>
+    );
+  } else if (toolset) {
+    visibilityContent = (
+      <MCPStatusIndicator
+        mcpEnabled={toolset.mcpEnabled}
+        mcpIsPublic={toolset.mcpIsPublic}
+        size="sm"
+      />
+    );
+  } else if (isLoading) {
+    visibilityContent = <Skeleton className="h-3.5 w-20" />;
+  } else {
+    visibilityContent = (
+      <Type small muted>
+        —
+      </Type>
+    );
+  }
+
+  return (
+    <DotRow
+      icon={<Network className="text-muted-foreground h-5 w-5" />}
+      href={href}
+      ariaLabel={`View server ${server.displayName}`}
+    >
+      <td className="px-3 py-3">
+        <Type
+          variant="subheading"
+          as="div"
+          className="group-hover:text-primary truncate text-sm transition-colors"
+          title={server.displayName}
+        >
+          {server.displayName}
+        </Type>
+      </td>
+      <td className="px-3 py-3">
+        {notYetPublished ? (
+          <Badge
+            variant="warning"
+            title="Added since the marketplace was last published"
+          >
+            Unpublished
+          </Badge>
+        ) : (
+          <Badge variant="success">Published</Badge>
+        )}
+      </td>
+      <td className="px-3 py-3">{typeContent}</td>
+      <td className="px-3 py-3">{visibilityContent}</td>
+      <td className="px-3 py-3">
+        <div
+          className="relative z-20 flex items-center justify-end"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            tooltip="Remove server"
+            aria-label={`Remove server ${server.displayName}`}
+            className="hover:text-destructive"
+            onClick={onRemove}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </td>
+    </DotRow>
+  );
+}

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -3,8 +3,11 @@ import { ErrorAlert } from "@/components/ui/alert";
 import { Button as UiButton } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { DotCard } from "@/components/ui/dot-card";
+import { DotRow } from "@/components/ui/dot-row";
+import { DotTable } from "@/components/ui/dot-table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import type { ViewMode } from "@/components/ui/use-view-mode";
 import { useProject } from "@/contexts/Auth";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { useRoutes } from "@/routes";
@@ -32,11 +35,14 @@ import { SectionEmptyState } from "./SectionEmptyState";
 export function PluginSkillsSection({
   pluginId,
   searchQuery,
+  viewMode,
   onMutated,
 }: {
   pluginId: string;
   /** Page-level search query; narrows the listed skill distributions. */
   searchQuery: string;
+  /** Page-level entry layout shared with the server section. */
+  viewMode: ViewMode;
   /** Invoked after a successful change, e.g. to offer a marketplace publish. */
   onMutated: (message: string) => void;
 }): JSX.Element {
@@ -154,6 +160,26 @@ export function PluginSkillsSection({
     );
   } else if (filteredDistributions.length === 0) {
     listContent = <SectionEmptyState title="No skills match your search" />;
+  } else if (viewMode === "table") {
+    listContent = (
+      <DotTable
+        headers={[
+          { label: "Name" },
+          { label: "Identifier" },
+          { label: "Version" },
+          { label: "", className: "text-right" },
+        ]}
+      >
+        {filteredDistributions.map((distribution) => (
+          <PluginSkillTableRow
+            key={distribution.id}
+            distribution={distribution}
+            isRemoving={undistribute.isPending}
+            onRemove={() => handleRemoveSkill(distribution)}
+          />
+        ))}
+      </DotTable>
+    );
   } else {
     listContent = (
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
@@ -309,19 +335,7 @@ function PluginSkillCard({
             {distribution.skillDisplayName}
           </Link>
         </Type>
-        {distribution.pinnedVersionId ? (
-          <Badge
-            variant="neutral"
-            className="text-xs"
-            title={distribution.pinnedVersionId}
-          >
-            Pinned
-          </Badge>
-        ) : (
-          <Badge variant="information" className="text-xs">
-            Latest
-          </Badge>
-        )}
+        <SkillVersionBadge distribution={distribution} />
       </div>
       <Type small muted className="truncate font-mono">
         {distribution.skillName}
@@ -351,5 +365,95 @@ function PluginSkillCard({
         </RequireScope>
       </div>
     </DotCard>
+  );
+}
+
+function PluginSkillTableRow({
+  distribution,
+  isRemoving,
+  onRemove,
+}: {
+  distribution: SkillDistribution;
+  isRemoving: boolean;
+  onRemove: () => void;
+}): JSX.Element {
+  const project = useProject();
+  const routes = useRoutes();
+  const href = routes.skills.detail.href(distribution.skillId);
+
+  return (
+    <DotRow
+      icon={<Sparkles className="text-muted-foreground h-5 w-5" />}
+      href={href}
+      ariaLabel={`View skill ${distribution.skillDisplayName}`}
+    >
+      <td className="px-3 py-3">
+        <Type
+          variant="subheading"
+          as="div"
+          className="group-hover:text-primary truncate text-sm transition-colors"
+          title={distribution.skillDisplayName}
+        >
+          {distribution.skillDisplayName}
+        </Type>
+      </td>
+      <td className="px-3 py-3">
+        <Type small muted className="truncate font-mono">
+          {distribution.skillName}
+        </Type>
+      </td>
+      <td className="px-3 py-3">
+        <SkillVersionBadge distribution={distribution} />
+      </td>
+      <td className="px-3 py-3">
+        <RequireScope
+          scope="skill:write"
+          resourceId={project.id}
+          level="component"
+        >
+          <div
+            className="relative z-20 flex items-center justify-end"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <UiButton
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              tooltip="Remove skill"
+              aria-label={`Remove skill ${distribution.skillDisplayName}`}
+              className="hover:text-destructive"
+              disabled={isRemoving}
+              onClick={onRemove}
+            >
+              <Trash2 className="h-4 w-4" />
+            </UiButton>
+          </div>
+        </RequireScope>
+      </td>
+    </DotRow>
+  );
+}
+
+function SkillVersionBadge({
+  distribution,
+}: {
+  distribution: SkillDistribution;
+}): JSX.Element {
+  if (distribution.pinnedVersionId) {
+    return (
+      <Badge
+        variant="neutral"
+        className="text-xs"
+        title={distribution.pinnedVersionId}
+      >
+        Pinned
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="information" className="text-xs">
+      Latest
+    </Badge>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add the shared grid/table view control to plugin detail pages
- render MCP server entries in a compact table with status, type, visibility, navigation, and remove actions
- render distributed skills in a matching table while preserving card view and the shared persisted preference

## Testing
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint`
- browser walkthrough: switched both entry sections between grid and table, filtered entries with shared search, followed a skill row link, and verified persisted view state

## Demo
<a href="https://cursor.com/agents/bc-6ac9dee5-48ce-44b9-9277-f66d33982aba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplugin_entry_grid_table_toggle.mp4"><img src="https://cursor.com/artifacts/c/art-4b67c10f-1ba9-4860-a6c0-f3a1d4be2f39" alt="plugin_entry_grid_table_toggle.mp4" /></a>

Linear: DNO-585
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-585](https://linear.app/speakeasy/issue/DNO-585/feat-add-table-view-for-plugin-detail-page-entries)

<div><a href="https://cursor.com/agents/bc-6ac9dee5-48ce-44b9-9277-f66d33982aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ac9dee5-48ce-44b9-9277-f66d33982aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a table view to plugin detail entries with a shared "view as" toggle so servers and skills are easier to scan. Implements Linear DNO-585 while keeping the existing card view and remembering the user’s preference.

- New Features
  - Added table view for MCP servers and distributed skills using `DotTable`/`DotRow`, with row navigation and remove actions.
  - Shared layout toggle via `Page.Toolbar.ViewAs` and `useViewMode`; applies to both sections and persists.
  - New `PluginServerTableRow` shows publish status, type (remote MCP or toolset), and visibility.
  - Updated skills section to support table rows and a `SkillVersionBadge` (Pinned/Latest).

<sup>Written for commit 656eb6ea3df8b6761c216b8d1d2a9cb3a1ea0e96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

