### PR TITLE
feat(skills): sync summary from current version and improve distribution UX

### DIFF
--- a/.changeset/skills-summary-sync-distribution-ux.md
+++ b/.changeset/skills-summary-sync-distribution-ux.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Skill summaries now stay in sync with the current version: publishing a new version — whether recorded manually or captured from a session — updates the skill's registry summary from the manifest description, so skills captured before their contents arrived no longer show "No summary" forever. The dashboard's Add Skills dialog on the plugin page is now a multi-select that batches distributions, keeps skills without a distributable version listed but disabled with the reason and a Fix link, and the skill page's distribution banner turns red and explains what blocks distribution when a skill has no versions or none pass validation. Version badges in the version history table no longer overlap the Validity column.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -56222,6 +56222,9 @@ components:
           type: string
           description: When this skill was first activated.
           format: date-time
+        has_valid_version:
+          type: boolean
+          description: Whether the skill has at least one valid version available to distribute.
         id:
           type: string
           description: The skill ID.
@@ -56268,6 +56271,7 @@ components:
         - source_kind
         - classification
         - version_count
+        - has_valid_version
         - seen_count
         - created_at
         - updated_at

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -1,6 +1,7 @@
 import { RequireScope } from "@/components/require-scope";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Button as UiButton } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog } from "@/components/ui/dialog";
 import { DotCard } from "@/components/ui/dot-card";
 import { DotRow } from "@/components/ui/dot-row";
@@ -11,6 +12,7 @@ import type { ViewMode } from "@/components/ui/use-view-mode";
 import { useProject } from "@/contexts/Auth";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { useRoutes } from "@/routes";
