### PR TITLE
fix(aiintegrations): treat empty anthropic analytics data_refreshed_at as a no-op sync

### DIFF
--- a/server/internal/aiintegrations/anthropic_analytics_polling.go
+++ b/server/internal/aiintegrations/anthropic_analytics_polling.go
@@ -266,6 +266,12 @@ func (src *anthropicUsageReportSource) UpperBound(ctx context.Context, endTime t
 	if err != nil {
 		return time.Time{}, err //nolint:wrapcheck // Preserve HTTPError for the access-denied classification upstream.
 	}
+	// An empty data_refreshed_at means Anthropic has not finalized any
+	// analytics data for this org yet. Report a zero upper bound so the
+	// poller no-ops the run instead of failing on an unparseable watermark.
+	if page.DataRefreshedAt == "" {
+		return time.Time{}, nil
+	}
 	refreshedAt, err := time.Parse(time.RFC3339, page.DataRefreshedAt)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parse usage report data_refreshed_at: %w", err)
@@ -314,6 +320,12 @@ func (src *anthropicCostReportSource) UpperBound(ctx context.Context, endTime ti
 	page, err := src.client.GetUserCostReport(ctx, analyticsProbeParams(endTime))
 	if err != nil {
 		return time.Time{}, err //nolint:wrapcheck // Preserve HTTPError for the access-denied classification upstream.
+	}
+	// An empty data_refreshed_at means Anthropic has not finalized any
+	// analytics data for this org yet. Report a zero upper bound so the
+	// poller no-ops the run instead of failing on an unparseable watermark.
+	if page.DataRefreshedAt == "" {
+		return time.Time{}, nil
 	}
 	refreshedAt, err := time.Parse(time.RFC3339, page.DataRefreshedAt)
 	if err != nil {

--- a/server/internal/aiintegrations/anthropic_analytics_polling_test.go
+++ b/server/internal/aiintegrations/anthropic_analytics_polling_test.go
@@ -280,6 +280,51 @@ func TestMaybeSyncAnthropicAnalyticsPullsOnlyUpToDataRefreshedAt(t *testing.T) {
 	require.Empty(t, state.LastPollError)
 }
 
+func TestMaybeSyncAnthropicAnalyticsEmptyDataRefreshedAtNoOps(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	// Anthropic reports no finalization watermark yet — e.g. an org with no
+	// Claude Chat analytics data. The sync must succeed as a no-op instead of
+	// failing on the unparseable empty data_refreshed_at.
+	var requests int
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":              []any{},
+			"data_refreshed_at": "",
+			"has_more":          false,
+			"next_page":         "",
+			"organization_id":   "org_ext_1",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	endTime := time.Now().UTC().Truncate(time.Second)
+	pollers := newTestAnalyticsPollers(t, store, server.URL)
+	cfg := createAnthropicComplianceConfig(t, ctx, conn, store, orgID)
+
+	pollers.syncBoth(t, ctx, cfg, endTime)
+
+	// Only the finality probes run; no window fetches happen.
+	mu.Lock()
+	require.Equal(t, 2, requests, "one probe per schedule, no window fetches")
+	mu.Unlock()
+
+	// The schedules stay never-synced so the next run with a real watermark
+	// performs the full initial lookback.
+	for _, schedule := range []string{ScheduleAnthropicAnalyticsUsage, ScheduleAnthropicAnalyticsCost} {
+		state, err := store.EnsureTimeSyncSchedule(ctx, cfg.ID, schedule)
+		require.NoError(t, err)
+		require.True(t, state.WatermarkAt.IsZero())
+		require.Empty(t, state.LastPollError)
+	}
+}
+
 func TestMaybeSyncAnthropicAnalyticsRecordsForbiddenAsFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/aiintegrations/timewindowpoller/poller.go
+++ b/server/internal/aiintegrations/timewindowpoller/poller.go
@@ -27,7 +27,8 @@ type Source[T any] interface {
 	// UpperBound returns the exclusive upper bound for pulls ending at
 	// endTime, e.g. a provider finalization watermark like Anthropic's
 	// data_refreshed_at. Sources whose data is immediately final return
-	// endTime.
+	// endTime. A zero time means the provider has no finalized data yet;
+	// the poller treats the run as a successful no-op.
 	UpperBound(ctx context.Context, endTime time.Time) (time.Time, error)
 	// FetchPage fetches one response page for the fixed window. pageToken is
 	// empty for the first request and otherwise the opaque value returned by
@@ -86,6 +87,12 @@ func (p *Poller[T]) Do(ctx context.Context) error {
 	upperBound, err := p.upperBound(ctx)
 	if err != nil {
 		return fmt.Errorf("fetch %s upper bound: %w", p.Schedule, err)
+	}
+	// A zero upper bound means the source has no finalized data to pull yet.
+	// Leave the watermark untouched and let the run succeed so the schedule
+	// retries at its normal cadence instead of burning failure retries.
+	if upperBound.IsZero() {
+		return nil
 	}
 
 	checkpoint := p.State.Checkpoint


### PR DESCRIPTION
## What

Treats an empty `data_refreshed_at` in the Anthropic Admin Analytics usage/cost reports as "no finalized data yet" instead of a failure.

## Why

The `UpperBound` probe parsed `data_refreshed_at` unconditionally. Orgs whose analytics reports return an empty watermark (e.g. no Claude Chat activity finalized yet) failed every poll with a parse error:

```
parse usage report data_refreshed_at: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
```

The error is classified retryable, so each poll burned all five Temporal retries (~15 minutes of backoff) and then failed `AIUsagePollerWorkflow` — repeating every cycle. Two production orgs currently hit this on both the usage and cost schedules.

## How

- Both analytics sources return a zero upper bound when `data_refreshed_at` is empty.
- `timewindowpoller.Poller.Do` short-circuits a zero upper bound into a successful no-op run: watermark untouched, failure streak cleared, schedule retries at its normal cadence. The `Source.UpperBound` contract documents this.
- New test covers the no-op: only the finality probes fire, no window fetches, and the schedule stays never-synced so the eventual first real sync still performs its full initial lookback.

## Verification

- `go test ./internal/aiintegrations/ ./internal/aiintegrations/timewindowpoller/` green.
- `mise lint:server` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty Anthropic Admin Analytics `data_refreshed_at` as “no finalized data” and no-op the sync, preventing parse errors, wasted retries, and failed workflow cycles for affected orgs.

- **Bug Fixes**
  - `UpperBound` for both usage and cost now returns zero time when `data_refreshed_at` is empty.
  - `timewindowpoller.Poller.Do` treats a zero upper bound as a successful no-op (watermark unchanged; normal cadence resumes).
  - Added tests to verify only finality probes run and schedules remain never-synced until real data appears.

<sup>Written for commit 76608bb6fd391b5c129f84ed37bd1738f2b02e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

