### PR TITLE
fix(dashboard): contain assignments multi-select selected badges

### DIFF
--- a/.changeset/dno-552-assignments-action-icons-overflow.md
+++ b/.changeset/dno-552-assignments-action-icons-overflow.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the plugin assignments multi-select trigger overflowing its container. Long selected-principal labels (e.g. email principals) now truncate with an ellipsis instead of bleeding past the right edge, and the clear/chevron controls stay pinned to the top-right aligned with the first badge row rather than floating in the vertical middle of a tall wrapped stack.

--- a/client/dashboard/src/components/ui/multi-select.tsx
+++ b/client/dashboard/src/components/ui/multi-select.tsx
@@ -892,10 +892,14 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
               }}
             >
               {selectedValues.length > 0 ? (
-                <div className="flex w-full items-center justify-between">
+                <div className="flex w-full items-start justify-between">
                   <div
                     className={cn(
-                      "flex items-center gap-1",
+                      // min-w-0 lets this badges column shrink below its content
+                      // width so a long badge label can't push the trailing
+                      // action controls (clear/chevron) past the container's
+                      // right edge (DNO-552).
+                      "flex min-w-0 items-center gap-1",
                       singleLine
                         ? "multiselect-singleline-scroll overflow-x-auto overflow-y-hidden"
                         : "flex-wrap",
@@ -932,8 +936,11 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 "border-transparent text-white",
                               responsiveSettings.compactMode &&
                                 "px-1.5 py-0.5 text-xs",
-                              screenSize === "mobile" &&
-                                "max-w-[120px] truncate",
+                              // Cap badge width to the container so a long label
+                              // (e.g. an email principal) truncates instead of
+                              // bleeding past the trigger's right edge (DNO-552).
+                              "min-w-0 max-w-full",
+                              screenSize === "mobile" && "max-w-[120px]",
                               singleLine && "shrink-0 whitespace-nowrap",
                               "[&>svg]:pointer-events-auto",
                             )}
@@ -948,7 +955,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                             {IconComponent && !responsiveSettings.hideIcons && (
                               <IconComponent
                                 className={cn(
-                                  "mr-2 h-4 w-4",
+                                  "mr-2 h-4 w-4 shrink-0",
                                   responsiveSettings.compactMode &&
                                     "mr-1 h-3 w-3",
                                   customStyle?.iconColor && "text-current",
@@ -958,11 +965,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 })}
                               />
                             )}
-                            <span
-                              className={cn(
-                                screenSize === "mobile" && "truncate",
-                              )}
-                            >
+                            <span className="min-w-0 truncate">
                               {option.label}
                             </span>
                             <div
@@ -983,7 +986,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                                 }
                               }}
                               aria-label={`Remove ${option.label} from selection`}
-                              className="flex h-4 w-4 cursor-pointer hover:bg-white/20 focus:ring-1 focus:ring-white/50 focus:outline-none"
+                              className="flex h-4 w-4 shrink-0 cursor-pointer hover:bg-white/20 focus:ring-1 focus:ring-white/50 focus:outline-none"
                             >
                               <XIcon
                                 className={cn(
@@ -1031,7 +1034,10 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                       </Badge>
                     )}
                   </div>
-                  <div className="flex items-center justify-between">
+                  {/* h-7 matches a badge row so the clear/chevron controls sit
+                      aligned with the first badge instead of floating in the
+                      vertical middle of a tall wrapped stack (DNO-552). */}
+                  <div className="flex h-7 shrink-0 items-center justify-between">
                     <div
                       role="button"
                       tabIndex={0}


### PR DESCRIPTION
## What

Fixes the plugin assignments multi-select trigger overflowing its container. When several principals are selected — especially ones with long labels like email principals — the badges bled past the panel's right edge and the clear/chevron controls ended up floating in the vertical middle of the wrapped badge stack.

Fixes DNO-552.

## Why

The shared `MultiSelect` trigger only truncated badges on mobile, so on desktop a long label (e.g. `email:very.long.address@…`) grew unbounded and pushed the trailing controls out of the container. The action group was also vertically centered against the badge column, so with a tall wrapped stack it no longer lined up with anything.

## Changes

`client/dashboard/src/components/ui/multi-select.tsx`:

- Cap each selected badge to the container width (`min-w-0 max-w-full`) and truncate its label on all breakpoints, so long labels ellipsize instead of overflowing.
- Keep the badge icon and remove (✕) button from shrinking so the ✕ stays visible.
- Top-align the clear/chevron group and give it a badge-height row so it sits with the first badge instead of the vertical middle.

All changes are containment-only (they only prevent overflow), so the other `MultiSelect` usages — observe filters, MCP details, tool-variation tags — are unaffected when there is room.

## Testing

- `pnpm -F dashboard type-check` passes.
- Verified in the dashboard on a plugin with 7 assignments (including 3 deliberately long email labels): measured **0px** horizontal overflow on the trigger and **0 / 7** badges bleeding past the right edge; clear/chevron render top-right aligned with the first badge.

## Notes

Independent of the DNO-549 dropdown-scroll change (different, not-yet-merged branch); this branches off `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain the plugin assignments multi-select trigger so long selected-principal badges truncate and the clear/chevron controls stay aligned with the first badge row. Fixes DNO-552.

- **Bug Fixes**
  - Truncate selected badge labels on all breakpoints and cap badge width so long labels ellipsize; icons and the remove `X` are non-shrinking.
  - Pin the clear/chevron group to the top-right aligned with the first badge row with a fixed row height to prevent mid-stack floating and keep controls inside the panel.

<sup>Written for commit b5c2b096bce26c4bd40a829332958cf76ef73744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

