### PR TITLE
chore: add CI checks for ClickHouse migration ordering

### DIFF
--- a/.agents/skills/clickhouse/SKILL.md
+++ b/.agents/skills/clickhouse/SKILL.md
@@ -20,10 +20,13 @@ This produces migrations in **two flavors** that must always stay in sync:
 
 **No semicolons in `COMMENT '...'` strings.** golang-migrate splits statements naively, so a semicolon inside a column/table comment breaks its parser and the local migrations fail to replay. Rephrase the comment instead.
 
-Two CI checks guard this on every PR:
+Three CI checks guard this on every PR:
 
 - **atlas-lint** — runs the Atlas migration linter, plus a porcelain check that migrations were generated and are up to date with both the Postgres and ClickHouse schemas. If you edited `schema.sql` without running `mise clickhouse:diff`, this fails.
 - **golang-migrate-clickhouse** — replays all golang-migrate migrations against a real ClickHouse instance to prove they're valid. If the two flavors drifted, this is where it shows up.
+- **migration-order** — fails if a newly added migration in either ClickHouse dir (`server/clickhouse/migrations` or `server/clickhouse/local/golang_migrate`) has a timestamp at or before the latest already on `main`. It also runs in the merge queue, so two PRs branched from the same head cannot both land and produce non-linear history (the INC-418 failure mode).
+
+**Out-of-order timestamps.** If `migration-order` reports a ClickHouse migration timestamp at or before the latest on `main`, do **not** rename the file or hand-edit `atlas.sum`. Delete the offending file in **both** flavor dirs (`server/clickhouse/migrations` and `server/clickhouse/local/golang_migrate`), rebase/merge `main`, then re-run `mise clickhouse:diff <name>`. That regenerates both flavors on top with fresh, ordered timestamps and keeps them in sync. Avoid `atlas migrate rebase`: it renames only one dir (drifting the two flavors apart) and, for golang-migrate, moves an already-applied migration to a higher version so `migrate up` silently skips it on teammates' local databases.
 
 ## ClickHouse Queries (Telemetry Package)
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -771,6 +771,60 @@ jobs:
           CH_URL: clickhouse://127.0.0.1:9000/default?username=gram&password=gram&secure=false&x-multi-statement=true
         run: mise run clickhouse:migrate --engine golang-migrate --url ${CH_URL}
 
+  lint-migrations:
+    name: Lint migrations
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: changes
+    # On pull_request, only run when migration files changed (the `changes` gate).
+    # In the merge queue always run, ignoring `changes`: dorny/paths-filter has no
+    # reliable base on merge_group, so its `migrations` output can't be trusted
+    # there. Merge-queue coverage is the point of this job: two PRs branched from
+    # the same head can each pass ordering individually and still land out of order
+    # once both merge (the INC-418 failure mode), which is only catchable when the
+    # check re-evaluates against the queued head.
+    if: >-
+      (github.event_name == 'pull_request' && needs.changes.outputs.migrations == 'true')
+      || github.event_name == 'merge_group'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          env: false
+
+      # The ordering check needs both the checked-out head and the base commit
+      # present, but not full history, so shallow-fetch just the base rather than
+      # using fetch-depth: 0 (a full clone on this large repo). checkout's `ref`
+      # can't do this: it sets the single HEAD, whereas we need head + base
+      # available together.
+      #
+      # In the merge queue, compare against the exact commit the group was built
+      # on, not live origin/main which may have advanced past it.
+      - name: Resolve and fetch base ref
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            git fetch --depth=1 origin "$MERGE_BASE_SHA"
+            echo "ref=$MERGE_BASE_SHA" >> "$GITHUB_OUTPUT"
+          else
+            git fetch --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+            echo "ref=origin/main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check migration ordering
+        env:
+          BASE_REF: ${{ steps.base.outputs.ref }}
+        run: mise run lint:migrations --git-base "$BASE_REF" --no-atlas
+
   atlas-lint:
     name: Lint migrations with Atlas
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -810,13 +864,6 @@ jobs:
           install: true
           cache: true
           env: false
