### PR TITLE
fix(dashboard): show IdP registration error details

### DIFF
--- a/client/dashboard/src/lib/proxyRegisterUpstreamClient.test.ts
+++ b/client/dashboard/src/lib/proxyRegisterUpstreamClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ProxyRegistrationError,
   proxyRegisterUpstreamClient,
   type AuthedFetch,
 } from "@/lib/proxyRegisterUpstreamClient";
@@ -44,11 +45,16 @@ describe("proxyRegisterUpstreamClient", () => {
       ),
     );
 
-    await expect(
-      proxyRegisterUpstreamClient(authedFetch, {
-        registrationEndpoint: "https://idp.example/register",
-      }),
-    ).rejects.toThrow(/redirect_uris must be loopback/);
+    const result = proxyRegisterUpstreamClient(authedFetch, {
+      registrationEndpoint: "https://idp.example/register",
+    });
+
+    await expect(result).rejects.toBeInstanceOf(ProxyRegistrationError);
+    await expect(result).rejects.toMatchObject({
+      title: "Registration failed (HTTP 400)",
+      message:
+        "identity provider rejected the client registration: invalid_client_metadata: redirect_uris must be loopback",
+    });
   });
 
   it("falls back to error_description when no message field is present", async () => {
@@ -66,15 +72,18 @@ describe("proxyRegisterUpstreamClient", () => {
     ).rejects.toThrow("scope not supported");
   });
 
-  it("falls back to the bare status when the body has nothing useful", async () => {
+  it("uses a separate fallback body when no details are returned", async () => {
     const authedFetch: AuthedFetch = vi.fn(
       async () => new Response("gateway boom", { status: 502 }),
     );
 
-    await expect(
-      proxyRegisterUpstreamClient(authedFetch, {
-        registrationEndpoint: "https://idp.example/register",
-      }),
-    ).rejects.toThrow("Registration failed (HTTP 502)");
+    const result = proxyRegisterUpstreamClient(authedFetch, {
+      registrationEndpoint: "https://idp.example/register",
+    });
+
+    await expect(result).rejects.toMatchObject({
+      title: "Registration failed (HTTP 502)",
+      message: "No additional error details were provided.",
+    });
   });
 });

--- a/client/dashboard/src/lib/proxyRegisterUpstreamClient.test.ts
+++ b/client/dashboard/src/lib/proxyRegisterUpstreamClient.test.ts
@@ -37,9 +37,9 @@ describe("proxyRegisterUpstreamClient", () => {
     const authedFetch: AuthedFetch = vi.fn(async () =>
       jsonResponse(
         {
-          message:
+          Message:
             "identity provider rejected the client registration: invalid_client_metadata: redirect_uris must be loopback",
-          name: "bad_request",
+          Name: "bad_request",
         },
         { status: 400 },
       ),

--- a/client/dashboard/src/lib/proxyRegisterUpstreamClient.test.ts
+++ b/client/dashboard/src/lib/proxyRegisterUpstreamClient.test.ts
@@ -72,7 +72,7 @@ describe("proxyRegisterUpstreamClient", () => {
     ).rejects.toThrow("scope not supported");
   });
 
-  it("uses a separate fallback body when no details are returned", async () => {
+  it("preserves the status fallback when no details are returned", async () => {
     const authedFetch: AuthedFetch = vi.fn(
       async () => new Response("gateway boom", { status: 502 }),
     );
@@ -83,7 +83,7 @@ describe("proxyRegisterUpstreamClient", () => {
 
     await expect(result).rejects.toMatchObject({
       title: "Registration failed (HTTP 502)",
-      message: "No additional error details were provided.",
+      message: "Registration failed (HTTP 502)",
     });
   });
 });

--- a/client/dashboard/src/lib/proxyRegisterUpstreamClient.ts
+++ b/client/dashboard/src/lib/proxyRegisterUpstreamClient.ts
@@ -15,6 +15,16 @@ export type ProxyRegisterUpstreamClientInput = {
   tokenEndpointAuthMethod?: string;
 };
 
+export class ProxyRegistrationError extends Error {
+  readonly title: string;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ProxyRegistrationError";
+    this.title = `Registration failed (HTTP ${status})`;
+  }
+}
+
 export async function proxyRegisterUpstreamClient(
   authedFetch: AuthedFetch,
   input: ProxyRegisterUpstreamClientInput,
@@ -37,7 +47,10 @@ export async function proxyRegisterUpstreamClient(
   });
 
   if (!response.ok) {
-    throw new Error(await registrationErrorMessage(response));
+    const message =
+      (await registrationErrorMessage(response)) ??
+      "No additional error details were provided.";
+    throw new ProxyRegistrationError(response.status, message);
   }
 
   const result = (await response.json()) as {
@@ -61,15 +74,15 @@ export async function proxyRegisterUpstreamClient(
 // /oauth/proxy-register response. The backend passes an upstream 4xx through as
 // a bad request whose `message` already carries the upstream
 // error/error_description; some responses may instead surface the raw RFC 7591
-// `error_description`/`error`. Fall back to the bare status when the body has
-// nothing useful so a genuine gateway outage still reads sensibly.
-async function registrationErrorMessage(response: Response): Promise<string> {
-  const fallback = `Registration failed (HTTP ${response.status})`;
+// `error_description`/`error`.
+async function registrationErrorMessage(
+  response: Response,
+): Promise<string | null> {
   let body: unknown;
   try {
     body = await response.json();
   } catch {
-    return fallback;
+    return null;
   }
   if (body && typeof body === "object") {
     const record = body as Record<string, unknown>;
@@ -78,5 +91,5 @@ async function registrationErrorMessage(response: Response): Promise<string> {
       if (typeof value === "string" && value.trim()) return value;
     }
   }
-  return fallback;
+  return null;
 }

--- a/client/dashboard/src/lib/proxyRegisterUpstreamClient.ts
+++ b/client/dashboard/src/lib/proxyRegisterUpstreamClient.ts
@@ -18,10 +18,11 @@ export type ProxyRegisterUpstreamClientInput = {
 export class ProxyRegistrationError extends Error {
   readonly title: string;
 
-  constructor(status: number, message: string) {
-    super(message);
+  constructor(status: number, message?: string) {
+    const title = `Registration failed (HTTP ${status})`;
+    super(message ?? title);
     this.name = "ProxyRegistrationError";
-    this.title = `Registration failed (HTTP ${status})`;
+    this.title = title;
   }
 }
 
@@ -47,10 +48,8 @@ export async function proxyRegisterUpstreamClient(
   });
 
   if (!response.ok) {
-    const message =
-      (await registrationErrorMessage(response)) ??
-      "No additional error details were provided.";
-    throw new ProxyRegistrationError(response.status, message);
+    const message = await registrationErrorMessage(response);
+    throw new ProxyRegistrationError(response.status, message ?? undefined);
   }
 
   const result = (await response.json()) as {

--- a/client/dashboard/src/lib/proxyRegisterUpstreamClient.ts
+++ b/client/dashboard/src/lib/proxyRegisterUpstreamClient.ts
@@ -71,7 +71,7 @@ export async function proxyRegisterUpstreamClient(
 
 // registrationErrorMessage pulls the most actionable message out of a failed
 // /oauth/proxy-register response. The backend passes an upstream 4xx through as
-// a bad request whose `message` already carries the upstream
+// a bad request whose `Message` already carries the upstream
 // error/error_description; some responses may instead surface the raw RFC 7591
 // `error_description`/`error`.
 async function registrationErrorMessage(
@@ -83,9 +83,15 @@ async function registrationErrorMessage(
   } catch {
     return null;
   }
+
   if (body && typeof body === "object") {
     const record = body as Record<string, unknown>;
-    for (const key of ["message", "error_description", "error"] as const) {
+    for (const key of [
+      "Message",
+      "message",
+      "error_description",
+      "error",
+    ] as const) {
       const value = record[key];
       if (typeof value === "string" && value.trim()) return value;
     }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -21,10 +21,7 @@ import {
   buildUserSessionResourceSlug,
   DEFAULT_USER_SESSION_DURATION_HOURS,
 } from "@/lib/externalMcpUserSessions";
-import {
-  ProxyRegistrationError,
-  proxyRegisterUpstreamClient,
-} from "@/lib/proxyRegisterUpstreamClient";
+import { proxyRegisterUpstreamClient } from "@/lib/proxyRegisterUpstreamClient";
 import { deriveRemoteSessionIssuerNameFromUrl } from "@/lib/sources";
 import { remoteSessionClientDisplayName } from "@/pages/remote-identity-providers/clientDisplay";
 import type { RemoteSessionClient } from "@gram/client/models/components/remotesessionclient.js";
@@ -34,7 +31,7 @@ import { CreateRemoteSessionClientFormTokenEndpointAuthMethod } from "@gram/clie
 import { invalidateAllRemoteSessionClients } from "@gram/client/react-query/remoteSessionClients.js";
 import { invalidateAllRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
 import { invalidateAllUserSessionIssuers } from "@gram/client/react-query/userSessionIssuers.js";
-import { Alert, Button, Stack } from "@speakeasy-api/moonshine";
+import { Button, Stack } from "@speakeasy-api/moonshine";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -53,33 +50,11 @@ import {
   parseScopes,
   pickPreferredAuthMethod,
 } from "./issuerFormUtils";
+import { IdentityProviderAttachmentErrorAlert } from "./IdentityProviderAttachmentErrorAlert";
 import { useAllRemoteSessionClients } from "./useAllRemoteSessionClients";
 import { useIssuerDiscovery } from "./useIssuerDiscovery";
 
 type Mode = "select" | "new";
-
-type SubmitError = {
-  title: string;
-  message: string;
-};
-
-function submissionError(error: unknown): SubmitError | null {
-  if (!error) {
-    return null;
-  }
-
-  if (error instanceof ProxyRegistrationError) {
-    return { title: error.title, message: error.message };
-  }
-
-  return {
-    title: "Failed to attach identity provider",
-    message:
-      error instanceof Error && error.message
-        ? error.message
-        : "An unexpected error occurred. Please try again.",
-  };
-}
 
 export function AttachRemoteIdentityProviderSheet({
   open,
@@ -434,7 +409,6 @@ export function AttachRemoteIdentityProviderSheet({
   });
 
   const submitting = attachMutation.isPending;
-  const submitError = submissionError(attachMutation.error);
   const { reset: resetAttachMutation } = attachMutation;
 
   // Reset transient state whenever the sheet is reopened. The target slug
@@ -733,14 +707,7 @@ export function AttachRemoteIdentityProviderSheet({
             </Stack>
           )}
 
-          {submitError ? (
-            <Alert variant="error" dismissible={false}>
-              <Stack gap={1}>
-                <Type className="font-medium">{submitError.title}</Type>
-                <Type small>{submitError.message}</Type>
-              </Stack>
-            </Alert>
-          ) : null}
+          <IdentityProviderAttachmentErrorAlert error={attachMutation.error} />
         </div>
 
         <SheetFooter className="flex-row items-center justify-end gap-2 border-t px-6 py-4">

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -21,7 +21,10 @@ import {
   buildUserSessionResourceSlug,
   DEFAULT_USER_SESSION_DURATION_HOURS,
 } from "@/lib/externalMcpUserSessions";
-import { proxyRegisterUpstreamClient } from "@/lib/proxyRegisterUpstreamClient";
+import {
+  ProxyRegistrationError,
+  proxyRegisterUpstreamClient,
+} from "@/lib/proxyRegisterUpstreamClient";
 import { deriveRemoteSessionIssuerNameFromUrl } from "@/lib/sources";
 import { remoteSessionClientDisplayName } from "@/pages/remote-identity-providers/clientDisplay";
 import type { RemoteSessionClient } from "@gram/client/models/components/remotesessionclient.js";
@@ -54,6 +57,29 @@ import { useAllRemoteSessionClients } from "./useAllRemoteSessionClients";
 import { useIssuerDiscovery } from "./useIssuerDiscovery";
 
 type Mode = "select" | "new";
+
+type SubmitError = {
+  title: string;
+  message: string;
+};
+
+function submissionError(error: unknown): SubmitError | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof ProxyRegistrationError) {
+    return { title: error.title, message: error.message };
+  }
+
+  return {
+    title: "Failed to attach identity provider",
+    message:
+      error instanceof Error && error.message
+        ? error.message
+        : "An unexpected error occurred. Please try again.",
+  };
+}
 
 export function AttachRemoteIdentityProviderSheet({
   open,
@@ -408,11 +434,7 @@ export function AttachRemoteIdentityProviderSheet({
   });
 
   const submitting = attachMutation.isPending;
-  const submitError = attachMutation.error
-    ? attachMutation.error instanceof Error && attachMutation.error.message
-      ? attachMutation.error.message
-      : "An unexpected error occurred. Please try again."
-    : null;
+  const submitError = submissionError(attachMutation.error);
   const { reset: resetAttachMutation } = attachMutation;
 
   // Reset transient state whenever the sheet is reopened. The target slug
@@ -711,11 +733,14 @@ export function AttachRemoteIdentityProviderSheet({
             </Stack>
           )}
 
-          {submitError && (
+          {submitError ? (
             <Alert variant="error" dismissible={false}>
-              {submitError}
+              <Stack gap={1}>
+                <Type className="font-medium">{submitError.title}</Type>
+                <Type small>{submitError.message}</Type>
+              </Stack>
             </Alert>
-          )}
+          ) : null}
         </div>
 
         <SheetFooter className="flex-row items-center justify-end gap-2 border-t px-6 py-4">

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
@@ -38,4 +38,17 @@ describe("IdentityProviderAttachmentErrorAlert", () => {
     ).toBeDefined();
     expect(screen.getByText("The provider could not be saved.")).toBeDefined();
   });
+
+  it("uses a non-duplicative body when the IdP returns no details", () => {
+    render(
+      <IdentityProviderAttachmentErrorAlert
+        error={new ProxyRegistrationError(502)}
+      />,
+    );
+
+    expect(screen.getByText("Registration failed (HTTP 502)")).toBeDefined();
+    expect(
+      screen.getByText("No additional error details were provided."),
+    ).toBeDefined();
+  });
 });

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
@@ -23,7 +23,7 @@ describe("IdentityProviderAttachmentErrorAlert", () => {
         error={
           new ProxyRegistrationError(
             400,
-            "The callback URL is not allowed by this identity provider.",
+            "the callback URL is not allowed by this identity provider.",
           )
         }
       />,
@@ -72,7 +72,7 @@ describe("IdentityProviderAttachmentErrorAlert", () => {
 
     expect(scrollIntoView).toHaveBeenCalledWith({
       behavior: "smooth",
-      block: "nearest",
+      block: "center",
     });
   });
 });

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
@@ -7,7 +7,11 @@ const scrollIntoView = vi.fn();
 
 beforeEach(() => {
   scrollIntoView.mockReset();
-  HTMLElement.prototype.scrollIntoView = scrollIntoView;
+  HTMLElement.prototype.scrollIntoView = (
+    arg?: boolean | ScrollIntoViewOptions,
+  ): void => {
+    scrollIntoView(arg);
+  };
 });
 
 afterEach(cleanup);

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
@@ -1,7 +1,14 @@
 import { ProxyRegistrationError } from "@/lib/proxyRegisterUpstreamClient";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IdentityProviderAttachmentErrorAlert } from "./IdentityProviderAttachmentErrorAlert";
+
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  scrollIntoView.mockReset();
+  HTMLElement.prototype.scrollIntoView = scrollIntoView;
+});
 
 afterEach(cleanup);
 
@@ -50,5 +57,18 @@ describe("IdentityProviderAttachmentErrorAlert", () => {
     expect(
       screen.getByText("No additional error details were provided."),
     ).toBeDefined();
+  });
+
+  it("scrolls the alert into view when an error appears", () => {
+    render(
+      <IdentityProviderAttachmentErrorAlert
+        error={new ProxyRegistrationError(400, "Registration rejected.")}
+      />,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "nearest",
+    });
   });
 });

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
@@ -1,0 +1,41 @@
+import { ProxyRegistrationError } from "@/lib/proxyRegisterUpstreamClient";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { IdentityProviderAttachmentErrorAlert } from "./IdentityProviderAttachmentErrorAlert";
+
+afterEach(cleanup);
+
+describe("IdentityProviderAttachmentErrorAlert", () => {
+  it("renders the registration status as the title and IdP detail as the body", () => {
+    render(
+      <IdentityProviderAttachmentErrorAlert
+        error={
+          new ProxyRegistrationError(
+            400,
+            "The callback URL is not allowed by this identity provider.",
+          )
+        }
+      />,
+    );
+
+    expect(screen.getByText("Registration failed (HTTP 400)")).toBeDefined();
+    expect(
+      screen.getByText(
+        "The callback URL is not allowed by this identity provider.",
+      ),
+    ).toBeDefined();
+  });
+
+  it("uses an attachment title for non-registration failures", () => {
+    render(
+      <IdentityProviderAttachmentErrorAlert
+        error={new Error("The provider could not be saved.")}
+      />,
+    );
+
+    expect(
+      screen.getByText("Failed to attach identity provider"),
+    ).toBeDefined();
+    expect(screen.getByText("The provider could not be saved.")).toBeDefined();
+  });
+});

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.test.tsx
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IdentityProviderAttachmentErrorAlert } from "./IdentityProviderAttachmentErrorAlert";
 
 const scrollIntoView = vi.fn();
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollIntoView",
+);
 
 beforeEach(() => {
   scrollIntoView.mockReset();
@@ -14,7 +18,18 @@ beforeEach(() => {
   };
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  if (originalScrollIntoView) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "scrollIntoView",
+      originalScrollIntoView,
+    );
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+  }
+});
 
 describe("IdentityProviderAttachmentErrorAlert", () => {
   it("renders the registration status as the title and IdP detail as the body", () => {

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
@@ -8,6 +8,10 @@ type ErrorContent = {
   message: string;
 };
 
+function capitalizeFirstCharacter(value: string): string {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}
+
 function errorContent(error: unknown): ErrorContent | null {
   if (!error) {
     return null;
@@ -46,7 +50,7 @@ export function IdentityProviderAttachmentErrorAlert({
 
     alertRef.current?.scrollIntoView({
       behavior: "smooth",
-      block: "nearest",
+      block: "center",
     });
   }, [error]);
 
@@ -60,7 +64,7 @@ export function IdentityProviderAttachmentErrorAlert({
       <Alert variant="error" dismissible={false}>
         <Stack gap={1}>
           <Type className="font-medium">{content.title}</Type>
-          <Type small>{content.message}</Type>
+          <Type small>{capitalizeFirstCharacter(content.message)}</Type>
         </Stack>
       </Alert>
     </div>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
@@ -13,7 +13,13 @@ function errorContent(error: unknown): ErrorContent | null {
   }
 
   if (error instanceof ProxyRegistrationError) {
-    return { title: error.title, message: error.message };
+    return {
+      title: error.title,
+      message:
+        error.message === error.title
+          ? "No additional error details were provided."
+          : error.message,
+    };
   }
 
   return {

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
@@ -1,6 +1,7 @@
 import { Type } from "@/components/ui/type";
 import { ProxyRegistrationError } from "@/lib/proxyRegisterUpstreamClient";
 import { Alert, Stack } from "@speakeasy-api/moonshine";
+import { useEffect, useRef } from "react";
 
 type ErrorContent = {
   title: string;
@@ -36,13 +37,26 @@ export function IdentityProviderAttachmentErrorAlert({
 }: {
   error: unknown;
 }): JSX.Element | null {
+  const alertRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+
+    alertRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+    });
+  }, [error]);
+
   const content = errorContent(error);
   if (!content) {
     return null;
   }
 
   return (
-    <Alert variant="error" dismissible={false}>
+    <Alert ref={alertRef} variant="error" dismissible={false}>
       <Stack gap={1}>
         <Type className="font-medium">{content.title}</Type>
         <Type small>{content.message}</Type>

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
@@ -56,11 +56,13 @@ export function IdentityProviderAttachmentErrorAlert({
   }
 
   return (
-    <Alert ref={alertRef} variant="error" dismissible={false}>
-      <Stack gap={1}>
-        <Type className="font-medium">{content.title}</Type>
-        <Type small>{content.message}</Type>
-      </Stack>
-    </Alert>
+    <div ref={alertRef}>
+      <Alert variant="error" dismissible={false}>
+        <Stack gap={1}>
+          <Type className="font-medium">{content.title}</Type>
+          <Type small>{content.message}</Type>
+        </Stack>
+      </Alert>
+    </div>
   );
 }

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/IdentityProviderAttachmentErrorAlert.tsx
@@ -1,0 +1,46 @@
+import { Type } from "@/components/ui/type";
+import { ProxyRegistrationError } from "@/lib/proxyRegisterUpstreamClient";
+import { Alert, Stack } from "@speakeasy-api/moonshine";
+
+type ErrorContent = {
+  title: string;
+  message: string;
+};
+
+function errorContent(error: unknown): ErrorContent | null {
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof ProxyRegistrationError) {
+    return { title: error.title, message: error.message };
+  }
+
+  return {
+    title: "Failed to attach identity provider",
+    message:
+      error instanceof Error && error.message
+        ? error.message
+        : "An unexpected error occurred. Please try again.",
+  };
+}
+
+export function IdentityProviderAttachmentErrorAlert({
+  error,
+}: {
+  error: unknown;
+}): JSX.Element | null {
+  const content = errorContent(error);
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <Alert variant="error" dismissible={false}>
+      <Stack gap={1}>
+        <Type className="font-medium">{content.title}</Type>
+        <Type small>{content.message}</Type>
+      </Stack>
+    </Alert>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- represent proxy registration failures with separate HTTP-status titles and provider-supplied details
- parse the Goa error response's actual `Message` field while retaining compatibility with lowercase/RFC 7591 fields
- render attach-provider failures as a structured error alert
- smoothly center the alert in the sheet so the complete message is visible
- capitalize the first character of displayed error details
- restore the mocked `scrollIntoView` prototype after each test to prevent cross-test leakage

## Testing
- [ ] Final focused tests, type-check, and lint
- [x] Runtime browser test against a controlled RFC 7591 HTTP 400 response
- [x] Verified the full alert is inside the scroll viewport (`fullyVisible: true`) and the body begins with `Identity`

## Demo
<a href="https://cursor.com/agents/bc-2c166de7-e7ce-4838-a62b-7c439a035fc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidp_registration_error_centered_capitalized_demo.mp4"><img src="https://cursor.com/artifacts/c/art-611b64cb-22cd-43c5-9be9-7d69b1d3935b" alt="idp_registration_error_centered_capitalized_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-348](https://linear.app/speakeasy/issue/AIS-348/bug-show-underlying-idp-registration-error-when-attach-provider-fails)

<div><a href="https://cursor.com/agents/bc-2c166de7-e7ce-4838-a62b-7c439a035fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c166de7-e7ce-4838-a62b-7c439a035fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show detailed IdP registration errors when attaching a provider, with HTTP status titles and provider messages, and auto-scroll to center the alert so the full message is visible. Addresses Linear AIS-348 by surfacing the underlying IdP error and ensuring it’s visible.

- **Bug Fixes**
  - Added ProxyRegistrationError with a status-based title; now parses Goa “Message” (preferred) and RFC 7591 fields, and preserves a status-only fallback when details are missing or the body can’t be parsed.
  - Replaced the inline alert with IdentityProviderAttachmentErrorAlert to clearly show registration vs. attachment failures, capitalize the first character of details, use a “no details” message when needed, and smoothly scroll the alert wrapper into view.
  - Updated tests for the parser, new error shape, alert titles/bodies, fallback behavior, capitalization, centered scrolling, and restored the scrollIntoView prototype after tests.

<sup>Written for commit 04c5118dabf33e50bb0dcc8f8781a2852d04241e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

