### PR TITLE
fix(skills): pin efficacy evaluation columns

### DIFF
--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -1275,7 +1275,24 @@ CROSS JOIN LATERAL (
 -- outlives both: a deletion after enqueue leaves a backlog whose subject is
 -- gone. The liveness recheck sits before paging so a deleted unit is never a
 -- candidate and never spends the organization's budget.
-SELECT e.*
+SELECT
+  e.id,
+  e.organization_id,
+  e.project_id,
+  e.surface,
+  e.session_id,
+  e.chat_id,
+  e.skill_id,
+  e.skill_version_id,
+  e.canonical_sha256,
+  e.observed_at,
+  e.state,
+  e.reserved_on,
+  e.attempts,
+  e.last_error,
+  e.scored_at,
+  e.created_at,
+  e.updated_at
 FROM skill_efficacy_evaluations e
 JOIN projects p
   ON p.id = e.project_id
@@ -1329,7 +1346,24 @@ WHERE e.project_id = @project_id
     LIMIT @batch_size
     FOR UPDATE SKIP LOCKED
   )
-RETURNING *;
+RETURNING
+  e.id,
+  e.organization_id,
+  e.project_id,
+  e.surface,
+  e.session_id,
+  e.chat_id,
+  e.skill_id,
+  e.skill_version_id,
+  e.canonical_sha256,
+  e.observed_at,
+  e.state,
+  e.reserved_on,
+  e.attempts,
+  e.last_error,
+  e.scored_at,
+  e.created_at,
+  e.updated_at;
 
 -- name: ResetStaleSkillEfficacyReservations :execrows
 -- Returns a crashed reservation to the queue. attempts is preserved so a

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -1889,7 +1889,24 @@ func (q *Queries) ListDeletedSkillEfficacyChatIDs(ctx context.Context, arg ListD
 }
 
 const listPendingSkillEfficacyEvaluations = `-- name: ListPendingSkillEfficacyEvaluations :many
-SELECT e.id, e.organization_id, e.project_id, e.surface, e.session_id, e.chat_id, e.skill_id, e.skill_version_id, e.canonical_sha256, e.observed_at, e.state, e.reserved_on, e.attempts, e.last_error, e.scored_at, e.created_at, e.updated_at
+SELECT
+  e.id,
+  e.organization_id,
+  e.project_id,
+  e.surface,
+  e.session_id,
+  e.chat_id,
+  e.skill_id,
+  e.skill_version_id,
+  e.canonical_sha256,
+  e.observed_at,
+  e.state,
+  e.reserved_on,
+  e.attempts,
+  e.last_error,
+  e.scored_at,
+  e.created_at,
+  e.updated_at
 FROM skill_efficacy_evaluations e
 JOIN projects p
   ON p.id = e.project_id
@@ -2893,7 +2910,24 @@ WHERE e.project_id = $1
     LIMIT $3
     FOR UPDATE SKIP LOCKED
   )
-RETURNING id, organization_id, project_id, surface, session_id, chat_id, skill_id, skill_version_id, canonical_sha256, observed_at, state, reserved_on, attempts, last_error, scored_at, created_at, updated_at
+RETURNING
+  e.id,
+  e.organization_id,
+  e.project_id,
+  e.surface,
+  e.session_id,
+  e.chat_id,
+  e.skill_id,
+  e.skill_version_id,
+  e.canonical_sha256,
+  e.observed_at,
+  e.state,
+  e.reserved_on,
+  e.attempts,
+  e.last_error,
+  e.scored_at,
+  e.created_at,
+  e.updated_at
 `
 
 type LoadReservedSkillEfficacyEvaluationsParams struct {


### PR DESCRIPTION
## Summary

- replace wildcard evaluation projections with explicit columns
- preserve the existing scan order for pending and reserved evaluation reads
- prepare rolling deployments for additive reservation recovery columns

Part of DNO-594.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned explicit column lists for pending and reserved skill efficacy evaluation queries to remove `*` and stabilize result schemas across deploys. This supports DNO-594 by enabling additive recovery columns without breaking workers.

- **Refactors**
  - Replaced wildcard projections with explicit columns in SELECT and RETURNING for pending and reserved evaluation queries.
  - Preserved existing read and paging order to keep worker behavior unchanged.

<sup>Written for commit 3f7aa9f78448406549c98dae2769fab956649506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

