### PR TITLE
fix: stop email-less id summaries shadowing employee token usage

### DIFF
--- a/.changeset/fix-enrollment-token-shadow.md
+++ b/.changeset/fix-enrollment-token-shadow.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the Employee Enrollment page showing enrolled employees with 0 tokens (their usage appearing under "Unknown users" instead). When a member's telemetry splits across identity keys — an opaque user_id with no email (e.g. Gram tool calls) plus their email (Claude/Cursor usage) — the id-keyed, token-less summary was shadowing the member's token-bearing email summary. `buildEmployees` now matches a member against both their id and their email and merges the results, so their tokens, activity, and linked accounts are attributed correctly and their usage is no longer orphaned into the unattributed list.

--- a/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.test.ts
@@ -128,6 +128,38 @@ describe("buildEmployees attributed/unattributed split", () => {
     expect(alias.tokenCount).toBe(0);
   });
 
+  it("merges a member's split identities so an email-less id summary can't shadow their email tokens", () => {
+    // The member's opaque user_id (Gram tool calls, no email) and their email
+    // (Claude/Cursor usage) are two summaries for the same person. Matching the
+    // id first must not attribute the token-less id summary and orphan the
+    // token-bearing email summary into the unattributed list (DNO-618).
+    const member = makeMember({
+      id: "01924a0eb409b0ecf44e06d0ec03cbc4",
+      email: "ada@example.com",
+      name: "Ada Lovelace",
+    });
+    const employees = buildEmployees([member], noRoles, [
+      makeSummary({
+        userId: "ada@example.com",
+        userEmail: "ada@example.com",
+        totalInputTokens: 700,
+        totalOutputTokens: 20,
+      }),
+      makeSummary({
+        userId: "01924a0eb409b0ecf44e06d0ec03cbc4",
+        userEmail: "",
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+      }),
+    ]);
+
+    expect(employees).toHaveLength(1);
+    const ada = employees[0]!;
+    expect(ada.status).toBe("enrolled");
+    expect(ada.tokenCount).toBe(720);
+    expect(isUnattributedEmployee(ada)).toBe(false);
+  });
+
   it("creates unattributed rows with a usage: id for unmatched summaries", () => {
     const employees = buildEmployees([], noRoles, [
       makeSummary({ userId: "ghost@example.com" }),

--- a/client/dashboard/src/components/observe/insightsEmployeesData.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.ts
@@ -69,6 +69,59 @@ function mostRecentAccount(
   return latest;
 }
 
+// dedupeSummaries returns the distinct, present summaries among the candidates.
+// A member can match the same summary by both id and email, and can match two
+// different summaries when their telemetry splits across identity keys.
+function dedupeSummaries(
+  candidates: (UserSummary | undefined)[],
+): UserSummary[] {
+  const out: UserSummary[] = [];
+  for (const summary of candidates) {
+    if (summary && !out.includes(summary)) out.push(summary);
+  }
+  return out;
+}
+
+// mostRecentSummary picks the matched summary with the latest activity, used for
+// a member's displayed last-activity when their usage spans multiple summaries.
+function mostRecentSummary(summaries: UserSummary[]): UserSummary | undefined {
+  let latest: UserSummary | undefined;
+  for (const summary of summaries) {
+    if (
+      !latest ||
+      BigInt(summary.lastSeenUnixNano) > BigInt(latest.lastSeenUnixNano)
+    ) {
+      latest = summary;
+    }
+  }
+  return latest;
+}
+
+// mergeAccounts unions the linked accounts across a member's matched summaries,
+// deduping by (provider, email) and keeping the most-recently-active instance.
+function mergeAccounts(summaries: UserSummary[]): EmployeeAccount[] {
+  const byKey = new Map<string, EmployeeAccount>();
+  for (const summary of summaries) {
+    for (const account of accountsFromSummary(summary)) {
+      const key = JSON.stringify([
+        account.provider,
+        account.email.toLowerCase(),
+      ]);
+      const existing = byKey.get(key);
+      if (
+        !existing ||
+        (account.lastSeenUnixNano != null &&
+          (existing.lastSeenUnixNano == null ||
+            BigInt(account.lastSeenUnixNano) >
+              BigInt(existing.lastSeenUnixNano)))
+      ) {
+        byKey.set(key, account);
+      }
+    }
+  }
+  return [...byKey.values()];
+}
+
 // Unattributed identities are usage rows that matched no org member; they are
 // marked with a synthetic "usage:"-prefixed id by buildEmployees().
 export function isUnattributedEmployee(employee: Employee): boolean {
@@ -99,22 +152,36 @@ export function buildEmployees(
   const matchedSummaryIds = new Set<string>();
 
   const employees = members.map((member) => {
-    const summary =
-      summaryByUserId.get(member.id) ??
-      summaryByEmail.get(member.email.toLowerCase());
-    if (summary) {
+    // A member's telemetry can split across identity keys: their opaque user_id
+    // (e.g. Gram MCP tool calls that carry no email) and their email
+    // (Claude/Cursor usage). Match BOTH and merge — otherwise a token-less,
+    // email-less id summary shadows the member's token-bearing email summary,
+    // showing them enrolled with 0 tokens while their real usage is orphaned
+    // into the unattributed list (DNO-618; regression of the DNO-468 merge).
+    const matched = dedupeSummaries([
+      summaryByUserId.get(member.id),
+      summaryByEmail.get(member.email.toLowerCase()),
+    ]);
+    for (const summary of matched) {
       matchedSummaryIds.add(summary.userId);
     }
-    const tokenCount =
-      (summary?.totalInputTokens ?? 0) + (summary?.totalOutputTokens ?? 0);
     const status: EmployeeStatus =
-      summary != null ? "enrolled" : "not_enrolled";
+      matched.length > 0 ? "enrolled" : "not_enrolled";
+    const tokenCount = matched.reduce(
+      (sum, summary) =>
+        sum +
+        (summary.totalInputTokens ?? 0) +
+        (summary.totalOutputTokens ?? 0),
+      0,
+    );
+    // Display fields (last activity) come from the most-recent matched summary.
+    const primary = mostRecentSummary(matched);
     const role =
       member.roleIds
         .map((id) => roleNameById.get(id))
         .filter(Boolean)
         .join(", ") || "Unknown";
-    const accounts = accountsFromSummary(summary);
+    const accounts = mergeAccounts(matched);
 
     return {
       id: member.id,
@@ -124,11 +191,11 @@ export function buildEmployees(
       status,
       tokenCount,
       photoUrl: member.photoUrl,
-      lastActivityTimestamp: summary
-        ? Number(BigInt(summary.lastSeenUnixNano) / 1_000_000n)
+      lastActivityTimestamp: primary
+        ? Number(BigInt(primary.lastSeenUnixNano) / 1_000_000n)
         : null,
-      lastActivity: summary
-        ? formatUnixNano(summary.lastSeenUnixNano)
+      lastActivity: primary
+        ? formatUnixNano(primary.lastSeenUnixNano)
         : "No activity found",
       accounts,
       mostRecentAccount: mostRecentAccount(accounts),


### PR DESCRIPTION
## What

Hotfix for a regression introduced by #4520 (agent-metrics enrollment path, DNO-618). A customer's Employee Enrollment page showed employees as **enrolled with 0 tokens**, with the org's entire token usage (~9B) landing in the **"Unknown users"** tab instead.

## Root cause

The agent-metrics path surfaces **email-less identities** (opaque `user_id`s that never carry an email in the window — e.g. Gram MCP tool calls) as separate 0-token summaries, alongside the token-bearing email summaries from the pre-aggregated view.

`buildEmployees` matched a member **by id before email**:

```js
summaryByUserId.get(member.id) ?? summaryByEmail.get(member.email...)
```

When a member's opaque `user_id` equals `member.id`, the token-less id summary won — so the member showed enrolled with 0 tokens, and their real (email-keyed) usage was left unmatched and orphaned into the unattributed list. This is a regression of the DNO-468 `known_emails` merge (the old logs path folded email-less rows into the email summary, so no shadowing 0-token id summary existed).

## Fix

Match a member against **both** their id and their email and **merge** the results:
- **tokens** are summed across the matched summaries,
- **last activity** comes from the most-recent one,
- **linked accounts** are unioned (deduped by provider + email),
- all matched summaries are marked attributed, so none leak into "Unknown users".

Frontend-only; no backend/API change. The DNO-618 perf win (agent-metrics source) is retained.

## Testing

- New `buildEmployees` regression test: a member with a token-less email-less id summary **and** a token-bearing email summary now shows enrolled with the correct token total and produces no orphaned unattributed row.
- All 14 `insightsEmployeesData` tests pass; dashboard `type-check` + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that showed enrolled employees with 0 tokens and moved their usage to "Unknown users." `buildEmployees` now merges id- and email-keyed summaries to attribute tokens and activity correctly, while keeping the DNO-618 agent-metrics performance win.

- **Bug Fixes**
  - Match members by both id and email and merge results: sum tokens, take the most recent activity, and union linked accounts (deduped by provider + email).
  - Mark all matched summaries as attributed so none leak into "Unknown users." Add a regression test for split identities; frontend-only, no API changes.

<sup>Written for commit d36e344ab15d5a5978622212437868098f4eafbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

