### PR TITLE
feat: enforce remote-MCP tool disposition in RBAC checks (AGE-2877)

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -836,6 +836,7 @@ func newStartCommand() *cli.Command {
 				telemLogger,
 				billingRepo,
 				billingTracker,
+				toolDispositionCache,
 			)
 
 			// guardian.WithAllowedCIDRBlocks silently drops invalid CIDRs, so a

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -825,6 +825,7 @@ func newStartCommand() *cli.Command {
 				serverURL,
 			)
 
+			toolDispositionCache := mcpservers.NewToolDispositionCache(logger, db, cache.NewRedisCacheAdapter(redisClient))
 			remoteProxyManager := remotemcp.NewProxyManager(
 				logger,
 				tracerProvider,
@@ -1179,7 +1180,7 @@ func newStartCommand() *cli.Command {
 			cliauth.Attach(mux, cliauth.NewService(logger, tracerProvider, db, sessionManager, authzEngine, redisClient, c.String("environment")))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))
 			environments.Attach(mux, environments.NewService(logger, tracerProvider, db, sessionManager, encryptionClient, authzEngine, auditLogger))
-			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
+			mcpservers.Attach(mux, mcpservers.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, toolDispositionCache, pluginsGitHub != nil))
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, cache.NewRedisCacheAdapter(redisClient))
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), remoteSessionsService))

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
@@ -212,7 +213,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub)
+	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter))
 	managedLogsTools := platformtoolsruntime.ManagedAssistantLogsTools(telemService)
 	feedbackRecorder := feedbackrecorder.NewRecorder(conn, logger, nil)
 	assistantSkillTools := platformtoolsruntime.AssistantSkillTools(logger, conn, feedbackRecorder)

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -54,6 +54,7 @@ type Service struct {
 	authz                *authz.Engine
 	audit                *audit.Logger
 	temporalEnv          *tenv.Environment
+	dispositionCache     *ToolDispositionCache
 	pluginsGitHubEnabled bool
 }
 
@@ -68,6 +69,7 @@ func NewService(
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
 	temporalEnv *tenv.Environment,
+	dispositionCache *ToolDispositionCache,
 	pluginsGitHubEnabled bool,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("mcpservers"))
@@ -80,6 +82,7 @@ func NewService(
 		authz:                authzEngine,
 		audit:                auditLogger,
 		temporalEnv:          temporalEnv,
+		dispositionCache:     dispositionCache,
 		pluginsGitHubEnabled: pluginsGitHubEnabled,
 	}
 }

--- a/server/internal/mcpservers/setup_test.go
+++ b/server/internal/mcpservers/setup_test.go
@@ -54,6 +54,7 @@ type testInstance struct {
 	service        *mcpservers.Service
 	conn           *pgxpool.Pool
 	sessionManager *sessions.Manager
+	dispositions   *mcpservers.ToolDispositionCache
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
@@ -79,12 +80,15 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 
 	auditLogger := audit.NewLogger()
 
-	svc := mcpservers.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, false)
+	dispositions := mcpservers.NewToolDispositionCache(logger, conn, cache.NewRedisCacheAdapter(redisClient))
+
+	svc := mcpservers.NewService(logger, tracerProvider, conn, sessionManager, authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()), auditLogger, nil, dispositions, false)
 
 	return ctx, &testInstance{
 		service:        svc,
 		conn:           conn,
 		sessionManager: sessionManager,
+		dispositions:   dispositions,
 	}
 }
 

