### PR TITLE
chore(dashboard): remove Preview badge from Employee Enrollment tab

### DIFF
--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -8,7 +8,6 @@ import { MetricCard } from "@/components/chart/MetricCard";
 import { InsightsConfig } from "@/components/insights-dock";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { useInsightsState } from "@/components/insights-context";
-import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { SegmentedControl } from "@/components/ui/segmented-control";
@@ -445,10 +444,7 @@ export function InsightsEmployeesContent(): JSX.Element {
         <div className="mx-auto flex max-w-7xl flex-col gap-6">
           <div className="flex flex-col gap-4">
             <div className="flex min-w-0 flex-col gap-1">
-              <div className="flex items-center gap-2">
-                <h1 className="text-xl font-semibold">Employee Enrollment</h1>
-                <ReleaseStageBadge stage="preview" />
-              </div>
+              <h1 className="text-xl font-semibold">Employee Enrollment</h1>
               <p className="text-muted-foreground text-sm">
                 Track platform adoption for organization members in this project
                 over {rangeLabel}. Employees with tool or agent session activity


### PR DESCRIPTION
## Why

The Employee Enrollment page is no longer in preview, so the "Preview" release-stage badge next to its heading should be removed.

## What changed

**Before:** The Employee Enrollment page heading rendered a `ReleaseStageBadge stage="preview"` pill next to the `<h1>`.

**After:** The badge is removed. The now-redundant flex wrapper `<div>` around the heading was collapsed to just the `<h1>`, and the unused `ReleaseStageBadge` import was dropped.

Type-check passes (`pnpm -F dashboard type-check`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Preview" badge from the Employee Enrollment page now that it’s no longer in preview. Simplified the heading markup and removed the unused ReleaseStageBadge import.

<sup>Written for commit 8972719f53df1a33c5fceb3569498dccedf2d124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

