### PR TITLE
chore: drops a slow query which is actually not used in the UI

### DIFF
--- a/.changeset/risk-list-drop-message-counts.md
+++ b/.changeset/risk-list-drop-message-counts.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+The `pending_messages` and `total_messages` fields on `RiskPolicy` are now optional and omitted from `risk.listPolicies` responses. Computing them re-aggregated every risk result for the project on each list call, and no consumer read them from the list. Single-policy responses (`risk.getRiskPolicy`, create/update) still populate both fields, and analysis progress remains available via `risk.getRiskPolicyStatus`.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -57054,7 +57054,7 @@ components:
           description: The policy name.
         pending_messages:
           type: integer
-          description: Number of messages not yet analyzed at the current policy version.
+          description: Number of messages not yet analyzed at the current policy version. Populated on single-policy reads; omitted from list responses (use riskPoliciesStatus for progress).
           format: int64
         policy_type:
           type: string
@@ -57108,7 +57108,7 @@ components:
           description: Detection sources enabled for this policy.
         total_messages:
           type: integer
-          description: Total number of messages in the project.
+          description: Total number of messages in the project. Populated on single-policy reads; omitted from list responses.
           format: int64
         updated_at:
           type: string
@@ -57136,8 +57136,6 @@ components:
         - version
         - created_at
         - updated_at
-        - pending_messages
-        - total_messages
     RiskPolicyBypassApprovalRequestBody:
       type: object
       properties:

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -2926,7 +2926,7 @@ examples:
         application/json: {"action": "flag", "audience_type": "everyone", "policy_type": "standard", "presidio_score_threshold": 0.75, "score": 5}
       responses:
         "200":
-          application/json: {"action": "flag", "audience_principal_urns": ["<value 1>", "<value 2>", "<value 3>"], "audience_type": "everyone", "auto_name": false, "created_at": "2026-11-27T08:06:34.693Z", "enabled": true, "id": "8fa1564d-044e-4c61-89b8-7bbe97a778ca", "name": "<value>", "pending_messages": 291308, "policy_type": "standard", "presidio_score_threshold": 0.75, "project_id": "e48ffff0-4e01-4690-a5b9-223e3363e5a2", "score": 5, "sources": ["<value 1>"], "total_messages": 415653, "updated_at": "2026-02-03T05:39:04.851Z", "version": 985427}
+          application/json: {"action": "flag", "audience_principal_urns": ["<value 1>", "<value 2>", "<value 3>"], "audience_type": "everyone", "auto_name": false, "created_at": "2026-11-27T08:06:34.693Z", "enabled": true, "id": "8fa1564d-044e-4c61-89b8-7bbe97a778ca", "name": "<value>", "policy_type": "standard", "presidio_score_threshold": 0.75, "project_id": "e48ffff0-4e01-4690-a5b9-223e3363e5a2", "score": 5, "sources": ["<value 1>"], "updated_at": "2026-02-03T05:39:04.851Z", "version": 985427}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": true}
         "500":
@@ -4268,7 +4268,7 @@ examples:
           id: "8fbf5ca1-aa4d-403a-a226-2071123a9a6b"
       responses:
         "200":
-          application/json: {"action": "flag", "audience_principal_urns": ["<value 1>", "<value 2>"], "audience_type": "everyone", "auto_name": true, "created_at": "2024-02-15T21:20:30.313Z", "enabled": true, "id": "0f8bca1d-18d7-471f-8408-5b7191c93c99", "name": "<value>", "pending_messages": 267392, "policy_type": "standard", "presidio_score_threshold": 0.75, "project_id": "7b79acf3-929f-4814-9cda-ff0d4f950b72", "score": 5, "sources": ["<value 1>", "<value 2>"], "total_messages": 752197, "updated_at": "2026-10-17T00:54:10.479Z", "version": 138155}
+          application/json: {"action": "flag", "audience_principal_urns": ["<value 1>", "<value 2>"], "audience_type": "everyone", "auto_name": true, "created_at": "2024-02-15T21:20:30.313Z", "enabled": true, "id": "0f8bca1d-18d7-471f-8408-5b7191c93c99", "name": "<value>", "policy_type": "standard", "presidio_score_threshold": 0.75, "project_id": "7b79acf3-929f-4814-9cda-ff0d4f950b72", "score": 5, "sources": ["<value 1>", "<value 2>"], "updated_at": "2026-10-17T00:54:10.479Z", "version": 138155}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": false}
         "500":
