### PR TITLE
feat: serve Employee Enrollment list from pre-aggregated agent-metrics view

### DIFF
--- a/.changeset/enrollment-agent-metrics-source.md
+++ b/.changeset/enrollment-agent-metrics-source.md
@@ -1,0 +1,8 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Serve the Employee Enrollment list from the pre-aggregated `attribute_metrics_summaries` view (DNO-618). `telemetry.searchUsers` gains a `source` level: `logs` (default, unchanged) scans raw `telemetry_logs`, while `agent_metrics` reads the pre-aggregated view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper (the enrollment query drops from ~seconds to tens of milliseconds on large projects). Identities that never carry an email in the window (which have no token usage) are surfaced separately from raw logs with activity but no token counts, so unknown users stay visible.
+
+Note the enrollment token numbers change: they now reflect the same canonical agent-usage measure the costs/billing pages use, rather than the previous raw `gen_ai.usage.*` sum that mixed in Gram-hosted completions and duplicate usage-metric rows while missing Claude Code OTEL usage. Only the enrollment list opts in via `source=agent_metrics`; all other `searchUsers` consumers are unchanged.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -58205,7 +58205,7 @@ components:
           maximum: 1000
         metrics:
           type: string
-          description: 'Level of usage metrics to compute per user. ''full'' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. ''basic'' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under ''basic''.'
+          description: 'Level of usage metrics to compute per user. ''full'' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. ''basic'' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under ''basic''. Ignored when source=''agent_metrics''.'
           default: full
           enum:
             - full
@@ -58217,6 +58217,13 @@ components:
           enum:
             - asc
             - desc
+        source:
+          type: string
+          description: Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+          default: logs
+          enum:
+            - logs
+            - agent_metrics
         user_type:
           type: string
           description: Type of user identifier to group by

--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -33,7 +33,7 @@ import {
   type OptionsById,
 } from "@/components/filters";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
-import { Metrics } from "@gram/client/models/components/searchuserspayload.js";
+import { Source } from "@gram/client/models/components/searchuserspayload.js";
 import type { UserSummary } from "@gram/client/models/components/usersummary.js";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useMembers } from "@gram/client/react-query/members.js";
@@ -1117,11 +1117,13 @@ async function fetchEmployeeUsage(
           limit: 1000,
           sort: "desc",
           userType: "internal",
-          // The enrollment list renders only identity, last activity, token
-          // totals, and linked accounts (the latter from Postgres enrichment),
-          // so request the lean aggregation and skip the per-tool/hook-source
-          // map aggregates that dominate the ClickHouse query cost (DNO-618).
-          metrics: Metrics.Basic,
+          // Serve the enrollment list from the pre-aggregated agent-usage view
+          // instead of scanning raw telemetry_logs: the list renders only
+          // identity, last activity, token totals, and linked accounts (the
+          // latter from Postgres enrichment), all of which the view provides far
+          // more cheaply. Email-less identities (no token usage) are surfaced by
+          // the backend from raw logs so unknown users stay visible (DNO-618).
+          source: Source.AgentMetrics,
         },
       }),
     );

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -6143,7 +6143,7 @@ examples:
   searchUsers:
     speakeasy-default-search-users:
       requestBody:
-        application/json: {"filter": {"from": "2025-12-19T10:00:00Z", "to": "2025-12-19T11:00:00Z"}, "group_by": "employee", "limit": 50, "metrics": "full", "sort": "desc", "user_type": "external"}
+        application/json: {"filter": {"from": "2025-12-19T10:00:00Z", "to": "2025-12-19T11:00:00Z"}, "group_by": "employee", "limit": 50, "metrics": "full", "sort": "desc", "source": "logs", "user_type": "external"}
       responses:
         "200":
           application/json: {"users": [{"avg_tokens_per_request": 2445.8, "cache_creation_input_tokens": 298116, "cache_read_input_tokens": 261654, "first_seen_unix_nano": "<value>", "hook_sources": [], "last_seen_unix_nano": "<value>", "tool_call_failure": 344370, "tool_call_success": 262843, "tools": [{"count": 505126, "failure_count": 421094, "success_count": 638666, "urn": "<value>"}], "total_chat_requests": 818926, "total_chats": 659984, "total_cost": 45.75, "total_input_tokens": 504437, "total_output_tokens": 325254, "total_tokens": 66646, "total_tool_calls": 681888, "user_email": "<value>", "user_id": "<id>"}]}

--- a/client/dashboard/src/sdk/src/models/components/searchuserspayload.ts
+++ b/client/dashboard/src/sdk/src/models/components/searchuserspayload.ts
@@ -26,14 +26,14 @@ export type SearchUsersPayloadGroupBy = ClosedEnum<
 >;
 
 /**
- * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.
+ * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'. Ignored when source='agent_metrics'.
  */
 export const Metrics = {
   Full: "full",
   Basic: "basic",
 } as const;
 /**
- * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.
+ * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'. Ignored when source='agent_metrics'.
  */
 export type Metrics = ClosedEnum<typeof Metrics>;
 
