### PR TITLE
feat(dashboard): permission remote MCP tools by name in the role editor

### DIFF
--- a/.changeset/remote-mcp-tool-rbac-picker.md
+++ b/.changeset/remote-mcp-tool-rbac-picker.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+permission remote MCP tools by name in the role editor

--- a/client/dashboard/src/hooks/useToolMetadata.ts
+++ b/client/dashboard/src/hooks/useToolMetadata.ts
@@ -16,7 +16,8 @@ export interface UseToolMetadataResult {
  * This is the admin-authoritative side of the Inspect tab: the remote server
  * advertises its own annotation hints over the live MCP session, and these
  * stored entries are what Speakeasy asserts on top of them (read by the runtime
- * proxy to fill the disposition dimension of RBAC checks).
+ * proxy to fill the disposition dimension of RBAC checks). The access-role
+ * editor reads the same table to let admins permission remote tools by name.
  *
  * Only servers backed by a remote MCP server carry tool metadata — the API
  * rejects toolset-backed ones, which persist hints on their tool-definition
@@ -24,12 +25,17 @@ export interface UseToolMetadataResult {
  */
 export function useToolMetadata(
   mcpServerId: string | undefined,
-  options?: { enabled?: boolean },
+  options?: { enabled?: boolean; projectSlug?: string },
 ): UseToolMetadataResult {
   const enabled = (options?.enabled ?? true) && !!mcpServerId;
 
   const { data, isLoading, fetchStatus } = useListMcpServerToolMetadata(
-    { mcpServerId: mcpServerId ?? "" },
+    // `gramProject` sets the per-call `Gram-Project` header. On project-scoped
+    // pages callers omit it and inherit the ambient project; the org-level
+    // access role editor lists servers across every project, so it must name
+    // each server's project explicitly or the request resolves against the
+    // wrong one (the endpoint hard-scopes tool metadata to the header project).
+    { mcpServerId: mcpServerId ?? "", gramProject: options?.projectSlug },
     undefined,
     {
       enabled,

--- a/client/dashboard/src/hooks/useToolMetadata.ts
+++ b/client/dashboard/src/hooks/useToolMetadata.ts
@@ -8,6 +8,10 @@ export type ToolMetadataByName = Record<string, ToolMetadata>;
 export interface UseToolMetadataResult {
   metadataByTool: ToolMetadataByName;
   isLoading: boolean;
+  /** The metadata request failed (network, 5xx, or an RBAC 403). */
+  isError: boolean;
+  /** Retry the request; used to recover from a transient load failure. */
+  refetch: () => void;
 }
 
 /**
@@ -29,22 +33,23 @@ export function useToolMetadata(
 ): UseToolMetadataResult {
   const enabled = (options?.enabled ?? true) && !!mcpServerId;
 
-  const { data, isLoading, fetchStatus } = useListMcpServerToolMetadata(
-    // `gramProject` sets the per-call `Gram-Project` header. On project-scoped
-    // pages callers omit it and inherit the ambient project; the org-level
-    // access role editor lists servers across every project, so it must name
-    // each server's project explicitly or the request resolves against the
-    // wrong one (the endpoint hard-scopes tool metadata to the header project).
-    { mcpServerId: mcpServerId ?? "", gramProject: options?.projectSlug },
-    undefined,
-    {
-      enabled,
-      // Stored metadata is supplementary to the live tool listing. A failure
-      // here shouldn't take down the tools list, so keep it inline — the rows
-      // simply fall back to the annotations the server advertised.
-      throwOnError: false,
-    },
-  );
+  const { data, isLoading, isError, fetchStatus, refetch } =
+    useListMcpServerToolMetadata(
+      // `gramProject` sets the per-call `Gram-Project` header. On project-scoped
+      // pages callers omit it and inherit the ambient project; the org-level
+      // access role editor lists servers across every project, so it must name
+      // each server's project explicitly or the request resolves against the
+      // wrong one (the endpoint hard-scopes tool metadata to the header project).
+      { mcpServerId: mcpServerId ?? "", gramProject: options?.projectSlug },
+      undefined,
+      {
+        enabled,
+        // Stored metadata is supplementary to the live tool listing. A failure
+        // here shouldn't take down the tools list, so keep it inline — the rows
+        // simply fall back to the annotations the server advertised.
+        throwOnError: false,
+      },
+    );
 
   const metadataByTool = useMemo(() => {
     // Null-prototype: tool names come from the remote server, so a tool called
@@ -62,5 +67,9 @@ export function useToolMetadata(
     // `isLoading` stays true for a disabled query; pair it with fetchStatus so
     // a gated server doesn't hold the section in a permanent skeleton.
     isLoading: isLoading && fetchStatus !== "idle",
+    isError,
+    refetch: () => {
+      void refetch();
+    },
   };
 }

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -3,12 +3,15 @@ import { RequireScope } from "@/components/require-scope";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { cn, getServerURL } from "@/lib/utils";
-import { useOrgRoutes } from "@/routes";
+import { mcpServerRouteParam } from "@/lib/sources";
+import { useToolMetadata } from "@/hooks/useToolMetadata";
+import { useOrgRoutes, useRoutes } from "@/routes";
 import { useListCollections } from "@gram/client/react-query/listCollections.js";
 import { useListMcpServersForOrg } from "@gram/client/react-query/listMcpServersForOrg.js";
 import { useListToolsetsForOrg } from "@gram/client/react-query/listToolsetsForOrg.js";
 import {
   AlertTriangle,
+  ArrowUpRight,
   Check,
   ChevronRight,
   Info,
@@ -20,6 +23,7 @@ import {
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
 import { useQueries } from "@tanstack/react-query";
 import type { Selector } from "@gram/client/models/components/selector.js";
 import type { ActivePanel, AnnotationHint, ResourceType } from "./types";
@@ -29,15 +33,11 @@ import {
 } from "./types";
 import { computePanelState, type CollectionGroup } from "./computePanelState";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   mergeMcpServersIntoGroups,
   type Server,
   type ServerGroup,
 } from "./serverMerge";
+import { toolMetadataToServerTools } from "./remoteToolMetadata";
 
 interface GrantRuleDrawerContentProps {
   /** The resource type determines which resource list to show */
@@ -144,6 +144,12 @@ export function GrantRuleDrawerContent({
 }: GrantRuleDrawerContentProps): JSX.Element {
   const organization = useOrganization();
   const mcpServers = useMCPServers(resourceType === "mcp");
+  // Project slug per id, so the tool picker can name each remote server's
+  // project when fetching its (project-scoped) stored tool metadata.
+  const projectSlugById = useMemo(
+    () => new Map(organization.projects.map((p) => [p.id, p.slug])),
+    [organization.projects],
+  );
   // Override for when user clicks a mode but selectors are still empty
   const [panelOverride, setPanelOverride] = useState<ActivePanel | null>(null);
   const [resourceSearch, setResourceSearch] = useState("");
@@ -291,11 +297,11 @@ export function GrantRuleDrawerContent({
       .filter((g) => g.servers.length > 0);
   }, [scopedMcpServers, resourceSearch]);
 
-  // The "Specific tools" picker only makes sense for servers with enumerable
-  // tools. Proxy servers (no tools/list at deploy time) appear in the
-  // "Specific servers" picker for server-level grants but must not render
-  // a zero-tools row here. Dynamic-tools servers (remote/tunneled) are kept
-  // so the panel can explain why their tools can't be selected.
+  // The "Specific tools" picker shows servers with enumerable deploy-time tools
+  // plus remote/tunneled (dynamic-tools) servers, whose tools it resolves from
+  // the stored metadata table on expand. Proxy servers (no tools/list at deploy
+  // time) appear in the "Specific servers" picker for server-level grants but
+  // must not render a zero-tools row here.
   const toolPanelMcpServers = useMemo(
     () =>
       scopedMcpServers
@@ -568,6 +574,7 @@ export function GrantRuleDrawerContent({
   const customTabs = (toolScrollClass?: string) => (
     <ToolSelectionPanel
       mcpServers={toolPanelMcpServers}
+      projectSlugById={projectSlugById}
       selectors={selectors ?? []}
       annotations={annotations}
       onChangeAnnotations={onChangeAnnotations}
@@ -652,6 +659,7 @@ export function GrantRuleDrawerContent({
 
 function ToolSelectionPanel({
   mcpServers,
+  projectSlugById,
   selectors,
   onToggleTool,
   onBatchToggleTools,
@@ -662,6 +670,7 @@ function ToolSelectionPanel({
   className,
 }: {
   mcpServers: ServerGroup[];
+  projectSlugById: Map<string, string>;
   selectors: Selector[];
   onToggleTool: (serverId: string, toolName: string) => void;
   onBatchToggleTools?: (
@@ -679,7 +688,11 @@ function ToolSelectionPanel({
     () =>
       mcpServers
         .flatMap((g) =>
-          g.servers.map((s) => ({ ...s, projectName: g.projectName })),
+          g.servers.map((s) => ({
+            ...s,
+            projectName: g.projectName,
+            projectSlug: projectSlugById.get(g.projectId),
+          })),
         )
         .sort((a, b) =>
           `${a.projectName}/${a.name}`.localeCompare(
@@ -887,176 +900,234 @@ function ToolSelectionPanel({
                   : "No matching tools or servers"}
               </div>
             ) : (
-              filteredServers.map((server) => {
-                if (server.dynamicTools) {
-                  return (
-                    <Tooltip key={server.id}>
-                      <TooltipTrigger asChild>
-                        {/* Focusable so keyboard users can surface the tooltip
-                            explaining why the row can't be selected. */}
-                        <div
-                          tabIndex={0}
-                          aria-disabled="true"
-                          className="border-border focus-visible:ring-ring flex cursor-not-allowed items-center border-b px-3 py-2.5 text-sm opacity-50 focus-visible:ring-1 focus-visible:outline-none last:border-b-0"
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatch
-                              text={`${server.projectName.toLowerCase()}/`}
-                              query={q}
-                              className="text-muted-foreground/60"
-                            />
-                            <HighlightMatch
-                              text={server.name}
-                              query={q}
-                              className="font-medium"
-                            />
-                          </span>
-                          <span className="text-muted-foreground shrink-0 text-xs">
-                            dynamic tools
-                          </span>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" className="max-w-xs">
-                        Tools are dynamically resolved for this server and
-                        cannot be individually permissioned.
-                      </TooltipContent>
-                    </Tooltip>
-                  );
-                }
-
-                const isExpanded = expandedServers.has(server.id);
-                const serverTools = server.tools
-                  .slice()
-                  .sort((a, b) => a.name.localeCompare(b.name));
-
-                const selectedCount = serverTools.filter((t) =>
-                  selectors.some(
-                    (s) => s.resourceId === server.id && s.tool === t.name,
-                  ),
-                ).length;
-                const allSelected =
-                  serverTools.length > 0 &&
-                  selectedCount === serverTools.length;
-                const someSelected = selectedCount > 0 && !allSelected;
-
-                return (
-                  <div
-                    key={server.id}
-                    className="border-border border-b last:border-b-0"
-                  >
-                    {/* Server header */}
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => toggleExpanded(server.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          toggleExpanded(server.id);
-                        }
-                      }}
-                      className="hover:bg-muted/50 flex cursor-pointer items-center"
-                    >
-                      <div className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2.5 text-sm">
-                        <ChevronRight
-                          className={cn(
-                            "text-muted-foreground h-3 w-3 shrink-0 transition-transform",
-                            isExpanded && "rotate-90",
-                          )}
-                        />
-                        <span className="min-w-0 truncate">
-                          <HighlightMatch
-                            text={`${server.projectName.toLowerCase()}/`}
-                            query={q}
-                            className="text-muted-foreground/60"
-                          />
-                          <HighlightMatch
-                            text={server.name}
-                            query={q}
-                            className="font-medium"
-                          />
-                        </span>
-                      </div>
-                      <div className="flex shrink-0 items-center gap-2 pr-3">
-                        <span className="text-muted-foreground text-xs">
-                          {selectedCount > 0
-                            ? `${selectedCount} of ${serverTools.length} selected`
-                            : `${serverTools.length} ${serverTools.length === 1 ? "tool" : "tools"} available`}
-                        </span>
-                        {
-                          <Checkbox
-                            checked={
-                              allSelected
-                                ? true
-                                : someSelected
-                                  ? "indeterminate"
-                                  : false
-                            }
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (hasAnnotationFilter && onChangeAnnotations) {
-                                onChangeAnnotations([]);
-                              }
-                              if (onBatchToggleTools) {
-                                onBatchToggleTools(
-                                  server.id,
-                                  serverTools.map((t) => t.name),
-                                  !allSelected,
-                                );
-                              }
-                            }}
-                            className="focus-visible:border-input pointer-events-auto cursor-pointer focus-visible:ring-0"
-                          />
-                        }
-                      </div>
-                    </div>
-
-                    {/* Expanded tool list */}
-                    {isExpanded && (
-                      <div className="bg-muted/30 border-border max-h-[300px] overflow-y-auto border-t">
-                        {serverTools.map((tool) => {
-                          const isSelected = selectors.some(
-                            (s) =>
-                              s.resourceId === server.id &&
-                              s.tool === tool.name,
-                          );
-                          return (
-                            <button
-                              key={tool.id}
-                              type="button"
-                              onClick={() => {
-                                if (
-                                  hasAnnotationFilter &&
-                                  onChangeAnnotations
-                                ) {
-                                  onChangeAnnotations([]);
-                                }
-                                onToggleTool(server.id, tool.name);
-                              }}
-                              className="hover:bg-accent flex w-full cursor-pointer items-center gap-2 py-1.5 pr-3 pl-8 text-sm"
-                            >
-                              <Checkbox
-                                checked={isSelected}
-                                className="focus-visible:border-input pointer-events-none focus-visible:ring-0"
-                                tabIndex={-1}
-                              />
-                              <HighlightMatch
-                                text={tool.name}
-                                query={q}
-                                className="truncate"
-                              />
-                            </button>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                );
-              })
+              filteredServers.map((server) => (
+                <ServerToolRow
+                  key={server.id}
+                  server={server}
+                  selectors={selectors}
+                  query={q}
+                  isExpanded={expandedServers.has(server.id)}
+                  onToggleExpanded={toggleExpanded}
+                  onToggleTool={onToggleTool}
+                  onBatchToggleTools={onBatchToggleTools}
+                  hasAnnotationFilter={hasAnnotationFilter}
+                  onClearAnnotations={
+                    onChangeAnnotations
+                      ? () => onChangeAnnotations([])
+                      : undefined
+                  }
+                />
+              ))
             )}
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/** A server row in the tool picker, enriched with its project's display name
+ *  and slug (the slug is what the remote metadata request scopes against). */
+type PanelServer = Server & { projectName: string; projectSlug?: string };
+
+/**
+ * One MCP server row in the "Specific tools" picker.
+ *
+ * Toolset-backed servers render their enumerable deploy-time tools directly.
+ * Remote/tunneled servers (`dynamicTools`) have no such list, so on expand this
+ * fetches their stored tool metadata and renders it as selectable rows. When a
+ * remote server has never been synced its table is empty, and the row points
+ * the admin at the Inspect tab (which materializes it from the live session).
+ */
+function ServerToolRow({
+  server,
+  selectors,
+  query,
+  isExpanded,
+  onToggleExpanded,
+  onToggleTool,
+  onBatchToggleTools,
+  hasAnnotationFilter,
+  onClearAnnotations,
+}: {
+  server: PanelServer;
+  selectors: Selector[];
+  query: string;
+  isExpanded: boolean;
+  onToggleExpanded: (serverId: string) => void;
+  onToggleTool: (serverId: string, toolName: string) => void;
+  onBatchToggleTools?: (
+    serverId: string,
+    toolNames: string[],
+    select: boolean,
+  ) => void;
+  hasAnnotationFilter: boolean;
+  onClearAnnotations?: () => void;
+}) {
+  const routes = useRoutes();
+  const isRemote = server.dynamicTools;
+
+  // Fetch lazily, only for the remote rows the admin actually opens, so the
+  // picker issues at most one metadata request per expanded server. The
+  // project slug scopes the (project-scoped) request to this server's project.
+  const { metadataByTool, isLoading } = useToolMetadata(server.id, {
+    enabled: isRemote && isExpanded,
+    projectSlug: server.projectSlug,
+  });
+
+  const serverTools = useMemo(() => {
+    const base = isRemote
+      ? toolMetadataToServerTools(server.id, Object.values(metadataByTool))
+      : server.tools;
+    return base.slice().sort((a, b) => a.name.localeCompare(b.name));
+  }, [isRemote, server.id, server.tools, metadataByTool]);
+
+  const q = query.toLowerCase();
+
+  // Persisted tool selections exist whether or not the remote list has loaded,
+  // so count them from the selectors rather than the (possibly empty) tools.
+  const selectedCount = selectors.filter(
+    (s) => s.resourceId === server.id && !!s.tool,
+  ).length;
+  const total = serverTools.length;
+  const allSelected =
+    total > 0 &&
+    serverTools.every((t) =>
+      selectors.some((s) => s.resourceId === server.id && s.tool === t.name),
+    );
+  const someSelected = selectedCount > 0 && !allSelected;
+
+  const toolsLoaded = !isRemote || (isExpanded && !isLoading);
+  const isEmptyRemote = isRemote && toolsLoaded && total === 0;
+
+  const countLabel =
+    isRemote && !isExpanded
+      ? selectedCount > 0
+        ? `${selectedCount} selected`
+        : "Expand to load tools"
+      : isLoading
+        ? "Loading…"
+        : isEmptyRemote
+          ? "Not synced"
+          : selectedCount > 0
+            ? `${selectedCount} of ${total} selected`
+            : `${total} ${total === 1 ? "tool" : "tools"} available`;
+
+  return (
+    <div className="border-border border-b last:border-b-0">
+      {/* Server header */}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => onToggleExpanded(server.id)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggleExpanded(server.id);
+          }
+        }}
+        className="hover:bg-muted/50 flex cursor-pointer items-center"
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2.5 text-sm">
+          <ChevronRight
+            className={cn(
+              "text-muted-foreground h-3 w-3 shrink-0 transition-transform",
+              isExpanded && "rotate-90",
+            )}
+          />
+          <span className="min-w-0 truncate">
+            <HighlightMatch
+              text={`${server.projectName.toLowerCase()}/`}
+              query={q}
+              className="text-muted-foreground/60"
+            />
+            <HighlightMatch
+              text={server.name}
+              query={q}
+              className="font-medium"
+            />
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 pr-3">
+          <span className="text-muted-foreground text-xs">{countLabel}</span>
+          {total > 0 && (
+            <Checkbox
+              checked={
+                allSelected ? true : someSelected ? "indeterminate" : false
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                if (hasAnnotationFilter) onClearAnnotations?.();
+                onBatchToggleTools?.(
+                  server.id,
+                  serverTools.map((t) => t.name),
+                  !allSelected,
+                );
+              }}
+              className="focus-visible:border-input pointer-events-auto cursor-pointer focus-visible:ring-0"
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Expanded tool list */}
+      {isExpanded && (
+        <div className="bg-muted/30 border-border max-h-[300px] overflow-y-auto border-t">
+          {isRemote && isLoading ? (
+            <div className="text-muted-foreground px-8 py-3 text-sm">
+              Loading tools…
+            </div>
+          ) : isEmptyRemote ? (
+            <div className="text-muted-foreground space-y-1 px-8 py-3 text-sm">
+              <p>This server&apos;s tools haven&apos;t been synced yet.</p>
+              <p>
+                <Link
+                  to={routes.mcp.x.inspect.href(
+                    mcpServerRouteParam({ id: server.id, slug: server.slug }),
+                  )}
+                  className="text-primary inline-flex items-center gap-1 hover:underline"
+                >
+                  Connect it on the Inspect tab
+                  <ArrowUpRight className="h-3 w-3" />
+                </Link>{" "}
+                to permission its tools individually.
+              </p>
+            </div>
+          ) : total === 0 ? (
+            <div className="text-muted-foreground px-8 py-3 text-sm">
+              No tools available
+            </div>
+          ) : (
+            serverTools.map((tool) => {
+              const isSelected = selectors.some(
+                (s) => s.resourceId === server.id && s.tool === tool.name,
+              );
+              return (
+                <button
+                  key={tool.id}
+                  type="button"
+                  onClick={() => {
+                    if (hasAnnotationFilter) onClearAnnotations?.();
+                    onToggleTool(server.id, tool.name);
+                  }}
+                  className="hover:bg-accent flex w-full cursor-pointer items-center gap-2 py-1.5 pr-3 pl-8 text-sm"
+                >
+                  <Checkbox
+                    checked={isSelected}
+                    className="focus-visible:border-input pointer-events-none focus-visible:ring-0"
+                    tabIndex={-1}
+                  />
+                  <HighlightMatch
+                    text={tool.name}
+                    query={q}
+                    className="truncate"
+                  />
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -33,6 +33,11 @@ import {
 } from "./types";
 import { computePanelState, type CollectionGroup } from "./computePanelState";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   mergeMcpServersIntoGroups,
   type Server,
   type ServerGroup,
@@ -118,6 +123,7 @@ function useMCPServers(enabled: boolean) {
         mcpSlug: t.mcpSlug ?? undefined,
         tools,
         dynamicTools: false,
+        remoteBacked: false,
       });
     }
     // Fold in mcp_servers rows (remote/tunneled and toolset-backed servers
@@ -298,10 +304,11 @@ export function GrantRuleDrawerContent({
   }, [scopedMcpServers, resourceSearch]);
 
   // The "Specific tools" picker shows servers with enumerable deploy-time tools
-  // plus remote/tunneled (dynamic-tools) servers, whose tools it resolves from
-  // the stored metadata table on expand. Proxy servers (no tools/list at deploy
-  // time) appear in the "Specific servers" picker for server-level grants but
-  // must not render a zero-tools row here.
+  // plus remote/tunneled (dynamic-tools) servers. Remote-backed ones resolve
+  // their tools from the stored metadata table on expand; tunneled ones stay a
+  // non-selectable row. Proxy servers (no tools/list at deploy time) appear in
+  // the "Specific servers" picker for server-level grants but must not render a
+  // zero-tools row here.
   const toolPanelMcpServers = useMemo(
     () =>
       scopedMcpServers
@@ -934,10 +941,12 @@ type PanelServer = Server & { projectName: string; projectSlug?: string };
  * One MCP server row in the "Specific tools" picker.
  *
  * Toolset-backed servers render their enumerable deploy-time tools directly.
- * Remote/tunneled servers (`dynamicTools`) have no such list, so on expand this
- * fetches their stored tool metadata and renders it as selectable rows. When a
- * remote server has never been synced its table is empty, and the row points
- * the admin at the Inspect tab (which materializes it from the live session).
+ * Remote-backed servers (`dynamicTools` + `remoteBacked`) have no such list, so
+ * on expand this fetches their stored tool metadata and renders it as
+ * selectable rows — with distinct loading, load-error (retry), and never-synced
+ * states; the never-synced state points the admin at the Inspect tab (which
+ * materializes the table from the live session). Tunneled dynamic servers carry
+ * no metadata table, so they render as a disabled, non-selectable row.
  */
 function ServerToolRow({
   server,
@@ -965,22 +974,29 @@ function ServerToolRow({
   onClearAnnotations?: () => void;
 }) {
   const routes = useRoutes();
-  const isRemote = server.dynamicTools;
+  // Only remote-MCP-backed servers carry stored tool metadata — the endpoint
+  // rejects everything else. Tunneled dynamic servers resolve their tools at
+  // call time with no metadata table, so they stay non-selectable.
+  const isRemoteBacked = server.dynamicTools && server.remoteBacked;
+  const isTunneled = server.dynamicTools && !server.remoteBacked;
 
-  // Fetch lazily, only for the remote rows the admin actually opens, so the
-  // picker issues at most one metadata request per expanded server. The
+  // Fetch lazily, only for the remote-backed rows the admin actually opens, so
+  // the picker issues at most one metadata request per expanded server. The
   // project slug scopes the (project-scoped) request to this server's project.
-  const { metadataByTool, isLoading } = useToolMetadata(server.id, {
-    enabled: isRemote && isExpanded,
-    projectSlug: server.projectSlug,
-  });
+  const { metadataByTool, isLoading, isError, refetch } = useToolMetadata(
+    server.id,
+    {
+      enabled: isRemoteBacked && isExpanded,
+      projectSlug: server.projectSlug,
+    },
+  );
 
   const serverTools = useMemo(() => {
-    const base = isRemote
+    const base = isRemoteBacked
       ? toolMetadataToServerTools(server.id, Object.values(metadataByTool))
       : server.tools;
     return base.slice().sort((a, b) => a.name.localeCompare(b.name));
-  }, [isRemote, server.id, server.tools, metadataByTool]);
+  }, [isRemoteBacked, server.id, server.tools, metadataByTool]);
 
   const q = query.toLowerCase();
 
@@ -997,21 +1013,62 @@ function ServerToolRow({
     );
   const someSelected = selectedCount > 0 && !allSelected;
 
-  const toolsLoaded = !isRemote || (isExpanded && !isLoading);
-  const isEmptyRemote = isRemote && toolsLoaded && total === 0;
+  const toolsLoaded = !isRemoteBacked || (isExpanded && !isLoading);
+  // A failed request is distinct from a genuinely empty (never-synced) table:
+  // only the latter should point the admin at the Inspect tab.
+  const showConnectPrompt =
+    isRemoteBacked && toolsLoaded && !isError && total === 0;
 
   const countLabel =
-    isRemote && !isExpanded
+    isRemoteBacked && !isExpanded
       ? selectedCount > 0
         ? `${selectedCount} selected`
         : "Expand to load tools"
       : isLoading
         ? "Loading…"
-        : isEmptyRemote
-          ? "Not synced"
-          : selectedCount > 0
-            ? `${selectedCount} of ${total} selected`
-            : `${total} ${total === 1 ? "tool" : "tools"} available`;
+        : isError
+          ? "Couldn't load"
+          : showConnectPrompt
+            ? "Not synced"
+            : selectedCount > 0
+              ? `${selectedCount} of ${total} selected`
+              : `${total} ${total === 1 ? "tool" : "tools"} available`;
+
+  // Tunneled dynamic servers can't be individually permissioned — keep them as
+  // a disabled, non-expandable row that explains why.
+  if (isTunneled) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            tabIndex={0}
+            aria-disabled="true"
+            className="border-border focus-visible:ring-ring flex cursor-not-allowed items-center border-b px-3 py-2.5 text-sm opacity-50 focus-visible:ring-1 focus-visible:outline-none last:border-b-0"
+          >
+            <span className="min-w-0 flex-1 truncate">
+              <HighlightMatch
+                text={`${server.projectName.toLowerCase()}/`}
+                query={q}
+                className="text-muted-foreground/60"
+              />
+              <HighlightMatch
+                text={server.name}
+                query={q}
+                className="font-medium"
+              />
+            </span>
+            <span className="text-muted-foreground shrink-0 text-xs">
+              dynamic tools
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-xs">
+          Tools are dynamically resolved for this server and cannot be
+          individually permissioned.
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
     <div className="border-border border-b last:border-b-0">
@@ -1073,11 +1130,25 @@ function ServerToolRow({
       {/* Expanded tool list */}
       {isExpanded && (
         <div className="bg-muted/30 border-border max-h-[300px] overflow-y-auto border-t">
-          {isRemote && isLoading ? (
+          {isRemoteBacked && isLoading ? (
             <div className="text-muted-foreground px-8 py-3 text-sm">
               Loading tools…
             </div>
-          ) : isEmptyRemote ? (
+          ) : isError ? (
+            <div className="text-muted-foreground space-y-1 px-8 py-3 text-sm">
+              <p className="flex items-center gap-1.5">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                Couldn&apos;t load this server&apos;s tools.
+              </p>
+              <button
+                type="button"
+                onClick={() => refetch()}
+                className="text-primary hover:underline"
+              >
+                Retry
+              </button>
+            </div>
+          ) : showConnectPrompt ? (
             <div className="text-muted-foreground space-y-1 px-8 py-3 text-sm">
               <p>This server&apos;s tools haven&apos;t been synced yet.</p>
               <p>

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -706,7 +706,7 @@ function ToolSelectionPanel({
             `${b.projectName}/${b.name}`,
           ),
         ),
-    [mcpServers],
+    [mcpServers, projectSlugById],
   );
 
   const [search, setSearch] = useState("");

--- a/client/dashboard/src/pages/access/remoteToolMetadata.test.ts
+++ b/client/dashboard/src/pages/access/remoteToolMetadata.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import { toolMetadataToServerTools } from "./remoteToolMetadata";
+
+function meta(
+  overrides: Partial<ToolMetadata> & { toolName: string },
+): ToolMetadata {
+  return {
+    mcpServerId: "server-1",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as ToolMetadata;
+}
+
+describe("toolMetadataToServerTools", () => {
+  it("maps tool names and synthesizes ids scoped to the server", () => {
+    const tools = toolMetadataToServerTools("srv", [
+      meta({ toolName: "search" }),
+      meta({ toolName: "delete_record" }),
+    ]);
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toMatchObject({ id: "srv:search", name: "search" });
+    expect(tools[1]).toMatchObject({
+      id: "srv:delete_record",
+      name: "delete_record",
+    });
+  });
+
+  it("carries the four annotation hints through as the disposition-hint object", () => {
+    const [tool] = toolMetadataToServerTools("srv", [
+      meta({
+        toolName: "wipe",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      }),
+    ]);
+
+    expect(tool!.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    });
+  });
+
+  it("leaves unset hints undefined rather than defaulting them", () => {
+    const [tool] = toolMetadataToServerTools("srv", [
+      meta({ toolName: "peek" }),
+    ]);
+
+    expect(tool!.annotations).toEqual({
+      readOnlyHint: undefined,
+      destructiveHint: undefined,
+      idempotentHint: undefined,
+      openWorldHint: undefined,
+    });
+  });
+
+  it("keeps ids unique per server so two servers' same-named tools don't collide", () => {
+    const [a] = toolMetadataToServerTools("srv-a", [meta({ toolName: "run" })]);
+    const [b] = toolMetadataToServerTools("srv-b", [meta({ toolName: "run" })]);
+
+    expect(a!.id).not.toBe(b!.id);
+  });
+
+  it("returns an empty list for a server with no synced metadata", () => {
+    expect(toolMetadataToServerTools("srv", [])).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/access/remoteToolMetadata.ts
+++ b/client/dashboard/src/pages/access/remoteToolMetadata.ts
@@ -1,0 +1,34 @@
+import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
+import type { ServerTool } from "./serverMerge";
+
+/**
+ * Maps stored remote-MCP tool metadata rows into the `ServerTool` shape the
+ * grant "Specific tools" picker renders.
+ *
+ * Remote/tunneled servers resolve their tools at call time, so they carry no
+ * enumerable tool list at deploy time (serverMerge gives them `tools: []`).
+ * The Inspect tab materializes what the live server advertises into the tool
+ * metadata table; this is how the role editor turns that table back into
+ * selectable rows. The stored annotation hints become the same disposition-hint
+ * object toolset tools carry, so annotation counting and selection treat remote
+ * and toolset tools uniformly.
+ */
+export function toolMetadataToServerTools(
+  serverId: string,
+  metadata: ToolMetadata[],
+): ServerTool[] {
+  return metadata.map((m) => ({
+    // Tool rows only need a stable React key and a name to match selectors on;
+    // the metadata table has no per-tool id, so synthesize one from the grant
+    // resource id and the tool name (unique within a server).
+    id: `${serverId}:${m.toolName}`,
+    name: m.toolName,
+    type: "remotemcp",
+    annotations: {
+      readOnlyHint: m.readOnlyHint,
+      destructiveHint: m.destructiveHint,
+      idempotentHint: m.idempotentHint,
+      openWorldHint: m.openWorldHint,
+    },
+  }));
+}

--- a/client/dashboard/src/pages/access/serverMerge.test.ts
+++ b/client/dashboard/src/pages/access/serverMerge.test.ts
@@ -17,6 +17,7 @@ const toolsetServer = (id: string, name = `toolset ${id}`): Server => ({
   mcpSlug: id,
   tools: [{ id: `${id}-tool`, name: "do_thing", type: "http" }],
   dynamicTools: false,
+  remoteBacked: false,
 });
 
 const group = (projectId: string, servers: Server[]): ServerGroup => ({
@@ -89,6 +90,24 @@ describe("mergeMcpServersIntoGroups", () => {
     });
   });
 
+  it("marks remoteBacked only for rows with a remote_mcp_server_id", () => {
+    const merged = mergeMcpServersIntoGroups(
+      [],
+      [
+        row({ id: "remote-1", remoteMcpServerId: "rmt-1" }),
+        row({ id: "tunneled-1" }),
+      ],
+      projectNames,
+    );
+    const servers = merged[0]!.servers;
+    // Remote-backed servers carry a metadata table; tunneled ones don't, so
+    // only the former should drive the metadata-backed tool picker.
+    expect(servers).toMatchObject([
+      { id: "remote-1", dynamicTools: true, remoteBacked: true },
+      { id: "tunneled-1", dynamicTools: true, remoteBacked: false },
+    ]);
+  });
+
   it("dedupes toolset-backed rows against the existing toolset entry", () => {
     const existing = toolsetServer("ts-1");
     const merged = mergeMcpServersIntoGroups(
@@ -115,6 +134,7 @@ describe("mergeMcpServersIntoGroups", () => {
         mcpSlug: undefined,
         tools: [],
         dynamicTools: false,
+        remoteBacked: false,
       },
     ]);
   });

--- a/client/dashboard/src/pages/access/serverMerge.ts
+++ b/client/dashboard/src/pages/access/serverMerge.ts
@@ -15,7 +15,7 @@
  * is the only place that decides which id a mcp_servers row contributes.
  */
 
-interface ServerTool {
+export interface ServerTool {
   id: string;
   name: string;
   type: string;
@@ -36,8 +36,9 @@ export interface Server {
   mcpSlug?: string;
   tools: ServerTool[];
   /**
-   * Remote/tunneled backends resolve their tools at call time, so they cannot
-   * be individually permissioned in the "Specific tools" picker.
+   * Remote/tunneled backends resolve their tools at call time, so they carry no
+   * deploy-time tool list. The "Specific tools" picker fetches their tools from
+   * the stored metadata table (materialized via the Inspect tab) on demand.
    */
   dynamicTools: boolean;
 }

--- a/client/dashboard/src/pages/access/serverMerge.ts
+++ b/client/dashboard/src/pages/access/serverMerge.ts
@@ -37,10 +37,18 @@ export interface Server {
   tools: ServerTool[];
   /**
    * Remote/tunneled backends resolve their tools at call time, so they carry no
-   * deploy-time tool list. The "Specific tools" picker fetches their tools from
-   * the stored metadata table (materialized via the Inspect tab) on demand.
+   * deploy-time tool list.
    */
   dynamicTools: boolean;
+  /**
+   * True for servers backed by a remote MCP server (they have a
+   * remote_mcp_server_id). Only these carry stored tool metadata — the
+   * `listToolMetadata` endpoint rejects everything else — so the "Specific
+   * tools" picker fetches their tools from the metadata table on demand.
+   * Tunneled-backed dynamic servers are false here: they cannot be
+   * individually permissioned and stay a non-selectable row.
+   */
+  remoteBacked: boolean;
 }
 
 export interface ServerGroup {
@@ -56,6 +64,8 @@ export interface McpServerRow {
   name?: string | undefined;
   slug?: string | undefined;
   toolsetId?: string | undefined;
+  /** Present only for remote-MCP-backed servers; absent for tunneled ones. */
+  remoteMcpServerId?: string | undefined;
 }
 
 /** See the GRANT ID INVARIANT at the top of this file. */
@@ -77,7 +87,9 @@ export function mcpServerDisplayName(row: McpServerRow): string {
  * - toolset-backed rows whose toolset entry is absent (e.g. filtered out for
  *   having no visible tools) are added with empty tools, still grantable at
  *   the server level;
- * - remote/tunneled rows are added with `dynamicTools: true`.
+ * - remote/tunneled rows are added with `dynamicTools: true`, with
+ *   `remoteBacked` set only for remote-MCP-backed rows (tunneled ones cannot
+ *   carry tool metadata).
  * Does not mutate the input groups; groups left with no servers are dropped.
  */
 export function mergeMcpServersIntoGroups(
@@ -111,6 +123,7 @@ export function mergeMcpServersIntoGroups(
       mcpSlug: undefined,
       tools: [],
       dynamicTools: !row.toolsetId,
+      remoteBacked: !!row.remoteMcpServerId,
     });
   }
 

--- a/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/RemoteMcpToolsSection.tsx
@@ -21,7 +21,10 @@ import { ToolAnnotationIndicators } from "./ToolAnnotationIndicators";
 import { ToolMetadataDriftPanel } from "./ToolMetadataDriftPanel";
 import { computeDrift } from "./toolMetadataSync";
 import { useSyncToolMetadata } from "./useSyncToolMetadata";
-import { useToolMetadata, type ToolMetadataByName } from "./useToolMetadata";
+import {
+  useToolMetadata,
+  type ToolMetadataByName,
+} from "@/hooks/useToolMetadata";
 import { Badge, Button } from "@speakeasy-api/moonshine";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { PlugZap } from "lucide-react";

--- a/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.test.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.test.ts
@@ -2,7 +2,7 @@ import type { ProxiedMcpTool } from "@/hooks/useProxiedMcpTools";
 import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
 import { describe, expect, it } from "vitest";
 import { computeDrift, fullSyncBatch, newToolsBatch } from "./toolMetadataSync";
-import type { ToolMetadataByName } from "./useToolMetadata";
+import type { ToolMetadataByName } from "@/hooks/useToolMetadata";
 
 function live(
   ...tools: Array<[string, ProxiedMcpTool["annotations"]]>

--- a/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/toolMetadataSync.ts
@@ -4,7 +4,7 @@ import type {
 } from "@/hooks/useProxiedMcpTools";
 import type { ToolMetadataForm } from "@gram/client/models/components/toolmetadataform.js";
 import type { ToolMetadata } from "@gram/client/models/components/toolmetadata.js";
-import type { ToolMetadataByName } from "./useToolMetadata";
+import type { ToolMetadataByName } from "@/hooks/useToolMetadata";
 
 /** The annotation fields Speakeasy mirrors from a tool's MCP `annotations` object. */
 const METADATA_FIELDS = [

--- a/client/dashboard/src/pages/mcp/x/tabs/useSyncToolMetadata.ts
+++ b/client/dashboard/src/pages/mcp/x/tabs/useSyncToolMetadata.ts
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { fullSyncBatch, newToolsBatch } from "./toolMetadataSync";
-import type { ToolMetadataByName } from "./useToolMetadata";
+import type { ToolMetadataByName } from "@/hooks/useToolMetadata";
 
 export interface UseSyncToolMetadataResult {
   /** Make the stored set mirror the session, removing tools it dropped. */


### PR DESCRIPTION
Lets admins permission **remote MCP tools by name** in the role editor. Maps to AGE-2878.

> **Stacked on #4362.** Base is `age-2876/post-tool-metadata-ui`, so the diff is just this one commit — the Inspect tab and tool-metadata sync it depends on live there. Draft until #4362 merges; retarget to `main` at that point. Do not rebase onto `main` (that would drop the Inspect tab and break the build).

## What changed

Remote/tunneled MCP servers resolve their tools at call time, so the "Specific tools" picker used to show them as a disabled *"dynamic tools — cannot be individually permissioned"* row. Now:

- **Selectable on expand.** Expanding a remote server lazily fetches its stored tool metadata (`listMcpServerToolMetadata`) and renders each tool as an individual `mcp` `tool` selector — same toggle/selector shape as toolset-backed tools, so existing grant round-trip logic is untouched. Fetches only for the rows an admin actually opens.
- **Connect prompt when unsynced.** A server with no materialized metadata shows *"This server's tools haven't been synced yet — Connect it on the Inspect tab"*, linking to that server's Inspect tab (which materializes the table from the live MCP session).
- **Project-scoping fix.** `listToolMetadata` is project-scoped but the role editor is org-level, so each server's project slug is threaded as a per-call `Gram-Project` header (honored because the SDK only sets the header when absent). Without it, cross-project fetches would resolve against the wrong project.
- **Shared hook.** Lifted `useToolMetadata` to `src/hooks/` now that both the Inspect tab and the role editor consume it.

## Testing

- `tsc -b` clean; `vitest` green (new `remoteToolMetadata.test.ts` covers the metadata→picker mapping; relocated `toolMetadataSync.test.ts` confirms the hook move).
- Manually verified end to end against the seeded remote server: connect-prompt empty state, and the toolset-server contrast (tools selectable). A demo video is attached in a comment.

## Scope notes

- The top-level **By annotation** counts still source only toolset tools, not remote metadata — including remote there would require eager-fetching every server, which fights the lazy-per-expand design. Remote tools are fully selectable individually; their disposition rules still enforce org-wide.
- The `tool_annotations` (`known`/`none`/`unknown`) **Review/Classification gate presets** are deferred to the AGE-2886 follow-up (that grammar isn't merged yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let admins permission remote MCP tools by name in the role editor. Remote-backed servers expand to load stored tool metadata and render selectable tools with clear loading, error (retry), and unsynced prompts; aligns with AGE-2878.

- **New Features**
  - On expand, lazy-fetch tools per remote-backed server from `listMcpServerToolMetadata` via a shared `useToolMetadata` (now in `src/hooks/`), mapping rows with `toolMetadataToServerTools`; send each server’s `projectSlug` as a `Gram-Project` header so org-level queries scope correctly.
  - When metadata is empty, show “Connect on Inspect tab” with a link; before opening, show “Expand to load tools.”

- **Bug Fixes**
  - Distinguish remote-backed vs tunneled dynamic servers: only `remoteBacked` servers load metadata; tunneled stay non-selectable.
  - Handle load failures distinctly from empty metadata with an error state and “Retry.”
  - Fix tool picker memo dependency to include `projectSlugById`, preventing stale project scoping for metadata requests.

<sup>Written for commit a99ffd11bafe3f9f2fcb6b8d530a79c51cfd286c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

