### PR TITLE
chore: restart pitchfork daemons sequentially

### DIFF
--- a/.agents/skills/pitchfork/SKILL.md
+++ b/.agents/skills/pitchfork/SKILL.md
@@ -32,11 +32,11 @@ Declared in `pitchfork.toml`. Names are shown namespaced by project (e.g. `gram/
 ## Whole-stack lifecycle
 
 ```bash
-mise run start   # supervisor start + clean + start --all-local --force
+mise run start   # supervisor start + stop + clean + start --all-local
 mise run stop    # pitchfork stop --all-local
 ```
 
-`mise run start` force-restarts everything. If services fail because Docker infra (Postgres, ClickHouse, etc.) isn't up, run `./zero --agent` for full environment setup instead.
+`mise run start` cleanly stops and restarts everything. If services fail because Docker infra (Postgres, ClickHouse, etc.) isn't up, run `./zero --agent` for full environment setup instead.
 
 ## Individual daemons
 

--- a/.mise-tasks/start/_default
+++ b/.mise-tasks/start/_default
@@ -9,8 +9,9 @@ if ! supervisor_output="$(pitchfork supervisor start 2>&1)"; then
   exit 1
 fi
 
+pitchfork stop --all-local
 pitchfork clean
-pitchfork start --all-local --force
+pitchfork start --all-local
 
 gum style \
   --foreground 10 --border-foreground 10 --border rounded \


### PR DESCRIPTION
## Why

Pitchfork's concurrent force-restart path can report a daemon as failed even after the replacement process becomes healthy. This makes repeated local setup runs fail nondeterministically.

## What changed

- Stop all local daemons before cleaning Pitchfork state and starting the stack again.
- Remove the per-daemon `--force` restart path.
- Update the Pitchfork skill documentation to match the synchronized lifecycle.

## Review notes

- The startup task still performs a full stack restart; it now separates shutdown and startup into ordered phases.
- No service implementation or production runtime behavior changes.

## Testing

- `bash -n .mise-tasks/start/_default`
- `./zero --agent` — passed with all daemons restarted, seed completed, and all services running.
- Verified `pitchfork stop --all-local` succeeds when the stack is already stopped, followed by a successful full start.
- Pre-commit `oxfmt` check — passed.
