### PR TITLE
fix(risk): decide shadow MCP findings from URL provenance

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -731,7 +731,7 @@ func newStartCommand() *cli.Command {
 			}
 			accessStore := accesscontrol.NewRedisStore(cache.NewRedisCacheAdapter(redisClient), accesscontrol.AlphaTTL)
 			oauthService := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cache.NewRedisCacheAdapter(redisClient), encryptionClient, env, sessionManager, identityResolver, guardianPolicy)
-			shadowMCPClient := shadowmcp.NewClient(logger, db, cache.NewRedisCacheAdapter(redisClient), accessStore)
+			shadowMCPClient := shadowmcp.NewClient(logger, db, cache.NewRedisCacheAdapter(redisClient), accessStore, serverURL)
 			triggerApp := newTriggersApp(logger, db, encryptionClient, temporalEnv, telemLogger, auditLogger, serverURL, siteURL, slackClient)
 
 			platformFeatureChecker := productFeatures.PlatformFeatureCheck
@@ -1044,7 +1044,6 @@ func newStartCommand() *cli.Command {
 				policyBypass,
 				shadowMCPClient,
 				chatWriter,
-				serverURL,
 				siteURL,
 				c.String("jwt-signing-key"),
 			))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -650,7 +650,7 @@ func newWorkerCommand() *cli.Command {
 			assistantTokenManager := assistanttokens.New(c.String(usersessions.JWTSigningKeyFlag), db, authzEngine)
 
 			accessStore := accesscontrol.NewRedisStore(cache.NewRedisCacheAdapter(redisClient), accesscontrol.AlphaTTL)
-			shadowMCPClient := shadowmcp.NewClient(logger, db, cache.NewRedisCacheAdapter(redisClient), accessStore)
+			shadowMCPClient := shadowmcp.NewClient(logger, db, cache.NewRedisCacheAdapter(redisClient), accessStore, serverURL)
 
 			memorySvc := memory.NewMemoryService(
 				logger,

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -69,7 +69,7 @@ func NewAnalyzeBatch(
 	piiScanner PIIScanner,
 	promptInjectionScanner *promptinjection.Scanner,
 	shadowMCPClient *shadowmcp.Client,
-	mcpMatchLookup MCPMatchLookup,
+	mcpProvenanceLookup MCPProvenanceLookup,
 	judge promptpolicy.Evaluator,
 	flags feature.Provider,
 	presidioPub gcp.Publisher[*riskv1.PresidioAnalysis],
@@ -94,15 +94,17 @@ func NewAnalyzeBatch(
 		return nil, fmt.Errorf("compile recommended scopes version %d: %w", recommendedscopes.Version, err)
 	}
 
+	metrics := newRiskMetrics(meterProvider, logger)
+
 	return &AnalyzeBatch{
 		logger:                 logger,
 		tracer:                 tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"),
-		metrics:                newRiskMetrics(meterProvider, logger),
+		metrics:                metrics,
 		db:                     db,
 		gitleaksScanner:        gitleaks.NewScanner(),
 		piiScanner:             piiScanner,
 		promptInjectionScanner: promptInjectionScanner,
-		shadowMCPScanner:       shadowmcpscan.NewScanner(logger, shadowMCPClient, mcpMatchLookup),
+		shadowMCPScanner:       shadowmcpscan.NewScanner(logger, shadowMCPClient, shadowMCPClient, mcpProvenanceLookup, metrics),
 		judge:                  judge,
 		flags:                  flags,
 		presidioPub:            presidioPub,

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -30,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	tsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -1224,11 +1226,20 @@ func insertAssistantToolCallsWithArgs(t *testing.T, conn *pgxpool.Pool, td testD
 	return uuid.Nil
 }
 
+// stubProvenanceLookup resolves no MCP provenance, so shadow_mcp scans in
+// these tests exercise the signature fallback. A nil lookup would be a nil
+// interface call the moment a test selects the shadow_mcp source.
+type stubProvenanceLookup struct{}
+
+func (stubProvenanceLookup) LookupMCPProvenanceByToolCallID(_ context.Context, _ uuid.UUID, _ []string, _ time.Time) (map[string]telemetryrepo.MCPProvenance, error) {
+	return map[string]telemetryrepo.MCPProvenance{}, nil
+}
+
 func executeAnalyzeBatch(t *testing.T, conn *pgxpool.Pool, td testData, messageIDs []uuid.UUID, sources []string) risk_analysis.AnalyzeBatchResult {
 	t.Helper()
 
 	accessStore := accesscontrol.NewRedisStore(cache.NoopCache, accesscontrol.AlphaTTL)
-	shadowMCPClient := shadowmcp.NewClient(testenv.NewLogger(t), conn, cache.NoopCache, accessStore)
+	shadowMCPClient := shadowmcp.NewClient(testenv.NewLogger(t), conn, cache.NoopCache, accessStore, nil)
 	ab, err := risk_analysis.NewAnalyzeBatch(
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
@@ -1237,7 +1248,7 @@ func executeAnalyzeBatch(t *testing.T, conn *pgxpool.Pool, td testData, messageI
 		&risk_analysis.StubPIIScanner{},
 		nil,
 		shadowMCPClient,
-		nil,
+		stubProvenanceLookup{},
 		nil,
 		nil,
 		newPresidioPub(),

--- a/server/internal/background/activities/risk_analysis/batch_messages.go
+++ b/server/internal/background/activities/risk_analysis/batch_messages.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -24,6 +25,12 @@ type batchMessage struct {
 	// UserID is the scanned chat's owner (empty for unattributed sessions),
 	// carried onto judge completions for scanning-volume attribution.
 	UserID string
+	// CreatedAt is when the message was recorded. The shadow-MCP scanner uses
+	// the batch's oldest value to bound its ClickHouse provenance lookup.
+	CreatedAt time.Time
+	// Source is the agent that recorded the message (Codex, Cursor, ...). The
+	// shadow-MCP scanner attributes unresolved provenance to it.
+	Source string
 }
 
 // scanSurface is the text content scanners (gitleaks, presidio) evaluate:
@@ -67,6 +74,10 @@ func newBatchMessages(ctx context.Context, logger *slog.Logger, rows []repo.GetM
 			continue
 		}
 		msg.UserID = row.ChatUserID
+		if row.CreatedAt.Valid {
+			msg.CreatedAt = row.CreatedAt.Time
+		}
+		msg.Source = row.Source.String
 		messages = append(messages, msg)
 	}
 	return messages
@@ -90,6 +101,8 @@ func newBatchMessage(ctx context.Context, logger *slog.Logger, id uuid.UUID, rol
 		RawToolCalls: toolCalls,
 		ToolCalls:    []recordedToolCall{},
 		UserID:       "",
+		CreatedAt:    time.Time{},
+		Source:       "",
 	}
 	if messageType == message.ToolRequest && len(toolCalls) > 0 {
 		msg.ToolCalls = parseRecordedToolCalls(ctx, logger, toolCalls)

--- a/server/internal/background/activities/risk_analysis/metrics.go
+++ b/server/internal/background/activities/risk_analysis/metrics.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/recommendedscopes"
@@ -21,6 +22,7 @@ const (
 	meterRiskPresidioScanSkipped                = "risk.presidio.scan_skipped"
 	meterRiskRecommendedScopePrefiltered        = "risk.recommended_scope.messages_prefiltered"
 	meterRiskRecommendedScopeFindingsSuppressed = "risk.recommended_scope.findings_suppressed"
+	meterRiskShadowMCPResolution                = "risk.shadow_mcp.resolution"
 )
 
 type riskMetrics struct {
@@ -30,6 +32,7 @@ type riskMetrics struct {
 	presidioScanSkipped                 metric.Int64Counter
 	recommendedScopeMessagesPrefiltered metric.Int64Counter
 	recommendedScopeFindingsSuppressed  metric.Int64Counter
+	shadowMCPResolution                 metric.Int64Counter
 }
 
 func newRiskMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *riskMetrics {
@@ -92,6 +95,15 @@ func newRiskMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *ri
 		logger.ErrorContext(ctx, "create metric", attr.SlogMetricName(meterRiskRecommendedScopeFindingsSuppressed), attr.SlogError(err))
 	}
 
+	shadowMCPResolution, err := meter.Int64Counter(
+		meterRiskShadowMCPResolution,
+		metric.WithDescription("MCP tool calls by how the shadow-MCP scanner resolved their server provenance"),
+		metric.WithUnit("{tool_call}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "create metric", attr.SlogMetricName(meterRiskShadowMCPResolution), attr.SlogError(err))
+	}
+
 	return &riskMetrics{
 		scanEvents:                          scanEvents,
 		scanDuration:                        scanDuration,
@@ -99,6 +111,7 @@ func newRiskMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *ri
 		presidioScanSkipped:                 presidioScanSkipped,
 		recommendedScopeMessagesPrefiltered: recommendedScopeMessagesPrefiltered,
 		recommendedScopeFindingsSuppressed:  recommendedScopeFindingsSuppressed,
+		shadowMCPResolution:                 shadowMCPResolution,
 	}
 }
 
@@ -137,6 +150,22 @@ func (m *riskMetrics) RecordRecommendedScopePrefiltered(ctx context.Context, org
 		attr.OrganizationID(orgID),
 		attr.RiskSource(source),
 		attribute.Int("risk.recommended_scopes.version", recommendedscopes.Version),
+	))
+}
+
+// RecordShadowMCPResolution counts one scanned MCP tool call by how its server
+// provenance resolved. hookSource is the reporting agent, empty when the call
+// had no provenance row at all; splitting on it is what makes the unresolved
+// rate actionable per sender rather than a single opaque number, which is the
+// signal for when the legacy signature fallback can be deleted.
+func (m *riskMetrics) RecordShadowMCPResolution(ctx context.Context, orgID string, hookSource string, resolution string) {
+	if m == nil || m.shadowMCPResolution == nil {
+		return
+	}
+	m.shadowMCPResolution.Add(ctx, 1, metric.WithAttributes(
+		attr.OrganizationID(orgID),
+		attribute.String("gram.hook.source", conv.Default(hookSource, "unknown")),
+		attribute.String("risk.shadow_mcp.resolution", resolution),
 	))
 }
 

--- a/server/internal/background/activities/risk_analysis/scan_tool_calls.go
+++ b/server/internal/background/activities/risk_analysis/scan_tool_calls.go
@@ -2,6 +2,7 @@ package risk_analysis
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -9,13 +10,15 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/scanners/clidestructive"
 	"github.com/speakeasy-api/gram/server/internal/scanners/destructivetool"
 	"github.com/speakeasy-api/gram/server/internal/scanners/shadowmcpscan"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
-// MCPMatchLookup resolves stored tool-call IDs to MCP match strings. It is the
-// risk_analysis-facing name for shadowmcpscan.MatchLookup, kept here because it
-// is part of the NewAnalyzeBatch constructor signature.
-type MCPMatchLookup interface {
-	LookupMCPMatchesByToolCallID(ctx context.Context, projectID uuid.UUID, toolCallIDs []string) (map[string]string, error)
+// MCPProvenanceLookup replays the MCP server identity recorded for a set of
+// tool calls. It is the risk_analysis-facing name for
+// shadowmcpscan.ProvenanceLookup, kept here because it is part of the
+// NewAnalyzeBatch constructor signature.
+type MCPProvenanceLookup interface {
+	LookupMCPProvenanceByToolCallID(ctx context.Context, projectID uuid.UUID, toolCallIDs []string, since time.Time) (map[string]telemetryrepo.MCPProvenance, error)
 }
 
 func (a *AnalyzeBatch) scanShadowMCP(ctx context.Context, orgID string, projectID uuid.UUID, messages []batchMessage) [][]scanners.Finding {
@@ -27,6 +30,8 @@ func (a *AnalyzeBatch) scanShadowMCP(ctx context.Context, orgID string, projectI
 				ID:        call.ID,
 				Name:      call.Function.Name,
 				Arguments: call.Function.Arguments,
+				CreatedAt: msg.CreatedAt,
+				Sender:    msg.Source,
 			})
 		}
 		calls[i] = msgCalls

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -1046,7 +1046,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 	switch {
 	case matched == nil:
 		detail = fmt.Sprintf("MCP server %q is not in the active configuration", serverPrefix)
-	case matched.URL != "" && !s.isGramHostedMCPURLForOrg(ctx, matched.URL, metadata.GramOrgID):
+	case matched.URL != "" && !s.shadowMCPClient.IsGramHostedMCPURLForOrg(ctx, matched.URL, metadata.GramOrgID):
 		detail = fmt.Sprintf("MCP server %q is not Gram-hosted (URL: %s)", serverPrefix, matched.URL)
 	case matched.URL == "" && matched.Command != "":
 		// Local stdio servers have no URL, so the Gram-hosted check above

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -572,8 +572,15 @@ func (s *Service) buildCursorTelemetryAttributes(ctx context.Context, payload *g
 		}
 		// Cursor surfaces the MCP server URL on the payload directly (no
 		// SessionStart inventory), so persist it alongside the tool call.
+		// The match key carries the same server-level identifier the other
+		// senders resolve from their inventory snapshot — full URL for
+		// HTTP/SSE, launch command for stdio — so the offline risk scanner
+		// reads one attribute regardless of which agent sent the event.
 		if payload.URL != nil && *payload.URL != "" {
 			attrs[attr.MCPServerURLKey] = *payload.URL
+			attrs[attr.MCPMatchKey] = *payload.URL
+		} else if payload.Command != nil && *payload.Command != "" {
+			attrs[attr.MCPMatchKey] = *payload.Command
 		}
 	}
 

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -54,7 +54,6 @@ type Service struct {
 	policyBypass       *risk.PolicyBypassEvaluator
 	shadowMCPClient    *shadowmcp.Client
 	writer             *chat.ChatMessageWriter
-	serverURL          *url.URL
 	siteURL            *url.URL
 	jwtSecret          string
 	// nowFunc supplies the event timestamp for ingest paths that stamp
@@ -169,7 +168,6 @@ func NewService(
 	policyBypass *risk.PolicyBypassEvaluator,
 	shadowMCPClient *shadowmcp.Client,
 	writer *chat.ChatMessageWriter,
-	serverURL *url.URL,
 	siteURL *url.URL,
 	jwtSecret string,
 ) *Service {
@@ -190,7 +188,6 @@ func NewService(
 		policyBypass:       policyBypass,
 		shadowMCPClient:    shadowMCPClient,
 		writer:             writer,
-		serverURL:          serverURL,
 		siteURL:            siteURL,
 		jwtSecret:          jwtSecret,
 		nowFunc:            time.Now,

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -3,21 +3,11 @@ package hooks
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
-
-// gramHostedMCPHosts are the built-in hosts for Gram-managed MCP servers.
-// Exact host matching keeps third-party subdomains from being treated as
-// trusted Gram-hosted MCP servers.
-var gramHostedMCPHosts = []string{
-	"app.getgram.ai",
-	"chat.speakeasy.com",
-}
 
 // parsedClaudeToolName is the result of splitting a Claude Code tool name
 // into its MCP "<server>" and "<tool>" parts. IsMCP is false for native
@@ -223,92 +213,6 @@ func resolvedMCPMatch(matched *MCPServerEntry, serverPrefix string) string {
 		}
 	}
 	return serverPrefix
-}
-
-// isGramHostedMCPURL reports whether rawURL points at a Gram-managed MCP
-// server. Checks the canonical host plus any additional trusted hosts.
-// Exact host match, case-insensitive.
-func isGramHostedMCPURL(rawURL string, additionalTrustedHosts ...string) bool {
-	if rawURL == "" {
-		return false
-	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return false
-	}
-	hostname := u.Hostname()
-	for _, h := range gramHostedMCPHosts {
-		if strings.EqualFold(hostname, h) {
-			return true
-		}
-	}
-	for _, h := range additionalTrustedHosts {
-		if trustedGramHostedMCPHostMatches(u, h) {
-			return true
-		}
-	}
-	return false
-}
-
-func trustedGramHostedMCPHostMatches(u *url.URL, trustedHost string) bool {
-	trustedHost = strings.TrimSpace(trustedHost)
-	if trustedHost == "" {
-		return false
-	}
-	if strings.Contains(trustedHost, "://") {
-		parsed, err := url.Parse(trustedHost)
-		if err != nil || parsed.Host == "" {
-			return false
-		}
-		trustedHost = parsed.Host
-	}
-	if strings.Contains(trustedHost, ":") {
-		return strings.EqualFold(u.Host, trustedHost)
-	}
-	return strings.EqualFold(u.Hostname(), trustedHost)
-}
-
-// gramHostedMCPTrustedHostsForOrg returns the trusted Gram-hosted MCP hosts
-// for an org — the configured server host plus the org's verified+activated
-// custom domain — with a single custom_domains query. Use it over
-// isGramHostedMCPURLForOrg when classifying many URLs for the same org in one
-// pass, which would otherwise repeat the custom-domain lookup per URL.
-func (s *Service) gramHostedMCPTrustedHostsForOrg(ctx context.Context, orgID string) []string {
-	trustedHosts := make([]string, 0, 2)
-	if s.serverURL != nil && s.serverURL.Host != "" {
-		trustedHosts = append(trustedHosts, s.serverURL.Host)
-	}
-	if orgID == "" {
-		return trustedHosts
-	}
-	customDomain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, orgID)
-	if err == nil && customDomain.Verified && customDomain.Activated {
-		trustedHosts = append(trustedHosts, customDomain.Domain)
-	}
-	return trustedHosts
-}
-
-// isGramHostedMCPURLForOrg checks if a URL is a Gram-managed MCP server for
-// the given organization. It checks against the canonical host first (no DB
-// hit), then falls back to checking the org's custom domain if needed.
-func (s *Service) isGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
-	trustedHosts := make([]string, 0, 1)
-	if s.serverURL != nil && s.serverURL.Host != "" {
-		trustedHosts = append(trustedHosts, s.serverURL.Host)
-	}
-
-	// Fast path: check built-in/configured hosts before consulting custom domains.
-	if isGramHostedMCPURL(rawURL, trustedHosts...) {
-		return true
-	}
-	if rawURL == "" || orgID == "" {
-		return false
-	}
-	customDomain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, orgID)
-	if err != nil || !customDomain.Verified || !customDomain.Activated {
-		return false
-	}
-	return isGramHostedMCPURL(rawURL, customDomain.Domain)
 }
 
 // getCachedMCPList retrieves the parsed `claude mcp list` snapshot stored

--- a/server/internal/hooks/mcp_match_test.go
+++ b/server/internal/hooks/mcp_match_test.go
@@ -162,60 +162,6 @@ func TestApplyMCPInventoryAttrs(t *testing.T) {
 	})
 }
 
-func TestIsGramHostedMCPURL(t *testing.T) {
-	t.Parallel()
-
-	t.Run("canonical host only", func(t *testing.T) {
-		t.Parallel()
-		cases := []struct {
-			url  string
-			want bool
-		}{
-			{"https://app.getgram.ai/mcp/team-foo", true},
-			{"https://APP.GETGRAM.AI/mcp/team-foo", true}, // case-insensitive
-			{"http://app.getgram.ai/mcp/team-foo", true},  // http allowed (rare but valid)
-			{"https://chat.speakeasy.com/mcp/linear", true},
-			{"https://CHAT.SPEAKEASY.COM/mcp/linear", true},
-			{"https://evil.getgram.ai/mcp/x", false}, // subdomain squat must NOT pass
-			{"https://mcp.slack.com/mcp", false},
-			{"http://localhost:8080/mcp/x", false},
-			{"", false},
-			{"not a url at all", false},
-		}
-		for _, tc := range cases {
-			t.Run(tc.url, func(t *testing.T) {
-				t.Parallel()
-				assert.Equal(t, tc.want, isGramHostedMCPURL(tc.url))
-			})
-		}
-	})
-
-	t.Run("with additional trusted hosts", func(t *testing.T) {
-		t.Parallel()
-		cases := []struct {
-			url         string
-			extraHosts  []string
-			want        bool
-			description string
-		}{
-			{"https://docs.example.com/mcp/linear", []string{"docs.example.com"}, true, "custom domain matches"},
-			{"https://DOCS.EXAMPLE.COM/mcp/linear", []string{"docs.example.com"}, true, "custom domain case-insensitive"},
-			{"https://localhost:8080/mcp/local-org", []string{"localhost:8080"}, true, "configured local Gram server host and port matches"},
-			{"https://localhost:35294/mcp/local-shadow", []string{"localhost:8080"}, false, "different local dev port stays external"},
-			{"https://app.getgram.ai/mcp/x", []string{"chat.speakeasy.com"}, true, "canonical still works with extra hosts"},
-			{"https://other.example.com/mcp/x", []string{"chat.speakeasy.com"}, false, "unknown host rejected"},
-			{"https://mcp.slack.com/mcp", []string{"chat.speakeasy.com"}, false, "third party rejected"},
-			{"", []string{"chat.speakeasy.com"}, false, "empty URL"},
-		}
-		for _, tc := range cases {
-			t.Run(tc.description, func(t *testing.T) {
-				t.Parallel()
-				assert.Equal(t, tc.want, isGramHostedMCPURL(tc.url, tc.extraHosts...))
-			})
-		}
-	})
-}
-
 func TestParseClaudeToolName(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -94,12 +94,12 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, conn, nil)
 	t.Cleanup(func() { _ = chatWriterShutdown(t.Context()) })
 	accessStore := accesscontrol.NewRedisStore(cacheAdapter, accesscontrol.AlphaTTL)
-	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore)
-	policyBypass := risk.NewPolicyBypassEvaluator(logger, conn)
 	siteURL, err := url.Parse("https://app.example.test")
 	require.NoError(t, err)
 	serverURL, err := url.Parse("https://localhost:8080")
 	require.NoError(t, err)
+	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore, serverURL)
+	policyBypass := risk.NewPolicyBypassEvaluator(logger, conn)
 	svc := NewService(
 		logger,
 		conn,
@@ -117,7 +117,6 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 		policyBypass,
 		shadowMCPClient,
 		chatWriter,
-		serverURL,
 		siteURL,
 		"test-jwt-secret",
 	)

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -25,7 +25,7 @@ func (s *Service) enforceShadowMCPToolAccess(
 	var detail string
 	switch {
 	case evidence.FullURL != "":
-		if s.isGramHostedMCPURLForOrg(ctx, evidence.FullURL, organizationID) {
+		if s.shadowMCPClient.IsGramHostedMCPURLForOrg(ctx, evidence.FullURL, organizationID) {
 			return "", false
 		}
 		detail = fmt.Sprintf("MCP server is not Gram-hosted (URL: %s)", evidence.FullURL)
@@ -153,7 +153,7 @@ func (s *Service) codexInventoryProvenanceDetail(ctx context.Context, matched *M
 		return ""
 	}
 	switch {
-	case matched.URL != "" && !s.isGramHostedMCPURLForOrg(ctx, matched.URL, orgID):
+	case matched.URL != "" && !s.shadowMCPClient.IsGramHostedMCPURLForOrg(ctx, matched.URL, orgID):
 		return fmt.Sprintf("MCP server %q is not Gram-hosted (URL: %s)", matched.Name, matched.URL)
 	case matched.URL == "" && matched.Command != "":
 		return fmt.Sprintf("MCP server %q is a local stdio server (command: %s)", matched.Name, matched.Command)

--- a/server/internal/hooks/shadow_mcp_inventory.go
+++ b/server/internal/hooks/shadow_mcp_inventory.go
@@ -32,13 +32,30 @@ func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, orgID string
 	go func() {
 		asyncCtx, cancel := context.WithTimeout(detachedCtx, shadowMCPInventoryUpsertTimeout)
 		defer cancel()
+		// One custom-domain lookup covers every entry — the per-entry
+		// IsGramHostedMCPURLForOrg variant would re-query custom_domains for
+		// each external URL in the inventory.
+		//
+		// Without the host list every Gram-hosted entry would read as external
+		// and be recorded as shadow inventory. This capture is best-effort
+		// telemetry, so skipping the batch beats writing wrong rows.
+		trustedHosts, err := s.shadowMCPClient.TrustedMCPHostsForOrg(asyncCtx, orgID)
+		if err != nil {
+			s.logger.WarnContext(asyncCtx, "skipping shadow MCP inventory capture: trusted host resolution failed",
+				attr.SlogEvent("shadow_mcp_inventory_trusted_hosts_failed"),
+				attr.SlogError(err),
+				attr.SlogOrganizationID(orgID),
+				attr.SlogProjectID(projectID),
+			)
+			return
+		}
 
 		inventoryURLs := make([]telemetry.ShadowMCPInventoryURL, 0, len(entries))
 		for _, entry := range entries {
 			if entry.URL == "" {
 				continue
 			}
-			if s.shadowMCPClient.IsGramHostedMCPURLForOrg(asyncCtx, entry.URL, orgID) {
+			if shadowmcp.IsGramHostedMCPURL(entry.URL, trustedHosts...) {
 				continue
 			}
 			invURL, ok := shadowmcp.CanonicalizeInventoryURL(entry.URL)

--- a/server/internal/hooks/shadow_mcp_inventory.go
+++ b/server/internal/hooks/shadow_mcp_inventory.go
@@ -32,17 +32,13 @@ func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, orgID string
 	go func() {
 		asyncCtx, cancel := context.WithTimeout(detachedCtx, shadowMCPInventoryUpsertTimeout)
 		defer cancel()
-		// One custom-domain lookup covers every entry — the per-entry
-		// isGramHostedMCPURLForOrg variant would re-query custom_domains for
-		// each external URL in the inventory.
-		trustedHosts := s.gramHostedMCPTrustedHostsForOrg(asyncCtx, orgID)
 
 		inventoryURLs := make([]telemetry.ShadowMCPInventoryURL, 0, len(entries))
 		for _, entry := range entries {
 			if entry.URL == "" {
 				continue
 			}
-			if isGramHostedMCPURL(entry.URL, trustedHosts...) {
+			if s.shadowMCPClient.IsGramHostedMCPURLForOrg(asyncCtx, entry.URL, orgID) {
 				continue
 			}
 			invURL, ok := shadowmcp.CanonicalizeInventoryURL(entry.URL)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -195,7 +195,7 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 	assistantTokens := assistanttokens.New("test-jwt-secret", conn, authzEngine)
 	_ = featClient
 	accessStore := accesscontrol.NewRedisStore(cacheAdapter, accesscontrol.AlphaTTL)
-	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore)
+	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore, nil)
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -859,7 +859,17 @@ WHERE id = ANY(@message_ids::uuid[])
 -- attribution rule as ListRiskOverviewTopUsers: the message's own user_id
 -- wins, the chat owner's is the fallback — and a soft-deleted chat's owner
 -- never is (LEFT JOIN so the message still gets scanned, just unattributed).
-SELECT cm.id, cm.role, cm.content, cm.tool_calls,
+--
+-- created_at bounds the shadow-MCP scanner's ClickHouse provenance lookup to
+-- the batch's own time range, keeping that query on the telemetry table's
+-- time-ordered primary key instead of scanning the full retention window.
+--
+-- source names the agent that recorded the message (Codex, Cursor, the ingest
+-- adapter, ...). The shadow-MCP scanner attributes its provenance-resolution
+-- metric to it, which is the one attribution available when the call resolved
+-- to no telemetry row at all — precisely the population that metric exists to
+-- measure.
+SELECT cm.id, cm.role, cm.content, cm.tool_calls, cm.created_at, cm.source,
   COALESCE(NULLIF(cm.user_id, ''), NULLIF(c.user_id, ''), '')::TEXT AS chat_user_id
 FROM chat_messages cm
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -1108,7 +1108,7 @@ func (q *Queries) GetCustomDetectionRule(ctx context.Context, arg GetCustomDetec
 }
 
 const getMessageContentBatch = `-- name: GetMessageContentBatch :many
-SELECT cm.id, cm.role, cm.content, cm.tool_calls,
+SELECT cm.id, cm.role, cm.content, cm.tool_calls, cm.created_at, cm.source,
   COALESCE(NULLIF(cm.user_id, ''), NULLIF(c.user_id, ''), '')::TEXT AS chat_user_id
 FROM chat_messages cm
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -1126,6 +1126,8 @@ type GetMessageContentBatchRow struct {
 	Role       string
 	Content    string
 	ToolCalls  []byte
+	CreatedAt  pgtype.Timestamptz
+	Source     pgtype.Text
 	ChatUserID string
 }
 
@@ -1134,6 +1136,16 @@ type GetMessageContentBatchRow struct {
 // attribution rule as ListRiskOverviewTopUsers: the message's own user_id
 // wins, the chat owner's is the fallback — and a soft-deleted chat's owner
 // never is (LEFT JOIN so the message still gets scanned, just unattributed).
+//
+// created_at bounds the shadow-MCP scanner's ClickHouse provenance lookup to
+// the batch's own time range, keeping that query on the telemetry table's
+// time-ordered primary key instead of scanning the full retention window.
+//
+// source names the agent that recorded the message (Codex, Cursor, the ingest
+// adapter, ...). The shadow-MCP scanner attributes its provenance-resolution
+// metric to it, which is the one attribution available when the call resolved
+// to no telemetry row at all — precisely the population that metric exists to
+// measure.
 func (q *Queries) GetMessageContentBatch(ctx context.Context, arg GetMessageContentBatchParams) ([]GetMessageContentBatchRow, error) {
 	rows, err := q.db.Query(ctx, getMessageContentBatch, arg.Ids, arg.ProjectID)
 	if err != nil {
@@ -1148,6 +1160,8 @@ func (q *Queries) GetMessageContentBatch(ctx context.Context, arg GetMessageCont
 			&i.Role,
 			&i.Content,
 			&i.ToolCalls,
+			&i.CreatedAt,
+			&i.Source,
 			&i.ChatUserID,
 		); err != nil {
 			return nil, err

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -156,7 +156,7 @@ func newTestRiskService(t *testing.T) (context.Context, *testInstance) {
 
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
 	accessStore := accesscontrol.NewRedisStore(cacheAdapter, accesscontrol.AlphaTTL)
-	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore)
+	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore, nil)
 	auditLogger := audit.NewLogger()
 	flags := &feature.InMemory{}
 

--- a/server/internal/scanners/shadowmcpscan/scanner.go
+++ b/server/internal/scanners/shadowmcpscan/scanner.go
@@ -71,10 +71,14 @@ type Validator interface {
 	ValidateToolsetCall(ctx context.Context, toolInput any, toolName string, orgID string) (string, bool)
 }
 
-// HostedChecker reports whether a resolved MCP server URL belongs to Gram for
-// the calling organization. *shadowmcp.Client satisfies it.
+// HostedChecker resolves the hosts that count as Gram-hosted for an
+// organization, on top of the built-in ones. *shadowmcp.Client satisfies it.
+//
+// Resolving hosts rather than classifying one URL at a time keeps the
+// organization's custom-domain lookup to a single database round-trip per
+// batch instead of one per scanned call.
 type HostedChecker interface {
-	IsGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool
+	TrustedMCPHostsForOrg(ctx context.Context, orgID string) []string
 }
 
 // ProvenanceLookup replays the server identity the hook recorded for a set of
@@ -132,12 +136,21 @@ func NewScanner(logger *slog.Logger, validator Validator, hosted HostedChecker, 
 func (s *Scanner) Scan(ctx context.Context, orgID string, projectID uuid.UUID, messages [][]ToolCall) [][]scanners.Finding {
 	out := make([][]scanners.Finding, len(messages))
 
-	provenance := s.lookupProvenance(ctx, projectID, messages)
+	ids, oldest := mcpCallIDs(messages)
+	if len(ids) == 0 {
+		return out
+	}
+
+	provenance := s.lookupProvenance(ctx, projectID, ids, oldest)
+	// Resolved once for the whole batch: the custom-domain lookup behind this
+	// is a database round-trip whose result is invariant for the organization,
+	// and a batch can hold hundreds of calls.
+	trustedHosts := s.hosted.TrustedMCPHostsForOrg(ctx, orgID)
 
 	for i, calls := range messages {
 		var findings []scanners.Finding
 		for _, call := range calls {
-			if finding := s.scanCall(ctx, orgID, call, provenance[call.ID]); finding != nil {
+			if finding := s.scanCall(ctx, orgID, call, provenance[call.ID], trustedHosts); finding != nil {
 				findings = append(findings, *finding)
 			}
 		}
@@ -146,10 +159,9 @@ func (s *Scanner) Scan(ctx context.Context, orgID string, projectID uuid.UUID, m
 	return out
 }
 
-// lookupProvenance issues the single batch-wide provenance query. A failure is
-// logged and yields an empty map: every call then falls through to the
-// signature check rather than being decided on absent evidence.
-func (s *Scanner) lookupProvenance(ctx context.Context, projectID uuid.UUID, messages [][]ToolCall) map[string]telemetryrepo.MCPProvenance {
+// mcpCallIDs collects the recorded ids of every MCP-routed call in the batch,
+// plus the oldest recording time among them, which bounds the provenance query.
+func mcpCallIDs(messages [][]ToolCall) ([]string, time.Time) {
 	var ids []string
 	var oldest time.Time
 	for _, calls := range messages {
@@ -163,10 +175,13 @@ func (s *Scanner) lookupProvenance(ctx context.Context, projectID uuid.UUID, mes
 			}
 		}
 	}
-	if len(ids) == 0 {
-		return map[string]telemetryrepo.MCPProvenance{}
-	}
+	return ids, oldest
+}
 
+// lookupProvenance issues the single batch-wide provenance query. A failure is
+// logged and yields an empty map: every call then falls through to the
+// signature check rather than being decided on absent evidence.
+func (s *Scanner) lookupProvenance(ctx context.Context, projectID uuid.UUID, ids []string, oldest time.Time) map[string]telemetryrepo.MCPProvenance {
 	var since time.Time
 	if !oldest.IsZero() {
 		since = oldest.Add(-provenanceLookback)
@@ -185,7 +200,7 @@ func (s *Scanner) lookupProvenance(ctx context.Context, projectID uuid.UUID, mes
 
 // scanCall decides a single tool call, returning nil when the call is clean or
 // is not an MCP call at all.
-func (s *Scanner) scanCall(ctx context.Context, orgID string, call ToolCall, prov telemetryrepo.MCPProvenance) *scanners.Finding {
+func (s *Scanner) scanCall(ctx context.Context, orgID string, call ToolCall, prov telemetryrepo.MCPProvenance, trustedHosts []string) *scanners.Finding {
 	if call.Name == "" || !toolref.IsMCPToolName(call.Name) {
 		return nil
 	}
@@ -194,7 +209,7 @@ func (s *Scanner) scanCall(ctx context.Context, orgID string, call ToolCall, pro
 	match, resolved := resolvedServerIdentity(prov, serverPrefix)
 
 	if resolved {
-		if s.isHostedIdentity(ctx, match, orgID) {
+		if isHostedIdentity(match, trustedHosts) {
 			s.recordResolution(ctx, orgID, senderOf(prov, call), ResolutionHosted)
 			return nil
 		}
@@ -301,30 +316,66 @@ func resolvedServerIdentity(prov telemetryrepo.MCPProvenance, serverPrefix strin
 
 // isHostedIdentity reports whether a resolved server identity points at Gram.
 //
-// The identity is tested directly, then — when it is a stdio launch command —
-// each absolute http(s) argument within it is tested too. Gram's own install
-// snippet for OAuth-backed servers is a stdio entry that fronts a Gram URL
-// (`npx mcp-remote@<version> https://app.getgram.ai/mcp/<slug>`), so treating
-// every stdio server as shadow would flag calls to Gram's own servers whenever
-// a customer installed them the way Gram told them to.
+// The identity is tested directly, then — when it is a stdio launch command
+// that proxies through `mcp-remote` — the URL that invocation targets is
+// tested too. Gram's own install snippet for OAuth-backed servers is exactly
+// that shape (`npx mcp-remote@<version> https://app.getgram.ai/mcp/<slug>`),
+// so treating every stdio server as shadow would flag calls to Gram's own
+// servers whenever a customer installed them the way Gram told them to.
+//
+// Only the proxy's target counts, never any Gram URL appearing somewhere in
+// the command. Accepting an arbitrary argument would let a local shadow server
+// clear the check by carrying an unrelated Gram URL (`npx @evil/mcp --docs
+// https://app.getgram.ai/...`), which is a single flag's worth of evasion.
 //
 // The hosted check is never gated on the identity parsing as a URL: it already
 // returns false for values with no host, and accepts forms (scheme-relative,
 // non-http schemes) that a stricter pre-filter would wrongly reject before the
 // host was ever compared.
-func (s *Scanner) isHostedIdentity(ctx context.Context, identity, orgID string) bool {
-	if s.hosted.IsGramHostedMCPURLForOrg(ctx, identity, orgID) {
+func isHostedIdentity(identity string, trustedHosts []string) bool {
+	if shadowmcp.IsGramHostedMCPURL(identity, trustedHosts...) {
 		return true
 	}
-	for field := range strings.FieldsSeq(identity) {
-		if !strings.HasPrefix(field, "http://") && !strings.HasPrefix(field, "https://") {
+	target, ok := mcpRemoteTarget(identity)
+	if !ok {
+		return false
+	}
+	return shadowmcp.IsGramHostedMCPURL(target, trustedHosts...)
+}
+
+// mcpRemoteTarget returns the URL a stdio `mcp-remote` command proxies to.
+//
+// The target is the first absolute http(s) argument following the mcp-remote
+// package spec; anything before that token is the launcher (`npx`, `-y`), and
+// first-wins means a trailing argument cannot displace the real target. ok is
+// false when the command does not invoke mcp-remote at all, which covers every
+// other stdio server.
+func mcpRemoteTarget(command string) (string, bool) {
+	seenSpec := false
+	for field := range strings.FieldsSeq(command) {
+		if !seenSpec {
+			seenSpec = isMCPRemoteSpec(field)
 			continue
 		}
-		if s.hosted.IsGramHostedMCPURLForOrg(ctx, field, orgID) {
-			return true
+		if strings.HasPrefix(field, "http://") || strings.HasPrefix(field, "https://") {
+			return field, true
 		}
 	}
-	return false
+	return "", false
+}
+
+// isMCPRemoteSpec reports whether an argument is an npm package spec for
+// mcp-remote, tolerating a version suffix (`mcp-remote@0.1.25`) and a scope
+// prefix (`@scope/mcp-remote`).
+func isMCPRemoteSpec(field string) bool {
+	spec := strings.TrimPrefix(field, "@")
+	if i := strings.LastIndex(spec, "@"); i > 0 {
+		spec = spec[:i]
+	}
+	if i := strings.LastIndex(spec, "/"); i >= 0 {
+		spec = spec[i+1:]
+	}
+	return spec == "mcp-remote"
 }
 
 // parseToolInput parses a recorded tool call's raw arguments into a value the

--- a/server/internal/scanners/shadowmcpscan/scanner.go
+++ b/server/internal/scanners/shadowmcpscan/scanner.go
@@ -78,7 +78,7 @@ type Validator interface {
 // organization's custom-domain lookup to a single database round-trip per
 // batch instead of one per scanned call.
 type HostedChecker interface {
-	TrustedMCPHostsForOrg(ctx context.Context, orgID string) []string
+	TrustedMCPHostsForOrg(ctx context.Context, orgID string) ([]string, error)
 }
 
 // ProvenanceLookup replays the server identity the hook recorded for a set of
@@ -142,10 +142,23 @@ func (s *Scanner) Scan(ctx context.Context, orgID string, projectID uuid.UUID, m
 	}
 
 	provenance := s.lookupProvenance(ctx, projectID, ids, oldest)
+
 	// Resolved once for the whole batch: the custom-domain lookup behind this
 	// is a database round-trip whose result is invariant for the organization,
 	// and a batch can hold hundreds of calls.
-	trustedHosts := s.hosted.TrustedMCPHostsForOrg(ctx, orgID)
+	//
+	// A failure here means we cannot tell a Gram host from a third-party one,
+	// so every call takes the unresolved path rather than being judged against
+	// an incomplete host list. Judging anyway would classify calls to an org's
+	// own verified custom domain as shadow MCP and persist that as findings.
+	trustedHosts, err := s.hosted.TrustedMCPHostsForOrg(ctx, orgID)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "shadow_mcp scan: trusted host resolution failed; falling back to signature validation",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(orgID),
+		)
+		provenance = map[string]telemetryrepo.MCPProvenance{}
+	}
 
 	for i, calls := range messages {
 		var findings []scanners.Finding
@@ -364,18 +377,17 @@ func mcpRemoteTarget(command string) (string, bool) {
 	return "", false
 }
 
-// isMCPRemoteSpec reports whether an argument is an npm package spec for
-// mcp-remote, tolerating a version suffix (`mcp-remote@0.1.25`) and a scope
-// prefix (`@scope/mcp-remote`).
+// isMCPRemoteSpec reports whether an argument is the canonical npm package
+// spec for mcp-remote, tolerating only a version suffix (`mcp-remote@0.1.25`).
+//
+// The scope is deliberately significant. Accepting any package whose last path
+// segment is "mcp-remote" would let `@evil/mcp-remote` — a package that can
+// connect anywhere — launder a Gram URL argument into a hosted verdict.
+// Unscoped mcp-remote is the only package Gram's own install snippets emit, so
+// a fork has to be added here explicitly to be trusted.
 func isMCPRemoteSpec(field string) bool {
-	spec := strings.TrimPrefix(field, "@")
-	if i := strings.LastIndex(spec, "@"); i > 0 {
-		spec = spec[:i]
-	}
-	if i := strings.LastIndex(spec, "/"); i >= 0 {
-		spec = spec[i+1:]
-	}
-	return spec == "mcp-remote"
+	name, _, _ := strings.Cut(field, "@")
+	return name == "mcp-remote"
 }
 
 // parseToolInput parses a recorded tool call's raw arguments into a value the

--- a/server/internal/scanners/shadowmcpscan/scanner.go
+++ b/server/internal/scanners/shadowmcpscan/scanner.go
@@ -1,16 +1,25 @@
 // Package shadowmcpscan is the single home for the shadow-MCP scanner. It flags
-// MCP-routed tool calls that fail shadow-MCP validation — calls that do not
-// carry a valid x-gram-toolset-id resolving to a toolset in the caller's
-// organization — and converts each into the shared scanners.Finding domain
-// type.
+// MCP-routed tool calls that did not go to a Gram-hosted MCP server, and
+// converts each into the shared scanners.Finding domain type.
 //
-// The scanner is a two-phase batch operation. Phase one validates every MCP
-// call across the batch (via a Validator, satisfied by *shadowmcp.Client) and
-// records the denied ones. Phase two issues a single MatchLookup for all denied
-// tool-call IDs to enrich each finding's Match with the stored MCP match string,
-// falling back to the tool name's server prefix when the lookup is unavailable
-// or misses. The batch shape is intrinsic: the enrichment lookup is amortized
-// across the whole batch rather than issued per message.
+// The scanner decides from provenance first. Every MCP-routed hook event
+// records the server it resolved (`gram.mcp.match` / `gram.mcp.server_url`),
+// and one batch-wide ProvenanceLookup replays those values back per tool call.
+// A call whose provenance resolves to a Gram-hosted host is clean; one that
+// resolves to anything else — a third-party URL or a local stdio command — is
+// flagged. This is the same question the realtime hook guard answers, so the
+// two paths agree on a call by construction.
+//
+// When provenance does not resolve — the hook log has not landed yet, the
+// sender never resolved a server, or the sender's recorded tool-call id is not
+// what its trace id derives from — the scanner falls back to the legacy
+// signature check: the x-gram-toolset-id constant Gram injects into tool
+// schemas and callers echo back. The fallback preserves today's behaviour for
+// senders provenance cannot yet cover, and is meant to be deleted once the
+// measured unresolved rate justifies it.
+//
+// The batch shape is intrinsic: the provenance lookup is one ClickHouse query
+// amortized across the whole batch rather than issued per message.
 package shadowmcpscan
 
 import (
@@ -18,12 +27,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
@@ -31,139 +43,288 @@ import (
 const Source = shadowmcp.SourceShadowMCP
 
 // Rule is the canonical rule id emitted for every shadow_mcp finding. The
-// detection mechanism (missing toolset id, unknown toolset, ...) is
+// detection mechanism (non-Gram URL, stdio server, missing toolset id, ...) is
 // implementation detail kept in logs; the rule id describes the risk itself.
 const Rule = "shadow_mcp"
+
+// provenanceLookback bounds how far back the provenance query scans relative
+// to the oldest message in the batch. The bound exists to keep the query on
+// the table's time-ordered primary key instead of degrading into a 90-day
+// scan; the slack absorbs hook events whose recorded time precedes the chat
+// message (clock skew, and replayed events redelivered from a device's
+// offline spool). A spool older than this window resolves to no provenance
+// and falls through to the signature check, which is the safe direction.
+const provenanceLookback = 7 * 24 * time.Hour
+
+// Resolution outcomes reported to CoverageRecorder.
+const (
+	ResolutionHosted     = "hosted"
+	ResolutionShadow     = "shadow"
+	ResolutionUnresolved = "unresolved"
+)
 
 // Validator enforces that a Gram-hosted tool call carries a valid
 // x-gram-toolset-id resolving to a toolset in the caller's organization.
 // *shadowmcp.Client satisfies it. The bool return is true when the call is
-// denied (fails validation).
+// denied (fails validation). Used only for calls provenance could not resolve.
 type Validator interface {
 	ValidateToolsetCall(ctx context.Context, toolInput any, toolName string, orgID string) (string, bool)
 }
 
-// MatchLookup resolves stored tool-call IDs to MCP match strings used to
-// enrich a denied finding's Match.
-type MatchLookup interface {
-	LookupMCPMatchesByToolCallID(ctx context.Context, projectID uuid.UUID, toolCallIDs []string) (map[string]string, error)
+// HostedChecker reports whether a resolved MCP server URL belongs to Gram for
+// the calling organization. *shadowmcp.Client satisfies it.
+type HostedChecker interface {
+	IsGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool
+}
+
+// ProvenanceLookup replays the server identity the hook recorded for a set of
+// tool calls. *telemetryrepo.Queries satisfies it.
+type ProvenanceLookup interface {
+	LookupMCPProvenanceByToolCallID(ctx context.Context, projectID uuid.UUID, toolCallIDs []string, since time.Time) (map[string]telemetryrepo.MCPProvenance, error)
+}
+
+// CoverageRecorder observes how each scanned MCP call was decided, so the
+// unresolved rate driving the signature fallback's removal is measurable per
+// sender rather than a single opaque number.
+type CoverageRecorder interface {
+	RecordShadowMCPResolution(ctx context.Context, orgID string, hookSource string, resolution string)
 }
 
 // ToolCall is one recorded tool invocation to scan. ID is the recorded
-// tool-call id used to key the enrichment lookup; Arguments is the raw JSON
-// arguments string exactly as recorded.
+// tool-call id used to key the provenance lookup; Arguments is the raw JSON
+// arguments string exactly as recorded. CreatedAt is the recording time of the
+// message the call belongs to, used to bound the provenance query. Sender is
+// the agent that recorded the message, used to attribute the resolution metric
+// when no provenance row was found to carry a hook source of its own.
 type ToolCall struct {
 	ID        string
 	Name      string
 	Arguments string
+	CreatedAt time.Time
+	Sender    string
 }
 
-// Scanner flags MCP tool calls denied by shadow-MCP validation. It is safe for
-// concurrent use so long as its Validator and MatchLookup are.
+// Scanner flags MCP tool calls that did not reach a Gram-hosted server. It is
+// safe for concurrent use so long as its dependencies are.
 type Scanner struct {
-	logger      *slog.Logger
-	validator   Validator
-	matchLookup MatchLookup
+	logger     *slog.Logger
+	validator  Validator
+	hosted     HostedChecker
+	provenance ProvenanceLookup
+	coverage   CoverageRecorder
 }
 
-// NewScanner returns a Scanner. logger, validator, and matchLookup must all be
-// non-nil.
-func NewScanner(logger *slog.Logger, validator Validator, matchLookup MatchLookup) *Scanner {
-	return &Scanner{logger: logger, validator: validator, matchLookup: matchLookup}
+// NewScanner returns a Scanner. logger, validator, hosted, and provenance must
+// all be non-nil; coverage may be nil to disable resolution metrics.
+func NewScanner(logger *slog.Logger, validator Validator, hosted HostedChecker, provenance ProvenanceLookup, coverage CoverageRecorder) *Scanner {
+	return &Scanner{
+		logger:     logger,
+		validator:  validator,
+		hosted:     hosted,
+		provenance: provenance,
+		coverage:   coverage,
+	}
 }
 
-// Scan validates every MCP tool call across the batch and returns a Finding for
-// each denied call, one findings slice per input message (positionally aligned
-// with messages). Denied findings are then enriched in a single MatchLookup
-// keyed by tool-call id; enrichment failures are logged and leave the
-// server-prefix fallback Match in place.
+// Scan returns a Finding for each MCP tool call that did not reach a
+// Gram-hosted server, one findings slice per input message (positionally
+// aligned with messages).
 func (s *Scanner) Scan(ctx context.Context, orgID string, projectID uuid.UUID, messages [][]ToolCall) [][]scanners.Finding {
 	out := make([][]scanners.Finding, len(messages))
 
-	var deniedCallIDs []string
+	provenance := s.lookupProvenance(ctx, projectID, messages)
+
 	for i, calls := range messages {
-		findings, ids := s.scanMessage(ctx, orgID, calls)
-		out[i] = findings
-		deniedCallIDs = append(deniedCallIDs, ids...)
-	}
-
-	if len(deniedCallIDs) == 0 {
-		return out
-	}
-
-	matches, err := s.matchLookup.LookupMCPMatchesByToolCallID(ctx, projectID, deniedCallIDs)
-	if err != nil {
-		s.logger.WarnContext(ctx, "shadow_mcp scan: mcp match lookup failed; using server-prefix fallback", attr.SlogError(err))
-		return out
-	}
-	for i := range out {
-		for j := range out[i] {
-			f := &out[i][j]
-			if f.Source != Source {
-				continue
-			}
-			if v, ok := matches[f.McpLookupToolCallID]; ok && v != "" {
-				f.Match = v
+		var findings []scanners.Finding
+		for _, call := range calls {
+			if finding := s.scanCall(ctx, orgID, call, provenance[call.ID]); finding != nil {
+				findings = append(findings, *finding)
 			}
 		}
+		out[i] = findings
 	}
 	return out
 }
 
-// scanMessage validates a single message's tool calls, returning a Finding per
-// denied MCP call plus the recorded ids of those calls (for batch enrichment).
-func (s *Scanner) scanMessage(ctx context.Context, orgID string, calls []ToolCall) ([]scanners.Finding, []string) {
-	var findings []scanners.Finding
-	var deniedCallIDs []string
-	for _, call := range calls {
-		toolName := call.Name
-		if toolName == "" || !toolref.IsMCPToolName(toolName) {
-			continue
-		}
-
-		toolInput := parseToolInput(call.Arguments)
-		bareName := toolref.MCPFunctionOf(toolName)
-		_, denied := s.validator.ValidateToolsetCall(ctx, toolInput, bareName, orgID)
-		if !denied {
-			continue
-		}
-
-		match := toolref.MCPServerOf(toolName)
-		if match == "" {
-			match = toolName
-		}
-		ruleID, description := describe(toolName)
-		findings = append(findings, scanners.Finding{
-			Source:      Source,
-			RuleID:      ruleID,
-			Description: description,
-			Match:       match,
-			StartPos:    0,
-			EndPos:      0,
-			Tags:        []string{},
-			Confidence:  1.0,
-
-			DeadLetterReason:    "",
-			McpLookupToolCallID: call.ID,
-			SpanGroupKey:        "",
-			Field:               "",
-			Path:                "",
-		})
-		if call.ID != "" {
-			deniedCallIDs = append(deniedCallIDs, call.ID)
+// lookupProvenance issues the single batch-wide provenance query. A failure is
+// logged and yields an empty map: every call then falls through to the
+// signature check rather than being decided on absent evidence.
+func (s *Scanner) lookupProvenance(ctx context.Context, projectID uuid.UUID, messages [][]ToolCall) map[string]telemetryrepo.MCPProvenance {
+	var ids []string
+	var oldest time.Time
+	for _, calls := range messages {
+		for _, call := range calls {
+			if call.ID == "" || call.Name == "" || !toolref.IsMCPToolName(call.Name) {
+				continue
+			}
+			ids = append(ids, call.ID)
+			if !call.CreatedAt.IsZero() && (oldest.IsZero() || call.CreatedAt.Before(oldest)) {
+				oldest = call.CreatedAt
+			}
 		}
 	}
-	return findings, deniedCallIDs
+	if len(ids) == 0 {
+		return map[string]telemetryrepo.MCPProvenance{}
+	}
+
+	var since time.Time
+	if !oldest.IsZero() {
+		since = oldest.Add(-provenanceLookback)
+	}
+
+	found, err := s.provenance.LookupMCPProvenanceByToolCallID(ctx, projectID, ids, since)
+	if err != nil {
+		s.logger.WarnContext(ctx, "shadow_mcp scan: provenance lookup failed; falling back to signature validation",
+			attr.SlogError(err),
+			attr.SlogProjectID(projectID.String()),
+		)
+		return map[string]telemetryrepo.MCPProvenance{}
+	}
+	return found
 }
 
-// describe returns the canonical (rule_id, description) for a shadow_mcp
-// finding. The description names the tool but never leaks validator internals
-// (e.g. the x-gram-toolset-id property).
-func describe(toolName string) (string, string) {
-	if toolName == "" {
-		return scanners.GuardRuleID(Rule), "Detected an unverified MCP tool call."
+// scanCall decides a single tool call, returning nil when the call is clean or
+// is not an MCP call at all.
+func (s *Scanner) scanCall(ctx context.Context, orgID string, call ToolCall, prov telemetryrepo.MCPProvenance) *scanners.Finding {
+	if call.Name == "" || !toolref.IsMCPToolName(call.Name) {
+		return nil
 	}
-	return scanners.GuardRuleID(Rule), fmt.Sprintf("Detected an unverified MCP tool call to %q.", toolName)
+
+	serverPrefix := toolref.MCPServerOf(call.Name)
+	match, resolved := resolvedServerIdentity(prov, serverPrefix)
+
+	if resolved {
+		if s.isHostedIdentity(ctx, match, orgID) {
+			s.recordResolution(ctx, orgID, senderOf(prov, call), ResolutionHosted)
+			return nil
+		}
+		// A resolved non-Gram URL, or a stdio server that does not front a
+		// Gram URL. Both are shadow MCP by the same rule the realtime guard
+		// applies.
+		s.recordResolution(ctx, orgID, senderOf(prov, call), ResolutionShadow)
+		finding := s.finding(call, match)
+		return &finding
+	}
+
+	s.recordResolution(ctx, orgID, senderOf(prov, call), ResolutionUnresolved)
+
+	// Provenance could not identify the server. Fall back to the echoed
+	// x-gram-toolset-id signature, which is self-contained in the recorded
+	// arguments and so is unaffected by whatever kept the hook log from
+	// joining.
+	toolInput := parseToolInput(call.Arguments)
+	bareName := toolref.MCPFunctionOf(call.Name)
+	if _, denied := s.validator.ValidateToolsetCall(ctx, toolInput, bareName, orgID); !denied {
+		return nil
+	}
+
+	fallbackMatch := serverPrefix
+	if fallbackMatch == "" {
+		fallbackMatch = call.Name
+	}
+	finding := s.finding(call, fallbackMatch)
+	return &finding
+}
+
+func (s *Scanner) finding(call ToolCall, match string) scanners.Finding {
+	description := "Detected an unverified MCP tool call."
+	if call.Name != "" {
+		description = fmt.Sprintf("Detected an unverified MCP tool call to %q.", call.Name)
+	}
+	return scanners.Finding{
+		Source:      Source,
+		RuleID:      scanners.GuardRuleID(Rule),
+		Description: description,
+		Match:       match,
+		StartPos:    0,
+		EndPos:      0,
+		Tags:        []string{},
+		Confidence:  1.0,
+
+		DeadLetterReason:    "",
+		McpLookupToolCallID: call.ID,
+		SpanGroupKey:        "",
+		Field:               "",
+		Path:                "",
+	}
+}
+
+func (s *Scanner) recordResolution(ctx context.Context, orgID, hookSource, resolution string) {
+	if s.coverage == nil {
+		return
+	}
+	s.coverage.RecordShadowMCPResolution(ctx, orgID, hookSource, resolution)
+}
+
+// senderOf names the agent to attribute a resolution to. The provenance row's
+// own hook source is authoritative when there is one, but the unresolved case
+// — the population the resolution metric exists to measure — has no row at
+// all, so it falls back to the sender recorded on the chat message. Without
+// that fallback every unresolved call would be attributed to "unknown",
+// producing exactly the single opaque number the split is meant to avoid.
+//
+// Lowercased because the two sources disagree on case ("Codex" on the message,
+// "codex" on the telemetry row) and a metric dimension must not split one
+// sender across two series.
+func senderOf(prov telemetryrepo.MCPProvenance, call ToolCall) string {
+	if prov.HookSource != "" {
+		return strings.ToLower(prov.HookSource)
+	}
+	return strings.ToLower(strings.TrimSpace(call.Sender))
+}
+
+// resolvedServerIdentity picks the server identifier to decide on and reports
+// whether it actually identifies a server.
+//
+// ServerURL is preferred: it is set only when the sender knew a real HTTP/SSE
+// URL. The match attribute is a union of URL, stdio command, and — when the
+// sender's inventory snapshot did not resolve the server — the bare
+// `mcp__<server>__` tool-name prefix. That last case carries no server
+// identity, so it is reported unresolved rather than being flagged on the
+// strength of a value derived from the tool name the scanner already has.
+func resolvedServerIdentity(prov telemetryrepo.MCPProvenance, serverPrefix string) (string, bool) {
+	// Trim both: senders relay these straight off a client payload without
+	// normalizing (the Cursor hook does not), and a trailing newline would
+	// otherwise defeat URL parsing in the hosted check.
+	if serverURL := strings.TrimSpace(prov.ServerURL); serverURL != "" {
+		return serverURL, true
+	}
+	match := strings.TrimSpace(prov.Match)
+	if match == "" {
+		return "", false
+	}
+	if serverPrefix != "" && match == serverPrefix {
+		return "", false
+	}
+	return match, true
+}
+
+// isHostedIdentity reports whether a resolved server identity points at Gram.
+//
+// The identity is tested directly, then — when it is a stdio launch command —
+// each absolute http(s) argument within it is tested too. Gram's own install
+// snippet for OAuth-backed servers is a stdio entry that fronts a Gram URL
+// (`npx mcp-remote@<version> https://app.getgram.ai/mcp/<slug>`), so treating
+// every stdio server as shadow would flag calls to Gram's own servers whenever
+// a customer installed them the way Gram told them to.
+//
+// The hosted check is never gated on the identity parsing as a URL: it already
+// returns false for values with no host, and accepts forms (scheme-relative,
+// non-http schemes) that a stricter pre-filter would wrongly reject before the
+// host was ever compared.
+func (s *Scanner) isHostedIdentity(ctx context.Context, identity, orgID string) bool {
+	if s.hosted.IsGramHostedMCPURLForOrg(ctx, identity, orgID) {
+		return true
+	}
+	for field := range strings.FieldsSeq(identity) {
+		if !strings.HasPrefix(field, "http://") && !strings.HasPrefix(field, "https://") {
+			continue
+		}
+		if s.hosted.IsGramHostedMCPURLForOrg(ctx, field, orgID) {
+			return true
+		}
+	}
+	return false
 }
 
 // parseToolInput parses a recorded tool call's raw arguments into a value the

--- a/server/internal/scanners/shadowmcpscan/scanner_test.go
+++ b/server/internal/scanners/shadowmcpscan/scanner_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/scanners"
-	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
@@ -37,14 +36,18 @@ func (f *fakeValidator) ValidateToolsetCall(_ context.Context, _ any, toolName s
 	return "", false
 }
 
-// fakeHosted defers to the real host-matching implementation rather than a
-// substring check, so tests exercise the same URL parsing and exact-host rules
-// production uses — a looser fake would pass a raw stdio command containing a
-// Gram hostname and hide whether the scanner really extracts the URL from it.
-type fakeHosted struct{}
+// fakeHosted resolves no extra trusted hosts, leaving the scanner to match
+// against the real built-in Gram hosts. Host matching itself is the production
+// implementation, so tests exercise the same URL parsing and exact-host rules
+// rather than a looser substring check that would pass a raw stdio command
+// containing a Gram hostname anywhere in it.
+type fakeHosted struct {
+	calls int
+}
 
-func (f *fakeHosted) IsGramHostedMCPURLForOrg(_ context.Context, rawURL, _ string) bool {
-	return shadowmcp.IsGramHostedMCPURL(rawURL)
+func (f *fakeHosted) TrustedMCPHostsForOrg(_ context.Context, _ string) []string {
+	f.calls++
+	return nil
 }
 
 // fakeProvenance returns provenance for the ids it is configured with, or an
@@ -439,10 +442,8 @@ func TestResolvedServerIdentity(t *testing.T) {
 	}
 }
 
-func TestScanner_IsHostedIdentity(t *testing.T) {
+func TestIsHostedIdentity(t *testing.T) {
 	t.Parallel()
-
-	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), noProvenance(), nil)
 
 	cases := []struct {
 		name     string
@@ -457,16 +458,76 @@ func TestScanner_IsHostedIdentity(t *testing.T) {
 		// Gram's own install snippet for OAuth-backed servers is a stdio
 		// entry fronting a Gram URL; it must not read as shadow MCP.
 		{"gram mcp-remote snippet", "npx mcp-remote@0.1.25 https://app.getgram.ai/mcp/team-foo", true},
+		{"mcp-remote with -y launcher flag", "npx -y mcp-remote https://app.getgram.ai/mcp/x", true},
 		{"mcp-remote with headers", "npx mcp-remote https://app.getgram.ai/mcp/x --header Authorization:${TOKEN}", true},
+		{"scoped mcp-remote spec", "npx @speakeasy/mcp-remote@1.2.3 https://app.getgram.ai/mcp/x", true},
 		{"mcp-remote to third party", "npx mcp-remote https://evil.example/mcp", false},
 		// A Gram-shaped path on a foreign host stays shadow: the hosted check
 		// is on the host, never the path.
 		{"gram path on foreign host", "npx mcp-remote https://evil.example/mcp/team-foo", false},
+		// Only the proxy's target counts. A local server carrying an unrelated
+		// Gram URL must not clear the check, or evasion costs one extra flag.
+		{"unrelated gram url argument", "npx @evil/mcp --docs https://app.getgram.ai/docs", false},
+		{"gram url without mcp-remote", "node server.js --ref https://app.getgram.ai/mcp/x", false},
+		// First URL after the spec wins, so a trailing argument cannot
+		// displace the real target.
+		{"trailing gram url does not displace target", "npx mcp-remote https://evil.example/mcp --header X:https://app.getgram.ai", false},
 	}
 
 	for _, tc := range cases {
-		require.Equal(t, tc.want, s.isHostedIdentity(t.Context(), tc.identity, "org-1"), tc.name)
+		require.Equal(t, tc.want, isHostedIdentity(tc.identity, nil), tc.name)
 	}
+}
+
+// A custom domain resolved for the org counts as Gram-hosted.
+func TestIsHostedIdentity_TrustedHosts(t *testing.T) {
+	t.Parallel()
+
+	hosts := []string{"mcp.customer.example"}
+	require.True(t, isHostedIdentity("https://mcp.customer.example/mcp/team", hosts))
+	require.True(t, isHostedIdentity("npx mcp-remote https://mcp.customer.example/mcp/team", hosts))
+	require.False(t, isHostedIdentity("https://other.example/mcp", hosts))
+}
+
+// The organization's custom-domain lookup sits behind this, so it must not be
+// repeated per scanned call.
+func TestScanner_ResolvesTrustedHostsOncePerScan(t *testing.T) {
+	t.Parallel()
+
+	hosted := gramHosted()
+	prov := &fakeProvenance{
+		found: map[string]telemetryrepo.MCPProvenance{
+			"call-0": {Match: "https://evil.example/mcp", ServerURL: "https://evil.example/mcp", HookSource: "claude"},
+			"call-1": {Match: "https://other.example/mcp", ServerURL: "https://other.example/mcp", HookSource: "claude"},
+		},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, hosted, prov, nil)
+
+	s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-0", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+		{{ID: "call-1", Name: "mcp__fs__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Equal(t, 1, hosted.calls)
+}
+
+// No MCP calls means neither the provenance query nor the trusted-host lookup
+// should be issued.
+func TestScanner_NoMCPCallsSkipsHostLookup(t *testing.T) {
+	t.Parallel()
+
+	hosted := gramHosted()
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, hosted, noProvenance(), nil)
+
+	s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "Bash", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Zero(t, hosted.calls)
 }
 
 // A Gram server installed through Gram's own stdio snippet resolves to a

--- a/server/internal/scanners/shadowmcpscan/scanner_test.go
+++ b/server/internal/scanners/shadowmcpscan/scanner_test.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/scanners"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
 // discardLogger returns a logger that discards output. This internal test
@@ -35,166 +37,503 @@ func (f *fakeValidator) ValidateToolsetCall(_ context.Context, _ any, toolName s
 	return "", false
 }
 
-// fakeLookup returns matches for the ids it is configured with, or an error.
-type fakeLookup struct {
-	matches map[string]string
-	err     error
-	gotIDs  []string
+// fakeHosted defers to the real host-matching implementation rather than a
+// substring check, so tests exercise the same URL parsing and exact-host rules
+// production uses — a looser fake would pass a raw stdio command containing a
+// Gram hostname and hide whether the scanner really extracts the URL from it.
+type fakeHosted struct{}
+
+func (f *fakeHosted) IsGramHostedMCPURLForOrg(_ context.Context, rawURL, _ string) bool {
+	return shadowmcp.IsGramHostedMCPURL(rawURL)
 }
 
-func (f *fakeLookup) LookupMCPMatchesByToolCallID(_ context.Context, _ uuid.UUID, ids []string) (map[string]string, error) {
+// fakeProvenance returns provenance for the ids it is configured with, or an
+// error. It records the ids and time bound it was called with.
+type fakeProvenance struct {
+	found     map[string]telemetryrepo.MCPProvenance
+	err       error
+	gotIDs    []string
+	gotSince  time.Time
+	callCount int
+}
+
+func (f *fakeProvenance) LookupMCPProvenanceByToolCallID(_ context.Context, _ uuid.UUID, ids []string, since time.Time) (map[string]telemetryrepo.MCPProvenance, error) {
+	f.callCount++
 	f.gotIDs = append(f.gotIDs, ids...)
+	f.gotSince = since
 	if f.err != nil {
 		return nil, f.err
 	}
-	return f.matches, nil
+	return f.found, nil
 }
 
-// emptyLookup is the null-object equivalent used by tests that don't exercise
-// enrichment: it returns no matches, so findings keep their fallback Match.
-// Callers never pass nil — the scanner's matchLookup is always non-nil.
-func emptyLookup() *fakeLookup {
-	return &fakeLookup{matches: map[string]string{}, err: nil, gotIDs: nil}
+// noProvenance is the null object for tests exercising the signature fallback.
+func noProvenance() *fakeProvenance {
+	return &fakeProvenance{found: map[string]telemetryrepo.MCPProvenance{}, err: nil, gotIDs: nil, gotSince: time.Time{}, callCount: 0}
 }
 
-func TestScanner_FlagsDeniedMCPCall_ServerPrefixFallback(t *testing.T) {
+// recordedResolution is one CoverageRecorder observation.
+type recordedResolution struct {
+	hookSource string
+	resolution string
+}
+
+type fakeCoverage struct {
+	got []recordedResolution
+}
+
+func (f *fakeCoverage) RecordShadowMCPResolution(_ context.Context, _ string, hookSource string, resolution string) {
+	f.got = append(f.got, recordedResolution{hookSource: hookSource, resolution: resolution})
+}
+
+func gramHosted() *fakeHosted {
+	return &fakeHosted{}
+}
+
+// A call whose provenance resolves to a Gram-hosted URL is clean even though
+// its arguments carry no x-gram-toolset-id — this is the /x/mcp false-flag the
+// provenance-first rework exists to fix.
+func TestScanner_HostedProvenanceIsCleanWithoutSignature(t *testing.T) {
 	t.Parallel()
 
 	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
-	s := NewScanner(discardLogger(), validator, emptyLookup())
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "https://app.getgram.ai/x/mcp/abc", ServerURL: "https://app.getgram.ai/x/mcp/abc", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, coverage)
 
 	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
-		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`}},
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
 	})
 
 	require.Len(t, out, 1)
+	require.Empty(t, out[0], "Gram-hosted provenance must not be flagged")
+	require.Empty(t, validator.orgIDs, "resolved provenance must not consult the signature validator")
+	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionHosted}}, coverage.got)
+}
+
+func TestScanner_ThirdPartyURLProvenanceIsFlagged(t *testing.T) {
+	t.Parallel()
+
+	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "https://evil.example/mcp", ServerURL: "https://evil.example/mcp", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, coverage)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
 	require.Len(t, out[0], 1)
 	f := out[0][0]
-	assert.Equal(t, Source, f.Source)
-	assert.Equal(t, Rule, f.RuleID)
-	assert.Equal(t, "db", f.Match, "no lookup: falls back to the tool name's server prefix")
-	assert.Equal(t, "call-1", f.McpLookupToolCallID)
-	assert.Contains(t, f.Description, "mcp__db__delete")
-	assert.Equal(t, []string{"org-1"}, validator.orgIDs)
+	require.Equal(t, Source, f.Source)
+	require.Equal(t, Rule, f.RuleID)
+	require.Equal(t, "https://evil.example/mcp", f.Match)
+	require.Equal(t, "call-1", f.McpLookupToolCallID)
+	require.Contains(t, f.Description, "mcp__db__delete")
+	require.Empty(t, validator.orgIDs, "a resolved verdict must not consult the signature validator")
+	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionShadow}}, coverage.got)
 }
 
-func TestScanner_EnrichesMatchFromLookup(t *testing.T) {
+// A stdio server has no URL; the launch command is the resolved identity and
+// is shadow MCP by the same rule the realtime guard applies.
+func TestScanner_StdioCommandProvenanceIsFlagged(t *testing.T) {
 	t.Parallel()
 
-	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
-	lookup := &fakeLookup{matches: map[string]string{"call-1": "https://evil.example/mcp"}, err: nil, gotIDs: nil}
-	s := NewScanner(discardLogger(), validator, lookup)
-
-	projectID := uuid.New()
-	out := s.Scan(t.Context(), "org-1", projectID, [][]ToolCall{
-		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`}},
-	})
-
-	require.Len(t, out[0], 1)
-	assert.Equal(t, "https://evil.example/mcp", out[0][0].Match, "lookup hit overrides the fallback Match")
-	assert.Equal(t, []string{"call-1"}, lookup.gotIDs)
-}
-
-func TestScanner_LookupErrorKeepsFallback(t *testing.T) {
-	t.Parallel()
-
-	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
-	lookup := &fakeLookup{matches: nil, err: errors.New("boom"), gotIDs: nil}
-	s := NewScanner(discardLogger(), validator, lookup)
+	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "npx -y @acme/mcp", ServerURL: "", HookSource: "codex"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, nil)
 
 	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
-		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`}},
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
 	})
+
 	require.Len(t, out[0], 1)
-	assert.Equal(t, "db", out[0][0].Match, "lookup error leaves the server-prefix fallback in place")
+	require.Equal(t, "npx -y @acme/mcp", out[0][0].Match)
+	require.Empty(t, validator.orgIDs)
 }
 
-func TestScanner_LookupMissKeepsFallback(t *testing.T) {
+// The match attribute degrades to the bare mcp__<server>__ prefix when the
+// sender's inventory snapshot didn't resolve the server. That value carries no
+// server identity — it is derived from the tool name the scanner already has —
+// so it must count as unresolved and fall through to the signature check
+// rather than flagging every call in a snapshot-less session.
+func TestScanner_BarePrefixProvenanceFallsBackToSignature(t *testing.T) {
 	t.Parallel()
 
-	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
-	// Miss (empty string) must not overwrite the fallback with "".
-	lookup := &fakeLookup{matches: map[string]string{"call-1": ""}, err: nil, gotIDs: nil}
-	s := NewScanner(discardLogger(), validator, lookup)
+	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "db", ServerURL: "", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, coverage)
 
 	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
-		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`}},
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
 	})
-	require.Len(t, out[0], 1)
-	assert.Equal(t, "db", out[0][0].Match)
+
+	require.Empty(t, out[0], "validator allowed the call, so the fallback keeps it clean")
+	require.Equal(t, []string{"org-1"}, validator.orgIDs, "bare prefix must reach the signature validator")
+	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionUnresolved}}, coverage.got)
 }
 
-func TestScanner_SkipsNonMCPNamelessAndAllowed(t *testing.T) {
+func TestScanner_UnresolvedProvenanceFallsBackToSignature(t *testing.T) {
 	t.Parallel()
 
 	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
-	s := NewScanner(discardLogger(), validator, emptyLookup())
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), validator, gramHosted(), noProvenance(), coverage)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now(), Sender: "Codex"}},
+		{{ID: "call-2", Name: "mcp__db__read", Arguments: `{}`, CreatedAt: time.Now(), Sender: "Codex"}},
+	})
+
+	require.Len(t, out[0], 1, "denied by signature")
+	require.Equal(t, "db", out[0][0].Match, "unresolved findings keep the server-prefix match")
+	require.Empty(t, out[1], "allowed by signature")
+	require.Equal(t, []string{"org-1", "org-1"}, validator.orgIDs)
+	// Unresolved calls have no provenance row and so no hook source of their
+	// own; attribution must fall back to the message's sender, lowercased to
+	// match the telemetry vocabulary. Without this the whole unresolved
+	// population collapses to "unknown" and the metric cannot gate removing
+	// the signature fallback per sender.
+	require.Equal(t, []recordedResolution{
+		{hookSource: "codex", resolution: ResolutionUnresolved},
+		{hookSource: "codex", resolution: ResolutionUnresolved},
+	}, coverage.got)
+}
+
+// The provenance row's own hook source wins over the message's sender when
+// both are present.
+func TestScanner_ProvenanceHookSourceWinsOverMessageSender(t *testing.T) {
+	t.Parallel()
+
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "https://evil.example/mcp", ServerURL: "https://evil.example/mcp", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), prov, coverage)
+
+	s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now(), Sender: "Cursor"}},
+	})
+
+	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionShadow}}, coverage.got)
+}
+
+// A provenance query failure must not decide anything: every call falls back
+// to the self-contained signature check rather than being judged on evidence
+// the scanner failed to load.
+func TestScanner_ProvenanceErrorFallsBackToSignature(t *testing.T) {
+	t.Parallel()
+
+	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
+	prov := &fakeProvenance{found: nil, err: errors.New("boom"), gotIDs: nil, gotSince: time.Time{}, callCount: 0}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, nil)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Len(t, out[0], 1)
+	require.Equal(t, "db", out[0][0].Match)
+	require.Equal(t, []string{"org-1"}, validator.orgIDs)
+}
+
+// ServerURL is the only value guaranteed to be a real resolved URL, so it wins
+// over the match union when both are present.
+func TestScanner_ServerURLPreferredOverMatch(t *testing.T) {
+	t.Parallel()
+
+	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "db", ServerURL: "https://app.getgram.ai/mcp/team", HookSource: "cursor"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, nil)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Empty(t, out[0], "server URL resolves to a Gram host despite the degraded match")
+	require.Empty(t, validator.orgIDs)
+}
+
+// Cursor emits "MCP:<tool>" rather than the mcp__ form; it must take the same
+// provenance path.
+func TestScanner_CursorStyleToolNameUsesProvenance(t *testing.T) {
+	t.Parallel()
+
+	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "https://evil.example/mcp", ServerURL: "https://evil.example/mcp", HookSource: "cursor"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, nil)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "MCP:delete_row", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Len(t, out[0], 1)
+	require.Equal(t, "https://evil.example/mcp", out[0][0].Match)
+}
+
+func TestScanner_SkipsNonMCPAndNamelessCalls(t *testing.T) {
+	t.Parallel()
+
+	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
+	prov := noProvenance()
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, nil)
 
 	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
 		{
-			{ID: "a", Name: "", Arguments: `{}`},              // nameless
-			{ID: "b", Name: "Bash", Arguments: `{}`},          // native, non-MCP
-			{ID: "c", Name: "mcp__db__read", Arguments: `{}`}, // MCP but not denied
+			{ID: "a", Name: "", Arguments: `{}`, CreatedAt: time.Now()},              // nameless
+			{ID: "b", Name: "Bash", Arguments: `{}`, CreatedAt: time.Now()},          // native, non-MCP
+			{ID: "c", Name: "mcp__db__read", Arguments: `{}`, CreatedAt: time.Now()}, // MCP, allowed
 		},
 	})
