### PR TITLE
feat: serve the sessions list from chat_session_summaries on wide windows

### DIFF
--- a/.changeset/chat-session-summaries-read-path.md
+++ b/.changeset/chat-session-summaries-read-path.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Serve the org-scoped sessions list from the chat_session_summaries materialized view on windows of 48 hours or more, keeping narrow windows on the raw telemetry_logs scan. Filters, sorting, and cursor pagination translate onto the pre-aggregated table, and a sync test pins the shared session predicates across the Go constants and the MV definition.

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2574,8 +2574,8 @@ async function seedPersonalAccounts(init: {
   // materialize into the like-named columns, so usage dashboards can split team
   // vs personal. user.id is the owning employee (matching the identity
   // enrichment), so personal usage rolls up under the employee. Idempotent via
-  // the targeted DELETE on the usage URNs (which observability seeding, running
-  // first, doesn't use).
+  // the targeted DELETE on the usage URNs scoped to this phase's deterministic
+  // session ids (observability seeding emits rows with the same URNs).
   const USAGE_URN: Record<string, string> = {
     anthropic: "claude-code:usage:metrics",
     openai: "codex:usage:metrics",
@@ -2588,6 +2588,7 @@ async function seedPersonalAccounts(init: {
   };
   const EVENTS_PER_ACCOUNT = 8;
   const chRows: string[] = [];
+  const usageSessionIds: string[] = [];
   accounts.forEach((acct, acctIdx) => {
     const models =
       MODELS[acct.provider as Personal["provider"]] ?? MODELS.anthropic;
@@ -2600,6 +2601,7 @@ async function seedPersonalAccounts(init: {
       const timeNano = BigInt(eventTime.getTime()) * BigInt(1000000);
       const traceId = crypto.randomBytes(16).toString("hex");
       const sessionId = seedUUID(`sess:${acct.id}:${k}`);
+      usageSessionIds.push(sessionId);
       const inputTokens = 1200 + ((acctIdx * 7 + k * 53) % 5000);
       const outputTokens = 300 + ((acctIdx * 11 + k * 29) % 1800);
       const totalTokens = inputTokens + outputTokens;
@@ -2670,19 +2672,34 @@ async function seedPersonalAccounts(init: {
     }
   });
 
-  // Idempotency: clear every provider's usage URN (derived from USAGE_URN so new
-  // providers like cursor are covered automatically) and the prior tool-call
-  // traces (by their deterministic chat ids) before re-inserting.
+  // Idempotency: clear this phase's prior rows (usage rows + tool-call traces,
+  // both keyed by their deterministic chat ids) before re-inserting. The usage
+  // delete must ALSO match the chat id, not just the URN: observability
+  // seeding emits codex/cursor \${surface}:usage:metrics rows too (its
+  // agent-session history), and an unscoped URN delete silently clobbered
+  // those after their aggregates were already backfilled, leaving the summary
+  // tables inconsistent with the raw rows.
   const usageUrnList = Object.values(USAGE_URN)
     .map((urn) => `'${urn}'`)
     .join(", ");
+  const usageSessionIdList = usageSessionIds.map((id) => `'${id}'`).join(", ");
   const toolSessionIdList = toolSessionIds.map((id) => `'${id}'`).join(", ");
+  // This phase runs after seedObservabilityData's chat_session_summaries
+  // backfill, and its rows sit before the chat_session_summaries_mv cutoff —
+  // so the summary rows for exactly this phase's chats are rebuilt here
+  // (delete + scoped backfill; an unscoped re-backfill would double the
+  // already-aggregated chats).
+  const personalChatIdList = [...usageSessionIds, ...toolSessionIds]
+    .map((id) => `'${id}'`)
+    .join(", ");
   const chSQL = `
     SET mutations_sync = 1;
-    ALTER TABLE telemetry_logs DELETE WHERE gram_project_id = '${projectId}' AND gram_urn IN (${usageUrnList});
+    ALTER TABLE telemetry_logs DELETE WHERE gram_project_id = '${projectId}' AND gram_urn IN (${usageUrnList}) AND gram_chat_id IN (${usageSessionIdList});
     ALTER TABLE telemetry_logs DELETE WHERE gram_project_id = '${projectId}' AND gram_chat_id IN (${toolSessionIdList});
     INSERT INTO telemetry_logs (time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id, attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id) VALUES
     ${chRows.concat(toolRows).join(",\n")};
+    ALTER TABLE chat_session_summaries DELETE WHERE gram_project_id = '${projectId}' AND chat_id IN (${personalChatIdList});
+    ${chatSessionBackfillSQL(projectId, "telemetry_logs", `time_unix_nano < chat_session_cutoff_unix_nano AND chat_id IN (${personalChatIdList})`)}
   `;
 
   try {
@@ -4325,10 +4342,12 @@ async function seedObservabilityData(init: {
     ALTER TABLE metrics_summaries DELETE WHERE gram_project_id = '${projectId}';
     ALTER TABLE attribute_metrics_summaries DELETE WHERE gram_project_id = '${projectId}';
     ALTER TABLE chat_token_summaries DELETE WHERE gram_project_id = '${projectId}';
+    ALTER TABLE chat_session_summaries DELETE WHERE gram_project_id = '${projectId}';
     ALTER TABLE attribute_keys DELETE WHERE gram_project_id = '${projectId}';
     INSERT INTO telemetry_logs (time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id, attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id) VALUES
     ${chInserts.join(",\n")};
     ${attributeMetricsBackfillSQL(projectId, "telemetry_logs", `time_unix_nano >= ${rawTtlBoundaryNano} AND time_unix_nano < attribute_metrics_cutoff_unix_nano`)}
+    ${chatSessionBackfillSQL(projectId, "telemetry_logs", `time_unix_nano < chat_session_cutoff_unix_nano`)}
     ${scratchBackfillSQL}
   `;
 
@@ -4451,6 +4470,102 @@ function attributeMetricsBackfillSQL(
         mcp_server_name,
         mcp_tool_name,
         hook_hostname;
+  `;
+}
+
+// Backfills chat_session_summaries for telemetry rows older than the MV's
+// live-ingestion cutoff (chat_session_summaries_mv skips rows before
+// 2026-07-21 22:00 UTC). Unlike attributeMetricsBackfillSQL this mirrors the CURRENT MV
+// rules exactly — production's out-of-band backfill for this table uses the
+// same provenance-first predicates, so seeded history stays an honest replica.
+// No scratch-clone (pre-TTL) variant: chat_session_summaries carries the same
+// 90-day TTL as raw telemetry_logs, so older rows would be dropped at insert.
+// `sourceTable` must be telemetry_logs or a clone of it (relies on its
+// materialized columns); `timePredicate` may reference
+// chat_session_cutoff_unix_nano from the WITH clause.
+function chatSessionBackfillSQL(
+  projectId: string,
+  sourceTable: string,
+  timePredicate: string,
+): string {
+  return `
+    INSERT INTO chat_session_summaries (gram_project_id, time_bucket, chat_id, session_user_email, session_hook_source, session_model, start_time_unix_nano, end_time_unix_nano, message_count, tool_call_count, failed_tool_call_count, total_input_tokens, total_output_tokens, total_tokens, cache_read_input_tokens, cache_creation_input_tokens, total_cost, department_names, job_titles, employee_types, division_names, cost_center_names, emails, hostnames, models, hook_sources, account_types, providers, billing_modes, roles, groups, attribution_tuples)
+    WITH
+        toUnixTimestamp64Nano(toDateTime64('2026-07-21 22:00:00', 9, 'UTC')) AS chat_session_cutoff_unix_nano,
+        (gram_urn = 'claude-code:otel:logs') AS is_claude_otel_row,
+        (
+            is_claude_otel_row
+            AND chat_id != ''
+            AND toString(attributes.prompt.id) != ''
+            AND (toString(attributes.event.name) = 'api_request' OR body = 'claude_code.api_request')
+        ) AS is_claude_api_request,
+        (
+            is_claude_otel_row
+            AND (toString(attributes.event.name) = 'tool_result' OR body = 'claude_code.tool_result')
+        ) AS is_claude_tool_result,
+        (startsWith(gram_urn, 'codex:usage') OR startsWith(gram_urn, 'cursor:usage') OR startsWith(gram_urn, 'claude_chat:usage') OR startsWith(gram_urn, 'claude_chat:cost')) AS is_agent_usage_row,
+        (
+            hook_source IN ('codex', 'cursor')
+            AND toString(attributes.gram.tool.name) != ''
+            AND toString(attributes.gram.tool.name) NOT IN ('claude-code', 'codex', 'cursor')
+            AND toString(attributes.gram.hook.event) IN ('PostToolUse', 'PostToolUseFailure')
+        ) AS is_agent_tool_call,
+        (is_claude_tool_result OR is_agent_tool_call) AS is_counted_tool_call,
+        (is_claude_api_request OR is_agent_usage_row) AS is_usage_row,
+        (
+            (is_claude_tool_result AND toString(attributes.success) = 'false')
+            OR (is_agent_tool_call AND (toString(attributes.gram.hook.event) = 'PostToolUseFailure' OR toInt32OrZero(toString(attributes.http.response.status_code)) >= 400))
+        ) AS is_failed_tool_call,
+        multiIf(
+            toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id),
+            toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id),
+            toString(id)
+        ) AS tool_call_dedup_id,
+        if(is_claude_api_request, toString(attributes.prompt.id), toString(attributes.gen_ai.response.id)) AS session_message_id,
+        multiIf(
+            is_claude_api_request AND toString(attributes.model) != '', toString(attributes.model),
+            is_claude_api_request AND toString(attributes.gen_ai.request.model) != '', toString(attributes.gen_ai.request.model),
+            toString(attributes.gen_ai.response.model)
+        ) AS effective_model
+    SELECT
+        gram_project_id,
+        toStartOfHour(fromUnixTimestamp64Nano(time_unix_nano, 'UTC')) AS time_bucket,
+        chat_id,
+        max(user_email) AS session_user_email,
+        max(hook_source) AS session_hook_source,
+        argMaxIfState(effective_model, time_unix_nano, effective_model != '') AS session_model,
+        min(time_unix_nano) AS start_time_unix_nano,
+        max(time_unix_nano) AS end_time_unix_nano,
+        uniqExactIfState(session_message_id, session_message_id != '') AS message_count,
+        uniqExactIfState(tool_call_dedup_id, is_counted_tool_call) AS tool_call_count,
+        countIf(is_failed_tool_call) AS failed_tool_call_count,
+        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.input_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))), is_usage_row) AS total_input_tokens,
+        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.output_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))), is_usage_row) AS total_output_tokens,
+        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.input_tokens)) + toInt64OrZero(toString(attributes.output_tokens)) + toInt64OrZero(toString(attributes.cache_creation_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens))), is_usage_row) AS total_tokens,
+        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.cache_read_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens))), is_usage_row) AS cache_read_input_tokens,
+        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.cache_creation_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens))), is_usage_row) AS cache_creation_input_tokens,
+        sumIf(if(is_claude_api_request, multiIf(toString(attributes.cost_usd) != '', toFloat64OrZero(toString(attributes.cost_usd)), toString(attributes.cost_usd_micros) != '', toFloat64OrZero(toString(attributes.cost_usd_micros)) / 1000000, 0), toFloat64OrZero(toString(attributes.gen_ai.usage.cost))), is_usage_row) AS total_cost,
+        groupUniqArray(toString(attributes.user.attributes.department_name)) AS department_names,
+        groupUniqArray(toString(attributes.user.attributes.job_title)) AS job_titles,
+        groupUniqArray(toString(attributes.user.attributes.employee_type)) AS employee_types,
+        groupUniqArray(toString(attributes.user.attributes.division_name)) AS division_names,
+        groupUniqArray(toString(attributes.user.attributes.cost_center_name)) AS cost_center_names,
+        groupUniqArray(if(user_email != '', user_email, toString(attributes.gram.hook.hostname))) AS emails,
+        groupUniqArray(toString(attributes.gram.hook.hostname)) AS hostnames,
+        groupUniqArray(effective_model) AS models,
+        groupUniqArray(hook_source) AS hook_sources,
+        groupUniqArray(account_type) AS account_types,
+        groupUniqArray(provider) AS providers,
+        groupUniqArray(billing_mode) AS billing_modes,
+        groupUniqArrayArray(arraySort(JSONExtract(ifNull(toJSONString(attributes.user.roles), '[]'), 'Array(String)'))) AS roles,
+        groupUniqArrayArray(arraySort(JSONExtract(ifNull(toJSONString(attributes.user.groups), '[]'), 'Array(String)'))) AS groups,
+        groupUniqArrayIf(tuple(toString(attributes.query_source), toString(attributes.skill.name), toString(attributes.agent.name), toString(attributes.mcp_server.name), toString(attributes.mcp_tool.name)), is_claude_api_request) AS attribution_tuples
+    FROM ${sourceTable}
+    WHERE gram_project_id = '${projectId}'
+      AND (${timePredicate})
+      AND chat_id != ''
+      AND (is_claude_api_request OR is_claude_tool_result OR is_agent_usage_row OR is_agent_tool_call)
+    GROUP BY gram_project_id, time_bucket, chat_id;
   `;
 }
 

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2685,9 +2685,12 @@ async function seedPersonalAccounts(init: {
   const usageSessionIdList = usageSessionIds.map((id) => `'${id}'`).join(", ");
   const toolSessionIdList = toolSessionIds.map((id) => `'${id}'`).join(", ");
   // This phase runs after seedObservabilityData's chat_session_summaries
-  // backfill, and its rows sit before the chat_session_summaries_mv cutoff —
-  // so the summary rows for exactly this phase's chats are rebuilt here
-  // (delete + scoped backfill; an unscoped re-backfill would double the
+  // backfill, so the summary rows for exactly this phase's chats are rebuilt
+  // here. The summary DELETE must run BEFORE the telemetry INSERT: rows with
+  // event times past the MV cutoff are summarized by the MV at insert time,
+  // and a delete placed after the insert would wipe those fresh rows with
+  // nothing to restore them — the scoped backfill below covers only
+  // pre-cutoff rows (an unscoped re-backfill would double the
   // already-aggregated chats).
   const personalChatIdList = [...usageSessionIds, ...toolSessionIds]
     .map((id) => `'${id}'`)
@@ -2696,9 +2699,9 @@ async function seedPersonalAccounts(init: {
     SET mutations_sync = 1;
     ALTER TABLE telemetry_logs DELETE WHERE gram_project_id = '${projectId}' AND gram_urn IN (${usageUrnList}) AND gram_chat_id IN (${usageSessionIdList});
     ALTER TABLE telemetry_logs DELETE WHERE gram_project_id = '${projectId}' AND gram_chat_id IN (${toolSessionIdList});
+    ALTER TABLE chat_session_summaries DELETE WHERE gram_project_id = '${projectId}' AND chat_id IN (${personalChatIdList});
     INSERT INTO telemetry_logs (time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id, attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id) VALUES
     ${chRows.concat(toolRows).join(",\n")};
-    ALTER TABLE chat_session_summaries DELETE WHERE gram_project_id = '${projectId}' AND chat_id IN (${personalChatIdList});
     ${chatSessionBackfillSQL(projectId, "telemetry_logs", `time_unix_nano < chat_session_cutoff_unix_nano AND chat_id IN (${personalChatIdList})`)}
   `;
 

--- a/server/internal/telemetry/list_sessions_summary_test.go
+++ b/server/internal/telemetry/list_sessions_summary_test.go
@@ -326,6 +326,151 @@ func TestListSessions_SummaryPathFilters(t *testing.T) {
 	require.Equal(t, int64(2), coLocated.Sessions[0].MessageCount)
 }
 
+// TestListSessions_SummaryPathDropsPhantomBoundarySessions covers the
+// exact-window overlap guard: the summary path's hour buckets admit whole
+// boundary hours, but a session whose activity falls entirely outside the
+// requested window must not appear even when its bucket does.
+func TestListSessions_SummaryPathDropsPhantomBoundarySessions(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	// Anchor the window end mid-hour so the trailing bucket is admitted by
+	// the bucket bound: the in-window chat sits before `to`, the phantom chat
+	// after it, both inside the same trailing hour bucket.
+	now := time.Now().UTC()
+	hourStart := now.Add(-2 * time.Hour).Truncate(time.Hour)
+	windowEnd := hourStart.Add(10 * time.Minute)
+	windowStart := windowEnd.Add(-(repo.SessionSummaryMinWindow + 24*time.Hour))
+
+	inWindowChatID := uuid.NewString()
+	phantomChatID := uuid.NewString()
+
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    hourStart.Add(5 * time.Minute),
+		chatID:       inWindowChatID,
+		email:        "in@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         1.0,
+	})
+	// Same trailing hour bucket, but strictly after the window end.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    hourStart.Add(30 * time.Minute),
+		chatID:       phantomChatID,
+		email:        "phantom@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         2.0,
+	})
+
+	res := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:   windowStart.Format(time.RFC3339),
+		To:     windowEnd.Format(time.RFC3339),
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == inWindowChatID
+	})
+	require.Len(t, res.Sessions, 1)
+	require.Equal(t, inWindowChatID, res.Sessions[0].GramChatID)
+}
+
+// TestListSessions_ArrayUnsetFilterAlignedAcrossPaths pins the role/group
+// "(unset)" semantics both paths now share: a chat matches "" only when NO
+// row carries a value — a chat mixing enriched and unenriched rows does not.
+func TestListSessions_ArrayUnsetFilterAlignedAcrossPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	mixedChatID := uuid.NewString()
+	rolelessChatID := uuid.NewString()
+
+	// A chat with an enriched row (roles present) plus an unenriched row.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-10 * time.Minute),
+		chatID:       mixedChatID,
+		email:        "mixed@example.com",
+		roles:        []string{"dev"},
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         1.0,
+	})
+	insertListSessionClaudeToolResultLog(t, ctx, listSessionLogParams{
+		projectID:  projectID,
+		timestamp:  now.Add(-9 * time.Minute),
+		chatID:     mixedChatID,
+		email:      "mixed@example.com",
+		statusCode: 200,
+	})
+	// A chat with no role value on any row.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-8 * time.Minute),
+		chatID:       rolelessChatID,
+		email:        "roleless@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         2.0,
+	})
+
+	unsetFilter := []*gen.QueryFilter{{Dimension: "role", Values: []string{""}}}
+	wideFrom, wideTo := summaryWindow(now)
+
+	rawRes := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:    now.Add(-1 * time.Hour).Format(time.RFC3339),
+		To:      now.Add(1 * time.Hour).Format(time.RFC3339),
+		Filters: unsetFilter,
+		SortBy:  "total_cost",
+		Limit:   10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == rolelessChatID
+	})
+	require.Len(t, rawRes.Sessions, 1)
+
+	summaryRes := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:    wideFrom,
+		To:      wideTo,
+		Filters: unsetFilter,
+		SortBy:  "total_cost",
+		Limit:   10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == rolelessChatID
+	})
+	require.Len(t, summaryRes.Sessions, 1)
+}
+
 // TestListSessions_SummaryPathCursorPagination mirrors the raw-path
 // pagination test over the summary route.
 func TestListSessions_SummaryPathCursorPagination(t *testing.T) {

--- a/server/internal/telemetry/list_sessions_summary_test.go
+++ b/server/internal/telemetry/list_sessions_summary_test.go
@@ -1,0 +1,396 @@
+package telemetry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	gen "github.com/speakeasy-api/gram/server/gen/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/stretchr/testify/require"
+)
+
+// Windows at least 48h wide route ListSessions onto chat_session_summaries
+// (sessionSummaryMinWindow); the ±1h windows used by list_sessions_test.go
+// stay on the raw telemetry_logs path. These tests insert rows at recent
+// timestamps (inside the MV's live-ingestion range) and query them through
+// wide windows so the summary path serves them.
+//
+// summaryFrom/summaryTo build such a window around now.
+func summaryWindow(now time.Time) (string, string) {
+	return now.Add(-72 * time.Hour).Format(time.RFC3339), now.Add(1 * time.Hour).Format(time.RFC3339)
+}
+
+// TestListSessions_SummaryPathMatchesRawPath asserts the two ListSessions
+// paths return identical sessions for the same data: the raw path via a
+// narrow window, the summary path via a wide one. Both windows fully contain
+// every inserted row, so any difference is a divergence between the raw
+// aggregation and the MV.
+func TestListSessions_SummaryPathMatchesRawPath(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	claudeChatID := uuid.NewString()
+	agentChatID := uuid.NewString()
+	failedChatID := uuid.NewString()
+
+	// A Claude session: two turns (different models) plus a successful tool
+	// call.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-10 * time.Minute),
+		chatID:       claudeChatID,
+		email:        "olivia@example.com",
+		department:   "Engineering",
+		roles:        []string{"dev"},
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		totalTokens:  150,
+		cost:         1.25,
+	})
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-9 * time.Minute),
+		chatID:       claudeChatID,
+		email:        "olivia@example.com",
+		department:   "Engineering",
+		roles:        []string{"dev"},
+		hookSource:   "claude-code",
+		model:        "sonnet",
+		inputTokens:  200,
+		outputTokens: 100,
+		totalTokens:  300,
+		cost:         0.75,
+	})
+	insertListSessionClaudeToolResultLog(t, ctx, listSessionLogParams{
+		projectID:  projectID,
+		timestamp:  now.Add(-8 * time.Minute),
+		chatID:     claudeChatID,
+		email:      "olivia@example.com",
+		department: "Engineering",
+		roles:      []string{"dev"},
+		statusCode: 200,
+		toolURN:    "mcp__petstore__listPets",
+	})
+	// A Cursor usage session.
+	insertListSessionCompletionLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-6 * time.Minute),
+		chatID:       agentChatID,
+		email:        "sam@example.com",
+		department:   "Sales",
+		roles:        []string{"seller"},
+		hookSource:   "cursor",
+		model:        "opus",
+		inputTokens:  500,
+		outputTokens: 100,
+		totalTokens:  600,
+		cost:         5.0,
+	})
+	// A Claude session whose only tool call failed.
+	insertListSessionClaudeToolResultLog(t, ctx, listSessionLogParams{
+		projectID:  projectID,
+		timestamp:  now.Add(-5 * time.Minute),
+		chatID:     failedChatID,
+		email:      "olivia@example.com",
+		department: "Engineering",
+		roles:      []string{"dev"},
+		statusCode: 500,
+		toolURN:    "mcp__petstore__createPet",
+	})
+
+	narrowFrom := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	narrowTo := now.Add(1 * time.Hour).Format(time.RFC3339)
+	wideFrom, wideTo := summaryWindow(now)
+
+	rawRes := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:   narrowFrom,
+		To:     narrowTo,
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 3
+	})
+
+	summaryRes := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:   wideFrom,
+		To:     wideTo,
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 3
+	})
+
+	require.Equal(t, rawRes.Sessions, summaryRes.Sessions,
+		"summary-backed sessions must be identical to the raw-log derivation")
+
+	// Spot-check the merged measures on the summary result directly.
+	byChat := map[string]*gen.SessionSummary{}
+	for _, s := range summaryRes.Sessions {
+		byChat[s.GramChatID] = s
+	}
+	claude := byChat[claudeChatID]
+	require.NotNil(t, claude)
+	require.Equal(t, int64(2), claude.MessageCount)
+	require.Equal(t, int64(1), claude.ToolCallCount)
+	require.Equal(t, int64(300), claude.TotalInputTokens)
+	require.InDelta(t, 2.0, claude.TotalCost, 1e-9)
+	require.Equal(t, "success", claude.Status)
+	require.NotNil(t, claude.Model)
+	require.Equal(t, "sonnet", *claude.Model, "argMax must pick the latest non-empty model")
+
+	failed := byChat[failedChatID]
+	require.NotNil(t, failed)
+	require.Equal(t, "error", failed.Status)
+}
+
+// TestListSessions_SummaryPathFilters covers the filter translation onto the
+// summary table: scalar HAVING over merged value arrays, the "(unset)"
+// bucket, and the co-located Claude attribution tuple match.
+func TestListSessions_SummaryPathFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	engChatID := uuid.NewString()
+	salesChatID := uuid.NewString()
+	anonChatID := uuid.NewString()
+	skillChatID := uuid.NewString()
+	skillWithAgentChatID := uuid.NewString()
+
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-10 * time.Minute),
+		chatID:       engChatID,
+		email:        "olivia@example.com",
+		department:   "Engineering",
+		roles:        []string{"dev"},
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         1.0,
+	})
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-9 * time.Minute),
+		chatID:       salesChatID,
+		email:        "sam@example.com",
+		department:   "Sales",
+		roles:        []string{"seller"},
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         2.0,
+	})
+	// An identity-less session: no email on any row, so it must land in the
+	// email dimension's "(unset)" bucket.
+	insertListSessionCompletionLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-8 * time.Minute),
+		chatID:       anonChatID,
+		email:        "",
+		department:   "",
+		hookSource:   "cursor",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         3.0,
+	})
+	// Co-located attribution: skillChatID has skill=golang with no agent on
+	// one row (matches the drilled slice), plus a later row with an agent.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-7 * time.Minute),
+		chatID:       skillChatID,
+		email:        "skill@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  100,
+		outputTokens: 50,
+		cost:         1.0,
+		skillName:    "golang",
+	})
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-6 * time.Minute),
+		chatID:       skillChatID,
+		email:        "skill@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  50,
+		outputTokens: 25,
+		cost:         0.5,
+		skillName:    "claude-api",
+		agentName:    "Explore",
+	})
+	// skillWithAgentChatID carries the requested skill only on a row WITH an
+	// agent — it must not match the skill=golang AND agent="" slice.
+	insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+		projectID:    projectID,
+		timestamp:    now.Add(-5 * time.Minute),
+		chatID:       skillWithAgentChatID,
+		email:        "skill@example.com",
+		hookSource:   "claude-code",
+		model:        "opus",
+		inputTokens:  200,
+		outputTokens: 50,
+		cost:         2.0,
+		skillName:    "golang",
+		agentName:    "Explore",
+	})
+
+	wideFrom, wideTo := summaryWindow(now)
+
+	deptFiltered := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From: wideFrom,
+		To:   wideTo,
+		Filters: []*gen.QueryFilter{
+			{Dimension: "department_name", Values: []string{"Engineering"}},
+		},
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == engChatID
+	})
+	require.Len(t, deptFiltered.Sessions, 1)
+
+	unsetEmail := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From: wideFrom,
+		To:   wideTo,
+		Filters: []*gen.QueryFilter{
+			{Dimension: "email", Values: []string{""}},
+		},
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == anonChatID
+	})
+	require.Len(t, unsetEmail.Sessions, 1)
+
+	roleFiltered := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From: wideFrom,
+		To:   wideTo,
+		Filters: []*gen.QueryFilter{
+			{Dimension: "role", Values: []string{"seller"}},
+		},
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == salesChatID
+	})
+	require.Len(t, roleFiltered.Sessions, 1)
+
+	coLocated := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From: wideFrom,
+		To:   wideTo,
+		Filters: []*gen.QueryFilter{
+			{Dimension: "skill_name", Values: []string{"golang"}},
+			{Dimension: "agent_name", Values: []string{""}},
+		},
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 1 && res.Sessions[0].GramChatID == skillChatID
+	})
+	require.Len(t, coLocated.Sessions, 1)
+	require.InDelta(t, 1.5, coLocated.Sessions[0].TotalCost, 1e-9)
+	require.Equal(t, int64(2), coLocated.Sessions[0].MessageCount)
+}
+
+// TestListSessions_SummaryPathCursorPagination mirrors the raw-path
+// pagination test over the summary route.
+func TestListSessions_SummaryPathCursorPagination(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	chatIDs := []string{uuid.NewString(), uuid.NewString(), uuid.NewString()}
+	costs := []float64{3.0, 2.0, 1.0}
+	for i, chatID := range chatIDs {
+		insertListSessionClaudeAPIRequestLog(t, ctx, listSessionLogParams{
+			projectID:    projectID,
+			timestamp:    now.Add(-time.Duration(10-i) * time.Minute),
+			chatID:       chatID,
+			email:        "user@example.com",
+			department:   "Engineering",
+			roles:        []string{"dev"},
+			hookSource:   "claude-code",
+			model:        "opus",
+			inputTokens:  100,
+			outputTokens: 50,
+			totalTokens:  150,
+			cost:         costs[i],
+		})
+	}
+
+	wideFrom, wideTo := summaryWindow(now)
+
+	waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
+		From:   wideFrom,
+		To:     wideTo,
+		SortBy: "total_cost",
+		Limit:  10,
+	}, func(res *gen.ListSessionsResult) bool {
+		return len(res.Sessions) == 3 &&
+			res.Sessions[0].GramChatID == chatIDs[0] &&
+			res.Sessions[1].GramChatID == chatIDs[1] &&
+			res.Sessions[2].GramChatID == chatIDs[2]
+	})
+
+	var cursor *string
+	for i, wantChatID := range chatIDs {
+		page, err := ti.service.ListSessions(ctx, &gen.ListSessionsPayload{
+			From:   wideFrom,
+			To:     wideTo,
+			SortBy: "total_cost",
+			Limit:  1,
+			Cursor: cursor,
+		})
+		require.NoError(t, err)
+		require.Len(t, page.Sessions, 1)
+		require.Equal(t, wantChatID, page.Sessions[0].GramChatID)
+		if i < len(chatIDs)-1 {
+			require.NotNil(t, page.NextCursor)
+		} else {
+			require.Nil(t, page.NextCursor)
+		}
+		cursor = page.NextCursor
+	}
+}

--- a/server/internal/telemetry/list_sessions_summary_test.go
+++ b/server/internal/telemetry/list_sessions_summary_test.go
@@ -9,18 +9,20 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/stretchr/testify/require"
 )
 
-// Windows at least 48h wide route ListSessions onto chat_session_summaries
-// (sessionSummaryMinWindow); the ±1h windows used by list_sessions_test.go
-// stay on the raw telemetry_logs path. These tests insert rows at recent
+// Windows at least repo.SessionSummaryMinWindow wide route ListSessions onto
+// chat_session_summaries; the ±1h windows used by list_sessions_test.go stay
+// on the raw telemetry_logs path. These tests insert rows at recent
 // timestamps (inside the MV's live-ingestion range) and query them through
-// wide windows so the summary path serves them.
-//
-// summaryFrom/summaryTo build such a window around now.
+// wide windows so the summary path serves them. The window width derives from
+// the routing constant so a retuned threshold cannot silently flip these
+// tests back onto the raw path.
 func summaryWindow(now time.Time) (string, string) {
-	return now.Add(-72 * time.Hour).Format(time.RFC3339), now.Add(1 * time.Hour).Format(time.RFC3339)
+	return now.Add(-(repo.SessionSummaryMinWindow + 24*time.Hour)).Format(time.RFC3339),
+		now.Add(1 * time.Hour).Format(time.RFC3339)
 }
 
 // TestListSessions_SummaryPathMatchesRawPath asserts the two ListSessions

--- a/server/internal/telemetry/query.go
+++ b/server/internal/telemetry/query.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
 	telem_gen "github.com/speakeasy-api/gram/server/gen/telemetry"
@@ -442,7 +444,7 @@ func (s *Service) ListSessions(ctx context.Context, payload *telem_gen.ListSessi
 		filters = append(filters, repo.AttributeMetricsFilter{Dimension: f.Dimension, Values: f.Values})
 	}
 
-	items, err := s.chRepo.ListSessions(ctx, repo.ListSessionsParams{
+	params := repo.ListSessionsParams{
 		ProjectIDs:       projectIDs,
 		TimeStart:        timeStart,
 		TimeEnd:          timeEnd,
@@ -451,7 +453,21 @@ func (s *Service) ListSessions(ctx context.Context, payload *telem_gen.ListSessi
 		CursorSortValue:  cursorSortValue,
 		CursorGramChatID: cursorGramChatID,
 		Limit:            limit + 1,
-	})
+	}
+	// Named per routed path so the raw telemetry_logs scan and the
+	// chat_session_summaries read stay separately visible in traces; the repo
+	// forwards this span's context to ClickHouse alongside the query.
+	spanName := "telemetry.listSessions.clickhouse.raw"
+	if params.UsesSummaryPath() {
+		spanName = "telemetry.listSessions.clickhouse.summary"
+	}
+	queryCtx, span := s.tracer.Start(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
+	items, err := s.chRepo.ListSessions(queryCtx, params)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error listing sessions")
 	}

--- a/server/internal/telemetry/repo/db.go
+++ b/server/internal/telemetry/repo/db.go
@@ -3,7 +3,9 @@ package repo
 import (
 	"context"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // CHTX is the interface for executing ClickHouse queries and commands.
@@ -30,4 +32,15 @@ func New(conn CHTX) *Queries {
 	return &Queries{
 		conn: conn,
 	}
+}
+
+// chQueryContext forwards the caller's OTel span context to ClickHouse so the
+// server-side query spans (system.opentelemetry_span_log) join the request
+// trace. clickhouse-go only sends trace context that is explicitly attached
+// via clickhouse.Context/WithSpan — it never reads the span from ctx itself.
+func chQueryContext(ctx context.Context) context.Context {
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		return clickhouse.Context(ctx, clickhouse.WithSpan(sc))
+	}
+	return ctx
 }

--- a/server/internal/telemetry/repo/dimensions.go
+++ b/server/internal/telemetry/repo/dimensions.go
@@ -18,6 +18,7 @@ type attributeDimension struct {
 	kind                   attributeDimensionKind
 	coLocateSessionFilters bool
 	emptyIsNotApplicable   bool
+	summaryTupleField      string
 }
 
 type telemetryDimension struct {
@@ -33,6 +34,16 @@ type telemetryDimension struct {
 	// consumers (the cost explorer's axis pruning) must be able to count it
 	// (DNO-384, DNO-425).
 	emptyIsNotApplicable bool
+	// summaryColumn is the chat_session_summaries column carrying the
+	// dimension's per-chat distinct values (a groupUniqArrayArray-merged
+	// Array(String) for scalar/array dimensions; the key column for
+	// project_id). Empty for the co-located Claude attribution dimensions,
+	// which are matched through summaryTupleField instead.
+	summaryColumn string
+	// summaryTupleField names the dimension's field inside the
+	// chat_session_summaries attribution_tuples named tuple, for the
+	// co-located Claude attribution dimensions.
+	summaryTupleField string
 }
 
 // telemetryDimensionRegistry is the single allowlist for public telemetry
@@ -46,6 +57,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "department_names",
+		summaryTupleField:      "",
 	},
 	"job_title": {
 		aggregateColumn:        "job_title",
@@ -53,6 +66,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "job_titles",
+		summaryTupleField:      "",
 	},
 	"employee_type": {
 		aggregateColumn:        "employee_type",
@@ -60,6 +75,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "employee_types",
+		summaryTupleField:      "",
 	},
 	"division_name": {
 		aggregateColumn:        "division_name",
@@ -67,6 +84,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "division_names",
+		summaryTupleField:      "",
 	},
 	"cost_center_name": {
 		aggregateColumn:        "cost_center_name",
@@ -74,6 +93,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "cost_center_names",
+		summaryTupleField:      "",
 	},
 	"email": {
 		// The user breakdown falls back to the device hostname when a session
@@ -89,6 +110,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "emails",
+		summaryTupleField:      "",
 	},
 	"hostname": {
 		// The device hostname the Go hooks report on every event
@@ -100,6 +123,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "hostnames",
+		summaryTupleField:      "",
 	},
 	"model": {
 		aggregateColumn: "model",
@@ -111,6 +136,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "models",
+		summaryTupleField:      "",
 	},
 	"hook_source": {
 		aggregateColumn:        "hook_source",
@@ -118,6 +145,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "hook_sources",
+		summaryTupleField:      "",
 	},
 	"account_type": {
 		// AI account classification: 'team' | 'personal' | '' (unclassified).
@@ -128,6 +157,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "account_types",
+		summaryTupleField:      "",
 	},
 	"provider": {
 		// AI provider for the account: 'anthropic' | 'openai' | 'cursor' | ''.
@@ -138,6 +169,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "providers",
+		summaryTupleField:      "",
 	},
 	"billing_mode": {
 		// How the account is billed: 'metered' (pay-per-token; cost is real spend)
@@ -150,6 +183,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "billing_modes",
+		summaryTupleField:      "",
 	},
 	"query_source": {
 		aggregateColumn:        "query_source",
@@ -157,6 +192,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
+		summaryColumn:          "",
+		summaryTupleField:      "query_source",
 	},
 	"skill_name": {
 		aggregateColumn:        "skill_name",
@@ -164,6 +201,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
+		summaryColumn:          "",
+		summaryTupleField:      "skill_name",
 	},
 	"agent_name": {
 		aggregateColumn:        "agent_name",
@@ -171,6 +210,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
+		summaryColumn:          "",
+		summaryTupleField:      "agent_name",
 	},
 	"mcp_server_name": {
 		aggregateColumn:        "mcp_server_name",
@@ -178,6 +219,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
+		summaryColumn:          "",
+		summaryTupleField:      "mcp_server_name",
 	},
 	"mcp_tool_name": {
 		aggregateColumn:        "mcp_tool_name",
@@ -185,6 +228,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimScalar,
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
+		summaryColumn:          "",
+		summaryTupleField:      "mcp_tool_name",
 	},
 	"role": {
 		aggregateColumn:        "roles",
@@ -192,6 +237,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimArray,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "roles",
+		summaryTupleField:      "",
 	},
 	"group": {
 		aggregateColumn:        "groups",
@@ -199,6 +246,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimArray,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "groups",
+		summaryTupleField:      "",
 	},
 	"project_id": {
 		aggregateColumn:        "gram_project_id",
@@ -206,6 +255,8 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		kind:                   attributeDimProject,
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
+		summaryColumn:          "gram_project_id",
+		summaryTupleField:      "",
 	},
 }
 
@@ -217,6 +268,7 @@ func buildDimensionRegistry(columnFor func(telemetryDimension) string) map[strin
 			kind:                   dim.kind,
 			coLocateSessionFilters: dim.coLocateSessionFilters,
 			emptyIsNotApplicable:   dim.emptyIsNotApplicable,
+			summaryTupleField:      dim.summaryTupleField,
 		}
 	}
 	return out
@@ -228,4 +280,12 @@ var attributeDimensionRegistry = buildDimensionRegistry(func(dim telemetryDimens
 
 var sessionDimensionRegistry = buildDimensionRegistry(func(dim telemetryDimension) string {
 	return dim.rawExpr
+})
+
+// sessionSummaryDimensionRegistry resolves dimensions against the
+// chat_session_summaries columns for the summary-backed ListSessions path.
+// Co-located attribution dimensions resolve to "" here and are matched via
+// summaryTupleField instead.
+var sessionSummaryDimensionRegistry = buildDimensionRegistry(func(dim telemetryDimension) string {
+	return dim.summaryColumn
 })

--- a/server/internal/telemetry/repo/dimensions.go
+++ b/server/internal/telemetry/repo/dimensions.go
@@ -18,7 +18,6 @@ type attributeDimension struct {
 	kind                   attributeDimensionKind
 	coLocateSessionFilters bool
 	emptyIsNotApplicable   bool
-	summaryTupleField      string
 }
 
 type telemetryDimension struct {
@@ -38,12 +37,10 @@ type telemetryDimension struct {
 	// dimension's per-chat distinct values (a groupUniqArrayArray-merged
 	// Array(String) for scalar/array dimensions; the key column for
 	// project_id). Empty for the co-located Claude attribution dimensions,
-	// which are matched through summaryTupleField instead.
+	// whose registry key doubles as their field name in the
+	// attribution_tuples named tuple (enforced by the registry bindings
+	// test in sessions_schema_sync_test.go).
 	summaryColumn string
-	// summaryTupleField names the dimension's field inside the
-	// chat_session_summaries attribution_tuples named tuple, for the
-	// co-located Claude attribution dimensions.
-	summaryTupleField string
 }
 
 // telemetryDimensionRegistry is the single allowlist for public telemetry
@@ -58,7 +55,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "department_names",
-		summaryTupleField:      "",
 	},
 	"job_title": {
 		aggregateColumn:        "job_title",
@@ -67,7 +63,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "job_titles",
-		summaryTupleField:      "",
 	},
 	"employee_type": {
 		aggregateColumn:        "employee_type",
@@ -76,7 +71,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "employee_types",
-		summaryTupleField:      "",
 	},
 	"division_name": {
 		aggregateColumn:        "division_name",
@@ -85,7 +79,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "division_names",
-		summaryTupleField:      "",
 	},
 	"cost_center_name": {
 		aggregateColumn:        "cost_center_name",
@@ -94,7 +87,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "cost_center_names",
-		summaryTupleField:      "",
 	},
 	"email": {
 		// The user breakdown falls back to the device hostname when a session
@@ -111,7 +103,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "emails",
-		summaryTupleField:      "",
 	},
 	"hostname": {
 		// The device hostname the Go hooks report on every event
@@ -124,7 +115,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "hostnames",
-		summaryTupleField:      "",
 	},
 	"model": {
 		aggregateColumn: "model",
@@ -137,7 +127,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "models",
-		summaryTupleField:      "",
 	},
 	"hook_source": {
 		aggregateColumn:        "hook_source",
@@ -146,7 +135,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "hook_sources",
-		summaryTupleField:      "",
 	},
 	"account_type": {
 		// AI account classification: 'team' | 'personal' | '' (unclassified).
@@ -158,7 +146,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "account_types",
-		summaryTupleField:      "",
 	},
 	"provider": {
 		// AI provider for the account: 'anthropic' | 'openai' | 'cursor' | ''.
@@ -170,7 +157,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "providers",
-		summaryTupleField:      "",
 	},
 	"billing_mode": {
 		// How the account is billed: 'metered' (pay-per-token; cost is real spend)
@@ -184,7 +170,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "billing_modes",
-		summaryTupleField:      "",
 	},
 	"query_source": {
 		aggregateColumn:        "query_source",
@@ -193,7 +178,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
 		summaryColumn:          "",
-		summaryTupleField:      "query_source",
 	},
 	"skill_name": {
 		aggregateColumn:        "skill_name",
@@ -202,7 +186,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
 		summaryColumn:          "",
-		summaryTupleField:      "skill_name",
 	},
 	"agent_name": {
 		aggregateColumn:        "agent_name",
@@ -211,7 +194,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
 		summaryColumn:          "",
-		summaryTupleField:      "agent_name",
 	},
 	"mcp_server_name": {
 		aggregateColumn:        "mcp_server_name",
@@ -220,7 +202,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
 		summaryColumn:          "",
-		summaryTupleField:      "mcp_server_name",
 	},
 	"mcp_tool_name": {
 		aggregateColumn:        "mcp_tool_name",
@@ -229,7 +210,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: true,
 		emptyIsNotApplicable:   true,
 		summaryColumn:          "",
-		summaryTupleField:      "mcp_tool_name",
 	},
 	"role": {
 		aggregateColumn:        "roles",
@@ -238,7 +218,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "roles",
-		summaryTupleField:      "",
 	},
 	"group": {
 		aggregateColumn:        "groups",
@@ -247,7 +226,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "groups",
-		summaryTupleField:      "",
 	},
 	"project_id": {
 		aggregateColumn:        "gram_project_id",
@@ -256,7 +234,6 @@ var telemetryDimensionRegistry = map[string]telemetryDimension{
 		coLocateSessionFilters: false,
 		emptyIsNotApplicable:   false,
 		summaryColumn:          "gram_project_id",
-		summaryTupleField:      "",
 	},
 }
 
@@ -268,7 +245,6 @@ func buildDimensionRegistry(columnFor func(telemetryDimension) string) map[strin
 			kind:                   dim.kind,
 			coLocateSessionFilters: dim.coLocateSessionFilters,
 			emptyIsNotApplicable:   dim.emptyIsNotApplicable,
-			summaryTupleField:      dim.summaryTupleField,
 		}
 	}
 	return out
@@ -284,8 +260,8 @@ var sessionDimensionRegistry = buildDimensionRegistry(func(dim telemetryDimensio
 
 // sessionSummaryDimensionRegistry resolves dimensions against the
 // chat_session_summaries columns for the summary-backed ListSessions path.
-// Co-located attribution dimensions resolve to "" here and are matched via
-// summaryTupleField instead.
+// Co-located attribution dimensions resolve to "" here; their registry key is
+// their field name in the attribution_tuples named tuple.
 var sessionSummaryDimensionRegistry = buildDimensionRegistry(func(dim telemetryDimension) string {
 	return dim.summaryColumn
 })

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/Masterminds/squirrel"
 )
 
@@ -282,18 +284,39 @@ func sessionScalarHaving(expr string, values []string) squirrel.Sqlizer {
 	return squirrel.Or{nonEmptyPred, emptyPred}
 }
 
+// sessionSummaryMinWindow routes ListSessions between the raw telemetry_logs
+// scan and the pre-aggregated chat_session_summaries read (INC-417). The
+// summary is hour-bucketed, so its window edges snap to bucket boundaries —
+// up to ~1h of slop, which is noise on multi-day windows but unacceptable on
+// the sub-day presets (15m/1h/4h). Short windows are also exactly where the
+// raw scan is already cheap (the primary key prunes it to the window's
+// granules), so they stay on the raw path.
+const sessionSummaryMinWindow = 48 * time.Hour
+
 // ListSessions retrieves org-scoped session summaries grouped by chat_id from
 // the same source-event classes as attribute_metrics_summaries: Claude OTEL
 // api_request/tool_result rows and Codex/Cursor usage plus tool-call hook
 // rows. Pagination is based on the selected sort measure plus chat_id so
 // ordering stays stable across pages.
 //
-//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+// Wide windows read the pre-aggregated chat_session_summaries table; narrow
+// windows scan raw telemetry_logs (see sessionSummaryMinWindow).
 func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]SessionSummary, error) {
 	if len(arg.ProjectIDs) == 0 {
 		return nil, nil
 	}
+	if arg.TimeEnd-arg.TimeStart >= sessionSummaryMinWindow.Nanoseconds() {
+		return q.listSessionsFromSummaries(ctx, arg)
+	}
+	return q.listSessionsFromRawLogs(ctx, arg)
+}
 
+// listSessionsFromRawLogs derives session summaries by scanning raw
+// telemetry_logs — exact to the nanosecond, but per-row JSON extraction makes
+// it expensive on wide windows.
+//
+//nolint:wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) listSessionsFromRawLogs(ctx context.Context, arg ListSessionsParams) ([]SessionSummary, error) {
 	sortExpr, ok := sessionMeasureSelects[arg.SortBy]
 	if !ok {
 		return nil, fmt.Errorf("unknown sort_by measure %q", arg.SortBy)
@@ -347,17 +370,216 @@ func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]S
 	if err != nil {
 		return nil, err
 	}
+	return scanSessionSummaries(rows)
+}
+
+// sessionSummaryMeasureSelects maps the public sort measures onto merged
+// aggregates over chat_session_summaries. Keep the key set identical to
+// sessionMeasureSelects so both paths accept the same sort_by values. The
+// s. qualifier pins identifiers to the source columns: several output aliases
+// (total_cost, total_tokens, ...) share the column names, and ClickHouse
+// prefers aliases when resolving unqualified identifiers, which would nest
+// aggregates (ILLEGAL_AGGREGATION).
+//
+// #nosec G101 -- These are allowlisted SQL measure expressions, not credentials.
+var sessionSummaryMeasureSelects = map[string]string{
+	"total_cost":                  "sum(s.total_cost)",
+	"total_input_tokens":          "sum(s.total_input_tokens)",
+	"total_output_tokens":         "sum(s.total_output_tokens)",
+	"total_tokens":                "sum(s.total_tokens)",
+	"cache_read_input_tokens":     "sum(s.cache_read_input_tokens)",
+	"cache_creation_input_tokens": "sum(s.cache_creation_input_tokens)",
+	"tool_call_count":             "uniqExactIfMerge(s.tool_call_count)",
+	"message_count":               "uniqExactIfMerge(s.message_count)",
+	"duration_seconds":            "toFloat64(max(s.end_time_unix_nano) - min(s.start_time_unix_nano)) / 1000000000.0",
+	// Kept as a service-level compatibility alias; the public listSessions API
+	// uses tool_call_count.
+	"total_tool_calls": "uniqExactIfMerge(s.tool_call_count)",
+}
+
+// listSessionsFromSummaries serves the session list from the pre-aggregated
+// chat_session_summaries table: one row per (project, hour bucket, chat),
+// merged per chat over the buckets inside the window. The window snaps to
+// hour-bucket boundaries (start rounds down), so edges carry up to ~1h of
+// slop relative to the raw path — acceptable on the wide windows routed here.
+//
+//nolint:wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSessionsParams) ([]SessionSummary, error) {
+	sortExpr, ok := sessionSummaryMeasureSelects[arg.SortBy]
+	if !ok {
+		return nil, fmt.Errorf("unknown sort_by measure %q", arg.SortBy)
+	}
+
+	sb := sq.Select(
+		"s.chat_id as gram_chat_id",
+		"any(toString(s.gram_project_id)) as project_id",
+		// max() so '' loses to a non-empty value, matching the summary
+		// columns' merge semantics.
+		"max(s.session_user_email) as session_user_email",
+		"max(s.session_hook_source) as session_hook_source",
+		"argMaxIfMerge(s.session_model) as session_model",
+		"min(s.start_time_unix_nano) as start_time_unix_nano",
+		"max(s.end_time_unix_nano) as end_time_unix_nano",
+		"toFloat64(max(s.end_time_unix_nano) - min(s.start_time_unix_nano)) / 1000000000.0 as duration_seconds",
+		"toInt64(uniqExactIfMerge(s.message_count)) as message_count",
+		"toInt64(uniqExactIfMerge(s.tool_call_count)) as tool_call_count",
+		"sum(s.total_input_tokens) as total_input_tokens",
+		"sum(s.total_output_tokens) as total_output_tokens",
+		"sum(s.total_tokens) as total_tokens",
+		"sum(s.total_cost) as total_cost",
+		"if(sum(s.failed_tool_call_count) > 0, 'error', 'success') as status",
+		"toFloat64("+sortExpr+") as sort_value",
+	).
+		From("chat_session_summaries s").
+		Where(squirrel.Eq{"s.gram_project_id": arg.ProjectIDs}).
+		Where("s.time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?, 'UTC'))", arg.TimeStart).
+		Where("s.time_bucket <= fromUnixTimestamp64Nano(?, 'UTC')", arg.TimeEnd)
+
+	sb, err := applySessionSummaryFilters(sb, arg.Filters)
+	if err != nil {
+		return nil, err
+	}
+
+	sb = sb.GroupBy("s.chat_id")
+
+	if arg.CursorSortValue != nil && arg.CursorGramChatID != "" {
+		sb = sb.Having("(sort_value, s.chat_id) < (?, ?)", *arg.CursorSortValue, arg.CursorGramChatID)
+	}
+
+	sb = sb.OrderBy("sort_value DESC", "gram_chat_id DESC").
+		Limit(uint64(arg.Limit)) //nolint:gosec // Limit is validated by the service layer.
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building list sessions summary query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return scanSessionSummaries(rows)
+}
+
+// applySessionSummaryFilters translates the per-chat "any row matches" filter
+// semantics of applySessionFilters onto the summary table's merged
+// distinct-value arrays. Scalar and array dimensions match via
+// hasAny/arrayExists over groupUniqArrayArray of the dimension's column; the
+// co-located Claude attribution dimensions match a single per-row tuple in
+// attribution_tuples, preserving drill-down semantics from the aggregate
+// cost table.
+func applySessionSummaryFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFilter) (squirrel.SelectBuilder, error) {
+	var tuplePredicates []string
+	var tupleArgs []any
+
+	for _, f := range filters {
+		if len(f.Values) == 0 {
+			continue
+		}
+		dim, ok := sessionSummaryDimensionRegistry[f.Dimension]
+		if !ok {
+			return sb, fmt.Errorf("unknown filter dimension %q", f.Dimension)
+		}
+		switch {
+		case dim.kind == attributeDimProject:
+			sb = sb.Where(squirrel.Eq{"s." + dim.column: f.Values})
+		case dim.coLocateSessionFilters:
+			pred, args := sessionSummaryTupleFieldPredicate(dim.summaryTupleField, f.Values)
+			tuplePredicates = append(tuplePredicates, pred)
+			tupleArgs = append(tupleArgs, args...)
+		default:
+			sb = sb.Having(sessionSummaryValuesHaving("s."+dim.column, f.Values))
+		}
+	}
+
+	if len(tuplePredicates) > 0 {
+		sb = sb.Having(squirrel.Expr(
+			"arrayExists(t -> "+strings.Join(tuplePredicates, " AND ")+", groupUniqArrayArray(s.attribution_tuples))",
+			tupleArgs...,
+		))
+	}
+	return sb, nil
+}
+
+// sessionSummaryValuesHaving matches a chat when the merged distinct values
+// of a dimension column contain one of the requested values. A requested ""
+// (the "(unset)" bucket) matches chats with no non-empty value anywhere,
+// mirroring sessionScalarHaving. For array dimensions (roles/groups) this
+// means "no value on any row", a deliberate tightening of the raw path's
+// per-row empty(...) check, which matches any chat containing a single
+// unenriched row.
+func sessionSummaryValuesHaving(colExpr string, values []string) squirrel.Sqlizer {
+	merged := "groupUniqArrayArray(" + colExpr + ")"
+
+	hasEmpty := false
+	nonEmpty := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+
+	emptyPred := squirrel.Expr("NOT arrayExists(x -> x != '', " + merged + ")")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+	nonEmptyPred := squirrel.Expr("hasAny("+merged+", ?)", nonEmpty)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
+}
+
+// sessionSummaryTupleFieldPredicate matches one attribution field of a
+// per-row tuple inside the arrayExists lambda (t is the lambda argument). A
+// requested "" means the row carried no value for the field, mirroring
+// sessionScalarRowPredicate. The field name comes from the compile-time
+// dimension registry, never from user input.
+func sessionSummaryTupleFieldPredicate(field string, values []string) (string, []any) {
+	fieldExpr := "tupleElement(t, '" + field + "')"
+
+	hasEmpty := false
+	nonEmpty := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+
+	emptyPred := fieldExpr + " = ''"
+	if len(nonEmpty) == 0 {
+		return emptyPred, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(nonEmpty)), ",")
+	args := make([]any, len(nonEmpty))
+	for i, v := range nonEmpty {
+		args[i] = v
+	}
+	nonEmptyPred := fieldExpr + " IN (" + placeholders + ")"
+	if !hasEmpty {
+		return nonEmptyPred, args
+	}
+	return "(" + nonEmptyPred + " OR " + emptyPred + ")", args
+}
+
+//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func scanSessionSummaries(rows driver.Rows) ([]SessionSummary, error) {
 	defer rows.Close()
 
 	var sessions []SessionSummary
 	for rows.Next() {
 		var session SessionSummary
-		if err = rows.ScanStruct(&session); err != nil {
+		if err := rows.ScanStruct(&session); err != nil {
 			return nil, fmt.Errorf("scanning session row: %w", err)
 		}
 		sessions = append(sessions, session)
 	}
-	if err = rows.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return sessions, nil

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -151,6 +151,14 @@ type ListSessionsParams struct {
 	Limit            int
 }
 
+// UsesSummaryPath reports whether the requested window is wide enough to be
+// served from chat_session_summaries instead of the raw telemetry_logs scan.
+// Exposed so callers (the service-layer query span) can label which path a
+// request routed to without duplicating the threshold comparison.
+func (p ListSessionsParams) UsesSummaryPath() bool {
+	return p.TimeEnd-p.TimeStart >= SessionSummaryMinWindow.Nanoseconds()
+}
+
 type SessionSummary struct {
 	GramChatID        string  `ch:"gram_chat_id"`
 	ProjectID         string  `ch:"project_id"`
@@ -330,7 +338,7 @@ func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]S
 	if len(arg.ProjectIDs) == 0 {
 		return nil, nil
 	}
-	if arg.TimeEnd-arg.TimeStart >= SessionSummaryMinWindow.Nanoseconds() {
+	if arg.UsesSummaryPath() {
 		return q.listSessionsFromSummaries(ctx, arg)
 	}
 	return q.listSessionsFromRawLogs(ctx, arg)
@@ -391,7 +399,7 @@ func (q *Queries) listSessionsFromRawLogs(ctx context.Context, arg ListSessionsP
 		return nil, fmt.Errorf("building list sessions query: %w", err)
 	}
 
-	rows, err := q.conn.Query(ctx, query, args...)
+	rows, err := q.conn.Query(chQueryContext(ctx), query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +495,7 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 		return nil, fmt.Errorf("building list sessions summary query: %w", err)
 	}
 
-	rows, err := q.conn.Query(ctx, query, args...)
+	rows, err := q.conn.Query(chQueryContext(ctx), query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -284,14 +284,15 @@ func sessionScalarHaving(expr string, values []string) squirrel.Sqlizer {
 	return squirrel.Or{nonEmptyPred, emptyPred}
 }
 
-// sessionSummaryMinWindow routes ListSessions between the raw telemetry_logs
+// SessionSummaryMinWindow routes ListSessions between the raw telemetry_logs
 // scan and the pre-aggregated chat_session_summaries read (INC-417). The
 // summary is hour-bucketed, so its window edges snap to bucket boundaries —
 // up to ~1h of slop, which is noise on multi-day windows but unacceptable on
 // the sub-day presets (15m/1h/4h). Short windows are also exactly where the
 // raw scan is already cheap (the primary key prunes it to the window's
-// granules), so they stay on the raw path.
-const sessionSummaryMinWindow = 48 * time.Hour
+// granules), so they stay on the raw path. Exported so tests derive their
+// window widths from it instead of encoding the threshold as magic numbers.
+const SessionSummaryMinWindow = 48 * time.Hour
 
 // ListSessions retrieves org-scoped session summaries grouped by chat_id from
 // the same source-event classes as attribute_metrics_summaries: Claude OTEL
@@ -300,12 +301,12 @@ const sessionSummaryMinWindow = 48 * time.Hour
 // ordering stays stable across pages.
 //
 // Wide windows read the pre-aggregated chat_session_summaries table; narrow
-// windows scan raw telemetry_logs (see sessionSummaryMinWindow).
+// windows scan raw telemetry_logs (see SessionSummaryMinWindow).
 func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]SessionSummary, error) {
 	if len(arg.ProjectIDs) == 0 {
 		return nil, nil
 	}
-	if arg.TimeEnd-arg.TimeStart >= sessionSummaryMinWindow.Nanoseconds() {
+	if arg.TimeEnd-arg.TimeStart >= SessionSummaryMinWindow.Nanoseconds() {
 		return q.listSessionsFromSummaries(ctx, arg)
 	}
 	return q.listSessionsFromRawLogs(ctx, arg)
@@ -412,7 +413,7 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 
 	sb := sq.Select(
 		"s.chat_id as gram_chat_id",
-		"any(toString(s.gram_project_id)) as project_id",
+		"toString(any(s.gram_project_id)) as project_id",
 		// max() so '' loses to a non-empty value, matching the summary
 		// columns' merge semantics.
 		"max(s.session_user_email) as session_user_email",
@@ -484,7 +485,15 @@ func applySessionSummaryFilters(sb squirrel.SelectBuilder, filters []AttributeMe
 		case dim.kind == attributeDimProject:
 			sb = sb.Where(squirrel.Eq{"s." + dim.column: f.Values})
 		case dim.coLocateSessionFilters:
-			pred, args := sessionSummaryTupleFieldPredicate(dim.summaryTupleField, f.Values)
+			// The dimension key doubles as the field name in the
+			// attribution_tuples named tuple (enforced by the registry
+			// bindings test), and sessionScalarRowPredicate supplies the same
+			// per-row value semantics the raw path uses — t is the arrayExists
+			// lambda argument.
+			pred, args, err := sessionScalarRowPredicate("tupleElement(t, '"+f.Dimension+"')", f.Values).ToSql()
+			if err != nil {
+				return sb, fmt.Errorf("building co-located session summary filter for %q: %w", f.Dimension, err)
+			}
 			tuplePredicates = append(tuplePredicates, pred)
 			tupleArgs = append(tupleArgs, args...)
 		default:
@@ -530,41 +539,6 @@ func sessionSummaryValuesHaving(colExpr string, values []string) squirrel.Sqlize
 		return nonEmptyPred
 	}
 	return squirrel.Or{nonEmptyPred, emptyPred}
-}
-
-// sessionSummaryTupleFieldPredicate matches one attribution field of a
-// per-row tuple inside the arrayExists lambda (t is the lambda argument). A
-// requested "" means the row carried no value for the field, mirroring
-// sessionScalarRowPredicate. The field name comes from the compile-time
-// dimension registry, never from user input.
-func sessionSummaryTupleFieldPredicate(field string, values []string) (string, []any) {
-	fieldExpr := "tupleElement(t, '" + field + "')"
-
-	hasEmpty := false
-	nonEmpty := make([]string, 0, len(values))
-	for _, v := range values {
-		if v == "" {
-			hasEmpty = true
-			continue
-		}
-		nonEmpty = append(nonEmpty, v)
-	}
-
-	emptyPred := fieldExpr + " = ''"
-	if len(nonEmpty) == 0 {
-		return emptyPred, nil
-	}
-
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(nonEmpty)), ",")
-	args := make([]any, len(nonEmpty))
-	for i, v := range nonEmpty {
-		args[i] = v
-	}
-	nonEmptyPred := fieldExpr + " IN (" + placeholders + ")"
-	if !hasEmpty {
-		return nonEmptyPred, args
-	}
-	return "(" + nonEmptyPred + " OR " + emptyPred + ")", args
 }
 
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -202,11 +202,7 @@ func applySessionFilters(sb squirrel.SelectBuilder, filters []AttributeMetricsFi
 			}
 			sb = sb.Having(sessionScalarHaving(dim.column, f.Values))
 		case attributeDimArray:
-			inner, args, err := arrayDimFilter(dim.column, f.Values).ToSql()
-			if err != nil {
-				return sb, fmt.Errorf("building array filter for %q: %w", f.Dimension, err)
-			}
-			sb = sb.Having(squirrel.Expr("countIf("+inner+") > 0", args...))
+			sb = sb.Having(sessionArrayHaving(dim.column, f.Values))
 		default:
 			return sb, fmt.Errorf("unhandled dimension kind for filter %q", f.Dimension)
 		}
@@ -246,6 +242,34 @@ func sessionScalarRowPredicate(expr string, values []string) squirrel.Sqlizer {
 		args[i] = v
 	}
 	nonEmptyPred := squirrel.Expr(expr+" IN ("+placeholders+")", args...)
+	if !hasEmpty {
+		return nonEmptyPred
+	}
+	return squirrel.Or{nonEmptyPred, emptyPred}
+}
+
+// sessionArrayHaving matches a chat when any of its rows' array carries one
+// of the requested values. A requested "" (the "(unset)" bucket) matches
+// chats with NO value on any row — the same chat-level semantics as
+// sessionSummaryValuesHaving on the summary path (a per-row empty(...) check
+// would match any chat containing a single unenriched row, i.e. nearly all
+// of them).
+func sessionArrayHaving(colExpr string, values []string) squirrel.Sqlizer {
+	hasEmpty := false
+	nonEmpty := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+			continue
+		}
+		nonEmpty = append(nonEmpty, v)
+	}
+
+	emptyPred := squirrel.Expr("countIf(notEmpty(" + colExpr + ")) = 0")
+	if len(nonEmpty) == 0 {
+		return emptyPred
+	}
+	nonEmptyPred := squirrel.Expr("countIf(hasAny("+colExpr+", ?)) > 0", nonEmpty)
 	if !hasEmpty {
 		return nonEmptyPred
 	}
@@ -442,6 +466,14 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 	}
 
 	sb = sb.GroupBy("s.chat_id")
+
+	// The bucket bounds above admit whole boundary hours; this exact-window
+	// overlap guard (on the nanosecond-precise merged min/max) drops phantom
+	// sessions whose activity falls entirely OUTSIDE the requested window in
+	// a boundary hour. Sessions with genuine in-window activity keep their
+	// (edge-padded) totals.
+	sb = sb.Having("max(s.end_time_unix_nano) >= ?", arg.TimeStart).
+		Having("min(s.start_time_unix_nano) <= ?", arg.TimeEnd)
 
 	if arg.CursorSortValue != nil && arg.CursorGramChatID != "" {
 		sb = sb.Having("(sort_value, s.chat_id) < (?, ?)", *arg.CursorSortValue, arg.CursorGramChatID)

--- a/server/internal/telemetry/repo/sessions_schema_sync_test.go
+++ b/server/internal/telemetry/repo/sessions_schema_sync_test.go
@@ -84,3 +84,28 @@ func TestSessionPredicates_SchemaMVStaysInSync(t *testing.T) {
 			"session* Go constants drifted from the pinned predicate fragment — apply the change on every path (Go constants, MV via MODIFY QUERY + backfill, seed)")
 	}
 }
+
+// TestSessionPredicates_SeedBackfillStaysInSync covers the third live copy of
+// the session predicates: chatSessionBackfillSQL in the local seed, which
+// re-derives chat_session_summaries for pre-cutoff seeded rows. (The prod
+// backfill runbook under clickhouse/local/backfill/ is a one-time executed
+// artifact and is deliberately not covered — drift after its execution is
+// inert.)
+func TestSessionPredicates_SeedBackfillStaysInSync(t *testing.T) {
+	t.Parallel()
+
+	seed, err := os.ReadFile("../../../../.mise-tasks/seed.mts")
+	require.NoError(t, err)
+
+	seedText := string(seed)
+	start := strings.Index(seedText, "function chatSessionBackfillSQL")
+	require.Positive(t, start, "chatSessionBackfillSQL not found in seed.mts")
+	end := strings.Index(seedText[start:], "\nfunction ")
+	require.Positive(t, end, "expected a declaration after chatSessionBackfillSQL")
+	backfillSQL := normalizeSQL(seedText[start : start+end])
+
+	for _, fragment := range sessionSharedPredicateFragments {
+		require.Contains(t, backfillSQL, normalizeSQL(fragment),
+			"seed.mts chatSessionBackfillSQL drifted from the pinned session predicate fragment — apply the change on every path (Go constants, MV via MODIFY QUERY + backfill, seed)")
+	}
+}

--- a/server/internal/telemetry/repo/sessions_schema_sync_test.go
+++ b/server/internal/telemetry/repo/sessions_schema_sync_test.go
@@ -1,0 +1,86 @@
+package repo
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The session classification logic lives in several places that must never
+// drift: the session* constants in this package (the raw ListSessions path),
+// the chat_session_summaries_mv definition in schema.sql (ingest for the
+// summary ListSessions path), and the backfill/seed SQL derived from the MV.
+// This test pins the shared SQL fragments on both sides — editing the Go
+// constants or the MV without moving the other breaks it, forcing the change
+// to be applied everywhere (including a MODIFY QUERY migration + backfill for
+// the MV; see the clickhouse skill).
+var sessionSharedPredicateFragments = []string{
+	// Claude OTEL provenance URN.
+	"(gram_urn = 'claude-code:otel:logs')",
+	// api_request row markers.
+	"(toString(attributes.event.name) = 'api_request' OR body = 'claude_code.api_request')",
+	// tool_result row markers.
+	"(toString(attributes.event.name) = 'tool_result' OR body = 'claude_code.tool_result')",
+	// Agent usage-row URN prefixes.
+	"(startsWith(gram_urn, 'codex:usage') OR startsWith(gram_urn, 'cursor:usage') OR startsWith(gram_urn, 'claude_chat:usage') OR startsWith(gram_urn, 'claude_chat:cost'))",
+	// Agent completed tool-call hook rows.
+	"hook_source IN ('codex', 'cursor') AND toString(attributes.gram.tool.name) != '' AND toString(attributes.gram.tool.name) NOT IN ('claude-code', 'codex', 'cursor') AND toString(attributes.gram.hook.event) IN ('PostToolUse', 'PostToolUseFailure')",
+	// Tool-call dedup identity.
+	"multiIf(toString(attributes.tool_use_id) != '', toString(attributes.tool_use_id), toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id), toString(id))",
+	// Failed tool-call markers.
+	"toString(attributes.success) = 'false'",
+	"(toString(attributes.gram.hook.event) = 'PostToolUseFailure' OR toInt32OrZero(toString(attributes.http.response.status_code)) >= 400)",
+	// Cost fallback chain.
+	"multiIf(toString(attributes.cost_usd) != '', toFloat64OrZero(toString(attributes.cost_usd)), toString(attributes.cost_usd_micros) != '', toFloat64OrZero(toString(attributes.cost_usd_micros)) / 1000000, 0)",
+	// total_tokens = input + output + cache writes.
+	"toInt64OrZero(toString(attributes.input_tokens)) + toInt64OrZero(toString(attributes.output_tokens)) + toInt64OrZero(toString(attributes.cache_creation_tokens))",
+}
+
+// normalizeSQL collapses whitespace so the multi-line schema formatting
+// compares equal to the single-line Go constants.
+func normalizeSQL(s string) string {
+	s = regexp.MustCompile(`\s+`).ReplaceAllString(s, " ")
+	s = strings.ReplaceAll(s, "( ", "(")
+	s = strings.ReplaceAll(s, " )", ")")
+	return s
+}
+
+func TestSessionPredicates_SchemaMVStaysInSync(t *testing.T) {
+	t.Parallel()
+
+	schema, err := os.ReadFile("../../../clickhouse/schema.sql")
+	require.NoError(t, err)
+
+	// Scope the check to the chat_session_summaries_mv definition so the
+	// fragments are asserted against OUR MV, not a sibling's.
+	schemaText := string(schema)
+	start := strings.Index(schemaText, "CREATE MATERIALIZED VIEW IF NOT EXISTS chat_session_summaries_mv")
+	require.Positive(t, start, "chat_session_summaries_mv not found in schema.sql")
+	end := strings.Index(schemaText[start:], "CREATE TABLE")
+	require.Positive(t, end, "expected a statement after chat_session_summaries_mv")
+	mvSQL := normalizeSQL(schemaText[start : start+end])
+
+	goConstants := normalizeSQL(strings.Join([]string{
+		sessionClaudeAPIRequestPredicate,
+		sessionClaudeToolResultPredicate,
+		sessionAgentUsageRowPredicate,
+		sessionAgentToolCallPredicate,
+		sessionFailedToolCallPredicate,
+		sessionCountedToolCallPredicate,
+		sessionToolCallDedupIDExpr,
+		sessionCostExpr,
+		sessionTotalTokensExpr,
+		sessionModelExpr,
+	}, "\n"))
+
+	for _, fragment := range sessionSharedPredicateFragments {
+		normalized := normalizeSQL(fragment)
+		require.Contains(t, mvSQL, normalized,
+			"chat_session_summaries_mv drifted from the pinned session predicate fragment — apply the change on every path (Go constants, MV via MODIFY QUERY + backfill, seed)")
+		require.Contains(t, goConstants, normalized,
+			"session* Go constants drifted from the pinned predicate fragment — apply the change on every path (Go constants, MV via MODIFY QUERY + backfill, seed)")
+	}
+}

--- a/server/internal/telemetry/repo/sessions_schema_sync_test.go
+++ b/server/internal/telemetry/repo/sessions_schema_sync_test.go
@@ -58,7 +58,7 @@ func TestSessionPredicates_SchemaMVStaysInSync(t *testing.T) {
 	// fragments are asserted against OUR MV, not a sibling's.
 	schemaText := string(schema)
 	start := strings.Index(schemaText, "CREATE MATERIALIZED VIEW IF NOT EXISTS chat_session_summaries_mv")
-	require.Positive(t, start, "chat_session_summaries_mv not found in schema.sql")
+	require.GreaterOrEqual(t, start, 0, "chat_session_summaries_mv not found in schema.sql")
 	end := strings.Index(schemaText[start:], "CREATE TABLE")
 	require.Positive(t, end, "expected a statement after chat_session_summaries_mv")
 	mvSQL := normalizeSQL(schemaText[start : start+end])
@@ -99,7 +99,7 @@ func TestSessionPredicates_SeedBackfillStaysInSync(t *testing.T) {
 
 	seedText := string(seed)
 	start := strings.Index(seedText, "function chatSessionBackfillSQL")
-	require.Positive(t, start, "chatSessionBackfillSQL not found in seed.mts")
+	require.GreaterOrEqual(t, start, 0, "chatSessionBackfillSQL not found in seed.mts")
 	end := strings.Index(seedText[start:], "\nfunction ")
 	require.Positive(t, end, "expected a declaration after chatSessionBackfillSQL")
 	backfillSQL := normalizeSQL(seedText[start : start+end])
@@ -107,5 +107,62 @@ func TestSessionPredicates_SeedBackfillStaysInSync(t *testing.T) {
 	for _, fragment := range sessionSharedPredicateFragments {
 		require.Contains(t, backfillSQL, normalizeSQL(fragment),
 			"seed.mts chatSessionBackfillSQL drifted from the pinned session predicate fragment — apply the change on every path (Go constants, MV via MODIFY QUERY + backfill, seed)")
+	}
+}
+
+// TestSessionSummaryDimensionBindings enforces the summary path's registry
+// invariants that the compiler cannot: every filterable dimension must bind
+// to a real chat_session_summaries backing — a distinct-values array column
+// for scalar/array dimensions, or (for co-located attribution dimensions,
+// whose registry key doubles as the tuple field name) a named field of
+// attribution_tuples. Without this, a future dimension added with rawExpr
+// only would compile, pass narrow-window tests, and emit malformed SQL on
+// every window wide enough to route to the summary path.
+func TestSessionSummaryDimensionBindings(t *testing.T) {
+	t.Parallel()
+
+	schema, err := os.ReadFile("../../../clickhouse/schema.sql")
+	require.NoError(t, err)
+
+	schemaText := string(schema)
+	start := strings.Index(schemaText, "CREATE TABLE IF NOT EXISTS chat_session_summaries (")
+	require.GreaterOrEqual(t, start, 0, "chat_session_summaries not found in schema.sql")
+	end := strings.Index(schemaText[start:], "COMMENT ")
+	require.Positive(t, end, "expected the chat_session_summaries table to end with a COMMENT")
+	tableSQL := schemaText[start : start+end]
+
+	for key, dim := range telemetryDimensionRegistry {
+		switch {
+		case dim.kind == attributeDimProject:
+			require.Equal(t, "gram_project_id", dim.summaryColumn,
+				"dimension %q: project dimensions must bind to the gram_project_id key column", key)
+		case dim.coLocateSessionFilters:
+			require.Empty(t, dim.summaryColumn,
+				"dimension %q: co-located dimensions are matched via attribution_tuples, not a summary column", key)
+			require.Contains(t, tableSQL, key+" String",
+				"dimension %q: registry key must name a field of the attribution_tuples named tuple in chat_session_summaries", key)
+		default:
+			require.NotEmpty(t, dim.summaryColumn,
+				"dimension %q: filterable dimensions need a chat_session_summaries distinct-values column", key)
+			require.Contains(t, tableSQL, dim.summaryColumn+" SimpleAggregateFunction(groupUniqArrayArray, Array(String))",
+				"dimension %q: summaryColumn %q is not a distinct-values array column of chat_session_summaries", key, dim.summaryColumn)
+		}
+	}
+}
+
+// TestSessionMeasureSelects_PathsAcceptSameSortKeys pins the two ListSessions
+// paths to one sort-measure surface: a measure present in only one map would
+// make sort_by succeed or fail depending on which side of the routing window
+// threshold the request lands.
+func TestSessionMeasureSelects_PathsAcceptSameSortKeys(t *testing.T) {
+	t.Parallel()
+
+	for key := range sessionMeasureSelects {
+		require.Contains(t, sessionSummaryMeasureSelects, key,
+			"sort measure %q is raw-path only — wide windows would return 'unknown sort_by measure'", key)
+	}
+	for key := range sessionSummaryMeasureSelects {
+		require.Contains(t, sessionMeasureSelects, key,
+			"sort measure %q is summary-path only — narrow windows would return 'unknown sort_by measure'", key)
 	}
 }


### PR DESCRIPTION
## Summary

Points the org-scoped sessions list (`telemetry.listSessions` — the costs page's session drill + "Most costly sessions" widget) at the `chat_session_summaries` materialized view shipped in #4428 (INC-417). The prod table is live and backfilled, so wide-window queries stop scanning raw `telemetry_logs` with per-row JSON extraction.

## How it routes

- **Windows ≥ 48h (`repo.SessionSummaryMinWindow`) → summary path**: measures merge from aggregate states (`uniqExactIfMerge`, `argMaxIfMerge`, plain `sum`/`min`/`max`), grouped per chat over the hour buckets inside the window. Sort measures and cursor pagination behave identically to the raw path, and an exact-window overlap guard on the nanosecond-precise merged min/max drops phantom sessions whose activity falls entirely inside a boundary hour but outside the requested window.
- **Windows < 48h → existing raw scan**: hour buckets carry edge slop that is unacceptable on the sub-day presets (15m/1h/4h) — and those are exactly the windows where the primary key already prunes the raw scan to a handful of granules.

## Filter translation

`applySessionSummaryFilters` maps the raw path's per-chat "any row matches" HAVING semantics onto the summary columns: scalar/array dimensions via `hasAny`/`arrayExists` over the merged distinct-value arrays (with the "(unset)" bucket as "no non-empty value anywhere"), and the co-located Claude attribution dimensions via a single-tuple `arrayExists` over `attribution_tuples` — sharing `sessionScalarRowPredicate` with the raw path, with the dimension key doubling as the tuple field name. All identifiers are `s.`-qualified — several output aliases share source column names, and ClickHouse's alias-first resolution would otherwise nest aggregates.

## Guarding against drift

- A sync test pins the shared session predicate fragments against the `session*` Go constants, the `chat_session_summaries_mv` definition in `schema.sql`, and the seed's backfill SQL — editing one copy without the others fails CI.
- A registry bindings test asserts every filterable dimension binds to a real summary column (checked against the schema DDL) or a real `attribution_tuples` field, so a future dimension added without summary backing fails CI instead of emitting malformed SQL only on wide windows.
- A key-set parity test pins the raw and summary sort-measure maps to each other (a one-sided measure would 500 only on one side of the routing threshold).
- The summary tests derive their window width from the exported routing constant, so retuning the threshold cannot silently flip them onto the raw path.

## Known behavioral deltas (wide windows only; accepted deliberately)

1. **Hour-granular window edges**: measures can include up to ~59min of activity adjacent to the window (matching the hour-bucketed aggregate endpoints shown alongside). Phantom sessions entirely outside the window are excluded by the overlap guard.
2. **Attribution filters requesting `""`** (`query_source`/`skill_name`/`agent_name`/`mcp_server_name`/`mcp_tool_name`): the summary path matches only chats with at least one Claude api_request row, where the raw path matched any row with an empty attribute. Unreachable from the UI (these dimensions hide the `""` bucket); an API-level delta only.
3. **Role/group `""` filters were aligned by fixing the raw path**: "(unset)" now means "no value on any row of the chat" on both paths, instead of the raw path's previous per-row `empty()` check that matched nearly every chat.
4. A bounded historical undercount exists for rows staging-promoted with pre-cutoff event times after the prod backfill ran (minutes of lag at most); one re-run of the backfill runbook's reset+insert unit closes it to zero whenever convenient.

## Also in this PR

Local seed support: `chat_session_summaries` joins the delete-before-insert set with a cutoff-scoped backfill (mirroring the prod runbook's rules), the personal-account phase rebuilds the summary rows for its own chats with correct delete-before-insert ordering, and its usage-URN idempotency delete is now scoped to its own session ids — previously it clobbered the observability phase's codex/cursor usage rows *after* their aggregates were derived, silently desyncing the summary tables from raw on every re-seed.

## Testing

- `TestListSessions_SummaryPathMatchesRawPath`: the two paths return byte-identical sessions for the same data (narrow vs wide window over fully-contained rows).
- Filter coverage: scalar, "(unset)" email bucket, roles array (including the aligned "(unset)" semantics on both paths), and the co-located skill+no-agent tuple case.
- Phantom-boundary-session exclusion and cursor pagination over the summary route.
- Predicate sync, registry bindings, and sort-measure parity guard tests; full telemetry suite green; `mise lint:server` clean.
- Verified end-to-end against the local dashboard: the costs sessions view renders from the MV with values matching a direct table query to the cent/token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)