-
-      - name: Run gram migration static checks
-        shell: bash
-        env:
-          usage_git_base: origin/main
-          usage_no_atlas: "true"
-        run: bash .mise-tasks/lint/migrations.sh
 
       - name: Lint PostgreSQL migrations
         uses: ariga/atlas-action/migrate/lint@v1.15.6
@@ -2023,6 +2070,7 @@ jobs:
       - otel-collector
       - ts-framework-test
       - golang-migrate-clickhouse
+      - lint-migrations
       - atlas-lint
       - atlas-push
       - webhooks-catalog-breaking-changes

--- a/.mise-tasks/lint/migrations.sh
+++ b/.mise-tasks/lint/migrations.sh
@@ -21,111 +21,188 @@ if [ -n "$usage_git_base" ]; then
   base_ref="$usage_git_base"
 fi
 
-files=()
-added_files=()
+# Migration directories whose files must stay in strictly increasing timestamp
+# order relative to the base ref. Each is checked independently:
+#
+#   server/migrations                      Postgres, Atlas format (<ts>_<name>.sql)
+#   server/clickhouse/migrations           ClickHouse, Atlas format (<ts>_<name>.sql)
+#   server/clickhouse/local/golang_migrate ClickHouse, golang-migrate format
+#                                          (<ts>_<name>.up.sql / .down.sql pairs)
+#
+# server/clickhouse/local/backfill holds hand-named data-backfill scripts, not
+# migrations, so it is deliberately absent.
+PG_DIR="server/migrations"
+CH_ATLAS_DIR="server/clickhouse/migrations"
+CH_GOLANG_DIR="server/clickhouse/local/golang_migrate"
 
-if [ -n "$usage_file" ]; then
-  files=("${usage_file[@]}")
-  added_files=("${usage_file[@]}")
-else
+# Print the --file entries that live under a directory, one per line.
+files_under() {
+  local dir="$1" f
+  for f in "${usage_file[@]}"; do
+    case "$f" in
+      "$dir"/*) echo "$f" ;;
+    esac
+  done
+}
+
+# Collect the migration files added under a directory relative to the base ref.
+#
+# --no-renames is essential: git's default rename detection pairs a migration a
+# stale branch adds with a similar main-only migration the branch is missing and
+# reports it as a rename, not an addition, so it silently escapes the ordering
+# check (the exact INC-418 failure mode). Disabling rename detection makes every
+# new migration surface as an addition.
+#
+# Args: <dir> <glob>. Prints one file path per line. Honors --file when given.
+collect_added() {
+  local dir="$1" glob="$2"
+  if [ -n "$usage_file" ]; then
+    files_under "$dir"
+  else
+    git diff --no-renames --relative --diff-filter=A --name-only "$base_ref" -- "$dir/$glob"
+  fi
+}
+
+# Fail if any newly-added migration in a directory has a timestamp at or before
+# the latest timestamp already on the base ref. Sets ORDERING_FAILED=1 rather
+# than exiting so every directory is reported in one run.
+#
+# Args: <dir> <added-glob> <name-filter-regex> <label> <diff-cmd>
+check_ordering() {
+  local dir="$1" glob="$2" filter="$3" label="$4" diff_cmd="$5"
+
+  local added=()
   while IFS= read -r line; do
-    files+=("$line")
-  done < <(git diff --relative --diff-filter=d --name-only "$base_ref" -- 'server/migrations/*.sql')
-  while IFS= read -r line; do
-    added_files+=("$line")
-  done < <(git diff --relative --diff-filter=A --name-only "$base_ref" -- 'server/migrations/*.sql')
-fi
+    [ -n "$line" ] && added+=("$line")
+  done < <(collect_added "$dir" "$glob")
 
-if [ ${#files[@]} -eq 0 ]; then
-  echo "No migrations were modified, skipping linting"
-  exit 0
-fi
+  if [ ${#added[@]} -eq 0 ]; then
+    echo "No newly added $label migrations, skipping ordering check"
+    return 0
+  fi
 
-printf "Changed files:\n%s\n" "${files[@]}"
+  local latest_base_name latest_base_ts
+  latest_base_name=$(git ls-tree --name-only "$base_ref" -- "$dir/" | grep "$filter" | sort | tail -n 1)
+  latest_base_ts="${latest_base_name##*/}"
+  latest_base_ts="${latest_base_ts%%_*}"
 
