### PR TITLE
feat(glint): no-bare-sqlstate lint — use pgerrcode constants, not raw SQLSTATE

### DIFF
--- a/glint/no_bare_sqlstate.go
+++ b/glint/no_bare_sqlstate.go
@@ -1,0 +1,209 @@
+package glint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/speakeasy-api/gram/glint/imports"
+)
+
+const (
+	noBareSqlstateAnalyzer       = "nobaresqlstate"
+	noBareSqlstateDefaultMessage = "compare pgconn.PgError.Code against a github.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal"
+
+	pgconnPkgPath             = "github.com/jackc/pgx/v5/pgconn"
+	pgErrorTypeName           = "PgError"
+	pgErrorCodeFieldName      = "Code"
+	pgerrcodePkgPath          = "github.com/jackc/pgerrcode"
+	pgerrcodeDefaultLocalName = "pgerrcode"
+)
+
+// sqlstateConstNames maps SQLSTATE codes to their github.com/jackc/pgerrcode
+// constant names so the suggested fix can name the code. It is a curated set,
+// not the full SQLSTATE table: the ones that realistically appear in this
+// codebase plus a few common cousins. Detection does not depend on it — any
+// string literal compared against pgconn.PgError.Code is reported — but a code
+// absent here is reported without an autofix, since we can't name its constant.
+var sqlstateConstNames = map[string]string{
+	"21000": "CardinalityViolation",
+	"23502": "NotNullViolation",
+	"23503": "ForeignKeyViolation",
+	"23505": "UniqueViolation",
+	"23514": "CheckViolation",
+	"40001": "SerializationFailure",
+	"40P01": "DeadlockDetected",
+}
+
+type noBareSqlstateSettings struct {
+	Disabled bool `json:"disabled"`
+}
+
+func newNoBareSqlstateAnalyzer(_ noBareSqlstateSettings) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name: noBareSqlstateAnalyzer,
+		Doc:  noBareSqlstateDefaultMessage,
+		// Manual per-file walk rather than the shared inspector, for the same
+		// reason as no_sql_err_no_rows: the fix adds the pgerrcode import once
+		// per file, and that file-scoped edit has to ride along with every
+		// occurrence's SuggestedFix. The shared inspector flattens the file
+		// boundary the import edit needs, so adopting it would mean re-bucketing
+		// nodes back by file with no traversal saved.
+		Run: func(pass *analysis.Pass) (any, error) {
+			for _, file := range pass.Files {
+				inspectFileForBareSqlstate(pass, file)
+			}
+			return nil, nil
+		},
+	}
+}
+
+// inspectFileForBareSqlstate walks file once, collecting comparisons of
+// pgconn.PgError.Code against a string literal. It then reports one diagnostic
+// per occurrence, attaching a SuggestedFix that swaps the literal for the
+// pgerrcode constant (and adds the import when needed) for codes it can name.
+func inspectFileForBareSqlstate(pass *analysis.Pass, file *ast.File) {
+	type occurrence struct {
+		lit       *ast.BasicLit
+		constName string // "" when the code has no known pgerrcode constant
+	}
+
+	var occurrences []occurrence
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		bin, ok := node.(*ast.BinaryExpr)
+		if !ok {
+			return true
+		}
+		if bin.Op != token.EQL && bin.Op != token.NEQ {
+			return true
+		}
+
+		lit, value, ok := bareSqlstateComparison(pass, bin)
+		if !ok {
+			return true
+		}
+
+		occurrences = append(occurrences, occurrence{lit: lit, constName: sqlstateConstNames[value]})
+		return true
+	})
+
+	if len(occurrences) == 0 {
+		return
+	}
+
+	localName, imported := imports.LocalName(file, pgerrcodePkgPath, pgerrcodeDefaultLocalName)
+
+	fixable := false
+	for _, occ := range occurrences {
+		if occ.constName != "" {
+			fixable = true
+			break
+		}
+	}
+
+	// importEdit is attached to every fixable occurrence's SuggestedFix, not
+	// just the first: analysistest's three-way merge dedupes identical edits
+	// when --fix applies them together, whereas splitting them risks an editor
+	// quick-fix branch adding the import for one occurrence while siblings go
+	// unfixed.
+	var importEdits []analysis.TextEdit
+	if fixable && !imported {
+		if e, ok := imports.Add(file, pgerrcodePkgPath); ok {
+			importEdits = append(importEdits, e)
+		}
+	}
+
+	for _, occ := range occurrences {
+		diag := analysis.Diagnostic{
+			Pos:      occ.lit.Pos(),
+			End:      occ.lit.End(),
+			Category: noBareSqlstateAnalyzer,
+			Message:  noBareSqlstateDefaultMessage,
+		}
+
+		if occ.constName != "" {
+			replacement := []byte(localName + "." + occ.constName)
+			edits := make([]analysis.TextEdit, 0, 1+len(importEdits))
+			edits = append(edits, analysis.TextEdit{Pos: occ.lit.Pos(), End: occ.lit.End(), NewText: replacement})
+			edits = append(edits, importEdits...)
+			diag.SuggestedFixes = []analysis.SuggestedFix{{
+				Message:   fmt.Sprintf("replace %s with %s.%s", occ.lit.Value, localName, occ.constName),
+				TextEdits: edits,
+			}}
+		}
+
+		pass.Report(diag)
+	}
+}
+
+// bareSqlstateComparison reports whether bin compares pgconn.PgError.Code
+// against a string literal, in either operand order, and returns the literal
+// node and its unquoted value.
+func bareSqlstateComparison(pass *analysis.Pass, bin *ast.BinaryExpr) (*ast.BasicLit, string, bool) {
+	if isPgErrorCodeField(pass, bin.X) {
+		if lit, value, ok := stringLiteral(bin.Y); ok {
+			return lit, value, true
+		}
+	}
+	if isPgErrorCodeField(pass, bin.Y) {
+		if lit, value, ok := stringLiteral(bin.X); ok {
+			return lit, value, true
+		}
+	}
+	return nil, "", false
+}
+
+// isPgErrorCodeField reports whether expr selects the Code field of
+// github.com/jackc/pgx/v5/pgconn.PgError, resolved through type information so
+// it survives aliased imports and pointer vs value receivers.
+func isPgErrorCodeField(pass *analysis.Pass, expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	selection, ok := pass.TypesInfo.Selections[sel]
+	if !ok || selection.Kind() != types.FieldVal {
+		return false
+	}
+
+	field := selection.Obj()
+	if field == nil || field.Name() != pgErrorCodeFieldName {
+		return false
+	}
+
+	recv := selection.Recv()
+	if ptr, ok := recv.(*types.Pointer); ok {
+		recv = ptr.Elem()
+	}
+
+	named, ok := recv.(*types.Named)
+	if !ok {
+		return false
+	}
+
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == pgconnPkgPath && obj.Name() == pgErrorTypeName
+}
+
+// stringLiteral returns the node and unquoted value when expr is a string
+// literal.
+func stringLiteral(expr ast.Expr) (*ast.BasicLit, string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return nil, "", false
+	}
+
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return nil, "", false
+	}
+
+	return lit, value, true
+}

