### PR TITLE
mig: drop user_session_issuers.mode column

### DIFF
--- a/server/migrations/20260721002846_add-user-session-issuer-mode-column.sql
+++ b/server/migrations/20260721002846_add-user-session-issuer-mode-column.sql
@@ -1,0 +1,4 @@
+-- Modify "user_session_issuers" table
+-- NOTE: This column may already exist in production due to schema drift.
+-- Using IF NOT EXISTS to make the migration idempotent.
+ALTER TABLE "user_session_issuers" ADD COLUMN IF NOT EXISTS "mode" text NULL;

--- a/server/migrations/20260721002911_drop-user-session-issuer-mode-column.sql
+++ b/server/migrations/20260721002911_drop-user-session-issuer-mode-column.sql
@@ -1,0 +1,2 @@
+-- Modify "user_session_issuers" table
+ALTER TABLE "user_session_issuers" DROP COLUMN "mode";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:MWaDAuvPhKCSZGoVtJdaBA+s83u/uTHTd+fIhx8hKGM=
+h1:gTI5iucIqYgQVNoxKB8bEHUnn+FPurD86TtXAtIB0zc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -276,3 +276,5 @@ h1:MWaDAuvPhKCSZGoVtJdaBA+s83u/uTHTd+fIhx8hKGM=
 20260718133423_assistant-skill-distributions-drop-old-index.sql h1:uXeDfnAwbzpH7GZglJYBhjBzwCzOj4MbX4cS04AZWFw=
 20260720164342_skill_observations_hash_mapping.sql h1:8JWYcuWH0uIvcI/pmn0XQZm2kgAqDNsWKss23M8jyFs=
 20260720233833_ai-integration-sync-schedules-expand.sql h1:TTyPfdanXp+Mex7mhcXwL3c62FcmGcgOHm4Rgp0kWl8=
+20260721002846_add-user-session-issuer-mode-column.sql h1:KS1kXlH/7ninurniP66IsCT4tmP/G9VVnFyoHI7thYU=
+20260721002911_drop-user-session-issuer-mode-column.sql h1:4jtSQFg8ELn91v3D7vymcBJqYSnFTBI2nZ9so70G/HA=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drop the useless `mode` column from the `user_session_issuers` table.

## Changes

This PR adds two migrations to handle the schema drift scenario where the `mode` column exists in production but is not tracked in the migration history:

1. **`20260721002846_add-user-session-issuer-mode-column.sql`**: An ADD migration using `IF NOT EXISTS` to make it idempotent. This records the column in the migration history without failing if it already exists in production.

2. **`20260721002911_drop-user-session-issuer-mode-column.sql`**: A DROP migration that removes the column.

### Behavior by Environment

| Environment | ADD Migration | DROP Migration | Net Effect |
|-------------|---------------|----------------|------------|
| Production (column exists) | No-op (IF NOT EXISTS) | Drops column | Column removed |
| Fresh environments | Adds column | Drops column | No column |

## Testing

- Ran migrations locally - both migrations applied successfully
- Verified the `mode` column no longer exists in the local database
- All `usersessions` tests pass
- All `remotesessions` tests pass
- Server linting passes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-2364](https://linear.app/speakeasy/issue/AGE-2364/drop-mode-column)

<div><a href="https://cursor.com/agents/bc-d8c1335a-c1b0-4587-8622-6d430d03d6e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8c1335a-c1b0-4587-8622-6d430d03d6e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused mode column from the user_session_issuers table with a safe two-step migration that fixes schema drift. Satisfies Linear AGE-2364.

- **Migration**
  - Add migration uses IF NOT EXISTS to register the column if missing, no-op if present.
  - Drop migration removes the column; net effect: no mode column in any environment.

<sup>Written for commit e2e3310fb369643cd3e5e5e5e513f41013cc4ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

