### PR TITLE
fix: Plugins remain in "needs sync" state after sync

### DIFF
--- a/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
+++ b/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
@@ -199,7 +199,7 @@ export function PluginStatusBanner({
       });
       await Promise.all([
         invalidateAllPlugins(queryClient),
-        invalidateAllPublishStatus(queryClient),
+        invalidateAllPublishStatus(queryClient, { refetchType: "all" }),
       ]);
       toast.success(describeSaveResult(toAdd.length, toRemove.length), {
         description: (

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -184,13 +184,13 @@ export default function PluginDetail(): JSX.Element | null {
   const invalidateAll = async () => {
     await invalidateAllPlugin(queryClient);
     await invalidateAllPlugins(queryClient);
-    await invalidateAllPublishStatus(queryClient);
+    await invalidateAllPublishStatus(queryClient, { refetchType: "all" });
   };
 
   const publishMutation = usePublishPluginsMutation({
     onSuccess: (data) => {
       setIsPublishDialogOpen(false);
-      void invalidateAllPublishStatus(queryClient);
+      void invalidateAllPublishStatus(queryClient, { refetchType: "all" });
       toast.success("Plugins published to GitHub", {
         description: data.repoUrl,
         action: {

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -119,7 +119,7 @@ export default function Plugins(): JSX.Element {
     onSuccess: (data) => {
       setIsPublishDialogOpen(false);
       setIsManageCollaboratorsOpen(false);
-      void invalidateAllPublishStatus(queryClient);
+      void invalidateAllPublishStatus(queryClient, { refetchType: "all" });
       toast.success("Plugins published to GitHub", {
         description: data.repoUrl,
         action: {
@@ -205,7 +205,7 @@ export default function Plugins(): JSX.Element {
       onSuccess: async (data) => {
         await Promise.all([
           invalidateAllMarketplaceSettings(queryClient),
-          invalidateAllPublishStatus(queryClient),
+          invalidateAllPublishStatus(queryClient, { refetchType: "all" }),
         ]);
         setMarketplaceNameInput(data.settings.marketplaceName ?? "");
         if (data.hooksUpdateDeferred) {

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -28,7 +28,7 @@ export function CreateMarketplaceStep({
   const publishMutation = usePublishPluginsMutation({
     onSuccess: (data) => {
       setDialogOpen(false);
-      void invalidateAllPublishStatus(queryClient);
+      void invalidateAllPublishStatus(queryClient, { refetchType: "all" });
       toast.success(
         dialogMode === "manage"
           ? "Collaborators added"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DNO-537

## Problem

When syncing plugins via the "Sync changes" button, the "Needs syncing" badge may persist after the sync operation completes. The customer report suggests this can be permanent, not just a temporary delay.

## Analysis

There are two potential issues:

1. **UI refetch delay (this PR fixes)**: The publish status query uses a 5-second polling interval. When the sync mutation completes, it calls `invalidateAllPublishStatus(queryClient)` which marks the query as stale but doesn't force an immediate refetch. The UI would only update on the next scheduled poll (up to 5 seconds later).

2. **Backend state update (needs investigation)**: If the badge remains permanently, the backend must be returning `upToDate: false` even after a successful publish. This could indicate:
   - Transaction timing issues
   - Fingerprint calculation inconsistencies
   - Race conditions with concurrent plugin modifications
   - Database replication lag (if using read replicas)

## Solution

Added `{ refetchType: "all" }` to all `invalidateAllPublishStatus` calls in mutation success handlers. This forces React Query to immediately refetch the publish status, ensuring the UI updates instantly after sync operations.

**Changed locations:**
- `Plugins.tsx`: publish mutation and marketplace settings mutation  
- `PluginDetail.tsx`: publish mutation and invalidateAll helper
- `create-marketplace-step.tsx`: publish mutation in onboarding wizard
- `PluginStatusBanner.tsx`: plugin assignment save handler

This pattern was already correctly used in `MCPServerDetails.tsx` and is now consistent across all plugin sync flows.

## Testing

The fix ensures immediate UI feedback for:
- ✅ Clicking "Sync changes" on the marketplace card
- ✅ Publishing plugins for the first time
- ✅ Renaming the marketplace (triggers republish)
- ✅ Managing collaborators
- ✅ Updating plugin assignments

## Follow-up

If the "needs sync" badge continues to persist after this fix is deployed, we should investigate potential backend issues:

1. Add server-side logging to track:
   - When fingerprints are saved during publish
   - What fingerprints are returned during status checks
   - Any transaction rollbacks or errors

2. Verify the `publishUpToDate` comparison logic is deterministic

3. Check for race conditions where plugins are modified between publish and status check

4. Investigate if database replication lag could cause reads to miss recent writes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-537](https://linear.app/speakeasy/issue/DNO-537/bug-plugins-remain-in-needs-sync-state-after-sync)

<div><a href="https://cursor.com/agents/bc-58b6ed82-9584-4480-8651-e3e84d9abc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58b6ed82-9584-4480-8651-e3e84d9abc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delayed "Needs syncing" badge by forcing an immediate publish status refetch after sync, so the UI updates right away. Addresses Linear DNO-537.

- **Bug Fixes**
  - Force immediate refetch of publish status by calling `invalidateAllPublishStatus(queryClient, { refetchType: "all" })` in mutation success handlers.
  - Applied across all plugin sync flows: Sync changes, first publish, marketplace rename/collaborators, assignment updates, and onboarding.

<sup>Written for commit b083af987d9e4be3cc1db88be9038e534c89d2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

