### PR TITLE
perf(hooks): collect Claude MCP inventory off the session-start path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/samber/slog-multi v1.8.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
-	github.com/speakeasy-api/agenthooks v0.2.1
+	github.com/speakeasy-api/agenthooks v0.2.2-0.20260723135916-2231cc6dc2e4
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/sorairolake/lzip-go v0.3.5 h1:ms5Xri9o1JBIWvOFAorYtUNik6HI3HgBTkISiqu
 github.com/sorairolake/lzip-go v0.3.5/go.mod h1:N0KYq5iWrMXI0ZEXKXaS9hCyOjZUQdBDEIbXfoUwbdk=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/speakeasy-api/agenthooks v0.2.1 h1:wo1APW8W5y/M6SzfDv5c2ckGAmA+LclH3txzBEACG3w=
-github.com/speakeasy-api/agenthooks v0.2.1/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
+github.com/speakeasy-api/agenthooks v0.2.2-0.20260723135916-2231cc6dc2e4 h1:b1SZF5YC40IoLTMbql9goP/0zqk1p836yXDRsc8YThM=
+github.com/speakeasy-api/agenthooks v0.2.2-0.20260723135916-2231cc6dc2e4/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/speakeasy-api/openapi v1.24.0 h1:opoD27rupX7zBVPq1HkIGLeMOzNNA7JalhYP8q34i04=

--- a/hooks/cmd/speakeasy-hooks/main.go
+++ b/hooks/cmd/speakeasy-hooks/main.go
@@ -49,6 +49,10 @@ func main() {
 			os.Exit(relay.RunDrain(context.Background(), os.Stdout))
 		case "upload-skill":
 			os.Exit(relay.RunSkillUpload(context.Background(), os.Args[2:], os.Stdin))
+		case "mcp-inventory":
+			// Detached collector spawned by the SessionStart/ConfigChange hook.
+			// Runs `claude mcp list` off the hook's path and relays the result.
+			os.Exit(relay.RunMCPInventoryCmd(context.Background(), os.Args[2:]))
 		}
 	}
 

