### PR TITLE
mig: adds denormalised columns

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260724083855_risk_findings_attribution.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260724083855_risk_findings_attribution.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `risk_findings` DROP INDEX `idx_risk_findings_chat_id`;
+ALTER TABLE `risk_findings` DROP COLUMN `false_positive_at`;
+ALTER TABLE `risk_findings` DROP COLUMN `category`;
+ALTER TABLE `risk_findings` DROP COLUMN `external_user_id`;
+ALTER TABLE `risk_findings` DROP COLUMN `user_id`;
+ALTER TABLE `risk_findings` DROP COLUMN `chat_id`;

--- a/server/clickhouse/local/golang_migrate/20260724083855_risk_findings_attribution.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260724083855_risk_findings_attribution.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `risk_findings` ADD COLUMN `chat_id` String DEFAULT '' COMMENT 'Denormalized chats.id of the chat the finding was detected in. Empty when unresolved.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `user_id` String DEFAULT '' COMMENT 'Resolved internal user id: chat_messages.user_id with fallback to chats.user_id. Empty when unresolved.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `external_user_id` String DEFAULT '' COMMENT 'Resolved external user id: chat_messages.external_user_id with fallback to chats.external_user_id. Empty when unresolved.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `category` LowCardinality(String) DEFAULT '' COMMENT 'Risk category derived from rule_id and source at ingest, e.g. pii or secrets. Empty when the rule maps to no category.';
+ALTER TABLE `risk_findings` ADD COLUMN `false_positive_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was marked a false positive, mirrored from Postgres after the fact. Null when the finding is not marked.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD INDEX `idx_risk_findings_chat_id` ((chat_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:5NeKrAq8SHDJxUzas4ZdR3YpbzXPDA64kdFs2yAvj+k=
+h1:yw0YFv59bZChUsWFsGdVjacR4zwjcifiTGsAvkSAtsI=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -75,3 +75,4 @@ h1:5NeKrAq8SHDJxUzas4ZdR3YpbzXPDA64kdFs2yAvj+k=
 20260723183828_add-telemetry-event-urn.up.sql h1:IpwvDnNV+MXWvIyfRAIJek9JEyM+liI7pky9VLZVQN4=
 20260723200913_chat-analysis-scores.up.sql h1:nDdYjmRJPmbxroG+ZYAxDf7R0f6Ak1CMYBvrkyE+3dM=
 20260723231517_work_delivered_efficiency.up.sql h1:+NibDX4zQXROmNmB3tVaLTZX8FQBHeIquu301CGGiY8=
+20260724083855_risk_findings_attribution.up.sql h1:1Tj5SJUC43cC2Lyh61nD+N5LVAROpQ9FyUxqEQjJYE4=

--- a/server/clickhouse/migrations/20260724083850_risk_findings_attribution.sql
+++ b/server/clickhouse/migrations/20260724083850_risk_findings_attribution.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `risk_findings` ADD COLUMN `chat_id` String DEFAULT '' COMMENT 'Denormalized chats.id of the chat the finding was detected in. Empty when unresolved.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `user_id` String DEFAULT '' COMMENT 'Resolved internal user id: chat_messages.user_id with fallback to chats.user_id. Empty when unresolved.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `external_user_id` String DEFAULT '' COMMENT 'Resolved external user id: chat_messages.external_user_id with fallback to chats.external_user_id. Empty when unresolved.' CODEC(ZSTD(1));
+ALTER TABLE `risk_findings` ADD COLUMN `category` LowCardinality(String) DEFAULT '' COMMENT 'Risk category derived from rule_id and source at ingest, e.g. pii or secrets. Empty when the rule maps to no category.';
+ALTER TABLE `risk_findings` ADD COLUMN `false_positive_at` Nullable(DateTime64(9)) COMMENT 'Time the finding was marked a false positive, mirrored from Postgres after the fact. Null when the finding is not marked.' CODEC(DoubleDelta, ZSTD(1));
+ALTER TABLE `risk_findings` ADD INDEX `idx_risk_findings_chat_id` ((chat_id)) TYPE bloom_filter(0.01) GRANULARITY 1;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TgxkW6GWdCF5imK6t6zTYJ+d0M34EIBbNCCUmAOu6C4=
+h1:h7N1d9FCGIIIsUTUsULjn7uOs9EOQnDSo54CzgmR3KA=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -80,3 +80,4 @@ h1:TgxkW6GWdCF5imK6t6zTYJ+d0M34EIBbNCCUmAOu6C4=
 20260723183824_add-telemetry-event-urn.sql h1:0UWuoNyzdWMr4Ye9x3hWoAhr7Ceb4YZi+7N2hli34sM=
 20260723200907_chat-analysis-scores.sql h1:y/Qvq/eB8xGDYyvPAre7ruYZ8V4DoV3GAwIrE6o3DTA=
 20260723231511_work_delivered_efficiency.sql h1:GQs/RUNtR094Hm48bWIIQk99QttL8jAPhq7+aLy2kWw=
+20260724083850_risk_findings_attribution.sql h1:1sev8sFRph7seEnkiDSHPiT7QA9keClkBC6lCVkQBVc=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1151,6 +1151,12 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     request_id String DEFAULT '' COMMENT 'Internal request ID that produced the finding, when set.' CODEC(ZSTD),
     chat_message_id String DEFAULT '' COMMENT 'Chat message the finding was detected in.' CODEC(ZSTD),
 
+    -- Denormalized attribution, resolved from Postgres at ingest so
+    -- session-level and per-user rollups never need a cross-store join.
+    chat_id String DEFAULT '' COMMENT 'Denormalized chats.id of the chat the finding was detected in. Empty when unresolved.' CODEC(ZSTD),
+    user_id String DEFAULT '' COMMENT 'Resolved internal user id: chat_messages.user_id with fallback to chats.user_id. Empty when unresolved.' CODEC(ZSTD),
+    external_user_id String DEFAULT '' COMMENT 'Resolved external user id: chat_messages.external_user_id with fallback to chats.external_user_id. Empty when unresolved.' CODEC(ZSTD),
+
     -- Owning policy
     risk_policy_id String DEFAULT '' COMMENT 'Risk policy the message was scanned against.' CODEC(ZSTD),
     risk_policy_version Int64 DEFAULT 0 COMMENT 'Version of the risk policy at scan time.',
@@ -1160,6 +1166,7 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     description String DEFAULT '' COMMENT 'Human-readable description of the rule that fired.' CODEC(ZSTD),
     source LowCardinality(String) COMMENT 'Detection source: gitleaks | presidio | shadow_mcp | prompt_injection | llm_judge | account_identity.',
     confidence Float64 DEFAULT 0 COMMENT 'Detection confidence in the range 0.0 to 1.0.',
+    category LowCardinality(String) DEFAULT '' COMMENT 'Risk category derived from rule_id and source at ingest, e.g. pii or secrets. Empty when the rule maps to no category.',
     tags Array(LowCardinality(String)) COMMENT 'Category tags for the finding, e.g. [pii].',
     start_pos Int32 DEFAULT 0 COMMENT 'Byte offset of the match start within the scanned field.',
     end_pos Int32 DEFAULT 0 COMMENT 'Byte offset of the match end within the scanned field.',
@@ -1180,7 +1187,8 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     -- it is recorded here rather than dropped, so excluded findings remain
     -- auditable and can be filtered in or out at read time.
     excluded_at Nullable(DateTime64(9)) COMMENT 'Time the finding was suppressed by an exclusion. Null when the finding is not excluded.' CODEC(DoubleDelta, ZSTD),
-    exclusion_id Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD)
+    exclusion_id Nullable(UUID) COMMENT 'Id of the risk_exclusions row that suppressed the finding. Null when the finding is not excluded.' CODEC(ZSTD),
+    false_positive_at Nullable(DateTime64(9)) COMMENT 'Time the finding was marked a false positive, mirrored from Postgres after the fact. Null when the finding is not marked.' CODEC(DoubleDelta, ZSTD)
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(created_at)
 ORDER BY (organization_id, project_id, created_at, id)
@@ -1191,6 +1199,7 @@ COMMENT 'Risk findings event log: one row per detected secret or sensitive-data 
 -- Bloom filter indices for point lookups (organization_id and project_id are
 -- already in the ORDER BY so no bloom filters needed for them).
 CREATE INDEX IF NOT EXISTS idx_risk_findings_chat_message_id ON risk_findings (chat_message_id) TYPE bloom_filter(0.01) GRANULARITY 1;
+CREATE INDEX IF NOT EXISTS idx_risk_findings_chat_id ON risk_findings (chat_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_risk_findings_risk_policy_id ON risk_findings (risk_policy_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 CREATE INDEX IF NOT EXISTS idx_risk_findings_rule_id ON risk_findings (rule_id) TYPE set(0) GRANULARITY 4;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add denormalized attribution to ClickHouse `risk_findings` to enable per-chat and per-user rollups without cross-store joins. Also adds `false_positive_at` and a bloom filter index on `chat_id` for faster lookups.

- **New Features**
  - Denormalized fields at ingest: `chat_id`, `user_id`, `external_user_id`, `category`, and `false_positive_at` (mirrored from Postgres).
  - Index: `idx_risk_findings_chat_id` bloom filter for faster chat-scoped queries.

<sup>Written for commit d2902efdb005bda522b8ecf7e8bd0dea26a95088. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

