### PR TITLE
feat(server): instrument synchronous ClickHouse telemetry writes on hook paths

### DIFF
--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -768,6 +768,8 @@ func newFeatureChecker(logger *slog.Logger, pf *productfeatures.Client, feat pro
 func newTelemetryLogger(
 	ctx context.Context,
 	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	db *pgxpool.Pool,
 	cacheImpl cache.Cache,
 	chDB clickhouse.Conn,
@@ -784,7 +786,7 @@ func newTelemetryLogger(
 
 	users := telemetry.NewUserInfoResolver(logger, db, cacheImpl)
 
-	return telemetry.NewLogger(shutdownCtx, logger, chDB, logsEnabled, toolIOLogsEnabled, users), shutdown
+	return telemetry.NewLogger(shutdownCtx, logger, tracerProvider, meterProvider, chDB, logsEnabled, toolIOLogsEnabled, users), shutdown
 }
 
 func newTriggersApp(

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -678,7 +678,7 @@ func newStartCommand() *cli.Command {
 				authz.EngineOpts{DevMode: c.String("environment") == "local"},
 			)
 
-			telemLogger, shutdown := newTelemetryLogger(ctx, logger, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled)
+			telemLogger, shutdown := newTelemetryLogger(ctx, logger, tracerProvider, meterProvider, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
 			telemSvc := tm.NewService(logger, tracerProvider, db, chDB, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -557,7 +557,7 @@ func newWorkerCommand() *cli.Command {
 				backgroundWorkOSClient = workos.NewStubClient()
 			}
 
-			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled)
+			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, tracerProvider, meterProvider, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled)
 			shutdownFuncs = append(shutdownFuncs, shutdown)
 
 			telemetryService := telemetry.NewService(logger, tracerProvider, db, chDB, nil, nil, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -343,6 +343,15 @@ const (
 	HookServerNameOverrideIDKey = attribute.Key("gram.hook.server_name_override_id")
 	HookHasPluginAuthKey        = attribute.Key("gram.hook.has_plugin_auth")
 	HookHostnameKey             = attribute.Key("gram.hook.hostname")
+	// HookRiskScannedKey marks hook duration metrics where a risk enforcement
+	// scan actually executed (as opposed to short-circuiting on missing
+	// context or no policies), so gating latency can be separated from the
+	// no-scan baseline.
+	HookRiskScannedKey = attribute.Key("gram.hook.risk_scanned")
+	// TelemetryCHOperationKey names the synchronous ClickHouse write measured
+	// on telemetry.clickhouse.write.duration spans and metrics.
+	TelemetryCHOperationKey = attribute.Key("gram.telemetry.operation")
+	TelemetryCHRowCountKey  = attribute.Key("gram.telemetry.row_count")
 	// HookReplayedKey is set (true) on telemetry rows for events redelivered
 	// from a device's offline spool after control-plane downtime, so
 	// dashboards can separate downtime backlog from live traffic. The row's
@@ -594,6 +603,11 @@ func SlogHookServerNameOverrideID(v string) slog.Attr {
 }
 
 func HookDecision(v string) attribute.KeyValue { return HookDecisionKey.String(v) }
+
+func HookRiskScanned(v bool) attribute.KeyValue { return HookRiskScannedKey.Bool(v) }
+
+func TelemetryCHOperation(v string) attribute.KeyValue { return TelemetryCHOperationKey.String(v) }
+func TelemetryCHRowCount(v int) attribute.KeyValue     { return TelemetryCHRowCountKey.Int(v) }
 
 func HookEvent(v string) attribute.KeyValue { return HookEventKey.String(v) }
 func SlogHookEvent(v string) slog.Attr      { return slog.String(string(HookEventKey), v) }

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -275,11 +275,12 @@ func (s *Service) Claude(ctx context.Context, payload *gen.ClaudePayload) (res *
 	}
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
+	ctx, riskScanned := withRiskScanTracker(ctx)
 	defer func() {
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
-		s.metrics.RecordHookEventDuration(ctx, "claude", hookEventName, outcome, claudeHookDecision(res), orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, "claude", hookEventName, outcome, claudeHookDecision(res), orgSlug, *riskScanned, time.Since(start))
 	}()
 
 	if hasPluginAuth {

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -30,11 +30,12 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *ge
 	}
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
+	ctx, riskScanned := withRiskScanTracker(ctx)
 	defer func() {
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
-		s.metrics.RecordHookEventDuration(ctx, "codex", hookEventName, outcome, codexHookDecision(res), orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, "codex", hookEventName, outcome, codexHookDecision(res), orgSlug, *riskScanned, time.Since(start))
 	}()
 
 	logger := s.logger.With(

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -35,11 +35,12 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (res *
 	}
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
+	ctx, riskScanned := withRiskScanTracker(ctx)
 	defer func() {
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
 		}
-		s.metrics.RecordHookEventDuration(ctx, "cursor", logHookEventName, outcome, cursorHookDecision(res), orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, "cursor", logHookEventName, outcome, cursorHookDecision(res), orgSlug, *riskScanned, time.Since(start))
 	}()
 
 	logger := s.logger.With(

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -55,6 +55,7 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 	eventType := ""
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
+	ctx, riskScanned := withRiskScanTracker(ctx)
 	defer func() {
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
@@ -63,7 +64,7 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 		if res != nil {
 			decision = res.Decision
 		}
-		s.metrics.RecordHookEventDuration(ctx, source, eventType, outcome, decision, orgSlug, time.Since(start))
+		s.metrics.RecordHookEventDuration(ctx, source, eventType, outcome, decision, orgSlug, *riskScanned, time.Since(start))
 	}()
 
 	if err := validateCanonicalIngestPayload(payload); err != nil {

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -634,7 +634,7 @@ func TestIngest_SkillRowSurvivesToolIOScrub(t *testing.T) {
 	require.NoError(t, err)
 	enabled := func(context.Context, string) (bool, error) { return true, nil }
 	disabled := func(context.Context, string) (bool, error) { return false, nil }
-	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), chConn, enabled, disabled, nil)
+	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, enabled, disabled, nil)
 	chClient := telemetryrepo.New(chConn)
 	authCtx := hookAuthContext(t, ctx)
 

--- a/server/internal/hooks/metrics.go
+++ b/server/internal/hooks/metrics.go
@@ -53,12 +53,12 @@ func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metric
 	}
 }
 
-func (m *metrics) RecordHookEventDuration(ctx context.Context, source string, eventName string, outcome string, decision string, orgSlug string, duration time.Duration) {
+func (m *metrics) RecordHookEventDuration(ctx context.Context, source string, eventName string, outcome string, decision string, orgSlug string, riskScanned bool, duration time.Duration) {
 	if m == nil || m.eventDuration == nil {
 		return
 	}
 
-	m.eventDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(hookEventMetricAttributes(source, eventName, outcome, decision, orgSlug)...))
+	m.eventDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(hookEventMetricAttributes(source, eventName, outcome, decision, orgSlug, riskScanned)...))
 }
 
 // claudeHookDecision maps a Claude hook response to the verdict dimension on
@@ -97,12 +97,13 @@ func codexHookDecision(res *gen.CodexHookResult) string {
 	return conv.Default(conv.PtrValOr(res.Decision, ""), hookMetricDecisionAllow)
 }
 
-func hookEventMetricAttributes(source string, eventName string, outcome string, decision string, orgSlug string) []attribute.KeyValue {
+func hookEventMetricAttributes(source string, eventName string, outcome string, decision string, orgSlug string, riskScanned bool) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attr.HookSource(source),
 		attr.HookEvent(eventName),
 		attr.Outcome(outcome),
 		attr.HookDecision(decision),
+		attr.HookRiskScanned(riskScanned),
 	}
 	if orgSlug != "" {
 		attrs = append(attrs, attr.OrganizationSlug(orgSlug))

--- a/server/internal/hooks/metrics_test.go
+++ b/server/internal/hooks/metrics_test.go
@@ -21,7 +21,7 @@ func TestMetrics_RecordHookEventDuration(t *testing.T) {
 	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	metrics := newMetrics(meterProvider, testenv.NewLogger(t))
 
-	metrics.RecordHookEventDuration(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, hookMetricDecisionDeny, "acme", 150*time.Millisecond)
+	metrics.RecordHookEventDuration(ctx, "claude", "PreToolUse", hookMetricOutcomeAccepted, hookMetricDecisionDeny, "acme", true, 150*time.Millisecond)
 
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
@@ -49,6 +49,10 @@ func TestMetrics_RecordHookEventDuration(t *testing.T) {
 	value, ok = histogramPoint.Attributes.Value(attr.OrganizationSlugKey)
 	require.True(t, ok)
 	require.Equal(t, "acme", value.AsString())
+
+	value, ok = histogramPoint.Attributes.Value(attr.HookRiskScannedKey)
+	require.True(t, ok)
+	require.True(t, value.AsBool())
 }
 
 func TestClaudeHookDecision(t *testing.T) {

--- a/server/internal/hooks/otel_test.go
+++ b/server/internal/hooks/otel_test.go
@@ -412,7 +412,7 @@ func enableHookTelemetryLogger(t *testing.T, ctx context.Context, ti *testInstan
 	t.Helper()
 
 	enabled := func(context.Context, string) (bool, error) { return true, nil }
-	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), ti.chConn, enabled, enabled, nil)
+	ti.service.telemetryLogger = telemetry.NewLogger(ctx, testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.chConn, enabled, enabled, nil)
 	return telemetryrepo.New(ti.chConn)
 }
 

--- a/server/internal/hooks/risk_scan.go
+++ b/server/internal/hooks/risk_scan.go
@@ -13,6 +13,24 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk"
 )
 
+// riskScanTrackerKey carries a flag the transport handlers install before
+// dispatching an event, flipped when an enforcement scan actually executes
+// (rather than short-circuiting on a guard). It feeds the risk_scanned
+// dimension on hooks.event.duration so gating latency that includes a scan is
+// separable from the no-scan baseline.
+type riskScanTrackerKey struct{}
+
+func withRiskScanTracker(ctx context.Context) (context.Context, *bool) {
+	scanned := new(bool)
+	return context.WithValue(ctx, riskScanTrackerKey{}, scanned), scanned
+}
+
+func markRiskScanned(ctx context.Context) {
+	if scanned, ok := ctx.Value(riskScanTrackerKey{}).(*bool); ok {
+		*scanned = true
+	}
+}
+
 func (s *Service) scanUserPromptForEnforcement(ctx context.Context, ev *hookevents.UserPromptSubmit) *risk.ScanResult {
 	if ev == nil {
 		return nil
@@ -60,6 +78,7 @@ func (s *Service) scanHookEventForEnforcement(ctx context.Context, ev hookevents
 		return nil
 	}
 
+	markRiskScanned(ctx)
 	result, err := s.riskScanner.ScanForEnforcement(ctx, ev.Context.OrganizationID, ev.Context.ProjectID, ev.Context.User.ID, text, messageType, toolName)
 	if err != nil {
 		s.logger.WarnContext(ctx, "risk scan failed for hook event",

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -173,7 +173,7 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 
-	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cacheAdapter))
+	telemLogger := telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cacheAdapter))
 	telemService := telemetry.NewService(
 		logger,
 		tracerProvider,

--- a/server/internal/remotemcp/tools_call_clickhouse_log_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_clickhouse_log_interceptor_test.go
@@ -38,7 +38,7 @@ func TestToolsCallClickHouseLogInterceptor_EmitsRow(t *testing.T) {
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
@@ -138,7 +138,7 @@ func TestToolsCallClickHouseLogInterceptor_DurationMissingSentinel(t *testing.T)
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return false, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()
@@ -210,7 +210,7 @@ func TestToolsCallClickHouseLogInterceptor_NoAuthContextSkips(t *testing.T) {
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, chConn, logsEnabled, toolIOLogsEnabled, nil)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, nil)
 
 	serverID := uuid.New().String()
 	mcpServerID := uuid.New().String()
@@ -347,7 +347,7 @@ func runStatusCodeMappingCase(t *testing.T, tc statusCodeCase) int32 {
 
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
-	telemLogger := telemetry.NewLogger(t.Context(), logger, conn, logsEnabled, toolIOLogsEnabled, nil)
+	telemLogger := telemetry.NewLogger(t.Context(), logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, logsEnabled, toolIOLogsEnabled, nil)
 
 	projectID := uuid.New()
 	serverID := uuid.New().String()

--- a/server/internal/telemetry/ch_write_metrics_test.go
+++ b/server/internal/telemetry/ch_write_metrics_test.go
@@ -1,0 +1,66 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// TestLoggerRecordsCHWriteMetric verifies that synchronous ClickHouse writes
+// through the telemetry Logger record the telemetry.clickhouse.write.duration
+// histogram with operation and outcome attributes (DNO-521).
+func TestLoggerRecordsCHWriteMetric(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	enabled := func(context.Context, string) (bool, error) { return true, nil }
+	telemLogger := telemetry.NewLogger(ctx, testenv.NewLogger(t), testenv.NewTracerProvider(t), meterProvider, ti.chConn, enabled, enabled, nil)
+
+	invURL, ok := shadowmcp.CanonicalizeInventoryURL("https://mcp.example.com/mcp")
+	require.True(t, ok)
+	require.NoError(t, telemLogger.UpsertShadowMCPInventoryURLs(ctx, []telemetry.ShadowMCPInventoryURL{{
+		GramProjectID: uuid.NewString(),
+		ServerURL:     invURL,
+		ServerName:    "Example",
+		SeenAt:        time.Date(2026, 6, 29, 15, 0, 0, 0, time.UTC),
+	}}))
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	var point *metricdata.HistogramDataPoint[float64]
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != "telemetry.clickhouse.write.duration" {
+				continue
+			}
+			histogram, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok)
+			require.Len(t, histogram.DataPoints, 1)
+			point = &histogram.DataPoints[0]
+		}
+	}
+	require.NotNil(t, point, "expected telemetry.clickhouse.write.duration to be recorded")
+	require.Equal(t, uint64(1), point.Count)
+
+	value, ok := point.Attributes.Value(attr.TelemetryCHOperationKey)
+	require.True(t, ok)
+	require.Equal(t, "upsert_shadow_mcp_inventory_urls", value.AsString())
+
+	value, ok = point.Attributes.Value(attr.OutcomeKey)
+	require.True(t, ok)
+	require.Equal(t, "success", value.AsString())
+}

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -15,6 +15,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -53,6 +55,8 @@ func WithOTELMetadata(params LogParams, observedTimestamp time.Time, resourceAtt
 type Logger struct {
 	shutdownCtx       func() context.Context
 	logger            *slog.Logger
+	tracer            trace.Tracer
+	metrics           *chWriteMetrics
 	chConn            clickhouse.Conn
 	logsEnabled       FeatureChecker
 	toolIOLogsEnabled FeatureChecker
@@ -62,14 +66,19 @@ type Logger struct {
 func NewLogger(
 	shutdownCtx context.Context,
 	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	meterProvider metric.MeterProvider,
 	chConn clickhouse.Conn,
 	logsEnabled FeatureChecker,
 	toolIOLogsEnabled FeatureChecker,
 	users *UserInfoResolver,
 ) *Logger {
+	logger = logger.With(attr.SlogComponent("telemetry_logger"))
 	return &Logger{
 		shutdownCtx:       func() context.Context { return shutdownCtx },
-		logger:            logger.With(attr.SlogComponent("telemetry_logger")),
+		logger:            logger,
+		tracer:            tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/telemetry"),
+		metrics:           newCHWriteMetrics(meterProvider, logger),
 		chConn:            chConn,
 		logsEnabled:       logsEnabled,
 		toolIOLogsEnabled: toolIOLogsEnabled,
@@ -84,6 +93,8 @@ func NewStub(logger *slog.Logger) *Logger {
 	return &Logger{
 		shutdownCtx:       context.Background,
 		logger:            logger.With(attr.SlogComponent("telemetry_logger_stub")),
+		tracer:            nil,
+		metrics:           nil,
 		chConn:            nil,
 		logsEnabled:       disabled,
 		toolIOLogsEnabled: disabled,
@@ -146,7 +157,10 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 	if len(logParams) == 0 {
 		return nil
 	}
-	if err := repo.New(l.chConn).InsertTelemetryLogs(l.shutdownCtx(), logParams); err != nil {
+	err := l.observeCHWrite(ctx, "telemetry.insertLogs", chWriteOperationInsertLogs, len(logParams), func(writeCtx context.Context) error {
+		return repo.New(l.chConn).InsertTelemetryLogs(writeCtx, logParams)
+	})
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "insert telemetry logs")
 	}
 	return nil
@@ -162,7 +176,10 @@ func (l *Logger) LogBulkStaging(ctx context.Context, params []LogParams) error {
 	if len(logParams) == 0 {
 		return nil
 	}
-	if err := repo.New(l.chConn).InsertTelemetryLogsStaging(l.shutdownCtx(), logParams); err != nil {
+	err := l.observeCHWrite(ctx, "telemetry.insertLogsStaging", chWriteOperationInsertLogsStaging, len(logParams), func(writeCtx context.Context) error {
+		return repo.New(l.chConn).InsertTelemetryLogsStaging(writeCtx, logParams)
+	})
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "insert staged telemetry logs")
 	}
 	return nil

--- a/server/internal/telemetry/metrics.go
+++ b/server/internal/telemetry/metrics.go
@@ -1,0 +1,77 @@
+package telemetry
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+const meterTelemetryCHWriteDuration = "telemetry.clickhouse.write.duration"
+
+// Operation values for the telemetry.clickhouse.write.duration metric. Each
+// names one synchronous ClickHouse write the Logger performs on a request
+// path (DNO-521: these writes were invisible in traces and metrics while
+// holding hook responses for seconds).
+const (
+	chWriteOperationInsertLogs        = "insert_telemetry_logs"
+	chWriteOperationInsertLogsStaging = "insert_telemetry_logs_staging"
+	chWriteOperationUpsertShadowMCP   = "upsert_shadow_mcp_inventory_urls"
+)
+
+type chWriteMetrics struct {
+	writeDuration metric.Float64Histogram
+}
+
+func newCHWriteMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *chWriteMetrics {
+	ctx := context.Background()
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/telemetry")
+
+	writeDuration, err := meter.Float64Histogram(
+		meterTelemetryCHWriteDuration,
+		metric.WithDescription("Duration of synchronous ClickHouse telemetry writes in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterTelemetryCHWriteDuration), attr.SlogError(err))
+	}
+
+	return &chWriteMetrics{writeDuration: writeDuration}
+}
+
+// observeCHWrite wraps a synchronous ClickHouse write in a span and duration
+// metric. The span is started on the caller's context so it parents into the
+// request trace, while the write itself runs on the detached shutdown context
+// (it must survive request cancellation, matching the pre-existing behavior).
+func (l *Logger) observeCHWrite(ctx context.Context, spanName string, operation string, rows int, write func(context.Context) error) error {
+	if l.tracer == nil {
+		// Stub logger: no tracing/metrics wiring, run the write as-is.
+		return write(l.shutdownCtx())
+	}
+
+	start := time.Now()
+	ctx, span := l.tracer.Start(ctx, spanName, trace.WithAttributes(
+		attr.TelemetryCHOperation(operation),
+		attr.TelemetryCHRowCount(rows),
+	))
+	defer span.End()
+
+	err := write(l.shutdownCtx())
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	}
+	if l.metrics != nil && l.metrics.writeDuration != nil {
+		l.metrics.writeDuration.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(
+			attr.TelemetryCHOperation(operation),
+			attr.Outcome(o11y.OutcomeFromErrorWithTimeout(err)),
+		))
+	}
+	return err
+}

--- a/server/internal/telemetry/setup_test.go
+++ b/server/internal/telemetry/setup_test.go
@@ -122,7 +122,7 @@ func newTestLogsServiceWithSessionCapture(t *testing.T, sessionCapture bool) (co
 
 	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 
-	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient)))
+	telemLogger := telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cache.NewRedisCacheAdapter(redisClient)))
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	svc := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
 

--- a/server/internal/telemetry/shadow_mcp_inventory.go
+++ b/server/internal/telemetry/shadow_mcp_inventory.go
@@ -66,8 +66,13 @@ func (l *Logger) UpsertShadowMCPInventoryURLs(ctx context.Context, inventoryURLs
 		return nil
 	}
 
-	chRepo := repo.New(l.chConn)
-	if err := chRepo.UpsertShadowMCPInventoryURLs(l.shutdownCtx(), params); err != nil {
+	// This currently issues one ClickHouse point-SELECT per URL plus the
+	// final insert (see repo.UpsertShadowMCPInventoryURLs), so the span and
+	// metric measure the whole sequential batch (DNO-521/DNO-606).
+	err := l.observeCHWrite(ctx, "telemetry.upsertShadowMCPInventoryURLs", chWriteOperationUpsertShadowMCP, len(params), func(writeCtx context.Context) error {
+		return repo.New(l.chConn).UpsertShadowMCPInventoryURLs(writeCtx, params)
+	})
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "upsert shadow mcp inventory urls")
 	}
 

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -144,7 +144,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	toolIOLogsEnabled := func(_ context.Context, _ string) (bool, error) { return false, nil }
 	sessionCaptureEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }
 
