### PR TITLE
fix: data race in risk_analysis prompt judge test recorder

### DIFF
--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -38,12 +39,25 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+// recordingPromptJudge captures judge inputs under a mutex: judgeFanout calls
+// Evaluate from concurrent goroutines.
 type recordingPromptJudge struct {
+	mu     sync.Mutex
 	inputs []promptpolicy.Input
 }
 
+func (j *recordingPromptJudge) recorded() []promptpolicy.Input {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	out := make([]promptpolicy.Input, len(j.inputs))
+	copy(out, j.inputs)
+	return out
+}
+
 func (j *recordingPromptJudge) Evaluate(_ context.Context, in promptpolicy.Input) (*promptpolicy.Verdict, error) {
+	j.mu.Lock()
 	j.inputs = append(j.inputs, in)
+	j.mu.Unlock()
 	return &promptpolicy.Verdict{
 		Matched:          true,
 		Confidence:       0.9,
@@ -546,8 +560,9 @@ func TestAnalyzeBatch_PromptJudgeUsesToolCallPayload(t *testing.T) {
 	require.NoError(t, val.Get(&result))
 	require.Equal(t, 1, result.Processed)
 	require.Equal(t, 1, result.Findings)
-	require.Len(t, judge.inputs, 1)
-	msg := judge.inputs[0].Message
+	inputs := judge.recorded()
+	require.Len(t, inputs, 1)
+	msg := inputs[0].Message
 	require.Equal(t, message.ToolRequest, msg.Type)
 	require.Equal(t, "Bash", msg.ToolName)
 	require.Empty(t, msg.MCPServer, "native tool has no MCP server")
@@ -647,10 +662,11 @@ func TestAnalyzeBatch_PromptJudgeMultiToolCallAttribution(t *testing.T) {
 
 	var result risk_analysis.AnalyzeBatchResult
 	require.NoError(t, val.Get(&result))
-	require.Len(t, judge.inputs, 1)
+	inputs := judge.recorded()
+	require.Len(t, inputs, 1)
 
 	// The judge sees both calls, each with its own attribution - not an opaque blob.
-	msg := judge.inputs[0].Message
+	msg := inputs[0].Message
 	require.Equal(t, message.ToolRequest, msg.Type)
 	require.Empty(t, msg.ToolName, "multi-call message carries no single tool name")
 	require.Len(t, msg.ToolCalls, 2)


### PR DESCRIPTION
## Summary

Fixes a data race in the `risk_analysis` test suite that fails any `go test -race` run of the package.

`judgeFanout` (`prompt_judge_batch.go`) invokes the prompt judge from concurrent goroutines, but the test helper `recordingPromptJudge` appended each input to its capture slice with no synchronization. Under `-race` this reports "race detected during execution of test" and cascades across roughly a dozen tests in the package.

The recorder now guards the capture slice with a mutex, and assertions read through a locked `recorded()` snapshot accessor.

## Verification

- `mise exec -- go test -race ./internal/background/activities/risk_analysis/` passes.
- Repeated `-race -count=5` run passes (previously failed on every attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data race in the `risk_analysis` test suite by guarding the prompt judge recorder with a mutex, making `go test -race` runs pass reliably.

- **Bug Fixes**
  - Protect `recordingPromptJudge.inputs` with a mutex and add a `recorded()` snapshot accessor.
  - Update assertions to read via `recorded()`, fixing races triggered by concurrent `judgeFanout` calls.

<sup>Written for commit 91b73b9febf3986b4234581b454e64afe833ba8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

