### PR TITLE
fix: derive Codex tool-call ids and trace ids from a shared key (DNO-604)

### DIFF
--- a/.changeset/codex-provenance-joinable-tool-call-ids.md
+++ b/.changeset/codex-provenance-joinable-tool-call-ids.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Make Codex MCP tool calls joinable to their recorded provenance (DNO-604). Codex hook payloads carry no per-call tool-call id, so the recorded chat tool-call id (previously the tool name) and the telemetry trace id (previously derived from the session id) could never satisfy the shadow-MCP provenance join `trace_id = sha256(tool_call_id)[:16]` — every Codex MCP call fell back to `x-gram-toolset-id` signature validation. Both sides now derive from a shared `sessionID + "|" + toolName` key, which also moves Codex trace grouping from one-trace-per-session to one-trace-per-(session, tool): Tool Logs rows now carry the actual tool name instead of an arbitrary one per session. The canonical ingest path applies the same shared-key fallback for any sender that omits per-call tool ids.

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -441,6 +441,14 @@ func (s *Service) buildCodexTelemetryAttributes(ctx context.Context, payload *ge
 	if payload.SessionID != nil && *payload.SessionID != "" {
 		attrs[attr.GenAIConversationIDKey] = *payload.SessionID
 		attrs[attr.TraceIDKey] = hashToolCallIDToTraceID(*payload.SessionID)
+		// Tool events trace per (session, tool) rather than per session so the
+		// trace id stays derivable from the recorded chat tool-call id — the
+		// provenance join requires trace_id = hash(recorded id), and
+		// writeCodexToolCallRequestToPG records this same key (DNO-604). The
+		// full tool name is used, not the server/function split applied below.
+		if key := syntheticToolCallID(*payload.SessionID, toolName); key != "" {
+			attrs[attr.TraceIDKey] = hashToolCallIDToTraceID(key)
+		}
 	}
 
 	if payload.HookEventName == "UserPromptSubmit" && payload.Prompt != nil && *payload.Prompt != "" {
@@ -518,11 +526,15 @@ func (s *Service) writeCodexToolCallRequestToPG(ctx context.Context, payload *ge
 
 	chatID := sessionIDToUUID(metadata.SessionID)
 
+	// The recorded id must hash to the telemetry trace id written by
+	// buildCodexTelemetryAttributes or the shadow-MCP provenance lookup can
+	// never join this call back to its hook log (DNO-604).
+	toolName := conv.PtrValOr(payload.ToolName, "")
 	toolCalls := []map[string]any{{
-		"id":   conv.PtrValOr(payload.ToolName, ""),
+		"id":   syntheticToolCallID(metadata.SessionID, toolName),
 		"type": "function",
 		"function": map[string]any{
-			"name":      conv.PtrValOr(payload.ToolName, ""),
+			"name":      toolName,
 			"arguments": marshalToJSON(payload.ToolInput),
 		},
 	}}
@@ -588,7 +600,7 @@ func (s *Service) writeCodexToolCallResultToPG(ctx context.Context, payload *gen
 		Content:          marshalToJSON(payload.ToolOutput),
 		UserID:           conv.ToPGTextEmpty(metadata.UserID),
 		Source:           conv.ToPGText("Codex"),
-		ToolCallID:       conv.ToPGTextEmpty(conv.PtrValOr(payload.ToolName, "")),
+		ToolCallID:       conv.ToPGTextEmpty(syntheticToolCallID(metadata.SessionID, conv.PtrValOr(payload.ToolName, ""))),
 		PromptTokens:     0,
 		CompletionTokens: 0,
 		TotalTokens:      0,

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -599,7 +599,7 @@ func TestCodex_ToolCall_RecordedIDHashesToTelemetryTraceID(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(toolRequest.ToolCalls, &toolCalls))
 	require.Len(t, toolCalls, 1)
-	require.Equal(t, sessionID+"|"+toolName, toolCalls[0].ID)
+	require.Equal(t, syntheticToolCallID(sessionID, toolName), toolCalls[0].ID)
 	require.Equal(t, toolName, toolCalls[0].Function.Name)
 	require.Equal(t, toolCalls[0].ID, toolResult.ToolCallID.String, "result rows must pair on the same id")
 

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -1,12 +1,14 @@
 package hooks
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	"github.com/speakeasy-api/gram/server/internal/risk"
@@ -533,6 +535,111 @@ func TestCodexShadowMCPEvidence_ResolvesURLFromInventory(t *testing.T) {
 	require.Equal(t, "unknown", evidence.ServerIdentity)
 	require.Empty(t, evidence.FullURL)
 	require.Nil(t, matched)
+}
+
+// The recorded chat tool-call id must hash to the telemetry trace id: the
+// shadow-MCP provenance lookup joins the two via
+// trace_id = hashToolCallIDToTraceID(recorded id) (DNO-604).
+func TestCodex_ToolCall_RecordedIDHashesToTelemetryTraceID(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := "codex-session-provenance-join"
+	toolName := "mcp__int_linear__get_issue"
+	userEmail := "dev@example.com"
+
+	result, err := ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolInput:     map[string]any{"id": "ABC-123"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Nil(t, result.Decision)
+
+	_, err = ti.service.Codex(ctx, &gen.CodexPayload{
+		HookEventName: "PostToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolOutput:    map[string]any{"ok": true},
+	})
+	require.NoError(t, err)
+
+	msgs, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{
+		ChatID:    sessionIDToUUID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	var toolRequest, toolResult chatRepo.ChatMessage
+	for _, msg := range msgs {
+		switch {
+		case msg.Role == "assistant" && len(msg.ToolCalls) > 0:
+			toolRequest = msg
+		case msg.Role == "tool":
+			toolResult = msg
+		}
+	}
+	require.NotEmpty(t, toolRequest.ID)
+	require.NotEmpty(t, toolResult.ID)
+
+	var toolCalls []struct {
+		ID       string `json:"id"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	require.NoError(t, json.Unmarshal(toolRequest.ToolCalls, &toolCalls))
+	require.Len(t, toolCalls, 1)
+	require.Equal(t, sessionID+"|"+toolName, toolCalls[0].ID)
+	require.Equal(t, toolName, toolCalls[0].Function.Name)
+	require.Equal(t, toolCalls[0].ID, toolResult.ToolCallID.String, "result rows must pair on the same id")
+
+	attrs := ti.service.buildCodexTelemetryAttributes(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		ToolName:      &toolName,
+	}, &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "Codex",
+		UserEmail:   userEmail,
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	})
+	require.Equal(t, hashToolCallIDToTraceID(toolCalls[0].ID), attrs[attr.TraceIDKey])
+}
+
+// Non-tool Codex events keep the per-session trace: only tool events move to
+// the per-(session, tool) grouping that makes the provenance join possible.
+func TestBuildCodexTelemetryAttributes_NonToolEventKeepsSessionTrace(t *testing.T) {
+	t.Parallel()
+	_, ti := newTestHooksService(t)
+
+	sessionID := "codex-session-trace-grouping"
+	email := "dev@example.com"
+	prompt := "hello"
+	attrs := ti.service.buildCodexTelemetryAttributes(t.Context(), &gen.CodexPayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		UserEmail:     &email,
+		Prompt:        &prompt,
+	}, &SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "Codex",
+		UserEmail:   email,
+		GramOrgID:   "org-id",
+		ProjectID:   "project-id",
+	})
+
+	require.Equal(t, hashToolCallIDToTraceID(sessionID), attrs[attr.TraceIDKey])
 }
 
 func TestCodexSessionMetadata_CachesSessionStartEmail(t *testing.T) {

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -260,6 +260,23 @@ func hashToolCallIDToTraceID(toolCallID string) string {
 	return hex.EncodeToString(hash[:16])
 }
 
+// syntheticToolCallID is the per-(session, tool) tool-call id for senders whose
+// hook payloads carry no per-call id (Codex, and canonical-API senders that
+// omit tool.id). The recorded chat tool_calls id and the telemetry trace id
+// must both derive from this one key: the shadow-MCP provenance lookup joins a
+// recorded id to its telemetry rows via
+// trace_id = hashToolCallIDToTraceID(recorded id) (see
+// internal/telemetry/repo/mcp_match_lookup.go), so deriving the two sides from
+// different values makes every call permanently unjoinable. Returns "" when
+// either part is missing — there is no meaningful per-tool key to share then,
+// and callers keep their previous fallback.
+func syntheticToolCallID(sessionID, toolName string) string {
+	if sessionID == "" || toolName == "" {
+		return ""
+	}
+	return sessionID + "|" + toolName
+}
+
 // generateSpanID generates a W3C-compliant span ID (16 hex characters)
 func generateSpanID() string {
 	b := make([]byte, 8)

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -270,11 +271,16 @@ func hashToolCallIDToTraceID(toolCallID string) string {
 // different values makes every call permanently unjoinable. Returns "" when
 // either part is missing — there is no meaningful per-tool key to share then,
 // and callers keep their previous fallback.
+//
+// The session id is length-prefixed so the encoding is injective: session ids
+// are client-controlled and may themselves contain "|", and two distinct
+// (session, tool) pairs colliding onto one key would let the provenance
+// lookup resolve one call to another call's MCP server.
 func syntheticToolCallID(sessionID, toolName string) string {
 	if sessionID == "" || toolName == "" {
 		return ""
 	}
-	return sessionID + "|" + toolName
+	return strconv.Itoa(len(sessionID)) + "|" + sessionID + "|" + toolName
 }
 
 // generateSpanID generates a W3C-compliant span ID (16 hex characters)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -1039,9 +1039,17 @@ func canonicalToolCallsJSON(payload *gen.IngestPayload) ([]byte, error) {
 	return toolCallsJSON, nil
 }
 
+// canonicalChatToolCallID falls back to the shared per-(session, tool) key
+// when the sender supplied no per-call id, matching canonicalTraceID's
+// fallback: hashing the recorded id must reproduce the trace id, or the
+// shadow-MCP provenance lookup can never join the recorded call to its hook
+// log (DNO-604).
 func canonicalChatToolCallID(payload *gen.IngestPayload) string {
 	if id := canonicalToolCallID(payload); id != "" {
 		return id
+	}
+	if key := syntheticToolCallID(canonicalSessionID(payload), canonicalToolName(payload)); key != "" {
+		return key
 	}
 	if name := canonicalToolName(payload); name != "" {
 		return name
@@ -1152,6 +1160,11 @@ func canonicalToolCallID(payload *gen.IngestPayload) string {
 func canonicalTraceID(payload *gen.IngestPayload) string {
 	if id := canonicalToolCallID(payload); id != "" {
 		return hashToolCallIDToTraceID(id)
+	}
+	// Tool events without a per-call id trace per (session, tool), keeping the
+	// trace id derivable from the id canonicalChatToolCallID records (DNO-604).
+	if key := syntheticToolCallID(canonicalSessionID(payload), canonicalToolName(payload)); key != "" {
+		return hashToolCallIDToTraceID(key)
 	}
 	if sessionID := canonicalSessionID(payload); sessionID != "" {
 		return hashToolCallIDToTraceID(sessionID)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -1048,13 +1048,31 @@ func canonicalChatToolCallID(payload *gen.IngestPayload) string {
 	if id := canonicalToolCallID(payload); id != "" {
 		return id
 	}
-	if key := syntheticToolCallID(canonicalSessionID(payload), canonicalToolName(payload)); key != "" {
+	if key := canonicalSyntheticToolCallID(payload); key != "" {
 		return key
 	}
 	if name := canonicalToolName(payload); name != "" {
 		return name
 	}
 	return canonicalTraceID(payload)
+}
+
+// canonicalSyntheticToolCallID returns the shared per-(session, tool) fallback
+// key for tool events only. canonicalTraceID runs for every ingested event
+// (hookTelemetryBaseAttrs), and the schema permits tool_call data on any
+// event, but only tool events have a recorded chat side to join — a
+// skill.activated or prompt row carrying a tool name must keep its
+// session-level trace instead of migrating into the tool's trace.
+func canonicalSyntheticToolCallID(payload *gen.IngestPayload) string {
+	if payload == nil || payload.Event == nil {
+		return ""
+	}
+	switch strings.TrimSpace(payload.Event.Type) {
+	case "tool.requested", "tool.completed", "tool.failed":
+		return syntheticToolCallID(canonicalSessionID(payload), canonicalToolName(payload))
+	default:
+		return ""
+	}
 }
 
 func canonicalToolResultContent(payload *gen.IngestPayload) string {
@@ -1163,7 +1181,7 @@ func canonicalTraceID(payload *gen.IngestPayload) string {
 	}
 	// Tool events without a per-call id trace per (session, tool), keeping the
 	// trace id derivable from the id canonicalChatToolCallID records (DNO-604).
-	if key := syntheticToolCallID(canonicalSessionID(payload), canonicalToolName(payload)); key != "" {
+	if key := canonicalSyntheticToolCallID(payload); key != "" {
 		return hashToolCallIDToTraceID(key)
 	}
 	if sessionID := canonicalSessionID(payload); sessionID != "" {

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1168,6 +1168,37 @@ func TestIngest_PermissionRequestsNotPersistedAsToolCalls(t *testing.T) {
 	require.Empty(t, msgs, "permission prompts must not persist chat rows")
 }
 
+// A sender that omits per-call tool ids must still produce a joinable
+// (recorded id, trace id) pair: the shadow-MCP provenance lookup joins via
+// trace_id = hashToolCallIDToTraceID(recorded id) (DNO-604).
+func TestCanonicalToolCallIDAndTraceID_JoinWithoutPerCallID(t *testing.T) {
+	t.Parallel()
+
+	toolName := "mcp__linear__get_issue"
+	payload := canonicalIngestPayload("custom-adapter", "tool.requested", "join-session")
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			Name: &toolName,
+		},
+	}
+
+	require.Equal(t, "join-session|mcp__linear__get_issue", canonicalChatToolCallID(payload))
+	require.Equal(t, hashToolCallIDToTraceID(canonicalChatToolCallID(payload)), canonicalTraceID(payload))
+
+	// A per-call id, when present, takes precedence on both sides.
+	id := "call_123"
+	payload.Data.ToolCall.ID = &id
+	require.Equal(t, id, canonicalChatToolCallID(payload))
+	require.Equal(t, hashToolCallIDToTraceID(id), canonicalTraceID(payload))
+
+	// Without a tool name there is no per-tool key: non-tool events keep the
+	// per-session trace.
+	require.Equal(t,
+		hashToolCallIDToTraceID("join-session"),
+		canonicalTraceID(canonicalIngestPayload("custom-adapter", "prompt.submitted", "join-session")),
+	)
+}
+
 func canonicalIngestPayload(adapter, eventType, sessionID string) *gen.IngestPayload {
 	return &gen.IngestPayload{
 		SchemaVersion: hookIngestSchemaV1,

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1182,7 +1182,7 @@ func TestCanonicalToolCallIDAndTraceID_JoinWithoutPerCallID(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, "join-session|mcp__linear__get_issue", canonicalChatToolCallID(payload))
+	require.Equal(t, "12|join-session|mcp__linear__get_issue", canonicalChatToolCallID(payload))
 	require.Equal(t, hashToolCallIDToTraceID(canonicalChatToolCallID(payload)), canonicalTraceID(payload))
 
 	// A per-call id, when present, takes precedence on both sides.
@@ -1197,6 +1197,35 @@ func TestCanonicalToolCallIDAndTraceID_JoinWithoutPerCallID(t *testing.T) {
 		hashToolCallIDToTraceID("join-session"),
 		canonicalTraceID(canonicalIngestPayload("custom-adapter", "prompt.submitted", "join-session")),
 	)
+
+	// A non-tool event carrying tool_call data must also keep the per-session
+	// trace: only tool events have a recorded chat side to join, and anything
+	// else migrating into the tool trace would regroup trace_summaries rows.
+	skillPayload := canonicalIngestPayload("custom-adapter", "skill.activated", "join-session")
+	skillPayload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			Name: &toolName,
+		},
+	}
+	require.Equal(t, hashToolCallIDToTraceID("join-session"), canonicalTraceID(skillPayload))
+}
+
+// The synthetic key encoding must be injective: session ids are
+// client-controlled, so a "|" inside one must not let two distinct
+// (session, tool) pairs share a recorded id — a collision would let the
+// provenance lookup resolve one call to another call's MCP server.
+func TestSyntheticToolCallID_InjectiveEncoding(t *testing.T) {
+	t.Parallel()
+
+	require.NotEqual(t,
+		syntheticToolCallID("a|b", "c"),
+		syntheticToolCallID("a", "b|c"),
+	)
+	require.Equal(t, "3|a|b|c", syntheticToolCallID("a|b", "c"))
+	require.Equal(t, "1|a|b|c", syntheticToolCallID("a", "b|c"))
+
+	require.Empty(t, syntheticToolCallID("", "tool"))
+	require.Empty(t, syntheticToolCallID("session", ""))
 }
 
 func canonicalIngestPayload(adapter, eventType, sessionID string) *gen.IngestPayload {


### PR DESCRIPTION
## Summary

Fixes DNO-604: Codex MCP provenance could never join to recorded tool calls.

The shadow-MCP provenance lookup (`LookupMCPProvenanceByToolCallID`) joins a recorded chat tool-call id to its telemetry rows via `trace_id = sha256(tool_call_id)[:16]`. For Codex the two sides derived from different values — the recorded id was the **tool name** while the trace id was derived from the **session id** — so the join was structurally impossible. Every Codex MCP call resolved to unknown provenance and fell back to `x-gram-toolset-id` signature validation, blocking the DNO-599 goal of deleting that fallback.

This implements option (a) from the issue: both sides now derive from a shared `sessionID + "|" + toolName` key.

- `syntheticToolCallID` helper in `internal/hooks/impl.go` documents and owns the join invariant.
- Codex: `buildCodexTelemetryAttributes` sets `trace_id = hash(session|tool)` for tool events; `writeCodexToolCallRequestToPG` records the same key as the tool_calls `id`, and `writeCodexToolCallResultToPG` pairs the result row on it. Non-tool events (UserPromptSubmit, Stop, ...) keep the per-session trace.
- Canonical ingest: `canonicalChatToolCallID` / `canonicalTraceID` get the same shared-key fallback tier, fixing the class for any sender that omits per-call tool ids. Senders that supply `tool.id` are untouched.

## Trace-grouping impact (product-visible, deliberate)

Codex trace grouping moves from one-trace-per-session to one-trace-per-(session, tool):

- Today a Codex session is a single `trace_summaries` row whose `tool_name` is `any()` over every tool the session called — one Tool Logs row per session labeled with an arbitrary tool. Claude (per `ToolUseID`) and Cursor (per correlation id) are already per-call; Codex is the outlier.
- After this change, tool events form per-(session, tool) traces with the correct tool name. The residual per-session trace (non-tool events) has an empty `tool_name`, which the Tool Logs queries already filter out.
- Session-level rollups (`chat_session_summaries`, usage) key on `gen_ai.conversation.id`, which still carries the raw session id — unaffected.
- One-time artifact: a session live during the deploy splits across old- and new-shape traces.

Option (b) (recovering the session id from `chat.id`) was rejected as strictly worse: all calls in a session share one trace, so the lookup's `max(match)` would collapse a multi-server session onto one arbitrary server — converting "always unresolved" into "sometimes wrongly resolved".

## Verification

- New end-to-end test asserts the recorded tool_calls id is `session|tool`, the result row pairs on it, and `sha256(recorded id)[:16]` equals the telemetry trace id — the exact join the provenance lookup performs.
- New tests cover the non-tool-event session trace and all canonical fallback tiers.
- Full `hooks` + `shadowmcpscan` suites pass (372 tests); golangci-lint clean.
- Post-deploy: the `codex` sender's unresolved rate on the `risk.shadow_mcp.resolution` metric should drop toward zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-604 by deriving Codex tool-call IDs and telemetry trace IDs from a shared, length-prefixed `sessionID|toolName` key so MCP provenance can join. Canonical ingest uses the same per-(session, tool) fallback for tool events only; Codex traces move from per-session to per-(session, tool).

- **Bug Fixes**
  - Codex tool events: set `trace_id = hash(sharedKey)` where `sharedKey = length-prefixed sessionID|toolName`, and record the same value as the chat `tool_calls.id`; non-tool events keep per-session traces.
  - Canonical ingest: `canonicalChatToolCallID`/`canonicalTraceID` fall back to the shared key for `tool.requested`/`tool.completed`/`tool.failed` only; other events remain session-scoped.
  - Hardening: the shared key is length-prefixed to be injective even if session IDs contain `|`. Tests cover the id↔trace join, non-tool session traces, event gating, and key encoding.

- **Migration**
  - No action needed. Tool Logs will now group Codex tool events by (session, tool) and show the correct tool name; sessions active during deploy may split across old/new traces.

<sup>Written for commit b4dfe3be0875aa2a2dc9c9000f407cf198b27c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

