### PR TITLE
fix(chat): stop losing resolved users on Claude Desktop sessions (DNO-590)

### DIFF
--- a/.changeset/claude-desktop-session-user-attribution.md
+++ b/.changeset/claude-desktop-session-user-attribution.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Fix Claude Desktop agent sessions showing an opaque user ID instead of the user's name. The Anthropic compliance import no longer clobbers a previously resolved chat owner when a later sync activity carries no actor identity (empty strings defeated the upsert's COALESCE guard — NULL is passed instead), and connected-user email resolution is now case-insensitive on both the server and the dashboard. When a session's owner still can't be matched to an org member, the agent-sessions list and session details now show a tooltip explaining why.

--- a/client/dashboard/src/components/chat-owner-label.tsx
+++ b/client/dashboard/src/components/chat-owner-label.tsx
@@ -21,11 +21,16 @@ export function ChatOwnerLabel({
 }): JSX.Element {
   const owner = chatOwnerDisplay(members, chat, currentUser, accountEmail);
 
-  if (owner.resolved) return <>{owner.label}</>;
+  // While the members query is still loading, matching hasn't been attempted
+  // yet — render plainly instead of claiming the user couldn't be matched.
+  if (owner.resolved || !members) return <>{owner.label}</>;
 
   return (
     <SimpleTooltip tooltip={unresolvedChatOwnerTooltip(chat)}>
-      <span className="cursor-help underline decoration-dotted underline-offset-2">
+      <span
+        tabIndex={0}
+        className="cursor-help underline decoration-dotted underline-offset-2"
+      >
         {owner.label}
       </span>
     </SimpleTooltip>

--- a/client/dashboard/src/components/chat-owner-label.tsx
+++ b/client/dashboard/src/components/chat-owner-label.tsx
@@ -1,0 +1,33 @@
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { chatOwnerDisplay, unresolvedChatOwnerTooltip } from "@/lib/chat-owner";
+import type { AccessMember } from "@gram/client/models/components/accessmember.js";
+import type { JSX } from "react";
+
+/**
+ * Renders a chat session's owner. When the owner can't be resolved to a known
+ * identity (the raw provider user ID or "anonymous" is shown), the label gets
+ * a tooltip explaining why.
+ */
+export function ChatOwnerLabel({
+  members,
+  chat,
+  currentUser,
+  accountEmail,
+}: {
+  members: AccessMember[] | undefined;
+  chat: { userId?: string; externalUserId?: string };
+  currentUser: { id: string; email: string };
+  accountEmail?: string;
+}): JSX.Element {
+  const owner = chatOwnerDisplay(members, chat, currentUser, accountEmail);
+
+  if (owner.resolved) return <>{owner.label}</>;
+
+  return (
+    <SimpleTooltip tooltip={unresolvedChatOwnerTooltip(chat)}>
+      <span className="cursor-help underline decoration-dotted underline-offset-2">
+        {owner.label}
+      </span>
+    </SimpleTooltip>
+  );
+}

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -18,6 +18,7 @@ import { stripMessageContextFraming } from "@/lib/projectAssistantTranscript";
 import { AssistantMarkdownLink } from "@/components/AssistantMarkdownLink";
 import { useAssistantLinkResolver } from "@/lib/assistantEntityLinks";
 import { useSession } from "@/contexts/Auth";
+import { emailsMatch, resolveChatOwner } from "@/lib/chat-owner";
 import {
   INSIGHTS_DOCK_CONTENT_VT_CLASS,
   INSIGHTS_DOCK_VT_CLASS,
@@ -763,12 +764,13 @@ export function InsightsProvider({
     }) => {
       if (!userId && !externalUserId) return undefined;
       // Chats started from the dashboard itself have no `userId` at capture
-      // time and stash the caller's email in `externalUserId` instead — fall
-      // back to an email match so those still resolve to a member.
-      const member = membersData?.members.find(
-        (m) =>
-          m.id === userId || (!!externalUserId && m.email === externalUserId),
-      );
+      // time and stash the caller's email in `externalUserId` instead —
+      // resolveChatOwner falls back to a case-insensitive email match so
+      // those still resolve to a member.
+      const member = resolveChatOwner(membersData?.members, {
+        userId,
+        externalUserId,
+      });
       return (
         member && {
           name: member.name,
@@ -795,7 +797,7 @@ export function InsightsProvider({
       externalUserId?: string;
     }) => {
       if (!userId && !externalUserId) return true;
-      return userId === user.id || externalUserId === user.email;
+      return userId === user.id || emailsMatch(externalUserId, user.email);
     },
     [user.id, user.email],
   );

--- a/client/dashboard/src/lib/chat-owner.test.ts
+++ b/client/dashboard/src/lib/chat-owner.test.ts
@@ -1,6 +1,11 @@
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import { describe, expect, it } from "vitest";
-import { chatOwnerLabel, resolveChatOwner } from "./chat-owner";
+import {
+  chatOwnerDisplay,
+  chatOwnerLabel,
+  resolveChatOwner,
+  unresolvedChatOwnerTooltip,
+} from "./chat-owner";
 
 function member(overrides: Partial<AccessMember>): AccessMember {
   return {
@@ -49,6 +54,14 @@ describe("resolveChatOwner", () => {
   it("returns undefined before members load", () => {
     expect(resolveChatOwner(undefined, { userId: "gram-1" })).toBeUndefined();
   });
+
+  it("matches external emails regardless of casing", () => {
+    const owner = resolveChatOwner(members, {
+      externalUserId: "Ada@Example.com",
+    });
+
+    expect(owner?.name).toBe("Ada");
+  });
 });
 
 describe("chatOwnerLabel", () => {
@@ -87,5 +100,52 @@ describe("chatOwnerLabel", () => {
     expect(
       chatOwnerLabel(members, { externalUserId: "user_opaque" }, currentUser),
     ).toBe("user_opaque");
+  });
+
+  it("labels the current user as You regardless of email casing", () => {
+    expect(
+      chatOwnerLabel(
+        members,
+        { externalUserId: "Grace@Example.com" },
+        {
+          id: "gram-2",
+          email: "grace@example.com",
+        },
+      ),
+    ).toBe("You");
+  });
+});
+
+describe("chatOwnerDisplay", () => {
+  it("marks known identities as resolved", () => {
+    expect(
+      chatOwnerDisplay(members, { userId: "gram-1" }, currentUser),
+    ).toEqual({ label: "Ada", resolved: true });
+  });
+
+  it("marks fallback labels as unresolved", () => {
+    expect(
+      chatOwnerDisplay(members, { externalUserId: "user_opaque" }, currentUser),
+    ).toEqual({ label: "user_opaque", resolved: false });
+  });
+});
+
+describe("unresolvedChatOwnerTooltip", () => {
+  it("explains an unmatched provider-reported user ID", () => {
+    expect(
+      unresolvedChatOwnerTooltip({ externalUserId: "user_opaque" }),
+    ).toContain("the user ID reported by the AI provider is shown instead");
+  });
+
+  it("explains an unmatched resolved user without claiming no identity was reported", () => {
+    expect(unresolvedChatOwnerTooltip({ userId: "gram-gone" })).toContain(
+      "couldn't be matched to a member",
+    );
+  });
+
+  it("explains a session with no reported identity", () => {
+    expect(unresolvedChatOwnerTooltip({})).toContain(
+      "didn't report a user identity",
+    );
   });
 });

--- a/client/dashboard/src/lib/chat-owner.ts
+++ b/client/dashboard/src/lib/chat-owner.ts
@@ -17,7 +17,10 @@ export type ChatOwnerDisplay = {
 
 // Emails can differ only by casing between sources (WorkOS-synced members vs
 // provider-reported identities), so all email comparisons are case-insensitive.
-function emailsMatch(a: string | undefined, b: string | undefined): boolean {
+export function emailsMatch(
+  a: string | undefined,
+  b: string | undefined,
+): boolean {
   return !!a && !!b && a.toLowerCase() === b.toLowerCase();
 }
 

--- a/client/dashboard/src/lib/chat-owner.ts
+++ b/client/dashboard/src/lib/chat-owner.ts
@@ -5,6 +5,16 @@ type ChatIdentity = {
   externalUserId?: string;
 };
 
+export type ChatOwnerDisplay = {
+  label: string;
+  /**
+   * True when the label is a known identity (personal-account email, the
+   * viewer, or an org member). False when we fell back to the raw external
+   * user ID or "anonymous".
+   */
+  resolved: boolean;
+};
+
 export function resolveChatOwner(
   members: AccessMember[] | undefined,
   chat: ChatIdentity,
@@ -18,21 +28,37 @@ export function resolveChatOwner(
   );
 }
 
+export function chatOwnerDisplay(
+  members: AccessMember[] | undefined,
+  chat: ChatIdentity,
+  currentUser: { id: string; email: string },
+  accountEmail?: string,
+): ChatOwnerDisplay {
+  if (accountEmail) return { label: accountEmail, resolved: true };
+
+  const isCurrentUser =
+    (!!chat.userId && chat.userId === currentUser.id) ||
+    (!!chat.externalUserId && chat.externalUserId === currentUser.email);
+  if (isCurrentUser) return { label: "You", resolved: true };
+
+  const member = resolveChatOwner(members, chat);
+  if (member) return { label: member.name || member.email, resolved: true };
+
+  return { label: chat.externalUserId || "anonymous", resolved: false };
+}
+
 export function chatOwnerLabel(
   members: AccessMember[] | undefined,
   chat: ChatIdentity,
   currentUser: { id: string; email: string },
   accountEmail?: string,
 ): string {
-  if (accountEmail) return accountEmail;
+  return chatOwnerDisplay(members, chat, currentUser, accountEmail).label;
+}
 
-  const isCurrentUser =
-    (!!chat.userId && chat.userId === currentUser.id) ||
-    (!!chat.externalUserId && chat.externalUserId === currentUser.email);
-  if (isCurrentUser) return "You";
-
-  const member = resolveChatOwner(members, chat);
-  if (member) return member.name || member.email;
-
-  return chat.externalUserId || "anonymous";
+export function unresolvedChatOwnerTooltip(chat: ChatIdentity): string {
+  if (chat.externalUserId) {
+    return "This session's user couldn't be matched to a member of your organization, so the user ID reported by the AI provider is shown instead. The user may not be provisioned in Gram or may have been removed from the organization.";
+  }
+  return "The AI provider didn't report a user identity for this session.";
 }

--- a/client/dashboard/src/lib/chat-owner.ts
+++ b/client/dashboard/src/lib/chat-owner.ts
@@ -15,6 +15,12 @@ export type ChatOwnerDisplay = {
   resolved: boolean;
 };
 
+// Emails can differ only by casing between sources (WorkOS-synced members vs
+// provider-reported identities), so all email comparisons are case-insensitive.
+function emailsMatch(a: string | undefined, b: string | undefined): boolean {
+  return !!a && !!b && a.toLowerCase() === b.toLowerCase();
+}
+
 export function resolveChatOwner(
   members: AccessMember[] | undefined,
   chat: ChatIdentity,
@@ -24,7 +30,7 @@ export function resolveChatOwner(
   return members.find(
     (member) =>
       (!!chat.userId && member.id === chat.userId) ||
-      (!!chat.externalUserId && member.email === chat.externalUserId),
+      emailsMatch(member.email, chat.externalUserId),
   );
 }
 
@@ -38,7 +44,7 @@ export function chatOwnerDisplay(
 
   const isCurrentUser =
     (!!chat.userId && chat.userId === currentUser.id) ||
-    (!!chat.externalUserId && chat.externalUserId === currentUser.email);
+    emailsMatch(chat.externalUserId, currentUser.email);
   if (isCurrentUser) return { label: "You", resolved: true };
 
   const member = resolveChatOwner(members, chat);
@@ -59,6 +65,9 @@ export function chatOwnerLabel(
 export function unresolvedChatOwnerTooltip(chat: ChatIdentity): string {
   if (chat.externalUserId) {
     return "This session's user couldn't be matched to a member of your organization, so the user ID reported by the AI provider is shown instead. The user may not be provisioned in Gram or may have been removed from the organization.";
+  }
+  if (chat.userId) {
+    return "This session's user couldn't be matched to a member of your organization. The user may have been removed from the organization or may not be provisioned in Gram.";
   }
   return "The AI provider didn't report a user identity for this session.";
 }

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -34,6 +34,7 @@ import {
 } from "@gram/client/react-query/listChats.js";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useSession } from "@/contexts/Auth";
+import { resolveChatOwner } from "@/lib/chat-owner";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   useHideInsightsDock,
@@ -642,9 +643,10 @@ function RecentRowIcon({
   externalUserId?: string;
 }): ReactElement {
   const { data: membersData } = useMembers();
-  const member = membersData?.members.find(
-    (m) => m.id === userId || (!!externalUserId && m.email === externalUserId),
-  );
+  const member = resolveChatOwner(membersData?.members, {
+    userId,
+    externalUserId,
+  });
 
   if (member) {
     const display = member.name || member.email;

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -59,6 +59,7 @@ import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useIsPlatformAdmin, useSession } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
+import { ChatOwnerLabel } from "@/components/chat-owner-label";
 import { chatOwnerLabel } from "@/lib/chat-owner";
 import { handleError, toError } from "@/lib/errors";
 import { formatPlatform } from "@/lib/formatPlatform";
@@ -261,7 +262,7 @@ function SessionSummary({
     lastMessageTimestamp?: Date;
     updatedAt: Date;
   };
-  userLabel: string;
+  userLabel: ReactNode;
   messageCount: number;
   toolCount: number;
   compact?: boolean;
@@ -638,7 +639,7 @@ function ChatDetailHeader({
 }: {
   chatId: string;
   chat: Parameters<typeof SessionSummary>[0]["chat"] & { title?: string };
-  userLabel: string;
+  userLabel: ReactNode;
   messageCount: number;
   toolCount: number;
   canManageChat: boolean;
@@ -870,6 +871,18 @@ function ChatDetailPanel({
         personalAccountEmail(chat),
       )
     : "anonymous";
+  // Same label as a node: unresolved owners get an explanatory tooltip in the
+  // header's session details, while transcript rows keep the plain string.
+  const userLabelNode = chat ? (
+    <ChatOwnerLabel
+      members={membersData?.members}
+      chat={chat}
+      currentUser={user}
+      accountEmail={personalAccountEmail(chat)}
+    />
+  ) : (
+    "anonymous"
+  );
   // Only the primary (or risk) initial load blanks the whole panel; a search
   // re-fetch updates the transcript in place — its loading shows in the search
   // bar and as a "Searching…" empty state instead.
@@ -1241,7 +1254,7 @@ function ChatDetailPanel({
       <ChatDetailHeader
         chatId={chatId}
         chat={chat}
-        userLabel={userLabel}
+        userLabel={userLabelNode}
         messageCount={chat.numMessages}
         toolCount={toolLogs.length}
         canManageChat={canManageChat}

--- a/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatLogsTable.tsx
@@ -1,9 +1,9 @@
 import { AccountTypeIcon } from "@/components/account-type-icon";
+import { ChatOwnerLabel } from "@/components/chat-owner-label";
 import { personalAccountEmail } from "@/components/observe/account-display-utils";
 import { TableRowContextMenu } from "@/components/table-row-context-menu";
 import { Dialog } from "@/components/ui/dialog";
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { chatOwnerLabel } from "@/lib/chat-owner";
 import { formatPlatform } from "@/lib/formatPlatform";
 import { cn } from "@/lib/utils";
 import { HookSourceIcon } from "@/pages/hooks/HookSourceIcon";
@@ -260,12 +260,12 @@ export function ChatLogsTable({
                           <>
                             <AccountTypeIcon accountType={chat.accountType} />
                             <span className="max-w-[120px] truncate">
-                              {chatOwnerLabel(
-                                membersData?.members,
-                                chat,
-                                user,
-                                personalAccountEmail(chat),
-                              )}
+                              <ChatOwnerLabel
+                                members={membersData?.members}
+                                chat={chat}
+                                currentUser={user}
+                                accountEmail={personalAccountEmail(chat)}
+                              />
                             </span>
                           </>
                         )}

--- a/server/internal/aiintegrations/compliance_import.go
+++ b/server/internal/aiintegrations/compliance_import.go
@@ -411,8 +411,10 @@ func (s *ComplianceImportService) upsertActivityChat(ctx context.Context, cfg Co
 		ID:             uuid.New(),
 		ProjectID:      cfg.ProjectID,
 		OrganizationID: cfg.OrganizationID,
-		UserID:         conv.ToPGText(userID),
-		ExternalUserID: conv.ToPGText(activity.Actor.UserID),
+		// NULL when unresolved so the upsert's COALESCE preserves a user
+		// resolved by an earlier activity or the message-page enrichment.
+		UserID:         conv.ToPGTextEmpty(userID),
+		ExternalUserID: conv.ToPGTextEmpty(activity.Actor.UserID),
 		ExternalChatID: conv.ToPGText(activity.ClaudeChatID),
 		// NULL so the upsert's COALESCE never clobbers the real title set by
 		// the one-time enrichment from the chat's first message page.
@@ -501,8 +503,10 @@ func (s *ComplianceImportService) upsertMessagePageChat(ctx context.Context, cfg
 		ID:             chatID,
 		ProjectID:      cfg.ProjectID,
 		OrganizationID: cfg.OrganizationID,
-		UserID:         conv.ToPGText(userID),
-		ExternalUserID: conv.ToPGText(page.User.ID),
+		// NULL when unresolved so the upsert's COALESCE preserves a user
+		// resolved from a prior sync.
+		UserID:         conv.ToPGTextEmpty(userID),
+		ExternalUserID: conv.ToPGTextEmpty(page.User.ID),
 		ExternalChatID: conv.ToPGText(page.ID),
 		Title:          conv.ToPGText(page.Name),
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),

--- a/server/internal/aiintegrations/compliance_import_db_test.go
+++ b/server/internal/aiintegrations/compliance_import_db_test.go
@@ -1,0 +1,103 @@
+package aiintegrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func TestUpsertActivityChatPreservesResolvedUserOnUnresolvedResync(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Compliance Import Test Project",
+		Slug:           "project-" + uuid.NewString()[:8],
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	userRow, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          "user_" + uuid.NewString(),
+		Email:       "ada@example.com",
+		DisplayName: "Ada",
+		PhotoUrl:    conv.ToPGTextEmpty(""),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, testrepo.New(conn).CreateOrganizationUserRelationshipFixture(ctx, testrepo.CreateOrganizationUserRelationshipFixtureParams{
+		OrganizationID: orgID,
+		UserID:         conv.ToPGText(userRow.ID),
+	}))
+
+	extOrgID := "ext-org"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderAnthropicCompliance, "anthropic-key", true, true, &extOrgID, nil)
+	cfg := created.Config
+	cfg.ProjectID = project.ID
+
+	svc := NewComplianceImportService(testenv.NewLogger(t), conn, nil, nil, func(context.Context, string, int) {})
+	resolver := newConnectedUserResolver(conn, orgID)
+
+	// First activity: the actor email resolves to a connected user.
+	resolved := complianceUserActivity("act_1", "chat_ext_1")
+	resolved.Actor.EmailAddress = "ada@example.com"
+	resolved.Actor.UserID = "anthropic_user_1"
+	chatID, _, err := svc.upsertActivityChat(ctx, cfg, resolved, resolver)
+	require.NoError(t, err)
+
+	chatRow, err := chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, userRow.ID, chatRow.UserID.String)
+
+	// A later activity for the same chat whose actor carries no identity (e.g.
+	// a claude_chat_updated event with an empty actor email) must not clobber
+	// the previously resolved user.
+	unresolved := complianceUserActivity("act_2", "chat_ext_1")
+	unresolved.Type = anthropicComplianceActivityUpdated
+	unresolved.Actor.EmailAddress = ""
+	unresolved.Actor.UserID = ""
+	sameChatID, _, err := svc.upsertActivityChat(ctx, cfg, unresolved, resolver)
+	require.NoError(t, err)
+	require.Equal(t, chatID, sameChatID)
+
+	chatRow, err = chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, userRow.ID, chatRow.UserID.String, "resolved user must survive an unresolved re-sync")
+	require.Equal(t, "anthropic_user_1", chatRow.ExternalUserID.String, "external user id must survive an unresolved re-sync")
+}
+
+func TestConnectedUserResolverMatchesMixedCaseStoredEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, _, orgID := newStoreTestDB(t)
+
+	// WorkOS-synced users can be stored with their original casing; the
+	// compliance feed reports lowercase emails.
+	userRow, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          "user_" + uuid.NewString(),
+		Email:       "Ada.Lovelace@Example.com",
+		DisplayName: "Ada",
+		PhotoUrl:    conv.ToPGTextEmpty(""),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, testrepo.New(conn).CreateOrganizationUserRelationshipFixture(ctx, testrepo.CreateOrganizationUserRelationshipFixtureParams{
+		OrganizationID: orgID,
+		UserID:         conv.ToPGText(userRow.ID),
+	}))
+
+	resolver := newConnectedUserResolver(conn, orgID)
+	resolvedID, err := resolver.resolve(ctx, "ada.lovelace@example.com")
+	require.NoError(t, err)
+	require.Equal(t, userRow.ID, resolvedID)
+}

--- a/server/internal/users/queries.sql
+++ b/server/internal/users/queries.sql
@@ -67,9 +67,11 @@ WHERE u.email = @email
 LIMIT 1;
 
 -- name: GetConnectedUsersByEmails :many
+-- Callers must pass lowercased emails (conv.NormalizeEmail); stored emails are
+-- lowered here since WorkOS-synced rows can preserve the original casing.
 SELECT u.* FROM users u
 JOIN organization_user_relationships our ON our.user_id = u.id
-WHERE u.email = ANY(@emails::text[])
+WHERE lower(u.email) = ANY(@emails::text[])
   AND our.organization_id = @organization_id
   AND our.deleted_at IS NULL;
 

--- a/server/internal/users/repo/queries.sql.go
+++ b/server/internal/users/repo/queries.sql.go
@@ -70,7 +70,7 @@ func (q *Queries) GetConnectedUserByEmail(ctx context.Context, arg GetConnectedU
 const getConnectedUsersByEmails = `-- name: GetConnectedUsersByEmails :many
 SELECT u.id, u.email, u.display_name, u.photo_url, u.admin, u.last_login, u.workos_id, u.workos_created_at, u.workos_updated_at, u.workos_deleted_at, u.deleted_at, u.created_at, u.updated_at FROM users u
 JOIN organization_user_relationships our ON our.user_id = u.id
-WHERE u.email = ANY($1::text[])
+WHERE lower(u.email) = ANY($1::text[])
   AND our.organization_id = $2
   AND our.deleted_at IS NULL
 `
@@ -80,6 +80,8 @@ type GetConnectedUsersByEmailsParams struct {
 	OrganizationID string
 }
 
+// Callers must pass lowercased emails (conv.NormalizeEmail); stored emails are
+// lowered here since WorkOS-synced rows can preserve the original casing.
 func (q *Queries) GetConnectedUsersByEmails(ctx context.Context, arg GetConnectedUsersByEmailsParams) ([]User, error) {
 	rows, err := q.db.Query(ctx, getConnectedUsersByEmails, arg.Emails, arg.OrganizationID)
 	if err != nil {


### PR DESCRIPTION
Fixes the remaining cases where agent sessions imported from the Anthropic Compliance API ("Claude Chat Desktop" / "Claude Chat Web" sources) show an opaque user ID or "anonymous" instead of the user's name — and explains the fallback in the UI when it still happens legitimately. Context in DNO-590.

## Bug 1: resolved users were erased on re-sync

`UpsertExternalChat` guards `user_id`/`external_user_id` with `COALESCE(EXCLUDED.x, chats.x)` so an unresolved import preserves an earlier resolution — but the compliance import passed `conv.ToPGText("")` (`Valid: true`, not NULL), which defeats the guard. Any later `claude_chat_updated` activity whose actor didn't resolve (empty email, unprovisioned user) permanently clobbered a chat that had already resolved correctly, since update activities never re-run the message-page enrichment. Now unresolved values are passed as NULL via `conv.ToPGTextEmpty`.

The new DB-backed test fails against the old code and passes with the fix.

## Bug 2: case-sensitive email matching

`GetConnectedUsersByEmails` compared the caller's normalized (lowercased) emails against `users.email` verbatim, but WorkOS-synced rows can preserve the user's original casing — so those users silently never resolved. The query now compares `lower(u.email)`. Both callers already normalize their input.

## UX: explain unresolved owners

When the owner label falls back to the raw provider user ID or "anonymous", the agent-sessions list and the session-details popover now render it with a dotted underline and a tooltip explaining that the session's user couldn't be matched to an org member (not provisioned in Gram, or removed from the org).

## Notes

- Rows already clobbered in prod stay unresolved until a new activity for that chat arrives; a backfill would need re-enrichment from the Compliance API (we don't persist actor emails). Left as follow-up in DNO-590.
- Searching/filtering sessions by user is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remaining cases where Claude Chat Desktop/Web sessions show “anonymous” or opaque IDs by preserving resolved users on re-sync, making email matching case-insensitive across server and dashboard, and unifying owner resolution across the UI with a clearer, focusable tooltip for unresolved owners. Addresses DNO-590.

- **Bug Fixes**
  - Preserve resolved users on compliance re-sync by sending NULL for unresolved `user_id`/`external_user_id` so upsert `COALESCE` keeps prior resolutions.
  - Case-insensitive connected-user matching on server and dashboard (including the “You” check), and route recent-session avatars and Elements history through `resolveChatOwner`/`emailsMatch` to avoid mixed-case mismatches.
  - DB and client tests cover user preservation, mixed-case emails, and tooltip copy selection.

- **UX Improvements**
  - New `ChatOwnerLabel` adds a dotted-underline tooltip only after members load, is keyboard-focusable, and explains the fallback based on what identity the session carries.
  - Integrated in agent-session lists and session details.

<sup>Written for commit 757c532e2ceefc6422951996c2412250dd35288f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

