### PR TITLE
mig(security): vacuum settings optimization

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3858,6 +3858,22 @@ CREATE TABLE IF NOT EXISTS risk_results (
   CONSTRAINT risk_results_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata(id) ON DELETE CASCADE,
   CONSTRAINT risk_results_risk_policy_id_fkey FOREIGN KEY (risk_policy_id) REFERENCES risk_policies(id) ON DELETE CASCADE,
   CONSTRAINT risk_results_chat_message_id_fkey FOREIGN KEY (chat_message_id) REFERENCES chat_messages(id) ON DELETE CASCADE
+) WITH (
+  -- This table is append-heavy and rarely updated, so the only autovacuum
+  -- trigger that ever fires is the insert one. With the global 0.2 scale
+  -- factor that threshold scales with the table itself, so on a table this
+  -- size vacuum only runs every several million inserts — longer than the
+  -- window the risk overview queries scan. The freshly inserted pages are
+  -- therefore never marked all-visible, and the overview's index-only scan
+  -- degrades into a random heap scan (observed: ~93% heap fetches).
+  --
+  -- A fixed threshold with no scale factor keeps the vacuum cadence constant
+  -- as the table grows instead of stretching indefinitely. Dead tuples stay
+  -- negligible here, so these passes skip index cleanup and mostly just set
+  -- visibility map bits.
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 250000,
+  autovacuum_vacuum_cost_limit = 2000
 );
 
 CREATE INDEX IF NOT EXISTS risk_results_project_policy_version_message_idx

--- a/server/migrations/20260721093938_risk-results-autovacuum-insert-cadence.sql
+++ b/server/migrations/20260721093938_risk-results-autovacuum-insert-cadence.sql
@@ -1,0 +1,6 @@
+-- Set "autovacuum_vacuum_insert_scale_factor" storage parameter on table: "risk_results"
+ALTER TABLE "risk_results" SET (autovacuum_vacuum_insert_scale_factor = 0);
+-- Set "autovacuum_vacuum_insert_threshold" storage parameter on table: "risk_results"
+ALTER TABLE "risk_results" SET (autovacuum_vacuum_insert_threshold = 250000);
+-- Set "autovacuum_vacuum_cost_limit" storage parameter on table: "risk_results"
+ALTER TABLE "risk_results" SET (autovacuum_vacuum_cost_limit = 2000);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:g28DwF/PMx1fUlzIc0dZyxTD7shNRvyR/bwDPx4IAhk=
+h1:+wKvJdrZqa2+MYo1vB3OecQMnSw18idRGA0zd8hSCFo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -280,3 +280,4 @@ h1:g28DwF/PMx1fUlzIc0dZyxTD7shNRvyR/bwDPx4IAhk=
 20260721005550_skill-observations-version-link.sql h1:fHhs3ENBlVtAjOysLa43p6GfI65ngQv3LYEB3v/2Bbw=
 20260721015036_skill-version-lineage.sql h1:AGskkUJirV1iKMZo8K/x0mPj8vL53ht8uqmxO2GXZHk=
 20260721023354_drop-sso-connection-id.sql h1:afqseo0AgAtex4aIM1sIvYzSdcbpMaMDkDAK6loIewc=
+20260721093938_risk-results-autovacuum-insert-cadence.sql h1:yUpY0HL6nQrNEl7HEkvOuGby0dSEX+QfFt4BrjK8KyM=


### PR DESCRIPTION
```
┌─────────────────────────────┬─────────────────────────────────────────┐
│            Fact             │                  Value                  │
├─────────────────────────────┼─────────────────────────────────────────┤
│ n_live_tup                  │ 28,969,663 (~29M)                       │
├─────────────────────────────┼─────────────────────────────────────────┤
│ n_ins_since_vacuum          │ 5,276,822                               │
├─────────────────────────────┼─────────────────────────────────────────┤
│ last_autovacuum             │ 2026-07-14 (~6 days ago)                │
├─────────────────────────────┼─────────────────────────────────────────┤
│ autovacuum_count (lifetime) │ 7                                       │
├─────────────────────────────┼─────────────────────────────────────────┤
│ n_dead_tup                  │ 176,711 (0.6% — churn is not the issue) │
├─────────────────────────────┼─────────────────────────────────────────┤
│ reloptions                  │ empty → pure globals                    │
└─────────────────────────────┴─────────────────────────────────────────┘
```
Both triggers use scale_factor = 0.2 against 29M rows:

- Insert trigger: 1000 + 0.2 × 28,969,663 = 5,794,932. We're at 5,276,822, 91%, hasn't fired.
- Dead-tuple trigger: 50 + 0.2 × 28,969,663 = 5,794,982 dead tuples needed; you have 176,711, 3%. This path will never fire.

So vacuum arrives only via the insert path, roughly every 5.8M inserts ≈ 6–7 days (≈880k inserts/day).