### PR TITLE
feat: treat AWS access key id as a detection anchor, not a reported secret

### DIFF
--- a/.changeset/aws-id-anchor-not-secret.md
+++ b/.changeset/aws-id-anchor-not-secret.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-Secret scanning no longer flags an AWS access key id as a leaked secret — it is an identifier (AWS logs it in CloudTrail), so it is used only as an anchor for detecting the co-located secret access key, never surfaced on its own. Findings now report the secret value rather than the surrounding label, so masking covers the secret and leaves the field name visible, and a specific rule deterministically wins over the generic catch-all when both match the same value.
+Secret scanning no longer flags an AWS access key id as a leaked secret — it's an identifier, used only to anchor detection of the co-located secret access key. Findings now mask just the secret value, not its surrounding label.

--- a/.changeset/aws-id-anchor-not-secret.md
+++ b/.changeset/aws-id-anchor-not-secret.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Secret scanning no longer flags an AWS access key id as a leaked secret — it is an identifier (AWS logs it in CloudTrail), so it is used only as an anchor for detecting the co-located secret access key, never surfaced on its own. Findings now report the secret value rather than the surrounding label, so masking covers the secret and leaves the field name visible, and a specific rule deterministically wins over the generic catch-all when both match the same value.

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -178,7 +178,7 @@ func TestAnalyzeBatch_GracefulDegradationWhenPresidioDown(t *testing.T) {
 		ChatID:    td.chatID,
 		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
 		Role:      "user",
-		Content:   "AWS key AKIAIOSFODNN7REALKEY and email alice@example.com",
+		Content:   "AccessKeyId ASIAZ2XY3WNBQR5TUVWX SecretAccessKey wJalrXUtnFEMIbKp7MDoRZfiCYqTvHgNsQ8xLcWd and email alice@example.com",
 	})
 	require.NoError(t, err)
 
@@ -733,8 +733,10 @@ func TestAnalyzeBatch_Gitleaks_SecretInToolCallArgsOnly(t *testing.T) {
 	conn := cloneDB(t)
 	td := seedTestData(t, conn, true)
 
+	// A full credential pair: the access key id anchors detection (it is not
+	// itself reported), and the secret access key is the flagged value.
 	msgID := insertAssistantToolCallWithArgs(t, conn, td, "Bash", map[string]any{
-		"command": "aws configure set aws_access_key_id AKIAIOSFODNN7REALKEY",
+		"command": "aws configure set aws_access_key_id ASIAZ2XY3WNBQR5TUVWX aws_secret_access_key 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",
 	})
 
 	result := executeAnalyzeBatch(t, conn, td, []uuid.UUID{msgID}, []string{"gitleaks"})
@@ -752,9 +754,12 @@ func TestAnalyzeBatch_Gitleaks_SecretInToolCallArgsOnly(t *testing.T) {
 	var saw bool
 	for _, row := range rows {
 		if row.Source == "gitleaks" && row.Found {
-			assert.Equal(t, "secret.aws_access_token", row.RuleID.String)
-			assert.Contains(t, row.Match.String, "AKIA")
-			saw = true
+			assert.NotEqual(t, "secret.aws_access_token", row.RuleID.String,
+				"the access key id must not be reported as a finding")
+			if row.RuleID.String == "secret.aws_secret_access_key" {
+				assert.Contains(t, row.Match.String, "wJalrXUtnFEMIbKp7MDoRZfiCYqTvHgNsQ8xLcWd")
+				saw = true
+			}
 		}
 	}
 	require.True(t, saw, "expected a gitleaks finding from tool-call arguments")
@@ -1527,7 +1532,7 @@ func TestAnalyzeBatch_SkipsWhenPolicyDisabled(t *testing.T) {
 		ChatID:    td.chatID,
 		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
 		Role:      "user",
-		Content:   "AWS key AKIAIOSFODNN7REALKEY",
+		Content:   "token ghp_R2D2C3POLuk3Skywalker1234567890ab",
 	})
 	require.NoError(t, err)
 
@@ -1554,7 +1559,7 @@ func TestAnalyzeBatch_SkipsWhenPolicyDeleted(t *testing.T) {
 		ChatID:    td.chatID,
 		ProjectID: uuid.NullUUID{UUID: td.projectID, Valid: true},
 		Role:      "user",
-		Content:   "AWS key AKIAIOSFODNN7REALKEY",
+		Content:   "token ghp_R2D2C3POLuk3Skywalker1234567890ab",
 	})
 	require.NoError(t, err)
 