--- a/hooks/relay/mcp_inventory.go
+++ b/hooks/relay/mcp_inventory.go
@@ -15,8 +15,6 @@ import (
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
 
-const claudeMCPInventoryTimeout = 15 * time.Second
-
 // newMCPInventoryCommand builds the detached collector invocation. Deployment
 // identity is forwarded via the same flags main.go accepts so the child
 // re-resolves the full config (including the config-file org key) itself,
@@ -82,15 +80,26 @@ func RunMCPInventoryCmd(ctx context.Context, args []string) int {
 	return RunMCPInventory(ctx, cfg, *cwd, *sessionID)
 }
 
-// RunMCPInventory collects the Claude MCP inventory and relays it as its own
-// fire-and-forget session.updated event. It is always non-blocking from the
-// hook's perspective because it runs in the detached child. Returns 0 even when
-// nothing is sent: an absent CLI, an empty list, or a missing credential are
-// all normal and must not surface as a failure.
+// RunMCPInventory warms the shared agenthooks MCP inventory cache and relays
+// the same list to the server as its own fire-and-forget session.updated event.
+// The single `claude mcp list` run serves both purposes: it primes the cache
+// that per-tool-call URL attribution reads (so the first MCP tool call never
+// stalls) and produces the full inventory for admin visibility. Always
+// non-blocking from the hook's perspective because it runs in the detached
+// child. Returns 0 even when nothing is sent: an absent CLI, an empty list, or a
+// missing credential are all normal and must not surface as a failure.
 func RunMCPInventory(ctx context.Context, cfg Config, cwd, sessionID string) int {
-	entries := collectClaudeMCPInventory(ctx, cwd)
-	if len(entries) == 0 {
+	// The CLI fallback only ever adds plugin- and claude.ai-connector servers,
+	// which are user-global rather than project-scoped (project servers come
+	// from config files via the cwd-aware fast path), so the collector needs no
+	// particular working directory.
+	listed := agenthooks.WarmClaudeMCPList()
+	if len(listed) == 0 {
 		return 0
+	}
+	entries := make([]mcpInventoryEntry, 0, len(listed))
+	for _, e := range listed {
+		entries = append(entries, mcpInventoryEntry{Name: e.Name, URL: e.URL, Command: e.Command})
 	}
 	NewRelay(cfg).sendMCPInventory(ctx, sessionID, cwd, entries)
 	return 0
@@ -154,88 +163,6 @@ type mcpInventoryEntry struct {
 	Name    string
 	URL     string
 	Command string
-}
-
-// collectClaudeMCPInventory asks Claude for the effective server list so
-// plugin and claude.ai connector servers, which are absent from config files,
-// are included. Collection is best-effort: hooks must continue when the CLI
-// is unavailable, slow, or returns an unfamiliar format.
-func collectClaudeMCPInventory(ctx context.Context, cwd string) []mcpInventoryEntry {
-	bin, err := exec.LookPath("claude")
-	if err != nil {
-		return nil
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, claudeMCPInventoryTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, bin, "mcp", "list")
-	if cwd != "" {
-		cmd.Dir = cwd
-	}
-	out, err := cmd.Output()
-	if err != nil && len(out) == 0 {
-		return nil
-	}
-	return parseClaudeMCPInventory(string(out))
-}
-
-// parseClaudeMCPInventory parses `<name>: <target> (<transport>) - <status>`.
-// Names may contain colons, so delimiters are consumed from the right.
-func parseClaudeMCPInventory(out string) []mcpInventoryEntry {
-	var entries []mcpInventoryEntry
-	for line := range strings.SplitSeq(out, "\n") {
-		line = strings.TrimSpace(line)
-		statusAt := strings.LastIndex(line, " - ")
-		if line == "" || statusAt < 0 {
-			continue
-		}
-
-		head := strings.TrimSpace(line[:statusAt])
-		if strings.HasSuffix(head, ")") {
-			if open := strings.LastIndex(head, " ("); open > 0 && upperAlpha(head[open+2:len(head)-1]) {
-				head = strings.TrimSpace(head[:open])
-			}
-		}
-		separator := strings.LastIndex(head, ": ")
-		if separator < 0 {
-			continue
-		}
-		name := strings.TrimSpace(head[:separator])
-		target := strings.TrimSpace(head[separator+2:])
-		if name == "" || target == "" {
-			continue
-		}
-		if after, ok := strings.CutPrefix(name, "claude.ai "); ok {
-			name = after
-		} else if after, ok := strings.CutPrefix(name, "plugin:"); ok {
-			if _, display, found := strings.Cut(after, ":"); found {
-				name = display
-			} else {
-				name = after
-			}
-		}
-
-		entry := mcpInventoryEntry{Name: name, URL: "", Command: ""}
-		if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
-			entry.URL = target
-		} else {
-			entry.Command = target
-		}
-		entries = append(entries, entry)
-	}
-	return entries
-}
-
-func upperAlpha(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, r := range s {
-		if r < 'A' || r > 'Z' {
-			return false
-		}
-	}
-	return true
 }
 
 func attachMCPInventory(payload *components.IngestRequestBody, entries []mcpInventoryEntry) {

--- a/hooks/relay/mcp_inventory.go
+++ b/hooks/relay/mcp_inventory.go
@@ -2,15 +2,153 @@ package relay
 
 import (
 	"context"
+	"flag"
+	"fmt"
+	"io"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/speakeasy-api/agenthooks"
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
 
 const claudeMCPInventoryTimeout = 15 * time.Second
+
+// newMCPInventoryCommand builds the detached collector invocation. Deployment
+// identity is forwarded via the same flags main.go accepts so the child
+// re-resolves the full config (including the config-file org key) itself,
+// keeping every credential out of argv. Session id and cwd ride as extra flags
+// SplitInlineFlags leaves untouched.
+var newMCPInventoryCommand = func(cfg Config, cwd, sessionID string) (*exec.Cmd, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve executable: %w", err)
+	}
+	args := []string{"mcp-inventory"}
+	if cfg.ConfigPath != "" {
+		args = append(args, "--config="+cfg.ConfigPath)
+	}
+	if cfg.ServerURL != "" {
+		args = append(args, "--server-url="+cfg.ServerURL)
+	}
+	if cfg.ProjectSlug != "" {
+		args = append(args, "--project="+cfg.ProjectSlug)
+	}
+	if cfg.OrgID != "" {
+		args = append(args, "--org="+cfg.OrgID)
+	}
+	if cwd != "" {
+		args = append(args, "--cwd="+cwd)
+	}
+	if sessionID != "" {
+		args = append(args, "--session-id="+sessionID)
+	}
+	return exec.Command(exe, args...), nil
+}
+
+// spawnMCPInventory launches the detached collector. A package var so tests can
+// intercept it. Detached from the hook's process group (like the drain worker)
+// so a provider that signals the hook on timeout cannot kill the collection
+// mid-run. agenthooks.Main os.Exits as soon as the handler returns, so only
+// process creation happens on the hook's path.
+var spawnMCPInventory = func(cfg Config, cwd, sessionID string) error {
+	cmd, err := newMCPInventoryCommand(cfg, cwd, sessionID)
+	if err != nil {
+		return err
+	}
+	cmd.SysProcAttr = drainSysProcAttr()
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start mcp-inventory: %w", err)
+	}
+	return cmd.Process.Release()
+}
+
+// RunMCPInventoryCmd is the entrypoint for the detached `mcp-inventory`
+// subcommand. It resolves the deployment config exactly as the hook path does,
+// then collects and relays the inventory.
+func RunMCPInventoryCmd(ctx context.Context, args []string) int {
+	flagCfg, rest := SplitInlineFlags(Config{ServerURL: "", ProjectSlug: "", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}, args)
+	cfg := LoadConfig(flagCfg)
+	fs := flag.NewFlagSet("mcp-inventory", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cwd := fs.String("cwd", "", "")
+	sessionID := fs.String("session-id", "", "")
+	if fs.Parse(rest) != nil {
+		return 1
+	}
+	return RunMCPInventory(ctx, cfg, *cwd, *sessionID)
+}
+
+// RunMCPInventory collects the Claude MCP inventory and relays it as its own
+// fire-and-forget session.updated event. It is always non-blocking from the
+// hook's perspective because it runs in the detached child. Returns 0 even when
+// nothing is sent: an absent CLI, an empty list, or a missing credential are
+// all normal and must not surface as a failure.
+func RunMCPInventory(ctx context.Context, cfg Config, cwd, sessionID string) int {
+	entries := collectClaudeMCPInventory(ctx, cwd)
+	if len(entries) == 0 {
+		return 0
+	}
+	NewRelay(cfg).sendMCPInventory(ctx, sessionID, cwd, entries)
+	return 0
+}
+
+// sendMCPInventory relays a collected inventory snapshot. It mirrors deliver's
+// pre-send guards (broken config, insecure URL, no credential) so a detached
+// collector never leaks events an in-line hook would have skipped.
+func (r *Relay) sendMCPInventory(ctx context.Context, sessionID, cwd string, entries []mcpInventoryEntry) {
+	if r.cfg.ConfigError != "" || insecureServerURL(r.cfg.ServerURL) {
+		return
+	}
+	c, ok := resolveAuth(r.cfg)
+	if !ok {
+		return
+	}
+	now := time.Now().UTC()
+	payload := components.IngestRequestBody{
+		SchemaVersion: schemaVersion,
+		Source: components.HookIngestSource{
+			Adapter:        adapterSlug(agenthooks.ProviderClaudeCode),
+			AdapterVersion: nil,
+			RawEventName:   optStr("SessionStart"),
+			Hostname:       optStr(hostname()),
+			UserEmail:      nil,
+		},
+		Session: &components.HookIngestSession{
+			ID:     optStr(sessionID),
+			TurnID: nil,
+			Cwd:    optStr(cwd),
+			Model:  nil,
+		},
+		Event: components.HookIngestEvent{
+			Type:       components.TypeSessionUpdated,
+			OccurredAt: &now,
+		},
+		Data: &components.HookIngestData{
+			Mcp:            nil,
+			McpAttribution: nil,
+			McpInventory:   nil,
+			Message:        nil,
+			Notification:   nil,
+			Prompt:         nil,
+			Skill:          nil,
+			ToolCall:       nil,
+			Usage:          nil,
+		},
+		Raw: nil,
+	}
+	attachMCPInventory(&payload, entries)
+	if isEmptyData(payload.Data) {
+		return
+	}
+	idemKey := newIdempotencyToken()
+	res := r.send(ctx, c, payload, idemKey)
+	r.debugf("mcp-inventory relayed servers=%d status=%d", len(payload.Data.McpInventory), res.statusCode)
+	r.finishExchange(idemKey, payload, res, nil)
+}
 
 type mcpInventoryEntry struct {
 	Name    string

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -650,23 +650,6 @@ func TestClaudeConfigChangeIsRelayed(t *testing.T) {
 	require.Nil(t, fs.last().Data, "the config-change event never carries inventory; the detached collector relays it")
 }
 
-func TestParseClaudeMCPInventory(t *testing.T) {
-	entries := parseClaudeMCPInventory(strings.Join([]string{
-		"Checking MCP server health...",
-		"remote: https://user:password@mcp.example.com/sse?api_key=secret&workspace=acme (SSE) - connected",
-		"plugin:linear:issues: npx -y mcp-remote https://linear.example.com/mcp?token=secret (STDIO) - connected",
-		"claude.ai Notion (Acme): https://mcp.notion.com/mcp (HTTP) - needs authentication",
-	}, "\n"))
-
-	require.Len(t, entries, 3)
-	require.Equal(t, "remote", entries[0].Name)
-	require.Equal(t, "https://user:password@mcp.example.com/sse?api_key=secret&workspace=acme", entries[0].URL)
-	require.Empty(t, entries[0].Command)
-	require.Equal(t, "issues", entries[1].Name)
-	require.Equal(t, "npx -y mcp-remote https://linear.example.com/mcp?token=secret", entries[1].Command)
-	require.Equal(t, "Notion (Acme)", entries[2].Name)
-}
-
 // recordedInventorySpawn captures one detached-collector spawn for assertions.
 type recordedInventorySpawn struct {
 	cwd       string
@@ -720,12 +703,13 @@ func TestMCPInventoryCollectorRelaysRedactedInventory(t *testing.T) {
 		t.Skip("fake claude executable uses a POSIX shell")
 	}
 
+	// WarmClaudeMCPList writes the shared cache under os.TempDir(); isolate it so
+	// the test is hermetic and doesn't inherit a stale global inventory.
+	t.Setenv("TMPDIR", t.TempDir())
 	binDir := t.TempDir()
 	claudePath := filepath.Join(binDir, "claude")
-	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\npwd > \"$FAKE_CLAUDE_CWD_FILE\"\nprintf '%s\\n' \"$FAKE_CLAUDE_MCP_LIST\"\n"), 0o700))
+	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\nprintf '%s\\n' \"$FAKE_CLAUDE_MCP_LIST\"\n"), 0o700))
 	t.Setenv("PATH", binDir)
