### PR TITLE
feat: surface 90-day log retention in dashboard

### DIFF
--- a/client/dashboard/src/components/observe/LoggingPageHeader.test.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.test.tsx
@@ -25,6 +25,7 @@ describe("LoggingPageHeader", () => {
       screen.getByRole("button", { name: "About data retention" }),
     );
 
-    expect(await screen.findByText(LOG_DATA_RETENTION_MESSAGE)).toBeTruthy();
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toBe(LOG_DATA_RETENTION_MESSAGE);
   });
 });

--- a/client/dashboard/src/components/observe/LoggingPageHeader.test.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   LOG_DATA_RETENTION_MESSAGE,
+  LogDataRetentionBanner,
   LoggingPageHeader,
 } from "./LoggingPageHeader";
 
@@ -27,5 +28,15 @@ describe("LoggingPageHeader", () => {
 
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip.textContent).toBe(LOG_DATA_RETENTION_MESSAGE);
+  });
+
+  it("shows a dismissible retention banner", () => {
+    render(<LogDataRetentionBanner />);
+
+    expect(screen.getByText(LOG_DATA_RETENTION_MESSAGE)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.queryByText(LOG_DATA_RETENTION_MESSAGE)).toBeNull();
   });
 });

--- a/client/dashboard/src/components/observe/LoggingPageHeader.test.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.test.tsx
@@ -1,0 +1,30 @@
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  LOG_DATA_RETENTION_MESSAGE,
+  LoggingPageHeader,
+} from "./LoggingPageHeader";
+
+afterEach(cleanup);
+
+describe("LoggingPageHeader", () => {
+  it("shows the log data retention period", async () => {
+    render(
+      <TooltipProvider>
+        <LoggingPageHeader
+          title="Tool Logs"
+          description="Inspect captured tool calls"
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Tool Logs" })).toBeTruthy();
+
+    fireEvent.focus(
+      screen.getByRole("button", { name: "About data retention" }),
+    );
+
+    expect(await screen.findByText(LOG_DATA_RETENTION_MESSAGE)).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/observe/LoggingPageHeader.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 export const LOG_DATA_RETENTION_MESSAGE =
   "Tool logs and agent sessions are retained for 90 days.";
 
-export function LogDataRetentionTooltip(): JSX.Element {
+function LogDataRetentionTooltip(): JSX.Element {
   return (
     <SimpleTooltip tooltip={LOG_DATA_RETENTION_MESSAGE}>
       <button

--- a/client/dashboard/src/components/observe/LoggingPageHeader.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.tsx
@@ -1,5 +1,5 @@
 import { SimpleTooltip } from "@/components/ui/tooltip";
-import { Icon } from "@speakeasy-api/moonshine";
+import { Alert, Icon } from "@speakeasy-api/moonshine";
 
 export const LOG_DATA_RETENTION_MESSAGE =
   "Tool logs and agent sessions are retained for 90 days.";
@@ -15,6 +15,15 @@ export function LogDataRetentionTooltip(): JSX.Element {
         <Icon name="info" className="size-3.5" />
       </button>
     </SimpleTooltip>
+  );
+}
+
+export function LogDataRetentionBanner(): JSX.Element {
+  return (
+    <Alert variant="info" dismissible className="mb-6 text-sm">
+      <span className="font-medium">Data retention:</span>{" "}
+      {LOG_DATA_RETENTION_MESSAGE}
+    </Alert>
   );
 }
 

--- a/client/dashboard/src/components/observe/LoggingPageHeader.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.tsx
@@ -1,0 +1,37 @@
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { Icon } from "@speakeasy-api/moonshine";
+
+export const LOG_DATA_RETENTION_MESSAGE =
+  "Tool logs and agent sessions are retained for 90 days.";
+
+export function LogDataRetentionTooltip() {
+  return (
+    <SimpleTooltip tooltip={LOG_DATA_RETENTION_MESSAGE}>
+      <button
+        type="button"
+        aria-label="About data retention"
+        className="text-muted-foreground hover:text-foreground inline-flex cursor-help items-center"
+      >
+        <Icon name="info" className="size-3.5" />
+      </button>
+    </SimpleTooltip>
+  );
+}
+
+export function LoggingPageHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <div className="flex items-center gap-1.5">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        <LogDataRetentionTooltip />
+      </div>
+      <p className="text-muted-foreground text-sm">{description}</p>
+    </div>
+  );
+}

--- a/client/dashboard/src/components/observe/LoggingPageHeader.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.tsx
@@ -1,5 +1,6 @@
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Alert, Icon } from "@speakeasy-api/moonshine";
+import { useState } from "react";
 
 export const LOG_DATA_RETENTION_MESSAGE =
   "Tool logs and agent sessions are retained for 90 days.";
@@ -18,9 +19,18 @@ export function LogDataRetentionTooltip(): JSX.Element {
   );
 }
 
-export function LogDataRetentionBanner(): JSX.Element {
+export function LogDataRetentionBanner(): JSX.Element | null {
+  const [isVisible, setIsVisible] = useState(true);
+
+  if (!isVisible) return null;
+
   return (
-    <Alert variant="info" dismissible className="mb-6 text-sm">
+    <Alert
+      variant="info"
+      dismissible
+      onDismiss={() => setIsVisible(false)}
+      className="mb-6 text-sm"
+    >
       <span className="font-medium">Data retention:</span>{" "}
       {LOG_DATA_RETENTION_MESSAGE}
     </Alert>

--- a/client/dashboard/src/components/observe/LoggingPageHeader.tsx
+++ b/client/dashboard/src/components/observe/LoggingPageHeader.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@speakeasy-api/moonshine";
 export const LOG_DATA_RETENTION_MESSAGE =
   "Tool logs and agent sessions are retained for 90 days.";
 
-export function LogDataRetentionTooltip() {
+export function LogDataRetentionTooltip(): JSX.Element {
   return (
     <SimpleTooltip tooltip={LOG_DATA_RETENTION_MESSAGE}>
       <button
@@ -24,7 +24,7 @@ export function LoggingPageHeader({
 }: {
   title: string;
   description: string;
-}) {
+}): JSX.Element {
   return (
     <div className="flex min-w-0 flex-col gap-1">
       <div className="flex items-center gap-1.5">

--- a/client/dashboard/src/components/observe/LogsAgents.tsx
+++ b/client/dashboard/src/components/observe/LogsAgents.tsx
@@ -2,6 +2,7 @@ import { InsightsConfig } from "@/components/insights-dock";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { EnableLoggingOverlay } from "@/components/EnableLoggingOverlay";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
+import { LoggingPageHeader } from "@/components/observe/LoggingPageHeader";
 import { useObservabilityMcpConfig } from "@/hooks/useObservabilityMcpConfig";
 import { useLogsEnabledErrorCheck } from "@/hooks/useLogsEnabled";
 import type { ChatOverview } from "@gram/client/models/components/chatoverview.js";
@@ -644,13 +645,10 @@ function AgentSessionsPageContent({
   if (isLogsDisabled) {
     return (
       <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto p-8 pb-24">
-        <div className="flex min-w-0 flex-col gap-1">
-          <h1 className="text-xl font-semibold">Agent Sessions</h1>
-          <p className="text-muted-foreground text-sm">
-            View and debug individual agent sessions captured for organization
-            members in this project
-          </p>
-        </div>
+        <LoggingPageHeader
+          title="Agent Sessions"
+          description="View and debug individual agent sessions captured for organization members in this project"
+        />
         <div className="relative flex-1">
           <div
             className="pointer-events-none h-full select-none"
@@ -668,13 +666,10 @@ function AgentSessionsPageContent({
     <>
       <div className="flex min-h-0 w-full flex-1 flex-col">
         <div className="shrink-0 space-y-4 px-8 py-4">
-          <div className="flex min-w-0 flex-col gap-1">
-            <h1 className="text-xl font-semibold">Agent Sessions</h1>
-            <p className="text-muted-foreground text-sm">
-              View and debug individual agent sessions captured for organization
-              members in this project
-            </p>
-          </div>
+          <LoggingPageHeader
+            title="Agent Sessions"
+            description="View and debug individual agent sessions captured for organization members in this project"
+          />
           {hasAssistantFilter && (
             <Badge
               variant="secondary"

--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -4,6 +4,7 @@ import { EnterpriseGate } from "@/components/enterprise-gate";
 import { InsightsConfig } from "@/components/insights-dock";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
 import { ObservabilitySkeleton } from "@/components/ObservabilitySkeleton";
+import { LoggingPageHeader } from "@/components/observe/LoggingPageHeader";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -487,13 +488,10 @@ export function LogsTools(): JSX.Element {
       />
       {isLogsDisabled ? (
         <div className="min-h-0 w-full flex-1 space-y-6 overflow-y-auto p-8 pb-24">
-          <div className="flex min-w-0 flex-col gap-1">
-            <h1 className="text-xl font-semibold">Tool Logs</h1>
-            <p className="text-muted-foreground text-sm">
-              Dive into tool traces across all tools, skills, and MCP servers
-              used by organization members in this project
-            </p>
-          </div>
+          <LoggingPageHeader
+            title="Tool Logs"
+            description="Dive into tool traces across all tools, skills, and MCP servers used by organization members in this project"
+          />
           <div className="relative flex-1">
             <div
               className="pointer-events-none h-full select-none"
@@ -678,13 +676,10 @@ function LogsToolsContent({
       <div className="flex min-h-0 w-full flex-1 flex-col">
         <div className="flex min-h-0 flex-1 flex-col gap-6 px-8 pt-8">
           <div className="flex shrink-0 items-start justify-between gap-4">
-            <div className="flex min-w-0 flex-col gap-1">
-              <h1 className="text-xl font-semibold">Tool Logs</h1>
-              <p className="text-muted-foreground text-sm">
-                Dive into tool traces across all tools, skills, and MCP servers
-                used by organization members in this project
-              </p>
-            </div>
+            <LoggingPageHeader
+              title="Tool Logs"
+              description="Dive into tool traces across all tools, skills, and MCP servers used by organization members in this project"
+            />
             <div className="flex items-center gap-2">
               <HooksSetupButton />
               <Button variant="outline" size="sm" asChild>

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -1,4 +1,5 @@
 import { Page } from "@/components/page-layout";
+import { LogDataRetentionTooltip } from "@/components/observe/LoggingPageHeader";
 import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { Switch } from "@/components/ui/switch";
@@ -166,9 +167,10 @@ function OrgLogsInner() {
 
   return (
     <>
-      <Heading variant="h4" className="mb-2">
-        Logs
-      </Heading>
+      <div className="mb-2 flex items-center gap-1.5">
+        <Heading variant="h4">Logs</Heading>
+        <LogDataRetentionTooltip />
+      </div>
       <Type muted small className="mb-6">
         Configure logging and telemetry settings for all your tool capture. When
         enabled, tool calls and traces are recorded for debugging and analytics.

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -1,5 +1,5 @@
 import { Page } from "@/components/page-layout";
-import { LogDataRetentionTooltip } from "@/components/observe/LoggingPageHeader";
+import { LogDataRetentionBanner } from "@/components/observe/LoggingPageHeader";
 import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/heading";
 import { Switch } from "@/components/ui/switch";
@@ -167,15 +167,15 @@ function OrgLogsInner() {
 
   return (
     <>
-      <div className="mb-2 flex items-center gap-1.5">
-        <Heading variant="h4">Logs</Heading>
-        <LogDataRetentionTooltip />
-      </div>
+      <Heading variant="h4" className="mb-2">
+        Logs
+      </Heading>
       <Type muted small className="mb-6">
         Configure logging and telemetry settings for all your tool capture. When
         enabled, tool calls and traces are recorded for debugging and analytics.
         These power the insights and logs page on the platform.
       </Type>
+      <LogDataRetentionBanner />
       <div className="border-border bg-card rounded-lg border p-4">
         <Stack gap={4}>
           <Stack direction="horizontal" justify="space-between" align="center">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared retention message for Tool Logs and Agent Sessions
- show compact retention tooltips on project Tool Logs and Agent Sessions pages
- show a prominent dismissible retention banner on the organization Logging & Telemetry setup page
- fully remove the banner from the layout after dismissal
- centralize duplicated logging page headers and add focused component coverage

## Testing
- `pnpm -F dashboard test src/components/observe/LoggingPageHeader.test.tsx` (2 tests passed)
- `pnpm -F dashboard lint`
- `pnpm -F dashboard knip`
- manually verified banner prominence, copy, dismissal, gap closure, and console state on `/speakeasy/logs`

## Demo
<a href="https://cursor.com/agents/bc-885c4efc-806c-40af-8790-b58725de7830/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdismissible_log_retention_banner.mp4"><img src="https://cursor.com/artifacts/c/art-c30c8119-09a3-4cd9-8f9d-da60f7aa4e86" alt="dismissible_log_retention_banner.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-616](https://linear.app/speakeasy/issue/DNO-616/feat-add-90-day-retention-tooltip-to-logging-pages)

<div><a href="https://cursor.com/agents/bc-885c4efc-806c-40af-8790-b58725de7830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-885c4efc-806c-40af-8790-b58725de7830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 90‑day log retention tooltip to Tool Logs and Agent Sessions, plus a dismissible banner on the org Logging & Telemetry setup page. Centralizes project logging headers to cut duplication and meet DNO‑616.

- New Features
  - Tooltip: "Tool logs and agent sessions are retained for 90 days."
  - Shown beside "Tool Logs" and "Agent Sessions" headings.
  - Dismissible retention banner on the org logging setup page; fully unmounts after dismissal.

- Refactors
  - Added `LoggingPageHeader` and `LogDataRetentionBanner`; replaced duplicated headers in `LogsTools` and `LogsAgents`.
  - Kept the retention tooltip helper private within `LoggingPageHeader`.
  - Added tests for tooltip content and banner dismissal (`LoggingPageHeader.test.tsx`).

<sup>Written for commit b182b0b6c90aaf97632d55c662004b0be6286989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