--- a/glint/no_bare_sqlstate_test.go
+++ b/glint/no_bare_sqlstate_test.go
@@ -1,0 +1,27 @@
+package glint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestNoBareSqlstate(t *testing.T) {
+	t.Parallel()
+
+	testdata := analysistest.TestData()
+	analysistest.RunWithSuggestedFixes(t, testdata, newNoBareSqlstateAnalyzer(noBareSqlstateSettings{}), "nobaresqlstate")
+}
+
+func TestBuildAnalyzersSkipsDisabledNoBareSqlstate(t *testing.T) {
+	t.Parallel()
+
+	p := disabledAllRulesPlugin()
+	p.settings.Rules.NoBareSqlstate.Disabled = false
+
+	analyzers, err := p.BuildAnalyzers()
+	require.NoError(t, err)
+	require.Len(t, analyzers, 1)
+	require.Equal(t, noBareSqlstateAnalyzer, analyzers[0].Name)
+}

--- a/glint/plugin.go
+++ b/glint/plugin.go
@@ -34,6 +34,7 @@ type ruleSettings struct {
 	NoSqlErrNoRows             noSqlErrNoRowsSettings             `json:"no-sql-err-no-rows"`
 	NoTestingRawSql            noTestingRawSqlSettings            `json:"no-testing-raw-sql"`
 	NoClientErrorLogError      noClientErrorLogErrorSettings      `json:"no-client-error-log-error"`
+	NoBareSqlstate             noBareSqlstateSettings             `json:"no-bare-sqlstate"`
 	RpcEndpointFormat          rpcEndpointFormatSettings          `json:"rpc-endpoint-format"`
 }
 