-	telemLogger := telemetry.NewLogger(ctx, logger, chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cacheAdapter))
+	telemLogger := telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), chConn, logsEnabled, toolIOLogsEnabled, telemetry.NewUserInfoResolver(logger, conn, cacheAdapter))
 	telemService := telemetry.NewService(logger, tracerProvider, conn, chConn, sessionManager, chatSessionsManager, logsEnabled, sessionCaptureEnabled, posthogClient, authzEngine)
 
 	temporalEnv, _ := infra.NewTemporalEnv(t)


### PR DESCRIPTION
## Summary

Instrumentation follow-up from the DNO-521 investigation: slow gating-hook responses turned out to be caused by **synchronous, un-instrumented ClickHouse writes on the hook request path** (not the prompt-policy judge, which is already instrumented). This PR makes those writes visible so the next latency alert points at the culprit directly. The behavioral fix (moving the shadow-MCP inventory upsert off the request path) is tracked separately in DNO-606.

## Changes

**ClickHouse telemetry layer** (`server/internal/telemetry`)

- New `telemetry.clickhouse.write.duration` histogram (seconds) with `gram.telemetry.operation` + `gram.outcome` attributes.
- `observeCHWrite` wraps each synchronous ClickHouse write in a span parented into the request trace (the write itself still runs on the detached shutdown context — behavior unchanged).
- Applied to `LogBulk`, `LogBulkStaging`, and `UpsertShadowMCPInventoryURLs` — the writes that showed up as multi-second "dark gaps" in `POST /rpc/hooks.claude` traces during the DNO-521 alert window.
- `telemetry.NewLogger` now takes tracer/meter providers; wired through `start.go`, `worker.go`, and test setups. `NewStub` skips instrumentation.