-	cwdFile := filepath.Join(t.TempDir(), "cwd")
-	t.Setenv("FAKE_CLAUDE_CWD_FILE", cwdFile)
 	t.Setenv("FAKE_CLAUDE_MCP_LIST", strings.Join([]string{
 		"remote: https://user:password@mcp.example.com/sse?api_key=secret&workspace=acme (SSE) - connected",
 		"local: env GITHUB_TOKEN=ghp_secret local-mcp --auth token (STDIO) - connected",
@@ -734,30 +718,29 @@ func TestMCPInventoryCollectorRelaysRedactedInventory(t *testing.T) {
 
 	fs := newFakeServer(t, nil)
 	cfg := authedConfig(t, fs.URL)
-	cwd := t.TempDir()
 
-	require.Equal(t, 0, RunMCPInventory(context.Background(), cfg, cwd, "session-inventory"))
+	require.Equal(t, 0, RunMCPInventory(context.Background(), cfg, t.TempDir(), "session-inventory"))
 
 	require.Equal(t, 1, fs.count())
 	require.Equal(t, components.TypeSessionUpdated, fs.last().Event.Type)
 	require.NotNil(t, fs.last().Data)
-	require.Len(t, fs.last().Data.McpInventory, 2)
-	require.Equal(t, "remote", *fs.last().Data.McpInventory[0].ServerName)
-	require.Equal(t, "https://mcp.example.com/sse?api_key=%2A%2A%2A&workspace=acme", *fs.last().Data.McpInventory[0].URL)
-	require.NotContains(t, *fs.last().Data.McpInventory[0].URL, "password")
-	require.Equal(t, "env GITHUB_TOKEN=*** local-mcp --auth ***", *fs.last().Data.McpInventory[1].Command)
-	invocationCWD, err := os.ReadFile(cwdFile)
-	require.NoError(t, err)
-	require.Equal(t, cwd, strings.TrimSpace(string(invocationCWD)))
+	// The malformed URL is dropped; remote and local survive, redacted.
+	inv := mcpInventoryByServer(fs.last().Data.McpInventory)
+	require.Len(t, inv, 2)
+	require.Equal(t, "https://mcp.example.com/sse?api_key=%2A%2A%2A&workspace=acme", *inv["remote"].URL)
+	require.NotContains(t, *inv["remote"].URL, "password")
+	require.Equal(t, "env GITHUB_TOKEN=*** local-mcp --auth ***", *inv["local"].Command)
 }
 
-// TestMCPInventoryCollectorCollectsFreshInventory proves each collector run
-// re-reads the live server list rather than reusing a stale snapshot.
-func TestMCPInventoryCollectorCollectsFreshInventory(t *testing.T) {
+// TestMCPInventoryCollectorMergesInventoryAcrossRuns proves the collector relays
+// the shared additive inventory: a later run that reports a different server
+// unions with, rather than replaces, the earlier one.
+func TestMCPInventoryCollectorMergesInventoryAcrossRuns(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake claude executable uses a POSIX shell")
 	}
 
+	t.Setenv("TMPDIR", t.TempDir())
 	binDir := t.TempDir()
 	claudePath := filepath.Join(binDir, "claude")
 	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\nprintf '%s\\n' \"$FAKE_CLAUDE_MCP_LIST\"\n"), 0o700))
@@ -774,8 +757,24 @@ func TestMCPInventoryCollectorCollectsFreshInventory(t *testing.T) {
 	require.Equal(t, 0, RunMCPInventory(context.Background(), cfg, cwd, "session-refresh"))
 
 	require.Equal(t, 2, fs.count())
-	require.Equal(t, "https://first.example.com/mcp", *fs.requests[0].Data.McpInventory[0].URL)
-	require.Equal(t, "https://second.example.com/mcp", *fs.requests[1].Data.McpInventory[0].URL)
+	// First upload has only first; the second unions first + second.
+	first := mcpInventoryByServer(fs.requests[0].Data.McpInventory)
+	require.Equal(t, "https://first.example.com/mcp", *first["first"].URL)
+	second := mcpInventoryByServer(fs.requests[1].Data.McpInventory)
+	require.Equal(t, "https://first.example.com/mcp", *second["first"].URL)
+	require.Equal(t, "https://second.example.com/mcp", *second["second"].URL)
+}
+
+// mcpInventoryByServer indexes a relayed inventory by server name so assertions
+// don't depend on the inventory's (sorted) order.
+func mcpInventoryByServer(inv []components.HookMCPData) map[string]components.HookMCPData {
+	out := make(map[string]components.HookMCPData, len(inv))
+	for _, e := range inv {
+		if e.ServerName != nil {
+			out[*e.ServerName] = e
+		}
+	}
+	return out
 }
 
 // TestLoginCommandQuotesUnsafePaths ensures the nudge command survives shell

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -638,6 +638,7 @@ func TestClaudeConfigChangeIsRelayed(t *testing.T) {
 	cfg := authedConfig(t, fs.URL)
 	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "speakeasy-hooks-test-missing-device-agent")
 	t.Setenv("PATH", t.TempDir())
+	stubMCPInventorySpawn(t)
 	payload := []byte(`{"session_id":"session-1","hook_event_name":"ConfigChange","source":"project_settings"}`)
 
 	res := agenthookstest.Invoke(t, NewRunner(cfg), agenthooks.ProviderClaudeCode, payload, "--variant=cli")
@@ -646,7 +647,7 @@ func TestClaudeConfigChangeIsRelayed(t *testing.T) {
 	require.Equal(t, 1, fs.count())
 	require.Equal(t, components.TypeSessionUpdated, fs.last().Event.Type)
 	require.Equal(t, "ConfigChange", *fs.last().Source.RawEventName)
-	require.Nil(t, fs.last().Data, "a missing Claude CLI must fail open without inventory")
+	require.Nil(t, fs.last().Data, "the config-change event never carries inventory; the detached collector relays it")
 }
 
 func TestParseClaudeMCPInventory(t *testing.T) {
@@ -666,7 +667,55 @@ func TestParseClaudeMCPInventory(t *testing.T) {
 	require.Equal(t, "Notion (Acme)", entries[2].Name)
 }
 
-func TestClaudeSessionStartRelaysRedactedMCPInventory(t *testing.T) {
+// recordedInventorySpawn captures one detached-collector spawn for assertions.
+type recordedInventorySpawn struct {
+	cwd       string
+	sessionID string
+}
+
+// stubMCPInventorySpawn replaces the detached collector spawn with a recorder so
+// tests that drive SessionStart/ConfigChange through the runner never fork a
+// real background process (which would re-exec the test binary). It returns a
+// pointer to the slice of recorded spawns.
+func stubMCPInventorySpawn(t *testing.T) *[]recordedInventorySpawn {
+	t.Helper()
+	var got []recordedInventorySpawn
+	orig := spawnMCPInventory
+	spawnMCPInventory = func(_ Config, cwd, sessionID string) error {
+		got = append(got, recordedInventorySpawn{cwd: cwd, sessionID: sessionID})
+		return nil
+	}
+	t.Cleanup(func() { spawnMCPInventory = orig })
+	return &got
+}
+
+// TestClaudeSessionStartSpawnsMCPInventoryCollector proves session start relays
+// immediately and delegates the slow inventory collection to a detached worker
+// instead of blocking on it (DNO-607).
+func TestClaudeSessionStartSpawnsMCPInventoryCollector(t *testing.T) {
+	fs := newFakeServer(t, nil)
+	cfg := authedConfig(t, fs.URL)
+	spawns := stubMCPInventorySpawn(t)
+	cwd := t.TempDir()
+	payload := []byte(`{"session_id":"session-inventory","cwd":"` + cwd + `","hook_event_name":"SessionStart","source":"startup"}`)
+
+	res := agenthookstest.Invoke(t, NewRunner(cfg), agenthooks.ProviderClaudeCode, payload, "--variant=cli")
+
+	require.Equal(t, 0, res.ExitCode)
+	// The session-start event is relayed without the inventory riding on it.
+	require.Equal(t, 1, fs.count())
+	require.Equal(t, components.TypeSessionStarted, fs.last().Event.Type)
+	require.Nil(t, fs.last().Data, "the session-start event never carries inventory; the detached collector relays it")
+	// The collector is spawned once, carrying the session's identity.
+	require.Len(t, *spawns, 1)
+	require.Equal(t, cwd, (*spawns)[0].cwd)
+	require.Equal(t, "session-inventory", (*spawns)[0].sessionID)
+}
+
+// TestMCPInventoryCollectorRelaysRedactedInventory exercises the detached
+// collector entrypoint: it runs `claude mcp list` in the session cwd and relays
+// a redacted inventory snapshot as its own session.updated event.
+func TestMCPInventoryCollectorRelaysRedactedInventory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake claude executable uses a POSIX shell")
 	}
@@ -686,12 +735,11 @@ func TestClaudeSessionStartRelaysRedactedMCPInventory(t *testing.T) {
 	fs := newFakeServer(t, nil)
 	cfg := authedConfig(t, fs.URL)
 	cwd := t.TempDir()
-	payload := []byte(`{"session_id":"session-inventory","cwd":"` + cwd + `","hook_event_name":"SessionStart","source":"startup"}`)
 
-	res := agenthookstest.Invoke(t, NewRunner(cfg), agenthooks.ProviderClaudeCode, payload, "--variant=cli")
+	require.Equal(t, 0, RunMCPInventory(context.Background(), cfg, cwd, "session-inventory"))
 
-	require.Equal(t, 0, res.ExitCode)
 	require.Equal(t, 1, fs.count())
+	require.Equal(t, components.TypeSessionUpdated, fs.last().Event.Type)
 	require.NotNil(t, fs.last().Data)
 	require.Len(t, fs.last().Data.McpInventory, 2)
 	require.Equal(t, "remote", *fs.last().Data.McpInventory[0].ServerName)
@@ -703,7 +751,9 @@ func TestClaudeSessionStartRelaysRedactedMCPInventory(t *testing.T) {
 	require.Equal(t, cwd, strings.TrimSpace(string(invocationCWD)))
 }
 
-func TestClaudeConfigChangeCollectsFreshMCPInventory(t *testing.T) {
+// TestMCPInventoryCollectorCollectsFreshInventory proves each collector run
+// re-reads the live server list rather than reusing a stale snapshot.
+func TestMCPInventoryCollectorCollectsFreshInventory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake claude executable uses a POSIX shell")
 	}
@@ -715,17 +765,13 @@ func TestClaudeConfigChangeCollectsFreshMCPInventory(t *testing.T) {
 
 	fs := newFakeServer(t, nil)
 	cfg := authedConfig(t, fs.URL)
-	runner := NewRunner(cfg)
 	cwd := t.TempDir()
-	payload := []byte(`{"session_id":"session-inventory-refresh","cwd":"` + cwd + `","hook_event_name":"ConfigChange","source":"project_settings"}`)
 
 	t.Setenv("FAKE_CLAUDE_MCP_LIST", "first: https://first.example.com/mcp (HTTP) - connected")
-	first := agenthookstest.Invoke(t, runner, agenthooks.ProviderClaudeCode, payload, "--variant=cli")
-	require.Equal(t, 0, first.ExitCode)
+	require.Equal(t, 0, RunMCPInventory(context.Background(), cfg, cwd, "session-refresh"))
 
 	t.Setenv("FAKE_CLAUDE_MCP_LIST", "second: https://second.example.com/mcp (HTTP) - connected")
-	second := agenthookstest.Invoke(t, runner, agenthooks.ProviderClaudeCode, payload, "--variant=cli")
-	require.Equal(t, 0, second.ExitCode)
+	require.Equal(t, 0, RunMCPInventory(context.Background(), cfg, cwd, "session-refresh"))
 
 	require.Equal(t, 2, fs.count())
 	require.Equal(t, "https://first.example.com/mcp", *fs.requests[0].Data.McpInventory[0].URL)

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -91,6 +91,7 @@ func NewRunner(cfg Config) *agenthooks.Runner {
 		return r.onObserve(ctx, e)
 	})
 	runner.OnOther("ConfigChange", func(ctx context.Context, e *agenthooks.Event) error {
+		r.maybeSpawnMCPInventory(e)
 		return r.onObserve(ctx, e)
 	})
 	// Cursor is the only provider whose rendered config subscribes
@@ -176,10 +177,11 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	}
 	base := agenthooks.EventOf(typed)
 	ctx = withHarnessInfo(ctx, base)
-	if base.Provider == agenthooks.ProviderClaudeCode &&
-		(base.Kind == agenthooks.KindSessionStart || base.NativeName == "ConfigChange") {
-		attachMCPInventory(&payload, collectClaudeMCPInventory(ctx, base.Session.CWD))
-	}
+	// The Claude MCP inventory is collected out of band: `claude mcp list`
+	// probes every configured server and can take 10s+, so blocking session
+	// start on it (DNO-607) added that latency to every session. onSessionStart
+	// and the ConfigChange handler spawn a detached collector instead, which
+	// relays the inventory as its own event when it finishes.
 	if email := resolveUserEmail(ctx, typed); email != "" {
 		payload.Source.UserEmail = new(email)
 	}
@@ -411,8 +413,27 @@ func (r *Relay) onSessionStart(ctx context.Context, e *agenthooks.SessionStartEv
 	if r.cfg.BrowserLogin && strings.TrimSpace(os.Getenv("GRAM_HOOKS_API_KEY")) == "" && !cached {
 		r.login.tryInteractive(ctx)
 	}
+	r.maybeSpawnMCPInventory(agenthooks.EventOf(e))
 	r.deliver(ctx, e)
 	return agenthooks.ContinueSession(), nil
+}
+
+// maybeSpawnMCPInventory launches the detached `claude mcp list` collector for
+// Claude Code session-start and config-change events. Collection is slow enough
+// (it probes every configured MCP server) that keeping it on the hook's path
+// added seconds to every session start; the detached worker relays the
+// inventory out of band instead. Best-effort: a spawn failure just means this
+// session reports no inventory snapshot.
+func (r *Relay) maybeSpawnMCPInventory(base *agenthooks.Event) {
+	if base.Provider != agenthooks.ProviderClaudeCode {
+		return
+	}
+	if base.Kind != agenthooks.KindSessionStart && base.NativeName != "ConfigChange" {
+		return
+	}
+	if err := spawnMCPInventory(r.cfg, base.Session.CWD, base.Session.ID); err != nil {
+		r.debugf("mcp-inventory spawn failed: %v", err)
+	}
 }
 
 func (r *Relay) onObserve(ctx context.Context, typed any) error {


### PR DESCRIPTION
> Depends on speakeasy-api/agenthooks#3 (shared/additive `claude mcp list` cache). This branch bumps agenthooks to that PR's commit; retarget to a released tag before merge.

## Why

Every Claude Code session start (and config change) blocked ~13-15s before the agent could proceed. Instrumenting the hooks binary traced the entire cost to one synchronous subprocess: `claude mcp list`, run to snapshot the MCP inventory. It health-checks every configured MCP server, so cost scales with server count. Measured: `claude mcp list` = **real 13.09s**; `SessionStart` hook = **14039ms in-binary**; every other hook event ~600ms.

**What the inventory is for:** not just admin visibility. It powers the **shadow MCP** feature (approved vs unapproved server) which is a gating concern. For Claude Code the tool-call hook only gives the tool name (`mcp__<server>__<tool>`), not the URL, so server→URL correlation needs the inventory.

## How correlation actually works (and where the fix lands)

The per-tool-call URL attribution already exists in `agenthooks`: its `resolveMCP` fills `tc.MCP.URL` for every MCP tool call (from config files, or from `claude mcp list` for plugin/connector servers), and our envelope already ships that URL. The problem was purely **when** `claude mcp list` runs:

- Our code ran it **synchronously at session start** (this repo) — the 13-15s block.
- `agenthooks` ran it **lazily, per session**, on the first unattributable MCP tool call — moving the stall to that first call, once per session, no cross-session sharing.

So the fix is two coordinated parts:

1. **agenthooks (speakeasy-api/agenthooks#3):** make the `claude mcp list` cache **global + additive** (merge by server name across sessions/processes) instead of per-session, and expose `WarmClaudeMCPList()` to warm it out of band. Now whichever session probed most recently keeps every other session's first tool call instant.
2. **This PR:** stop collecting inventory on the session-start critical path; spawn a detached collector that calls `agenthooks.WarmClaudeMCPList()` — one `claude mcp list` run that both warms the shared cache and returns the full inventory we relay for admin visibility.

## What changed (Before/After)

### Before
```
SessionStart hook
  -> collectClaudeMCPInventory()   // blocks ~13-15s
  -> attach inventory to session.started
  -> send                          // session waits on all of it
first MCP tool call (plugin/connector)
  -> agenthooks runs `claude mcp list` (per-session)   // ~13s stall, once/session
```

### After
```
SessionStart / ConfigChange hook
  -> spawn detached `speakeasy-hooks mcp-inventory`   // ~1ms
  -> send session.started immediately                 // no wait, no inventory attached
detached collector (off the hook's path)
  -> agenthooks.WarmClaudeMCPList()   // one `claude mcp list`: warms shared cache + returns list
  -> relay full (redacted) inventory as its own session.updated event
first MCP tool call
  -> agenthooks resolveMCP reads the ALREADY-WARM shared cache   // instant URL attach, no stall
```

- `deliver` no longer collects inventory inline; `onSessionStart` / `ConfigChange` spawn the detached collector (Claude Code only).
- New `mcp-inventory` subcommand → `RunMCPInventory` → `agenthooks.WarmClaudeMCPList()`, maps entries to the redacted upload, mirrors deliver's pre-send guards (broken config, insecure URL, missing credential). Removed the relay's duplicate `claude mcp list` collect/parse.
- The upload is the shared additive inventory, so a later run unions with earlier ones rather than replacing them (full "servers seen" picture for admin visibility).
- Full inventory upload is **kept** (decision: don't lose that data); it just no longer blocks startup.

## Shadow MCP correlation: no startup gap

Because the shared cache is warmed off-band at session start and read per tool call by `agenthooks`, the first MCP tool call attaches its server URL from the warm cache with no stall, and no dependence on our async upload landing first. On a cache miss (server installed mid-session), `agenthooks` re-probes once (throttled) then fails open.

## Tests

- Session start relays immediately and spawns the collector; the event carries no inventory.
- Collector relays a redacted inventory via the shared cache; a second run unions rather than replaces.
- agenthooks side (in its PR): shared-across-sessions probe, additive merge, stale-miss re-probe, warm-then-resolve.
