### PR TITLE
fix(server): declare ClickHouse insert async posture explicitly

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -274,6 +274,9 @@ linters:
         - pattern: ^time\.Sleep$
           pkg: ^time$
           msg: "GG013: Avoid time.Sleep. In tests, poll with require.EventuallyWithT (wait until assertions pass) or require.Never (assert a condition never holds)."
+        - pattern: ^clickhouse\.With(Std)?Async$
+          pkg: ^github\.com/ClickHouse/clickhouse-go/v2$
+          msg: "GG014: clickhouse.WithAsync does not enable or disable async insert. It always sets async_insert=1 and its bool only picks wait_for_async_insert, so WithAsync(false) is fire-and-forget. State the posture explicitly with WithSettings instead: async_insert 0 for a synchronous insert, or async_insert 1 plus wait_for_async_insert 0 for fire-and-forget."
     sloglint:
       no-mixed-args: true
       attr-only: true

--- a/server/internal/authz/repo/queries.go
+++ b/server/internal/authz/repo/queries.go
@@ -15,13 +15,10 @@ var sq = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Question)
 // The call is fire-and-forget from CH's perspective: it acks once the row is
 // queued in CH's async insert buffer, not once the row is committed to disk.
 func (q *Queries) InsertChallenge(ctx context.Context, row ChallengeRow) error {
-	ctx = clickhouse.Context(ctx,
-		clickhouse.WithAsync(false),
-		clickhouse.WithSettings(clickhouse.Settings{
-			"async_insert":          1,
-			"wait_for_async_insert": 0,
-		}),
-	)
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 0,
+	}))
 
 	reqScope := make([]string, len(row.RequestedChecks))
 	reqKind := make([]string, len(row.RequestedChecks))

--- a/server/internal/risk/chrepo/queries.go
+++ b/server/internal/risk/chrepo/queries.go
@@ -69,13 +69,10 @@ func (q *Queries) InsertRiskFindings(ctx context.Context, rows []RiskFindingRow)
 		return nil
 	}
 
-	ctx = clickhouse.Context(ctx,
-		clickhouse.WithAsync(false),
-		clickhouse.WithSettings(clickhouse.Settings{
-			"async_insert":          1,
-			"wait_for_async_insert": 0,
-		}),
-	)
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 0,
+	}))
 
 	builder := sq.Insert("risk_findings").
 		Columns(

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -296,6 +296,10 @@ func (q *Queries) InsertTelemetryLog(ctx context.Context, arg InsertTelemetryLog
 // from CH's perspective: it acks once the rows are queued in CH's async insert
 // buffer, not once they are committed to disk.
 func (q *Queries) InsertTelemetryLogs(ctx context.Context, args []InsertTelemetryLogParams) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 0,
+	}))
 	return q.insertTelemetryLogsInto(ctx, "telemetry_logs", args)
 }
 
@@ -602,7 +606,9 @@ func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []Upser
 	for _, upsert := range upserts {
 		rows = append(rows, upsert)
 	}
-	ctx = clickhouse.Context(ctx, clickhouse.WithAsync(false))
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert": 0,
+	}))
 	if err := q.insertShadowMCPInventoryURLRows(ctx, rows); err != nil {
 		return fmt.Errorf("upserting shadow mcp inventory urls: %w", err)
 	}

--- a/server/internal/telemetry/repo/skill_session_versions.go
+++ b/server/internal/telemetry/repo/skill_session_versions.go
@@ -22,6 +22,10 @@ type SkillSessionVersion struct {
 	Surface         string
 }
 
+// InsertSkillSessionVersions writes rows using a server-side async insert
+// (async_insert=1, wait_for_async_insert=0). The call is fire-and-forget from
+// CH's perspective: it acks once the rows are queued in CH's async insert
+// buffer, not once they are committed to disk.
 func (q *Queries) InsertSkillSessionVersions(ctx context.Context, rows []SkillSessionVersion) error {
 	if len(rows) == 0 {
 		return nil
@@ -58,7 +62,11 @@ func (q *Queries) InsertSkillSessionVersions(ctx context.Context, rows []SkillSe
 	if err != nil {
 		return fmt.Errorf("building skill session version insert: %w", err)
 	}
-	if err := q.conn.Exec(clickhouse.Context(ctx, clickhouse.WithAsync(false)), query, args...); err != nil {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 0,
+	}))
+	if err := q.conn.Exec(ctx, query, args...); err != nil {
 		return fmt.Errorf("inserting skill session versions: %w", err)
 	}
 	return nil

--- a/server/internal/telemetry/repo/staging.go
+++ b/server/internal/telemetry/repo/staging.go
@@ -68,8 +68,16 @@ type StagedTelemetryLogRow struct {
 const stagedTelemetryRowsLimit = 1000
 
 // InsertTelemetryLogsStaging inserts telemetry log records into the staging
-// table in a single synchronous statement.
+// table using a server-side async insert (async_insert=1,
+// wait_for_async_insert=0). The call is fire-and-forget from CH's perspective:
+// it acks once the rows are queued in CH's async insert buffer, not once they
+// are committed to disk. Staging has no read-your-writes requirement — the
+// promotion dispatcher sweeps it on a timer and each pass is idempotent.
 func (q *Queries) InsertTelemetryLogsStaging(ctx context.Context, args []InsertTelemetryLogParams) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 0,
+	}))
 	return q.insertTelemetryLogsInto(ctx, "telemetry_logs_staging", args)
 }
 