**`gram.hook.risk_scanned` dimension on `hooks.event.duration`** (`server/internal/hooks`)

- All four hook transports (claude/cursor/codex/ingest) install a context tracker that `scanHookEventForEnforcement` flips right before invoking `ScanForEnforcement`, so the hook-latency monitor can separate scanned gating evaluations from the no-scan baseline.

## Testing

- `go build ./server/...`, `mise lint:server` clean.
- New `ch_write_metrics_test.go` asserts the histogram records with correct operation/outcome attributes on a real ClickHouse write.
- `telemetry`, `hooks`, and `remotemcp` package tests pass.

## References

- DNO-521 (investigation + full evidence trail), DNO-606 (request-path fix), DNO-600/DNO-601 (judge deadline / latency floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instrumented synchronous ClickHouse writes on hook paths with request-parented spans and a `telemetry.clickhouse.write.duration` histogram, and added a `gram.hook.risk_scanned` dimension to hook latency. This addresses Linear DNO-521 by making the slow path visible and separating scanned vs no-scan latency.

- New Features
  - Wrapped `LogBulk`, `LogBulkStaging`, and `UpsertShadowMCPInventoryURLs` in `observeCHWrite` spans and recorded `telemetry.clickhouse.write.duration` with `gram.telemetry.operation`, `gram.telemetry.row_count`, and `gram.outcome` attributes; span writes still run on the shutdown context.
  - Added `gram.hook.risk_scanned` to `hooks.event.duration` across `claude`, `cursor`, `codex`, and `ingest`, using a context flag toggled when `ScanForEnforcement` runs.

- Migration
  - `telemetry.NewLogger` now requires `trace.TracerProvider` and `metric.MeterProvider`: `telemetry.NewLogger(ctx, logger, tracerProvider, meterProvider, chConn, ...)`. `telemetry.NewStub` remains available and uninstrumented.

<sup>Written for commit bb1a1319dfc4dcbe68a98eae095b24afd2236c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

