### PR TITLE
chore(hooks): serve the 0.3.0 hooks binary

### DIFF
--- a/.changeset/repin-hooks-binary-030.md
+++ b/.changeset/repin-hooks-binary-030.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Serve the hooks@0.3.0 binary to hook installations. Activated skills now upload their manifest content, so captured skills show a summary and a version instead of a name-only entry. The previously served 0.1.1 archives stay available so existing installations can still cold-install.

--- a/server/internal/plugins/artifacts.go
+++ b/server/internal/plugins/artifacts.go
@@ -37,6 +37,7 @@ const HooksReleaseRoutePrefix = "/hooks/releases/"
 // version's path, and dropping it bricks their cold installs.
 var hooksArtifactIndex = map[string]map[string]hooksBinaryTarget{
 	hooksBinaryVersion: hooksBinaryTargets,
+	"0.1.1":            hooksBinaryTargets0_1_1,
 }
 
 // Release archives are ~15MB; anything past this limit means the upstream

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -356,7 +356,7 @@ const mcpGeneratorVersion = "9"
 //
 // The Plugin Generate Check CI workflow requires the relevant one of these two
 // constants to change whenever generate.go does.
-const hooksGeneratorVersion = "16"
+const hooksGeneratorVersion = "17"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 )
 
-const hooksBinaryVersion = "0.1.1"
+const hooksBinaryVersion = "0.3.0"
 
 type hooksBinaryTarget struct {
 	URL    string `json:"url"`
@@ -38,6 +38,19 @@ func hooksReleaseTargets(version string, sha256s map[string]string) map[string]h
 // sandbox) often cannot reach GitHub while the Gram domain is already
 // allowlisted for ingest.
 var hooksBinaryTargets = hooksReleaseTargets(hooksBinaryVersion, map[string]string{
+	"darwin-amd64":  "c740eb39906e6a85f51f9774598e2b7d2e3a8acc89b78e04d615b86a9a35868f",
+	"darwin-arm64":  "049da3779681c2b5894dff02c4fd2726d1131d751e09d24f44651d24ab55811a",
+	"linux-amd64":   "0d1720c37f3feb6cb193d93ffb7ed393bfe3e9ac1ac1a66b9c841e9c7ee4d4e6",
+	"linux-arm64":   "2328b36e84034690008f289a46385c1c2ca78eebe4f09fed352a5f459918cf3c",
+	"windows-amd64": "218e38648129236425b172529bd3dbbfa7f74124fc09f3b3a001bc0a5752587f",
+	"windows-arm64": "bb5998a6489e0d8dc738530f7885058a98bda349df2f589e151887f7e79d3b60",
+})
+
+// hooksBinaryTargets0_1_1 keeps the previously pinned release fetchable. Hook
+// installations that have not regenerated their bootstrap script still request
+// this version's path, and their cold installs fail if the server stops
+// serving it.
+var hooksBinaryTargets0_1_1 = hooksReleaseTargets("0.1.1", map[string]string{
 	"darwin-amd64":  "ff5fda9b48e9ff33a789bf92563f1f93822e17411e9de36584198eaa704cb5c0",
 	"darwin-arm64":  "a61c5cc2721f1637262c91a710299941b0cd1316882c7338916c1349b56cccc5",
 	"linux-amd64":   "4127504a2d01d3e07dc4f6852e8e1551f404a98bf14f60a766d8dae110d361d3",


### PR DESCRIPTION
Pins `hooksBinaryVersion` to the `hooks@0.3.0` release so hook installations download the binary that actually uploads skill manifest content. Until this lands, every machine runs 0.1.1 (tagged 16 July), which has no `upload-skill` command — activated skills are recorded by name and hash, and the skills list shows them with no summary and zero versions.

`hooksArtifactIndex` keeps the 0.1.1 archive set alongside 0.3.0. The server only proxies versions listed there, and bootstrap scripts already installed on user machines keep requesting the 0.1.1 path until they regenerate, so dropping the entry would break their cold installs.

Verified before pinning: downloaded `speakeasy-hooks_darwin_arm64.zip` from the release, confirmed its SHA-256 matches the value pinned here, and confirmed the extracted binary reports `speakeasy-hooks 0.3.0` and contains the `upload-skill` command.

Note that 0.2.0 was released on 17 July and never pinned, so this also picks up the org-settings fail-open cache and the offline payload spool that shipped in it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the `hooks@0.3.0` binary for new installs and keep `0.1.1` archives available for older bootstrap scripts. Also bumps the hooks generator version to `17` to reflect the pin.

- **New Features**
  - Enables `upload-skill`; activated skills upload manifest content and show summaries and versions.
  - Includes `0.2.0` changes: org-settings fail-open cache and offline payload spool.

- **Migration**
  - Regenerate hook bootstrap scripts to download `0.3.0`; older scripts will continue fetching `0.1.1`.

<sup>Written for commit c84de87b598236643fa1490ce8f9320a6ad2d44a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

