### PR TITLE
mig: add chats.summary columns for session summarization

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1598,6 +1598,11 @@ CREATE TABLE IF NOT EXISTS chats (
   -- dedicated section above recents; the timestamp orders them by pin time.
   pinned_at timestamptz,
 
+  -- On-demand LLM summary of the session transcript (NULL until generated).
+  -- Written by chat.summarize; regenerated in place when requested.
+  summary text,
+  summary_generated_at timestamptz,
+
   -- Personal-account tracking: the external AI account (user_accounts row) this
   -- session belongs to. Join to user_accounts for provider, account_type
   -- (team/personal), external_org_id, the owning employee, etc. — set by ingest.

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -592,7 +592,7 @@ func (q *Queries) GetAssistantThreadAssistantIDByChatID(ctx context.Context, arg
 }
 
 const getChat = `-- name: GetChat :one
-SELECT c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.external_chat_id, c.title, c.title_manually_set, c.pinned_at, c.user_account_id, c.created_at, c.updated_at, c.deleted_at, c.deleted, COALESCE(ua.account_type, '')::text AS account_type, COALESCE(ua.email, '')::text AS account_email,
+SELECT c.id, c.project_id, c.organization_id, c.user_id, c.external_user_id, c.external_chat_id, c.title, c.title_manually_set, c.pinned_at, c.summary, c.summary_generated_at, c.user_account_id, c.created_at, c.updated_at, c.deleted_at, c.deleted, COALESCE(ua.account_type, '')::text AS account_type, COALESCE(ua.email, '')::text AS account_email,
   at.assistant_id, a.name AS assistant_name
 FROM chats c
 LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
@@ -602,24 +602,26 @@ WHERE c.id = $1 AND c.deleted IS FALSE
 `
 
 type GetChatRow struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	OrganizationID   string
-	UserID           pgtype.Text
-	ExternalUserID   pgtype.Text
-	ExternalChatID   pgtype.Text
-	Title            pgtype.Text
-	TitleManuallySet bool
-	PinnedAt         pgtype.Timestamptz
-	UserAccountID    uuid.NullUUID
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	DeletedAt        pgtype.Timestamptz
-	Deleted          bool
-	AccountType      string
-	AccountEmail     string
-	AssistantID      uuid.NullUUID
-	AssistantName    pgtype.Text
+	ID                 uuid.UUID
+	ProjectID          uuid.UUID
+	OrganizationID     string
+	UserID             pgtype.Text
+	ExternalUserID     pgtype.Text
+	ExternalChatID     pgtype.Text
+	Title              pgtype.Text
+	TitleManuallySet   bool
+	PinnedAt           pgtype.Timestamptz
+	Summary            pgtype.Text
+	SummaryGeneratedAt pgtype.Timestamptz
+	UserAccountID      uuid.NullUUID
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+	DeletedAt          pgtype.Timestamptz
+	Deleted            bool
+	AccountType        string
+	AccountEmail       string
+	AssistantID        uuid.NullUUID
+	AssistantName      pgtype.Text
 }
 
 // Loads a chat plus the team/personal classification of the AI account that
@@ -639,6 +641,8 @@ func (q *Queries) GetChat(ctx context.Context, id uuid.UUID) (GetChatRow, error)
 		&i.Title,
 		&i.TitleManuallySet,
 		&i.PinnedAt,
+		&i.Summary,
+		&i.SummaryGeneratedAt,
 		&i.UserAccountID,
 		&i.CreatedAt,
 		&i.UpdatedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -307,20 +307,22 @@ type BillingMetadatum struct {
 }
 
 type Chat struct {
-	ID               uuid.UUID
-	ProjectID        uuid.UUID
-	OrganizationID   string
-	UserID           pgtype.Text
-	ExternalUserID   pgtype.Text
-	ExternalChatID   pgtype.Text
-	Title            pgtype.Text
-	TitleManuallySet bool
-	PinnedAt         pgtype.Timestamptz
-	UserAccountID    uuid.NullUUID
-	CreatedAt        pgtype.Timestamptz
-	UpdatedAt        pgtype.Timestamptz
-	DeletedAt        pgtype.Timestamptz
-	Deleted          bool
+	ID                 uuid.UUID
+	ProjectID          uuid.UUID
+	OrganizationID     string
+	UserID             pgtype.Text
+	ExternalUserID     pgtype.Text
+	ExternalChatID     pgtype.Text
+	Title              pgtype.Text
+	TitleManuallySet   bool
+	PinnedAt           pgtype.Timestamptz
+	Summary            pgtype.Text
+	SummaryGeneratedAt pgtype.Timestamptz
+	UserAccountID      uuid.NullUUID
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+	DeletedAt          pgtype.Timestamptz
+	Deleted            bool
 }
 
 type ChatAnalysisEvaluation struct {

--- a/server/migrations/20260727173846_chats-add-summary.sql
+++ b/server/migrations/20260727173846_chats-add-summary.sql
@@ -1,0 +1,2 @@
+-- Modify "chats" table
+ALTER TABLE "chats" ADD COLUMN "summary" text NULL, ADD COLUMN "summary_generated_at" timestamptz NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:kK1eCJFUYontBz+DIYvrsqZ7oRuUFi72rZsBI80oZMA=
+h1:kl5bVUkQNw249wxSimdk7N+hAEABk6vNGw4fiFPKTVk=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -297,3 +297,4 @@ h1:kK1eCJFUYontBz+DIYvrsqZ7oRuUFi72rZsBI80oZMA=
 20260724165656_spend-rules.sql h1:JolKgUjLUpWw1E4/lG/u8OfG178/wMP2TMPo46HOxdY=
 20260724173649_directory_users_lower_email_idx.sql h1:OphnMDp0OG2qCzr2mVYapCGGExOOfL8/lW3H0NIrjI8=
 20260727135457_tunneled-mcp-servers-add-allow-public.sql h1:yTSYYjmGsEfyHfQxLI5OTodAx8HP5oFFCAc7FsKJpjE=
+20260727173846_chats-add-summary.sql h1:1xqsL2hbwBYsQncZCrlTYNUgE3SH75CWW6lC7LUQzu4=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds nullable `chats.summary` and `chats.summary_generated_at` columns for on-demand agent-session summarization.

Migration-only PR (no application logic). Rebased onto current `main`.

## Stack

1. **This PR** — schema + migration + sqlc model regen
2. https://github.com/speakeasy-api/gram/pull/4533 — `chat.summarize` RPC, pin UI, summarize UI (bases on this branch)

## Notes

- Expand-only: nullable columns, no backfill
- Merge this first, then retarget #4533 to `main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b1c02ed-404d-4f6c-9b8f-ac0518a67fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b1c02ed-404d-4f6c-9b8f-ac0518a67fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nullable `summary` and `summary_generated_at` columns to `chats` for on-demand session summaries. Schema + migration only; `sqlc` regen updates `GetChat`/`database.Chat` to surface them until `chat.summarize` writes values.

<sup>Written for commit b2301bdfae3618c55eba89d896d244f54c8475c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

