### PR TITLE
chore(dashboard): update nginx CORS comment for CDN bucket origin

### DIFF
--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -23,14 +23,16 @@ server {
         add_header Access-Control-Allow-Origin "*";
     }
 
-    # Serve static assets with an efficient cache policy. CORS is required
-    # here: Vite emits <script type="module" crossorigin> and stylesheet
-    # links, so when assets are served via the CDN host the app origin
-    # fetches them in CORS mode. The CDN passes origin headers through and
-    # deliberately adds none of its own (see cdn.tf in gram-infra).
-    # Sourcemaps need the CORS header too: devtools fetch them from the CDN
-    # host (resolved against the JS file's URL) in CORS mode, and without it
-    # the fetch fails with a NetworkError.
+    # Serve static assets with an efficient cache policy. Note: with
+    # GRAM_CDN_URL set, browsers fetch /assets from the CDN, whose origin is
+    # a GCS bucket rather than this nginx (see cdn.tf / cdn-bucket.tf in
+    # gram-infra); the LB there sets its own Access-Control-Allow-Origin: *,
+    # mirroring the header here. These headers still cover anything served
+    # directly from this container: CDN disabled (GRAM_CDN_URL empty), local
+    # runs, or clients hitting the origin host. Vite emits
+    # <script type="module" crossorigin> and stylesheet links, and devtools
+    # fetch sourcemaps in CORS mode, so cross-origin consumers need the
+    # header or the fetch fails with a NetworkError.
     location ~* \.(js|css|map)$ {
         expires max;
         add_header Cache-Control "public, max-age=31536000, immutable";


### PR DESCRIPTION
The comment previously claimed the CDN passes these origin headers through, but since dashboard assets moved to a GCS bucket origin the CDN load balancer sets its own Access-Control-Allow-Origin header and never touches this nginx. Rewrite the comment so it accurately explains when these headers matter: CDN disabled, local runs, or clients hitting the origin host directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the CORS comment in dashboard nginx.conf to reflect that the CDN now serves from a GCS bucket where the load balancer sets Access-Control-Allow-Origin. The nginx header only matters when the CDN is disabled, during local runs, or when clients hit the origin directly (still needed for Vite module/stylesheet and sourcemap fetches).

<sup>Written for commit 12eb0729a7c00e3c92f362d86659063f382305c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

