### PR TITLE
fix: stop default-plugin display-name collisions blocking MCP server enablement

### DIFF
--- a/.changeset/default-plugin-attach-collisions.md
+++ b/.changeset/default-plugin-attach-collisions.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Enabling an MCP server no longer fails when the project's Default plugin already lists a server under the same display name. The Default-plugin attach now picks the first available display name — the requested one, then a backend-id-suffixed variant — instead of letting the `(plugin_id, display_name)` unique index abort the enclosing transaction, so a same-named toolset attachment or a stale row can't block enablement. Deleting an MCP server also detaches it from its plugins (recording a `plugin:server_remove` audit event per detachment), releasing the display name for a replacement server.

--- a/server/internal/mcpservers/deletemcpserver_test.go
+++ b/server/internal/mcpservers/deletemcpserver_test.go
@@ -15,6 +15,9 @@ import (
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/plugins"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -77,6 +80,88 @@ func TestDeleteMcpServer(t *testing.T) {
 		ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestDeleteMcpServer_DetachesFromPlugins(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	backendID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	created, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "detach test server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &backendID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+
+	tx := testenv.BeginTx(t, ctx, ti.conn)
+	attached, err := plugins.AttachToDefaultPlugin(ctx, tx, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{},
+		McpServerID:    uuid.NullUUID{UUID: uuid.MustParse(created.ID), Valid: true},
+		DisplayName:    "detach test server",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, attached)
+	require.NoError(t, tx.Commit(ctx))
+
+	beforeRemoveCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerRemove)
+	require.NoError(t, err)
+
+	err = ti.service.DeleteMcpServer(ctx, &gen.DeleteMcpServerPayload{
+		ID:               created.ID,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	servers, err := pluginsrepo.New(ti.conn).ListPluginServers(ctx, attached.PluginID)
+	require.NoError(t, err)
+	require.Empty(t, servers, "deleting the mcp server must soft-delete its plugin attachments")
+
+	afterRemoveCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionPluginServerRemove)
+	require.NoError(t, err)
+	require.Equal(t, beforeRemoveCount+1, afterRemoveCount)
+
+	// The display name is free again: a replacement server with the same name
+	// attaches under the original, un-suffixed name — the scenario where a
+	// stale attachment from a deleted server blocked enabling its successor.
+	replacementBackendID := seedRemoteMcpServer(t, ctx, ti.conn, *authCtx.ProjectID).String()
+	replacement, err := ti.service.CreateMcpServer(ctx, &gen.CreateMcpServerPayload{
+		SessionToken:      nil,
+		ApikeyToken:       nil,
+		ProjectSlugInput:  nil,
+		Name:              "detach test server",
+		EnvironmentID:     nil,
+		RemoteMcpServerID: &replacementBackendID,
+		ToolsetID:         nil,
+		Visibility:        types.McpServerVisibility("disabled"),
+	})
+	require.NoError(t, err)
+
+	tx2 := testenv.BeginTx(t, ctx, ti.conn)
+	reattached, err := plugins.AttachToDefaultPlugin(ctx, tx2, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{},
+		McpServerID:    uuid.NullUUID{UUID: uuid.MustParse(replacement.ID), Valid: true},
+		DisplayName:    "detach test server",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, reattached)
+	require.NoError(t, tx2.Commit(ctx))
+	require.Equal(t, "detach test server", reattached.Server.DisplayName)
 }
 
 func TestDeleteMcpServer_NotFound(t *testing.T) {

--- a/server/internal/mcpservers/impl.go
+++ b/server/internal/mcpservers/impl.go
@@ -36,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
+	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -681,6 +682,38 @@ func (s *Service) DeleteMcpServer(ctx context.Context, payload *gen.DeleteMcpSer
 			Slug:             endpoint.Slug,
 		}); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "log mcp endpoint deletion").LogError(ctx, logger)
