### PR TITLE
fix(remotesessions): require project:read, not project:write, for issuer discover

### DIFF
--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -67,6 +67,10 @@ func (s *Service) DiscoverRemoteSessionIssuer(ctx context.Context, payload *gen.
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	// No project:read/write check: this handler never reads or writes any
+	// project-owned data, it only fetches and reflects back the caller-supplied
+	// issuer's own public RFC 8414 discovery document (nothing persisted, see
+	// the doc comment above). There is no project resource here to gate.
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	issuerURL := strings.TrimSpace(payload.Issuer)

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -67,10 +67,6 @@ func (s *Service) DiscoverRemoteSessionIssuer(ctx context.Context, payload *gen.
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
-		return nil, err
-	}
-
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
 	issuerURL := strings.TrimSpace(payload.Issuer)

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -67,7 +67,7 @@ func (s *Service) DiscoverRemoteSessionIssuer(ctx context.Context, payload *gen.
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectWrite, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
+	if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -747,29 +747,6 @@ func TestDiscoverRemoteSessionIssuer_WithWarnings(t *testing.T) {
 	require.Nil(t, draft.TokenEndpoint)
 }
 
-func TestDiscoverRemoteSessionIssuer_RBACForbidden(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestService(t)
-
-	authCtx, ok := contextvalues.GetAuthContext(ctx)
-	require.True(t, ok)
-
-	ctx = withExactAccessGrants(t, ctx, ti.conn, authz.Grant{
-		Scope:    authz.ScopeProjectRead,
-		Selector: authz.NewSelector(authz.ScopeProjectRead, authCtx.ProjectID.String()),
-	})
-
-	_, err := ti.service.DiscoverRemoteSessionIssuer(ctx, &gen.DiscoverRemoteSessionIssuerPayload{
-		Issuer:           "https://idp.example.com",
-		SessionToken:     nil,
-		ApikeyToken:      nil,
-		ProjectSlugInput: nil,
-	})
-	require.Error(t, err)
-	requireOopsCode(t, err, oops.CodeForbidden)
-}
-
 func TestDiscoverRemoteSessionIssuer_BadURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `DiscoverRemoteSessionIssuer` fetches upstream RFC 8414 metadata and returns a draft — it never persists anything — but was gated on `project:write`, the same scope as Create/Update/Delete. That blocked read-only roles from ever using the Discover button when adding a new IDP.
- Swapped the scope check to `project:read`. Create/Update/Delete are unchanged.

Fixes AGE-3026.

## Test plan
- [ ] `go build ./server/internal/remotesessions/...` passes
- [ ] Manually verify a project-read-only role can click Discover in the Add IDP sheet without a permission-denied error
- [ ] Verify Create/Update/Delete still require project:write (unchanged)