### PR TITLE
chore: remove stray terraform-provider-google-beta replace from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -346,5 +346,3 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
-
-replace github.com/hashicorp/terraform-provider-google-beta => github.com/hashicorp/terraform-provider-google-beta v1.20.0


### PR DESCRIPTION
## What

Removes a stray `replace github.com/hashicorp/terraform-provider-google-beta => github.com/hashicorp/terraform-provider-google-beta v1.20.0` directive from `go.mod`.

## Why

The directive landed accidentally in an unrelated PR (#3359, policy deletion cleanup). Nothing in the module requires or imports `terraform-provider-google-beta`, it never appeared in `go.sum`, and `go mod why` reports `main module does not need package github.com/hashicorp/terraform-provider-google-beta`. It is a no-op that only adds noise to the module graph.

## Verification

- `mise go:tidy` runs clean and does not re-add the directive; `go.sum` is unchanged.
- `mise build:server` builds successfully.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stray `replace github.com/hashicorp/terraform-provider-google-beta => github.com/hashicorp/terraform-provider-google-beta v1.20.0` from `go.mod`. The provider is not required; this is a no-op that removes module graph noise and leaves builds and `go.sum` unchanged.

<sup>Written for commit 73e78e5a0bef05a9b761eb0bba908e227c609cf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