@@ -93,6 +94,9 @@ func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
 	}
 	if !p.settings.Rules.NoClientErrorLogError.Disabled {
 		analyzers = append(analyzers, newNoClientErrorLogErrorAnalyzer(p.settings.Rules.NoClientErrorLogError))
+	}
+	if !p.settings.Rules.NoBareSqlstate.Disabled {
+		analyzers = append(analyzers, newNoBareSqlstateAnalyzer(p.settings.Rules.NoBareSqlstate))
 	}
 	if !p.settings.Rules.RpcEndpointFormat.Disabled {
 		analyzers = append(analyzers, newRpcEndpointFormatAnalyzer(p.settings.Rules.RpcEndpointFormat))

--- a/glint/plugin_test.go
+++ b/glint/plugin_test.go
@@ -26,6 +26,7 @@ func disabledAllRulesPlugin() *plugin {
 				NoSqlErrNoRows:             noSqlErrNoRowsSettings{Disabled: true},
 				NoTestingRawSql:            noTestingRawSqlSettings{Disabled: true},
 				NoClientErrorLogError:      noClientErrorLogErrorSettings{Disabled: true},
+				NoBareSqlstate:             noBareSqlstateSettings{Disabled: true},
 				RpcEndpointFormat:          rpcEndpointFormatSettings{Disabled: true},
 			},
 		},
@@ -47,5 +48,5 @@ func TestBuildAnalyzersAllEnabled(t *testing.T) {
 	p := &plugin{}
 	analyzers, err := p.BuildAnalyzers()
 	require.NoError(t, err)
-	require.Len(t, analyzers, 15)
+	require.Len(t, analyzers, 16)
 }

--- a/glint/testdata/src/github.com/jackc/pgerrcode/errcode.go
+++ b/glint/testdata/src/github.com/jackc/pgerrcode/errcode.go
@@ -1,0 +1,13 @@
+package pgerrcode
+
+// Minimal stand-in for github.com/jackc/pgerrcode, carrying the named SQLSTATE
+// constants the nobaresqlstate fixtures reference.
+const (
+	CardinalityViolation = "21000"
+	NotNullViolation     = "23502"
+	ForeignKeyViolation  = "23503"
+	UniqueViolation      = "23505"
+	CheckViolation       = "23514"
+	SerializationFailure = "40001"
+	DeadlockDetected     = "40P01"
+)

--- a/glint/testdata/src/github.com/jackc/pgx/v5/pgconn/pgconn.go
+++ b/glint/testdata/src/github.com/jackc/pgx/v5/pgconn/pgconn.go
@@ -1,0 +1,11 @@
+package pgconn
+
+// PgError is a minimal stand-in for github.com/jackc/pgx/v5/pgconn.PgError,
+// carrying only the Code field the nobaresqlstate analyzer keys on.
+type PgError struct {
+	Severity string
+	Code     string
+	Message  string
+}
+
+func (e *PgError) Error() string { return e.Message }