+
 	require.Len(t, out, 1)
-	assert.Empty(t, out[0])
-	// Only the MCP-routed call reaches the validator.
-	assert.Equal(t, []string{"org-1"}, validator.orgIDs)
+	require.Empty(t, out[0])
+	require.Equal(t, []string{"org-1"}, validator.orgIDs, "only the MCP-routed call reaches the validator")
+	require.Equal(t, []string{"c"}, prov.gotIDs, "only MCP-routed calls are looked up")
 }
 
-func TestScanner_BatchPositionalAlignment(t *testing.T) {
+func TestScanner_BatchPositionalAlignmentAndSingleLookup(t *testing.T) {
 	t.Parallel()
 
-	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
-	lookup := &fakeLookup{
-		matches: map[string]string{"call-0": "match-0", "call-2": "match-2"},
-		err:     nil,
-		gotIDs:  nil,
+	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found: map[string]telemetryrepo.MCPProvenance{
+			"call-0": {Match: "https://evil.example/mcp", ServerURL: "https://evil.example/mcp", HookSource: "claude"},
+			"call-1": {Match: "https://app.getgram.ai/mcp/team", ServerURL: "https://app.getgram.ai/mcp/team", HookSource: "claude"},
+			"call-2": {Match: "npx -y @acme/mcp", ServerURL: "", HookSource: "claude"},
+		},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
 	}
-	s := NewScanner(discardLogger(), validator, lookup)
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, nil)
 
 	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
-		{{ID: "call-0", Name: "mcp__db__delete", Arguments: `{}`}}, // denied
-		{{ID: "call-1", Name: "mcp__db__read", Arguments: `{}`}},   // allowed
-		{{ID: "call-2", Name: "mcp__fs__delete", Arguments: `{}`}}, // denied
+		{{ID: "call-0", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+		{{ID: "call-1", Name: "mcp__db__read", Arguments: `{}`, CreatedAt: time.Now()}},
+		{{ID: "call-2", Name: "mcp__fs__delete", Arguments: `{}`, CreatedAt: time.Now()}},
 	})
 
 	require.Len(t, out, 3)
 	require.Len(t, out[0], 1)
-	assert.Equal(t, "match-0", out[0][0].Match)
-	assert.Empty(t, out[1])
+	require.Equal(t, "https://evil.example/mcp", out[0][0].Match)
+	require.Empty(t, out[1])
 	require.Len(t, out[2], 1)
-	assert.Equal(t, "match-2", out[2][0].Match)
+	require.Equal(t, "npx -y @acme/mcp", out[2][0].Match)
 
-	// Both denied ids are looked up in a single batched call.
-	assert.ElementsMatch(t, []string{"call-0", "call-2"}, lookup.gotIDs)
+	require.Equal(t, 1, prov.callCount, "the whole batch resolves in a single lookup")
+	require.ElementsMatch(t, []string{"call-0", "call-1", "call-2"}, prov.gotIDs)
 }
 
