### PR TITLE
fix(dashboard): send robots noindex signal for public /shared/* pages

### DIFF
--- a/.changeset/shared-skills-noindex.md
+++ b/.changeset/shared-skills-noindex.md
@@ -1,0 +1,7 @@
+---
+"dashboard": patch
+---
+
+Send a robots noindex signal for public share pages: nginx now adds
+`X-Robots-Tag: noindex, nofollow` to `/shared/*` responses, and the shared
+skill page injects a matching robots meta tag at runtime.

--- a/.changeset/shared-skills-noindex.md
+++ b/.changeset/shared-skills-noindex.md
@@ -2,6 +2,4 @@
 "dashboard": patch
 ---
 
-Send a robots noindex signal for public share pages: nginx now adds
-`X-Robots-Tag: noindex, nofollow` to `/shared/*` responses, and the shared
-skill page injects a matching robots meta tag at runtime.
+Send a robots noindex signal for the whole dashboard host: the app shell now carries `<meta name="robots" content="noindex, nofollow">` and nginx adds a matching `X-Robots-Tag` header (including on error responses). Nothing on the host wants search indexing — the app is behind login and `/shared/*` pages are tokenized public share links.

--- a/client/dashboard/index.html
+++ b/client/dashboard/index.html
@@ -10,6 +10,10 @@
          default: light). Keep these in sync. -->
     <script src="/src/theme-init.ts" vite-ignore></script>
 
+    <!-- Nothing on this host wants search indexing: the app is behind login
+         and /shared/* pages are tokenized capability URLs. -->
+    <meta name="robots" content="noindex, nofollow" />
+
     <meta property="og:title" content="Speakeasy AI Control Plane" />
     <meta
       property="og:description"

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -1,3 +1,15 @@
+# Public share pages (e.g. /shared/skills/:token) must not be indexed by
+# search engines. The API responses backing them already send X-Robots-Tag,
+# but the SPA HTML shell needs it too or the URL itself can end up in search
+# results. This is a map (not a /shared/ location) because the SPA fallback
+# internally redirects to /index.html, and headers added in the original
+# location are dropped when the redirect re-matches the .html location below.
+# $request_uri keeps the original request path across that redirect.
+map $request_uri $gram_robots_tag {
+    default "";
+    ~^/shared/ "noindex, nofollow";
+}
+
 server {
     listen 3000;
     server_name localhost;
@@ -44,16 +56,19 @@ server {
         add_header Access-Control-Allow-Origin "*";
     }
 
-    # Serve HTML with no cache
+    # Serve HTML with no cache. X-Robots-Tag is empty (and therefore omitted)
+    # for everything except /shared/* requests — see the map above.
     location ~* \.html$ {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        add_header X-Robots-Tag $gram_robots_tag;
     }
 
     # Handle SPA routing
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+        add_header X-Robots-Tag $gram_robots_tag;
     }
 
     # Error pages

--- a/client/dashboard/nginx.conf
+++ b/client/dashboard/nginx.conf
@@ -1,15 +1,3 @@
-# Public share pages (e.g. /shared/skills/:token) must not be indexed by
-# search engines. The API responses backing them already send X-Robots-Tag,
-# but the SPA HTML shell needs it too or the URL itself can end up in search
-# results. This is a map (not a /shared/ location) because the SPA fallback
-# internally redirects to /index.html, and headers added in the original
-# location are dropped when the redirect re-matches the .html location below.
-# $request_uri keeps the original request path across that redirect.
-map $request_uri $gram_robots_tag {
-    default "";
-    ~^/shared/ "noindex, nofollow";
-}
-
 server {
     listen 3000;
     server_name localhost;
@@ -56,19 +44,20 @@ server {
         add_header Access-Control-Allow-Origin "*";
     }
 
-    # Serve HTML with no cache. X-Robots-Tag is empty (and therefore omitted)
-    # for everything except /shared/* requests — see the map above.
+    # Serve HTML with no cache. Nothing on this host wants search indexing —
+    # it is either behind login or a tokenized public share page — so noindex
+    # everything ("always" keeps the header on error responses too).
     location ~* \.html$ {
         expires -1;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-        add_header X-Robots-Tag $gram_robots_tag;
+        add_header X-Robots-Tag "noindex, nofollow" always;
     }
 
     # Handle SPA routing
     location / {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-        add_header X-Robots-Tag $gram_robots_tag;
+        add_header X-Robots-Tag "noindex, nofollow" always;
     }
 
     # Error pages

--- a/client/dashboard/src/pages/skills/SharedSkillPage.tsx
+++ b/client/dashboard/src/pages/skills/SharedSkillPage.tsx
@@ -6,6 +6,7 @@ import { dateTimeFormatters } from "@/lib/dates";
 import type { SharedSkill2 } from "@gram/client/models/components/sharedskill2.js";
 import { useSharedSkill } from "@gram/client/react-query/sharedSkill.js";
 import { Icon, Stack } from "@speakeasy-api/moonshine";
+import { useEffect } from "react";
 import { useParams } from "react-router";
 import { toast } from "sonner";
 import { stripSkillFrontmatter } from "./skill-manifest";
@@ -17,8 +18,28 @@ import { stripSkillFrontmatter } from "./skill-manifest";
  * credential, so anonymous visitors can read the latest version of a shared
  * skill without signing in.
  */
