### PR TITLE
feat(dashboard): exclude local tools by default on tool insights and logs

### DIFF
--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/observe/ObserveFilterBar";
 import {
   buildServerOptionGroups,
+  isDefaultToolUsageTypeSelection,
   parseTargetFilter,
   selectedHookSources,
   selectedTargetValues,
@@ -775,7 +776,7 @@ function LogsToolsContent({
                     traces={traces}
                     hasActiveFilters={
                       activeFilters.length > 0 ||
-                      selectedTypes.length > 0 ||
+                      !isDefaultToolUsageTypeSelection(selectedTypes) ||
                       selectedStatuses.length > 0 ||
                       selectedRoleIds.length > 0 ||
                       attributeFilters.length > 0 ||

--- a/client/dashboard/src/components/observe/ObserveFilterBar.tsx
+++ b/client/dashboard/src/components/observe/ObserveFilterBar.tsx
@@ -1,4 +1,5 @@
 import { type DateRangePreset } from "@/elements";
+import { X } from "lucide-react";
 import { type ReactNode, useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import {
@@ -415,6 +416,21 @@ export function ObserveFilterBar({
     );
   }, [setSearchParams]);
 
+  // The type filter defaults to excluding local tools on the tool-usage pages
+  // (see TOOL_USAGE_DEFAULT_TYPES), and the Type dimension is sheet-only, so
+  // without a cue the exclusion would be invisible. Surface it as a dismissible
+  // badge; the × opts local tools back in. Gated on the page actually offering
+  // a "local_tool" type so the hooks pages (different type vocabulary) are
+  // unaffected.
+  const localToolsExcluded =
+    typeOptions.some((option) => option.value === "local_tool") &&
+    selectedTypes.length > 0 &&
+    !selectedTypes.includes("local_tool");
+  const includeLocalTools = useCallback(
+    () => onTypesChange([...selectedTypes, "local_tool"]),
+    [onTypesChange, selectedTypes],
+  );
+
   // Compose the schema from the base filters plus whichever opt-in dimensions
   // the caller wired handlers for. defineFilters is an identity helper, so the
   // runtime array is all the toolbar needs (values/options are keyed by id).
@@ -440,6 +456,22 @@ export function ObserveFilterBar({
         onClearAll={handleClearAll}
         projectSlug={projectSlug}
         customBuilder={attributeSearchControl}
+        extraChips={
+          localToolsExcluded && (
+            <span className="border-border text-muted-foreground inline-flex h-10 shrink-0 items-center gap-2 rounded-md border border-dashed px-3 text-sm font-medium">
+              Local tools excluded
+              <button
+                type="button"
+                onClick={includeLocalTools}
+                aria-label="Include local tools"
+                title="Include local tools"
+                className="hover:text-foreground transition-colors"
+              >
+                <X className="size-4" />
+              </button>
+            </span>
+          )
+        }
       />
       {onRefresh && (
         <Page.Toolbar.Refresh

--- a/client/dashboard/src/components/observe/observeTargetFilters.ts
+++ b/client/dashboard/src/components/observe/observeTargetFilters.ts
@@ -18,7 +18,15 @@ const HOOK_SOURCE_FILTER_PATH = "gram.hook.source";
 const HOSTED_SERVER_PREFIX = "hosted:";
 const SHADOW_SERVER_PREFIX = "shadow:";
 
-export const TOOL_USAGE_DEFAULT_TYPES: ObserveTypeFilterValue[] = [];
+// Local tools are excluded by default: they dominate event volume and drown
+// out the MCP server and skill usage these pages are meant to surface. Users
+// can opt back in via the type filter.
+export const TOOL_USAGE_DEFAULT_TYPES: ObserveTypeFilterValue[] = [
+  "hosted_mcp_server",
+  "tunneled_mcp_server",
+  "shadow_mcp_server",
+  "skill",
+];
 export const TOOL_USAGE_VALID_TYPES: ObserveTypeFilterValue[] = [
   "hosted_mcp_server",
   "tunneled_mcp_server",
@@ -104,6 +112,15 @@ export function selectedHookSources(activeFilters: FilterChip[]): string[] {
     .filter((f) => f.path === HOOK_SOURCE_FILTER_PATH)
     .flatMap((f) => f.filters)
     .filter(Boolean);
+}
+
+export function isDefaultToolUsageTypeSelection(
+  selectedTypes: ObserveTypeFilterValue[],
+): boolean {
+  return (
+    selectedTypes.length === TOOL_USAGE_DEFAULT_TYPES.length &&
+    TOOL_USAGE_DEFAULT_TYPES.every((type) => selectedTypes.includes(type))
+  );
 }
 
 export function toTargetTypes(

--- a/client/dashboard/src/components/ui/toolbar.tsx
+++ b/client/dashboard/src/components/ui/toolbar.tsx
@@ -261,6 +261,11 @@ interface ToolbarFiltersProps {
   onRemoveCustomFilter?: (id: string) => void;
   /** Page-supplied arbitrary-attribute builder, rendered inside the sheet. */
   customBuilder?: ReactNode;
+  /**
+   * Page-supplied chips rendered after the filter chips, before the "More
+   * filters" trigger — for informational badges that belong in the chip row.
+   */
+  extraChips?: ReactNode;
   projectSlug?: string;
 }
 
@@ -275,6 +280,7 @@ function ToolbarFilters({
   onEditCustomFilter,
   onRemoveCustomFilter,
   customBuilder,
+  extraChips,
   projectSlug,
 }: ToolbarFiltersProps): JSX.Element {
   const [sheetOpen, setSheetOpen] = useState(false);
@@ -326,6 +332,8 @@ function ToolbarFilters({
           onRemove={onRemoveCustomFilter ?? (() => {})}
         />
       ))}
+
+      {extraChips}
 
       <Button
         variant="outline"


### PR DESCRIPTION
## What

Local tools are now excluded by default on the MCP & Tools insights page and the tool logs page. A dashed "Local tools excluded" badge appears in the filter chip row (before "More filters") whenever the exclusion is active; its × opts local tools back in, or users can check "Local Tools" in the Type filter sheet.

## Why

Local tool calls dominate event volume and drown out the MCP server and skill usage these pages are meant to surface — filtering them out server-side by default makes the pages both faster to load and more useful at a glance. The badge keeps the exclusion discoverable and one click to undo.

<img width="2816" height="1414" alt="CleanShot 2026-07-21 at 16 53 43@2x" src="https://github.com/user-attachments/assets/8174e3da-ab6b-4737-9c1f-00a9abee3f17" />

## How

- `TOOL_USAGE_DEFAULT_TYPES` now defaults to every target type except `local_tool`, so with no `hookTypes` URL param both pages send `targetTypes` that omit local tools. Selecting all five types (or a local-tools-only view via chart clicks) still works and round-trips through the URL as before.
- Added an `extraChips` slot to `Page.Toolbar.Filters`, rendered between the filter chips and the "More filters" trigger, and used it for the badge in `ObserveFilterBar`. The badge is gated on the page offering a `local_tool` type option, so the hooks pages (different type vocabulary) are unaffected.
- `LogsTools` empty-state logic now compares the type selection against the default (`isDefaultToolUsageTypeSelection`) instead of `length > 0`, so a workspace with no data still gets the onboarding empty state rather than "adjust your filters".

Notes for reviewers: "Clear all" / "Reset to default" resets to the new default (local tools excluded), and existing bookmarked URLs without a `hookTypes` param now exclude local tools too — both intended.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude local tools by default on Tool Insights and Tool Logs to cut noise and speed up page load. A dashed “Local tools excluded” badge makes the default visible and lets users opt back in with one click.

- **New Features**
  - Default type filter omits `local_tool` on tool-usage pages; URLs without type params now exclude local tools by default. Selecting all types or local-only still works.
  - Added a dismissible “Local tools excluded” badge in the chip row (via `extraChips` in `Page.Toolbar.Filters`); only shows when `local_tool` is a valid type.
  - Tool Logs empty-state now keys off the default selection (`isDefaultToolUsageTypeSelection`) so new workspaces see onboarding instead of “adjust your filters.”

- **Migration**
  - “Clear all” / “Reset to default” restores the new default (local tools excluded).
  - Existing bookmarked URLs without a type param now exclude local tools.

<sup>Written for commit 876bc2d1492faf6c6a041154e7aa88b3503151eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

