### PR TITLE
fix: speed up Employee Enrollment page with a basic searchUsers metrics mode

### DIFF
--- a/.changeset/employee-enrollment-basic-metrics.md
+++ b/.changeset/employee-enrollment-basic-metrics.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Speed up the Employee Enrollment page (DNO-618). `telemetry.searchUsers` gains a `metrics` level: `full` (default, unchanged) computes the complete set of aggregates, while `basic` projects only user identity, first/last activity, input/output token sums, and the raw user ids the account-enrichment join needs — skipping the per-tool and per-hook-source map aggregations (`sumMapIf`), chat-cardinality (`uniqExactIf`), and cost/cache/avg columns that dominate the per-row ClickHouse work. The enrollment list, which renders only the lean fields (linked accounts come from Postgres), now requests `basic`, so its query no longer builds breakdowns it discards.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -57896,6 +57896,13 @@ components:
           format: int64
           minimum: 1
           maximum: 1000
+        metrics:
+          type: string
+          description: 'Level of usage metrics to compute per user. ''full'' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. ''basic'' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under ''basic''.'
+          default: full
+          enum:
+            - full
+            - basic
         sort:
           type: string
           description: Sort order

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -1116,6 +1116,11 @@ async function fetchEmployeeUsage(
           limit: 1000,
           sort: "desc",
           userType: "internal",
+          // The enrollment list renders only identity, last activity, token
+          // totals, and linked accounts (the latter from Postgres enrichment),
+          // so request the lean aggregation and skip the per-tool/hook-source
+          // map aggregates that dominate the ClickHouse query cost (DNO-618).
+          metrics: "basic",
         },
       }),
     );

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -33,6 +33,7 @@ import {
   type OptionsById,
 } from "@/components/filters";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
+import { Metrics } from "@gram/client/models/components/searchuserspayload.js";
 import type { UserSummary } from "@gram/client/models/components/usersummary.js";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useMembers } from "@gram/client/react-query/members.js";
@@ -1120,7 +1121,7 @@ async function fetchEmployeeUsage(
           // totals, and linked accounts (the latter from Postgres enrichment),
           // so request the lean aggregation and skip the per-tool/hook-source
           // map aggregates that dominate the ClickHouse query cost (DNO-618).
-          metrics: "basic",
+          metrics: Metrics.Basic,
         },
       }),
     );

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -6117,7 +6117,7 @@ examples:
   searchUsers:
     speakeasy-default-search-users:
       requestBody:
-        application/json: {"filter": {"from": "2025-12-19T10:00:00Z", "to": "2025-12-19T11:00:00Z"}, "group_by": "employee", "limit": 50, "sort": "desc", "user_type": "external"}
+        application/json: {"filter": {"from": "2025-12-19T10:00:00Z", "to": "2025-12-19T11:00:00Z"}, "group_by": "employee", "limit": 50, "metrics": "full", "sort": "desc", "user_type": "external"}
       responses:
         "200":
           application/json: {"users": [{"avg_tokens_per_request": 2445.8, "cache_creation_input_tokens": 298116, "cache_read_input_tokens": 261654, "first_seen_unix_nano": "<value>", "hook_sources": [], "last_seen_unix_nano": "<value>", "tool_call_failure": 344370, "tool_call_success": 262843, "tools": [{"count": 505126, "failure_count": 421094, "success_count": 638666, "urn": "<value>"}], "total_chat_requests": 818926, "total_chats": 659984, "total_cost": 45.75, "total_input_tokens": 504437, "total_output_tokens": 325254, "total_tokens": 66646, "total_tool_calls": 681888, "user_email": "<value>", "user_id": "<id>"}]}

