### PR TITLE
fix(server): move shadow-MCP inventory upsert off the synchronous hook request path

### DIFF
--- a/.changeset/async-shadow-mcp-inventory-upsert.md
+++ b/.changeset/async-shadow-mcp-inventory-upsert.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Move the shadow-MCP inventory upsert off the synchronous hook request path. The capture previously ran inside SessionStart/ConfigChange handling and issued one `custom_domains` query plus one sequential ClickHouse point-SELECT per inventory entry, holding hook responses for seconds on large inventories. The whole unit now runs detached from the request, the existing-row lookup is batched into one query per project, and the org's trusted hosts are resolved once per capture. Enforcement is unaffected — the shadow-MCP guard reads the Redis snapshot, which is still written synchronously.

--- a/server/internal/hooks/mcp_match.go
+++ b/server/internal/hooks/mcp_match.go
@@ -268,6 +268,26 @@ func trustedGramHostedMCPHostMatches(u *url.URL, trustedHost string) bool {
 	return strings.EqualFold(u.Hostname(), trustedHost)
 }
 
+// gramHostedMCPTrustedHostsForOrg returns the trusted Gram-hosted MCP hosts
+// for an org — the configured server host plus the org's verified+activated
+// custom domain — with a single custom_domains query. Use it over
+// isGramHostedMCPURLForOrg when classifying many URLs for the same org in one
+// pass, which would otherwise repeat the custom-domain lookup per URL.
+func (s *Service) gramHostedMCPTrustedHostsForOrg(ctx context.Context, orgID string) []string {
+	trustedHosts := make([]string, 0, 2)
+	if s.serverURL != nil && s.serverURL.Host != "" {
+		trustedHosts = append(trustedHosts, s.serverURL.Host)
+	}
+	if orgID == "" {
+		return trustedHosts
+	}
+	customDomain, err := repo.New(s.db).GetCustomDomainByOrganization(ctx, orgID)
+	if err == nil && customDomain.Verified && customDomain.Activated {
+		trustedHosts = append(trustedHosts, customDomain.Domain)
+	}
+	return trustedHosts
+}
+
 // isGramHostedMCPURLForOrg checks if a URL is a Gram-managed MCP server for
 // the given organization. It checks against the canonical host first (no DB
 // hit), then falls back to checking the org's custom domain if needed.

--- a/server/internal/hooks/shadow_mcp_inventory.go
+++ b/server/internal/hooks/shadow_mcp_inventory.go
@@ -9,41 +9,56 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
+// upsertShadowMCPInventoryURLs records the session's external MCP servers in
+// the shadow-MCP inventory. The upsert is pure telemetry — nothing in the hook
+// response depends on it — so the whole unit (custom-domain lookup,
+// canonicalization, ClickHouse write) runs detached from the request:
+// synchronous ClickHouse writes here held hook responses for multiple seconds
+// (DNO-521/DNO-606). WithoutCancel keeps the write alive after the hook
+// response is sent.
 func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, orgID string, projectID string, sessionID string, entries []MCPServerEntry) {
 	if s.telemetryLogger == nil || projectID == "" || len(entries) == 0 {
 		return
 	}
 
 	seenAt := time.Now()
-	inventoryURLs := make([]telemetry.ShadowMCPInventoryURL, 0, len(entries))
-	for _, entry := range entries {
-		if entry.URL == "" {
-			continue
-		}
-		if s.isGramHostedMCPURLForOrg(ctx, entry.URL, orgID) {
-			continue
-		}
-		invURL, ok := shadowmcp.CanonicalizeInventoryURL(entry.URL)
-		if !ok {
-			continue
-		}
-		inventoryURLs = append(inventoryURLs, telemetry.ShadowMCPInventoryURL{
-			GramProjectID: projectID,
-			ServerURL:     invURL,
-			ServerName:    entry.Name,
-			SeenAt:        seenAt,
-		})
-	}
-	if len(inventoryURLs) == 0 {
-		return
-	}
+	asyncCtx := context.WithoutCancel(ctx)
+	go func() {
+		// One custom-domain lookup covers every entry — the per-entry
+		// isGramHostedMCPURLForOrg variant would re-query custom_domains for
+		// each external URL in the inventory.
+		trustedHosts := s.gramHostedMCPTrustedHostsForOrg(asyncCtx, orgID)
 
-	if err := s.telemetryLogger.UpsertShadowMCPInventoryURLs(ctx, inventoryURLs); err != nil {
-		s.logger.WarnContext(ctx, "shadow MCP inventory URL upsert failed",
-			attr.SlogEvent("shadow_mcp_inventory_url_upsert_failed"),
-			attr.SlogError(err),
-			attr.SlogProjectID(projectID),
-			attr.SlogGenAIConversationID(sessionID),
-		)
-	}
+		inventoryURLs := make([]telemetry.ShadowMCPInventoryURL, 0, len(entries))
+		for _, entry := range entries {
+			if entry.URL == "" {
+				continue
+			}
+			if isGramHostedMCPURL(entry.URL, trustedHosts...) {
+				continue
+			}
+			invURL, ok := shadowmcp.CanonicalizeInventoryURL(entry.URL)
+			if !ok {
+				continue
+			}
+			inventoryURLs = append(inventoryURLs, telemetry.ShadowMCPInventoryURL{
+				GramProjectID: projectID,
+				ServerURL:     invURL,
+				ServerName:    entry.Name,
+				SeenAt:        seenAt,
+			})
+		}
+		if len(inventoryURLs) == 0 {
+			return
+		}
+
+		if err := s.telemetryLogger.UpsertShadowMCPInventoryURLs(asyncCtx, inventoryURLs); err != nil {
+			s.logger.WarnContext(asyncCtx, "shadow MCP inventory URL upsert failed",
+				attr.SlogEvent("shadow_mcp_inventory_url_upsert_failed"),
+				attr.SlogError(err),
+				attr.SlogProjectID(projectID),
+				attr.SlogGenAIConversationID(sessionID),
+			)
+		}
+	}()
 }

