### PR TITLE
feat(dashboard): make Shadow MCP detector exclusive

### DIFF
--- a/.changeset/shadow-mcp-detector-exclusivity.md
+++ b/.changeset/shadow-mcp-detector-exclusivity.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Make the Shadow MCP detector mutually exclusive with other built-in policy detectors in create and edit flows, with disabled-switch tooltips explaining how to change the selection.

--- a/client/dashboard/src/pages/security/DetectorCard.test.tsx
+++ b/client/dashboard/src/pages/security/DetectorCard.test.tsx
@@ -41,7 +41,7 @@ describe("DetectorCard", () => {
     expect(onToggle).toHaveBeenCalledWith(true);
   });
 
-  it("puts only a disabled switch inside a focusable tooltip trigger", async () => {
+  it("shows a disabled switch reason only when its tooltip trigger is hovered", async () => {
     const reason = "Turn off other built-in rules to select Shadow MCP.";
     renderCard({ disabledReason: reason });
 
@@ -59,8 +59,14 @@ describe("DetectorCard", () => {
     expect(trigger?.children.length).toBe(1);
     expect(trigger?.firstElementChild).toBe(toggle);
 
-    fireEvent.focus(trigger!);
+    const card = trigger?.parentElement;
+    expect(card).not.toBeNull();
+
+    fireEvent.pointerMove(card!, { pointerType: "mouse" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    fireEvent.pointerMove(trigger!, { pointerType: "mouse" });
     const tooltip = await screen.findByRole("tooltip");
-    expect(tooltip.textContent).toContain(reason);
+    expect(tooltip.textContent).toBe(reason);
   });
 });

--- a/client/dashboard/src/pages/security/DetectorCard.test.tsx
+++ b/client/dashboard/src/pages/security/DetectorCard.test.tsx
@@ -1,0 +1,66 @@
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DetectorCard } from "./DetectorCard";
+
+afterEach(cleanup);
+
+function renderCard({
+  disabledReason,
+  onToggle = vi.fn(),
+}: {
+  disabledReason?: string;
+  onToggle?: (checked: boolean) => void;
+} = {}) {
+  render(
+    <TooltipProvider>
+      <DetectorCard
+        category="shadow_mcp"
+        selected={false}
+        disabledRules={new Set()}
+        disabledReason={disabledReason}
+        onToggle={onToggle}
+        onCustomize={vi.fn()}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("DetectorCard", () => {
+  it("keeps an enabled switch interactive and unwrapped", () => {
+    const onToggle = vi.fn();
+    renderCard({ onToggle });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Shadow MCP built-in rule",
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(toggle.closest('[data-slot="tooltip-trigger"]')).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("puts only a disabled switch inside a focusable tooltip trigger", async () => {
+    const reason = "Turn off other built-in rules to select Shadow MCP.";
+    renderCard({ disabledReason: reason });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Shadow MCP built-in rule",
+    }) as HTMLButtonElement;
+    const trigger = toggle.closest<HTMLElement>(
+      '[data-slot="tooltip-trigger"]',
+    );
+
+    expect(toggle.disabled).toBe(true);
+    expect(trigger).not.toBeNull();
+    expect(trigger?.tabIndex).toBe(0);
+    expect(trigger?.getAttribute("aria-label")).toBe("Shadow MCP unavailable");
+    expect(trigger?.children.length).toBe(1);
+    expect(trigger?.firstElementChild).toBe(toggle);
+
+    fireEvent.focus(trigger!);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toContain(reason);
+  });
+});

--- a/client/dashboard/src/pages/security/DetectorCard.test.tsx
+++ b/client/dashboard/src/pages/security/DetectorCard.test.tsx
@@ -69,4 +69,22 @@ describe("DetectorCard", () => {
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip.textContent).toBe(reason);
   });
+
+  it("shows a disabled switch reason when its tooltip trigger is focused", async () => {
+    const reason = "Turn off other built-in rules to select Shadow MCP.";
+    renderCard({ disabledReason: reason });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Shadow MCP built-in rule",
+    });
+    const trigger = toggle.closest<HTMLElement>(
+      '[data-slot="tooltip-trigger"]',
+    );
+
+    expect(trigger).not.toBeNull();
+
+    fireEvent.focus(trigger!);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toBe(reason);
+  });
 });