--- a/client/dashboard/src/sdk/src/models/components/searchuserspayload.ts
+++ b/client/dashboard/src/sdk/src/models/components/searchuserspayload.ts
@@ -26,6 +26,18 @@ export type SearchUsersPayloadGroupBy = ClosedEnum<
 >;
 
 /**
+ * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.
+ */
+export const Metrics = {
+  Full: "full",
+  Basic: "basic",
+} as const;
+/**
+ * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.
+ */
+export type Metrics = ClosedEnum<typeof Metrics>;
+
+/**
  * Sort order
  */
 export const SearchUsersPayloadSort = {
@@ -72,6 +84,10 @@ export type SearchUsersPayload = {
    */
   limit?: number | undefined;
   /**
+   * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.
+   */
+  metrics?: Metrics | undefined;
+  /**
    * Sort order
    */
   sort?: SearchUsersPayloadSort | undefined;
@@ -85,6 +101,11 @@ export type SearchUsersPayload = {
 export const SearchUsersPayloadGroupBy$outboundSchema: z.ZodMiniEnum<
   typeof SearchUsersPayloadGroupBy
 > = z.enum(SearchUsersPayloadGroupBy);
+
+/** @internal */
+export const Metrics$outboundSchema: z.ZodMiniEnum<typeof Metrics> = z.enum(
+  Metrics,
+);
 
 /** @internal */
 export const SearchUsersPayloadSort$outboundSchema: z.ZodMiniEnum<
@@ -102,6 +123,7 @@ export type SearchUsersPayload$Outbound = {
   filter: SearchUsersFilter$Outbound;
   group_by: string;
   limit: number;
+  metrics: string;
   sort: string;
   user_type: string;
 };
@@ -116,6 +138,7 @@ export const SearchUsersPayload$outboundSchema: z.ZodMiniType<
     filter: SearchUsersFilter$outboundSchema,
     groupBy: z._default(SearchUsersPayloadGroupBy$outboundSchema, "employee"),
     limit: z._default(z.int(), 50),
+    metrics: z._default(Metrics$outboundSchema, "full"),
     sort: z._default(SearchUsersPayloadSort$outboundSchema, "desc"),
     userType: SearchUsersPayloadUserType$outboundSchema,
   }),

--- a/server/design/telemetry/design.go
+++ b/server/design/telemetry/design.go
@@ -1208,6 +1208,10 @@ var SearchUsersPayload = Type("SearchUsersPayload", func() {
 		Maximum(1000)
 		Default(50)
 	})
+	Attribute("metrics", String, "Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.", func() {
+		Enum("full", "basic")
+		Default("full")
+	})
 
 	Required("filter", "user_type")
 })

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -15703,7 +15703,7 @@ func telemetrySearchUsersUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "telemetry search-users --body '{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"sort\": \"desc\",\n      \"user_type\": \"external\"\n   }' --apikey-token \"abc123\" --session-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "telemetry search-users --body '{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"metrics\": \"basic\",\n      \"sort\": \"desc\",\n      \"user_type\": \"external\"\n   }' --apikey-token \"abc123\" --session-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func telemetryCaptureEventUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -58224,6 +58224,13 @@ components:
                     format: int64
                     minimum: 1
                     maximum: 1000
+                metrics:
+                    type: string
+                    description: 'Level of usage metrics to compute per user. ''full'' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. ''basic'' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under ''basic''.'
+                    default: full
+                    enum:
+                        - full
+                        - basic
                 sort:
                     type: string
                     description: Sort order

--- a/server/gen/http/telemetry/client/cli.go
+++ b/server/gen/http/telemetry/client/cli.go
@@ -204,7 +204,7 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 	{
 		err = json.Unmarshal([]byte(telemetrySearchUsersBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"sort\": \"desc\",\n      \"user_type\": \"external\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"metrics\": \"basic\",\n      \"sort\": \"desc\",\n      \"user_type\": \"external\"\n   }'")
 		}
 		if body.Filter == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("filter", "body"))
@@ -228,6 +228,9 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 		}
 		if body.Limit > 1000 {
 			err = goa.MergeErrors(err, goa.InvalidRangeError("body.limit", body.Limit, 1000, false))
+		}
+		if !(body.Metrics == "full" || body.Metrics == "basic") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.metrics", body.Metrics, []any{"full", "basic"}))
 		}
 		if err != nil {
 			return nil, err
@@ -257,6 +260,7 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 		Cursor:   body.Cursor,
 		Sort:     body.Sort,
 		Limit:    body.Limit,
+		Metrics:  body.Metrics,
 	}
 	if body.Filter != nil {
 		v.Filter = marshalSearchUsersFilterRequestBodyToTelemetrySearchUsersFilter(body.Filter)
@@ -277,6 +281,12 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 		var zero int
 		if v.Limit == zero {
 			v.Limit = 50
+		}
+	}
+	{
+		var zero string
+		if v.Metrics == zero {
+			v.Metrics = "full"
 		}
 	}
 	v.ApikeyToken = apikeyToken