--- a/server/internal/hooks/shadow_mcp_inventory.go
+++ b/server/internal/hooks/shadow_mcp_inventory.go
@@ -9,21 +9,29 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
+// shadowMCPInventoryUpsertTimeout bounds the detached inventory capture. The
+// work is best-effort telemetry, so the bound is not about latency — it stops
+// a saturated Postgres pool (a deadline-less acquire can wait unboundedly) or
+// a hung write from retaining one goroutine per capture.
+const shadowMCPInventoryUpsertTimeout = 10 * time.Second
+
 // upsertShadowMCPInventoryURLs records the session's external MCP servers in
 // the shadow-MCP inventory. The upsert is pure telemetry — nothing in the hook
 // response depends on it — so the whole unit (custom-domain lookup,
 // canonicalization, ClickHouse write) runs detached from the request:
 // synchronous ClickHouse writes here held hook responses for multiple seconds
-// (DNO-521/DNO-606). WithoutCancel keeps the write alive after the hook
-// response is sent.
+// (DNO-521/DNO-606). WithoutCancel keeps the work alive after the hook
+// response is sent; the re-bound timeout keeps it from living forever.
 func (s *Service) upsertShadowMCPInventoryURLs(ctx context.Context, orgID string, projectID string, sessionID string, entries []MCPServerEntry) {
 	if s.telemetryLogger == nil || projectID == "" || len(entries) == 0 {
 		return
 	}
 
 	seenAt := time.Now()
-	asyncCtx := context.WithoutCancel(ctx)
+	detachedCtx := context.WithoutCancel(ctx)
 	go func() {
+		asyncCtx, cancel := context.WithTimeout(detachedCtx, shadowMCPInventoryUpsertTimeout)
+		defer cancel()
 		// One custom-domain lookup covers every entry — the per-entry
 		// isGramHostedMCPURLForOrg variant would re-query custom_domains for
 		// each external URL in the inventory.

--- a/server/internal/hooks/shadow_mcp_inventory_capture_test.go
+++ b/server/internal/hooks/shadow_mcp_inventory_capture_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
@@ -429,13 +430,20 @@ func requireShadowMCPInventoryURLsFromHooks(
 ) []telemetryrepo.ShadowMCPInventoryURLRow {
 	t.Helper()
 
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
-	rows, err := chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
-		GramProjectID: projectID,
-		Limit:         50,
-	})
-	require.NoError(t, err)
-	require.Len(t, rows, wantLen)
+	// The inventory upsert runs detached from the hook request (DNO-606), so
+	// poll until the background write lands. Rows from one capture arrive in a
+	// single insert, so a matching length means the batch is complete.
+	var rows []telemetryrepo.ShadowMCPInventoryURLRow
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+		var err error
+		rows, err = chClient.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         50,
+		})
+		assert.NoError(c, err)
+		assert.Len(c, rows, wantLen)
+	}, 10*time.Second, 50*time.Millisecond)
 
 	return rows
 }

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -493,8 +493,10 @@ func decodeShadowMCPInventoryUserCursor(cursor string) (shadowMCPInventoryUserCu
 }
 
 // UpsertShadowMCPInventoryURLs merges the given rows with any existing
