### PR TITLE
feat: Allow search by user name in agent sessions tab

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -7800,11 +7800,11 @@ paths:
       operationId: listChats
       parameters:
         - allowEmptyValue: true
-          description: Search query (searches chat ID, user ID, and title)
+          description: Search query (searches chat ID, user ID, user name, and title)
           in: query
           name: search
           schema:
-            description: Search query (searches chat ID, user ID, and title)
+            description: Search query (searches chat ID, user ID, user name, and title)
             type: string
         - allowEmptyValue: true
           description: Filter by external user ID

--- a/client/dashboard/src/components/observe/LogsAgents.tsx
+++ b/client/dashboard/src/components/observe/LogsAgents.tsx
@@ -701,7 +701,7 @@ function AgentSessionsPageContent({
             <Page.Toolbar.Search
               value={searchQuery}
               onChange={setSearchQuery}
-              placeholder="Search by chat ID, user ID, or title..."
+              placeholder="Search by chat ID, user ID, user name, or title..."
               debounceMs={500}
             />
             <Page.Toolbar.Filters

--- a/client/dashboard/src/sdk/src/models/operations/listchats.ts
+++ b/client/dashboard/src/sdk/src/models/operations/listchats.ts
@@ -85,7 +85,7 @@ export type SortOrder = ClosedEnum<typeof SortOrder>;
 
 export type ListChatsRequest = {
   /**
-   * Search query (searches chat ID, user ID, and title)
+   * Search query (searches chat ID, user ID, user name, and title)
    */
   search?: string | undefined;
   /**

--- a/server/design/chat/design.go
+++ b/server/design/chat/design.go
@@ -21,7 +21,7 @@ var _ = Service("chat", func() {
 			security.SessionPayload()
 			security.ProjectPayload()
 			security.ChatSessionsTokenPayload()
-			Attribute("search", String, "Search query (searches chat ID, user ID, and title)")
+			Attribute("search", String, "Search query (searches chat ID, user ID, user name, and title)")
 			Attribute("external_user_id", String, "Filter by external user ID")
 			Attribute("source", String, "Filter by agent source. Comma-separated list of exact source values (e.g. 'claude-code,Codex,playground') matched against each session's inferred source; empty for no filter. Use chat.listSources to discover the available values.")
 			Attribute("assistant_id", String, "Filter to chats produced by this assistant", func() {

--- a/server/gen/chat/service.go
+++ b/server/gen/chat/service.go
@@ -345,7 +345,7 @@ type ListChatsPayload struct {
 	SessionToken      *string
 	ProjectSlugInput  *string
 	ChatSessionsToken *string
-	// Search query (searches chat ID, user ID, and title)
+	// Search query (searches chat ID, user ID, user name, and title)
 	Search *string
 	// Filter by external user ID
 	ExternalUserID *string

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -8482,11 +8482,11 @@ paths:
             operationId: listChats
             parameters:
                 - allowEmptyValue: true
-                  description: Search query (searches chat ID, user ID, and title)
+                  description: Search query (searches chat ID, user ID, user name, and title)
                   in: query
                   name: search
                   schema:
-                    description: Search query (searches chat ID, user ID, and title)
+                    description: Search query (searches chat ID, user ID, user name, and title)
                     type: string
                 - allowEmptyValue: true
                   description: Filter by external user ID

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -300,6 +300,8 @@ candidate_chats AS (
   FROM chats c
   LEFT JOIN risk_counts rc ON rc.chat_id = c.id
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
+  -- Join users table to enable searching by user display name
+  LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = @project_id
     AND c.deleted IS FALSE
     AND (@external_user_id = '' OR c.external_user_id = @external_user_id)
@@ -314,6 +316,7 @@ candidate_chats AS (
       OR c.id::text ILIKE '%' || @search || '%'
       OR c.external_user_id ILIKE '%' || @search || '%'
       OR c.title ILIKE '%' || @search || '%'
+      OR u.display_name ILIKE '%' || @search || '%'
     )
     AND (
       @assistant_id = ''
@@ -421,6 +424,8 @@ candidate_chats AS (
   -- Resolve the AI account that produced the chat (chats.user_account_id has no FK,
   -- matching chats.user_id) to expose its team/personal classification.
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
+  -- Join users table to enable searching by user display name
+  LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = @project_id
     AND c.deleted IS FALSE
     AND (@external_user_id = '' OR c.external_user_id = @external_user_id)
@@ -435,6 +440,7 @@ candidate_chats AS (
       OR c.id::text ILIKE '%' || @search || '%'
       OR c.external_user_id ILIKE '%' || @search || '%'
       OR c.title ILIKE '%' || @search || '%'
+      OR u.display_name ILIKE '%' || @search || '%'
     )
     AND (
       @assistant_id = ''
@@ -1003,6 +1009,8 @@ ORDER BY created_at DESC;
 -- name: CountChatsWithResolutions :one
 SELECT COUNT(DISTINCT c.id) as total
 FROM chats c
+-- Join users table to enable searching by user display name
+LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
 WHERE c.project_id = @project_id
   AND c.deleted IS FALSE
   AND (@external_user_id = '' OR c.external_user_id = @external_user_id)
@@ -1013,6 +1021,7 @@ WHERE c.project_id = @project_id
     OR c.id::text ILIKE '%' || @search || '%'
     OR c.external_user_id ILIKE '%' || @search || '%'
     OR c.title ILIKE '%' || @search || '%'
+    OR u.display_name ILIKE '%' || @search || '%'
   )
   AND (
     @assistant_id = ''

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -95,6 +95,8 @@ candidate_chats AS (
   FROM chats c
   LEFT JOIN risk_counts rc ON rc.chat_id = c.id
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
+  -- Join users table to enable searching by user display name
+  LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = $5
     AND c.deleted IS FALSE
     AND ($6 = '' OR c.external_user_id = $6)
@@ -109,6 +111,7 @@ candidate_chats AS (
       OR c.id::text ILIKE '%' || $9 || '%'
       OR c.external_user_id ILIKE '%' || $9 || '%'
       OR c.title ILIKE '%' || $9 || '%'
+      OR u.display_name ILIKE '%' || $9 || '%'
     )
     AND (
       $10 = ''
@@ -230,6 +233,7 @@ func (q *Queries) CountChats(ctx context.Context, arg CountChatsParams) (int64, 
 const countChatsWithResolutions = `-- name: CountChatsWithResolutions :one
 SELECT COUNT(DISTINCT c.id) as total
 FROM chats c
+LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
 WHERE c.project_id = $1
   AND c.deleted IS FALSE
   AND ($2 = '' OR c.external_user_id = $2)
@@ -240,6 +244,7 @@ WHERE c.project_id = $1
     OR c.id::text ILIKE '%' || $5 || '%'
     OR c.external_user_id ILIKE '%' || $5 || '%'
     OR c.title ILIKE '%' || $5 || '%'
+    OR u.display_name ILIKE '%' || $5 || '%'
   )
   AND (
     $6 = ''
@@ -307,6 +312,7 @@ type CountChatsWithResolutionsParams struct {
 	HasRiskFilter    string
 }
 
+// Join users table to enable searching by user display name
 func (q *Queries) CountChatsWithResolutions(ctx context.Context, arg CountChatsWithResolutionsParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countChatsWithResolutions,
 		arg.ProjectID,
@@ -1699,6 +1705,8 @@ candidate_chats AS (
   -- Resolve the AI account that produced the chat (chats.user_account_id has no FK,
   -- matching chats.user_id) to expose its team/personal classification.
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
+  -- Join users table to enable searching by user display name
+  LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = $1
     AND c.deleted IS FALSE
     AND ($4 = '' OR c.external_user_id = $4)
@@ -1713,6 +1721,7 @@ candidate_chats AS (
       OR c.id::text ILIKE '%' || $7 || '%'
       OR c.external_user_id ILIKE '%' || $7 || '%'
       OR c.title ILIKE '%' || $7 || '%'
+      OR u.display_name ILIKE '%' || $7 || '%'
     )
     AND (
       $8 = ''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR adds the ability to search by user name in the agent sessions tab.

## Changes
- **Backend**: Added LEFT JOIN to `users` table in `ListChats`, `CountChats`, and `CountChatsWithResolutions` SQL queries
- **Backend**: Added search condition for user `display_name` field  
- **Backend**: Updated Goa design description to include user name in search capabilities
- **Frontend**: Updated placeholder text from "Search by chat ID, user ID, or title..." to "Search by chat ID, user ID, user name, or title..."
- **Generated Code**: Regenerated SQLc and Goa code

## Testing
The changes enable users to search for agent sessions by typing a user's display name (e.g., "diogo") in the search box on the Agent Sessions tab.

To test:
1. Navigate to the Agent Sessions tab
2. In the search box, type a user's name (e.g., "diogo")
3. The list should filter to show only sessions from users whose display name matches the search query

## Resolves
- DNO-595

## Screenshots
See attached images in the Linear issue showing the before (current placeholder) and after (desired functionality) states.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-595](https://linear.app/speakeasy/issue/DNO-595/feat-allow-search-by-users-name-in-agent-sessions-tab)

<div><a href="https://cursor.com/agents/bc-7df364e0-de72-410d-b1fa-2ead3810daac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7df364e0-de72-410d-b1fa-2ead3810daac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add search by user display name in the Agent Sessions tab. Users can now type a name to filter sessions, aligning with Linear DNO-595.

- New Features
  - Backend/API: Join `users` table and include `display_name` in search for list/count queries; updated `goa` design and OpenAPI docs.
  - Generated: Regenerated `sqlc`/`goa` code and client SDK typings.
  - Frontend: Search placeholder now includes “user name”.

<sup>Written for commit 2d5579ada6bba7492f41c38d2231b88cb90d8c2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

