### PR TITLE
fix(dashboard): keep MultiSelect trigger icons inside the container (DNO-552)

### DIFF
--- a/.changeset/multiselect-trigger-overflow.md
+++ b/.changeset/multiselect-trigger-overflow.md
@@ -1,0 +1,8 @@
+---
+"dashboard": patch
+---
+
+Keep MultiSelect trigger controls inside the container: selected badges now
+shrink and truncate long labels with an ellipsis instead of pushing the
+clear "X" and dropdown chevron past the right edge, as seen on the plugin
+Manage assignments sheet.

--- a/client/dashboard/src/components/ui/multi-select.tsx
+++ b/client/dashboard/src/components/ui/multi-select.tsx
@@ -895,7 +895,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                 <div className="flex w-full items-center justify-between">
                   <div
                     className={cn(
-                      "flex items-center gap-1",
+                      "flex min-w-0 flex-1 items-center gap-1",
                       singleLine
                         ? "multiselect-singleline-scroll overflow-x-auto overflow-y-hidden"
                         : "flex-wrap",
@@ -932,9 +932,14 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 "border-transparent text-white",
                               responsiveSettings.compactMode &&
                                 "px-1.5 py-0.5 text-xs",
+                              // Long labels truncate instead of forcing the
+                              // trigger row past the button's right edge
+                              // (DNO-552).
+                              singleLine
+                                ? "shrink-0 whitespace-nowrap"
+                                : "min-w-0 max-w-full shrink",
                               screenSize === "mobile" &&
                                 "max-w-[120px] truncate",
-                              singleLine && "shrink-0 whitespace-nowrap",
                               "[&>svg]:pointer-events-auto",
                             )}
                             style={{
@@ -948,7 +953,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                             {IconComponent && !responsiveSettings.hideIcons && (
                               <IconComponent
                                 className={cn(
-                                  "mr-2 h-4 w-4",
+                                  "mr-2 h-4 w-4 shrink-0",
                                   responsiveSettings.compactMode &&
                                     "mr-1 h-3 w-3",
                                   customStyle?.iconColor && "text-current",
@@ -958,11 +963,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 })}
                               />
                             )}
-                            <span
-                              className={cn(
-                                screenSize === "mobile" && "truncate",
-                              )}
-                            >
+                            <span className="min-w-0 truncate">
                               {option.label}
                             </span>
                             <div
@@ -983,7 +984,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 }
                               }}
                               aria-label={`Remove ${option.label} from selection`}
-                              className="flex h-4 w-4 cursor-pointer hover:bg-white/20 focus:ring-1 focus:ring-white/50 focus:outline-none"
+                              className="flex h-4 w-4 shrink-0 cursor-pointer hover:bg-white/20 focus:ring-1 focus:ring-white/50 focus:outline-none"
                             >
                               <XIcon
                                 className={cn(
@@ -1031,7 +1032,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                       </Badge>
                     )}
                   </div>
-                  <div className="flex items-center justify-between">
+                  <div className="flex shrink-0 items-center justify-between">
                     <div
                       role="button"
                       tabIndex={0}


### PR DESCRIPTION
Fixes DNO-552.

## Problem

On the plugin **Manage assignments** sheet, a principal row with a long label — a member shown as `Name (email)`, or an email assignment added via "Create" — pushed the row's trailing controls (clear "X" and dropdown chevron) past the right edge of the "Assigned principals" container. With long enough labels the controls left the viewport entirely and the sheet grew a horizontal scrollbar.

## Root cause

The shared `MultiSelect` trigger couldn't absorb long badge labels:

- The `Badge` primitive hardcodes `w-fit shrink-0 whitespace-nowrap`, so a badge can never shrink below its content width.
- The badge list wrapper is a flex item without `min-w-0`, so it inherited that content width and forced the whole trigger row wider than the button, shoving the trailing icon group outside the border.

## Fix

All in `client/dashboard/src/components/ui/multi-select.tsx`, so every `MultiSelect` benefits:

- Badge list wrapper gets `min-w-0 flex-1` so it can shrink to the available space.
- Trailing clear/chevron group gets `shrink-0` so it stays pinned inside the border.
- In wrap mode, badges get `min-w-0 max-w-full shrink` (overriding the primitive's `shrink-0`) and labels always truncate with an ellipsis; the badge's icon and remove-X keep `shrink-0` so only the text compresses.
- `singleLine` scroll mode and the mobile `max-w-[120px]` cap keep their existing behavior.

## Verification

Reproduced before/after locally on the Manage assignments sheet with a member assignment and a long created-email assignment (screenshots in PR comment below). `pnpm -F dashboard type-check` and `pnpm -F dashboard lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes assignment row icons overflowing the right edge in the plugin Manage Assignments sheet by updating the shared `MultiSelect` trigger to shrink and truncate correctly, and adds a changeset for a dashboard patch. Addresses Linear DNO-552 and applies to all `MultiSelect` instances.

- **Bug Fixes**
  - Let the badge list shrink within the trigger: `min-w-0 flex-1`.
  - Truncate long badge labels in wrap mode; keep badge icon and remove-X `shrink-0`.
  - Pin trailing controls (clear and chevron) inside the border: `shrink-0`.
  - Preserve existing `singleLine` scroll behavior and mobile `max-w-[120px]` cap.

<sup>Written for commit 0509599a1936fb8ff45a92374f939803565f0e43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