-# Check for concurrent index creation statements without -- atlas:txmode none
-invalid_indexes=false
-echo -e "\n🔎 Checking for concurrent index creation statements without -- atlas:txmode none..."
-for file in "${files[@]}"; do
-  if grep -i -q "CREATE INDEX CONCURRENTLY" "$file" || grep -i -q "CREATE UNIQUE INDEX CONCURRENTLY" "$file"; then
-    # Check if the first line contains --atlas:txmode none
-    first_line=$(head -n 1 "$file")
-    if [ "$first_line" != "-- atlas:txmode none" ]; then
-      invalid_indexes=true
-      echo "❌ $file"
-      gh_error "$file" "Migration uses CREATE [UNIQUE] INDEX CONCURRENTLY but does not have '-- atlas:txmode none' as the first line."
+  local bad=() file base_name ts
+  for file in "${added[@]}"; do
+    base_name="${file##*/}"
+    ts="${base_name%%_*}"
+    if [ -n "$latest_base_ts" ] && { [ "$ts" \< "$latest_base_ts" ] || [ "$ts" = "$latest_base_ts" ]; }; then
+      bad+=("$file")
+      echo "❌ $file (timestamp $ts <= latest on $base_ref: $latest_base_ts)"
+      gh_error "$file" "Migration $base_name has timestamp $ts <= latest on $base_ref ($latest_base_ts). Do NOT rename the file or hand-edit atlas.sum. Delete this file, rebase $base_ref, then re-run '$diff_cmd <name>' so it is regenerated on top with a fresh timestamp."
     else
       echo "✅ $file"
     fi
-  fi
-done
+  done
 
