### PR TITLE
mig(aiintegrations): add poll checkpoint column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3007,6 +3007,7 @@ CREATE TABLE IF NOT EXISTS ai_integration_syncs (
   -- the expand-contract transition, same as schedule.
   kind TEXT NULL,
   poll_watermark_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  poll_checkpoint TEXT,
   last_cursor_id TEXT,
   next_poll_after timestamptz NOT NULL DEFAULT clock_timestamp(),
   last_poll_error TEXT,

--- a/server/internal/aiintegrations/repo/queries.sql.go
+++ b/server/internal/aiintegrations/repo/queries.sql.go
@@ -59,12 +59,12 @@ WITH inserted AS (
     FROM ai_integration_syncs
     WHERE ai_integration_config_id = $1
   )
-  RETURNING created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+  RETURNING created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
 )
-SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
 FROM inserted
 UNION ALL
-SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
 FROM ai_integration_syncs
 WHERE ai_integration_config_id = $1
 LIMIT 1
@@ -77,6 +77,7 @@ type EnsureSyncRow struct {
 	Schedule              pgtype.Text
 	Kind                  pgtype.Text
 	PollWatermarkAt       pgtype.Timestamptz
+	PollCheckpoint        pgtype.Text
 	LastCursorID          pgtype.Text
 	NextPollAfter         pgtype.Timestamptz
 	LastPollError         pgtype.Text
@@ -100,6 +101,7 @@ func (q *Queries) EnsureSync(ctx context.Context, aiIntegrationConfigID uuid.UUI
 		&i.Schedule,
 		&i.Kind,
 		&i.PollWatermarkAt,
+		&i.PollCheckpoint,
 		&i.LastCursorID,
 		&i.NextPollAfter,
 		&i.LastPollError,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -56,6 +56,7 @@ type AiIntegrationSync struct {
 	Schedule              pgtype.Text
 	Kind                  pgtype.Text
 	PollWatermarkAt       pgtype.Timestamptz
+	PollCheckpoint        pgtype.Text
 	LastCursorID          pgtype.Text
 	NextPollAfter         pgtype.Timestamptz
 	LastPollError         pgtype.Text

--- a/server/migrations/20260721125001_ai-integration-poll-checkpoint.sql
+++ b/server/migrations/20260721125001_ai-integration-poll-checkpoint.sql
@@ -1,0 +1,2 @@
+-- Modify "ai_integration_syncs" table
+ALTER TABLE "ai_integration_syncs" ADD COLUMN "poll_checkpoint" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:+wKvJdrZqa2+MYo1vB3OecQMnSw18idRGA0zd8hSCFo=
+h1:/m4aEwcO79uGcOPQKWxTbhSs9wGa+R79fzaInOzVgh0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -281,3 +281,4 @@ h1:+wKvJdrZqa2+MYo1vB3OecQMnSw18idRGA0zd8hSCFo=
 20260721015036_skill-version-lineage.sql h1:AGskkUJirV1iKMZo8K/x0mPj8vL53ht8uqmxO2GXZHk=
 20260721023354_drop-sso-connection-id.sql h1:afqseo0AgAtex4aIM1sIvYzSdcbpMaMDkDAK6loIewc=
 20260721093938_risk-results-autovacuum-insert-cadence.sql h1:yUpY0HL6nQrNEl7HEkvOuGby0dSEX+QfFt4BrjK8KyM=
+20260721125001_ai-integration-poll-checkpoint.sql h1:OMjSUB9GcRGrONy32TNzXHuapkFOaVwYvoAPuZbxylk=


### PR DESCRIPTION
## Summary
- Add nullable `poll_checkpoint` to `ai_integration_syncs` for time-window poller resume state.
- Regenerate the Postgres migration and DB model field on top of current `main`.

## Test plan
- `mise db:diff ai-integration-poll-checkpoint`
- `mise lint:migrations` checked migration ordering successfully; local Atlas snapshot failed because the connected local DB was not clean (`agent_executions` already exists).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nullable `poll_checkpoint` to `ai_integration_syncs` to store poller resume state for time-window polling. Regenerates models and the `EnsureSync` query to read/write this field for safer restarts without replaying work.

- **Migration**
  - Run database migrations; the new column is nullable and requires no backfill.

<sup>Written for commit 5e83cec4f06a8aef0e4669ce035d0362b58cf05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