-// inventory rows and writes them using a server-side async insert
-// (fire-and-forget), same as InsertTelemetryLogs.
+// inventory rows (one batched lookup per project) and writes them with a
+// synchronous insert: the read-merge-write depends on previously written rows
+// being visible, so the insert must not be deferred by ClickHouse async
+// insert buffering.
 func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []UpsertShadowMCPInventoryURLParams) error {
 	if len(args) == 0 {
 		return nil
@@ -562,26 +564,37 @@ func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []Upser
 		return nil
 	}
 
+	// Fetch existing rows with one batched lookup per project instead of one
+	// point-SELECT per URL — the sequential per-URL reads dominated the
+	// upsert's latency for inventories with many servers (DNO-606).
+	urlsByProject := make(map[string][]string)
 	for _, upsert := range upserts {
-		existing, err := q.getShadowMCPInventoryURL(ctx, upsert.GramProjectID, upsert.CanonicalServerURL)
+		urlsByProject[upsert.GramProjectID] = append(urlsByProject[upsert.GramProjectID], upsert.CanonicalServerURL)
+	}
+	for projectID, urls := range urlsByProject {
+		existingByURL, err := q.listShadowMCPInventoryURLRowsByURLs(ctx, projectID, urls)
 		if err != nil {
 			return err
 		}
-		if existing == nil {
-			continue
-		}
-		upsert.ServerNameOverride = existing.ServerNameOverride
-		if upsert.URLHost == "" {
-			upsert.URLHost = existing.URLHost
-		}
-		if upsert.ServerName == "" {
-			upsert.ServerName = existing.ServerName
-		}
-		if existing.FirstSeen.Before(upsert.FirstSeen) {
-			upsert.FirstSeen = existing.FirstSeen
-		}
-		if existing.LastSeen.After(upsert.LastSeen) {
-			upsert.LastSeen = existing.LastSeen
+		for _, url := range urls {
+			existing, ok := existingByURL[url]
+			if !ok {
+				continue
+			}
+			upsert := upserts[projectID+"\x00"+url]
+			upsert.ServerNameOverride = existing.ServerNameOverride
+			if upsert.URLHost == "" {
+				upsert.URLHost = existing.URLHost
+			}
+			if upsert.ServerName == "" {
+				upsert.ServerName = existing.ServerName
+			}
+			if existing.FirstSeen.Before(upsert.FirstSeen) {
+				upsert.FirstSeen = existing.FirstSeen
+			}
+			if existing.LastSeen.After(upsert.LastSeen) {
+				upsert.LastSeen = existing.LastSeen
+			}
 		}
 	}
 
@@ -709,6 +722,54 @@ func (q *Queries) ListShadowMCPInventoryURLsBySlugHash(ctx context.Context, arg 
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating shadow mcp inventory slug hash lookup rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// listShadowMCPInventoryURLRowsByURLs fetches the existing inventory rows for
+// a set of canonical URLs within one project in a single query, keyed by
+// canonical URL. Batch counterpart of getShadowMCPInventoryURL for the upsert
+// merge path.
+func (q *Queries) listShadowMCPInventoryURLRowsByURLs(ctx context.Context, projectID string, canonicalURLs []string) (map[string]*ShadowMCPInventoryURLRow, error) {
+	if len(canonicalURLs) == 0 {
+		return map[string]*ShadowMCPInventoryURLRow{}, nil
+	}
+
+	sb := sq.Select(
+		"canonical_server_url",
+		"max(url_host) AS url_host",
+		"argMaxIf(server_name, updated_at, server_name != '') AS server_name",
+		"argMax(server_name_override, updated_at) AS server_name_override",
+		"min(first_seen) AS first_seen",
+		"max(last_seen) AS last_seen",
+	).
+		From("shadow_mcp_inventory_urls").
+		Where("gram_project_id = ?", projectID).
+		Where(squirrel.Eq{"canonical_server_url": canonicalURLs}).
+		GroupBy("gram_project_id", "canonical_server_url")
+
+	query, queryArgs, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building shadow mcp inventory url batch lookup query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("querying shadow mcp inventory url batch lookup: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]*ShadowMCPInventoryURLRow, len(canonicalURLs))
+	for rows.Next() {
+		var row ShadowMCPInventoryURLRow
+		if err := rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scanning shadow mcp inventory url batch lookup row: %w", err)
+		}
+		result[row.CanonicalServerURL] = &row
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating shadow mcp inventory url batch lookup rows: %w", err)
 	}
 
 	return result, nil


### PR DESCRIPTION
## Summary

Fixes the root cause of the DNO-521 latency alert: the shadow-MCP inventory upsert ran **synchronously inside hook request handling** and was far more expensive than it looked — one `custom_domains` Postgres query per inventory entry, then one sequential ClickHouse point-SELECT per URL, then a synchronous insert. For a session inventory with ~14 external MCP servers that held SessionStart/ConfigChange responses for 1.4–2.5s (and still ~0.25–0.35s today, ~30× the ~8ms baseline). Full evidence trail on DNO-521; instrumentation for these writes landed in #4420.

## Changes

- **Off the request path** (`server/internal/hooks/shadow_mcp_inventory.go`): the whole unit — trusted-host resolution, canonicalization, ClickHouse write — now runs in a goroutine on a `context.WithoutCancel` context, matching the existing `persistHook` / `insertToolCallBlock` patterns. Nothing in the hook response depends on it; failures are still warn-logged.
- **One batched existing-row lookup** (`server/internal/telemetry/repo/queries.sql.go`): new `listShadowMCPInventoryURLRowsByURLs` fetches all existing rows for a project's URLs in a single query; the upsert merge loop uses it instead of one point-SELECT per URL.
- **One `custom_domains` query per capture** (`server/internal/hooks/mcp_match.go`): new `gramHostedMCPTrustedHostsForOrg` resolves the org's trusted hosts once; entries are then classified with the pure `isGramHostedMCPURL` check. The per-URL `isGramHostedMCPURLForOrg` remains for single-URL callers.
- **Doc comment corrected**: `UpsertShadowMCPInventoryURLs` claimed to be an async fire-and-forget insert; it is (deliberately) synchronous because the read-merge-write needs previously written rows visible. The comment now says so.

Deliberately out of scope: `telemetryLogger.Log` on the block/warn verdict paths is also a synchronous ClickHouse insert, but it only fires on actual policy blocks and moving it async changes block-telemetry ordering guarantees — tracked on DNO-606.

## Testing

- `go build`, `go vet`, `mise lint:server` clean.
- Full `hooks` and `telemetry` package suites pass; shadow-MCP inventory tests also run under `-race`.
- The shared test helper now polls with `require.EventuallyWithT` for the detached write; the negative test (snapshot-cache failure skips the upsert) stays deterministic because the skip decision remains synchronous.

## References

- DNO-606 (this fix), DNO-521 (investigation), #4420 (instrumentation for these writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the shadow‑MCP inventory upsert off the synchronous hook path to cut multi‑second latency on SessionStart/ConfigChange and bound the detached work with a 10s timeout. Addresses Linear DNO-606 and the DNO-521 latency alert by detaching the write, batching lookups, and reducing DB/ClickHouse round trips.

- **Bug Fixes**
  - Run inventory upsert in a detached goroutine with `context.WithoutCancel` and a 10s timeout in `server/internal/hooks/shadow_mcp_inventory.go` to prevent leaked work on pool saturation.
  - Batch existing-row lookup via `listShadowMCPInventoryURLRowsByURLs` in `server/internal/telemetry/repo/queries.sql.go` (one query per project).
  - Resolve trusted hosts once per org with `gramHostedMCPTrustedHostsForOrg` in `server/internal/hooks/mcp_match.go` to avoid per-URL `custom_domains` queries.
  - Correct `UpsertShadowMCPInventoryURLs` doc: insert is synchronous to preserve read-merge-write semantics.
  - Update tests to poll for the detached write using `require.EventuallyWithT` in `server/internal/hooks/shadow_mcp_inventory_capture_test.go`.
  - Add changeset `async-shadow-mcp-inventory-upsert.md` to publish a patch release.

<sup>Written for commit e7a4beb525610ee4922e63a566c07e6ecc8d989f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