-func TestScanner_NoDeniedCallsSkipsLookup(t *testing.T) {
+// The lookup is bounded to the batch's own time range so the ClickHouse query
+// stays on the telemetry table's time-ordered primary key.
+func TestScanner_LookupIsBoundedByOldestMessage(t *testing.T) {
 	t.Parallel()
 
-	validator := &fakeValidator{denied: map[string]bool{}, orgIDs: nil}
-	lookup := &fakeLookup{matches: map[string]string{}, err: nil, gotIDs: nil}
-	s := NewScanner(discardLogger(), validator, lookup)
+	oldest := time.Now().Add(-48 * time.Hour)
+	prov := noProvenance()
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), prov, nil)
+
+	s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-0", Name: "mcp__db__read", Arguments: `{}`, CreatedAt: time.Now()}},
+		{{ID: "call-1", Name: "mcp__db__read", Arguments: `{}`, CreatedAt: oldest}},
+	})
+
+	require.Equal(t, oldest.Add(-provenanceLookback), prov.gotSince)
+}
+
+func TestScanner_NoMCPCallsSkipsLookup(t *testing.T) {
+	t.Parallel()
+
+	prov := noProvenance()
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), prov, nil)
 
 	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
-		{{ID: "call-1", Name: "mcp__db__read", Arguments: `{}`}},
+		{{ID: "call-1", Name: "Bash", Arguments: `{}`, CreatedAt: time.Now()}},
 	})
