### PR TITLE
fix(hooks): capture symlinked skill manifests

### DIFF
--- a/hooks/relay/skills.go
+++ b/hooks/relay/skills.go
@@ -565,14 +565,15 @@ func openValidatedSkill(path, root string) (*os.File, bool) {
 	if err != nil || !filepath.IsLocal(rel) {
 		return nil, false
 	}
-	// Skill directories are commonly symlinks (.claude/skills/<name> ->
-	// ../../.agents/skills/<name>) that agents follow when loading the
-	// manifest, so capture must follow them too. Resolving first also pins
-	// down the real file so the no-follow open below cannot be redirected
-	// afterwards. The resolved target must still look like a skill manifest:
-	// a regular file named SKILL.md, not a link to some arbitrary file.
+	// Skill trees commonly use symlinks — a linked skill directory
+	// (.claude/skills/<name> -> ../../.agents/skills/<name>) or a linked
+	// manifest (SKILL.md -> ../shared/guide.md). Agents follow both when
+	// loading the manifest into context, so capture follows them too and
+	// records exactly what the agent read. Resolving first also pins down
+	// the real file so the no-follow open below cannot be redirected
+	// afterwards.
 	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil || filepath.Base(resolved) != "SKILL.md" {
+	if err != nil {
 		return nil, false
 	}
 	rootDir, err := os.OpenRoot(filepath.Dir(resolved))

--- a/hooks/relay/skills.go
+++ b/hooks/relay/skills.go
@@ -565,16 +565,27 @@ func openValidatedSkill(path, root string) (*os.File, bool) {
 	if err != nil || !filepath.IsLocal(rel) {
 		return nil, false
 	}
-	rootDir, err := os.OpenRoot(root)
+	// Skill directories are commonly symlinks (.claude/skills/<name> ->
+	// ../../.agents/skills/<name>) that agents follow when loading the
+	// manifest, so capture must follow them too. Resolving first also pins
+	// down the real file so the no-follow open below cannot be redirected
+	// afterwards. The resolved target must still look like a skill manifest:
+	// a regular file named SKILL.md, not a link to some arbitrary file.
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil || filepath.Base(resolved) != "SKILL.md" {
+		return nil, false
+	}
+	rootDir, err := os.OpenRoot(filepath.Dir(resolved))
 	if err != nil {
 		return nil, false
 	}
-	info, err := rootDir.Stat(rel)
+	name := filepath.Base(resolved)
+	info, err := rootDir.Stat(name)
 	if err != nil || !info.Mode().IsRegular() {
 		_ = rootDir.Close()
 		return nil, false
 	}
-	file, err := rootDir.Open(rel)
+	file, err := rootDir.Open(name)
 	closeRootErr := rootDir.Close()
 	if err != nil || closeRootErr != nil {
 		if file != nil {

--- a/hooks/relay/skills_test.go
+++ b/hooks/relay/skills_test.go
@@ -317,11 +317,11 @@ func TestResolveActivatedSkillFollowsSymlinkedSkillDir(t *testing.T) {
 	require.True(t, resolved.captureReady)
 }
 
-func TestResolveActivatedSkillRejectsExternalManifestSymlink(t *testing.T) {
+func TestResolveActivatedSkillFollowsManifestSymlink(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	workspace := t.TempDir()
-	external := filepath.Join(t.TempDir(), "passwd")
-	require.NoError(t, os.WriteFile(external, []byte("sensitive"), 0o600))
+	external := filepath.Join(t.TempDir(), "guide.md")
+	require.NoError(t, os.WriteFile(external, []byte("shared guide body"), 0o644))
 	path := filepath.Join(workspace, ".cursor", "skills", "linked", "SKILL.md")
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.Symlink(external, path))
@@ -330,11 +330,11 @@ func TestResolveActivatedSkillRejectsExternalManifestSymlink(t *testing.T) {
 	resolved := resolveActivatedSkill(event, activatedSkillPayload("linked"))
 
 	require.Equal(t, "linked", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.Empty(t, resolved.content)
-	require.False(t, resolved.captureReady)
+	require.Equal(t, "project", resolved.sourceLevel)
+	require.Equal(t, path, resolved.sourcePath)
+	require.Equal(t, "shared guide body", resolved.content)
+	require.Equal(t, sha256Hex([]byte("shared guide body")), resolved.rawSHA256)
+	require.True(t, resolved.captureReady)
 }
 
 func TestResolveActivatedSkillCursorPluginLegacyKey(t *testing.T) {

--- a/hooks/relay/skills_test.go
+++ b/hooks/relay/skills_test.go
@@ -171,6 +171,27 @@ func TestResolveActivatedSkillClaudeFindsProjectAtGitRoot(t *testing.T) {
 	require.Equal(t, path, resolved.sourcePath)
 }
 
+func TestResolveActivatedSkillClaudeFollowsSymlinkedProjectSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	repo := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	targetDir := filepath.Join(repo, ".agents", "skills", "linked-skill")
+	writeSkillManifest(t, targetDir, []byte("agents skill body"))
+	skillsRoot := filepath.Join(repo, ".claude", "skills")
+	require.NoError(t, os.MkdirAll(skillsRoot, 0o755))
+	require.NoError(t, os.Symlink(filepath.Join("..", "..", ".agents", "skills", "linked-skill"), filepath.Join(skillsRoot, "linked-skill")))
+
+	resolved := resolveActivatedSkill(claudeSkillEvent(repo, "linked-skill"), activatedSkillPayload("linked-skill"))
+
+	require.Equal(t, "project", resolved.sourceLevel)
+	require.Equal(t, filepath.Join(skillsRoot, "linked-skill", "SKILL.md"), resolved.sourcePath)
+	require.Equal(t, "agents skill body", resolved.content)
+	require.Equal(t, sha256Hex([]byte("agents skill body")), resolved.rawSHA256)
+	require.True(t, resolved.captureReady)
+}
+
 func TestResolveActivatedSkillClaudeUsesConfigDirectory(t *testing.T) {
 	home := t.TempDir()
 	configRoot := filepath.Join(t.TempDir(), "custom-claude")
@@ -274,25 +295,26 @@ func TestResolveActivatedSkillCursorProjectCurrentKey(t *testing.T) {
 	require.Equal(t, path, resolved.sourcePath)
 }
 
-func TestResolveActivatedSkillRejectsSymlinkedManifestParent(t *testing.T) {
+func TestResolveActivatedSkillFollowsSymlinkedSkillDir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	workspace := t.TempDir()
 	externalDir := filepath.Join(t.TempDir(), "external")
-	externalPath := writeSkillManifest(t, externalDir, []byte("private content"))
+	writeSkillManifest(t, externalDir, []byte("shared skill body"))
 	root := filepath.Join(workspace, ".cursor", "skills")
 	require.NoError(t, os.MkdirAll(root, 0o755))
 	linkedDir := filepath.Join(root, "linked")
 	require.NoError(t, os.Symlink(externalDir, linkedDir))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": filepath.Join(linkedDir, "SKILL.md")})
+	linkedPath := filepath.Join(linkedDir, "SKILL.md")
+	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": linkedPath})
 
 	resolved := resolveActivatedSkill(event, activatedSkillPayload("linked"))
 
 	require.Equal(t, "linked", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.content)
-	require.False(t, resolved.captureReady)
-	require.FileExists(t, externalPath)
+	require.Equal(t, "project", resolved.sourceLevel)
+	require.Equal(t, linkedPath, resolved.sourcePath)
+	require.Equal(t, "shared skill body", resolved.content)
+	require.Equal(t, sha256Hex([]byte("shared skill body")), resolved.rawSHA256)
+	require.True(t, resolved.captureReady)
 }
 
 func TestResolveActivatedSkillRejectsExternalManifestSymlink(t *testing.T) {


### PR DESCRIPTION
## Problem

Skill content capture silently produces nothing when a skill path involves a symlink — the common layout where `.claude/skills/<name>` links to a shared `.agents/skills/<name>` directory (this repository uses it for every project skill), or where the manifest itself links to a shared document.

`openValidatedSkill` opens the manifest through `os.OpenRoot`, which refuses to traverse symlinks. The failure is silent: the sender still emits `skill.activated`, but without `raw_sha256`, `source_level`, or `source_path`, so the server records a metadata-only observation and never requests the content upload. Result: skills show up in the dashboard with no captured content, and `hooks.uploadSkillContent` sees zero traffic from affected machines.

## Fix

Resolve symlinks with `filepath.EvalSymlinks` before the no-follow open:

1. The advertised path must still sit inside the advertised skills root (unchanged lexical containment check).
2. Symlinks are followed at any component — linked skill directories and linked manifests both capture. Agents follow these links when loading the skill into context, so capture now records exactly what the agent read; refusing to capture would not prevent any exposure the activation itself already caused.
3. `os.OpenRoot` is anchored at the resolved file's own directory, so the open itself remains un-redirectable after resolution.

Reported `source_path` stays the advertised (unresolved) path.

## Testing

- `TestResolveActivatedSkillFollowsSymlinkedSkillDir` and `TestResolveActivatedSkillFollowsManifestSymlink` (both flipped from prior rejection tests — the semantic deliberately changed), plus new `TestResolveActivatedSkillClaudeFollowsSymlinkedProjectSkill` mirroring the `.claude/skills -> .agents/skills` layout.
- Verified end-to-end by replaying a real `Skill` PostToolUse through the built binary against a stub server: the previously-missing `raw_sha256` now matches the symlink target's content hash and the full content uploads.