--- a/server/gen/http/telemetry/client/types.go
+++ b/server/gen/http/telemetry/client/types.go
@@ -74,6 +74,13 @@ type SearchUsersRequestBody struct {
 	Sort string `form:"sort" json:"sort" xml:"sort"`
 	// Number of items to return (1-1000)
 	Limit int `form:"limit" json:"limit" xml:"limit"`
+	// Level of usage metrics to compute per user. 'full' (default) returns the
+	// complete set: chat counts, cost, cache tokens, tool-call totals, and the
+	// per-tool and per-hook-source breakdowns. 'basic' computes only user
+	// identity, first/last activity, and input/output token sums — a much cheaper
+	// aggregation for large orgs (e.g. the employee enrollment list, which renders
+	// only those fields). The remaining fields are zero/empty under 'basic'.
+	Metrics string `form:"metrics" json:"metrics" xml:"metrics"`
 }
 
 // CaptureEventRequestBody is the type of the "telemetry" service
@@ -7207,6 +7214,7 @@ func NewSearchUsersRequestBody(p *telemetry.SearchUsersPayload) *SearchUsersRequ
 		Cursor:   p.Cursor,
 		Sort:     p.Sort,
 		Limit:    p.Limit,
+		Metrics:  p.Metrics,
 	}
 	if p.Filter != nil {
 		body.Filter = marshalTelemetrySearchUsersFilterToSearchUsersFilterRequestBody(p.Filter)
@@ -7227,6 +7235,12 @@ func NewSearchUsersRequestBody(p *telemetry.SearchUsersPayload) *SearchUsersRequ
 		var zero int
 		if body.Limit == zero {
 			body.Limit = 50
+		}
+	}
+	{
+		var zero string
+		if body.Metrics == zero {
+			body.Metrics = "full"
 		}
 	}
 	return body

--- a/server/gen/http/telemetry/server/types.go
+++ b/server/gen/http/telemetry/server/types.go
@@ -74,6 +74,13 @@ type SearchUsersRequestBody struct {
 	Sort *string `form:"sort,omitempty" json:"sort,omitempty" xml:"sort,omitempty"`
 	// Number of items to return (1-1000)
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty" xml:"limit,omitempty"`
+	// Level of usage metrics to compute per user. 'full' (default) returns the
+	// complete set: chat counts, cost, cache tokens, tool-call totals, and the
+	// per-tool and per-hook-source breakdowns. 'basic' computes only user
+	// identity, first/last activity, and input/output token sums — a much cheaper
+	// aggregation for large orgs (e.g. the employee enrollment list, which renders
+	// only those fields). The remaining fields are zero/empty under 'basic'.
+	Metrics *string `form:"metrics,omitempty" json:"metrics,omitempty" xml:"metrics,omitempty"`
 }
 
 // CaptureEventRequestBody is the type of the "telemetry" service
