### PR TITLE
fix: friendly error state for dead skill share links, redact tokens in crash screen

### DIFF
--- a/.changeset/shared-skill-error-state.md
+++ b/.changeset/shared-skill-error-state.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Dead or mistyped public skill share links now show the page's friendly "This skill isn't available" state instead of the full-page crash screen. The crash screen's debug details also redact capability tokens from error messages and request URLs so a share token is never displayed verbatim.

--- a/client/dashboard/src/components/full-page-error.test.tsx
+++ b/client/dashboard/src/components/full-page-error.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FullPageError } from "./full-page-error";
+
+describe("FullPageError", () => {
+  afterEach(cleanup);
+
+  it("redacts token query parameters in the error message", () => {
+    render(
+      <FullPageError
+        error={
+          new Error(
+            "GET https://app.example.com/rpc/skills.getShared?token=supersecrettoken failed",
+          )
+        }
+      />,
+    );
+
+    expect(screen.queryByText(/supersecrettoken/)).toBeNull();
+    expect(screen.getByText(/token=REDACTED/)).toBeDefined();
+  });
+
+  it("redacts shared skill path tokens in the error message", () => {
+    render(
+      <FullPageError
+        error={new Error("failed loading /shared/skills/supersecrettoken")}
+      />,
+    );
+
+    expect(screen.queryByText(/supersecrettoken/)).toBeNull();
+    expect(screen.getByText(/\/shared\/skills\/REDACTED/)).toBeDefined();
+  });
+});

--- a/client/dashboard/src/components/full-page-error.tsx
+++ b/client/dashboard/src/components/full-page-error.tsx
@@ -6,6 +6,16 @@ interface FullPageErrorProps {
   error: unknown;
 }
 
+// Several public capability-URL endpoints carry a live credential in a
+// "token" query parameter (e.g. skills.getShared) or as the path segment
+// after /shared/skills/. Error messages and request URLs shown in this
+// debug box must never display them verbatim.
+function redactTokens(text: string): string {
+  return text
+    .replace(/([?&]token=)[^&\s]+/g, "$1REDACTED")
+    .replace(/(\/shared\/skills\/)[^/?\s]+/g, "$1REDACTED");
+}
+
 export function FullPageError({
   error: rawError,
 }: FullPageErrorProps): JSX.Element {
@@ -28,13 +38,13 @@ export function FullPageError({
 
           <div className="bg-muted w-full rounded-md p-3">
             <p className="text-muted-foreground font-mono text-xs break-all">
-              {error.message}
+              {redactTokens(error.message)}
             </p>
             {"rawResponse" in error &&
               error.rawResponse instanceof Response &&
               error.rawResponse.url && (
                 <p className="text-muted-foreground mt-2 font-mono text-xs break-all">
-                  {error.rawResponse.url}
+                  {redactTokens(error.rawResponse.url)}
                 </p>
               )}
           </div>

--- a/client/dashboard/src/pages/skills/SharedSkillPage.test.tsx
+++ b/client/dashboard/src/pages/skills/SharedSkillPage.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SharedSkillPage } from "./SharedSkillPage";
+
+const testState = vi.hoisted(() => ({
+  query: {
+    isPending: false,
+    error: null as Error | null,
+    data: undefined as { result: Record<string, unknown> } | undefined,
+  },
+  lastOptions: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ token: "tok_test" }),
+}));
+vi.mock("@gram/client/react-query/sharedSkill.js", () => ({
+  useSharedSkill: (
+    _request: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => {
+    testState.lastOptions = options;
+    return testState.query;
+  },
+}));
+
+describe("SharedSkillPage", () => {
+  afterEach(() => {
+    cleanup();
+    testState.query = { isPending: false, error: null, data: undefined };
+  });
+
+  it("renders the friendly unavailable state on query error instead of throwing", () => {
+    testState.query = {
+      isPending: false,
+      error: new Error("link not found or no longer available"),
+      data: undefined,
+    };
+
+    render(<SharedSkillPage />);
+
+    expect(screen.getByText("This skill isn't available")).toBeDefined();
+    // The raw server error (and anything token-shaped) must not render.
+    expect(screen.queryByText(/link not found/)).toBeNull();
+    expect(screen.queryByText(/tok_test/)).toBeNull();
+  });
+
+  it("opts out of the global throwOnError default so a dead link never hits the crash boundary", () => {
+    render(<SharedSkillPage />);
+
+    expect(testState.lastOptions?.throwOnError).toBe(false);
+  });
+
+  it("renders the shared skill document on success", () => {
+    testState.query = {
+      isPending: false,
+      error: null,
+      data: {
+        result: {
+          name: "example",
+          displayName: "Example Skill",
+          summary: "A summary.",
+          content: "---\nname: example\n---\n# Body",
+          updatedAt: new Date("2026-07-16T00:00:00Z"),
+        },
+      },
+    };
+
+    render(<SharedSkillPage />);
+
+    expect(screen.getByText("Example Skill")).toBeDefined();
+  });
+});

--- a/client/dashboard/src/pages/skills/SharedSkillPage.tsx
+++ b/client/dashboard/src/pages/skills/SharedSkillPage.tsx
@@ -42,6 +42,11 @@ function SharedSkillBody({ token }: { token: string | undefined }) {
       enabled: !!token,
       retry: false,
       refetchOnWindowFocus: false,
+      // The QueryClient default rethrows non-403 errors to the nearest error
+      // boundary, which for this standalone page is the full-page crash
+      // screen. A dead or mistyped link is an expected state here — handle
+      // it inline with the friendly unavailable panel instead.
+      throwOnError: false,
     },
   );
 
