### PR TITLE
fix(dashboard): traffic preview crash on null CEL span payloads

### DIFF
--- a/.changeset/cel-wasm-null-spans.md
+++ b/.changeset/cel-wasm-null-spans.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix a crash in the policy scope traffic preview when a matched message produced no highlight spans.

--- a/client/dashboard/src/pages/security/cel-wasm.ts
+++ b/client/dashboard/src/pages/security/cel-wasm.ts
@@ -182,7 +182,9 @@ async function start(): Promise<CelEngine> {
       return {
         ok: true,
         matched: r.matched ?? false,
-        spans: r.spans ? (JSON.parse(r.spans) as CelSpan[]) : [],
+        // Go marshals a nil slice as the string "null" (truthy), so parse
+        // first and coalesce.
+        spans: r.spans ? ((JSON.parse(r.spans) as CelSpan[] | null) ?? []) : [],
       };
     },
   };


### PR DESCRIPTION
Fixes a crash ("Cannot read properties of null (reading 'filter')") in the policy scope traffic preview / Show messages sheet, hit while dogfooding the detection scopes feature from #4078.

The wasm bridge receives spans as a JSON string from Go. A nil span slice marshals to the string `"null"`, which is truthy, so `JSON.parse` stored `null` typed as `CelSpan[]` and `highlight()` crashed for any matched message whose expression produced no spans (e.g. `kind == "user_message"`). The bridge now coalesces the parsed value, so all consumers get a real array.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash in the policy scope traffic preview when a matched message has no highlight spans. Null CEL span payloads from the Go→WASM bridge are now treated as an empty array to prevent errors.

- Bug Fixes
  - Parse `r.spans` and coalesce `null` to `[]` to normalize span data from Go’s JSON marshaling (“null” for nil slices).

<sup>Written for commit 17739e2c62d66fff332ba3eea9dee2d13bb6220f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