--- a/client/dashboard/src/pages/security/DetectorCard.test.tsx
+++ b/client/dashboard/src/pages/security/DetectorCard.test.tsx
@@ -7,7 +7,7 @@ afterEach(cleanup);
 
 function renderCard({
   disabledReason,
-  onToggle = vi.fn(),
+  onToggle = vi.fn<(checked: boolean) => void>(),
 }: {
   disabledReason?: string;
   onToggle?: (checked: boolean) => void;
@@ -20,7 +20,7 @@ function renderCard({
         disabledRules={new Set()}
         disabledReason={disabledReason}
         onToggle={onToggle}
-        onCustomize={vi.fn()}
+        onCustomize={vi.fn<() => void>()}
       />
     </TooltipProvider>,
   );
@@ -28,7 +28,7 @@ function renderCard({
 
 describe("DetectorCard", () => {
   it("keeps an enabled switch interactive and unwrapped", () => {
-    const onToggle = vi.fn();
+    const onToggle = vi.fn<(checked: boolean) => void>();
     renderCard({ onToggle });
 
     const toggle = screen.getByRole("switch", {

--- a/client/dashboard/src/pages/security/DetectorCard.tsx
+++ b/client/dashboard/src/pages/security/DetectorCard.tsx
@@ -1,0 +1,111 @@
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { Badge, Icon } from "@speakeasy-api/moonshine";
+import type { IconName } from "@speakeasy-api/moonshine";
+import {
+  DETECTION_RULES,
+  RULE_CATEGORY_META,
+  type RuleCategory,
+} from "./policy-data";
+import { AVAILABLE_CATEGORIES } from "./policy-form";
+
+export type DetectorCardProps = {
+  category: RuleCategory;
+  selected: boolean;
+  disabledRules: Set<string>;
+  disabledReason?: string;
+  onToggle: (checked: boolean) => void;
+  onCustomize: () => void;
+};
+
+export function DetectorCard({
+  category,
+  selected,
+  disabledRules,
+  disabledReason,
+  onToggle,
+  onCustomize,
+}: DetectorCardProps): JSX.Element {
+  const meta = RULE_CATEGORY_META[category];
+  const available = AVAILABLE_CATEGORIES.has(category);
+  const rules = DETECTION_RULES[category].filter((rule) => !rule.hidden);
+  const customizable = available && rules.length > 1;
+  const enabledCount = rules.filter(
+    (rule) => !disabledRules.has(rule.id),
+  ).length;
+  const customized = selected && enabledCount < rules.length;
+  const disabled = !available || disabledReason !== undefined;
+
+  const toggle = (
+    <Switch
+      aria-label={`${meta.label} built-in rule`}
+      checked={selected}
+      disabled={disabled}
+      onCheckedChange={onToggle}
+    />
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex gap-3 rounded-lg border p-3 transition-colors",
+        selected ? "border-foreground bg-muted/40" : "border-border",
+      )}
+    >
+      <Icon
+        name={meta.icon as IconName}
+        className="text-muted-foreground mt-0.5 size-5 shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{meta.label}</span>
+          {!available && (
+            <Badge variant="neutral">
+              <Badge.Text>Coming soon</Badge.Text>
+            </Badge>
+          )}
+        </div>
+        <p className="text-muted-foreground mt-0.5 text-xs">
+          {meta.description}
+        </p>
+        <div className="mt-2 flex items-center gap-3 text-xs">
+          {rules.length > 0 && (
+            <span
+              className={cn(
+                "bg-muted rounded-full px-2 py-0.5",
+                customized ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              {customized
+                ? `${enabledCount} of ${rules.length} rules`
+                : `${rules.length} rules`}
+            </span>
+          )}
+          {selected && customizable && (
+            <button
+              type="button"
+              onClick={onCustomize}
+              className="text-primary hover:underline"
+            >
+              Customize
+            </button>
+          )}
+        </div>
+      </div>
+      {disabledReason ? (
+        <SimpleTooltip tooltip={disabledReason}>
+          <span
+            aria-label={`${meta.label} unavailable`}
+            className="inline-flex cursor-not-allowed [&>button]:pointer-events-none"
+            tabIndex={0}
+          >
+            {toggle}
+          </span>
+        </SimpleTooltip>
+      ) : (
+        toggle
+      )}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -36,11 +36,10 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Icon,
   Stack,
   Table,
 } from "@speakeasy-api/moonshine";
-import type { BadgeProps, IconName } from "@speakeasy-api/moonshine";
+import type { BadgeProps } from "@speakeasy-api/moonshine";
 import {
   Plus,
   Shield,
@@ -95,7 +94,6 @@ import { Outlet } from "react-router";
 import {
   ACTION_OPTIONS,
   ALL_POLICY_MESSAGE_TYPES,
-  AVAILABLE_CATEGORIES,
   categoriesToPayload,
   policyMessageTypesForForm,
   policyToCategories,
@@ -106,83 +104,6 @@ import {
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
 import { SeverityBadge } from "./risk-ui";
-
-/** One built-in detector as a toggleable card (Detect step). "Customize" opens
- *  a side-sheet to pick which rules in the category are active. */
-export function DetectorCard({
-  category,
-  selected,
-  disabledRules,
-  onToggle,
-  onCustomize,
-}: {
-  category: RuleCategory;
-  selected: boolean;
-  disabledRules: Set<string>;
-  onToggle: (checked: boolean) => void;
-  onCustomize: () => void;
-}): JSX.Element {
-  const meta = RULE_CATEGORY_META[category];
-  const available = AVAILABLE_CATEGORIES.has(category);
-  const rules = DETECTION_RULES[category].filter((r) => !r.hidden);
-  const customizable = available && rules.length > 1;
-  const enabledCount = rules.filter((r) => !disabledRules.has(r.id)).length;
-  const customized = selected && enabledCount < rules.length;
-  return (
-    <div
-      className={cn(
-        "flex gap-3 rounded-lg border p-3 transition-colors",
-        selected ? "border-foreground bg-muted/40" : "border-border",
-      )}
-    >
-      <Icon
-        name={meta.icon as IconName}
-        className="text-muted-foreground mt-0.5 size-5 shrink-0"
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{meta.label}</span>
-          {!available && (
-            <Badge variant="neutral">
-              <Badge.Text>Coming soon</Badge.Text>
-            </Badge>
-          )}
-        </div>
-        <p className="text-muted-foreground mt-0.5 text-xs">
-          {meta.description}
-        </p>
-        <div className="mt-2 flex items-center gap-3 text-xs">
-          {rules.length > 0 && (
-            <span
-              className={cn(
-                "bg-muted rounded-full px-2 py-0.5",
-                customized ? "text-foreground" : "text-muted-foreground",
-              )}
-            >
-              {customized
-                ? `${enabledCount} of ${rules.length} rules`
-                : `${rules.length} rules`}
-            </span>
-          )}
-          {selected && customizable && (
-            <button
-              type="button"
-              onClick={onCustomize}
-              className="text-primary hover:underline"
-            >
-              Customize
-            </button>
-          )}
-        </div>
-      </div>
-      <Switch
-        checked={selected}
-        disabled={!available}
-        onCheckedChange={onToggle}
-      />
-    </div>
-  );
-}
 
 /** Per-policy config for the Non-Corporate Accounts category: the list of
  *  email domains treated as corporate. Rendered inside the category's

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -95,10 +95,10 @@ import {
 import {
   ActionPicker,
   CustomizeRulesSheet,
-  DetectorCard,
   PolicyAudiencePicker,
   RuleSelectList,
 } from "./PolicyCenter";
+import { DetectorCard } from "./DetectorCard";
 import {
   ALL_CATEGORIES,
   CATEGORY_LEVEL_DETECTORS,

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -99,6 +99,7 @@ import {
   RuleSelectList,
 } from "./PolicyCenter";
 import { DetectorCard } from "./DetectorCard";
+import { builtInRuleDisabledReason } from "./policy-built-in-rule-exclusivity";
 import {
   ALL_CATEGORIES,
   CATEGORY_LEVEL_DETECTORS,
@@ -3663,6 +3664,13 @@ export function StandardPolicyEditor({
   // Toggle a whole built-in detector category (clears its per-rule disables).
   // Flag-only categories force the policy action to flag.
   const toggleCategory = (cat: RuleCategory, checked: boolean) => {
+    if (
+      checked &&
+      builtInRuleDisabledReason(cat, selectedCategories) !== undefined
+    ) {
+      return;
+    }
+
     const rules = DETECTION_RULES[cat].filter((r) => !r.hidden);
     const nextCats = new Set(selectedCategories);
     const nextDisabled = new Set(disabledRules);
@@ -3827,6 +3835,10 @@ export function StandardPolicyEditor({
                       category={cat}
                       selected={selectedCategories.has(cat)}
                       disabledRules={disabledRules}
+                      disabledReason={builtInRuleDisabledReason(
+                        cat,
+                        selectedCategories,
+                      )}
                       onToggle={(checked) => toggleCategory(cat, checked)}
                       onCustomize={() => setCustomizeCategory(cat)}
                     />

--- a/client/dashboard/src/pages/security/policy-built-in-rule-exclusivity.test.ts
+++ b/client/dashboard/src/pages/security/policy-built-in-rule-exclusivity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { RuleCategory } from "./policy-data";
+import {
+  OTHER_BUILT_IN_RULE_DISABLED_REASON,
+  SHADOW_MCP_DISABLED_REASON,
+  builtInRuleDisabledReason,
+} from "./policy-built-in-rule-exclusivity";
+
+const selected = (...categories: RuleCategory[]) =>
+  new Set<RuleCategory>(categories);
+
+describe("builtInRuleDisabledReason", () => {
+  it("allows every built-in rule when none is selected", () => {
+    expect(builtInRuleDisabledReason("shadow_mcp", selected())).toBeUndefined();
+    expect(builtInRuleDisabledReason("secrets", selected())).toBeUndefined();
+  });
+
+  it("disables Shadow MCP when another built-in rule is selected", () => {
+    expect(
+      builtInRuleDisabledReason("shadow_mcp", selected("secrets", "pii")),
+    ).toBe(SHADOW_MCP_DISABLED_REASON);
+  });
+
+  it("disables other built-in rules when Shadow MCP is selected", () => {
+    expect(builtInRuleDisabledReason("secrets", selected("shadow_mcp"))).toBe(
+      OTHER_BUILT_IN_RULE_DISABLED_REASON,
+    );
+    expect(builtInRuleDisabledReason("pii", selected("shadow_mcp"))).toBe(
+      OTHER_BUILT_IN_RULE_DISABLED_REASON,
+    );
+  });
+
+  it("keeps non-Shadow MCP built-in rules combinable", () => {
+    expect(
+      builtInRuleDisabledReason("pii", selected("secrets")),
+    ).toBeUndefined();
+  });
+
+  it("does not treat the custom category marker as another built-in rule", () => {
+    expect(
+      builtInRuleDisabledReason("shadow_mcp", selected("custom")),
+    ).toBeUndefined();
+  });
+
+  it("keeps a selected rule enabled so it can always be turned off", () => {
+    const conflicting = selected("shadow_mcp", "secrets");
+    expect(
+      builtInRuleDisabledReason("shadow_mcp", conflicting),
+    ).toBeUndefined();
+    expect(builtInRuleDisabledReason("secrets", conflicting)).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/pages/security/policy-built-in-rule-exclusivity.ts
+++ b/client/dashboard/src/pages/security/policy-built-in-rule-exclusivity.ts
@@ -1,0 +1,30 @@
+import type { RuleCategory } from "./policy-data";
+import { ALL_CATEGORIES } from "./policy-form";
+
+export const SHADOW_MCP_DISABLED_REASON =
+  "Turn off other built-in rules to select Shadow MCP.";
+
+export const OTHER_BUILT_IN_RULE_DISABLED_REASON =
+  "Turn off Shadow MCP to select this rule.";
+
+export function builtInRuleDisabledReason(
+  category: RuleCategory,
+  selectedCategories: ReadonlySet<RuleCategory>,
+): string | undefined {
+  if (selectedCategories.has(category)) return undefined;
+
+  if (category === "shadow_mcp") {
+    const anotherBuiltInRuleSelected = ALL_CATEGORIES.some(
+      (selectedCategory) =>
+        selectedCategory !== "shadow_mcp" &&
+        selectedCategories.has(selectedCategory),
+    );
+    return anotherBuiltInRuleSelected ? SHADOW_MCP_DISABLED_REASON : undefined;
+  }
+
+  if (category !== "custom" && selectedCategories.has("shadow_mcp")) {
+    return OTHER_BUILT_IN_RULE_DISABLED_REASON;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Reviewer summary

Shadow MCP must be configured independently from other built-in policy detectors. This PR prevents mixing those selections in both create and edit flows, leaves custom rules unaffected, and explains disabled switches with a short tooltip.

## Summary

- make Shadow MCP mutually exclusive with other built-in detectors in standard policy create and edit flows
- disable incompatible built-in detector switches and explain the constraint with a tooltip on the switch
- keep custom detection rules independent from built-in detector selection

## Visual

[shadow-mcp-policy-demo.webm](https://github.com/user-attachments/assets/533714c1-c253-4dad-bd72-3983f6062829)

## Stack

- stacked on #4274

## Testing

- `pnpm -F dashboard test` (126 files, 1,087 tests)
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint`
- manually created a Shadow MCP block policy with no allowed servers and verified the saved edit state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Shadow MCP a mutually exclusive built‑in detector in the policy create/edit flow. Conflicting detectors are disabled with a tooltip, and custom rules remain independent.

- **New Features**
  - Enforce exclusivity between `shadow_mcp` and other built‑in detectors; block toggle attempts when a conflict exists.
  - Show clear disabled reasons via tooltip on detector switches.
  - Keep custom detection rules independent from built‑in detector selection.

- **Refactors**
  - Extracted `DetectorCard` to its own component and updated the editor to use it.
  - Added `builtInRuleDisabledReason` helper and unit tests for exclusivity and tooltip hover/focus behavior.
  - Added changeset to publish a minor update for `dashboard`.

<sup>Written for commit 5140a97c8ba0c491919230253375768c26f32d6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