+		}
+	}
+
+	// Detach the server from any plugins (Default or manually curated). The
+	// (plugin_id, display_name) unique index only excludes soft-deleted rows,
+	// so a live attachment left behind would keep holding the display name and
+	// block a later same-named server from ever attaching — i.e. from being
+	// enabled at all via UpdateMcpServer's attach-on-enable path.
+	detachedPluginServers, err := pluginsrepo.New(dbtx).SoftDeletePluginServersByMCPServerID(ctx, pluginsrepo.SoftDeletePluginServersByMCPServerIDParams{
+		ProjectID:   *authCtx.ProjectID,
+		McpServerID: uuid.NullUUID{UUID: deleted.ID, Valid: true},
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "detach mcp server from plugins").LogError(ctx, logger)
+	}
+
+	deletedServerURN := urn.NewMcpServer(deleted.ID)
+	for _, pluginServer := range detachedPluginServers {
+		if err := s.audit.LogPluginServerRemove(ctx, dbtx, audit.LogPluginServerRemoveEvent{
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			ProjectID:        *authCtx.ProjectID,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName: authCtx.Email,
+			ActorSlug:        nil,
+			PluginID:         pluginServer.PluginID,
+			PluginName:       pluginServer.PluginName,
+			PluginSlug:       pluginServer.PluginSlug,
+			ServerID:         pluginServer.ID,
+			ToolsetURN:       nil,
+			McpServerURN:     &deletedServerURN,
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "log mcp server plugin detachment").LogError(ctx, logger)
 		}
 	}
 

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -181,11 +181,30 @@ func AttachToDefaultPlugin(ctx context.Context, tx pgx.Tx, params AttachToDefaul
 		return nil, fmt.Errorf("check existing default plugin server: %w", err)
 	}
 
+	// A different attached server (a same-named toolset row, or a stale row
+	// from a deleted server) may already hold the display name, which the
+	// (plugin_id, display_name) unique index spans across backends. Blocking
+	// the attach — and with it the triggering action, e.g. enabling a server —
+	// over a marketplace display name is disproportionate, so uniquify with a
+	// backend-id suffix instead, mirroring the mcpservers slug convention.
+	displayName := params.DisplayName
+	taken, err := q.PluginServerDisplayNameExists(ctx, repo.PluginServerDisplayNameExistsParams{
+		PluginID:    ensured.Plugin.ID,
+		ProjectID:   params.ProjectID,
+		DisplayName: displayName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("check default plugin display name availability: %w", err)
+	}
+	if taken {
+		displayName = fmt.Sprintf("%s (%s)", params.DisplayName, backendIDSuffix(params))
+	}
+
 	server, err := q.AddPluginServer(ctx, repo.AddPluginServerParams{
 		PluginID:    ensured.Plugin.ID,
 		ToolsetID:   params.ToolsetID,
 		McpServerID: params.McpServerID,
-		DisplayName: params.DisplayName,
+		DisplayName: displayName,
 		Policy:      "required",
 		SortOrder:   0,
 	})
@@ -201,10 +220,10 @@ func AttachToDefaultPlugin(ctx context.Context, tx pgx.Tx, params AttachToDefaul
 				// check and no-ops cleanly.
 				return nil, nil
 			default:
-				// display_name collision with a different, already-attached
-				// server (or a manually-added one) is a real conflict, not
-				// "already attached" — surface it instead of silently
-				// dropping the server from the Default plugin.
+				// display_name still collided after the availability check —
+				// a concurrent attach of a same-named server won the race.
+				// The failed insert aborts the surrounding transaction; a
+				// retry sees the winner via the check above and uniquifies.
 			}
 		}
 		return nil, fmt.Errorf("attach server to default plugin: %w", err)
@@ -217,6 +236,19 @@ func AttachToDefaultPlugin(ctx context.Context, tx pgx.Tx, params AttachToDefaul
 		PluginCreated: ensured.Created,
 		Server:        server,
 	}, nil
