### PR TITLE
chore(risk): cover args-only secrets and PII in batch scan tests

### DIFF
--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -706,6 +706,117 @@ func TestAnalyzeBatch_CLIDestructive_BashRmRf(t *testing.T) {
 	assert.Equal(t, "Bash", rows[0].Match.String)
 }
 
+// TestAnalyzeBatch_Gitleaks_SecretInToolCallArgsOnly plants a secret solely in
+// tool-call arguments (content empty) and asserts the batch gitleaks scan
+// composes the argument surface and reports it - the POC-314 scenario where
+// args-only credentials never triggered risk policies.
+func TestAnalyzeBatch_Gitleaks_SecretInToolCallArgsOnly(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "Bash", map[string]any{
+		"command": "aws configure set aws_access_key_id AKIAIOSFODNN7REALKEY",
+	})
+
+	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{"gitleaks"})
+	require.Equal(t, 1, result.Processed)
+	require.Positive(t, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		CursorID:     uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+
+	var saw bool
+	for _, row := range rows {
+		if row.Source == "gitleaks" && row.Found {
+			assert.Equal(t, "secret.aws_access_token", row.RuleID.String)
+			assert.Contains(t, row.Match.String, "AKIA")
+			saw = true
+		}
+	}
+	require.True(t, saw, "expected a gitleaks finding from tool-call arguments")
+}
+
+// TestAnalyzeBatch_Presidio_PIIInToolCallArgsOnly mirrors the gitleaks case for
+// Presidio: PII only in tool-call arguments must survive the composed scan
+// surface end to end through the batch activity.
+func TestAnalyzeBatch_Presidio_PIIInToolCallArgsOnly(t *testing.T) {
+	t.Parallel()
+	conn := cloneDB(t)
+	td := seedTestData(t, conn, true)
+
+	// Not @example.com: placeholder domains are suppressed by the presidiofp
+	// false-positive catalog and would never surface as findings.
+	msgID := insertAssistantToolCallWithArgs(t, conn, td, "mcp__crm__update_contact", map[string]any{
+		"email": "alice.smith@bluesky-mail.com",
+	})
+
+	ab, err := risk_analysis.NewAnalyzeBatch(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		conn,
+		infra.NewPresidioClient(t),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		newPresidioPub(),
+		newGitleaksPub(),
+		newPromptInjectionPub(),
+		newPromptPolicyPub(),
+		newCustomRulesPub(),
+		mustCustomRuleScanner(t, conn),
+		mustCELEngine(t),
+		nil,
+	)
+	require.NoError(t, err)
+
+	var ts testsuite.WorkflowTestSuite
+	env := ts.NewTestActivityEnvironment()
+	env.RegisterActivity(ab.Do)
+
+	val, err := env.ExecuteActivity(ab.Do, risk_analysis.AnalyzeBatchArgs{
+		ProjectID:        td.projectID,
+		OrganizationID:   td.orgID,
+		RiskPolicyID:     td.policyID,
+		PolicyVersion:    td.policyVersion,
+		MessageIDs:       []uuid.UUID{msgID},
+		Sources:          []string{"presidio"},
+		PresidioEntities: nil,
+		CustomRuleIds:    nil,
+	})
+	require.NoError(t, err)
+
+	var result risk_analysis.AnalyzeBatchResult
+	require.NoError(t, val.Get(&result))
+	require.Equal(t, 1, result.Processed)
+	require.Positive(t, result.Findings)
+
+	rows, err := riskrepo.New(conn).ListRiskResultsByProjectAndPolicy(t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:    td.projectID,
+		RiskPolicyID: td.policyID,
+		CursorID:     uuid.NullUUID{},
+		PageLimit:    10,
+	})
+	require.NoError(t, err)
+
+	var saw bool
+	for _, row := range rows {
+		if row.Source == "presidio" && row.Found && row.RuleID.String == "pii.email_address" {
+			assert.Contains(t, row.Match.String, "alice.smith@bluesky-mail.com")
+			saw = true
+		}
+	}
+	require.True(t, saw, "expected a presidio email finding from tool-call arguments")
+}
+
 func TestAnalyzeBatch_CLIDestructive_GitForcePush(t *testing.T) {
 	t.Parallel()
 	conn := cloneDB(t)


### PR DESCRIPTION
Regression tests for the [POC-314](https://linear.app/speakeasy/issue/POC-314/bug-tool-call-credential-detections-do-not-trigger-risk-policies) drive-by fix that shipped in #4078: batch content scanning now composes tool-call arguments into the scan surface, but the existing gitleaks/presidio batch tests only planted secrets in message content.

- Gitleaks: an AWS key solely in `Bash` tool-call arguments (empty content) produces a `secret.aws_access_token` finding.
- Presidio: an email solely in tool-call arguments produces a `pii.email_address` finding through the real activity path (mock analyzer). The fixture avoids `@example.com`, which the presidiofp placeholder-domain catalog deliberately suppresses.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to batch risk analysis to ensure tool-call arguments are included in the scan surface (POC-314). An AWS key only in `Bash` tool-call args produces a `gitleaks` secret finding, and an email only in args produces a `presidio` PII finding.

<sup>Written for commit f0e9c4db8bf051ddf77f7d4d22d2eed6c0391672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