@@ -80,9 +88,16 @@ func (q *Queries) InsertTelemetryLogsStaging(ctx context.Context, args []InsertT
 // the promotion path instead relies on a per-row Redis SET NX claim (see
 // PromoteStagedTelemetry) to prevent a double insert. Promotion batches are
 // tiny (a session's redacted rows), so per-row inserts are fine.
+//
+// The insert is synchronous (async_insert=0) because the dedup guard reads
+// these rows back: ListExistingTelemetryLogIDs must see committed rows, not
+// rows still buffered in CH's async insert queue. It also keeps the
+// deduplication token effective, which async inserts ignore unless
+// async_insert_deduplicate is on.
 func (q *Queries) InsertPromotedTelemetryLogs(ctx context.Context, args []InsertTelemetryLogParams) error {
 	for _, arg := range args {
 		tokenCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+			"async_insert":               0,
 			"insert_deduplication_token": "promote:" + arg.ID,
 		}))
 		if err := q.insertTelemetryLogsInto(tokenCtx, "telemetry_logs", []InsertTelemetryLogParams{arg}); err != nil {
@@ -92,12 +107,9 @@ func (q *Queries) InsertPromotedTelemetryLogs(ctx context.Context, args []Insert
 	return nil
 }
 
+// insertTelemetryLogsInto writes rows to table. Callers own the async posture:
+// set it on ctx before calling.
 func (q *Queries) insertTelemetryLogsInto(ctx context.Context, table string, args []InsertTelemetryLogParams) error {
-	ctx = clickhouse.Context(ctx, clickhouse.WithAsync(false))
-	return q.insertTelemetryLogsIntoContext(ctx, table, args)
-}
-
-func (q *Queries) insertTelemetryLogsIntoContext(ctx context.Context, table string, args []InsertTelemetryLogParams) error {
 	if len(args) == 0 {
 		return nil
 	}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-3049/bug-flaky-testbackfillshadowmcpinventoryurls-canonicalizesandupserts

`clickhouse-go`'s `WithAsync(wait bool)` is confusing. Any use of the option routes `Exec` through `conn.asyncInsert`, which sets `async_insert=1` unconditionally and uses the bool only to pick `wait_for_async_insert`. `WithAsync(false)` therefore means "async insert, do not wait", the opposite of how it reads.

Two writes depend on reading their own writes back and were silently fire-and-forget as a result. Both are now `async_insert=0`:

- `UpsertShadowMCPInventoryURLs` documents a synchronous insert because its read-merge-write needs prior rows visible. This is the cause of the flaky `TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts`, and in production it lets a concurrent write clobber a user-set `server_name_override` (DNO-615).
- `InsertPromotedTelemetryLogs` is read back by the promotion dedup guard, `ListExistingTelemetryLogIDs`. `select_sequential_consistency` addresses replica lag, not rows still buffered in the async insert queue. Going synchronous also lets the per-row `insert_deduplication_token` engage, which async inserts ignore unless `async_insert_deduplicate` is on. The Redis SET NX claim already covered the gap, so this strengthens a documented guarantee rather than fixing an active duplicate-counting bug.

The remaining inserts keep their fire-and-forget behavior and now say so with explicit settings, so nothing else changes at runtime: `InsertTelemetryLogs`, `InsertTelemetryLogsStaging`, `InsertSkillSessionVersions`, `InsertChallenge`, `InsertRiskFindings`.

`InsertTelemetryLogsStaging` also carried a stale "in a single synchronous statement" doc. It is the same sentence `InsertTelemetryLogs` had before #4127 corrected it; `staging.go` was created by #4122 and the correction missed the copy. Nothing reads staging synchronously, so the doc was wrong, not the code.

New forbidigo rule `GG014` bans `clickhouse.WithAsync` and `WithStdAsync` in favor of explicit settings, with no exclusions. `WithSettings` is equivalent, since `conn.exec` and `conn.asyncInsert` both bind and `sendQuery` the same options.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set ClickHouse insert async posture and stop using `clickhouse.WithAsync`. Make inventory upserts and promoted telemetry inserts synchronous to ensure read-your-writes and dedup, fixing the flaky test in Linear AGE-3049.

- **Bug Fixes**
  - `UpsertShadowMCPInventoryURLs`: set `async_insert=0` so the read-merge-write sees committed rows; resolves the flaky `TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts` and prevents `server_name_override` being clobbered.
  - `InsertPromotedTelemetryLogs`: set `async_insert=0` so the dedup guard reads committed rows and the `insert_deduplication_token` applies.

- **Refactors**
  - Replace `clickhouse.WithAsync` with explicit `WithSettings`.
  - Declare fire-and-forget inserts with `async_insert=1` and `wait_for_async_insert=0`: `InsertTelemetryLogs`, `InsertTelemetryLogsStaging`, `InsertSkillSessionVersions`, `InsertChallenge`, `InsertRiskFindings` (no runtime change).
  - Add forbidigo rule `GG014` banning `clickhouse.WithAsync`/`WithStdAsync`; fix stale “synchronous” doc in `InsertTelemetryLogsStaging`.

<sup>Written for commit 09425fef3af43ade6c0789028fffa3838ee608cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

