### PR TITLE
mig(domains): add custom domain health state

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -915,6 +915,12 @@ CREATE TABLE IF NOT EXISTS custom_domains (
   provisioner_kind TEXT NOT NULL DEFAULT 'ingress',
   -- IP addresses or CIDR ranges allowed to access this domain. Empty array = unrestricted.
   ip_allowlist TEXT[] NOT NULL DEFAULT '{}',
+  health_status TEXT,
+  health_issue TEXT,
+  health_checked_at timestamptz,
+  unhealthy_since timestamptz,
+  certificate_expires_at timestamptz,
+  consecutive_failures INTEGER CONSTRAINT custom_domains_consecutive_failures_check CHECK (consecutive_failures >= 0),
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   deleted_at timestamptz,

--- a/server/internal/customdomains/repo/models.go
+++ b/server/internal/customdomains/repo/models.go
@@ -10,17 +10,23 @@ import (
 )
 
 type CustomDomain struct {
-	ID              uuid.UUID
-	OrganizationID  string
-	Domain          string
-	Verified        bool
-	Activated       bool
-	IngressName     pgtype.Text
-	CertSecretName  pgtype.Text
-	ProvisionerKind string
-	IpAllowlist     []string
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
-	DeletedAt       pgtype.Timestamptz
-	Deleted         bool
+	ID                   uuid.UUID
+	OrganizationID       string
+	Domain               string
+	Verified             bool
+	Activated            bool
+	IngressName          pgtype.Text
+	CertSecretName       pgtype.Text
+	ProvisionerKind      string
+	IpAllowlist          []string
+	HealthStatus         pgtype.Text
+	HealthIssue          pgtype.Text
+	HealthCheckedAt      pgtype.Timestamptz
+	UnhealthySince       pgtype.Timestamptz
+	CertificateExpiresAt pgtype.Timestamptz
+	ConsecutiveFailures  pgtype.Int4
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
 }

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -28,7 +28,7 @@ INSERT INTO custom_domains (
     $5,
     $6
 )
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateCustomDomainParams struct {
@@ -60,6 +60,12 @@ func (q *Queries) CreateCustomDomain(ctx context.Context, arg CreateCustomDomain
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -81,7 +87,7 @@ func (q *Queries) DeleteCustomDomain(ctx context.Context, organizationID string)
 }
 
 const getCustomDomainByDomain = `-- name: GetCustomDomainByDomain :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE domain = $1
   AND deleted IS FALSE
@@ -100,6 +106,12 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -109,7 +121,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 }
 
 const getCustomDomainByID = `-- name: GetCustomDomainByID :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND deleted IS FALSE
@@ -128,6 +140,12 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -137,7 +155,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 }
 
 const getCustomDomainByIDAndOrganization = `-- name: GetCustomDomainByIDAndOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND organization_id = $2
@@ -166,6 +184,12 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -175,7 +199,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 }
 
 const getCustomDomainByOrganization = `-- name: GetCustomDomainByOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -195,6 +219,12 @@ func (q *Queries) GetCustomDomainByOrganization(ctx context.Context, organizatio
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -214,7 +244,7 @@ SET
     updated_at = clock_timestamp()
 WHERE id = $6
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainParams struct {
@@ -246,6 +276,12 @@ func (q *Queries) UpdateCustomDomain(ctx context.Context, arg UpdateCustomDomain
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -261,7 +297,7 @@ SET
     updated_at = clock_timestamp()
 WHERE organization_id = $2
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainIPAllowlistParams struct {
@@ -282,6 +318,12 @@ func (q *Queries) UpdateCustomDomainIPAllowlist(ctx context.Context, arg UpdateC
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.HealthStatus,
+		&i.HealthIssue,
+		&i.HealthCheckedAt,
+		&i.UnhealthySince,
+		&i.CertificateExpiresAt,
+		&i.ConsecutiveFailures,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -384,19 +384,25 @@ type ChatUserFeedback struct {
 }
 
 type CustomDomain struct {
-	ID              uuid.UUID
-	OrganizationID  string
-	Domain          string
-	Verified        bool
-	Activated       bool
-	IngressName     pgtype.Text
-	CertSecretName  pgtype.Text
-	ProvisionerKind string
-	IpAllowlist     []string
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
-	DeletedAt       pgtype.Timestamptz
-	Deleted         bool
+	ID                   uuid.UUID
+	OrganizationID       string
+	Domain               string
+	Verified             bool
+	Activated            bool
+	IngressName          pgtype.Text
+	CertSecretName       pgtype.Text
+	ProvisionerKind      string
+	IpAllowlist          []string
+	HealthStatus         pgtype.Text
+	HealthIssue          pgtype.Text
+	HealthCheckedAt      pgtype.Timestamptz
+	UnhealthySince       pgtype.Timestamptz
+	CertificateExpiresAt pgtype.Timestamptz
+	ConsecutiveFailures  pgtype.Int4
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+	DeletedAt            pgtype.Timestamptz
+	Deleted              bool
 }
 
 type Deployment struct {

--- a/server/migrations/20260722094814_custom-domains-add-health.sql
+++ b/server/migrations/20260722094814_custom-domains-add-health.sql
@@ -1,0 +1,2 @@
+-- Modify "custom_domains" table
+ALTER TABLE "custom_domains" ADD CONSTRAINT "custom_domains_consecutive_failures_check" CHECK (consecutive_failures >= 0), ADD COLUMN "health_status" text NULL, ADD COLUMN "health_issue" text NULL, ADD COLUMN "health_checked_at" timestamptz NULL, ADD COLUMN "unhealthy_since" timestamptz NULL, ADD COLUMN "certificate_expires_at" timestamptz NULL, ADD COLUMN "consecutive_failures" integer NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Hx4VDcebW8bPicuksf34UMbJRlxoXgOf1Au8CwFMaio=
+h1:RH+lSbjSS4GGoo2aPDFzqvUaPhZ+RRARdCzOJnF5/FY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -284,3 +284,4 @@ h1:Hx4VDcebW8bPicuksf34UMbJRlxoXgOf1Au8CwFMaio=
 20260721125001_ai-integration-poll-checkpoint.sql h1:OMjSUB9GcRGrONy32TNzXHuapkFOaVwYvoAPuZbxylk=
 20260721225140_ai-integration-sync-schedules-contract.sql h1:To66VlwrBJi3Entrc9+zF5ZGryrGLMp8jEkSrmi+6LY=
 20260722090456_chat-messages-autovacuum-cadence.sql h1:q8qNe7ClCif2mg7vy6/5OPXyfRgPwJ57cS7gY66hPQI=
+20260722094814_custom-domains-add-health.sql h1:rPyAbSNozU6SrxQBB0ZnKi0sdWOkYbtFDl1xKOn4FWw=


### PR DESCRIPTION
## Summary

- add nullable custom-domain health observation columns
- store check time, unhealthy start, certificate expiry, and consecutive failures
- leave legacy rows unset until their first scheduled check

## Validation

- generated with Atlas
- Atlas migration lint passed against an isolated PostgreSQL database

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nullable health columns to `custom_domains` to track routing status and certificate expiry for daily checks without relying on Temporal history. Enforce a non-negative `consecutive_failures` check.

- **Migration**
  - No new index added; primary key is enough for sweep pagination and keeps the migration transactional.
  - Update generated models and queries to include the new fields.
  - Legacy rows stay null until their first scheduled check.

<sup>Written for commit a1c380d62fc2f5abff1353b70e2b62376cef14e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

