### PR TITLE
mig: chat_messages auto vacuum settings

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1834,6 +1834,20 @@ CREATE TABLE IF NOT EXISTS chat_messages (
   CONSTRAINT chat_messages_pkey PRIMARY KEY (id),
   CONSTRAINT chat_messages_chat_id_fkey FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
   CONSTRAINT chat_messages_seq_key UNIQUE (seq)
+) WITH (
+  -- Insert-heavy like risk_results, but also update-heavy: risk_analyzed_at
+  -- is set on every message after analysis, so dead tuples accumulate too.
+  -- With the global 0.2 scale factor a table this size tolerates >1.4M dead
+  -- tuples before autovacuum runs, leaving a large fraction of pages not
+  -- all-visible (observed: 76% visible) and pushing the planner off
+  -- index-only scans for project-wide counts onto full seq scans.
+  --
+  -- Fixed insert threshold keeps the vacuum cadence constant as the table
+  -- grows; the tighter dead-tuple scale factor covers the update churn.
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_vacuum_insert_scale_factor = 0,
+  autovacuum_vacuum_insert_threshold = 250000,
+  autovacuum_vacuum_cost_limit = 2000
 );
 
 CREATE INDEX IF NOT EXISTS chat_messages_chat_id_idx ON chat_messages (chat_id);

--- a/server/migrations/20260722090456_chat-messages-autovacuum-cadence.sql
+++ b/server/migrations/20260722090456_chat-messages-autovacuum-cadence.sql
@@ -1,0 +1,8 @@
+-- Set "autovacuum_vacuum_insert_scale_factor" storage parameter on table: "chat_messages"
+ALTER TABLE "chat_messages" SET (autovacuum_vacuum_insert_scale_factor = 0);
+-- Set "autovacuum_vacuum_insert_threshold" storage parameter on table: "chat_messages"
+ALTER TABLE "chat_messages" SET (autovacuum_vacuum_insert_threshold = 250000);
+-- Set "autovacuum_vacuum_cost_limit" storage parameter on table: "chat_messages"
+ALTER TABLE "chat_messages" SET (autovacuum_vacuum_cost_limit = 2000);
+-- Set "autovacuum_vacuum_scale_factor" storage parameter on table: "chat_messages"
+ALTER TABLE "chat_messages" SET (autovacuum_vacuum_scale_factor = 0.02);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:QnOCCrQ4nf1kmheMzHSvXBje3BrOpJLWh7GSc3Cngik=
+h1:Hx4VDcebW8bPicuksf34UMbJRlxoXgOf1Au8CwFMaio=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -283,3 +283,4 @@ h1:QnOCCrQ4nf1kmheMzHSvXBje3BrOpJLWh7GSc3Cngik=
 20260721093938_risk-results-autovacuum-insert-cadence.sql h1:yUpY0HL6nQrNEl7HEkvOuGby0dSEX+QfFt4BrjK8KyM=
 20260721125001_ai-integration-poll-checkpoint.sql h1:OMjSUB9GcRGrONy32TNzXHuapkFOaVwYvoAPuZbxylk=
 20260721225140_ai-integration-sync-schedules-contract.sql h1:To66VlwrBJi3Entrc9+zF5ZGryrGLMp8jEkSrmi+6LY=
+20260722090456_chat-messages-autovacuum-cadence.sql h1:q8qNe7ClCif2mg7vy6/5OPXyfRgPwJ57cS7gY66hPQI=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tuned Postgres autovacuum on the `chat_messages` table to vacuum earlier and more consistently, reducing dead tuples and keeping more pages all-visible. This improves planner choices (index-only scans) and speeds up read queries and counts.

- **Migration**
  - Sets autovacuum params on `chat_messages`: scale_factor 0.02; insert_scale_factor 0; insert_threshold 250k; cost_limit 2000.
  - Run the DB migration; no data changes or downtime.

<sup>Written for commit 6ba1f2604930c63f4ee52595d7b65e4fe1e9e930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

