### PR TITLE
fix(dashboard): restrict Shadow MCP allow rule policies

### DIFF
--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryActions.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryActions.tsx
@@ -215,6 +215,7 @@ export function ShadowMCPInventoryActionMenu({
 
 function PolicySelection({
   disabled,
+  emptyMessage,
   members,
   onSelectionChange,
   policies,
@@ -222,6 +223,7 @@ function PolicySelection({
   selectedPolicyIDs,
 }: {
   disabled: boolean;
+  emptyMessage: string;
   members: AccessMember[];
   onSelectionChange: (policyIDs: string[]) => void;
   policies: ShadowMCPPolicy[];
@@ -238,7 +240,7 @@ function PolicySelection({
       <div className="space-y-2">
         {policies.length === 0 && (
           <Type muted small>
-            {ALLOW_RULE_POLICY_REQUIRED}
+            {emptyMessage}
           </Type>
         )}
         {policies.map((policy) => {
@@ -287,6 +289,7 @@ export function ShadowMCPInventoryActionSheet({
   onOpenChange,
   onSubmit,
   open,
+  policyUnavailableMessage = ALLOW_RULE_POLICY_REQUIRED,
   roles,
   shadowMCPPolicies,
 }: {
@@ -300,6 +303,7 @@ export function ShadowMCPInventoryActionSheet({
     policyIDs: string[];
   }) => Promise<void>;
   open: boolean;
+  policyUnavailableMessage?: string;
   roles: Role[];
   shadowMCPPolicies: ShadowMCPPolicy[];
 }): JSX.Element | null {
@@ -413,6 +417,7 @@ export function ShadowMCPInventoryActionSheet({
           {needsPolicySelection && (
             <PolicySelection
               disabled={isSubmitting}
+              emptyMessage={policyUnavailableMessage}
               members={members}
               onSelectionChange={setSelectedPolicyIDs}
               policies={shadowMCPPolicies}

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryActions.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryActions.tsx
@@ -11,7 +11,10 @@ import {
 } from "@/components/ui/sheet";
 import { Type } from "@/components/ui/type";
 import { cn } from "@/lib/utils";
-import { shadowMCPInventoryActions } from "./shadowMCPInventoryActionItems";
+import {
+  ALLOW_RULE_POLICY_REQUIRED,
+  shadowMCPInventoryActions,
+} from "./shadowMCPInventoryActionItems";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { Role } from "@gram/client/models/components/role.js";
 import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
@@ -148,10 +151,12 @@ function initialPolicyIDsForAction(
 }
 
 export function ShadowMCPInventoryActionMenu({
+  canManageAllowRules,
   disabled,
   onOpenAction,
   server,
 }: {
+  canManageAllowRules: boolean;
   disabled: boolean;
   onOpenAction: (
     mode: InventoryActionMode,
@@ -159,7 +164,11 @@ export function ShadowMCPInventoryActionMenu({
   ) => void;
   server: ShadowMCPInventoryServer;
 }): JSX.Element {
-  const actions = shadowMCPInventoryActions(server, { disabled, onOpenAction });
+  const actions = shadowMCPInventoryActions(server, {
+    canManageAllowRules,
+    disabled,
+    onOpenAction,
+  });
 
   return (
     <DropdownMenu modal={false}>
@@ -180,13 +189,23 @@ export function ShadowMCPInventoryActionMenu({
       >
         {actions.map((action, index) => (
           <DropdownMenuItem
+            disabled={action.disabled}
             key={index}
             onSelect={(event) => {
               event.stopPropagation();
               action.onClick();
             }}
           >
-            {action.label}
+            {action.description ? (
+              <span className="flex min-w-0 flex-col">
+                <span>{action.label}</span>
+                <span className="text-muted-foreground text-xs">
+                  {action.description}
+                </span>
+              </span>
+            ) : (
+              action.label
+            )}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
@@ -217,6 +236,11 @@ function PolicySelection({
         Policies
       </Type>
       <div className="space-y-2">
+        {policies.length === 0 && (
+          <Type muted small>
+            {ALLOW_RULE_POLICY_REQUIRED}
+          </Type>
+        )}
         {policies.map((policy) => {
           const checked = selectedPolicyIDSet.has(policy.id);
           return (

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.test.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.test.tsx
@@ -1426,6 +1426,81 @@ describe("ShadowMCPInventoryTable", () => {
     });
   });
 
+  it("disables add when no allow-rule policy is eligible", async () => {
+    mockShadowMCPInventory({
+      servers: [
+        inventoryServer({
+          canonicalServerUrl: "https://observed.example.com/mcp",
+          serverName: "Observed MCP",
+        }),
+      ],
+    });
+
+    renderInventoryTable("project-id-1", "flagging", []);
+
+    const addButton = await screen.findByRole("button", {
+      name: /Add Allow Rule/,
+    });
+    expect((addButton as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      screen.getByText("An enabled blocking Shadow MCP policy is required."),
+    ).toBeTruthy();
+  });
+
+  it("allows denying a request when no allow-rule policy is eligible", async () => {
+    const resolveInventoryRequest = vi.fn().mockResolvedValue({});
+    mockShadowMCPInventory({
+      servers: [
+        inventoryServer({
+          access: "blocked",
+          canonicalServerUrl: "https://requested.example.com/mcp",
+          latestRequest: {
+            id: "request-1",
+            policyId: "inactive-policy",
+            requestedAt: new Date("2026-01-04T11:30:00Z"),
+            requesterEmail: "requester@example.com",
+            requesterUserId: "user-1",
+          },
+          requestCount: 1,
+          serverName: "Requested MCP",
+        }),
+      ],
+    });
+    mocks.resolveInventoryRequestMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: resolveInventoryRequest,
+    });
+
+    renderInventoryTable("project-id-1", "flagging", []);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Review Request" }),
+    );
+
+    const sheet = within(await screen.findByTestId("shadow-mcp-action-sheet"));
+    expect(
+      (
+        sheet.getByRole("button", {
+          name: "Approve Request",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    fireEvent.click(sheet.getByRole("radio", { name: /Deny/ }));
+    fireEvent.click(sheet.getByRole("button", { name: "Deny Request" }));
+
+    await waitFor(() => {
+      expect(resolveInventoryRequest).toHaveBeenCalledWith({
+        request: {
+          resolveShadowMCPInventoryRequestForm: {
+            decision: "deny",
+            policyIds: undefined,
+            projectId: "project-id-1",
+            serverUrl: "https://requested.example.com/mcp",
+          },
+        },
+      });
+    });
+  });
+
   it("renders observed status when blocking is inactive", async () => {
     mockShadowMCPInventory({
       servers: [

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPInventoryTable.tsx
@@ -191,6 +191,7 @@ export function ShadowMCPInventoryTable({
     deletePolicyBypass.isPending ||
     resolveInventoryRequest.isPending;
   const isActionPending = isSubmitting || activeAction !== null;
+  const canManageAllowRules = shadowMCPPolicies.length > 0;
 
   useEffect(() => {
     setPaginationScope(inventoryScope);
@@ -331,6 +332,7 @@ export function ShadowMCPInventoryTable({
   const renderActionsCell = (server: ShadowMCPInventoryServer) => {
     return (
       <ShadowMCPInventoryActionMenu
+        canManageAllowRules={canManageAllowRules}
         disabled={isActionPending}
         onOpenAction={(mode, selectedServer) =>
           setActiveAction({ mode, server: selectedServer })
@@ -498,6 +500,7 @@ export function ShadowMCPInventoryTable({
             <TableRowContextMenu
               key={row.canonicalServerUrl}
               actions={shadowMCPInventoryActions(row, {
+                canManageAllowRules,
                 disabled: isActionPending,
                 onOpenAction: (mode, selectedServer) =>
                   setActiveAction({ mode, server: selectedServer }),

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryActionItems.test.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryActionItems.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
+import {
+  ALLOW_RULE_POLICY_REQUIRED,
+  shadowMCPInventoryActions,
+} from "./shadowMCPInventoryActionItems";
+
+function server(
+  overrides: Partial<ShadowMCPInventoryServer> = {},
+): ShadowMCPInventoryServer {
+  return {
+    access: "none",
+    allowedPolicyIds: [],
+    canonicalServerUrl: "https://example.com/mcp",
+    firstSeen: new Date("2026-01-01T00:00:00Z"),
+    lastCalled: new Date("2026-01-01T00:00:00Z"),
+    lastSeen: new Date("2026-01-01T00:00:00Z"),
+    observedUseCount: 1,
+    requestCount: 0,
+    serverName: "Example MCP",
+    serverSlug: "example-mcp",
+    topUsers: [],
+    urlHost: "example.com",
+    userCount: 1,
+    ...overrides,
+  };
+}
+
+describe("shadowMCPInventoryActions", () => {
+  it("disables add and edit with a reason when no policy is eligible", () => {
+    const options = {
+      canManageAllowRules: false,
+      disabled: false,
+      onOpenAction: vi.fn(() => {}),
+    };
+
+    expect(shadowMCPInventoryActions(server(), options)).toEqual([
+      expect.objectContaining({
+        label: "Add Allow Rule",
+        disabled: true,
+        description: ALLOW_RULE_POLICY_REQUIRED,
+      }),
+    ]);
+    expect(
+      shadowMCPInventoryActions(server({ access: "allowed" }), options),
+    ).toEqual([
+      expect.objectContaining({
+        label: "Edit Rule",
+        disabled: true,
+        description: ALLOW_RULE_POLICY_REQUIRED,
+      }),
+      expect.objectContaining({ label: "Delete Rule", disabled: false }),
+    ]);
+  });
+
+  it("keeps review available so a pending request can be denied", () => {
+    const actions = shadowMCPInventoryActions(
+      server({ access: "blocked", requestCount: 1 }),
+      {
+        canManageAllowRules: false,
+        disabled: false,
+        onOpenAction: vi.fn(() => {}),
+      },
+    );
+
+    expect(actions).toEqual([
+      expect.objectContaining({ label: "Review Request", disabled: false }),
+    ]);
+  });
+});

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryActionItems.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryActionItems.ts
@@ -2,6 +2,9 @@ import type { Action } from "@/components/ui/more-actions";
 import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
 import type { InventoryActionMode } from "./ShadowMCPInventoryActions";
 
+export const ALLOW_RULE_POLICY_REQUIRED =
+  "An enabled blocking Shadow MCP policy is required.";
+
 /**
  * The per-server action set, shared by the visible "⋯" dropdown and the row's
  * right-click context menu so the two stay in sync. The entries are additive
@@ -12,9 +15,11 @@ import type { InventoryActionMode } from "./ShadowMCPInventoryActions";
 export function shadowMCPInventoryActions(
   server: ShadowMCPInventoryServer,
   {
+    canManageAllowRules,
     disabled,
     onOpenAction,
   }: {
+    canManageAllowRules: boolean;
     disabled: boolean;
     onOpenAction: (
       mode: InventoryActionMode,
@@ -24,6 +29,10 @@ export function shadowMCPInventoryActions(
 ): Action[] {
   const hasRequest = server.requestCount > 0;
   const hasAllowDecision = server.access === "allowed";
+  const allowRuleDisabled = disabled || !canManageAllowRules;
+  const allowRuleDescription = canManageAllowRules
+    ? undefined
+    : ALLOW_RULE_POLICY_REQUIRED;
 
   const openAction = (mode: InventoryActionMode) => () => {
     window.setTimeout(() => onOpenAction(mode, server), 0);
@@ -40,13 +49,19 @@ export function shadowMCPInventoryActions(
   if (!hasRequest && !hasAllowDecision) {
     actions.push({
       label: "Add Allow Rule",
-      disabled,
+      description: allowRuleDescription,
+      disabled: allowRuleDisabled,
       onClick: openAction("add"),
     });
   }
   if (hasAllowDecision) {
     actions.push(
-      { label: "Edit Rule", disabled, onClick: openAction("edit") },
+      {
+        label: "Edit Rule",
+        description: allowRuleDescription,
+        disabled: allowRuleDisabled,
+        onClick: openAction("edit"),
+      },
       {
         label: "Delete Rule",
         destructive: true,

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.test.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.test.ts
@@ -2,6 +2,7 @@ import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
 import type { ShadowMCPInventoryServer } from "@gram/client/models/components/shadowmcpinventoryserver.js";
 import { describe, expect, it } from "vitest";
 import {
+  eligibleShadowMCPAllowRulePolicies,
   shadowMCPInventoryStatus,
   shadowMCPInventoryStatusDescription,
   shadowMCPPolicyState,
@@ -48,6 +49,29 @@ function server(
     ...overrides,
   };
 }
+
+describe("eligibleShadowMCPAllowRulePolicies", () => {
+  it("returns only enabled blocking Shadow MCP policies", () => {
+    const policies = [
+      policy({ action: "block", id: "eligible" }),
+      policy({ action: "flag", id: "flag" }),
+      policy({ action: "block", enabled: false, id: "disabled" }),
+      policy({
+        action: "block",
+        id: "other-source",
+        sources: ["prompt_injection"],
+      }),
+    ];
+
+    expect(
+      eligibleShadowMCPAllowRulePolicies(policies).map((item) => item.id),
+    ).toEqual(["eligible"]);
+  });
+
+  it("returns an empty list while policies are unavailable", () => {
+    expect(eligibleShadowMCPAllowRulePolicies(undefined)).toEqual([]);
+  });
+});
 
 describe("shadowMCPPolicyState", () => {
   it("prioritizes blocking policies over flagging policies", () => {

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.ts
@@ -15,6 +15,19 @@ export type ShadowMCPInventoryStatus =
   | "pending"
   | "unavailable";
 
+export function eligibleShadowMCPAllowRulePolicies(
+  policies: RiskPolicy[] | undefined,
+): RiskPolicy[] {
+  return (
+    policies?.filter(
+      (policy) =>
+        policy.enabled &&
+        policy.action === "block" &&
+        policy.sources.includes("shadow_mcp"),
+    ) ?? []
+  );
+}
+
 export function shadowMCPPolicyState(
   policies: RiskPolicy[] | undefined,
 ): ShadowMCPPolicyState {

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
@@ -220,6 +220,7 @@ describe("ShadowMCP", () => {
       data: {
         policies: [
           riskPolicy({ action: "flag" }),
+          riskPolicy({ action: "block", enabled: false, id: "disabled-block" }),
           riskPolicy({ action: "block", id: "block-policy-1" }),
         ],
       },
@@ -242,7 +243,7 @@ describe("ShadowMCP", () => {
       ),
     ).toBeTruthy();
     expect(
-      screen.getByText("Shadow MCP policies: flag-policy,block-policy-1"),
+      screen.getByText("Shadow MCP policies: block-policy-1"),
     ).toBeTruthy();
     expect(screen.getByText("Roles: Admin")).toBeTruthy();
     expect(screen.getByText("Members: Admin User")).toBeTruthy();

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
@@ -1,8 +1,12 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import type { ShadowMCPPolicy } from "@/components/shadow-mcp/ShadowMCPInventoryActions";
 import { ShadowMCPInventoryTable } from "@/components/shadow-mcp/ShadowMCPInventoryTable";
 import { ShadowMCPPolicyStatus } from "@/components/shadow-mcp/ShadowMCPPolicyStatus";
-import { shadowMCPPolicyState } from "@/components/shadow-mcp/shadowMCPInventoryStatus";
+import {
+  eligibleShadowMCPAllowRulePolicies,
+  shadowMCPPolicyState,
+} from "@/components/shadow-mcp/shadowMCPInventoryStatus";
 import { SkeletonTable } from "@/components/ui/skeleton";
 import { useProject } from "@/contexts/Auth";
 import { useRoutes } from "@/routes";
@@ -41,10 +45,8 @@ export default function ShadowMCP(): JSX.Element {
   const policyState = policiesQuery.isError
     ? "unavailable"
     : shadowMCPPolicyState(policiesQuery.data?.policies);
-  const shadowMCPPolicies =
-    policiesQuery.data?.policies.filter(
-      (policy) => policy.enabled && policy.sources.includes("shadow_mcp"),
-    ) ?? [];
+  const shadowMCPPolicies: ShadowMCPPolicy[] =
+    eligibleShadowMCPAllowRulePolicies(policiesQuery.data?.policies);
 
   return (
     <Page>

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
@@ -890,4 +890,66 @@ describe("ShadowMCPServerDetail", () => {
       screen.getByText("An enabled blocking Shadow MCP policy is required."),
     ).toBeTruthy();
   });
+
+  it("explains why edit is disabled while review and delete remain available", () => {
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            action: "flag",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "flag-policy",
+            name: "Flag policy",
+            sources: ["shadow_mcp"],
+          },
+        ],
+      },
+      isError: false,
+      isLoading: false,
+    });
+    mocks.useShadowMCPInventoryServer.mockReturnValue({
+      data: inventoryServer({
+        access: "allowed",
+        latestRequest: {
+          id: "request-1",
+          policyId: "inactive-policy",
+          requestedAt: new Date("2026-01-04T11:30:00Z"),
+          requesterEmail: "requester@example.com",
+          requesterUserId: "user-1",
+        },
+        requestCount: 1,
+      }),
+      error: null,
+      isLoading: false,
+    });
+
+    renderDetailPage();
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Review Request",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Edit Rule",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Delete Rule",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(
+      screen.getByText("An enabled blocking Shadow MCP policy is required."),
+    ).toBeTruthy();
+  });
 });

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
@@ -891,6 +891,92 @@ describe("ShadowMCPServerDetail", () => {
     ).toBeTruthy();
   });
 
+  it("explains when allow-rule policy status is unavailable", () => {
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            action: "block",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "cached-policy",
+            name: "Cached blocking policy",
+            sources: ["shadow_mcp"],
+          },
+        ],
+      },
+      isError: true,
+      isLoading: false,
+    });
+
+    renderDetailPage();
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Edit Rule",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText(
+        "Policy status is unavailable. Refresh the page to try again.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("An enabled blocking Shadow MCP policy is required."),
+    ).toBeNull();
+  });
+
+  it("explains unavailable policy status while reviewing a pending request", () => {
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            action: "block",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "cached-policy",
+            name: "Cached blocking policy",
+            sources: ["shadow_mcp"],
+          },
+        ],
+      },
+      isError: true,
+      isLoading: false,
+    });
+    mocks.useShadowMCPInventoryServer.mockReturnValue({
+      data: inventoryServer({
+        access: "none",
+        allowedPolicyIds: [],
+        latestRequest: {
+          id: "request-1",
+          policyId: "cached-policy",
+          requestedAt: new Date("2026-01-04T11:30:00Z"),
+          requesterEmail: "requester@example.com",
+          requesterUserId: "user-1",
+        },
+        requestCount: 1,
+      }),
+      error: null,
+      isLoading: false,
+    });
+
+    renderDetailPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Review Request" }));
+    expect(
+      screen.getByText(
+        "Policy status is unavailable. Refresh the page to try again.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("An enabled blocking Shadow MCP policy is required."),
+    ).toBeNull();
+  });
+
   it("explains why edit is disabled while review and delete remain available", () => {
     mocks.useRiskListPolicies.mockReturnValue({
       data: {

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
@@ -852,4 +852,42 @@ describe("ShadowMCPServerDetail", () => {
     });
     expect(mocks.invalidateShadowMCPInventory).toHaveBeenCalled();
   });
+
+  it("disables add when no allow-rule policy is eligible", () => {
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            action: "flag",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "flag-policy",
+            name: "Flag policy",
+            sources: ["shadow_mcp"],
+          },
+        ],
+      },
+      isError: false,
+      isLoading: false,
+    });
+    mocks.useShadowMCPInventoryServer.mockReturnValue({
+      data: inventoryServer({ access: "none", allowedPolicyIds: [] }),
+      error: null,
+      isLoading: false,
+    });
+
+    renderDetailPage();
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Add Allow Rule",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText("An enabled blocking Shadow MCP policy is required."),
+    ).toBeTruthy();
+  });
 });

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
@@ -763,6 +763,50 @@ describe("ShadowMCPServerDetail", () => {
 
   it("adds an allow decision from the detail page action menu", async () => {
     const upsertPolicyBypass = vi.fn().mockResolvedValue({});
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: {
+        policies: [
+          {
+            action: "block",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "policy-1",
+            name: "Blocking policy",
+            sources: ["shadow_mcp"],
+          },
+          {
+            action: "flag",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "flag-policy",
+            name: "Flag policy",
+            sources: ["shadow_mcp"],
+          },
+          {
+            action: "block",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: false,
+            id: "disabled-policy",
+            name: "Disabled policy",
+            sources: ["shadow_mcp"],
+          },
+          {
+            action: "block",
+            audiencePrincipalUrns: ["user:all"],
+            audienceType: "everyone",
+            enabled: true,
+            id: "other-source-policy",
+            name: "Other source policy",
+            sources: ["prompt_injection"],
+          },
+        ],
+      },
+      isError: false,
+      isLoading: false,
+    });
     mocks.useShadowMCPInventoryServer.mockReturnValue({
       data: inventoryServer({
         access: "none",
@@ -784,6 +828,10 @@ describe("ShadowMCPServerDetail", () => {
         screen.getByRole("heading", { name: "Add Allow Rule" }),
       ).toBeTruthy();
     });
+    expect(screen.getByText("Blocking policy")).toBeTruthy();
+    expect(screen.queryByText("Flag policy")).toBeNull();
+    expect(screen.queryByText("Disabled policy")).toBeNull();
+    expect(screen.queryByText("Other source policy")).toBeNull();
     fireEvent.click(
       within(screen.getByTestId("shadow-mcp-action-sheet")).getByRole(
         "button",

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -18,6 +18,7 @@ import {
   shadowMCPPolicyState,
   type ShadowMCPPolicyState,
 } from "@/components/shadow-mcp/shadowMCPInventoryStatus";
+import { ALLOW_RULE_POLICY_REQUIRED } from "@/components/shadow-mcp/shadowMCPInventoryActionItems";
 import { SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { useProject } from "@/contexts/Auth";
@@ -250,45 +251,58 @@ function TopUsersTable({
 }
 
 function DetailActionButtons({
+  canManageAllowRules,
   disabled,
   onOpenAction,
   server,
 }: {
+  canManageAllowRules: boolean;
   disabled: boolean;
   onOpenAction: (mode: InventoryActionMode) => void;
   server: ShadowMCPInventoryServer;
 }) {
   const primaryMode = actionModeForServer(server);
+  const primaryRequiresAllowRule =
+    primaryMode === "add" || primaryMode === "edit";
+  const primaryDisabled =
+    disabled || (primaryRequiresAllowRule && !canManageAllowRules);
 
   return (
-    <div className="flex items-center gap-2">
-      <Button
-        disabled={disabled}
-        onClick={() => onOpenAction(primaryMode)}
-        variant="primary"
-      >
-        <Button.Text>{actionLabel(primaryMode)}</Button.Text>
-      </Button>
-      {server.access === "allowed" && primaryMode !== "edit" && (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-2">
         <Button
-          disabled={disabled}
-          onClick={() => onOpenAction("edit")}
-          variant="tertiary"
+          disabled={primaryDisabled}
+          onClick={() => onOpenAction(primaryMode)}
+          variant="primary"
         >
-          <Button.Text>{actionLabel("edit")}</Button.Text>
+          <Button.Text>{actionLabel(primaryMode)}</Button.Text>
         </Button>
-      )}
-      {server.access === "allowed" && (
-        <Button
-          disabled={disabled}
-          onClick={() => onOpenAction("delete")}
-          variant="tertiary"
-        >
-          <Button.LeftIcon>
-            <Icon name="trash-2" />
-          </Button.LeftIcon>
-          <Button.Text>Delete Rule</Button.Text>
-        </Button>
+        {server.access === "allowed" && primaryMode !== "edit" && (
+          <Button
+            disabled={disabled || !canManageAllowRules}
+            onClick={() => onOpenAction("edit")}
+            variant="tertiary"
+          >
+            <Button.Text>{actionLabel("edit")}</Button.Text>
+          </Button>
+        )}
+        {server.access === "allowed" && (
+          <Button
+            disabled={disabled}
+            onClick={() => onOpenAction("delete")}
+            variant="tertiary"
+          >
+            <Button.LeftIcon>
+              <Icon name="trash-2" />
+            </Button.LeftIcon>
+            <Button.Text>Delete Rule</Button.Text>
+          </Button>
+        )}
+      </div>
+      {primaryRequiresAllowRule && !canManageAllowRules && (
+        <Type muted small>
+          {ALLOW_RULE_POLICY_REQUIRED}
+        </Type>
       )}
     </div>
   );
@@ -555,6 +569,7 @@ export default function ShadowMCPServerDetail(): JSX.Element {
             <Page.Section.CTA>
               {server && (
                 <DetailActionButtons
+                  canManageAllowRules={shadowMCPPolicies.length > 0}
                   disabled={isSubmitting}
                   onOpenAction={openAction}
                   server={server}

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -251,11 +251,13 @@ function TopUsersTable({
 }
 
 function DetailActionButtons({
+  allowRuleUnavailableMessage,
   canManageAllowRules,
   disabled,
   onOpenAction,
   server,
 }: {
+  allowRuleUnavailableMessage: string;
   canManageAllowRules: boolean;
   disabled: boolean;
   onOpenAction: (mode: InventoryActionMode) => void;
@@ -303,7 +305,7 @@ function DetailActionButtons({
       </div>
       {hasVisibleAllowRuleAction && !canManageAllowRules && (
         <Type muted small>
-          {ALLOW_RULE_POLICY_REQUIRED}
+          {allowRuleUnavailableMessage}
         </Type>
       )}
     </div>
@@ -320,8 +322,15 @@ export default function ShadowMCPServerDetail(): JSX.Element {
   const policyState = policiesQuery.isError
     ? "unavailable"
     : shadowMCPPolicyState(policiesQuery.data?.policies);
-  const shadowMCPPolicies: ShadowMCPPolicy[] =
-    eligibleShadowMCPAllowRulePolicies(policiesQuery.data?.policies);
+  let shadowMCPPolicies: ShadowMCPPolicy[] = [];
+  if (!policiesQuery.isError) {
+    shadowMCPPolicies = eligibleShadowMCPAllowRulePolicies(
+      policiesQuery.data?.policies,
+    );
+  }
+  const allowRuleUnavailableMessage = policiesQuery.isError
+    ? "Policy status is unavailable. Refresh the page to try again."
+    : ALLOW_RULE_POLICY_REQUIRED;
   const queryEnabled = project.id.length > 0 && serverSlug.length > 0;
   const [usersCursor, setUsersCursor] = useState<string | undefined>(undefined);
   const [userPages, setUserPages] = useState<UsersPage[]>([]);
@@ -571,6 +580,7 @@ export default function ShadowMCPServerDetail(): JSX.Element {
             <Page.Section.CTA>
               {server && (
                 <DetailActionButtons
+                  allowRuleUnavailableMessage={allowRuleUnavailableMessage}
                   canManageAllowRules={shadowMCPPolicies.length > 0}
                   disabled={isSubmitting}
                   onOpenAction={openAction}
@@ -603,6 +613,7 @@ export default function ShadowMCPServerDetail(): JSX.Element {
                     }}
                     onSubmit={submitInventoryAction}
                     open={activeAction !== null}
+                    policyUnavailableMessage={allowRuleUnavailableMessage}
                     roles={rolesQuery.data?.roles ?? []}
                     shadowMCPPolicies={shadowMCPPolicies}
                   />

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -10,6 +10,7 @@ import {
   type ShadowMCPPolicy,
 } from "@/components/shadow-mcp/ShadowMCPInventoryActions";
 import {
+  eligibleShadowMCPAllowRulePolicies,
   shadowMCPInventoryStatus,
   shadowMCPInventoryStatusBadgeVariant,
   shadowMCPInventoryStatusDescription,
@@ -304,9 +305,7 @@ export default function ShadowMCPServerDetail(): JSX.Element {
     ? "unavailable"
     : shadowMCPPolicyState(policiesQuery.data?.policies);
   const shadowMCPPolicies: ShadowMCPPolicy[] =
-    policiesQuery.data?.policies.filter((policy) =>
-      policy.sources.includes("shadow_mcp"),
-    ) ?? [];
+    eligibleShadowMCPAllowRulePolicies(policiesQuery.data?.policies);
   const queryEnabled = project.id.length > 0 && serverSlug.length > 0;
   const [usersCursor, setUsersCursor] = useState<string | undefined>(undefined);
   const [userPages, setUserPages] = useState<UsersPage[]>([]);

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.tsx
@@ -264,6 +264,8 @@ function DetailActionButtons({
   const primaryMode = actionModeForServer(server);
   const primaryRequiresAllowRule =
     primaryMode === "add" || primaryMode === "edit";
+  const hasVisibleAllowRuleAction =
+    primaryRequiresAllowRule || server.access === "allowed";
   const primaryDisabled =
     disabled || (primaryRequiresAllowRule && !canManageAllowRules);
 
@@ -299,7 +301,7 @@ function DetailActionButtons({
           </Button>
         )}
       </div>
-      {primaryRequiresAllowRule && !canManageAllowRules && (
+      {hasVisibleAllowRuleAction && !canManageAllowRules && (
         <Type muted small>
           {ALLOW_RULE_POLICY_REQUIRED}
         </Type>


### PR DESCRIPTION
## Summary

- centralize the eligibility rule for Shadow MCP policies that can receive allow rules
- offer only enabled blocking Shadow MCP policies from inventory and server-detail flows
- disable add/edit with a clear explanation when no eligible policy exists while preserving deny and delete actions
- retain the server's atomic validation as a defensive boundary

## Reviewer guide

- `shadowMCPInventoryStatus.ts` owns the shared policy eligibility predicate
- `ShadowMCP.tsx` and `ShadowMCPServerDetail.tsx` apply it at both query boundaries
- shared inventory actions distinguish allow-rule eligibility from global mutation state so review/deny and delete remain available
- regression tests cover mixed policy sets, zero-policy actions, denial without an eligible policy, and the combined pending-request/existing-rule state

## Test plan

- `pnpm -F dashboard test -- shadowMCPInventoryStatus.test.ts ShadowMCP.test.tsx ShadowMCPInventoryActionItems.test.ts ShadowMCPInventoryTable.test.tsx ShadowMCPServerDetail.test.tsx` — 111 files, 995 tests passed
- `pnpm -F dashboard lint`
- `git diff --check origin/main...HEAD`

Linear: DNO-579

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts Shadow MCP allow rules to enabled, blocking `shadow_mcp` policies and disables Add/Edit with clear reasons when none are eligible or policy status is unavailable. Fixes the 400 caused by selecting non‑blocking policies and keeps Review/Deny and Delete available (Linear: DNO-579).

- **Bug Fixes**
  - Centralized eligibility in `eligibleShadowMCPAllowRulePolicies` (enabled + block + `shadow_mcp`).
  - Inventory table, context menu, and server detail filter options and gate actions via `canManageAllowRules`.
  - Disabled Add/Edit show a reason in menus and under buttons; selection panel shows an inline empty-state note.
  - When policy status can’t be loaded, show “Policy status is unavailable. Refresh the page to try again.” and keep Review/Deny/Delete available.
  - Approve is disabled if no eligible policy exists; Deny continues to work.
  - Kept server-side validation; added tests for empty/mixed policies, disabled states, and deny flow without an eligible policy.

<sup>Written for commit b9baf4a926ab2e8bea384ad2f2aeaacd7606b4d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