--- a/server/internal/background/activities/risk_analysis/presidio_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_test.go
@@ -210,7 +210,7 @@ func TestCombinedScanners_BothSourcesAppear(t *testing.T) {
 	client := infra.NewPresidioClient(t)
 
 	// Message with both a secret (AWS key) and PII (email)
-	content := "Here is my AWS key: AKIAIOSFODNN7REALKEY and my email is alice@globex.com"
+	content := "Here is my AccessKeyId ASIAZ2XY3WNBQR5TUVWX SecretAccessKey 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 and my email is alice@globex.com"
 
 	gitleaksFindings, err := gitleaks.NewScanner().Scan(t.Context(), content)
 	require.NoError(t, err)

--- a/server/internal/scanners/gitleaks/aws_rules_test.go
+++ b/server/internal/scanners/gitleaks/aws_rules_test.go
@@ -56,38 +56,6 @@ func TestExtendedConfig_MatchIsValueNotLabel(t *testing.T) {
 	require.Equal(t, content[tok.StartPos:tok.EndPos], tok.Match, "span must bracket exactly the value")
 }
 
-// When the generic catch-all and a specific rule match the same secret value,
-// the specific rule must sort first so downstream position-dedup keeps it —
-// deterministically, not by detector map-iteration order.
-func TestExtendedConfig_SpecificRuleOutranksGeneric(t *testing.T) {
-	t.Parallel()
-
-	content := `{
-  "AccessKeyId": "` + fakeAccessKeyID + `",
-  "SecretAccessKey": "` + fakeSecret + `"
-}`
-	findings, err := gitleaks.NewScanner().Scan(context.Background(), content)
-	require.NoError(t, err)
-
-	specificIdx, genericIdx := -1, -1
-	for i, f := range findings {
-		if f.Match != fakeSecret {
-			continue
-		}
-		switch f.RuleID {
-		case gitleaks.SecretAccessKeyRuleID:
-			specificIdx = i
-		case "secret.generic_api_key":
-			genericIdx = i
-		}
-	}
-	require.GreaterOrEqual(t, specificIdx, 0, "aws_secret_access_key should fire on the value")
-	if genericIdx >= 0 {
-		require.Less(t, specificIdx, genericIdx,
-			"the specific AWS rule must sort before the generic catch-all at the same value")
-	}
-}
-
 // The access key id is an identifier, not a secret: it anchors detection but is
 // NEVER surfaced as its own finding. The secret access key and session token
 // are the values that get flagged.

--- a/server/internal/scanners/gitleaks/aws_rules_test.go
+++ b/server/internal/scanners/gitleaks/aws_rules_test.go
@@ -34,9 +34,64 @@ func ruleSet(t *testing.T, content string) map[string]bool {
 	return out
 }
 
-// The extended config must detect all three AWS credential flavors — the id
-// (built-in) plus the secret access key and session token (our added rules).
-func TestExtendedConfig_DetectsAllThreeFlavors(t *testing.T) {
+// A label-anchored rule's reported match must be the secret VALUE only, never
+// the surrounding label — so downstream masking covers the secret and leaves
+// the (non-sensitive) JSON key visible. Also asserts the span brackets the value.
+func TestExtendedConfig_MatchIsValueNotLabel(t *testing.T) {
+	t.Parallel()
+
+	content := `{ "SessionToken": "` + fakeToken + `" }`
+	findings, err := gitleaks.NewScanner().Scan(context.Background(), content)
+	require.NoError(t, err)
+
+	var tok *scanners.Finding
+	for i := range findings {
+		if findings[i].RuleID == gitleaks.SessionTokenRuleID {
+			tok = &findings[i]
+		}
+	}
+	require.NotNil(t, tok, "session token should be detected")
+	require.Equal(t, fakeToken, tok.Match, "match must be the token value, not include the SessionToken label")
+	require.NotContains(t, tok.Match, "SessionToken")
+	require.Equal(t, content[tok.StartPos:tok.EndPos], tok.Match, "span must bracket exactly the value")
+}
+
+// When the generic catch-all and a specific rule match the same secret value,
+// the specific rule must sort first so downstream position-dedup keeps it —
+// deterministically, not by detector map-iteration order.
+func TestExtendedConfig_SpecificRuleOutranksGeneric(t *testing.T) {
+	t.Parallel()
+
+	content := `{
+  "AccessKeyId": "` + fakeAccessKeyID + `",
+  "SecretAccessKey": "` + fakeSecret + `"
+}`
+	findings, err := gitleaks.NewScanner().Scan(context.Background(), content)
+	require.NoError(t, err)
+
+	specificIdx, genericIdx := -1, -1
+	for i, f := range findings {
+		if f.Match != fakeSecret {
+			continue
+		}
+		switch f.RuleID {
+		case gitleaks.SecretAccessKeyRuleID:
+			specificIdx = i
+		case "secret.generic_api_key":
+			genericIdx = i
+		}
+	}
+	require.GreaterOrEqual(t, specificIdx, 0, "aws_secret_access_key should fire on the value")
+	if genericIdx >= 0 {
+		require.Less(t, specificIdx, genericIdx,
+			"the specific AWS rule must sort before the generic catch-all at the same value")
+	}
+}
+
+// The access key id is an identifier, not a secret: it anchors detection but is
+// NEVER surfaced as its own finding. The secret access key and session token
+// are the values that get flagged.
+func TestExtendedConfig_FlagsSecretsNotID(t *testing.T) {
 	t.Parallel()
 
 	content := `{
@@ -46,13 +101,23 @@ func TestExtendedConfig_DetectsAllThreeFlavors(t *testing.T) {
 }`
 
 	got := ruleSet(t, content)
-	require.True(t, got[gitleaks.AccessKeyIDRuleID], "access key id (built-in) should be detected")
+	require.False(t, got[gitleaks.AccessKeyIDRuleID], "the access key id must NOT be reported as a leaked secret")
 	require.True(t, got[gitleaks.SecretAccessKeyRuleID], "secret access key should be detected")
 	require.True(t, got[gitleaks.SessionTokenRuleID], "session token should be detected")
 }
 
-// The secret access key must also be caught with no label, purely by proximity
-// to the access key id — the native composite (RequiredRules) path.
+// A lone access key id, with no secret nearby, produces no AWS finding — an id
+// on its own is not a credential leak.
+func TestExtendedConfig_LoneAccessKeyIDNotFlagged(t *testing.T) {
+	t.Parallel()
+
+	got := ruleSet(t, `{ "AccessKeyId": "`+fakeAccessKeyID+`" }`)
+	require.False(t, got[gitleaks.AccessKeyIDRuleID], "the access key id must not be reported")
+	require.False(t, got[gitleaks.SecretAccessKeyRuleID])
+}
+
+// The secret access key must be caught with no label, purely by proximity to the
+// (unreported) access key id — the native composite (RequiredRules) path.
 func TestExtendedConfig_SecretAnchoredToIDWithoutLabel(t *testing.T) {
 	t.Parallel()
 
@@ -61,7 +126,7 @@ func TestExtendedConfig_SecretAnchoredToIDWithoutLabel(t *testing.T) {
 	content := "creds  " + fakeAccessKeyID + "  " + fakeSecret + "\n"
 
 	got := ruleSet(t, content)
-	require.True(t, got[gitleaks.AccessKeyIDRuleID])
+	require.False(t, got[gitleaks.AccessKeyIDRuleID], "the id anchors but is not reported")
 	require.True(t, got[gitleaks.SecretAccessKeyRuleID],
 		"a bare secret within WithinLines of the id should be reported via the composite rule")
 }
@@ -76,18 +141,15 @@ func TestExtendedConfig_BareSecretWithoutAnchorNotDetected(t *testing.T) {
 		"an unanchored, unlabeled base64 blob must not be flagged as a secret access key")
 }
 
-// A 40-char lowercase hex hash sitting next to a real access key id must not be
-// reported: the composite rule's entropy floor rejects it.
+// A 40-char lowercase hex hash sitting next to an access key id must not be
+// reported: the composite rule's entropy floor rejects it. A positive control
+// proves the anchor works (the id itself is no longer a reportable finding).
 func TestExtendedConfig_HashNextToIDNotDetected(t *testing.T) {
 	t.Parallel()
 
-	content := fakeAccessKeyID + " " + sha1Empty + "\n"
-	got := ruleSet(t, content)
-	// Assert the anchor fired: otherwise the composite rule couldn't have run at
-	// all, and the negative result below would be a broken fixture, not entropy
-	// rejection.
-	require.True(t, got[gitleaks.AccessKeyIDRuleID], "the access key id anchor must be detected")
-	require.False(t, got[gitleaks.SecretAccessKeyRuleID],
+	require.True(t, ruleSet(t, fakeAccessKeyID+" "+fakeSecret+"\n")[gitleaks.SecretAccessKeyRuleID],
+		"positive control: a real secret next to the id IS detected, so the anchor works")
+	require.False(t, ruleSet(t, fakeAccessKeyID+" "+sha1Empty+"\n")[gitleaks.SecretAccessKeyRuleID],
 		"a lowercase-hex hash must fall below the entropy floor")
 }
 

--- a/server/internal/scanners/gitleaks/handler_test.go
+++ b/server/internal/scanners/gitleaks/handler_test.go
@@ -47,7 +47,9 @@ func TestHandle_PublishesGitleaksFinding(t *testing.T) {
 	pub, published := capturingPub(t)
 	h := gitleaks.NewHandler(testenv.NewLogger(t), pub)
 
-	content := `Here is my AWS key: AKIAIOSFODNN7REALKEY and secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYREALKEYXX`
+	// The access key id anchors detection but is not itself reported (it is an
+	// identifier, not a secret); the secret access key is the reported finding.
+	content := `AccessKeyId: ` + fakeAccessKeyID + `, SecretAccessKey: ` + fakeSecret
 	require.NoError(t, h.Handle(t.Context(), newRequest(content), gcp.MessageMetadata{}))
 
 	require.NotEmpty(t, *published, "expected at least one finding published")
@@ -68,11 +70,13 @@ func TestHandle_PublishesGitleaksFinding(t *testing.T) {
 		require.LessOrEqual(t, end, len(content))
 		require.Equal(t, f.GetMatch(), content[start:end])
 
-		if f.GetRuleId() == "secret.aws_access_token" {
+		if f.GetRuleId() == "secret.aws_secret_access_key" {
 			awsFinding = f
 		}
+		require.NotEqual(t, "secret.aws_access_token", f.GetRuleId(),
+			"the access key id must not be reported as a finding")
 	}
-	require.NotNil(t, awsFinding, "expected an aws access token finding")
+	require.NotNil(t, awsFinding, "expected an aws secret access key finding")
 }
 
 func TestHandle_CleanContentPublishesNothing(t *testing.T) {

--- a/server/internal/scanners/gitleaks/scanner.go
+++ b/server/internal/scanners/gitleaks/scanner.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -239,27 +238,7 @@ func convertFindings(content string, raw []report.Finding) []scanners.Finding {
 			Path:                "",
 		})
 	}
-	// Order by position, ranking the generic catch-all rule after more specific
-	// ones at the same span. Both narrow to the same secret value, so downstream
-	// position-dedup keeps whichever comes first — this makes it deterministically
-	// the specific rule (e.g. aws_secret_access_key over generic_api_key) instead
-	// of whatever the detector's map iteration happened to emit first.
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].StartPos != out[j].StartPos {
-			return out[i].StartPos < out[j].StartPos
-		}
-		return rulePriority(out[i].RuleID) < rulePriority(out[j].RuleID)
-	})
 	return out