@@ -48,6 +48,18 @@ export const SearchUsersPayloadSort = {
  * Sort order
  */
 export type SearchUsersPayloadSort = ClosedEnum<typeof SearchUsersPayloadSort>;
+
+/**
+ * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+ */
+export const Source = {
+  Logs: "logs",
+  AgentMetrics: "agent_metrics",
+} as const;
+/**
+ * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+ */
+export type Source = ClosedEnum<typeof Source>;
 
 /**
  * Type of user identifier to group by
@@ -84,13 +96,17 @@ export type SearchUsersPayload = {
    */
   limit?: number | undefined;
   /**
-   * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.
+   * Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'. Ignored when source='agent_metrics'.
    */
   metrics?: Metrics | undefined;
   /**
    * Sort order
    */
   sort?: SearchUsersPayloadSort | undefined;
+  /**
+   * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+   */
+  source?: Source | undefined;
   /**
    * Type of user identifier to group by
    */
@@ -113,6 +129,11 @@ export const SearchUsersPayloadSort$outboundSchema: z.ZodMiniEnum<
 > = z.enum(SearchUsersPayloadSort);
 
 /** @internal */
+export const Source$outboundSchema: z.ZodMiniEnum<typeof Source> = z.enum(
+  Source,
+);
+
+/** @internal */
 export const SearchUsersPayloadUserType$outboundSchema: z.ZodMiniEnum<
   typeof SearchUsersPayloadUserType
 > = z.enum(SearchUsersPayloadUserType);
@@ -125,6 +146,7 @@ export type SearchUsersPayload$Outbound = {
   limit: number;
   metrics: string;
   sort: string;
+  source: string;
   user_type: string;
 };
 
@@ -140,6 +162,7 @@ export const SearchUsersPayload$outboundSchema: z.ZodMiniType<
     limit: z._default(z.int(), 50),
     metrics: z._default(Metrics$outboundSchema, "full"),
     sort: z._default(SearchUsersPayloadSort$outboundSchema, "desc"),
+    source: z._default(Source$outboundSchema, "logs"),
     userType: SearchUsersPayloadUserType$outboundSchema,
   }),
   z.transform((v) => {

--- a/server/design/telemetry/design.go
+++ b/server/design/telemetry/design.go
@@ -1208,9 +1208,13 @@ var SearchUsersPayload = Type("SearchUsersPayload", func() {
 		Maximum(1000)
 		Default(50)
 	})
-	Attribute("metrics", String, "Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'.", func() {
+	Attribute("metrics", String, "Level of usage metrics to compute per user. 'full' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. 'basic' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under 'basic'. Ignored when source='agent_metrics'.", func() {
 		Enum("full", "basic")
 		Default("full")
+	})
+	Attribute("source", String, "Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.", func() {
+		Enum("logs", "agent_metrics")
+		Default("logs")
 	})
 
 	Required("filter", "user_type")

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -15808,7 +15808,7 @@ func telemetrySearchUsersUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "telemetry search-users --body '{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"metrics\": \"basic\",\n      \"sort\": \"desc\",\n      \"user_type\": \"external\"\n   }' --apikey-token \"abc123\" --session-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "telemetry search-users --body '{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"metrics\": \"basic\",\n      \"sort\": \"desc\",\n      \"source\": \"agent_metrics\",\n      \"user_type\": \"external\"\n   }' --apikey-token \"abc123\" --session-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func telemetryCaptureEventUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -58531,7 +58531,7 @@ components:
                     maximum: 1000
                 metrics:
                     type: string
-                    description: 'Level of usage metrics to compute per user. ''full'' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. ''basic'' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under ''basic''.'
+                    description: 'Level of usage metrics to compute per user. ''full'' (default) returns the complete set: chat counts, cost, cache tokens, tool-call totals, and the per-tool and per-hook-source breakdowns. ''basic'' computes only user identity, first/last activity, and input/output token sums — a much cheaper aggregation for large orgs (e.g. the employee enrollment list, which renders only those fields). The remaining fields are zero/empty under ''basic''. Ignored when source=''agent_metrics''.'
                     default: full
                     enum:
                         - full
@@ -58543,6 +58543,13 @@ components:
                     enum:
                         - asc
                         - desc
+                source:
+                    type: string
+                    description: Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+                    default: logs
+                    enum:
+                        - logs
+                        - agent_metrics
                 user_type:
                     type: string
                     description: Type of user identifier to group by

--- a/server/gen/http/telemetry/client/cli.go
+++ b/server/gen/http/telemetry/client/cli.go
@@ -204,7 +204,7 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 	{
 		err = json.Unmarshal([]byte(telemetrySearchUsersBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"metrics\": \"basic\",\n      \"sort\": \"desc\",\n      \"user_type\": \"external\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"cursor\": \"abc123\",\n      \"filter\": {\n         \"account_type\": \"abc123\",\n         \"deployment_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n         \"event_source\": \"abc123\",\n         \"external_org_id\": \"abc123\",\n         \"from\": \"2025-12-19T10:00:00Z\",\n         \"hook_source\": \"abc123\",\n         \"to\": \"2025-12-19T11:00:00Z\",\n         \"user_ids\": [\n            \"abc123\"\n         ]\n      },\n      \"group_by\": \"role\",\n      \"limit\": 2,\n      \"metrics\": \"basic\",\n      \"sort\": \"desc\",\n      \"source\": \"agent_metrics\",\n      \"user_type\": \"external\"\n   }'")
 		}
 		if body.Filter == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("filter", "body"))
@@ -231,6 +231,9 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 		}
 		if !(body.Metrics == "full" || body.Metrics == "basic") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.metrics", body.Metrics, []any{"full", "basic"}))
+		}
+		if !(body.Source == "logs" || body.Source == "agent_metrics") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.source", body.Source, []any{"logs", "agent_metrics"}))
 		}
 		if err != nil {
 			return nil, err
@@ -261,6 +264,7 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 		Sort:     body.Sort,
 		Limit:    body.Limit,
 		Metrics:  body.Metrics,
+		Source:   body.Source,
 	}
 	if body.Filter != nil {
 		v.Filter = marshalSearchUsersFilterRequestBodyToTelemetrySearchUsersFilter(body.Filter)
@@ -287,6 +291,12 @@ func BuildSearchUsersPayload(telemetrySearchUsersBody string, telemetrySearchUse
 		var zero string
 		if v.Metrics == zero {
 			v.Metrics = "full"
+		}
+	}
+	{
+		var zero string
+		if v.Source == zero {
+			v.Source = "logs"
 		}
 	}
 	v.ApikeyToken = apikeyToken

--- a/server/gen/http/telemetry/client/types.go
+++ b/server/gen/http/telemetry/client/types.go
@@ -80,7 +80,17 @@ type SearchUsersRequestBody struct {
 	// identity, first/last activity, and input/output token sums — a much cheaper
 	// aggregation for large orgs (e.g. the employee enrollment list, which renders
 	// only those fields). The remaining fields are zero/empty under 'basic'.
+	// Ignored when source='agent_metrics'.
 	Metrics string `form:"metrics" json:"metrics" xml:"metrics"`
+	// Where per-user summaries are read from (internal employee grouping only).
+	// 'logs' (default) scans raw telemetry_logs and computes the metrics selected
+	// by 'metrics'. 'agent_metrics' reads the pre-aggregated
+	// attribute_metrics_summaries view — canonical observed agent usage (Claude
+	// Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but
+	// returns only identity, last activity (hourly), and input/output/total token
+	// sums; users without an email in the window are surfaced separately from raw
+	// logs with activity but no token counts.
+	Source string `form:"source" json:"source" xml:"source"`
 }
 
 // CaptureEventRequestBody is the type of the "telemetry" service
@@ -7215,6 +7225,7 @@ func NewSearchUsersRequestBody(p *telemetry.SearchUsersPayload) *SearchUsersRequ
 		Sort:     p.Sort,
 		Limit:    p.Limit,
 		Metrics:  p.Metrics,
+		Source:   p.Source,
 	}
 	if p.Filter != nil {
 		body.Filter = marshalTelemetrySearchUsersFilterToSearchUsersFilterRequestBody(p.Filter)
@@ -7241,6 +7252,12 @@ func NewSearchUsersRequestBody(p *telemetry.SearchUsersPayload) *SearchUsersRequ
 		var zero string
 		if body.Metrics == zero {
 			body.Metrics = "full"
+		}
+	}
+	{
+		var zero string
+		if body.Source == zero {
+			body.Source = "logs"
 		}
 	}
 	return body

--- a/server/gen/http/telemetry/server/types.go
+++ b/server/gen/http/telemetry/server/types.go
@@ -80,7 +80,17 @@ type SearchUsersRequestBody struct {
 	// identity, first/last activity, and input/output token sums — a much cheaper
 	// aggregation for large orgs (e.g. the employee enrollment list, which renders
 	// only those fields). The remaining fields are zero/empty under 'basic'.
+	// Ignored when source='agent_metrics'.
 	Metrics *string `form:"metrics,omitempty" json:"metrics,omitempty" xml:"metrics,omitempty"`
+	// Where per-user summaries are read from (internal employee grouping only).
+	// 'logs' (default) scans raw telemetry_logs and computes the metrics selected
+	// by 'metrics'. 'agent_metrics' reads the pre-aggregated
+	// attribute_metrics_summaries view — canonical observed agent usage (Claude
+	// Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but
+	// returns only identity, last activity (hourly), and input/output/total token
+	// sums; users without an email in the window are surfaced separately from raw
+	// logs with activity but no token counts.
+	Source *string `form:"source,omitempty" json:"source,omitempty" xml:"source,omitempty"`
 }
 
 // CaptureEventRequestBody is the type of the "telemetry" service
@@ -12072,6 +12082,9 @@ func NewSearchUsersPayload(body *SearchUsersRequestBody, apikeyToken *string, se
 	if body.Metrics != nil {
 		v.Metrics = *body.Metrics
 	}
+	if body.Source != nil {
+		v.Source = *body.Source
+	}
 	v.Filter = unmarshalSearchUsersFilterRequestBodyToTelemetrySearchUsersFilter(body.Filter)
 	if body.GroupBy == nil {
 		v.GroupBy = "employee"
@@ -12084,6 +12097,9 @@ func NewSearchUsersPayload(body *SearchUsersRequestBody, apikeyToken *string, se
 	}
 	if body.Metrics == nil {
 		v.Metrics = "full"
+	}
+	if body.Source == nil {
+		v.Source = "logs"
 	}
 	v.ApikeyToken = apikeyToken
 	v.SessionToken = sessionToken
@@ -13038,6 +13054,11 @@ func ValidateSearchUsersRequestBody(body *SearchUsersRequestBody) (err error) {
 	if body.Metrics != nil {
 		if !(*body.Metrics == "full" || *body.Metrics == "basic") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.metrics", *body.Metrics, []any{"full", "basic"}))
+		}
+	}
+	if body.Source != nil {
+		if !(*body.Source == "logs" || *body.Source == "agent_metrics") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.source", *body.Source, []any{"logs", "agent_metrics"}))
 		}
 	}
 	return

--- a/server/gen/telemetry/service.go
+++ b/server/gen/telemetry/service.go
@@ -1464,7 +1464,17 @@ type SearchUsersPayload struct {
 	// identity, first/last activity, and input/output token sums — a much cheaper
 	// aggregation for large orgs (e.g. the employee enrollment list, which renders
 	// only those fields). The remaining fields are zero/empty under 'basic'.
+	// Ignored when source='agent_metrics'.
 	Metrics string
+	// Where per-user summaries are read from (internal employee grouping only).
+	// 'logs' (default) scans raw telemetry_logs and computes the metrics selected
+	// by 'metrics'. 'agent_metrics' reads the pre-aggregated
+	// attribute_metrics_summaries view — canonical observed agent usage (Claude
+	// Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but
+	// returns only identity, last activity (hourly), and input/output/total token
+	// sums; users without an email in the window are surfaced separately from raw
+	// logs with activity but no token counts.
+	Source string
 }
 
 // SearchUsersResult is the result type of the telemetry service searchUsers

--- a/server/internal/platformtools/logs/tool_search_users.go
+++ b/server/internal/platformtools/logs/tool_search_users.go
@@ -86,7 +86,7 @@ func (s *SearchUsers) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payloa
 		Sort:             input.Sort,
 		Limit:            input.Limit,
 		Metrics:          "full", // API metrics level; surfaces the complete per-user metrics
-
+		Source:           "logs", // read from raw telemetry_logs (full metric set)
 	})
 	if err != nil {
 		if errors.Is(err, telemetryerrs.ErrLogsDisabled) {

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -412,6 +412,14 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		return nil, err
 	}
 
+	// The employee enrollment list can opt into the pre-aggregated
+	// attribute_metrics_summaries view instead of scanning raw telemetry_logs.
+	// The view is email-keyed and internal-only, so external grouping falls
+	// through to the raw-logs path below.
+	if payload.Source == searchUsersSourceAgentMetrics && payload.UserType != "external" {
+		return s.searchEmployeesFromAgentMetrics(ctx, payload.UserType, params)
+	}
+
 	deploymentID := conv.PtrValOr(filter.DeploymentID, "")
 
 	groupBy := "user_id"
@@ -445,6 +453,85 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 		items = items[:params.limit]
 	}
 
