### PR TITLE
chore: Fix flaky TestBackfillShadowMCPInventoryURLs with EventuallyWithT

### DIFF
--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
@@ -663,17 +664,23 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 
 	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
-	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
-		GramProjectID: projectID,
-		Limit:         50,
-		Cursor:        "",
-	})
-	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	require.Equal(t, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
-	require.Equal(t, "mcp.speakeasy.com", rows[0].URLHost)
-	require.Equal(t, observedAt, rows[0].FirstSeen)
-	require.Equal(t, observedAt.Add(time.Minute), rows[0].LastSeen)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         50,
+			Cursor:        "",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.Len(c, rows, 1) {
+			return
+		}
+		assert.Equal(c, "https://mcp.speakeasy.com/mcp", rows[0].CanonicalServerURL)
+		assert.Equal(c, "mcp.speakeasy.com", rows[0].URLHost)
+		assert.Equal(c, observedAt, rows[0].FirstSeen)
+		assert.Equal(c, observedAt.Add(time.Minute), rows[0].LastSeen)
+	}, 5*time.Second, 100*time.Millisecond, "shadow mcp inventory should eventually be visible")
 }
 
 func TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames(t *testing.T) {
@@ -728,13 +735,19 @@ func TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames(t *testing.T) {
 
 	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
-	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
-		GramProjectID: projectID,
-		Limit:         50,
-	})
-	require.NoError(t, err)
-	require.Len(t, rows, 1)
-	require.Equal(t, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
+			GramProjectID: projectID,
+			Limit:         50,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.Len(c, rows, 1) {
+			return
+		}
+		assert.Equal(c, "https://external.example.com/mcp", rows[0].CanonicalServerURL)
+	}, 5*time.Second, 100*time.Millisecond, "shadow mcp inventory should eventually be visible")
 }
 
 type historicalShadowMCPCall struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes intermittent CI failure in `TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts` where the ClickHouse read-back returns 0 rows instead of the expected 1 row.

Most recent sighting: https://github.com/speakeasy-api/gram/actions/runs/29933658523/job/88969716785

## Root Cause

The test writes to a `ReplacingMergeTree` table multiple times with the same key (runs backfill twice), then immediately tries to read back the deduplicated result. The failure occurs because:

1. **ReplacingMergeTree deduplication is asynchronous** - multiple writes to the same key create new parts that are deduplicated during background merges
2. **Part visibility can be delayed** - until the merge happens or all parts become visible, the aggregation query may see incomplete data
3. **The test had no visibility barrier** - it only called `FlushClickHouseAsyncInserts`, which is correct for async-inserted data but doesn't guarantee visibility of synchronous upserts or merged results

The compute-and-write path succeeded (both `InventoryURLCount` assertions passed), so this was purely a read-visibility problem, not a write problem.

## Solution

Use `require.EventuallyWithT` for the ClickHouse read-back assertions, following the pattern already used by many other tests in the telemetry package (`query_test.go`, `list_filter_options_test.go`, `search_users_test.go`, etc.).

The wrapper retries the assertion for up to 5 seconds with 100ms intervals, allowing time for:
- Parts to become visible
- ReplacingMergeTree deduplication to take effect
- The aggregation query to see the complete dataset

## Changes

### Fixed Tests

1. **`TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts`** (reported flake)
   - Runs backfill twice on the same data, writing to the same key twice
   - Most likely to hit the visibility issue

2. **`TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames`** (preventive fix)
   - Also runs backfill and upserts, could potentially have the same issue
   - Fixed for consistency and to prevent future flakes

### Verification

Ran each test 5 times consecutively - all runs passed:

```
=== Run 1 ===
ok  	github.com/speakeasy-api/gram/server/internal/telemetry	6.823s
=== Run 2 ===
ok  	github.com/speakeasy-api/gram/server/internal/telemetry	6.936s
=== Run 3 ===
ok  	github.com/speakeasy-api/gram/server/internal/telemetry	5.899s
=== Run 4 ===
ok  	github.com/speakeasy-api/gram/server/internal/telemetry	5.866s
=== Run 5 ===
ok  	github.com/speakeasy-api/gram/server/internal/telemetry	6.835s
```

All telemetry package tests pass: `go test ./internal/telemetry` completed successfully.

## Related Issue

Fixes AGE-3049
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3049](https://linear.app/speakeasy/issue/AGE-3049/bug-flaky-testbackfillshadowmcpinventoryurls-canonicalizesandupserts)

<div><a href="https://cursor.com/agents/bc-7381e67a-beeb-4bce-8e15-860d0369a4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7381e67a-beeb-4bce-8e15-860d0369a4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Shadow MCP inventory tests by wrapping ClickHouse read-back assertions with `require.EventuallyWithT` to wait for `ReplacingMergeTree` visibility and deduplication. Fixes CI flake and aligns with AGE-3049.

- **Bug Fixes**
  - `TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts`: retries read assertions for up to 5s (100ms interval) after backfill.
  - `TestBackfillShadowMCPInventoryURLs_ExcludesHostedHostnames`: applies the same retry to prevent future flakes.

<sup>Written for commit 26574510da4b281993a8a7d918fb6a847d8e5159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