@@ -12062,6 +12069,9 @@ func NewSearchUsersPayload(body *SearchUsersRequestBody, apikeyToken *string, se
 	if body.Limit != nil {
 		v.Limit = *body.Limit
 	}
+	if body.Metrics != nil {
+		v.Metrics = *body.Metrics
+	}
 	v.Filter = unmarshalSearchUsersFilterRequestBodyToTelemetrySearchUsersFilter(body.Filter)
 	if body.GroupBy == nil {
 		v.GroupBy = "employee"
@@ -12071,6 +12081,9 @@ func NewSearchUsersPayload(body *SearchUsersRequestBody, apikeyToken *string, se
 	}
 	if body.Limit == nil {
 		v.Limit = 50
+	}
+	if body.Metrics == nil {
+		v.Metrics = "full"
 	}
 	v.ApikeyToken = apikeyToken
 	v.SessionToken = sessionToken
@@ -13020,6 +13033,11 @@ func ValidateSearchUsersRequestBody(body *SearchUsersRequestBody) (err error) {
 	if body.Limit != nil {
 		if *body.Limit > 1000 {
 			err = goa.MergeErrors(err, goa.InvalidRangeError("body.limit", *body.Limit, 1000, false))
+		}
+	}
+	if body.Metrics != nil {
+		if !(*body.Metrics == "full" || *body.Metrics == "basic") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.metrics", *body.Metrics, []any{"full", "basic"}))
 		}
 	}
 	return

--- a/server/gen/telemetry/service.go
+++ b/server/gen/telemetry/service.go
@@ -1458,6 +1458,13 @@ type SearchUsersPayload struct {
 	Sort string
 	// Number of items to return (1-1000)
 	Limit int
+	// Level of usage metrics to compute per user. 'full' (default) returns the
+	// complete set: chat counts, cost, cache tokens, tool-call totals, and the
+	// per-tool and per-hook-source breakdowns. 'basic' computes only user
+	// identity, first/last activity, and input/output token sums — a much cheaper
+	// aggregation for large orgs (e.g. the employee enrollment list, which renders
+	// only those fields). The remaining fields are zero/empty under 'basic'.
+	Metrics string
 }
 
 // SearchUsersResult is the result type of the telemetry service searchUsers

--- a/server/internal/platformtools/logs/tool_search_users.go
+++ b/server/internal/platformtools/logs/tool_search_users.go
@@ -85,7 +85,8 @@ func (s *SearchUsers) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		Cursor:           input.Cursor,
 		Sort:             input.Sort,
 		Limit:            input.Limit,
-		Metrics:          "full", // platform tool surfaces the complete per-user metrics
+		Metrics:          "full", // API metrics level; surfaces the complete per-user metrics
+
 	})
 	if err != nil {
 		if errors.Is(err, telemetryerrs.ErrLogsDisabled) {

--- a/server/internal/platformtools/logs/tool_search_users.go
+++ b/server/internal/platformtools/logs/tool_search_users.go
@@ -85,6 +85,7 @@ func (s *SearchUsers) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		Cursor:           input.Cursor,
 		Sort:             input.Sort,
 		Limit:            input.Limit,
+		Metrics:          "full", // platform tool surfaces the complete per-user metrics
 	})
 	if err != nil {
 		if errors.Is(err, telemetryerrs.ErrLogsDisabled) {

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -378,6 +378,17 @@ func (s *Service) SearchUsers(ctx context.Context, payload *telem_gen.SearchUser
 	return s.searchUsersByEmployee(ctx, payload)
 }
 
+// metricsDetailFromPayload maps the telemetry.searchUsers `metrics` API level to
+// the repo detail level. Only the explicit "basic" value trims the projection;
+// any other value (including the empty default) resolves to the full set, so a
+// caller can never silently drop aggregates — full is the safe default.
+func metricsDetailFromPayload(metrics string) string {
+	if metrics == repo.MetricsDetailBasic {
+		return repo.MetricsDetailBasic
+	}
+	return repo.MetricsDetailFull
+}
+
 func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.SearchUsersPayload) (*telem_gen.SearchUsersResult, error) {
 	// Filter is required by the Goa design, but direct callers (e.g. platform
 	// tools) bypass transport validation and may pass a nil filter. Normalize to
@@ -422,7 +433,7 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		SortOrder:        params.sortOrder,
 		Cursor:           params.cursor,
 		Limit:            params.limit + 1,
-		MetricsDetail:    payload.Metrics,
+		MetricsDetail:    metricsDetailFromPayload(payload.Metrics),
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error searching users")
@@ -692,8 +703,8 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 			UserIDs:          filter.UserIds,
 			SortOrder:        "desc",
 			Cursor:           "",
-			Limit:            10001,  // Upper bound; orgs rarely have >10k users
-			MetricsDetail:    "full", // role aggregation sums cost/tokens across the full metric set
+			Limit:            10001,                  // Upper bound; orgs rarely have >10k users
+			MetricsDetail:    repo.MetricsDetailFull, // role aggregation sums cost/tokens across the full metric set
 		})
 		if fetchErr != nil {
 			return oops.E(oops.CodeUnexpected, fetchErr, "error searching users for role aggregation")

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -422,6 +422,7 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		SortOrder:        params.sortOrder,
 		Cursor:           params.cursor,
 		Limit:            params.limit + 1,
+		MetricsDetail:    payload.Metrics,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error searching users")
@@ -691,7 +692,8 @@ func (s *Service) searchUsersByRole(ctx context.Context, payload *telem_gen.Sear
 			UserIDs:          filter.UserIds,
 			SortOrder:        "desc",
 			Cursor:           "",
-			Limit:            10001, // Upper bound; orgs rarely have >10k users
+			Limit:            10001,  // Upper bound; orgs rarely have >10k users
+			MetricsDetail:    "full", // role aggregation sums cost/tokens across the full metric set
 		})
 		if fetchErr != nil {
 			return oops.E(oops.CodeUnexpected, fetchErr, "error searching users for role aggregation")

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2445,14 +2445,25 @@ type SearchUsersParams struct {
 	SortOrder        string // "asc" or "desc"
 	Cursor           string // user identifier to paginate from
 	Limit            int
-	// MetricsDetail selects how many aggregates to compute. "basic" projects only
-	// identity, first/last activity, input/output token sums, and raw_user_ids —
-	// skipping the per-tool/hook-source map aggregations and chat/cost/cache/avg
-	// columns, which are the bulk of the per-row work. Any other value ("" or
-	// "full") computes the complete set. The employee enrollment list uses "basic"
-	// because it renders only the lean fields.
+	// MetricsDetail selects how many aggregates to compute: one of the
+	// MetricsDetail* constants. MetricsDetailBasic projects only identity,
+	// first/last activity, input/output token sums, and raw_user_ids — skipping
+	// the per-tool/hook-source map aggregations and chat/cost/cache/avg columns,
+	// which are the bulk of the per-row work. Any other value (including the empty
+	// zero value) computes the complete set, so full is the safe default. The
+	// employee enrollment list uses MetricsDetailBasic because it renders only the
+	// lean fields.
 	MetricsDetail string
 }
+
+// MetricsDetail levels for SearchUsersParams.MetricsDetail. The string values
+// match the telemetry.searchUsers `metrics` API enum. Basic is the only value
+// that trims the projection; every other value (including "") means full, so a
+// caller can never silently lose aggregates by omitting it.
+const (
+	MetricsDetailFull  = "full"
+	MetricsDetailBasic = "basic"
+)
 
 // SearchUsers retrieves aggregated usage metrics grouped by user identifier.
 //
@@ -2491,9 +2502,10 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 
 	// The heavy aggregates — per-tool and per-hook-source maps (sumMapIf), chat
 	// cardinality (uniqExactIf), and cost/cache/avg — dominate the per-row work.
-	// They are only computed for the full detail level; "basic" leaves the
-	// corresponding UserSummary fields zero/empty.
-	if arg.MetricsDetail != "basic" {
+	// They are only computed for the full detail level; MetricsDetailBasic leaves
+	// the corresponding UserSummary fields zero/empty. Full is the safe default:
+	// only an explicit MetricsDetailBasic trims the projection.
+	if arg.MetricsDetail != MetricsDetailBasic {
 		tc := toolCallExprsFor(arg.EventSource)
 		columns = append(columns,
 			// Chat metrics

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2445,6 +2445,13 @@ type SearchUsersParams struct {
 	SortOrder        string // "asc" or "desc"
 	Cursor           string // user identifier to paginate from
 	Limit            int
+	// MetricsDetail selects how many aggregates to compute. "basic" projects only
+	// identity, first/last activity, input/output token sums, and raw_user_ids —
+	// skipping the per-tool/hook-source map aggregations and chat/cost/cache/avg
+	// columns, which are the bulk of the per-row work. Any other value ("" or
+	// "full") computes the complete set. The employee enrollment list uses "basic"
+	// because it renders only the lean fields.
+	MetricsDetail string
 }
 
 // SearchUsers retrieves aggregated usage metrics grouped by user identifier.
@@ -2461,50 +2468,64 @@ func (q *Queries) SearchUsers(ctx context.Context, arg SearchUsersParams) ([]Use
 	}
 	groupExpr := searchUsersGroupExpr(arg.GroupBy)
 
-	tc := toolCallExprsFor(arg.EventSource)
-
-	sb := sq.Select(
-		groupExpr+" AS user_id",
+	// Lean columns rendered by every caller (identity, activity window, tokens) and
+	// the raw ids the account-enrichment join needs. The employee enrollment list
+	// consumes only these, so "basic" stops here — see MetricsDetail.
+	columns := []string{
+		groupExpr + " AS user_id",
 		"anyIf(user_email, user_email != '') AS user_email",
 
 		// Activity timestamps
 		"min(time_unix_nano) AS first_seen_unix_nano",
 		"max(time_unix_nano) AS last_seen_unix_nano",
 
-		// Chat metrics
-		"uniqExactIf(toString(attributes.gen_ai.conversation.id), toString(attributes.gen_ai.conversation.id) != '') AS total_chats",
-		"uniqExactIf(toString(attributes.gen_ai.response.id), toString(attributes.gen_ai.response.id) != '') AS total_chat_requests",
-
 		// Token metrics (from any event with gen_ai usage data)
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') AS total_input_tokens",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)), toString(attributes.gen_ai.usage.output_tokens) != '') AS total_output_tokens",
-		totalTokensExpr+" AS total_tokens",
-		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens)), toString(attributes.gen_ai.usage.cache_read.input_tokens) != '') AS cache_read_input_tokens",
-		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens)), toString(attributes.gen_ai.usage.cache_creation.input_tokens) != '') AS cache_creation_input_tokens",
-		"avgIf(toFloat64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS avg_tokens_per_request",
-		"sumIf(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') AS total_cost",
-
-		// Tool call metrics (path depends on event source — Gram MCP tools vs AI-coding hook tools)
-		"countIf("+tc.isCall+") AS total_tool_calls",
-		"countIf("+tc.isSuccess+") AS tool_call_success",
-		"countIf("+tc.isFailure+") AS tool_call_failure",
-
-		// Tool breakdowns (maps of tool URN or hook tool name -> count)
-		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isCall+") AS tool_counts",
-		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isSuccess+") AS tool_success_counts",
-		"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isFailure+") AS tool_failure_counts",
-
-		// Hook source breakdowns (maps of hook source -> count)
-		"sumMapIf(map(hook_source, toUInt64(1)), hook_source != '') AS hook_source_counts",
-
-		// Distinct account types observed (powers the employees personal-account indicator)
-		"groupUniqArrayIf(account_type, account_type != '') AS account_types",
 
 		// Raw user_id values folded into this summary. The group key is email-first,
 		// so callers joining against user_id-keyed stores (user_accounts, role
 		// assignments) need these to find the summary's underlying ids.
 		"groupUniqArrayIf(telemetry_logs.user_id, telemetry_logs.user_id != '') AS raw_user_ids",
