### PR TITLE
feat(remotesessions): make the platform issuer tier consumable by tenants

### DIFF
--- a/.changeset/ais-332-platform-issuer-inheritance.md
+++ b/.changeset/ais-332-platform-issuer-inheritance.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Let tenants inherit and attach clients to platform (global) remote identity providers while the issuers themselves stay read-only, and keep tenant clients on a platform issuer fully manageable through the organization-admin surface. The dashboard renders the new `Platform` tier and resolves issuers by `project > organization > platform` precedence.

--- a/client/dashboard/src/lib/sources.ts
+++ b/client/dashboard/src/lib/sources.ts
@@ -82,6 +82,56 @@ export function formatRemoteSessionIssuerDisplay(issuer: {
   return formatRemoteMcpDisplay({ name: issuer.name, url: issuer.issuer });
 }
 
+// A remote identity provider or session client belongs to one of three tenancy
+// tiers, derived from which owning ids it carries. The API serializes an absent
+// owner as an empty string, so a falsy check is the tier test.
+//
+// - project: owned by a single project (projectId set).
+// - organization: shared across the org's projects (projectId empty,
+//   organizationId set).
+// - platform: the shared catalog curated by platform admins (both empty). Tenants
+//   inherit these read-only and may attach their own clients, but cannot edit,
+//   move, or delete them.
+export type RemoteSessionScopeTier = "project" | "organization" | "platform";
+
+export function remoteSessionScopeTier(entity: {
+  projectId?: string | null;
+  organizationId?: string | null;
+}): RemoteSessionScopeTier {
+  if (entity.projectId) return "project";
+  if (entity.organizationId) return "organization";
+  return "platform";
+}
+
+const REMOTE_SESSION_TIER_RANK: Record<RemoteSessionScopeTier, number> = {
+  project: 0,
+  organization: 1,
+  platform: 2,
+};
+
+// resolveRemoteSessionIssuerByTierPrecedence picks the single entity a tenant
+// should resolve to when several tiers expose a matching candidate (same slug or
+// same upstream URL). Slugs are unique per project and, separately, across the
+// platform catalog, but the organization tier has no slug uniqueness constraint,
+// and any tier may point at the same URL, so callers must not rely on list order
+// (which is by creation time and says nothing about tier). Returns the
+// highest-priority candidate — project > organization > platform — or undefined
+// when the list is empty.
+export function resolveRemoteSessionIssuerByTierPrecedence<
+  T extends { projectId?: string | null; organizationId?: string | null },
+>(candidates: T[]): T | undefined {
+  let best: T | undefined;
+  let bestRank = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const rank = REMOTE_SESSION_TIER_RANK[remoteSessionScopeTier(candidate)];
+    if (rank < bestRank) {
+      best = candidate;
+      bestRank = rank;
+    }
+  }
+  return best;
+}
+
 // Derive a default display name from an Issuer URL's hostname. Unlike the slug
 // transform this keeps the hostname human-readable: dots are preserved rather
 // than hyphenated. (URL parsing lowercases the host either way.) Returns null

--- a/client/dashboard/src/pages/mcp/wire-user-session-issuer/WireUserSessionIssuerModal.tsx
+++ b/client/dashboard/src/pages/mcp/wire-user-session-issuer/WireUserSessionIssuerModal.tsx
@@ -12,6 +12,7 @@ import { useIsPlatformAdmin } from "@/contexts/Auth";
 import { useFetcher } from "@/contexts/Fetcher";
 import { useSdkClient } from "@/contexts/Sdk";
 import { remoteLoginCallbackURL } from "@/lib/externalMcpUserSessions";