-if [ "$invalid_indexes" = true ]; then
+  if [ ${#bad[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  ORDERING_FAILED=1
   echo "
+🚨 The following $label migration(s) were added out of order (timestamp <= $latest_base_ts on $base_ref):
+🚨"
+  for file in "${bad[@]}"; do
+    echo "🚨   - $file"
+  done
+  echo "🚨
+🚨 Do NOT rename the file(s) or hand-edit atlas.sum. Migration files and
+🚨 atlas.sum must only be produced by the Atlas CLI.
+🚨
+🚨 To fix:
+🚨   1. Delete the out-of-order file(s) listed above on this branch."
+  if [ "$dir" = "$CH_ATLAS_DIR" ] || [ "$dir" = "$CH_GOLANG_DIR" ]; then
+    echo "🚨      For ClickHouse, delete the matching file in BOTH flavor dirs
+🚨      ($CH_ATLAS_DIR and $CH_GOLANG_DIR)."
+  fi
+  echo "🚨   2. Rebase or merge $base_ref into your branch.
+🚨   3. Re-run '$diff_cmd <name>' so the migration is regenerated on top
+🚨      with a fresh timestamp."
+  if [ "$dir" = "$CH_ATLAS_DIR" ] || [ "$dir" = "$CH_GOLANG_DIR" ]; then
+    echo "🚨      'mise clickhouse:diff' regenerates both ClickHouse flavors together,
+🚨      keeping the Atlas and golang-migrate dirs in sync."
+  fi
+  echo ""
+}
+
+# Postgres files modified in this change, used by the concurrent-index check and
+# to gate the local 'atlas migrate lint' step.
+collect_pg_modified() {
+  if [ -n "$usage_file" ]; then
+    files_under "$PG_DIR"
+  else
+    git diff --no-renames --relative --diff-filter=d --name-only "$base_ref" -- "$PG_DIR/*.sql"
+  fi
+}
+
+pg_files=()
+while IFS= read -r line; do
+  [ -n "$line" ] && pg_files+=("$line")
+done < <(collect_pg_modified)
+
+# Check for concurrent index creation statements without -- atlas:txmode none.
+# Postgres-only: ClickHouse has no CREATE INDEX CONCURRENTLY.
+if [ ${#pg_files[@]} -gt 0 ]; then
+  invalid_indexes=false
+  echo -e "\n🔎 Checking for concurrent index creation statements without -- atlas:txmode none..."
+  for file in "${pg_files[@]}"; do
+    if grep -i -q "CREATE INDEX CONCURRENTLY" "$file" || grep -i -q "CREATE UNIQUE INDEX CONCURRENTLY" "$file"; then
+      # Check if the first line contains --atlas:txmode none
+      first_line=$(head -n 1 "$file")
+      if [ "$first_line" != "-- atlas:txmode none" ]; then
+        invalid_indexes=true
+        echo "❌ $file"
+        gh_error "$file" "Migration uses CREATE [UNIQUE] INDEX CONCURRENTLY but does not have '-- atlas:txmode none' as the first line."
+      else
+        echo "✅ $file"
+      fi
+    fi
+  done
+
+  if [ "$invalid_indexes" = true ]; then
+    echo "
 🚨 Migration files contain CREATE [UNIQUE] INDEX CONCURRENTLY statements but do
 🚨 not have -- atlas:txmode none as the first line.
 🚨
 🚨 If you are creating migrations to add/remove indexes then ensure these are
 🚨 are isolated to their own files and disable transaction mode.
 "
+    exit 1
+  fi
+fi
+
+# Ordering only applies to newly-added migrations: edits and renames don't move a
+# file's timestamp, so they can't make the migration sequence out of order.
+echo -e "\n🔎 Checking for out-of-order migrations..."
+ORDERING_FAILED=0
+check_ordering "$PG_DIR" '*.sql' '\.sql$' "Postgres" "mise db:diff"
+check_ordering "$CH_ATLAS_DIR" '*.sql' '\.sql$' "ClickHouse (Atlas)" "mise clickhouse:diff"
+check_ordering "$CH_GOLANG_DIR" '*.up.sql' '\.up\.sql$' "ClickHouse (golang-migrate)" "mise clickhouse:diff"
+
+if [ "$ORDERING_FAILED" -eq 1 ]; then
   exit 1
 fi
 
-# Ordering only applies to newly-added migrations: edits and renames don't
-# move a file's timestamp, so they can't make the migration sequence out of order.
-echo -e "\n🔎 Checking for out-of-order migrations..."
-
-if [ ${#added_files[@]} -eq 0 ]; then
-  echo "No newly added migrations, skipping ordering check"
-else
-  latest_base_name=$(git ls-tree --name-only "$base_ref" -- server/migrations/ | grep '\.sql$' | sort | tail -n 1)
-  latest_base_ts="${latest_base_name##*/}"
-  latest_base_ts="${latest_base_ts%%_*}"
-
-  bad_files=()
-  for file in "${added_files[@]}"; do
-    base_name="${file##*/}"
-    ts="${base_name%%_*}"
-    if [ -n "$latest_base_ts" ] && { [ "$ts" \< "$latest_base_ts" ] || [ "$ts" = "$latest_base_ts" ]; }; then
-      bad_files+=("$file")
-      echo "❌ $file (timestamp $ts <= latest on $base_ref: $latest_base_ts)"
-      gh_error "$file" "Migration $base_name has timestamp $ts <= latest on $base_ref ($latest_base_ts). Do NOT rename or hand-edit atlas.sum. Delete this file, rebase $base_ref, then re-run 'mise db:diff <name>' so it is regenerated on top."
-    fi
-  done
-
-  if [ ${#bad_files[@]} -gt 0 ]; then
-    echo "
-🚨 The following migration(s) were added out of order (timestamp <= $latest_base_ts on $base_ref):
-🚨"
-    for f in "${bad_files[@]}"; do
-      echo "🚨   - $f"
-    done
-    echo "🚨
-🚨 Do NOT rename the file(s) or hand-edit atlas.sum. Migration files
-🚨 and atlas.sum must only be produced by the Atlas CLI.
-🚨
-🚨 To fix:
-🚨   1. Delete the file(s) listed above on this branch:
-🚨"
-    for f in "${bad_files[@]}"; do
-      echo "🚨        rm $f"
-    done
-    echo "🚨   2. Rebase or merge $base_ref into your branch.
-🚨   3. Re-run the migration diff (e.g. 'mise db:diff <name>') so the
-🚨      migration is regenerated on top with a fresh timestamp.
-"
-    exit 1
-  fi
-
-  echo "✅ All new migrations are ordered correctly"
-fi
+echo "✅ All new migrations are ordered correctly"
 
 if [ "${usage_no_atlas:-}" = "true" ]; then
   echo -e "\nSkipping 'atlas migrate lint' (--no-atlas)"
   exit 0
 fi
 
-# Run atlas migrate lint
+if [ ${#pg_files[@]} -eq 0 ]; then
+  echo -e "\nNo Postgres migrations were modified, skipping 'atlas migrate lint'"
+  exit 0
+fi
+
+# Run atlas migrate lint (Postgres). ClickHouse Atlas linting requires a
+# docker://clickhouse dev database and is handled by the dedicated atlas-action
+# CI step, so it is intentionally not run here.
 echo -e "\n🔎 Running atlas migrate lint..."
 atlas migrate lint \
   --config "file://server/atlas.hcl" \


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-3051/feat-add-ci-checks-for-clickhouse-migration-ordering

Out-of-order ClickHouse migrations wedged the dev ArgoCD sync during INC-418: two migrations merged with timestamps earlier than an already-applied head, which Atlas rejected as non-linear history.

The existing ordering lint only covered `server/migrations` (Postgres). Generalize it to all three migration dirs (Postgres, the ClickHouse Atlas dir, and the ClickHouse `golang-migrate` dir), each checked independently against the base ref.

Add a dedicated `lint-migrations` job that also runs in the merge queue, so two PRs branched from the same head cannot each pass individually and still land out of order. In the queue it compares against the queued base commit rather than live `main`.

Fix a latent false negative in the ordering check: git rename detection paired a stale branch's new migration with a similar migration present only on `main` and reported it as a rename, so it escaped the check. Disable rename detection so every added migration is evaluated.

Document the ClickHouse recovery path (delete both flavors, rebase, regenerate with `mise clickhouse:diff`) in the `clickhouse` skill.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI checks to enforce ClickHouse migration ordering and prevent non-linear histories, addressing Linear AGE-3051. The ordering lint now covers Postgres and both ClickHouse migration flavors and runs in the merge queue to catch cross-PR conflicts.

- **New Features**
  - Added `lint-migrations` CI job that checks timestamp ordering in `server/migrations`, `server/clickhouse/migrations`, and `server/clickhouse/local/golang_migrate`. On PRs it compares to `origin/main`; in the merge queue it compares to the queued `base_sha`.
  - Updated `.mise-tasks/lint/migrations.sh` to validate each directory independently and to fail on out-of-order additions with clear guidance. Also keeps the Postgres concurrent index `-- atlas:txmode none` check.
  - Disabled Git rename detection in ordering checks to avoid false negatives.
  - Documented the new `migration-order` check and ClickHouse recovery steps (delete both flavors, rebase, rerun `mise clickhouse:diff`) in `clickhouse` skill docs.

<sup>Written for commit 450e7c436d79a10817acf6af5948669f4693645b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

