### PR TITLE
mig: adds index on open policy to speed up list results

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -3898,6 +3898,18 @@ CREATE INDEX IF NOT EXISTS risk_results_project_found_idx
 ON risk_results (project_id, created_at DESC)
 WHERE found IS TRUE AND excluded_at IS NULL AND false_positive_at IS NULL;
 
+-- Open-findings reads that join risk_policies (CountFindings*,
+-- ListRiskResultsByProjectFound) filter on the same open-findings predicate
+-- but need risk_policy_id, which _project_found_idx lacks — and the planner
+-- overestimates the predicate's row count ~5x (it multiplies the
+-- found/excluded_at/false_positive_at selectivities as if independent), which
+-- priced the resulting bitmap heap scan above a parallel seq scan of the
+-- whole table. Keying on risk_policy_id makes the policy-join count an
+-- index-only scan, which stays cheap no matter how far off the estimate is.
+CREATE INDEX IF NOT EXISTS risk_results_project_open_policy_idx
+ON risk_results (project_id, risk_policy_id)
+WHERE found IS TRUE AND excluded_at IS NULL AND false_positive_at IS NULL;
+
 -- Serves the risk overview window scan (GetRiskOverviewCounts): counts every
 -- scanned message in a project's created_at window regardless of found state,
 -- so the partial _project_found_idx cannot help. Range-scans just the window;

--- a/server/migrations/20260722101626_risk-results-open-policy-idx.sql
+++ b/server/migrations/20260722101626_risk-results-open-policy-idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "risk_results_project_open_policy_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_open_policy_idx" ON "risk_results" ("project_id", "risk_policy_id") WHERE ((found IS TRUE) AND (excluded_at IS NULL) AND (false_positive_at IS NULL));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Hx4VDcebW8bPicuksf34UMbJRlxoXgOf1Au8CwFMaio=
+h1:iAUMATzVf3sSBoH4fDqRMzL+mMLeVV6H+S3KAEbRPnw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -284,3 +284,4 @@ h1:Hx4VDcebW8bPicuksf34UMbJRlxoXgOf1Au8CwFMaio=
 20260721125001_ai-integration-poll-checkpoint.sql h1:OMjSUB9GcRGrONy32TNzXHuapkFOaVwYvoAPuZbxylk=
 20260721225140_ai-integration-sync-schedules-contract.sql h1:To66VlwrBJi3Entrc9+zF5ZGryrGLMp8jEkSrmi+6LY=
 20260722090456_chat-messages-autovacuum-cadence.sql h1:q8qNe7ClCif2mg7vy6/5OPXyfRgPwJ57cS7gY66hPQI=
+20260722101626_risk-results-open-policy-idx.sql h1:biFA08ZHg0b+Wt3SZzWYe++7DU9HyvO86PtN1D0K9CI=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a partial index on risk_results (project_id, risk_policy_id) for open findings to speed up policy-joined list and count queries (`ListRiskResultsByProjectFound`, `CountFindings*`). The migration creates the index concurrently to avoid blocking writes.

<sup>Written for commit af56439cab75a57b6fbf0dee8761b780c2d2a5b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

