### PR TITLE
fix(auth): use crypto/rand for dashboard session tokens

### DIFF
--- a/.changeset/session-token-entropy.md
+++ b/.changeset/session-token-entropy.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Dashboard session tokens are now generated from 256 bits of `crypto/rand` entropy (base64url-encoded) instead of a v4 UUID. Session tokens are bearer credentials validated by a bare cache lookup, so they must be unguessable; a UUID carries only 122 bits of entropy in a recognizable, structured format and is not intended for use as a security token. Existing sessions remain valid, this only affects newly issued tokens.

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -278,7 +277,10 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		return redirectWithError(authErrInit, err)
 	}
 
-	sessionID := uuid.New().String()
+	sessionID, err := sessions.NewSessionID()
+	if err != nil {
+		return redirectWithError(authErrInit, err)
+	}
 	session := sessions.Session{
 		SessionID:            sessionID,
 		UserID:               userID,

--- a/server/internal/auth/sessions/sessions.go
+++ b/server/internal/auth/sessions/sessions.go
@@ -2,6 +2,8 @@ package sessions
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 
@@ -17,6 +19,26 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 )
+
+// sessionTokenBytes is the number of random bytes drawn for a session token.
+// 32 bytes yields 256 bits of entropy, base64url-encoded to a 43-character
+// opaque string.
+const sessionTokenBytes = 32
+
+// NewSessionID generates a cryptographically secure, opaque session token.
+//
+// Session tokens are bearer credentials: possession of the token string is
+// sufficient to authenticate as the user (validation is a bare cache lookup in
+// Authenticate). They must therefore be unguessable. A v4 UUID carries only 122
+// bits of entropy in a recognizable, structured format and is not intended as a
+// security token, so we draw 256 bits directly from crypto/rand instead.
+func NewSessionID() (string, error) {
+	b := make([]byte, sessionTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate session token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
 
 // SessionRevoker invalidates an IDP session. Implemented by the WorkOS
 // adapter so sessions.Manager doesn't depend on the WorkOS SDK directly.

--- a/server/internal/auth/sessions/sessions_test.go
+++ b/server/internal/auth/sessions/sessions_test.go
@@ -1,0 +1,34 @@
+package sessions
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestNewSessionID(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 1000
+	seen := make(map[string]struct{}, iterations)
+
+	for range iterations {
+		token, err := NewSessionID()
+		if err != nil {
+			t.Fatalf("NewSessionID() returned error: %v", err)
+		}
+
+		if _, dup := seen[token]; dup {
+			t.Fatalf("NewSessionID() produced a duplicate token: %q", token)
+		}
+		seen[token] = struct{}{}
+
+		decoded, err := base64.RawURLEncoding.DecodeString(token)
+		if err != nil {
+			t.Fatalf("token %q is not valid base64url: %v", token, err)
+		}
+
+		if len(decoded) != sessionTokenBytes {
+			t.Fatalf("token decoded to %d bytes, want %d", len(decoded), sessionTokenBytes)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Dashboard session tokens (the `gram_session` cookie) were generated with `uuid.New().String()` (`server/internal/auth/impl.go`). That value is a bearer credential: it is validated purely by a cache-existence lookup in `sessions.Manager.Authenticate` (`server/internal/auth/sessions/sessions.go`), with no signature or secondary check, so possession of the token string is authentication.

A v4 UUID is the wrong primitive for this. It carries only 122 bits of entropy in a well-known, structured layout and is not designed to be an unguessable secret. Using UUIDs for authentication tokens is a long-standing anti-pattern ([discussion](https://security.stackexchange.com/questions/157270/using-v4-uuid-for-authentication)).

## What changed

**Before:** session token = `uuid.New().String()` (122 bits, structured UUID format).

**After:** session token = 256 bits from `crypto/rand`, base64url-encoded to an opaque 43-character string, via a new `sessions.NewSessionID()` helper.

- New `NewSessionID()` in `server/internal/auth/sessions/sessions.go` with a doc comment explaining the bearer-credential threat model.
- `Callback` in `impl.go` uses it and propagates any RNG error through the existing `redirectWithError` path; drops the now-unused `google/uuid` import.
- Added `sessions_test.go` covering uniqueness, base64url validity, and decoded length.

Storage is unchanged (Redis key `sessions:<token>`, 15-day TTL), and the token stays opaque to clients, so existing sessions remain valid. This only affects newly issued tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure dashboard session tokens by replacing v4 UUIDs with 256-bit random tokens from `crypto/rand`, base64url-encoded, so bearer tokens are unguessable. Existing sessions remain valid; only new tokens change.

- **Bug Fixes**
  - Added `sessions.NewSessionID()` to generate 32-byte random tokens via `crypto/rand`, encoded with `base64.RawURLEncoding`.
  - `Callback` now uses the helper and propagates RNG errors; removed `github.com/google/uuid`.
  - Added tests for uniqueness, base64url validity, and decoded length.
  - Storage key format and TTL unchanged.

<sup>Written for commit d39a2e07618724cc3dbe5c755e631054c931d9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