+/**
+ * Injects <meta name="robots" content="noindex, nofollow"> for the lifetime
+ * of the page. The production nginx config also sends X-Robots-Tag for
+ * /shared/* responses; this is the belt-and-braces signal for environments
+ * that serve the SPA shell without that header (Google honors
+ * client-rendered robots meta tags).
+ */
+function useNoIndexMeta(): void {
+  useEffect(() => {
+    const meta = document.createElement("meta");
+    meta.name = "robots";
+    meta.content = "noindex, nofollow";
+    document.head.appendChild(meta);
+    return () => {
+      meta.remove();
+    };
+  }, []);
+}
+
 export function SharedSkillPage(): JSX.Element {
   const { token } = useParams<{ token: string }>();
+  useNoIndexMeta();
 
   return (
     <div className="bg-background flex min-h-screen w-full flex-col">

--- a/client/dashboard/src/pages/skills/SharedSkillPage.tsx
+++ b/client/dashboard/src/pages/skills/SharedSkillPage.tsx
@@ -6,7 +6,6 @@ import { dateTimeFormatters } from "@/lib/dates";
 import type { SharedSkill2 } from "@gram/client/models/components/sharedskill2.js";
 import { useSharedSkill } from "@gram/client/react-query/sharedSkill.js";
 import { Icon, Stack } from "@speakeasy-api/moonshine";
-import { useEffect } from "react";
 import { useParams } from "react-router";
 import { toast } from "sonner";
 import { stripSkillFrontmatter } from "./skill-manifest";
@@ -18,28 +17,8 @@ import { stripSkillFrontmatter } from "./skill-manifest";
  * credential, so anonymous visitors can read the latest version of a shared
  * skill without signing in.
  */
-/**
- * Injects <meta name="robots" content="noindex, nofollow"> for the lifetime
- * of the page. The production nginx config also sends X-Robots-Tag for
- * /shared/* responses; this is the belt-and-braces signal for environments
- * that serve the SPA shell without that header (Google honors
- * client-rendered robots meta tags).
- */
-function useNoIndexMeta(): void {
-  useEffect(() => {
-    const meta = document.createElement("meta");
-    meta.name = "robots";
-    meta.content = "noindex, nofollow";
-    document.head.appendChild(meta);
-    return () => {
-      meta.remove();
-    };
-  }, []);
-}
-
 export function SharedSkillPage(): JSX.Element {
   const { token } = useParams<{ token: string }>();
-  useNoIndexMeta();
 
   return (
     <div className="bg-background flex min-h-screen w-full flex-col">


### PR DESCRIPTION
## What

Ensures the public skill share pages (`/shared/skills/:token`) carry a robots `noindex` signal. The data endpoint (`/rpc/skills.getShared`) already responds with `X-Robots-Tag: noindex, nofollow`, but the SPA HTML shell served for `/shared/*` had no robots signal at all, so search engines could index the page shell and share URLs.

## How

Two layers:

1. **nginx** (`client/dashboard/nginx.conf`): a `map $request_uri $gram_robots_tag` sets `noindex, nofollow` for paths starting with `/shared/`, emitted via `add_header X-Robots-Tag` from both the `.html` location and the SPA-fallback `location /`. A dedicated `location /shared/` block does **not** work: `try_files` internally redirects to `/index.html`, which re-matches the `\.html$` location and drops the original location's `add_header` directives. The map keys on `$request_uri`, which survives the internal redirect; for all other paths the value is empty, so nginx omits the header entirely. SPA fallback and no-cache behavior are unchanged.

2. **Runtime meta tag** (`SharedSkillPage.tsx`): a small `useNoIndexMeta` hook injects `<meta name="robots" content="noindex, nofollow">` into `document.head` on mount and removes it on unmount — belt-and-braces for any environment serving the shell without the header (Google honors client-rendered robots meta for SPAs). The dashboard has no existing per-route head/meta mechanism (`usePageTitle` covers titles only), so this stays local to the page.

## Verification

- Ran the real production image (`nginxinc/nginx-unprivileged:alpine`) with this config through its envsubst template entrypoint and curled:
  - `/shared/skills/<token>` and `/shared/` → `200` + `X-Robots-Tag: noindex, nofollow` + existing no-store cache headers, SPA shell served
  - `/`, `/index.html`, `/org/projects/x` → `200`, **no** `X-Robots-Tag`
  - This also caught (and is why the PR uses a map instead of) the naive `location /shared/` approach, which silently loses the header on the try_files internal redirect.
- `tsc -b --noEmit --force`, `pnpm -F dashboard lint`, and `pnpm knip` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141ZwLrsFPSHeaZhoGDqSDT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block search engines from indexing the entire dashboard host. Adds a global `noindex, nofollow` signal on all pages and responses, replacing the previous `/shared/*`-only approach.

- **Bug Fixes**
  - Nginx: set `X-Robots-Tag: noindex, nofollow` for `.html` and SPA fallback routes with `always` so error responses include it.
  - App shell: add `<meta name="robots" content="noindex, nofollow" />` in `index.html` (removes the page-level hook).

<sup>Written for commit a642f4a4a2165ad01c5243eaa6183e7b34ffaa98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

