### PR TITLE
fix(hooks): exercise local binary in hooks test

### DIFF
--- a/.mise-tasks/hooks/test.sh
+++ b/.mise-tasks/hooks/test.sh
@@ -99,7 +99,21 @@ EOF
 fi
 echo ""
 
-if [ "${usage_local:-}" = "true" ] || ! git diff --quiet main -- server/internal/plugins/ server/cmd/export-hook-plugin/; then
+if [ "${usage_local:-}" = "true" ]; then
+  plugin_out="$(mktemp -d)"
+  hooks_binary="${plugin_out}/speakeasy-hooks"
+  echo "Building local hooks binary: ${hooks_binary}"
+  go build -o "$hooks_binary" ./hooks/cmd/speakeasy-hooks
+  "$hooks_binary" install \
+    --provider=claude \
+    --dir="${plugin_out}/plugin-claude" \
+    --server-url="$GRAM_SERVER_URL" \
+    --project="$project_slug" \
+    --browser-login \
+    --binary="$hooks_binary"
+  echo ""
+  exec claude --setting-sources project,local --plugin-dir "${plugin_out}/plugin-claude" --debug
+elif ! git diff --quiet main -- server/internal/plugins/ server/cmd/export-hook-plugin/; then
   plugin_out="$(mktemp -d)"
   echo "Rendering local plugin into: ${plugin_out}"
   (cd server && go run ./cmd/export-hook-plugin -out "$plugin_out" >/dev/null)


### PR DESCRIPTION
## Why

`hooks:test --local` still rendered the legacy server-generated plugin, so it did not exercise changes to the current Go hooks binary. This made the local workflow misleading when validating Go hook behavior.

## Summary

- build the current Go `speakeasy-hooks` binary when `hooks:test --local` is requested
- render the Claude plugin through that binary’s `install` command
- preserve the generated-plugin and published-plugin fallback paths

## Verification

- `mise run test:hooks` (333 tests)
- `mise run hooks:test --local --project default` with local command stubs to validate the built binary and rendered Claude plugin
- `bash -n .mise-tasks/hooks/test.sh`
- `shellcheck -e SC2154 .mise-tasks/hooks/test.sh`
- `git diff origin/main..HEAD --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update hooks test to build and run the local `speakeasy-hooks` binary when `hooks:test --local` is used, installing and launching the Claude plugin through that binary. When not local, keep existing behavior: render a local plugin only if plugin code changed; otherwise use the generated/published plugin.

<sup>Written for commit 7072a32543dd148c8038cf20a38afc43670a2af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->