### PR TITLE
fix: disable resumable uploads when syncing dashboard assets to CDN buckets

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1553,6 +1553,10 @@ jobs:
           path: dist/assets
           destination: ${{ secrets[matrix.bucket_secret] }}/assets
           parent: false
+          # Resumable sessions flake under high concurrency ("offset is lower
+          # than the number of bytes written"); these files are small enough
+          # that simple uploads with client retries are safer.
+          resumable: false
           # The CDN compresses at the edge (compression_mode AUTOMATIC) and
           # skips responses that are already content-encoded, so objects must
           # be stored uncompressed.


### PR DESCRIPTION
## Problem

The `upload-dashboard-assets` job in `pr.yaml` intermittently fails with:

```
google-github-actions/upload-cloud-storage failed with: the offset is lower than the number of bytes written. The server has 0 bytes and while 131072 bytes has been uploaded - thus 131072 bytes are missing. Stopping as this could result in data loss. Initiate a new upload to continue.
```

## Why it happens

The action defaults to **resumable uploads** at a concurrency of 100. In a resumable session the GCS Node.js client PUTs a chunk (131072 bytes is exactly the first 128 KiB chunk of a small file), then validates the byte offset the server reports as persisted. When a transient network hiccup or a retried request lands on a session the server never durably started, GCS answers "0 bytes committed" and the client deliberately aborts with the "data loss" error instead of resending. One flaky session out of ~100 parallel ones fails the whole step. This is a recurring flake in `@google-cloud/storage`'s resumable path, aggravated by many concurrent sessions of tiny files.

## Fix

Set `resumable: false` on the upload step. Resumable uploads exist to avoid re-sending large files after a failure — they buy nothing for small content-hashed dashboard asset chunks. Simple multipart uploads are retried from scratch by the client's built-in retry logic, which is idempotent and has no offset-validation failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable resumable uploads in the dashboard asset CDN sync to remove flaky GCS offset errors and improve CI reliability. Uploads now use simple multipart with built-in retries, which is safer for many small files.

- **Bug Fixes**
  - Set `resumable: false` on the `google-github-actions/upload-cloud-storage` step in `.github/workflows/pr.yaml` to avoid intermittent "offset is lower than the number of bytes written" failures seen with high-concurrency resumable sessions.

<sup>Written for commit 7cf60acf41f5bd6c3d0ca95903187017d4148f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