+}
+
+// backendIDSuffix returns the last hex characters of the backend id (the
+// toolset or mcp_server, exactly one of which is set) used to uniquify a
+// colliding display name — the same suffix mcpservers bakes into server slugs,
+// so the two stay recognizable as the same server.
+func backendIDSuffix(params AttachToDefaultPluginParams) string {
+	id := params.McpServerID.UUID
+	if params.ToolsetID.Valid {
+		id = params.ToolsetID.UUID
+	}
+	s := id.String()
+	return s[len(s)-4:]
 }
 
 // AttachToDefaultPluginAudited runs AttachToDefaultPlugin and records the

--- a/server/internal/plugins/default_plugin.go
+++ b/server/internal/plugins/default_plugin.go
@@ -185,19 +185,10 @@ func AttachToDefaultPlugin(ctx context.Context, tx pgx.Tx, params AttachToDefaul
 	// from a deleted server) may already hold the display name, which the
 	// (plugin_id, display_name) unique index spans across backends. Blocking
 	// the attach — and with it the triggering action, e.g. enabling a server —
-	// over a marketplace display name is disproportionate, so uniquify with a
-	// backend-id suffix instead, mirroring the mcpservers slug convention.
-	displayName := params.DisplayName
-	taken, err := q.PluginServerDisplayNameExists(ctx, repo.PluginServerDisplayNameExistsParams{
-		PluginID:    ensured.Plugin.ID,
-		ProjectID:   params.ProjectID,
-		DisplayName: displayName,
-	})
+	// over a marketplace display name is disproportionate, so uniquify instead.
+	displayName, err := availableDisplayName(ctx, q, ensured.Plugin.ID, params)
 	if err != nil {
-		return nil, fmt.Errorf("check default plugin display name availability: %w", err)
-	}
-	if taken {
-		displayName = fmt.Sprintf("%s (%s)", params.DisplayName, backendIDSuffix(params))
+		return nil, err
 	}
 
 	server, err := q.AddPluginServer(ctx, repo.AddPluginServerParams{
@@ -236,6 +227,46 @@ func AttachToDefaultPlugin(ctx context.Context, tx pgx.Tx, params AttachToDefaul
 		PluginCreated: ensured.Created,
 		Server:        server,
 	}, nil
+}
+
+// displayNameCandidates bounds how many names availableDisplayName probes
+// before giving up. Reaching the bound needs every candidate to be occupied,
+// which takes deliberately crafted names: the first suffixed candidate is
+// already specific to this backend.
+const displayNameCandidates = 8
+
+// availableDisplayName returns the first display name free on the plugin,
+// starting from the requested one. Display names are unique per plugin across
+// backends and are user-editable (UpdatePluginServer), so neither the
+// requested name nor any single derived candidate is guaranteed free —
+// probing a deterministic ladder keeps a marketplace label from failing the
+// caller's triggering action, e.g. enabling a server.
+func availableDisplayName(ctx context.Context, q *repo.Queries, pluginID uuid.UUID, params AttachToDefaultPluginParams) (string, error) {
+	suffix := backendIDSuffix(params)
+
+	for attempt := range displayNameCandidates {
+		candidate := params.DisplayName
+		switch {
+		case attempt == 1:
+			candidate = fmt.Sprintf("%s (%s)", params.DisplayName, suffix)
+		case attempt > 1:
+			candidate = fmt.Sprintf("%s (%s %d)", params.DisplayName, suffix, attempt)
+		}
+
+		taken, err := q.PluginServerDisplayNameExists(ctx, repo.PluginServerDisplayNameExistsParams{
+			PluginID:    pluginID,
+			ProjectID:   params.ProjectID,
+			DisplayName: candidate,
+		})
+		if err != nil {
+			return "", fmt.Errorf("check default plugin display name availability: %w", err)
+		}
+		if !taken {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("no available display name derived from %q on plugin %s after %d candidates", params.DisplayName, pluginID, displayNameCandidates)
 }
 
 // backendIDSuffix returns the last hex characters of the backend id (the

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -1,6 +1,7 @@
 package plugins_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -130,7 +131,7 @@ func TestEnsureDefaultPlugin_PromotesExistingDefaultSlugPlugin(t *testing.T) {
 	require.Equal(t, pgtype.Bool{Bool: true, Valid: true}, result.Plugin.IsDefault)
 }
 
-func TestAttachToDefaultPlugin_DisplayNameCollision_ReturnsError(t *testing.T) {
+func TestAttachToDefaultPlugin_DisplayNameCollision_Uniquifies(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestPluginsService(t)
@@ -145,6 +146,7 @@ func TestAttachToDefaultPlugin_DisplayNameCollision_ReturnsError(t *testing.T) {
 	result, err := plugins.AttachToDefaultPlugin(ctx, tx1, plugins.AttachToDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{},
 		McpServerID:    uuid.NullUUID{UUID: first.id, Valid: true},
 		DisplayName:    "Attach Test Server",
 	})
@@ -152,22 +154,29 @@ func TestAttachToDefaultPlugin_DisplayNameCollision_ReturnsError(t *testing.T) {
 	require.NotNil(t, result)
 	require.NoError(t, tx1.Commit(ctx))
 
-	// A different mcp_server that happens to derive the same display name
-	// must not be silently dropped — the display_name unique violation is a
-	// different failure mode than "already attached" and must surface.
+	// A different mcp_server deriving the same display name must neither be
+	// silently dropped nor block the attach (the caller's triggering action —
+	// e.g. enabling the server — would fail with it): the name is uniquified
+	// with the backend-id suffix instead.
 	second := createTestMcpServer(t, ctx, ti.conn, "Attach Test Server 2", mcpservers.VisibilityPublic)
 	tx2 := testenv.BeginTx(t, ctx, ti.conn)
-	_, err = plugins.AttachToDefaultPlugin(ctx, tx2, plugins.AttachToDefaultPluginParams{
+	attached, err := plugins.AttachToDefaultPlugin(ctx, tx2, plugins.AttachToDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{},
 		McpServerID:    uuid.NullUUID{UUID: second.id, Valid: true},
 		DisplayName:    "Attach Test Server",
 	})
-	require.Error(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, attached)
+	require.NoError(t, tx2.Commit(ctx))
+
+	idStr := second.id.String()
+	require.Equal(t, fmt.Sprintf("Attach Test Server (%s)", idStr[len(idStr)-4:]), attached.Server.DisplayName)
 
 	servers, err := queries.ListPluginServers(ctx, result.PluginID)
 	require.NoError(t, err)
-	require.Len(t, servers, 1, "the colliding server must not have been attached")
+	require.Len(t, servers, 2, "both same-named servers must be attached")
 }
 
 func TestListPluginPublishCandidates_IncludesNeverPublishedDefaultPlugin(t *testing.T) {

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -179,6 +179,67 @@ func TestAttachToDefaultPlugin_DisplayNameCollision_Uniquifies(t *testing.T) {
 	require.Len(t, servers, 2, "both same-named servers must be attached")
 }
 
+func TestAttachToDefaultPlugin_SuffixedNameAlsoTaken_ProbesLadder(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	first := createTestMcpServer(t, ctx, ti.conn, "Ladder Test Server", mcpservers.VisibilityPublic)
+	tx1 := testenv.BeginTx(t, ctx, ti.conn)
+	result, err := plugins.AttachToDefaultPlugin(ctx, tx1, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{},
+		McpServerID:    uuid.NullUUID{UUID: first.id, Valid: true},
+		DisplayName:    "Ladder Test Server",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NoError(t, tx1.Commit(ctx))
+
+	// Occupy the backend-id-suffixed candidate too, the way a user renaming a
+	// plugin server (UpdatePluginServer) can. A single derived candidate is
+	// therefore not enough: the attach must keep probing rather than trip the
+	// unique index and fail the caller's triggering action.
+	second := createTestMcpServer(t, ctx, ti.conn, "Ladder Test Server 2", mcpservers.VisibilityPublic)
+	idStr := second.id.String()
+	suffix := idStr[len(idStr)-4:]
+
+	squatter := createTestToolset(t, ctx, ti.conn, "ladder-squatter")
+	_, err = queries.AddPluginServer(ctx, pluginsrepo.AddPluginServerParams{
+		PluginID:    result.PluginID,
+		ToolsetID:   uuid.NullUUID{UUID: squatter.ID, Valid: true},
+		McpServerID: uuid.NullUUID{},
+		DisplayName: fmt.Sprintf("Ladder Test Server (%s)", suffix),
+		Policy:      "required",
+		SortOrder:   0,
+	})
+	require.NoError(t, err)
+
+	tx2 := testenv.BeginTx(t, ctx, ti.conn)
+	attached, err := plugins.AttachToDefaultPlugin(ctx, tx2, plugins.AttachToDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		ToolsetID:      uuid.NullUUID{},
+		McpServerID:    uuid.NullUUID{UUID: second.id, Valid: true},
+		DisplayName:    "Ladder Test Server",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, attached)
+	require.NoError(t, tx2.Commit(ctx))
+
+	require.Equal(t, fmt.Sprintf("Ladder Test Server (%s 2)", suffix), attached.Server.DisplayName)
+
+	servers, err := queries.ListPluginServers(ctx, result.PluginID)
+	require.NoError(t, err)
+	require.Len(t, servers, 3, "the attach must succeed alongside both occupied names")
+}
+
 func TestListPluginPublishCandidates_IncludesNeverPublishedDefaultPlugin(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -136,6 +136,38 @@ WHERE plugin_id = @plugin_id
   AND mcp_server_id IS NOT DISTINCT FROM sqlc.narg('mcp_server_id')::uuid
   AND deleted IS FALSE;
 
+-- name: PluginServerDisplayNameExists :one
+-- Reports whether a live plugin server on the plugin already uses the display
+-- name. AttachToDefaultPlugin checks this before inserting so it can uniquify
+-- the name instead of tripping the (plugin_id, display_name) unique index,
+-- whose failed insert would abort the caller's surrounding transaction.
+-- Joins plugins to scope by project_id as defense-in-depth against IDOR.
+SELECT EXISTS (
+  SELECT 1 FROM plugin_servers
+  JOIN plugins ON plugins.id = plugin_servers.plugin_id
+  WHERE plugin_servers.plugin_id = @plugin_id
+    AND plugins.project_id = @project_id
+    AND plugin_servers.display_name = @display_name
+    AND plugin_servers.deleted IS FALSE
+);
+
+-- name: SoftDeletePluginServersByMCPServerID :many
+-- Soft-deletes every live plugin server backed by the mcp_server, joining
+-- plugins for project scoping. Returns the removed rows with their plugin's
+-- name and slug so callers can audit-log each removal. Used by mcpservers on
+-- server deletion so a deleted server does not keep holding a plugin's
+-- display name: the (plugin_id, display_name) unique index only excludes
+-- soft-deleted rows.
+UPDATE plugin_servers
+SET deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+FROM plugins
+WHERE plugins.id = plugin_servers.plugin_id
+  AND plugins.project_id = @project_id
+  AND plugin_servers.mcp_server_id = @mcp_server_id
+  AND plugin_servers.deleted IS FALSE
+RETURNING plugin_servers.*, plugins.name AS plugin_name, plugins.slug AS plugin_slug;
+
 -- name: AddPluginServer :one
 -- Inserts a plugin server backed by exactly one of a toolset or an mcp_server.
 -- The plugin_servers backend-exclusivity CHECK enforces the XOR; callers must

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -1146,6 +1146,35 @@ func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, projectI
 	return items, nil
 }
 
+const pluginServerDisplayNameExists = `-- name: PluginServerDisplayNameExists :one
+SELECT EXISTS (
+  SELECT 1 FROM plugin_servers
+  JOIN plugins ON plugins.id = plugin_servers.plugin_id
+  WHERE plugin_servers.plugin_id = $1
+    AND plugins.project_id = $2
+    AND plugin_servers.display_name = $3
+    AND plugin_servers.deleted IS FALSE
+)
+`
+
+type PluginServerDisplayNameExistsParams struct {
+	PluginID    uuid.UUID
+	ProjectID   uuid.UUID
+	DisplayName string
+}
+
+// Reports whether a live plugin server on the plugin already uses the display
+// name. AttachToDefaultPlugin checks this before inserting so it can uniquify
+// the name instead of tripping the (plugin_id, display_name) unique index,
+// whose failed insert would abort the caller's surrounding transaction.
+// Joins plugins to scope by project_id as defense-in-depth against IDOR.
+func (q *Queries) PluginServerDisplayNameExists(ctx context.Context, arg PluginServerDisplayNameExistsParams) (bool, error) {
+	row := q.db.QueryRow(ctx, pluginServerDisplayNameExists, arg.PluginID, arg.ProjectID, arg.DisplayName)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const promoteToDefaultPlugin = `-- name: PromoteToDefaultPlugin :one
 UPDATE plugins
 SET is_default = TRUE,
@@ -1337,6 +1366,79 @@ WHERE plugin_id = $1
 func (q *Queries) SoftDeletePluginServers(ctx context.Context, pluginID uuid.UUID) error {
 	_, err := q.db.Exec(ctx, softDeletePluginServers, pluginID)
 	return err
+}
+
+const softDeletePluginServersByMCPServerID = `-- name: SoftDeletePluginServersByMCPServerID :many
+UPDATE plugin_servers
+SET deleted_at = clock_timestamp(),
+    updated_at = clock_timestamp()
+FROM plugins
+WHERE plugins.id = plugin_servers.plugin_id
+  AND plugins.project_id = $1
+  AND plugin_servers.mcp_server_id = $2
+  AND plugin_servers.deleted IS FALSE
+RETURNING plugin_servers.id, plugin_servers.plugin_id, plugin_servers.toolset_id, plugin_servers.mcp_server_id, plugin_servers.display_name, plugin_servers.policy, plugin_servers.sort_order, plugin_servers.created_at, plugin_servers.updated_at, plugin_servers.deleted_at, plugin_servers.deleted, plugins.name AS plugin_name, plugins.slug AS plugin_slug
+`
+
+type SoftDeletePluginServersByMCPServerIDParams struct {
+	ProjectID   uuid.UUID
+	McpServerID uuid.NullUUID
+}
+
+type SoftDeletePluginServersByMCPServerIDRow struct {
+	ID          uuid.UUID
+	PluginID    uuid.UUID
+	ToolsetID   uuid.NullUUID
+	McpServerID uuid.NullUUID
+	DisplayName string
+	Policy      string
+	SortOrder   int32
+	CreatedAt   pgtype.Timestamptz
+	UpdatedAt   pgtype.Timestamptz
+	DeletedAt   pgtype.Timestamptz
+	Deleted     bool
+	PluginName  string
+	PluginSlug  string
+}
+
+// Soft-deletes every live plugin server backed by the mcp_server, joining
+// plugins for project scoping. Returns the removed rows with their plugin's
+// name and slug so callers can audit-log each removal. Used by mcpservers on
+// server deletion so a deleted server does not keep holding a plugin's
+// display name: the (plugin_id, display_name) unique index only excludes
+// soft-deleted rows.
+func (q *Queries) SoftDeletePluginServersByMCPServerID(ctx context.Context, arg SoftDeletePluginServersByMCPServerIDParams) ([]SoftDeletePluginServersByMCPServerIDRow, error) {
+	rows, err := q.db.Query(ctx, softDeletePluginServersByMCPServerID, arg.ProjectID, arg.McpServerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SoftDeletePluginServersByMCPServerIDRow
+	for rows.Next() {
+		var i SoftDeletePluginServersByMCPServerIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.PluginID,
+			&i.ToolsetID,
+			&i.McpServerID,
+			&i.DisplayName,
+			&i.Policy,
+			&i.SortOrder,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+			&i.PluginName,
+			&i.PluginSlug,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const updatePlugin = `-- name: UpdatePlugin :one


### PR DESCRIPTION
Closes [DNO-636](https://linear.app/speakeasy/issue/DNO-636/mcp-server-delete-orphans-plugin-attachments-re-adding-a-same-named)

## Problem

Enabling an MCP server returned a 500 whenever the project's Default plugin already had a `plugin_servers` row with the same display name. `AttachToDefaultPlugin`'s idempotency check only matches on backend id, but the `plugin_servers_plugin_id_display_name_key` unique index spans all backends — so a same-named toolset attachment, or a stale row left by a deleted server, tripped a 23505 that aborted the whole `mcpServers.update` transaction. The failure was deterministic: retrying could never enable the server (this is what paged as elevated nginx 5XX on prod; details in the Linear issue).

Two defects compounded:

1. The attach treated a display-name collision as a hard error and blocked the triggering action (enabling a server) over a marketplace display name.
2. `DeleteMcpServer` never detached `plugin_servers` rows, so a deleted server kept holding its display name forever (the unique index only excludes soft-deleted rows).

## Fix

* `AttachToDefaultPlugin` now checks display-name availability first (new project-qualified `PluginServerDisplayNameExists` query) and, on collision, uniquifies the name with the backend-id suffix — the same last-4 convention `computeServerSlug` uses. All three attach callers (mcpservers enable, toolsets MCP-enable, mcpendpoints first-endpoint) benefit. The residual unique-violation branch now only covers a concurrent race, which self-heals on retry.
* `DeleteMcpServer` soft-deletes the server's `plugin_servers` rows in the same transaction via the new `SoftDeletePluginServersByMCPServerID` query (project-scoped), recording a `plugin:server_remove` audit event per detachment to match the manual remove path.

No schema change; no migration.

## Testing

* `TestAttachToDefaultPlugin_DisplayNameCollision_Uniquifies` replaces the test that pinned the old fail-on-collision behavior: both same-named servers attach, the second with a suffixed display name.
* `TestDeleteMcpServer_DetachesFromPlugins` covers the full incident scenario: attach → delete → attachment released + audited → a same-named replacement attaches under the original name.
* `plugins`, `mcpservers`, `toolsets`, `mcpendpoints` suites pass with `-race` (the `TestGenerateCodexInstallScript*` failures are environmental and reproduce on a clean `main` checkout).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

## Summary by cubic

Stops 500s when enabling an MCP server by handling Default plugin display-name collisions. Fixes [DNO-636](https://linear.app/speakeasy/issue/DNO-636/mcp-server-delete-orphans-plugin-attachments-re-adding-a-same-named) and makes enablement reliable even with same‑named servers.

* **Bug Fixes**
  * In `plugins`, AttachToDefaultPlugin checks name availability within the project; on collision, it uniquifies with the backend-id suffix (last 4 chars). Concurrent races now self-heal on retry.
  * In `mcpservers`, DeleteMcpServer soft-deletes related `plugin_servers` rows in the same transaction and logs `plugin:server_remove` audit events, freeing names for replacements.
  * Tests added for collision uniquifying and detach-on-delete.

Written for commit 010a72c9bb38ba11876b1ea178b1ff52749e79ad. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)