+	users := s.assembleUserSummaries(ctx, payload.UserType, items)
+
+	return &telem_gen.SearchUsersResult{
+		Users:      users,
+		Roles:      nil,
+		NextCursor: nextCursor,
+	}, nil
+}
+
+// searchUsersSourceAgentMetrics is the SearchUsersPayload.Source value that
+// routes the internal employee grouping to the pre-aggregated
+// attribute_metrics_summaries view (see searchEmployeesFromAgentMetrics). Any
+// other value uses the raw telemetry_logs path.
+const searchUsersSourceAgentMetrics = "agent_metrics"
+
+// searchEmployeesFromAgentMetrics serves the employee enrollment list from the
+// pre-aggregated attribute_metrics_summaries view. It runs two reads
+// concurrently: the email-keyed agent-usage rollup (token totals + last
+// activity) and a cheap supplement listing email-less identities (activity
+// only, no tokens) so unattributed usage stays visible. The merged summaries go
+// through the same assembly + account enrichment as the raw path. Results are
+// returned in a single page (the enrollment directory is bounded), so there is
+// no cursor.
+func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType string, params *searchParams) (*telem_gen.SearchUsersResult, error) {
+	// Full-directory fetch: enrollment orgs sit well under this bound. The raw
+	// supplement is capped identically so a pathological project can't stream
+	// unboundedly.
+	const maxEmployees = 10001
+
+	var agentItems, emaillessItems []repo.UserSummary
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		items, err := s.chRepo.SearchEmployeeAgentUsage(gctx, repo.SearchEmployeeAgentUsageParams{
+			GramProjectID: params.projectID,
+			TimeStart:     params.timeStart,
+			TimeEnd:       params.timeEnd,
+			Limit:         maxEmployees,
+		})
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "error reading employee agent usage")
+		}
+		agentItems = items
+		return nil
+	})
+	g.Go(func() error {
+		items, err := s.chRepo.ListEmaillessIdentities(gctx, repo.ListEmaillessIdentitiesParams{
+			GramProjectID: params.projectID,
+			TimeStart:     params.timeStart,
+			TimeEnd:       params.timeEnd,
+			Limit:         maxEmployees,
+		})
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "error listing email-less identities")
+		}
+		emaillessItems = items
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err //nolint:wrapcheck // already an oops error from the goroutines
+	}
+
+	items := make([]repo.UserSummary, 0, len(agentItems)+len(emaillessItems))
+	items = append(items, agentItems...)
+	items = append(items, emaillessItems...)
+
+	users := s.assembleUserSummaries(ctx, userType, items)
+
+	return &telem_gen.SearchUsersResult{
+		Users:      users,
+		Roles:      nil,
+		NextCursor: nil,
+	}, nil
+}
+
+// assembleUserSummaries converts repo user rows into API summaries and attaches
+// each user's linked AI accounts from the user_accounts directory. Shared by the
+// raw-logs and agent-metrics employee paths; rows that carry no tool/hook/chat
+// aggregates (the agent-metrics path) simply yield empty breakdowns.
+func (s *Service) assembleUserSummaries(ctx context.Context, userType string, items []repo.UserSummary) []*telem_gen.UserSummary {
 	users := make([]*telem_gen.UserSummary, len(items))
 	rawUserIDsByKey := make(map[string][]string, len(items))
 	for i, item := range items {
@@ -499,17 +586,13 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	// Attach each user's linked AI accounts (team + personal, across providers)
 	// from the user_accounts directory. Only meaningful when grouping by internal
 	// user_id — external ids don't map to a directory owner.
-	if payload.UserType != "external" {
+	if userType != "external" {
 		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
 			s.attachUserAccounts(ctx, authCtx.ActiveOrganizationID, users, rawUserIDsByKey)
 		}
 	}
 
-	return &telem_gen.SearchUsersResult{
-		Users:      users,
-		Roles:      nil,
-		NextCursor: nextCursor,
-	}, nil
+	return users
 }
 
 // resolveSummaryOwnerIDs maps summary group keys to the Gram user id each key

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -417,6 +417,9 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 	// The view is email-keyed and internal-only, so external grouping falls
 	// through to the raw-logs path below.
 	if payload.Source == searchUsersSourceAgentMetrics && payload.UserType != "external" {
+		if err := validateAgentMetricsFilter(filter); err != nil {
+			return nil, err
+		}
 		return s.searchEmployeesFromAgentMetrics(ctx, payload.UserType, params)
 	}
 
@@ -468,20 +471,48 @@ func (s *Service) searchUsersByEmployee(ctx context.Context, payload *telem_gen.
 // other value uses the raw telemetry_logs path.
 const searchUsersSourceAgentMetrics = "agent_metrics"
 
+// agentMetricsDirectoryCap bounds each of the two agent-metrics reads. The
+// enrollment directory is fetched as a single page (see
+// searchEmployeesFromAgentMetrics), so this is a safety ceiling, not a page
+// size — real orgs sit far below it. A hit is logged rather than silently
+// truncating.
+const agentMetricsDirectoryCap = 10001
+
+// validateAgentMetricsFilter rejects filters the agent_metrics source cannot
+// honor. The pre-aggregated view is keyed by email and time only, so a caller
+// that set a deployment, user, event/hook source, account-type, or provider-org
+// filter would otherwise silently receive unfiltered, project-wide summaries.
+// Only the time range (applied by both underlying queries) is supported.
+func validateAgentMetricsFilter(filter *telem_gen.SearchUsersFilter) error {
+	switch {
+	case conv.PtrValOr(filter.DeploymentID, "") != "":
+		return oops.E(oops.CodeBadRequest, nil, "deployment_id filter is not supported with source=agent_metrics")
+	case len(filter.UserIds) > 0:
+		return oops.E(oops.CodeBadRequest, nil, "user_ids filter is not supported with source=agent_metrics")
+	case conv.PtrValOr(filter.EventSource, "") != "":
+		return oops.E(oops.CodeBadRequest, nil, "event_source filter is not supported with source=agent_metrics")
+	case conv.PtrValOr(filter.HookSource, "") != "":
+		return oops.E(oops.CodeBadRequest, nil, "hook_source filter is not supported with source=agent_metrics")
+	case conv.PtrValOr(filter.AccountType, "") != "":
+		return oops.E(oops.CodeBadRequest, nil, "account_type filter is not supported with source=agent_metrics")
+	case conv.PtrValOr(filter.ExternalOrgID, "") != "":
+		return oops.E(oops.CodeBadRequest, nil, "external_org_id filter is not supported with source=agent_metrics")
+	}
+	return nil
+}
+
 // searchEmployeesFromAgentMetrics serves the employee enrollment list from the
 // pre-aggregated attribute_metrics_summaries view. It runs two reads
 // concurrently: the email-keyed agent-usage rollup (token totals + last
 // activity) and a cheap supplement listing email-less identities (activity
 // only, no tokens) so unattributed usage stays visible. The merged summaries go
-// through the same assembly + account enrichment as the raw path. Results are
-// returned in a single page (the enrollment directory is bounded), so there is
-// no cursor.
+// through the same assembly + account enrichment as the raw path.
+//
+// The enrollment directory is returned as a single page ordered by last
+// activity — the frontend fetches the whole directory (paging the two merged
+// sources by cursor would be slower and defeat the point), so limit/cursor are
+// not used and no cursor is emitted.
 func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType string, params *searchParams) (*telem_gen.SearchUsersResult, error) {
-	// Full-directory fetch: enrollment orgs sit well under this bound. The raw
-	// supplement is capped identically so a pathological project can't stream
-	// unboundedly.
-	const maxEmployees = 10001
-
 	var agentItems, emaillessItems []repo.UserSummary
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -489,7 +520,7 @@ func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType 
 			GramProjectID: params.projectID,
 			TimeStart:     params.timeStart,
 			TimeEnd:       params.timeEnd,
-			Limit:         maxEmployees,
+			Limit:         agentMetricsDirectoryCap,
 		})
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "error reading employee agent usage")
@@ -502,7 +533,7 @@ func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType 
 			GramProjectID: params.projectID,
 			TimeStart:     params.timeStart,
 			TimeEnd:       params.timeEnd,