+import { resolveRemoteSessionIssuerByTierPrecedence } from "@/lib/sources";
 import { Toolset } from "@/lib/toolTypes";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
 import {
@@ -190,9 +191,15 @@ function WireUserSessionIssuerBody({
       (issuer) => issuer.slug === defaults.userSessionIssuerSlug,
     ) ?? null;
 
+  // A slug can now appear across more than one tier (a project issuer, an
+  // inherited org issuer, and a platform issuer may all share it), so resolve by
+  // tier precedence — project > organization > platform — rather than taking the
+  // first list match, which is ordered by creation time and tier-blind.
   const existingRemoteSessionIssuer =
-    remoteIssuers.data?.result.items?.find(
-      (issuer) => issuer.slug === defaults.remoteSessionIssuerSlug,
+    resolveRemoteSessionIssuerByTierPrecedence(
+      remoteIssuers.data?.result.items?.filter(
+        (issuer) => issuer.slug === defaults.remoteSessionIssuerSlug,
+      ) ?? [],
     ) ?? null;
 
   const existingRemoteSessionClient =

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -88,9 +88,11 @@ export function AuthenticationSectionBody({
     enabled: issuerConfigured,
   });
 
-  // listRemoteSessionIssuers returns both this project's issuers and inherited
-  // organization-level ones (project_id IS NULL, same org), so the selectable
-  // list spans organizational and project-scoped providers.
+  // listRemoteSessionIssuers returns this project's own issuers, inherited
+  // organization-level ones (same org), and inherited platform issuers from the
+  // shared catalog, so the selectable list spans all three tiers. A client can
+  // be attached to any of them; only project-owned issuer metadata is editable
+  // here.
   const { data: issuersResult, isLoading: isLoadingIssuers } =
     useRemoteSessionIssuers();
   const allIssuers = useMemo(

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/RemoteIdentityProvidersField.tsx
@@ -2,7 +2,11 @@ import { AssetImage } from "@/components/asset-image";
 import { RequireScope } from "@/components/require-scope";
 import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Type } from "@/components/ui/type";
-import { formatRemoteSessionIssuerDisplay } from "@/lib/sources";
+import {
+  formatRemoteSessionIssuerDisplay,
+  remoteSessionScopeTier,
+} from "@/lib/sources";
+import { ScopeBadge } from "@/pages/remote-identity-providers/ScopeBadge";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
 import { Button } from "@speakeasy-api/moonshine";
 import { Plus, Trash2 } from "lucide-react";
@@ -82,6 +86,13 @@ function RemoteIdentityProviderRow({
   onEdit: () => void;
   onDelete: () => void;
 }) {
+  // Editing rewrites the issuer's own metadata, which only the owning tenant can
+  // do. Organization-level and platform issuers are managed on their own admin
+  // surfaces (and the project-scoped update endpoint rejects them), so offer Edit
+  // only for a project-owned issuer. Delete stays available for every tier: it
+  // detaches the tenant's own client, never the shared issuer.
+  const canEdit = remoteSessionScopeTier(issuer) === "project";
+
   return (
     <div className="rounded-md border p-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -92,18 +103,26 @@ function RemoteIdentityProviderRow({
           />
         ) : null}
         <div className="min-w-0 flex-1">
-          <Type small className="truncate font-medium">
-            {formatRemoteSessionIssuerDisplay(issuer)}
-          </Type>
+          <div className="flex items-center gap-2">
+            <Type small className="truncate font-medium">
+              {formatRemoteSessionIssuerDisplay(issuer)}
+            </Type>
+            <ScopeBadge
+              projectId={issuer.projectId}
+              organizationId={issuer.organizationId}
+            />
+          </div>
           <Type muted mono variant="small" className="break-all">
             {issuer.issuer}
           </Type>
         </div>
         <RequireScope scope="mcp:write" level="component">
           <div className="flex shrink-0 items-center gap-2">
-            <Button size="md" variant="secondary" onClick={onEdit}>
-              <Button.Text>Edit</Button.Text>
-            </Button>
+            {canEdit && (
+              <Button size="md" variant="secondary" onClick={onEdit}>
+                <Button.Text>Edit</Button.Text>
+              </Button>
+            )}
             <Button
               size="md"
               variant="destructive-secondary"

--- a/client/dashboard/src/pages/remote-identity-providers/RemoteIdentityProviderDetail.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/RemoteIdentityProviderDetail.tsx
@@ -9,6 +9,7 @@ import {
   TabsList,
 } from "@/components/ui/tabs";
 import { Type } from "@/components/ui/type";
+import { remoteSessionScopeTier } from "@/lib/sources";
 import { useOrgRoutes } from "@/routes";
 import { useOrganizationRemoteSessionIssuer } from "@gram/client/react-query/organizationRemoteSessionIssuer.js";
 import { Link, Navigate, useLocation, useParams } from "react-router";
@@ -37,6 +38,11 @@ export default function RemoteIdentityProviderDetail(): JSX.Element {
 
   const label = issuer ? issuerDisplayName(issuer) : "Remote Identity Provider";
 
+  // Platform issuers are read-only to tenants. The Settings tab holds the only
+  // issuer mutation controls (edit + delete), both refused by the backend, so it
+  // is hidden for a platform issuer; client management on the Clients tab stays.
+  const isPlatform = !!issuer && remoteSessionScopeTier(issuer) === "platform";
+
   // The issuer doesn't exist (or failed to load); return to the listing.
   if (isError || (!isLoading && !issuer)) {
     return <Navigate to={orgRoutes.remoteIdentityProviders.href()} replace />;
@@ -44,6 +50,12 @@ export default function RemoteIdentityProviderDetail(): JSX.Element {
 
   // The bare /:issuerId URL has no tab; canonicalize to the Overview tab.
   if (!activeTab) {
+    return <Navigate to={tabHref("overview")} replace />;
+  }
+
+  // A direct Settings URL on a platform issuer has no editable surface; send it
+  // back to Overview.
+  if (isPlatform && activeTab === "settings") {
     return <Navigate to={tabHref("overview")} replace />;
   }
 
@@ -58,7 +70,12 @@ export default function RemoteIdentityProviderDetail(): JSX.Element {
             <Type small muted>
               Remote Identity Provider
             </Type>
-            {issuer && <ScopeBadge projectScoped={Boolean(issuer.projectId)} />}
+            {issuer && (
+              <ScopeBadge
+                projectId={issuer.projectId}
+                organizationId={issuer.organizationId}
+              />
+            )}
           </div>
           <Heading variant="h1" className="break-all normal-case">
             {label}
@@ -76,9 +93,11 @@ export default function RemoteIdentityProviderDetail(): JSX.Element {
                   <PageTabsTrigger value="clients" asChild>
                     <Link to={tabHref("clients")}>Clients</Link>
                   </PageTabsTrigger>
-                  <PageTabsTrigger value="settings" asChild>
-                    <Link to={tabHref("settings")}>Settings</Link>
-                  </PageTabsTrigger>
+                  {!isPlatform && (
+                    <PageTabsTrigger value="settings" asChild>
+                      <Link to={tabHref("settings")}>Settings</Link>
+                    </PageTabsTrigger>
+                  )}
                 </TabsList>
               </div>
             </div>
@@ -91,10 +110,12 @@ export default function RemoteIdentityProviderDetail(): JSX.Element {
                 {issuer && <ClientsTab issuer={issuer} />}
                 {isLoading && <Type muted>Loading…</Type>}
               </TabsContent>
-              <TabsContent value="settings" className="mt-0">
-                {issuer && <SettingsTab key={issuer.id} issuer={issuer} />}
-                {isLoading && <Type muted>Loading…</Type>}
-              </TabsContent>
+              {!isPlatform && (
+                <TabsContent value="settings" className="mt-0">
+                  {issuer && <SettingsTab key={issuer.id} issuer={issuer} />}
+                  {isLoading && <Type muted>Loading…</Type>}
+                </TabsContent>
+              )}
             </div>
           </Tabs>
         </RequireScope>

--- a/client/dashboard/src/pages/remote-identity-providers/RemoteIdentityProviders.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/RemoteIdentityProviders.tsx
@@ -46,6 +46,7 @@ import { CreateRemoteIdentityProviderSheet } from "./CreateRemoteIdentityProvide
 import { issuerDisplayName } from "./issuerDisplay";
 import { MigrateIssuerDialog } from "./MigrateIssuerDialog";
 import { migrationCandidates } from "./migrationCandidates";
+import { remoteSessionScopeTier } from "@/lib/sources";
 
 export function RemoteIdentityProvidersRoot(): JSX.Element {
   return <Outlet />;
@@ -79,10 +80,20 @@ function RemoteIdentityProvidersOverview() {
 
   const allItems = useMemo(() => data?.result.items ?? [], [data]);
 
-  const { organizational, projectSpecific } = useMemo(
+  // Three tenancy tiers. Platform issuers are inherited from the shared catalog
+  // and are read-only to the tenant, so they render in their own section without
+  // the move/consolidate/delete actions that would 404 against a global row.
+  const { platform, organizational, projectSpecific } = useMemo(
     () => ({
-      organizational: allItems.filter((item) => !item.issuer.projectId),
-      projectSpecific: allItems.filter((item) => !!item.issuer.projectId),
+      platform: allItems.filter(
+        (item) => remoteSessionScopeTier(item.issuer) === "platform",
+      ),
+      organizational: allItems.filter(
+        (item) => remoteSessionScopeTier(item.issuer) === "organization",
+      ),
+      projectSpecific: allItems.filter(
+        (item) => remoteSessionScopeTier(item.issuer) === "project",
+      ),
     }),
     [allItems],
   );
@@ -211,6 +222,35 @@ function RemoteIdentityProvidersOverview() {
         </Page.Section.Body>
       </Page.Section>
 
+      {platform.length > 0 && (
+        <Page.Section>
+          <Page.Section.Title>
+            Platform Remote Identity Providers
+          </Page.Section.Title>
+          <Page.Section.Description className="max-w-2xl">
+            Well-known upstream identity providers curated by platform admins
+            and inherited by every organization. These are read-only here; you
+            can register your own clients against them, but only platform admins
+            can edit, move, or delete them.
+          </Page.Section.Description>
+          <Page.Section.Body>
+            <IssuerTable
+              items={platform}
+              isLoading={isLoading}
+              showProject={false}
+              readOnly
+              emptyMessage="No platform identity providers available."
+              onDelete={setDeleteTarget}
+              onMakeOrganizational={handleMakeOrganizational}
+              onMoveToProject={setMoveTarget}
+              onConsolidate={setMigrateSource}
+              onRefreshMetadata={handleRefreshMetadata}
+              refreshPending={refreshMetadata.isPending}
+            />
+          </Page.Section.Body>
+        </Page.Section>
+      )}
+
       <CreateRemoteIdentityProviderSheet
         open={createOpen}
         onOpenChange={setCreateOpen}
@@ -247,6 +287,7 @@ function IssuerTable({
   items,
   isLoading,
   showProject,
+  readOnly = false,
   emptyMessage,
   onDelete,
   onMakeOrganizational,
@@ -258,6 +299,9 @@ function IssuerTable({
   items: OrganizationRemoteSessionIssuer[];
   isLoading: boolean;
   showProject: boolean;
+  // readOnly drops the actions column for tiers the tenant cannot mutate
+  // (platform issuers): the row still links to the read-only detail view.
+  readOnly?: boolean;
   emptyMessage: string;
   onDelete: (item: OrganizationRemoteSessionIssuer) => void;
   onMakeOrganizational: (item: OrganizationRemoteSessionIssuer) => void;
@@ -268,14 +312,15 @@ function IssuerTable({
 }) {
   const orgRoutes = useOrgRoutes();
 
+  const actionsHeader = readOnly ? [] : [{ label: "" }];
   const headers = showProject
     ? [
         { label: "Provider" },
         { label: "Project" },
         { label: "Clients" },
-        { label: "" },
+        ...actionsHeader,
       ]
-    : [{ label: "Provider" }, { label: "Clients" }, { label: "" }];
+    : [{ label: "Provider" }, { label: "Clients" }, ...actionsHeader];
 
   if (!isLoading && items.length === 0) {
     return (
@@ -325,17 +370,19 @@ function IssuerTable({
               {item.clientCount} {item.clientCount === 1 ? "client" : "clients"}
             </Type>
           </td>
-          <td className="px-3 py-3 text-right">
-            <RowActions
-              item={item}
-              onDelete={() => onDelete(item)}
-              onMakeOrganizational={() => onMakeOrganizational(item)}
-              onMoveToProject={() => onMoveToProject(item)}
-              onConsolidate={() => onConsolidate(item)}
-              onRefreshMetadata={() => onRefreshMetadata(item)}
-              refreshPending={refreshPending}
-            />
-          </td>
+          {!readOnly && (
+            <td className="px-3 py-3 text-right">
+              <RowActions
+                item={item}
+                onDelete={() => onDelete(item)}
+                onMakeOrganizational={() => onMakeOrganizational(item)}
+                onMoveToProject={() => onMoveToProject(item)}
+                onConsolidate={() => onConsolidate(item)}
+                onRefreshMetadata={() => onRefreshMetadata(item)}
+                refreshPending={refreshPending}
+              />
+            </td>
+          )}
         </DotRow>
       ))}
     </DotTable>

--- a/client/dashboard/src/pages/remote-identity-providers/RemoteSessionClientDetail.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/RemoteSessionClientDetail.tsx
@@ -94,7 +94,12 @@ export default function RemoteSessionClientDetail(): JSX.Element {
             <Type small muted>
               Remote Session Client
             </Type>
-            {client && <ScopeBadge projectScoped={Boolean(client.projectId)} />}
+            {client && (
+              <ScopeBadge
+                projectId={client.projectId}
+                organizationId={client.organizationId}
+              />
+            )}
           </div>
           <Heading variant="h1" className="break-all normal-case">
             {label}

--- a/client/dashboard/src/pages/remote-identity-providers/ScopeBadge.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/ScopeBadge.tsx
@@ -1,17 +1,30 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  remoteSessionScopeTier,
+  type RemoteSessionScopeTier,
+} from "@/lib/sources";
 
-// ScopeBadge labels a remote identity provider or session client as
-// organization-wide or scoped to a single project, based on whether it carries
-// an owning project id. Shared by the issuer and client detail headers so the
-// two never drift.
+// ScopeBadge labels a remote identity provider or session client with its
+// tenancy tier — project-specific, organizational, or platform — derived from
+// the owning ids on the entity. Shared by the issuer and client detail headers
+// and the org-admin listing so the three tiers never render inconsistently.
+const TIER_BADGE: Record<
+  RemoteSessionScopeTier,
+  { label: string; variant: "outline" | "secondary" | "default" }
+> = {
+  project: { label: "Project-Specific", variant: "outline" },
+  organization: { label: "Organizational", variant: "secondary" },
+  platform: { label: "Platform", variant: "default" },
+};
+
 export function ScopeBadge({
-  projectScoped,
+  projectId,
+  organizationId,
 }: {
-  projectScoped: boolean;
+  projectId?: string | null;
+  organizationId?: string | null;
 }): JSX.Element {
-  return projectScoped ? (
-    <Badge variant="outline">Project-Specific</Badge>
-  ) : (
-    <Badge variant="secondary">Organizational</Badge>
-  );
+  const { label, variant } =
+    TIER_BADGE[remoteSessionScopeTier({ projectId, organizationId })];
+  return <Badge variant={variant}>{label}</Badge>;
 }

--- a/client/dashboard/src/pages/remote-identity-providers/migrationCandidates.ts
+++ b/client/dashboard/src/pages/remote-identity-providers/migrationCandidates.ts
@@ -1,10 +1,13 @@
 import type { OrganizationRemoteSessionIssuer } from "@gram/client/models/components/organizationremotesessionissuer.js";
+import { remoteSessionScopeTier } from "@/lib/sources";
 
 // migrationCandidates narrows the org's issuers to those a source may be
 // consolidated onto, mirroring the server's scope ladder so the picker never
 // offers a target the mutation would reject:
 //
 //   - never itself
+//   - never a platform issuer: it is shared and read-only to tenants, and
+//     migrateIssuer refuses a global target
 //   - project-specific sources may target their own project or any
 //     organizational issuer
 //   - organizational sources may target only other organizational issuers
@@ -21,6 +24,7 @@ export function migrationCandidates(
 
   return all.filter((candidate) => {
     if (candidate.issuer.id === source.issuer.id) return false;
+    if (remoteSessionScopeTier(candidate.issuer) === "platform") return false;
 
     const candidateProjectId = candidate.issuer.projectId;
     if (!candidateProjectId) return true;

--- a/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.test.ts
+++ b/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.test.ts
@@ -139,6 +139,77 @@ describe("autoConfigureRemoteMcpAuth", () => {
     );
   });
 
+  it("reuses an org issuer over a platform issuer for the same URL", async () => {
+    // Both match the discovered URL and neither is project-scoped; tier
+    // precedence must prefer the organization issuer over the shared platform
+    // one regardless of list order.
+    const platformIssuer = remoteSessionIssuer({
+      id: "platform-issuer",
+      projectId: "",
+      organizationId: "",
+      issuer: "https://idp.example.com/",
+    });
+    const orgIssuer = remoteSessionIssuer({
+      id: "org-issuer",
+      projectId: "",
+      organizationId: "org-1",
+      issuer: "https://idp.example.com",
+    });
+    const client = mockClient({
+      issuers: [platformIssuer, orgIssuer],
+    });
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result.status).toBe("configured");
+    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
+    expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
+      {
+        createRemoteSessionClientForm: expect.objectContaining({
+          remoteSessionIssuerId: "org-issuer",
+        }),
+      },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("reuses a platform issuer when no tenant issuer matches", async () => {
+    const platformIssuer = remoteSessionIssuer({
+      id: "platform-issuer",
+      projectId: "",
+      organizationId: "",
+      issuer: "https://idp.example.com",
+    });
+    const client = mockClient({
+      issuers: [platformIssuer],
+    });
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result.status).toBe("configured");
+    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
+    expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
+      {
+        createRemoteSessionClientForm: expect.objectContaining({
+          remoteSessionIssuerId: "platform-issuer",
+        }),
+      },
+      undefined,
+      undefined,
+    );
+  });
+
   it("does not normalize issuer matches beyond trailing slashes", async () => {
     const client = mockClient({
       issuers: [
@@ -394,7 +465,7 @@ function remoteSessionIssuer(
   return {
     id: overrides.id ?? "issuer-1",
     projectId: overrides.projectId ?? "project-1",
-    organizationId: "org-1",
+    organizationId: overrides.organizationId ?? "org-1",
     slug: "issuer",
     issuer: overrides.issuer ?? "https://idp.example.com",
     authorizationEndpoint:

--- a/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.ts
+++ b/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.ts
@@ -14,7 +14,10 @@ import {
   type AuthedFetch,
   proxyRegisterUpstreamClient,
 } from "@/lib/proxyRegisterUpstreamClient";
-import { deriveRemoteSessionIssuerNameFromUrl } from "@/lib/sources";
+import {
+  deriveRemoteSessionIssuerNameFromUrl,
+  resolveRemoteSessionIssuerByTierPrecedence,
+} from "@/lib/sources";
 import {
   narrowTokenEndpointAuthMethod,
   pickPreferredAuthMethod,
@@ -115,12 +118,7 @@ export async function autoConfigureRemoteMcpAuth({
 
   let existingIssuer: RemoteSessionIssuer | null;
   try {
-    existingIssuer = await findMatchingIssuer(
-      client,
-      mcpServer.projectId,
-      draft.issuer,
-      options,
-    );
+    existingIssuer = await findMatchingIssuer(client, draft.issuer, options);
   } catch (error) {
     console.info("Remote MCP matching issuer lookup failed.", {
       remoteMcpServerId: remoteMcpServer.id,
@@ -297,14 +295,19 @@ async function setMcpServerVisibility(
   );
 }
 
+// findMatchingIssuer resolves the issuer a discovered authorization-server URL
+// should reuse. The listing is project-scoped, so any project-tier match belongs
+// to this project; resolution is by tier precedence — project > organization >
+// platform — never by list order, which is by creation time and would otherwise
+// pick an organization or platform issuer over an equally-valid project one
+// depending on when each was created.
 async function findMatchingIssuer(
   client: Gram,
-  projectId: string,
   discoveredIssuer: string,
   options?: RequestOptions,
 ): Promise<RemoteSessionIssuer | null> {
   const normalized = normalizeIssuerURL(discoveredIssuer);
-  let organizationMatch: RemoteSessionIssuer | null = null;
+  const matches: RemoteSessionIssuer[] = [];
   const pages = await client.remoteSessionIssuers.list(
     { limit: 100 },
     undefined,
@@ -313,15 +316,13 @@ async function findMatchingIssuer(
 
   for await (const page of pages) {
     for (const issuer of page.result.items) {
-      if (normalizeIssuerURL(issuer.issuer) !== normalized) continue;
-      if (issuer.projectId === projectId) return issuer;
-      if (!issuer.projectId && !organizationMatch) {
-        organizationMatch = issuer;
+      if (normalizeIssuerURL(issuer.issuer) === normalized) {
+        matches.push(issuer);
       }
     }
   }
 
-  return organizationMatch;
+  return resolveRemoteSessionIssuerByTierPrecedence(matches) ?? null;
 }
 
 function preferredScopes(

--- a/server/internal/remotesessions/adminhandlers.go
+++ b/server/internal/remotesessions/adminhandlers.go
@@ -336,10 +336,23 @@ func (s *Service) DeleteGlobalIssuer(ctx context.Context, payload *adminrsgen.De
 
 	txRepo := repo.New(dbtx)
 
+	// Take the advisory lock BEFORE the FOR UPDATE row lock below. Tenant client
+	// creation acquires the advisory lock first and then locks the issuer row via
+	// its client insert's FK KEY SHARE. Acquiring the row lock first here would
+	// invert that order and deadlock: this delete would hold the issuer row and
+	// wait for the advisory lock while a concurrent create holds the advisory lock
+	// and waits for the row. Same order on both paths (advisory, then row) avoids
+	// the cycle. The advisory lock also serializes the count-then-delete against
+	// every client writer, tenant and global alike, so a client cannot be inserted
+	// between the count and the delete.
+	if err := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "lock remote session issuer for client binding").LogError(ctx, logger)
+	}
+
 	// Establish the issuer is global before counting clients or deleting, so a
 	// non-global id returns NotFound rather than probing client counts. FOR
-	// UPDATE locks the issuer row so a concurrent CreateGlobalClient can't
-	// insert a client between the count and the delete.
+	// UPDATE also serializes this delete against a concurrent CreateGlobalClient,
+	// which takes the same row lock.
 	if _, err := txRepo.GetGlobalRemoteSessionIssuerByIDForUpdate(ctx, issuerID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "global remote session issuer not found").LogError(ctx, logger)
@@ -347,12 +360,24 @@ func (s *Service) DeleteGlobalIssuer(ctx context.Context, payload *adminrsgen.De
 		return oops.E(oops.CodeUnexpected, err, "get global remote session issuer").LogError(ctx, logger)
 	}
 
+	// Count all clients as the fail-safe (a delete must never strand a live
+	// client), then split out the tenant-held ones. Tenant clients on a platform
+	// issuer are owned by projects and organizations; they never appear in
+	// ListGlobalRemoteSessionClientsByIssuerID, so a bare "delete the clients
+	// first" would point a platform admin at clients they cannot see or remove.
+	// Reporting the two counts distinctly tells them which blockers are theirs
+	// (the global clients) and which belong to tenants.
 	clientCount, err := txRepo.CountRemoteSessionClientsByIssuerID(ctx, issuerID)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "count remote session clients").LogError(ctx, logger)
 	}
 	if clientCount > 0 {
-		return oops.E(oops.CodeConflict, nil, "global remote session issuer has active clients; delete the clients first").LogError(ctx, logger)
+		tenantCount, err := txRepo.CountTenantRemoteSessionClientsByIssuerID(ctx, issuerID)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "count tenant remote session clients").LogError(ctx, logger)
+		}
+		globalCount := clientCount - tenantCount
+		return oops.E(oops.CodeConflict, nil, "global remote session issuer has active clients: %d global, %d tenant-owned; delete the %d global client(s) here, tenant-owned clients must be removed by their owning organizations", globalCount, tenantCount, globalCount).LogError(ctx, logger)
 	}
 
 	deleted, err := txRepo.DeleteGlobalRemoteSessionIssuer(ctx, issuerID)

--- a/server/internal/remotesessions/adminhandlers_test.go
+++ b/server/internal/remotesessions/adminhandlers_test.go
@@ -3,9 +3,11 @@ package remotesessions_test
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	adminrsgen "github.com/speakeasy-api/gram/server/gen/admin_remote_sessions"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
@@ -379,4 +381,42 @@ func TestAdminRemoteSessions_CreateGlobalClient_RejectsNonGlobalIssuer(t *testin
 		Audience:                nil,
 	})
 	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// TestDeleteGlobalIssuer_BlockedByTenantClient proves the platform-admin delete
+// is blocked once a tenant attaches a client, and that the blocking client does
+// not appear in the global client listing — the invisible-blocker the enriched
+// 409 message calls out.
+func TestDeleteGlobalIssuer_BlockedByTenantClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	adminCtx := withAdmin(t, ctx)
+
+	globalIssuer, err := ti.service.CreateGlobalIssuer(adminCtx, createGlobalIssuer(t, "delete-guard-global"))
+	require.NoError(t, err)
+	issuerUUID := uuid.MustParse(globalIssuer.ID)
+
+	// A tenant (the caller's org) attaches a client to the platform issuer.
+	seedOrgLevelRemoteClient(t, ctx, ti.conn, authCtx.ActiveOrganizationID, issuerUUID, "delete-guard-tenant-client")
+
+	// The platform admin sees zero global clients...
+	list, err := ti.service.ListGlobalClients(adminCtx, &adminrsgen.ListGlobalClientsPayload{
+		RemoteSessionIssuerID: globalIssuer.ID,
+		Cursor:                nil,
+		Limit:                 nil,
+		SessionToken:          nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, list.Items, "tenant clients never appear in the global client listing")
+
+	// ...yet the delete is correctly blocked by the tenant-held client.
+	err = ti.service.DeleteGlobalIssuer(adminCtx, &adminrsgen.DeleteGlobalIssuerPayload{
+		ID:           globalIssuer.ID,
+		SessionToken: nil,
+	})
+	requireOopsCode(t, err, oops.CodeConflict)
 }

--- a/server/internal/remotesessions/clienthandlers.go
+++ b/server/internal/remotesessions/clienthandlers.go
@@ -279,12 +279,16 @@ func (s *Service) validateNewClientIssuers(
 		return repo.RemoteSessionIssuer{}, oops.E(oops.CodeUnexpected, err, "lock remote session issuer for client binding").LogError(ctx, logger)
 	}
 
-	// The lookup accepts both the project's own issuers and organization-level
-	// issuers, so a client can't be attached to another tenant's issuer.
+	// The lookup accepts the project's own issuers, organization-level issuers,
+	// and platform issuers from the shared catalog, so a client can't be attached
+	// to another tenant's issuer. The client row created against a platform
+	// issuer is still owned by this project; only the issuer is shared.
 	issuer, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
-		ID:             issuerID,
-		ProjectID:      conv.ToNullUUID(projectID),
-		OrganizationID: conv.ToPGTextEmpty(organizationID),
+		ID:                    issuerID,
+		ProjectID:             conv.ToNullUUID(projectID),
+		OrganizationID:        conv.ToPGTextEmpty(organizationID),
+		IncludeOrganizational: true,
+		IncludeGlobal:         true,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -444,15 +448,18 @@ func (s *Service) CloneClientFromOAuthProxyProvider(ctx context.Context, payload
 	}
 
 	// Confirm the issuer the caller named is reachable from the caller's
-	// project — either an issuer the project owns or an organization-level
-	// issuer inherited from the project's org — so a clone cannot graft a
-	// client onto an unrelated tenant's issuer. The cloned client row is still
-	// owned by the caller's project regardless of the issuer's scope; this
-	// mirrors the reachability gate in CreateRemoteSessionClient.
+	// project — an issuer the project owns, an organization-level issuer
+	// inherited from the project's org, or a platform issuer from the shared
+	// catalog — so a clone cannot graft a client onto an unrelated tenant's
+	// issuer. The cloned client row is still owned by the caller's project
+	// regardless of the issuer's scope; this mirrors the reachability gate in
+	// validateNewClientIssuers, and the two must stay in step.
 	if _, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
-		ID:             issuerID,
-		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
-		OrganizationID: conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
+		ID:                    issuerID,
+		ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		OrganizationID:        conv.ToPGTextEmpty(authCtx.ActiveOrganizationID),
+		IncludeOrganizational: true,
+		IncludeGlobal:         true,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)

--- a/server/internal/remotesessions/clienthandlers_test.go
+++ b/server/internal/remotesessions/clienthandlers_test.go
@@ -1404,3 +1404,28 @@ func TestCreateRemoteSessionClient_DeduplicatesIssuers(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, countRemoteSessionClientUserSessionIssuerBindings(t, ctx, ti.conn, clientUUID, u1))
 }
+
+// TestCreateRemoteSessionClient_AttachesToPlatformIssuer proves a project-level
+// client can be created against a platform issuer. The client stays owned by the
+// project; only the issuer is shared.
+func TestCreateRemoteSessionClient_AttachesToPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "attach-platform-proj")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "attach-platform-usi").String()
+
+	clientID := createRemoteClient(t, ctx, ti, platformID.String(), userIssuerID, "attach-platform-client")
+
+	created, err := repo.New(ti.conn).GetRemoteSessionClientByID(ctx, repo.GetRemoteSessionClientByIDParams{
+		ID:        uuid.MustParse(clientID),
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, platformID, created.RemoteSessionClient.RemoteSessionIssuerID)
+	require.Equal(t, *authCtx.ProjectID, created.RemoteSessionClient.ProjectID.UUID)
+}

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -369,12 +369,16 @@ func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.Up
 	txRepo := repo.New(dbtx)
 
 	// Keep the pre-update lookup strictly project-scoped: organization-level
-	// issuers are edited via the organizationRemoteSessionIssuers service, and
-	// the project-scoped UpdateRemoteSessionIssuer below cannot modify them.
+	// issuers are edited via the organizationRemoteSessionIssuers service,
+	// platform issuers only by platform admins, and the project-scoped
+	// UpdateRemoteSessionIssuer below cannot modify either. Both inherited arms
+	// stay off (IncludeOrganizational and IncludeGlobal false).
 	existing, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
-		ID:             issuerID,
-		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
-		OrganizationID: conv.ToPGTextEmpty(""),
+		ID:                    issuerID,
+		ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeOrganizational: false,
+		IncludeGlobal:         false,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -457,10 +461,12 @@ func (s *Service) ListRemoteSessionIssuers(ctx context.Context, payload *gen.Lis
 	}
 
 	rows, err := repo.New(s.db).ListRemoteSessionIssuersByProjectID(ctx, repo.ListRemoteSessionIssuersByProjectIDParams{
-		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
-		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
-		Cursor:         cursor,
-		LimitValue:     limit,
+		ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeOrganizational: true,
+		IncludeGlobal:         true,
+		Cursor:                cursor,
+		LimitValue:            limit,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list remote session issuers").LogError(ctx, s.logger)
@@ -510,9 +516,11 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 			return nil, err
 		}
 		issuer, err = repo.New(s.db).GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
-			ID:             issuerID,
-			ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
-			OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+			ID:                    issuerID,
+			ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+			OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
+			IncludeOrganizational: true,
+			IncludeGlobal:         true,
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -566,6 +574,38 @@ func (s *Service) DeleteRemoteSessionIssuer(ctx context.Context, payload *gen.De
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	txRepo := repo.New(dbtx)
+
+	// Serialize the count-then-delete below against client creation: every
+	// client writer takes this advisory lock before binding a client to the
+	// issuer. Without it a create commits in the gap and strands a live client
+	// on a deleted issuer, because the soft delete only rewrites deleted_at and
+	// its FOR NO KEY UPDATE row lock does not conflict with the FOR KEY SHARE
+	// the client insert's foreign key takes. Taking the advisory lock before any
+	// row lock also matches the order the create paths use, so neither can
+	// deadlock against the other.
+	if err := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "lock remote session issuer for client binding").LogError(ctx, logger)
+	}
+
+	// Establish the issuer belongs to the caller's project before counting
+	// clients, so a foreign or platform issuer id returns NotFound. Without this
+	// pre-read the unscoped count below runs first: a platform issuer that some
+	// tenant has attached to would return a 409 (a cross-tenant existence oracle),
+	// and one with no clients would fall through to the project-scoped delete,
+	// match nothing, and return a silent success. Both inherited arms stay off: a
+	// tenant must never delete an organization-level or platform issuer here.
+	if _, err := txRepo.GetRemoteSessionIssuerByID(ctx, repo.GetRemoteSessionIssuerByIDParams{
+		ID:                    issuerID,
+		ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeOrganizational: false,
+		IncludeGlobal:         false,
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
+		}
+		return oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
+	}
 
 	clientCount, err := txRepo.CountRemoteSessionClientsByIssuerID(ctx, issuerID)
 	if err != nil {

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -17,6 +18,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 // newIssuerPayload returns a CreateRemoteSessionIssuerPayload with a fresh
@@ -649,6 +652,52 @@ func TestDeleteRemoteSessionIssuer(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeNotFound)
 }
 
+// TestDeleteRemoteSessionIssuer_SerializedAgainstClientBinding proves the
+// delete takes the client-binding advisory lock before its count-then-delete.
+// Nothing else serializes the two: the delete only rewrites deleted_at, so its
+// row lock never conflicts with the one a client insert's foreign key takes,
+// and a create committing between the count and the delete would strand a live
+// client on a deleted issuer. Holding the lock from another transaction (which
+// is what every client writer does) must therefore block the delete until that
+// transaction ends.
+func TestDeleteRemoteSessionIssuer_SerializedAgainstClientBinding(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	created, err := ti.service.CreateRemoteSessionIssuer(ctx, newIssuerPayload("idp-delete-lock"))
+	require.NoError(t, err)
+
+	issuerID, err := uuid.Parse(created.ID)
+	require.NoError(t, err)
+
+	tx := testenv.BeginTx(t, ctx, ti.conn)
+	require.NoError(t, repo.New(tx).LockRemoteSessionIssuerForClientBinding(ctx, issuerID))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ti.service.DeleteRemoteSessionIssuer(ctx, &gen.DeleteRemoteSessionIssuerPayload{
+			ID:               created.ID,
+			SessionToken:     nil,
+			ApikeyToken:      nil,
+			ProjectSlugInput: nil,
+		})
+	}()
+
+	require.Never(t, func() bool { return len(done) > 0 }, 500*time.Millisecond, 25*time.Millisecond,
+		"delete completed while another transaction held the client-binding lock")
+
+	require.NoError(t, tx.Rollback(ctx))
+
+	require.Eventually(t, func() bool { return len(done) > 0 }, 30*time.Second, 25*time.Millisecond,
+		"delete did not complete after the client-binding lock was released")
+	require.NoError(t, <-done)
+}
+
+// TestDeleteRemoteSessionIssuer_NotFound proves deleting an issuer the project
+// does not own returns NotFound. The ownership pre-read makes a missing id and a
+// non-owned id (another tenant's, or a platform issuer) indistinguishable, so
+// the endpoint is no longer an existence oracle. No audit entry is written.
 func TestDeleteRemoteSessionIssuer_NotFound(t *testing.T) {
 	t.Parallel()
 
@@ -663,7 +712,7 @@ func TestDeleteRemoteSessionIssuer_NotFound(t *testing.T) {
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,
 	})
-	require.NoError(t, err, "delete is idempotent: missing issuer returns success")
+	requireOopsCode(t, err, oops.CodeNotFound)
 
 	afterCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRemoteSessionIssuerDelete)
 	require.NoError(t, err)
@@ -1194,4 +1243,140 @@ func TestUpdateRemoteSessionIssuer_RejectsNonHTTPDocumentationURL(t *testing.T) 
 	})
 	require.Error(t, err)
 	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// TestListRemoteSessionIssuers_InheritsPlatformIssuer proves the project-scoped
+// listing surfaces a platform (global) issuer once the caller opts in.
+func TestListRemoteSessionIssuers_InheritsPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "inherit-platform-list")
+
+	result, err := ti.service.ListRemoteSessionIssuers(ctx, &gen.ListRemoteSessionIssuersPayload{
+		Cursor:           nil,
+		Limit:            nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	found := false
+	for _, item := range result.Items {
+		if item.ID == platformID.String() {
+			found = true
+			require.Empty(t, item.ProjectID, "platform issuer carries no project")
+			require.Empty(t, item.OrganizationID, "platform issuer carries no organization")
+		}
+	}
+	require.True(t, found, "platform issuer should be inherited into the project listing")
+}
+
+// TestGetRemoteSessionIssuer_ResolvesPlatformIssuerByID proves a project-scoped
+// get-by-id resolves a platform issuer.
+func TestGetRemoteSessionIssuer_ResolvesPlatformIssuerByID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "inherit-platform-get")
+	idStr := platformID.String()
+
+	fetched, err := ti.service.GetRemoteSessionIssuer(ctx, &gen.GetRemoteSessionIssuerPayload{
+		ID:               &idStr,
+		Slug:             nil,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, idStr, fetched.ID)
+	require.Empty(t, fetched.ProjectID)
+	require.Empty(t, fetched.OrganizationID)
+}
+
+// TestGetRemoteSessionIssuer_BySlugDoesNotResolvePlatform proves slug lookups
+// stay strictly project-scoped: a platform issuer is not slug-addressable from a
+// tenant context, even though it is now resolvable by id.
+func TestGetRemoteSessionIssuer_BySlugDoesNotResolvePlatform(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	seedGlobalRemoteIssuer(t, ctx, ti.conn, "inherit-platform-slug")
+	slug := "inherit-platform-slug"
+
+	_, err := ti.service.GetRemoteSessionIssuer(ctx, &gen.GetRemoteSessionIssuerPayload{
+		ID:               nil,
+		Slug:             &slug,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// TestUpdateRemoteSessionIssuer_CannotMutatePlatformIssuer proves a project
+// admin cannot edit a platform issuer through the project-scoped update.
+func TestUpdateRemoteSessionIssuer_CannotMutatePlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "refuse-proj-update")
+	renamed := "Hijacked"
+
+	_, err := ti.service.UpdateRemoteSessionIssuer(ctx, &gen.UpdateRemoteSessionIssuerPayload{
+		ID:                                platformID.String(),
+		Slug:                              nil,
+		Issuer:                            nil,
+		Name:                              &renamed,
+		LogoAssetID:                       nil,
+		ClientSetupDocumentationURL:       nil,
+		AuthorizationEndpoint:             nil,
+		TokenEndpoint:                     nil,
+		RegistrationEndpoint:              nil,
+		JwksURI:                           nil,
+		ServiceDocumentation:              nil,
+		OpPolicyURI:                       nil,
+		OpTosURI:                          nil,
+		ScopesSupported:                   nil,
+		GrantTypesSupported:               nil,
+		ResponseTypesSupported:            nil,
+		TokenEndpointAuthMethodsSupported: nil,
+		ClientIDMetadataDocumentSupported: nil,
+		Oidc:                              nil,
+		Passthrough:                       nil,
+		SessionToken:                      nil,
+		ApikeyToken:                       nil,
+		ProjectSlugInput:                  nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	requirePlatformIssuerUnchanged(t, ctx, ti.conn, platformID)
+}
+
+// TestDeleteRemoteSessionIssuer_CannotDeletePlatformIssuer proves a project
+// admin deleting a platform issuer gets a clean NotFound and the row survives.
+// Without the ownership pre-read this returned a silent success (the
+// project-scoped delete matched nothing and the handler swallowed ErrNoRows).
+func TestDeleteRemoteSessionIssuer_CannotDeletePlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "refuse-proj-delete")
+
+	err := ti.service.DeleteRemoteSessionIssuer(ctx, &gen.DeleteRemoteSessionIssuerPayload{
+		ID:               platformID.String(),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	requirePlatformIssuerUnchanged(t, ctx, ti.conn, platformID)
 }

--- a/server/internal/remotesessions/organizationclienthandlers.go
+++ b/server/internal/remotesessions/organizationclienthandlers.go
@@ -276,11 +276,26 @@ func (s *Service) CreateClient(ctx context.Context, payload *orgclientsgen.Creat
 
 	txRepo := repo.New(dbtx)
 
+	// Serialize against migrateIssuer and against DeleteGlobalIssuer before
+	// reading the issuer. Without it a concurrent migration could soft-delete
+	// this issuer between the read and the insert, leaving a client bound to a
+	// tombstoned issuer, and a concurrent global-issuer delete could count zero
+	// clients and delete the issuer out from under this insert. The project-level
+	// create paths have always taken this lock; these org-admin paths did not,
+	// which was a pre-existing gap against migrateIssuer independent of platform
+	// issuers. See the full rationale in validateNewClientIssuers.
+	if err := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "lock remote session issuer for client binding").LogError(ctx, logger)
+	}
+
 	// Reject an issuer that isn't in the caller's organization so a client can't
-	// be registered against another tenant's issuer.
+	// be registered against another tenant's issuer. Platform issuers resolve
+	// too: the client row is owned by this organization, only the issuer is
+	// shared.
 	issuer, err := txRepo.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  true,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -345,8 +360,10 @@ func (s *Service) CreateClient(ctx context.Context, payload *orgclientsgen.Creat
 // project_id — an organization-level client every project in the org can attach.
 // For a project-specific issuer a supplied project_id must match the issuer's
 // own project so the client stays reachable from it. An organization-level
-// client can therefore only arise from an organization-level issuer. Must run
-// inside the create transaction. Shared by CreateClient and CreateCimdClient.
+// client therefore arises from an issuer that carries no project of its own:
+// an organization-level issuer, or a platform issuer from the shared catalog
+// (whose project_id is likewise NULL). Must run inside the create transaction.
+// Shared by CreateClient and CreateCimdClient.
 func (s *Service) resolveOrganizationClientProject(ctx context.Context, dbtx pgx.Tx, logger *slog.Logger, issuer repo.RemoteSessionIssuer, payloadProjectID *string, organizationID string) (uuid.NullUUID, error) {
 	clientProjectID := issuer.ProjectID
 	if payloadProjectID != nil && strings.TrimSpace(*payloadProjectID) != "" {
@@ -403,11 +420,20 @@ func (s *Service) CreateCimdClient(ctx context.Context, payload *orgclientsgen.C
 
 	txRepo := repo.New(dbtx)
 
+	// Serialize against migrateIssuer and DeleteGlobalIssuer before reading the
+	// issuer; see the matching lock in CreateClient for the full rationale.
+	if err := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "lock remote session issuer for client binding").LogError(ctx, logger)
+	}
+
 	// Reject an issuer that isn't in the caller's organization so a client can't
-	// be registered against another tenant's issuer.
+	// be registered against another tenant's issuer. Platform issuers resolve
+	// too: the client row is owned by this organization, only the issuer is
+	// shared.
 	issuer, err := txRepo.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  true,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/server/internal/remotesessions/organizationclienthandlers_test.go
+++ b/server/internal/remotesessions/organizationclienthandlers_test.go
@@ -475,3 +475,95 @@ func TestCreateClient_EncryptsSecret(t *testing.T) {
 	require.NotEmpty(t, stored.RemoteSessionClient.ClientSecretEncrypted.String)
 	require.NotEqual(t, secret, stored.RemoteSessionClient.ClientSecretEncrypted.String)
 }
+
+// TestCreateClient_OrgAdminAttachesToPlatformIssuer proves an org-admin
+// standalone client can be created against a platform issuer. With no owning
+// project on the issuer, the client is organization-level (NULL project,
+// organization_id set), attachable by every project in the org.
+func TestCreateClient_OrgAdminAttachesToPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "attach-platform-org")
+
+	created, err := ti.service.CreateClient(ctx, newCreateClientPayload(platformID.String(), nil, nil))
+	require.NoError(t, err)
+	require.Empty(t, created.ProjectID, "client on a platform issuer with no project is organization-level")
+	require.Equal(t, authCtx.ActiveOrganizationID, created.OrganizationID)
+	require.Equal(t, platformID.String(), created.RemoteSessionIssuerID)
+}
+
+// TestOrgAdmin_ManagesTenantClientOnPlatformIssuer proves that once an org-admin
+// client is created on a platform issuer it stays fully manageable through the
+// org-admin surface: listable under the issuer, fetchable, patchable, and
+// deletable. Before the org-reachability rescope these all scoped through the
+// issuer's organization_id, which is NULL for a platform issuer, so the client
+// was write-only state.
+func TestOrgAdmin_ManagesTenantClientOnPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "manage-platform")
+	created, err := ti.service.CreateClient(ctx, newCreateClientPayload(platformID.String(), nil, nil))
+	require.NoError(t, err)
+
+	// Listable under the issuer.
+	list, err := ti.service.ListClients(ctx, &orgclientsgen.ListClientsPayload{
+		IssuerID:     platformID.String(),
+		Cursor:       nil,
+		Limit:        nil,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+	foundInList := false
+	for _, item := range list.Items {
+		if item.Client.ID == created.ID {
+			foundInList = true
+		}
+	}
+	require.True(t, foundInList, "tenant client on a platform issuer should be listable by the org admin")
+
+	// Fetchable.
+	got, err := ti.service.GetClient(ctx, &orgclientsgen.GetClientPayload{
+		ID:           created.ID,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, created.ID, got.ID)
+
+	// Patchable.
+	newMethod := "client_secret_post"
+	updated, err := ti.service.UpdateClient(ctx, &orgclientsgen.UpdateClientPayload{
+		ID:                      created.ID,
+		ClientSecret:            nil,
+		TokenEndpointAuthMethod: &newMethod,
+		Scope:                   nil,
+		Audience:                nil,
+		SessionToken:            nil,
+		ApikeyToken:             nil,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.TokenEndpointAuthMethod)
+	require.Equal(t, newMethod, *updated.TokenEndpointAuthMethod)
+
+	// Deletable.
+	err = ti.service.DeleteClient(ctx, &orgclientsgen.DeleteClientPayload{
+		ID:           created.ID,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.GetClient(ctx, &orgclientsgen.GetClientPayload{
+		ID:           created.ID,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}

--- a/server/internal/remotesessions/organizationissuerhandlers.go
+++ b/server/internal/remotesessions/organizationissuerhandlers.go
@@ -186,6 +186,7 @@ func (s *Service) ListIssuers(ctx context.Context, payload *orgissuersgen.ListIs
 
 	rows, err := repo.New(s.db).ListOrganizationRemoteSessionIssuers(ctx, repo.ListOrganizationRemoteSessionIssuersParams{
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  true,
 		Cursor:         cursor,
 		LimitValue:     limit,
 	})
@@ -233,9 +234,12 @@ func (s *Service) GetIssuer(ctx context.Context, payload *orgissuersgen.GetIssue
 		return nil, err
 	}
 
+	// Read-only, so platform issuers resolve here: the org listing surfaces them
+	// and the detail view has to be able to open one.
 	issuer, err := repo.New(s.db).GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  true,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -268,9 +272,15 @@ func (s *Service) GetIssuerDeletePreflight(ctx context.Context, payload *orgissu
 
 	r := repo.New(s.db)
 
+	// Platform issuers are deliberately excluded. A tenant cannot delete one, so
+	// the preflight is unreachable for them by design — and both queries below
+	// are unscoped by organization, so resolving a platform issuer here would
+	// report other tenants' client counts and MCP server names to this caller.
+	// Keep IncludeGlobal false unless those queries are org-scoped first.
 	if _, err := r.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  false,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
@@ -358,9 +368,14 @@ func (s *Service) UpdateIssuer(ctx context.Context, payload *orgissuersgen.Updat
 
 	txRepo := repo.New(dbtx)
 
+	// A tenant must never edit a platform issuer: it is shared across every
+	// organization and curated by platform admins.
+	// UpdateOrganizationRemoteSessionIssuer below is org-scoped and would refuse
+	// anyway; opting the pre-read out keeps the refusal a clean 404.
 	existing, err := txRepo.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  false,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -497,9 +512,15 @@ func (s *Service) RefreshIssuerMetadata(ctx context.Context, payload *orgissuers
 	// under a ten-second budget and must not hold a pooled connection. The
 	// update re-asserts this row's identity, so a concurrent move or issuer
 	// rename aborts the write rather than letting the gap be exploited.
+	//
+	// IncludeGlobal is false because this persists discovered metadata: a tenant
+	// must never rewrite a platform issuer's endpoints. The row-locked re-read
+	// below is org-scoped and would refuse anyway; opting the pre-read out keeps
+	// the refusal a clean 404.
 	existing, err := repo.New(s.db).GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  false,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -599,12 +620,27 @@ func (s *Service) DeleteIssuer(ctx context.Context, payload *orgissuersgen.Delet
 
 	txRepo := repo.New(dbtx)
 
+	// Serialize the count-then-delete below against client creation: every
+	// client writer takes this advisory lock before binding a client to the
+	// issuer. Without it a create commits in the gap and strands a live client
+	// on a deleted issuer, because the soft delete only rewrites deleted_at and
+	// its FOR NO KEY UPDATE row lock does not conflict with the FOR KEY SHARE
+	// the client insert's foreign key takes. Taking the advisory lock before any
+	// row lock also matches the order the create paths use, so neither can
+	// deadlock against the other.
+	if err := txRepo.LockRemoteSessionIssuerForClientBinding(ctx, issuerID); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "lock remote session issuer for client binding").LogError(ctx, logger)
+	}
+
 	// Establish org ownership of the issuer before counting clients or deleting,
 	// so a cross-org id returns NotFound rather than probing client counts or
-	// silently succeeding against the org-scoped delete below.
+	// silently succeeding against the org-scoped delete below. Platform issuers
+	// are excluded for the same reason: a tenant must never delete one, and
+	// CountRemoteSessionClientsByIssuerID below is unscoped by organization.
 	if _, err := txRepo.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  false,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
@@ -700,9 +736,13 @@ func (s *Service) MoveIssuer(ctx context.Context, payload *orgissuersgen.MoveIss
 
 	txRepo := repo.New(dbtx)
 
+	// A platform issuer has no owning organization to re-scope within, and a
+	// tenant must never move one. SetOrganizationRemoteSessionIssuerProject is
+	// org-scoped and would refuse anyway; opting out keeps it a clean 404.
 	existing, err := txRepo.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 		ID:             issuerID,
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		IncludeGlobal:  false,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -778,6 +818,12 @@ func loadMigrationPair(ctx context.Context, r *repo.Queries, logger *slog.Logger
 		return source, target, oops.E(oops.CodeBadRequest, nil, "source and target issuer must differ").LogError(ctx, logger)
 	}
 
+	// Both arms stay org-scoped: migrating onto a platform issuer is AIS-335, and
+	// it needs more than a widened read here. There is deliberately no
+	// global-inclusive ForUpdate variant — a lock-consistent read across the org
+	// and global partitions is what that work has to design, and quietly widening
+	// the non-locking arm alone would let a migration validate against a scope it
+	// never locked.
 	loadIssuer := func(id uuid.UUID) (repo.RemoteSessionIssuer, error) {
 		if forUpdate {
 			return r.GetOrganizationRemoteSessionIssuerByIDForUpdate(ctx, repo.GetOrganizationRemoteSessionIssuerByIDForUpdateParams{
@@ -788,6 +834,7 @@ func loadMigrationPair(ctx context.Context, r *repo.Queries, logger *slog.Logger
 		return r.GetOrganizationRemoteSessionIssuerByID(ctx, repo.GetOrganizationRemoteSessionIssuerByIDParams{
 			ID:             id,
 			OrganizationID: conv.ToPGText(organizationID),
+			IncludeGlobal:  false,
 		})
 	}
 

--- a/server/internal/remotesessions/organizationissuerhandlers_test.go
+++ b/server/internal/remotesessions/organizationissuerhandlers_test.go
@@ -2,6 +2,7 @@ package remotesessions_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 // TestListIssuers returns both organizational and project-specific issuers
@@ -141,6 +143,43 @@ func TestDeleteIssuer_BlockedByClients(t *testing.T) {
 		ApikeyToken:  nil,
 	})
 	require.NoError(t, err)
+}
+
+// TestDeleteIssuer_SerializedAgainstClientBinding is the organization-tier
+// counterpart to TestDeleteRemoteSessionIssuer_SerializedAgainstClientBinding:
+// the org-admin delete must take the same client-binding advisory lock, so a
+// concurrent client create cannot commit between its client count and its soft
+// delete and strand a live client on a deleted issuer.
+func TestDeleteIssuer_SerializedAgainstClientBinding(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "admin-delissuer-lock", "")
+
+	parsed, err := uuid.Parse(issuerID)
+	require.NoError(t, err)
+
+	tx := testenv.BeginTx(t, ctx, ti.conn)
+	require.NoError(t, repo.New(tx).LockRemoteSessionIssuerForClientBinding(ctx, parsed))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- ti.service.DeleteIssuer(ctx, &orgissuersgen.DeleteIssuerPayload{
+			ID:           issuerID,
+			SessionToken: nil,
+			ApikeyToken:  nil,
+		})
+	}()
+
+	require.Never(t, func() bool { return len(done) > 0 }, 500*time.Millisecond, 25*time.Millisecond,
+		"delete completed while another transaction held the client-binding lock")
+
+	require.NoError(t, tx.Rollback(ctx))
+
+	require.Eventually(t, func() bool { return len(done) > 0 }, 30*time.Second, 25*time.Millisecond,
+		"delete did not complete after the client-binding lock was released")
+	require.NoError(t, <-done)
 }
 
 // TestDeleteIssuer_CrossOrgNotFound proves an issuer owned by another
@@ -495,4 +534,153 @@ func TestMoveIssuer_RBACForbidden(t *testing.T) {
 	})
 	require.Error(t, err)
 	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+// TestGetIssuer_OrgAdminResolvesPlatformIssuer proves the org-admin get-by-id
+// resolves a platform issuer (read-only surfaces opt in).
+func TestGetIssuer_OrgAdminResolvesPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "orgadmin-get-platform")
+
+	fetched, err := ti.service.GetIssuer(ctx, &orgissuersgen.GetIssuerPayload{
+		ID:           platformID.String(),
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, platformID.String(), fetched.ID)
+	require.Empty(t, fetched.OrganizationID)
+}
+
+// TestUpdateIssuer_OrgAdminCannotMutatePlatformIssuer proves an org admin cannot
+// edit a platform issuer through the org-scoped update.
+func TestUpdateIssuer_OrgAdminCannotMutatePlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "refuse-org-update")
+	renamed := "Hijacked"
+
+	_, err := ti.service.UpdateIssuer(ctx, newUpdateIssuerNamePayload(platformID.String(), &renamed))
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	requirePlatformIssuerUnchanged(t, ctx, ti.conn, platformID)
+}
+
+// TestDeleteIssuer_OrgAdminCannotDeletePlatformIssuer proves an org admin cannot
+// delete a platform issuer through the org-scoped delete.
+func TestDeleteIssuer_OrgAdminCannotDeletePlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "refuse-org-delete")
+
+	err := ti.service.DeleteIssuer(ctx, &orgissuersgen.DeleteIssuerPayload{
+		ID:           platformID.String(),
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	requirePlatformIssuerUnchanged(t, ctx, ti.conn, platformID)
+}
+
+// TestMoveIssuer_OrgAdminCannotMovePlatformIssuer proves an org admin cannot
+// re-scope a platform issuer into a project through moveIssuer.
+func TestMoveIssuer_OrgAdminCannotMovePlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "refuse-org-move")
+	pid := authCtx.ProjectID.String()
+
+	_, err := ti.service.MoveIssuer(ctx, &orgissuersgen.MoveIssuerPayload{
+		ID:           platformID.String(),
+		ProjectID:    &pid,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	requirePlatformIssuerUnchanged(t, ctx, ti.conn, platformID)
+}
+
+// TestListIssuers_PlatformIssuerClientCountIsOrgScoped proves the client count
+// reported for a shared platform issuer counts only the caller's own clients,
+// never another organization's clients on the same issuer.
+func TestListIssuers_PlatformIssuerClientCountIsOrgScoped(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "count-platform")
+
+	// One client owned by the caller's org.
+	_, err := ti.service.CreateClient(ctx, newCreateClientPayload(platformID.String(), nil, nil))
+	require.NoError(t, err)
+
+	// Two clients owned by a different org on the same shared issuer.
+	otherOrgID := createOrganization(t, ctx, ti.conn, "count-other-org")
+	seedOrgLevelRemoteClient(t, ctx, ti.conn, otherOrgID, platformID, "count-foreign-1")
+	seedOrgLevelRemoteClient(t, ctx, ti.conn, otherOrgID, platformID, "count-foreign-2")
+
+	result, err := ti.service.ListIssuers(ctx, &orgissuersgen.ListIssuersPayload{
+		Cursor:       nil,
+		Limit:        nil,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+
+	var platform *orgissuersgen.OrganizationRemoteSessionIssuer
+	for _, item := range result.Items {
+		if item.Issuer.ID == platformID.String() {
+			platform = item
+		}
+	}
+	require.NotNil(t, platform, "platform issuer should be inherited into the org listing")
+	require.Equal(t, 1, platform.ClientCount, "count reflects only the caller's own clients, not the other org's")
+}
+
+// TestListIssuers_ClientCountIncludesPreBackfillClients proves the client count
+// for an org-owned issuer counts clients whose organization_id was never
+// backfilled (NULL), matching the org-reachability predicate. The count arm
+// resolves through the issuer's org for org-owned rows, so it does not depend on
+// the client row carrying organization_id.
+func TestListIssuers_ClientCountIncludesPreBackfillClients(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "count-backfill-issuer", "")
+	seedProjectRemoteClientNoOrg(t, ctx, ti.conn, *authCtx.ProjectID, uuid.MustParse(issuerID), "count-backfill-client")
+
+	result, err := ti.service.ListIssuers(ctx, &orgissuersgen.ListIssuersPayload{
+		Cursor:       nil,
+		Limit:        nil,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+
+	var found *orgissuersgen.OrganizationRemoteSessionIssuer
+	for _, item := range result.Items {
+		if item.Issuer.ID == issuerID {
+			found = item
+		}
+	}
+	require.NotNil(t, found, "the project-owned issuer should be listed")
+	require.Equal(t, 1, found.ClientCount, "a client with NULL organization_id must still be counted for its org-owned issuer")
 }

--- a/server/internal/remotesessions/organizationsessionhandlers_test.go
+++ b/server/internal/remotesessions/organizationsessionhandlers_test.go
@@ -118,3 +118,44 @@ func TestRevokeAllClientSessions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, before+1, after)
 }
+
+// TestOrgAdmin_ManagesSessionsOnTenantClientOverPlatformIssuer proves an
+// org-admin can list and revoke the sessions of a tenant client that points at a
+// platform issuer. These session queries also scoped through the issuer's
+// organization_id before the rescope.
+func TestOrgAdmin_ManagesSessionsOnTenantClientOverPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "manage-sessions-platform")
+
+	// An organization-level client on the platform issuer, attached to a project
+	// user_session_issuer so a session can be minted against it.
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "manage-sessions-usi")
+	clientID := seedOrgLevelRemoteClient(t, ctx, ti.conn, authCtx.ActiveOrganizationID, platformID, "manage-sessions-client", userIssuerID)
+
+	seedUser(t, ctx, ti.conn, "manage-sessions-user", "user@example.com", "Session User")
+	subject := urn.NewUserSubject("manage-sessions-user")
+	session := insertRemoteSession(t, ctx, ti.conn, subject, userIssuerID.String(), clientID.String())
+
+	sessions, err := ti.service.ListClientSessions(ctx, &orgsessionsgen.ListClientSessionsPayload{
+		ClientID:     clientID.String(),
+		Cursor:       nil,
+		Limit:        nil,
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, sessions.Items, 1)
+	require.Equal(t, session.ID.String(), sessions.Items[0].ID)
+
+	err = ti.service.RevokeSession(ctx, &orgsessionsgen.RevokeSessionPayload{
+		ID:           session.ID.String(),
+		SessionToken: nil,
+		ApikeyToken:  nil,
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -54,12 +54,21 @@ VALUES (
 RETURNING *;
 
 -- name: GetRemoteSessionIssuerByID :one
--- Project-scoped read that also resolves organization-level issuers belonging
--- to the project's org, so projects inherit cross-project issuers.
+-- Project-scoped read of the project's own issuers, plus each inherited tier the
+-- caller opts in to. Each inherited arm is gated by its own boolean:
+-- include_organizational resolves organization-level issuers belonging to the
+-- project's org (so projects inherit cross-project issuers), and include_global
+-- resolves platform issuers from the shared catalog. Both default off, so a
+-- caller widens only by explicitly asking; organization_id is always passed
+-- (the arm is off when include_organizational is false regardless of its value).
 SELECT *
 FROM remote_session_issuers
 WHERE id = @id
-  AND (project_id = @project_id OR (project_id IS NULL AND organization_id = @organization_id))
+  AND (
+    project_id = @project_id
+    OR (@include_organizational::boolean AND project_id IS NULL AND organization_id = @organization_id)
+    OR (@include_global::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
   AND deleted IS FALSE;
 
 -- name: GetRemoteSessionIssuerByIDProjectOwned :one
@@ -108,11 +117,26 @@ FROM remote_session_issuers
 WHERE slug = @slug AND project_id = @project_id AND deleted IS FALSE;
 
 -- name: ListRemoteSessionIssuersByProjectID :many
--- Lists the project's own issuers plus organization-level issuers inherited
--- from the project's org.
+-- Lists the project's own issuers plus each inherited tier the caller opts in
+-- to, gated by its own boolean: include_organizational for organization-level
+-- issuers inherited from the project's org, include_global for platform issuers
+-- from the shared catalog. Both default off; organization_id is always passed
+-- (the arm is off when include_organizational is false regardless of its value).
+--
+-- Slugs are unique per (project_id, slug) and, separately, across the global
+-- partition; the organization tier has no slug uniqueness constraint at all. So
+-- this listing can legitimately return several rows sharing a slug. Resolution
+-- precedence is project > organization > platform; consumers that pick a single
+-- issuer by slug must apply it explicitly rather than relying on row order,
+-- which is by descending uuidv7 (creation time) and therefore says nothing
+-- about tier.
 SELECT *
 FROM remote_session_issuers
-WHERE (project_id = @project_id OR (project_id IS NULL AND organization_id = @organization_id))
+WHERE (
+    project_id = @project_id
+    OR (@include_organizational::boolean AND project_id IS NULL AND organization_id = @organization_id)
+    OR (@include_global::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
   AND deleted IS FALSE
   AND (sqlc.narg('cursor')::uuid IS NULL OR id < sqlc.narg('cursor')::uuid)
 ORDER BY id DESC
@@ -245,9 +269,26 @@ WHERE id = @id AND project_id = @project_id AND deleted IS FALSE
 RETURNING *;
 
 -- name: CountRemoteSessionClientsByIssuerID :one
+-- Every non-deleted client on an issuer, across every tenancy tier. Delete
+-- guards use this as the fail-safe: a count that ignored rows the caller cannot
+-- see would let a delete strand live clients.
 SELECT COUNT(*)
 FROM remote_session_clients
 WHERE remote_session_issuer_id = @remote_session_issuer_id AND deleted IS FALSE;
+
+-- name: CountTenantRemoteSessionClientsByIssuerID :one
+-- Non-deleted clients on an issuer that belong to a tenant (a project or an
+-- organization) rather than to the global partition. Subtracting this from
+-- CountRemoteSessionClientsByIssuerID gives the global client count, which lets
+-- the global issuer delete preflight tell a platform admin which of the
+-- blocking clients they can actually see and remove. Without the split, delete
+-- reports "delete the clients first" about tenant-owned clients that never
+-- appear in ListGlobalRemoteSessionClientsByIssuerID.
+SELECT COUNT(*)
+FROM remote_session_clients
+WHERE remote_session_issuer_id = @remote_session_issuer_id
+  AND (project_id IS NOT NULL OR organization_id IS NOT NULL)
+  AND deleted IS FALSE;
 
 -- Remote session clients — credentials Gram uses when acting as an OAuth
 -- client of a remote_session_issuer. client_secret_encrypted is stored
@@ -722,31 +763,62 @@ RETURNING s.*;
 -- header.
 
 -- name: ListOrganizationRemoteSessionIssuers :many
--- All issuers in the org (organizational and project-specific), each with its
--- associated non-deleted client count and, for project-specific issuers, the
--- owning project name.
+-- All issuers in the org (organizational and project-specific) and — when the
+-- caller opts in with include_global — platform issuers from the shared
+-- catalog, each with its associated non-deleted client count and, for
+-- project-specific issuers, the owning project name.
+--
+-- client_count mirrors the ORG REACHABILITY predicate used by the client
+-- queries: (i.organization_id = @org OR c.organization_id = @org). For an
+-- org-owned issuer the issuer arm is true, so every client on it counts
+-- regardless of whether the client row's organization_id was backfilled (an
+-- unscoped count for org rows, which is correct — they can only carry that org's
+-- clients). For a platform issuer the issuer arm is false, so the client arm
+-- restricts the count to the caller's own clients; other tenants' clients and
+-- global clients on the shared issuer are excluded. It used to scope on the
+-- client arm alone, which undercounts an org issuer's pre-backfill clients.
+--
+-- See ListRemoteSessionIssuersByProjectID for the slug-precedence caveat that
+-- applies to any listing spanning more than one tier.
 SELECT
     sqlc.embed(i),
     COALESCE(p.name, '')::text AS project_name,
     (
         SELECT COUNT(*)
         FROM remote_session_clients AS c
-        WHERE c.remote_session_issuer_id = i.id AND c.deleted IS FALSE
+        WHERE c.remote_session_issuer_id = i.id
+          AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
+          AND c.deleted IS FALSE
     )::bigint AS client_count
 FROM remote_session_issuers AS i
 LEFT JOIN projects AS p ON p.id = i.project_id
-WHERE i.organization_id = @organization_id
+WHERE (
+    i.organization_id = @organization_id
+    OR (@include_global::boolean AND i.project_id IS NULL AND i.organization_id IS NULL)
+  )
   AND i.deleted IS FALSE
   AND (sqlc.narg('cursor')::uuid IS NULL OR i.id < sqlc.narg('cursor')::uuid)
 ORDER BY i.id DESC
 LIMIT sqlc.arg('limit_value');
 
 -- name: GetOrganizationRemoteSessionIssuerByID :one
--- Any issuer in the org by id — organizational or project-specific.
+-- Any issuer in the org by id — organizational or project-specific — and, when
+-- the caller opts in with include_global, any platform issuer.
+--
+-- Callers that go on to MUTATE the issuer must pass include_global = false. A
+-- tenant must never edit, move, delete or migrate a platform row. The write
+-- queries are independently scoped and would refuse anyway, but opting the
+-- pre-read out keeps the refusal a clean 404 instead of a confusing partial
+-- success. Callers that report an issuer's blast radius must also pass false
+-- unless their counting queries are org-scoped: the delete-preflight helpers
+-- count clients and name MCP servers across all tenants.
 SELECT *
 FROM remote_session_issuers
 WHERE id = @id
-  AND organization_id = @organization_id
+  AND (
+    organization_id = @organization_id
+    OR (@include_global::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
   AND deleted IS FALSE;
 
 -- name: GetOrganizationRemoteSessionIssuerByIDForUpdate :one
@@ -850,6 +922,25 @@ RETURNING *;
 -- attachments. The active_session_count counts non-deleted remote_sessions
 -- minted against the client, matching CountActiveRemoteSessionsByClientID and
 -- the delete preflight.
+--
+-- ORG REACHABILITY (this predicate is repeated across every org-admin client
+-- and session query; change them together):
+--
+--   (i.organization_id = @organization_id OR c.organization_id = @organization_id)
+--
+-- Reaching the org through the ISSUER alone was sufficient while every issuer a
+-- tenant could attach to carried an organization_id. Platform issuers do not —
+-- their organization_id is NULL by definition — so an issuer-only predicate
+-- makes every tenant client on a platform issuer unreachable: not listable,
+-- fetchable, patchable, deletable, and its sessions neither viewable nor
+-- revocable. That is write-only state, so the client's own organization_id is
+-- accepted as an alternative path to the same org.
+--
+-- The arm is additive on purpose. Every row reachable before is still reachable
+-- on the issuer arm regardless of whether organization_id was ever backfilled
+-- on older client rows, so this cannot silently narrow a result or undercount.
+-- Global clients (project_id and organization_id both NULL) match neither arm
+-- and stay correctly invisible to tenants; they are platform-admin owned.
 SELECT
     sqlc.embed(c),
     (
@@ -876,7 +967,7 @@ SELECT
 FROM remote_session_clients AS c
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 WHERE c.remote_session_issuer_id = @remote_session_issuer_id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
   AND (sqlc.narg('cursor')::uuid IS NULL OR c.id < sqlc.narg('cursor')::uuid)
@@ -884,7 +975,9 @@ ORDER BY c.id DESC
 LIMIT sqlc.arg('limit_value');
 
 -- name: GetOrganizationRemoteSessionClientByID :one
--- A client in the org by id, scoped through its issuer's organization_id.
+-- A client in the org by id. See the ORG REACHABILITY note on
+-- ListOrganizationRemoteSessionClientsByIssuerID for why the org is reached
+-- through either the issuer or the client.
 SELECT
     sqlc.embed(c),
     (
@@ -895,14 +988,16 @@ SELECT
 FROM remote_session_clients AS c
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 WHERE c.id = @id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE;
 
 -- name: UpdateOrganizationRemoteSessionClient :one
--- Patch a client's fields, scoped through its issuer's organization_id. The
--- handler encrypts a rotated client_secret before passing it as
--- client_secret_encrypted; an omitted narg keeps the existing secret.
+-- Patch a client's fields. The handler encrypts a rotated client_secret before
+-- passing it as client_secret_encrypted; an omitted narg keeps the existing
+-- secret. See the ORG REACHABILITY note on
+-- ListOrganizationRemoteSessionClientsByIssuerID. Note this mutates the CLIENT,
+-- which the tenant owns, never the platform issuer it points at.
 UPDATE remote_session_clients AS c
 SET
     client_secret_encrypted = COALESCE(sqlc.narg('client_secret_encrypted'), c.client_secret_encrypted),
@@ -916,20 +1011,22 @@ SET
 FROM remote_session_issuers AS i
 WHERE c.id = @id
   AND c.remote_session_issuer_id = i.id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
 RETURNING c.*;
 
 -- name: DeleteOrganizationRemoteSessionClient :one
--- Soft-delete a client, scoped through its issuer's organization_id. The
--- handler cascades the client's remote_sessions via SoftDeleteRemoteSessionsByClientID.
+-- Soft-delete a client; the handler cascades the client's remote_sessions via
+-- SoftDeleteRemoteSessionsByClientID. See the ORG REACHABILITY note on
+-- ListOrganizationRemoteSessionClientsByIssuerID. Note this deletes the CLIENT,
+-- which the tenant owns, never the platform issuer it points at.
 UPDATE remote_session_clients AS c
 SET deleted_at = clock_timestamp()
 FROM remote_session_issuers AS i
 WHERE c.id = @id
   AND c.remote_session_issuer_id = i.id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
 RETURNING c.*;
@@ -1049,8 +1146,8 @@ WHERE remote_session_client_id = @remote_session_client_id
   AND user_session_issuer_id = @user_session_issuer_id;
 
 -- name: ListOrganizationRemoteSessionsByClientID :many
--- Sessions minted against a client, scoped through the client's issuer's
--- organization_id.
+-- Sessions minted against a client. See the ORG REACHABILITY note on
+-- ListOrganizationRemoteSessionClientsByIssuerID.
 SELECT sqlc.embed(s),
   u.display_name AS subject_display_name,
   u.email AS subject_email
@@ -1059,7 +1156,7 @@ JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 LEFT JOIN users AS u ON s.subject_urn = 'user:' || u.id AND u.deleted_at IS NULL
 WHERE s.remote_session_client_id = @remote_session_client_id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
@@ -1068,27 +1165,29 @@ ORDER BY s.id DESC
 LIMIT sqlc.arg('limit_value');
 
 -- name: RevokeOrganizationRemoteSession :one
--- Soft-delete a single session, scoped through the client's issuer's
--- organization_id. Returns the owning client's project_id so the handler can
--- attribute the audit event to the right project (NULL for org-level issuers).
+-- Soft-delete a single session. Returns the owning client's project_id so the
+-- handler can attribute the audit event to the right project (NULL for
+-- organization-level clients). See the ORG REACHABILITY note on
+-- ListOrganizationRemoteSessionClientsByIssuerID.
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
 FROM remote_session_clients AS c, remote_session_issuers AS i
 WHERE s.id = @id
   AND s.remote_session_client_id = c.id
   AND c.remote_session_issuer_id = i.id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
 RETURNING s.*, c.project_id AS client_project_id;
 
 -- name: GetOrganizationRemoteSessionByID :one
--- Load a single active session by id, scoped through the client's issuer's
--- organization_id. Returns the full embedded session row (including the
--- encrypted refresh token, which the org-admin refresh handler needs but the
--- API view never exposes), the owning client's project_id for audit
--- attribution, and the resolved subject identity for the returned view.
+-- Load a single active session by id. Returns the full embedded session row
+-- (including the encrypted refresh token, which the org-admin refresh handler
+-- needs but the API view never exposes), the owning client's project_id for
+-- audit attribution, and the resolved subject identity for the returned view.
+-- See the ORG REACHABILITY note on
+-- ListOrganizationRemoteSessionClientsByIssuerID.
 SELECT sqlc.embed(s),
   c.project_id AS client_project_id,
   u.display_name AS subject_display_name,
@@ -1098,7 +1197,7 @@ JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 LEFT JOIN users AS u ON s.subject_urn = 'user:' || u.id AND u.deleted_at IS NULL
 WHERE s.id = @id
-  AND i.organization_id = @organization_id
+  AND (i.organization_id = @organization_id OR c.organization_id = @organization_id)
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE;

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -72,8 +72,33 @@ FROM remote_session_clients
 WHERE remote_session_issuer_id = $1 AND deleted IS FALSE
 `
 
+// Every non-deleted client on an issuer, across every tenancy tier. Delete
+// guards use this as the fail-safe: a count that ignored rows the caller cannot
+// see would let a delete strand live clients.
 func (q *Queries) CountRemoteSessionClientsByIssuerID(ctx context.Context, remoteSessionIssuerID uuid.UUID) (int64, error) {
 	row := q.db.QueryRow(ctx, countRemoteSessionClientsByIssuerID, remoteSessionIssuerID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countTenantRemoteSessionClientsByIssuerID = `-- name: CountTenantRemoteSessionClientsByIssuerID :one
+SELECT COUNT(*)
+FROM remote_session_clients
+WHERE remote_session_issuer_id = $1
+  AND (project_id IS NOT NULL OR organization_id IS NOT NULL)
+  AND deleted IS FALSE
+`
+
+// Non-deleted clients on an issuer that belong to a tenant (a project or an
+// organization) rather than to the global partition. Subtracting this from
+// CountRemoteSessionClientsByIssuerID gives the global client count, which lets
+// the global issuer delete preflight tell a platform admin which of the
+// blocking clients they can actually see and remove. Without the split, delete
+// reports "delete the clients first" about tenant-owned clients that never
+// appear in ListGlobalRemoteSessionClientsByIssuerID.
+func (q *Queries) CountTenantRemoteSessionClientsByIssuerID(ctx context.Context, remoteSessionIssuerID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countTenantRemoteSessionClientsByIssuerID, remoteSessionIssuerID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -453,7 +478,7 @@ SET deleted_at = clock_timestamp()
 FROM remote_session_issuers AS i
 WHERE c.id = $1
   AND c.remote_session_issuer_id = i.id
-  AND i.organization_id = $2
+  AND (i.organization_id = $2 OR c.organization_id = $2)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
 RETURNING c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted
@@ -464,8 +489,10 @@ type DeleteOrganizationRemoteSessionClientParams struct {
 	OrganizationID pgtype.Text
 }
 
-// Soft-delete a client, scoped through its issuer's organization_id. The
-// handler cascades the client's remote_sessions via SoftDeleteRemoteSessionsByClientID.
+// Soft-delete a client; the handler cascades the client's remote_sessions via
+// SoftDeleteRemoteSessionsByClientID. See the ORG REACHABILITY note on
+// ListOrganizationRemoteSessionClientsByIssuerID. Note this deletes the CLIENT,
+// which the tenant owns, never the platform issuer it points at.
 func (q *Queries) DeleteOrganizationRemoteSessionClient(ctx context.Context, arg DeleteOrganizationRemoteSessionClientParams) (RemoteSessionClient, error) {
 	row := q.db.QueryRow(ctx, deleteOrganizationRemoteSessionClient, arg.ID, arg.OrganizationID)
 	var i RemoteSessionClient
@@ -874,7 +901,7 @@ JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 LEFT JOIN users AS u ON s.subject_urn = 'user:' || u.id AND u.deleted_at IS NULL
 WHERE s.id = $1
-  AND i.organization_id = $2
+  AND (i.organization_id = $2 OR c.organization_id = $2)
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
@@ -892,11 +919,12 @@ type GetOrganizationRemoteSessionByIDRow struct {
 	SubjectEmail       pgtype.Text
 }
 
-// Load a single active session by id, scoped through the client's issuer's
-// organization_id. Returns the full embedded session row (including the
-// encrypted refresh token, which the org-admin refresh handler needs but the
-// API view never exposes), the owning client's project_id for audit
-// attribution, and the resolved subject identity for the returned view.
+// Load a single active session by id. Returns the full embedded session row
+// (including the encrypted refresh token, which the org-admin refresh handler
+// needs but the API view never exposes), the owning client's project_id for
+// audit attribution, and the resolved subject identity for the returned view.
+// See the ORG REACHABILITY note on
+// ListOrganizationRemoteSessionClientsByIssuerID.
 func (q *Queries) GetOrganizationRemoteSessionByID(ctx context.Context, arg GetOrganizationRemoteSessionByIDParams) (GetOrganizationRemoteSessionByIDRow, error) {
 	row := q.db.QueryRow(ctx, getOrganizationRemoteSessionByID, arg.ID, arg.OrganizationID)
 	var i GetOrganizationRemoteSessionByIDRow
@@ -932,7 +960,7 @@ SELECT
 FROM remote_session_clients AS c
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 WHERE c.id = $1
-  AND i.organization_id = $2
+  AND (i.organization_id = $2 OR c.organization_id = $2)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
 `
@@ -947,7 +975,9 @@ type GetOrganizationRemoteSessionClientByIDRow struct {
 	UserSessionIssuerIds []uuid.UUID
 }
 
-// A client in the org by id, scoped through its issuer's organization_id.
+// A client in the org by id. See the ORG REACHABILITY note on
+// ListOrganizationRemoteSessionClientsByIssuerID for why the org is reached
+// through either the issuer or the client.
 func (q *Queries) GetOrganizationRemoteSessionClientByID(ctx context.Context, arg GetOrganizationRemoteSessionClientByIDParams) (GetOrganizationRemoteSessionClientByIDRow, error) {
 	row := q.db.QueryRow(ctx, getOrganizationRemoteSessionClientByID, arg.ID, arg.OrganizationID)
 	var i GetOrganizationRemoteSessionClientByIDRow
@@ -978,18 +1008,31 @@ const getOrganizationRemoteSessionIssuerByID = `-- name: GetOrganizationRemoteSe
 SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, client_id_metadata_document_supported, oidc, passthrough, name, logo_asset_id, client_setup_documentation_url, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
 WHERE id = $1
-  AND organization_id = $2
+  AND (
+    organization_id = $2
+    OR ($3::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
   AND deleted IS FALSE
 `
 
 type GetOrganizationRemoteSessionIssuerByIDParams struct {
 	ID             uuid.UUID
 	OrganizationID pgtype.Text
+	IncludeGlobal  bool
 }
 
-// Any issuer in the org by id — organizational or project-specific.
+// Any issuer in the org by id — organizational or project-specific — and, when
+// the caller opts in with include_global, any platform issuer.
+//
+// Callers that go on to MUTATE the issuer must pass include_global = false. A
+// tenant must never edit, move, delete or migrate a platform row. The write
+// queries are independently scoped and would refuse anyway, but opting the
+// pre-read out keeps the refusal a clean 404 instead of a confusing partial
+// success. Callers that report an issuer's blast radius must also pass false
+// unless their counting queries are org-scoped: the delete-preflight helpers
+// count clients and name MCP servers across all tenants.
 func (q *Queries) GetOrganizationRemoteSessionIssuerByID(ctx context.Context, arg GetOrganizationRemoteSessionIssuerByIDParams) (RemoteSessionIssuer, error) {
-	row := q.db.QueryRow(ctx, getOrganizationRemoteSessionIssuerByID, arg.ID, arg.OrganizationID)
+	row := q.db.QueryRow(ctx, getOrganizationRemoteSessionIssuerByID, arg.ID, arg.OrganizationID, arg.IncludeGlobal)
 	var i RemoteSessionIssuer
 	err := row.Scan(
 		&i.ID,
@@ -1272,20 +1315,37 @@ const getRemoteSessionIssuerByID = `-- name: GetRemoteSessionIssuerByID :one
 SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, client_id_metadata_document_supported, oidc, passthrough, name, logo_asset_id, client_setup_documentation_url, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
 WHERE id = $1
-  AND (project_id = $2 OR (project_id IS NULL AND organization_id = $3))
+  AND (
+    project_id = $2
+    OR ($3::boolean AND project_id IS NULL AND organization_id = $4)
+    OR ($5::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
   AND deleted IS FALSE
 `
 
 type GetRemoteSessionIssuerByIDParams struct {
-	ID             uuid.UUID
-	ProjectID      uuid.NullUUID
-	OrganizationID pgtype.Text
+	ID                    uuid.UUID
+	ProjectID             uuid.NullUUID
+	IncludeOrganizational bool
+	OrganizationID        pgtype.Text
+	IncludeGlobal         bool
 }
 
-// Project-scoped read that also resolves organization-level issuers belonging
-// to the project's org, so projects inherit cross-project issuers.
+// Project-scoped read of the project's own issuers, plus each inherited tier the
+// caller opts in to. Each inherited arm is gated by its own boolean:
+// include_organizational resolves organization-level issuers belonging to the
+// project's org (so projects inherit cross-project issuers), and include_global
+// resolves platform issuers from the shared catalog. Both default off, so a
+// caller widens only by explicitly asking; organization_id is always passed
+// (the arm is off when include_organizational is false regardless of its value).
 func (q *Queries) GetRemoteSessionIssuerByID(ctx context.Context, arg GetRemoteSessionIssuerByIDParams) (RemoteSessionIssuer, error) {
-	row := q.db.QueryRow(ctx, getRemoteSessionIssuerByID, arg.ID, arg.ProjectID, arg.OrganizationID)
+	row := q.db.QueryRow(ctx, getRemoteSessionIssuerByID,
+		arg.ID,
+		arg.ProjectID,
+		arg.IncludeOrganizational,
+		arg.OrganizationID,
+		arg.IncludeGlobal,
+	)
 	var i RemoteSessionIssuer
 	err := row.Scan(
 		&i.ID,
@@ -1877,7 +1937,7 @@ SELECT
 FROM remote_session_clients AS c
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 WHERE c.remote_session_issuer_id = $1
-  AND i.organization_id = $2
+  AND (i.organization_id = $2 OR c.organization_id = $2)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
   AND ($3::uuid IS NULL OR c.id < $3::uuid)
@@ -1906,6 +1966,25 @@ type ListOrganizationRemoteSessionClientsByIssuerIDRow struct {
 // attachments. The active_session_count counts non-deleted remote_sessions
 // minted against the client, matching CountActiveRemoteSessionsByClientID and
 // the delete preflight.
+//
+// ORG REACHABILITY (this predicate is repeated across every org-admin client
+// and session query; change them together):
+//
+//	(i.organization_id = @organization_id OR c.organization_id = @organization_id)
+//
+// Reaching the org through the ISSUER alone was sufficient while every issuer a
+// tenant could attach to carried an organization_id. Platform issuers do not —
+// their organization_id is NULL by definition — so an issuer-only predicate
+// makes every tenant client on a platform issuer unreachable: not listable,
+// fetchable, patchable, deletable, and its sessions neither viewable nor
+// revocable. That is write-only state, so the client's own organization_id is
+// accepted as an alternative path to the same org.
+//
+// The arm is additive on purpose. Every row reachable before is still reachable
+// on the issuer arm regardless of whether organization_id was ever backfilled
+// on older client rows, so this cannot silently narrow a result or undercount.
+// Global clients (project_id and organization_id both NULL) match neither arm
+// and stay correctly invisible to tenants; they are platform-admin owned.
 func (q *Queries) ListOrganizationRemoteSessionClientsByIssuerID(ctx context.Context, arg ListOrganizationRemoteSessionClientsByIssuerIDParams) ([]ListOrganizationRemoteSessionClientsByIssuerIDRow, error) {
 	rows, err := q.db.Query(ctx, listOrganizationRemoteSessionClientsByIssuerID,
 		arg.RemoteSessionIssuerID,
@@ -1960,19 +2039,25 @@ SELECT
     (
         SELECT COUNT(*)
         FROM remote_session_clients AS c
-        WHERE c.remote_session_issuer_id = i.id AND c.deleted IS FALSE
+        WHERE c.remote_session_issuer_id = i.id
+          AND (i.organization_id = $1 OR c.organization_id = $1)
+          AND c.deleted IS FALSE
     )::bigint AS client_count
 FROM remote_session_issuers AS i
 LEFT JOIN projects AS p ON p.id = i.project_id
-WHERE i.organization_id = $1
+WHERE (
+    i.organization_id = $1
+    OR ($2::boolean AND i.project_id IS NULL AND i.organization_id IS NULL)
+  )
   AND i.deleted IS FALSE
-  AND ($2::uuid IS NULL OR i.id < $2::uuid)
+  AND ($3::uuid IS NULL OR i.id < $3::uuid)
 ORDER BY i.id DESC
-LIMIT $3
+LIMIT $4
 `
 
 type ListOrganizationRemoteSessionIssuersParams struct {
 	OrganizationID pgtype.Text
+	IncludeGlobal  bool
 	Cursor         uuid.NullUUID
 	LimitValue     int32
 }
@@ -1989,11 +2074,30 @@ type ListOrganizationRemoteSessionIssuersRow struct {
 // project-specific rows); client/session queries reach the org through their
 // issuer, the sole cross-tenant guard since these endpoints carry no project
 // header.
-// All issuers in the org (organizational and project-specific), each with its
-// associated non-deleted client count and, for project-specific issuers, the
-// owning project name.
+// All issuers in the org (organizational and project-specific) and — when the
+// caller opts in with include_global — platform issuers from the shared
+// catalog, each with its associated non-deleted client count and, for
+// project-specific issuers, the owning project name.
+//
+// client_count mirrors the ORG REACHABILITY predicate used by the client
+// queries: (i.organization_id = @org OR c.organization_id = @org). For an
+// org-owned issuer the issuer arm is true, so every client on it counts
+// regardless of whether the client row's organization_id was backfilled (an
+// unscoped count for org rows, which is correct — they can only carry that org's
+// clients). For a platform issuer the issuer arm is false, so the client arm
+// restricts the count to the caller's own clients; other tenants' clients and
+// global clients on the shared issuer are excluded. It used to scope on the
+// client arm alone, which undercounts an org issuer's pre-backfill clients.
+//
+// See ListRemoteSessionIssuersByProjectID for the slug-precedence caveat that
+// applies to any listing spanning more than one tier.
 func (q *Queries) ListOrganizationRemoteSessionIssuers(ctx context.Context, arg ListOrganizationRemoteSessionIssuersParams) ([]ListOrganizationRemoteSessionIssuersRow, error) {
-	rows, err := q.db.Query(ctx, listOrganizationRemoteSessionIssuers, arg.OrganizationID, arg.Cursor, arg.LimitValue)
+	rows, err := q.db.Query(ctx, listOrganizationRemoteSessionIssuers,
+		arg.OrganizationID,
+		arg.IncludeGlobal,
+		arg.Cursor,
+		arg.LimitValue,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -2050,7 +2154,7 @@ JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN remote_session_issuers AS i ON i.id = c.remote_session_issuer_id
 LEFT JOIN users AS u ON s.subject_urn = 'user:' || u.id AND u.deleted_at IS NULL
 WHERE s.remote_session_client_id = $1
-  AND i.organization_id = $2
+  AND (i.organization_id = $2 OR c.organization_id = $2)
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
@@ -2072,8 +2176,8 @@ type ListOrganizationRemoteSessionsByClientIDRow struct {
 	SubjectEmail       pgtype.Text
 }
 
-// Sessions minted against a client, scoped through the client's issuer's
-// organization_id.
+// Sessions minted against a client. See the ORG REACHABILITY note on
+// ListOrganizationRemoteSessionClientsByIssuerID.
 func (q *Queries) ListOrganizationRemoteSessionsByClientID(ctx context.Context, arg ListOrganizationRemoteSessionsByClientIDParams) ([]ListOrganizationRemoteSessionsByClientIDRow, error) {
 	rows, err := q.db.Query(ctx, listOrganizationRemoteSessionsByClientID,
 		arg.RemoteSessionClientID,
@@ -2380,26 +2484,45 @@ func (q *Queries) ListRemoteSessionClientsForUserSessionIssuer(ctx context.Conte
 const listRemoteSessionIssuersByProjectID = `-- name: ListRemoteSessionIssuersByProjectID :many
 SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, client_id_metadata_document_supported, oidc, passthrough, name, logo_asset_id, client_setup_documentation_url, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers
-WHERE (project_id = $1 OR (project_id IS NULL AND organization_id = $2))
+WHERE (
+    project_id = $1
+    OR ($2::boolean AND project_id IS NULL AND organization_id = $3)
+    OR ($4::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
   AND deleted IS FALSE
-  AND ($3::uuid IS NULL OR id < $3::uuid)
+  AND ($5::uuid IS NULL OR id < $5::uuid)
 ORDER BY id DESC
-LIMIT $4
+LIMIT $6
 `
 
 type ListRemoteSessionIssuersByProjectIDParams struct {
-	ProjectID      uuid.NullUUID
-	OrganizationID pgtype.Text
-	Cursor         uuid.NullUUID
-	LimitValue     int32
+	ProjectID             uuid.NullUUID
+	IncludeOrganizational bool
+	OrganizationID        pgtype.Text
+	IncludeGlobal         bool
+	Cursor                uuid.NullUUID
+	LimitValue            int32
 }
 
-// Lists the project's own issuers plus organization-level issuers inherited
-// from the project's org.
+// Lists the project's own issuers plus each inherited tier the caller opts in
+// to, gated by its own boolean: include_organizational for organization-level
+// issuers inherited from the project's org, include_global for platform issuers
+// from the shared catalog. Both default off; organization_id is always passed
+// (the arm is off when include_organizational is false regardless of its value).
+//
+// Slugs are unique per (project_id, slug) and, separately, across the global
+// partition; the organization tier has no slug uniqueness constraint at all. So
+// this listing can legitimately return several rows sharing a slug. Resolution
+// precedence is project > organization > platform; consumers that pick a single
+// issuer by slug must apply it explicitly rather than relying on row order,
+// which is by descending uuidv7 (creation time) and therefore says nothing
+// about tier.
 func (q *Queries) ListRemoteSessionIssuersByProjectID(ctx context.Context, arg ListRemoteSessionIssuersByProjectIDParams) ([]RemoteSessionIssuer, error) {
 	rows, err := q.db.Query(ctx, listRemoteSessionIssuersByProjectID,
 		arg.ProjectID,
+		arg.IncludeOrganizational,
 		arg.OrganizationID,
+		arg.IncludeGlobal,
 		arg.Cursor,
 		arg.LimitValue,
 	)
@@ -2712,7 +2835,7 @@ FROM remote_session_clients AS c, remote_session_issuers AS i
 WHERE s.id = $1
   AND s.remote_session_client_id = c.id
   AND c.remote_session_issuer_id = i.id
-  AND i.organization_id = $2
+  AND (i.organization_id = $2 OR c.organization_id = $2)
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
@@ -2741,9 +2864,10 @@ type RevokeOrganizationRemoteSessionRow struct {
 	ClientProjectID       uuid.NullUUID
 }
 
-// Soft-delete a single session, scoped through the client's issuer's
-// organization_id. Returns the owning client's project_id so the handler can
-// attribute the audit event to the right project (NULL for org-level issuers).
+// Soft-delete a single session. Returns the owning client's project_id so the
+// handler can attribute the audit event to the right project (NULL for
+// organization-level clients). See the ORG REACHABILITY note on
+// ListOrganizationRemoteSessionClientsByIssuerID.
 func (q *Queries) RevokeOrganizationRemoteSession(ctx context.Context, arg RevokeOrganizationRemoteSessionParams) (RevokeOrganizationRemoteSessionRow, error) {
 	row := q.db.QueryRow(ctx, revokeOrganizationRemoteSession, arg.ID, arg.OrganizationID)
 	var i RevokeOrganizationRemoteSessionRow
@@ -3106,7 +3230,7 @@ SET
 FROM remote_session_issuers AS i
 WHERE c.id = $5
   AND c.remote_session_issuer_id = i.id
-  AND i.organization_id = $6
+  AND (i.organization_id = $6 OR c.organization_id = $6)
   AND c.deleted IS FALSE
   AND i.deleted IS FALSE
 RETURNING c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted
@@ -3121,9 +3245,11 @@ type UpdateOrganizationRemoteSessionClientParams struct {
 	OrganizationID          pgtype.Text
 }
 
-// Patch a client's fields, scoped through its issuer's organization_id. The
-// handler encrypts a rotated client_secret before passing it as
-// client_secret_encrypted; an omitted narg keeps the existing secret.
+// Patch a client's fields. The handler encrypts a rotated client_secret before
+// passing it as client_secret_encrypted; an omitted narg keeps the existing
+// secret. See the ORG REACHABILITY note on
+// ListOrganizationRemoteSessionClientsByIssuerID. Note this mutates the CLIENT,
+// which the tenant owns, never the platform issuer it points at.
 func (q *Queries) UpdateOrganizationRemoteSessionClient(ctx context.Context, arg UpdateOrganizationRemoteSessionClientParams) (RemoteSessionClient, error) {
 	row := q.db.QueryRow(ctx, updateOrganizationRemoteSessionClient,
 		arg.ClientSecretEncrypted,

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -331,6 +331,28 @@ func seedOrgLevelRemoteIssuer(t *testing.T, ctx context.Context, conn *pgxpool.P
 	return issuer.ID
 }
 
+// seedGlobalRemoteIssuer creates a platform (global) remote session issuer:
+// project_id IS NULL AND organization_id IS NULL, the shared catalog partition
+// owned by Speakeasy platform admins. Tenants inherit it read-only and may
+// attach their own clients to it.
+func seedGlobalRemoteIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug string) uuid.UUID {
+	t.Helper()
+	issuer, err := repo.New(conn).CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         uuid.NullUUID{},
+		OrganizationID:                    pgtype.Text{String: "", Valid: false},
+		Slug:                              slug,
+		Issuer:                            "https://" + slug + ".example.com",
+		AuthorizationEndpoint:             conv.ToPGText("https://" + slug + ".example.com/authorize"),
+		TokenEndpoint:                     conv.ToPGText("https://" + slug + ".example.com/token"),
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+	})
+	require.NoError(t, err)
+	return issuer.ID
+}
+
 // seedOrgLevelRemoteClient creates an organization-level (project_id IS NULL,
 // organization_id set) remote_session_client referencing remoteIssuerID and
 // attaches it to each userSessionIssuerID through the join table. Org-level
@@ -574,4 +596,34 @@ func seedEnvironmentWithEntries(t *testing.T, ctx context.Context, ti *testInsta
 	})
 	require.NoError(t, err)
 	return envRow.Slug
+}
+
+// requirePlatformIssuerUnchanged asserts the platform issuer row still exists in
+// the global partition (NULL project_id, NULL organization_id) and was not
+// renamed, i.e. no tenant-scoped mutation touched it. Reads through the
+// platform-admin global query, which matches only global rows.
+func requirePlatformIssuerUnchanged(t *testing.T, ctx context.Context, conn *pgxpool.Pool, id uuid.UUID) {
+	t.Helper()
+	row, err := repo.New(conn).GetGlobalRemoteSessionIssuerByID(ctx, id)
+	require.NoError(t, err, "platform issuer should still exist in the global partition")
+	require.False(t, row.ProjectID.Valid, "platform issuer project_id must stay NULL")
+	require.False(t, row.OrganizationID.Valid, "platform issuer organization_id must stay NULL")
+	require.False(t, row.Name.Valid, "platform issuer name must be untouched")
+}
+
+// seedProjectRemoteClientNoOrg creates a project-owned remote_session_client
+// with a NULL organization_id, mirroring a legacy row from before the
+// organization_id backfill. Used to prove counts and reachability do not depend
+// on the client's organization_id being populated.
+func seedProjectRemoteClientNoOrg(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID, remoteIssuerID uuid.UUID, clientID string) uuid.UUID {
+	t.Helper()
+	created, err := repo.New(conn).CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:             conv.ToNullUUID(projectID),
+		OrganizationID:        pgtype.Text{String: "", Valid: false},
+		RemoteSessionIssuerID: remoteIssuerID,
+		ClientID:              clientID,
+		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now().UTC()),
+	})
+	require.NoError(t, err)
+	return created.ID
 }

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -164,3 +164,38 @@ func TestResolveAccessTokens_MissingSessionReturnsErrNoValidToken(t *testing.T) 
 	require.ErrorIs(t, err, remotesessions.ErrNoValidToken)
 	require.Nil(t, tokens)
 }
+
+// TestResolveAccessTokens_TenantClientOnPlatformIssuer proves an existing remote
+// session on a tenant client that points at a platform issuer resolves its
+// upstream token through the unchanged runtime path.
+func TestResolveAccessTokens_TenantClientOnPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	enc := testenv.NewEncryptionClient(t)
+	mgr := newResolveManager(t, ti.conn, enc)
+
+	platformID := seedGlobalRemoteIssuer(t, ctx, ti.conn, "resolve-platform")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "resolve-platform-usi")
+	clientID := createRemoteClient(t, ctx, ti, platformID.String(), userIssuerID.String(), "resolve-platform-client")
+
+	subject := urn.NewUserSubject("resolve-platform-subject")
+	accessEnc, err := enc.Encrypt([]byte("platform-upstream-token"))
+	require.NoError(t, err)
+	_, err = repo.New(ti.conn).InsertRemoteSession(ctx, repo.InsertRemoteSessionParams{
+		SubjectUrn:            subject,
+		UserSessionIssuerID:   userIssuerID,
+		RemoteSessionClientID: uuid.MustParse(clientID),
+		AccessTokenEncrypted:  accessEnc,
+		AccessExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+
+	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject, "")
+	require.NoError(t, err)
+	require.Equal(t, map[uuid.UUID]string{platformID: "platform-upstream-token"}, tokens)
+}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-332/feat-make-the-platform-issuer-tier-consumable-by-tenants

Tenant-facing issuer reads opt in to inheriting platform (global) issuers via per-tier booleans (`include_organizational`, `include_global`), so a project-level or organization-level remote session client can be created against a platform issuer while the issuer itself stays read-only to tenants. Update, delete, move, and migrate remain refused with a clean `404`.

Organization-admin client and session queries now reach the caller's org through either the issuer or the client, so a tenant client on a platform issuer stays fully manageable and its sessions viewable and revocable. The organization listing's client count is scoped to the caller's own clients. The global issuer delete guard takes the client-binding advisory lock and reports tenant-held references distinctly from global clients, and the project issuer delete gains an ownership pre-read that closes an existence oracle.

The dashboard renders the new `Platform` tier as read-only and resolves issuers by project, then organization, then platform precedence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let tenants inherit and attach clients to platform (global) remote identity providers while issuers stay read‑only. Projects and orgs can use platform issuers, and the dashboard adds a clear Platform tier with project > organization > platform precedence. Aligns with Linear AIS-332.

- **New Features**
  - Opt-in inheritance via `include_organizational` and `include_global`; project- and org-level clients can attach to platform issuers while clients remain tenant-owned.
  - Org-admin surfaces include platform issuers read-only and can manage tenant clients and sessions that point at them; organization listing and detail APIs opt in to globals.
  - Precedence: resolve by project > organization > platform for slug/URL matching and auto-config; dashboard adds Platform badges, separates tiers, hides Settings for platform issuers; migration picker excludes platform. Helpers: `remoteSessionScopeTier`, `resolveRemoteSessionIssuerByTierPrecedence`.

- **Bug Fixes**
  - Delete guards: global issuer delete now takes the client-binding advisory lock before the row lock, reports tenant-held references separately from global clients, and serializes count-then-delete with all client creators; every issuer delete takes the same lock. Project issuer delete adds an ownership pre-read; org-admin client create takes the lock to prevent binding against deleted/migrated issuers.
  - Runtime unchanged; tests cover token resolution for a tenant client on a platform issuer.

<sup>Written for commit 36949d4ae33a7adf1e8c36d801d91033fa13ab75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