+
 	require.Empty(t, out[0])
-	assert.Empty(t, lookup.gotIDs, "no denied calls: the lookup is never issued")
+	require.Zero(t, prov.callCount, "no MCP calls: the lookup is never issued")
 }
 
-func TestDescribe_ReturnsCanonicalRuleID(t *testing.T) {
+func TestFinding_UsesCanonicalRuleIDAndLeaksNoInternals(t *testing.T) {
 	t.Parallel()
 
-	id, desc := describe("mcp__db__delete")
-	assert.Equal(t, Rule, id)
-	require.NoError(t, scanners.ValidateRuleID(id))
-	assert.Contains(t, desc, "mcp__db__delete")
-	assert.NotContains(t, desc, "x-gram-toolset-id", "must not leak validator internals")
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), noProvenance(), nil)
 
-	idNoTool, descNoTool := describe("")
-	assert.Equal(t, Rule, idNoTool)
-	assert.NotEmpty(t, descNoTool)
+	f := s.finding(ToolCall{ID: "call-1", Name: "mcp__db__delete", Arguments: "", CreatedAt: time.Time{}}, "db")
+	require.Equal(t, Rule, f.RuleID)
+	require.NoError(t, scanners.ValidateRuleID(f.RuleID))
+	require.Contains(t, f.Description, "mcp__db__delete")
+	require.NotContains(t, f.Description, "x-gram-toolset-id", "must not leak validator internals")
+
+	nameless := s.finding(ToolCall{ID: "call-2", Name: "", Arguments: "", CreatedAt: time.Time{}}, "db")
+	require.Equal(t, Rule, nameless.RuleID)
+	require.NotEmpty(t, nameless.Description)
+}
+
+func TestResolvedServerIdentity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		prov         telemetryrepo.MCPProvenance
+		serverPrefix string
+		wantValue    string
+		wantResolved bool
+	}{
+		{"server url wins", telemetryrepo.MCPProvenance{Match: "db", ServerURL: "https://x.test/mcp", HookSource: ""}, "db", "https://x.test/mcp", true},
+		{"url match", telemetryrepo.MCPProvenance{Match: "https://x.test/mcp", ServerURL: "", HookSource: ""}, "db", "https://x.test/mcp", true},
+		{"stdio command match", telemetryrepo.MCPProvenance{Match: "npx -y @acme/mcp", ServerURL: "", HookSource: ""}, "db", "npx -y @acme/mcp", true},
+		{"bare prefix is unresolved", telemetryrepo.MCPProvenance{Match: "db", ServerURL: "", HookSource: ""}, "db", "", false},
+		{"empty is unresolved", telemetryrepo.MCPProvenance{Match: "", ServerURL: "", HookSource: ""}, "db", "", false},
+		{"whitespace is unresolved", telemetryrepo.MCPProvenance{Match: "   ", ServerURL: "", HookSource: ""}, "db", "", false},
+	}
+
+	for _, tc := range cases {
+		value, resolved := resolvedServerIdentity(tc.prov, tc.serverPrefix)
+		require.Equal(t, tc.wantResolved, resolved, tc.name)
+		require.Equal(t, tc.wantValue, value, tc.name)
+	}
+}
+
+func TestScanner_IsHostedIdentity(t *testing.T) {
+	t.Parallel()
+
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), noProvenance(), nil)
+
+	cases := []struct {
+		name     string
+		identity string
+		want     bool
+	}{
+		{"gram url", "https://app.getgram.ai/mcp/team", true},
+		{"third party url", "https://evil.example/mcp", false},
+		{"third party stdio command", "npx -y @acme/mcp", false},
+		{"bare token", "db", false},
+		{"empty", "", false},
+		// Gram's own install snippet for OAuth-backed servers is a stdio
+		// entry fronting a Gram URL; it must not read as shadow MCP.
+		{"gram mcp-remote snippet", "npx mcp-remote@0.1.25 https://app.getgram.ai/mcp/team-foo", true},
+		{"mcp-remote with headers", "npx mcp-remote https://app.getgram.ai/mcp/x --header Authorization:${TOKEN}", true},
+		{"mcp-remote to third party", "npx mcp-remote https://evil.example/mcp", false},
+		// A Gram-shaped path on a foreign host stays shadow: the hosted check
+		// is on the host, never the path.
+		{"gram path on foreign host", "npx mcp-remote https://evil.example/mcp/team-foo", false},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, s.isHostedIdentity(t.Context(), tc.identity, "org-1"), tc.name)
+	}
+}
+
+// A Gram server installed through Gram's own stdio snippet resolves to a
+// launch command, not a URL. Flagging every stdio server would flag calls to
+// Gram's own servers — the exact false positive this scanner exists to avoid.
+func TestScanner_StdioCommandFrontingGramURLIsClean(t *testing.T) {
+	t.Parallel()
+
+	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "npx mcp-remote@0.1.25 https://app.getgram.ai/mcp/team-foo", ServerURL: "", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), validator, gramHosted(), prov, coverage)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Empty(t, out[0], "a stdio server fronting a Gram URL is Gram-hosted")
+	require.Empty(t, validator.orgIDs)
+	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionHosted}}, coverage.got)
+}
+
+// The hosted check must not be gated on the identity parsing as an http(s)
+// URL: IsGramHostedMCPURL accepts forms a stricter pre-filter would reject
+// before the host was ever compared.
+func TestScanner_NonHTTPSchemeGramURLIsClean(t *testing.T) {
+	t.Parallel()
+
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "", ServerURL: "sse://app.getgram.ai/mcp/team", HookSource: "cursor"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), prov, nil)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Empty(t, out[0])
+}
+
+// Senders relay the server URL straight off a client payload without
+// normalizing, so a stray newline must not defeat the hosted check.
+func TestScanner_UntrimmedServerURLIsClean(t *testing.T) {
+	t.Parallel()
+
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "", ServerURL: "https://app.getgram.ai/mcp/team\n", HookSource: "cursor"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, gramHosted(), prov, nil)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Empty(t, out[0])
 }

