### PR TITLE
fix: preserve MCP install redirect query parameters

### DIFF
--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1006,7 +1006,19 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 	// Honour the installation override URL on either backend.
 	if metadataRecord != nil {
 		if overrideURL := conv.FromPGText[string](metadataRecord.InstallationOverrideUrl); overrideURL != nil && *overrideURL != "" {
-			http.Redirect(w, r, *overrideURL, http.StatusFound)
+			redirectURL, err := url.Parse(*overrideURL)
+			if err != nil {
+				return oops.E(oops.CodeUnexpected, err, "parse installation override URL").LogError(ctx, s.logger)
+			}
+			if r.URL.RawQuery != "" {
+				if redirectURL.RawQuery != "" {
+					redirectURL.RawQuery += "&" + r.URL.RawQuery
+				} else {
+					redirectURL.RawQuery = r.URL.RawQuery
+				}
+			}
+
+			http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 			return nil
 		}
 	}

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -1600,8 +1601,8 @@ func TestServeInstallPage_McpServer_FallsBackToToolsetMetadata(t *testing.T) {
 }
 
 // TestServeInstallPage_McpServer_InstallationOverrideURL ensures the override
-// redirect honors mcp_server-keyed metadata, matching the existing toolset
-// behaviour so customer-hosted install pages keep working across backends.
+// redirect honors mcp_server-keyed metadata and preserves request query
+// parameters, including explicit referrer attribution.
 func TestServeInstallPage_McpServer_InstallationOverrideURL(t *testing.T) {
 	t.Parallel()
 
@@ -1625,7 +1626,7 @@ func TestServeInstallPage_McpServer_InstallationOverrideURL(t *testing.T) {
 		userSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
 	})
 
-	override := "https://custom-install-page.example.com/install"
+	override := "https://custom-install-page.example.com/install?configured=1#setup"
 	serverID := server.ID.String()
 	_, err := ti.service.SetMcpMetadata(ctx, &gen.SetMcpMetadataPayload{
 		McpServerID:             &serverID,
@@ -1633,7 +1634,12 @@ func TestServeInstallPage_McpServer_InstallationOverrideURL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", "/mcp/"+endpointSlug+"/install", nil)
+	req := httptest.NewRequest(
+		"GET",
+		"/mcp/"+endpointSlug+"/install?utm_source=directory&campaign=spring&campaign=summer&referrer=https%3A%2F%2Fdirectory.example.com%2Fcatalog%3Fcategory%3Dai",
+		nil,
+	)
+	req.Header.Set("Referer", "https://different-referrer.example.com/page")
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("mcpSlug", endpointSlug)
 	req = req.WithContext(context.WithValue(context.Background(), chi.RouteCtxKey, rctx))
@@ -1641,5 +1647,15 @@ func TestServeInstallPage_McpServer_InstallationOverrideURL(t *testing.T) {
 	rr := httptest.NewRecorder()
 	require.NoError(t, ti.service.ServeInstallPage(rr, req))
 	require.Equal(t, http.StatusFound, rr.Code)
-	require.Equal(t, override, rr.Header().Get("Location"))
+
+	location, err := url.Parse(rr.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "https", location.Scheme)
+	require.Equal(t, "custom-install-page.example.com", location.Host)
+	require.Equal(t, "/install", location.Path)
+	require.Equal(t, "setup", location.Fragment)
+	require.Equal(t, "1", location.Query().Get("configured"))
+	require.Equal(t, "directory", location.Query().Get("utm_source"))
+	require.Equal(t, []string{"spring", "summer"}, location.Query()["campaign"])
+	require.Equal(t, "https://directory.example.com/catalog?category=ai", location.Query().Get("referrer"))
 }

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1636,7 +1636,7 @@ func TestServeInstallPage_McpServer_InstallationOverrideURL(t *testing.T) {
 
 	req := httptest.NewRequest(
 		"GET",
-		"/mcp/"+endpointSlug+"/install?utm_source=directory&campaign=spring&campaign=summer&referrer=https%3A%2F%2Fdirectory.example.com%2Fcatalog%3Fcategory%3Dai",
+		"/mcp/"+endpointSlug+"/install?configured=caller&utm_source=directory&campaign=spring&campaign=summer&referrer=https%3A%2F%2Fdirectory.example.com%2Fcatalog%3Fcategory%3Dai",
 		nil,
 	)
 	req.Header.Set("Referer", "https://different-referrer.example.com/page")
@@ -1654,7 +1654,7 @@ func TestServeInstallPage_McpServer_InstallationOverrideURL(t *testing.T) {
 	require.Equal(t, "custom-install-page.example.com", location.Host)
 	require.Equal(t, "/install", location.Path)
 	require.Equal(t, "setup", location.Fragment)
-	require.Equal(t, "1", location.Query().Get("configured"))
+	require.Equal(t, []string{"1", "caller"}, location.Query()["configured"])
 	require.Equal(t, "directory", location.Query().Get("utm_source"))
 	require.Equal(t, []string{"spring", "summer"}, location.Query()["campaign"])
 	require.Equal(t, "https://directory.example.com/catalog?category=ai", location.Query().Get("referrer"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- append incoming install-page query parameters to external installation override redirects
- retain configured destination query parameters and URL fragments
- cover repeated parameters, query-key collisions, and explicit referrer attribution with a regression test

## Testing
- `mise exec -- go test ./server/internal/mcpmetadata -run '^TestServeInstallPage_McpServer_InstallationOverrideURL$' -count=1`
- `mise exec -- go test ./server/internal/mcpmetadata -run '^TestServeInstallPage_McpServer_(RemoteBacked_PublicRenders|FallsBackToToolsetMetadata)$' -count=1`
- `mise exec -- go test ./server/internal/mcpmetadata -count=1`
- `mise lint:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-342](https://linear.app/speakeasy/issue/AIS-342/bug-preserve-query-parameters-and-referrer-on-external-mcp-install)

<div><a href="https://cursor.com/agents/bc-b7b83c1e-e48a-450e-b2d4-8e4edbc4a6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7b83c1e-e48a-450e-b2d4-8e4edbc4a6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves query parameters and URL fragments when redirecting from the MCP install page to an external override URL, fixing lost UTM/referrer context and supporting repeated params and key collisions (Linear AIS-342).

- **Bug Fixes**
  - Parse the configured override URL and merge the incoming query string, keeping existing params, duplicates on key collisions, and the fragment.
  - Add server tests covering repeated params, key collisions, and explicit referrer attribution.

<sup>Written for commit f33b1169256cc850d4b6bfc76360205a473bbe9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