-			Limit:         maxEmployees,
+			Limit:         agentMetricsDirectoryCap,
 		})
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "error listing email-less identities")
@@ -514,9 +545,23 @@ func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType 
 		return nil, err //nolint:wrapcheck // already an oops error from the goroutines
 	}
 
+	// Surface truncation rather than silently dropping employees: at these sizes
+	// a hit means the enrollment page is showing a partial directory.
+	if len(agentItems) >= agentMetricsDirectoryCap || len(emaillessItems) >= agentMetricsDirectoryCap {
+		s.logger.WarnContext(ctx, fmt.Sprintf(
+			"employee enrollment agent-metrics directory hit the %d-row cap (%d agent, %d email-less); results may be partial",
+			agentMetricsDirectoryCap, len(agentItems), len(emaillessItems),
+		))
+	}
+
 	items := make([]repo.UserSummary, 0, len(agentItems)+len(emaillessItems))
 	items = append(items, agentItems...)
 	items = append(items, emaillessItems...)
+
+	// Each query is only locally ordered, so sort the merged directory globally
+	// by last activity (respecting the requested direction, user key as a stable
+	// tie-breaker) to honor the sort contract.
+	sortUserSummariesByLastSeen(items, params.sortOrder)
 
 	users := s.assembleUserSummaries(ctx, userType, items)
 