--- a/server/internal/scanners/shadowmcpscan/scanner_test.go
+++ b/server/internal/scanners/shadowmcpscan/scanner_test.go
@@ -43,11 +43,15 @@ func (f *fakeValidator) ValidateToolsetCall(_ context.Context, _ any, toolName s
 // containing a Gram hostname anywhere in it.
 type fakeHosted struct {
 	calls int
+	err   error
 }
 
-func (f *fakeHosted) TrustedMCPHostsForOrg(_ context.Context, _ string) []string {
+func (f *fakeHosted) TrustedMCPHostsForOrg(_ context.Context, _ string) ([]string, error) {
 	f.calls++
-	return nil
+	if f.err != nil {
+		return nil, f.err
+	}
+	return nil, nil
 }
 
 // fakeProvenance returns provenance for the ids it is configured with, or an
@@ -90,7 +94,7 @@ func (f *fakeCoverage) RecordShadowMCPResolution(_ context.Context, _ string, ho
 }
 
 func gramHosted() *fakeHosted {
-	return &fakeHosted{}
+	return &fakeHosted{calls: 0, err: nil}
 }
 
 // A call whose provenance resolves to a Gram-hosted URL is clean even though
@@ -460,7 +464,12 @@ func TestIsHostedIdentity(t *testing.T) {
 		{"gram mcp-remote snippet", "npx mcp-remote@0.1.25 https://app.getgram.ai/mcp/team-foo", true},
 		{"mcp-remote with -y launcher flag", "npx -y mcp-remote https://app.getgram.ai/mcp/x", true},
 		{"mcp-remote with headers", "npx mcp-remote https://app.getgram.ai/mcp/x --header Authorization:${TOKEN}", true},
-		{"scoped mcp-remote spec", "npx @speakeasy/mcp-remote@1.2.3 https://app.getgram.ai/mcp/x", true},
+		// A scoped package is a different package. Trusting any name ending in
+		// "mcp-remote" would let @evil/mcp-remote, which can connect anywhere,
+		// launder a Gram URL argument into a hosted verdict.
+		{"scoped lookalike rejected", "npx @evil/mcp-remote https://app.getgram.ai/mcp/x", false},
+		{"scoped vendor fork rejected", "npx @speakeasy/mcp-remote@1.2.3 https://app.getgram.ai/mcp/x", false},
+		{"path lookalike rejected", "npx foo/mcp-remote https://app.getgram.ai/mcp/x", false},
 		{"mcp-remote to third party", "npx mcp-remote https://evil.example/mcp", false},
 		// A Gram-shaped path on a foreign host stays shadow: the hosted check
 		// is on the host, never the path.
@@ -513,6 +522,58 @@ func TestScanner_ResolvesTrustedHostsOncePerScan(t *testing.T) {
 	})
 
 	require.Equal(t, 1, hosted.calls)
+}
+
+// Without a trusted-host list the scanner cannot tell a Gram host from a third
+// party, so it must not judge on the incomplete list. Judging anyway would
+// persist shadow findings for calls to an org's own verified custom domain.
+func TestScanner_HostResolutionFailureFallsBackToSignature(t *testing.T) {
+	t.Parallel()
+
+	hosted := gramHosted()
+	hosted.err = errors.New("boom")
+	validator := &fakeValidator{denied: map[string]bool{"delete": true}, orgIDs: nil}
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "https://mcp.customer.example/mcp", ServerURL: "https://mcp.customer.example/mcp", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	coverage := &fakeCoverage{got: nil}
+	s := NewScanner(discardLogger(), validator, hosted, prov, coverage)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now(), Sender: "Claude"}},
+	})
+
+	require.Len(t, out[0], 1, "the signature check still denies this call")
+	require.Equal(t, "db", out[0][0].Match, "decided by the fallback, not by provenance")
+	require.Equal(t, []string{"org-1"}, validator.orgIDs, "host resolution failure must reach the signature validator")
+	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionUnresolved}}, coverage.got)
+}
+
+// The same failure must not manufacture findings for calls the signature check
+// clears.
+func TestScanner_HostResolutionFailureDoesNotFlagSignedCalls(t *testing.T) {
+	t.Parallel()
+
+	hosted := gramHosted()
+	hosted.err = errors.New("boom")
+	prov := &fakeProvenance{
+		found:     map[string]telemetryrepo.MCPProvenance{"call-1": {Match: "https://mcp.customer.example/mcp", ServerURL: "https://mcp.customer.example/mcp", HookSource: "claude"}},
+		err:       nil,
+		gotIDs:    nil,
+		gotSince:  time.Time{},
+		callCount: 0,
+	}
+	s := NewScanner(discardLogger(), &fakeValidator{denied: map[string]bool{}, orgIDs: nil}, hosted, prov, nil)
+
+	out := s.Scan(t.Context(), "org-1", uuid.New(), [][]ToolCall{
+		{{ID: "call-1", Name: "mcp__db__delete", Arguments: `{}`, CreatedAt: time.Now()}},
+	})
+
+	require.Empty(t, out[0])
 }
 
 // No MCP calls means neither the provenance query nor the trusted-host lookup

