### PR TITLE
feat: trace ClickHouse client calls by default at the connection level (DNO-602)

### DIFF
--- a/.changeset/clickhouse-client-tracing.md
+++ b/.changeset/clickhouse-client-tracing.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Trace every ClickHouse client call by default: the connection is wrapped once at creation so all Query/Select/Exec calls — from any repo, current or future — emit client spans carrying the query text, forward their span context to ClickHouse's server-side execution spans, and record a per-table duration histogram (clickhouse.client.query.duration) for dashboards and monitors.

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -129,7 +129,7 @@ func newGuardianPolicy(c *cli.Context, logger *slog.Logger, tracerProvider trace
 	return policy, nil
 }
 
-func newClickhouseClient(ctx context.Context, logger *slog.Logger, c *cli.Context) (clickhouse.Conn, func(context.Context) error, error) {
+func newClickhouseClient(ctx context.Context, logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, c *cli.Context) (clickhouse.Conn, func(context.Context) error, error) {
 	logger = logger.With(attr.SlogComponent("clickhouse"))
 	nilFunc := noopShutdown
 
@@ -216,7 +216,10 @@ func newClickhouseClient(ctx context.Context, logger *slog.Logger, c *cli.Contex
 		}
 		return nil
 	}
-	return conn, shutdown, nil
+	// Every consumer of this connection — all repos, current and future —
+	// inherits query tracing and the per-table duration metric by default
+	// (INC-417); no per-call-site wiring exists or is needed.
+	return o11y.TraceClickhouseConn(conn, tracerProvider, meterProvider, logger), shutdown, nil
 }
 
 type dbClientOptions struct {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -484,7 +484,7 @@ func newStartCommand() *cli.Command {
 			}
 			defer db.Close()
 
-			chDB, shutdown, err := newClickhouseClient(ctx, logger, c)
+			chDB, shutdown, err := newClickhouseClient(ctx, logger, tracerProvider, meterProvider, c)
 			if err != nil {
 				return fmt.Errorf("failed to connect to clickhouse database: %w", err)
 			}

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -322,7 +322,7 @@ func newStreamsCommand() *cli.Command {
 			enableCHRiskWrites := !c.Bool("disable-clickhouse-risk-writes")
 			var chConn clickhouse.Conn
 			if enableCHRiskWrites {
-				conn, shutdown, err := newClickhouseClient(ctx, logger, c)
+				conn, shutdown, err := newClickhouseClient(ctx, logger, tracerProvider, meterProvider, c)
 				if err != nil {
 					logger.ErrorContext(ctx, "failed to create clickhouse client, disabling clickhouse risk_findings writer", attr.SlogError(err))
 					enableCHRiskWrites = false

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -531,7 +531,7 @@ func newWorkerCommand() *cli.Command {
 			challengeLoggingEnabled := authz.ChallengeLoggingEnabled(newFeatureChecker(logger, productFeatures, productfeatures.FeatureAuthzChallengeLogging))
 
 			// Create ClickHouse client and telemetry service for resolution events
-			chDB, chShutdown, err := newClickhouseClient(ctx, logger, c)
+			chDB, chShutdown, err := newClickhouseClient(ctx, logger, tracerProvider, meterProvider, c)
 			if err != nil {
 				return fmt.Errorf("failed to connect to clickhouse database: %w", err)
 			}

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -401,6 +401,10 @@ const (
 	// targets (first FROM / INSERT INTO / ALTER TABLE identifier in the
 	// query) — a low-cardinality label for per-table latency dashboards.
 	ClickhouseTableKey = attribute.Key("gram.clickhouse.table")
+	// ClickhouseOperationKey is the Go function that issued a ClickHouse
+	// client call (e.g. ListSessions), derived from the call stack — a
+	// low-cardinality label naming each query for dashboards and monitors.
+	ClickhouseOperationKey = attribute.Key("gram.clickhouse.operation")
 
 	RetryAttemptKey = attribute.Key("retry.attempt")
 	RetryWaitKey    = attribute.Key("retry.wait")
@@ -1601,7 +1605,10 @@ func SlogClickhouseQueryDurationMs(v float64) slog.Attr {
 }
 
 func ClickhouseTable(v string) attribute.KeyValue { return ClickhouseTableKey.String(v) }
-func SlogClickhouseTable(v string) slog.Attr      { return slog.String(string(ClickhouseTableKey), v) }
+func ClickhouseOperation(v string) attribute.KeyValue {
+	return ClickhouseOperationKey.String(v)
+}
+func SlogClickhouseTable(v string) slog.Attr { return slog.String(string(ClickhouseTableKey), v) }
 
 func MCPRegistryID(v string) attribute.KeyValue { return MCPRegistryIDKey.String(v) }
 func SlogMCPRegistryID(v string) slog.Attr      { return slog.String(string(MCPRegistryIDKey), v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -397,6 +397,10 @@ const (
 	PaginationHasNextPageKey = attribute.Key("gram.pagination.has_next_page")
 
 	ClickhouseQueryDurationMsKey = attribute.Key("gram.clickhouse.query_duration_ms")
+	// ClickhouseTableKey is the primary table a ClickHouse client call
+	// targets (first FROM / INSERT INTO / ALTER TABLE identifier in the
+	// query) — a low-cardinality label for per-table latency dashboards.
+	ClickhouseTableKey = attribute.Key("gram.clickhouse.table")
 
 	RetryAttemptKey = attribute.Key("retry.attempt")
 	RetryWaitKey    = attribute.Key("retry.wait")
@@ -1595,6 +1599,9 @@ func ClickhouseQueryDurationMs(v float64) attribute.KeyValue {
 func SlogClickhouseQueryDurationMs(v float64) slog.Attr {
 	return slog.Float64(string(ClickhouseQueryDurationMsKey), v)
 }
+
+func ClickhouseTable(v string) attribute.KeyValue { return ClickhouseTableKey.String(v) }
+func SlogClickhouseTable(v string) slog.Attr      { return slog.String(string(ClickhouseTableKey), v) }
 
 func MCPRegistryID(v string) attribute.KeyValue { return MCPRegistryIDKey.String(v) }
 func SlogMCPRegistryID(v string) slog.Attr      { return slog.String(string(MCPRegistryIDKey), v) }

--- a/server/internal/o11y/clickhouse.go
+++ b/server/internal/o11y/clickhouse.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"regexp"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -89,15 +91,48 @@ func clickhouseTargetTable(query string) string {
 	return "unknown"
 }
 
+// clickhouseCallerOperation names the query after the function that issued
+// it: the first stack frame outside this package (and the runtime), which is
+// the repo method or caller function — e.g. ListSessions or
+// listSessionsFromSummaries. Automatic for every query with no per-call-site
+// wiring, and bounded in cardinality by the number of query functions.
+func clickhouseCallerOperation() string {
+	pc := make([]uintptr, 16)
+	n := runtime.Callers(2, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	for {
+		frame, more := frames.Next()
+		// Skip this decorator's own frames by name rather than frame count:
+		// counting is fragile under inlining.
+		if frame.Function != "" &&
+			!strings.Contains(frame.Function, "o11y.clickhouseCallerOperation") &&
+			!strings.Contains(frame.Function, "o11y.(*tracedClickhouseConn)") {
+			name := frame.Function
+			if i := strings.LastIndex(name, "/"); i >= 0 {
+				name = name[i+1:]
+			}
+			// Trim the package qualifier, keeping Type.Method or function.
+			if i := strings.Index(name, "."); i >= 0 {
+				name = name[i+1:]
+			}
+			return strings.NewReplacer("(", "", ")", "", "*", "").Replace(name)
+		}
+		if !more {
+			return "unknown"
+		}
+	}
+}
+
 // start opens the client span and returns everything the call needs to
 // finish it: the ClickHouse-bound context (span context attached for
 // server-side spans), the span, and a done callback recording status +
 // duration metric.
 func (c *tracedClickhouseConn) start(ctx context.Context, spanName, query string) (context.Context, trace.Span, func(err error)) {
 	table := clickhouseTargetTable(query)
+	operation := clickhouseCallerOperation()
 	ctx, span := c.tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(semconv.DBSystemNameClickHouse, semconv.DBQueryText(query), attr.ClickhouseTable(table)),
+		trace.WithAttributes(semconv.DBSystemNameClickHouse, semconv.DBQueryText(query), attr.ClickhouseTable(table), attr.ClickhouseOperation(operation)),
 	)
 	if sc := span.SpanContext(); sc.IsValid() {
 		ctx = clickhouse.Context(ctx, clickhouse.WithSpan(sc))
@@ -112,6 +147,7 @@ func (c *tracedClickhouseConn) start(ctx context.Context, spanName, query string
 		if c.queryDuration != nil {
 			c.queryDuration.Record(ctx, time.Since(begin).Seconds(), metric.WithAttributes(
 				attr.ClickhouseTable(table),
+				attr.ClickhouseOperation(operation),
 				attr.Outcome(OutcomeFromErrorWithTimeout(err)),
 			))
 		}

--- a/server/internal/o11y/clickhouse.go
+++ b/server/internal/o11y/clickhouse.go
@@ -26,10 +26,13 @@ import (
 const meterClickhouseQueryDuration = "clickhouse.client.query.duration"
 
 // tracedClickhouseConn decorates a clickhouse.Conn so every query issued
-// through it — by any repo, current or future — emits a client span carrying
-// the query text (db.query.text) plus a duration metric, with the span
-// context forwarded to ClickHouse so the server-side execution spans
-// (system.opentelemetry_span_log) join the request trace. clickhouse-go only
+// through it — by any repo, current or future — emits a client span plus a
+// duration metric, labeled with the issuing function
+// (gram.clickhouse.operation) and target table. The full SQL text is
+// deliberately NOT attached: the operation name identifies the code that
+// builds the query, and omitting the text keeps span ingest volume flat.
+// The span context is forwarded to ClickHouse so the server-side execution
+// spans (system.opentelemetry_span_log) join the request trace. clickhouse-go only
 // sends trace context that is explicitly attached via
 // clickhouse.Context/WithSpan; it never reads the span from ctx itself.
 //
@@ -67,8 +70,8 @@ func TraceClickhouseConn(conn clickhouse.Conn, tracerProvider trace.TracerProvid
 
 // clickhouseTablePatterns extract the primary table a statement targets, for
 // the metric/span label only — a mismatch can mislabel a dashboard bucket but
-// never affects query behavior, and the full query text rides the span as
-// ground truth. Inputs are exclusively our own placeholder-parameterized SQL
+// never affects query behavior, and the operation label names the function
+// whose SQL is the ground truth. Inputs are exclusively our own placeholder-parameterized SQL
 // (user values are bound as args, never interpolated). Known label limits,
 // pinned by TestClickhouseTargetTable: the first FROM wins (a CTE reading
 // another table labels that table; JOINs label the leading table), and an
@@ -132,7 +135,7 @@ func (c *tracedClickhouseConn) start(ctx context.Context, spanName, query string
 	operation := clickhouseCallerOperation()
 	ctx, span := c.tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(semconv.DBSystemNameClickHouse, semconv.DBQueryText(query), attr.ClickhouseTable(table), attr.ClickhouseOperation(operation)),
+		trace.WithAttributes(semconv.DBSystemNameClickHouse, attr.ClickhouseTable(table), attr.ClickhouseOperation(operation)),
 	)
 	if sc := span.SpanContext(); sc.IsValid() {
 		ctx = clickhouse.Context(ctx, clickhouse.WithSpan(sc))

--- a/server/internal/o11y/clickhouse.go
+++ b/server/internal/o11y/clickhouse.go
@@ -1,0 +1,165 @@
+package o11y
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// meterClickhouseQueryDuration measures every ClickHouse client call routed
+// through a traced connection (Query/Select/Exec), labeled with the
+// low-cardinality target table and outcome — the read-side counterpart of
+// telemetry.clickhouse.write.duration, and the series to build per-table
+// latency dashboards and monitors on (INC-417).
+const meterClickhouseQueryDuration = "clickhouse.client.query.duration"
+
+// tracedClickhouseConn decorates a clickhouse.Conn so every query issued
+// through it — by any repo, current or future — emits a client span carrying
+// the query text (db.query.text) plus a duration metric, with the span
+// context forwarded to ClickHouse so the server-side execution spans
+// (system.opentelemetry_span_log) join the request trace. clickhouse-go only
+// sends trace context that is explicitly attached via
+// clickhouse.Context/WithSpan; it never reads the span from ctx itself.
+//
+// PrepareBatch and AsyncInsert pass through untraced: the synchronous
+// telemetry write path is instrumented at the Logger layer (observeCHWrite),
+// which owns its own spans and metric.
+type tracedClickhouseConn struct {
+	clickhouse.Conn
+	tracer        trace.Tracer
+	queryDuration metric.Float64Histogram
+}
+
+// TraceClickhouseConn wraps conn so all Query, Select, and Exec calls are
+// traced and measured by default. Wrap once at connection creation
+// (cmd/gram's newClickhouseClient); everything built on the connection
+// inherits the instrumentation without per-call-site wiring.
+func TraceClickhouseConn(conn clickhouse.Conn, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger) clickhouse.Conn {
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/o11y")
+	queryDuration, err := meter.Float64Histogram(
+		meterClickhouseQueryDuration,
+		metric.WithDescription("Duration of ClickHouse client calls in seconds"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(meterClickhouseQueryDuration), attr.SlogError(err))
+	}
+
+	return &tracedClickhouseConn{
+		Conn:          conn,
+		tracer:        tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/o11y"),
+		queryDuration: queryDuration,
+	}
+}
+
+// clickhouseTablePatterns extract the primary table a statement targets, for
+// the metric/span label only — a mismatch can mislabel a dashboard bucket but
+// never affects query behavior, and the full query text rides the span as
+// ground truth. Inputs are exclusively our own placeholder-parameterized SQL
+// (user values are bound as args, never interpolated). Known label limits,
+// pinned by TestClickhouseTargetTable: the first FROM wins (a CTE reading
+// another table labels that table; JOINs label the leading table), and an
+// unmatched statement labels "unknown". The FROM pattern skips subquery
+// parens by requiring an identifier, so a
+// "FROM (SELECT ... FROM chat_session_summaries s)" resolves to the inner
+// table.
+var clickhouseTablePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bINSERT\s+INTO\s+` + "`?" + `([a-zA-Z_][a-zA-Z0-9_]*)`),
+	regexp.MustCompile(`(?i)\bALTER\s+TABLE\s+` + "`?" + `([a-zA-Z_][a-zA-Z0-9_]*)`),
+	regexp.MustCompile(`(?i)\bFROM\s+` + "`?" + `([a-zA-Z_][a-zA-Z0-9_]*)`),
+}
+
+func clickhouseTargetTable(query string) string {
+	for _, pattern := range clickhouseTablePatterns {
+		if m := pattern.FindStringSubmatch(query); m != nil {
+			return m[1]
+		}
+	}
+	return "unknown"
+}
+
+// start opens the client span and returns everything the call needs to
+// finish it: the ClickHouse-bound context (span context attached for
+// server-side spans), the span, and a done callback recording status +
+// duration metric.
+func (c *tracedClickhouseConn) start(ctx context.Context, spanName, query string) (context.Context, trace.Span, func(err error)) {
+	table := clickhouseTargetTable(query)
+	ctx, span := c.tracer.Start(ctx, spanName,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(semconv.DBSystemNameClickHouse, semconv.DBQueryText(query), attr.ClickhouseTable(table)),
+	)
+	if sc := span.SpanContext(); sc.IsValid() {
+		ctx = clickhouse.Context(ctx, clickhouse.WithSpan(sc))
+	}
+
+	begin := time.Now()
+	done := func(err error) {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		if c.queryDuration != nil {
+			c.queryDuration.Record(ctx, time.Since(begin).Seconds(), metric.WithAttributes(
+				attr.ClickhouseTable(table),
+				attr.Outcome(OutcomeFromErrorWithTimeout(err)),
+			))
+		}
+		span.End()
+	}
+	return ctx, span, done
+}
+
+//nolint:wrapcheck // A transparent decorator must return the driver's error unchanged.
+func (c *tracedClickhouseConn) Exec(ctx context.Context, query string, args ...any) error {
+	ctx, _, done := c.start(ctx, "clickhouse.exec", query)
+	err := c.Conn.Exec(ctx, query, args...)
+	done(err)
+	return err
+}
+
+//nolint:wrapcheck // A transparent decorator must return the driver's error unchanged.
+func (c *tracedClickhouseConn) Select(ctx context.Context, dest any, query string, args ...any) error {
+	ctx, _, done := c.start(ctx, "clickhouse.select", query)
+	err := c.Conn.Select(ctx, dest, query, args...)
+	done(err)
+	return err
+}
+
+//nolint:wrapcheck // A transparent decorator must return the driver's error unchanged.
+func (c *tracedClickhouseConn) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
+	ctx, _, done := c.start(ctx, "clickhouse.query", query)
+	rows, err := c.Conn.Query(ctx, query, args...)
+	if err != nil {
+		done(err)
+		return nil, err
+	}
+	// ClickHouse streams results: finishing here would measure only dispatch,
+	// not the query's real duration. The span and metric complete when the
+	// caller closes the result set.
+	return &tracedClickhouseRows{Rows: rows, done: done}, nil
+}
+
+// tracedClickhouseRows completes the query span and duration metric when the
+// result set is closed.
+type tracedClickhouseRows struct {
+	driver.Rows
+	done func(err error)
+}
+
+//nolint:wrapcheck // A transparent decorator must return the driver's error unchanged.
+func (r *tracedClickhouseRows) Close() error {
+	err := r.Rows.Close()
+	r.done(err)
+	return err
+}

--- a/server/internal/o11y/clickhouse_test.go
+++ b/server/internal/o11y/clickhouse_test.go
@@ -1,0 +1,213 @@
+package o11y
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type fakeClickhouseRows struct {
+	driver.Rows
+	closeErr error
+	closed   bool
+}
+
+func (r *fakeClickhouseRows) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+// fakeClickhouseConn captures the context and query each call receives and
+// returns the configured results. Only the traced methods are implemented;
+// everything else panics via the embedded nil interface if reached.
+type fakeClickhouseConn struct {
+	clickhouse.Conn
+	execErr   error
+	queryErr  error
+	selectErr error
+	rows      *fakeClickhouseRows
+
+	gotSpanContext trace.SpanContext
+	gotQuery       string
+}
+
+func (f *fakeClickhouseConn) Exec(ctx context.Context, query string, _ ...any) error {
+	f.gotSpanContext = trace.SpanContextFromContext(ctx)
+	f.gotQuery = query
+	return f.execErr
+}
+
+func (f *fakeClickhouseConn) Select(ctx context.Context, _ any, query string, _ ...any) error {
+	f.gotSpanContext = trace.SpanContextFromContext(ctx)
+	f.gotQuery = query
+	return f.selectErr
+}
+
+func (f *fakeClickhouseConn) Query(ctx context.Context, query string, _ ...any) (driver.Rows, error) {
+	f.gotSpanContext = trace.SpanContextFromContext(ctx)
+	f.gotQuery = query
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.rows, nil
+}
+
+func newRecordingTracedConn(t *testing.T, inner clickhouse.Conn) (clickhouse.Conn, *tracetest.SpanRecorder) {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	meterProvider := sdkmetric.NewMeterProvider()
+	t.Cleanup(func() {
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+		require.NoError(t, meterProvider.Shutdown(context.Background()))
+	})
+	// testenv.NewLogger is unavailable here: testenv imports o11y, so the
+	// in-package test would cycle. Nothing asserts on logs.
+	return TraceClickhouseConn(inner, tracerProvider, meterProvider, slog.New(slog.DiscardHandler)), recorder //nolint:forbidigo // GG006: testenv imports o11y; using it here would be an import cycle.
+}
+
+func requireSpanAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, want string) {
+	t.Helper()
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			require.Equal(t, want, kv.Value.AsString())
+			return
+		}
+	}
+	require.Failf(t, "missing span attribute", "span %q has no attribute %q", span.Name(), key)
+}
+
+func TestTraceClickhouseConn_ExecEmitsSpanWithQueryText(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder := newRecordingTracedConn(t, inner)
+
+	require.NoError(t, conn.Exec(t.Context(), "ALTER TABLE chat_session_summaries DELETE WHERE 1"))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "clickhouse.exec", spans[0].Name())
+	require.Equal(t, trace.SpanKindClient, spans[0].SpanKind())
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	requireSpanAttr(t, spans[0], "db.query.text", "ALTER TABLE chat_session_summaries DELETE WHERE 1")
+	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "chat_session_summaries")
+
+	// The inner call must receive the client span's context so ClickHouse's
+	// server-side spans parent under it.
+	require.True(t, inner.gotSpanContext.IsValid())
+	require.Equal(t, spans[0].SpanContext().SpanID(), inner.gotSpanContext.SpanID())
+}
+
+func TestTraceClickhouseConn_ExecRecordsError(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{execErr: errors.New("boom")}
+	conn, recorder := newRecordingTracedConn(t, inner)
+
+	require.Error(t, conn.Exec(t.Context(), "ALTER TABLE t DELETE WHERE 1"))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.NotEmpty(t, spans[0].Events(), "error must be recorded on the span")
+}
+
+func TestTraceClickhouseConn_SelectEmitsSpan(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder := newRecordingTracedConn(t, inner)
+
+	var dest []struct{}
+	require.NoError(t, conn.Select(t.Context(), &dest, "SELECT 1 FROM trace_summaries"))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "clickhouse.select", spans[0].Name())
+	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "trace_summaries")
+}
+
+func TestTraceClickhouseConn_QuerySpanEndsOnRowsClose(t *testing.T) {
+	t.Parallel()
+
+	rows := &fakeClickhouseRows{}
+	inner := &fakeClickhouseConn{rows: rows}
+	conn, recorder := newRecordingTracedConn(t, inner)
+
+	got, err := conn.Query(t.Context(), "SELECT chat_id FROM chat_session_summaries")
+	require.NoError(t, err)
+	// ClickHouse streams results, so the span must stay open until the
+	// caller finishes consuming them.
+	require.Empty(t, recorder.Ended(), "query span must not end before rows are closed")
+
+	require.NoError(t, got.Close())
+	require.True(t, rows.closed)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "clickhouse.query", spans[0].Name())
+	requireSpanAttr(t, spans[0], "db.query.text", "SELECT chat_id FROM chat_session_summaries")
+	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "chat_session_summaries")
+}
+
+func TestTraceClickhouseConn_QueryErrorEndsSpanWithError(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{queryErr: errors.New("no such table")}
+	conn, recorder := newRecordingTracedConn(t, inner)
+
+	_, err := conn.Query(t.Context(), "SELECT broken")
+	require.Error(t, err)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+}
+
+func TestTraceClickhouseConn_RowsCloseErrorMarksSpan(t *testing.T) {
+	t.Parallel()
+
+	rows := &fakeClickhouseRows{closeErr: errors.New("connection reset")}
+	inner := &fakeClickhouseConn{rows: rows}
+	conn, recorder := newRecordingTracedConn(t, inner)
+
+	got, err := conn.Query(t.Context(), "SELECT 1")
+	require.NoError(t, err)
+	require.Error(t, got.Close())
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+}
+
+func TestClickhouseTargetTable(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"SELECT chat_id FROM chat_session_summaries s WHERE 1":   "chat_session_summaries",
+		"SELECT * FROM (SELECT * FROM telemetry_logs) WHERE 1":   "telemetry_logs",
+		"WITH x AS (SELECT 1) SELECT * FROM trace_summaries":     "trace_summaries",
+		"INSERT INTO telemetry_logs (a, b) VALUES (?, ?)":        "telemetry_logs",
+		"INSERT INTO `chat_token_summaries` (a) VALUES (?)":      "chat_token_summaries",
+		"ALTER TABLE attribute_metrics_summaries DELETE WHERE 1": "attribute_metrics_summaries",
+		"select lower.case from lowercase_table":                 "lowercase_table",
+		"SELECT 1":                                               "unknown",
+		// Pinned label limits: first FROM wins, JOINs label the leading table.
+		"WITH c AS (SELECT x FROM table_a) SELECT y FROM table_b JOIN c": "table_a",
+		"SELECT a.x FROM table_a a JOIN table_b b ON a.id = b.id":        "table_a",
+	}
+	for query, want := range cases {
+		require.Equal(t, want, clickhouseTargetTable(query), "query: %s", query)
+	}
+}

--- a/server/internal/o11y/clickhouse_test.go
+++ b/server/internal/o11y/clickhouse_test.go
@@ -3,14 +3,18 @@ package o11y
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -27,9 +31,10 @@ func (r *fakeClickhouseRows) Close() error {
 	return r.closeErr
 }
 
-// fakeClickhouseConn captures the context and query each call receives and
-// returns the configured results. Only the traced methods are implemented;
-// everything else panics via the embedded nil interface if reached.
+// fakeClickhouseConn captures the span context and query each call receives
+// and returns the configured results. Only the traced methods are
+// implemented; everything else panics via the embedded nil interface if
+// reached.
 type fakeClickhouseConn struct {
 	clickhouse.Conn
 	execErr   error
@@ -62,36 +67,69 @@ func (f *fakeClickhouseConn) Query(ctx context.Context, query string, _ ...any) 
 	return f.rows, nil
 }
 
-func newRecordingTracedConn(t *testing.T, inner clickhouse.Conn) (clickhouse.Conn, *tracetest.SpanRecorder) {
+func newRecordingTracedConn(t *testing.T, inner clickhouse.Conn) (clickhouse.Conn, *tracetest.SpanRecorder, *sdkmetric.ManualReader) {
 	t.Helper()
 	recorder := tracetest.NewSpanRecorder()
 	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-	meterProvider := sdkmetric.NewMeterProvider()
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	t.Cleanup(func() {
 		require.NoError(t, tracerProvider.Shutdown(context.Background()))
 		require.NoError(t, meterProvider.Shutdown(context.Background()))
 	})
 	// testenv.NewLogger is unavailable here: testenv imports o11y, so the
 	// in-package test would cycle. Nothing asserts on logs.
-	return TraceClickhouseConn(inner, tracerProvider, meterProvider, slog.New(slog.DiscardHandler)), recorder //nolint:forbidigo // GG006: testenv imports o11y; using it here would be an import cycle.
+	return TraceClickhouseConn(inner, tracerProvider, meterProvider, slog.New(slog.DiscardHandler)), recorder, reader //nolint:forbidigo // GG006: testenv imports o11y; using it here would be an import cycle.
+}
+
+func spanAttr(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
 }
 
 func requireSpanAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, want string) {
 	t.Helper()
-	for _, kv := range span.Attributes() {
-		if string(kv.Key) == key {
-			require.Equal(t, want, kv.Value.AsString())
-			return
-		}
-	}
-	require.Failf(t, "missing span attribute", "span %q has no attribute %q", span.Name(), key)
+	got, ok := spanAttr(span, key)
+	require.True(t, ok, "span %q has no attribute %q", span.Name(), key)
+	require.Equal(t, want, got)
 }
 
-func TestTraceClickhouseConn_ExecEmitsSpanWithQueryText(t *testing.T) {
+// queryDurationDataPoints collects the clickhouse.client.query.duration
+// histogram's data points, or an empty slice when nothing was recorded yet.
+func queryDurationDataPoints(t *testing.T, reader *sdkmetric.ManualReader) []metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name != meterClickhouseQueryDuration {
+				continue
+			}
+			require.Equal(t, "s", m.Unit)
+			hist, ok := m.Data.(metricdata.Histogram[float64])
+			require.True(t, ok, "expected a float64 histogram")
+			return hist.DataPoints
+		}
+	}
+	return nil
+}
+
+func dataPointAttr(dp metricdata.HistogramDataPoint[float64], key string) string {
+	if v, ok := dp.Attributes.Value(attribute.Key(key)); ok {
+		return v.AsString()
+	}
+	return ""
+}
+
+func TestTraceClickhouseConn_ExecEmitsSpan(t *testing.T) {
 	t.Parallel()
 
 	inner := &fakeClickhouseConn{}
-	conn, recorder := newRecordingTracedConn(t, inner)
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
 
 	require.NoError(t, conn.Exec(t.Context(), "ALTER TABLE chat_session_summaries DELETE WHERE 1"))
 
@@ -100,10 +138,8 @@ func TestTraceClickhouseConn_ExecEmitsSpanWithQueryText(t *testing.T) {
 	require.Equal(t, "clickhouse.exec", spans[0].Name())
 	require.Equal(t, trace.SpanKindClient, spans[0].SpanKind())
 	require.Equal(t, codes.Unset, spans[0].Status().Code)
-	requireSpanAttr(t, spans[0], "db.query.text", "ALTER TABLE chat_session_summaries DELETE WHERE 1")
 	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "chat_session_summaries")
-	// The operation is the calling function, derived from the stack.
-	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "TestTraceClickhouseConn_ExecEmitsSpanWithQueryText")
+	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "TestTraceClickhouseConn_ExecEmitsSpan")
 
 	// The inner call must receive the client span's context so ClickHouse's
 	// server-side spans parent under it.
@@ -111,11 +147,29 @@ func TestTraceClickhouseConn_ExecEmitsSpanWithQueryText(t *testing.T) {
 	require.Equal(t, spans[0].SpanContext().SpanID(), inner.gotSpanContext.SpanID())
 }
 
+// TestTraceClickhouseConn_NoQueryTextOnSpan pins a deliberate decision: the
+// full SQL text is NOT attached to spans. The operation label identifies the
+// function whose code builds the query, and omitting the text keeps span
+// ingest volume flat even for multi-kilobyte statements.
+func TestTraceClickhouseConn_NoQueryTextOnSpan(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
+
+	require.NoError(t, conn.Exec(t.Context(), "SELECT big FROM telemetry_logs WHERE x = ?"))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	_, ok := spanAttr(spans[0], "db.query.text")
+	require.False(t, ok, "spans must not carry the SQL text")
+}
+
 func TestTraceClickhouseConn_ExecRecordsError(t *testing.T) {
 	t.Parallel()
 
 	inner := &fakeClickhouseConn{execErr: errors.New("boom")}
-	conn, recorder := newRecordingTracedConn(t, inner)
+	conn, recorder, reader := newRecordingTracedConn(t, inner)
 
 	require.Error(t, conn.Exec(t.Context(), "ALTER TABLE t DELETE WHERE 1"))
 
@@ -123,13 +177,17 @@ func TestTraceClickhouseConn_ExecRecordsError(t *testing.T) {
 	require.Len(t, spans, 1)
 	require.Equal(t, codes.Error, spans[0].Status().Code)
 	require.NotEmpty(t, spans[0].Events(), "error must be recorded on the span")
+
+	dps := queryDurationDataPoints(t, reader)
+	require.Len(t, dps, 1)
+	require.Equal(t, "failure", dataPointAttr(dps[0], "gram.outcome"))
 }
 
 func TestTraceClickhouseConn_SelectEmitsSpan(t *testing.T) {
 	t.Parallel()
 
 	inner := &fakeClickhouseConn{}
-	conn, recorder := newRecordingTracedConn(t, inner)
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
 
 	var dest []struct{}
 	require.NoError(t, conn.Select(t.Context(), &dest, "SELECT 1 FROM trace_summaries"))
@@ -138,20 +196,22 @@ func TestTraceClickhouseConn_SelectEmitsSpan(t *testing.T) {
 	require.Len(t, spans, 1)
 	require.Equal(t, "clickhouse.select", spans[0].Name())
 	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "trace_summaries")
+	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "TestTraceClickhouseConn_SelectEmitsSpan")
 }
 
-func TestTraceClickhouseConn_QuerySpanEndsOnRowsClose(t *testing.T) {
+func TestTraceClickhouseConn_QuerySpanAndMetricCompleteOnRowsClose(t *testing.T) {
 	t.Parallel()
 
 	rows := &fakeClickhouseRows{}
 	inner := &fakeClickhouseConn{rows: rows}
-	conn, recorder := newRecordingTracedConn(t, inner)
+	conn, recorder, reader := newRecordingTracedConn(t, inner)
 
 	got, err := conn.Query(t.Context(), "SELECT chat_id FROM chat_session_summaries")
 	require.NoError(t, err)
-	// ClickHouse streams results, so the span must stay open until the
-	// caller finishes consuming them.
+	// ClickHouse streams results, so both the span and the duration metric
+	// must wait for the caller to finish consuming them.
 	require.Empty(t, recorder.Ended(), "query span must not end before rows are closed")
+	require.Empty(t, queryDurationDataPoints(t, reader), "duration must not be recorded before rows are closed")
 
 	require.NoError(t, got.Close())
 	require.True(t, rows.closed)
@@ -159,15 +219,20 @@ func TestTraceClickhouseConn_QuerySpanEndsOnRowsClose(t *testing.T) {
 	spans := recorder.Ended()
 	require.Len(t, spans, 1)
 	require.Equal(t, "clickhouse.query", spans[0].Name())
-	requireSpanAttr(t, spans[0], "db.query.text", "SELECT chat_id FROM chat_session_summaries")
 	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "chat_session_summaries")
+
+	dps := queryDurationDataPoints(t, reader)
+	require.Len(t, dps, 1)
+	require.Equal(t, uint64(1), dps[0].Count)
+	require.Equal(t, "success", dataPointAttr(dps[0], "gram.outcome"))
+	require.Equal(t, "chat_session_summaries", dataPointAttr(dps[0], "gram.clickhouse.table"))
 }
 
 func TestTraceClickhouseConn_QueryErrorEndsSpanWithError(t *testing.T) {
 	t.Parallel()
 
 	inner := &fakeClickhouseConn{queryErr: errors.New("no such table")}
-	conn, recorder := newRecordingTracedConn(t, inner)
+	conn, recorder, reader := newRecordingTracedConn(t, inner)
 
 	_, err := conn.Query(t.Context(), "SELECT broken")
 	require.Error(t, err)
@@ -175,6 +240,10 @@ func TestTraceClickhouseConn_QueryErrorEndsSpanWithError(t *testing.T) {
 	spans := recorder.Ended()
 	require.Len(t, spans, 1)
 	require.Equal(t, codes.Error, spans[0].Status().Code)
+
+	dps := queryDurationDataPoints(t, reader)
+	require.Len(t, dps, 1)
+	require.Equal(t, "failure", dataPointAttr(dps[0], "gram.outcome"))
 }
 
 func TestTraceClickhouseConn_RowsCloseErrorMarksSpan(t *testing.T) {
@@ -182,7 +251,7 @@ func TestTraceClickhouseConn_RowsCloseErrorMarksSpan(t *testing.T) {
 
 	rows := &fakeClickhouseRows{closeErr: errors.New("connection reset")}
 	inner := &fakeClickhouseConn{rows: rows}
-	conn, recorder := newRecordingTracedConn(t, inner)
+	conn, recorder, reader := newRecordingTracedConn(t, inner)
 
 	got, err := conn.Query(t.Context(), "SELECT 1")
 	require.NoError(t, err)
@@ -191,7 +260,163 @@ func TestTraceClickhouseConn_RowsCloseErrorMarksSpan(t *testing.T) {
 	spans := recorder.Ended()
 	require.Len(t, spans, 1)
 	require.Equal(t, codes.Error, spans[0].Status().Code)
+
+	dps := queryDurationDataPoints(t, reader)
+	require.Len(t, dps, 1)
+	require.Equal(t, "failure", dataPointAttr(dps[0], "gram.outcome"))
 }
+
+func TestTraceClickhouseConn_TimeoutOutcome(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{execErr: context.DeadlineExceeded}
+	conn, _, reader := newRecordingTracedConn(t, inner)
+
+	require.Error(t, conn.Exec(t.Context(), "SELECT 1"))
+
+	dps := queryDurationDataPoints(t, reader)
+	require.Len(t, dps, 1)
+	require.Equal(t, "timeout", dataPointAttr(dps[0], "gram.outcome"))
+}
+
+// ---- Operation-name derivation ------------------------------------------
+
+// fakeRepo mirrors the real call shape: a repository type whose methods
+// issue queries through the shared connection.
+type fakeRepo struct {
+	conn clickhouse.Conn
+}
+
+func (r *fakeRepo) ListWidgets(ctx context.Context) error {
+	if err := r.conn.Exec(ctx, "SELECT 1 FROM widgets"); err != nil {
+		return fmt.Errorf("list widgets: %w", err)
+	}
+	return nil
+}
+
+func execViaHelper(ctx context.Context, conn clickhouse.Conn) error {
+	if err := conn.Exec(ctx, "SELECT 1"); err != nil {
+		return fmt.Errorf("exec via helper: %w", err)
+	}
+	return nil
+}
+
+func execOuterHelper(ctx context.Context, conn clickhouse.Conn) error {
+	return execViaHelper(ctx, conn)
+}
+
+func TestClickhouseOperation_RepoMethod(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder, reader := newRecordingTracedConn(t, inner)
+
+	repo := &fakeRepo{conn: conn}
+	require.NoError(t, repo.ListWidgets(t.Context()))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	// Pointer-receiver methods clean up to Type.Method.
+	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "fakeRepo.ListWidgets")
+
+	dps := queryDurationDataPoints(t, reader)
+	require.Len(t, dps, 1)
+	require.Equal(t, "fakeRepo.ListWidgets", dataPointAttr(dps[0], "gram.clickhouse.operation"))
+}
+
+func TestClickhouseOperation_PlainFunction(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
+
+	require.NoError(t, execViaHelper(t.Context(), conn))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "execViaHelper")
+}
+
+func TestClickhouseOperation_NestedHelpersNameInnermostCaller(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
+
+	require.NoError(t, execOuterHelper(t.Context(), conn))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	// The FIRST frame outside the decorator wins: the innermost caller, not
+	// the outer orchestration. Pinned so a filter change cannot silently
+	// shift every label up or down the stack.
+	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "execViaHelper")
+}
+
+func TestClickhouseOperation_Closure(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
+
+	issue := func() error {
+		return conn.Exec(t.Context(), "SELECT 1")
+	}
+	require.NoError(t, issue())
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	op, ok := spanAttr(spans[0], "gram.clickhouse.operation")
+	require.True(t, ok)
+	// Anonymous functions carry their parent's name plus a funcN suffix —
+	// still attributable, still bounded cardinality.
+	require.True(t, strings.HasPrefix(op, "TestClickhouseOperation_Closure.func"), "got %q", op)
+}
+
+func TestClickhouseOperation_Goroutine(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, recorder, _ := newRecordingTracedConn(t, inner)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- conn.Exec(context.Background(), "SELECT 1")
+	}()
+	require.NoError(t, <-done)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	op, ok := spanAttr(spans[0], "gram.clickhouse.operation")
+	require.True(t, ok)
+	// A goroutine's stack roots at its closure: attribution survives the
+	// goroutine boundary instead of degrading to "unknown".
+	require.True(t, strings.HasPrefix(op, "TestClickhouseOperation_Goroutine.func"), "got %q", op)
+}
+
+func TestClickhouseOperation_DistinctSeriesPerOperation(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeClickhouseConn{}
+	conn, _, reader := newRecordingTracedConn(t, inner)
+
+	repo := &fakeRepo{conn: conn}
+	require.NoError(t, repo.ListWidgets(t.Context()))
+	require.NoError(t, execViaHelper(t.Context(), conn))
+	require.NoError(t, execViaHelper(t.Context(), conn))
+
+	dps := queryDurationDataPoints(t, reader)
+	counts := map[string]uint64{}
+	for _, dp := range dps {
+		counts[dataPointAttr(dp, "gram.clickhouse.operation")] += dp.Count
+	}
+	require.Equal(t, map[string]uint64{
+		"fakeRepo.ListWidgets": 1,
+		"execViaHelper":        2,
+	}, counts, "each operation must be its own metric series")
+}
+
+// ---- Table extraction ----------------------------------------------------
 
 func TestClickhouseTargetTable(t *testing.T) {
 	t.Parallel()

--- a/server/internal/o11y/clickhouse_test.go
+++ b/server/internal/o11y/clickhouse_test.go
@@ -102,6 +102,8 @@ func TestTraceClickhouseConn_ExecEmitsSpanWithQueryText(t *testing.T) {
 	require.Equal(t, codes.Unset, spans[0].Status().Code)
 	requireSpanAttr(t, spans[0], "db.query.text", "ALTER TABLE chat_session_summaries DELETE WHERE 1")
 	requireSpanAttr(t, spans[0], "gram.clickhouse.table", "chat_session_summaries")
+	// The operation is the calling function, derived from the stack.
+	requireSpanAttr(t, spans[0], "gram.clickhouse.operation", "TestTraceClickhouseConn_ExecEmitsSpanWithQueryText")
 
 	// The inner call must receive the client span's context so ClickHouse's
 	// server-side spans parent under it.

--- a/server/internal/telemetry/repo/db.go
+++ b/server/internal/telemetry/repo/db.go
@@ -3,9 +3,7 @@ package repo
 import (
 	"context"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // CHTX is the interface for executing ClickHouse queries and commands.
@@ -32,15 +30,4 @@ func New(conn CHTX) *Queries {
 	return &Queries{
 		conn: conn,
 	}
-}
-
-// chQueryContext forwards the caller's OTel span context to ClickHouse so the
-// server-side query spans (system.opentelemetry_span_log) join the request
-// trace. clickhouse-go only sends trace context that is explicitly attached
-// via clickhouse.Context/WithSpan — it never reads the span from ctx itself.
-func chQueryContext(ctx context.Context) context.Context {
-	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
-		return clickhouse.Context(ctx, clickhouse.WithSpan(sc))
-	}
-	return ctx
 }

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -399,7 +399,7 @@ func (q *Queries) listSessionsFromRawLogs(ctx context.Context, arg ListSessionsP
 		return nil, fmt.Errorf("building list sessions query: %w", err)
 	}
 
-	rows, err := q.conn.Query(chQueryContext(ctx), query, args...)
+	rows, err := q.conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func (q *Queries) listSessionsFromSummaries(ctx context.Context, arg ListSession
 		return nil, fmt.Errorf("building list sessions summary query: %w", err)
 	}
 
-	rows, err := q.conn.Query(chQueryContext(ctx), query, args...)
+	rows, err := q.conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Continues the ClickHouse observability work from b27616c (per-path ListSessions spans) by making client-call tracing the **default for every query, including future ones**: the `clickhouse.Conn` is wrapped once at connection creation (`newClickhouseClient`), so all `Query`/`Select`/`Exec` calls from any repo — server, worker, and streams — are instrumented with zero per-call-site wiring (DNO-602; motivated by INC-417, where reads were invisible in traces while dashboard queries ran for seconds).

## What each call emits

- **A client span** (`clickhouse.query`/`clickhouse.select`/`clickhouse.exec`) with `db.system.name=clickhouse` and a low-cardinality `gram.clickhouse.table` attribute. The full SQL text is deliberately **not** attached (pinned by a test): the operation label identifies the code that builds the query, and omitting the text keeps span ingest volume flat even for multi-kilobyte statements. Query spans stay open until the result set closes, so streaming reads report their real duration rather than dispatch time.
- **Span-context forwarding to ClickHouse** (`clickhouse.Context(WithSpan(...))`, generalizing b27616c's `chQueryContext`), so ClickHouse's own server-side execution spans (`system.opentelemetry_span_log`) parent under the client span in the request trace.
- **A logical operation name** (`gram.clickhouse.operation`) derived from the first non-decorator stack frame — e.g. `Queries.ListSessions`, `Queries.GetToolUsageSummary` — so every query is nameable in dashboards without per-call-site wiring, with cardinality bounded by the number of query functions.
- **A duration histogram** `clickhouse.client.query.duration` labeled `{gram.clickhouse.table, gram.clickhouse.operation, outcome}` — the read-side counterpart of `telemetry.clickhouse.write.duration` (#4420). Both traces and metrics flow through the otel-collector's Datadog exporter, so this is the series to build the INC-417 dashboard and latency monitor on: per-table p95s directly chart "raw `telemetry_logs` reads vs `chat_session_summaries` reads".

## Table label

The `gram.clickhouse.table` label is regex-extracted (first `INSERT INTO` / `ALTER TABLE` / `FROM` identifier — subquery parens are skipped so the inner physical table wins). It labels only the metric/span; a mismatch can never affect query behavior, inputs are exclusively our own placeholder-parameterized SQL, and unmatched statements label `unknown`. Known limits (first-FROM-wins for CTEs, leading table for JOINs) are documented and pinned by tests, and the operation label names the function whose SQL is ground truth for any mislabel.

## Scope notes

- `PrepareBatch`/`AsyncInsert` pass through untraced: the synchronous telemetry write path is already instrumented at the Logger layer (`observeCHWrite`) with its own spans and metric.
- b27616c's per-call `chQueryContext` wiring in ListSessions is superseded and removed; its per-path service spans (`telemetry.listSessions.clickhouse.raw|summary`) remain as the endpoint layer above these client spans.

## Testing

Unit tests with an in-memory span recorder **and** a manual metric reader: span naming/kind/attributes per method; error status + recorded error events; span *and metric* deferral until `rows.Close()` (including close errors); span-context forwarding into the inner connection; outcome classification (success/failure/timeout); the no-SQL-text decision; and table-extraction cases incl. the pinned CTE/JOIN limits. Operation-name derivation is covered across every call shape: repo methods (`fakeRepo.ListWidgets`), plain and nested helpers (innermost-caller-wins, pinned), closures, and goroutine boundaries, plus a test asserting each operation forms its own metric series. Full `o11y` + `telemetry` suites and `mise lint:server` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
