### PR TITLE
fix: preserve protected-resource scopes for remote MCP OAuth

### DIFF
--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet.tsx
@@ -63,6 +63,7 @@ export function AttachRemoteIdentityProviderSheet({
   userSessionIssuer,
   selectableIssuers,
   initialIssuerUrl,
+  initialScopes,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -80,6 +81,9 @@ export function AttachRemoteIdentityProviderSheet({
   // in "new" mode and runs RFC 8414 discovery against this URL to prefill the
   // upstream endpoints.
   initialIssuerUrl?: string;
+  // RFC 9728 protected-resource scopes. Some providers advertise these only
+  // on the protected resource, not in authorization-server metadata.
+  initialScopes?: string[];
 }): JSX.Element {
   const client = useSdkClient();
   const { fetch: authedFetch } = useFetcher();
@@ -435,7 +439,7 @@ export function AttachRemoteIdentityProviderSheet({
     setClientId("");
     setClientSecret("");
     setTokenEndpointAuthMethod("");
-    setScopeOverride("");
+    setScopeOverride(initialScopes?.join(", ") ?? "");
     setAudienceOverride("");
     setClientMode("select");
     setSelectedClientId("");
@@ -444,6 +448,7 @@ export function AttachRemoteIdentityProviderSheet({
     open,
     target.slug,
     initialIssuerUrl,
+    initialScopes,
     hasSelectable,
     setIssuerUrl,
     resetEndpointState,

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthenticationSectionBody } from "./AuthenticationSection";
+import type { AuthTarget } from "./authTarget";
+
+const { useProtectedResourceMetadata, useAllRemoteSessionClients } = vi.hoisted(
+  () => ({
+    useProtectedResourceMetadata: vi.fn(),
+    useAllRemoteSessionClients: vi.fn(),
+  }),
+);
+
+vi.mock("@gram/client/react-query/userSessionIssuer.js", () => ({
+  useUserSessionIssuer: () => ({
+    data: { id: "user-session-issuer" },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/remoteSessionIssuers.js", () => ({
+  useRemoteSessionIssuers: () => ({
+    data: { result: { items: [] } },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("./useAllRemoteSessionClients", () => ({
+  useAllRemoteSessionClients: (...args: unknown[]) =>
+    useAllRemoteSessionClients(...args),
+}));
+
+vi.mock("./useProtectedResourceMetadata", () => ({
+  useProtectedResourceMetadata: (...args: unknown[]) =>
+    useProtectedResourceMetadata(...args),
+}));
+
+vi.mock("./AttachRemoteIdentityProviderSheet", () => ({
+  AttachRemoteIdentityProviderSheet: ({
+    open,
+    initialIssuerUrl,
+    initialScopes,
+  }: {
+    open: boolean;
+    initialIssuerUrl?: string;
+    initialScopes?: string[];
+  }) =>
+    open ? (
+      <output>
+        {initialIssuerUrl}|{initialScopes?.join(" ")}
+      </output>
+    ) : null,
+}));
+
+vi.mock("./RemoteIdentityProvidersField", () => ({
+  RemoteIdentityProvidersField: ({ onAdd }: { onAdd: () => void }) => (
+    <button onClick={onAdd}>Add provider</button>
+  ),
+}));
+
+vi.mock("./UserSessionDurationField", () => ({
+  UserSessionDurationField: () => null,
+}));
+
+vi.mock("./McpServerSessionsPanel", () => ({
+  McpServerSessionsPanel: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AuthenticationSectionBody", () => {
+  it("preserves protected-resource scopes when recovering an unconfigured remote server", () => {
+    useAllRemoteSessionClients.mockReturnValue({
+      items: [],
+      isLoading: false,
+    });
+    useProtectedResourceMetadata.mockReturnValue({
+      status: "available",
+      metadata: {
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: ["resource.read", "resource.write"],
+      },
+    });
+
+    render(<AuthenticationSectionBody target={remoteTarget} />);
+
+    expect(useProtectedResourceMetadata).toHaveBeenCalledWith(
+      "remote-mcp-server",
+      true,
+    );
+
+    fireEvent.click(screen.getByText("Add provider"));
+
+    expect(
+      screen.getByText("https://auth.example.com|resource.read resource.write"),
+    ).toBeDefined();
+  });
+
+  it("does not probe configured remote servers that already have a client", () => {
+    useAllRemoteSessionClients.mockReturnValue({
+      items: [{ id: "remote-session-client" }],
+      isLoading: false,
+    });
+    useProtectedResourceMetadata.mockReturnValue({
+      status: "idle",
+      metadata: null,
+    });
+
+    render(<AuthenticationSectionBody target={remoteTarget} />);
+
+    expect(useProtectedResourceMetadata).toHaveBeenCalledWith(
+      "remote-mcp-server",
+      false,
+    );
+  });
+});
+
+const remoteTarget: AuthTarget = {
+  slug: "remote-server",
+  userSessionIssuerId: "user-session-issuer",
+  remoteMcpServerId: "remote-mcp-server",
+  invalidate: vi.fn(),
+};

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -1,21 +1,20 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthenticationSectionBody } from "./AuthenticationSection";
 import type { AuthTarget } from "./authTarget";
 
-const { useProtectedResourceMetadata, useAllRemoteSessionClients } = vi.hoisted(
-  () => ({
-    useProtectedResourceMetadata: vi.fn(),
-    useAllRemoteSessionClients: vi.fn(),
-  }),
-);
+const {
+  useProtectedResourceMetadata,
+  useAllRemoteSessionClients,
+  useUserSessionIssuer,
+} = vi.hoisted(() => ({
+  useProtectedResourceMetadata: vi.fn(),
+  useAllRemoteSessionClients: vi.fn(),
+  useUserSessionIssuer: vi.fn(),
+}));
 
 vi.mock("@gram/client/react-query/userSessionIssuer.js", () => ({
-  useUserSessionIssuer: () => ({
-    data: { id: "user-session-issuer" },
-    isLoading: false,
-    isError: false,
-  }),
+  useUserSessionIssuer: (...args: unknown[]) => useUserSessionIssuer(...args),
 }));
 
 vi.mock("@gram/client/react-query/remoteSessionIssuers.js", () => ({
@@ -62,6 +61,14 @@ vi.mock("./RemoteIdentityProvidersField", () => ({
   ),
 }));
 
+vi.mock("./AuthenticationSetupActions", () => ({
+  AuthenticationSetupActions: ({
+    onUseDiscovered,
+  }: {
+    onUseDiscovered: () => void;
+  }) => <button onClick={onUseDiscovered}>Use Discovered</button>,
+}));
+
 vi.mock("./DeleteRemoteIdentityProviderDialog", () => ({
   DeleteRemoteIdentityProviderDialog: () => null,
 }));
@@ -78,13 +85,21 @@ vi.mock("./McpServerSessionsPanel", () => ({
   McpServerSessionsPanel: () => null,
 }));
 
+beforeEach(() => {
+  useUserSessionIssuer.mockReturnValue({
+    data: { id: "user-session-issuer" },
+    isLoading: false,
+    isError: false,
+  });
+});
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
 describe("AuthenticationSectionBody", () => {
-  it("preserves protected-resource scopes when recovering an unconfigured remote server", () => {
+  it("preserves scopes when a remote server has a session issuer but no upstream client", () => {
     useAllRemoteSessionClients.mockReturnValue({
       items: [],
       isLoading: false,
@@ -97,7 +112,9 @@ describe("AuthenticationSectionBody", () => {
       },
     });
 
-    render(<AuthenticationSectionBody target={remoteTarget} />);
+    render(
+      <AuthenticationSectionBody target={remoteTargetWithSessionIssuer} />,
+    );
 
     expect(useProtectedResourceMetadata).toHaveBeenCalledWith(
       "remote-mcp-server",
@@ -105,6 +122,40 @@ describe("AuthenticationSectionBody", () => {
     );
 
     fireEvent.click(screen.getByText("Add provider"));
+
+    expect(
+      screen.getByText("https://auth.example.com|resource.read resource.write"),
+    ).toBeDefined();
+  });
+
+  it("preserves scopes during first-time setup without a session issuer", () => {
+    useUserSessionIssuer.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    });
+    useAllRemoteSessionClients.mockReturnValue({
+      items: [],
+      isLoading: false,
+    });
+    useProtectedResourceMetadata.mockReturnValue({
+      status: "available",
+      metadata: {
+        authorizationServers: ["https://auth.example.com"],
+        scopesSupported: ["resource.read", "resource.write"],
+      },
+    });
+
+    render(
+      <AuthenticationSectionBody target={remoteTargetWithoutSessionIssuer} />,
+    );
+
+    expect(useProtectedResourceMetadata).toHaveBeenCalledWith(
+      "remote-mcp-server",
+      true,
+    );
+
+    fireEvent.click(screen.getByText("Use Discovered"));
 
     expect(
       screen.getByText("https://auth.example.com|resource.read resource.write"),
@@ -121,7 +172,9 @@ describe("AuthenticationSectionBody", () => {
       metadata: null,
     });
 
-    render(<AuthenticationSectionBody target={remoteTarget} />);
+    render(
+      <AuthenticationSectionBody target={remoteTargetWithSessionIssuer} />,
+    );
 
     expect(useProtectedResourceMetadata).toHaveBeenCalledWith(
       "remote-mcp-server",
@@ -130,9 +183,14 @@ describe("AuthenticationSectionBody", () => {
   });
 });
 
-const remoteTarget: AuthTarget = {
+const remoteTargetWithSessionIssuer: AuthTarget = {
   slug: "remote-server",
   userSessionIssuerId: "user-session-issuer",
   remoteMcpServerId: "remote-mcp-server",
   invalidate: vi.fn(),
+};
+
+const remoteTargetWithoutSessionIssuer: AuthTarget = {
+  ...remoteTargetWithSessionIssuer,
+  userSessionIssuerId: null,
 };

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -62,6 +62,14 @@ vi.mock("./RemoteIdentityProvidersField", () => ({
   ),
 }));
 
+vi.mock("./DeleteRemoteIdentityProviderDialog", () => ({
+  DeleteRemoteIdentityProviderDialog: () => null,
+}));
+
+vi.mock("./ModifyRemoteIdentityProviderSheet", () => ({
+  ModifyRemoteIdentityProviderSheet: () => null,
+}));
+
 vi.mock("./UserSessionDurationField", () => ({
   UserSessionDurationField: () => null,
 }));

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -25,6 +25,10 @@ vi.mock("@gram/client/react-query/remoteSessionIssuers.js", () => ({
   }),
 }));
 
+vi.mock("./authTarget", () => ({
+  useMcpServerAuthTarget: vi.fn(),
+}));
+
 vi.mock("./useAllRemoteSessionClients", () => ({
   useAllRemoteSessionClients: (...args: unknown[]) =>
     useAllRemoteSessionClients(...args),

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -88,14 +88,6 @@ export function AuthenticationSectionBody({
     enabled: issuerConfigured,
   });
 
-  // Probe protected-resource metadata so setup can offer discovery when the
-  // server advertises OAuth metadata. Idle for targets with no probeable
-  // upstream (tunneled, toolset-backed).
-  const { status: probeStatus, metadata: protectedResourceMetadata } =
-    useProtectedResourceMetadata(target.remoteMcpServerId, !issuerConfigured);
-  const authorizationServer =
-    protectedResourceMetadata?.authorizationServers?.[0];
-
   // listRemoteSessionIssuers returns both this project's issuers and inherited
   // organization-level ones (project_id IS NULL, same org), so the selectable
   // list spans organizational and project-scoped providers.
@@ -111,6 +103,23 @@ export function AuthenticationSectionBody({
       { userSessionIssuerId },
       { enabled: issuerConfigured },
     );
+
+  // Remote MCP servers receive a user-session issuer when they are created,
+  // before any upstream OAuth client is attached. Keep protected-resource
+  // discovery available in that recovery state so providers that advertise
+  // scopes only in RFC 9728 metadata can still be configured manually.
+  const shouldProbeProtectedResource =
+    !!target.remoteMcpServerId &&
+    (!issuerConfigured || (!isLoadingClients && allClients.length === 0));
+  const { status: probeStatus, metadata: protectedResourceMetadata } =
+    useProtectedResourceMetadata(
+      target.remoteMcpServerId,
+      shouldProbeProtectedResource,
+    );
+  const authorizationServer =
+    protectedResourceMetadata?.authorizationServers?.[0];
+  const protectedResourceScopes =
+    protectedResourceMetadata?.scopesSupported ?? [];
 
   const associatedIssuerIds = useMemo(
     () => new Set(allClients.map((client) => client.remoteSessionIssuerId)),
@@ -129,9 +138,11 @@ export function AuthenticationSectionBody({
 
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetInitialUrl, setSheetInitialUrl] = useState<string | undefined>();
+  const [sheetInitialScopes, setSheetInitialScopes] = useState<string[]>();
 
-  const openSheet = (initialIssuerUrl?: string) => {
+  const openSheet = (initialIssuerUrl?: string, initialScopes?: string[]) => {
     setSheetInitialUrl(initialIssuerUrl);
+    setSheetInitialScopes(initialScopes);
     setSheetOpen(true);
   };
 
@@ -162,7 +173,9 @@ export function AuthenticationSectionBody({
       <IdentityProviderSetupField
         probeStatus={probeStatus}
         hasDiscoveredAuthorizationServer={!!authorizationServer}
-        onUseDiscovered={() => openSheet(authorizationServer)}
+        onUseDiscovered={() =>
+          openSheet(authorizationServer, protectedResourceScopes)
+        }
         onStartManual={() => openSheet(undefined)}
       />
     );
@@ -176,8 +189,10 @@ export function AuthenticationSectionBody({
         <UserSessionDurationField userSessionIssuer={userSessionIssuer} />
         <RemoteIdentityProvidersField
           associatedIssuers={associatedIssuers}
-          isLoading={isLoadingIssuers || isLoadingClients}
-          onAdd={() => openSheet(undefined)}
+          isLoading={
+            isLoadingIssuers || isLoadingClients || probeStatus === "loading"
+          }
+          onAdd={() => openSheet(authorizationServer, protectedResourceScopes)}
           onEdit={handleEdit}
           onDelete={handleDelete}
         />
@@ -196,6 +211,7 @@ export function AuthenticationSectionBody({
         userSessionIssuer={userSessionIssuer ?? null}
         selectableIssuers={selectableIssuers}
         initialIssuerUrl={sheetInitialUrl}
+        initialScopes={sheetInitialScopes}
       />
 
       {deleteTarget && userSessionIssuerId && (

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -204,6 +204,13 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 		result.TokenEndpoint = authServerMeta.TokenEndpoint
 		result.RegistrationEndpoint = authServerMeta.RegistrationEndpoint
 		result.ScopesSupported = authServerMeta.ScopesSupported
+		if resourceMeta != nil && len(resourceMeta.ScopesSupported) > 0 {
+			// Protected-resource scopes describe the permissions accepted by
+			// this MCP server. Prefer them over the authorization server's
+			// potentially broader list, and retain them when the AS omits
+			// scopes_supported entirely.
+			result.ScopesSupported = resourceMeta.ScopesSupported
+		}
 
 		// If we have a registration endpoint, it's full MCP OAuth (2.1)
 		// Otherwise it's legacy OAuth 2.0

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -1,9 +1,15 @@
 package externalmcp
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestBuildWellKnownURL_OriginOnly(t *testing.T) {
@@ -48,4 +54,46 @@ func TestParseWWWAuthenticate_WithParams(t *testing.T) {
 	params := parseWWWAuthenticate(header)
 	require.Equal(t, "OAuth", params["realm"])
 	require.Equal(t, "https://example.com/.well-known/oauth-protected-resource/mcp/test", params["resource_metadata"])
+}
+
+func TestDiscoverOAuthMetadata_PreservesProtectedResourceScopes(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/resource-metadata":
+			require.NoError(t, json.NewEncoder(w).Encode(protectedResourceMetadata{
+				Resource:             server.URL + "/mcp",
+				AuthorizationServers: []string{server.URL},
+				ScopesSupported:      []string{"resource.read", "resource.write"},
+			}))
+		case "/.well-known/oauth-authorization-server":
+			require.NoError(t, json.NewEncoder(w).Encode(authServerMetadata{
+				Issuer:                server.URL,
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+				RegistrationEndpoint:  server.URL + "/register",
+				ScopesSupported:       nil,
+			}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	result, err := DiscoverOAuthMetadata(
+		t.Context(),
+		testenv.NewLogger(t),
+		policy,
+		`Bearer resource_metadata="`+server.URL+`/resource-metadata"`,
+		server.URL+"/mcp",
+	)
+	require.NoError(t, err)
+	require.Equal(t, OAuthVersion21, result.Version)
+	require.Equal(t, []string{"resource.read", "resource.write"}, result.ScopesSupported)
 }

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -64,19 +64,23 @@ func TestDiscoverOAuthMetadata_PreservesProtectedResourceScopes(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/resource-metadata":
-			require.NoError(t, json.NewEncoder(w).Encode(protectedResourceMetadata{
+			if err := json.NewEncoder(w).Encode(protectedResourceMetadata{
 				Resource:             server.URL + "/mcp",
 				AuthorizationServers: []string{server.URL},
 				ScopesSupported:      []string{"resource.read", "resource.write"},
-			}))
+			}); err != nil {
+				t.Errorf("encode protected resource metadata: %v", err)
+			}
 		case "/.well-known/oauth-authorization-server":
-			require.NoError(t, json.NewEncoder(w).Encode(authServerMetadata{
+			if err := json.NewEncoder(w).Encode(authServerMetadata{
 				Issuer:                server.URL,
 				AuthorizationEndpoint: server.URL + "/authorize",
 				TokenEndpoint:         server.URL + "/token",
 				RegistrationEndpoint:  server.URL + "/register",
 				ScopesSupported:       nil,
-			}))
+			}); err != nil {
+				t.Errorf("encode authorization server metadata: %v", err)
+			}
 		default:
 			http.NotFound(w, r)
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep RFC 9728 protected-resource discovery available when a remote MCP server has a session issuer but no upstream OAuth client
- seed manual identity-provider recovery with protected-resource scopes
- prefer resource-specific scopes during external MCP OAuth discovery when authorization-server metadata omits or broadens them

## Testing
- `pnpm -F dashboard test AuthenticationSection.test.tsx`
- `mise exec -- go test ./server/internal/externalmcp`
- `pnpm -F dashboard lint`
- `mise lint:server`
- local dashboard walkthrough against a third-party MCP endpoint that advertises scopes only in RFC 9728 protected-resource metadata; verified fallback recovery prefills issuer, endpoints, token auth method `none`, and protected-resource scopes
- CI gate passed

## Demo
<a href="https://cursor.com/agents/bc-7db1aae3-cace-4e42-b5f4-2796d0f985d5/artifacts"><img src="https://cursor.com/artifacts/c/art-0d0219a1-f1ee-4696-8f88-4749957350d9" alt="oauth scope recovery demo" /></a>

Linear: AIS-363
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-363](https://linear.app/speakeasy/issue/AIS-363)

<div><a href="https://cursor.com/agents/bc-7db1aae3-cace-4e42-b5f4-2796d0f985d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7db1aae3-cace-4e42-b5f4-2796d0f985d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves RFC 9728 protected-resource OAuth scopes during remote MCP discovery and manual setup, preferring resource-specific scopes and seeding the add-provider sheet so tool calls use the right permissions. Fixes external MCP tool call failures in AIS-363.

- **Bug Fixes**
  - Discovery prefers protected-resource `scopes_supported` over authorization-server metadata and retains them when the AS omits scopes; adds a test confirming scope preservation.
  - Dashboard keeps protected-resource probing enabled for remote servers with a user-session issuer until an upstream client exists, and stops probing once a client is present; avoids probing when a client already exists.
  - Seeds `AttachRemoteIdentityProviderSheet` for both “Use Discovered” and “Add provider” with issuer URL and protected-resource scopes; pre-fills the scope override; disables add-provider while probing; adds focused dashboard tests and fixes authentication test isolation.

<sup>Written for commit 891867c15a7abb379e865384e7016634594dd3b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