-	).
+	}
+
+	// The heavy aggregates — per-tool and per-hook-source maps (sumMapIf), chat
+	// cardinality (uniqExactIf), and cost/cache/avg — dominate the per-row work.
+	// They are only computed for the full detail level; "basic" leaves the
+	// corresponding UserSummary fields zero/empty.
+	if arg.MetricsDetail != "basic" {
+		tc := toolCallExprsFor(arg.EventSource)
+		columns = append(columns,
+			// Chat metrics
+			"uniqExactIf(toString(attributes.gen_ai.conversation.id), toString(attributes.gen_ai.conversation.id) != '') AS total_chats",
+			"uniqExactIf(toString(attributes.gen_ai.response.id), toString(attributes.gen_ai.response.id) != '') AS total_chat_requests",
+
+			// Remaining token/cost metrics
+			totalTokensExpr+" AS total_tokens",
+			"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens)), toString(attributes.gen_ai.usage.cache_read.input_tokens) != '') AS cache_read_input_tokens",
+			"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens)), toString(attributes.gen_ai.usage.cache_creation.input_tokens) != '') AS cache_creation_input_tokens",
+			"avgIf(toFloat64OrZero(toString(attributes.gen_ai.usage.total_tokens)), toString(attributes.gen_ai.usage.total_tokens) != '') AS avg_tokens_per_request",
+			"sumIf(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') AS total_cost",
+
+			// Tool call metrics (path depends on event source — Gram MCP tools vs AI-coding hook tools)
+			"countIf("+tc.isCall+") AS total_tool_calls",
+			"countIf("+tc.isSuccess+") AS tool_call_success",
+			"countIf("+tc.isFailure+") AS tool_call_failure",
+
+			// Tool breakdowns (maps of tool URN or hook tool name -> count)
+			"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isCall+") AS tool_counts",
+			"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isSuccess+") AS tool_success_counts",
+			"sumMapIf(map("+tc.key+", toUInt64(1)), "+tc.isFailure+") AS tool_failure_counts",
+
+			// Hook source breakdowns (maps of hook source -> count)
+			"sumMapIf(map(hook_source, toUInt64(1)), hook_source != '') AS hook_source_counts",
+
+			// Distinct account types observed (powers the employees personal-account indicator)
+			"groupUniqArrayIf(account_type, account_type != '') AS account_types",
+		)
+	}
+
+	sb := sq.Select(columns...).
 		From("telemetry_logs").
 		Where("gram_project_id = ?", arg.GramProjectID).
 		Where("time_unix_nano >= ?", arg.TimeStart).

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -1196,6 +1196,71 @@ func TestSearchUsers_ScopedByProject(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
+// TestSearchUsers_BasicMetricsOmitsBreakdowns pins the "basic" metrics detail
+// level used by the employee enrollment list (DNO-618): identity, activity
+// window, token sums, and raw_user_ids are computed, while the heavier
+// chat/cost/tool/hook aggregates are skipped and left zero/empty.
+func TestSearchUsers_BasicMetricsOmitsBreakdowns(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	userID := "basic-user-" + uuid.New().String()
+	chatID := uuid.New().String()
+
+	// A chat completion (tokens/cost/chat) plus a tool call and a hook row, so the
+	// full path would populate every breakdown — basic must still leave them empty.
+	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai", userID, "")
+	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, 200, 100, 300, 2.0, "tool_calls", "gpt-4", "openai", userID, "")
+	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), "tools:http:petstore:listPets", 200, 0.5, userID, "")
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+			Filter: &gen.SearchUsersFilter{
+				From: from,
+				To:   to,
+			},
+			UserType: "internal",
+			Limit:    100,
+			Sort:     "desc",
+			Metrics:  "basic",
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, res) {
+			return
+		}
+		if !assert.Len(c, res.Users, 1) {
+			return
+		}
+
+		u := res.Users[0]
+		// Lean fields the enrollment list renders are computed.
+		assert.Equal(c, userID, u.UserID)
+		assert.Equal(c, int64(300), u.TotalInputTokens)  // 100 + 200
+		assert.Equal(c, int64(150), u.TotalOutputTokens) // 50 + 100
+		assert.NotEqual(c, "0", u.LastSeenUnixNano, "last activity should be populated")
+
+		// Heavy aggregates are skipped under basic and left zero/empty.
+		assert.Equal(c, int64(0), u.TotalChats)
+		assert.Equal(c, int64(0), u.TotalChatRequests)
+		assert.Equal(c, int64(0), u.TotalTokens)
+		assert.Equal(c, int64(0), u.TotalToolCalls)
+		assert.Zero(c, u.TotalCost)
+		assert.Empty(c, u.Tools)
+		assert.Empty(c, u.HookSources)
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
 func insertHookLogWithUser(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID, externalUserID, hookSource string, success bool) {
 	t.Helper()
 

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -14,6 +14,7 @@ import (
 	hooksRepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1213,52 +1214,49 @@ func TestSearchUsers_BasicMetricsOmitsBreakdowns(t *testing.T) {
 	userID := "basic-user-" + uuid.New().String()
 	chatID := uuid.New().String()
 
-	// A chat completion (tokens/cost/chat) plus a tool call and a hook row, so the
-	// full path would populate every breakdown — basic must still leave them empty.
+	// A chat completion (tokens/cost/chat) plus a tool call, so the full path would
+	// populate every breakdown — basic must still leave them empty.
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-10*time.Minute), chatID, 100, 50, 150, 1.5, "stop", "gpt-4", "openai", userID, "")
 	insertChatCompletionLogWithUser(t, ctx, projectID, deploymentID, now.Add(-9*time.Minute), chatID, 200, 100, 300, 2.0, "tool_calls", "gpt-4", "openai", userID, "")
 	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), "tools:http:petstore:listPets", 200, 0.5, userID, "")
 
