### PR TITLE
chore: seed skill scopes into dev-user RBAC grants

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2221,6 +2221,8 @@ async function enableRBACForDevUser(init: {
     { scope: "mcp:connect", kind: "mcp" },
     { scope: "environment:read", kind: "environment" },
     { scope: "environment:write", kind: "environment" },
+    { scope: "skill:read", kind: "skill" },
+    { scope: "skill:write", kind: "skill" },
     { scope: "chat:read", kind: "chat" },
   ];
   const sqlStr = (v: string) => `'${v.replace(/'/g, "''")}'`;


### PR DESCRIPTION
## What

Adds `skill:read` and `skill:write` to the dev-user RBAC grant list in the local seed (`.mise-tasks/seed.mts`, `enableRBACForDevUser`), with selectors `{"resource_kind":"skill","resource_id":"*"}` mirroring the existing per-scope pattern.

## Why

The seed grants the dev user the admin scope set directly on the `user:<id>` principal (locally the dev user has no WorkOS-synced role assignment to inherit role grants from). That list predates the skill scopes added in #4224, so with RBAC evaluation active in a local dev stack the skills pages show "Access restricted" for the seeded admin user unless the dev toolbar scope override is used.

## Where the role-level grants come from (why this PR only touches the user list)

The `principal_urn = 'role:global:...'` rows are not written by the seed script — they come from the server's `SeedSystemRoleGrantsTx` (`server/internal/authz/grants.go`), triggered by the seed's `accessEnableRBAC` call. `adminScopes` / `memberScopes` in `server/internal/authz/scopes.go` already include the skill scopes (admin: `skill:read` + `skill:write`; member: `skill:read`), so fresh RBAC enables get correct role grants without any change here.

Caveat for pre-existing dev DBs: `SeedSystemRoleGrantsTx` intentionally skips roles that already hold grants, so role rows seeded before #4224 are not backfilled. That does not affect the seeded dev admin user (this PR's direct user grants cover it), only hypothetical locally-created member users relying on the stale member role rows.

## Idempotency

Existing dev databases pick the new grants up automatically on the next `mise seed`:

- Editing `seed.mts` changes the seed fingerprint, invalidating the `devtools.seed_markers` completion marker and forcing a re-seed.
- The grant insert is `ON CONFLICT ... DO NOTHING`, so re-runs add only the two new rows.

## Related newer scopes checked (left as-is, staying scoped)

- `chat:read` — already present in the dev-user grant list.
- `risk_policy:evaluate` / `risk_policy:bypass` — absent from both the dev-user list and the system-role defaults; these are granted per-policy via resource grants (`server/internal/risk/policy_audience.go`, `policybypass/`), so a wildcard seed grant is intentionally not added.

## Verification

- `./node_modules/.bin/tsc -b --noEmit --force` — no errors in `seed.mts` (only pre-existing `.mise-tasks/hooks/e2e.js` errors, identical on the base commit).
- `mise run build:server` — passes (no Go touched).
- No automated test covers the seed script; the change is a two-entry addition to a literal array feeding an already-exercised SQL template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141ZwLrsFPSHeaZhoGDqSDT


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `skill:read` and `skill:write` to the dev-user RBAC grants in the local seed, using wildcard selectors for the `skill` resource. This removes “Access restricted” on skills pages in local dev without using the scope override.

- **Migration**
  - Run `mise seed` to apply; inserts are idempotent.

<sup>Written for commit a64c0f6c149bd74c0e8376ec30f8f29697b5fad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

