### PR TITLE
mig(aiintegrations): add auto_paused_at to ai_integration_syncs

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3031,6 +3031,16 @@ CREATE TABLE IF NOT EXISTS ai_integration_syncs (
   last_poll_failed_at timestamptz,
   last_poll_success_at timestamptz,
   consecutive_failures integer NOT NULL DEFAULT 0,
+  -- Set when the scheduler stops polling this schedule because the provider
+  -- repeatedly rejected the configuration (e.g. a revoked api key). Paused
+  -- schedules are skipped by candidate selection until the user updates the
+  -- integration, which resets the sync state and clears this.
+  auto_paused_at timestamptz,
+  -- Set when a user explicitly pauses this schedule from the dashboard.
+  -- Deliberately separate from auto_paused_at so "you paused this" and "we
+  -- paused this over a rejected configuration" stay distinguishable. Only the
+  -- user re-enabling the schedule clears it; config saves do not.
+  disabled_at timestamptz,
   id uuid PRIMARY KEY DEFAULT generate_uuidv7(),
 
   CONSTRAINT ai_integration_syncs_config_id_fkey FOREIGN KEY (ai_integration_config_id) REFERENCES ai_integration_configs (id) ON DELETE CASCADE

--- a/server/internal/aiintegrations/repo/queries.sql.go
+++ b/server/internal/aiintegrations/repo/queries.sql.go
@@ -138,12 +138,12 @@ WITH inserted AS (
     , $5
   )
   ON CONFLICT (ai_integration_config_id, schedule) DO UPDATE SET updated_at = ai_integration_syncs.updated_at
-  RETURNING created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+  RETURNING created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, auto_paused_at, disabled_at, id
 )
-SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, auto_paused_at, disabled_at, id
 FROM inserted
 UNION ALL
-SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, id
+SELECT created_at, updated_at, ai_integration_config_id, schedule, kind, poll_watermark_at, poll_checkpoint, last_cursor_id, next_poll_after, last_poll_error, last_poll_failed_at, last_poll_success_at, consecutive_failures, auto_paused_at, disabled_at, id
 FROM ai_integration_syncs
 WHERE ai_integration_config_id = $1
   AND schedule = $2
@@ -172,6 +172,8 @@ type EnsureSyncRow struct {
 	LastPollFailedAt      pgtype.Timestamptz
 	LastPollSuccessAt     pgtype.Timestamptz
 	ConsecutiveFailures   int32
+	AutoPausedAt          pgtype.Timestamptz
+	DisabledAt            pgtype.Timestamptz
 	ID                    uuid.UUID
 }
 
@@ -198,6 +200,8 @@ func (q *Queries) EnsureSync(ctx context.Context, arg EnsureSyncParams) (EnsureS
 		&i.LastPollFailedAt,
 		&i.LastPollSuccessAt,
 		&i.ConsecutiveFailures,
+		&i.AutoPausedAt,
+		&i.DisabledAt,
 		&i.ID,
 	)
 	return i, err

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -63,6 +63,8 @@ type AiIntegrationSync struct {
 	LastPollFailedAt      pgtype.Timestamptz
 	LastPollSuccessAt     pgtype.Timestamptz
 	ConsecutiveFailures   int32
+	AutoPausedAt          pgtype.Timestamptz
+	DisabledAt            pgtype.Timestamptz
 	ID                    uuid.UUID
 }
 

--- a/server/migrations/20260722120647_aiintegrations-sync-pause-controls.sql
+++ b/server/migrations/20260722120647_aiintegrations-sync-pause-controls.sql
@@ -1,0 +1,2 @@
+-- Modify "ai_integration_syncs" table
+ALTER TABLE "ai_integration_syncs" ADD COLUMN "auto_paused_at" timestamptz NULL, ADD COLUMN "disabled_at" timestamptz NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:hBKHirnPTTQNKjtVXtx9xj2P9rhp97tZlHfAjyQPCZ8=
+h1:cn9J46i6DCc+Rx3wVr1yoNFG+OBtxpM2+nmgnYXpnxc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -286,3 +286,4 @@ h1:hBKHirnPTTQNKjtVXtx9xj2P9rhp97tZlHfAjyQPCZ8=
 20260722090456_chat-messages-autovacuum-cadence.sql h1:q8qNe7ClCif2mg7vy6/5OPXyfRgPwJ57cS7gY66hPQI=
 20260722094814_custom-domains-add-health.sql h1:rPyAbSNozU6SrxQBB0ZnKi0sdWOkYbtFDl1xKOn4FWw=
 20260722101626_risk-results-open-policy-idx.sql h1:L1Wbe6sg3DIFE0yJ3kWKR/Bob5IsgMGN8vkFL64EL/E=
+20260722120647_aiintegrations-sync-pause-controls.sql h1:RE2myegMIhHtZjD/aPL6hipMereyE/gZ53+W24lcwC4=


### PR DESCRIPTION
## What

Adds a nullable `auto_paused_at timestamptz` column to `ai_integration_syncs`.

## Why

Non-retryable AI usage poll failures (revoked API key, missing compliance/analytics API access) are permanent until the user fixes the integration, but candidate selection keeps re-enqueueing the schedule every cycle — one production org has been failing every 10 minutes since Jul 16 (~150 failed workflows/day).

This column lets the poll activity pause a schedule after repeated provider rejections so candidate selection skips it. The application logic lands separately in a follow-up PR, per the migrations-ship-alone rule.

## How

- Schema-only change generated with `mise db:diff` (nullable column, backwards compatible).
- Applied cleanly on a local database via `mise db:migrate`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add nullable `auto_paused_at` and `disabled_at` (timestamptz) to `ai_integration_syncs` to support automatic pauses after repeated provider rejections and explicit user pauses. Auto-paused schedules are skipped by candidate selection; user pauses remain separate.

- **Migration**
  - Schema-only and backward compatible; adds columns and updates generated query/model fields. No runtime changes in this PR.

<sup>Written for commit 8738ec6fef392ccc51ecd8f859aedee2836c31e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