+	// Telemetry writes use ClickHouse async inserts; drain the queue synchronously
+	// so the rows are deterministically visible (no polling — see the telemetry
+	// README).
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
 	to := now.Add(1 * time.Hour).Format(time.RFC3339)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
-			Filter: &gen.SearchUsersFilter{
-				From: from,
-				To:   to,
-			},
-			UserType: "internal",
-			Limit:    100,
-			Sort:     "desc",
-			Metrics:  "basic",
-		})
-		if !assert.NoError(c, err) {
-			return
-		}
-		if !assert.NotNil(c, res) {
-			return
-		}
-		if !assert.Len(c, res.Users, 1) {
-			return
-		}
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From: from,
+			To:   to,
+		},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+		Metrics:  "basic",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Len(t, res.Users, 1)
 
-		u := res.Users[0]
-		// Lean fields the enrollment list renders are computed.
-		assert.Equal(c, userID, u.UserID)
-		assert.Equal(c, int64(300), u.TotalInputTokens)  // 100 + 200
-		assert.Equal(c, int64(150), u.TotalOutputTokens) // 50 + 100
-		assert.NotEqual(c, "0", u.LastSeenUnixNano, "last activity should be populated")
+	u := res.Users[0]
+	// Lean fields the enrollment list renders are computed.
+	assert.Equal(t, userID, u.UserID)
+	assert.Equal(t, int64(300), u.TotalInputTokens)  // 100 + 200
+	assert.Equal(t, int64(150), u.TotalOutputTokens) // 50 + 100
+	// Last activity is the most recent inserted row (the -8m tool call).
+	assert.Equal(t, strconv.FormatInt(now.Add(-8*time.Minute).UnixNano(), 10), u.LastSeenUnixNano)
 
