### PR TITLE
fix: identify cowork, Claude Code Desktop, and CLI sessions from OTEL service.name

### DIFF
--- a/client/dashboard/src/lib/formatPlatform.test.ts
+++ b/client/dashboard/src/lib/formatPlatform.test.ts
@@ -11,6 +11,7 @@ describe("formatPlatform", () => {
   it("keeps Claude product surfaces distinct", () => {
     expect(formatPlatform("claude-code")).toBe("Claude Code");
     expect(formatPlatform("ClaudeCode")).toBe("Claude Code");
+    expect(formatPlatform("claude-code-desktop")).toBe("Claude Code Desktop");
     expect(formatPlatform("cowork")).toBe("Claude Cowork");
     expect(formatPlatform("Claude Web")).toBe("Claude Chat Web");
     expect(formatPlatform("Claude Chat Web")).toBe("Claude Chat Web");

--- a/client/dashboard/src/lib/formatPlatform.ts
+++ b/client/dashboard/src/lib/formatPlatform.ts
@@ -10,6 +10,10 @@ const PRODUCT_SURFACE_LABELS: Record<string, string> = {
   "claude-chat-web": "Claude Chat Web",
   claudecode: "Claude Code",
   "claude-code": "Claude Code",
+  // Claude Code Desktop is its own surface, distinct from the claude-code CLI
+  // and from cowork (which shares CCD's hook adapter slug but resolves to
+  // "cowork" server-side via the OTEL service.name).
+  "claude-code-desktop": "Claude Code Desktop",
   cowork: "Claude Cowork",
   "claude-cowork": "Claude Cowork",
   cursor: "Cursor",

--- a/server/internal/chat/sources.go
+++ b/server/internal/chat/sources.go
@@ -13,9 +13,14 @@ var sourceAliases = map[string][]string{
 	"claude":          {"claude", "claude-desktop", "claude-chat-desktop", "Claude Chat Desktop"},
 	"claude-chat-web": {"claude-chat-web", "Claude Chat Web"},
 	"claude-code":     {"claude-code", "ClaudeCode"},
-	"cowork":          {"cowork", "claude-cowork", "Claude Cowork"},
-	"cursor":          {"cursor", "Cursor"},
-	"codex":           {"codex", "Codex"},
+	// Claude Code Desktop is its own surface, distinct from the claude-code
+	// CLI and from cowork. Note: sessions captured before surface resolution
+	// landed stored this adapter slug for cowork sessions too — those
+	// historical rows are indistinguishable from genuine CCD by source alone.
+	"claude-code-desktop": {"claude-code-desktop"},
+	"cowork":              {"cowork", "claude-cowork", "Claude Cowork"},
+	"cursor":              {"cursor", "Cursor"},
+	"codex":               {"codex", "Codex"},
 }
 
 // rawToCanonicalSource is the reverse of sourceAliases: each known raw value

--- a/server/internal/chat/sources_test.go
+++ b/server/internal/chat/sources_test.go
@@ -15,6 +15,7 @@ func TestCanonicalizeSources_CollapsesAliasesAndDropsEmpty(t *testing.T) {
 		"Claude Chat Web",
 		"claude-code",
 		"ClaudeCode",
+		"claude-code-desktop",
 		"Codex",
 		"cursor",
 		"Cursor",
@@ -24,7 +25,7 @@ func TestCanonicalizeSources_CollapsesAliasesAndDropsEmpty(t *testing.T) {
 		"claude-code",
 	})
 
-	require.Equal(t, []string{"claude", "claude-chat-web", "claude-code", "codex", "cowork", "cursor"}, got)
+	require.Equal(t, []string{"claude", "claude-chat-web", "claude-code", "claude-code-desktop", "codex", "cowork", "cursor"}, got)
 }
 
 func TestCanonicalizeSources_Empty(t *testing.T) {
@@ -38,6 +39,9 @@ func TestExpandSourceAliases_ExpandsCanonical(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, []string{"claude-code", "ClaudeCode"}, expandSourceAliases([]string{"claude-code"}))
+	// Claude Code Desktop is its own surface — it must not expand into (or be
+	// swallowed by) the claude-code CLI aliases.
+	require.Equal(t, []string{"claude-code-desktop"}, expandSourceAliases([]string{"claude-code-desktop"}))
 	require.Equal(
 		t,
 		[]string{"claude", "claude-desktop", "claude-chat-desktop", "Claude Chat Desktop"},

--- a/server/internal/hooks/cache.go
+++ b/server/internal/hooks/cache.go
@@ -47,6 +47,14 @@ const (
 	// agentVariantClaudeCode marks a session that originated from the
 	// standard Claude Code CLI (where `claude mcp list` was reachable).
 	agentVariantClaudeCode = "claude-code"
+	// surfaceClaudeCodeDesktop is the Claude Code Desktop (CCD) product
+	// surface. It is never stamped as an agent variant — the SessionStart
+	// inventory shape cannot tell CCD from the CLI — but the desktop hook
+	// client self-identifies with this adapter slug, which is how CCD
+	// sessions are told apart from CLI ones. Cowork sessions ship the same
+	// adapter, so only the OTEL service.name (or the inventory variant)
+	// separates cowork from CCD.
+	surfaceClaudeCodeDesktop = "claude-code-desktop"
 )
 
 // sessionMCPListTTL is how long the parsed MCP list survives without any

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -624,6 +624,12 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 	// hook row and the chat persistence below stamp the same AI-account
 	// attribution.
 	metadata := s.canonicalSessionMetadata(ctx, payload, authCtx, actor)
+	// Resolve the product surface once per event: the OTEL-cached service.name
+	// wins ("cowork" vs "claude-code"), the SessionStart variant fills in for
+	// sessions whose OTEL stream hasn't arrived, and non-Claude adapters pass
+	// through unchanged. Telemetry hook_source and the chat message source both
+	// stamp this value.
+	hookSource := conv.Default(s.claudeSessionSurface(ctx, &metadata), strings.TrimSpace(payload.Source.Adapter))
 	// Hostname counts as cacheable identity: a session ingested with an
 	// org-scoped key and no self-reported email carries nothing else, and the
 	// OTEL path needs the cached hostname to stamp Claude cost rows so the
@@ -643,8 +649,8 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 			)
 		}
 	}
-	s.writeCanonicalTelemetry(ctx, payload, authCtx, &metadata, timestamp, blockReason)
-	if err := s.persistCanonicalConversationEvent(ctx, payload, authCtx, &metadata, timestamp); err != nil {
+	s.writeCanonicalTelemetry(ctx, payload, authCtx, &metadata, hookSource, timestamp, blockReason)
+	if err := s.persistCanonicalConversationEvent(ctx, payload, authCtx, &metadata, hookSource, timestamp); err != nil {
 		s.logger.WarnContext(ctx, "failed to persist canonical hook conversation event",
 			attr.SlogEvent("hooks_ingest_chat_persist_failed"),
 			attr.SlogError(err),
@@ -693,6 +699,12 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 
 	if cached, err := s.getSessionMetadata(ctx, metadata.SessionID); err == nil &&
 		cached.GramOrgID == metadata.GramOrgID && cached.ProjectID == metadata.ProjectID {
+		// Surface-specificity merge: the OTEL path caches "cowork" from the
+		// resource service.name, which must survive this event's re-cache —
+		// cowork ships the same "claude-code-desktop" adapter slug as Claude
+		// Code Desktop, so the adapter alone can never downgrade it. The
+		// adapter in turn beats a cached ambiguous "claude-code".
+		metadata.ServiceName = preferClaudeServiceName(metadata.ServiceName, cached.ServiceName)
 		metadata.Provider = cached.Provider
 		metadata.ExternalOrgID = cached.ExternalOrgID
 		metadata.ExternalAccountUUID = cached.ExternalAccountUUID
@@ -719,7 +731,7 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 	return metadata
 }
 
-func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, timestamp time.Time, blockReason string) {
+func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, hookSource string, timestamp time.Time, blockReason string) {
 	if s.telemetryLogger == nil {
 		return
 	}
@@ -730,7 +742,7 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 		toolName = hookEventName
 	}
 
-	attrs := hookTelemetryBaseAttrs(payload, authCtx, hookEventName)
+	attrs := hookTelemetryBaseAttrs(payload, authCtx, hookEventName, hookSource)
 	if blockReason != "" {
 		attrs[attr.HookBlockReasonKey] = blockReason
 	}
@@ -803,7 +815,7 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 	// dashboards see the same skill.activated vocabulary as Claude senders.
 	// A policy-blocked event never ran, so it is not an activation.
 	if skill != "" && !isExplicitSkillActivation(payload) && blockReason == "" {
-		attrs = hookTelemetryBaseAttrs(payload, authCtx, eventTypeSkillActivated)
+		attrs = hookTelemetryBaseAttrs(payload, authCtx, eventTypeSkillActivated, hookSource)
 		// Skill counts aggregate at trace level (trace_summaries), and its MV
 		// resolves tool_name/skill_name with any(): sharing a trace with the
 		// underlying tool or prompt rows lets a non-Skill sibling win the
@@ -822,11 +834,11 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 // hookTelemetryBaseAttrs builds the attributes shared by every telemetry row
 // derived from one ingested hook event. Each row gets its own span id; the
 // trace id is payload-derived so sibling rows stay on one trace.
-func hookTelemetryBaseAttrs(payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, hookEventName string) map[attr.Key]any {
+func hookTelemetryBaseAttrs(payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, hookEventName string, hookSource string) map[attr.Key]any {
 	attrs := map[attr.Key]any{
 		attr.EventSourceKey:    string(telemetry.EventSourceHook),
 		attr.HookEventKey:      hookEventName,
-		attr.HookSourceKey:     strings.TrimSpace(payload.Source.Adapter),
+		attr.HookSourceKey:     hookSource,
 		attr.ProjectIDKey:      authCtx.ProjectID.String(),
 		attr.OrganizationIDKey: authCtx.ActiveOrganizationID,
 		attr.SpanIDKey:         generateSpanID(),
@@ -932,7 +944,7 @@ func telemetryHookEventName(payload *gen.IngestPayload) string {
 // so the chat row, telemetry, and enforcement carry the exact same
 // server-resolved time for one event — a recomputed fallback or clamp would
 // drift by the handler's processing latency.
-func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, occurredAt time.Time) error {
+func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, hookSource string, occurredAt time.Time) error {
 	sessionID := canonicalSessionID(payload)
 	if sessionID == "" || authCtx.ProjectID == nil {
 		return nil
@@ -959,7 +971,7 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 			Origin:           conv.ToPGTextEmpty(""),
 			UserAgent:        conv.ToPGTextEmpty(""),
 			IpAddress:        conv.ToPGTextEmpty(""),
-			Source:           conv.ToPGTextEmpty(strings.TrimSpace(payload.Source.Adapter)),
+			Source:           conv.ToPGTextEmpty(hookSource),
 			ContentHash:      nil,
 			Generation:       0,
 			// Downtime backlog redelivered from a device's offline spool:

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -95,6 +95,50 @@ func TestIngest_AcceptsCustomHookSource(t *testing.T) {
 	require.Equal(t, "allow", result.Decision)
 }
 
+// The OTEL logs path caches service.name "cowork" for a session's metadata;
+// the desktop hook client then sends its generic "claude-code-desktop"
+// adapter slug on every canonical event (cowork and Claude Code Desktop share
+// it). The metadata merge must keep the more specific cowork identity so
+// chat sources and hook_source stay "cowork", and a session.started re-cache
+// never downgrades it back to the adapter.
+func TestCanonicalSessionMetadata_KeepsCachedCoworkServiceName(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := "canonical-cowork-surface"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "cowork",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}, 0))
+
+	payload := canonicalIngestPayload("claude-code-desktop", "session.started", sessionID)
+	metadata := ti.service.canonicalSessionMetadata(ctx, payload, authCtx, canonicalActor{UserID: "", Email: ""})
+	require.Equal(t, "cowork", metadata.ServiceName)
+}
+
+// With no cached OTEL identity (the session's log stream has not arrived
+// yet), the canonical metadata keeps the adapter slug — for the desktop
+// client that means "claude-code-desktop", which is itself a distinct surface
+// from the claude-code CLI.
+func TestCanonicalSessionMetadata_AdapterStandsWithoutCachedServiceName(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	payload := canonicalIngestPayload("claude-code-desktop", "session.started", "canonical-ccd-no-cache")
+	metadata := ti.service.canonicalSessionMetadata(ctx, payload, authCtx, canonicalActor{UserID: "", Email: ""})
+	require.Equal(t, "claude-code-desktop", metadata.ServiceName)
+}
+
 func TestIngest_RequiresCurrentSchemaVersion(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -115,8 +115,12 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		}
 
 		completeMetadata := SessionMetadata{
-			SessionID:           session.SessionID,
-			ServiceName:         conv.Default(session.ServiceName, cached.ServiceName),
+			SessionID: session.SessionID,
+			// Surface-specificity merge, not plain first-non-empty: the OTEL
+			// stream reports "claude-code" for the CLI and Claude Code Desktop
+			// alike, so a cached desktop adapter slug must survive this batch,
+			// while an incoming "cowork" upgrades whatever was cached.
+			ServiceName:         preferClaudeServiceName(session.ServiceName, cached.ServiceName),
 			UserEmail:           userEmail,
 			UserID:              userID,
 			Provider:            providerAnthropic,
@@ -379,9 +383,19 @@ func (s *Service) writeClaudeOTELLogsToClickHouse(ctx context.Context, payload *
 				logAttrs[attr.ProjectIDKey] = projectID
 				logAttrs[attr.OrganizationIDKey] = orgID
 				logAttrs[attr.ResourceURNKey] = claudeOTELLogsURN
-				logAttrs[attr.HookSourceKey] = "claude-code"
 				sessionID := stringAttr(logAttrs, attribute.Key("session.id"))
 				sessionMeta := attributionBySession[sessionID]
+				// Label the row with the session's product surface — cowork,
+				// claude-code-desktop, or claude-code. The resource's
+				// service.name is the source of truth where it disambiguates
+				// (cowork self-identifies); the session's merged service name
+				// carries the desktop adapter slug that separates CCD from
+				// the CLI, both of which report "claude-code" over OTEL.
+				surface := conv.Default(
+					claudeSurfaceFromServiceName(preferClaudeServiceName(resourceServiceName, sessionMeta.ServiceName)),
+					"claude-code",
+				)
+				logAttrs[attr.HookSourceKey] = surface
 				stampAccountAttribution(logAttrs, sessionMeta)
 				if shouldTriggerClaudePromptCorrelation(logAttrs) {
 					correlationSessionIDs[sessionID] = struct{}{}
@@ -424,7 +438,7 @@ func (s *Service) writeClaudeOTELLogsToClickHouse(ctx context.Context, payload *
 				timestamp, observedTimestamp := otelLogTimestamps(logRecord)
 				logParams := telemetry.WithOTELMetadata(telemetry.LogParams{
 					Timestamp:  timestamp,
-					ToolInfo:   claudeOTELLogToolInfo(orgID, parsedProjectID.String()),
+					ToolInfo:   claudeOTELLogToolInfo(surface, orgID, parsedProjectID.String()),
 					UserInfo:   userInfo,
 					Attributes: logAttrs,
 				}, observedTimestamp, resourceAttrs)
@@ -496,9 +510,13 @@ func (s *Service) scheduleClaudePromptCorrelation(ctx context.Context, projectID
 	}
 }
 
-func claudeOTELLogToolInfo(orgID string, projectID string) telemetry.ToolInfo {
+// claudeOTELLogToolInfo labels an OTEL log row with the session's product
+// surface (claude-code or cowork). The URN stays claude-code:otel:logs for
+// every surface — it identifies the stream's provenance, and the session and
+// cost aggregations anchor their Claude predicates on it.
+func claudeOTELLogToolInfo(surface string, orgID string, projectID string) telemetry.ToolInfo {
 	return telemetry.ToolInfo{
-		Name:           "claude-code",
+		Name:           surface,
 		OrganizationID: orgID,
 		ProjectID:      projectID,
 		ID:             "",

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -76,7 +76,8 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		// ClickHouse stamping below runs each batch.
 		//
 		// Exception: re-attribute when this batch carries an identity field the
-		// cached attribution lacks. A collector can split a session's records so a
+		// cached attribution lacks (or a service.name that pins the product
+		// surface more precisely). A collector can split a session's records so a
 		// later batch is the first to carry the work email or provider org id;
 		// short-circuiting there would freeze a session first seen without an email
 		// as personal and never persist the late-arriving email / external_org_id
@@ -241,13 +242,18 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 // this returns false, preserving the fast path. Note this keys on raw field
 // presence, not email resolution: a batch that merely repeats an already-seen
 // email whose membership changed does not re-trigger (that heals on the next
-// session, by design).
+// session, by design). A batch whose service.name pins the product surface
+// more precisely than the cached one (e.g. "cowork" after a resumed session's
+// client upgrade replaced the ambiguous "claude-code") also yields, so the
+// slow path's preferClaudeServiceName merge can upgrade the cached
+// ServiceName.
 func sessionEnrichesAttribution(incoming claudeLogMetadata, cached SessionMetadata) bool {
 	return (incoming.UserEmail != "" && cached.UserEmail == "") ||
 		(incoming.ExternalOrgID != "" && cached.ExternalOrgID == "") ||
 		(incoming.ExternalAccountUUID != "" && cached.ExternalAccountUUID == "") ||
 		(incoming.ExternalAccountID != "" && cached.ExternalAccountID == "") ||
-		(incoming.DeviceID != "" && cached.DeviceID == "")
+		(incoming.DeviceID != "" && cached.DeviceID == "") ||
+		claudeServiceNameSpecificity(incoming.ServiceName) > claudeServiceNameSpecificity(cached.ServiceName)
 }
 
 type claudeLogMetadata struct {
@@ -359,6 +365,12 @@ func (s *Service) writeClaudeOTELLogsToClickHouse(ctx context.Context, payload *
 	params := make([]telemetry.LogParams, 0)
 	stagedParams := make([]telemetry.LogParams, 0)
 	correlationSessionIDs := make(map[string]struct{})
+	// claudeSessionSurface consults the SessionStart agent-variant cache (a
+	// Redis GET per call), and this loop runs per log record — memoize the
+	// resolved surface per session + merged service name so each session pays
+	// for at most one lookup per payload.
+	type surfaceKey struct{ sessionID, serviceName string }
+	surfaceBySession := make(map[surfaceKey]string)
 	for _, resourceLog := range payload.ResourceLogs {
 		if resourceLog == nil {
 			continue
@@ -390,11 +402,20 @@ func (s *Service) writeClaudeOTELLogsToClickHouse(ctx context.Context, payload *
 				// service.name is the source of truth where it disambiguates
 				// (cowork self-identifies); the session's merged service name
 				// carries the desktop adapter slug that separates CCD from
-				// the CLI, both of which report "claude-code" over OTEL.
-				surface := conv.Default(
-					claudeSurfaceFromServiceName(preferClaudeServiceName(resourceServiceName, sessionMeta.ServiceName)),
-					"claude-code",
-				)
+				// the CLI, both of which report "claude-code" over OTEL; and
+				// the SessionStart agent variant covers older cowork builds
+				// whose OTEL still reports "claude-code". Empty and non-Claude
+				// values keep the claude-code default, matching the hook and
+				// chat capture paths.
+				mergedServiceName := preferClaudeServiceName(resourceServiceName, sessionMeta.ServiceName)
+				surface, ok := surfaceBySession[surfaceKey{sessionID, mergedServiceName}]
+				if !ok {
+					surfaceMeta := sessionMeta
+					surfaceMeta.SessionID = sessionID
+					surfaceMeta.ServiceName = mergedServiceName
+					surface = conv.Default(claudeSurfaceFromServiceName(s.claudeSessionSurface(ctx, &surfaceMeta)), "claude-code")
+					surfaceBySession[surfaceKey{sessionID, mergedServiceName}] = surface
+				}
 				logAttrs[attr.HookSourceKey] = surface
 				stampAccountAttribution(logAttrs, sessionMeta)
 				if shouldTriggerClaudePromptCorrelation(logAttrs) {

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -375,12 +375,14 @@ func (s *Service) writeMetricsToClickHouse(ctx context.Context, payload *gen.Met
 		// Cost/token metric rows carry the session's resolved surface (OTEL
 		// service.name first, SessionStart agent variant fallback for older
 		// cowork builds whose OTEL reports "claude-code") so cowork and Claude
-		// Code Desktop spend is not misfiled under claude-code. A cache miss
-		// (metrics beating the logs path) keeps the claude-code default and
-		// self-heals on the session's later batches.
-		surfaceMeta := sessionMeta
-		surfaceMeta.SessionID = m.SessionID
-		if surface := claudeSurfaceFromServiceName(s.claudeSessionSurface(ctx, &surfaceMeta)); surface != "" {
+		// Code Desktop spend is not misfiled under claude-code. The variant
+		// fallback rides sessionMeta's SessionID, which is only populated once
+		// the tenant check above validated the cached metadata — the variant
+		// cache is keyed by session id alone, and an unvalidated id must not
+		// pull another tenant's surface label. Until then (metrics beating the
+		// logs path, or a rejected id) rows keep the claude-code default and
+		// self-heal on the session's later batches.
+		if surface := claudeSurfaceFromServiceName(s.claudeSessionSurface(ctx, &sessionMeta)); surface != "" {
 			attrs[attr.HookSourceKey] = surface
 		}
 

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -372,11 +372,15 @@ func (s *Service) writeMetricsToClickHouse(ctx context.Context, payload *gen.Met
 			}
 		}
 		stampAccountAttribution(attrs, sessionMeta)
-		// Cost/token metric rows carry the session's resolved surface so cowork
-		// and Claude Code Desktop spend is not misfiled under claude-code. A
-		// cache miss (metrics beating the logs path) keeps the claude-code
-		// default and self-heals on the session's later batches.
-		if surface := claudeSurfaceFromServiceName(sessionMeta.ServiceName); surface != "" {
+		// Cost/token metric rows carry the session's resolved surface (OTEL
+		// service.name first, SessionStart agent variant fallback for older
+		// cowork builds whose OTEL reports "claude-code") so cowork and Claude
+		// Code Desktop spend is not misfiled under claude-code. A cache miss
+		// (metrics beating the logs path) keeps the claude-code default and
+		// self-heals on the session's later batches.
+		surfaceMeta := sessionMeta
+		surfaceMeta.SessionID = m.SessionID
+		if surface := claudeSurfaceFromServiceName(s.claudeSessionSurface(ctx, &surfaceMeta)); surface != "" {
 			attrs[attr.HookSourceKey] = surface
 		}
 

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -179,18 +179,10 @@ func (s *Service) buildTelemetryAttributesWithMetadata(ctx context.Context, payl
 		toolName = *payload.ToolName
 	}
 
-	hookSource := "claude"
-	if metadata.ServiceName != "" {
-		hookSource = metadata.ServiceName
-	}
-	// Cowork runs the same claude-code binary and reports the same OTEL
-	// service.name, so ServiceName can't distinguish it — it lands on the
-	// "claude"/"claude-code" default. SessionStart stamps the agent variant
-	// into the cache, so prefer that when it identifies a cowork session, so
-	// per-tool-call tool logs are labelled "cowork" and stay filterable.
-	if s.sessionAgentVariant(ctx, metadata.SessionID) == agentVariantCowork {
-		hookSource = agentVariantCowork
-	}
+	// The resolved product surface (OTEL service.name first, SessionStart
+	// variant fallback) labels per-tool-call rows so cowork sessions stay
+	// filterable in tool logs.
+	hookSource := conv.Default(s.claudeSessionSurface(ctx, metadata), "claude")
 
 	attrs := map[attr.Key]any{
 		attr.EventSourceKey:    string(telemetry.EventSourceHook),
@@ -380,6 +372,13 @@ func (s *Service) writeMetricsToClickHouse(ctx context.Context, payload *gen.Met
 			}
 		}
 		stampAccountAttribution(attrs, sessionMeta)
+		// Cost/token metric rows carry the session's resolved surface so cowork
+		// and Claude Code Desktop spend is not misfiled under claude-code. A
+		// cache miss (metrics beating the logs path) keeps the claude-code
+		// default and self-heals on the session's later batches.
+		if surface := claudeSurfaceFromServiceName(sessionMeta.ServiceName); surface != "" {
+			attrs[attr.HookSourceKey] = surface
+		}
 
 		// Only include non-zero values
 		if m.InputTokens > 0 {

--- a/server/internal/hooks/pending_helpers_test.go
+++ b/server/internal/hooks/pending_helpers_test.go
@@ -139,6 +139,62 @@ func TestBuildTelemetryAttributesWithMetadata_HookSourceCoworkFromSessionStart(t
 	assert.Equal(t, agentVariantCowork, attrs[attr.HookSourceKey])
 }
 
+// Current cowork builds self-identify with OTEL service.name "cowork" — the
+// source of truth. Tool rows must be labelled cowork from it alone, with no
+// SessionStart inventory variant on file (the canonical ingest transport
+// stamps none).
+func TestBuildTelemetryAttributesWithMetadata_HookSourceFromCoworkServiceName(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sessionID := uuid.NewString()
+	metadata := &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "cowork",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	attrs := ti.service.buildTelemetryAttributesWithMetadata(ctx, &hooks.ClaudePayload{
+		HookEventName: "PreToolUse",
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		SessionID:     &sessionID,
+	}, metadata)
+
+	assert.Equal(t, agentVariantCowork, attrs[attr.HookSourceKey])
+}
+
+// Claude Code Desktop is its own surface: the desktop hook adapter slug must
+// pass through as hook_source, not collapse into claude-code (CLI) — and not
+// into cowork, which shares the same adapter but is distinguished by the OTEL
+// service.name or the SessionStart variant.
+func TestBuildTelemetryAttributesWithMetadata_HookSourceClaudeCodeDesktop(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	sessionID := uuid.NewString()
+	metadata := &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "claude-code-desktop",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	attrs := ti.service.buildTelemetryAttributesWithMetadata(ctx, &hooks.ClaudePayload{
+		HookEventName: "PreToolUse",
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		SessionID:     &sessionID,
+	}, metadata)
+
+	assert.Equal(t, surfaceClaudeCodeDesktop, attrs[attr.HookSourceKey])
+}
+
 // A claude-code variant (or no cached variant) must not be rewritten to
 // "cowork"; hook_source keeps the ServiceName / "claude" default.
 func TestBuildTelemetryAttributesWithMetadata_HookSourceDefaultsWithoutCoworkVariant(t *testing.T) {

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -46,20 +47,99 @@ func isConversationEvent(eventName string) bool {
 }
 
 // defaultChatTitleForSession picks the default chat title based on the
-// session's agent variant stamped by SessionStart. If the variant is
-// unknown (no SessionStart cached yet, or stamped with an unrecognized
-// value) we fall back to the ambiguous "Claude Session" title rather than
-// assuming claude-code — the title generator will replace it with a real
-// one once enough conversation is on file.
-func (s *Service) defaultChatTitleForSession(ctx context.Context, sessionID string) string {
-	switch s.sessionAgentVariant(ctx, sessionID) {
+// session's resolved product surface. If the surface is unknown (no OTEL
+// service.name or SessionStart variant on file yet) we fall back to the
+// ambiguous "Claude Session" title rather than assuming claude-code — the
+// title generator will replace it with a real one once enough conversation
+// is on file.
+func (s *Service) defaultChatTitleForSession(ctx context.Context, metadata *SessionMetadata) string {
+	switch s.claudeSessionSurface(ctx, metadata) {
 	case agentVariantCowork:
 		return activities.DefaultCoworkChatTitle
-	case agentVariantClaudeCode:
+	case agentVariantClaudeCode, surfaceClaudeCodeDesktop:
 		return activities.DefaultClaudeChatTitle
 	default:
 		return activities.DefaultClaudeAmbiguous
 	}
+}
+
+// claudeSurfaceFromServiceName maps a reported service name or hook adapter
+// slug to the canonical Claude product surface: "cowork", "claude-code-desktop"
+// (CCD), or "claude-code" (the CLI). The OTEL resource service.name is the
+// source of truth where it disambiguates: cowork self-identifies on it, while
+// the CLI and CCD both report "claude-code" — CCD is identified by the desktop
+// hook client's adapter slug instead. Returns "" when the value identifies no
+// Claude surface (Cursor, Codex, unknown adapters).
+func claudeSurfaceFromServiceName(name string) string {
+	switch n := strings.ToLower(strings.TrimSpace(name)); {
+	case strings.Contains(n, "cowork"):
+		return agentVariantCowork
+	case n == surfaceClaudeCodeDesktop:
+		return surfaceClaudeCodeDesktop
+	case n == "claude-code" || n == "claudecode":
+		return agentVariantClaudeCode
+	default:
+		return ""
+	}
+}
+
+// claudeServiceNameSpecificity ranks how precisely a service name or adapter
+// slug identifies the product surface. "cowork" is unambiguous; the desktop
+// adapter slug narrows to CCD; "claude-code" is the OTEL name shared by the
+// CLI and CCD, so it is the least specific Claude value. Non-Claude values
+// rank zero.
+func claudeServiceNameSpecificity(name string) int {
+	switch claudeSurfaceFromServiceName(name) {
+	case agentVariantCowork:
+		return 3
+	case surfaceClaudeCodeDesktop:
+		return 2
+	case agentVariantClaudeCode:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// preferClaudeServiceName merges a freshly reported service name (or adapter
+// slug) with the session's previously cached one, keeping whichever identifies
+// the product surface more precisely. This is what lets the two signals
+// compose: the OTEL stream's "cowork" upgrades a cached desktop adapter slug,
+// while a cached "claude-code-desktop" survives OTEL batches that only report
+// the ambiguous "claude-code". Ties keep the fresh value.
+func preferClaudeServiceName(incoming, cached string) string {
+	if incoming == "" {
+		return cached
+	}
+	if claudeServiceNameSpecificity(cached) > claudeServiceNameSpecificity(incoming) {
+		return cached
+	}
+	return incoming
+}
+
+// claudeSessionSurface resolves the product surface for a session from the
+// service name carried on SessionMetadata (the OTEL service.name once the
+// session's log stream has been seen, the hook adapter slug before then) with
+// the inventory-shape variant stamped at SessionStart as fallback — it covers
+// cowork builds that predate the cowork service.name and sessions whose OTEL
+// stream has not arrived yet. Values that identify no Claude surface pass
+// through unchanged so non-Claude senders keep their reported name.
+func (s *Service) claudeSessionSurface(ctx context.Context, metadata *SessionMetadata) string {
+	surface := claudeSurfaceFromServiceName(metadata.ServiceName)
+	if surface == agentVariantCowork {
+		return surface
+	}
+	variant := s.sessionAgentVariant(ctx, metadata.SessionID)
+	if variant == agentVariantCowork {
+		return agentVariantCowork
+	}
+	if surface != "" {
+		return surface
+	}
+	if variant != "" {
+		return variant
+	}
+	return metadata.ServiceName
 }
 
 // sessionAgentVariant returns the agent variant ("cowork" or "claude-code")
@@ -331,7 +411,7 @@ func (s *Service) persistConversationEvent(ctx context.Context, payload *gen.Cla
 		Content:          content,
 		Model:            model,
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
-		Source:           conv.ToPGText(metadata.ServiceName),
+		Source:           conv.ToPGText(s.claudeSessionSurface(ctx, metadata)),
 		PromptTokens:     0,
 		CompletionTokens: 0,
 		TotalTokens:      0,
@@ -350,7 +430,7 @@ func (s *Service) persistConversationEvent(ctx context.Context, payload *gen.Cla
 		Generation:       0,
 	}
 
-	if err := s.insertMessageWithFallbackUpsert(ctx, metadata, chatID, projectID, msgParams, s.defaultChatTitleForSession(ctx, conv.PtrValOr(payload.SessionID, ""))); err != nil {
+	if err := s.insertMessageWithFallbackUpsert(ctx, metadata, chatID, projectID, msgParams, s.defaultChatTitleForSession(ctx, metadata)); err != nil {
 		return err
 	}
 
@@ -429,7 +509,7 @@ func (s *Service) writeToolCallRequestToPG(ctx context.Context, payload *gen.Cla
 		Content:          "", // Tool call requests typically have empty content
 		Model:            conv.ToPGTextEmpty(conv.PtrValOr(payload.Model, "")),
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
-		Source:           conv.ToPGText(metadata.ServiceName),
+		Source:           conv.ToPGText(s.claudeSessionSurface(ctx, metadata)),
 		ToolCalls:        toolCallsJSON,
 		FinishReason:     conv.ToPGText("tool_calls"),
 		PromptTokens:     0,
@@ -448,7 +528,7 @@ func (s *Service) writeToolCallRequestToPG(ctx context.Context, payload *gen.Cla
 		Generation:       0,
 	}
 
-	return s.insertMessageWithFallbackUpsert(ctx, metadata, chatID, projectID, msgParams, s.defaultChatTitleForSession(ctx, conv.PtrValOr(payload.SessionID, "")))
+	return s.insertMessageWithFallbackUpsert(ctx, metadata, chatID, projectID, msgParams, s.defaultChatTitleForSession(ctx, metadata))
 }
 
 // writeToolCallResultToPG writes a tool result message to PostgreSQL.
@@ -481,7 +561,7 @@ func (s *Service) writeToolCallResultToPG(ctx context.Context, payload *gen.Clau
 		Role:             "tool",
 		Content:          content,
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
-		Source:           conv.ToPGText(metadata.ServiceName),
+		Source:           conv.ToPGText(s.claudeSessionSurface(ctx, metadata)),
 		ToolCallID:       conv.ToPGTextEmpty(conv.PtrValOr(payload.ToolUseID, "")),
 		PromptTokens:     0,
 		CompletionTokens: 0,
@@ -504,7 +584,7 @@ func (s *Service) writeToolCallResultToPG(ctx context.Context, payload *gen.Clau
 	// If this was an error, we could optionally set tool_outcome based on isError
 	_ = isError
 
-	return s.insertMessageWithFallbackUpsert(ctx, metadata, chatID, projectID, msgParams, s.defaultChatTitleForSession(ctx, conv.PtrValOr(payload.SessionID, "")))
+	return s.insertMessageWithFallbackUpsert(ctx, metadata, chatID, projectID, msgParams, s.defaultChatTitleForSession(ctx, metadata))
 }
 
 // marshalToJSON converts any value to a JSON string.

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -103,13 +103,19 @@ func claudeServiceNameSpecificity(name string) int {
 
 // preferClaudeServiceName merges a freshly reported service name (or adapter
 // slug) with the session's previously cached one, keeping whichever identifies
-// the product surface more precisely. This is what lets the two signals
+// the Claude product surface more precisely. This is what lets the two signals
 // compose: the OTEL stream's "cowork" upgrades a cached desktop adapter slug,
 // while a cached "claude-code-desktop" survives OTEL batches that only report
-// the ambiguous "claude-code". Ties keep the fresh value.
+// the ambiguous "claude-code". Ties keep the fresh value. A non-empty incoming
+// value that identifies no Claude surface (Cursor, Codex, unknown adapters)
+// always wins: non-Claude senders keep their reported name instead of being
+// overwritten by a Claude value cached under the same session id.
 func preferClaudeServiceName(incoming, cached string) string {
 	if incoming == "" {
 		return cached
+	}
+	if claudeSurfaceFromServiceName(incoming) == "" {
+		return incoming
 	}
 	if claudeServiceNameSpecificity(cached) > claudeServiceNameSpecificity(incoming) {
 		return cached

--- a/server/internal/hooks/session_capture_test.go
+++ b/server/internal/hooks/session_capture_test.go
@@ -122,6 +122,127 @@ func TestClaudeHookSource_ConsistentAcrossAllWrites(t *testing.T) {
 	}
 }
 
+// The three Claude surfaces must resolve distinctly: cowork self-identifies
+// on the OTEL service.name, Claude Code Desktop on the desktop hook adapter
+// slug, and the CLI on the shared "claude-code" name. Non-Claude values must
+// not resolve at all.
+func TestClaudeSurfaceFromServiceName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "cowork", claudeSurfaceFromServiceName("cowork"))
+	assert.Equal(t, "cowork", claudeSurfaceFromServiceName("claude-cowork"))
+	assert.Equal(t, "cowork", claudeSurfaceFromServiceName(" Claude Cowork "))
+	assert.Equal(t, "claude-code-desktop", claudeSurfaceFromServiceName("claude-code-desktop"))
+	assert.Equal(t, "claude-code", claudeSurfaceFromServiceName("claude-code"))
+	assert.Equal(t, "claude-code", claudeSurfaceFromServiceName("ClaudeCode"))
+	assert.Empty(t, claudeSurfaceFromServiceName("cursor"))
+	assert.Empty(t, claudeSurfaceFromServiceName("codex_cli_rs"))
+	assert.Empty(t, claudeSurfaceFromServiceName(""))
+}
+
+// Merging a fresh service name with the cached one keeps whichever pins the
+// surface more precisely: "cowork" beats the desktop adapter slug, the
+// desktop adapter slug beats the ambiguous "claude-code" the OTEL stream
+// reports for both desktop and CLI, and ties keep the fresh value.
+func TestPreferClaudeServiceName(t *testing.T) {
+	t.Parallel()
+
+	// OTEL "cowork" upgrades a cached desktop adapter slug.
+	assert.Equal(t, "cowork", preferClaudeServiceName("cowork", "claude-code-desktop"))
+	// A cached "cowork" survives both the ambiguous OTEL name and the shared
+	// desktop adapter slug.
+	assert.Equal(t, "cowork", preferClaudeServiceName("claude-code", "cowork"))
+	assert.Equal(t, "cowork", preferClaudeServiceName("claude-code-desktop", "cowork"))
+	// A cached desktop adapter slug survives OTEL batches reporting the
+	// ambiguous "claude-code"; the adapter upgrades a cached ambiguous name.
+	assert.Equal(t, "claude-code-desktop", preferClaudeServiceName("claude-code", "claude-code-desktop"))
+	assert.Equal(t, "claude-code-desktop", preferClaudeServiceName("claude-code-desktop", "claude-code"))
+	// Empty incoming keeps the cache; empty cache takes the incoming value.
+	assert.Equal(t, "cowork", preferClaudeServiceName("", "cowork"))
+	assert.Equal(t, "claude-code", preferClaudeServiceName("claude-code", ""))
+	// Non-Claude values tie at zero specificity: fresh wins.
+	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "Cursor"))
+}
+
+// A session whose OTEL stream reports service.name "cowork" must persist its
+// chat messages with source "cowork" — no SessionStart inventory variant
+// needed. This is the current cowork identification path: the canonical
+// ingest transport stamps no variant, so the service name is the only signal.
+func TestClaudeChatSource_CoworkFromServiceName(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+	prompt := "hello from cowork"
+
+	metadata := &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "cowork",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	require.NoError(t, ti.service.persistConversationEvent(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		Prompt:        &prompt,
+	}, metadata))
+
+	msgs, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.True(t, msgs[0].Source.Valid)
+	require.Equal(t, "cowork", msgs[0].Source.String)
+}
+
+// Older cowork builds report service.name "claude-code"; for those the
+// inventory-shape variant stamped at SessionStart must still relabel chat
+// messages as cowork.
+func TestClaudeChatSource_CoworkFromVariantOverridesAmbiguousServiceName(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := uuid.NewString()
+	chatID := sessionIDToUUID(sessionID)
+	prompt := "hello from legacy cowork"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionAgentVariantCacheKey(sessionID),
+		agentVariantCowork, sessionMCPListTTL))
+
+	metadata := &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "claude-code",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	require.NoError(t, ti.service.persistConversationEvent(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		Prompt:        &prompt,
+	}, metadata))
+
+	msgs, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.True(t, msgs[0].Source.Valid)
+	require.Equal(t, "cowork", msgs[0].Source.String)
+}
+
 func TestClaudeUserPromptSubmitDoesNotPersistPromptIDAsMessageID(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/hooks/session_capture_test.go
+++ b/server/internal/hooks/session_capture_test.go
@@ -143,7 +143,9 @@ func TestClaudeSurfaceFromServiceName(t *testing.T) {
 // Merging a fresh service name with the cached one keeps whichever pins the
 // surface more precisely: "cowork" beats the desktop adapter slug, the
 // desktop adapter slug beats the ambiguous "claude-code" the OTEL stream
-// reports for both desktop and CLI, and ties keep the fresh value.
+// reports for both desktop and CLI, and ties keep the fresh value. Non-Claude
+// incoming values pass through unchanged so non-Claude senders keep their
+// reported name.
 func TestPreferClaudeServiceName(t *testing.T) {
 	t.Parallel()
 
@@ -160,8 +162,12 @@ func TestPreferClaudeServiceName(t *testing.T) {
 	// Empty incoming keeps the cache; empty cache takes the incoming value.
 	assert.Equal(t, "cowork", preferClaudeServiceName("", "cowork"))
 	assert.Equal(t, "claude-code", preferClaudeServiceName("claude-code", ""))
-	// Non-Claude values tie at zero specificity: fresh wins.
+	// A non-Claude incoming value always keeps its reported name — even
+	// against a cached Claude value under the same session id.
 	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "Cursor"))
+	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "claude-code"))
+	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "claude-code-desktop"))
+	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "cowork"))
 }
 
 // A session whose OTEL stream reports service.name "cowork" must persist its


### PR DESCRIPTION
## Summary

Cowork sessions stopped being identified ~3 weeks ago: their OTEL logs carry `resource_attributes.service.name = "cowork"`, but log rows landed with `name`/`hook_source = "claude-code"` and `chat.source` came back as the raw desktop adapter slug `claude-code-desktop`.

Root cause: when desktop-hosted sessions moved onto the canonical hook ingest path (#3824), nothing on that path resolved the product surface — the adapter slug was stamped everywhere, and the OTEL write path hardcoded `claude-code`. The only cowork detection (SessionStart MCP-inventory variant) lives on the legacy hooks path, which those sessions no longer take.

This PR makes the OTEL `service.name` the source of truth and distinguishes all three Claude surfaces: **cowork**, **claude-code-desktop** (CCD), and **claude-code** (CLI).

## How resolution works

`service.name` can't express everything on its own: CCD and the CLI both report `service.name = "claude-code"`, while cowork and CCD share the `claude-code-desktop` hook adapter slug. Surfaces are therefore merged by specificity (`preferClaudeServiceName`):

```
cowork (3)  >  claude-code-desktop (2)  >  claude-code (1)  >  other (0)
```

Whenever a fresh signal meets a cached one, the more specific value wins: the OTEL stream's `cowork` upgrades a cached adapter slug, and a cached adapter slug survives OTEL batches that only report the ambiguous `claude-code`. The SessionStart inventory variant remains as a fallback for older cowork builds that still report `service.name = "claude-code"` and for the window before a session's first OTEL batch.

## Changes

- **OTEL log rows** (`otel.go`): `hook_source` and the row's tool name come from the resolved surface per session instead of hardcoded `"claude-code"`. `gram_urn` stays `claude-code:otel:logs` — session/cost aggregations anchor Claude provenance on the URN, and their tool-name exclusions are guarded by `hook_source IN ('codex','cursor')`, so relabeling does not leak rows into them.
- **Session metadata cache**: both writers merge `ServiceName` by specificity — the canonical ingest path no longer clobbers a cached `cowork` with the adapter slug on `session.started` re-caches (the bug behind `chat.source = "claude-code-desktop"`), and the OTEL path no longer uses plain first-non-empty.
- **chat.source**: every chat-message write path (legacy conversation/tool writes and canonical ingest) stamps the resolved surface; default chat titles follow it.
- **Cost/token metric rows** stamp the resolved surface as `hook_source` so cowork/CCD spend is not misfiled under `claude-code`.
- **Taxonomy**: `claude-code-desktop` becomes its own canonical source in `chat/sources.go` and formats as "Claude Code Desktop" in the dashboard — it does not alias into `claude-code`.

Known limitation: cowork chats captured during the regression window stored source `claude-code-desktop` and are indistinguishable from genuine CCD by source string alone; they will display as Claude Code Desktop. New sessions resolve correctly (immediately via the variant on the legacy path, on first OTEL batch via `service.name` on the canonical path).

## Testing

- New unit tests for surface mapping and specificity merge.
- New integration tests: cowork chat source from `service.name` alone, variant override for ambiguous service names, CCD adapter pass-through in tool logs, canonical metadata merge in both directions.
- Full `server/internal/hooks` (354), `chat` + `telemetry` (398) packages pass; dashboard vitest + type-check pass; `mise lint:server` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mislabeling of Claude sessions by using OTEL `service.name` to reliably identify `cowork`, `claude-code-desktop` (CCD), and `claude-code` (CLI) across telemetry, chat, and cost metrics. Ensures dashboards and spend attribution reflect the correct product surface.

- **Bug Fixes**
  - Resolve surface by specificity: `cowork` > `claude-code-desktop` > `claude-code`; merge cached and incoming values so the more specific wins, and re-attribute when a batch’s `service.name` is more specific than the cache.
  - Preserve non-Claude adapters: a non-empty non-Claude incoming value passes through unchanged and is not overwritten by a cached Claude value.
  - Stamp the resolved surface into `hook_source`, `chat.source`, and default chat titles; non-Claude adapters pass through unchanged.
  - Label OTEL logs and ToolInfo with the resolved surface (via `service.name` first, SessionStart variant as fallback); keep URN `claude-code:otel:logs`.
  - Cost/token metrics carry the resolved surface; variant fallback is gated on tenant-validated session metadata and defaults to `claude-code` until validated, then self-heals on later batches.
  - Treat `claude-code-desktop` as a distinct canonical source; dashboard displays “Claude Code Desktop”.

- **Migration**
  - No action required. Cowork chats captured during the regression that stored `claude-code-desktop` will continue to display as Claude Code Desktop; new sessions resolve correctly.

<sup>Written for commit d72dc06eeedd85fe008d6ea59a8115725117869f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