-}
-
-// rulePriority ranks rules for dedup ordering: the generic catch-all loses to
-// any more specific rule that matched the same value.
-func rulePriority(ruleID string) int {
-	if ruleID == "secret.generic_api_key" {
-		return 1
-	}
-	return 0
 }
 
 // narrowToSecret locates a finding's SecretGroup value inside its full-match
@@ -267,6 +246,11 @@ func rulePriority(ruleID string) int {
 // ok=false — leaving the caller with the full match — when there is nothing to
 // narrow (no distinct secret group) or the value cannot be located inside the
 // span (a positioning edge case), so the fallback never drops a finding.
+//
+// The value is located by its LAST occurrence in the match: label-anchored rules
+// capture the trailing value (`Label: "<secret>"`), so if the value string also
+// appears earlier (e.g. inside the label), the last occurrence is the captured
+// secret — the one that must stay covered.
 func narrowToSecret(content string, start, end int, fullMatch, secret string) (string, int, int, bool) {
 	if secret == "" || secret == fullMatch {
 		return "", 0, 0, false
@@ -274,7 +258,7 @@ func narrowToSecret(content string, start, end int, fullMatch, secret string) (s
 	if start < 0 || end > len(content) || start > end {
 		return "", 0, 0, false
 	}
-	rel := strings.Index(content[start:end], secret)
+	rel := strings.LastIndex(content[start:end], secret)
 	if rel < 0 {
 		return "", 0, 0, false
 	}

--- a/server/internal/scanners/gitleaks/scanner.go
+++ b/server/internal/scanners/gitleaks/scanner.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -70,6 +71,16 @@ func newDetector() (*detect.Detector, error) {
 		for _, k := range rule.Keywords {
 			cfg.Keywords[strings.ToLower(k)] = struct{}{}
 		}
+	}
+
+	// An AWS access key id (AKIA/ASIA...) is an identifier, not a secret — AWS
+	// logs it in CloudTrail — so we do not surface it as a leaked-secret finding.
+	// But the composite aws-secret-access-key rule needs it as a proximity anchor,
+	// so we keep the built-in rule evaluated and only suppress its own report via
+	// SkipReport (the finding still counts for RequiredRules matching).
+	if r, ok := cfg.Rules[awsAccessTokenRuleID]; ok {
+		r.SkipReport = true
+		cfg.Rules[awsAccessTokenRuleID] = r
 	}
 
 	return detect.NewDetector(cfg), nil
@@ -194,15 +205,27 @@ func (s *Scanner) ScanBatch(ctx context.Context, contents []string) ([][]scanner
 // are canonicalized to the shared snake_case-with-dots form and line/column
 // positions are mapped to byte offsets. Gitleaks ships human-readable
 // descriptions that never echo the matched secret, so they pass through.
+//
+// The reported Match (and its span) is narrowed to the rule's SecretGroup value
+// when the rule captures one — i.e. the secret itself, not the surrounding
+// context. Label-anchored rules (gitleaks' generic-api-key, our
+// aws-session-token, ...) match `Label: "value"` but set finding.Secret to the
+// value alone; reporting the full match would mask/redact the non-sensitive
+// label along with the secret. Narrowing keeps the invariant Match ==
+// content[StartPos:EndPos].
 func convertFindings(content string, raw []report.Finding) []scanners.Finding {
 	out := make([]scanners.Finding, 0, len(raw))
 	for _, f := range raw {
 		startPos := lineColToBytePos(content, f.StartLine, f.StartColumn)
 		endPos := min(lineColToBytePos(content, f.EndLine, f.EndColumn)+1, len(content))
+		match := f.Match
+		if narrowed, ns, ne, ok := narrowToSecret(content, startPos, endPos, f.Match, f.Secret); ok {
+			match, startPos, endPos = narrowed, ns, ne
+		}
 		out = append(out, scanners.Finding{
 			RuleID:      guardRuleID(CanonicalRuleID(f.RuleID)),
 			Description: f.Description,
-			Match:       f.Match,
+			Match:       match,
 			StartPos:    startPos,
 			EndPos:      endPos,
 			Tags:        parseTags(f.Tags),
@@ -216,7 +239,47 @@ func convertFindings(content string, raw []report.Finding) []scanners.Finding {
 			Path:                "",
 		})
 	}
+	// Order by position, ranking the generic catch-all rule after more specific
+	// ones at the same span. Both narrow to the same secret value, so downstream
+	// position-dedup keeps whichever comes first — this makes it deterministically
+	// the specific rule (e.g. aws_secret_access_key over generic_api_key) instead
+	// of whatever the detector's map iteration happened to emit first.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].StartPos != out[j].StartPos {
+			return out[i].StartPos < out[j].StartPos
+		}
+		return rulePriority(out[i].RuleID) < rulePriority(out[j].RuleID)
+	})
 	return out
+}
+
+// rulePriority ranks rules for dedup ordering: the generic catch-all loses to
+// any more specific rule that matched the same value.
+func rulePriority(ruleID string) int {
+	if ruleID == "secret.generic_api_key" {
+		return 1
+	}
+	return 0
+}
+
+// narrowToSecret locates a finding's SecretGroup value inside its full-match
+// span [start,end) and returns the value plus its byte span. It returns
+// ok=false — leaving the caller with the full match — when there is nothing to
+// narrow (no distinct secret group) or the value cannot be located inside the
+// span (a positioning edge case), so the fallback never drops a finding.
+func narrowToSecret(content string, start, end int, fullMatch, secret string) (string, int, int, bool) {
+	if secret == "" || secret == fullMatch {
+		return "", 0, 0, false
+	}
+	if start < 0 || end > len(content) || start > end {
+		return "", 0, 0, false
+	}
+	rel := strings.Index(content[start:end], secret)
+	if rel < 0 {
+		return "", 0, 0, false
+	}
+	ns := start + rel
+	return secret, ns, ns + len(secret), true
 }
 
 // guardRuleID panics in test builds when id is not canonical, catching rule-id

--- a/server/internal/scanners/gitleaks/scanner_test.go
+++ b/server/internal/scanners/gitleaks/scanner_test.go
@@ -33,14 +33,18 @@ func TestScan_NoSecrets(t *testing.T) {
 
 func TestScan_DetectsAWSKey(t *testing.T) {
 	t.Parallel()
-	// Use realistic-looking keys — "EXAMPLE" is globally allowlisted by gitleaks.
-	content := `Here is my AWS key: AKIAIOSFODNN7REALKEY and secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYREALKEYXX`
+	// The access key id anchors detection but is not reported on its own; the
+	// secret access key is the flagged finding. ("EXAMPLE" values are globally
+	// allowlisted by gitleaks, so the fixtures avoid them.)
+	content := `AccessKeyId: ` + fakeAccessKeyID + `, SecretAccessKey: ` + fakeSecret
 	findings, err := gitleaks.NewScanner().Scan(t.Context(), content)
 	require.NoError(t, err)
 	assert.NotEmpty(t, findings, "expected at least one finding for AWS credentials")
 	for _, f := range findings {
 		assert.NotEmpty(t, f.RuleID)
 		assert.NotEmpty(t, f.Description)
+		assert.NotEqual(t, gitleaks.AccessKeyIDRuleID, f.RuleID,
+			"the access key id must not be reported as a finding")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #4493 · Linear: [FDE-34](https://linear.app/speakeasy/issue/FDE-34)

## What & why

QA on the merged change surfaced that an **AWS access key id was still being flagged as a leaked secret**, and its co-located secret/token had two display problems. An access key id (`AKIA…`/`ASIA…`) is an *identifier*, not a secret — AWS logs it in CloudTrail — so it shouldn't surface as a finding at all. This makes it a detection **anchor only**, and fixes how the actual secrets are reported.

## Changes (all in the gitleaks scanner)

1. **Id is an anchor, not a finding.** `SkipReport` the built-in `aws-access-token` rule: it still satisfies the composite `aws-secret-access-key` rule's `RequiredRules` proximity anchor, but no longer produces its own finding. A lone access key id (no secret nearby) is no longer flagged.
2. **Report the value, not the label.** Findings now report the rule's `SecretGroup` value (and narrow the span to it) instead of the full regex match. Label-anchored rules (`generic-api-key`, `aws-session-token`, …) match `"Label": "value"`; reporting the whole match meant masking/redaction covered the non-sensitive field name too. The invariant `Match == content[StartPos:EndPos]` is preserved.
3. **Deterministic rule attribution.** When the generic catch-all and a specific rule match the same value (now the same span, post-#2), rank the generic one last so position-dedup keeps the specific rule (e.g. `aws_secret_access_key` over `generic_api_key`) — instead of relying on Go map-iteration order.

## Result

For an STS credentials payload the reviewer now sees: the access key id as **plain text** (not flagged), the secret access key and session token **values** flagged and masked, and their **JSON labels visible**.

## Notes

- The composite anchor keeps working with the id suppressed — verified by a positive-control test (a real secret next to the id is detected; a hex hash next to it is rejected by the entropy floor).
- The "show the id if flagged" display carve-out from #4493 (in `redactMatch`) is now dormant defense-in-depth, since the id is suppressed at the source.

## Testing

- `gitleaks`: id not reported (creds block + lone id), composite anchor still fires, value-only match (label excluded from span), specific-outranks-generic ordering, hash rejection with positive control.
- `risk_analysis`: fixtures updated to detectable AWS pairs; combined/graceful-degradation/tool-call-args suites pass.
- `go build ./…`, `go vet`, `mise run lint:server` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop flagging AWS access key IDs as leaked secrets and use them only as detection anchors in `gitleaks`. Findings now report and mask just the secret value, leaving labels visible. Linear: FDE-34.

- **Bug Fixes**
  - In `gitleaks`, suppress reporting of the AWS access key ID (`aws-access-token`) while keeping it as the proximity anchor; lone IDs are not flagged.
  - Narrow finding spans to the rule’s `SecretGroup` value using the last occurrence in the match, so masking covers only the secret and preserves field names (e.g., `generic-api-key`, `aws-session-token`).

<sup>Written for commit 685b08494281e35687719cea59ebead7f504855d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

