### PR TITLE
feat: loads new fields to CH

### DIFF
--- a/server/internal/risk/chrepo/queries.go
+++ b/server/internal/risk/chrepo/queries.go
@@ -19,27 +19,39 @@ var sq = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Question)
 // string, and one-way fingerprints. See internal/risk/finding_ch.go for how it
 // is populated and internal/risk/fingerprint.go for the fingerprint scheme.
 type RiskFindingRow struct {
-	ID                       uuid.UUID `ch:"id"`
-	CreatedAt                time.Time `ch:"created_at"`
-	OrganizationID           string    `ch:"organization_id"`
-	ProjectID                string    `ch:"project_id"`
-	RequestID                string    `ch:"request_id"`
-	ChatMessageID            string    `ch:"chat_message_id"`
-	RiskPolicyID             string    `ch:"risk_policy_id"`
-	RiskPolicyVersion        int64     `ch:"risk_policy_version"`
-	RuleID                   string    `ch:"rule_id"`
-	Description              string    `ch:"description"`
-	Source                   string    `ch:"source"`
-	Confidence               float64   `ch:"confidence"`
-	Tags                     []string  `ch:"tags"`
-	StartPos                 int32     `ch:"start_pos"`
-	EndPos                   int32     `ch:"end_pos"`
-	DeadLetterReason         string    `ch:"dead_letter_reason"`
-	MatchLen                 uint32    `ch:"match_len"`
-	MatchRedacted            string    `ch:"match_redacted"`
-	FingerprintPepperVersion string    `ch:"fingerprint_pepper_version"`
-	FingerprintGlobalHS256   string    `ch:"fingerprint_global_hs256"`
-	FingerprintTenantHS256   string    `ch:"fingerprint_tenant_hs256"`
+	ID                uuid.UUID `ch:"id"`
+	CreatedAt         time.Time `ch:"created_at"`
+	OrganizationID    string    `ch:"organization_id"`
+	ProjectID         string    `ch:"project_id"`
+	RequestID         string    `ch:"request_id"`
+	ChatMessageID     string    `ch:"chat_message_id"`
+	RiskPolicyID      string    `ch:"risk_policy_id"`
+	RiskPolicyVersion int64     `ch:"risk_policy_version"`
+	RuleID            string    `ch:"rule_id"`
+	Description       string    `ch:"description"`
+	Source            string    `ch:"source"`
+	Confidence        float64   `ch:"confidence"`
+	Tags              []string  `ch:"tags"`
+	StartPos          int32     `ch:"start_pos"`
+	EndPos            int32     `ch:"end_pos"`
+	DeadLetterReason  string    `ch:"dead_letter_reason"`
+
+	// Denormalized attribution, resolved from Postgres at ingest so
+	// session-level and per-user rollups never need a cross-store join. All
+	// empty when unresolved (missing message, deleted chat, lookup failure).
+	ChatID         string `ch:"chat_id"`
+	UserID         string `ch:"user_id"`
+	ExternalUserID string `ch:"external_user_id"`
+
+	// Category is the canonical risk category for (source, rule_id), computed
+	// via internal/risk/categories at ingest. Empty for dead-letter sentinels.
+	Category string `ch:"category"`
+
+	MatchLen                 uint32 `ch:"match_len"`
+	MatchRedacted            string `ch:"match_redacted"`
+	FingerprintPepperVersion string `ch:"fingerprint_pepper_version"`
+	FingerprintGlobalHS256   string `ch:"fingerprint_global_hs256"`
+	FingerprintTenantHS256   string `ch:"fingerprint_tenant_hs256"`
 
 	// Exclusion annotation: set when a going-forward exclusion suppressed the
 	// finding. Both nil when the finding is not excluded (maps to the Nullable
@@ -92,6 +104,10 @@ func (q *Queries) InsertRiskFindings(ctx context.Context, rows []RiskFindingRow)
 			"start_pos",
 			"end_pos",
 			"dead_letter_reason",
+			"chat_id",
+			"user_id",
+			"external_user_id",
+			"category",
 			"match_len",
 			"match_redacted",
 			"fingerprint_pepper_version",
@@ -119,6 +135,10 @@ func (q *Queries) InsertRiskFindings(ctx context.Context, rows []RiskFindingRow)
 			row.StartPos,
 			row.EndPos,
 			row.DeadLetterReason,
+			row.ChatID,
+			row.UserID,
+			row.ExternalUserID,
+			row.Category,
 			row.MatchLen,
 			row.MatchRedacted,
 			row.FingerprintPepperVersion,

--- a/server/internal/risk/chrepo_roundtrip_test.go
+++ b/server/internal/risk/chrepo_roundtrip_test.go
@@ -47,6 +47,10 @@ func TestInsertRiskFindings_RoundTrip(t *testing.T) {
 		StartPos:                 3,
 		EndPos:                   10,
 		DeadLetterReason:         "",
+		ChatID:                   uuid.NewString(),
+		UserID:                   "user-1",
+		ExternalUserID:           "user-1@example.com",
+		Category:                 "pii",
 		MatchLen:                 7,
 		MatchRedacted:            "<redacted len=7 sha=deadbeef>",
 		FingerprintPepperVersion: "v1",
@@ -71,7 +75,7 @@ func TestInsertRiskFindings_RoundTrip(t *testing.T) {
 	// flushes, so poll until both are visible.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		rows, err := conn.Query(t.Context(), `
-			SELECT id, tags, match_redacted, excluded_at, exclusion_id
+			SELECT id, tags, match_redacted, chat_id, user_id, external_user_id, category, excluded_at, exclusion_id
 			FROM risk_findings
 			WHERE organization_id = ?
 			ORDER BY created_at
@@ -81,29 +85,26 @@ func TestInsertRiskFindings_RoundTrip(t *testing.T) {
 		}
 		defer func() { _ = rows.Close() }()
 
-		got := map[uuid.UUID]struct {
-			tags        []string
-			redacted    string
-			excludedAt  *time.Time
-			exclusionID *uuid.UUID
-		}{}
+		type foundRow struct {
+			tags           []string
+			redacted       string
+			chatID         string
+			userID         string
+			externalUserID string
+			category       string
+			excludedAt     *time.Time
+			exclusionID    *uuid.UUID
+		}
+		got := map[uuid.UUID]foundRow{}
 		for rows.Next() {
 			var (
-				id       uuid.UUID
-				tags     []string
-				redacted string
-				exAt     *time.Time
-				exID     *uuid.UUID
+				id  uuid.UUID
+				row foundRow
 			)
-			if !assert.NoError(c, rows.Scan(&id, &tags, &redacted, &exAt, &exID)) {
+			if !assert.NoError(c, rows.Scan(&id, &row.tags, &row.redacted, &row.chatID, &row.userID, &row.externalUserID, &row.category, &row.excludedAt, &row.exclusionID)) {
 				return
 			}
-			got[id] = struct {
-				tags        []string
-				redacted    string
-				excludedAt  *time.Time
-				exclusionID *uuid.UUID
-			}{tags, redacted, exAt, exID}
+			got[id] = row
 		}
 
 		if !assert.Contains(c, got, plain.ID) || !assert.Contains(c, got, excluded.ID) {
@@ -113,6 +114,10 @@ func TestInsertRiskFindings_RoundTrip(t *testing.T) {
 		p := got[plain.ID]
 		assert.Equal(c, []string{"pii", "secret"}, p.tags, "tags array round-trips")
 		assert.Equal(c, plain.MatchRedacted, p.redacted)
+		assert.Equal(c, plain.ChatID, p.chatID, "attribution chat_id round-trips")
+		assert.Equal(c, plain.UserID, p.userID, "attribution user_id round-trips")
+		assert.Equal(c, plain.ExternalUserID, p.externalUserID, "attribution external_user_id round-trips")
+		assert.Equal(c, plain.Category, p.category, "category round-trips")
 		assert.Nil(c, p.excludedAt, "non-excluded row stores NULL excluded_at")
 		assert.Nil(c, p.exclusionID, "non-excluded row stores NULL exclusion_id")
 

--- a/server/internal/risk/finding_ch.go
+++ b/server/internal/risk/finding_ch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
@@ -42,7 +43,10 @@ type FindingCHWriter struct {
 	fingerprinter Fingerprinter
 
 	exclusionsCache *expirable.LRU[string, risk_analysis.ExclusionSet]
-	exclusionsDB    repo.DBTX
+
+	// db backs the per-batch Postgres reads: exclusion sets and chat message
+	// attribution. A read replica is fine — both are best-effort enrichment.
+	db repo.DBTX
 }
 
 const (
@@ -50,14 +54,14 @@ const (
 	exclusionsSetCacheTTL  = time.Minute
 )
 
-func NewFindingCHWriter(logger *slog.Logger, exclusionsDB repo.DBTX, meterProvider metric.MeterProvider, inserter RiskFindingInserter, fingerprinter Fingerprinter) *FindingCHWriter {
+func NewFindingCHWriter(logger *slog.Logger, db repo.DBTX, meterProvider metric.MeterProvider, inserter RiskFindingInserter, fingerprinter Fingerprinter) *FindingCHWriter {
 	logger = logger.With(attr.SlogComponent("finding-ch-writer"))
 	return &FindingCHWriter{
 		logger:          logger,
 		metrics:         newMetrics(meterProvider, logger),
 		inserter:        inserter,
 		fingerprinter:   fingerprinter,
-		exclusionsDB:    exclusionsDB,
+		db:              db,
 		exclusionsCache: expirable.NewLRU[string, risk_analysis.ExclusionSet](exclusionsSetCacheSize, nil, exclusionsSetCacheTTL),
 	}
 }
@@ -68,6 +72,11 @@ func (w *FindingCHWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 	// Cache per-tenant derived keys for the lifetime of this batch so repeated
 	// findings from the same org don't each re-run HKDF.
 	tenantKeyCache := make(map[string][]byte)
+
+	// Batch-resolve the denormalized attribution (chat id, user ids) for every
+	// finding that carries a well-formed chat_message_id — one Postgres query
+	// per batch, best-effort.
+	attribution := w.chatMessageAttribution(ctx, messages)
 
 	rows := make([]chrepo.RiskFindingRow, 0, len(messages))
 	for _, message := range messages {
@@ -170,6 +179,24 @@ func (w *FindingCHWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 			tags = []string{}
 		}
 
+		// Attribution is an enrichment: findings whose message id is absent,
+		// malformed, or unresolved keep empty strings rather than being dropped.
+		var chatID, userID, externalUserID string
+		if msgID, err := uuid.Parse(message.GetChatMessageId()); err == nil {
+			if a, ok := attribution[msgID]; ok {
+				chatID = a.ChatID.String()
+				userID = a.UserID
+				externalUserID = a.ExternalUserID
+			}
+		}
+
+		// Dead-letter sentinels carry no meaningful (source, rule_id), so they
+		// get no category instead of the classifier's "custom" fallback.
+		category := ""
+		if !deadLetter {
+			category = string(categories.Classify(message.GetSource(), message.GetRuleId()))
+		}
+
 		rows = append(rows, chrepo.RiskFindingRow{
 			ID:                       id,
 			CreatedAt:                createdAt.UTC(),
@@ -187,6 +214,10 @@ func (w *FindingCHWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 			StartPos:                 message.GetStartPos(),
 			EndPos:                   message.GetEndPos(),
 			DeadLetterReason:         message.GetDeadLetterReason(),
+			ChatID:                   chatID,
+			UserID:                   userID,
+			ExternalUserID:           externalUserID,
+			Category:                 category,
 			MatchLen:                 matchLen,
 			MatchRedacted:            matchRedacted,
 			FingerprintPepperVersion: pepperVersion,
@@ -211,6 +242,42 @@ func (w *FindingCHWriter) HandleBatch(ctx context.Context, messages []*riskv1.Fi
 	w.metrics.RecordFindingCHInserts(ctx, len(rows), o11y.OutcomeFromError(err))
 
 	return nil
+}
+
+// chatMessageAttribution batch-fetches the denormalized attribution stamped
+// onto risk_findings rows, keyed by chat message id. Fail-open like the
+// exclusion lookup: message ids that are empty, malformed, or fail to resolve
+// simply get no attribution; a query error logs and enriches nothing rather
+// than dropping or redriving findings.
+func (w *FindingCHWriter) chatMessageAttribution(ctx context.Context, messages []*riskv1.Finding) map[uuid.UUID]repo.GetChatMessageAttributionRow {
+	ids := make([]uuid.UUID, 0, len(messages))
+	seen := make(map[uuid.UUID]struct{}, len(messages))
+	for _, message := range messages {
+		id, err := uuid.Parse(message.GetChatMessageId())
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	rows, err := repo.New(w.db).GetChatMessageAttribution(ctx, ids)
+	if err != nil {
+		w.logger.ErrorContext(ctx, "resolve chat message attribution", attr.SlogError(err))
+		return nil
+	}
+
+	out := make(map[uuid.UUID]repo.GetChatMessageAttributionRow, len(rows))
+	for _, row := range rows {
+		out[row.ID] = row
+	}
+	return out
 }
 
 // matchedExclusion returns the id of the going-forward exclusion that
@@ -269,7 +336,7 @@ func (w *FindingCHWriter) exclusionSetFor(ctx context.Context, projectID, policy
 		return risk_analysis.ExclusionSet{}
 	}
 
-	exclusions, err := repo.New(w.exclusionsDB).ListEnabledExclusionsForPolicy(ctx, repo.ListEnabledExclusionsForPolicyParams{
+	exclusions, err := repo.New(w.db).ListEnabledExclusionsForPolicy(ctx, repo.ListEnabledExclusionsForPolicyParams{
 		ProjectID:    projectUUID,
 		RiskPolicyID: uuid.NullUUID{UUID: policyUUID, Valid: true},
 	})

--- a/server/internal/risk/finding_ch_test.go
+++ b/server/internal/risk/finding_ch_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	ra "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
@@ -164,6 +165,14 @@ func TestFindingCHWriter_HandleBatch_MapsAllFields(t *testing.T) {
 	require.Empty(t, row.DeadLetterReason)
 	require.True(t, time.Date(2026, 6, 27, 12, 30, 0, 0, time.UTC).Equal(row.CreatedAt))
 
+	// "chat-1" is not a UUID, so attribution resolution is skipped and the
+	// denormalized fields stay empty. The classifier still runs: ("input",
+	// "rule-1") matches nothing and falls back to custom.
+	require.Empty(t, row.ChatID)
+	require.Empty(t, row.UserID)
+	require.Empty(t, row.ExternalUserID)
+	require.Equal(t, "custom", row.Category)
+
 	// Hashes-only: the raw match is never stored, only its length + redaction.
 	require.Equal(t, uint32(len("hunter2")), row.MatchLen)
 	require.Equal(t, wantRedacted(t, "org-1", "hunter2"), row.MatchRedacted)
@@ -229,6 +238,32 @@ func TestFindingCHWriter_HandleBatch_DeadLetterSuppressesFingerprintsAndRedactio
 	require.Empty(t, row.FingerprintTenantHS256)
 	require.Empty(t, row.MatchRedacted)
 	require.Equal(t, uint32(0), row.MatchLen)
+	require.Empty(t, row.Category, "dead-letter sentinels get no category, not the custom fallback")
+}
+
+func TestFindingCHWriter_HandleBatch_ClassifiesCategory(t *testing.T) {
+	t.Parallel()
+
+	w, ins := newCHWriter(t)
+
+	pii := chFinding()
+	pii.SetSource("presidio")
+	pii.SetRuleId("pii.email_address")
+
+	secret := chFinding()
+	secret.SetSource("gitleaks")
+	secret.SetRuleId("secret.aws_access_key")
+
+	require.NoError(t, w.HandleBatch(context.Background(), []*riskv1.Finding{pii, secret}, nil))
+
+	rows := chRows(t, ins)
+	require.Len(t, rows, 2)
+	byID := map[uuid.UUID]chrepo.RiskFindingRow{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+	require.Equal(t, "pii", byID[uuid.MustParse(pii.GetId())].Category)
+	require.Equal(t, "secrets", byID[uuid.MustParse(secret.GetId())].Category)
 }
 
 func TestFindingCHWriter_HandleBatch_TenantFingerprintRequiresOrg(t *testing.T) {
@@ -376,6 +411,88 @@ func TestFindingCHWriter_HandleBatch_AnnotatesExcludedFindings(t *testing.T) {
 	keptRow := byID[uuid.MustParse(kept.GetId())]
 	require.Nil(t, keptRow.ExclusionID, "non-excluded finding must not carry an exclusion id")
 	require.Nil(t, keptRow.ExcludedAt, "non-excluded finding must not carry excluded_at")
+}
+
+// Integration test against a real Postgres: the writer batch-resolves the
+// denormalized attribution (chat id, user ids) for findings that reference a
+// real chat message. Message-level ids win over chat-level ids; unresolvable
+// message ids leave the attribution empty without dropping the finding.
+func TestFindingCHWriter_HandleBatch_ResolvesAttribution(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestRiskService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	queries := riskrepo.New(ti.conn)
+	chatID, err := queries.CreateChatForTest(t.Context(), riskrepo.CreateChatForTestParams{
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText("chat-user"),
+		ExternalUserID: conv.ToPGText("chat-user@example.com"),
+	})
+	require.NoError(t, err)
+
+	// Message with its own attribution: message-level ids win over the chat's.
+	msgOwn, err := queries.CreateChatMessageForTest(t.Context(), riskrepo.CreateChatMessageForTestParams{
+		ChatID:         chatID,
+		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		Content:        "hello",
+		UserID:         conv.ToPGText("msg-user"),
+		ExternalUserID: conv.ToPGText("msg-user@example.com"),
+	})
+	require.NoError(t, err)
+
+	// Message without its own attribution: falls back to the chat's ids.
+	msgFallback, err := queries.CreateChatMessageForTest(t.Context(), riskrepo.CreateChatMessageForTestParams{
+		ChatID:         chatID,
+		ProjectID:      uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		Content:        "hello again",
+		UserID:         conv.ToPGTextEmpty(""),
+		ExternalUserID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+
+	ins := &fakeCHInserter{}
+	fp, err := risk.ParsePepperKeyRing(keyRingJSON(t, testPepperVersion, map[string][]byte{testPepperVersion: testPepperKey}))
+	require.NoError(t, err)
+	w := risk.NewFindingCHWriter(testenv.NewLogger(t), ti.conn, testenv.NewMeterProvider(t), ins, fp)
+
+	own := chFinding()
+	own.SetChatMessageId(msgOwn.String())
+
+	fallback := chFinding()
+	fallback.SetChatMessageId(msgFallback.String())
+
+	// Well-formed UUID that matches no chat message: enrichment resolves
+	// nothing, the finding still inserts with empty attribution.
+	unknown := chFinding()
+	unknown.SetChatMessageId(uuid.Must(uuid.NewV7()).String())
+
+	require.NoError(t, w.HandleBatch(ctx, []*riskv1.Finding{own, fallback, unknown}, nil))
+
+	rows := chRows(t, ins)
+	require.Len(t, rows, 3)
+	byID := map[uuid.UUID]chrepo.RiskFindingRow{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+
+	ownRow := byID[uuid.MustParse(own.GetId())]
+	require.Equal(t, chatID.String(), ownRow.ChatID)
+	require.Equal(t, "msg-user", ownRow.UserID)
+	require.Equal(t, "msg-user@example.com", ownRow.ExternalUserID)
+
+	fallbackRow := byID[uuid.MustParse(fallback.GetId())]
+	require.Equal(t, chatID.String(), fallbackRow.ChatID)
+	require.Equal(t, "chat-user", fallbackRow.UserID)
+	require.Equal(t, "chat-user@example.com", fallbackRow.ExternalUserID)
+
+	unknownRow := byID[uuid.MustParse(unknown.GetId())]
+	require.Empty(t, unknownRow.ChatID)
+	require.Empty(t, unknownRow.UserID)
+	require.Empty(t, unknownRow.ExternalUserID)
 }
 
 // chMessagesInsertedPoint returns the single data point for the CH

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -1543,6 +1543,31 @@ WHERE project_id = @project_id
   AND deleted IS FALSE
 RETURNING *;
 
+-- name: GetChatMessageAttribution :many
+-- Resolves the denormalized attribution (chat id, user ids) the ClickHouse
+-- finding writer stamps on risk_findings rows at ingest. Message-level ids win
+-- over chat-level ids; both empty and NULL collapse to ''.
+SELECT
+    cm.id
+  , cm.chat_id
+  , COALESCE(NULLIF(cm.user_id, ''), NULLIF(c.user_id, ''), '')::text AS user_id
+  , COALESCE(NULLIF(cm.external_user_id, ''), NULLIF(c.external_user_id, ''), '')::text AS external_user_id
+FROM chat_messages cm
+LEFT JOIN chats c
+  ON c.id = cm.chat_id
+  AND c.deleted IS FALSE
+WHERE cm.id = ANY(@ids::uuid[]);
+
+-- name: CreateChatForTest :one
+INSERT INTO chats (project_id, organization_id, user_id, external_user_id)
+VALUES (@project_id, @organization_id, @user_id, @external_user_id)
+RETURNING id;
+
+-- name: CreateChatMessageForTest :one
+INSERT INTO chat_messages (chat_id, project_id, role, content, user_id, external_user_id)
+VALUES (@chat_id, @project_id, 'user', @content, @user_id, @external_user_id)
+RETURNING id;
+
 -- name: SetRiskResultExcludedForTest :exec
 UPDATE risk_results
 SET excluded_at = clock_timestamp()

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -440,6 +440,58 @@ func (q *Queries) CountTotalMessages(ctx context.Context, projectID uuid.NullUUI
 	return column_1, err
 }
 
+const createChatForTest = `-- name: CreateChatForTest :one
+INSERT INTO chats (project_id, organization_id, user_id, external_user_id)
+VALUES ($1, $2, $3, $4)
+RETURNING id
+`
+
+type CreateChatForTestParams struct {
+	ProjectID      uuid.UUID
+	OrganizationID string
+	UserID         pgtype.Text
+	ExternalUserID pgtype.Text
+}
+
+func (q *Queries) CreateChatForTest(ctx context.Context, arg CreateChatForTestParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, createChatForTest,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.UserID,
+		arg.ExternalUserID,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const createChatMessageForTest = `-- name: CreateChatMessageForTest :one
+INSERT INTO chat_messages (chat_id, project_id, role, content, user_id, external_user_id)
+VALUES ($1, $2, 'user', $3, $4, $5)
+RETURNING id
+`
+
+type CreateChatMessageForTestParams struct {
+	ChatID         uuid.UUID
+	ProjectID      uuid.NullUUID
+	Content        string
+	UserID         pgtype.Text
+	ExternalUserID pgtype.Text
+}
+
+func (q *Queries) CreateChatMessageForTest(ctx context.Context, arg CreateChatMessageForTestParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, createChatMessageForTest,
+		arg.ChatID,
+		arg.ProjectID,
+		arg.Content,
+		arg.UserID,
+		arg.ExternalUserID,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const createCustomDetectionRule = `-- name: CreateCustomDetectionRule :one
 INSERT INTO risk_custom_detection_rules (
     project_id
@@ -1022,6 +1074,54 @@ func (q *Queries) GetBatchChatIdentities(ctx context.Context, arg GetBatchChatId
 			&i.AccountType,
 			&i.Email,
 			&i.FlaggedRuleIds,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getChatMessageAttribution = `-- name: GetChatMessageAttribution :many
+SELECT
+    cm.id
+  , cm.chat_id
+  , COALESCE(NULLIF(cm.user_id, ''), NULLIF(c.user_id, ''), '')::text AS user_id
+  , COALESCE(NULLIF(cm.external_user_id, ''), NULLIF(c.external_user_id, ''), '')::text AS external_user_id
+FROM chat_messages cm
+LEFT JOIN chats c
+  ON c.id = cm.chat_id
+  AND c.deleted IS FALSE
+WHERE cm.id = ANY($1::uuid[])
+`
+
+type GetChatMessageAttributionRow struct {
+	ID             uuid.UUID
+	ChatID         uuid.UUID
+	UserID         string
+	ExternalUserID string
+}
+
+// Resolves the denormalized attribution (chat id, user ids) the ClickHouse
+// finding writer stamps on risk_findings rows at ingest. Message-level ids win
+// over chat-level ids; both empty and NULL collapse to ”.
+func (q *Queries) GetChatMessageAttribution(ctx context.Context, ids []uuid.UUID) ([]GetChatMessageAttributionRow, error) {
+	rows, err := q.db.Query(ctx, getChatMessageAttribution, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetChatMessageAttributionRow
+	for rows.Next() {
+		var i GetChatMessageAttributionRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ChatID,
+			&i.UserID,
+			&i.ExternalUserID,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add denormalized attribution and a computed category to ClickHouse `risk_findings` at ingest to enable user/session rollups without cross-store joins. Attribution is batch-resolved from Postgres by chat message id; dead-letter findings keep `category` empty.

- **New Features**
  - Added `chat_id`, `user_id`, `external_user_id`, and `category` to `chrepo.RiskFindingRow` and the ClickHouse insert.
  - Compute `category` via `internal/risk/categories` for `(source, rule_id)`; empty for dead-letter sentinels.
  - Batch-resolve attribution via `repo.GetChatMessageAttribution` (message-level IDs override chat-level; fallback to chat; best-effort, one query per batch).
  - Tests updated: field mapping, category classification, attribution integration, and ClickHouse roundtrip.

- **Refactors**
  - Consolidated Postgres access in `FindingCHWriter` to a single `db` used for exclusions and attribution.

<sup>Written for commit 68f1cc8b5a436f7515b9d787e75cf7455ebcd08a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