--- a/server/internal/mcpservers/tooldisposition.go
+++ b/server/internal/mcpservers/tooldisposition.go
@@ -1,0 +1,142 @@
+package mcpservers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+)
+
+// toolDispositionTTL bounds staleness of the disposition cache. Writes evict
+// eagerly (see ToolDispositionCache.Invalidate), so this is only the ceiling
+// for a change that slips past invalidation — e.g. an eviction that failed
+// against a briefly-unavailable Redis.
+const toolDispositionTTL = 15 * time.Minute
+
+// serverToolDispositions is the cached per-server view the cache serves: a tool
+// name -> disposition token map, already derived from the stored annotation
+// hints. Only tools with a non-empty disposition are present; a missing key
+// reads as the empty disposition, so an empty (but non-nil) map is a valid
+// negative-cache entry for a server with no classifying metadata and still
+// costs a single Redis GET on later calls.
+type serverToolDispositions struct {
+	McpServerID  string            `json:"mcp_server_id"`
+	Dispositions map[string]string `json:"dispositions"`
+}
+
+var _ cache.CacheableObject[serverToolDispositions] = (*serverToolDispositions)(nil)
+
+func serverToolDispositionsCacheKey(mcpServerID string) string {
+	return fmt.Sprintf("mcpservers:tool_disposition:%s", mcpServerID)
+}
+
+func (s serverToolDispositions) CacheKey() string {
+	return serverToolDispositionsCacheKey(s.McpServerID)
+}
+
+func (s serverToolDispositions) AdditionalCacheKeys() []string {
+	return []string{}
+}
+
+func (s serverToolDispositions) TTL() time.Duration {
+	return toolDispositionTTL
+}
+
+// ToolDispositionCache resolves the RBAC `disposition` dimension for a
+// remote-MCP tool from admin-authored metadata (mcp_server_tool_metadata),
+// through a Redis pull-through cache over Postgres. It is the read path of the
+// Tool Metadata Materialization design (RFC §4.2): no upstream fetch and no
+// writes on the hot path. It lives beside the metadata write methods so those
+// evict it directly; the remote-MCP proxy consumes it read-only. One instance
+// is constructed per server process and shared by both.
+type ToolDispositionCache struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+	cache  cache.TypedCacheObject[serverToolDispositions]
+}
+
+// NewToolDispositionCache builds the cache over the given database and cache
+// backends.
+func NewToolDispositionCache(logger *slog.Logger, db *pgxpool.Pool, c cache.Cache) *ToolDispositionCache {
+	logger = logger.With(attr.SlogComponent("tool-disposition"))
+	return &ToolDispositionCache{
+		logger: logger,
+		db:     db,
+		cache:  cache.NewTypedObjectCache[serverToolDispositions](logger.With(attr.SlogCacheNamespace("tool-disposition")), c, cache.SuffixNone),
+	}
+}
+
+// Dispositions returns the tool-name -> disposition token map for a server,
+// through the cache. An empty (non-nil) map means the server has no classifying
+// metadata; a missing tool key reads as the empty disposition.
+//
+// A non-nil error means resolution itself failed (bad id, cache miss then DB
+// error). Callers gating a tool call MUST fail closed on it — disposition is a
+// security dimension, and silently substituting the empty disposition would
+// relax an annotation-scoped policy exactly when the store is unavailable.
+func (c *ToolDispositionCache) Dispositions(ctx context.Context, mcpServerID, projectID string) (map[string]string, error) {
+	if cached, err := c.cache.Get(ctx, serverToolDispositionsCacheKey(mcpServerID)); err == nil {
+		return cached.Dispositions, nil
+	}
+
+	serverUUID, err := uuid.Parse(mcpServerID)
+	if err != nil {
+		return nil, fmt.Errorf("parse mcp server id: %w", err)
+	}
+	projectUUID, err := uuid.Parse(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("parse project id: %w", err)
+	}
+
+	rows, err := repo.New(c.db).ListMCPServerToolMetadata(ctx, repo.ListMCPServerToolMetadataParams{
+		McpServerID:    serverUUID,
+		ProjectID:      projectUUID,
+		IncludeDeleted: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list tool metadata for disposition: %w", err)
+	}
+
+	dispositions := make(map[string]string, len(rows))
+	for _, row := range rows {
+		disposition := conv.DispositionFromAnnotations(conv.AnnotationsFromColumns(
+			row.ReadOnlyHint,
+			row.DestructiveHint,
+			row.IdempotentHint,
+			row.OpenWorldHint,
+		))
+		// Tools reviewed with no behavior class are omitted: absent reads as the
+		// empty disposition, which is what an empty token would mean anyway.
+		if disposition == "" {
+			continue
+		}
+		dispositions[row.ToolName] = disposition
+	}
+
+	entry := serverToolDispositions{McpServerID: mcpServerID, Dispositions: dispositions}
+	if err := c.cache.Store(ctx, entry); err != nil {
+		c.logger.WarnContext(ctx, "cache remote MCP tool dispositions",
+			attr.SlogError(err),
+			attr.SlogMcpServerID(mcpServerID),
+		)
+	}
+
+	return dispositions, nil
+}
+
+// Invalidate evicts a server's cached disposition set so an admin metadata
+// write takes effect before the TTL lapses.
+func (c *ToolDispositionCache) Invalidate(ctx context.Context, mcpServerID string) error {
+	if err := c.cache.DeleteByKey(ctx, serverToolDispositionsCacheKey(mcpServerID)); err != nil {
+		return fmt.Errorf("invalidate tool dispositions: %w", err)
+	}
+	return nil
+}

--- a/server/internal/mcpservers/tooldisposition.go
+++ b/server/internal/mcpservers/tooldisposition.go
@@ -83,10 +83,8 @@ func NewToolDispositionCache(logger *slog.Logger, db *pgxpool.Pool, c cache.Cach
 // security dimension, and silently substituting the empty disposition would
 // relax an annotation-scoped policy exactly when the store is unavailable.
 func (c *ToolDispositionCache) Dispositions(ctx context.Context, mcpServerID, projectID string) (map[string]string, error) {
-	if cached, err := c.cache.Get(ctx, serverToolDispositionsCacheKey(mcpServerID)); err == nil {
-		return cached.Dispositions, nil
-	}
-
+	// Validate before the cache read so a warm entry can't bypass the check: a
+	// bad id must fail closed whether or not the server was resolved before.
 	serverUUID, err := uuid.Parse(mcpServerID)
 	if err != nil {
 		return nil, fmt.Errorf("parse mcp server id: %w", err)
@@ -94,6 +92,10 @@ func (c *ToolDispositionCache) Dispositions(ctx context.Context, mcpServerID, pr
 	projectUUID, err := uuid.Parse(projectID)
 	if err != nil {
 		return nil, fmt.Errorf("parse project id: %w", err)
+	}
+
+	if cached, err := c.cache.Get(ctx, serverToolDispositionsCacheKey(mcpServerID)); err == nil {
+		return cached.Dispositions, nil
 	}
 
 	rows, err := repo.New(c.db).ListMCPServerToolMetadata(ctx, repo.ListMCPServerToolMetadataParams{

--- a/server/internal/mcpservers/tooldisposition_resolver_test.go
+++ b/server/internal/mcpservers/tooldisposition_resolver_test.go
@@ -1,0 +1,132 @@
+package mcpservers_test
+
+// The resolver under test (remotemcp.ToolDispositionResolver) lives in the
+// remotemcp package, but its integration test lives here: it reads the
+// mcp_server_tool_metadata rows this package owns, and the remote-backed-server
+// + metadata fixtures (createRemoteBackedMcpServer, AddToolMetadataBatch) are
+// one-liners here versus a full FK chain to hand-roll in remotemcp. ti.dispositions
+// is the same resolver instance wired as the service's cache invalidator, so
+// writes and reads share one cache.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/mcp_servers"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+func TestToolDispositionResolver_DerivesFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	serverID := createRemoteBackedMcpServer(t, ctx, ti)
+
+	_, err := ti.service.AddToolMetadataBatch(ctx, &gen.AddToolMetadataBatchPayload{
+		McpServerID: serverID,
+		Tools: []*gen.ToolMetadataForm{
+			{ToolName: "list_items", Title: nil, ReadOnlyHint: new(true), DestructiveHint: nil, IdempotentHint: nil, OpenWorldHint: nil},
+			{ToolName: "delete_item", Title: nil, ReadOnlyHint: new(false), DestructiveHint: new(true), IdempotentHint: nil, OpenWorldHint: nil},
+			// Reviewed with no behavior class (every hint unset): omitted from the
+			// map, since an absent key reads as the empty disposition anyway.
+			{ToolName: "ping", Title: nil, ReadOnlyHint: nil, DestructiveHint: nil, IdempotentHint: nil, OpenWorldHint: nil},
+		},
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	got, err := ti.dispositions.Dispositions(ctx, serverID, authCtx.ProjectID.String())
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"list_items":  "read_only",
+		"delete_item": "destructive",
+	}, got)
+}
+
+func TestToolDispositionResolver_UnknownServerResolvesEmpty(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	// A remote-backed server with no recorded metadata resolves (successfully)
+	// to an empty map — the negative-cache case.
+	serverID := createRemoteBackedMcpServer(t, ctx, ti)
+
+	got, err := ti.dispositions.Dispositions(ctx, serverID, authCtx.ProjectID.String())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// TestToolDispositionResolver_ServiceWriteInvalidatesCache proves the write path
+// evicts the read cache: a delete through the service is reflected on the next
+// resolve rather than waiting out the TTL, because the service shares this
+// resolver as its cache invalidator.
+func TestToolDispositionResolver_ServiceWriteInvalidatesCache(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	serverID := createRemoteBackedMcpServer(t, ctx, ti)
+	_, err := ti.service.AddToolMetadataBatch(ctx, &gen.AddToolMetadataBatchPayload{
+		McpServerID: serverID,
+		Tools: []*gen.ToolMetadataForm{
+			{ToolName: "list_items", Title: nil, ReadOnlyHint: new(true), DestructiveHint: nil, IdempotentHint: nil, OpenWorldHint: nil},
+		},
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	// Warm the cache.
+	first, err := ti.dispositions.Dispositions(ctx, serverID, authCtx.ProjectID.String())
+	require.NoError(t, err)
+	require.Equal(t, "read_only", first["list_items"])
+
+	// A delete through the service invalidates the cached view...
+	err = ti.service.DeleteToolMetadata(ctx, &gen.DeleteToolMetadataPayload{
+		McpServerID:      serverID,
+		ToolName:         "list_items",
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	// ...so the next resolve reflects the deletion immediately.
+	second, err := ti.dispositions.Dispositions(ctx, serverID, authCtx.ProjectID.String())
+	require.NoError(t, err)
+	require.Empty(t, second)
+}
+
+func TestToolDispositionResolver_InvalidServerIDFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	_, err := ti.dispositions.Dispositions(ctx, "not-a-uuid", authCtx.ProjectID.String())
+	require.Error(t, err)
+}
+
+func TestToolDispositionResolver_InvalidProjectIDFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	serverID := createRemoteBackedMcpServer(t, ctx, ti)
+
+	_, err := ti.dispositions.Dispositions(ctx, serverID, "not-a-uuid")
+	require.Error(t, err)
+}

--- a/server/internal/mcpservers/tooldisposition_resolver_test.go
+++ b/server/internal/mcpservers/tooldisposition_resolver_test.go
@@ -124,9 +124,16 @@ func TestToolDispositionResolver_InvalidProjectIDFailsClosed(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
 
 	serverID := createRemoteBackedMcpServer(t, ctx, ti)
 
-	_, err := ti.dispositions.Dispositions(ctx, serverID, "not-a-uuid")
+	// Warm the cache for this server first, so the bad-project rejection can't
+	// be skipped by a subsequent cache hit.
+	_, err := ti.dispositions.Dispositions(ctx, serverID, authCtx.ProjectID.String())
+	require.NoError(t, err)
+
+	_, err = ti.dispositions.Dispositions(ctx, serverID, "not-a-uuid")
 	require.Error(t, err)
 }

--- a/server/internal/mcpservers/toolmetadata.go
+++ b/server/internal/mcpservers/toolmetadata.go
@@ -199,6 +199,8 @@ func (s *Service) SetToolMetadataBatch(ctx context.Context, payload *gen.SetTool
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
+	s.invalidateDispositionCache(ctx, serverID, logger)
+
 	return &gen.SetToolMetadataBatchResult{Tools: after, Deleted: deleted}, nil
 }
 
@@ -300,6 +302,8 @@ func (s *Service) AddToolMetadataBatch(ctx context.Context, payload *gen.AddTool
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
+
+	s.invalidateDispositionCache(ctx, serverID, logger)
 
 	return &gen.AddToolMetadataBatchResult{Tools: created}, nil
 }
@@ -440,6 +444,8 @@ func (s *Service) SetToolMetadata(ctx context.Context, payload *gen.SetToolMetad
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
+	s.invalidateDispositionCache(ctx, serverID, logger)
+
 	return mv.BuildToolMetadataView(updated), nil
 }
 
@@ -515,7 +521,20 @@ func (s *Service) DeleteToolMetadata(ctx context.Context, payload *gen.DeleteToo
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
 	}
 
+	s.invalidateDispositionCache(ctx, serverID, logger)
+
 	return nil
+}
+
+// invalidateDispositionCache best-effort evicts the server's cached tool
+// dispositions after a committed metadata write, so an admin edit takes effect
+// in remote-MCP enforcement without waiting out the read cache's TTL. A failure
+// only means that cache serves the prior view until it expires, so it is logged
+// rather than surfaced — the write itself has already committed.
+func (s *Service) invalidateDispositionCache(ctx context.Context, serverID uuid.UUID, logger *slog.Logger) {
+	if err := s.dispositionCache.Invalidate(ctx, serverID.String()); err != nil {
+		logger.WarnContext(ctx, "invalidate tool disposition cache", attr.SlogError(err), attr.SlogMcpServerID(serverID.String()))
+	}
 }
 
 // logToolMetadataChange records one collection-level audit entry, skipping

--- a/server/internal/mcpservers/toolmetadata.go
+++ b/server/internal/mcpservers/toolmetadata.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
@@ -532,6 +533,12 @@ func (s *Service) DeleteToolMetadata(ctx context.Context, payload *gen.DeleteToo
 // only means that cache serves the prior view until it expires, so it is logged
 // rather than surfaced — the write itself has already committed.
 func (s *Service) invalidateDispositionCache(ctx context.Context, serverID uuid.UUID, logger *slog.Logger) {
+	// Detach from the request context: the write has already committed, so a
+	// client disconnect after the response must not cancel the eviction and
+	// strand a stale disposition in cache until the TTL lapses.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
 	if err := s.dispositionCache.Invalidate(ctx, serverID.String()); err != nil {
 		logger.WarnContext(ctx, "invalidate tool disposition cache", attr.SlogError(err), attr.SlogMcpServerID(serverID.String()))
 	}

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -39,6 +39,8 @@ type ProxyManager struct {
 	proxyMetrics *proxy.Metrics
 	mcpMetrics   *ProxyMetrics
 
+	toolDispositions ToolDispositionResolver
+
 	toolsCallUsageLimitsInterceptor       *ToolsCallUsageLimitsInterceptor
 	toolsCallUsageTrackingInterceptor     *ToolsCallUsageTrackingInterceptor
 	resourcesReadUsageLimitsInterceptor   *ResourcesReadUsageLimitsInterceptor
@@ -59,6 +61,7 @@ func NewProxyManager(
 	telemLogger *tm.Logger,
 	billingRepo billing.Repository,
 	billingTracker billing.Tracker,
+	toolDispositions ToolDispositionResolver,
 ) *ProxyManager {
 	logger = logger.With(attr.SlogComponent("remotemcp"))
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/remotemcp")
@@ -72,6 +75,7 @@ func NewProxyManager(
 		telemLogger:                           telemLogger,
 		proxyMetrics:                          proxy.NewMetrics(meter, logger),
 		mcpMetrics:                            NewProxyMetrics(meter, logger),
+		toolDispositions:                      toolDispositions,
 		toolsCallUsageLimitsInterceptor:       NewToolsCallUsageLimitsInterceptor(billingRepo, logger),
 		toolsCallUsageTrackingInterceptor:     NewToolsCallUsageTrackingInterceptor(billingTracker, logger),
 		resourcesReadUsageLimitsInterceptor:   NewResourcesReadUsageLimitsInterceptor(billingRepo, logger),
@@ -169,14 +173,14 @@ func (f *ProxyManager) BuildTarget(
 	}
 	if visibility == mcpservers.VisibilityPrivate {
 		toolsCallReqInterceptors = append(toolsCallReqInterceptors,
-			NewToolsCallAuthzInterceptor(f.authz, identity.McpServerID, projectID, logger),
+			NewToolsCallAuthzInterceptor(f.authz, f.toolDispositions, identity.McpServerID, projectID, logger),
 		)
 	}
 
 	toolsListRespInterceptors := []proxy.ToolsListResponseInterceptor{}
 	if visibility == mcpservers.VisibilityPrivate {
 		toolsListRespInterceptors = append(toolsListRespInterceptors,
-			NewToolsListMCPConnectFilterInterceptor(f.authz, identity.McpServerID, projectID, logger),
+			NewToolsListMCPConnectFilterInterceptor(f.authz, f.toolDispositions, identity.McpServerID, projectID, logger),
 		)
 	}
 

--- a/server/internal/remotemcp/tool_disposition.go
+++ b/server/internal/remotemcp/tool_disposition.go
@@ -1,0 +1,19 @@
+package remotemcp
+
+import "context"
+
+// ToolDispositionResolver is the read-only seam the per-tool authz interceptors
+// depend on to fill the RBAC `disposition` dimension for a remote-MCP tool. The
+// production implementation is mcpservers.ToolDispositionCache (which owns the
+// backing table and the cache); tests inject a fake.
+type ToolDispositionResolver interface {
+	// Dispositions returns the tool-name -> disposition token map for a server.
+	// An empty (non-nil) map means the server has no classifying metadata; a
+	// missing tool key reads as the empty disposition.
+	//
+	// A non-nil error means resolution itself failed. Callers gating a tool
+	// call MUST fail closed on it — disposition is a security dimension, and
+	// silently substituting the empty disposition would relax an
+	// annotation-scoped policy exactly when the store is unavailable.
+	Dispositions(ctx context.Context, mcpServerID, projectID string) (map[string]string, error)
+}

--- a/server/internal/remotemcp/tool_disposition_fake_test.go
+++ b/server/internal/remotemcp/tool_disposition_fake_test.go
@@ -1,0 +1,28 @@
+package remotemcp_test
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp"
+)
+
+// fakeToolDispositionResolver is a canned [remotemcp.ToolDispositionResolver]
+// for interceptor tests: it returns a fixed disposition map (or error) without
+// touching Postgres or Redis, so the interceptor's disposition wiring and
+// fail-closed behavior are exercised in isolation from the resolver's own
+// storage-backed tests (those live in the mcpservers package, next to the
+// metadata fixtures).
+type fakeToolDispositionResolver struct {
+	dispositions map[string]string
+	err          error
+}
+
+func (f fakeToolDispositionResolver) Dispositions(_ context.Context, _, _ string) (map[string]string, error) {
+	return f.dispositions, f.err
+}
+
+// emptyResolver resolves every tool to the empty disposition, reducing each
+// check to a pure tool-name match.
+func emptyResolver() remotemcp.ToolDispositionResolver {
+	return fakeToolDispositionResolver{dispositions: nil, err: nil}
+}

--- a/server/internal/remotemcp/tools_call_authz_interceptor.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor.go
@@ -20,11 +20,13 @@ import (
 // visibility. Public servers bypass server-level RBAC by design, so per-tool
 // RBAC is also skipped — see the conditional attach in [Service.buildProxy].
 //
-// Only the tool-name dimension is checked here. Disposition awareness depends
-// on the per-session tools/list response cache tracked separately, and is
-// added when that cache lands.
+// The check carries both the tool-name and `disposition` dimensions. The
+// disposition is resolved from admin-authored tool metadata via the injected
+// [ToolDispositionResolver]; a tool with no recorded metadata resolves to the
+// empty disposition, leaving the check as a pure tool-name match.
 type ToolsCallAuthzInterceptor struct {
 	authz       *authz.Engine
+	resolver    ToolDispositionResolver
 	mcpServerID string
 	projectID   string
 	logger      *slog.Logger
@@ -41,9 +43,10 @@ var _ proxy.ToolsCallRequestInterceptor = (*ToolsCallAuthzInterceptor)(nil)
 // keeping per-tool and server-level authorization consistent. projectID is
 // the owning project for the mcp_endpoint and is forwarded as a dimension so
 // project-scoped grants can match.
-func NewToolsCallAuthzInterceptor(authzEngine *authz.Engine, mcpServerID, projectID string, logger *slog.Logger) *ToolsCallAuthzInterceptor {
+func NewToolsCallAuthzInterceptor(authzEngine *authz.Engine, resolver ToolDispositionResolver, mcpServerID, projectID string, logger *slog.Logger) *ToolsCallAuthzInterceptor {
 	return &ToolsCallAuthzInterceptor{
 		authz:       authzEngine,
+		resolver:    resolver,
 		mcpServerID: mcpServerID,
 		projectID:   projectID,
 		logger:      logger,
@@ -78,9 +81,19 @@ func (i *ToolsCallAuthzInterceptor) InterceptToolsCallRequest(ctx context.Contex
 		return nil
 	}
 
-	err := i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
+	// Fail closed: a resolution failure rejects the call rather than falling
+	// back to the empty disposition, which would relax an annotation-scoped
+	// grant exactly when the metadata store is unavailable. This is an internal
+	// failure, not a permission denial, so it surfaces as-is (any interceptor
+	// error aborts the call) rather than through the "you lack access" message.
+	dispositions, err := i.resolver.Dispositions(ctx, i.mcpServerID, i.projectID)
+	if err != nil {
+		return fmt.Errorf("resolve remote MCP tool disposition: %w", err)
+	}
+
+	err = i.authz.Require(ctx, authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
 		Tool:        call.Params.Name,
-		Disposition: "",
+		Disposition: dispositions[call.Params.Name],
 		ProjectID:   i.projectID,
 	}))
 	if err != nil {

--- a/server/internal/remotemcp/tools_call_authz_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor_test.go
@@ -1,6 +1,7 @@
 package remotemcp_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -62,7 +63,7 @@ func newToolsCallRequest(toolName string) *proxy.ToolsCallRequest {
 func TestToolsCallAuthzInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsCallAuthzInterceptor(newAuthzEngineForTest(t), testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(newAuthzEngineForTest(t), emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 	require.Equal(t, "tools-call-authz", interceptor.Name())
 }
 
@@ -70,7 +71,7 @@ func TestToolsCallAuthzInterceptor_NilEnginePassesThrough(t *testing.T) {
 	t.Parallel()
 
 	// Defensive: a nil engine must not panic and must not reject.
-	interceptor := remotemcp.NewToolsCallAuthzInterceptor(nil, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(nil, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	require.NoError(t, interceptor.InterceptToolsCallRequest(t.Context(), newToolsCallRequest("any_tool")))
 }
@@ -88,7 +89,7 @@ func TestToolsCallAuthzInterceptor_GrantsAllowMatchingTool(t *testing.T) {
 		}),
 	)
 
-	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	require.NoError(t, interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("search_tickets")))
 }
@@ -106,7 +107,7 @@ func TestToolsCallAuthzInterceptor_GrantsRejectNonMatchingTool(t *testing.T) {
 		}),
 	)
 
-	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	err := interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("delete_ticket"))
 
@@ -123,11 +124,66 @@ func TestToolsCallAuthzInterceptor_NoGrantsRejects(t *testing.T) {
 	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
 	ctx = authztest.WithExactGrants(t, ctx)
 
-	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	err := interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("any_tool"))
 
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestToolsCallAuthzInterceptor_DispositionScopedGrantMatches(t *testing.T) {
+	t.Parallel()
+
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	// Grant applies to any read_only tool on the server (no tool key).
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"disposition":   "read_only",
+		}),
+	)
+
+	resolver := fakeToolDispositionResolver{dispositions: map[string]string{
+		"list_items":  "read_only",
+		"delete_item": "destructive",
+	}}
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
+
+	// read_only tool matches the disposition-scoped grant.
+	require.NoError(t, interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("list_items")))
+
+	// destructive tool carries a disposition the grant does not cover, and no
+	// tool-scoped grant exists, so it is denied.
+	err := interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("delete_item"))
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+}
+
+func TestToolsCallAuthzInterceptor_ResolverErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	// A grant that would otherwise allow the call — the resolver error must
+	// deny anyway.
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"tool":          "search_tickets",
+		}),
+	)
+
+	resolver := fakeToolDispositionResolver{err: errors.New("metadata store unavailable")}
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
+
+	// The call is rejected despite the allowing grant: a resolver failure
+	// aborts before the authz check rather than proceeding on empty disposition.
+	err := interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("search_tickets"))
+	require.Error(t, err)
 }

--- a/server/internal/remotemcp/tools_call_authz_interceptor_test.go
+++ b/server/internal/remotemcp/tools_call_authz_interceptor_test.go
@@ -187,3 +187,26 @@ func TestToolsCallAuthzInterceptor_ResolverErrorFailsClosed(t *testing.T) {
 	err := interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("search_tickets"))
 	require.Error(t, err)
 }
+
+func TestToolsCallAuthzInterceptor_UnclassifiedToolAuthorizedByToolGrant(t *testing.T) {
+	t.Parallel()
+
+	// The called tool has no cached disposition — it is absent from the
+	// resolver map even though a sibling tool on the same server is classified.
+	// It must still authorize on its tool-name grant: adding disposition
+	// resolution does not regress tools that carry no metadata.
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"tool":          "search_tickets",
+		}),
+	)
+
+	resolver := fakeToolDispositionResolver{dispositions: map[string]string{"delete_ticket": "destructive"}}
+	interceptor := remotemcp.NewToolsCallAuthzInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
+
+	require.NoError(t, interceptor.InterceptToolsCallRequest(ctx, newToolsCallRequest("search_tickets")))
+}

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor.go
@@ -22,13 +22,14 @@ import (
 // servers bypass server-level RBAC by design — filtering the catalog
 // would be a no-op against grants that don't constrain the caller.
 //
-// Tool annotations (read-only, destructive, idempotent) are
-// deliberately not factored into the check yet. Annotation-aware
-// filtering depends on the per-session tools/list response cache
-// tracked separately; until that cache lands the disposition dimension
-// would have nothing to read.
+// Each per-tool check carries the `disposition` dimension, resolved from
+// admin-authored tool metadata via the injected [ToolDispositionResolver] so
+// the filter matches disposition-scoped grants the same way the paired
+// tools/call enforcement does. A tool with no recorded metadata resolves to
+// the empty disposition, leaving a pure tool-name match.
 type ToolsListMCPConnectFilterInterceptor struct {
 	authz       *authz.Engine
+	resolver    ToolDispositionResolver
 	mcpServerID string
 	projectID   string
 	logger      *slog.Logger
@@ -42,9 +43,10 @@ var _ proxy.ToolsListResponseInterceptor = (*ToolsListMCPConnectFilterIntercepto
 // the filter resolves grants against the same mcp_servers row that the
 // handler's upfront server-level `mcp:connect` check uses, the same shape
 // [authz.MCPToolCallCheck] uses for the paired tools/call enforcement.
-func NewToolsListMCPConnectFilterInterceptor(authzEngine *authz.Engine, mcpServerID, projectID string, logger *slog.Logger) *ToolsListMCPConnectFilterInterceptor {
+func NewToolsListMCPConnectFilterInterceptor(authzEngine *authz.Engine, resolver ToolDispositionResolver, mcpServerID, projectID string, logger *slog.Logger) *ToolsListMCPConnectFilterInterceptor {
 	return &ToolsListMCPConnectFilterInterceptor{
 		authz:       authzEngine,
+		resolver:    resolver,
 		mcpServerID: mcpServerID,
 		projectID:   projectID,
 		logger:      logger,
@@ -75,11 +77,20 @@ func (i *ToolsListMCPConnectFilterInterceptor) InterceptToolsListResponse(ctx co
 		return nil
 	}
 
+	// Fail closed: if disposition resolution fails, surface the error rather
+	// than filtering on the empty disposition, which would leak tools an
+	// annotation-scoped grant is meant to withhold. One lookup covers the
+	// whole batch (the resolver caches the server's full tool set).
+	dispositions, err := i.resolver.Dispositions(ctx, i.mcpServerID, i.projectID)
+	if err != nil {
+		return fmt.Errorf("resolve remote MCP tool dispositions: %w", err)
+	}
+
 	checks := make([]authz.Check, len(tools))
 	for idx, t := range tools {
 		checks[idx] = authz.MCPToolCallCheck(i.mcpServerID, authz.MCPToolCallDimensions{
 			Tool:        t.Name,
-			Disposition: "",
+			Disposition: dispositions[t.Name],
 			ProjectID:   i.projectID,
 		})
 	}

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
@@ -1,6 +1,7 @@
 package remotemcp_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
@@ -48,7 +49,7 @@ func newToolsListResponse(t *testing.T, tools []*mcp.Tool) *proxy.ToolsListRespo
 func TestToolsListMCPConnectFilterInterceptor_Name(t *testing.T) {
 	t.Parallel()
 
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(newAuthzEngineForTest(t), testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(newAuthzEngineForTest(t), emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 	require.Equal(t, "tools-list-mcp-connect-filter", interceptor.Name())
 }
 
@@ -56,7 +57,7 @@ func TestToolsListMCPConnectFilterInterceptor_NilEnginePassesThrough(t *testing.
 	t.Parallel()
 
 	// A nil engine must not panic; pass the response through unchanged.
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(nil, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(nil, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	resp := newToolsListResponse(t, []*mcp.Tool{
 		{Name: "tool_a", InputSchema: map[string]any{}},
@@ -79,7 +80,7 @@ func TestToolsListMCPConnectFilterInterceptor_KeepsOnlyGrantedTools(t *testing.T
 		}),
 	)
 
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	resp := newToolsListResponse(t, []*mcp.Tool{
 		{Name: "search_tickets", InputSchema: map[string]any{}},
@@ -102,7 +103,7 @@ func TestToolsListMCPConnectFilterInterceptor_EmptyArrayWhenNoGrantsMatch(t *tes
 	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
 	ctx = authztest.WithExactGrants(t, ctx)
 
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	resp := newToolsListResponse(t, []*mcp.Tool{
 		{Name: "tool_a", InputSchema: map[string]any{}},
@@ -133,7 +134,7 @@ func TestToolsListMCPConnectFilterInterceptor_PreservesInputOrderInFilteredResul
 		}),
 	)
 
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	resp := newToolsListResponse(t, []*mcp.Tool{
 		{Name: "tool_a", InputSchema: map[string]any{}},
@@ -154,7 +155,7 @@ func TestToolsListMCPConnectFilterInterceptor_NilResultPassesThrough(t *testing.
 	// An error-shaped response (no Result) must short-circuit without
 	// touching the typed view. The downstream relay surfaces the
 	// upstream's JSON-RPC error envelope to the user unchanged.
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(newAuthzEngineForTest(t), testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(newAuthzEngineForTest(t), emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	resp := &proxy.ToolsListResponse{
 		Error:         &jsonrpc.Error{Code: -32601, Message: "method not found", Data: nil},
@@ -175,9 +176,68 @@ func TestToolsListMCPConnectFilterInterceptor_EmptyToolsListShortCircuits(t *tes
 	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
 	ctx = authztest.WithExactGrants(t, ctx)
 
-	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, testServerID, testProjectID, testenv.NewLogger(t))
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, emptyResolver(), testServerID, testProjectID, testenv.NewLogger(t))
 
 	resp := newToolsListResponse(t, nil)
 	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
 	require.Empty(t, resp.Result.Tools)
+}
+
+func TestToolsListMCPConnectFilterInterceptor_FiltersByDisposition(t *testing.T) {
+	t.Parallel()
+
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	// Grant covers any read_only tool on the server (no tool key).
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"disposition":   "read_only",
+		}),
+	)
+
+	resolver := fakeToolDispositionResolver{dispositions: map[string]string{
+		"list_items":  "read_only",
+		"delete_item": "destructive",
+	}}
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
+
+	resp := newToolsListResponse(t, []*mcp.Tool{
+		{Name: "list_items", InputSchema: map[string]any{}},
+		{Name: "delete_item", InputSchema: map[string]any{}},
+	})
+	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
+
+	require.Len(t, resp.Result.Tools, 1)
+	require.Equal(t, "list_items", resp.Result.Tools[0].Name)
+}
+
+func TestToolsListMCPConnectFilterInterceptor_ResolverErrorFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	// A grant that would otherwise keep the tool — the resolver error must
+	// short-circuit the whole filter rather than fall back to filtering on the
+	// empty disposition.
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"tool":          "list_items",
+		}),
+	)
+
+	resolver := fakeToolDispositionResolver{err: errors.New("metadata store unavailable")}
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
+
+	resp := newToolsListResponse(t, []*mcp.Tool{
+		{Name: "list_items", InputSchema: map[string]any{}},
+	})
+	err := interceptor.InterceptToolsListResponse(ctx, resp)
+	require.Error(t, err)
+	// The tools slice is left untouched: the error propagates for the proxy to
+	// surface, rather than a silently emptied or unfiltered list.
+	require.Len(t, resp.Result.Tools, 1)
 }

--- a/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
+++ b/server/internal/remotemcp/tools_list_mcp_connect_filter_interceptor_test.go
@@ -241,3 +241,34 @@ func TestToolsListMCPConnectFilterInterceptor_ResolverErrorFailsClosed(t *testin
 	// surface, rather than a silently emptied or unfiltered list.
 	require.Len(t, resp.Result.Tools, 1)
 }
+
+func TestToolsListMCPConnectFilterInterceptor_KeepsUnclassifiedGrantedTool(t *testing.T) {
+	t.Parallel()
+
+	// tool_a has no cached disposition; tool_b is classified but ungranted.
+	// Filtering keys off the tool-name grant regardless of disposition state,
+	// so the unclassified-but-granted tool survives and the classified-but-
+	// ungranted one is dropped — disposition classification of a sibling does
+	// not change how an un-annotated tool is authorized.
+	engine := newAuthzEngineForTest(t)
+	ctx := contextvalues.SetAuthContext(t.Context(), authzAuthContext(t))
+	ctx = authztest.WithExactGrants(t, ctx,
+		authz.NewGrantWithSelector(authz.ScopeMCPConnect, authz.Selector{
+			"resource_kind": "mcp",
+			"resource_id":   testServerID,
+			"tool":          "tool_a",
+		}),
+	)
+
+	resolver := fakeToolDispositionResolver{dispositions: map[string]string{"tool_b": "destructive"}}
+	interceptor := remotemcp.NewToolsListMCPConnectFilterInterceptor(engine, resolver, testServerID, testProjectID, testenv.NewLogger(t))
+
+	resp := newToolsListResponse(t, []*mcp.Tool{
+		{Name: "tool_a", InputSchema: map[string]any{}},
+		{Name: "tool_b", InputSchema: map[string]any{}},
+	})
+	require.NoError(t, interceptor.InterceptToolsListResponse(ctx, resp))
+
+	require.Len(t, resp.Result.Tools, 1)
+	require.Equal(t, "tool_a", resp.Result.Tools[0].Name)
+}

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -154,7 +154,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient)
+	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter))
 	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,


### PR DESCRIPTION
Fills the `disposition` dimension in the remote-MCP per-tool `mcp:connect` RBAC checks, which until now always passed it empty. Closes AGE-2877.

Only affects private remote-MCP servers with admin-authored tool metadata; servers without metadata resolve to the empty disposition, so enforcement is unchanged for them.

## What changed

**`feat(mcpservers)`: cache and evict remote-MCP tool dispositions**
- New `ToolDispositionCache`, colocated with the tool-metadata write methods it serves. Read path of the Tool Metadata Materialization design (RFC §4.2): resolves a tool's disposition from `mcp_server_tool_metadata` through a Redis pull-through cache over Postgres, reusing `conv.AnnotationsFromColumns` + `DispositionFromAnnotations` — no upstream fetch, no writes on the hot path.
- Whole per-server tool set cached under one key (one GET serves `tools/list` and every `tools/call`); an empty non-nil map negative-caches a metadata-less server.
- Writes evict directly: each committed metadata change (`set`/`add` batch, single set, delete) calls `Invalidate`, so an admin edit takes effect without waiting out the TTL. Because the cache lives in the table's own package, eviction is a plain internal call — no cross-package invalidator interface.

**`feat(remotemcp)`: enforce tool disposition in per-tool RBAC**
- `tools/call` and the `tools/list` filter resolve and stamp `disposition` on their checks. The interceptors depend on a one-method read-only `ToolDispositionResolver` seam (consumer-owned interface), satisfied by `mcpservers.ToolDispositionCache`, constructed once at the composition root and shared with the write path.

## Fail closed
Both paths reject the call / filter on a resolution error rather than falling back to the empty disposition — that fallback would relax an annotation-scoped grant exactly when the metadata store is unavailable. Since `disposition` is a security dimension, unavailability denies.

## Scope / sequencing
- Depends only on the already-merged schema (AGE-2874). Uses the existing single-valued `disposition` grammar; the three-valued `tool_annotations` ternary is intentionally out of scope and stays with AGE-2886.
- Inert for servers without authored metadata; behavior-neutral until the policy-authoring surface (AGE-2878) makes these grants writable.

## Testing
- `mcpservers`: cache derivation (read-only/destructive/omit-unset), negative cache, invalidation-on-service-write, fail-closed on bad ids — against real Postgres + Redis with the existing remote-backed-server + metadata fixtures.
- `remotemcp`: interceptor tests inject a fake resolver — disposition-scoped allow/deny reaches the check on both paths, and a resolver error fails closed.
- `mise lint:server` clean; `remotemcp` + `mcpservers` suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces per‑tool RBAC `disposition` for remote‑MCP by resolving it from admin‑authored metadata via a Redis pull‑through cache and wiring it into `tools/call` and `tools/list`. Applies only to private servers; tools without metadata continue to authorize by name. Implements AGE‑2877.

- **New Features**
  - Adds `mcpservers.ToolDispositionCache` (Redis over Postgres, 15m TTL, per‑server map with negative caching; writes evict immediately).
  - Introduces `remotemcp.ToolDispositionResolver`; `remotemcp.ProxyManager` receives a shared cache instance and passes it to both interceptors.
  - `tools/call` and `tools/list` now stamp `disposition` from the cache; resolution errors fail closed; unclassified tools keep name‑only behavior. Tests cover cache derivation/invalidation, mixed classified/unclassified tools, and fail‑closed behavior.

- **Bug Fixes**
  - Cache invalidation detached from the request context with a 5s timeout so evictions aren’t lost on client disconnects.
  - Validates `mcpServerID` and `projectID` before cache reads so bad IDs fail closed even with a warm cache.

<sup>Written for commit c66f30ff3663b75a78bc1cc58a429d385818f626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