@@ -126,12 +131,14 @@ function SharedSkillDocument({ skill }: { skill: SharedSkill2 }): JSX.Element {
 
 function SharedSkillUnavailable(): JSX.Element {
   return (
-    <Stack gap={2} align="center" className="py-24">
+    <Stack gap={3} align="center" className="py-24">
+      <Icon name="link-2-off" className="text-muted-foreground size-8" />
       <Type variant="subheading" className="text-center">
         This skill isn't available
       </Type>
       <Type muted small className="max-w-md text-center">
-        The link may have been turned off or the address is wrong.
+        The link may have been turned off by its owner, or the address might not
+        be quite right. Ask whoever shared it with you for a fresh link.
       </Type>
     </Stack>
   );


### PR DESCRIPTION
## Summary

Fixes the ugly crash screen when opening a revoked or mistyped public skill share link (screenshot in thread): the visitor now gets `SharedSkillPage`'s friendly "This skill isn't available" panel.

**Root cause:** the page's query options never overrode the QueryClient's global `throwOnError` default (which rethrows all non-403 errors to the nearest error boundary), so the 404 from `skills.getShared` threw during render — before the page's own `if (query.error)` branch could handle it — and landed on `FullPageError`, whose debug box printed the failing request URL **including the share token**.

## Changes

- `SharedSkillPage`: `throwOnError: false` on the query; dead links render the friendly panel (copy warmed up, icon added). Regression tests assert the error state renders, the opt-out is set, and no raw error/token text appears.
- `FullPageError`: debug details now redact `token` query params and `/shared/skills/<token>` path segments from error messages and request URLs (mirrors the server-side `logSafeURL` redaction). Covers any other tokenized endpoint whose error surfaces there.

Note on exposure severity: the token shown was the viewer's own (they navigated with it), and telemetry is disabled on `/shared/*`, so this wasn't a cross-user leak — but the crash box should never display credentials regardless.

## Verification

- New tests: `SharedSkillPage.test.tsx` (3) and `full-page-error.test.tsx` (2) — pass.
- `tsc -b --noEmit --force` (CI-exact), `pnpm -F dashboard lint`, knip — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141ZwLrsFPSHeaZhoGDqSDT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a friendly “This skill isn’t available” page for revoked or mistyped public skill share links instead of crashing. Also redacts capability tokens from crash screen details.

- **Bug Fixes**
  - `SharedSkillPage`: sets `throwOnError: false` so 404s render the friendly panel (copy updated, icon added).
  - `FullPageError`: redacts `token` query params and `/shared/skills/<token>` path segments in error messages and URLs.
  - Tests cover the unavailable state, the opt-out, and token redaction.

<sup>Written for commit 852c317cc4bb18e785b2e1c60762629ec0ad9cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