--- a/glint/testdata/src/nobaresqlstate/aliased.go
+++ b/glint/testdata/src/nobaresqlstate/aliased.go
@@ -1,0 +1,12 @@
+package nobaresqlstate
+
+import (
+	pgcode "github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// aliasedImport ensures the fix uses the import's alias, not the default name.
+func aliasedImport(pgErr *pgconn.PgError) bool {
+	_ = pgcode.UniqueViolation
+	return pgErr.Code == "40001" // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/glint/testdata/src/nobaresqlstate/aliased.go.golden
+++ b/glint/testdata/src/nobaresqlstate/aliased.go.golden
@@ -1,0 +1,12 @@
+package nobaresqlstate
+
+import (
+	pgcode "github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// aliasedImport ensures the fix uses the import's alias, not the default name.
+func aliasedImport(pgErr *pgconn.PgError) bool {
+	_ = pgcode.UniqueViolation
+	return pgErr.Code == pgcode.SerializationFailure // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/glint/testdata/src/nobaresqlstate/alreadyimported.go
+++ b/glint/testdata/src/nobaresqlstate/alreadyimported.go
@@ -1,0 +1,13 @@
+package nobaresqlstate
+
+import (
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// pgerrcodeAlreadyImported ensures the fix reuses the existing import rather
+// than adding a duplicate.
+func pgerrcodeAlreadyImported(pgErr *pgconn.PgError) bool {
+	_ = pgerrcode.UniqueViolation
+	return pgErr.Code == "23514" // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/glint/testdata/src/nobaresqlstate/alreadyimported.go.golden
+++ b/glint/testdata/src/nobaresqlstate/alreadyimported.go.golden
@@ -1,0 +1,13 @@
+package nobaresqlstate
+
+import (
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// pgerrcodeAlreadyImported ensures the fix reuses the existing import rather
+// than adding a duplicate.
+func pgerrcodeAlreadyImported(pgErr *pgconn.PgError) bool {
+	_ = pgerrcode.UniqueViolation
+	return pgErr.Code == pgerrcode.CheckViolation // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/glint/testdata/src/nobaresqlstate/direct.go
+++ b/glint/testdata/src/nobaresqlstate/direct.go
@@ -1,0 +1,17 @@
+package nobaresqlstate
+
+import (
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func pointerReceiver(pgErr *pgconn.PgError) bool {
+	return pgErr.Code == "23505" // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}
+
+func valueReceiver(pgErr pgconn.PgError) bool {
+	return pgErr.Code != "21000" // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}
+
+func literalOnLeft(pgErr *pgconn.PgError) bool {
+	return "23503" == pgErr.Code // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/glint/testdata/src/nobaresqlstate/direct.go.golden
+++ b/glint/testdata/src/nobaresqlstate/direct.go.golden
@@ -1,0 +1,18 @@
+package nobaresqlstate
+
+import (
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func pointerReceiver(pgErr *pgconn.PgError) bool {
+	return pgErr.Code == pgerrcode.UniqueViolation // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}
+
+func valueReceiver(pgErr pgconn.PgError) bool {
+	return pgErr.Code != pgerrcode.CardinalityViolation // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}
+
+func literalOnLeft(pgErr *pgconn.PgError) bool {
+	return pgerrcode.ForeignKeyViolation == pgErr.Code // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/glint/testdata/src/nobaresqlstate/good.go
+++ b/glint/testdata/src/nobaresqlstate/good.go
@@ -1,0 +1,31 @@
+package nobaresqlstate
+
+import (
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// alreadyUsingConstant must not be flagged: it already uses pgerrcode.
+func alreadyUsingConstant(pgErr *pgconn.PgError) bool {
+	return pgErr.Code == pgerrcode.UniqueViolation
+}
+
+// nonLiteralOperand must not be flagged: the other operand is not a string
+// literal.
+func nonLiteralOperand(pgErr *pgconn.PgError, code string) bool {
+	return pgErr.Code == code
+}
+
+type response struct {
+	Code string
+}
+
+// unrelatedCodeField must not be flagged: Code here is not pgconn.PgError.Code.
+func unrelatedCodeField(r response) bool {
+	return r.Code == "23505"
+}
+
+// bareLiteralNotCompared must not be flagged: no comparison to PgError.Code.
+func bareLiteralNotCompared() string {
+	return "23505"
+}

--- a/glint/testdata/src/nobaresqlstate/unknowncode.go
+++ b/glint/testdata/src/nobaresqlstate/unknowncode.go
@@ -1,0 +1,11 @@
+package nobaresqlstate
+
+import (
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// unknownCode is reported but has no autofix: this SQLSTATE has no known
+// pgerrcode constant, so the analyzer can't name a replacement.
+func unknownCode(pgErr *pgconn.PgError) bool {
+	return pgErr.Code == "99999" // want `compare pgconn\.PgError\.Code against a github\.com/jackc/pgerrcode constant instead of a bare SQLSTATE string literal`
+}

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -30,8 +31,7 @@ var ErrChatNotFound = errors.New("chat not found")
 func isForeignKeyViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
-		// 23503 is PostgreSQL's foreign_key_violation error code
-		return pgErr.Code == "23503"
+		return pgErr.Code == pgerrcode.ForeignKeyViolation
 	}
 	return false
 }

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -440,7 +441,7 @@ func buildClientRedirect(redirectURI, code, originalState, errCode, errDescripti
 // violation. Used to detect duplicate consent inserts (idempotent re-consent).
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation
 }
 
 // shouldAutoCloseFirstParty reports whether a first-party connect tab is fully

--- a/server/internal/remotesessions/errors.go
+++ b/server/internal/remotesessions/errors.go
@@ -3,6 +3,7 @@ package remotesessions
 import (
 	"errors"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
@@ -12,7 +13,7 @@ import (
 func isRemoteSessionIssuerSlugConflict(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) &&
-		pgErr.Code == "23505" &&
+		pgErr.Code == pgerrcode.UniqueViolation &&
 		pgErr.ConstraintName == "remote_session_issuers_project_slug_key"
 }
 
@@ -22,6 +23,6 @@ func isRemoteSessionIssuerSlugConflict(err error) bool {
 func isGlobalRemoteSessionIssuerSlugConflict(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) &&
-		pgErr.Code == "23505" &&
+		pgErr.Code == pgerrcode.UniqueViolation &&
 		pgErr.ConstraintName == "remote_session_issuers_global_slug_key"
 }

--- a/server/internal/spendrules/impl.go
+++ b/server/internal/spendrules/impl.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -195,7 +196,7 @@ func (s *Service) CreateSpendRule(ctx context.Context, payload *gen.CreateSpendR
 		Version:        1,
 	})
 	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
 		// Lost a race with a concurrent create picking the same slug.
 		return nil, oops.E(oops.CodeConflict, err, "a rule with a conflicting name was just created, try again")
 	}


### PR DESCRIPTION
## What

Adds a `glint` analyzer, **`no-bare-sqlstate`**, that flags comparing `pgconn.PgError.Code` against a bare SQLSTATE string literal and steers to the already-vendored `github.com/jackc/pgerrcode` constants:

```go
if errors.As(err, &pgErr) && pgErr.Code == "23505" { ... }   // flagged
if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation { ... }  // ✓
```

For a code it can name, it offers an autofix that swaps the literal for the constant and adds the import (`golangci-lint --fix` / editor quick-fix). Codes outside the curated map are still reported, just without a fix.

**Detection is type-scoped** via `pass.TypesInfo.Selections` — it only fires on the `Code` field of `pgconn.PgError` (through aliases and pointer-vs-value receivers), so unrelated string comparisons are never touched. Modeled on the existing `no-sql-err-no-rows` analyzer (same pgx error-handling domain, same per-file import-edit handling), sharing the `glint/imports` helper. They stay separate rules on purpose: one detects a wrong sentinel value (symbol→symbol), this one a magic literal (literal→named-constant, value-dependent).

Fixtures under `glint/testdata/src/nobaresqlstate/` cover both operand orders, pointer/value receivers, unknown-code (flag-only), import reuse, aliased import, and negatives (already-a-constant, non-literal operand, unrelated `Code` field). `plugin.go` / `plugin_test.go` wired per convention (analyzer count 15 → 16).

Also **fixes the pre-existing SQLSTATE literals** the rule surfaces, so the tree stays green: `remotesessions/errors.go` (×2), `mcp/authnchallenge_consent.go`, `hooks/session_capture.go`. That absorbs the sweep tracked in **AGE-3057** (now closed).

`mise lint:server` is green across the whole server with the rule enabled.

## Why

Came out of review feedback on #4359, where new code hand-rolled `const pgUniqueViolation = "23505"` (fixed inline there). The decision happens in Go error-handling, where docs alone don't reliably surface — a lint rule enforces it at the point of the mistake. Codebase check confirmed the mistake is a real, low-frequency slip made by several authors, not a one-off.

## Scope

`glint` analyzer + fixtures, three trivially-equivalent constant swaps in server code. No runtime/schema/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)