### PR TITLE
mig: add index on remote session issuer URL

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1207,6 +1207,16 @@ CREATE INDEX IF NOT EXISTS remote_session_issuers_organization_id_idx
 ON remote_session_issuers (organization_id)
 WHERE deleted IS FALSE;
 
+-- Backs resolving an issuer by its upstream URL, where the URL equality is the
+-- selective predicate and the tenancy tier is applied as a filter on top.
+-- Deliberately NOT unique: a project, an organization and a platform issuer may
+-- all legitimately point at the same authorization server, and a customer may
+-- keep a private duplicate carrying its own client setup documentation. Do not
+-- convert this to a unique index.
+CREATE INDEX IF NOT EXISTS remote_session_issuers_issuer_idx
+ON remote_session_issuers (issuer)
+WHERE deleted IS FALSE;
+
 -- Remote Session Clients are records of Gram's client registrations with
 -- upstream authorization servers
 CREATE TABLE IF NOT EXISTS remote_session_clients (

--- a/server/migrations/20260722152825_remote-session-issuers-issuer-idx.sql
+++ b/server/migrations/20260722152825_remote-session-issuers-issuer-idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "remote_session_issuers_issuer_idx" to table: "remote_session_issuers"
+CREATE INDEX CONCURRENTLY "remote_session_issuers_issuer_idx" ON "remote_session_issuers" ("issuer") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qEzjseIla/L49JEScohOwmW9mYiP3WeikkWUXxaIek8=
+h1:4jFtcpImzt3yoJcXXqfMG9tWrsmdFzMiTfj26IgKVFg=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -288,3 +288,4 @@ h1:qEzjseIla/L49JEScohOwmW9mYiP3WeikkWUXxaIek8=
 20260722101626_risk-results-open-policy-idx.sql h1:L1Wbe6sg3DIFE0yJ3kWKR/Bob5IsgMGN8vkFL64EL/E=
 20260722120647_aiintegrations-sync-pause-controls.sql h1:RE2myegMIhHtZjD/aPL6hipMereyE/gZ53+W24lcwC4=
 20260722123722_users-email-lower-idx.sql h1:HsbU8RAGn9Nq8TQ3f3ENQNBC4G6RzUrMmFN9BhJkCn8=
+20260722152825_remote-session-issuers-issuer-idx.sql h1:QCe0CiKPf003pUpVNbt51Vu5+z8xeyM8JFKWU53FP/g=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-331/mig-add-index-on-remote-session-issuersissuer

Adds a non-unique partial index on `remote_session_issuers.issuer`, filtered `WHERE deleted IS FALSE` to match the existing partial indexes on the table. Nothing looks up an issuer by its URL today. AIS-333 adds server-side resolution by URL, and that query needs the index in place before it ships, or its first deploy runs sequential scans.

Non-unique is deliberate. A project issuer, an organization issuer, and a platform issuer may all point at the same upstream authorization server, and a customer may keep a private duplicate carrying its own client setup documentation. The schema comment records that so the index does not later get "fixed" into a unique one.

Single column rather than composite: the URL equality is the selective predicate, and the tier predicate AIS-333 applies is an OR across three different column shapes, so a trailing composite column would add write cost without serving it.

Created CONCURRENTLY (Atlas `txmode none`), so no lock impact on deploy. The longest `issuer` value in production is 59 bytes, well inside the btree row limit, so the concurrent build cannot fail on an oversized entry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a non-unique partial index on `remote_session_issuers.issuer` (WHERE deleted IS FALSE) to support AIS-331 and enable fast issuer-by-URL lookups, avoiding sequential scans. Created CONCURRENTLY via Atlas; duplicates across project, organization, and platform tiers are expected, so uniqueness is intentionally not enforced.

<sup>Written for commit 3b3305c9076800ccea8c08248463dd4e21f18bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

