### PR TITLE
mig: add skill_share_links table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1690,6 +1690,32 @@ CREATE INDEX IF NOT EXISTS skill_distributions_skill_id_pinned_version_id_idx ON
 CREATE INDEX IF NOT EXISTS skill_distributions_plugin_id_idx ON skill_distributions (plugin_id);
 CREATE INDEX IF NOT EXISTS skill_distributions_assistant_id_idx ON skill_distributions (assistant_id);
 
+CREATE TABLE IF NOT EXISTS skill_share_links (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  skill_id uuid NOT NULL,
+
+  token TEXT NOT NULL,
+  created_by_user_id TEXT NOT NULL,
+  revoked_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skill_share_links_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_share_links_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT skill_share_links_project_id_skill_id_fkey FOREIGN KEY (project_id, skill_id) REFERENCES skills (project_id, id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_share_links_token_key ON skill_share_links (token);
+
+-- At most one active public share link per skill.
+CREATE UNIQUE INDEX IF NOT EXISTS skill_share_links_skill_id_key
+ON skill_share_links (skill_id)
+WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS skill_share_links_project_id_idx ON skill_share_links (project_id);
+
 -- project_managed_assistants maps a project to its single platform-managed
 -- assistant (the one powering the AI Insights sidebar). Kept in its own table
 -- rather than a flag on assistants/projects so the relation has an explicit

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1733,6 +1733,17 @@ type SkillRawHash struct {
 	CreatedAt       pgtype.Timestamptz
 }
 
+type SkillShareLink struct {
+	ID              uuid.UUID
+	ProjectID       uuid.UUID
+	SkillID         uuid.UUID
+	Token           string
+	CreatedByUserID string
+	RevokedAt       pgtype.Timestamptz
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+}
+
 type SkillSyncReceipt struct {
 	ProjectID      uuid.UUID
 	SkillID        uuid.UUID

--- a/server/migrations/20260723042033_skill-share-links.sql
+++ b/server/migrations/20260723042033_skill-share-links.sql
@@ -1,0 +1,20 @@
+-- Create "skill_share_links" table
+CREATE TABLE "skill_share_links" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "skill_id" uuid NOT NULL,
+  "token" text NOT NULL,
+  "created_by_user_id" text NOT NULL,
+  "revoked_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skill_share_links_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "skill_share_links_project_id_skill_id_fkey" FOREIGN KEY ("project_id", "skill_id") REFERENCES "skills" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "skill_share_links_project_id_idx" to table: "skill_share_links"
+CREATE INDEX "skill_share_links_project_id_idx" ON "skill_share_links" ("project_id");
+-- Create index "skill_share_links_skill_id_key" to table: "skill_share_links"
+CREATE UNIQUE INDEX "skill_share_links_skill_id_key" ON "skill_share_links" ("skill_id") WHERE (revoked_at IS NULL);
+-- Create index "skill_share_links_token_key" to table: "skill_share_links"
+CREATE UNIQUE INDEX "skill_share_links_token_key" ON "skill_share_links" ("token");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:aXquNqKpat40TlLJgcmlx0R8SKr7F8txE4+LWMPyLw8=
+h1:SZjpr9vL5cXRK9zOZW287h0DOmfBQlMUD5ec8by9gZc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -292,3 +292,4 @@ h1:aXquNqKpat40TlLJgcmlx0R8SKr7F8txE4+LWMPyLw8=
 20260722165353_skill-observations-metrics-sync.sql h1:XjGfajcAFeuuyOpMubKJAA2ZVpetF/x/HXAgnTooCm0=
 20260722165701_add-skill-efficacy-pipeline.sql h1:SWL2LPA0fHEdRohT2mYWmJZJMvB6sAdm2/KZZn7OqsU=
 20260722220532_skill-efficacy-reservation-recovery.sql h1:iSc/QDP1ySptfvBBw0GnH7DKOeMx3bCG6YlrmbbzO4o=
+20260723042033_skill-share-links.sql h1:IM3Yk3pO7qHVuxYd6ANArxKcvciakiqJ5NZVwkZSftc=


### PR DESCRIPTION
## Summary

Additive migration backing public share links for skills (feature PR stacked on top: see the `sagar/skill-share-links` branch).

New table `skill_share_links`, cloning the `skill_distributions` revocation pattern:

- one row per minted link: `token` (unique), `project_id`/`skill_id` composite FK, `created_by_user_id`, `revoked_at`
- partial unique index on `skill_id WHERE revoked_at IS NULL` — at most one **active** link per skill; rows are revoked, never deleted, so re-sharing mints a fresh token and history is preserved

Includes the regenerated `server/internal/database/models.go` and `atlas.sum`.

## Verification

- Migration generated with `mise db:diff`, hashed with `mise db:hash`
- `mise build:server` and `go test ./server/internal/skills/...` pass on the stacked feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141ZwLrsFPSHeaZhoGDqSDT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `skill_share_links` table for public skill share links. Each link has a unique token, is revocable, and only one active link per skill is allowed.

- **Migration**
  - Schema: `id`, `project_id`, `skill_id`, `token`, `created_by_user_id`, `revoked_at`, timestamps; FKs to `projects` and composite `(project_id, skill_id)` to `skills`; unique `token`; partial unique index on `skill_id` where `revoked_at IS NULL`; index on `project_id`.
  - Includes new migration, updated server models, and `atlas.sum`.

<sup>Written for commit 8f6aaf337169ad35ed0f7d4ed9c225aed0d63e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

