### PR TITLE
fix(hooks): identify Cowork sessions reliably

### DIFF
--- a/.changeset/identify-cowork-sessions.md
+++ b/.changeset/identify-cowork-sessions.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Use the product surface detected by the session hook to label Claude Cowork and Claude Code sessions instead of relying on their ambiguous service name.

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -179,17 +179,9 @@ func (s *Service) buildTelemetryAttributesWithMetadata(ctx context.Context, payl
 		toolName = *payload.ToolName
 	}
 
-	hookSource := "claude"
-	if metadata.ServiceName != "" {
-		hookSource = metadata.ServiceName
-	}
-	// Cowork runs the same claude-code binary and reports the same OTEL
-	// service.name, so ServiceName can't distinguish it — it lands on the
-	// "claude"/"claude-code" default. SessionStart stamps the agent variant
-	// into the cache, so prefer that when it identifies a cowork session, so
-	// per-tool-call tool logs are labelled "cowork" and stay filterable.
-	if s.sessionAgentVariant(ctx, metadata.SessionID) == agentVariantCowork {
-		hookSource = agentVariantCowork
+	hookSource := s.claudeSessionSource(ctx, metadata)
+	if hookSource == "" {
+		hookSource = "claude"
 	}
 
 	attrs := map[attr.Key]any{

--- a/server/internal/hooks/pending_helpers_test.go
+++ b/server/internal/hooks/pending_helpers_test.go
@@ -139,9 +139,9 @@ func TestBuildTelemetryAttributesWithMetadata_HookSourceCoworkFromSessionStart(t
 	assert.Equal(t, agentVariantCowork, attrs[attr.HookSourceKey])
 }
 
-// A claude-code variant (or no cached variant) must not be rewritten to
-// "cowork"; hook_source keeps the ServiceName / "claude" default.
-func TestBuildTelemetryAttributesWithMetadata_HookSourceDefaultsWithoutCoworkVariant(t *testing.T) {
+// A Claude Code inventory is also authoritative when service.name is the
+// ambiguous "claude" value shared with Cowork.
+func TestBuildTelemetryAttributesWithMetadata_HookSourceFromClaudeCodeVariant(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
 
@@ -154,7 +154,7 @@ func TestBuildTelemetryAttributesWithMetadata_HookSourceDefaultsWithoutCoworkVar
 
 	metadata := &SessionMetadata{
 		SessionID:   sessionID,
-		ServiceName: "claude-code",
+		ServiceName: "claude",
 		GramOrgID:   authCtx.ActiveOrganizationID,
 		ProjectID:   authCtx.ProjectID.String(),
 	}

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -82,6 +82,22 @@ func (s *Service) sessionAgentVariant(ctx context.Context, sessionID string) str
 	return variant
 }
 
+// claudeSessionSource returns the product surface detected by Gram's
+// SessionStart hook. Cowork and Claude Code run the same binary and may report
+// the same service.name, so the inventory shape cached at SessionStart is more
+// specific than ServiceName. Preserve ServiceName when no variant was observed
+// so older hook installations keep their existing source.
+func (s *Service) claudeSessionSource(ctx context.Context, metadata *SessionMetadata) string {
+	switch s.sessionAgentVariant(ctx, metadata.SessionID) {
+	case agentVariantCowork:
+		return agentVariantCowork
+	case agentVariantClaudeCode:
+		return agentVariantClaudeCode
+	default:
+		return metadata.ServiceName
+	}
+}
+
 // sessionIDToUUID converts a Claude Code session_id string to a UUID.
 // The session_id is expected to already be a valid UUID string.
 // If parsing fails, falls back to generating a deterministic UUIDv5 from the session_id.
@@ -340,7 +356,7 @@ func (s *Service) persistConversationEvent(ctx context.Context, payload *gen.Cla
 		Content:          content,
 		Model:            model,
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
-		Source:           conv.ToPGText(metadata.ServiceName),
+		Source:           conv.ToPGText(s.claudeSessionSource(ctx, metadata)),
 		PromptTokens:     0,
 		CompletionTokens: 0,
 		TotalTokens:      0,
@@ -438,7 +454,7 @@ func (s *Service) writeToolCallRequestToPG(ctx context.Context, payload *gen.Cla
 		Content:          "", // Tool call requests typically have empty content
 		Model:            conv.ToPGTextEmpty(conv.PtrValOr(payload.Model, "")),
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
-		Source:           conv.ToPGText(metadata.ServiceName),
+		Source:           conv.ToPGText(s.claudeSessionSource(ctx, metadata)),
 		ToolCalls:        toolCallsJSON,
 		FinishReason:     conv.ToPGText("tool_calls"),
 		PromptTokens:     0,
@@ -490,7 +506,7 @@ func (s *Service) writeToolCallResultToPG(ctx context.Context, payload *gen.Clau
 		Role:             "tool",
 		Content:          content,
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
-		Source:           conv.ToPGText(metadata.ServiceName),
+		Source:           conv.ToPGText(s.claudeSessionSource(ctx, metadata)),
 		ToolCallID:       conv.ToPGTextEmpty(conv.PtrValOr(payload.ToolUseID, "")),
 		PromptTokens:     0,
 		CompletionTokens: 0,

--- a/server/internal/hooks/session_capture_test.go
+++ b/server/internal/hooks/session_capture_test.go
@@ -20,12 +20,37 @@ func (alwaysEnabledFeatures) IsFeatureEnabled(_ context.Context, _ string, _ pro
 	return true, nil
 }
 
-// TestClaudeHookSource_ConsistentAcrossAllWrites asserts that every
-// chat_messages row produced by a single Claude Code session carries the same
-// Source value, regardless of which hook handler wrote it. This guards
-// against drift between the conversation-event path
-// (UserPromptSubmit/Stop) and the tool-call paths (Pre/PostToolUse).
-func TestClaudeHookSource_ConsistentAcrossAllWrites(t *testing.T) {
+func TestClaudeSessionSource_PreservesAmbiguousSourceWithoutVariant(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	metadata := &SessionMetadata{
+		SessionID:           uuid.NewString(),
+		ServiceName:         "claude",
+		UserEmail:           "",
+		UserID:              "",
+		Provider:            "",
+		ExternalOrgID:       "",
+		ExternalAccountUUID: "",
+		ExternalAccountID:   "",
+		DeviceID:            "",
+		Hostname:            "",
+		AccountType:         "",
+		BillingMode:         "",
+		UserAccountID:       "",
+		ObservedUserEmail:   "",
+		GramOrgID:           "",
+		ProjectID:           "",
+	}
+
+	require.Equal(t, "claude", ti.service.claudeSessionSource(ctx, metadata))
+}
+
+// TestCoworkHookSource_ConsistentAcrossAllWrites asserts that the product
+// surface detected from SessionStart wins over the ambiguous service.name on
+// every chat_messages write path. The chat list infers a session's source from
+// these rows, so one path falling back to "claude" would mislabel the session.
+func TestCoworkHookSource_ConsistentAcrossAllWrites(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
 
@@ -39,14 +64,16 @@ func TestClaudeHookSource_ConsistentAcrossAllWrites(t *testing.T) {
 
 	sessionID := uuid.NewString()
 	chatID := sessionIDToUUID(sessionID)
-	const wantSource = "test-agent-source"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionAgentVariantCacheKey(sessionID),
+		agentVariantCowork, sessionMCPListTTL))
+	const wantSource = "cowork"
 	const wantUserID = "session-capture-user"
 	const wantUserEmail = "tester@example.com"
 	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, wantUserID, wantUserEmail)
 
 	metadata := &SessionMetadata{
 		SessionID:     sessionID,
-		ServiceName:   wantSource,
+		ServiceName:   "claude",
 		UserEmail:     wantUserEmail,
 		UserID:        wantUserID,
 		ExternalOrgID: "",
@@ -62,9 +89,8 @@ func TestClaudeHookSource_ConsistentAcrossAllWrites(t *testing.T) {
 	toolResponse := map[string]any{"ok": true}
 	errorData := map[string]any{"message": "boom"}
 
-	// Each of these is a distinct write path that previously either used
-	// metadata.ServiceName or a hardcoded string. The fix unified them — this
-	// test asserts the unification stays unified.
+	// Each of these is a distinct write path. They must all consult the cached
+	// variant rather than persisting the ambiguous service.name.
 	require.NoError(t, ti.service.persistConversationEvent(ctx, &gen.ClaudePayload{
 		HookEventName: "UserPromptSubmit",
 		SessionID:     &sessionID,
@@ -113,7 +139,7 @@ func TestClaudeHookSource_ConsistentAcrossAllWrites(t *testing.T) {
 	for _, m := range msgs {
 		assert.True(t, m.Source.Valid, "Source should be set (role=%s)", m.Role)
 		assert.Equal(t, wantSource, m.Source.String,
-			"Source should match metadata.ServiceName for all hook writes (role=%s)", m.Role)
+			"Source should match the detected Cowork variant for all hook writes (role=%s)", m.Role)
 		assert.True(t, m.UserID.Valid, "UserID should be set (role=%s)", m.Role)
 		assert.Equal(t, wantUserID, m.UserID.String,
 			"UserID should match metadata.UserID for all hook writes (role=%s)", m.Role)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- use the SessionStart inventory shape as the authoritative Claude product-surface signal
- persist `cowork` or `claude-code` on every chat message path instead of trusting ambiguous `service.name` values such as `claude`
- preserve existing source values for older hook installations where no variant signal is available

## Root cause
Gram already distinguished Cowork (`mcp_inventory_cowork`) from Claude Code (`mcp_inventory_claude_code`) and cached that variant, but only tool-log telemetry and default titles consulted it. Agent Sessions derives Source from the latest `chat_messages.source`, and every Claude chat-message writer persisted the ambiguous OTEL `service.name` directly.

## Testing
- `mise exec -- go test ./server/internal/hooks -count=1`
- `mise lint:server`
- focused PostgreSQL integration test verifies all five conversation/tool message paths persist `cowork` when `service.name` is `claude`

Linear: DNO-587
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-587](https://linear.app/speakeasy/issue/DNO-587/investigation-reliably-identify-cowork-sessions)

<div><a href="https://cursor.com/agents/bc-6d71695a-82ad-4be3-b990-1297367ce652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d71695a-82ad-4be3-b990-1297367ce652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reliably identify Claude Cowork vs Claude Code by using the SessionStart inventory as the source of truth and persisting that product surface on all chat message writes. This addresses Linear DNO-587 by removing reliance on ambiguous `service.name` values like "claude".

- **Bug Fixes**
  - Added `claudeSessionSource` to read the cached agent variant and return `cowork` or `claude-code`; falls back to `ServiceName` for older hooks.
  - Persisted the derived source in all write paths (conversation events and tool calls) for consistent `chat_messages.Source`.
  - Updated tests to enforce consistent labeling across handlers and to preserve `ServiceName` when no variant is available.

<sup>Written for commit 72a017821ba155cf9f479ad8f4e16892a4992d0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