+import type { Skill } from "@gram/client/models/components/skill.js";
 import type { SkillDistribution } from "@gram/client/models/components/skilldistribution.js";
 import { useDistributeSkillMutation } from "@gram/client/react-query/distributeSkill.js";
 import {
@@ -19,7 +21,7 @@ import {
 } from "@gram/client/react-query/skillDistributions.js";
 import { useSkillsInfinite } from "@gram/client/react-query/skills.js";
 import { useUndistributeSkillMutation } from "@gram/client/react-query/undistributeSkill.js";
-import { Badge, Button, Icon } from "@speakeasy-api/moonshine";
+import { Badge, Button, cn, Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Sparkles, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -86,37 +88,55 @@ export function PluginSkillsSection({
   });
   useDrainInfiniteQuery(skillsQuery, isAddSkillOpen);
   const isSkillListLoading = skillsQuery.isPending || skillsQuery.hasNextPage;
+  // Skills without a valid version stay listed but disabled: the distribute
+  // endpoint rejects them, so the picker explains why and links to the fix.
   const availableSkills = useMemo(() => {
     const distributedSkillIds = new Set(distributions.map((d) => d.skillId));
     return (
       skillsQuery.data?.pages.flatMap((page) => page.result.skills) ?? []
-    ).filter(
-      (skill) =>
-        skill.latestVersionId != null && !distributedSkillIds.has(skill.id),
-    );
+    ).filter((skill) => !distributedSkillIds.has(skill.id));
   }, [distributions, skillsQuery.data?.pages]);
 
   const distribute = useDistributeSkillMutation();
   const undistribute = useUndistributeSkillMutation();
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
 
-  const handleAddSkill: React.FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    const skillId = new FormData(e.currentTarget).get("skillId") as string;
-    if (!skillId) return;
-    distribute.mutate(
-      {
-        request: { distributeSkillRequestBody: { id: skillId, pluginId } },
-      },
-      {
-        onSuccess: () => {
-          setIsAddSkillOpen(false);
-          void invalidateAllSkillDistributions(queryClient);
-          onMutated("Skill added to plugin");
-        },
-        onError: () => {
-          toast.error("Unable to add skill to plugin");
-        },
-      },
+  const openAddSkillDialog = (open: boolean) => {
+    setIsAddSkillOpen(open);
+    if (open) setSelectedSkillIds([]);
+  };
+
+  const toggleSkill = (skillId: string) => {
+    setSelectedSkillIds((prev) =>
+      prev.includes(skillId)
+        ? prev.filter((id) => id !== skillId)
+        : [...prev, skillId],
+    );
+  };
+
+  const handleAddSkills = async () => {
+    if (selectedSkillIds.length === 0) return;
+    // allSettled + unconditional invalidation: some mutations in the batch
+    // may succeed even when others fail, and the cache must reflect what the
+    // server actually committed.
+    const results = await Promise.allSettled(
+      selectedSkillIds.map((skillId) =>
+        distribute.mutateAsync({
+          request: { distributeSkillRequestBody: { id: skillId, pluginId } },
+        }),
+      ),
+    );
+    await invalidateAllSkillDistributions(queryClient);
+    const firstFailure = results.find((result) => result.status === "rejected");
+    if (firstFailure) {
+      toast.error("Unable to add skill to plugin");
+      return;
+    }
+    setIsAddSkillOpen(false);
+    onMutated(
+      selectedSkillIds.length > 1
+        ? `${selectedSkillIds.length} skills added to plugin`
+        : "Skill added to plugin",
     );
   };
 
@@ -244,62 +264,113 @@ export function PluginSkillsSection({
       <div className="mb-8">{listContent}</div>
 
       {/* Add Skill Dialog */}
-      <Dialog open={isAddSkillOpen} onOpenChange={setIsAddSkillOpen}>
+      <Dialog open={isAddSkillOpen} onOpenChange={openAddSkillDialog}>
         <Dialog.Content>
           <Dialog.Header>
-            <Dialog.Title>Add Skill</Dialog.Title>
+            <Dialog.Title>Add Skills</Dialog.Title>
             <Dialog.Description>
-              Distribute a project skill to this plugin bundle.
+              Distribute project skills to this plugin bundle.
             </Dialog.Description>
           </Dialog.Header>
-          <form onSubmit={handleAddSkill} className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">Skill</label>
-              {isSkillListLoading ? (
-                <Skeleton className="h-9 w-full" />
-              ) : availableSkills.length > 0 ? (
-                <select
-                  name="skillId"
-                  className="bg-background rounded-md border px-3 py-2 text-sm"
-                  required
-                >
-                  <option value="">Select a skill</option>
-                  {availableSkills.map((skill) => (
-                    <option key={skill.id} value={skill.id}>
-                      {skill.displayName}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <Type muted small>
-                  No skills available to add. Record a skill in this project
-                  first.
-                </Type>
-              )}
-            </div>
-            <Dialog.Footer>
-              <Button
-                variant="secondary"
-                onClick={() => setIsAddSkillOpen(false)}
-                type="button"
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={
-                  distribute.isPending ||
-                  isSkillListLoading ||
-                  availableSkills.length === 0
-                }
-              >
-                Add
-              </Button>
-            </Dialog.Footer>
-          </form>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Skills</label>
+            {isSkillListLoading ? (
+              <Skeleton className="h-24 w-full" />
+            ) : availableSkills.length > 0 ? (
+              <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-md border p-1">
+                {availableSkills.map((skill) => (
+                  <AddSkillOption
+                    key={skill.id}
+                    skill={skill}
+                    checked={selectedSkillIds.includes(skill.id)}
+                    disabled={distribute.isPending}
+                    onToggle={() => toggleSkill(skill.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Type muted small>
+                No skills available to add. Record a skill in this project
+                first.
+              </Type>
+            )}
+          </div>
+          <Dialog.Footer>
+            <Button
+              variant="secondary"
+              onClick={() => setIsAddSkillOpen(false)}
+              type="button"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={
+                distribute.isPending ||
+                isSkillListLoading ||
+                selectedSkillIds.length === 0
+              }
+              onClick={() => void handleAddSkills()}
+            >
+              {selectedSkillIds.length > 1
+                ? `Add ${selectedSkillIds.length} skills`
+                : "Add"}
+            </Button>
+          </Dialog.Footer>
         </Dialog.Content>
       </Dialog>
     </>
+  );
+}
+
+function AddSkillOption({
+  skill,
+  checked,
+  disabled,
+  onToggle,
+}: {
+  skill: Skill;
+  checked: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}): JSX.Element {
+  const routes = useRoutes();
+  const isDistributable = skill.hasValidVersion;
+
+  return (
+    <label
+      className={cn(
+        "flex items-start gap-2 rounded-sm px-2 py-1.5 text-sm",
+        isDistributable ? "hover:bg-accent cursor-pointer" : "opacity-70",
+      )}
+    >
+      <Checkbox
+        checked={checked}
+        disabled={disabled || !isDistributable}
+        onCheckedChange={onToggle}
+        className="mt-0.5"
+      />
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate">{skill.displayName}</span>
+        <span className="text-muted-foreground truncate font-mono text-xs">
+          {skill.name}
+        </span>
+        {!isDistributable && (
+          <span className="text-muted-foreground text-xs">
+            {skill.versionCount === 0
+              ? "No versions recorded"
+              : "No valid version"}
+            {" · "}
+            <Link
+              to={routes.skills.detail.href(skill.id)}
+              className="text-foreground underline underline-offset-2"
+            >
+              Fix
+            </Link>
+          </span>
+        )}
+      </div>
+    </label>
   );
 }
 

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -100,6 +100,9 @@ export function PluginSkillsSection({
   const distribute = useDistributeSkillMutation();
   const undistribute = useUndistributeSkillMutation();
   const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  // Shared mutation observers only reflect their latest call, so a local flag
+  // covers the whole allSettled batch to keep the dialog locked until it ends.
+  const [isBatchAdding, setIsBatchAdding] = useState(false);
 
   const openAddSkillDialog = (open: boolean) => {
     setIsAddSkillOpen(open);
@@ -115,29 +118,44 @@ export function PluginSkillsSection({
   };
 
   const handleAddSkills = async () => {
-    if (selectedSkillIds.length === 0) return;
-    // allSettled + unconditional invalidation: some mutations in the batch
-    // may succeed even when others fail, and the cache must reflect what the
-    // server actually committed.
-    const results = await Promise.allSettled(
-      selectedSkillIds.map((skillId) =>
-        distribute.mutateAsync({
-          request: { distributeSkillRequestBody: { id: skillId, pluginId } },
-        }),
-      ),
-    );
-    await invalidateAllSkillDistributions(queryClient);
-    const firstFailure = results.find((result) => result.status === "rejected");
-    if (firstFailure) {
-      toast.error("Unable to add skill to plugin");
-      return;
+    if (selectedSkillIds.length === 0 || isBatchAdding) return;
+    setIsBatchAdding(true);
+    try {
+      // allSettled + unconditional invalidation: some mutations in the batch
+      // may succeed even when others fail, and the cache must reflect what the
+      // server actually committed.
+      const results = await Promise.allSettled(
+        selectedSkillIds.map((skillId) =>
+          distribute.mutateAsync({
+            request: { distributeSkillRequestBody: { id: skillId, pluginId } },
+          }),
+        ),
+      );
+      await invalidateAllSkillDistributions(queryClient);
+      const failedIds = selectedSkillIds.filter(
+        (_, index) => results[index]?.status === "rejected",
+      );
+      const addedCount = selectedSkillIds.length - failedIds.length;
+      if (failedIds.length === 0) {
+        setIsAddSkillOpen(false);
+        onMutated(
+          addedCount > 1
+            ? `${addedCount} skills added to plugin`
+            : "Skill added to plugin",
+        );
+        return;
+      }
+      // Keep only the failures selected so a retry doesn't re-add the skills
+      // the server already committed.
+      setSelectedSkillIds(failedIds);
+      toast.error(
+        addedCount > 0
+          ? `Added ${addedCount} skill${addedCount > 1 ? "s" : ""}, ${failedIds.length} failed`
+          : `Unable to add skill${failedIds.length > 1 ? "s" : ""} to plugin`,
+      );
+    } finally {
+      setIsBatchAdding(false);
     }
-    setIsAddSkillOpen(false);
-    onMutated(
-      selectedSkillIds.length > 1
-        ? `${selectedSkillIds.length} skills added to plugin`
-        : "Skill added to plugin",
-    );
   };
 
   const handleRemoveSkill = (distribution: SkillDistribution) => {
@@ -252,7 +270,7 @@ export function PluginSkillsSection({
             variant="secondary"
             size="sm"
             disabled={!isMembershipLoaded}
-            onClick={() => setIsAddSkillOpen(true)}
+            onClick={() => openAddSkillDialog(true)}
           >
             <Button.LeftIcon>
               <Icon name="plus" className="h-4 w-4" />
@@ -283,7 +301,7 @@ export function PluginSkillsSection({
                     key={skill.id}
                     skill={skill}
                     checked={selectedSkillIds.includes(skill.id)}
-                    disabled={distribute.isPending}
+                    disabled={isBatchAdding}
                     onToggle={() => toggleSkill(skill.id)}
                   />
                 ))}
@@ -306,7 +324,7 @@ export function PluginSkillsSection({
             <Button
               type="button"
               disabled={
-                distribute.isPending ||
+                isBatchAdding ||
                 isSkillListLoading ||
                 selectedSkillIds.length === 0
               }

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -340,7 +340,7 @@ function AddSkillOption({
   return (
     <label
       className={cn(
-        "flex items-start gap-2 rounded-sm px-2 py-1.5 text-sm",
+        "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
         isDistributable ? "hover:bg-accent cursor-pointer" : "opacity-70",
       )}
     >
@@ -348,7 +348,6 @@ function AddSkillOption({
         checked={checked}
         disabled={disabled || !isDistributable}
         onCheckedChange={onToggle}
-        className="mt-0.5"
       />
       <div className="flex min-w-0 flex-col">
         <span className="truncate">{skill.displayName}</span>

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -105,6 +105,9 @@ export function PluginSkillsSection({
   const [isBatchAdding, setIsBatchAdding] = useState(false);
 
   const openAddSkillDialog = (open: boolean) => {
+    // Closing mid-batch would hide in-flight requests and drop the
+    // failed-only retry selection.
+    if (!open && isBatchAdding) return;
     setIsAddSkillOpen(open);
     if (open) setSelectedSkillIds([]);
   };
@@ -316,7 +319,8 @@ export function PluginSkillsSection({
           <Dialog.Footer>
             <Button
               variant="secondary"
-              onClick={() => setIsAddSkillOpen(false)}
+              disabled={isBatchAdding}
+              onClick={() => openAddSkillDialog(false)}
               type="button"
             >
               Cancel

--- a/client/dashboard/src/pages/skills/EditSkillDetailsDialog.test.tsx
+++ b/client/dashboard/src/pages/skills/EditSkillDetailsDialog.test.tsx
@@ -49,6 +49,7 @@ const skill = {
   sourceKind: "captured",
   classification: "custom",
   versionCount: 1,
+  hasValidVersion: true,
   seenCount: 2,
   createdAt: new Date("2026-01-01T00:00:00Z"),
   updatedAt: new Date("2026-01-01T00:00:00Z"),

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -268,7 +268,8 @@ describe("SkillDetail", () => {
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Edit SKILL.md" })).toBeNull();
     expect(screen.queryByText("Version history")).toBeNull();
-    expect(screen.queryByText("Distribution banner")).toBeNull();
+    // The banner stays visible so it can explain why distribution is blocked.
+    expect(screen.getByText("Distribution banner")).toBeTruthy();
     expect(screen.queryByText("Distribution controls")).toBeNull();
   });
 

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -550,7 +550,7 @@ function versionColumns({
     {
       key: "hash",
       header: "Version",
-      width: "230px",
+      width: "280px",
       render: (version) => (
         <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-sm">

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -170,7 +170,7 @@ function SkillDetailSections({
 
   return (
     <>
-      {latestVersion && <SkillPluginBanner skillId={skillId} />}
+      <SkillPluginBanner skill={skill} />
 
       <SettingsSection>
         <SettingsSection.Header>
@@ -550,9 +550,9 @@ function versionColumns({
     {
       key: "hash",
       header: "Version",
-      width: "160px",
+      width: "230px",
       render: (version) => (
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="font-mono text-sm">
             {version.canonicalSha256.slice(0, 8)}
           </span>

--- a/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
+++ b/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
@@ -103,6 +103,9 @@ export function SkillPluginBanner({
   const undistribute = useUndistributeSkillMutation();
   const [selectedPluginIds, setSelectedPluginIds] = useState<string[]>([]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  // Shared mutation observers only reflect their latest call, so a local flag
+  // covers the whole allSettled batch to keep the controls locked until it ends.
+  const [isSaving, setIsSaving] = useState(false);
 
   // Sort+join so the effect only re-fires when membership actually changes,
   // not on every unrelated refetch.
@@ -136,8 +139,6 @@ export function SkillPluginBanner({
     distributions.some(
       (distribution) => !selectedIdSet.has(distribution.pluginId),
     );
-  const isSaving = distribute.isPending || undistribute.isPending;
-
   const togglePlugin = (pluginId: string) => {
     setSelectedPluginIds((prev) =>
       prev.includes(pluginId)
@@ -151,40 +152,47 @@ export function SkillPluginBanner({
     const toRemove = distributions.filter(
       (distribution) => !selectedIdSet.has(distribution.pluginId),
     );
-    if (toAdd.length === 0 && toRemove.length === 0) return;
-    // allSettled + unconditional invalidation: some mutations in the batch
-    // may succeed even when others fail, and the cache must reflect what the
-    // server actually committed.
-    const results = await Promise.allSettled([
-      ...toAdd.map((pluginId) =>
-        distribute.mutateAsync({
-          request: {
-            distributeSkillRequestBody: { id: skillId, pluginId },
-          },
-        }),
-      ),
-      ...toRemove.map((distribution) =>
-        undistribute.mutateAsync({
-          request: {
-            undistributeSkillRequestBody: {
-              id: skillId,
-              pluginId: distribution.pluginId,
+    if ((toAdd.length === 0 && toRemove.length === 0) || isSaving) return;
+    setIsSaving(true);
+    try {
+      // allSettled + unconditional invalidation: some mutations in the batch
+      // may succeed even when others fail, and the cache must reflect what the
+      // server actually committed.
+      const results = await Promise.allSettled([
+        ...toAdd.map((pluginId) =>
+          distribute.mutateAsync({
+            request: {
+              distributeSkillRequestBody: { id: skillId, pluginId },
             },
-          },
-        }),
-      ),
-    ]);
-    await invalidateAllSkillDistributions(queryClient);
-    const firstFailure = results.find((result) => result.status === "rejected");
-    if (firstFailure) {
-      toast.error(
-        firstFailure.reason instanceof Error
-          ? firstFailure.reason.message
-          : "Failed to update plugin distributions",
+          }),
+        ),
+        ...toRemove.map((distribution) =>
+          undistribute.mutateAsync({
+            request: {
+              undistributeSkillRequestBody: {
+                id: skillId,
+                pluginId: distribution.pluginId,
+              },
+            },
+          }),
+        ),
+      ]);
+      await invalidateAllSkillDistributions(queryClient);
+      const firstFailure = results.find(
+        (result) => result.status === "rejected",
       );
-      return;
+      if (firstFailure) {
+        toast.error(
+          firstFailure.reason instanceof Error
+            ? firstFailure.reason.message
+            : "Failed to update plugin distributions",
+        );
+        return;
+      }
+      toast.success(describeSaveResult(toAdd.length, toRemove.length));
+    } finally {
+      setIsSaving(false);
     }
-    toast.success(describeSaveResult(toAdd.length, toRemove.length));
   };
 
   const isBlocked = !skill.hasValidVersion;

--- a/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
+++ b/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
@@ -11,6 +11,7 @@ import { useProject } from "@/contexts/Auth";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { ClientIconFan } from "@/pages/mcp/overview/PluginStatusBanner";
 import type { Plugin } from "@gram/client/models/components/plugin.js";
+import type { Skill } from "@gram/client/models/components/skill.js";
 import { useDistributeSkillMutation } from "@gram/client/react-query/distributeSkill.js";
 import { usePlugins } from "@gram/client/react-query/plugins.js";
 import {
@@ -20,7 +21,12 @@ import {
 import { useUndistributeSkillMutation } from "@gram/client/react-query/undistributeSkill.js";
 import { Button, cn } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ChevronDown, CircleCheck } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  CircleAlert,
+  CircleCheck,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -59,13 +65,17 @@ function saveButtonLabel(isSaving: boolean, isDistributed: boolean): string {
 /**
  * The distribution status banner at the top of the skill detail page:
  * summarizes which plugins carry this skill and lets writers stage and save
- * plugin membership changes in one place.
+ * plugin membership changes in one place. When the skill has nothing the
+ * distribute endpoint would accept (no versions, or none valid), the banner
+ * turns red and explains what blocks distribution instead of offering the
+ * picker.
  */
 export function SkillPluginBanner({
-  skillId,
+  skill,
 }: {
-  skillId: string;
+  skill: Skill;
 }): JSX.Element | null {
+  const skillId = skill.id;
   const project = useProject();
   const queryClient = useQueryClient();
   const { data: pluginsData } = usePlugins(undefined, undefined, {
@@ -177,49 +187,75 @@ export function SkillPluginBanner({
     toast.success(describeSaveResult(toAdd.length, toRemove.length));
   };
 
+  const isBlocked = !skill.hasValidVersion;
+  const blockedReason =
+    skill.versionCount === 0
+      ? "This skill has no recorded versions yet. Record a SKILL.md manifest before it can be distributed."
+      : "None of this skill's versions pass validation. Fix the validation errors in SKILL.md before it can be distributed.";
+
+  let headline: JSX.Element;
+  if (isBlocked) {
+    headline = (
+      <>
+        <CircleAlert className="text-destructive h-4 w-4 shrink-0" />
+        <Type className="text-destructive text-base font-semibold">
+          Distribution blocked
+        </Type>
+      </>
+    );
+  } else if (isDistributed) {
+    headline = (
+      <>
+        <CircleCheck className="text-emerald-500 h-4 w-4 shrink-0" />
+        <Type className="text-emerald-500 text-base font-semibold">
+          Distributed to {distributions.length} plugin
+          {distributions.length > 1 ? "s" : ""}
+        </Type>
+      </>
+    );
+  } else {
+    headline = (
+      <>
+        <AlertTriangle className="text-warning-foreground h-4 w-4 shrink-0" />
+        <Type className="text-warning-foreground text-base font-semibold">
+          Not distributed to any plugin
+        </Type>
+      </>
+    );
+  }
+
   return (
     <div className="border-border/70 relative overflow-hidden rounded-xl border shadow-sm">
       <div
         aria-hidden="true"
         className={cn(
           "absolute inset-0 bg-gradient-to-tr from-slate-50 via-slate-50 to-orange-100 transition-all duration-700 ease-in-out dark:from-slate-950 dark:via-neutral-800 dark:to-amber-900/60",
-          isDistributed ? "opacity-0" : "opacity-100",
+          !isDistributed && !isBlocked ? "opacity-100" : "opacity-0",
         )}
       />
       <div
         aria-hidden="true"
         className={cn(
           "absolute inset-0 bg-gradient-to-br from-slate-50/10 via-slate-50 to-emerald-100/50 transition-colors transition-opacity duration-700 ease-in-out dark:from-slate-950/60 dark:via-neutral-800 dark:to-emerald-900/30",
-          isDistributed ? "opacity-100" : "opacity-0",
+          isDistributed && !isBlocked ? "opacity-100" : "opacity-0",
+        )}
+      />
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 bg-gradient-to-tr from-slate-50 via-slate-50 to-red-100 transition-all duration-700 ease-in-out dark:from-slate-950 dark:via-neutral-800 dark:to-red-900/60",
+          isBlocked ? "opacity-100" : "opacity-0",
         )}
       />
       <div className="relative flex items-center justify-between gap-8 p-6">
         <div className="flex max-w-md flex-col gap-3">
-          <div className="flex items-center gap-2">
-            {isDistributed ? (
-              <CircleCheck className="text-emerald-500 h-4 w-4 shrink-0" />
-            ) : (
-              <AlertTriangle className="text-warning-foreground h-4 w-4 shrink-0" />
-            )}
-            <Type
-              className={cn(
-                "text-warning-foreground text-base font-semibold",
-                isDistributed && "text-emerald-500",
-              )}
-            >
-              {isDistributed
-                ? `Distributed to ${distributions.length} plugin${
-                    distributions.length > 1 ? "s" : ""
-                  }`
-                : "Not distributed to any plugin"}
-            </Type>
-          </div>
+          <div className="flex items-center gap-2">{headline}</div>
           <Type variant="small" className="text-muted-foreground/90">
-            Plugins are the preferred way to distribute skills to your
-            organization's users. Skills distributed to a plugin ship inside the
-            plugin package and reach everyone who installs it.
+            {isBlocked
+              ? blockedReason
+              : "Plugins are the preferred way to distribute skills to your organization's users. Skills distributed to a plugin ship inside the plugin package and reach everyone who installs it."}
           </Type>
-          {plugins.length > 0 && (
+          {!isBlocked && plugins.length > 0 && (
             <RequireScope
               scope="skill:write"
               resourceId={project.id}

--- a/client/dashboard/src/pages/skills/SkillsList.test.ts
+++ b/client/dashboard/src/pages/skills/SkillsList.test.ts
@@ -13,6 +13,7 @@ function skill(overrides: Partial<Skill>): Skill {
     classification: "custom",
     latestVersionId: "version_a",
     versionCount: 1,
+    hasValidVersion: true,
     createdAt: new Date("2026-07-16T00:00:00Z"),
     updatedAt: new Date("2026-07-16T00:00:00Z"),
     ...overrides,

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -2240,7 +2240,7 @@ examples:
         application/json: {"content": "<value>", "id": "104f5927-f9aa-409a-86bf-44c0840df1ef"}
       responses:
         "200":
-          application/json: {"created_skill": true, "created_version": true, "skill": {"classification": "<value>", "created_at": "2024-08-08T21:51:24.554Z", "display_name": "Haven.Morar32", "id": "8efe7fe2-2883-4364-ac53-724a85f9e654", "name": "<value>", "project_id": "3905e984-9fa4-4329-b718-85f9ba073020", "seen_count": 115197, "source_kind": "<value>", "updated_at": "2025-12-03T10:35:10.200Z", "version_count": 945826}, "version": {"canonical_sha256": "<value>", "content": "<value>", "created_at": "2026-09-24T06:04:07.980Z", "created_by_user_id": "<id>", "frontmatter": {}, "id": "b0ac1a92-6523-4258-ae53-fed55482cfaf", "metadata": {"key": "<value>", "key1": "<value>"}, "raw_sha256": "<value>", "seen_count": 34366, "skill_id": "506b16a6-9645-4f91-923e-6eb8af1756c7", "spec_valid": false, "validation_errors": [{"code": "<value>", "field": "<value>", "message": "<value>"}]}}
+          application/json: {"created_skill": true, "created_version": true, "skill": {"classification": "<value>", "created_at": "2024-08-08T21:51:24.554Z", "display_name": "Haven.Morar32", "has_valid_version": true, "id": "8efe7fe2-2883-4364-ac53-724a85f9e654", "name": "<value>", "project_id": "3905e984-9fa4-4329-b718-85f9ba073020", "seen_count": 115197, "source_kind": "<value>", "updated_at": "2025-12-03T10:35:10.200Z", "version_count": 945826}, "version": {"canonical_sha256": "<value>", "content": "<value>", "created_at": "2026-09-24T06:04:07.980Z", "created_by_user_id": "<id>", "frontmatter": {}, "id": "b0ac1a92-6523-4258-ae53-fed55482cfaf", "metadata": {"key": "<value>", "key1": "<value>"}, "raw_sha256": "<value>", "seen_count": 34366, "skill_id": "506b16a6-9645-4f91-923e-6eb8af1756c7", "spec_valid": false, "validation_errors": [{"code": "<value>", "field": "<value>", "message": "<value>"}]}}
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": false}
         "500":
@@ -2839,7 +2839,7 @@ examples:
         application/json: {"content": "<value>"}
       responses:
         "200":
-          application/json: {"created_skill": true, "created_version": false, "skill": {"classification": "<value>", "created_at": "2024-01-13T21:05:53.029Z", "display_name": "Rogelio69", "id": "2e459553-2788-40d9-9e7f-cb880cd0af9b", "name": "<value>", "project_id": "ed4b5d13-e447-4362-b38c-56e022bbde92", "seen_count": 91660, "source_kind": "<value>", "updated_at": "2024-03-04T07:12:28.139Z", "version_count": 10884}, "version": {"canonical_sha256": "<value>", "content": "<value>", "created_at": "2024-02-08T17:49:00.730Z", "created_by_user_id": "<id>", "frontmatter": {}, "id": "6cc0e78a-6a20-4ed4-bfe0-3715423123bb", "metadata": {}, "raw_sha256": "<value>", "seen_count": 819902, "skill_id": "230cdb0e-343f-4b0b-b323-5520def4b85d", "spec_valid": false, "validation_errors": [{"code": "<value>", "field": "<value>", "message": "<value>"}]}}
+          application/json: {"created_skill": true, "created_version": false, "skill": {"classification": "<value>", "created_at": "2024-01-13T21:05:53.029Z", "display_name": "Rogelio69", "has_valid_version": true, "id": "2e459553-2788-40d9-9e7f-cb880cd0af9b", "name": "<value>", "project_id": "ed4b5d13-e447-4362-b38c-56e022bbde92", "seen_count": 91660, "source_kind": "<value>", "updated_at": "2024-03-04T07:12:28.139Z", "version_count": 10884}, "version": {"canonical_sha256": "<value>", "content": "<value>", "created_at": "2024-02-08T17:49:00.730Z", "created_by_user_id": "<id>", "frontmatter": {}, "id": "6cc0e78a-6a20-4ed4-bfe0-3715423123bb", "metadata": {}, "raw_sha256": "<value>", "seen_count": 819902, "skill_id": "230cdb0e-343f-4b0b-b323-5520def4b85d", "spec_valid": false, "validation_errors": [{"code": "<value>", "field": "<value>", "message": "<value>"}]}}
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": true}
         "500":
@@ -4156,7 +4156,7 @@ examples:
           id: "3600ba92-a629-4238-b118-2374ee531ccc"
       responses:
         "200":
-          application/json: {"adoption": {"activations_in_window": 193282, "distinct_hostnames": 385005, "window_end": "2024-02-17T23:16:40.002Z", "window_start": "2024-01-07T02:41:01.226Z"}, "assistant_count": 728301, "drift": {"active_machines": 675725, "drifted_machines": 591176, "indeterminate_machines": 139736, "on_target_machines": 674561, "target_state": "single", "target_version_ids": [], "window_end": "2025-09-18T07:28:40.508Z", "window_start": "2024-06-13T03:54:30.891Z"}, "sighting_timeline": [], "skill": {"classification": "<value>", "created_at": "2026-06-16T05:42:51.497Z", "display_name": "Adan_Parisian83", "id": "2f844f68-8ade-4021-927e-ce44754f24fc", "name": "<value>", "project_id": "cb362ec4-4029-48dd-8e7d-90248980a327", "seen_count": 500904, "source_kind": "<value>", "updated_at": "2024-08-06T14:28:41.275Z", "version_count": 278392}}
+          application/json: {"adoption": {"activations_in_window": 193282, "distinct_hostnames": 385005, "window_end": "2024-02-17T23:16:40.002Z", "window_start": "2024-01-07T02:41:01.226Z"}, "assistant_count": 728301, "drift": {"active_machines": 675725, "drifted_machines": 591176, "indeterminate_machines": 139736, "on_target_machines": 674561, "target_state": "single", "target_version_ids": [], "window_end": "2025-09-18T07:28:40.508Z", "window_start": "2024-06-13T03:54:30.891Z"}, "sighting_timeline": [], "skill": {"classification": "<value>", "created_at": "2026-06-16T05:42:51.497Z", "display_name": "Adan_Parisian83", "has_valid_version": true, "id": "2f844f68-8ade-4021-927e-ce44754f24fc", "name": "<value>", "project_id": "cb362ec4-4029-48dd-8e7d-90248980a327", "seen_count": 500904, "source_kind": "<value>", "updated_at": "2024-08-06T14:28:41.275Z", "version_count": 278392}}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": true}
         "500":
@@ -5120,7 +5120,7 @@ examples:
           limit: 50
       responses:
         "200":
-          application/json: {"skills": [{"classification": "<value>", "created_at": "2025-12-01T14:04:14.090Z", "display_name": "Ted_Medhurst44", "id": "a629e09f-919e-4d88-8c05-cebb47ad66a9", "latest_version_id": "77214f80-c570-4870-b5c3-21f19e9fee9e", "name": "<value>", "project_id": "e35c924f-8388-4d55-a06c-1f5093920091", "seen_count": 708579, "source_kind": "<value>", "updated_at": "2025-12-29T20:39:39.995Z", "version_count": 665804}]}
+          application/json: {"skills": [{"classification": "<value>", "created_at": "2025-12-01T14:04:14.090Z", "display_name": "Ted_Medhurst44", "has_valid_version": false, "id": "a629e09f-919e-4d88-8c05-cebb47ad66a9", "latest_version_id": "77214f80-c570-4870-b5c3-21f19e9fee9e", "name": "<value>", "project_id": "e35c924f-8388-4d55-a06c-1f5093920091", "seen_count": 708579, "source_kind": "<value>", "updated_at": "2025-12-29T20:39:39.995Z", "version_count": 665804}]}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": true}
         "500":
@@ -6465,7 +6465,7 @@ examples:
         application/json: {"display_name": "Kennedy24", "id": "5ad39359-acba-4ff3-904b-3242f20370ba", "name": "<value>"}
       responses:
         "200":
-          application/json: {"classification": "<value>", "created_at": "2024-01-07T01:45:50.347Z", "display_name": "Norma83", "id": "773db674-64d7-4196-9645-07f32d236cfa", "name": "<value>", "project_id": "fbbefcde-8905-4f51-80f3-ee6b3bb662e6", "seen_count": 574354, "source_kind": "<value>", "updated_at": "2025-09-30T20:45:41.117Z", "version_count": 628989}
+          application/json: {"classification": "<value>", "created_at": "2024-01-07T01:45:50.347Z", "display_name": "Norma83", "has_valid_version": false, "id": "773db674-64d7-4196-9645-07f32d236cfa", "name": "<value>", "project_id": "fbbefcde-8905-4f51-80f3-ee6b3bb662e6", "seen_count": 574354, "source_kind": "<value>", "updated_at": "2025-09-30T20:45:41.117Z", "version_count": 628989}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": false}
         "500":

--- a/client/dashboard/src/sdk/src/models/components/skill.ts
+++ b/client/dashboard/src/sdk/src/models/components/skill.ts
@@ -29,6 +29,10 @@ export type Skill = {
    */
   firstSeenAt?: Date | undefined;
   /**
+   * Whether the skill has at least one valid version available to distribute.
+   */
+  hasValidVersion: boolean;
+  /**
    * The skill ID.
    */
   id: string;
@@ -82,6 +86,7 @@ export const Skill$inboundSchema: z.ZodMiniType<Skill, unknown> = z.pipe(
     first_seen_at: z.optional(
       z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
     ),
+    has_valid_version: z.boolean(),
     id: z.string(),
     last_seen_at: z.optional(
       z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
@@ -103,6 +108,7 @@ export const Skill$inboundSchema: z.ZodMiniType<Skill, unknown> = z.pipe(
       "created_at": "createdAt",
       "display_name": "displayName",
       "first_seen_at": "firstSeenAt",
+      "has_valid_version": "hasValidVersion",
       "last_seen_at": "lastSeenAt",
       "latest_version_id": "latestVersionId",
       "project_id": "projectId",

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -451,6 +451,7 @@ var Skill = Type("Skill", func() {
 		Format(FormatUUID)
 	})
 	Attribute("version_count", Int64, "The number of immutable versions recorded for the skill.")
+	Attribute("has_valid_version", Boolean, "Whether the skill has at least one valid version available to distribute.")
 	Attribute("first_seen_at", String, "When this skill was first activated.", func() { Format(FormatDateTime) })
 	Attribute("last_seen_at", String, "When this skill was most recently activated.", func() { Format(FormatDateTime) })
 	Attribute("seen_count", Int64, "The number of reconciled activations observed for this skill.")
@@ -461,7 +462,7 @@ var Skill = Type("Skill", func() {
 		Format(FormatDateTime)
 	})
 
-	Required("id", "project_id", "name", "display_name", "source_kind", "classification", "version_count", "seen_count", "created_at", "updated_at")
+	Required("id", "project_id", "name", "display_name", "source_kind", "classification", "version_count", "has_valid_version", "seen_count", "created_at", "updated_at")
 })
 
 var SkillVersion = Type("SkillVersion", func() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -56574,6 +56574,9 @@ components:
                     type: string
                     description: When this skill was first activated.
                     format: date-time
+                has_valid_version:
+                    type: boolean
+                    description: Whether the skill has at least one valid version available to distribute.
                 id:
                     type: string
                     description: The skill ID.
@@ -56620,6 +56623,7 @@ components:
                 - source_kind
                 - classification
                 - version_count
+                - has_valid_version
                 - seen_count
                 - created_at
                 - updated_at

--- a/server/gen/http/skills/client/encode_decode.go
+++ b/server/gen/http/skills/client/encode_decode.go
@@ -2684,6 +2684,7 @@ func unmarshalSkillResponseBodyToTypesSkill(v *SkillResponseBody) *types.Skill {
 		Classification:  *v.Classification,
 		LatestVersionID: v.LatestVersionID,
 		VersionCount:    *v.VersionCount,
+		HasValidVersion: *v.HasValidVersion,
 		FirstSeenAt:     v.FirstSeenAt,
 		LastSeenAt:      v.LastSeenAt,
 		SeenCount:       *v.SeenCount,

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -128,6 +128,8 @@ type UpdateResponseBody struct {
 	LatestVersionID *string `form:"latest_version_id,omitempty" json:"latest_version_id,omitempty" xml:"latest_version_id,omitempty"`
 	// The number of immutable versions recorded for the skill.
 	VersionCount *int64 `form:"version_count,omitempty" json:"version_count,omitempty" xml:"version_count,omitempty"`
+	// Whether the skill has at least one valid version available to distribute.
+	HasValidVersion *bool `form:"has_valid_version,omitempty" json:"has_valid_version,omitempty" xml:"has_valid_version,omitempty"`
 	// When this skill was first activated.
 	FirstSeenAt *string `form:"first_seen_at,omitempty" json:"first_seen_at,omitempty" xml:"first_seen_at,omitempty"`
 	// When this skill was most recently activated.
@@ -2245,6 +2247,8 @@ type SkillResponseBody struct {
 	LatestVersionID *string `form:"latest_version_id,omitempty" json:"latest_version_id,omitempty" xml:"latest_version_id,omitempty"`
 	// The number of immutable versions recorded for the skill.
 	VersionCount *int64 `form:"version_count,omitempty" json:"version_count,omitempty" xml:"version_count,omitempty"`
+	// Whether the skill has at least one valid version available to distribute.
+	HasValidVersion *bool `form:"has_valid_version,omitempty" json:"has_valid_version,omitempty" xml:"has_valid_version,omitempty"`
 	// When this skill was first activated.
 	FirstSeenAt *string `form:"first_seen_at,omitempty" json:"first_seen_at,omitempty" xml:"first_seen_at,omitempty"`
 	// When this skill was most recently activated.
@@ -2795,6 +2799,7 @@ func NewUpdateSkillOK(body *UpdateResponseBody) *types.Skill {
 		Classification:  *body.Classification,
 		LatestVersionID: body.LatestVersionID,
 		VersionCount:    *body.VersionCount,
+		HasValidVersion: *body.HasValidVersion,
 		FirstSeenAt:     body.FirstSeenAt,
 		LastSeenAt:      body.LastSeenAt,
 		SeenCount:       *body.SeenCount,
@@ -4329,6 +4334,9 @@ func ValidateUpdateResponseBody(body *UpdateResponseBody) (err error) {
 	}
 	if body.VersionCount == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("version_count", "body"))
+	}
+	if body.HasValidVersion == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("has_valid_version", "body"))
 	}
 	if body.SeenCount == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("seen_count", "body"))
@@ -7204,6 +7212,9 @@ func ValidateSkillResponseBody(body *SkillResponseBody) (err error) {
 	}
 	if body.VersionCount == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("version_count", "body"))
+	}
+	if body.HasValidVersion == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("has_valid_version", "body"))
 	}
 	if body.SeenCount == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("seen_count", "body"))

--- a/server/gen/http/skills/server/encode_decode.go
+++ b/server/gen/http/skills/server/encode_decode.go
@@ -2683,6 +2683,7 @@ func marshalTypesSkillToSkillResponseBody(v *types.Skill) *SkillResponseBody {
 		Classification:  v.Classification,
 		LatestVersionID: v.LatestVersionID,
 		VersionCount:    v.VersionCount,
+		HasValidVersion: v.HasValidVersion,
 		FirstSeenAt:     v.FirstSeenAt,
 		LastSeenAt:      v.LastSeenAt,
 		SeenCount:       v.SeenCount,

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -130,6 +130,8 @@ type UpdateResponseBody struct {
 	LatestVersionID *string `form:"latest_version_id,omitempty" json:"latest_version_id,omitempty" xml:"latest_version_id,omitempty"`
 	// The number of immutable versions recorded for the skill.
 	VersionCount int64 `form:"version_count" json:"version_count" xml:"version_count"`
+	// Whether the skill has at least one valid version available to distribute.
+	HasValidVersion bool `form:"has_valid_version" json:"has_valid_version" xml:"has_valid_version"`
 	// When this skill was first activated.
 	FirstSeenAt *string `form:"first_seen_at,omitempty" json:"first_seen_at,omitempty" xml:"first_seen_at,omitempty"`
 	// When this skill was most recently activated.
@@ -2247,6 +2249,8 @@ type SkillResponseBody struct {
 	LatestVersionID *string `form:"latest_version_id,omitempty" json:"latest_version_id,omitempty" xml:"latest_version_id,omitempty"`
 	// The number of immutable versions recorded for the skill.
 	VersionCount int64 `form:"version_count" json:"version_count" xml:"version_count"`
+	// Whether the skill has at least one valid version available to distribute.
+	HasValidVersion bool `form:"has_valid_version" json:"has_valid_version" xml:"has_valid_version"`
 	// When this skill was first activated.
 	FirstSeenAt *string `form:"first_seen_at,omitempty" json:"first_seen_at,omitempty" xml:"first_seen_at,omitempty"`
 	// When this skill was most recently activated.
@@ -2444,6 +2448,7 @@ func NewUpdateResponseBody(res *types.Skill) *UpdateResponseBody {
 		Classification:  res.Classification,
 		LatestVersionID: res.LatestVersionID,
 		VersionCount:    res.VersionCount,
+		HasValidVersion: res.HasValidVersion,
 		FirstSeenAt:     res.FirstSeenAt,
 		LastSeenAt:      res.LastSeenAt,
 		SeenCount:       res.SeenCount,

--- a/server/gen/types/skill.go
+++ b/server/gen/types/skill.go
@@ -28,6 +28,8 @@ type Skill struct {
 	LatestVersionID *string
 	// The number of immutable versions recorded for the skill.
 	VersionCount int64
+	// Whether the skill has at least one valid version available to distribute.
+	HasValidVersion bool
 	// When this skill was first activated.
 	FirstSeenAt *string
 	// When this skill was most recently activated.

--- a/server/internal/mv/skill.go
+++ b/server/internal/mv/skill.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/skills/repo"
 )
 
-func BuildSkillView(skill repo.Skill, latestVersionID uuid.UUID, versionCount int64) *types.Skill {
+func BuildSkillView(skill repo.Skill, latestVersionID uuid.UUID, versionCount int64, hasValidVersion bool) *types.Skill {
 	var latestVersionIDValue *string
 	if latestVersionID != uuid.Nil {
 		latestVersionIDValue = conv.PtrEmpty(latestVersionID.String())
@@ -28,6 +28,7 @@ func BuildSkillView(skill repo.Skill, latestVersionID uuid.UUID, versionCount in
 		Classification:  skill.Classification,
 		LatestVersionID: latestVersionIDValue,
 		VersionCount:    versionCount,
+		HasValidVersion: hasValidVersion,
 		FirstSeenAt:     conv.PtrEmpty(conv.FromPGTimestamptz(skill.FirstSeenAt)),
 		LastSeenAt:      conv.PtrEmpty(conv.FromPGTimestamptz(skill.LastSeenAt)),
 		SeenCount:       skill.SeenCount,
@@ -39,7 +40,7 @@ func BuildSkillView(skill repo.Skill, latestVersionID uuid.UUID, versionCount in
 func BuildSkillListView(rows []repo.ListSkillsRow) []*types.Skill {
 	result := make([]*types.Skill, len(rows))
 	for i, row := range rows {
-		result[i] = BuildSkillView(row.Skill, row.LatestVersionID, row.VersionCount)
+		result[i] = BuildSkillView(row.Skill, row.LatestVersionID, row.VersionCount, row.HasValidVersion)
 	}
 
 	return result

--- a/server/internal/skills/capture.go
+++ b/server/internal/skills/capture.go
@@ -115,6 +115,15 @@ func CaptureSkillContent(ctx context.Context, db *pgxpool.Pool, projectID uuid.U
 		}); err != nil {
 			return nil, fmt.Errorf("record captured skill version origin: %w", err)
 		}
+		// The captured version becomes the skill's current version, so the
+		// registry summary follows its manifest description — same step as the
+		// manual record-version flow.
+		skill, err = queries.SyncSkillSummary(ctx, repo.SyncSkillSummaryParams{
+			ProjectID: projectID, ID: skill.ID, Summary: conv.PtrToPGText(parsed.Description),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("sync captured skill summary: %w", err)
+		}
 	}
 
 	matches, err := queries.StoreSkillRawHashAlias(ctx, repo.StoreSkillRawHashAliasParams{

--- a/server/internal/skills/capture_test.go
+++ b/server/internal/skills/capture_test.go
@@ -47,6 +47,25 @@ func TestCaptureSkillContent_CreatesCapturedSkillVersionAndAlias(t *testing.T) {
 	require.NotEmpty(t, alias.CanonicalSha256)
 }
 
+func TestCaptureSkillContent_BackfillsSummaryOnObservedSkill(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	observed, err := ti.repo.CreateObservedSkill(ctx, repo.CreateObservedSkillParams{
+		ProjectID: ti.projectID, Name: "observed-skill", DisplayName: "observed-skill",
+	})
+	require.NoError(t, err)
+	require.False(t, observed.Summary.Valid)
+
+	result, err := skills.CaptureSkillContent(ctx, ti.conn, ti.projectID, capturedManifest("observed-skill", "Backfilled summary.", "body"))
+	require.NoError(t, err)
+	require.False(t, result.CreatedSkill)
+	require.True(t, result.CreatedVersion)
+	require.Equal(t, observed.ID, result.SkillID)
+	skill, err := ti.repo.GetSkill(ctx, repo.GetSkillParams{ProjectID: ti.projectID, ID: result.SkillID})
+	require.NoError(t, err)
+	require.Equal(t, "Backfilled summary.", skill.Summary.String)
+}
+
 func TestCaptureSkillContent_RawVariantsCollapseAndSameNameContentVersions(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -92,7 +111,8 @@ func TestCaptureSkillContent_DedupesManualWithoutOriginAndPreservesPresentation(
 	skill, err := ti.repo.GetSkill(ctx, repo.GetSkillParams{ProjectID: ti.projectID, ID: result.SkillID})
 	require.NoError(t, err)
 	require.Equal(t, "manual-skill", skill.DisplayName)
-	require.Equal(t, "Manual summary.", skill.Summary.String)
+	// The newly captured version became current, so the summary follows it.
+	require.Equal(t, "Captured replacement.", skill.Summary.String)
 }
 
 func TestCaptureSkillContent_ReusesRenamedSkillByRawHash(t *testing.T) {

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -159,16 +159,16 @@ func manifestErrorMessage(err error) string {
 	}
 }
 
-func loadDerivedSkillState(ctx context.Context, queries *repo.Queries, projectID, skillID uuid.UUID) (uuid.UUID, int64, error) {
+func loadDerivedSkillState(ctx context.Context, queries *repo.Queries, projectID, skillID uuid.UUID) (repo.GetSkillStateRow, error) {
 	state, err := queries.GetSkillState(ctx, repo.GetSkillStateParams{
 		ProjectID: projectID,
 		SkillID:   skillID,
 	})
 	if err != nil {
-		return uuid.Nil, 0, fmt.Errorf("get skill state: %w", err)
+		return repo.GetSkillStateRow{LatestVersionID: uuid.Nil, VersionCount: 0, HasValidVersion: false}, fmt.Errorf("get skill state: %w", err)
 	}
 
-	return state.LatestVersionID, state.VersionCount, nil
+	return state, nil
 }
 
 func buildSkillAuditSnapshot(skill repo.Skill, latestVersionID uuid.UUID, versionCount int64) *audit.SkillSnapshot {
@@ -285,12 +285,12 @@ func (s *Service) recordVersion(
 
 	var beforeSnapshot *audit.SkillSnapshot
 	if !createdSkill {
-		latestBeforeID, countBefore, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+		stateBefore, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeUnexpected, err, "load skill state before adding version").LogError(ctx, logger)
 		}
 		if err == nil {
-			beforeSnapshot = buildSkillAuditSnapshot(skill, latestBeforeID, countBefore)
+			beforeSnapshot = buildSkillAuditSnapshot(skill, stateBefore.LatestVersionID, stateBefore.VersionCount)
 		}
 	}
 
@@ -323,7 +323,7 @@ func (s *Service) recordVersion(
 			return nil, oops.E(oops.CodeUnexpected, deleteErr, "promote captured skill version to manual").LogError(ctx, logger)
 		}
 
-		latestID, count, stateErr := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+		state, stateErr := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 		if stateErr != nil {
 			return nil, oops.E(oops.CodeUnexpected, stateErr, "load current skill state after version no-op").LogError(ctx, logger)
 		}
@@ -341,7 +341,7 @@ func (s *Service) recordVersion(
 		}
 
 		return &gen.RecordSkillResult{
-			Skill:          mv.BuildSkillView(skill, latestID, count),
+			Skill:          mv.BuildSkillView(skill, state.LatestVersionID, state.VersionCount, state.HasValidVersion),
 			Version:        matchedView,
 			CreatedSkill:   false,
 			CreatedVersion: false,
@@ -361,19 +361,22 @@ func (s *Service) recordVersion(
 		}
 	}
 
-	updated, err := queries.TouchSkill(ctx, repo.TouchSkillParams{
+	// The new version becomes the skill's current version, so the registry
+	// summary follows its manifest description.
+	updated, err := queries.SyncSkillSummary(ctx, repo.SyncSkillSummaryParams{
 		ProjectID: *authCtx.ProjectID,
 		ID:        skill.ID,
+		Summary:   conv.PtrToPGText(parsed.Description),
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "update skill after adding version").LogError(ctx, logger)
 	}
 
-	latestID, count, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+	state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load skill state after adding version").LogError(ctx, logger)
 	}
-	afterView := mv.BuildSkillView(updated, latestID, count)
+	afterView := mv.BuildSkillView(updated, state.LatestVersionID, state.VersionCount, state.HasValidVersion)
 	versionView, err := mv.BuildSkillVersionView(version, derivedFromVersionID, manifestFrontmatter(version.Content), mv.SkillVersionSightingStats{
 		FirstSeenAt: pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
 		LastSeenAt:  pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
@@ -396,7 +399,7 @@ func (s *Service) recordVersion(
 			SkillDisplayName: updated.DisplayName,
 		})
 	} else {
-		afterSnapshot := buildSkillAuditSnapshot(updated, latestID, count)
+		afterSnapshot := buildSkillAuditSnapshot(updated, state.LatestVersionID, state.VersionCount)
 		err = s.audit.LogSkillAddVersion(ctx, dbtx, audit.LogSkillAddVersionEvent{
 			OrganizationID:      authCtx.ActiveOrganizationID,
 			ProjectID:           *authCtx.ProjectID,
@@ -474,9 +477,9 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*gen.
 		return nil, oops.E(oops.CodeUnexpected, err, "resolve skill by manifest name").LogError(ctx, logger)
 	}
 	if !createdSkill && skill.SourceKind == "captured" {
-		_, versionCount, stateErr := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+		observedState, stateErr := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 		switch {
-		case stateErr == nil && versionCount == 0, errors.Is(stateErr, pgx.ErrNoRows):
+		case stateErr == nil && observedState.VersionCount == 0, errors.Is(stateErr, pgx.ErrNoRows):
 			skill, err = queries.PromoteObservedSkillToManual(ctx, repo.PromoteObservedSkillToManualParams{
 				ProjectID: *authCtx.ProjectID,
 				ID:        skill.ID,
@@ -603,7 +606,7 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 	case err != nil:
 		return nil, oops.E(oops.CodeUnexpected, err, "get skill for update").LogError(ctx, logger)
 	}
-	latestVersionID, versionCount, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+	state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load skill state before update").LogError(ctx, logger)
 	}
@@ -632,8 +635,8 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		SkillURN:            urn.NewSkill(updated.ID),
 		SkillName:           updated.Name,
 		SkillDisplayName:    updated.DisplayName,
-		SkillSnapshotBefore: buildSkillAuditSnapshot(skill, latestVersionID, versionCount),
-		SkillSnapshotAfter:  buildSkillAuditSnapshot(updated, latestVersionID, versionCount),
+		SkillSnapshotBefore: buildSkillAuditSnapshot(skill, state.LatestVersionID, state.VersionCount),
+		SkillSnapshotAfter:  buildSkillAuditSnapshot(updated, state.LatestVersionID, state.VersionCount),
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "log skill update").LogError(ctx, logger)
 	}
@@ -641,7 +644,7 @@ func (s *Service) Update(ctx context.Context, payload *gen.UpdatePayload) (*type
 		return nil, oops.E(oops.CodeUnexpected, err, "commit update skill transaction").LogError(ctx, logger)
 	}
 
-	return mv.BuildSkillView(updated, latestVersionID, versionCount), nil
+	return mv.BuildSkillView(updated, state.LatestVersionID, state.VersionCount, state.HasValidVersion), nil
 }
 
 func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.ListSkillsResult, error) {
@@ -781,7 +784,7 @@ func (s *Service) Get(ctx context.Context, payload *gen.GetPayload) (*gen.GetSki
 	}
 
 	return &gen.GetSkillResult{
-		Skill:          mv.BuildSkillView(details.Skill, details.LatestVersionID, details.VersionCount),
+		Skill:          mv.BuildSkillView(details.Skill, details.LatestVersionID, details.VersionCount, details.HasValidVersion),
 		LatestVersion:  latestView,
 		AssistantCount: details.AssistantCount,
 		Adoption: &gen.SkillAdoption{
@@ -1259,11 +1262,11 @@ func (s *Service) Archive(ctx context.Context, payload *gen.ArchivePayload) erro
 		return oops.E(oops.CodeUnexpected, err, "get skill for archive").LogError(ctx, logger)
 	}
 
-	latestID, count, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
+	state, err := loadDerivedSkillState(ctx, queries, *authCtx.ProjectID, skill.ID)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "load skill state before archive").LogError(ctx, logger)
 	}
-	beforeSnapshot := buildSkillAuditSnapshot(skill, latestID, count)
+	beforeSnapshot := buildSkillAuditSnapshot(skill, state.LatestVersionID, state.VersionCount)
 
 	revokedDistributions, err := queries.RevokeAllSkillDistributionsBySkill(ctx, repo.RevokeAllSkillDistributionsBySkillParams{
 		ProjectID: *authCtx.ProjectID,
@@ -1299,7 +1302,7 @@ func (s *Service) Archive(ctx context.Context, payload *gen.ArchivePayload) erro
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "archive skill").LogError(ctx, logger)
 	}
-	afterSnapshot := buildSkillAuditSnapshot(archived, latestID, count)
+	afterSnapshot := buildSkillAuditSnapshot(archived, state.LatestVersionID, state.VersionCount)
 
 	if err := s.audit.LogSkillArchive(ctx, dbtx, audit.LogSkillArchiveEvent{
 		OrganizationID:      authCtx.ActiveOrganizationID,

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -371,9 +371,10 @@ FROM skill_raw_hashes
 WHERE project_id = @project_id
   AND raw_sha256 = @raw_sha256;
 
--- name: TouchSkill :one
+-- name: SyncSkillSummary :one
 UPDATE skills
-SET updated_at = clock_timestamp()
+SET summary = sqlc.narg(summary)::text,
+    updated_at = clock_timestamp()
 WHERE project_id = @project_id
   AND id = @id
   AND archived_at IS NULL
@@ -413,6 +414,10 @@ SELECT
   sqlc.embed(s),
   COALESCE(state.latest_version_id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
   COALESCE(state.version_count, 0)::bigint AS version_count,
+  EXISTS (
+    SELECT 1 FROM skill_versions sv
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+  )::boolean AS has_valid_version,
   (
     SELECT COUNT(*)::bigint
     FROM skill_distributions sd
@@ -444,7 +449,11 @@ WHERE s.project_id = @project_id
 -- name: GetSkillState :one
 SELECT
   COALESCE(state.latest_version_id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
-  COALESCE(state.version_count, 0)::bigint AS version_count
+  COALESCE(state.version_count, 0)::bigint AS version_count,
+  EXISTS (
+    SELECT 1 FROM skill_versions sv
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+  )::boolean AS has_valid_version
 FROM skills s
 LEFT JOIN LATERAL (
   SELECT
@@ -463,7 +472,11 @@ WHERE s.project_id = @project_id
 SELECT
   sqlc.embed(s),
   COALESCE(latest.id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
-  COALESCE(latest.version_count, 0)::bigint AS version_count
+  COALESCE(latest.version_count, 0)::bigint AS version_count,
+  EXISTS (
+    SELECT 1 FROM skill_versions sv
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+  )::boolean AS has_valid_version
 FROM skills s
 LEFT JOIN LATERAL (
   SELECT

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -928,6 +928,10 @@ SELECT
   s.id, s.project_id, s.name, s.display_name, s.summary, s.source_kind, s.classification, s.first_seen_at, s.last_seen_at, s.seen_count, s.archived_at, s.created_at, s.updated_at,
   COALESCE(state.latest_version_id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
   COALESCE(state.version_count, 0)::bigint AS version_count,
+  EXISTS (
+    SELECT 1 FROM skill_versions sv
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+  )::boolean AS has_valid_version,
   (
     SELECT COUNT(*)::bigint
     FROM skill_distributions sd
@@ -966,6 +970,7 @@ type GetSkillDetailsRow struct {
 	Skill           Skill
 	LatestVersionID uuid.UUID
 	VersionCount    int64
+	HasValidVersion bool
 	AssistantCount  int64
 }
 
@@ -988,6 +993,7 @@ func (q *Queries) GetSkillDetails(ctx context.Context, arg GetSkillDetailsParams
 		&i.Skill.UpdatedAt,
 		&i.LatestVersionID,
 		&i.VersionCount,
+		&i.HasValidVersion,
 		&i.AssistantCount,
 	)
 	return i, err
@@ -1075,7 +1081,11 @@ func (q *Queries) GetSkillRawHash(ctx context.Context, arg GetSkillRawHashParams
 const getSkillState = `-- name: GetSkillState :one
 SELECT
   COALESCE(state.latest_version_id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
-  COALESCE(state.version_count, 0)::bigint AS version_count
+  COALESCE(state.version_count, 0)::bigint AS version_count,
+  EXISTS (
+    SELECT 1 FROM skill_versions sv
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+  )::boolean AS has_valid_version
 FROM skills s
 LEFT JOIN LATERAL (
   SELECT
@@ -1099,12 +1109,13 @@ type GetSkillStateParams struct {
 type GetSkillStateRow struct {
 	LatestVersionID uuid.UUID
 	VersionCount    int64
+	HasValidVersion bool
 }
 
 func (q *Queries) GetSkillState(ctx context.Context, arg GetSkillStateParams) (GetSkillStateRow, error) {
 	row := q.db.QueryRow(ctx, getSkillState, arg.ProjectID, arg.SkillID)
 	var i GetSkillStateRow
-	err := row.Scan(&i.LatestVersionID, &i.VersionCount)
+	err := row.Scan(&i.LatestVersionID, &i.VersionCount, &i.HasValidVersion)
 	return i, err
 }
 
@@ -1701,7 +1712,11 @@ const listSkills = `-- name: ListSkills :many
 SELECT
   s.id, s.project_id, s.name, s.display_name, s.summary, s.source_kind, s.classification, s.first_seen_at, s.last_seen_at, s.seen_count, s.archived_at, s.created_at, s.updated_at,
   COALESCE(latest.id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
-  COALESCE(latest.version_count, 0)::bigint AS version_count
+  COALESCE(latest.version_count, 0)::bigint AS version_count,
+  EXISTS (
+    SELECT 1 FROM skill_versions sv
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+  )::boolean AS has_valid_version
 FROM skills s
 LEFT JOIN LATERAL (
   SELECT
@@ -1732,6 +1747,7 @@ type ListSkillsRow struct {
 	Skill           Skill
 	LatestVersionID uuid.UUID
 	VersionCount    int64
+	HasValidVersion bool
 }
 
 func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListSkillsRow, error) {
@@ -1759,6 +1775,7 @@ func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListS
 			&i.Skill.UpdatedAt,
 			&i.LatestVersionID,
 			&i.VersionCount,
+			&i.HasValidVersion,
 		); err != nil {
 			return nil, err
 		}
@@ -2116,22 +2133,24 @@ func (q *Queries) StoreSkillRawHashAlias(ctx context.Context, arg StoreSkillRawH
 	return matches, err
 }
 
-const touchSkill = `-- name: TouchSkill :one
+const syncSkillSummary = `-- name: SyncSkillSummary :one
 UPDATE skills
-SET updated_at = clock_timestamp()
-WHERE project_id = $1
-  AND id = $2
+SET summary = $1::text,
+    updated_at = clock_timestamp()
+WHERE project_id = $2
+  AND id = $3
   AND archived_at IS NULL
 RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
-type TouchSkillParams struct {
+type SyncSkillSummaryParams struct {
+	Summary   pgtype.Text
 	ProjectID uuid.UUID
 	ID        uuid.UUID
 }
 
-func (q *Queries) TouchSkill(ctx context.Context, arg TouchSkillParams) (Skill, error) {
-	row := q.db.QueryRow(ctx, touchSkill, arg.ProjectID, arg.ID)
+func (q *Queries) SyncSkillSummary(ctx context.Context, arg SyncSkillSummaryParams) (Skill, error) {
+	row := q.db.QueryRow(ctx, syncSkillSummary, arg.Summary, arg.ProjectID, arg.ID)
 	var i Skill
 	err := row.Scan(
 		&i.ID,

--- a/server/internal/skills/service_test.go
+++ b/server/internal/skills/service_test.go
@@ -138,7 +138,7 @@ func TestSkillsVersioningByNormalizedNameAndExplicitAdd(t *testing.T) {
 	require.NotEqual(t, first.Version.ID, second.Version.ID)
 	require.Equal(t, "my-skill", second.Skill.Name)
 	require.Equal(t, "My_Skill", second.Skill.DisplayName)
-	require.Equal(t, "First summary.", *second.Skill.Summary)
+	require.Equal(t, "Second summary.", *second.Skill.Summary)
 	require.Equal(t, int64(2), second.Skill.VersionCount)
 	require.NotNil(t, second.Skill.LatestVersionID)
 	require.Equal(t, second.Version.ID, *second.Skill.LatestVersionID)
@@ -158,7 +158,7 @@ func TestSkillsVersioningByNormalizedNameAndExplicitAdd(t *testing.T) {
 	require.Equal(t, int64(3), third.Skill.VersionCount)
 	require.NotNil(t, third.Skill.LatestVersionID)
 	require.Equal(t, third.Version.ID, *third.Skill.LatestVersionID)
-	require.Equal(t, "First summary.", *third.Skill.Summary)
+	require.Equal(t, "Third summary.", *third.Skill.Summary)
 
 	_, err = ti.service.AddVersion(ctx, &gen.AddVersionPayload{
 		ID:               first.Skill.ID,
@@ -221,7 +221,7 @@ func TestSkillsCurateCapturedSkillWithVersionLineage(t *testing.T) {
 	require.Equal(t, captured.SkillVersionID.String(), *derived.Version.DerivedFromVersionID)
 	require.Equal(t, "curated-name", derived.Skill.Name)
 	require.Equal(t, "Curated skill", derived.Skill.DisplayName)
-	require.Equal(t, "Curated summary.", *derived.Skill.Summary)
+	require.Equal(t, "Edited description.", *derived.Skill.Summary)
 
 	other := createSkill(t, ctx, ti, "other-skill", "Other summary.")
 	_, err = ti.service.AddVersion(ctx, &gen.AddVersionPayload{
@@ -316,7 +316,9 @@ func TestSkillsHistoricalDuplicateDoesNotMoveLatestBackward(t *testing.T) {
 	require.NotNil(t, duplicate.Skill.LatestVersionID)
 	require.Equal(t, newer.Version.ID, *duplicate.Skill.LatestVersionID)
 	require.Equal(t, int64(2), duplicate.Skill.VersionCount)
-	require.Equal(t, "First.", *duplicate.Skill.Summary)
+	// The duplicate re-record creates no version, so the summary stays with
+	// the current (newer) version's description.
+	require.Equal(t, "Second.", *duplicate.Skill.Summary)
 }
 
 func TestSkillsArchiveIsIdempotentAndAllowsReplacement(t *testing.T) {


### PR DESCRIPTION
Skills captured from user sessions could end up with a permanently empty summary: observation-only ingest creates the skill row with `summary = NULL`, and no flow updated it when the first real version landed. This PR fixes that and tightens the distribution UX around invalid skills.

## Summary follows the current version

- New `SyncSkillSummary` query (replaces `TouchSkill`, which had a single caller) sets the skill summary from the manifest description of a newly created version.
- Both flows now share it: the manual record-version path (`Create`/`AddVersion`) and hooks capture (`CaptureSkillContent`), so an observed skill's empty summary is backfilled when its first captured version arrives — and every subsequent version keeps the summary in sync with the current version.
- Behavior change: the summary always tracks the newest version's description, including captured versions replacing a manually edited summary.

## `has_valid_version` on the Skill API type

Exposed on `GetSkillState`/`GetSkillDetails`/`ListSkills` and the Goa `Skill` type. Mirrors exactly what `Distribute` enforces (`GetLatestValidSkillVersion`), so the dashboard can gate distribution affordances without guessing.

## Dashboard

- **Version history**: the hash column no longer lets `Latest`/`Derived` badges overflow into the Validity column (wider column + wrapping).
- **Add Skills dialog** (plugin detail): now a multi-select checkbox list. Skills the distribute endpoint would reject stay listed but disabled, with the reason ("No versions recorded" / "No valid version") and a **Fix** link to the skill page. Batch adds use `allSettled` + broad invalidation.
- **Skill distribution banner**: new blocked state with a red gradient when the skill has nothing distributable — explains whether the skill has no versions or none pass validation, and hides the plugin picker (saving would 400). The banner now also renders for version-less observed skills.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the skill summary to the current version’s description and improve distribution UX. Adds `has_valid_version`, blocks invalid skills in the UI, and locks batch distribution with clear partial-failure handling.

- **New Features**
  - Added `has_valid_version` to Skill on `GetSkillState`, `GetSkillDetails`, `ListSkills`, and wired through `@gram/client`.
  - Dashboard: Add Skills dialog is multi-select; invalid skills stay listed but disabled with a reason and a “Fix” link; batches use `allSettled`, the dialog cannot be closed mid-batch, and partial failures show a toast and keep only failed selections; checkboxes are centered.
  - Dashboard: Distribution banner shows a red “blocked” state when the skill has no versions or no valid version, stays visible to explain the block, hides the plugin picker, and membership saves run as a locked batch; version history column widened to keep badges on one row.

- **Bug Fixes**
  - New `SyncSkillSummary` query keeps a skill’s summary in sync with the current version’s manifest in both manual (`Create`/`AddVersion`) and capture (`CaptureSkillContent`) flows, backfilling observed skills and allowing captured versions to replace a manually edited summary.

<sup>Written for commit 849e41ec53f4f6d3d2e9da49f56802daa7b1663d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