@@ -6835,7 +6835,7 @@ examples:
         application/json: {"id": "843674e6-50ce-48e3-8373-0f97e164413d", "name": "<value>", "presidio_score_threshold": 0.75, "score": 5}
       responses:
         "200":
-          application/json: {"action": "flag", "audience_principal_urns": ["<value 1>", "<value 2>"], "audience_type": "everyone", "auto_name": true, "created_at": "2024-08-16T09:14:30.128Z", "enabled": false, "id": "8cfa981a-1dce-4a60-b3a5-be6272d6685f", "name": "<value>", "pending_messages": 625941, "policy_type": "standard", "presidio_score_threshold": 0.75, "project_id": "7cc9a5e0-4efa-4e61-87ad-977f4945e432", "score": 5, "sources": ["<value 1>", "<value 2>", "<value 3>"], "total_messages": 272683, "updated_at": "2025-10-31T18:54:42.086Z", "version": 171926}
+          application/json: {"action": "flag", "audience_principal_urns": ["<value 1>", "<value 2>"], "audience_type": "everyone", "auto_name": true, "created_at": "2024-08-16T09:14:30.128Z", "enabled": false, "id": "8cfa981a-1dce-4a60-b3a5-be6272d6685f", "name": "<value>", "policy_type": "standard", "presidio_score_threshold": 0.75, "project_id": "7cc9a5e0-4efa-4e61-87ad-977f4945e432", "score": 5, "sources": ["<value 1>", "<value 2>", "<value 3>"], "updated_at": "2025-10-31T18:54:42.086Z", "version": 171926}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": false}
         "500":