-		// Heavy aggregates are skipped under basic and left zero/empty.
-		assert.Equal(c, int64(0), u.TotalChats)
-		assert.Equal(c, int64(0), u.TotalChatRequests)
-		assert.Equal(c, int64(0), u.TotalTokens)
-		assert.Equal(c, int64(0), u.TotalToolCalls)
-		assert.Zero(c, u.TotalCost)
-		assert.Empty(c, u.Tools)
-		assert.Empty(c, u.HookSources)
-	}, 10*time.Second, 200*time.Millisecond)
+	// Heavy aggregates are skipped under basic and left zero/empty.
+	assert.Equal(t, int64(0), u.TotalChats)
+	assert.Equal(t, int64(0), u.TotalChatRequests)
+	assert.Equal(t, int64(0), u.TotalTokens)
+	assert.Equal(t, int64(0), u.TotalToolCalls)
+	assert.Zero(t, u.TotalCost)
+	assert.Empty(t, u.Tools)
 }
 
 func insertHookLogWithUser(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID, externalUserID, hookSource string, success bool) {


### PR DESCRIPTION
## What

The Employee Enrollment list (Insights → Employees) took ~7s to load (DNO-618, same incident family as the MCP & Tools perf work / INC-417).

The page paginates `telemetry.searchUsers`, but its row transform (`buildEmployees`) consumes only **user identity, last activity, and input/output token totals** — linked accounts come from a separate Postgres enrichment, not ClickHouse. Yet the shared `SearchUsers` query computes the *full* aggregate set on every row of the window: three per-tool `sumMapIf(map(...))` breakdowns, a per-hook-source map, `uniqExactIf` chat cardinality, and cost/cache/avg columns — all discarded by the list.

`telemetry_logs` is already partition-pruned by day, so the window scan is fine; the cost is the per-row JSON extraction and map aggregation.

## Change

Add an additive `metrics` level to `searchUsers`:

- **`full`** (default, unchanged) — the complete aggregate set.
- **`basic`** — only identity, first/last activity, input/output token sums, and the raw user ids the account-enrichment join needs. The heavy map/chat/cost/cache/avg aggregates are skipped and their `UserSummary` fields left zero/empty.

The enrollment list requests `basic`. Every other consumer (project dashboard tool breakdowns, agents view, role grouping, platform tools) stays on `full` and is unchanged.

## Impact (measured on prod, read-only, 30-day window)

| | full (current) | basic (this PR) |
|---|---|---|
| Largest project (~20M rows/30d, ~500 users) | ~6.0s / 7.0 GB read | **~2.7s / 3.9 GB** |
| Second project (~700 users) | ~4.3s | **~1.8s** |

~2.2–2.4× faster; same rows scanned, ~44% fewer bytes read — the win is purely not building the aggregates the list throws away.

## Testing

- New `TestSearchUsers_BasicMetricsOmitsBreakdowns` pins that `basic` returns identity + tokens + last-seen and leaves the breakdowns empty.
- Existing full-path and identity-merge tests unchanged and passing (ClickHouse-backed).
- `go build`, `mise lint:server`, dashboard `type-check` all green.

## Follow-ups (not in this PR)

- The `known_emails` self-join re-scans the window (rows read ≈ 2× base). Removing it reaches ~2.1s but changes the email-less-row identity merge (naive removal shifted the result count) — a separate, correctness-sensitive rewrite.
- The frontend still gates the whole page on the full paginated loop; streaming/parallelizing is a separate UX improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the Employee Enrollment page by adding a `metrics` mode to `telemetry.searchUsers` and using the lightweight `basic` mode for that view. Resolves DNO-618 with ~2.2x faster loads on large orgs.

- **New Features**
  - Added `metrics` param to `telemetry.searchUsers`: `full` (default) and `basic`.
  - `basic` returns identity, first/last activity, input/output token sums, and `raw_user_ids`; other fields are empty.
  - The Insights → Employees view now requests `basic`; all other consumers stay on `full`.

- **Refactors**
  - Replaced magic strings with `repo.MetricsDetailFull`/`repo.MetricsDetailBasic` and added `metricsDetailFromPayload` to default unknown/empty to `full`; frontend uses the generated `Metrics.Basic` enum.
  - Updated tests to flush ClickHouse async inserts with `testenv.FlushClickHouseAsyncInserts` for deterministic visibility in the basic metrics path.

<sup>Written for commit b8d7a85ab2d71b91cad52d379714ffa04a9cfbc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

