### PR TITLE
fix: keep version-manager shims out of codex install script tests

### DIFF
--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1082,19 +1082,44 @@ func execCodexInstallScript(t *testing.T, script []byte, home string) {
 
 	bashPath, err := exec.LookPath("bash")
 	require.NoError(t, err, "bash is required to run the generated install script")
-	pythonPath, err := exec.LookPath("python3")
-	require.NoError(t, err, "python3 is required by the generated install script")
 
-	scriptPath := filepath.Join(t.TempDir(), "install.sh")
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "install.sh")
 	require.NoError(t, os.WriteFile(scriptPath, script, 0o755))
 
 	cmd := exec.Command(bashPath, scriptPath)
+	// Run from outside the repository so nothing the script executes can pick
+	// up repo-local configuration by walking up from the working directory.
+	cmd.Dir = scriptDir
 	cmd.Env = []string{
 		"HOME=" + home,
-		"PATH=" + filepath.Dir(pythonPath) + ":/usr/bin:/bin",
+		"PATH=" + realPythonBinDir(t) + ":/usr/bin:/bin",
 	}
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "install script failed: %s", out)
+}
+
+// realPythonBinDir returns a directory whose only entry is a python3 symlink
+// pointing at the real interpreter. exec.LookPath can resolve python3 to a
+// version-manager shim (e.g. mise), and putting the shim directory on the
+// subprocess PATH breaks the test's isolation twice over: the directory holds
+// shims for every managed tool (including codex, defeating the stub), and each
+// shim re-execs the manager, which under the scrubbed HOME cannot see the
+// user's per-machine trust state and refuses to run at all. Asking the
+// interpreter for sys.executable pierces any shim.
+func realPythonBinDir(t *testing.T) string {
+	t.Helper()
+
+	pythonPath, err := exec.LookPath("python3")
+	require.NoError(t, err, "python3 is required by the generated install script")
+	out, err := exec.Command(pythonPath, "-c", "import sys; print(sys.executable)").Output()
+	require.NoError(t, err, "resolve the real python3 interpreter")
+	realPython := strings.TrimSpace(string(out))
+	require.NotEmpty(t, realPython, "sys.executable must not be empty")
+
+	dir := t.TempDir()
+	require.NoError(t, os.Symlink(realPython, filepath.Join(dir, "python3")))
+	return dir
 }
 
 func seededCodexInstallConfig(plugin, marketplace string, approvals []codexHookApproval) string {


### PR DESCRIPTION
## Root cause

The six `TestGenerateCodexInstallScript*` tests run the generated install script as a subprocess with a scrubbed environment (fake `HOME`, minimal `PATH`), but built that `PATH` from `filepath.Dir(exec.LookPath("python3"))`. On developer machines where `python3` resolves to a version-manager shim directory (e.g. mise shims), this breaks the harness's isolation twice:

- The shim directory carries shims for **every** managed tool — including `codex` — so the script's `command -v codex` found the shim instead of the test's stub at `~/.local/bin`.
- Every shim re-execs the version manager, which walks up from the subprocess cwd (inside the repo), finds the repo's mise config, and aborts with `Config files ... are not trusted` — the per-user trust store lives under the real `HOME` (`~/.local/state/mise`), which the scrubbed `HOME` hides. That's why a normal shell reports everything trusted while the test subprocess fails.

## Fix

Test harness only; no product behavior change:

- Resolve the real interpreter by asking Python for `sys.executable` (pierces any shim) and expose only a `python3` symlink to it in a private temp bin dir on the subprocess `PATH`.
- Run the script from a temp directory so nothing it executes can discover repo-local configuration by walking up from cwd.

## Testing

- `mise exec -- go test -race -run 'TestGenerateCodexInstallScript' ./server/internal/plugins/` — was failing all six on a clean checkout with mise-shimmed `python3`, now passes.
- `mise exec -- go test -race ./server/internal/plugins/` — passes.
- `mise lint:server` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the codex install script tests to bypass version‑manager shims and run from a temp directory. This restores isolation and fixes failures on machines with shimmed Python (e.g., mise).

- **Bug Fixes**
  - Expose only the real `python3` by resolving `sys.executable`, symlinking it into a private temp bin, and using that on PATH.
  - Run the script from a temp directory so nothing can pick up repo-local config by walking up from cwd.

<sup>Written for commit 9f0b1028276f03932d731fbf094b30d5a2855194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