--- a/client/dashboard/src/sdk/src/models/components/riskpolicy.ts
+++ b/client/dashboard/src/sdk/src/models/components/riskpolicy.ts
@@ -109,9 +109,9 @@ export type RiskPolicy = {
    */
   name: string;
   /**
-   * Number of messages not yet analyzed at the current policy version.
+   * Number of messages not yet analyzed at the current policy version. Populated on single-policy reads; omitted from list responses (use riskPoliciesStatus for progress).
    */
-  pendingMessages: number;
+  pendingMessages?: number | undefined;
   /**
    * Policy type: standard (regex/presidio/custom detection) or prompt_based (LLM-judge).
    */
@@ -153,9 +153,9 @@ export type RiskPolicy = {
    */
   sources: Array<string>;
   /**
-   * Total number of messages in the project.
+   * Total number of messages in the project. Populated on single-policy reads; omitted from list responses.
    */
-  totalMessages: number;
+  totalMessages?: number | undefined;
   /**
    * When the policy was last updated.
    */
@@ -209,7 +209,7 @@ export const RiskPolicy$inboundSchema: z.ZodMiniType<RiskPolicy, unknown> = z
       message_types: z.optional(z.array(z.string())),
       model_config: z.optional(RiskPolicyModelConfig$inboundSchema),
       name: z.string(),
-      pending_messages: z.int(),
+      pending_messages: z.optional(z.int()),
       policy_type: z._default(RiskPolicyPolicyType$inboundSchema, "standard"),
       presidio_entities: z.optional(z.array(z.string())),
       presidio_score_threshold: z.optional(z.number()),
@@ -220,7 +220,7 @@ export const RiskPolicy$inboundSchema: z.ZodMiniType<RiskPolicy, unknown> = z
       scope_include: z.optional(z.string()),
       score: z._default(z.number(), 5),
       sources: z.array(z.string()),
-      total_messages: z.int(),
+      total_messages: z.optional(z.int()),
       updated_at: z.pipe(
         z.iso.datetime({ offset: true }),
         z.transform(v => new Date(v)),

--- a/server/design/shared/risk.go
+++ b/server/design/shared/risk.go
@@ -168,10 +168,10 @@ var RiskPolicy = Type("RiskPolicy", func() {
 	Attribute("updated_at", String, "When the policy was last updated.", func() {
 		Format(FormatDateTime)
 	})
-	Attribute("pending_messages", Int64, "Number of messages not yet analyzed at the current policy version.")
-	Attribute("total_messages", Int64, "Total number of messages in the project.")
+	Attribute("pending_messages", Int64, "Number of messages not yet analyzed at the current policy version. Populated on single-policy reads; omitted from list responses (use riskPoliciesStatus for progress).")
+	Attribute("total_messages", Int64, "Total number of messages in the project. Populated on single-policy reads; omitted from list responses.")
 
-	Required("id", "project_id", "name", "policy_type", "sources", "enabled", "action", "audience_type", "audience_principal_urns", "auto_name", "score", "version", "created_at", "updated_at", "pending_messages", "total_messages")
+	Required("id", "project_id", "name", "policy_type", "sources", "enabled", "action", "audience_type", "audience_principal_urns", "auto_name", "score", "version", "created_at", "updated_at")
 })
 
 var RiskCustomDetectionRule = Type("RiskCustomDetectionRule", func() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -57380,7 +57380,7 @@ components:
                     description: The policy name.
                 pending_messages:
                     type: integer
-                    description: Number of messages not yet analyzed at the current policy version.
+                    description: Number of messages not yet analyzed at the current policy version. Populated on single-policy reads; omitted from list responses (use riskPoliciesStatus for progress).
                     format: int64
                 policy_type:
                     type: string
@@ -57434,7 +57434,7 @@ components:
                     description: Detection sources enabled for this policy.
                 total_messages:
                     type: integer
-                    description: Total number of messages in the project.
+                    description: Total number of messages in the project. Populated on single-policy reads; omitted from list responses.
                     format: int64
                 updated_at:
                     type: string
@@ -57462,8 +57462,6 @@ components:
                 - version
                 - created_at
                 - updated_at
-                - pending_messages
-                - total_messages
         RiskPolicyBypassApprovalRequestBody:
             type: object
             properties:

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -10519,8 +10519,8 @@ func unmarshalRiskPolicyResponseBodyToTypesRiskPolicy(v *RiskPolicyResponseBody)
 		Version:                *v.Version,
 		CreatedAt:              *v.CreatedAt,
 		UpdatedAt:              *v.UpdatedAt,
-		PendingMessages:        *v.PendingMessages,
-		TotalMessages:          *v.TotalMessages,
+		PendingMessages:        v.PendingMessages,
+		TotalMessages:          v.TotalMessages,
 	}
 	res.Sources = make([]string, len(v.Sources))
 	for i, val := range v.Sources {

--- a/server/gen/http/risk/client/types.go
+++ b/server/gen/http/risk/client/types.go
@@ -458,9 +458,12 @@ type CreateRiskPolicyResponseBody struct {
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the policy was last updated.
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
-	// Number of messages not yet analyzed at the current policy version.
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
 	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
-	// Total number of messages in the project.
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
 	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
@@ -561,9 +564,12 @@ type GetRiskPolicyResponseBody struct {
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the policy was last updated.
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
-	// Number of messages not yet analyzed at the current policy version.
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
 	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
-	// Total number of messages in the project.
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
 	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
@@ -648,9 +654,12 @@ type UpdateRiskPolicyResponseBody struct {
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the policy was last updated.
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
-	// Number of messages not yet analyzed at the current policy version.
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
 	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
-	// Total number of messages in the project.
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
 	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
@@ -9390,9 +9399,12 @@ type RiskPolicyResponseBody struct {
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// When the policy was last updated.
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
-	// Number of messages not yet analyzed at the current policy version.
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
 	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
-	// Total number of messages in the project.
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
 	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
@@ -10311,8 +10323,8 @@ func NewCreateRiskPolicyRiskPolicyOK(body *CreateRiskPolicyResponseBody) *types.
 		Version:                *body.Version,
 		CreatedAt:              *body.CreatedAt,
 		UpdatedAt:              *body.UpdatedAt,
-		PendingMessages:        *body.PendingMessages,
-		TotalMessages:          *body.TotalMessages,
+		PendingMessages:        body.PendingMessages,
+		TotalMessages:          body.TotalMessages,
 	}
 	v.Sources = make([]string, len(body.Sources))
 	for i, val := range body.Sources {
@@ -10880,8 +10892,8 @@ func NewGetRiskPolicyRiskPolicyOK(body *GetRiskPolicyResponseBody) *types.RiskPo
 		Version:                *body.Version,
 		CreatedAt:              *body.CreatedAt,
 		UpdatedAt:              *body.UpdatedAt,
-		PendingMessages:        *body.PendingMessages,
-		TotalMessages:          *body.TotalMessages,
+		PendingMessages:        body.PendingMessages,
+		TotalMessages:          body.TotalMessages,
 	}
 	v.Sources = make([]string, len(body.Sources))
 	for i, val := range body.Sources {
@@ -11115,8 +11127,8 @@ func NewUpdateRiskPolicyRiskPolicyOK(body *UpdateRiskPolicyResponseBody) *types.
 		Version:                *body.Version,
 		CreatedAt:              *body.CreatedAt,
 		UpdatedAt:              *body.UpdatedAt,
-		PendingMessages:        *body.PendingMessages,
-		TotalMessages:          *body.TotalMessages,
+		PendingMessages:        body.PendingMessages,
+		TotalMessages:          body.TotalMessages,
 	}
 	v.Sources = make([]string, len(body.Sources))
 	for i, val := range body.Sources {
@@ -17727,12 +17739,6 @@ func ValidateCreateRiskPolicyResponseBody(body *CreateRiskPolicyResponseBody) (e
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
 	}
-	if body.PendingMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("pending_messages", "body"))
-	}
-	if body.TotalMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("total_messages", "body"))
-	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))
 	}
@@ -17870,12 +17876,6 @@ func ValidateGetRiskPolicyResponseBody(body *GetRiskPolicyResponseBody) (err err
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
 	}
-	if body.PendingMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("pending_messages", "body"))
-	}
-	if body.TotalMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("total_messages", "body"))
-	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))
 	}
