### PR TITLE
feat: detect AWS secret access key and session token in secret scanning

### DIFF
--- a/.changeset/aws-secret-and-session-token-detection.md
+++ b/.changeset/aws-secret-and-session-token-detection.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Secret scanning now detects AWS secret access keys and session tokens, not just the access key id. The gitleaks default ruleset is extended with a native composite rule that reports a bare secret access key only when it is co-located with an AWS access key id (with an entropy floor to reject hash-shaped false positives) and a contextual rule for the session token. Redaction is updated so the access key id — an identifier, not a secret — is shown unmasked while the secret access key and session token are masked.

--- a/.changeset/aws-secret-and-session-token-detection.md
+++ b/.changeset/aws-secret-and-session-token-detection.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-Secret scanning now detects AWS secret access keys and session tokens, not just the access key id. The gitleaks default ruleset is extended with a native composite rule that reports a bare secret access key only when it is co-located with an AWS access key id (with an entropy floor to reject hash-shaped false positives) and a contextual rule for the session token. Redaction is updated so the access key id — an identifier, not a secret — is shown unmasked while the secret access key and session token are masked.
+Secret scanning now flags AWS secret access keys and session tokens, not just the access key id — and masks them while leaving the access key id (an identifier, not a secret) visible.

--- a/server/internal/background/activities/risk_analysis/sources.go
+++ b/server/internal/background/activities/risk_analysis/sources.go
@@ -8,10 +8,7 @@ import (
 )
 
 const (
-	// SourceGitleaks is the policy source value for secret scanning. Its default
-	// ruleset is extended with AWS secret-access-key and session-token rules
-	// (see the gitleaks package), so all three AWS credential flavors surface
-	// under this one source.
+	// SourceGitleaks is the policy source value for secret scanning.
 	SourceGitleaks = gitleaks.Source
 	// SourceCLIDestructive is the policy source value that flags tool calls
 	// whose arguments contain a curated destructive CLI command pattern

--- a/server/internal/background/activities/risk_analysis/sources.go
+++ b/server/internal/background/activities/risk_analysis/sources.go
@@ -8,7 +8,10 @@ import (
 )
 
 const (
-	// SourceGitleaks is the policy source value for secret scanning.
+	// SourceGitleaks is the policy source value for secret scanning. Its default
+	// ruleset is extended with AWS secret-access-key and session-token rules
+	// (see the gitleaks package), so all three AWS credential flavors surface
+	// under this one source.
 	SourceGitleaks = gitleaks.Source
 	// SourceCLIDestructive is the policy source value that flags tool calls
 	// whose arguments contain a curated destructive CLI command pattern

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1430,11 +1430,9 @@ func RedactMatchAll(match string, orgID string) string {
 // a secret:
 //   - shadow_mcp / account_identity: an MCP server URL or account email IS the
 //     report.
-//   - an AWS access key id (the gitleaks aws-access-token rule): the AKIA/ASIA
-//     prefix identifies the key type (long-lived vs temporary) and is useful to
-//     see. AWS itself treats the id as non-sensitive (it appears in CloudTrail).
-//     The paired secret access key and session token are NOT passed through —
-//     they fall to RedactMatchAll like any other secret.
+//   - an AWS access key id (the gitleaks aws-access-token rule): an identifier,
+//     non-sensitive (AWS logs it in CloudTrail). Its paired secret access key
+//     and session token still redact like any other secret.
 func redactMatch(source, ruleID string, match *string, orgID string) string {
 	if match == nil || *match == "" {
 		return "<redacted len=0>"

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1139,7 +1139,7 @@ func (s *Service) ListRiskResults(ctx context.Context, payload *gen.ListRiskResu
 // Spans aren't given a redacted counterpart here because nothing on this
 // (non-agent) redacted path renders them.
 func redactResultMatchInPlace(r *types.RiskResult, orgID string) {
-	matchRedacted := redactMatch(r.Source, r.Match, orgID)
+	matchRedacted := redactMatch(r.Source, conv.PtrValOrEmpty(r.RuleID, ""), r.Match, orgID)
 	r.MatchRedacted = &matchRedacted
 	r.Match = nil
 	r.Spans = nil
@@ -1361,7 +1361,8 @@ func (s *Service) UnmaskRiskResult(ctx context.Context, payload *gen.UnmaskRiskR
 // secret across organizations even if some future code path widens the
 // surface beyond org-scoped access.
 func redactRiskResult(r *types.RiskResult, orgID string) *types.RiskResultRedacted {
-	matchRedacted := redactMatch(r.Source, r.Match, orgID)
+	ruleID := conv.PtrValOrEmpty(r.RuleID, "")
+	matchRedacted := redactMatch(r.Source, ruleID, r.Match, orgID)
 
 	var spansRedacted []*types.RiskSpanRedacted
 	if len(r.Spans) > 0 {
@@ -1369,7 +1370,7 @@ func redactRiskResult(r *types.RiskResult, orgID string) *types.RiskResultRedact
 		for _, sp := range r.Spans {
 			match := sp.Match
 			spansRedacted = append(spansRedacted, &types.RiskSpanRedacted{
-				MatchRedacted: redactMatch(r.Source, &match, orgID),
+				MatchRedacted: redactMatch(r.Source, ruleID, &match, orgID),
 				Field:         sp.Field,
 				Path:          sp.Path,
 				PositionKnown: sp.StartPos != nil && sp.EndPos != nil,
@@ -1424,14 +1425,24 @@ func RedactMatchAll(match string, orgID string) string {
 	return fmt.Sprintf("<redacted len=%d sha=%s>", len(match), hex.EncodeToString(sum[:4]))
 }
 
-// redactMatch is the API-facing redaction: like RedactMatchAll, except
-// shadow_mcp and account_identity findings pass through verbatim — an MCP server
-// URL or an account email IS the report, not a secret.
-func redactMatch(source string, match *string, orgID string) string {
+// redactMatch is the API-facing redaction: like RedactMatchAll, except certain
+// findings pass through verbatim because the matched value is an identifier, not
+// a secret:
+//   - shadow_mcp / account_identity: an MCP server URL or account email IS the
+//     report.
+//   - an AWS access key id (the gitleaks aws-access-token rule): the AKIA/ASIA
+//     prefix identifies the key type (long-lived vs temporary) and is useful to
+//     see. AWS itself treats the id as non-sensitive (it appears in CloudTrail).
+//     The paired secret access key and session token are NOT passed through —
+//     they fall to RedactMatchAll like any other secret.
+func redactMatch(source, ruleID string, match *string, orgID string) string {
 	if match == nil || *match == "" {
 		return "<redacted len=0>"
 	}
 	if source == shadowmcp.SourceShadowMCP || source == ra.SourceAccountIdentity {
+		return *match
+	}
+	if ruleID == gitleaks.AccessKeyIDRuleID {
 		return *match
 	}
 	return RedactMatchAll(*match, orgID)

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1440,7 +1440,10 @@ func redactMatch(source, ruleID string, match *string, orgID string) string {
 	if source == shadowmcp.SourceShadowMCP || source == ra.SourceAccountIdentity {
 		return *match
 	}
-	if ruleID == gitleaks.AccessKeyIDRuleID {
+	// Scoped to the gitleaks source so only the built-in aws-access-token rule
+	// gets the carve-out; another source reusing this rule id must not bypass
+	// redaction if its match is a secret.
+	if source == gitleaks.Source && ruleID == gitleaks.AccessKeyIDRuleID {
 		return *match
 	}
 	return RedactMatchAll(*match, orgID)

--- a/server/internal/risk/redact_internal_test.go
+++ b/server/internal/risk/redact_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/scanners/gitleaks"
 )
 
 // White-box tests for the per-org-salted redaction helper. The integration
@@ -16,8 +18,8 @@ func TestRedactMatch_FingerprintDiffersAcrossOrgs(t *testing.T) {
 
 	secret := "sk-shared-across-orgs-7777"
 
-	fpOrgA := redactMatch("gitleaks", &secret, "org-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
-	fpOrgB := redactMatch("gitleaks", &secret, "org-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	fpOrgA := redactMatch("gitleaks", "", &secret, "org-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	fpOrgB := redactMatch("gitleaks", "", &secret, "org-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 
 	require.NotEqual(t, fpOrgA, fpOrgB,
 		"same secret in two different orgs must produce different fingerprints (org-salted sha256)")
@@ -31,8 +33,8 @@ func TestRedactMatch_FingerprintDeterministicWithinOrg(t *testing.T) {
 	secret := "sk-abc123def456"
 	orgID := "org-cccccccc-cccc-cccc-cccc-cccccccccccc"
 
-	fp1 := redactMatch("gitleaks", &secret, orgID)
-	fp2 := redactMatch("gitleaks", &secret, orgID)
+	fp1 := redactMatch("gitleaks", "", &secret, orgID)
+	fp2 := redactMatch("gitleaks", "", &secret, orgID)
 
 	require.Equal(t, fp1, fp2,
 		"same secret in same org must produce identical fingerprints so agents can dedupe")
@@ -44,7 +46,7 @@ func TestRedactMatch_ShadowMCPIgnoresSalt(t *testing.T) {
 	const serverID = "mcp__evil-server__"
 	match := serverID
 
-	got := redactMatch("shadow_mcp", &match, "any-org-id")
+	got := redactMatch("shadow_mcp", "", &match, "any-org-id")
 
 	require.Equal(t, serverID, got,
 		"shadow_mcp match should pass through verbatim regardless of orgID")
@@ -56,7 +58,7 @@ func TestRedactMatch_AccountIdentityIgnoresSalt(t *testing.T) {
 	const email = "jane@gmail.com"
 	match := email
 
-	got := redactMatch("account_identity", &match, "any-org-id")
+	got := redactMatch("account_identity", "", &match, "any-org-id")
 
 	require.Equal(t, email, got,
 		"account_identity match should pass through verbatim regardless of orgID")
@@ -66,8 +68,36 @@ func TestRedactMatch_EmptyMatchCollapses(t *testing.T) {
 	t.Parallel()
 
 	empty := ""
-	require.Equal(t, "<redacted len=0>", redactMatch("gitleaks", nil, "org-x"))
-	require.Equal(t, "<redacted len=0>", redactMatch("gitleaks", &empty, "org-x"))
+	require.Equal(t, "<redacted len=0>", redactMatch("gitleaks", "", nil, "org-x"))
+	require.Equal(t, "<redacted len=0>", redactMatch("gitleaks", "", &empty, "org-x"))
+}
+
+// The AWS access key id is an identifier, not a secret: it passes through
+// unredacted so its AKIA/ASIA prefix stays visible. Its paired secret access
+// key and session token are ordinary gitleaks/aws_creds secrets and stay
+// redacted.
+func TestRedactMatch_AWSAccessKeyIDPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	const id = "AKIAIOSFODNN7EXAMPLE"
+	match := id
+
+	got := redactMatch(gitleaks.Source, gitleaks.AccessKeyIDRuleID, &match, "any-org-id")
+	require.Equal(t, id, got, "an AWS access key id must pass through unredacted")
+}
+
+func TestRedactMatch_AWSSecretAndTokenStayRedacted(t *testing.T) {
+	t.Parallel()
+
+	secret := "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789+/Ab"
+	got := redactMatch(gitleaks.Source, gitleaks.SecretAccessKeyRuleID, &secret, "org-x")
+	require.Regexp(t, `^<redacted len=40 sha=[0-9a-f]{8}>$`, got,
+		"the secret access key must be redacted")
+
+	token := "FwoGZXIvYXdzEDoaDExampleSessionTokenValueLongEnoughToPass"
+	gotTok := redactMatch(gitleaks.Source, gitleaks.SessionTokenRuleID, &token, "org-x")
+	require.Regexp(t, `^<redacted len=\d+ sha=[0-9a-f]{8}>$`, gotTok,
+		"the session token must be redacted")
 }
 
 // Guards against an "org_id || match" concatenation bug where an attacker
@@ -78,8 +108,8 @@ func TestRedactMatch_NULSeparatorPreventsBoundaryAmbiguity(t *testing.T) {
 	t.Parallel()
 
 	left, right := "bcd", "cd"
-	fpA := redactMatch("gitleaks", &left, "a")
-	fpB := redactMatch("gitleaks", &right, "ab")
+	fpA := redactMatch("gitleaks", "", &left, "a")
+	fpB := redactMatch("gitleaks", "", &right, "ab")
 
 	require.NotEqual(t, fpA, fpB,
 		"shifting bytes from match into orgID must change the fingerprint (NUL separator boundary)")

--- a/server/internal/risk/redact_internal_test.go
+++ b/server/internal/risk/redact_internal_test.go
@@ -86,6 +86,17 @@ func TestRedactMatch_AWSAccessKeyIDPassesThrough(t *testing.T) {
 	require.Equal(t, id, got, "an AWS access key id must pass through unredacted")
 }
 
+// The id carve-out is scoped to the gitleaks source: another source reusing the
+// access-key-id rule id must NOT bypass redaction.
+func TestRedactMatch_AccessKeyIDCarveOutIsSourceScoped(t *testing.T) {
+	t.Parallel()
+
+	match := "AKIAIOSFODNN7EXAMPLE"
+	got := redactMatch("custom", gitleaks.AccessKeyIDRuleID, &match, "org-x")
+	require.Regexp(t, `^<redacted len=\d+ sha=[0-9a-f]{8}>$`, got,
+		"a non-gitleaks finding with this rule id must still be redacted")
+}
+
 func TestRedactMatch_AWSSecretAndTokenStayRedacted(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/scanners/gitleaks/aws_rules.go
+++ b/server/internal/scanners/gitleaks/aws_rules.go
@@ -1,0 +1,86 @@
+package gitleaks
+
+import (
+	"regexp"
+
+	"github.com/zricethezav/gitleaks/v8/config"
+)
+
+// Canonical rule ids (post-CanonicalRuleID) for the AWS credential findings.
+// These are the shared identifiers the rest of the system keys on — categories
+// classification (via the `secret.` prefix) and, crucially, the redaction
+// policy, which passes the access key id through unmasked while redacting the
+// secret access key and session token.
+const (
+	// AccessKeyIDRuleID is the gitleaks built-in "aws-access-token" rule. The
+	// value it matches is an identifier (the AKIA/ASIA-prefixed access key id),
+	// not a secret — AWS itself logs it in CloudTrail — so the redaction layer
+	// passes it through unmasked.
+	AccessKeyIDRuleID = "secret.aws_access_token"
+	// SecretAccessKeyRuleID is our added "aws-secret-access-key" rule.
+	SecretAccessKeyRuleID = "secret.aws_secret_access_key" //nolint:gosec // G101: a rule identifier, not a credential
+	// SessionTokenRuleID is our added "aws-session-token" rule.
+	SessionTokenRuleID = "secret.aws_session_token" //nolint:gosec // G101: a rule identifier, not a credential
+)
+
+// awsAccessTokenRuleID is the gitleaks (pre-canonical) rule id for the built-in
+// AWS access key id rule. Our composite secret rule requires it as an anchor.
+const awsAccessTokenRuleID = "aws-access-token"
+
+func intPtr(i int) *int { return &i }
+
+// awsRules returns the custom rules layered onto gitleaks' default config to
+// close its AWS coverage gap. The stock config detects only the access key id
+// (AKIA/ASIA...), which is an identifier; it ships no rule for the two actual
+// secrets — the secret access key and the session token. These rules add them
+// using gitleaks' native mechanisms:
+//
+//   - aws-secret-access-key is a native COMPOSITE rule: a bare 40-char base64
+//     blob (SecretGroup 1) is only reported when an aws-access-token finding
+//     sits within WithinLines of it (RequiredRules). This is gitleaks-native
+//     anchored detection — it mirrors how AWS credentials actually travel (the
+//     secret always accompanies its access key id, in an STS response, an INI
+//     profile, or an `aws configure` dump) and needs no per-secret label. The
+//     entropy floor (4.1, above the 4.0 ceiling of 40-char lowercase hex)
+//     rejects SHA-1 / git object id false positives. A single secret rule keeps
+//     the reported rule id deterministic (two rules matching the same span would
+//     race on Go map iteration order).
+//   - aws-session-token uses the contextual-regex pattern gitleaks' own
+//     generic-api-key rule uses: the token's conventional label captured with
+//     the value (SecretGroup 1). Session tokens are effectively always labeled
+//     (AWS_SESSION_TOKEN, the STS SessionToken field, or the x-amz-security-token
+//     header), so a label anchor fits them where an id anchor fits the secret.
+//
+// The built-in aws-access-token rule still fires independently, so the id is
+// always reported alongside the secret it anchors.
+func awsRules() []config.Rule {
+	return []config.Rule{
+		//nolint:exhaustruct // third-party gitleaks rule; only the set fields are relevant
+		{
+			RuleID:      "aws-secret-access-key",
+			Description: "Identified a probable AWS secret access key co-located with an AWS access key id.",
+			Regex:       regexp.MustCompile(`\b([A-Za-z0-9/+]{40})\b`),
+			SecretGroup: 1,
+			Entropy:     4.1,
+			// Prefilter on the access-key-id prefixes so this broad regex only runs
+			// on fragments that could contain an anchor in the first place.
+			Keywords: []string{"akia", "asia", "abia", "acca", "a3t", "agpa", "aida", "aipa", "anpa", "anva", "aroa", "apka", "asca"},
+			RequiredRules: []*config.Required{
+				{RuleID: awsAccessTokenRuleID, WithinLines: intPtr(4)},
+			},
+			Tags: []string{"aws"},
+		},
+		//nolint:exhaustruct // third-party gitleaks rule; only the set fields are relevant
+		{
+			RuleID:      "aws-session-token",
+			Description: "Identified a probable AWS session (STS security) token adjacent to its credential label.",
+			// (aws_)session/security_token <sep> <long base64/base64url>. Session
+			// tokens run to hundreds of chars; the 100-char floor keeps ordinary
+			// values out.
+			Regex:       regexp.MustCompile(`(?i)(?:aws[_.\-]?)?(?:session|security)[_.\-]?token["'` + "`" + `\s:=,]{1,8}([A-Za-z0-9/+_=\-]{100,})`),
+			SecretGroup: 1,
+			Keywords:    []string{"token"},
+			Tags:        []string{"aws"},
+		},
+	}
+}

--- a/server/internal/scanners/gitleaks/aws_rules_test.go
+++ b/server/internal/scanners/gitleaks/aws_rules_test.go
@@ -83,6 +83,10 @@ func TestExtendedConfig_HashNextToIDNotDetected(t *testing.T) {
 
 	content := fakeAccessKeyID + " " + sha1Empty + "\n"
 	got := ruleSet(t, content)
+	// Assert the anchor fired: otherwise the composite rule couldn't have run at
+	// all, and the negative result below would be a broken fixture, not entropy
+	// rejection.
+	require.True(t, got[gitleaks.AccessKeyIDRuleID], "the access key id anchor must be detected")
 	require.False(t, got[gitleaks.SecretAccessKeyRuleID],
 		"a lowercase-hex hash must fall below the entropy floor")
 }

--- a/server/internal/scanners/gitleaks/aws_rules_test.go
+++ b/server/internal/scanners/gitleaks/aws_rules_test.go
@@ -1,0 +1,115 @@
+package gitleaks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/scanners"
+	"github.com/speakeasy-api/gram/server/internal/scanners/gitleaks"
+)
+
+// Synthetic, non-real credential values. They avoid sequential runs
+// (0123456789) and dictionary words so gitleaks' default stopword allowlist
+// does not treat them as placeholders.
+const (
+	fakeAccessKeyID = "ASIAZ2XY3WNBQR5TUVWX" // ASIA prefix + 16 base32 chars
+	fakeSecret      = "wJalrXUtnFEMIbKp7MDoRZfiCYqTvHgNsQ8xLcWd"
+	fakeToken       = "9x34WiYVTCAnxboiPBmqNrCFKD/3tyqFMmVo8mc0cNlyFFd93N5Z/o8gIIyX0hOWxvWRp/dO9Smp" +
+		"CVXShsKReY3ef4sMrpkDz2IbZR9eAQyIioVhzt6O9p894tYWerLw9pGMezSLJLyNJ4DQO/A2CU2e8QsY1Buamkhl"
+	// sha1Empty is the SHA-1 of the empty string: 40 lowercase hex chars. The
+	// canonical false positive a bare 40-char rule would flag.
+	sha1Empty = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+)
+
+func ruleSet(t *testing.T, content string) map[string]bool {
+	t.Helper()
+	findings, err := gitleaks.NewScanner().Scan(context.Background(), content)
+	require.NoError(t, err)
+	out := map[string]bool{}
+	for _, f := range findings {
+		out[f.RuleID] = true
+	}
+	return out
+}
+
+// The extended config must detect all three AWS credential flavors — the id
+// (built-in) plus the secret access key and session token (our added rules).
+func TestExtendedConfig_DetectsAllThreeFlavors(t *testing.T) {
+	t.Parallel()
+
+	content := `{
+  "AccessKeyId": "` + fakeAccessKeyID + `",
+  "SecretAccessKey": "` + fakeSecret + `",
+  "SessionToken": "` + fakeToken + `"
+}`
+
+	got := ruleSet(t, content)
+	require.True(t, got[gitleaks.AccessKeyIDRuleID], "access key id (built-in) should be detected")
+	require.True(t, got[gitleaks.SecretAccessKeyRuleID], "secret access key should be detected")
+	require.True(t, got[gitleaks.SessionTokenRuleID], "session token should be detected")
+}
+
+// The secret access key must also be caught with no label, purely by proximity
+// to the access key id — the native composite (RequiredRules) path.
+func TestExtendedConfig_SecretAnchoredToIDWithoutLabel(t *testing.T) {
+	t.Parallel()
+
+	// Three space-separated values, as in `aws sts` table output: only the id
+	// carries a recognizable shape; the secret has no label of its own.
+	content := "creds  " + fakeAccessKeyID + "  " + fakeSecret + "\n"
+
+	got := ruleSet(t, content)
+	require.True(t, got[gitleaks.AccessKeyIDRuleID])
+	require.True(t, got[gitleaks.SecretAccessKeyRuleID],
+		"a bare secret within WithinLines of the id should be reported via the composite rule")
+}
+
+// A bare 40-char secret with NO anchor nearby must not be reported — the
+// composite rule requires the access key id.
+func TestExtendedConfig_BareSecretWithoutAnchorNotDetected(t *testing.T) {
+	t.Parallel()
+
+	got := ruleSet(t, "value = "+fakeSecret+"\n")
+	require.False(t, got[gitleaks.SecretAccessKeyRuleID],
+		"an unanchored, unlabeled base64 blob must not be flagged as a secret access key")
+}
+
+// A 40-char lowercase hex hash sitting next to a real access key id must not be
+// reported: the composite rule's entropy floor rejects it.
+func TestExtendedConfig_HashNextToIDNotDetected(t *testing.T) {
+	t.Parallel()
+
+	content := fakeAccessKeyID + " " + sha1Empty + "\n"
+	got := ruleSet(t, content)
+	require.False(t, got[gitleaks.SecretAccessKeyRuleID],
+		"a lowercase-hex hash must fall below the entropy floor")
+}
+
+// The extended detector must construct without error — newDetector validates
+// each AWS rule, so a malformed rule (bad SecretGroup, missing regex) surfaces
+// here rather than as a rule that silently never matches.
+func TestExtendedConfig_ConstructsCleanly(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() {
+		require.NoError(t, gitleaks.NewScanner().Prime())
+	})
+}
+
+// The AWS rule ids the rest of the system keys on must be canonical.
+func TestExtendedConfig_RuleIDsAreCanonical(t *testing.T) {
+	t.Parallel()
+	for _, id := range []string{
+		gitleaks.AccessKeyIDRuleID,
+		gitleaks.SecretAccessKeyRuleID,
+		gitleaks.SessionTokenRuleID,
+	} {
+		require.NoError(t, scanners.ValidateRuleID(id), id)
+	}
+	// The id our added rules produce must match what CanonicalRuleID derives, so
+	// the canonicalization and our constants can't drift.
+	require.Equal(t, gitleaks.SecretAccessKeyRuleID, gitleaks.CanonicalRuleID("aws-secret-access-key"))
+	require.Equal(t, gitleaks.SessionTokenRuleID, gitleaks.CanonicalRuleID("aws-session-token"))
+	require.Equal(t, gitleaks.AccessKeyIDRuleID, gitleaks.CanonicalRuleID("aws-access-token"))
+}

--- a/server/internal/scanners/gitleaks/scanner.go
+++ b/server/internal/scanners/gitleaks/scanner.go
@@ -36,16 +36,41 @@ const prefixSecret = "secret."
 // initialization.
 var detectorInitMu sync.Mutex
 
-// newDetector creates a gitleaks detector using the default config, serialized
-// by detectorInitMu to avoid viper's init-time data race.
+// newDetector creates a gitleaks detector using the default config extended with
+// our AWS credential rules (see awsRules), serialized by detectorInitMu to avoid
+// viper's init-time data race.
+//
+// The AWS rules — in particular the composite aws-secret-access-key-paired rule
+// — carry keywords that must be present in the detector's aho-corasick prefilter,
+// which NewDetector builds once from Config.Keywords. So we inject the rules and
+// their keywords into the default config and construct the detector from the
+// extended config, rather than mutating a detector after the fact (which would
+// leave the prefilter stale and silently skip keyworded rules).
 func newDetector() (*detect.Detector, error) {
 	detectorInitMu.Lock()
 	defer detectorInitMu.Unlock()
-	detector, err := detect.NewDetectorDefaultConfig()
+	base, err := detect.NewDetectorDefaultConfig()
 	if err != nil {
 		return nil, fmt.Errorf("create gitleaks detector: %w", err)
 	}
-	return detector, nil
+
+	cfg := base.Config
+	for _, rule := range awsRules() {
+		// Validate explicitly: constructing config.Rule values in Go bypasses the
+		// TOML translation path that would normally call Validate, so a malformed
+		// rule (e.g. a SecretGroup past the regex's capture count) would otherwise
+		// fail silently as a rule that never matches. Surface it at startup.
+		if err := rule.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid AWS gitleaks rule %q: %w", rule.RuleID, err)
+		}
+		cfg.Rules[rule.RuleID] = rule
+		cfg.OrderedRules = append(cfg.OrderedRules, rule.RuleID)
+		for _, k := range rule.Keywords {
+			cfg.Keywords[strings.ToLower(k)] = struct{}{}
+		}
+	}
+
+	return detect.NewDetector(cfg), nil
 }
 
 // Scanner is the single gitleaks scanner used across the codebase — batch

--- a/server/internal/scanners/gitleaks/scanner.go
+++ b/server/internal/scanners/gitleaks/scanner.go
@@ -40,12 +40,14 @@ var detectorInitMu sync.Mutex
 // our AWS credential rules (see awsRules), serialized by detectorInitMu to avoid
 // viper's init-time data race.
 //
-// The AWS rules — in particular the composite aws-secret-access-key-paired rule
-// — carry keywords that must be present in the detector's aho-corasick prefilter,
-// which NewDetector builds once from Config.Keywords. So we inject the rules and
-// their keywords into the default config and construct the detector from the
-// extended config, rather than mutating a detector after the fact (which would
-// leave the prefilter stale and silently skip keyworded rules).
+// For speed, gitleaks does not run every rule's regex against every input: it
+// first does a single Aho-Corasick pass for all rules' keywords and only
+// evaluates a rule's regex when one of that rule's keywords is present. That
+// keyword trie is built once, inside NewDetector, from Config.Keywords — so a
+// keyworded rule whose keywords are absent from the trie is silently never
+// evaluated. We therefore inject the AWS rules AND their keywords into the config
+// and then construct the detector, rather than adding rules to an already-built
+// detector (which would leave the trie stale and skip our rules).
 func newDetector() (*detect.Detector, error) {
 	detectorInitMu.Lock()
 	defer detectorInitMu.Unlock()


### PR DESCRIPTION
Linear: [FDE-34](https://linear.app/speakeasy/issue/FDE-34)

## What & why

Secret scanning previously detected only the **AWS access key id** (`AKIA…`/`ASIA…`) — an *identifier*, not a secret (AWS logs it in CloudTrail). The two values that actually need protecting, the **secret access key** and the **session token**, were invisible: the default gitleaks ruleset ships no rule for either. So the portal masked the one value that's safe to show and left the real secrets exposed.

## How

Extends the gitleaks default config using its own native mechanisms (no separate scanner):

- **`aws-secret-access-key`** — a native **composite rule** (`RequiredRules` + `WithinLines`): a bare 40-char base64 value is reported only when an `aws-access-token` finding sits within a few lines of it, mirroring how AWS credentials travel. An entropy floor (4.1, above the 4.0 ceiling of 40-char lowercase hex) rejects SHA-1 / git-object-id false positives.
- **`aws-session-token`** — a contextual-regex rule capturing the long token after its conventional label (`AWS_SESSION_TOKEN`, STS `SessionToken`, `x-amz-security-token`).
- **Masking** — `redactMatch` keys on rule id: the access key id passes through **unmasked**; the secret access key and session token are **redacted**.
- Rules are **validated** at detector construction, so a malformed rule fails loudly instead of silently never matching.

All three flavors surface under the existing `gitleaks` source (canonical ids `secret.aws_access_token` / `secret.aws_secret_access_key` / `secret.aws_session_token`), classified as Secrets. No new source to configure.

## Trade-offs

- **Single id-anchored secret rule:** a labeled secret with no nearby id isn't caught — acceptable since AWS creds always travel as an id+secret set, and a second rule would race on Go map order for the same finding.
- **Session token uses a label anchor, not id-proximity:** a 100+ char base64 run is self-distinctive and essentially always labeled (and often appears without the id, e.g. a lone `x-amz-security-token` header), so a label anchor gives better recall than requiring the id nearby.
- **No direct `viper` dependency:** builds on gitleaks' exported Go API rather than re-parsing TOML through viper's process-global singleton.

## Testing

`aws_rules_test.go` covers: all three flavors in a creds block; secret caught label-less by proximity; bare-secret-without-anchor rejected; hex-hash-next-to-id rejected by entropy (asserting the anchor fired first); clean construction; canonical rule ids. Redaction tested in `redact_internal_test.go`. `go build`/`vet`/`gofmt`/`lint:server` and the scanners + risk + risk_analysis suites pass.