@@ -525,6 +570,26 @@ func (s *Service) searchEmployeesFromAgentMetrics(ctx context.Context, userType 
 		Roles:      nil,
 		NextCursor: nil,
 	}, nil
+}
+
+// sortUserSummariesByLastSeen orders rows by LastSeenUnixNano in the requested
+// direction ("asc" ascending, anything else descending), with UserID as a
+// stable tie-breaker.
+func sortUserSummariesByLastSeen(items []repo.UserSummary, sortOrder string) {
+	asc := sortOrder == "asc"
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.LastSeenUnixNano != b.LastSeenUnixNano {
+			if asc {
+				return a.LastSeenUnixNano < b.LastSeenUnixNano
+			}
+			return a.LastSeenUnixNano > b.LastSeenUnixNano
+		}
+		if asc {
+			return a.UserID < b.UserID
+		}
+		return a.UserID > b.UserID
+	})
 }
 
 // assembleUserSummaries converts repo user rows into API summaries and attaches

--- a/server/internal/telemetry/repo/employee_agent_usage.go
+++ b/server/internal/telemetry/repo/employee_agent_usage.go
@@ -1,0 +1,157 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+)
+
+// SearchEmployeeAgentUsageParams parameterizes the MV-backed employee usage read.
+type SearchEmployeeAgentUsageParams struct {
+	GramProjectID string
+	TimeStart     int64 // inclusive window start, unix nanoseconds
+	TimeEnd       int64 // inclusive window end, unix nanoseconds
+	Limit         int
+}
+
+// SearchEmployeeAgentUsage returns per-user usage summaries for the employee
+// enrollment list from the pre-aggregated attribute_metrics_summaries view
+// instead of scanning raw telemetry_logs. It is far cheaper (the view is a
+// per-(user, hour, ...) rollup) but carries three consequences the caller must
+// accept:
+//
+//   - Scope is canonical observed agent usage only — Claude Code, Codex, Cursor,
+//     and Claude Chat — matching the costs/billing pages. Gram-hosted chat
+//     completions and duplicate usage-metric rows are excluded.
+//   - Users are keyed by email. Identities that never carry an email in the
+//     window are absent here; surface them via ListEmaillessIdentities.
+//   - Activity timestamps are hour-truncated (the view buckets by hour).
+//
+// Only identity, first/last activity, and input/output/total token sums are
+// populated; the remaining UserSummary fields (chats, cost, cache, tool and
+// hook breakdowns) are left zero/empty.
+//
+//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) SearchEmployeeAgentUsage(ctx context.Context, arg SearchEmployeeAgentUsageParams) ([]UserSummary, error) {
+	sb := sq.Select(
+		// Identity: email is the group key for this path.
+		"user_email AS user_id",
+		"user_email AS user_email",
+
+		// Activity window. time_bucket is a whole-hour DateTime, so these are
+		// hour-truncated. toInt64(DateTime) yields unix seconds; scale to nanos to
+		// match the UserSummary contract (mirrors QueryAttributeMetricsTimeseries).
+		"toInt64(min(time_bucket)) * 1000000000 AS first_seen_unix_nano",
+		"toInt64(max(time_bucket)) * 1000000000 AS last_seen_unix_nano",
+
+		// Token sums. The view stores AggregateFunction(sumIf, ...) states, so
+		// reads use the matching sumIfMerge combinator (see attributeMeasureSelects).
+		"sumIfMerge(total_input_tokens) AS total_input_tokens",
+		"sumIfMerge(total_output_tokens) AS total_output_tokens",
+		"sumIfMerge(total_tokens) AS total_tokens",
+	).
+		From("attribute_metrics_summaries").
+		// Exclude tombstoned backfill rows (see the is_active column comment in
+		// server/clickhouse/schema.sql).
+		Where("is_active = 1").
+		Where("gram_project_id = ?", arg.GramProjectID).
+		Where("time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeStart).
+		Where("time_bucket <= toStartOfHour(fromUnixTimestamp64Nano(?))", arg.TimeEnd).
+		// Email-keyed rows only; the empty-email bucket is handled by
+		// ListEmaillessIdentities so it isn't shown as one synthetic user.
+		Where("user_email != ''").
+		GroupBy("user_email").
+		OrderBy("last_seen_unix_nano DESC", "user_email DESC").
+		Limit(uint64(arg.Limit)) //nolint:gosec // Limit is always positive
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building employee agent usage query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []UserSummary
+	for rows.Next() {
+		var u UserSummary
+		if err = rows.ScanStruct(&u); err != nil {
+			return nil, fmt.Errorf("error scanning row: %w", err)
+		}
+		users = append(users, u)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// ListEmaillessIdentitiesParams parameterizes the email-less identity supplement.
+type ListEmaillessIdentitiesParams struct {
+	GramProjectID string
+	TimeStart     int64 // inclusive window start, unix nanoseconds
+	TimeEnd       int64 // inclusive window end, unix nanoseconds
+	Limit         int
+}
+
+// ListEmaillessIdentities returns telemetry identities that carry a user_id but
+// never an email anywhere in the window. These are typically tool-call/hook rows
+// that carry no token usage, so the email-keyed attribute_metrics_summaries view
+// cannot represent them. The employee enrollment list surfaces them alongside
+// SearchEmployeeAgentUsage so unattributed activity stays visible — with last
+// activity but no token counts (they genuinely have none).
+//
+// The scan reads only materialized columns (user_id, user_email, time_unix_nano)
+// with no JSON extraction, join, or map aggregation, so it is much cheaper than
+// the full SearchUsers query. Only identity, activity window, and raw_user_ids
+// are populated.
+//
+//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) ListEmaillessIdentities(ctx context.Context, arg ListEmaillessIdentitiesParams) ([]UserSummary, error) {
+	sb := sq.Select(
+		"user_id AS user_id",
+		"'' AS user_email",
+		"min(time_unix_nano) AS first_seen_unix_nano",
+		"max(time_unix_nano) AS last_seen_unix_nano",
+		// Grouped by user_id, so this yields the single id — carried through for
+		// the account-enrichment join, exactly like SearchUsers' raw_user_ids.
+		"groupUniqArray(user_id) AS raw_user_ids",
+	).
+		From("telemetry_logs").
+		Where("gram_project_id = ?", arg.GramProjectID).
+		Where("time_unix_nano >= ?", arg.TimeStart).
+		Where("time_unix_nano <= ?", arg.TimeEnd).
+		Where("user_id != ''").
+		GroupBy("user_id").
+		// Keep only user_ids that never co-occur with an email in the window;
+		// those that do are folded into an email key by SearchEmployeeAgentUsage.
+		Having("max(user_email != '') = 0").
+		OrderBy("last_seen_unix_nano DESC", "user_id DESC").
+		Limit(uint64(arg.Limit)) //nolint:gosec // Limit is always positive
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building emailless identities query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []UserSummary
+	for rows.Next() {
+		var u UserSummary
+		if err = rows.ScanStruct(&u); err != nil {
+			return nil, fmt.Errorf("error scanning row: %w", err)
+		}
+		users = append(users, u)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -1309,6 +1309,12 @@ func TestSearchUsers_AgentMetricsSource(t *testing.T) {
 		byID[u.UserID] = u
 	}
 
+	// Global sort across the two sources: the email-less identity's activity
+	// (-8m) is more recent than the agent user's (-10m), so it sorts first even
+	// though the supplement rows are appended after the view rows.
+	require.NotEmpty(t, res.Users)
+	assert.Equal(t, emaillessUserID, res.Users[0].UserID, "merged results should be globally sorted by last activity")
+
 	// Email-keyed user comes from the view, keyed by email, with token totals.
 	agentUser := byID[email]
 	require.NotNil(t, agentUser, "email-keyed agent user should be present from the view")
@@ -1322,6 +1328,35 @@ func TestSearchUsers_AgentMetricsSource(t *testing.T) {
 	assert.Equal(t, int64(0), emaillessUser.TotalInputTokens)
 	assert.Equal(t, int64(0), emaillessUser.TotalOutputTokens)
 	assert.NotEqual(t, "0", emaillessUser.LastSeenUnixNano, "email-less identity should carry last activity")
+}
+
+// TestSearchUsers_AgentMetricsSourceRejectsUnsupportedFilters pins that the
+// agent-metrics source fails loud rather than silently returning project-wide
+// data when given a filter it cannot honor (the view is keyed by email + time
+// only).
+func TestSearchUsers_AgentMetricsSourceRejectsUnsupportedFilters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	now := time.Now().UTC()
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+	deploymentID := uuid.New().String()
+
+	_, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From:         from,
+			To:           to,
+			DeploymentID: &deploymentID,
+		},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+		Source:   "agent_metrics",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported with source=agent_metrics")
 }
 
 func insertHookLogWithUser(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID, externalUserID, hookSource string, success bool) {

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -1259,6 +1259,71 @@ func TestSearchUsers_BasicMetricsOmitsBreakdowns(t *testing.T) {
 	assert.Empty(t, u.Tools)
 }
 
+// TestSearchUsers_AgentMetricsSource pins the enrollment-list path that reads
+// the pre-aggregated attribute_metrics_summaries view (source=agent_metrics):
+// email-keyed users come from the view with token totals, and identities that
+// never carry an email in the window are supplemented from raw logs with
+// activity but no token counts, so unknown users stay visible (DNO-618).
+func TestSearchUsers_AgentMetricsSource(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+
+	now := time.Now().UTC()
+	email := "agent-user-" + uuid.New().String() + "@example.com"
+	emaillessUserID := "emailless-" + uuid.New().String()
+
+	// Email user: a Claude api_request row flows into attribute_metrics_summaries
+	// with token usage (300 in / 150 out).
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, now.Add(-10*time.Minute), uuid.New().String(), 1.5, 300, 150, 0, 0, "claude-sonnet-4", email, "", nil, "", "", "", "", "")
+	// Email-less identity: a tool-call row carrying a user_id but no email. It is
+	// not an agent-usage row, so the view can't key it — the supplement must.
+	insertToolCallLogWithUser(t, ctx, projectID, deploymentID, now.Add(-8*time.Minute), "tools:http:petstore:listPets", 200, 0.5, emaillessUserID, "")
+
+	// Drain async inserts (and the MV write they trigger) so the view is
+	// deterministically populated before querying (see the telemetry README).
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From: from,
+			To:   to,
+		},
+		UserType: "internal",
+		Limit:    100,
+		Sort:     "desc",
+		Source:   "agent_metrics",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	byID := make(map[string]*gen.UserSummary, len(res.Users))
+	for _, u := range res.Users {
+		byID[u.UserID] = u
+	}
+
+	// Email-keyed user comes from the view, keyed by email, with token totals.
+	agentUser := byID[email]
+	require.NotNil(t, agentUser, "email-keyed agent user should be present from the view")
+	assert.Equal(t, int64(300), agentUser.TotalInputTokens)
+	assert.Equal(t, int64(150), agentUser.TotalOutputTokens)
+	assert.NotEqual(t, "0", agentUser.LastSeenUnixNano, "agent user should carry last activity")
+
+	// Email-less identity is surfaced from raw logs with activity but no tokens.
+	emaillessUser := byID[emaillessUserID]
+	require.NotNil(t, emaillessUser, "email-less identity should still be surfaced")
+	assert.Equal(t, int64(0), emaillessUser.TotalInputTokens)
+	assert.Equal(t, int64(0), emaillessUser.TotalOutputTokens)
+	assert.NotEqual(t, "0", emaillessUser.LastSeenUnixNano, "email-less identity should carry last activity")
+}
+
 func insertHookLogWithUser(t *testing.T, ctx context.Context, projectID, deploymentID string, timestamp time.Time, userID, externalUserID, hookSource string, success bool) {
 	t.Helper()
 


### PR DESCRIPTION
## What

Follow-up to #4485 (DNO-618). The enrollment list was still scanning raw `telemetry_logs` per request (~2.7s on the largest project, even after the `basic` metrics change). This serves it from the pre-aggregated `attribute_metrics_summaries` view instead.

`telemetry.searchUsers` gains a `source` level:
- **`logs`** (default, unchanged) — scans raw `telemetry_logs`, computes the metrics selected by `metrics`.
- **`agent_metrics`** — reads the pre-aggregated view (canonical observed agent usage — Claude Code, Codex, Cursor, Claude Chat — keyed by email) for token totals + last activity, and supplements it with a cheap raw-logs query for **email-less identities** (activity only, no token counts) so unknown users stay visible.

Only the enrollment list opts in (`source=agent_metrics`); every other `searchUsers` consumer (InsightsAgents, ProjectDashboard, EmployeeDetail, the role path, platform tools) is unchanged.

## Measured (largest project, 30-day window, prod read replica)

| | rows read | CH elapsed |
|---|---|---|
| Raw `logs` path (current) | 41.5M | ~2.7s |
| MV `agent_metrics` path | 311K | **~17ms** |
| + email-less supplement (parallel) | 20.7M | ~0.6–0.9s |

The two reads run concurrently, so wall-clock is bounded by the supplement (~0.8s) — a ~3.4× improvement, with the common Employees view served almost entirely from the ~17ms MV read. (Making the supplement lazy on the Unknown-users tab, dropping the Employees tab to ~instant, is a clean follow-up.)

## Behavior change to be aware of

Enrollment token numbers change. They now reflect the **canonical agent-usage measure the costs/billing pages already use**, instead of the previous raw `gen_ai.usage.*` sum — which mixed in Gram-hosted completions and duplicate usage-metric rows while **missing Claude Code OTEL usage entirely** (Claude OTEL uses native token fields the old query didn't read). On the largest project the total moved 16.1B → 8.9B and, more importantly, is now composed correctly. Email-less identities (verified to carry 0 tokens) are surfaced with activity but no counts.

## Testing

- New `TestSearchUsers_AgentMetricsSource`: a Claude api_request row flows into the view (email-keyed, token totals) and an email-less tool-call identity is supplemented from raw logs (activity, 0 tokens) — asserts both surface.
- Existing 23 `SearchUsers` tests unchanged and green (the raw-logs conversion was refactored into a shared `assembleUserSummaries` helper).
- `go build`, `mise lint:server`, dashboard `type-check` all pass.

## Not included

No migration — this only reads the existing `attribute_metrics_summaries` view and `telemetry_logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the Employee Enrollment list from the pre-aggregated `attribute_metrics_summaries` view via `telemetry.searchUsers` using `source=agent_metrics`, cutting load time on large projects from ~2.7s to ~0.8s. Token totals now match the canonical agent-usage measure used by costs/billing. Addresses DNO-618.

- **New Features**
  - Added `source` to `telemetry.searchUsers`: `logs` (default) or `agent_metrics` (email-keyed pre-aggregated view; `metrics` is ignored). Enrollment now calls with `source: agent_metrics`; other consumers stay on `logs`. OpenAPI/SDK/CLI updated.
  - Email-less identities are supplemented from raw logs with activity only (no tokens). Safeguards: reject unsupported filters with `source=agent_metrics` (deployment, user_ids, event/hook source, account_type, external_org_id), globally sort merged results by last activity, and warn if a read hits the row cap; the directory returns as a single full-page (no cursor).

- **Performance**
  - ClickHouse: 41.5M rows (~2.7s) → 311K rows (~17ms) + 20.7M supplement (~0.6–0.9s) in parallel; wall ~0.8s.

<sup>Written for commit f6c5c4dd79a887c69c81d61a55c7aaeba3f8d100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

