### PR TITLE
fix: enforce RBAC for legacy enterprise organizations

### DIFF
--- a/.changeset/enforce-enterprise-rbac.md
+++ b/.changeset/enforce-enterprise-rbac.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Enterprise organizations now automatically provision and enable RBAC before authorization checks run, preventing disabled or unseeded legacy organizations from bypassing server-side role enforcement.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -737,7 +737,7 @@ paths:
         type: mutation
   /rpc/access.disableRBAC:
     post:
-      description: Disable RBAC enforcement for the current organization.
+      description: Legacy compatibility endpoint. RBAC cannot be disabled.
       operationId: disableRBAC
       parameters:
         - allowEmptyValue: true

--- a/client/dashboard/src/components/platform-admin-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-panel.tsx
@@ -2,7 +2,6 @@ import { Input } from "@/components/ui/input";
 import { useOrganization } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { FeatureName } from "@gram/client/models/components/setproductfeaturerequestbody.js";
-import { useDisableRBACMutation } from "@gram/client/react-query/disableRBAC.js";
 import { useEnableRBACMutation } from "@gram/client/react-query/enableRBAC.js";
 import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
 import { invalidateAllGrants } from "@gram/client/react-query/grants.js";
@@ -142,9 +141,7 @@ function FeatureToggle({
 
 function RBACManagementSection(): ReactElement {
   const queryClient = useQueryClient();
-  const [confirmAction, setConfirmAction] = useState<
-    "enable" | "disable" | null
-  >(null);
+  const [confirmEnable, setConfirmEnable] = useState(false);
 
   const { data: status, isLoading, error } = useRbacStatus();
 
@@ -152,20 +149,9 @@ function RBACManagementSection(): ReactElement {
     onSuccess: () => {
       void invalidateAllRbacStatus(queryClient);
       void invalidateAllGrants(queryClient);
-      setConfirmAction(null);
+      setConfirmEnable(false);
     },
   });
-
-  const disableMutation = useDisableRBACMutation({
-    onSuccess: () => {
-      void invalidateAllRbacStatus(queryClient);
-      void invalidateAllGrants(queryClient);
-      setConfirmAction(null);
-    },
-  });
-
-  const toggleMutation =
-    confirmAction === "enable" ? enableMutation : disableMutation;
 
   if (isLoading) {
     return (
@@ -188,51 +174,46 @@ function RBACManagementSection(): ReactElement {
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2">
         <StatusPill enabled={status.rbacEnabled} />
-        {confirmAction === null && (
+        {!status.rbacEnabled && !confirmEnable ? (
           <ActionButton
-            onClick={() =>
-              setConfirmAction(status.rbacEnabled ? "disable" : "enable")
-            }
-            destructive={status.rbacEnabled}
+            onClick={() => setConfirmEnable(true)}
           >
-            {status.rbacEnabled ? "Disable RBAC" : "Enable RBAC"}
+            Enable RBAC
           </ActionButton>
-        )}
+        ) : null}
       </div>
 
-      {confirmAction !== null && (
+      {confirmEnable ? (
         // Inline confirmation instead of a modal: the platform-admin-toolbar collapses on
         // outside clicks, which would tear down a portalled dialog mid-flow.
         <div className="border-border bg-muted/40 rounded-md border p-2">
           <p className="text-foreground mb-2 text-[11px] leading-snug">
-            {confirmAction === "enable"
-              ? "Seed default grants for system roles and enforce access control for this organization?"
-              : "Disable access control enforcement? All members will have unrestricted access."}
+            Seed default grants for system roles and enforce access control for
+            this organization?
           </p>
           <div className="flex items-center gap-2">
             <ActionButton
-              onClick={() => toggleMutation.mutate({})}
-              pending={toggleMutation.isPending}
-              destructive={confirmAction === "disable"}
+              onClick={() => enableMutation.mutate({})}
+              pending={enableMutation.isPending}
             >
-              {confirmAction === "enable" ? "Enable" : "Disable"}
+              Enable
             </ActionButton>
             <button
               type="button"
-              onClick={() => setConfirmAction(null)}
+              onClick={() => setConfirmEnable(false)}
               className="text-muted-foreground hover:text-foreground text-[11px]"
             >
               Cancel
             </button>
           </div>
         </div>
-      )}
+      ) : null}
 
-      {toggleMutation.error && (
+      {enableMutation.error ? (
         <p className="text-destructive text-[11px]">
-          {toggleMutation.error.message}
+          {enableMutation.error.message}
         </p>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -289,7 +270,7 @@ function ProductFeaturesSection(): ReactElement {
       <Section
         icon={ShieldCheck}
         title="RBAC"
-        description="Role-based access control enforcement. Ensure all members have roles assigned before enabling."
+        description="Role-based access control is required for enterprise organizations and cannot be disabled."
       >
         <RBACManagementSection />
       </Section>

--- a/client/dashboard/src/components/platform-admin-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-panel.tsx
@@ -175,9 +175,7 @@ function RBACManagementSection(): ReactElement {
       <div className="flex items-center justify-between gap-2">
         <StatusPill enabled={status.rbacEnabled} />
         {!status.rbacEnabled && !confirmEnable ? (
-          <ActionButton
-            onClick={() => setConfirmEnable(true)}
-          >
+          <ActionButton onClick={() => setConfirmEnable(true)}>
             Enable RBAC
           </ActionButton>
         ) : null}

--- a/client/dashboard/src/sdk/src/funcs/accessDisableRBAC.ts
+++ b/client/dashboard/src/sdk/src/funcs/accessDisableRBAC.ts
@@ -38,7 +38,7 @@ import { Result } from "../types/fp.js";
  * disableRBAC access
  *
  * @remarks
- * Disable RBAC enforcement for the current organization.
+ * Legacy compatibility endpoint. RBAC cannot be disabled.
  */
 export function accessDisableRBAC(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/react-query/disableRBAC.ts
+++ b/client/dashboard/src/sdk/src/react-query/disableRBAC.ts
@@ -53,7 +53,7 @@ export type DisableRBACMutationError =
  * disableRBAC access
  *
  * @remarks
- * Disable RBAC enforcement for the current organization.
+ * Legacy compatibility endpoint. RBAC cannot be disabled.
  */
 export function useDisableRBACMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/access.ts
+++ b/client/dashboard/src/sdk/src/sdk/access.ts
@@ -332,7 +332,7 @@ export class Access extends ClientSDK {
    * disableRBAC access
    *
    * @remarks
-   * Disable RBAC enforcement for the current organization.
+   * Legacy compatibility endpoint. RBAC cannot be disabled.
    */
   async disableRBAC(
     request?: DisableRBACRequest | undefined,

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -545,11 +545,11 @@ Handlers do not query grants directly. Their job is to describe the access they 
 
 ### When RBAC is enforced
 
-`authz.Engine.ShouldEnforce` decides whether checks should actually be applied. Today, RBAC is enforced for authenticated enterprise requests when the RBAC feature flag is enabled for the active organization, as long as the request is not using an API key. The request also needs a session, except for assistant-token requests, which are allowed through this path.
+`authz.Engine.ShouldEnforce` decides whether checks should actually be applied. RBAC is enforced for authenticated enterprise requests as long as the request is not using an API key. The request also needs a session, except for assistant-token requests, which are allowed through this path. If an enterprise organization does not yet have the RBAC feature enabled, the engine atomically seeds its built-in Admin and Member grants and enables RBAC before evaluating the request. If that bootstrap fails, authorization fails closed.
 
 Scope overrides are a special case. In local development, authenticated users can use override headers. In production, only platform admins can. When valid overrides are present, RBAC is enforced so the overridden grant set is what the request experiences.
 
-That means RBAC is not currently enforced for API key requests, non-enterprise accounts, or organizations where the RBAC feature flag is disabled. Unauthenticated contexts are handled as authorization errors by the normal auth path. This may change as the RBAC model expands, especially when API keys move into RBAC.
+That means RBAC is not currently enforced for API key requests or non-enterprise accounts. Unauthenticated contexts are handled as authorization errors by the normal auth path. This may change as the RBAC model expands, especially when API keys move into RBAC.
 
 ### Add checks at the handler boundary
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -545,7 +545,7 @@ Handlers do not query grants directly. Their job is to describe the access they 
 
 ### When RBAC is enforced
 
-`authz.Engine.ShouldEnforce` decides whether checks should actually be applied. RBAC is enforced for authenticated enterprise requests as long as the request is not using an API key. The request also needs a session, except for assistant-token requests, which are allowed through this path. If an enterprise organization does not yet have the RBAC feature enabled, the engine atomically seeds its built-in Admin and Member grants and enables RBAC before evaluating the request. If that bootstrap fails, authorization fails closed.
+`authz.Engine.ShouldEnforce` decides whether checks should actually be applied. RBAC is enforced for authenticated enterprise requests as long as the request is not using an API key. The request also needs a session, except for assistant-token requests, which are allowed through this path. If an enterprise organization does not yet have the RBAC feature enabled, the engine atomically seeds its built-in Admin and Member grants and enables RBAC before evaluating the request. If that bootstrap fails, authorization fails closed. RBAC cannot be disabled for enterprise organizations.
 
 Scope overrides are a special case. In local development, authenticated users can use override headers. In production, only platform admins can. When valid overrides are present, RBAC is enforced so the overridden grant set is what the request experiences.
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -682,7 +682,10 @@ func newStartCommand() *cli.Command {
 				rbacEnabled,
 				challengeLoggingEnabled,
 				roleClient,
-				authz.EngineOpts{DevMode: c.String("environment") == "local"},
+				authz.EngineOpts{
+					DevMode:     c.String("environment") == "local",
+					RBACEnabler: productFeatures,
+				},
 			)
 
 			_, psbroker, pubsubShutdown, err := newPubSubClient(ctx, c, logger)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -548,7 +548,10 @@ func newWorkerCommand() *cli.Command {
 				rbacEnabled,
 				challengeLoggingEnabled,
 				workos.NewStubClient(),
-				authz.EngineOpts{DevMode: c.String("environment") == "local"},
+				authz.EngineOpts{
+					DevMode:     c.String("environment") == "local",
+					RBACEnabler: productFeatures,
+				},
 			)
 
 			workosClient, workosAvailable, err := newWorkOSClient(guardianPolicy, c)

--- a/server/design/access/design.go
+++ b/server/design/access/design.go
@@ -700,7 +700,7 @@ var _ = Service("access", func() {
 	})
 
 	Method("disableRBAC", func() {
-		Description("Disable RBAC enforcement for the current organization.")
+		Description("Legacy compatibility endpoint. RBAC cannot be disabled.")
 		Security(security.Session)
 
 		Payload(func() {

--- a/server/gen/access/service.go
+++ b/server/gen/access/service.go
@@ -78,7 +78,7 @@ type Service interface {
 	// Enable RBAC for the current organization. Seeds default grants for system
 	// roles.
 	EnableRBAC(context.Context, *EnableRBACPayload) (err error)
-	// Disable RBAC enforcement for the current organization.
+	// Legacy compatibility endpoint. RBAC cannot be disabled.
 	DisableRBAC(context.Context, *DisableRBACPayload) (err error)
 	// List authz challenge events from ClickHouse, enriched with resolution state
 	// from PostgreSQL.

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -6881,7 +6881,7 @@ func accessUsage() {
 	fmt.Fprintln(os.Stderr, `    delete-shadow-mcp-access-rule: Delete a managed Shadow MCP access rule.`)
 	fmt.Fprintln(os.Stderr, `    get-rbac-status: Returns whether RBAC is currently enabled for the current organization.`)
 	fmt.Fprintln(os.Stderr, `    enable-rbac: Enable RBAC for the current organization. Seeds default grants for system roles.`)
-	fmt.Fprintln(os.Stderr, `    disable-rbac: Disable RBAC enforcement for the current organization.`)
+	fmt.Fprintln(os.Stderr, `    disable-rbac: Legacy compatibility endpoint. RBAC cannot be disabled.`)
 	fmt.Fprintln(os.Stderr, `    list-challenges: List authz challenge events from ClickHouse, enriched with resolution state from PostgreSQL.`)
 	fmt.Fprintln(os.Stderr, `    list-challenge-buckets: List authz challenges grouped into time-based burst buckets. Consecutive challenges with the same dimensions within a 10-minute window are collapsed into a single bucket.`)
 	fmt.Fprintln(os.Stderr, `    resolve-challenge: Record resolutions for one or more denied authz challenges. The caller is responsible for assigning the role first.`)
@@ -7451,7 +7451,7 @@ func accessDisableRBACUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Disable RBAC enforcement for the current organization.`)
+	fmt.Fprintln(os.Stderr, `Legacy compatibility endpoint. RBAC cannot be disabled.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -1507,7 +1507,7 @@ paths:
                 type: mutation
     /rpc/access.disableRBAC:
         post:
-            description: Disable RBAC enforcement for the current organization.
+            description: Legacy compatibility endpoint. RBAC cannot be disabled.
             operationId: disableRBAC
             parameters:
                 - allowEmptyValue: true

--- a/server/internal/access/disablerbac_test.go
+++ b/server/internal/access/disablerbac_test.go
@@ -1,0 +1,28 @@
+package access
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestService_DisableRBAC_RejectsPlatformAdmin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	email := "admin@speakeasy.com"
+	authCtx.Email = &email
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	err := ti.service.DisableRBAC(ctx, &gen.DisableRBACPayload{})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeBadRequest, oopsErr.Code)
+	require.ErrorContains(t, err, "RBAC cannot be disabled")
+}

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -43,11 +43,9 @@ import (
 var errConnectedUserNotFound = errors.New("connected user not found")
 
 // ProductFeatures is the subset of *productfeatures.Client the access service
-// needs: enabling RBAC for an org (seed grants + flag, atomically) and keeping
-// the feature cache consistent after a direct DB write.
+// needs to enable RBAC for an organization atomically.
 type ProductFeatures interface {
 	EnableRBAC(ctx context.Context, organizationID string) error
-	UpdateFeatureCache(ctx context.Context, organizationID string, feature productfeatures.Feature, enabled bool)
 }
 
 type Service struct {
@@ -618,25 +616,12 @@ func (s *Service) EnableRBAC(ctx context.Context, _ *gen.EnableRBACPayload) erro
 }
 
 func (s *Service) DisableRBAC(ctx context.Context, _ *gen.DisableRBACPayload) error {
-	ac, err := s.requirePlatformAdmin(ctx)
+	_, err := s.requirePlatformAdmin(ctx)
 	if err != nil {
 		return err
 	}
-	logger := s.logger.With(attr.SlogOrganizationID(ac.ActiveOrganizationID))
 
-	if _, err := pfRepo.New(s.db).DeleteFeature(ctx, pfRepo.DeleteFeatureParams{
-		OrganizationID: ac.ActiveOrganizationID,
-		FeatureName:    string(productfeatures.FeatureRBAC),
-	}); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			// Already disabled — no active feature row to soft-delete.
-			return nil
-		}
-		return oops.E(oops.CodeUnexpected, err, "disable RBAC feature flag").LogError(ctx, logger)
-	}
-
-	s.productFeatures.UpdateFeatureCache(ctx, ac.ActiveOrganizationID, productfeatures.FeatureRBAC, false)
-	return nil
+	return oops.E(oops.CodeBadRequest, nil, "RBAC cannot be disabled")
 }
 
 // requirePlatformAdmin returns the auth context and an error if the caller is not

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -195,7 +195,7 @@ func TestService_ListGrants_NonEnterpriseReturnsFullAccess(t *testing.T) {
 	}
 }
 
-func TestService_ListGrants_RBACDisabledReturnsFullAccess(t *testing.T) {
+func TestService_ListGrants_RBACDisabledFailsClosedWithoutEnabler(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestAccessService(t)
@@ -210,19 +210,10 @@ func TestService_ListGrants_RBACDisabledReturnsFullAccess(t *testing.T) {
 	ti.service.authz = authz.NewEngine(ti.service.logger, ti.conn, chConn, authztest.RBACAlwaysDisabled, authztest.ChallengeLoggingAlwaysDisabled, ti.roles)
 
 	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
-	require.NoError(t, err)
-	require.Len(t, result.Grants, len(expectedFullAccessScopes))
-
-	byScope := make(map[string]*gen.ListRoleGrant, len(result.Grants))
-	for _, grant := range result.Grants {
-		byScope[grant.Scope] = grant
-	}
-
-	for _, scope := range expectedFullAccessScopes {
-		grant, ok := byScope[scope]
-		require.True(t, ok)
-		require.Nil(t, grant.Selectors)
-	}
+	require.Nil(t, result)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
 }
 
 func TestService_ListGrants_EnterpriseWithoutSessionReturnsFullAccess(t *testing.T) {

--- a/server/internal/access/setup_test.go
+++ b/server/internal/access/setup_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/email"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
-	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
@@ -40,9 +39,6 @@ var (
 type noopProductFeatures struct{}
 
 func (noopProductFeatures) EnableRBAC(context.Context, string) error { return nil }
-
-func (noopProductFeatures) UpdateFeatureCache(context.Context, string, productfeatures.Feature, bool) {
-}
 
 func TestMain(m *testing.M) {
 	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true})

--- a/server/internal/assistantmemories/impl_test.go
+++ b/server/internal/assistantmemories/impl_test.go
@@ -87,7 +87,7 @@ func newTestHarness(t *testing.T) (*testHarness, context.Context) {
 		ProjectID:             &projectID,
 		OrganizationSlug:      orgID,
 		Email:                 nil,
-		AccountType:           "enterprise",
+		AccountType:           "pro",
 		HasActiveSubscription: false,
 		Whitelisted:           false,
 		ProjectSlug:           &projectSlug,

--- a/server/internal/authz/context_test.go
+++ b/server/internal/authz/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -40,6 +41,64 @@ func TestPrepareContext_loadsUserGrants(t *testing.T) {
 	_, ok = GrantsFromContext(ctx)
 	require.True(t, ok)
 	require.NoError(t, engine.Require(ctx, Check{Scope: ScopeProjectRead, ResourceID: "project_123"}))
+}
+
+func TestPrepareContext_enablesRBACForLegacyOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx := enterpriseTestCtx(t.Context())
+	conn := newTestDB(t)
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	seedOrganization(t, ctx, conn, authCtx.ActiveOrganizationID)
+	require.NoError(t, SeedSystemRoleGrants(ctx, conn, authCtx.ActiveOrganizationID))
+	seedConnectedUser(t, ctx, conn, authCtx.ActiveOrganizationID, authCtx.UserID, "test@example.com", "Test User", "user_workos_test", "membership_test")
+	seedRoleAssignmentForUser(t, ctx, conn, authCtx.ActiveOrganizationID, authCtx.UserID, SystemRoleMember)
+
+	memberRole, err := accessrepo.New(conn).GetGlobalRoleBySlug(ctx, SystemRoleMember)
+	require.NoError(t, err)
+	_, err = accessrepo.New(conn).DeletePrincipalGrantsByPrincipal(ctx, accessrepo.DeletePrincipalGrantsByPrincipalParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeRole, "global:"+memberRole.ID.String()),
+	})
+	require.NoError(t, err)
+
+	enabled := false
+	enableCalls := 0
+	engine := NewEngine(
+		testenv.NewLogger(t),
+		conn,
+		chConn,
+		func(context.Context, string) (bool, error) { return enabled, nil },
+		challengeLoggingAlwaysEnabled,
+		workos.NewStubClient(),
+		EngineOpts{
+			DevMode: false,
+			RBACEnabler: rbacEnablerFunc(func(enableCtx context.Context, organizationID string) error {
+				enableCalls++
+				if err := SeedSystemRoleGrants(enableCtx, conn, organizationID); err != nil {
+					return err
+				}
+				enabled = true
+				return nil
+			}),
+		},
+	)
+
+	ctx, err = engine.PrepareContext(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, enableCalls)
+	require.NoError(t, engine.Require(ctx, Check{Scope: ScopeOrgRead, ResourceID: authCtx.ActiveOrganizationID}))
+
+	err = engine.Require(ctx, Check{Scope: ScopeOrgAdmin, ResourceID: authCtx.ActiveOrganizationID})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestPrepareContext_rejectsInvalidUserPrincipal(t *testing.T) {

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -650,6 +650,10 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 
 	organizationID := authCtx.ActiveOrganizationID
 	_, err, _ = e.rbacEnableGroup.Do(organizationID, func() (any, error) {
+		if _, bootstrapped := e.bootstrappedOrgs.Load(organizationID); bootstrapped {
+			return nil, nil
+		}
+
 		// The feature may have been enabled while this request waited for
 		// another bootstrap attempt.
 		enabled, err := e.isEnabled(ctx, organizationID)
@@ -658,7 +662,7 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 		}
 		if !enabled {
 			if err := e.rbacEnabler.EnableRBAC(ctx, organizationID); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("bootstrap RBAC: %w", err)
 			}
 		}
 

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -22,8 +22,14 @@ type MembershipFetcher interface {
 	GetOrgMembership(ctx context.Context, workOSUserID, workOSOrgID string) (*workos.Member, error)
 }
 
+// RBACEnabler provisions the built-in role grants and enables RBAC for an organization.
+type RBACEnabler interface {
+	EnableRBAC(ctx context.Context, organizationID string) error
+}
+
 type EngineOpts struct {
-	DevMode bool
+	DevMode     bool
+	RBACEnabler RBACEnabler
 }
 
 // ChallengeLoggingEnabled checks whether authz challenge logging to ClickHouse
@@ -38,12 +44,15 @@ type Engine struct {
 	challengeLoggingEnabled ChallengeLoggingEnabled
 	isDev                   bool
 	membership              MembershipFetcher
+	rbacEnabler             RBACEnabler
 }
 
 func NewEngine(logger *slog.Logger, db *pgxpool.Pool, chDB clickhouse.Conn, isEnabled IsRBACEnabled, challengeLogging ChallengeLoggingEnabled, membership MembershipFetcher, opts ...EngineOpts) *Engine {
 	var devMode bool
+	var rbacEnabler RBACEnabler
 	if len(opts) > 0 {
 		devMode = opts[0].DevMode
+		rbacEnabler = opts[0].RBACEnabler
 	}
 
 	authzLogger := logger.With(attr.SlogComponent("authz"))
@@ -56,6 +65,7 @@ func NewEngine(logger *slog.Logger, db *pgxpool.Pool, chDB clickhouse.Conn, isEn
 		challengeLoggingEnabled: challengeLogging,
 		isDev:                   devMode,
 		membership:              membership,
+		rbacEnabler:             rbacEnabler,
 	}
 }
 
@@ -101,19 +111,11 @@ func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
 		return GrantsToContext(ctx, GrantsFromOverrides(overrides)), nil
 	}
 
-	if authCtx.AccountType != "enterprise" {
-		return ctx, nil
-	}
-
-	enabled, err := e.isEnabled(ctx, authCtx.ActiveOrganizationID)
+	enforce, err := e.ShouldEnforce(ctx)
 	if err != nil {
-		e.logger.WarnContext(ctx, "failed to check RBAC feature flag, skipping grant loading",
-			attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
-			attr.SlogError(err),
-		)
-		return ctx, nil
+		return ctx, err
 	}
-	if !enabled {
+	if !enforce {
 		return ctx, nil
 	}
 
@@ -628,7 +630,19 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 		return false, oops.E(oops.CodeUnexpected, err, "check RBAC feature").LogError(ctx, e.logger)
 	}
 
-	return enabled, nil
+	if enabled {
+		return true, nil
+	}
+
+	if e.rbacEnabler == nil {
+		return false, oops.E(oops.CodeUnexpected, nil, "RBAC is not enabled for this organization").LogError(ctx, e.logger)
+	}
+
+	if err := e.rbacEnabler.EnableRBAC(ctx, authCtx.ActiveOrganizationID); err != nil {
+		return false, oops.E(oops.CodeUnexpected, err, "enable RBAC for organization").LogError(ctx, e.logger)
+	}
+
+	return true, nil
 }
 
 func validateInput(c Check) error {

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -13,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"golang.org/x/sync/singleflight"
 )
 
 type IsRBACEnabled func(ctx context.Context, organizationID string) (bool, error)
@@ -45,6 +47,8 @@ type Engine struct {
 	isDev                   bool
 	membership              MembershipFetcher
 	rbacEnabler             RBACEnabler
+	rbacEnableGroup         singleflight.Group
+	bootstrappedOrgs        sync.Map
 }
 
 func NewEngine(logger *slog.Logger, db *pgxpool.Pool, chDB clickhouse.Conn, isEnabled IsRBACEnabled, challengeLogging ChallengeLoggingEnabled, membership MembershipFetcher, opts ...EngineOpts) *Engine {
@@ -66,6 +70,8 @@ func NewEngine(logger *slog.Logger, db *pgxpool.Pool, chDB clickhouse.Conn, isEn
 		isDev:                   devMode,
 		membership:              membership,
 		rbacEnabler:             rbacEnabler,
+		rbacEnableGroup:         singleflight.Group{},
+		bootstrappedOrgs:        sync.Map{},
 	}
 }
 
@@ -625,6 +631,10 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
+	if _, bootstrapped := e.bootstrappedOrgs.Load(authCtx.ActiveOrganizationID); bootstrapped {
+		return true, nil
+	}
+
 	enabled, err := e.isEnabled(ctx, authCtx.ActiveOrganizationID)
 	if err != nil {
 		return false, oops.E(oops.CodeUnexpected, err, "check RBAC feature").LogError(ctx, e.logger)
@@ -638,7 +648,24 @@ func (e *Engine) ShouldEnforce(ctx context.Context) (bool, error) {
 		return false, oops.E(oops.CodeUnexpected, nil, "RBAC is not enabled for this organization").LogError(ctx, e.logger)
 	}
 
-	if err := e.rbacEnabler.EnableRBAC(ctx, authCtx.ActiveOrganizationID); err != nil {
+	organizationID := authCtx.ActiveOrganizationID
+	_, err, _ = e.rbacEnableGroup.Do(organizationID, func() (any, error) {
+		// The feature may have been enabled while this request waited for
+		// another bootstrap attempt.
+		enabled, err := e.isEnabled(ctx, organizationID)
+		if err != nil {
+			return nil, fmt.Errorf("recheck RBAC feature: %w", err)
+		}
+		if !enabled {
+			if err := e.rbacEnabler.EnableRBAC(ctx, organizationID); err != nil {
+				return nil, err
+			}
+		}
+
+		e.bootstrappedOrgs.Store(organizationID, struct{}{})
+		return nil, nil
+	})
+	if err != nil {
 		return false, oops.E(oops.CodeUnexpected, err, "enable RBAC for organization").LogError(ctx, e.logger)
 	}
 

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -3,6 +3,8 @@ package authz
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -103,6 +105,46 @@ func TestEngineRequire_failsClosedWhenRBACCannotBeEnabled(t *testing.T) {
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
 	require.ErrorContains(t, err, "RBAC is not enabled for this organization")
+}
+
+func TestEngineRequire_coalescesConcurrentRBACBootstrap(t *testing.T) {
+	t.Parallel()
+
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	var enableCalls atomic.Int32
+	engine := NewEngine(
+		testenv.NewLogger(t),
+		nil,
+		chConn,
+		staticRBAC(false),
+		staticChallengeLogging(true),
+		workos.NewStubClient(),
+		EngineOpts{
+			DevMode: false,
+			RBACEnabler: rbacEnablerFunc(func(context.Context, string) error {
+				enableCalls.Add(1)
+				return nil
+			}),
+		},
+	)
+	ctx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeOrgAdmin, "org_123")})
+
+	const requestCount = 20
+	errs := make(chan error, requestCount)
+	var wg sync.WaitGroup
+	for range requestCount {
+		wg.Go(func() {
+			errs <- engine.Require(ctx, Check{Scope: ScopeOrgAdmin, ResourceID: "org_123"})
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.EqualValues(t, 1, enableCalls.Load())
 }
 
 func TestEngineRequire_mapsDeniedToForbidden(t *testing.T) {

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -34,6 +34,12 @@ func failingRBAC(err error) IsRBACEnabled {
 	}
 }
 
+type rbacEnablerFunc func(context.Context, string) error
+
+func (f rbacEnablerFunc) EnableRBAC(ctx context.Context, organizationID string) error {
+	return f(ctx, organizationID)
+}
+
 func TestEngineRequire_requiresAuthContext(t *testing.T) {
 	t.Parallel()
 
@@ -47,15 +53,56 @@ func TestEngineRequire_requiresAuthContext(t *testing.T) {
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 }
 
-func TestEngineRequire_skipsWhenRBACFeatureDisabled(t *testing.T) {
+func TestEngineRequire_enablesRBACBeforeAuthorizing(t *testing.T) {
+	t.Parallel()
+
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	enabled := false
+	enableCalls := 0
+	engine := NewEngine(
+		testenv.NewLogger(t),
+		nil,
+		chConn,
+		func(context.Context, string) (bool, error) { return enabled, nil },
+		staticChallengeLogging(true),
+		workos.NewStubClient(),
+		EngineOpts{
+			DevMode: false,
+			RBACEnabler: rbacEnablerFunc(func(_ context.Context, organizationID string) error {
+				require.Equal(t, "org_test", organizationID)
+				enabled = true
+				enableCalls++
+				return nil
+			}),
+		},
+	)
+
+	memberCtx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeOrgRead, "org_test")})
+	err = engine.Require(memberCtx, Check{Scope: ScopeOrgAdmin, ResourceID: "org_test"})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
+	require.Equal(t, 1, enableCalls)
+
+	adminCtx := GrantsToContext(enterpriseSessionCtx(t), []Grant{NewGrant(ScopeOrgAdmin, "org_test")})
+	err = engine.Require(adminCtx, Check{Scope: ScopeOrgAdmin, ResourceID: "org_test"})
+	require.NoError(t, err)
+	require.Equal(t, 1, enableCalls)
+}
+
+func TestEngineRequire_failsClosedWhenRBACCannotBeEnabled(t *testing.T) {
 	t.Parallel()
 
 	chConn, err := newClickhouseClient(t)
 	require.NoError(t, err)
 	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(false), staticChallengeLogging(true), workos.NewStubClient())
 
-	err = engine.Require(enterpriseSessionCtx(t), Check{Scope: ScopeProjectRead, ResourceID: "proj_123"})
-	require.NoError(t, err)
+	err = engine.Require(enterpriseSessionCtx(t), Check{Scope: ScopeOrgAdmin, ResourceID: "org_test"})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnexpected, oopsErr.Code)
+	require.ErrorContains(t, err, "RBAC is not enabled for this organization")
 }
 
 func TestEngineRequire_mapsDeniedToForbidden(t *testing.T) {
@@ -1172,7 +1219,7 @@ func TestCanUseOverride_devPlusAdmin(t *testing.T) {
 	t.Parallel()
 	chConn, err := newClickhouseClient(t)
 	require.NoError(t, err)
-	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(false), staticChallengeLogging(true), workos.NewStubClient(), EngineOpts{DevMode: true})
+	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(false), staticChallengeLogging(true), workos.NewStubClient(), EngineOpts{DevMode: true, RBACEnabler: nil})
 	ctx := scopeOverrideCtx(t, true, "pro")
 
 	enforce, err := engine.ShouldEnforce(ctx)
@@ -1184,7 +1231,7 @@ func TestCanUseOverride_devPlusNonAdmin(t *testing.T) {
 	t.Parallel()
 	chConn, err := newClickhouseClient(t)
 	require.NoError(t, err)
-	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(false), staticChallengeLogging(true), workos.NewStubClient(), EngineOpts{DevMode: true})
+	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(false), staticChallengeLogging(true), workos.NewStubClient(), EngineOpts{DevMode: true, RBACEnabler: nil})
 	ctx := scopeOverrideCtx(t, false, "pro")
 
 	enforce, err := engine.ShouldEnforce(ctx)

--- a/server/internal/authz/engine_test.go
+++ b/server/internal/authz/engine_test.go
@@ -70,7 +70,7 @@ func TestEngineRequire_enablesRBACBeforeAuthorizing(t *testing.T) {
 		EngineOpts{
 			DevMode: false,
 			RBACEnabler: rbacEnablerFunc(func(_ context.Context, organizationID string) error {
-				require.Equal(t, "org_test", organizationID)
+				require.Equal(t, "org_123", organizationID)
 				enabled = true
 				enableCalls++
 				return nil
@@ -983,14 +983,19 @@ func TestEngineEvaluate_falseWhenUnsatisfied(t *testing.T) {
 	require.False(t, allowed)
 }
 
-func TestEngineEvaluate_trueWhenRBACDisabled(t *testing.T) {
+func TestEngineEvaluate_trueForNonEnterpriseRequest(t *testing.T) {
 	t.Parallel()
 
 	chConn, err := newClickhouseClient(t)
 	require.NoError(t, err)
 	engine := NewEngine(testenv.NewLogger(t), nil, chConn, staticRBAC(false), staticChallengeLogging(true), workos.NewStubClient())
+	ctx := enterpriseSessionCtx(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.AccountType = "pro"
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
 
-	allowed, err := engine.Evaluate(enterpriseSessionCtx(t), ChatReadCheck("proj_123"))
+	allowed, err := engine.Evaluate(ctx, ChatReadCheck("proj_123"))
 	require.NoError(t, err)
 	require.True(t, allowed)
 }

--- a/server/internal/authztest/helpers.go
+++ b/server/internal/authztest/helpers.go
@@ -18,7 +18,7 @@ type RBACState struct {
 
 // NewRBACState creates test RBAC state with the requested initial value.
 func NewRBACState(enabled bool) *RBACState {
-	state := &RBACState{}
+	state := new(RBACState)
 	state.enabled.Store(enabled)
 	return state
 }

--- a/server/internal/authztest/helpers.go
+++ b/server/internal/authztest/helpers.go
@@ -2,6 +2,7 @@ package authztest
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,29 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 )
+
+// RBACState is a concurrency-safe feature checker and enabler for tests.
+type RBACState struct {
+	enabled atomic.Bool
+}
+
+// NewRBACState creates test RBAC state with the requested initial value.
+func NewRBACState(enabled bool) *RBACState {
+	state := &RBACState{}
+	state.enabled.Store(enabled)
+	return state
+}
+
+// IsEnabled reports the current test RBAC state.
+func (s *RBACState) IsEnabled(context.Context, string) (bool, error) {
+	return s.enabled.Load(), nil
+}
+
+// EnableRBAC changes the test RBAC state to enabled.
+func (s *RBACState) EnableRBAC(context.Context, string) error {
+	s.enabled.Store(true)
+	return nil
+}
 
 // WithExactGrants marks the context as enterprise and loads the given grants
 // directly into the context. Pass no grants to simulate RBAC active with no permissions.

--- a/server/internal/projects/createproject_test.go
+++ b/server/internal/projects/createproject_test.go
@@ -91,7 +91,7 @@ func TestProjectsService_CreateProject_ForbiddenWithoutOrgAdminGrant(t *testing.
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
-func TestProjectsService_CreateProject_SkipsRBACWhenDisabled(t *testing.T) {
+func TestProjectsService_CreateProject_BootstrapsRBACWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, false)
@@ -103,9 +103,10 @@ func TestProjectsService_CreateProject_SkipsRBACWhenDisabled(t *testing.T) {
 		OrganizationID: authCtx.ActiveOrganizationID,
 		Name:           "rbac-disabled-" + uuid.NewString()[:8],
 	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotNil(t, result.Project)
+	require.Nil(t, result)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestProjectsService_CreateProject_AuditLogRecord(t *testing.T) {

--- a/server/internal/projects/deleteproject_test.go
+++ b/server/internal/projects/deleteproject_test.go
@@ -88,7 +88,7 @@ func TestProjectsService_DeleteProject_ForbiddenWithoutOrgAdminGrant(t *testing.
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
-func TestProjectsService_DeleteProject_SkipsRBACWhenDisabled(t *testing.T) {
+func TestProjectsService_DeleteProject_BootstrapsRBACWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, false)
@@ -98,7 +98,9 @@ func TestProjectsService_DeleteProject_SkipsRBACWhenDisabled(t *testing.T) {
 	err := ti.service.DeleteProject(ctx, &gen.DeleteProjectPayload{
 		ID: project.ID.String(),
 	})
-	require.NoError(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func createProjectForDeletion(t *testing.T, ctx context.Context, ti *testInstance, name string) projectsrepo.Project {

--- a/server/internal/projects/getproject_test.go
+++ b/server/internal/projects/getproject_test.go
@@ -43,7 +43,7 @@ func TestProjectsService_GetProject(t *testing.T) {
 		assert.NotEmpty(t, result.Project.UpdatedAt)
 	})
 
-	t.Run("it skips RBAC when feature is disabled", func(t *testing.T) {
+	t.Run("it bootstraps RBAC when feature is disabled", func(t *testing.T) {
 		t.Parallel()
 
 		ctx, ti := newTestProjectsService(t, false)

--- a/server/internal/projects/listprojects_test.go
+++ b/server/internal/projects/listprojects_test.go
@@ -12,7 +12,7 @@ import (
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 )
 
-func TestProjectsService_ListProjects_SkipsRBACWhenDisabled(t *testing.T) {
+func TestProjectsService_ListProjects_BootstrapsRBACWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, false)
@@ -38,7 +38,7 @@ func TestProjectsService_ListProjects_SkipsRBACWhenDisabled(t *testing.T) {
 	for _, p := range result.Projects {
 		projectIDs = append(projectIDs, p.ID)
 	}
-	require.Contains(t, projectIDs, ungrantedProject.ID.String())
+	require.NotContains(t, projectIDs, ungrantedProject.ID.String())
 }
 
 func TestProjectsService_ListProjects_FiltersByBuildReadGrant(t *testing.T) {

--- a/server/internal/projects/setlogo_test.go
+++ b/server/internal/projects/setlogo_test.go
@@ -208,7 +208,7 @@ func TestSetLogo_ForbiddenWithoutBuildWriteGrant(t *testing.T) {
 	assert.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
-func TestSetLogo_SkipsRBACWhenDisabled(t *testing.T) {
+func TestSetLogo_BootstrapsRBACWhenDisabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestProjectsService(t, false)
@@ -221,11 +221,10 @@ func TestSetLogo_SkipsRBACWhenDisabled(t *testing.T) {
 		SessionToken:     nil,
 		AssetID:          assetID.String(),
 	})
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.NotNil(t, result.Project)
-	require.NotNil(t, result.Project.LogoAssetID)
-	require.Equal(t, assetID.String(), *result.Project.LogoAssetID)
+	require.Nil(t, result)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestSetLogo_UnauthorizedNoAuthContext(t *testing.T) {

--- a/server/internal/projects/setup_test.go
+++ b/server/internal/projects/setup_test.go
@@ -91,6 +91,7 @@ func newTestProjectsService(t *testing.T, enableRBAC bool) (context.Context, *te
 	require.NoError(t, err)
 
 	auditLogger := audit.NewLogger()
+	rbacState := authztest.NewRBACState(enableRBAC)
 
 	svc := projects.NewService(
 		logger,
@@ -101,11 +102,13 @@ func newTestProjectsService(t *testing.T, enableRBAC bool) (context.Context, *te
 			logger,
 			conn,
 			chConn,
-			func(context.Context, string) (bool, error) {
-				return enableRBAC, nil
-			},
+			rbacState.IsEnabled,
 			authztest.ChallengeLoggingAlwaysDisabled,
 			workos.NewStubClient(),
+			authz.EngineOpts{
+				DevMode:     false,
+				RBACEnabler: rbacState,
+			},
 		),
 		auditLogger,
 		nil,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- automatically bootstrap RBAC before authorizing enterprise requests for legacy organizations where it is disabled or unseeded
- fail closed if RBAC cannot be provisioned; coalesce concurrent bootstrap attempts per organization
- preserve default Member/Admin privilege boundaries across the reported access, invite, API-key, and risk-policy endpoints
- retire RBAC disablement server-side and remove the platform-admin disable control
- update the API contract, generated SDK documentation, and RBAC operational docs

## Testing
- `mise run test:server` — 7,619 tests passed
- `mise run test:server ./internal/authz/... ./internal/access/... ./internal/organizations/... ./internal/keys/... ./internal/risk/... ./internal/projects/...` — 1,014 tests passed
- concurrent bootstrap regression stress-run 10 times
- `mise run lint:server`
- `mise run build:server`
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint`
- `GOTOOLCHAIN=go1.26.4 mise run gen:sdk`

## Walkthrough
<a href="https://cursor.com/agents/bc-87bdc826-915f-483e-a40c-c464f2ce1542/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmandatory_rbac_admin_ui_short.mp4"><img src="https://cursor.com/artifacts/c/art-d8216cc7-9e35-4035-a8ec-bf892757d259" alt="mandatory_rbac_admin_ui_short.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-360](https://linear.app/speakeasy/issue/AIS-360/bug-systemic-vertical-privilege-escalation)

<div><a href="https://cursor.com/agents/bc-87bdc826-915f-483e-a40c-c464f2ce1542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87bdc826-915f-483e-a40c-c464f2ce1542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces RBAC for all authenticated enterprise requests, including legacy orgs with RBAC off, by bootstrapping RBAC before any checks run. Removes any path to disable RBAC, closing the AIS-360 escalation path.

- **Bug Fixes**
  - Auto-provisions RBAC for legacy enterprise orgs in `authz.Engine.ShouldEnforce` via a new `RBACEnabler` (`EngineOpts`); seeds built‑in Admin/Member grants, enables the feature, caches bootstrapped orgs, and uses singleflight with a recheck to safely coalesce concurrent attempts.
  - Fails closed when RBAC cannot be enabled or no `RBACEnabler` is provided; legacy requests no longer bypass authorization.
  - Removes the “Disable RBAC” control and updates copy to clarify RBAC cannot be disabled; marks `/rpc/access.disableRBAC` as a legacy endpoint that always returns 400; updates OpenAPI, SDK comments, docs, and tests; wires `RBACEnabler` into server start/worker.

<sup>Written for commit b0620fe8c06ff05f623503742148a8e044418b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