@@ -17977,12 +17977,6 @@ func ValidateUpdateRiskPolicyResponseBody(body *UpdateRiskPolicyResponseBody) (e
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
-	}
-	if body.PendingMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("pending_messages", "body"))
-	}
-	if body.TotalMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("total_messages", "body"))
 	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))
@@ -29497,12 +29491,6 @@ func ValidateRiskPolicyResponseBody(body *RiskPolicyResponseBody) (err error) {
 	}
 	if body.UpdatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("updated_at", "body"))
-	}
-	if body.PendingMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("pending_messages", "body"))
-	}
-	if body.TotalMessages == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("total_messages", "body"))
 	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -460,10 +460,13 @@ type CreateRiskPolicyResponseBody struct {
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the policy was last updated.
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
-	// Number of messages not yet analyzed at the current policy version.
-	PendingMessages int64 `form:"pending_messages" json:"pending_messages" xml:"pending_messages"`
-	// Total number of messages in the project.
-	TotalMessages int64 `form:"total_messages" json:"total_messages" xml:"total_messages"`
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
+	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
+	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
 // ListRiskPoliciesResponseBody is the type of the "risk" service
@@ -563,10 +566,13 @@ type GetRiskPolicyResponseBody struct {
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the policy was last updated.
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
-	// Number of messages not yet analyzed at the current policy version.
-	PendingMessages int64 `form:"pending_messages" json:"pending_messages" xml:"pending_messages"`
-	// Total number of messages in the project.
-	TotalMessages int64 `form:"total_messages" json:"total_messages" xml:"total_messages"`
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
+	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
+	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
 // UpdateRiskPolicyResponseBody is the type of the "risk" service
@@ -650,10 +656,13 @@ type UpdateRiskPolicyResponseBody struct {
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the policy was last updated.
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
-	// Number of messages not yet analyzed at the current policy version.
-	PendingMessages int64 `form:"pending_messages" json:"pending_messages" xml:"pending_messages"`
-	// Total number of messages in the project.
-	TotalMessages int64 `form:"total_messages" json:"total_messages" xml:"total_messages"`
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
+	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
+	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
 // ListRiskResultsResponseBody is the type of the "risk" service
@@ -9366,10 +9375,13 @@ type RiskPolicyResponseBody struct {
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// When the policy was last updated.
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
-	// Number of messages not yet analyzed at the current policy version.
-	PendingMessages int64 `form:"pending_messages" json:"pending_messages" xml:"pending_messages"`
-	// Total number of messages in the project.
-	TotalMessages int64 `form:"total_messages" json:"total_messages" xml:"total_messages"`
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
+	PendingMessages *int64 `form:"pending_messages,omitempty" json:"pending_messages,omitempty" xml:"pending_messages,omitempty"`
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
+	TotalMessages *int64 `form:"total_messages,omitempty" json:"total_messages,omitempty" xml:"total_messages,omitempty"`
 }
 
 // BuiltinExclusionCategoryResponseBody is used to define fields on response

--- a/server/gen/types/risk_policy.go
+++ b/server/gen/types/risk_policy.go
@@ -87,8 +87,11 @@ type RiskPolicy struct {
 	CreatedAt string
 	// When the policy was last updated.
 	UpdatedAt string
-	// Number of messages not yet analyzed at the current policy version.
-	PendingMessages int64
-	// Total number of messages in the project.
-	TotalMessages int64
+	// Number of messages not yet analyzed at the current policy version. Populated
+	// on single-policy reads; omitted from list responses (use riskPoliciesStatus
+	// for progress).
+	PendingMessages *int64
+	// Total number of messages in the project. Populated on single-policy reads;
+	// omitted from list responses.
+	TotalMessages *int64
 }

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -512,28 +512,6 @@ func (s *Service) ListRiskPolicies(ctx context.Context, payload *gen.ListRiskPol
 		return &gen.ListRiskPoliciesResult{Policies: []*types.RiskPolicy{}}, nil
 	}
 
-	// Enrichment is resolved once for the whole set rather than per policy (the
-	// old N+1). totalMessages is project-wide and identical for every policy;
-	// analyzed counts and audience grants are batched into one query each and
-	// looked up per row below.
-	totalMessages, err := s.repo.CountTotalMessages(ctx, uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true})
-	if err != nil {
-		totalMessages = 0
-	}
-
-	// Analyzed counts are optional status enrichment, so a failure degrades to
-	// zero (pending = total) rather than failing the whole list — matching the
-	// tolerance of the single-policy CountAnalyzedMessages path.
-	analyzedByPolicy := map[analyzedMessagesKey]int64{}
-	if analyzedRows, err := s.repo.CountAnalyzedMessagesByProject(ctx, *authCtx.ProjectID); err != nil {
-		s.logger.WarnContext(ctx, "count analyzed messages for risk policy list failed", attr.SlogError(err))
-	} else {
-		analyzedByPolicy = make(map[analyzedMessagesKey]int64, len(analyzedRows))
-		for _, r := range analyzedRows {
-			analyzedByPolicy[analyzedMessagesKey{policyID: r.RiskPolicyID, version: r.RiskPolicyVersion}] = r.AnalyzedMessages
-		}
-	}
-
 	policyIDs := make([]string, 0, len(rows))
 	for _, row := range rows {
 		policyIDs = append(policyIDs, row.ID.String())
@@ -543,20 +521,16 @@ func (s *Service) ListRiskPolicies(ctx context.Context, payload *gen.ListRiskPol
 		return nil, oops.E(oops.CodeUnexpected, err, "load risk policy audiences").LogError(ctx, s.logger)
 	}
 
+	// Message counts are intentionally omitted here: no list consumer reads
+	// them, and computing them re-aggregates every risk_results row for the
+	// project on each call. Progress lives on the single-policy paths
+	// (riskPoliciesStatus, getRiskPolicy).
 	policies := make([]*types.RiskPolicy, 0, len(rows))
 	for _, row := range rows {
-		analyzedMessages := analyzedByPolicy[analyzedMessagesKey{policyID: row.ID, version: row.Version}]
-		policies = append(policies, buildRiskPolicyType(row, totalMessages, analyzedMessages, audienceByPolicy[row.ID.String()]))
+		policies = append(policies, buildRiskPolicyType(row, nil, nil, audienceByPolicy[row.ID.String()]))
 	}
 
 	return &gen.ListRiskPoliciesResult{Policies: policies}, nil
-}
-
-// analyzedMessagesKey keys the batched analyzed-message counts by the
-// (policy, version) pair they were aggregated on.
-type analyzedMessagesKey struct {
-	policyID uuid.UUID
-	version  int64
 }
 
 // ListBuiltinExclusions returns the built-in exclusion library grouped by
@@ -3293,15 +3267,17 @@ func (s *Service) policyToType(ctx context.Context, row repo.RiskPolicy) (*types
 		return nil, fmt.Errorf("load risk policy audience: %w", err)
 	}
 
-	return buildRiskPolicyType(row, totalMessages, analyzedMessages, audiencePrincipalURNs), nil
+	return buildRiskPolicyType(row, &totalMessages, &analyzedMessages, audiencePrincipalURNs), nil
 }
 
 // buildRiskPolicyType assembles the API type from a policy row and its already
-// resolved message counts and audience. The enrichment queries are the caller's
-// responsibility so batched paths (ListRiskPolicies) can resolve them once for
-// the whole set instead of per policy.
-func buildRiskPolicyType(row repo.RiskPolicy, totalMessages, analyzedMessages int64, audiencePrincipalURNs []string) *types.RiskPolicy {
-	pendingMessages := max(totalMessages-analyzedMessages, 0)
+// resolved message counts and audience. Counts are optional enrichment: nil
+// (the list path) omits them from the response rather than reporting zeros.
+func buildRiskPolicyType(row repo.RiskPolicy, totalMessages, analyzedMessages *int64, audiencePrincipalURNs []string) *types.RiskPolicy {
+	var pendingMessages *int64
+	if totalMessages != nil && analyzedMessages != nil {
+		pendingMessages = new(max(*totalMessages-*analyzedMessages, 0))
+	}
 
 	return &types.RiskPolicy{
 		ID:                     row.ID.String(),
@@ -3368,8 +3344,8 @@ func policyRowSnapshotWithAudience(row repo.RiskPolicy, audiencePrincipalURNs []
 		Version:                row.Version,
 		CreatedAt:              row.CreatedAt.Time.Format(time.RFC3339),
 		UpdatedAt:              row.UpdatedAt.Time.Format(time.RFC3339),
-		PendingMessages:        -1,
-		TotalMessages:          -1,
+		PendingMessages:        nil,
+		TotalMessages:          nil,
 	}
 }
 

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -486,18 +486,6 @@ WHERE rr.project_id = @project_id
   AND rr.risk_policy_id = @risk_policy_id
   AND rr.risk_policy_version = @risk_policy_version;
 
--- name: CountAnalyzedMessagesByProject :many
--- Batched form of CountAnalyzedMessages: the analyzed-message count for every
--- (policy, version) in a project in one query, so ListRiskPolicies avoids a
--- per-policy round trip.
-SELECT
-    rr.risk_policy_id
-  , rr.risk_policy_version
-  , COUNT(DISTINCT rr.chat_message_id)::BIGINT AS analyzed_messages
-FROM risk_results rr
-WHERE rr.project_id = @project_id
-GROUP BY rr.risk_policy_id, rr.risk_policy_version;
-
 -- name: CountFindingsByPolicy :one
 SELECT COUNT(*)::BIGINT
 FROM risk_results

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -336,45 +336,6 @@ func (q *Queries) CountAnalyzedMessages(ctx context.Context, arg CountAnalyzedMe
 	return column_1, err
 }
 
-const countAnalyzedMessagesByProject = `-- name: CountAnalyzedMessagesByProject :many
-SELECT
-    rr.risk_policy_id
-  , rr.risk_policy_version
-  , COUNT(DISTINCT rr.chat_message_id)::BIGINT AS analyzed_messages
-FROM risk_results rr
-WHERE rr.project_id = $1
-GROUP BY rr.risk_policy_id, rr.risk_policy_version
-`
-
-type CountAnalyzedMessagesByProjectRow struct {
-	RiskPolicyID      uuid.UUID
-	RiskPolicyVersion int64
-	AnalyzedMessages  int64
-}
-
-// Batched form of CountAnalyzedMessages: the analyzed-message count for every
-// (policy, version) in a project in one query, so ListRiskPolicies avoids a
-// per-policy round trip.
-func (q *Queries) CountAnalyzedMessagesByProject(ctx context.Context, projectID uuid.UUID) ([]CountAnalyzedMessagesByProjectRow, error) {
-	rows, err := q.db.Query(ctx, countAnalyzedMessagesByProject, projectID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []CountAnalyzedMessagesByProjectRow
-	for rows.Next() {
-		var i CountAnalyzedMessagesByProjectRow
-		if err := rows.Scan(&i.RiskPolicyID, &i.RiskPolicyVersion, &i.AnalyzedMessages); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const countEnabledRegexExclusionsInScope = `-- name: CountEnabledRegexExclusionsInScope :one
 SELECT COUNT(*)::BIGINT
 FROM risk_exclusions


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop computing message counts in `risk.listPolicies` to remove a slow, unused query. `pending_messages` and `total_messages` are now optional and omitted from list responses; single-policy endpoints still return them, and progress is available via `risk.getRiskPolicyStatus`.

- **Refactors**
  - Removed the per-project analyzed-message aggregation query and related code.
  - Updated server types, OpenAPI specs, and SDK models to make counts optional.
  - List path skips count enrichment; single-policy reads still compute and return counts.

- **Migration**
  - Do not rely on `pending_messages`/`total_messages` in `risk.listPolicies` responses.
  - Use `risk.getRiskPolicyStatus` (or `risk.getRiskPolicy`) for progress.
  - Update SDK consumers: counts are optional; handle undefined/null.

<sup>Written for commit 021da05a90b812cb9e18714846318d8462fe168b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

