### PR TITLE
fix(security): lift partition guard in the migration

### DIFF
--- a/server/cmd/tools/migrations/main.go
+++ b/server/cmd/tools/migrations/main.go
@@ -67,6 +67,7 @@ type config struct {
 	batchSize     int
 	bufferSize    int
 	dryRun        bool
+	liftPartGuard bool
 }
 
 func main() {
@@ -116,7 +117,7 @@ func run() int {
 
 	source := riskfindings.NewSource(pool)
 	transformer := riskfindings.NewTransformer(fingerprinter)
-	sink := riskfindings.NewSink(chConn, cfg.bufferSize, cfg.batchSize, cfg.dryRun)
+	sink := riskfindings.NewSink(chConn, cfg.bufferSize, cfg.batchSize, cfg.dryRun, cfg.liftPartGuard)
 
 	runErr := pipeline.Run[riskfindings.SourceRow, riskfindings.FindingRow](
 		ctx, source, transformer, sink, cfg.criteria(), cfg.bufferSize,
@@ -214,6 +215,7 @@ func parseFlags() (config, error) {
 		batchSize         = flag.Int("batch-size", riskfindings.DefaultBatchSize, "rows per source page and sink batch")
 		bufferSize        = flag.Int("buffer", riskfindings.DefaultBatchSize, "channel buffer between pipeline stages")
 		dryRun            = flag.Bool("dry-run", true, "when true (default) read and transform but do not write; pass -dry-run=false to insert")
+		liftPartGuard     = flag.Bool("lift-partition-guard", true, "set max_partitions_per_insert_block=0 on inserts; pass -lift-partition-guard=false when the ClickHouse settings profile constrains that setting (code 452)")
 	)
 	flag.Parse()
 
@@ -244,6 +246,7 @@ func parseFlags() (config, error) {
 		batchSize:     *batchSize,
 		bufferSize:    *bufferSize,
 		dryRun:        *dryRun,
+		liftPartGuard: *liftPartGuard,
 	}
 
 	if cfg.dbURL == "" {

--- a/server/cmd/tools/migrations/riskfindings/sink.go
+++ b/server/cmd/tools/migrations/riskfindings/sink.go
@@ -32,10 +32,11 @@ const insertStatement = `INSERT INTO risk_findings (
 // channel exposed by Input; the pipeline's transform stage is the sole producer
 // and closes the channel when the source is exhausted.
 type Sink struct {
-	conn      clickhouse.Conn
-	in        chan FindingRow
-	batchSize int
-	dryRun    bool
+	conn               clickhouse.Conn
+	in                 chan FindingRow
+	batchSize          int
+	dryRun             bool
+	liftPartitionGuard bool
 
 	inserted      int64
 	lastCommitted uuid.UUID
@@ -43,8 +44,10 @@ type Sink struct {
 
 // NewSink builds a ClickHouse sink. conn may be nil when dryRun is true, in which
 // case rows are counted but never written. bufferSize sizes the input channel;
-// batchSize bounds each insert.
-func NewSink(conn clickhouse.Conn, bufferSize, batchSize int, dryRun bool) *Sink {
+// batchSize bounds each insert. liftPartitionGuard sets
+// max_partitions_per_insert_block=0 on each insert; pass false against servers
+// whose settings profile constrains that setting (constraint violation, code 452).
+func NewSink(conn clickhouse.Conn, bufferSize, batchSize int, dryRun, liftPartitionGuard bool) *Sink {
 	if bufferSize < 0 {
 		bufferSize = 0
 	}
@@ -52,12 +55,13 @@ func NewSink(conn clickhouse.Conn, bufferSize, batchSize int, dryRun bool) *Sink
 		batchSize = DefaultSinkBatchSize
 	}
 	return &Sink{
-		conn:          conn,
-		in:            make(chan FindingRow, bufferSize),
-		batchSize:     batchSize,
-		dryRun:        dryRun,
-		inserted:      0,
-		lastCommitted: uuid.Nil,
+		conn:               conn,
+		in:                 make(chan FindingRow, bufferSize),
+		batchSize:          batchSize,
+		dryRun:             dryRun,
+		liftPartitionGuard: liftPartitionGuard,
+		inserted:           0,
+		lastCommitted:      uuid.Nil,
 	}
 }
 
@@ -127,14 +131,17 @@ func (s *Sink) flush(ctx context.Context, rows []FindingRow) error {
 	}
 
 	token := deduplicationToken(rows)
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+	settings := clickhouse.Settings{
 		"insert_deduplication_token": token,
+	}
+	if s.liftPartitionGuard {
 		// risk_findings is PARTITION BY toYYYYMMDD(created_at). A single backfill
 		// batch is time-ordered but can still span more than the default 100
 		// partitions when historical data is sparse, so lift the guard (0 = no
 		// limit) for this one-shot operator insert.
-		"max_partitions_per_insert_block": 0,
-	}))
+		settings["max_partitions_per_insert_block"] = 0
+	}
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
 
 	batch, err := s.conn.PrepareBatch(ctx, insertStatement)
 	if err != nil {

--- a/server/cmd/tools/migrations/riskfindings/sink_test.go
+++ b/server/cmd/tools/migrations/riskfindings/sink_test.go
@@ -14,7 +14,7 @@ func TestSinkDryRunCountsButExposesNoCursor(t *testing.T) {
 	t.Parallel()
 
 	const batchSize = 2
-	sink := NewSink(nil, 4, batchSize, true)
+	sink := NewSink(nil, 4, batchSize, true, true)
 
 	done := make(chan error, 1)
 	go func() { done <- sink.Run(t.Context()) }()
@@ -54,7 +54,7 @@ func TestDeduplicationTokenDistinguishesInteriors(t *testing.T) {
 func TestSinkEmptyCommitsNothing(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(nil, 1, 2, true)
+	sink := NewSink(nil, 1, 2, true, true)
 
 	done := make(chan error, 1)
 	go func() { done <- sink.Run(t.Context()) }()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the migration optionally lift the ClickHouse partition guard to prevent insert failures when a batch spans many partitions. Adds a CLI flag to enable/disable this behavior (on by default).

- New Features
  - Added `-lift-partition-guard` flag (default true) that sets `max_partitions_per_insert_block=0` on `risk_findings` inserts to avoid ClickHouse constraint errors (code 452); can be disabled when server settings forbid it.
  - Plumbed the flag into the sink and applied the setting per-insert alongside the existing `insert_deduplication_token`; updated tests to match the new signature.

<sup>Written for commit 4198af0c2e404759fce4518cf964dff7d70d51cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