--- a/server/internal/shadowmcp/cache.go
+++ b/server/internal/shadowmcp/cache.go
@@ -3,6 +3,7 @@ package shadowmcp
 import (
 	"context"
 	"log/slog"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -59,14 +60,20 @@ type Client struct {
 	cache        cache.TypedCacheObject[PolicyEnabledCache]
 	toolsetCache cache.TypedCacheObject[mv.ToolsetBaseContents]
 	accessStore  accesscontrol.Store
+	// serverURL is the deployment's own base URL, trusted as a Gram-hosted
+	// MCP host alongside the built-in ones. Nil in contexts that never
+	// classify URLs (the check then falls back to the built-ins plus the
+	// org's custom domain).
+	serverURL *url.URL
 }
 
-func NewClient(logger *slog.Logger, db *pgxpool.Pool, cacheImpl cache.Cache, accessStore accesscontrol.Store) *Client {
+func NewClient(logger *slog.Logger, db *pgxpool.Pool, cacheImpl cache.Cache, accessStore accesscontrol.Store, serverURL *url.URL) *Client {
 	logger = logger.With(attr.SlogComponent("shadowmcp"))
 	return &Client{
-		logger: logger,
-		db:     db,
-		repo:   risk_repo.New(db),
+		logger:    logger,
+		db:        db,
+		repo:      risk_repo.New(db),
+		serverURL: serverURL,
 		cache: cache.NewTypedObjectCache[PolicyEnabledCache](
 			logger.With(attr.SlogCacheNamespace("shadow_mcp_policy_enabled")),
 			cacheImpl,

--- a/server/internal/shadowmcp/hosted.go
+++ b/server/internal/shadowmcp/hosted.go
@@ -2,9 +2,13 @@ package shadowmcp
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 )
 
@@ -62,29 +66,74 @@ func trustedGramHostedMCPHostMatches(u *url.URL, trustedHost string) bool {
 	return strings.EqualFold(u.Hostname(), trustedHost)
 }
 
+// TrustedMCPHostsForOrg returns the hosts that count as Gram-hosted for an
+// organization on top of the built-in ones: the deployment's own host and the
+// org's verified, activated custom domain.
+//
+// Callers that classify many URLs for one organization should resolve this
+// once and pass it to [IsGramHostedMCPURL], rather than calling
+// [Client.IsGramHostedMCPURLForOrg] per URL — the custom-domain lookup is a
+// database round-trip whose result is invariant for the organization.
+//
+// A lookup failure is logged and yields only the built-in hosts. That is the
+// same answer a genuinely domain-less org gets, so callers must treat a
+// negative as "not known to be Gram-hosted" rather than as proof of a shadow
+// server.
+func (c *Client) TrustedMCPHostsForOrg(ctx context.Context, orgID string) []string {
+	hosts := make([]string, 0, 2)
+	if c.serverURL != nil && c.serverURL.Host != "" {
+		hosts = append(hosts, c.serverURL.Host)
+	}
+	if orgID == "" {
+		return hosts
+	}
+
+	customDomain, err := customdomainsrepo.New(c.db).GetCustomDomainByOrganization(ctx, orgID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return hosts
+	case err != nil:
+		// Distinguished from the no-rows case: a transient database failure
+		// would otherwise be indistinguishable from "this org has no custom
+		// domain" and silently produce shadow findings for calls to the org's
+		// own Gram deployment.
+		c.logger.ErrorContext(ctx, "resolve organization custom domain for Gram-hosted MCP check; treating as no custom domain",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(orgID),
+		)
+		return hosts
+	}
+	if !customDomain.Verified || !customDomain.Activated {
+		return hosts
+	}
+	return append(hosts, customDomain.Domain)
+}
+
 // IsGramHostedMCPURLForOrg reports whether rawURL is a Gram-managed MCP server
 // for the given organization. It checks the canonical and configured hosts
 // first (no DB hit), then falls back to the org's verified custom domain.
 //
-// This is the single definition of "Gram-hosted" shared by the realtime hook
-// guard and the offline batch scanner, so a call the hook allows can never be
-// flagged by the scanner on host grounds alone.
+// This is the definition of "Gram-hosted" shared by the realtime hook guard
+// and the offline batch scanner, so a call the hook allows is not flagged by
+// the scanner on host grounds alone. Use it for one-off classifications; for
+// many URLs under one organization, see [Client.TrustedMCPHostsForOrg].
 func (c *Client) IsGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
-	trustedHosts := make([]string, 0, 1)
-	if c.serverURL != nil && c.serverURL.Host != "" {
-		trustedHosts = append(trustedHosts, c.serverURL.Host)
+	if rawURL == "" {
+		return false
 	}
-
-	// Fast path: check built-in/configured hosts before consulting custom domains.
-	if IsGramHostedMCPURL(rawURL, trustedHosts...) {
+	// Fast path: check built-in and configured hosts before the DB round-trip.
+	if IsGramHostedMCPURL(rawURL, c.serverHost()...) {
 		return true
 	}
-	if rawURL == "" || orgID == "" {
+	if orgID == "" {
 		return false
 	}
-	customDomain, err := customdomainsrepo.New(c.db).GetCustomDomainByOrganization(ctx, orgID)
-	if err != nil || !customDomain.Verified || !customDomain.Activated {
-		return false
+	return IsGramHostedMCPURL(rawURL, c.TrustedMCPHostsForOrg(ctx, orgID)...)
+}
+
+func (c *Client) serverHost() []string {
+	if c.serverURL == nil || c.serverURL.Host == "" {
+		return nil
 	}
-	return IsGramHostedMCPURL(rawURL, customDomain.Domain)
+	return []string{c.serverURL.Host}
 }

--- a/server/internal/shadowmcp/hosted.go
+++ b/server/internal/shadowmcp/hosted.go
@@ -1,0 +1,90 @@
+package shadowmcp
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
+)
+
+// gramHostedMCPHosts are the built-in hosts for Gram-managed MCP servers.
+// Exact host matching keeps third-party subdomains from being treated as
+// trusted Gram-hosted MCP servers.
+var gramHostedMCPHosts = []string{
+	"app.getgram.ai",
+	"chat.speakeasy.com",
+}
+
+// IsGramHostedMCPURL reports whether rawURL points at a Gram-managed MCP
+// server. Checks the canonical hosts plus any additional trusted hosts.
+// Exact host match, case-insensitive.
+//
+// Matching is on the host, never on the path: a path-shaped check would
+// classify https://evil.example.com/mcp/<known-slug> as Gram-hosted.
+func IsGramHostedMCPURL(rawURL string, additionalTrustedHosts ...string) bool {
+	if rawURL == "" {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	hostname := u.Hostname()
+	for _, h := range gramHostedMCPHosts {
+		if strings.EqualFold(hostname, h) {
+			return true
+		}
+	}
+	for _, h := range additionalTrustedHosts {
+		if trustedGramHostedMCPHostMatches(u, h) {
+			return true
+		}
+	}
+	return false
+}
+
+func trustedGramHostedMCPHostMatches(u *url.URL, trustedHost string) bool {
+	trustedHost = strings.TrimSpace(trustedHost)
+	if trustedHost == "" {
+		return false
+	}
+	if strings.Contains(trustedHost, "://") {
+		parsed, err := url.Parse(trustedHost)
+		if err != nil || parsed.Host == "" {
+			return false
+		}
+		trustedHost = parsed.Host
+	}
+	if strings.Contains(trustedHost, ":") {
+		return strings.EqualFold(u.Host, trustedHost)
+	}
+	return strings.EqualFold(u.Hostname(), trustedHost)
+}
+
+// IsGramHostedMCPURLForOrg reports whether rawURL is a Gram-managed MCP server
+// for the given organization. It checks the canonical and configured hosts
+// first (no DB hit), then falls back to the org's verified custom domain.
+//
+// This is the single definition of "Gram-hosted" shared by the realtime hook
+// guard and the offline batch scanner, so a call the hook allows can never be
+// flagged by the scanner on host grounds alone.
+func (c *Client) IsGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
+	trustedHosts := make([]string, 0, 1)
+	if c.serverURL != nil && c.serverURL.Host != "" {
+		trustedHosts = append(trustedHosts, c.serverURL.Host)
+	}
+
+	// Fast path: check built-in/configured hosts before consulting custom domains.
+	if IsGramHostedMCPURL(rawURL, trustedHosts...) {
+		return true
+	}
+	if rawURL == "" || orgID == "" {
+		return false
+	}
+	customDomain, err := customdomainsrepo.New(c.db).GetCustomDomainByOrganization(ctx, orgID)
+	if err != nil || !customDomain.Verified || !customDomain.Activated {
+		return false
+	}
+	return IsGramHostedMCPURL(rawURL, customDomain.Domain)
+}

--- a/server/internal/shadowmcp/hosted.go
+++ b/server/internal/shadowmcp/hosted.go
@@ -3,6 +3,7 @@ package shadowmcp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -75,38 +76,32 @@ func trustedGramHostedMCPHostMatches(u *url.URL, trustedHost string) bool {
 // [Client.IsGramHostedMCPURLForOrg] per URL — the custom-domain lookup is a
 // database round-trip whose result is invariant for the organization.
 //
-// A lookup failure is logged and yields only the built-in hosts. That is the
-// same answer a genuinely domain-less org gets, so callers must treat a
-// negative as "not known to be Gram-hosted" rather than as proof of a shadow
-// server.
-func (c *Client) TrustedMCPHostsForOrg(ctx context.Context, orgID string) []string {
+// The error is returned rather than swallowed. A transient custom-domain
+// lookup failure is not the same answer as "this org has no custom domain":
+// treating it as the latter classifies calls to the org's own verified domain
+// as shadow MCP. Callers that would act on a negative must treat an error as
+// "host resolution unavailable" and fall back to whatever they do when
+// provenance is unknown.
+func (c *Client) TrustedMCPHostsForOrg(ctx context.Context, orgID string) ([]string, error) {
 	hosts := make([]string, 0, 2)
 	if c.serverURL != nil && c.serverURL.Host != "" {
 		hosts = append(hosts, c.serverURL.Host)
 	}
 	if orgID == "" {
-		return hosts
+		return hosts, nil
 	}
 
 	customDomain, err := customdomainsrepo.New(c.db).GetCustomDomainByOrganization(ctx, orgID)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return hosts
+		return hosts, nil
 	case err != nil:
-		// Distinguished from the no-rows case: a transient database failure
-		// would otherwise be indistinguishable from "this org has no custom
-		// domain" and silently produce shadow findings for calls to the org's
-		// own Gram deployment.
-		c.logger.ErrorContext(ctx, "resolve organization custom domain for Gram-hosted MCP check; treating as no custom domain",
-			attr.SlogError(err),
-			attr.SlogOrganizationID(orgID),
-		)
-		return hosts
+		return nil, fmt.Errorf("get custom domain for organization: %w", err)
 	}
 	if !customDomain.Verified || !customDomain.Activated {
-		return hosts
+		return hosts, nil
 	}
-	return append(hosts, customDomain.Domain)
+	return append(hosts, customDomain.Domain), nil
 }
 
 // IsGramHostedMCPURLForOrg reports whether rawURL is a Gram-managed MCP server
@@ -117,6 +112,12 @@ func (c *Client) TrustedMCPHostsForOrg(ctx context.Context, orgID string) []stri
 // and the offline batch scanner, so a call the hook allows is not flagged by
 // the scanner on host grounds alone. Use it for one-off classifications; for
 // many URLs under one organization, see [Client.TrustedMCPHostsForOrg].
+//
+// A custom-domain lookup failure is logged and reported as not hosted, which
+// makes the realtime guard fail closed (deny) on an infrastructure blip. That
+// is the right direction for a single in-flight request but not for the batch
+// scanner, whose verdicts persist as findings — it calls
+// [Client.TrustedMCPHostsForOrg] directly and handles the error itself.
 func (c *Client) IsGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID string) bool {
 	if rawURL == "" {
 		return false
@@ -128,7 +129,16 @@ func (c *Client) IsGramHostedMCPURLForOrg(ctx context.Context, rawURL, orgID str
 	if orgID == "" {
 		return false
 	}
-	return IsGramHostedMCPURL(rawURL, c.TrustedMCPHostsForOrg(ctx, orgID)...)
+
+	hosts, err := c.TrustedMCPHostsForOrg(ctx, orgID)
+	if err != nil {
+		c.logger.ErrorContext(ctx, "resolve organization trusted MCP hosts; treating URL as not Gram-hosted",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(orgID),
+		)
+		return false
+	}
+	return IsGramHostedMCPURL(rawURL, hosts...)
 }
 
 func (c *Client) serverHost() []string {

--- a/server/internal/shadowmcp/hosted_test.go
+++ b/server/internal/shadowmcp/hosted_test.go
@@ -1,0 +1,63 @@
+package shadowmcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+func TestIsGramHostedMCPURL_CanonicalHosts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"canonical app host", "https://app.getgram.ai/mcp/team-foo", true},
+		{"canonical app host uppercase", "https://APP.GETGRAM.AI/mcp/team-foo", true},
+		{"canonical app host over http", "http://app.getgram.ai/mcp/team-foo", true},
+		{"canonical chat host", "https://chat.speakeasy.com/mcp/linear", true},
+		{"canonical chat host uppercase", "https://CHAT.SPEAKEASY.COM/mcp/linear", true},
+		{"subdomain squat rejected", "https://evil.getgram.ai/mcp/x", false},
+		{"third party rejected", "https://mcp.slack.com/mcp", false},
+		{"unconfigured localhost rejected", "http://localhost:8080/mcp/x", false},
+		{"empty url", "", false},
+		{"unparseable url", "not a url at all", false},
+		// A Gram-shaped path on a foreign host must never pass: the check is
+		// on the host, never the path.
+		{"gram path on foreign host rejected", "https://evil.example.com/mcp/team-foo", false},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, shadowmcp.IsGramHostedMCPURL(tc.url), tc.name)
+	}
+}
+
+func TestIsGramHostedMCPURL_AdditionalTrustedHosts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		url        string
+		extraHosts []string
+		want       bool
+	}{
+		{"custom domain matches", "https://docs.example.com/mcp/linear", []string{"docs.example.com"}, true},
+		{"custom domain case-insensitive", "https://DOCS.EXAMPLE.COM/mcp/linear", []string{"docs.example.com"}, true},
+		{"configured host and port matches", "https://localhost:8080/mcp/local-org", []string{"localhost:8080"}, true},
+		{"different port stays external", "https://localhost:35294/mcp/local-shadow", []string{"localhost:8080"}, false},
+		{"canonical still works with extra hosts", "https://app.getgram.ai/mcp/x", []string{"chat.speakeasy.com"}, true},
+		{"unknown host rejected", "https://other.example.com/mcp/x", []string{"chat.speakeasy.com"}, false},
+		{"third party rejected", "https://mcp.slack.com/mcp", []string{"chat.speakeasy.com"}, false},
+		{"empty url", "", []string{"chat.speakeasy.com"}, false},
+		{"trusted host given as full url", "https://docs.example.com/mcp/x", []string{"https://docs.example.com"}, true},
+		{"blank trusted host ignored", "https://other.example.com/mcp/x", []string{"  "}, false},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.want, shadowmcp.IsGramHostedMCPURL(tc.url, tc.extraHosts...), tc.name)
+	}
+}

--- a/server/internal/shadowmcp/setup_test.go
+++ b/server/internal/shadowmcp/setup_test.go
@@ -64,7 +64,7 @@ func newFixture(t *testing.T) *fixture {
 	logger := testenv.NewLogger(t)
 	cacheImpl := cache.NewRedisCacheAdapter(redisClient)
 	accessStore := accesscontrol.NewRedisStore(cacheImpl, accesscontrol.AlphaTTL)
-	client := shadowmcp.NewClient(logger, conn, cacheImpl, accessStore)
+	client := shadowmcp.NewClient(logger, conn, cacheImpl, accessStore, nil)
 
 	orgID := "test-org-" + uuid.NewString()[:8]
 	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{

--- a/server/internal/telemetry/repo/mcp_match_lookup.go
+++ b/server/internal/telemetry/repo/mcp_match_lookup.go
@@ -5,24 +5,50 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
 
-// LookupMCPMatchesByToolCallID returns a map of tool_call_id →
-// resolved MCP server identifier (the `gram.mcp.match` attribute set by
-// the hook on every MCP-routed PreToolUse log). Tool call IDs missing
-// from the result either had no associated log row yet or their hook
-// log was written before the attribute existed; callers should fall back
-// to their own match derivation in that case.
+// MCPProvenance is the server-level identity the hook recorded for one MCP
+// tool call.
+//
+// Match is the `gram.mcp.match` attribute: an HTTP/SSE URL, a stdio launch
+// command, or — when the sender's inventory snapshot didn't resolve the
+// server — the bare `mcp__<server>__` tool-name prefix. The three are not
+// distinguishable from the value alone, so callers that need to know whether
+// a URL was resolved should read ServerURL, which is set only for HTTP/SSE
+// servers whose URL the sender actually knew.
+//
+// HookSource is the reporting agent (claude, codex, cursor, ...), carried so
+// callers can attribute provenance coverage per sender rather than as a
+// single opaque rate.
+type MCPProvenance struct {
+	Match      string
+	ServerURL  string
+	HookSource string
+}
+
+// LookupMCPProvenanceByToolCallID returns a map of tool_call_id → the MCP
+// provenance the hook recorded for that call. Tool call IDs missing from the
+// result had no matching log row: the hook log hasn't landed yet, the sender
+// never resolved a server, or — for senders whose recorded tool-call id is not
+// the value their trace id derives from — the join cannot succeed at all.
+// Callers must treat an absent entry as "unknown provenance", never as "not
+// Gram-hosted".
 //
 // Trace IDs in telemetry_logs are derived from tool call IDs via SHA256
-// truncation (see internal/hooks/impl.go), so the lookup is implemented
-// as a single CH query against the trace_id bloom-filter index instead
-// of a JSON predicate on the tool call ID itself.
-func (q *Queries) LookupMCPMatchesByToolCallID(ctx context.Context, projectID uuid.UUID, toolCallIDs []string) (map[string]string, error) {
+// truncation (see internal/hooks/impl.go), so the lookup is implemented as a
+// single CH query against the trace_id bloom-filter index instead of a JSON
+// predicate on the tool call ID itself.
+//
+// since bounds the scan on time_unix_nano, which leads the table's ORDER BY
+// and its daily partition key. Without it the trace_id bloom filter (0.01 FPR)
+// degrades toward a full 90-day scan once the probe list holds more than a
+// handful of ids. A zero value disables the bound.
+func (q *Queries) LookupMCPProvenanceByToolCallID(ctx context.Context, projectID uuid.UUID, toolCallIDs []string, since time.Time) (map[string]MCPProvenance, error) {
 	if len(toolCallIDs) == 0 {
-		return map[string]string{}, nil
+		return map[string]MCPProvenance{}, nil
 	}
 
 	traceToToolCallID := make(map[string]string, len(toolCallIDs))
@@ -36,44 +62,63 @@ func (q *Queries) LookupMCPMatchesByToolCallID(ctx context.Context, projectID uu
 		traceIDs = append(traceIDs, traceID)
 	}
 	if len(traceIDs) == 0 {
-		return map[string]string{}, nil
+		return map[string]MCPProvenance{}, nil
 	}
 
-	// Select the latest non-empty gram.mcp.match per trace_id. The attribute
-	// is set on every MCP-routed PreToolUse log via
-	// buildTelemetryAttributesWithMetadata, so any matching row is
-	// authoritative for its trace.
-	const query = `
-		SELECT trace_id, toString(attributes.gram.mcp.match) AS match
+	// Admit a row when either attribute is present. Senders that resolve a
+	// server from an inventory snapshot write both; Cursor-era rows predating
+	// the match attribute carry only the URL, and gating on match alone would
+	// silently drop every one of them.
+	//
+	// A trace can span several rows (PreToolUse, PostToolUse, ...) whose
+	// attributes differ — a row written before the sender's inventory snapshot
+	// landed carries the degraded tool-name prefix while a sibling carries the
+	// real server. Collapse per trace with max() so the populated value always
+	// wins over an empty one and the result never depends on row order; the
+	// trace_summaries MV resolves the same columns the same way and for the
+	// same reason (see clickhouse/schema.sql).
+	query := `
+		SELECT trace_id,
+		       max(toString(attributes.gram.mcp.match)) AS match,
+		       max(toString(attributes.gram.mcp.server_url)) AS server_url,
+		       max(hook_source) AS hook_source
 		FROM telemetry_logs
 		WHERE gram_project_id = ?
 		  AND trace_id IN ?
-		  AND toString(attributes.gram.mcp.match) != ''
+		  AND (toString(attributes.gram.mcp.match) != '' OR toString(attributes.gram.mcp.server_url) != '')
 	`
-	rows, err := q.conn.Query(ctx, query, projectID, traceIDs)
+	args := []any{projectID, traceIDs}
+	if !since.IsZero() {
+		query += "\t\t  AND time_unix_nano >= ?\n"
+		args = append(args, since.UnixNano())
+	}
+	query += "\t\tGROUP BY trace_id\n"
+
+	rows, err := q.conn.Query(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query mcp match by trace_id: %w", err)
+		return nil, fmt.Errorf("query mcp provenance by trace_id: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	out := make(map[string]string, len(traceIDs))
+	out := make(map[string]MCPProvenance, len(traceIDs))
 	for rows.Next() {
-		var traceID, match string
-		if err := rows.Scan(&traceID, &match); err != nil {
-			return nil, fmt.Errorf("scan mcp match row: %w", err)
+		var traceID, match, serverURL, hookSource string
+		if err := rows.Scan(&traceID, &match, &serverURL, &hookSource); err != nil {
+			return nil, fmt.Errorf("scan mcp provenance row: %w", err)
 		}
 		toolCallID, ok := traceToToolCallID[traceID]
 		if !ok {
 			continue
 		}
-		// First non-empty wins per tool call — the attribute value is
-		// expected to be identical across rows for the same trace.
-		if _, exists := out[toolCallID]; !exists {
-			out[toolCallID] = match
+		// One row per trace: the GROUP BY already collapsed siblings.
+		out[toolCallID] = MCPProvenance{
+			Match:      match,
+			ServerURL:  serverURL,
+			HookSource: hookSource,
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate mcp match rows: %w", err)
+		return nil, fmt.Errorf("iterate mcp provenance rows: %w", err)
 	}
 	return out, nil
 }

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -151,7 +151,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	assistantTokens := assistanttokens.New("test-jwt-secret", conn, authzEngine)
 	accessStore := accesscontrol.NewRedisStore(cacheAdapter, accesscontrol.AlphaTTL)
-	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore)
+	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore, nil)
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)


### PR DESCRIPTION
Linear Issue: [DNO-599](https://linear.app/speakeasy/issue/DNO-599/bug-rework-flag-action-provenance-before-removing-x-gram-toolset-id)

The flag path validated recorded tool calls with `ValidateToolsetCall`, which requires the `x-gram-toolset-id` constant Gram injects into tool schemas and callers echo back.

**This now fixes a live regression rather than unblocking one.** #4425 (DNO-603) removed that injection from the remote MCP proxy, so calls through `/x/mcp` and through `/mcp` backed by remote or tunneled servers no longer carry the property. Against the current flag path every one of them looks unsigned, so any project with a flag-action `shadow_mcp` policy is flagging its own legitimate remote MCP traffic.

The scanner now resolves provenance for every MCP call in the batch up front, reading the `gram.mcp.match` and `gram.mcp.server_url` attributes that each MCP-routed hook event already records, and decides from the resolved server URL using the same Gram-hosted check the realtime block guard uses. When provenance does not resolve, the call falls back to the signature check, preserving current behavior for senders that provenance cannot yet cover.

## Details worth calling out

* A stdio server that fronts a Gram URL counts as Gram-hosted. Gram's own install snippet for OAuth-backed servers is `npx mcp-remote <gram url>`, so treating every stdio server as shadow would flag calls to Gram's own servers. Only the proxy's target counts, and only for the canonical unscoped `mcp-remote` package, so neither an unrelated Gram URL argument nor a `@scope/mcp-remote` lookalike clears the check.
* The match attribute degrades to the bare `mcp__<server>__` tool name prefix when the sender's inventory snapshot did not resolve. That value carries no server identity, so it counts as unresolved rather than as a verdict.
* When the organization's trusted hosts cannot be resolved, the whole batch takes the unresolved path. Judging against an incomplete host list would classify calls to an org's own verified custom domain as shadow MCP, and batch verdicts persist as findings.
* The Cursor hook now emits `gram.mcp.match`, and the lookup admits rows carrying either attribute. Gating on match alone silently dropped every Cursor row.
* The Gram-hosted URL check moved into the `shadowmcp` package so the realtime guard and the batch scanner share one definition. The inventory capture added in #4425's neighbourhood now uses the same helpers.
* The lookup collapses rows per trace with `max()` and is bounded to the batch time range, keeping it on the telemetry table's time-ordered primary key.
* A new `risk.shadow_mcp.resolution` metric counts each scanned call as `hosted`, `shadow`, or `unresolved`, split by sender, so the unresolved rate that gates removing the signature fallback is measurable per agent.

This also fixes a false positive that predates #4425: calls through `/x/mcp` echo a remote MCP server id, which never resolves as a toolset, so they were flagged even though the block path allows them.

## Scope

The toolset-backed `/mcp` injection is unchanged. It cannot be removed until `destructive_tool` has its own provenance story, since `ResolveToolsetCall` is that scanner's only way to resolve a call and `IsEnabledForProject` turns injection on for either policy source.

Codex provenance still cannot join, tracked in [DNO-604](https://linear.app/speakeasy/issue/DNO-604/bug-codex-mcp-provenance-cannot-join-to-recorded-tool-calls). The flag path still ignores policy bypass grants, tracked in [DNO-605](https://linear.app/speakeasy/issue/DNO-605/bug-shadow-mcp-flag-path-ignores-risk-policy-bypass-grants).
