### PR TITLE
feat(spend-control): evaluation, enforcement, and usage-trigger runtime

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1059,6 +1059,10 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("create spend rules cel engine: %w", err)
 			}
+			spendGate, err := spendrules.NewGate(logger, cache.NewRedisCacheAdapter(redisClient), spendCelEngine)
+			if err != nil {
+				return fmt.Errorf("create spend gate: %w", err)
+			}
 
 			about.Attach(mux, about.NewService(logger, tracerProvider))
 			external.AttachWebhookHandler(mux, external.NewWebhookHandler(logger, tracerProvider, newWorkOSWebhooksClient(c), temporalEnv))
@@ -1089,6 +1093,7 @@ func newStartCommand() *cli.Command {
 				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
 				riskScanner,
 				policyBypass,
+				spendGate,
 				shadowMCPClient,
 				chatWriter,
 				efficacySignaler,
@@ -1236,8 +1241,7 @@ func newStartCommand() *cli.Command {
 			chatWriter.AddObserver(riskService)
 			risk.Attach(mux, riskService)
 
-			// Mutation-triggered re-evaluation is wired in the spend-control
-			// runtime PR; the API serves reads/writes with a nil signaler.
+			spendEvaluator := &background.TemporalSpendRuleEvaluator{TemporalEnv: temporalEnv}
 			spendrules.Attach(mux, spendrules.NewService(
 				logger,
 				tracerProvider,
@@ -1247,8 +1251,22 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 				auditLogger,
 				spendCelEngine,
-				nil,
+				spendEvaluator,
 			))
+
+			// Fresh spend-relevant telemetry (Claude Code OTEL logs,
+			// Codex/Cursor usage rows) triggers a throttled per-org
+			// evaluation so breached budgets block within seconds instead of
+			// waiting for the scheduled sweep. Flushed in the drain goroutine
+			// below, not via shutdownFuncs, for the same gRPC-close race
+			// reason as riskSignaler.
+			spendUsageTrigger := spendrules.NewUsageTrigger(
+				logger,
+				cache.NewRedisCacheAdapter(redisClient),
+				spendEvaluator,
+				spendrules.UsageSignalCooldown,
+			)
+			telemLogger.AddObserver(spendUsageTrigger)
 
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantChatsTools(chatService)...)
 			managedInsightsTools = append(managedInsightsTools, platformtoolsruntime.ManagedAssistantUsersTools(organizationsService)...)
@@ -1385,6 +1403,9 @@ func newStartCommand() *cli.Command {
 				}
 				if err := chatAnalysisSignaler.Shutdown(graceCtx); err != nil {
 					logger.ErrorContext(ctx, "flush pending chat analysis signals", attr.SlogError(err))
+				}
+				if err := spendUsageTrigger.Shutdown(graceCtx); err != nil {
+					logger.ErrorContext(ctx, "flush pending spend rule usage signals", attr.SlogError(err))
 				}
 			})
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1252,6 +1252,7 @@ func newStartCommand() *cli.Command {
 				auditLogger,
 				spendCelEngine,
 				cache.NewRedisCacheAdapter(redisClient),
+				featureFlags,
 				spendEvaluator,
 			))
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1251,6 +1251,7 @@ func newStartCommand() *cli.Command {
 				authzEngine,
 				auditLogger,
 				spendCelEngine,
+				cache.NewRedisCacheAdapter(redisClient),
 				spendEvaluator,
 			))
 

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -62,6 +62,7 @@ import (
 	piopenrouter "github.com/speakeasy-api/gram/server/internal/scanners/promptinjection/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	ghclient "github.com/speakeasy-api/gram/server/internal/thirdparty/github"
@@ -606,6 +607,19 @@ func newWorkerCommand() *cli.Command {
 			)
 			chatWriter.AddObserver(analysis.NewObserver(logger, chatAnalysisSignaler))
 
+			// Spend-relevant telemetry written by worker-side pollers
+			// (Cursor usage polling, Codex cost import) triggers a throttled
+			// per-org spend rule evaluation, mirroring the server-side
+			// trigger on the hooks ingest path. Its flush shares the
+			// deferred drain below.
+			spendUsageTrigger := spendrules.NewUsageTrigger(
+				logger,
+				cache.NewRedisCacheAdapter(redisClient),
+				&background.TemporalSpendRuleEvaluator{TemporalEnv: temporalEnv},
+				spendrules.UsageSignalCooldown,
+			)
+			telemetryLogger.AddObserver(spendUsageTrigger)
+
 			completionsClient := openrouter.NewUnifiedClient(
 				logger,
 				guardianPolicy,
@@ -841,6 +855,9 @@ func newWorkerCommand() *cli.Command {
 				}
 				if ferr := chatAnalysisSignaler.Shutdown(ctx); ferr != nil {
 					logger.ErrorContext(ctx, "flush pending chat analysis signals", attr.SlogError(ferr))
+				}
+				if ferr := spendUsageTrigger.Shutdown(ctx); ferr != nil {
+					logger.ErrorContext(ctx, "flush pending spend rule usage signals", attr.SlogError(ferr))
 				}
 			}()
 

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -304,6 +304,7 @@ const (
 	RiskPolicyTypeKey                 = attribute.Key("gram.risk.policy_type")
 	RiskMessageTypeKey                = attribute.Key("gram.risk.message_type")
 	RiskRuleIDKey                     = attribute.Key("gram.risk.rule_id")
+	SpendRuleIDKey                    = attribute.Key("gram.spend.rule_id")
 	RiskSourceKey                     = attribute.Key("gram.risk.source")
 	RiskScanAttemptKey                = attribute.Key("gram.risk.scan.attempt")
 	RiskScanMaxAttemptsKey            = attribute.Key("gram.risk.scan.max_attempts")
@@ -1388,6 +1389,9 @@ func SlogRiskMessageType(v string) slog.Attr      { return slog.String(string(Ri
 
 func RiskRuleID(v string) attribute.KeyValue { return RiskRuleIDKey.String(v) }
 func SlogRiskRuleID(v string) slog.Attr      { return slog.String(string(RiskRuleIDKey), v) }
+
+func SpendRuleID(v string) attribute.KeyValue { return SpendRuleIDKey.String(v) }
+func SlogSpendRuleID(v string) slog.Attr      { return slog.String(string(SpendRuleIDKey), v) }
 
 func RiskSource(v string) attribute.KeyValue { return RiskSourceKey.String(v) }
 func SlogRiskSource(v string) slog.Attr      { return slog.String(string(RiskSourceKey), v) }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -646,3 +646,10 @@ func (a *Activities) EvaluateOrgSpendRules(ctx context.Context, args spend_rules
 	}
 	return nil
 }
+
+func (a *Activities) RefreshSpendRuleActor(ctx context.Context, args spend_rules.EvaluateActorArgs) error {
+	if err := a.evaluateOrgSpendRules.RefreshActor(ctx, args); err != nil {
+		return fmt.Errorf("refresh spend rule actor: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -26,6 +26,7 @@ import (
 	risk_analysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
 	"github.com/speakeasy-api/gram/server/internal/background/activities/risk_exclusion"
 	risk_policy "github.com/speakeasy-api/gram/server/internal/background/activities/risk_policy"
+	spend_rules "github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -49,6 +50,7 @@ import (
 	ppopenrouter "github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
+	spendrulesch "github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
@@ -126,6 +128,8 @@ type Activities struct {
 	outboxRelay                     *outbox_relay.Relay
 	outboxGC                        *outbox_relay.GC
 	pluginPublisher                 *activities.PluginPublisher
+	listSpendRuleOrgs               *spend_rules.ListOrgs
+	evaluateOrgSpendRules           *spend_rules.EvaluateOrg
 	skillEfficacyScorer             *activities.SkillEfficacyScorer
 	chatAnalysisScorer              *activities.ChatAnalysisScorer
 }
@@ -175,6 +179,13 @@ func NewActivities(
 	judgeRateLimiter *ratelimit.Limiter,
 	builtinPresets *presetlib.Library,
 ) *Activities {
+	// Spend rule evaluation reads ClickHouse; workers without a ClickHouse
+	// connection get a nil repo and the activity fails loudly if scheduled.
+	var spendRulesCH *spendrulesch.Queries
+	if chConn != nil {
+		spendRulesCH = spendrulesch.New(chConn)
+	}
+
 	analyzeBatch, err := risk_analysis.NewAnalyzeBatch(
 		logger,
 		tracerProvider,
@@ -271,6 +282,8 @@ func NewActivities(
 		outboxRelay:                     outbox_relay.New(logger, tracerProvider, db, svixClient, productFeatures),
 		outboxGC:                        outbox_relay.NewGC(logger, meterProvider, db),
 		pluginPublisher:                 activities.NewPluginPublisher(logger, db, pluginPublisher),
+		listSpendRuleOrgs:               spend_rules.NewListOrgs(logger, db),
+		evaluateOrgSpendRules:           spend_rules.NewEvaluateOrg(logger, tracerProvider, db, spendRulesCH, cacheAdapter, features),
 		// The judge draws on the same per-(org, model) bucket and the same
 		// completion client as every other platform judge, so efficacy scoring
 		// cannot outspend the org's key behind their backs.
@@ -617,4 +630,19 @@ func (a *Activities) PublishPluginProject(ctx context.Context, input plugins.Pub
 		return nil, fmt.Errorf("publish plugin project: %w", err)
 	}
 	return result, nil
+}
+
+func (a *Activities) ListSpendRuleOrgs(ctx context.Context) ([]string, error) {
+	orgs, err := a.listSpendRuleOrgs.Do(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list spend rule orgs: %w", err)
+	}
+	return orgs, nil
+}
+
+func (a *Activities) EvaluateOrgSpendRules(ctx context.Context, args spend_rules.EvaluateOrgArgs) error {
+	if err := a.evaluateOrgSpendRules.Do(ctx, args); err != nil {
+		return fmt.Errorf("evaluate org spend rules: %w", err)
+	}
+	return nil
 }

--- a/server/internal/background/activities/spend_rules/evaluate.go
+++ b/server/internal/background/activities/spend_rules/evaluate.go
@@ -1,0 +1,290 @@
+// Package spend_rules holds the background activities that evaluate spend
+// control rules: per-organization budget evaluation against ClickHouse spend,
+// warning/breach event writes, and spend gate snapshot publication for the
+// hooks gate.
+package spend_rules
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
+	chrepo "github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/money"
+	spendrepo "github.com/speakeasy-api/gram/server/internal/spendrules/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// ListOrgs returns the organizations that currently have enabled spend rules.
+type ListOrgs struct {
+	logger *slog.Logger
+	db     *pgxpool.Pool
+}
+
+func NewListOrgs(logger *slog.Logger, db *pgxpool.Pool) *ListOrgs {
+	return &ListOrgs{
+		logger: logger.With(attr.SlogComponent("spend_rules_list_orgs")),
+		db:     db,
+	}
+}
+
+func (a *ListOrgs) Do(ctx context.Context) ([]string, error) {
+	orgs, err := spendrepo.New(a.db).ListOrganizationsWithEnabledSpendRules(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list organizations with enabled spend rules: %w", err)
+	}
+	return orgs, nil
+}
+
+// EvaluateOrg evaluates every enabled spend rule for one organization:
+// CEL-matches directory actors, sums their window spend from ClickHouse,
+// records warning/breach events (deduped by the unique index), and replaces
+// the organization's spend gate snapshot.
+type EvaluateOrg struct {
+	logger    *slog.Logger
+	tracer    trace.Tracer
+	db        *pgxpool.Pool
+	chQueries *chrepo.Queries
+	cacheImpl cache.Cache
+	celEng    *celenv.Engine
+	flags     feature.Provider
+}
+
+func NewEvaluateOrg(
+	logger *slog.Logger,
+	tracerProvider trace.TracerProvider,
+	db *pgxpool.Pool,
+	chQueries *chrepo.Queries,
+	cacheImpl cache.Cache,
+	flags feature.Provider,
+) *EvaluateOrg {
+	logger = logger.With(attr.SlogComponent("spend_rules_evaluate_org"))
+
+	// The CEL environment is deterministic to build; an error here is a code
+	// bug. Keep the nil engine and fail evaluation loudly rather than
+	// panicking worker startup.
+	celEng, err := celenv.New()
+	if err != nil {
+		logger.ErrorContext(context.Background(), "build spend rules CEL engine", attr.SlogError(err))
+	}
+
+	return &EvaluateOrg{
+		logger:    logger,
+		tracer:    tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"),
+		db:        db,
+		chQueries: chQueries,
+		cacheImpl: cacheImpl,
+		celEng:    celEng,
+		flags:     flags,
+	}
+}
+
+type EvaluateOrgArgs struct {
+	OrganizationID string
+}
+
+func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) {
+	ctx, span := a.tracer.Start(ctx, "spendrules.evaluateOrg")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	logger := a.logger.With(attr.SlogOrganizationID(args.OrganizationID))
+	queries := spendrepo.New(a.db)
+
+	// The Budgets rollout flag (feature.FlagBudgets) gates enforcement org by
+	// org — the same key hides the dashboard surface. When the flag is off
+	// the org's rules stay dormant: no warning/breach events are recorded and
+	// the gate snapshot is cleared, so an already-open circuit lifts on this
+	// cycle instead of blocking users on a feature they cannot see.
+	if !a.budgetsEnabled(ctx, logger, args.OrganizationID) {
+		if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, spendrules.GateState{Rules: nil, Actors: nil}); err != nil {
+			return fmt.Errorf("clear spend gate snapshot: %w", err)
+		}
+		return nil
+	}
+
+	rules, err := queries.ListEnabledSpendRules(ctx, args.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("list enabled spend rules: %w", err)
+	}
+
+	if len(rules) == 0 {
+		if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, spendrules.GateState{Rules: nil, Actors: nil}); err != nil {
+			return fmt.Errorf("clear spend gate snapshot: %w", err)
+		}
+		return nil
+	}
+
+	actors, err := spendrules.LoadActors(ctx, queries, args.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("load directory actors: %w", err)
+	}
+
+	projects, err := projectsRepo.New(a.db).ListProjectsByOrganization(ctx, args.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("list organization projects: %w", err)
+	}
+	projectIDs := make([]string, 0, len(projects))
+	for _, p := range projects {
+		projectIDs = append(projectIDs, p.ID.String())
+	}
+
+	now := time.Now().UTC()
+	actorWindowSpend, err := chrepo.LoadActorWindowSpend(ctx, a.chQueries, projectIDs, now)
+	if err != nil {
+		return fmt.Errorf("load actor window spend: %w", err)
+	}
+
+	gateState := spendrules.NewGateState(args.OrganizationID, actors)
+	for _, actor := range actors {
+		gateState.SetActorWindowSpend(args.OrganizationID, actor, actorWindowSpend[conv.NormalizeEmail(actor.Email)])
+	}
+
+	for _, rule := range rules {
+		if err := a.evaluateRule(ctx, logger, queries, rule, actors, actorWindowSpend, now, &gateState); err != nil {
+			// One broken rule (e.g. an expression that no longer compiles)
+			// must not stall evaluation of the org's other rules.
+			logger.ErrorContext(ctx, "evaluate spend rule", attr.SlogError(err))
+		}
+	}
+
+	if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, gateState); err != nil {
+		return fmt.Errorf("write spend gate snapshot: %w", err)
+	}
+
+	return nil
+}
+
+// budgetsEnabled reports whether the Budgets rollout flag is on for the
+// organization. The flag is targeted by PostHog organization group (org
+// slug), the same way the dashboard evaluates it, so the org slug is
+// forwarded as the group key. A nil provider or a failed lookup degrades to
+// disabled — enforcement stays off rather than blocking users on an
+// unresolved flag. (The PostHog provider itself returns enabled when PostHog
+// is disabled outright, e.g. in local development.)
+func (a *EvaluateOrg) budgetsEnabled(ctx context.Context, logger *slog.Logger, organizationID string) bool {
+	if a.flags == nil {
+		return false
+	}
+
+	var groups map[string]string
+	org, err := orgRepo.New(a.db).GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		// Group targeting degrades to distinct-id-only evaluation; a flag
+		// released purely by org group will read as off for this org until
+		// the metadata lookup recovers.
+		logger.WarnContext(ctx, "resolve organization slug for budgets flag", attr.SlogError(err))
+	} else {
+		groups = feature.OrgProjectGroups(org.Slug, "")
+	}
+
+	on, err := a.flags.IsFlagEnabled(ctx, feature.FlagBudgets, organizationID, groups)
+	if err != nil {
+		logger.WarnContext(ctx, "budgets flag check failed; treating as disabled", attr.SlogError(err))
+		return false
+	}
+	return on
+}
+
+func (a *EvaluateOrg) evaluateRule(
+	ctx context.Context,
+	logger *slog.Logger,
+	queries *spendrepo.Queries,
+	rule spendrepo.SpendRule,
+	actors []spendrules.Actor,
+	actorWindowSpend map[string]chrepo.ActorWindowSpendRow,
+	now time.Time,
+	gateState *spendrules.GateState,
+) error {
+	windowStart, windowEnd, err := spendrules.WindowBounds(rule.WindowKind, now)
+	if err != nil {
+		return fmt.Errorf("window bounds for rule %s: %w", rule.ID, err)
+	}
+	ruleURN := urn.NewSpendRule(rule.Slug, rule.Version)
+	limitUSD := rule.LimitUsdCents.USD()
+
+	matched, err := spendrules.MatchActors(a.celEng, rule.TargetExpr, actors)
+	if err != nil {
+		return fmt.Errorf("match actors for rule %s: %w", rule.ID, err)
+	}
+
+	gateState.Rules = append(gateState.Rules, spendrules.GateRule{
+		RuleURN:    ruleURN.String(),
+		RuleName:   rule.Name,
+		Action:     rule.Action,
+		TargetExpr: rule.TargetExpr,
+		RuleExpr:   rule.RuleExpr,
+		LimitUSD:   limitUSD,
+		WarnAtPct:  rule.WarnAtPct,
+		WindowKind: rule.WindowKind,
+		WindowEnd:  windowEnd,
+	})
+	if len(matched) == 0 {
+		return nil
+	}
+
+	usages, err := spendrules.BuildActorWindowUsages(matched, actorWindowSpend, rule.WindowKind, limitUSD)
+	if err != nil {
+		return fmt.Errorf("select actor spend for rule %s: %w", rule.ID, err)
+	}
+
+	usages, err = spendrules.EvalRuleUsages(a.celEng, rule.RuleExpr, rule.WarnAtPct, usages)
+	if err != nil {
+		return fmt.Errorf("evaluate rule expression for rule %s: %w", rule.ID, err)
+	}
+
+	for _, usage := range usages {
+		breached := usage.Breached
+		warned := !breached && usage.UsedPct >= float64(rule.WarnAtPct)
+
+		if !breached && !warned {
+			continue
+		}
+
+		eventType := spendrules.EventTypeWarning
+		if breached {
+			eventType = spendrules.EventTypeBreach
+		}
+		spendUSDCents, err := money.FromUSD(usage.SpendUSD)
+		if err != nil {
+			return fmt.Errorf("convert spend to cents for rule %s: %w", rule.ID, err)
+		}
+		limitUSDCents := rule.LimitUsdCents
+
+		if _, err := queries.InsertSpendRuleEvent(ctx, spendrepo.InsertSpendRuleEventParams{
+			OrganizationID: rule.OrganizationID,
+			SpendRuleID:    rule.ID,
+			RuleUrn:        ruleURN.String(),
+			EventType:      eventType,
+			UserID:         conv.ToPGTextEmpty(usage.Actor.UserID),
+			Email:          conv.NormalizeEmail(usage.Actor.Email),
+			DisplayName:    conv.ToPGTextEmpty(usage.Actor.DisplayName),
+			SpendUsdCents:  spendUSDCents,
+			LimitUsdCents:  limitUSDCents,
+			WindowStart:    conv.ToPGTimestamptz(windowStart),
+			WindowEnd:      conv.ToPGTimestamptz(windowEnd),
+		}); err != nil {
+			logger.ErrorContext(ctx, "record spend rule event", attr.SlogError(err))
+		}
+
+	}
+
+	return nil
+}

--- a/server/internal/background/activities/spend_rules/evaluate.go
+++ b/server/internal/background/activities/spend_rules/evaluate.go
@@ -1,7 +1,7 @@
 // Package spend_rules holds the background activities that evaluate spend
 // control rules: per-organization budget evaluation against ClickHouse spend,
-// warning/breach event writes, and spend gate snapshot publication for the
-// hooks gate.
+// warning/breach event writes, and spend gate cache publication for the hooks
+// gate.
 package spend_rules
 
 import (
@@ -52,8 +52,8 @@ func (a *ListOrgs) Do(ctx context.Context) ([]string, error) {
 
 // EvaluateOrg evaluates every enabled spend rule for one organization:
 // CEL-matches directory actors, sums their window spend from ClickHouse,
-// records warning/breach events (deduped by the unique index), and replaces
-// the organization's spend gate snapshot.
+// records warning/breach events (deduped by the unique index), and refreshes
+// the organization's spend gate cache entries.
 type EvaluateOrg struct {
 	logger    *slog.Logger
 	tracer    trace.Tracer
@@ -97,6 +97,12 @@ type EvaluateOrgArgs struct {
 	OrganizationID string
 }
 
+type EvaluateActorArgs struct {
+	OrganizationID string
+	UserID         string
+	Email          string
+}
+
 func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) {
 	ctx, span := a.tracer.Start(ctx, "spendrules.evaluateOrg")
 	defer func() {
@@ -110,13 +116,13 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 	queries := spendrepo.New(a.db)
 
 	// The Budgets rollout flag (feature.FlagBudgets) gates enforcement org by
-	// org — the same key hides the dashboard surface. When the flag is off
-	// the org's rules stay dormant: no warning/breach events are recorded and
-	// the gate snapshot is cleared, so an already-open circuit lifts on this
+	// org — the same key hides the dashboard surface. When the flag is off the
+	// org's rules stay dormant: no warning/breach events are recorded and the
+	// gate rules payload is cleared, so an already-open circuit lifts on this
 	// cycle instead of blocking users on a feature they cannot see.
 	if !a.budgetsEnabled(ctx, logger, args.OrganizationID) {
-		if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, spendrules.GateState{Rules: nil, Actors: nil}); err != nil {
-			return fmt.Errorf("clear spend gate snapshot: %w", err)
+		if err := spendrules.WriteGateRules(ctx, a.cacheImpl, args.OrganizationID, spendrules.GateRules{SourceUpdatedAt: time.Now().UTC(), Rules: nil}); err != nil {
+			return fmt.Errorf("clear spend gate rules: %w", err)
 		}
 		return nil
 	}
@@ -126,10 +132,16 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 		return fmt.Errorf("list enabled spend rules: %w", err)
 	}
 
+	now := time.Now().UTC()
+	gateRules, err := spendrules.BuildGateRules(rules, now)
+	if err != nil {
+		return fmt.Errorf("build spend gate rules: %w", err)
+	}
+	if err := spendrules.WriteGateRules(ctx, a.cacheImpl, args.OrganizationID, gateRules); err != nil {
+		return fmt.Errorf("write spend gate rules: %w", err)
+	}
+
 	if len(rules) == 0 {
-		if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, spendrules.GateState{Rules: nil, Actors: nil}); err != nil {
-			return fmt.Errorf("clear spend gate snapshot: %w", err)
-		}
 		return nil
 	}
 
@@ -155,15 +167,19 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 		return fmt.Errorf("spend rule evaluation requires a ClickHouse connection")
 	}
 
-	now := time.Now().UTC()
 	actorWindowSpend, err := chrepo.LoadActorWindowSpend(ctx, a.chQueries, projectIDs, now)
 	if err != nil {
 		return fmt.Errorf("load actor window spend: %w", err)
 	}
 
-	gateState := spendrules.NewGateState(args.OrganizationID, actors)
 	for _, actor := range actors {
-		gateState.SetActorWindowSpend(args.OrganizationID, actor, actorWindowSpend[conv.NormalizeEmail(actor.Email)])
+		spend := actorWindowSpend[conv.NormalizeEmail(actor.Email)]
+		if spend.Email == "" {
+			spend = spendrules.EmptyActorSpend(actor.Email)
+		}
+		if err := spendrules.WriteGateActor(ctx, a.cacheImpl, args.OrganizationID, spendrules.NewGateActor(actor, spend, now)); err != nil {
+			return fmt.Errorf("write spend gate actor: %w", err)
+		}
 	}
 
 	// evaluateRule logs and skips per-rule logic errors (a bad expression must
@@ -171,23 +187,104 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 	// only errors it returns are transient event-write failures.
 	var eventWriteErrs []error
 	for _, rule := range rules {
-		if err := a.evaluateRule(ctx, logger, queries, rule, actors, actorWindowSpend, now, &gateState); err != nil {
+		if err := a.evaluateRule(ctx, logger, queries, rule, actors, actorWindowSpend, now); err != nil {
 			eventWriteErrs = append(eventWriteErrs, err)
 		}
 	}
 
-	if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, gateState); err != nil {
-		return fmt.Errorf("write spend gate snapshot: %w", err)
-	}
-
 	// A transient failure recording warning/breach events must fail the
-	// activity so Temporal retries it. The snapshot is already written and
-	// events dedupe on the unique index, so the retry is idempotent.
+	// activity so Temporal retries it. Actor cache entries are already written
+	// and events dedupe on the unique index, so the retry is idempotent.
 	if len(eventWriteErrs) > 0 {
 		return fmt.Errorf("record spend rule events: %w", errors.Join(eventWriteErrs...))
 	}
 
 	return nil
+}
+
+func (a *EvaluateOrg) RefreshActor(ctx context.Context, args EvaluateActorArgs) (err error) {
+	ctx, span := a.tracer.Start(ctx, "spendrules.refreshActor")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	logger := a.logger.With(attr.SlogOrganizationID(args.OrganizationID))
+	if args.OrganizationID == "" || (args.UserID == "" && args.Email == "") {
+		return nil
+	}
+	if !a.budgetsEnabled(ctx, logger, args.OrganizationID) {
+		return nil
+	}
+
+	queries := spendrepo.New(a.db)
+	actors, err := spendrules.LoadActors(ctx, queries, args.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("load directory actors: %w", err)
+	}
+	actor, ok := findActor(actors, args.UserID, args.Email)
+	if !ok || actor.UserID == "" {
+		return nil
+	}
+
+	if a.chQueries == nil {
+		return fmt.Errorf("spend rule actor refresh requires a ClickHouse connection")
+	}
+
+	projects, err := projectsRepo.New(a.db).ListProjectsByOrganization(ctx, args.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("list organization projects: %w", err)
+	}
+	projectIDs := make([]string, 0, len(projects))
+	for _, p := range projects {
+		projectIDs = append(projectIDs, p.ID.String())
+	}
+
+	computedAt := time.Now().UTC()
+	spend, err := chrepo.LoadActorWindowSpendByEmail(ctx, a.chQueries, projectIDs, actor.Email, computedAt)
+	if err != nil {
+		return fmt.Errorf("load actor window spend by email: %w", err)
+	}
+	if spend.Email == "" {
+		spend = spendrules.EmptyActorSpend(actor.Email)
+	}
+	if err := spendrules.WriteGateActor(ctx, a.cacheImpl, args.OrganizationID, spendrules.NewGateActor(actor, spend, computedAt)); err != nil {
+		return fmt.Errorf("write spend gate actor: %w", err)
+	}
+	return nil
+}
+
+func findActor(actors []spendrules.Actor, userID, email string) (spendrules.Actor, bool) {
+	normalizedEmail := conv.NormalizeEmail(email)
+	for _, actor := range actors {
+		if userID != "" && actor.UserID == userID {
+			return actor, true
+		}
+		if normalizedEmail != "" && conv.NormalizeEmail(actor.Email) == normalizedEmail {
+			return actor, true
+		}
+	}
+	return spendrules.Actor{
+		UserID:      "",
+		Email:       "",
+		DisplayName: "",
+		Attrs: celenv.Actor{
+			Email:          "",
+			DepartmentName: "",
+			JobTitle:       "",
+			EmployeeType:   "",
+			DivisionName:   "",
+			CostCenterName: "",
+			Groups:         nil,
+			Roles:          nil,
+			SpendUSD:       0,
+			LimitUSD:       0,
+			UsedPct:        0,
+			WarnAtPct:      0,
+		},
+	}, false
 }
 
 // budgetsEnabled reports whether the Budgets rollout flag is on for the
@@ -231,7 +328,6 @@ func (a *EvaluateOrg) evaluateRule(
 	actors []spendrules.Actor,
 	actorWindowSpend map[string]chrepo.ActorWindowSpendRow,
 	now time.Time,
-	gateState *spendrules.GateState,
 ) error {
 	windowStart, windowEnd, err := spendrules.WindowBounds(rule.WindowKind, now)
 	if err != nil {
@@ -247,17 +343,6 @@ func (a *EvaluateOrg) evaluateRule(
 		return nil
 	}
 
-	gateState.Rules = append(gateState.Rules, spendrules.GateRule{
-		RuleURN:    ruleURN.String(),
-		RuleName:   rule.Name,
-		Action:     rule.Action,
-		TargetExpr: rule.TargetExpr,
-		RuleExpr:   rule.RuleExpr,
-		LimitUSD:   limitUSD,
-		WarnAtPct:  rule.WarnAtPct,
-		WindowKind: rule.WindowKind,
-		WindowEnd:  windowEnd,
-	})
 	if len(matched) == 0 {
 		return nil
 	}

--- a/server/internal/background/activities/spend_rules/evaluate.go
+++ b/server/internal/background/activities/spend_rules/evaluate.go
@@ -6,6 +6,7 @@ package spend_rules
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -146,6 +147,14 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 		projectIDs = append(projectIDs, p.ID.String())
 	}
 
+	// The worker may be started without a ClickHouse connection (see
+	// NewActivities); fail the activity loudly rather than dereferencing a nil
+	// repo, so the scheduled sweep surfaces the misconfiguration instead of
+	// panicking the worker.
+	if a.chQueries == nil {
+		return fmt.Errorf("spend rule evaluation requires a ClickHouse connection")
+	}
+
 	now := time.Now().UTC()
 	actorWindowSpend, err := chrepo.LoadActorWindowSpend(ctx, a.chQueries, projectIDs, now)
 	if err != nil {
@@ -157,16 +166,25 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 		gateState.SetActorWindowSpend(args.OrganizationID, actor, actorWindowSpend[conv.NormalizeEmail(actor.Email)])
 	}
 
+	// evaluateRule logs and skips per-rule logic errors (a bad expression must
+	// not stall the org's other rules or permanently fail the activity); the
+	// only errors it returns are transient event-write failures.
+	var eventWriteErrs []error
 	for _, rule := range rules {
 		if err := a.evaluateRule(ctx, logger, queries, rule, actors, actorWindowSpend, now, &gateState); err != nil {
-			// One broken rule (e.g. an expression that no longer compiles)
-			// must not stall evaluation of the org's other rules.
-			logger.ErrorContext(ctx, "evaluate spend rule", attr.SlogError(err))
+			eventWriteErrs = append(eventWriteErrs, err)
 		}
 	}
 
 	if err := spendrules.WriteGateState(ctx, a.cacheImpl, args.OrganizationID, gateState); err != nil {
 		return fmt.Errorf("write spend gate snapshot: %w", err)
+	}
+
+	// A transient failure recording warning/breach events must fail the
+	// activity so Temporal retries it. The snapshot is already written and
+	// events dedupe on the unique index, so the retry is idempotent.
+	if len(eventWriteErrs) > 0 {
+		return fmt.Errorf("record spend rule events: %w", errors.Join(eventWriteErrs...))
 	}
 
 	return nil
@@ -175,10 +193,12 @@ func (a *EvaluateOrg) Do(ctx context.Context, args EvaluateOrgArgs) (err error) 
 // budgetsEnabled reports whether the Budgets rollout flag is on for the
 // organization. The flag is targeted by PostHog organization group (org
 // slug), the same way the dashboard evaluates it, so the org slug is
-// forwarded as the group key. A nil provider or a failed lookup degrades to
-// disabled — enforcement stays off rather than blocking users on an
-// unresolved flag. (The PostHog provider itself returns enabled when PostHog
-// is disabled outright, e.g. in local development.)
+// forwarded as the group key. Every unresolved state degrades to disabled —
+// a nil provider, a failed lookup, or PostHog being disabled outright (the
+// provider returns false in that mode). This is deliberate for a blocking
+// feature: enforcement stays off until its rollout flag is affirmatively on,
+// rather than starting to block users on an unconfirmed flag. Local dev opts
+// in by enabling the flag (e.g. via the seed task), not implicitly.
 func (a *EvaluateOrg) budgetsEnabled(ctx context.Context, logger *slog.Logger, organizationID string) bool {
 	if a.flags == nil {
 		return false
@@ -215,14 +235,16 @@ func (a *EvaluateOrg) evaluateRule(
 ) error {
 	windowStart, windowEnd, err := spendrules.WindowBounds(rule.WindowKind, now)
 	if err != nil {
-		return fmt.Errorf("window bounds for rule %s: %w", rule.ID, err)
+		logger.ErrorContext(ctx, "window bounds for rule", attr.SlogError(err), attr.SlogSpendRuleID(rule.ID.String()))
+		return nil
 	}
 	ruleURN := urn.NewSpendRule(rule.Slug, rule.Version)
 	limitUSD := rule.LimitUsdCents.USD()
 
 	matched, err := spendrules.MatchActors(a.celEng, rule.TargetExpr, actors)
 	if err != nil {
-		return fmt.Errorf("match actors for rule %s: %w", rule.ID, err)
+		logger.ErrorContext(ctx, "match actors for rule", attr.SlogError(err), attr.SlogSpendRuleID(rule.ID.String()))
+		return nil
 	}
 
 	gateState.Rules = append(gateState.Rules, spendrules.GateRule{
@@ -242,14 +264,17 @@ func (a *EvaluateOrg) evaluateRule(
 
 	usages, err := spendrules.BuildActorWindowUsages(matched, actorWindowSpend, rule.WindowKind, limitUSD)
 	if err != nil {
-		return fmt.Errorf("select actor spend for rule %s: %w", rule.ID, err)
+		logger.ErrorContext(ctx, "select actor spend for rule", attr.SlogError(err), attr.SlogSpendRuleID(rule.ID.String()))
+		return nil
 	}
 
 	usages, err = spendrules.EvalRuleUsages(a.celEng, rule.RuleExpr, rule.WarnAtPct, usages)
 	if err != nil {
-		return fmt.Errorf("evaluate rule expression for rule %s: %w", rule.ID, err)
+		logger.ErrorContext(ctx, "evaluate rule expression for rule", attr.SlogError(err), attr.SlogSpendRuleID(rule.ID.String()))
+		return nil
 	}
 
+	var writeErrs []error
 	for _, usage := range usages {
 		breached := usage.Breached
 		warned := !breached && usage.UsedPct >= float64(rule.WarnAtPct)
@@ -264,7 +289,10 @@ func (a *EvaluateOrg) evaluateRule(
 		}
 		spendUSDCents, err := money.FromUSD(usage.SpendUSD)
 		if err != nil {
-			return fmt.Errorf("convert spend to cents for rule %s: %w", rule.ID, err)
+			// A single actor's unconvertible spend (e.g. non-finite) must not
+			// drop the other actors' events; log and skip this one.
+			logger.ErrorContext(ctx, "convert spend to cents", attr.SlogError(err), attr.SlogSpendRuleID(rule.ID.String()))
+			continue
 		}
 		limitUSDCents := rule.LimitUsdCents
 
@@ -281,10 +309,11 @@ func (a *EvaluateOrg) evaluateRule(
 			WindowStart:    conv.ToPGTimestamptz(windowStart),
 			WindowEnd:      conv.ToPGTimestamptz(windowEnd),
 		}); err != nil {
-			logger.ErrorContext(ctx, "record spend rule event", attr.SlogError(err))
+			// Surface transient write failures so the activity retries rather
+			// than silently succeeding without the event recorded.
+			writeErrs = append(writeErrs, fmt.Errorf("record %s event for rule %s: %w", eventType, rule.ID, err))
 		}
-
 	}
 
-	return nil
+	return errors.Join(writeErrs...)
 }

--- a/server/internal/background/debounced.go
+++ b/server/internal/background/debounced.go
@@ -13,9 +13,10 @@ import (
 // allow for enqueuing subsequent runs of the workflow.
 //
 // `wrapped` is the workflow function whose body runs once per execution. It
-// must return (result, nil) and must not issue its own ContinueAsNew —
-// continuation is owned by this wrapper. Errors returned by `wrapped` are
-// propagated unchanged.
+// must not issue its own ContinueAsNew — continuation is owned by this wrapper.
+// Errors returned by `wrapped` are propagated unless another signal arrived
+// while it was running; in that case the pending signal is answered with a
+// fresh run instead of being stranded behind a closed workflow.
 //
 // `continueAsSelf` is the function used as the ContinueAsNew target when the
 // wrapper decides to enqueue another run. It MUST be the debounced wrapper
@@ -48,6 +49,9 @@ func Debounce[Params any, Result any](
 
 		res, err := wrapped(ctx, params)
 		if err != nil {
+			if drainSignals(signalCh) {
+				return res, workflow.NewContinueAsNewError(ctx, continueAsSelf, params)
+			}
 			return res, err
 		}
 

--- a/server/internal/background/spend_rule_evaluation.go
+++ b/server/internal/background/spend_rule_evaluation.go
@@ -1,0 +1,202 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	spend_rules "github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const (
+	spendRuleEvaluationWorkflowID = "v1:spend-rule-evaluation"
+	spendRuleEvaluationScheduleID = "v1:spend-rule-evaluation-schedule"
+
+	// spendRuleEvaluationRunTimeout budgets one full scheduled sweep across
+	// every org with enabled rules.
+	spendRuleEvaluationRunTimeout = 15 * time.Minute
+
+	// spendRuleEvaluationActivityTimeout budgets one activity: listing orgs
+	// or evaluating a single org (directory match + one ClickHouse query per
+	// rule).
+	spendRuleEvaluationActivityTimeout = 2 * time.Minute
+)
+
+// SpendRuleEvaluationWorkflow is the scheduled coordinator: it lists every
+// organization with enabled spend rules and evaluates each in turn. Runs
+// every spendrules.EvaluationInterval with overlap-skip, so a slow sweep
+// delays rather than stacks.
+func SpendRuleEvaluationWorkflow(ctx workflow.Context) error {
+	activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: spendRuleEvaluationActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+		},
+	})
+
+	var a *Activities
+
+	var orgs []string
+	if err := workflow.ExecuteActivity(activityCtx, a.ListSpendRuleOrgs).Get(activityCtx, &orgs); err != nil {
+		return fmt.Errorf("list spend rule orgs: %w", err)
+	}
+
+	var errCount int
+	for _, org := range orgs {
+		if err := workflow.ExecuteActivity(activityCtx, a.EvaluateOrgSpendRules, spend_rules.EvaluateOrgArgs{
+			OrganizationID: org,
+		}).Get(activityCtx, nil); err != nil {
+			// Evaluate every org even when one fails; surface the failure at
+			// the end so the run is visibly unhealthy.
+			workflow.GetLogger(ctx).Error("evaluate org spend rules", "organization_id", org, "error", err)
+			errCount++
+		}
+	}
+
+	if errCount > 0 {
+		return fmt.Errorf("spend rule evaluation failed for %d of %d orgs", errCount, len(orgs))
+	}
+	return nil
+}
+
+// SpendRuleOrgEvaluationWorkflow evaluates a single organization's spend
+// rules immediately. Runs as the body of the debounced wrapper below so
+// circuits open and close without waiting for the next scheduled sweep. It
+// must not issue its own ContinueAsNew — continuation is owned by Debounce.
+func SpendRuleOrgEvaluationWorkflow(ctx workflow.Context, organizationID string) error {
+	activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: spendRuleEvaluationActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+		},
+	})
+
+	var a *Activities
+	if err := workflow.ExecuteActivity(activityCtx, a.EvaluateOrgSpendRules, spend_rules.EvaluateOrgArgs{
+		OrganizationID: organizationID,
+	}).Get(activityCtx, nil); err != nil {
+		return fmt.Errorf("evaluate org spend rules: %w", err)
+	}
+	return nil
+}
+
+func buildSpendRuleOrgEvaluationWorkflowID(organizationID string) string {
+	return "v1:spend-rule-eval:" + organizationID
+}
+
+// spendRuleOrgEvaluationDebounceSignal names the debounce signal channel.
+// Signals are addressed to a per-org workflow ID, so a single constant name
+// is unambiguous across organizations.
+func spendRuleOrgEvaluationDebounceSignal(string) string {
+	return "v1:spend-rule-eval/signal"
+}
+
+// SpendRuleOrgEvaluationResult carries no data; the Debounce wrapper requires
+// a result type.
+type SpendRuleOrgEvaluationResult struct{}
+
+// SpendRuleOrgEvaluationWorkflowDebounced is the signal-with-start entry
+// point for per-org evaluation. Signals that arrive while a run is in flight
+// (fresh usage landing mid-evaluation) coalesce into exactly one follow-up
+// run via ContinueAsNew instead of being dropped; the workflow completes when
+// no work is pending.
+func SpendRuleOrgEvaluationWorkflowDebounced(ctx workflow.Context, organizationID string) (SpendRuleOrgEvaluationResult, error) {
+	return Debounce(
+		func(ctx workflow.Context, organizationID string) (SpendRuleOrgEvaluationResult, error) {
+			return SpendRuleOrgEvaluationResult{}, SpendRuleOrgEvaluationWorkflow(ctx, organizationID)
+		},
+		SpendRuleOrgEvaluationWorkflowDebounced,
+		spendRuleOrgEvaluationDebounceSignal,
+		func(string, SpendRuleOrgEvaluationResult) bool { return false },
+	)(ctx, organizationID)
+}
+
+// TemporalSpendRuleEvaluator implements spendrules.EvaluationSignaler by
+// signal-with-starting the debounced per-org evaluation workflow. If a run is
+// already in flight the signal enqueues exactly one follow-up run, so state
+// committed mid-evaluation (a rule mutation or fresh usage) is always picked
+// up rather than waiting for the next scheduled sweep.
+type TemporalSpendRuleEvaluator struct {
+	TemporalEnv *tenv.Environment
+}
+
+var _ spendrules.EvaluationSignaler = (*TemporalSpendRuleEvaluator)(nil)
+
+func (e *TemporalSpendRuleEvaluator) Signal(ctx context.Context, organizationID string) error {
+	id := buildSpendRuleOrgEvaluationWorkflowID(organizationID)
+	_, err := e.TemporalEnv.Client().SignalWithStartWorkflow(
+		ctx,
+		id,
+		spendRuleOrgEvaluationDebounceSignal(organizationID),
+		"enqueue",
+		client.StartWorkflowOptions{
+			ID:                       id,
+			TaskQueue:                string(e.TemporalEnv.Queue()),
+			WorkflowIDReusePolicy:    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIDConflictPolicy: enums.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		},
+		SpendRuleOrgEvaluationWorkflowDebounced,
+		organizationID,
+	)
+	if err != nil {
+		return fmt.Errorf("signal spend rule org evaluation: %w", err)
+	}
+	return nil
+}
+
+func AddSpendRuleEvaluationSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	scheduleClient := temporalEnv.Client().ScheduleClient()
+	options := buildSpendRuleEvaluationScheduleOptions(temporalEnv)
+
+	_, err := scheduleClient.Create(ctx, options)
+	if err != nil && !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+		return fmt.Errorf("create spend rule evaluation schedule: %w", err)
+	}
+
+	if err := scheduleClient.GetHandle(ctx, spendRuleEvaluationScheduleID).Update(ctx, client.ScheduleUpdateOptions{
+		DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+			schedule := input.Description.Schedule
+			schedule.Spec = &options.Spec
+			schedule.Action = options.Action
+			if schedule.Policy == nil {
+				schedule.Policy = &client.SchedulePolicies{
+					Overlap:        enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+					CatchupWindow:  0,
+					PauseOnFailure: false,
+				}
+			}
+			return &client.ScheduleUpdate{Schedule: &schedule, TypedSearchAttributes: nil}, nil
+		},
+	}); err != nil {
+		return fmt.Errorf("update spend rule evaluation schedule: %w", err)
+	}
+	return nil
+}
+
+func buildSpendRuleEvaluationScheduleOptions(temporalEnv *tenv.Environment) client.ScheduleOptions {
+	return client.ScheduleOptions{
+		ID:      spendRuleEvaluationScheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Spec: client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{{Every: spendrules.EvaluationInterval}},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			ID:                 spendRuleEvaluationWorkflowID,
+			Workflow:           SpendRuleEvaluationWorkflow,
+			TaskQueue:          string(temporalEnv.Queue()),
+			WorkflowRunTimeout: spendRuleEvaluationRunTimeout,
+		},
+	}
+}

--- a/server/internal/background/spend_rule_evaluation.go
+++ b/server/internal/background/spend_rule_evaluation.go
@@ -148,9 +148,9 @@ func SpendRuleOrgEvaluationWorkflowDebounced(ctx workflow.Context, organizationI
 	)(ctx, organizationID)
 }
 
-// SpendRuleActorEvaluationWorkflow refreshes one actor's spend cache. Identity
-// resolution is owned by the activity: signals may carry a Gram user ID, an
-// email, or both, and unresolved actors are skipped.
+// SpendRuleActorEvaluationWorkflow refreshes one actor's spend cache. Signals
+// are keyed by stable Gram user ID; email remains optional metadata the
+// activity can use when loading ClickHouse spend.
 func SpendRuleActorEvaluationWorkflow(ctx workflow.Context, signal spendrules.ActorEvaluationSignal) error {
 	activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: spendRuleEvaluationActivityTimeout,
@@ -173,11 +173,7 @@ func SpendRuleActorEvaluationWorkflow(ctx workflow.Context, signal spendrules.Ac
 }
 
 func buildSpendRuleActorEvaluationWorkflowID(signal spendrules.ActorEvaluationSignal) string {
-	key := signal.UserID
-	if key == "" {
-		key = signal.Email
-	}
-	return "v1:spend-rule-actor-eval:" + signal.OrganizationID + ":" + key
+	return "v1:spend-rule-actor-eval:" + signal.OrganizationID + ":" + signal.UserID
 }
 
 func spendRuleActorEvaluationDebounceSignal(spendrules.ActorEvaluationSignal) string {
@@ -232,6 +228,9 @@ func (e *TemporalSpendRuleEvaluator) Signal(ctx context.Context, organizationID 
 }
 
 func (e *TemporalSpendRuleEvaluator) SignalActor(ctx context.Context, signal spendrules.ActorEvaluationSignal) error {
+	if signal.UserID == "" {
+		return nil
+	}
 	id := buildSpendRuleActorEvaluationWorkflowID(signal)
 	_, err := e.TemporalEnv.Client().SignalWithStartWorkflow(
 		ctx,

--- a/server/internal/background/spend_rule_evaluation.go
+++ b/server/internal/background/spend_rule_evaluation.go
@@ -123,6 +123,55 @@ func SpendRuleOrgEvaluationWorkflowDebounced(ctx workflow.Context, organizationI
 	)(ctx, organizationID)
 }
 
+// SpendRuleActorEvaluationWorkflow refreshes one actor's spend cache. Identity
+// resolution is owned by the activity: signals may carry a Gram user ID, an
+// email, or both, and unresolved actors are skipped.
+func SpendRuleActorEvaluationWorkflow(ctx workflow.Context, signal spendrules.ActorEvaluationSignal) error {
+	activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: spendRuleEvaluationActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+		},
+	})
+
+	var a *Activities
+	if err := workflow.ExecuteActivity(activityCtx, a.RefreshSpendRuleActor, spend_rules.EvaluateActorArgs{
+		OrganizationID: signal.OrganizationID,
+		UserID:         signal.UserID,
+		Email:          signal.Email,
+	}).Get(activityCtx, nil); err != nil {
+		return fmt.Errorf("refresh spend rule actor: %w", err)
+	}
+	return nil
+}
+
+func buildSpendRuleActorEvaluationWorkflowID(signal spendrules.ActorEvaluationSignal) string {
+	key := signal.UserID
+	if key == "" {
+		key = signal.Email
+	}
+	return "v1:spend-rule-actor-eval:" + signal.OrganizationID + ":" + key
+}
+
+func spendRuleActorEvaluationDebounceSignal(spendrules.ActorEvaluationSignal) string {
+	return "v1:spend-rule-actor-eval/signal"
+}
+
+type SpendRuleActorEvaluationResult struct{}
+
+func SpendRuleActorEvaluationWorkflowDebounced(ctx workflow.Context, signal spendrules.ActorEvaluationSignal) (SpendRuleActorEvaluationResult, error) {
+	return Debounce(
+		func(ctx workflow.Context, signal spendrules.ActorEvaluationSignal) (SpendRuleActorEvaluationResult, error) {
+			return SpendRuleActorEvaluationResult{}, SpendRuleActorEvaluationWorkflow(ctx, signal)
+		},
+		SpendRuleActorEvaluationWorkflowDebounced,
+		spendRuleActorEvaluationDebounceSignal,
+		func(spendrules.ActorEvaluationSignal, SpendRuleActorEvaluationResult) bool { return false },
+	)(ctx, signal)
+}
+
 // TemporalSpendRuleEvaluator implements spendrules.EvaluationSignaler by
 // signal-with-starting the debounced per-org evaluation workflow. If a run is
 // already in flight the signal enqueues exactly one follow-up run, so state
@@ -133,6 +182,7 @@ type TemporalSpendRuleEvaluator struct {
 }
 
 var _ spendrules.EvaluationSignaler = (*TemporalSpendRuleEvaluator)(nil)
+var _ spendrules.ActorEvaluationSignaler = (*TemporalSpendRuleEvaluator)(nil)
 
 func (e *TemporalSpendRuleEvaluator) Signal(ctx context.Context, organizationID string) error {
 	id := buildSpendRuleOrgEvaluationWorkflowID(organizationID)
@@ -152,6 +202,28 @@ func (e *TemporalSpendRuleEvaluator) Signal(ctx context.Context, organizationID 
 	)
 	if err != nil {
 		return fmt.Errorf("signal spend rule org evaluation: %w", err)
+	}
+	return nil
+}
+
+func (e *TemporalSpendRuleEvaluator) SignalActor(ctx context.Context, signal spendrules.ActorEvaluationSignal) error {
+	id := buildSpendRuleActorEvaluationWorkflowID(signal)
+	_, err := e.TemporalEnv.Client().SignalWithStartWorkflow(
+		ctx,
+		id,
+		spendRuleActorEvaluationDebounceSignal(signal),
+		"enqueue",
+		client.StartWorkflowOptions{
+			ID:                       id,
+			TaskQueue:                string(e.TemporalEnv.Queue()),
+			WorkflowIDReusePolicy:    enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIDConflictPolicy: enums.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		},
+		SpendRuleActorEvaluationWorkflowDebounced,
+		signal,
+	)
+	if err != nil {
+		return fmt.Errorf("signal spend rule actor evaluation: %w", err)
 	}
 	return nil
 }

--- a/server/internal/background/spend_rule_evaluation.go
+++ b/server/internal/background/spend_rule_evaluation.go
@@ -20,21 +20,34 @@ const (
 	spendRuleEvaluationWorkflowID = "v1:spend-rule-evaluation"
 	spendRuleEvaluationScheduleID = "v1:spend-rule-evaluation-schedule"
 
-	// spendRuleEvaluationRunTimeout budgets one full scheduled sweep across
-	// every org with enabled rules.
+	// spendRuleEvaluationRunTimeout budgets one bounded page of the scheduled
+	// sweep. Larger sweeps ContinueAsNew with the remaining orgs.
 	spendRuleEvaluationRunTimeout = 15 * time.Minute
 
 	// spendRuleEvaluationActivityTimeout budgets one activity: listing orgs
 	// or evaluating a single org (directory match + one ClickHouse query per
 	// rule).
-	spendRuleEvaluationActivityTimeout = 2 * time.Minute
+	spendRuleEvaluationActivityTimeout = 30 * time.Second
+
+	// spendRuleEvaluationOrgPageSize bounds each workflow run. With a 30s
+	// activity attempt and 3 attempts, five unhealthy orgs still fit under the
+	// run timeout with retry backoff.
+	spendRuleEvaluationOrgPageSize = 5
 )
 
+type SpendRuleEvaluationParams struct {
+	OrganizationIDs []string `json:"organization_ids"`
+	EvaluatedCount  int      `json:"evaluated_count"`
+	ErrorCount      int      `json:"error_count"`
+}
+
 // SpendRuleEvaluationWorkflow is the scheduled coordinator: it lists every
-// organization with enabled spend rules and evaluates each in turn. Runs
-// every spendrules.EvaluationInterval with overlap-skip, so a slow sweep
-// delays rather than stacks.
-func SpendRuleEvaluationWorkflow(ctx workflow.Context) error {
+// organization with enabled spend rules and evaluates a bounded page per run.
+// Larger sweeps ContinueAsNew with the remaining orgs so slow/failing orgs do
+// not prevent later orgs from being evaluated. Runs every
+// spendrules.EvaluationInterval with overlap-skip, so a slow sweep delays
+// rather than stacks.
+func SpendRuleEvaluationWorkflow(ctx workflow.Context, params SpendRuleEvaluationParams) error {
 	activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: spendRuleEvaluationActivityTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
@@ -46,25 +59,37 @@ func SpendRuleEvaluationWorkflow(ctx workflow.Context) error {
 
 	var a *Activities
 
-	var orgs []string
-	if err := workflow.ExecuteActivity(activityCtx, a.ListSpendRuleOrgs).Get(activityCtx, &orgs); err != nil {
-		return fmt.Errorf("list spend rule orgs: %w", err)
-	}
-
-	var errCount int
-	for _, org := range orgs {
-		if err := workflow.ExecuteActivity(activityCtx, a.EvaluateOrgSpendRules, spend_rules.EvaluateOrgArgs{
-			OrganizationID: org,
-		}).Get(activityCtx, nil); err != nil {
-			// Evaluate every org even when one fails; surface the failure at
-			// the end so the run is visibly unhealthy.
-			workflow.GetLogger(ctx).Error("evaluate org spend rules", "organization_id", org, "error", err)
-			errCount++
+	orgs := params.OrganizationIDs
+	if len(orgs) == 0 && params.EvaluatedCount == 0 {
+		if err := workflow.ExecuteActivity(activityCtx, a.ListSpendRuleOrgs).Get(activityCtx, &orgs); err != nil {
+			return fmt.Errorf("list spend rule orgs: %w", err)
 		}
 	}
 
+	pageEnd := min(len(orgs), spendRuleEvaluationOrgPageSize)
+	errCount := params.ErrorCount
+	evaluatedCount := params.EvaluatedCount
+	for _, org := range orgs[:pageEnd] {
+		if err := workflow.ExecuteActivity(activityCtx, a.EvaluateOrgSpendRules, spend_rules.EvaluateOrgArgs{
+			OrganizationID: org,
+		}).Get(activityCtx, nil); err != nil {
+			// Evaluate every org in this page even when one fails; surface the
+			// failure after the sweep finishes so later pages still run.
+			workflow.GetLogger(ctx).Error("evaluate org spend rules", "organization_id", org, "error", err)
+			errCount++
+		}
+		evaluatedCount++
+	}
+
+	if pageEnd < len(orgs) {
+		return workflow.NewContinueAsNewError(ctx, SpendRuleEvaluationWorkflow, SpendRuleEvaluationParams{
+			OrganizationIDs: orgs[pageEnd:],
+			EvaluatedCount:  evaluatedCount,
+			ErrorCount:      errCount,
+		})
+	}
 	if errCount > 0 {
-		return fmt.Errorf("spend rule evaluation failed for %d of %d orgs", errCount, len(orgs))
+		return fmt.Errorf("spend rule evaluation failed for %d of %d orgs", errCount, evaluatedCount)
 	}
 	return nil
 }
@@ -267,6 +292,7 @@ func buildSpendRuleEvaluationScheduleOptions(temporalEnv *tenv.Environment) clie
 		Action: &client.ScheduleWorkflowAction{
 			ID:                 spendRuleEvaluationWorkflowID,
 			Workflow:           SpendRuleEvaluationWorkflow,
+			Args:               []any{SpendRuleEvaluationParams{OrganizationIDs: nil, EvaluatedCount: 0, ErrorCount: 0}},
 			TaskQueue:          string(temporalEnv.Queue()),
 			WorkflowRunTimeout: spendRuleEvaluationRunTimeout,
 		},

--- a/server/internal/background/spend_rule_evaluation_test.go
+++ b/server/internal/background/spend_rule_evaluation_test.go
@@ -1,0 +1,96 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	spend_rules "github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"
+)
+
+func TestSpendRuleOrgEvaluationWorkflowID(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "v1:spend-rule-eval:org_01HZ", buildSpendRuleOrgEvaluationWorkflowID("org_01HZ"))
+	require.Equal(t, "v1:spend-rule-eval/signal", spendRuleOrgEvaluationDebounceSignal("org_01HZ"))
+}
+
+func TestSpendRuleOrgEvaluationWorkflowDebounced_CompletesWithoutSignals(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	evalCalls := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args spend_rules.EvaluateOrgArgs) error {
+			evalCalls++
+			require.Equal(t, "org_01HZ", args.OrganizationID)
+			return nil
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleOrgEvaluationWorkflowDebounced, "org_01HZ")
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, evalCalls)
+}
+
+func TestSpendRuleOrgEvaluationWorkflowDebounced_StartSignalDoesNotSelfLoop(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	// Simulate SignalWithStart: the signal that started the run is queued
+	// before workflow code executes. The wrapper must drain it up front so
+	// the post-run check does not immediately ContinueAsNew.
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(spendRuleOrgEvaluationDebounceSignal("org_01HZ"), "enqueue")
+	}, 0)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ spend_rules.EvaluateOrgArgs) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleOrgEvaluationWorkflowDebounced, "org_01HZ")
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError(), "start signal must be drained at top; should complete, not ContinueAsNew")
+}
+
+func TestSpendRuleOrgEvaluationWorkflowDebounced_SignalMidRunContinuesAsNew(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	// A signal landing while evaluation is in flight (fresh usage committed
+	// mid-run) must enqueue exactly one follow-up run.
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ spend_rules.EvaluateOrgArgs) error {
+			env.SignalWorkflow(spendRuleOrgEvaluationDebounceSignal("org_01HZ"), "enqueue")
+			return nil
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleOrgEvaluationWorkflowDebounced, "org_01HZ")
+
+	require.True(t, env.IsWorkflowCompleted())
+
+	// The ContinueAsNew must target the debounced wrapper itself, not the
+	// inner workflow, or the next run loses debounce semantics.
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+	require.Equal(t, "SpendRuleOrgEvaluationWorkflowDebounced", canErr.WorkflowType.Name)
+}

--- a/server/internal/background/spend_rule_evaluation_test.go
+++ b/server/internal/background/spend_rule_evaluation_test.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,97 @@ import (
 
 	spend_rules "github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"
 )
+
+func TestSpendRuleEvaluationWorkflowContinuesWithRemainingOrgs(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	orgs := []string{"org_01", "org_02", "org_03", "org_04", "org_05", "org_06"}
+	env.RegisterActivityWithOptions(
+		func(context.Context) ([]string, error) {
+			return orgs, nil
+		},
+		activity.RegisterOptions{Name: "ListSpendRuleOrgs"},
+	)
+
+	evaluated := make([]string, 0, spendRuleEvaluationOrgPageSize)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, args spend_rules.EvaluateOrgArgs) error {
+			evaluated = append(evaluated, args.OrganizationID)
+			return nil
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleEvaluationWorkflow, SpendRuleEvaluationParams{
+		OrganizationIDs: nil,
+		EvaluatedCount:  0,
+		ErrorCount:      0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+	require.Equal(t, "SpendRuleEvaluationWorkflow", canErr.WorkflowType.Name)
+	require.Equal(t, orgs[:spendRuleEvaluationOrgPageSize], evaluated)
+}
+
+func TestSpendRuleEvaluationWorkflowContinuesBeforeReportingPageErrors(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	orgs := []string{"org_01", "org_02", "org_03", "org_04", "org_05", "org_06"}
+	env.RegisterActivityWithOptions(
+		func(context.Context) ([]string, error) {
+			return orgs, nil
+		},
+		activity.RegisterOptions{Name: "ListSpendRuleOrgs"},
+	)
+	env.RegisterActivityWithOptions(
+		func(context.Context, spend_rules.EvaluateOrgArgs) error {
+			return errors.New("evaluate failed")
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleEvaluationWorkflow, SpendRuleEvaluationParams{
+		OrganizationIDs: nil,
+		EvaluatedCount:  0,
+		ErrorCount:      0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+	require.Equal(t, "SpendRuleEvaluationWorkflow", canErr.WorkflowType.Name)
+}
+
+func TestSpendRuleEvaluationWorkflowReportsAggregatedErrorsOnFinalPage(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(context.Context, spend_rules.EvaluateOrgArgs) error {
+			return errors.New("evaluate failed")
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleEvaluationWorkflow, SpendRuleEvaluationParams{
+		OrganizationIDs: []string{"org_06"},
+		EvaluatedCount:  5,
+		ErrorCount:      2,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.ErrorContains(t, env.GetWorkflowError(), "spend rule evaluation failed for 3 of 6 orgs")
+}
 
 func TestSpendRuleOrgEvaluationWorkflowID(t *testing.T) {
 	t.Parallel()
@@ -90,6 +182,28 @@ func TestSpendRuleOrgEvaluationWorkflowDebounced_SignalMidRunContinuesAsNew(t *t
 
 	// The ContinueAsNew must target the debounced wrapper itself, not the
 	// inner workflow, or the next run loses debounce semantics.
+	var canErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
+	require.Equal(t, "SpendRuleOrgEvaluationWorkflowDebounced", canErr.WorkflowType.Name)
+}
+
+func TestSpendRuleOrgEvaluationWorkflowDebounced_FailingRunWithSignalContinuesAsNew(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ spend_rules.EvaluateOrgArgs) error {
+			env.SignalWorkflow(spendRuleOrgEvaluationDebounceSignal("org_01HZ"), "enqueue")
+			return errors.New("evaluate failed")
+		},
+		activity.RegisterOptions{Name: "EvaluateOrgSpendRules"},
+	)
+
+	env.ExecuteWorkflow(SpendRuleOrgEvaluationWorkflowDebounced, "org_01HZ")
+
+	require.True(t, env.IsWorkflowCompleted())
 	var canErr *workflow.ContinueAsNewError
 	require.ErrorAs(t, env.GetWorkflowError(), &canErr)
 	require.Equal(t, "SpendRuleOrgEvaluationWorkflowDebounced", canErr.WorkflowType.Name)

--- a/server/internal/background/spend_rule_evaluation_test.go
+++ b/server/internal/background/spend_rule_evaluation_test.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	spend_rules "github.com/speakeasy-api/gram/server/internal/background/activities/spend_rules"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
 )
 
 func TestSpendRuleEvaluationWorkflowContinuesWithRemainingOrgs(t *testing.T) {
@@ -109,6 +110,21 @@ func TestSpendRuleOrgEvaluationWorkflowID(t *testing.T) {
 
 	require.Equal(t, "v1:spend-rule-eval:org_01HZ", buildSpendRuleOrgEvaluationWorkflowID("org_01HZ"))
 	require.Equal(t, "v1:spend-rule-eval/signal", spendRuleOrgEvaluationDebounceSignal("org_01HZ"))
+}
+
+func TestSpendRuleActorEvaluationWorkflowIDUsesUserIDOnly(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "v1:spend-rule-actor-eval:org_01HZ:user_123", buildSpendRuleActorEvaluationWorkflowID(spendrules.ActorEvaluationSignal{
+		OrganizationID: "org_01HZ",
+		UserID:         "user_123",
+		Email:          "ada@acme.com",
+	}))
+	require.Equal(t, "v1:spend-rule-actor-eval:org_01HZ:user_123", buildSpendRuleActorEvaluationWorkflowID(spendrules.ActorEvaluationSignal{
+		OrganizationID: "org_01HZ",
+		UserID:         "user_123",
+		Email:          "other@acme.com",
+	}))
 }
 
 func TestSpendRuleOrgEvaluationWorkflowDebounced_CompletesWithoutSignals(t *testing.T) {

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -404,6 +404,7 @@ func NewTemporalWorker(
 	// Spend rule evaluation activities
 	temporalWorker.RegisterActivity(activities.ListSpendRuleOrgs)
 	temporalWorker.RegisterActivity(activities.EvaluateOrgSpendRules)
+	temporalWorker.RegisterActivity(activities.RefreshSpendRuleActor)
 	// Skill efficacy activities — the database steps run on the main queue and
 	// only the judged publication goes to the dedicated worker.
 	temporalWorker.RegisterActivity(activities.skillEfficacyScorer.EnqueueSkillEfficacyPage)
@@ -485,6 +486,8 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(SpendRuleEvaluationWorkflow)
 	temporalWorker.RegisterWorkflow(SpendRuleOrgEvaluationWorkflow)
 	temporalWorker.RegisterWorkflow(SpendRuleOrgEvaluationWorkflowDebounced)
+	temporalWorker.RegisterWorkflow(SpendRuleActorEvaluationWorkflow)
+	temporalWorker.RegisterWorkflow(SpendRuleActorEvaluationWorkflowDebounced)
 	// Skill efficacy workflows
 	temporalWorker.RegisterWorkflow(SkillEfficacyCoordinatorWorkflow)
 	temporalWorker.RegisterWorkflow(SkillEfficacySweepWorkflow)

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -401,6 +401,9 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GCOutboxProcessedRows)
 	temporalWorker.RegisterActivity(activities.ListPluginPublishCandidates)
 	temporalWorker.RegisterActivity(activities.PublishPluginProject)
+	// Spend rule evaluation activities
+	temporalWorker.RegisterActivity(activities.ListSpendRuleOrgs)
+	temporalWorker.RegisterActivity(activities.EvaluateOrgSpendRules)
 	// Skill efficacy activities — the database steps run on the main queue and
 	// only the judged publication goes to the dedicated worker.
 	temporalWorker.RegisterActivity(activities.skillEfficacyScorer.EnqueueSkillEfficacyPage)
@@ -478,6 +481,10 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(OutboxGCWorkflow)
 	temporalWorker.RegisterWorkflow(PluginGeneratorRolloutWorkflow)
 	temporalWorker.RegisterWorkflow(PluginInitialPublishWorkflow)
+	// Spend rule evaluation workflows
+	temporalWorker.RegisterWorkflow(SpendRuleEvaluationWorkflow)
+	temporalWorker.RegisterWorkflow(SpendRuleOrgEvaluationWorkflow)
+	temporalWorker.RegisterWorkflow(SpendRuleOrgEvaluationWorkflowDebounced)
 	// Skill efficacy workflows
 	temporalWorker.RegisterWorkflow(SkillEfficacyCoordinatorWorkflow)
 	temporalWorker.RegisterWorkflow(SkillEfficacySweepWorkflow)
@@ -545,6 +552,12 @@ func NewTemporalWorker(
 
 	if err := AddStagedTelemetrySweepSchedule(context.Background(), env); err != nil {
 		logger.ErrorContext(context.Background(), "failed to add staged telemetry sweep schedule", attr.SlogError(err))
+	}
+
+	if err := AddSpendRuleEvaluationSchedule(context.Background(), env); err != nil {
+		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+			logger.ErrorContext(context.Background(), "failed to add spend rule evaluation schedule", attr.SlogError(err))
+		}
 	}
 
 	if err := AddSkillObservationReconciliationSchedule(context.Background(), env); err != nil {

--- a/server/internal/hooks/cache.go
+++ b/server/internal/hooks/cache.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"time"
 )
@@ -28,6 +29,15 @@ func sessionMCPListCacheKey(sessionID string) string {
 // reuses across retries.
 func hookIdempotencyCacheKey(token string) string {
 	return fmt.Sprintf("hook:idempotency:%s", token)
+}
+
+// blockedPromptTelemetryCacheKey returns the Redis key that dedupes block
+// telemetry for clients that do not send a per-delivery idempotency key. The
+// deny response is still returned on every delivery; this only gates the
+// ClickHouse side-effect.
+func blockedPromptTelemetryCacheKey(provider, sessionID, prompt string) string {
+	digest := sha256.Sum256([]byte(provider + "\x00" + sessionID + "\x00" + prompt))
+	return fmt.Sprintf("hook:blocked-prompt:%x", digest)
 }
 
 // sessionAgentVariantCacheKey returns the Redis key for the agent variant

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -840,6 +840,43 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 	if payload == nil {
 		return makeHookResult(ev.RawEventType), nil
 	}
+	// Spend gate runs before any risk-policy evaluation: an over-budget user
+	// gets tool calls denied even mid-turn, for native and MCP tools alike.
+	if block := s.checkSpendGate(ctx, ev.Event); block != nil {
+		auditReason := spendBlockReason("tool call", block)
+		userReason := auditReason
+		if payload.SessionID != nil {
+			if metadata, err := s.getSessionMetadata(ctx, *payload.SessionID); err == nil {
+				s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, auditReason)
+			}
+		}
+		if blockID, err := uuid.NewV7(); err == nil {
+			userReason = appendBlockURL(userReason, s.blockViewURL(blockID))
+			userID := ev.Context.User.ID
+			userEmail := ev.Context.User.Email
+			asyncCtx := context.WithoutCancel(ctx)
+			// Resolve the owning user inside the goroutine so any DB lookup
+			// stays off the deny hot path.
+			go func() {
+				if userID == "" {
+					userID = s.resolveUserByEmail(asyncCtx, userEmail, ev.Context.OrganizationID)
+				}
+				s.insertToolCallBlock(asyncCtx, blockID, toolCallBlockParams{
+					Provider:       "claude",
+					OrganizationID: ev.Context.OrganizationID,
+					ProjectID:      ev.Context.ProjectID,
+					Reason:         auditReason,
+					ToolName:       ev.ToolName,
+					UserID:         userID,
+					RiskPolicyID:   uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+					RiskResultID:   uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+					ChatID:         chatIDForBlock(conv.PtrValOr(payload.SessionID, "")),
+					ChatMessageID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+				})
+			}()
+		}
+		return constructBlockResponse(payload.HookEventName, userReason), nil
+	}
 	if s.riskScanner != nil && ev.ConversationID != "" {
 		// Acknowledged warn is excluded from the enforcement block so it falls
 		// through to the shadow-MCP guard below: an ack clears the risk

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -850,7 +850,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 				s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, auditReason)
 			}
 		}
-		if blockID, err := uuid.NewV7(); err == nil {
+		if blockID, err := uuid.NewV7(); err == nil && !s.isHookDuplicate(ctx) && s.repo != nil && strings.TrimSpace(ev.Context.OrganizationID) != "" && ev.Context.ProjectID != uuid.Nil {
 			userReason = appendBlockURL(userReason, s.blockViewURL(blockID))
 			userID := ev.Context.User.ID
 			userEmail := ev.Context.User.Email

--- a/server/internal/hooks/idempotency_test.go
+++ b/server/internal/hooks/idempotency_test.go
@@ -103,6 +103,31 @@ func TestClaimHookIdempotency_Guard(t *testing.T) {
 	assert.True(t, ti.service.claimHookIdempotency(ctx, "   ", false), "blank token always proceeds")
 }
 
+func TestClaimBlockedPromptTelemetryDedupesSessionPrompt(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	sessionID := uuid.NewString()
+	prompt := "please do the blocked thing"
+	payload := &gen.ClaudePayload{
+		SessionID: &sessionID,
+		Prompt:    &prompt,
+	}
+
+	require.True(t, ti.service.claimBlockedPromptTelemetry(ctx, payload), "first blocked prompt writes telemetry")
+	require.False(t, ti.service.claimBlockedPromptTelemetry(ctx, payload), "same session and prompt is duplicate telemetry")
+
+	otherPrompt := "please do a different blocked thing"
+	require.True(t, ti.service.claimBlockedPromptTelemetry(ctx, &gen.ClaudePayload{
+		SessionID: &sessionID,
+		Prompt:    &otherPrompt,
+	}), "different prompt gets its own telemetry claim")
+	require.True(t, ti.service.claimBlockedPromptTelemetry(ctx, &gen.ClaudePayload{
+		SessionID: nil,
+		Prompt:    &prompt,
+	}), "missing session fails open")
+}
+
 // TestHookDuplicateContextFlag verifies the flag that gates the block-path
 // write side-effects (block-reason telemetry, shadow-MCP findings) on a
 // redelivery: untagged contexts are live, tagged ones are duplicates.

--- a/server/internal/hooks/impl.go
+++ b/server/internal/hooks/impl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -54,6 +55,7 @@ type Service struct {
 	chatTitleGenerator ChatTitleGenerator
 	riskScanner        risk.RiskScanner
 	policyBypass       *risk.PolicyBypassEvaluator
+	spendGate          *spendrules.Gate
 	shadowMCPClient    *shadowmcp.Client
 	writer             *chat.ChatMessageWriter
 	// efficacySignaler is optional: when nil, hook paths record exactly as
@@ -195,6 +197,7 @@ func NewService(
 	chatTitleGenerator ChatTitleGenerator,
 	riskScanner risk.RiskScanner,
 	policyBypass *risk.PolicyBypassEvaluator,
+	spendGate *spendrules.Gate,
 	shadowMCPClient *shadowmcp.Client,
 	writer *chat.ChatMessageWriter,
 	efficacySignaler efficacy.Signaler,
@@ -217,6 +220,7 @@ func NewService(
 		chatTitleGenerator: chatTitleGenerator,
 		riskScanner:        riskScanner,
 		policyBypass:       policyBypass,
+		spendGate:          spendGate,
 		shadowMCPClient:    shadowMCPClient,
 		writer:             writer,
 		efficacySignaler:   efficacySignaler,

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -409,7 +409,22 @@ func isReservedAssistantAdapter(adapter string) bool {
 
 func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, actor canonicalActor, timestamp time.Time) (string, string) {
 	event := canonicalHookEvent(payload, authCtx, actor, timestamp)
-	switch strings.TrimSpace(payload.Event.Type) {
+	eventType := strings.TrimSpace(payload.Event.Type)
+
+	// Spend gate runs before any risk-policy evaluation. v1 enforcement
+	// surface is Claude only; other adapters pass through untouched.
+	if strings.TrimSpace(payload.Source.Adapter) == "claude" && (eventType == "prompt.submitted" || eventType == "tool.requested") {
+		if block := s.checkSpendGate(ctx, event); block != nil {
+			if eventType == "tool.requested" {
+				auditReason := spendBlockReason("tool call", block)
+				return auditReason, s.appendCanonicalBlockURL(ctx, authCtx, actor, payload, auditReason, canonicalToolName(payload), "", auditReason)
+			}
+			auditReason := spendBlockReason("prompt", block)
+			return auditReason, auditReason
+		}
+	}
+
+	switch eventType {
 	case "prompt.submitted":
 		ev := hookevents.NewUserPromptSubmit(event, hookevents.UserPromptSubmitParams{
 			Prompt: canonicalPromptText(payload),

--- a/server/internal/hooks/pending_helpers.go
+++ b/server/internal/hooks/pending_helpers.go
@@ -81,6 +81,32 @@ func (s *Service) claimHookIdempotency(ctx context.Context, token string, replay
 	return claimed
 }
 
+func (s *Service) claimBlockedPromptTelemetry(ctx context.Context, payload *gen.ClaudePayload) bool {
+	if payload == nil || payload.SessionID == nil || payload.Prompt == nil {
+		return true
+	}
+	sessionID := strings.TrimSpace(*payload.SessionID)
+	prompt := strings.TrimSpace(*payload.Prompt)
+	if sessionID == "" || prompt == "" {
+		return true
+	}
+
+	claimed, err := s.cache.Add(context.WithoutCancel(ctx), blockedPromptTelemetryCacheKey("claude", sessionID, prompt), hookIdempotencyTTL)
+	if err != nil {
+		s.logger.WarnContext(ctx, "blocked prompt telemetry guard failed; persisting anyway",
+			attr.SlogEvent("blocked_prompt_telemetry_guard_failed"),
+			attr.SlogError(err),
+		)
+		return true
+	}
+	if !claimed {
+		s.logger.InfoContext(ctx, "skipping duplicate blocked prompt telemetry",
+			attr.SlogEvent("blocked_prompt_telemetry_duplicate"),
+		)
+	}
+	return claimed
+}
+
 // bufferHook stores a hook payload in Redis for later processing using atomic RPUSH
 func (s *Service) bufferHook(ctx context.Context, sessionID string, payload *gen.ClaudePayload) error {
 	// Use atomic RPUSH operation to append to the list

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -269,7 +269,7 @@ func (s *Service) handleUserPromptSubmit(ctx context.Context, ev *hookevents.Use
 	// is denied outright.
 	if block := s.checkSpendGate(ctx, ev.Event); block != nil {
 		reason := spendBlockReason("prompt", block)
-		if payload.SessionID != nil {
+		if payload.SessionID != nil && s.claimBlockedPromptTelemetry(ctx, payload) {
 			if metadata, err := s.getSessionMetadata(ctx, *payload.SessionID); err == nil {
 				s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, reason)
 			}
@@ -289,8 +289,11 @@ func (s *Service) handleUserPromptSubmit(ctx context.Context, ev *hookevents.Use
 			userReason := renderUserBlockReason(scanResult.UserMessage, auditReason)
 			// ClickHouse always gets the technical reason; the user_message
 			// override only changes what the agent / end user sees.
-			if metadata, err := s.getSessionMetadata(ctx, *payload.SessionID); err == nil {
-				s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, auditReason)
+			if s.claimBlockedPromptTelemetry(ctx, payload) {
+				metadata, err := s.getSessionMetadata(ctx, conv.PtrValOr(payload.SessionID, ""))
+				if err == nil {
+					s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, auditReason)
+				}
 			}
 			return constructBlockResponse(payload.HookEventName, userReason), nil
 		}

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -265,6 +265,17 @@ func (s *Service) handleUserPromptSubmit(ctx context.Context, ev *hookevents.Use
 	if payload == nil {
 		return makeHookResult(ev.RawEventType), nil
 	}
+	// Spend gate runs before any risk-policy evaluation: an over-budget user
+	// is denied outright.
+	if block := s.checkSpendGate(ctx, ev.Event); block != nil {
+		reason := spendBlockReason("prompt", block)
+		if payload.SessionID != nil {
+			if metadata, err := s.getSessionMetadata(ctx, *payload.SessionID); err == nil {
+				s.writeClaudeBlockToClickHouse(ctx, payload, &metadata, reason)
+			}
+		}
+		return constructBlockResponse(payload.HookEventName, reason), nil
+	}
 	if s.riskScanner != nil && ev.Prompt != "" && ev.ConversationID != "" {
 		if scanResult := s.scanUserPromptForEnforcement(ctx, ev); scanResult != nil {
 			// Warn (challenge) defers to the tool call: Claude Code can only show

--- a/server/internal/hooks/setup_test.go
+++ b/server/internal/hooks/setup_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/url"
 	"os"
@@ -29,6 +30,8 @@ import (
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+	spendcelenv "github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
@@ -62,6 +65,7 @@ type testInstance struct {
 	conn            *pgxpool.Pool
 	chConn          clickhouse.Conn
 	redisClient     *redis.Client
+	spendGateCache  cache.Cache
 	accessStore     accesscontrol.Store
 	sessionManager  *sessions.Manager
 	efficacySignals *recordingEfficacySignaler
@@ -96,6 +100,45 @@ func (r *recordingEfficacySignaler) signaled() []uuid.UUID {
 	return slices.Clone(r.signals)
 }
 
+// namespacedSpendGateCache keeps snapshots isolated even though hook tests use
+// the same Redis database and organization fixture in parallel.
+type namespacedSpendGateCache struct {
+	cache.Cache
+	namespace string
+}
+
+func (c *namespacedSpendGateCache) key(key string) string {
+	return c.namespace + ":" + key
+}
+
+func (c *namespacedSpendGateCache) Get(ctx context.Context, key string, value any) error {
+	if err := c.Cache.Get(ctx, c.key(key), value); err != nil {
+		return fmt.Errorf("get namespaced spend gate cache: %w", err)
+	}
+	return nil
+}
+
+func (c *namespacedSpendGateCache) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
+	if err := c.Cache.Set(ctx, c.key(key), value, ttl); err != nil {
+		return fmt.Errorf("set namespaced spend gate cache: %w", err)
+	}
+	return nil
+}
+
+func (c *namespacedSpendGateCache) Delete(ctx context.Context, key string) error {
+	if err := c.Cache.Delete(ctx, c.key(key)); err != nil {
+		return fmt.Errorf("delete namespaced spend gate cache: %w", err)
+	}
+	return nil
+}
+
+func (c *namespacedSpendGateCache) DeleteByPrefix(ctx context.Context, prefix string) error {
+	if err := c.Cache.DeleteByPrefix(ctx, c.key(prefix)); err != nil {
+		return fmt.Errorf("delete namespaced spend gate cache by prefix: %w", err)
+	}
+	return nil
+}
+
 func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
@@ -117,6 +160,13 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
 
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
+	spendGateCache := &namespacedSpendGateCache{
+		Cache:     cacheAdapter,
+		namespace: "hooks-spend-gate-test:" + uuid.NewString(),
+	}
+	t.Cleanup(func() {
+		require.NoError(t, spendGateCache.DeleteByPrefix(context.Background(), ""))
+	})
 
 	// Pass nil for telemetry logger, temporalEnv, productFeatures, and chatTitleGenerator in tests
 	chConn, err := infra.NewClickhouseClient(t)
@@ -133,6 +183,10 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 	efficacySignals := &recordingEfficacySignaler{mu: sync.Mutex{}, err: nil, signals: nil}
 	shadowMCPClient := shadowmcp.NewClient(logger, conn, cacheAdapter, accessStore, serverURL)
 	policyBypass := risk.NewPolicyBypassEvaluator(logger, conn)
+	spendCelEngine, err := spendcelenv.New()
+	require.NoError(t, err)
+	spendGate, err := spendrules.NewGate(logger, spendGateCache, spendCelEngine)
+	require.NoError(t, err)
 	svc := NewService(
 		logger,
 		conn,
@@ -148,6 +202,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 		nil,
 		nil,
 		policyBypass,
+		spendGate,
 		shadowMCPClient,
 		chatWriter,
 		efficacySignals,
@@ -161,6 +216,7 @@ func newTestHooksService(t *testing.T) (context.Context, *testInstance) {
 		conn:            conn,
 		chConn:          chConn,
 		redisClient:     redisClient,
+		spendGateCache:  spendGateCache,
 		accessStore:     accessStore,
 		sessionManager:  sessionManager,
 		efficacySignals: efficacySignals,

--- a/server/internal/hooks/spend_gate.go
+++ b/server/internal/hooks/spend_gate.go
@@ -1,0 +1,45 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/hookevents"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+)
+
+// checkSpendGate consults the spend rule circuit for the actor on a hook
+// event. It runs BEFORE risk-policy scans — an over-budget actor is denied
+// before any policy evaluation. Every failure mode resolves to "not blocked"
+// (fail-open): a nil gate, an unresolved org/email identity (same guard as
+// scanHookEventForEnforcement), and cache infrastructure errors.
+func (s *Service) checkSpendGate(ctx context.Context, ev hookevents.Event) *spendrules.Block {
+	if s.spendGate == nil {
+		return nil
+	}
+	if ev.Context.OrganizationID == "" || ev.Context.User.Email == "" {
+		return nil
+	}
+
+	block, err := s.spendGate.CheckBlocked(ctx, ev.Context.OrganizationID, ev.Context.User.Email)
+	if err != nil {
+		s.logger.WarnContext(ctx, "spend gate check failed; failing open",
+			attr.SlogError(err),
+			attr.SlogEvent("spend_gate_error"),
+			attr.SlogHookSource(string(ev.Provider)),
+			attr.SlogHookEvent(ev.RawEventType),
+			attr.SlogOrganizationID(ev.Context.OrganizationID),
+		)
+		return nil
+	}
+	return block
+}
+
+// spendBlockReason renders the reason shown to the agent and stored on
+// traces when the spend gate denies an event. kind is "prompt" or
+// "tool call".
+func spendBlockReason(kind string, block *spendrules.Block) string {
+	return fmt.Sprintf("Speakeasy blocked this %s: spend rule %q — budget resets %s",
+		kind, block.RuleName, block.WindowEnd.UTC().Format("Jan 2, 2006 15:04 MST"))
+}

--- a/server/internal/hooks/spend_gate.go
+++ b/server/internal/hooks/spend_gate.go
@@ -12,17 +12,17 @@ import (
 // checkSpendGate consults the spend rule circuit for the actor on a hook
 // event. It runs BEFORE risk-policy scans — an over-budget actor is denied
 // before any policy evaluation. Every failure mode resolves to "not blocked"
-// (fail-open): a nil gate, an unresolved org/email identity (same guard as
-// scanHookEventForEnforcement), and cache infrastructure errors.
+// (fail-open): a nil gate, an unresolved org/user identity, and cache
+// infrastructure errors.
 func (s *Service) checkSpendGate(ctx context.Context, ev hookevents.Event) *spendrules.Block {
 	if s.spendGate == nil {
 		return nil
 	}
-	if ev.Context.OrganizationID == "" || ev.Context.User.Email == "" {
+	if ev.Context.OrganizationID == "" || ev.Context.User.ID == "" {
 		return nil
 	}
 
-	block, err := s.spendGate.CheckBlocked(ctx, ev.Context.OrganizationID, ev.Context.User.Email)
+	block, err := s.spendGate.CheckBlocked(ctx, ev.Context.OrganizationID, ev.Context.User.ID)
 	if err != nil {
 		s.logger.WarnContext(ctx, "spend gate check failed; failing open",
 			attr.SlogError(err),

--- a/server/internal/hooks/spend_gate_test.go
+++ b/server/internal/hooks/spend_gate_test.go
@@ -1,0 +1,327 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	redisCache "github.com/go-redis/cache/v9"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
+)
+
+// recordingRiskScanner counts ScanForEnforcement calls so tests can assert
+// the spend gate runs BEFORE any risk-policy evaluation.
+type recordingRiskScanner struct {
+	scans int
+}
+
+func (s *recordingRiskScanner) ScanForEnforcement(_ context.Context, _ string, _ uuid.UUID, _ string, _ string, _ string, _ string) (*risk.ScanResult, error) {
+	s.scans++
+	return nil, nil
+}
+
+func (s *recordingRiskScanner) LookupShadowMCPBlockingPolicy(_ context.Context, _ string, _ uuid.UUID, _ string) (*risk.ShadowMCPPolicy, error) {
+	return nil, nil
+}
+
+func (s *recordingRiskScanner) HasEnabledShadowMCPPolicy(_ context.Context, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+func (s *recordingRiskScanner) HasAcknowledgedChallenge(_ context.Context, _ uuid.UUID, _, _, _, _ string) bool {
+	return false
+}
+
+func (s *recordingRiskScanner) RecordPolicyChallenge(_ context.Context, _ string, _ uuid.UUID, _, _, _, _, _, _, _ string) {
+}
+
+// seedSpendBlock writes gate state that makes the given emails breach a
+// blocking rule. The request path still evaluates both target and rule CEL.
+func seedSpendBlock(t *testing.T, ctx context.Context, ti *testInstance, organizationID string, emails ...string) {
+	t.Helper()
+	ruleURN := "spend_rule:33333333-3333-3333-3333-333333333333:v2"
+
+	state := spendrules.NewGateState(organizationID, nil)
+	err := ti.spendGateCache.Get(ctx, "spend_gate:"+organizationID, &state)
+	if err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
+		require.NoError(t, err)
+	}
+	if state.Actors == nil {
+		state.Actors = map[string]spendrules.GateActor{}
+	}
+	state.Rules = []spendrules.GateRule{{
+		RuleURN:    ruleURN,
+		RuleName:   "Intern hard limit",
+		Action:     spendrules.ActionBlock,
+		TargetExpr: `true`,
+		RuleExpr:   `spend_usd >= limit_usd`,
+		LimitUSD:   100,
+		WarnAtPct:  80,
+		WindowKind: spendrules.WindowMonthly,
+		WindowEnd:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+	}}
+	for _, email := range emails {
+		actor := spendrules.Actor{
+			UserID:      "",
+			Email:       email,
+			DisplayName: "",
+			Attrs: celenv.Actor{
+				Email:          email,
+				DepartmentName: "",
+				JobTitle:       "",
+				EmployeeType:   "",
+				DivisionName:   "",
+				CostCenterName: "",
+				Groups:         nil,
+				Roles:          nil,
+				SpendUSD:       0,
+				LimitUSD:       0,
+				UsedPct:        0,
+				WarnAtPct:      0,
+			},
+		}
+		state.SetActor(organizationID, actor)
+		state.SetActorWindowSpend(organizationID, actor, chrepo.ActorWindowSpendRow{
+			Email:       actor.Email,
+			DailyCost:   0,
+			WeeklyCost:  0,
+			MonthlyCost: 100,
+		})
+	}
+	require.NoError(t, spendrules.WriteGateState(ctx, ti.spendGateCache, organizationID, state))
+}
+
+func TestClaude_UserPromptSubmit_SpendGateBlocksBeforeRiskScan(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	scanner := &recordingRiskScanner{}
+	ti.service.riskScanner = scanner
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	// The Claude path resolves the actor from the payload email, not the API
+	// key owner.
+	userID := "user_spend_prompt_block"
+	userEmail := "spend-prompt-block@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, userID, userEmail)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, userEmail)
+
+	sessionID := uuid.NewString()
+	prompt := "please write some code"
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		Prompt:        &prompt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.NotNil(t, result.Decision)
+	assert.Equal(t, "block", *result.Decision)
+	require.NotNil(t, result.Reason)
+	assert.Contains(t, *result.Reason, "Intern hard limit")
+	assert.Contains(t, *result.Reason, "budget resets")
+
+	assert.Zero(t, scanner.scans, "spend gate must deny before any risk-policy scan runs")
+}
+
+func TestClaude_PreToolUse_SpendGateDeniesNativeTool(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	scanner := &recordingRiskScanner{}
+	ti.service.riskScanner = scanner
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	userID := "user_spend_tool_block"
+	userEmail := "spend-tool-block@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, userID, userEmail)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, userEmail)
+
+	sessionID := uuid.NewString()
+	toolName := "Bash"
+	toolUseID := "toolu_spend_gate_native"
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput:     map[string]any{"command": "ls"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "deny", *output.PermissionDecision)
+	require.NotNil(t, output.PermissionDecisionReason)
+	assert.Contains(t, *output.PermissionDecisionReason, "Intern hard limit")
+	assert.Contains(t, *output.PermissionDecisionReason, "/blocks/",
+		"deny reason should carry the durable block page URL")
+
+	assert.Zero(t, scanner.scans, "spend gate must deny before any risk-policy scan runs")
+}
+
+func TestClaude_SpendGateMatchesByEmailIdentifier(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	userEmail := "blocked-by-email@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "user_spend_email", userEmail)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, userEmail)
+
+	sessionID := uuid.NewString()
+	prompt := "hello"
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		Prompt:        &prompt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Decision)
+	assert.Equal(t, "block", *result.Decision)
+}
+
+func TestClaude_SpendGateAllowsUnblockedUser(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	// A different actor is blocked; the caller must pass through.
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, "someone-else@example.com")
+
+	sessionID := uuid.NewString()
+	prompt := "hello"
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		Prompt:        &prompt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Nil(t, result.Decision)
+}
+
+func TestClaude_SpendGateSkipsUnresolvedIdentity(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	// Clear the caller identity: the event context resolves no user, so the
+	// gate must fail open rather than guess.
+	authCtx.UserID = ""
+	authCtx.Email = nil
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	sessionID := uuid.NewString()
+	prompt := "hello"
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     &sessionID,
+		Prompt:        &prompt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Nil(t, result.Decision)
+}
+
+func TestIngest_SpendGateDeniesClaudePrompt(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	payload := canonicalIngestPayload("claude", "prompt.submitted", "spend-gate-ingest")
+	text := "hello"
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &text},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "deny", result.Decision)
+	require.NotNil(t, result.Message)
+	assert.Contains(t, *result.Message, "Intern hard limit")
+}
+
+func TestIngest_SpendGateDeniesClaudeToolCallWithBlockURL(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	payload := canonicalIngestPayload("claude", "tool.requested", "spend-gate-ingest-tool")
+	toolName := "Bash"
+	toolCallID := "call-spend-1"
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"command": "ls"},
+		},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "deny", result.Decision)
+	require.NotNil(t, result.Message)
+	assert.Contains(t, *result.Message, "Intern hard limit")
+	assert.Contains(t, *result.Message, "/blocks/")
+}
+
+func TestIngest_SpendGateIgnoresOtherAdapters(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.Email)
+
+	payload := canonicalIngestPayload("cursor", "prompt.submitted", "spend-gate-cursor")
+	text := "hello"
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &text},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "allow", result.Decision,
+		"v1 spend enforcement is Claude-only; other adapters pass through")
+}

--- a/server/internal/hooks/spend_gate_test.go
+++ b/server/internal/hooks/spend_gate_test.go
@@ -54,15 +54,16 @@ func seedSpendBlock(t *testing.T, ctx context.Context, ti *testInstance, organiz
 	require.NoError(t, spendrules.WriteGateRules(ctx, ti.spendGateCache, organizationID, spendrules.GateRules{
 		SourceUpdatedAt: time.Now().UTC(),
 		Rules: []spendrules.GateRule{{
-			RuleURN:    ruleURN,
-			RuleName:   "Intern hard limit",
-			Action:     spendrules.ActionBlock,
-			TargetExpr: `true`,
-			RuleExpr:   `spend_usd >= limit_usd`,
-			LimitUSD:   100,
-			WarnAtPct:  80,
-			WindowKind: spendrules.WindowMonthly,
-			WindowEnd:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			RuleURN:     ruleURN,
+			RuleName:    "Intern hard limit",
+			Action:      spendrules.ActionBlock,
+			TargetExpr:  `true`,
+			RuleExpr:    `spend_usd >= limit_usd`,
+			LimitUSD:    100,
+			WarnAtPct:   80,
+			WindowKind:  spendrules.WindowMonthly,
+			WindowStart: time.Now().UTC().Add(-time.Hour),
+			WindowEnd:   time.Now().UTC().AddDate(0, 0, 7),
 		}},
 	}))
 	for _, email := range emails {

--- a/server/internal/hooks/spend_gate_test.go
+++ b/server/internal/hooks/spend_gate_test.go
@@ -2,21 +2,21 @@ package hooks
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
-	redisCache "github.com/go-redis/cache/v9"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/spendrules"
 	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
 	"github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 // recordingRiskScanner counts ScanForEnforcement calls so tests can assert
@@ -51,32 +51,32 @@ func seedSpendBlock(t *testing.T, ctx context.Context, ti *testInstance, organiz
 	t.Helper()
 	ruleURN := "spend_rule:33333333-3333-3333-3333-333333333333:v2"
 
-	state := spendrules.NewGateState(organizationID, nil)
-	err := ti.spendGateCache.Get(ctx, "spend_gate:"+organizationID, &state)
-	if err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
-		require.NoError(t, err)
-	}
-	if state.Actors == nil {
-		state.Actors = map[string]spendrules.GateActor{}
-	}
-	state.Rules = []spendrules.GateRule{{
-		RuleURN:    ruleURN,
-		RuleName:   "Intern hard limit",
-		Action:     spendrules.ActionBlock,
-		TargetExpr: `true`,
-		RuleExpr:   `spend_usd >= limit_usd`,
-		LimitUSD:   100,
-		WarnAtPct:  80,
-		WindowKind: spendrules.WindowMonthly,
-		WindowEnd:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
-	}}
+	require.NoError(t, spendrules.WriteGateRules(ctx, ti.spendGateCache, organizationID, spendrules.GateRules{
+		SourceUpdatedAt: time.Now().UTC(),
+		Rules: []spendrules.GateRule{{
+			RuleURN:    ruleURN,
+			RuleName:   "Intern hard limit",
+			Action:     spendrules.ActionBlock,
+			TargetExpr: `true`,
+			RuleExpr:   `spend_usd >= limit_usd`,
+			LimitUSD:   100,
+			WarnAtPct:  80,
+			WindowKind: spendrules.WindowMonthly,
+			WindowEnd:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		}},
+	}))
 	for _, email := range emails {
+		user, err := usersrepo.New(ti.conn).GetConnectedUserByEmail(ctx, usersrepo.GetConnectedUserByEmailParams{
+			Email:          conv.NormalizeEmail(email),
+			OrganizationID: organizationID,
+		})
+		require.NoError(t, err)
 		actor := spendrules.Actor{
-			UserID:      "",
-			Email:       email,
+			UserID:      user.ID,
+			Email:       user.Email,
 			DisplayName: "",
 			Attrs: celenv.Actor{
-				Email:          email,
+				Email:          user.Email,
 				DepartmentName: "",
 				JobTitle:       "",
 				EmployeeType:   "",
@@ -90,15 +90,13 @@ func seedSpendBlock(t *testing.T, ctx context.Context, ti *testInstance, organiz
 				WarnAtPct:      0,
 			},
 		}
-		state.SetActor(organizationID, actor)
-		state.SetActorWindowSpend(organizationID, actor, chrepo.ActorWindowSpendRow{
+		require.NoError(t, spendrules.WriteGateActor(ctx, ti.spendGateCache, organizationID, spendrules.NewGateActor(actor, chrepo.ActorWindowSpendRow{
 			Email:       actor.Email,
 			DailyCost:   0,
 			WeeklyCost:  0,
 			MonthlyCost: 100,
-		})
+		}, time.Now().UTC())))
 	}
-	require.NoError(t, spendrules.WriteGateState(ctx, ti.spendGateCache, organizationID, state))
 }
 
 func TestClaude_UserPromptSubmit_SpendGateBlocksBeforeRiskScan(t *testing.T) {
@@ -211,6 +209,7 @@ func TestClaude_SpendGateAllowsUnblockedUser(t *testing.T) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	// A different actor is blocked; the caller must pass through.
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "user_someone_else", "someone-else@example.com")
 	seedSpendBlock(t, ctx, ti, authCtx.ActiveOrganizationID, "someone-else@example.com")
 
 	sessionID := uuid.NewString()

--- a/server/internal/spendrules/cache_rules.go
+++ b/server/internal/spendrules/cache_rules.go
@@ -17,20 +17,21 @@ func BuildGateRules(rows []repo.SpendRule, now time.Time) (GateRules, error) {
 		if row.UpdatedAt.Valid && row.UpdatedAt.Time.After(sourceUpdatedAt) {
 			sourceUpdatedAt = row.UpdatedAt.Time
 		}
-		_, windowEnd, err := WindowBounds(row.WindowKind, now)
+		windowStart, windowEnd, err := WindowBounds(row.WindowKind, now)
 		if err != nil {
 			return GateRules{}, fmt.Errorf("window bounds for rule %s: %w", row.ID, err)
 		}
 		rules = append(rules, GateRule{
-			RuleURN:    urn.NewSpendRule(row.Slug, row.Version).String(),
-			RuleName:   row.Name,
-			Action:     row.Action,
-			TargetExpr: row.TargetExpr,
-			RuleExpr:   row.RuleExpr,
-			LimitUSD:   row.LimitUsdCents.USD(),
-			WarnAtPct:  row.WarnAtPct,
-			WindowKind: row.WindowKind,
-			WindowEnd:  windowEnd,
+			RuleURN:     urn.NewSpendRule(row.Slug, row.Version).String(),
+			RuleName:    row.Name,
+			Action:      row.Action,
+			TargetExpr:  row.TargetExpr,
+			RuleExpr:    row.RuleExpr,
+			LimitUSD:    row.LimitUsdCents.USD(),
+			WarnAtPct:   row.WarnAtPct,
+			WindowKind:  row.WindowKind,
+			WindowStart: windowStart,
+			WindowEnd:   windowEnd,
 		})
 	}
 	if sourceUpdatedAt.IsZero() {

--- a/server/internal/spendrules/cache_rules.go
+++ b/server/internal/spendrules/cache_rules.go
@@ -1,0 +1,58 @@
+package spendrules
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func BuildGateRules(rows []repo.SpendRule, now time.Time) (GateRules, error) {
+	sourceUpdatedAt := time.Time{}
+	rules := make([]GateRule, 0, len(rows))
+	for _, row := range rows {
+		if row.UpdatedAt.Valid && row.UpdatedAt.Time.After(sourceUpdatedAt) {
+			sourceUpdatedAt = row.UpdatedAt.Time
+		}
+		_, windowEnd, err := WindowBounds(row.WindowKind, now)
+		if err != nil {
+			return GateRules{}, fmt.Errorf("window bounds for rule %s: %w", row.ID, err)
+		}
+		rules = append(rules, GateRule{
+			RuleURN:    urn.NewSpendRule(row.Slug, row.Version).String(),
+			RuleName:   row.Name,
+			Action:     row.Action,
+			TargetExpr: row.TargetExpr,
+			RuleExpr:   row.RuleExpr,
+			LimitUSD:   row.LimitUsdCents.USD(),
+			WarnAtPct:  row.WarnAtPct,
+			WindowKind: row.WindowKind,
+			WindowEnd:  windowEnd,
+		})
+	}
+	if sourceUpdatedAt.IsZero() {
+		sourceUpdatedAt = now
+	}
+	return GateRules{
+		SourceUpdatedAt: sourceUpdatedAt,
+		Rules:           rules,
+	}, nil
+}
+
+func WriteGateRulesFromDB(ctx context.Context, cacheImpl cache.Cache, queries *repo.Queries, organizationID string, now time.Time) error {
+	rules, err := queries.ListEnabledSpendRules(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("list enabled spend rules: %w", err)
+	}
+	gateRules, err := BuildGateRules(rules, now)
+	if err != nil {
+		return err
+	}
+	if err := WriteGateRules(ctx, cacheImpl, organizationID, gateRules); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/internal/spendrules/chrepo/queries.go
+++ b/server/internal/spendrules/chrepo/queries.go
@@ -57,6 +57,40 @@ func LoadActorWindowSpend(ctx context.Context, queries *Queries, projectIDs []st
 	return spendByEmail, nil
 }
 
+// LoadActorWindowSpendByEmail returns one actor's spend across the fixed UTC
+// windows used by spend-rule enforcement. The Redis actor key is user-id keyed,
+// but the current ClickHouse rollup is email-keyed, so callers resolve the
+// actor first and query by normalized email here.
+func LoadActorWindowSpendByEmail(ctx context.Context, queries *Queries, projectIDs []string, email string, now time.Time) (ActorWindowSpendRow, error) {
+	if len(projectIDs) == 0 || conv.NormalizeEmail(email) == "" {
+		return ActorWindowSpendRow{Email: conv.NormalizeEmail(email), DailyCost: 0, WeeklyCost: 0, MonthlyCost: 0}, nil
+	}
+
+	dailyStart, weeklyStart, monthlyStart := fixedWindowStarts(now)
+	timeStart := earliestTime(dailyStart, weeklyStart, monthlyStart)
+	rows, err := queries.ListActorWindowSpendForRulesByEmail(
+		ctx,
+		projectIDs,
+		conv.NormalizeEmail(email),
+		dailyStart.UnixNano(),
+		weeklyStart.UnixNano(),
+		monthlyStart.UnixNano(),
+		timeStart.UnixNano(),
+		now.UnixNano(),
+	)
+	if err != nil {
+		return ActorWindowSpendRow{}, fmt.Errorf("list actor window spend by email: %w", err)
+	}
+
+	spend := ActorWindowSpendRow{Email: conv.NormalizeEmail(email), DailyCost: 0, WeeklyCost: 0, MonthlyCost: 0}
+	for _, row := range rows {
+		spend.DailyCost += row.DailyCost
+		spend.WeeklyCost += row.WeeklyCost
+		spend.MonthlyCost += row.MonthlyCost
+	}
+	return spend, nil
+}
+
 // ListActorSpendForRules returns per-actor total_cost over [timeStart, timeEnd]
 // from the dedicated spend-rule rollup. The rollup is bucketed by minute and is
 // intentionally narrower than attribute_metrics_summaries so enforcement stays
@@ -126,6 +160,55 @@ func (q *Queries) ListActorWindowSpendForRules(
 	}
 	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate actor window spend for rules rows: %w", err)
+	}
+	return out, nil
+}
+
+// ListActorWindowSpendForRulesByEmail returns fixed-window spend rows matching
+// a normalized email. Grouping still happens by raw user_email because the
+// ClickHouse rollup stores raw event values; callers collapse casing variants.
+func (q *Queries) ListActorWindowSpendForRulesByEmail(
+	ctx context.Context,
+	projectIDs []string,
+	email string,
+	dailyStart, weeklyStart, monthlyStart, timeStart, timeEnd int64,
+) ([]ActorWindowSpendRow, error) {
+	if len(projectIDs) == 0 || email == "" {
+		return nil, nil
+	}
+
+	sb := sq.Select("user_email").
+		Column(squirrel.Expr("sumIf(total_cost, time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))) AS m_daily_total_cost", dailyStart)).
+		Column(squirrel.Expr("sumIf(total_cost, time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))) AS m_weekly_total_cost", weeklyStart)).
+		Column(squirrel.Expr("sumIf(total_cost, time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))) AS m_monthly_total_cost", monthlyStart)).
+		From("spend_rule_usage_summaries").
+		Where(squirrel.Eq{"gram_project_id": projectIDs}).
+		Where("time_bucket >= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeStart).
+		Where("time_bucket <= toStartOfMinute(fromUnixTimestamp64Nano(?))", timeEnd).
+		Where("lowerUTF8(user_email) = ?", email).
+		GroupBy("user_email")
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building actor window spend for rules by email query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query actor window spend for rules by email: %w", err)
+	}
+	defer o11y.NoLogDefer(rows.Close)
+
+	var out []ActorWindowSpendRow
+	for rows.Next() {
+		var row ActorWindowSpendRow
+		if err = rows.ScanStruct(&row); err != nil {
+			return nil, fmt.Errorf("scanning actor window spend for rules by email row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate actor window spend for rules by email rows: %w", err)
 	}
 	return out, nil
 }

--- a/server/internal/spendrules/gate.go
+++ b/server/internal/spendrules/gate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	redisCache "github.com/go-redis/cache/v9"
@@ -23,9 +24,17 @@ import (
 const EvaluationInterval = 5 * time.Minute
 
 // spendGateSnapshotTTL bounds how long a gate snapshot survives without the
-// evaluator rewriting it: roughly two evaluation cycles, so a stalled
-// evaluator fails open instead of blocking users on stale data forever.
-const spendGateSnapshotTTL = 2 * EvaluationInterval
+// evaluator rewriting it. It must comfortably exceed one scheduled sweep
+// (SpendRuleEvaluationWorkflow's run timeout) so a slow-but-progressing sweep
+// does not let snapshots expire and enforcement fail open between cycles.
+const spendGateSnapshotTTL = 4 * EvaluationInterval
+
+// maxGatePrograms bounds the compiled-CEL cache. Rule edits mint new target
+// and rule expressions over a long-lived gate process, so the cache is flushed
+// wholesale once it grows past this cap rather than retaining every historical
+// expression forever. Recompilation after a flush is cheap next to the
+// hot-path cache hit.
+const maxGatePrograms = 1024
 
 // Block describes why an actor is currently blocked by a spend rule.
 type Block struct {
@@ -82,22 +91,30 @@ func spendGateActorKey(organizationID, email string) string {
 // resolves to "not blocked" (fail-open) so a cache outage never denies
 // traffic.
 type Gate struct {
-	logger   *slog.Logger
-	cache    cache.Cache
-	celEng   *celenv.Engine
-	programs sync.Map
+	logger       *slog.Logger
+	cache        cache.Cache
+	celEng       *celenv.Engine
+	programs     sync.Map
+	programCount atomic.Int64
 }
 
 func NewGate(logger *slog.Logger, cacheImpl cache.Cache, celEng *celenv.Engine) (*Gate, error) {
 	if celEng == nil {
 		return nil, fmt.Errorf("spend gate CEL engine is required")
 	}
+	if cacheImpl == nil {
+		// The hot-path CheckBlocked dereferences the cache on every call;
+		// a nil cache would panic there rather than failing open, so reject
+		// it at construction.
+		return nil, fmt.Errorf("spend gate cache is required")
+	}
 
 	return &Gate{
-		logger:   logger.With(attr.SlogComponent("spendrules_gate")),
-		cache:    cacheImpl,
-		celEng:   celEng,
-		programs: sync.Map{},
+		logger:       logger.With(attr.SlogComponent("spendrules_gate")),
+		cache:        cacheImpl,
+		celEng:       celEng,
+		programs:     sync.Map{},
+		programCount: atomic.Int64{},
 	}, nil
 }
 
@@ -213,7 +230,15 @@ func (g *Gate) compile(expr string) (cel.Program, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compile spend gate expression: %w", err)
 	}
-	actual, _ := g.programs.LoadOrStore(expr, prg)
+	actual, loaded := g.programs.LoadOrStore(expr, prg)
+	if !loaded && g.programCount.Add(1) > maxGatePrograms {
+		// Soft bound: flush wholesale once the cache outgrows the cap so
+		// repeated rule edits cannot grow program memory without limit. The
+		// count can drift slightly under concurrency; that only affects when
+		// the next flush happens, not correctness.
+		g.programs.Clear()
+		g.programCount.Store(0)
+	}
 	typed, ok := actual.(cel.Program)
 	if !ok {
 		return nil, fmt.Errorf("cached spend gate program has unexpected type %T", actual)

--- a/server/internal/spendrules/gate.go
+++ b/server/internal/spendrules/gate.go
@@ -27,7 +27,7 @@ const EvaluationInterval = 30 * time.Second
 // write or evaluator refresh. It must comfortably exceed one scheduled sweep so
 // a slow-but-progressing reconciler does not let entries expire and enforcement
 // fail open between cycles.
-const spendGateTTL = 4 * EvaluationInterval
+const spendGateTTL = 30 * time.Minute
 
 // maxGatePrograms bounds the compiled-CEL cache. Rule edits mint new target
 // and rule expressions over a long-lived gate process, so the cache is flushed
@@ -48,15 +48,16 @@ type Block struct {
 // on rule mutations so the hook gate can evaluate the same CEL predicates as
 // background evaluation without touching Postgres or ClickHouse.
 type GateRule struct {
-	RuleURN    string    `json:"rule_urn"`
-	RuleName   string    `json:"rule_name"`
-	Action     string    `json:"action"`
-	TargetExpr string    `json:"target_expr"`
-	RuleExpr   string    `json:"rule_expr"`
-	LimitUSD   float64   `json:"limit_usd"`
-	WarnAtPct  int32     `json:"warn_at_pct"`
-	WindowKind string    `json:"window_kind"`
-	WindowEnd  time.Time `json:"window_end"`
+	RuleURN     string    `json:"rule_urn"`
+	RuleName    string    `json:"rule_name"`
+	Action      string    `json:"action"`
+	TargetExpr  string    `json:"target_expr"`
+	RuleExpr    string    `json:"rule_expr"`
+	LimitUSD    float64   `json:"limit_usd"`
+	WarnAtPct   int32     `json:"warn_at_pct"`
+	WindowKind  string    `json:"window_kind"`
+	WindowStart time.Time `json:"window_start"`
+	WindowEnd   time.Time `json:"window_end"`
 }
 
 type GateRules struct {
@@ -157,9 +158,14 @@ func (g *Gate) CheckBlocked(ctx context.Context, organizationID, userID string) 
 		}
 
 		// The actor entry holds spend for the window that was current when the
-		// evaluator last wrote it. Once that window has ended, the block must
-		// lift immediately (spend resets to zero for the new window) rather than
-		// keep denying on stale spend until the next refresh.
+		// evaluator last wrote it. If rules have advanced to a newer window,
+		// ignore the stale actor entry until the next refresh.
+		if !rule.WindowStart.IsZero() && actor.ComputedAt.Before(rule.WindowStart) {
+			continue
+		}
+
+		// Once the rule window has ended, the block must lift immediately
+		// rather than keep denying on stale spend until the next refresh.
 		if !rule.WindowEnd.IsZero() && !now.Before(rule.WindowEnd) {
 			continue
 		}
@@ -293,6 +299,17 @@ func WriteGateRules(ctx context.Context, cacheImpl cache.Cache, organizationID s
 		}
 		return nil
 	}
+	var current GateRules
+	err := cacheImpl.Get(ctx, key, &current)
+	if err == nil && current.SourceUpdatedAt.After(rules.SourceUpdatedAt) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
+		if cacheImpl == cache.NoopCache {
+			return nil
+		}
+		return fmt.Errorf("read spend gate rules for write: %w", err)
+	}
 	if err := cacheImpl.Set(ctx, key, rules, spendGateTTL); err != nil {
 		return fmt.Errorf("write spend gate rules: %w", err)
 	}
@@ -347,6 +364,9 @@ func WriteGateActor(ctx context.Context, cacheImpl cache.Cache, organizationID s
 		return nil
 	}
 	if err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
+		if cacheImpl == cache.NoopCache {
+			return nil
+		}
 		return fmt.Errorf("read spend gate actor for write: %w", err)
 	}
 	if err := cacheImpl.Set(ctx, key, actor, spendGateTTL); err != nil {

--- a/server/internal/spendrules/gate.go
+++ b/server/internal/spendrules/gate.go
@@ -19,15 +19,15 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
 )
 
-// EvaluationInterval is how often the background evaluator recomputes spend
-// against every enabled rule and rewrites the spend gate snapshot.
-const EvaluationInterval = 5 * time.Minute
+// EvaluationInterval is how often the background reconciler recomputes spend
+// against every enabled rule and repairs actor spend cache entries.
+const EvaluationInterval = 30 * time.Second
 
-// spendGateSnapshotTTL bounds how long a gate snapshot survives without the
-// evaluator rewriting it. It must comfortably exceed one scheduled sweep
-// (SpendRuleEvaluationWorkflow's run timeout) so a slow-but-progressing sweep
-// does not let snapshots expire and enforcement fail open between cycles.
-const spendGateSnapshotTTL = 4 * EvaluationInterval
+// spendGateTTL bounds how long request-path gate data survives without an API
+// write or evaluator refresh. It must comfortably exceed one scheduled sweep so
+// a slow-but-progressing reconciler does not let entries expire and enforcement
+// fail open between cycles.
+const spendGateTTL = 4 * EvaluationInterval
 
 // maxGatePrograms bounds the compiled-CEL cache. Rule edits mint new target
 // and rule expressions over a long-lived gate process, so the cache is flushed
@@ -44,9 +44,9 @@ type Block struct {
 	WindowEnd time.Time `json:"window_end"`
 }
 
-// GateRule is the request-path view of a spend rule. The evaluator refreshes
-// these alongside actor usage so the hook gate can evaluate the same CEL
-// predicates as background evaluation without touching Postgres or ClickHouse.
+// GateRule is the request-path view of a spend rule. The API refreshes these
+// on rule mutations so the hook gate can evaluate the same CEL predicates as
+// background evaluation without touching Postgres or ClickHouse.
 type GateRule struct {
 	RuleURN    string    `json:"rule_urn"`
 	RuleName   string    `json:"rule_name"`
@@ -59,7 +59,13 @@ type GateRule struct {
 	WindowEnd  time.Time `json:"window_end"`
 }
 
+type GateRules struct {
+	SourceUpdatedAt time.Time  `json:"source_updated_at"`
+	Rules           []GateRule `json:"rules"`
+}
+
 type GateActor struct {
+	ComputedAt  time.Time                  `json:"computed_at"`
 	UserID      string                     `json:"user_id"`
 	Email       string                     `json:"email"`
 	DisplayName string                     `json:"display_name"`
@@ -67,29 +73,24 @@ type GateActor struct {
 	Spend       chrepo.ActorWindowSpendRow `json:"spend"`
 }
 
-// GateState is the full request-path state for one organization. Actors are
-// keyed by "{org_id}:{user_email}" with normalized email so a hook event can
-// resolve its actor without scanning the organization.
-type GateState struct {
-	Rules  []GateRule           `json:"rules"`
-	Actors map[string]GateActor `json:"actors"`
+type mutatingCache interface {
+	Mutate(ctx context.Context, key string, value any, ttl time.Duration, fn func(exists bool) error) error
 }
 
-func spendGateSnapshotKey(organizationID string) string {
-	return "spend_gate:" + organizationID
+func spendGateRulesKey(organizationID string) string {
+	return "spend_gate:rules:" + organizationID
 }
 
-func spendGateActorKey(organizationID, email string) string {
-	if organizationID == "" || email == "" {
+func spendGateActorKey(organizationID, userID string) string {
+	if organizationID == "" || userID == "" {
 		return ""
 	}
-	return organizationID + ":" + conv.NormalizeEmail(email)
+	return "spend_gate:actor:" + organizationID + ":" + userID
 }
 
 // Gate is the hot-path spend check consulted by the Claude hooks handlers
-// before risk-policy scans. Reads are a single cache GET; every failure mode
-// resolves to "not blocked" (fail-open) so a cache outage never denies
-// traffic.
+// before risk-policy scans. Reads stay Redis-only; every failure mode resolves
+// to "not blocked" (fail-open) so a cache outage never denies traffic.
 type Gate struct {
 	logger       *slog.Logger
 	cache        cache.Cache
@@ -119,41 +120,46 @@ func NewGate(logger *slog.Logger, cacheImpl cache.Cache, celEng *celenv.Engine) 
 }
 
 // CheckBlocked reports whether the given actor is currently blocked by a spend
-// rule. The actor is looked up only by "{org_id}:{user_email}". A nil Block
-// means the actor is not blocked. Errors are cache infrastructure failures —
-// callers should treat them as "not blocked" (fail-open); they are returned for
-// logging.
-func (g *Gate) CheckBlocked(ctx context.Context, organizationID, email string) (*Block, error) {
-	actorKey := spendGateActorKey(organizationID, email)
+// rule. The actor is looked up only by stable Gram user ID. A nil Block means
+// the actor is not blocked. Errors are cache infrastructure failures — callers
+// should treat them as "not blocked" (fail-open); they are returned for logging.
+func (g *Gate) CheckBlocked(ctx context.Context, organizationID, userID string) (*Block, error) {
+	actorKey := spendGateActorKey(organizationID, userID)
 	if actorKey == "" || g.celEng == nil {
 		return nil, nil
 	}
 
-	var state GateState
-	err := g.cache.Get(ctx, spendGateSnapshotKey(organizationID), &state)
+	var rules GateRules
+	err := g.cache.Get(ctx, spendGateRulesKey(organizationID), &rules)
 	if errors.Is(err, redisCache.ErrCacheMiss) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read spend gate state: %w", err)
+		return nil, fmt.Errorf("read spend gate rules: %w", err)
 	}
-
-	actor, ok := state.Actors[actorKey]
-	if !ok {
+	if len(rules.Rules) == 0 {
 		return nil, nil
 	}
 
+	var actor GateActor
+	err = g.cache.Get(ctx, actorKey, &actor)
+	if errors.Is(err, redisCache.ErrCacheMiss) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read spend gate actor: %w", err)
+	}
+
 	now := time.Now().UTC()
-	for _, rule := range state.Rules {
+	for _, rule := range rules.Rules {
 		if rule.Action != ActionBlock {
 			continue
 		}
 
-		// The snapshot holds the spend for the window that was current when the
+		// The actor entry holds spend for the window that was current when the
 		// evaluator last wrote it. Once that window has ended, the block must
 		// lift immediately (spend resets to zero for the new window) rather than
-		// keep denying on stale spend until the next evaluation cycle rewrites
-		// the snapshot.
+		// keep denying on stale spend until the next refresh.
 		if !rule.WindowEnd.IsZero() && !now.Before(rule.WindowEnd) {
 			continue
 		}
@@ -246,74 +252,105 @@ func (g *Gate) compile(expr string) (cel.Program, error) {
 	return typed, nil
 }
 
-func NewGateState(organizationID string, actors []Actor) GateState {
-	state := GateState{
-		Rules:  []GateRule{},
-		Actors: map[string]GateActor{},
-	}
-	for _, actor := range actors {
-		state.SetActor(organizationID, actor)
-	}
-	return state
-}
-
-func (s *GateState) SetActor(organizationID string, actor Actor) {
-	actorKey := spendGateActorKey(organizationID, actor.Email)
-	if actorKey == "" {
-		return
-	}
-
-	gateActor := GateActor{
+func NewGateActor(actor Actor, spend chrepo.ActorWindowSpendRow, computedAt time.Time) GateActor {
+	return GateActor{
+		ComputedAt:  computedAt.UTC(),
 		UserID:      actor.UserID,
 		Email:       actor.Email,
 		DisplayName: actor.DisplayName,
 		Attrs:       actor.Attrs,
-		Spend: chrepo.ActorWindowSpendRow{
-			Email:       "",
-			DailyCost:   0,
-			WeeklyCost:  0,
-			MonthlyCost: 0,
-		},
+		Spend:       spend,
 	}
-	s.Actors[actorKey] = gateActor
 }
 
-func (s *GateState) SetActorWindowSpend(organizationID string, actor Actor, spend chrepo.ActorWindowSpendRow) {
-	actorKey := spendGateActorKey(organizationID, actor.Email)
-	if actorKey == "" {
-		return
+func EmptyActorSpend(email string) chrepo.ActorWindowSpendRow {
+	return chrepo.ActorWindowSpendRow{
+		Email:       conv.NormalizeEmail(email),
+		DailyCost:   0,
+		WeeklyCost:  0,
+		MonthlyCost: 0,
 	}
-	gateActor, ok := s.Actors[actorKey]
-	if !ok {
-		gateActor = GateActor{
-			UserID:      actor.UserID,
-			Email:       actor.Email,
-			DisplayName: actor.DisplayName,
-			Attrs:       actor.Attrs,
-			Spend: chrepo.ActorWindowSpendRow{
-				Email:       "",
-				DailyCost:   0,
-				WeeklyCost:  0,
-				MonthlyCost: 0,
-			},
-		}
-	}
-	gateActor.Spend = spend
-	s.Actors[actorKey] = gateActor
 }
 
-// WriteGateState replaces the organization's request-path state. An empty set
-// deletes the key so the gate's common case stays a cheap miss.
-func WriteGateState(ctx context.Context, cacheImpl cache.Cache, organizationID string, state GateState) error {
-	key := spendGateSnapshotKey(organizationID)
-	if len(state.Rules) == 0 {
-		if err := cacheImpl.Delete(ctx, key); err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
-			return fmt.Errorf("clear spend gate state: %w", err)
+// WriteGateRules replaces the organization's request-path rules only when the
+// payload was built from at least as fresh a DB source as the existing value.
+func WriteGateRules(ctx context.Context, cacheImpl cache.Cache, organizationID string, rules GateRules) error {
+	key := spendGateRulesKey(organizationID)
+	rules.SourceUpdatedAt = rules.SourceUpdatedAt.UTC()
+	if rules.Rules == nil {
+		rules.Rules = []GateRule{}
+	}
+	if mutable, ok := cacheImpl.(mutatingCache); ok {
+		current := GateRules{SourceUpdatedAt: time.Time{}, Rules: nil}
+		if err := mutable.Mutate(ctx, key, &current, spendGateTTL, func(exists bool) error {
+			if exists && current.SourceUpdatedAt.After(rules.SourceUpdatedAt) {
+				return nil
+			}
+			current = rules
+			return nil
+		}); err != nil {
+			return fmt.Errorf("write spend gate rules: %w", err)
 		}
 		return nil
 	}
-	if err := cacheImpl.Set(ctx, key, state, spendGateSnapshotTTL); err != nil {
-		return fmt.Errorf("write spend gate state: %w", err)
+	if err := cacheImpl.Set(ctx, key, rules, spendGateTTL); err != nil {
+		return fmt.Errorf("write spend gate rules: %w", err)
+	}
+	return nil
+}
+
+// WriteGateActor stores one actor's ClickHouse spend snapshot. Concurrent
+// refreshers use write-if-newer semantics so an older org reconciler run cannot
+// overwrite a fresher per-actor usage-triggered refresh.
+func WriteGateActor(ctx context.Context, cacheImpl cache.Cache, organizationID string, actor GateActor) error {
+	key := spendGateActorKey(organizationID, actor.UserID)
+	if key == "" {
+		return nil
+	}
+	actor.ComputedAt = actor.ComputedAt.UTC()
+	if mutable, ok := cacheImpl.(mutatingCache); ok {
+		current := GateActor{
+			ComputedAt:  time.Time{},
+			UserID:      "",
+			Email:       "",
+			DisplayName: "",
+			Attrs: celenv.Actor{
+				Email:          "",
+				DepartmentName: "",
+				JobTitle:       "",
+				EmployeeType:   "",
+				DivisionName:   "",
+				CostCenterName: "",
+				Groups:         nil,
+				Roles:          nil,
+				SpendUSD:       0,
+				LimitUSD:       0,
+				UsedPct:        0,
+				WarnAtPct:      0,
+			},
+			Spend: chrepo.ActorWindowSpendRow{Email: "", DailyCost: 0, WeeklyCost: 0, MonthlyCost: 0},
+		}
+		if err := mutable.Mutate(ctx, key, &current, spendGateTTL, func(exists bool) error {
+			if exists && current.ComputedAt.After(actor.ComputedAt) {
+				return nil
+			}
+			current = actor
+			return nil
+		}); err != nil {
+			return fmt.Errorf("write spend gate actor: %w", err)
+		}
+		return nil
+	}
+	var current GateActor
+	err := cacheImpl.Get(ctx, key, &current)
+	if err == nil && current.ComputedAt.After(actor.ComputedAt) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
+		return fmt.Errorf("read spend gate actor for write: %w", err)
+	}
+	if err := cacheImpl.Set(ctx, key, actor, spendGateTTL); err != nil {
+		return fmt.Errorf("write spend gate actor: %w", err)
 	}
 	return nil
 }

--- a/server/internal/spendrules/gate.go
+++ b/server/internal/spendrules/gate.go
@@ -1,0 +1,294 @@
+package spendrules
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	redisCache "github.com/go-redis/cache/v9"
+	"github.com/google/cel-go/cel"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
+)
+
+// EvaluationInterval is how often the background evaluator recomputes spend
+// against every enabled rule and rewrites the spend gate snapshot.
+const EvaluationInterval = 5 * time.Minute
+
+// spendGateSnapshotTTL bounds how long a gate snapshot survives without the
+// evaluator rewriting it: roughly two evaluation cycles, so a stalled
+// evaluator fails open instead of blocking users on stale data forever.
+const spendGateSnapshotTTL = 2 * EvaluationInterval
+
+// Block describes why an actor is currently blocked by a spend rule.
+type Block struct {
+	RuleURN  string `json:"rule_urn"`
+	RuleName string `json:"rule_name"`
+	// WindowEnd is when the budget window resets and the block lifts.
+	WindowEnd time.Time `json:"window_end"`
+}
+
+// GateRule is the request-path view of a spend rule. The evaluator refreshes
+// these alongside actor usage so the hook gate can evaluate the same CEL
+// predicates as background evaluation without touching Postgres or ClickHouse.
+type GateRule struct {
+	RuleURN    string    `json:"rule_urn"`
+	RuleName   string    `json:"rule_name"`
+	Action     string    `json:"action"`
+	TargetExpr string    `json:"target_expr"`
+	RuleExpr   string    `json:"rule_expr"`
+	LimitUSD   float64   `json:"limit_usd"`
+	WarnAtPct  int32     `json:"warn_at_pct"`
+	WindowKind string    `json:"window_kind"`
+	WindowEnd  time.Time `json:"window_end"`
+}
+
+type GateActor struct {
+	UserID      string                     `json:"user_id"`
+	Email       string                     `json:"email"`
+	DisplayName string                     `json:"display_name"`
+	Attrs       celenv.Actor               `json:"attrs"`
+	Spend       chrepo.ActorWindowSpendRow `json:"spend"`
+}
+
+// GateState is the full request-path state for one organization. Actors are
+// keyed by "{org_id}:{user_email}" with normalized email so a hook event can
+// resolve its actor without scanning the organization.
+type GateState struct {
+	Rules  []GateRule           `json:"rules"`
+	Actors map[string]GateActor `json:"actors"`
+}
+
+func spendGateSnapshotKey(organizationID string) string {
+	return "spend_gate:" + organizationID
+}
+
+func spendGateActorKey(organizationID, email string) string {
+	if organizationID == "" || email == "" {
+		return ""
+	}
+	return organizationID + ":" + conv.NormalizeEmail(email)
+}
+
+// Gate is the hot-path spend check consulted by the Claude hooks handlers
+// before risk-policy scans. Reads are a single cache GET; every failure mode
+// resolves to "not blocked" (fail-open) so a cache outage never denies
+// traffic.
+type Gate struct {
+	logger   *slog.Logger
+	cache    cache.Cache
+	celEng   *celenv.Engine
+	programs sync.Map
+}
+
+func NewGate(logger *slog.Logger, cacheImpl cache.Cache, celEng *celenv.Engine) (*Gate, error) {
+	if celEng == nil {
+		return nil, fmt.Errorf("spend gate CEL engine is required")
+	}
+
+	return &Gate{
+		logger:   logger.With(attr.SlogComponent("spendrules_gate")),
+		cache:    cacheImpl,
+		celEng:   celEng,
+		programs: sync.Map{},
+	}, nil
+}
+
+// CheckBlocked reports whether the given actor is currently blocked by a spend
+// rule. The actor is looked up only by "{org_id}:{user_email}". A nil Block
+// means the actor is not blocked. Errors are cache infrastructure failures —
+// callers should treat them as "not blocked" (fail-open); they are returned for
+// logging.
+func (g *Gate) CheckBlocked(ctx context.Context, organizationID, email string) (*Block, error) {
+	actorKey := spendGateActorKey(organizationID, email)
+	if actorKey == "" || g.celEng == nil {
+		return nil, nil
+	}
+
+	var state GateState
+	err := g.cache.Get(ctx, spendGateSnapshotKey(organizationID), &state)
+	if errors.Is(err, redisCache.ErrCacheMiss) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read spend gate state: %w", err)
+	}
+
+	actor, ok := state.Actors[actorKey]
+	if !ok {
+		return nil, nil
+	}
+
+	now := time.Now().UTC()
+	for _, rule := range state.Rules {
+		if rule.Action != ActionBlock {
+			continue
+		}
+
+		// The snapshot holds the spend for the window that was current when the
+		// evaluator last wrote it. Once that window has ended, the block must
+		// lift immediately (spend resets to zero for the new window) rather than
+		// keep denying on stale spend until the next evaluation cycle rewrites
+		// the snapshot.
+		if !rule.WindowEnd.IsZero() && !now.Before(rule.WindowEnd) {
+			continue
+		}
+
+		spendUSD, err := actor.Spend.SpendUSD(rule.WindowKind)
+		if err != nil {
+			g.logger.WarnContext(ctx, "read spend gate window spend",
+				attr.SlogError(err),
+				attr.SlogOrganizationID(organizationID),
+			)
+			continue
+		}
+		usedPct := 0.0
+		if rule.LimitUSD > 0 {
+			usedPct = spendUSD / rule.LimitUSD * 100
+		}
+		attrs := actor.Attrs
+		attrs.SpendUSD = spendUSD
+		attrs.LimitUSD = rule.LimitUSD
+		attrs.UsedPct = usedPct
+		attrs.WarnAtPct = float64(rule.WarnAtPct)
+
+		matched, err := g.eval(ctx, organizationID, rule.TargetExpr, attrs)
+		if err != nil || !matched {
+			continue
+		}
+
+		ruleExpr := conv.Default(rule.RuleExpr, DefaultRuleExpr)
+		breached, err := g.eval(ctx, organizationID, ruleExpr, attrs)
+		if err != nil || !breached {
+			continue
+		}
+
+		return &Block{
+			RuleURN:   rule.RuleURN,
+			RuleName:  rule.RuleName,
+			WindowEnd: rule.WindowEnd,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (g *Gate) eval(ctx context.Context, organizationID, expr string, actor celenv.Actor) (bool, error) {
+	prg, err := g.compile(expr)
+	if err != nil {
+		g.logger.WarnContext(ctx, "compile spend gate expression",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+		return false, err
+	}
+
+	ok, err := g.celEng.Eval(prg, actor)
+	if err != nil {
+		g.logger.WarnContext(ctx, "evaluate spend gate expression",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+		return false, fmt.Errorf("evaluate spend gate expression: %w", err)
+	}
+	return ok, nil
+}
+
+func (g *Gate) compile(expr string) (cel.Program, error) {
+	if prg, ok := g.programs.Load(expr); ok {
+		typed, ok := prg.(cel.Program)
+		if !ok {
+			return nil, fmt.Errorf("cached spend gate program has unexpected type %T", prg)
+		}
+		return typed, nil
+	}
+	prg, err := g.celEng.Compile(expr)
+	if err != nil {
+		return nil, fmt.Errorf("compile spend gate expression: %w", err)
+	}
+	actual, _ := g.programs.LoadOrStore(expr, prg)
+	typed, ok := actual.(cel.Program)
+	if !ok {
+		return nil, fmt.Errorf("cached spend gate program has unexpected type %T", actual)
+	}
+	return typed, nil
+}
+
+func NewGateState(organizationID string, actors []Actor) GateState {
+	state := GateState{
+		Rules:  []GateRule{},
+		Actors: map[string]GateActor{},
+	}
+	for _, actor := range actors {
+		state.SetActor(organizationID, actor)
+	}
+	return state
+}
+
+func (s *GateState) SetActor(organizationID string, actor Actor) {
+	actorKey := spendGateActorKey(organizationID, actor.Email)
+	if actorKey == "" {
+		return
+	}
+
+	gateActor := GateActor{
+		UserID:      actor.UserID,
+		Email:       actor.Email,
+		DisplayName: actor.DisplayName,
+		Attrs:       actor.Attrs,
+		Spend: chrepo.ActorWindowSpendRow{
+			Email:       "",
+			DailyCost:   0,
+			WeeklyCost:  0,
+			MonthlyCost: 0,
+		},
+	}
+	s.Actors[actorKey] = gateActor
+}
+
+func (s *GateState) SetActorWindowSpend(organizationID string, actor Actor, spend chrepo.ActorWindowSpendRow) {
+	actorKey := spendGateActorKey(organizationID, actor.Email)
+	if actorKey == "" {
+		return
+	}
+	gateActor, ok := s.Actors[actorKey]
+	if !ok {
+		gateActor = GateActor{
+			UserID:      actor.UserID,
+			Email:       actor.Email,
+			DisplayName: actor.DisplayName,
+			Attrs:       actor.Attrs,
+			Spend: chrepo.ActorWindowSpendRow{
+				Email:       "",
+				DailyCost:   0,
+				WeeklyCost:  0,
+				MonthlyCost: 0,
+			},
+		}
+	}
+	gateActor.Spend = spend
+	s.Actors[actorKey] = gateActor
+}
+
+// WriteGateState replaces the organization's request-path state. An empty set
+// deletes the key so the gate's common case stays a cheap miss.
+func WriteGateState(ctx context.Context, cacheImpl cache.Cache, organizationID string, state GateState) error {
+	key := spendGateSnapshotKey(organizationID)
+	if len(state.Rules) == 0 {
+		if err := cacheImpl.Delete(ctx, key); err != nil && !errors.Is(err, redisCache.ErrCacheMiss) {
+			return fmt.Errorf("clear spend gate state: %w", err)
+		}
+		return nil
+	}
+	if err := cacheImpl.Set(ctx, key, state, spendGateSnapshotTTL); err != nil {
+		return fmt.Errorf("write spend gate state: %w", err)
+	}
+	return nil
+}

--- a/server/internal/spendrules/gate_test.go
+++ b/server/internal/spendrules/gate_test.go
@@ -113,6 +113,21 @@ func (c *gateCache) DeleteByPrefix(_ context.Context, prefix string) error {
 	return nil
 }
 
+func writeGateRules(t *testing.T, ctx context.Context, cacheImpl *gateCache, organizationID string, rules ...spendrules.GateRule) {
+	t.Helper()
+
+	require.NoError(t, spendrules.WriteGateRules(ctx, cacheImpl, organizationID, spendrules.GateRules{
+		SourceUpdatedAt: time.Now().UTC(),
+		Rules:           rules,
+	}))
+}
+
+func writeGateActor(t *testing.T, ctx context.Context, cacheImpl *gateCache, organizationID string, actor spendrules.Actor, spend chrepo.ActorWindowSpendRow) {
+	t.Helper()
+
+	require.NoError(t, spendrules.WriteGateActor(ctx, cacheImpl, organizationID, spendrules.NewGateActor(actor, spend, time.Now().UTC())))
+}
+
 func TestGateEvaluatesRuleCELAgainstCachedUsage(t *testing.T) {
 	t.Parallel()
 
@@ -122,8 +137,7 @@ func TestGateEvaluatesRuleCELAgainstCachedUsage(t *testing.T) {
 	// Future window: the block must fire on cached usage, not be skipped as an
 	// already-reset window.
 	windowEnd := time.Now().UTC().AddDate(0, 0, 7)
-	state := spendrules.NewGateState("org_123", actors)
-	state.Rules = append(state.Rules, spendrules.GateRule{
+	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
 		RuleURN:    "spend_rule:engineering:v1",
 		RuleName:   "Engineering budget",
 		Action:     spendrules.ActionBlock,
@@ -134,18 +148,15 @@ func TestGateEvaluatesRuleCELAgainstCachedUsage(t *testing.T) {
 		WindowKind: spendrules.WindowMonthly,
 		WindowEnd:  windowEnd,
 	})
-	state.SetActorWindowSpend("org_123", actors[0], chrepo.ActorWindowSpendRow{
+	writeGateActor(t, ctx, cacheImpl, "org_123", actors[0], chrepo.ActorWindowSpendRow{
 		Email:       "ada@acme.com",
 		DailyCost:   0,
 		WeeklyCost:  0,
 		MonthlyCost: 90,
 	})
-	require.Contains(t, state.Actors, "org_123:ada@acme.com")
-
-	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
 	gate := newTestGate(t, cacheImpl)
 
-	block, err := gate.CheckBlocked(ctx, "org_123", "Ada@Acme.com")
+	block, err := gate.CheckBlocked(ctx, "org_123", "user_ada")
 	require.NoError(t, err)
 	require.NotNil(t, block)
 	require.Equal(t, "spend_rule:engineering:v1", block.RuleURN)
@@ -159,8 +170,7 @@ func TestGateSkipsExpiredWindow(t *testing.T) {
 	ctx := t.Context()
 	cacheImpl := newGateCache()
 	actors := testActors()
-	state := spendrules.NewGateState("org_123", actors)
-	state.Rules = append(state.Rules, spendrules.GateRule{
+	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
 		RuleURN:    "spend_rule:engineering:v1",
 		RuleName:   "Engineering budget",
 		Action:     spendrules.ActionBlock,
@@ -169,21 +179,19 @@ func TestGateSkipsExpiredWindow(t *testing.T) {
 		LimitUSD:   100,
 		WarnAtPct:  80,
 		WindowKind: spendrules.WindowMonthly,
-		// Window already ended: the snapshot's spend belongs to a window that
+		// Window already ended: the actor entry's spend belongs to a window that
 		// has reset, so the block must lift even though the cached usage breaches.
 		WindowEnd: time.Now().UTC().Add(-time.Hour),
 	})
-	state.SetActorWindowSpend("org_123", actors[0], chrepo.ActorWindowSpendRow{
+	writeGateActor(t, ctx, cacheImpl, "org_123", actors[0], chrepo.ActorWindowSpendRow{
 		Email:       "ada@acme.com",
 		DailyCost:   0,
 		WeeklyCost:  0,
 		MonthlyCost: 90,
 	})
-
-	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
 	gate := newTestGate(t, cacheImpl)
 
-	block, err := gate.CheckBlocked(ctx, "org_123", "Ada@Acme.com")
+	block, err := gate.CheckBlocked(ctx, "org_123", "user_ada")
 	require.NoError(t, err)
 	require.Nil(t, block)
 }
@@ -194,8 +202,7 @@ func TestGateEvaluatesTargetCELBeforeRuleCEL(t *testing.T) {
 	ctx := t.Context()
 	cacheImpl := newGateCache()
 	actors := testActors()
-	state := spendrules.NewGateState("org_123", actors)
-	state.Rules = append(state.Rules, spendrules.GateRule{
+	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
 		RuleURN:    "spend_rule:engineering:v1",
 		RuleName:   "Engineering budget",
 		Action:     spendrules.ActionBlock,
@@ -206,17 +213,15 @@ func TestGateEvaluatesTargetCELBeforeRuleCEL(t *testing.T) {
 		WindowKind: spendrules.WindowMonthly,
 		WindowEnd:  time.Now().UTC().AddDate(0, 0, 7),
 	})
-	state.SetActorWindowSpend("org_123", actors[1], chrepo.ActorWindowSpendRow{
+	writeGateActor(t, ctx, cacheImpl, "org_123", actors[1], chrepo.ActorWindowSpendRow{
 		Email:       "sam@acme.com",
 		DailyCost:   0,
 		WeeklyCost:  0,
 		MonthlyCost: 150,
 	})
-
-	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
 	gate := newTestGate(t, cacheImpl)
 
-	block, err := gate.CheckBlocked(ctx, "org_123", "Sam@Acme.com")
+	block, err := gate.CheckBlocked(ctx, "org_123", "user_sam")
 	require.NoError(t, err)
 	require.Nil(t, block)
 }
@@ -229,7 +234,7 @@ func TestGateSkipsUnresolvedIdentity(t *testing.T) {
 	cacheImpl.getErr = errors.New("gate must not read the cache for unresolved identities")
 	gate := newTestGate(t, cacheImpl)
 
-	block, err := gate.CheckBlocked(ctx, "", "ada@acme.com")
+	block, err := gate.CheckBlocked(ctx, "", "user_ada")
 	require.NoError(t, err)
 	require.Nil(t, block)
 
@@ -246,34 +251,26 @@ func TestGateSurfacesCacheFailuresForFailOpen(t *testing.T) {
 	cacheImpl.getErr = errors.New("redis unavailable")
 	gate := newTestGate(t, cacheImpl)
 
-	block, err := gate.CheckBlocked(ctx, "org_123", "ada@acme.com")
+	block, err := gate.CheckBlocked(ctx, "org_123", "user_ada")
 	require.Error(t, err)
 	require.Nil(t, block)
 }
 
-func TestGateWriteEmptyStateClearsCache(t *testing.T) {
+func TestGateEmptyRulesAllow(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	cacheImpl := newGateCache()
-	state := spendrules.NewGateState("org_123", testActors())
-	state.Rules = append(state.Rules, spendrules.GateRule{
-		RuleURN:    "spend_rule:engineering:v1",
-		RuleName:   "Engineering budget",
-		Action:     spendrules.ActionBlock,
-		TargetExpr: `department_name == "Engineering"`,
-		RuleExpr:   `spend_usd >= limit_usd`,
-		LimitUSD:   100,
-		WarnAtPct:  80,
-		WindowKind: spendrules.WindowMonthly,
-		WindowEnd:  time.Date(2026, time.July, 5, 0, 0, 0, 0, time.UTC),
+	writeGateActor(t, ctx, cacheImpl, "org_123", testActors()[0], chrepo.ActorWindowSpendRow{
+		Email:       "ada@acme.com",
+		DailyCost:   0,
+		WeeklyCost:  0,
+		MonthlyCost: 150,
 	})
-
-	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
-	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", spendrules.GateState{Rules: nil, Actors: nil}))
+	writeGateRules(t, ctx, cacheImpl, "org_123")
 
 	gate := newTestGate(t, cacheImpl)
-	block, err := gate.CheckBlocked(ctx, "org_123", "ada@acme.com")
+	block, err := gate.CheckBlocked(ctx, "org_123", "user_ada")
 	require.NoError(t, err)
 	require.Nil(t, block)
 }

--- a/server/internal/spendrules/gate_test.go
+++ b/server/internal/spendrules/gate_test.go
@@ -1,0 +1,279 @@
+package spendrules_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	redisCache "github.com/go-redis/cache/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
+	"github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type gateCache struct {
+	values map[string]any
+	getErr error
+}
+
+func newGateCache() *gateCache {
+	return &gateCache{values: map[string]any{}, getErr: nil}
+}
+
+func newTestGate(t *testing.T, cacheImpl *gateCache) *spendrules.Gate {
+	t.Helper()
+
+	celEng, err := celenv.New()
+	require.NoError(t, err)
+	gate, err := spendrules.NewGate(testenv.NewLogger(t), cacheImpl, celEng)
+	require.NoError(t, err)
+	return gate
+}
+
+func TestNewGateRequiresCELEngine(t *testing.T) {
+	t.Parallel()
+
+	gate, err := spendrules.NewGate(testenv.NewLogger(t), newGateCache(), nil)
+	require.Error(t, err)
+	require.Nil(t, gate)
+}
+
+func (c *gateCache) Get(_ context.Context, key string, value any) error {
+	if c.getErr != nil {
+		return c.getErr
+	}
+	raw, ok := c.values[key]
+	if !ok {
+		return redisCache.ErrCacheMiss
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshal gate cache value: %w", err)
+	}
+	if err := json.Unmarshal(data, value); err != nil {
+		return fmt.Errorf("unmarshal gate cache value: %w", err)
+	}
+	return nil
+}
+
+func (c *gateCache) GetAndDelete(ctx context.Context, key string, value any) error {
+	if err := c.Get(ctx, key, value); err != nil {
+		return err
+	}
+	delete(c.values, key)
+	return nil
+}
+
+func (c *gateCache) Set(_ context.Context, key string, value any, _ time.Duration) error {
+	c.values[key] = value
+	return nil
+}
+
+func (c *gateCache) Add(_ context.Context, key string, _ time.Duration) (bool, error) {
+	if _, ok := c.values[key]; ok {
+		return false, nil
+	}
+	c.values[key] = "1"
+	return true, nil
+}
+
+func (c *gateCache) Update(ctx context.Context, key string, value any) error {
+	return c.Set(ctx, key, value, 0)
+}
+
+func (c *gateCache) Delete(_ context.Context, key string) error {
+	delete(c.values, key)
+	return nil
+}
+
+func (c *gateCache) Expire(_ context.Context, _ string, _ time.Duration) error {
+	return nil
+}
+
+func (c *gateCache) ListAppend(_ context.Context, _ string, _ any, _ time.Duration) error {
+	return nil
+}
+
+func (c *gateCache) ListRange(_ context.Context, _ string, _, _ int64, _ any) error {
+	return nil
+}
+
+func (c *gateCache) DeleteByPrefix(_ context.Context, prefix string) error {
+	for key := range c.values {
+		if len(key) >= len(prefix) && key[:len(prefix)] == prefix {
+			delete(c.values, key)
+		}
+	}
+	return nil
+}
+
+func TestGateEvaluatesRuleCELAgainstCachedUsage(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	actors := testActors()
+	// Future window: the block must fire on cached usage, not be skipped as an
+	// already-reset window.
+	windowEnd := time.Now().UTC().AddDate(0, 0, 7)
+	state := spendrules.NewGateState("org_123", actors)
+	state.Rules = append(state.Rules, spendrules.GateRule{
+		RuleURN:    "spend_rule:engineering:v1",
+		RuleName:   "Engineering budget",
+		Action:     spendrules.ActionBlock,
+		TargetExpr: `department_name == "Engineering"`,
+		RuleExpr:   `used_pct >= warn_at_pct`,
+		LimitUSD:   100,
+		WarnAtPct:  80,
+		WindowKind: spendrules.WindowMonthly,
+		WindowEnd:  windowEnd,
+	})
+	state.SetActorWindowSpend("org_123", actors[0], chrepo.ActorWindowSpendRow{
+		Email:       "ada@acme.com",
+		DailyCost:   0,
+		WeeklyCost:  0,
+		MonthlyCost: 90,
+	})
+	require.Contains(t, state.Actors, "org_123:ada@acme.com")
+
+	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
+	gate := newTestGate(t, cacheImpl)
+
+	block, err := gate.CheckBlocked(ctx, "org_123", "Ada@Acme.com")
+	require.NoError(t, err)
+	require.NotNil(t, block)
+	require.Equal(t, "spend_rule:engineering:v1", block.RuleURN)
+	require.Equal(t, "Engineering budget", block.RuleName)
+	require.Equal(t, windowEnd, block.WindowEnd)
+}
+
+func TestGateSkipsExpiredWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	actors := testActors()
+	state := spendrules.NewGateState("org_123", actors)
+	state.Rules = append(state.Rules, spendrules.GateRule{
+		RuleURN:    "spend_rule:engineering:v1",
+		RuleName:   "Engineering budget",
+		Action:     spendrules.ActionBlock,
+		TargetExpr: `department_name == "Engineering"`,
+		RuleExpr:   `used_pct >= warn_at_pct`,
+		LimitUSD:   100,
+		WarnAtPct:  80,
+		WindowKind: spendrules.WindowMonthly,
+		// Window already ended: the snapshot's spend belongs to a window that
+		// has reset, so the block must lift even though the cached usage breaches.
+		WindowEnd: time.Now().UTC().Add(-time.Hour),
+	})
+	state.SetActorWindowSpend("org_123", actors[0], chrepo.ActorWindowSpendRow{
+		Email:       "ada@acme.com",
+		DailyCost:   0,
+		WeeklyCost:  0,
+		MonthlyCost: 90,
+	})
+
+	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
+	gate := newTestGate(t, cacheImpl)
+
+	block, err := gate.CheckBlocked(ctx, "org_123", "Ada@Acme.com")
+	require.NoError(t, err)
+	require.Nil(t, block)
+}
+
+func TestGateEvaluatesTargetCELBeforeRuleCEL(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	actors := testActors()
+	state := spendrules.NewGateState("org_123", actors)
+	state.Rules = append(state.Rules, spendrules.GateRule{
+		RuleURN:    "spend_rule:engineering:v1",
+		RuleName:   "Engineering budget",
+		Action:     spendrules.ActionBlock,
+		TargetExpr: `department_name == "Engineering"`,
+		RuleExpr:   `spend_usd >= limit_usd`,
+		LimitUSD:   100,
+		WarnAtPct:  80,
+		WindowKind: spendrules.WindowMonthly,
+		WindowEnd:  time.Now().UTC().AddDate(0, 0, 7),
+	})
+	state.SetActorWindowSpend("org_123", actors[1], chrepo.ActorWindowSpendRow{
+		Email:       "sam@acme.com",
+		DailyCost:   0,
+		WeeklyCost:  0,
+		MonthlyCost: 150,
+	})
+
+	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
+	gate := newTestGate(t, cacheImpl)
+
+	block, err := gate.CheckBlocked(ctx, "org_123", "Sam@Acme.com")
+	require.NoError(t, err)
+	require.Nil(t, block)
+}
+
+func TestGateSkipsUnresolvedIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	cacheImpl.getErr = errors.New("gate must not read the cache for unresolved identities")
+	gate := newTestGate(t, cacheImpl)
+
+	block, err := gate.CheckBlocked(ctx, "", "ada@acme.com")
+	require.NoError(t, err)
+	require.Nil(t, block)
+
+	block, err = gate.CheckBlocked(ctx, "org_123", "")
+	require.NoError(t, err)
+	require.Nil(t, block)
+}
+
+func TestGateSurfacesCacheFailuresForFailOpen(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	cacheImpl.getErr = errors.New("redis unavailable")
+	gate := newTestGate(t, cacheImpl)
+
+	block, err := gate.CheckBlocked(ctx, "org_123", "ada@acme.com")
+	require.Error(t, err)
+	require.Nil(t, block)
+}
+
+func TestGateWriteEmptyStateClearsCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	state := spendrules.NewGateState("org_123", testActors())
+	state.Rules = append(state.Rules, spendrules.GateRule{
+		RuleURN:    "spend_rule:engineering:v1",
+		RuleName:   "Engineering budget",
+		Action:     spendrules.ActionBlock,
+		TargetExpr: `department_name == "Engineering"`,
+		RuleExpr:   `spend_usd >= limit_usd`,
+		LimitUSD:   100,
+		WarnAtPct:  80,
+		WindowKind: spendrules.WindowMonthly,
+		WindowEnd:  time.Date(2026, time.July, 5, 0, 0, 0, 0, time.UTC),
+	})
+
+	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", state))
+	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, "org_123", spendrules.GateState{Rules: nil, Actors: nil}))
+
+	gate := newTestGate(t, cacheImpl)
+	block, err := gate.CheckBlocked(ctx, "org_123", "ada@acme.com")
+	require.NoError(t, err)
+	require.Nil(t, block)
+}

--- a/server/internal/spendrules/gate_test.go
+++ b/server/internal/spendrules/gate_test.go
@@ -11,6 +11,7 @@ import (
 	redisCache "github.com/go-redis/cache/v9"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/spendrules"
 	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
 	"github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
@@ -136,17 +137,19 @@ func TestGateEvaluatesRuleCELAgainstCachedUsage(t *testing.T) {
 	actors := testActors()
 	// Future window: the block must fire on cached usage, not be skipped as an
 	// already-reset window.
+	windowStart := time.Now().UTC().Add(-time.Hour)
 	windowEnd := time.Now().UTC().AddDate(0, 0, 7)
 	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
-		RuleURN:    "spend_rule:engineering:v1",
-		RuleName:   "Engineering budget",
-		Action:     spendrules.ActionBlock,
-		TargetExpr: `department_name == "Engineering"`,
-		RuleExpr:   `used_pct >= warn_at_pct`,
-		LimitUSD:   100,
-		WarnAtPct:  80,
-		WindowKind: spendrules.WindowMonthly,
-		WindowEnd:  windowEnd,
+		RuleURN:     "spend_rule:engineering:v1",
+		RuleName:    "Engineering budget",
+		Action:      spendrules.ActionBlock,
+		TargetExpr:  `department_name == "Engineering"`,
+		RuleExpr:    `used_pct >= warn_at_pct`,
+		LimitUSD:    100,
+		WarnAtPct:   80,
+		WindowKind:  spendrules.WindowMonthly,
+		WindowStart: windowStart,
+		WindowEnd:   windowEnd,
 	})
 	writeGateActor(t, ctx, cacheImpl, "org_123", actors[0], chrepo.ActorWindowSpendRow{
 		Email:       "ada@acme.com",
@@ -171,14 +174,15 @@ func TestGateSkipsExpiredWindow(t *testing.T) {
 	cacheImpl := newGateCache()
 	actors := testActors()
 	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
-		RuleURN:    "spend_rule:engineering:v1",
-		RuleName:   "Engineering budget",
-		Action:     spendrules.ActionBlock,
-		TargetExpr: `department_name == "Engineering"`,
-		RuleExpr:   `used_pct >= warn_at_pct`,
-		LimitUSD:   100,
-		WarnAtPct:  80,
-		WindowKind: spendrules.WindowMonthly,
+		RuleURN:     "spend_rule:engineering:v1",
+		RuleName:    "Engineering budget",
+		Action:      spendrules.ActionBlock,
+		TargetExpr:  `department_name == "Engineering"`,
+		RuleExpr:    `used_pct >= warn_at_pct`,
+		LimitUSD:    100,
+		WarnAtPct:   80,
+		WindowKind:  spendrules.WindowMonthly,
+		WindowStart: time.Now().UTC().Add(-2 * time.Hour),
 		// Window already ended: the actor entry's spend belongs to a window that
 		// has reset, so the block must lift even though the cached usage breaches.
 		WindowEnd: time.Now().UTC().Add(-time.Hour),
@@ -203,15 +207,16 @@ func TestGateEvaluatesTargetCELBeforeRuleCEL(t *testing.T) {
 	cacheImpl := newGateCache()
 	actors := testActors()
 	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
-		RuleURN:    "spend_rule:engineering:v1",
-		RuleName:   "Engineering budget",
-		Action:     spendrules.ActionBlock,
-		TargetExpr: `department_name == "Engineering"`,
-		RuleExpr:   `spend_usd >= limit_usd`,
-		LimitUSD:   100,
-		WarnAtPct:  80,
-		WindowKind: spendrules.WindowMonthly,
-		WindowEnd:  time.Now().UTC().AddDate(0, 0, 7),
+		RuleURN:     "spend_rule:engineering:v1",
+		RuleName:    "Engineering budget",
+		Action:      spendrules.ActionBlock,
+		TargetExpr:  `department_name == "Engineering"`,
+		RuleExpr:    `spend_usd >= limit_usd`,
+		LimitUSD:    100,
+		WarnAtPct:   80,
+		WindowKind:  spendrules.WindowMonthly,
+		WindowStart: time.Now().UTC().Add(-time.Hour),
+		WindowEnd:   time.Now().UTC().AddDate(0, 0, 7),
 	})
 	writeGateActor(t, ctx, cacheImpl, "org_123", actors[1], chrepo.ActorWindowSpendRow{
 		Email:       "sam@acme.com",
@@ -222,6 +227,38 @@ func TestGateEvaluatesTargetCELBeforeRuleCEL(t *testing.T) {
 	gate := newTestGate(t, cacheImpl)
 
 	block, err := gate.CheckBlocked(ctx, "org_123", "user_sam")
+	require.NoError(t, err)
+	require.Nil(t, block)
+}
+
+func TestGateSkipsActorComputedBeforeWindowStart(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	actors := testActors()
+	windowStart := time.Now().UTC().Add(time.Hour)
+	writeGateRules(t, ctx, cacheImpl, "org_123", spendrules.GateRule{
+		RuleURN:     "spend_rule:engineering:v1",
+		RuleName:    "Engineering budget",
+		Action:      spendrules.ActionBlock,
+		TargetExpr:  `department_name == "Engineering"`,
+		RuleExpr:    `spend_usd >= limit_usd`,
+		LimitUSD:    100,
+		WarnAtPct:   80,
+		WindowKind:  spendrules.WindowMonthly,
+		WindowStart: windowStart,
+		WindowEnd:   windowStart.AddDate(0, 1, 0),
+	})
+	require.NoError(t, spendrules.WriteGateActor(ctx, cacheImpl, "org_123", spendrules.NewGateActor(actors[0], chrepo.ActorWindowSpendRow{
+		Email:       "ada@acme.com",
+		DailyCost:   0,
+		WeeklyCost:  0,
+		MonthlyCost: 150,
+	}, windowStart.Add(-time.Second))))
+
+	gate := newTestGate(t, cacheImpl)
+	block, err := gate.CheckBlocked(ctx, "org_123", "user_ada")
 	require.NoError(t, err)
 	require.Nil(t, block)
 }
@@ -273,4 +310,55 @@ func TestGateEmptyRulesAllow(t *testing.T) {
 	block, err := gate.CheckBlocked(ctx, "org_123", "user_ada")
 	require.NoError(t, err)
 	require.Nil(t, block)
+}
+
+func TestWriteGateActorNoopCacheDoesNotFail(t *testing.T) {
+	t.Parallel()
+
+	actor := testActors()[0]
+	err := spendrules.WriteGateActor(t.Context(), cache.NoopCache, "org_123", spendrules.NewGateActor(actor, spendrules.EmptyActorSpend(actor.Email), time.Now().UTC()))
+	require.NoError(t, err)
+}
+
+func TestWriteGateRulesFallbackSkipsOlderPayload(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	newer := spendrules.GateRules{
+		SourceUpdatedAt: time.Date(2026, time.July, 2, 0, 0, 0, 0, time.UTC),
+		Rules: []spendrules.GateRule{{
+			RuleURN:     "spend_rule:newer:v1",
+			RuleName:    "Newer",
+			Action:      spendrules.ActionBlock,
+			TargetExpr:  `true`,
+			RuleExpr:    `spend_usd >= limit_usd`,
+			LimitUSD:    100,
+			WarnAtPct:   80,
+			WindowKind:  spendrules.WindowMonthly,
+			WindowStart: time.Now().UTC().Add(-time.Hour),
+			WindowEnd:   time.Now().UTC().Add(time.Hour),
+		}},
+	}
+	older := spendrules.GateRules{
+		SourceUpdatedAt: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		Rules: []spendrules.GateRule{{
+			RuleURN:     "spend_rule:older:v1",
+			RuleName:    "Older",
+			Action:      spendrules.ActionBlock,
+			TargetExpr:  `true`,
+			RuleExpr:    `spend_usd >= limit_usd`,
+			LimitUSD:    100,
+			WarnAtPct:   80,
+			WindowKind:  spendrules.WindowMonthly,
+			WindowStart: time.Now().UTC().Add(-time.Hour),
+			WindowEnd:   time.Now().UTC().Add(time.Hour),
+		}},
+	}
+	require.NoError(t, spendrules.WriteGateRules(ctx, cacheImpl, "org_123", newer))
+	require.NoError(t, spendrules.WriteGateRules(ctx, cacheImpl, "org_123", older))
+
+	var cached spendrules.GateRules
+	require.NoError(t, cacheImpl.Get(ctx, "spend_gate:rules:org_123", &cached))
+	require.Equal(t, "spend_rule:newer:v1", cached.Rules[0].RuleURN)
 }

--- a/server/internal/spendrules/impl.go
+++ b/server/internal/spendrules/impl.go
@@ -214,12 +214,10 @@ func (s *Service) CreateSpendRule(ctx context.Context, payload *gen.CreateSpendR
 		return nil, oops.E(oops.CodeUnexpected, err, "log spend rule create").LogError(ctx, s.logger)
 	}
 
-	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID, queries); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
-	}
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit spend rule create").LogError(ctx, s.logger)
 	}
+	s.refreshGateRulesAfterCommit(ctx, authCtx.ActiveOrganizationID)
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
 	return buildSpendRuleView(row), nil
@@ -468,12 +466,10 @@ func (s *Service) UpdateSpendRule(ctx context.Context, payload *gen.UpdateSpendR
 		return nil, oops.E(oops.CodeUnexpected, err, "log spend rule update").LogError(ctx, s.logger)
 	}
 
-	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID, queries); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
-	}
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit spend rule update").LogError(ctx, s.logger)
 	}
+	s.refreshGateRulesAfterCommit(ctx, authCtx.ActiveOrganizationID)
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
 	return buildSpendRuleView(row), nil
@@ -544,12 +540,10 @@ func (s *Service) ArchiveSpendRule(ctx context.Context, payload *gen.ArchiveSpen
 		return oops.E(oops.CodeUnexpected, err, "log spend rule archive").LogError(ctx, s.logger)
 	}
 
-	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID, queries); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
-	}
 	if err := dbtx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit spend rule archive").LogError(ctx, s.logger)
 	}
+	s.refreshGateRulesAfterCommit(ctx, authCtx.ActiveOrganizationID)
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
 	return nil
@@ -885,6 +879,15 @@ func (s *Service) refreshGateRules(ctx context.Context, organizationID string, q
 		return fmt.Errorf("refresh gate rules from db: %w", err)
 	}
 	return nil
+}
+
+func (s *Service) refreshGateRulesAfterCommit(ctx context.Context, organizationID string) {
+	if err := s.refreshGateRules(ctx, organizationID, repo.New(s.db)); err != nil {
+		s.logger.ErrorContext(ctx, "refresh spend gate rules after commit",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+	}
 }
 
 func (s *Service) budgetsEnabled(ctx context.Context, organizationID string) bool {

--- a/server/internal/spendrules/impl.go
+++ b/server/internal/spendrules/impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
@@ -60,6 +61,16 @@ type EvaluationSignaler interface {
 	Signal(ctx context.Context, organizationID string) error
 }
 
+type ActorEvaluationSignal struct {
+	OrganizationID string
+	UserID         string
+	Email          string
+}
+
+type ActorEvaluationSignaler interface {
+	SignalActor(ctx context.Context, signal ActorEvaluationSignal) error
+}
+
 type Service struct {
 	tracer trace.Tracer
 	logger *slog.Logger
@@ -69,6 +80,7 @@ type Service struct {
 	authz  *authz.Engine
 	audit  *audit.Logger
 	celEng *celenv.Engine
+	cache  cache.Cache
 	// signaler is optional; nil disables mutation-triggered re-evaluation.
 	signaler EvaluationSignaler
 }
@@ -82,6 +94,7 @@ func NewService(
 	authzEngine *authz.Engine,
 	auditLogger *audit.Logger,
 	celEng *celenv.Engine,
+	cacheImpl cache.Cache,
 	signaler EvaluationSignaler,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("spendrules"))
@@ -95,6 +108,7 @@ func NewService(
 		authz:    authzEngine,
 		audit:    auditLogger,
 		celEng:   celEng,
+		cache:    cacheImpl,
 		signaler: signaler,
 	}
 }
@@ -199,6 +213,9 @@ func (s *Service) CreateSpendRule(ctx context.Context, payload *gen.CreateSpendR
 		return nil, oops.E(oops.CodeUnexpected, err, "commit spend rule create").LogError(ctx, s.logger)
 	}
 
+	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
+	}
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
 	return buildSpendRuleView(row), nil
@@ -451,6 +468,9 @@ func (s *Service) UpdateSpendRule(ctx context.Context, payload *gen.UpdateSpendR
 		return nil, oops.E(oops.CodeUnexpected, err, "commit spend rule update").LogError(ctx, s.logger)
 	}
 
+	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
+	}
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
 	return buildSpendRuleView(row), nil
@@ -523,6 +543,9 @@ func (s *Service) ArchiveSpendRule(ctx context.Context, payload *gen.ArchiveSpen
 		return oops.E(oops.CodeUnexpected, err, "commit spend rule archive").LogError(ctx, s.logger)
 	}
 
+	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
+	}
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
 	return nil
@@ -842,6 +865,16 @@ func (s *Service) signalEvaluation(ctx context.Context, organizationID string) {
 	if err := s.signaler.Signal(ctx, organizationID); err != nil {
 		s.logger.ErrorContext(ctx, "signal spend rule evaluation", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
 	}
+}
+
+func (s *Service) refreshGateRules(ctx context.Context, organizationID string) error {
+	if s.cache == nil {
+		return nil
+	}
+	if err := WriteGateRulesFromDB(ctx, s.cache, repo.New(s.db), organizationID, time.Now().UTC()); err != nil {
+		return fmt.Errorf("refresh gate rules from db: %w", err)
+	}
+	return nil
 }
 
 // ruleSlug derives the URN slug for a new rule from its name, appending a

--- a/server/internal/spendrules/impl.go
+++ b/server/internal/spendrules/impl.go
@@ -29,9 +29,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
 	chrepo "github.com/speakeasy-api/gram/server/internal/spendrules/chrepo"
@@ -81,6 +83,7 @@ type Service struct {
 	audit  *audit.Logger
 	celEng *celenv.Engine
 	cache  cache.Cache
+	flags  feature.Provider
 	// signaler is optional; nil disables mutation-triggered re-evaluation.
 	signaler EvaluationSignaler
 }
@@ -95,6 +98,7 @@ func NewService(
 	auditLogger *audit.Logger,
 	celEng *celenv.Engine,
 	cacheImpl cache.Cache,
+	flags feature.Provider,
 	signaler EvaluationSignaler,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("spendrules"))
@@ -109,6 +113,7 @@ func NewService(
 		audit:    auditLogger,
 		celEng:   celEng,
 		cache:    cacheImpl,
+		flags:    flags,
 		signaler: signaler,
 	}
 }
@@ -209,12 +214,11 @@ func (s *Service) CreateSpendRule(ctx context.Context, payload *gen.CreateSpendR
 		return nil, oops.E(oops.CodeUnexpected, err, "log spend rule create").LogError(ctx, s.logger)
 	}
 
+	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID, queries); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
+	}
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit spend rule create").LogError(ctx, s.logger)
-	}
-
-	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
 	}
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
@@ -464,12 +468,11 @@ func (s *Service) UpdateSpendRule(ctx context.Context, payload *gen.UpdateSpendR
 		return nil, oops.E(oops.CodeUnexpected, err, "log spend rule update").LogError(ctx, s.logger)
 	}
 
+	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID, queries); err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
+	}
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit spend rule update").LogError(ctx, s.logger)
-	}
-
-	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID); err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
 	}
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
@@ -497,9 +500,11 @@ func (s *Service) ArchiveSpendRule(ctx context.Context, payload *gen.ArchiveSpen
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
+	queries := repo.New(dbtx)
+
 	// superseded_by stays NULL: an admin archive ends the lineage outright,
 	// unlike the archive an edit performs on the way to a successor row.
-	row, err := repo.New(dbtx).ArchiveSpendRule(ctx, repo.ArchiveSpendRuleParams{
+	row, err := queries.ArchiveSpendRule(ctx, repo.ArchiveSpendRuleParams{
 		ID:             id,
 		OrganizationID: authCtx.ActiveOrganizationID,
 	})
@@ -511,7 +516,7 @@ func (s *Service) ArchiveSpendRule(ctx context.Context, payload *gen.ArchiveSpen
 		//     audit event);
 		//   - lookup returns ErrNoRows -> the rule never existed, 404;
 		//   - lookup fails otherwise -> surface the real (retryable) error.
-		_, lookupErr := repo.New(dbtx).GetArchivedSpendRule(ctx, repo.GetArchivedSpendRuleParams{
+		_, lookupErr := queries.GetArchivedSpendRule(ctx, repo.GetArchivedSpendRuleParams{
 			ID:             id,
 			OrganizationID: authCtx.ActiveOrganizationID,
 		})
@@ -539,12 +544,11 @@ func (s *Service) ArchiveSpendRule(ctx context.Context, payload *gen.ArchiveSpen
 		return oops.E(oops.CodeUnexpected, err, "log spend rule archive").LogError(ctx, s.logger)
 	}
 
+	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID, queries); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
+	}
 	if err := dbtx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit spend rule archive").LogError(ctx, s.logger)
-	}
-
-	if err := s.refreshGateRules(ctx, authCtx.ActiveOrganizationID); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "refresh spend gate rules").LogError(ctx, s.logger)
 	}
 	s.signalEvaluation(ctx, authCtx.ActiveOrganizationID)
 
@@ -867,14 +871,41 @@ func (s *Service) signalEvaluation(ctx context.Context, organizationID string) {
 	}
 }
 
-func (s *Service) refreshGateRules(ctx context.Context, organizationID string) error {
+func (s *Service) refreshGateRules(ctx context.Context, organizationID string, queries *repo.Queries) error {
 	if s.cache == nil {
 		return nil
 	}
-	if err := WriteGateRulesFromDB(ctx, s.cache, repo.New(s.db), organizationID, time.Now().UTC()); err != nil {
+	if !s.budgetsEnabled(ctx, organizationID) {
+		if err := WriteGateRules(ctx, s.cache, organizationID, GateRules{SourceUpdatedAt: time.Now().UTC(), Rules: nil}); err != nil {
+			return fmt.Errorf("clear disabled gate rules: %w", err)
+		}
+		return nil
+	}
+	if err := WriteGateRulesFromDB(ctx, s.cache, queries, organizationID, time.Now().UTC()); err != nil {
 		return fmt.Errorf("refresh gate rules from db: %w", err)
 	}
 	return nil
+}
+
+func (s *Service) budgetsEnabled(ctx context.Context, organizationID string) bool {
+	if s.flags == nil {
+		return false
+	}
+
+	var groups map[string]string
+	org, err := orgRepo.New(s.db).GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		s.logger.WarnContext(ctx, "resolve organization slug for budgets flag", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
+	} else {
+		groups = feature.OrgProjectGroups(org.Slug, "")
+	}
+
+	on, err := s.flags.IsFlagEnabled(ctx, feature.FlagBudgets, organizationID, groups)
+	if err != nil {
+		s.logger.WarnContext(ctx, "budgets flag check failed; treating as disabled", attr.SlogError(err), attr.SlogOrganizationID(organizationID))
+		return false
+	}
+	return on
 }
 
 // ruleSlug derives the URN slug for a new rule from its name, appending a

--- a/server/internal/spendrules/setup_test.go
+++ b/server/internal/spendrules/setup_test.go
@@ -97,6 +97,7 @@ func newTestSpendRulesService(t *testing.T) (context.Context, *testInstance) {
 		authzEngine,
 		audit.NewLogger(),
 		celEng,
+		cache.NewRedisCacheAdapter(redisClient),
 		sig,
 	)
 

--- a/server/internal/spendrules/setup_test.go
+++ b/server/internal/spendrules/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/spendrules"
 	"github.com/speakeasy-api/gram/server/internal/spendrules/celenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -77,6 +78,8 @@ func newTestSpendRulesService(t *testing.T) (context.Context, *testInstance) {
 	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient, cache.Suffix("gram-local"), billingClient)
 
 	ctx = testenv.InitAuthContext(t, ctx, conn, sessionManager)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
 
 	chConn, err := infra.NewClickhouseClient(t)
 	require.NoError(t, err)
@@ -87,6 +90,8 @@ func newTestSpendRulesService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	sig := &signalerStub{}
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagBudgets, authCtx.ActiveOrganizationID, true)
 
 	svc := spendrules.NewService(
 		logger,
@@ -98,6 +103,7 @@ func newTestSpendRulesService(t *testing.T) (context.Context, *testInstance) {
 		audit.NewLogger(),
 		celEng,
 		cache.NewRedisCacheAdapter(redisClient),
+		flags,
 		sig,
 	)
 

--- a/server/internal/spendrules/trigger.go
+++ b/server/internal/spendrules/trigger.go
@@ -1,0 +1,116 @@
+package spendrules
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"time"
+
+	redisCache "github.com/go-redis/cache/v9"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/throttle"
+)
+
+// UsageSignalCooldown is the per-organization throttle window for
+// usage-triggered evaluation signals. The first spend-relevant telemetry
+// write for an org signals immediately (leading edge); writes inside the
+// window coalesce into one trailing signal, so breach-to-block latency is
+// bounded by roughly this window plus one evaluation instead of the
+// scheduled sweep interval.
+const UsageSignalCooldown = 30 * time.Second
+
+// isSpendRelevantURN mirrors the row predicates of
+// spend_rule_usage_summaries_mv (server/clickhouse/schema.sql): only Claude
+// Code OTEL logs and Codex/Cursor usage rows feed spend-rule enforcement.
+// The check is deliberately looser than the MV (no api_request filtering) —
+// a spurious trigger costs one throttled no-op evaluation.
+func isSpendRelevantURN(urn string) bool {
+	return urn == "claude-code:otel:logs" ||
+		strings.HasPrefix(urn, "codex:usage") ||
+		strings.HasPrefix(urn, "cursor:usage")
+}
+
+// UsageTrigger turns spend-relevant telemetry writes into debounced per-org
+// evaluation signals. It observes the telemetry logger, throttles per
+// organization, and only signals organizations that currently have a spend
+// gate snapshot — the evaluator maintains one for every org with enabled
+// rules and the budgets flag on, so its absence means evaluation would be a
+// no-op. Orgs whose snapshot is missing (first rule just created, Redis
+// flush) are covered by the mutation-time signal and the scheduled sweep.
+type UsageTrigger struct {
+	logger   *slog.Logger
+	cache    cache.Cache
+	signaler EvaluationSignaler
+	throttle *throttle.Throttle[string, string]
+}
+
+var _ telemetry.LogObserver = (*UsageTrigger)(nil)
+
+func NewUsageTrigger(logger *slog.Logger, cacheImpl cache.Cache, signaler EvaluationSignaler, cooldown time.Duration) *UsageTrigger {
+	t := &UsageTrigger{
+		logger:   logger.With(attr.SlogComponent("spendrules_usage_trigger")),
+		cache:    cacheImpl,
+		signaler: signaler,
+		throttle: nil,
+	}
+	t.throttle = throttle.New(cooldown, func(organizationID string) string {
+		return organizationID
+	}, func(organizationID string) error {
+		// Trailing edge fires from a timer goroutine after the request
+		// context that suppressed it is gone.
+		t.signal(context.Background(), organizationID)
+		return nil
+	})
+	return t
+}
+
+func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []telemetry.LogParams) {
+	seen := make(map[string]struct{}, 1)
+	for _, p := range params {
+		organizationID := p.ToolInfo.OrganizationID
+		if organizationID == "" || !isSpendRelevantURN(p.ToolInfo.URN) {
+			continue
+		}
+		if _, ok := seen[organizationID]; ok {
+			continue
+		}
+		seen[organizationID] = struct{}{}
+		if t.throttle.Do(organizationID) {
+			t.signal(ctx, organizationID)
+		}
+	}
+}
+
+func (t *UsageTrigger) signal(ctx context.Context, organizationID string) {
+	var state GateState
+	err := t.cache.Get(ctx, spendGateSnapshotKey(organizationID), &state)
+	if errors.Is(err, redisCache.ErrCacheMiss) {
+		return
+	}
+	if err != nil {
+		t.logger.WarnContext(ctx, "read spend gate snapshot for usage trigger",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+		return
+	}
+
+	if err := t.signaler.Signal(ctx, organizationID); err != nil {
+		t.logger.WarnContext(ctx, "signal spend rule evaluation for fresh usage",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(organizationID),
+		)
+	}
+}
+
+// Shutdown flushes pending trailing signals. Call it while the Temporal
+// client is still open — after traffic has drained, before runShutdown
+// closes the client.
+func (t *UsageTrigger) Shutdown(context.Context) error {
+	t.throttle.Flush()
+	return nil
+}

--- a/server/internal/spendrules/trigger.go
+++ b/server/internal/spendrules/trigger.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/throttle"
 )
@@ -59,9 +60,7 @@ func NewUsageTrigger(logger *slog.Logger, cacheImpl cache.Cache, signaler ActorE
 		signaler: signaler,
 		throttle: nil,
 	}
-	t.throttle = throttle.New(cooldown, func(signal ActorEvaluationSignal) string {
-		return signal.OrganizationID + ":" + signal.UserID + ":" + strings.ToLower(signal.Email)
-	}, func(signal ActorEvaluationSignal) error {
+	t.throttle = throttle.New(cooldown, usageSignalKey, func(signal ActorEvaluationSignal) error {
 		// Trailing edge fires from a timer goroutine after the request
 		// context that suppressed it is gone. Bound it so a stuck Redis or
 		// Temporal call cannot outlive the graceful-shutdown flush.
@@ -88,7 +87,7 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 		if signal.UserID == "" && signal.Email == "" {
 			continue
 		}
-		key := organizationID + ":" + signal.UserID + ":" + strings.ToLower(signal.Email)
+		key := usageSignalKey(signal)
 		if _, ok := seen[key]; ok {
 			continue
 		}
@@ -97,6 +96,10 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 			t.signalAsync(ctx, signal)
 		}
 	}
+}
+
+func usageSignalKey(signal ActorEvaluationSignal) string {
+	return signal.OrganizationID + ":" + signal.UserID + ":" + conv.NormalizeEmail(signal.Email)
 }
 
 // signalAsync fires a leading-edge signal off the telemetry write path. The

--- a/server/internal/spendrules/trigger.go
+++ b/server/internal/spendrules/trigger.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/throttle"
 )
@@ -42,8 +41,8 @@ func isSpendRelevantURN(urn string) bool {
 }
 
 // UsageTrigger turns spend-relevant telemetry writes into debounced per-actor
-// evaluation signals. It observes the telemetry logger, throttles per raw actor
-// identity, and only signals organizations that currently have spend gate rules.
+// evaluation signals. It observes the telemetry logger, throttles per Gram user
+// ID, and only signals organizations that currently have spend gate rules.
 type UsageTrigger struct {
 	logger   *slog.Logger
 	cache    cache.Cache
@@ -84,7 +83,7 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 			UserID:         p.UserInfo.UserID(),
 			Email:          p.UserInfo.Email(),
 		}
-		if signal.UserID == "" && signal.Email == "" {
+		if signal.UserID == "" {
 			continue
 		}
 		key := usageSignalKey(signal)
@@ -99,7 +98,7 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 }
 
 func usageSignalKey(signal ActorEvaluationSignal) string {
-	return signal.OrganizationID + ":" + signal.UserID + ":" + conv.NormalizeEmail(signal.Email)
+	return signal.OrganizationID + ":" + signal.UserID
 }
 
 // signalAsync fires a leading-edge signal off the telemetry write path. The

--- a/server/internal/spendrules/trigger.go
+++ b/server/internal/spendrules/trigger.go
@@ -15,15 +15,15 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/throttle"
 )
 
-// usageSignalTimeout bounds one signal attempt (a Redis snapshot read plus a
+// usageSignalTimeout bounds one signal attempt (a Redis rules read plus a
 // Temporal SignalWithStart). It caps how long a fired signal can run so a slow
 // dependency cannot pin a leading-edge goroutine or hold graceful shutdown open
 // while trailing signals flush.
 const usageSignalTimeout = 10 * time.Second
 
-// UsageSignalCooldown is the per-organization throttle window for
+// UsageSignalCooldown is the per-actor throttle window for
 // usage-triggered evaluation signals. The first spend-relevant telemetry
-// write for an org signals immediately (leading edge); writes inside the
+// write for an actor signals immediately (leading edge); writes inside the
 // window coalesce into one trailing signal, so breach-to-block latency is
 // bounded by roughly this window plus one evaluation instead of the
 // scheduled sweep interval.
@@ -40,38 +40,34 @@ func isSpendRelevantURN(urn string) bool {
 		strings.HasPrefix(urn, "cursor:usage")
 }
 
-// UsageTrigger turns spend-relevant telemetry writes into debounced per-org
-// evaluation signals. It observes the telemetry logger, throttles per
-// organization, and only signals organizations that currently have a spend
-// gate snapshot — the evaluator maintains one for every org with enabled
-// rules and the budgets flag on, so its absence means evaluation would be a
-// no-op. Orgs whose snapshot is missing (first rule just created, Redis
-// flush) are covered by the mutation-time signal and the scheduled sweep.
+// UsageTrigger turns spend-relevant telemetry writes into debounced per-actor
+// evaluation signals. It observes the telemetry logger, throttles per raw actor
+// identity, and only signals organizations that currently have spend gate rules.
 type UsageTrigger struct {
 	logger   *slog.Logger
 	cache    cache.Cache
-	signaler EvaluationSignaler
-	throttle *throttle.Throttle[string, string]
+	signaler ActorEvaluationSignaler
+	throttle *throttle.Throttle[string, ActorEvaluationSignal]
 }
 
 var _ telemetry.LogObserver = (*UsageTrigger)(nil)
 
-func NewUsageTrigger(logger *slog.Logger, cacheImpl cache.Cache, signaler EvaluationSignaler, cooldown time.Duration) *UsageTrigger {
+func NewUsageTrigger(logger *slog.Logger, cacheImpl cache.Cache, signaler ActorEvaluationSignaler, cooldown time.Duration) *UsageTrigger {
 	t := &UsageTrigger{
 		logger:   logger.With(attr.SlogComponent("spendrules_usage_trigger")),
 		cache:    cacheImpl,
 		signaler: signaler,
 		throttle: nil,
 	}
-	t.throttle = throttle.New(cooldown, func(organizationID string) string {
-		return organizationID
-	}, func(organizationID string) error {
+	t.throttle = throttle.New(cooldown, func(signal ActorEvaluationSignal) string {
+		return signal.OrganizationID + ":" + signal.UserID + ":" + strings.ToLower(signal.Email)
+	}, func(signal ActorEvaluationSignal) error {
 		// Trailing edge fires from a timer goroutine after the request
 		// context that suppressed it is gone. Bound it so a stuck Redis or
 		// Temporal call cannot outlive the graceful-shutdown flush.
 		bctx, cancel := context.WithTimeout(context.Background(), usageSignalTimeout)
 		defer cancel()
-		t.signal(bctx, organizationID)
+		t.signal(bctx, signal)
 		return nil
 	})
 	return t
@@ -84,12 +80,21 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 		if organizationID == "" || !isSpendRelevantURN(p.ToolInfo.URN) {
 			continue
 		}
-		if _, ok := seen[organizationID]; ok {
+		signal := ActorEvaluationSignal{
+			OrganizationID: organizationID,
+			UserID:         p.UserInfo.UserID(),
+			Email:          p.UserInfo.Email(),
+		}
+		if signal.UserID == "" && signal.Email == "" {
 			continue
 		}
-		seen[organizationID] = struct{}{}
-		if t.throttle.Do(organizationID) {
-			t.signalAsync(ctx, organizationID)
+		key := organizationID + ":" + signal.UserID + ":" + strings.ToLower(signal.Email)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		if t.throttle.Do(signal) {
+			t.signalAsync(ctx, signal)
 		}
 	}
 }
@@ -101,33 +106,36 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 // values, and bounds the work with usageSignalTimeout. A completed ClickHouse
 // write therefore still wakes enforcement even when the request/activity that
 // produced it is already gone.
-func (t *UsageTrigger) signalAsync(ctx context.Context, organizationID string) {
+func (t *UsageTrigger) signalAsync(ctx context.Context, signal ActorEvaluationSignal) {
 	detached := context.WithoutCancel(ctx)
 	go func() {
 		bctx, cancel := context.WithTimeout(detached, usageSignalTimeout)
 		defer cancel()
-		t.signal(bctx, organizationID)
+		t.signal(bctx, signal)
 	}()
 }
 
-func (t *UsageTrigger) signal(ctx context.Context, organizationID string) {
-	var state GateState
-	err := t.cache.Get(ctx, spendGateSnapshotKey(organizationID), &state)
+func (t *UsageTrigger) signal(ctx context.Context, signal ActorEvaluationSignal) {
+	var rules GateRules
+	err := t.cache.Get(ctx, spendGateRulesKey(signal.OrganizationID), &rules)
 	if errors.Is(err, redisCache.ErrCacheMiss) {
 		return
 	}
 	if err != nil {
-		t.logger.WarnContext(ctx, "read spend gate snapshot for usage trigger",
+		t.logger.WarnContext(ctx, "read spend gate rules for usage trigger",
 			attr.SlogError(err),
-			attr.SlogOrganizationID(organizationID),
+			attr.SlogOrganizationID(signal.OrganizationID),
 		)
 		return
 	}
+	if len(rules.Rules) == 0 {
+		return
+	}
 
-	if err := t.signaler.Signal(ctx, organizationID); err != nil {
+	if err := t.signaler.SignalActor(ctx, signal); err != nil {
 		t.logger.WarnContext(ctx, "signal spend rule evaluation for fresh usage",
 			attr.SlogError(err),
-			attr.SlogOrganizationID(organizationID),
+			attr.SlogOrganizationID(signal.OrganizationID),
 		)
 	}
 }

--- a/server/internal/spendrules/trigger.go
+++ b/server/internal/spendrules/trigger.go
@@ -15,6 +15,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/throttle"
 )
 
+// usageSignalTimeout bounds one signal attempt (a Redis snapshot read plus a
+// Temporal SignalWithStart). It caps how long a fired signal can run so a slow
+// dependency cannot pin a leading-edge goroutine or hold graceful shutdown open
+// while trailing signals flush.
+const usageSignalTimeout = 10 * time.Second
+
 // UsageSignalCooldown is the per-organization throttle window for
 // usage-triggered evaluation signals. The first spend-relevant telemetry
 // write for an org signals immediately (leading edge); writes inside the
@@ -61,8 +67,11 @@ func NewUsageTrigger(logger *slog.Logger, cacheImpl cache.Cache, signaler Evalua
 		return organizationID
 	}, func(organizationID string) error {
 		// Trailing edge fires from a timer goroutine after the request
-		// context that suppressed it is gone.
-		t.signal(context.Background(), organizationID)
+		// context that suppressed it is gone. Bound it so a stuck Redis or
+		// Temporal call cannot outlive the graceful-shutdown flush.
+		bctx, cancel := context.WithTimeout(context.Background(), usageSignalTimeout)
+		defer cancel()
+		t.signal(bctx, organizationID)
 		return nil
 	})
 	return t
@@ -80,9 +89,25 @@ func (t *UsageTrigger) OnTelemetryLogsWritten(ctx context.Context, params []tele
 		}
 		seen[organizationID] = struct{}{}
 		if t.throttle.Do(organizationID) {
-			t.signal(ctx, organizationID)
+			t.signalAsync(ctx, organizationID)
 		}
 	}
+}
+
+// signalAsync fires a leading-edge signal off the telemetry write path. The
+// observer runs inside LogBulk (and inside poll activities whose context is
+// canceled the instant they return), so the signal must not block the caller
+// and must survive that cancellation: it detaches the context, keeps only its
+// values, and bounds the work with usageSignalTimeout. A completed ClickHouse
+// write therefore still wakes enforcement even when the request/activity that
+// produced it is already gone.
+func (t *UsageTrigger) signalAsync(ctx context.Context, organizationID string) {
+	detached := context.WithoutCancel(ctx)
+	go func() {
+		bctx, cancel := context.WithTimeout(detached, usageSignalTimeout)
+		defer cancel()
+		t.signal(bctx, organizationID)
+	}()
 }
 
 func (t *UsageTrigger) signal(ctx context.Context, organizationID string) {

--- a/server/internal/spendrules/trigger_test.go
+++ b/server/internal/spendrules/trigger_test.go
@@ -1,0 +1,171 @@
+package spendrules_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/spendrules"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type usageSignalerStub struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (s *usageSignalerStub) Signal(_ context.Context, organizationID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, organizationID)
+	return nil
+}
+
+func (s *usageSignalerStub) Calls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func usageRow(organizationID, urn string) telemetry.LogParams {
+	return telemetry.LogParams{
+		Timestamp: time.Now(),
+		ToolInfo: telemetry.ToolInfo{
+			Name:           "claude-code",
+			OrganizationID: organizationID,
+			ProjectID:      "9a3c8f0e-0000-0000-0000-000000000001",
+			ID:             "",
+			URN:            urn,
+			DeploymentID:   "",
+			FunctionID:     nil,
+		},
+		UserInfo:   telemetry.UserInfoByEmail("ada@acme.com"),
+		Attributes: nil,
+	}
+}
+
+// writeTestGateSnapshot puts a minimal gate snapshot in the cache so the
+// trigger sees the organization as having enabled spend rules.
+func writeTestGateSnapshot(t *testing.T, ctx context.Context, cacheImpl *gateCache, organizationID string) {
+	t.Helper()
+
+	state := spendrules.NewGateState(organizationID, testActors())
+	state.Rules = append(state.Rules, spendrules.GateRule{
+		RuleURN:    "spend_rule:engineering:v1",
+		RuleName:   "Engineering budget",
+		Action:     spendrules.ActionBlock,
+		TargetExpr: `department_name == "Engineering"`,
+		RuleExpr:   `used_pct >= warn_at_pct`,
+		LimitUSD:   100,
+		WarnAtPct:  80,
+		WindowKind: spendrules.WindowMonthly,
+		WindowEnd:  time.Now().UTC().AddDate(0, 0, 7),
+	})
+	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, organizationID, state))
+}
+
+func TestUsageTriggerSignalsOrgWithGateSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	writeTestGateSnapshot(t, ctx, cacheImpl, "org_123")
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
+
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
+		usageRow("org_123", "claude-code:otel:logs"),
+	})
+
+	require.Equal(t, []string{"org_123"}, sig.Calls())
+}
+
+func TestUsageTriggerIgnoresIrrelevantRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	writeTestGateSnapshot(t, ctx, cacheImpl, "org_123")
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
+
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
+		// Not a spend-relevant URN (generic gen_ai chat rows are excluded
+		// from spend_rule_usage_summaries_mv).
+		usageRow("org_123", "tools:http:acme"),
+		// Spend-relevant URN but no organization attribution.
+		usageRow("", "claude-code:otel:logs"),
+	})
+
+	require.Empty(t, sig.Calls())
+}
+
+func TestUsageTriggerSkipsOrgWithoutGateSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
+
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
+		usageRow("org_no_rules", "cursor:usage:metrics"),
+	})
+
+	require.Empty(t, sig.Calls())
+}
+
+func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	writeTestGateSnapshot(t, ctx, cacheImpl, "org_a")
+	writeTestGateSnapshot(t, ctx, cacheImpl, "org_b")
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
+
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
+		usageRow("org_a", "claude-code:otel:logs"),
+		usageRow("org_a", "codex:usage:metrics"),
+		usageRow("org_b", "cursor:usage:metrics"),
+	})
+
+	require.ElementsMatch(t, []string{"org_a", "org_b"}, sig.Calls())
+}
+
+func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	writeTestGateSnapshot(t, ctx, cacheImpl, "org_123")
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+
+	// Leading edge signals immediately; the second batch inside the cooldown
+	// is suppressed and left pending.
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{usageRow("org_123", "claude-code:otel:logs")})
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{usageRow("org_123", "claude-code:otel:logs")})
+	require.Equal(t, []string{"org_123"}, sig.Calls())
+
+	// Shutdown flushes the pending trailing signal while Temporal would
+	// still be reachable.
+	require.NoError(t, trigger.Shutdown(ctx))
+	require.Equal(t, []string{"org_123", "org_123"}, sig.Calls())
+}

--- a/server/internal/spendrules/trigger_test.go
+++ b/server/internal/spendrules/trigger_test.go
@@ -34,10 +34,18 @@ func (s *usageSignalerStub) Calls() []spendrules.ActorEvaluationSignal {
 }
 
 func usageRow(organizationID, urn string) telemetry.LogParams {
-	return usageRowWithEmail(organizationID, urn, "ada@acme.com")
+	return usageRowWithIdentity(organizationID, urn, "user_ada", "ada@acme.com")
 }
 
 func usageRowWithEmail(organizationID, urn, email string) telemetry.LogParams {
+	return usageRowWithUserInfo(organizationID, urn, telemetry.UserInfoByEmail(email))
+}
+
+func usageRowWithIdentity(organizationID, urn, userID, email string) telemetry.LogParams {
+	return usageRowWithUserInfo(organizationID, urn, telemetry.UserInfoByIDAndEmail(userID, email))
+}
+
+func usageRowWithUserInfo(organizationID, urn string, userInfo telemetry.UserInfo) telemetry.LogParams {
 	return telemetry.LogParams{
 		Timestamp: time.Now(),
 		ToolInfo: telemetry.ToolInfo{
@@ -49,7 +57,7 @@ func usageRowWithEmail(organizationID, urn, email string) telemetry.LogParams {
 			DeploymentID:   "",
 			FunctionID:     nil,
 		},
-		UserInfo:   telemetry.UserInfoByEmail(email),
+		UserInfo:   userInfo,
 		Attributes: nil,
 	}
 }
@@ -93,7 +101,7 @@ func TestUsageTriggerSignalsOrgWithGateSnapshot(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(sig.Calls()) == 1
 	}, 2*time.Second, 5*time.Millisecond)
-	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"}}, sig.Calls())
+	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "user_ada", Email: "ada@acme.com"}}, sig.Calls())
 }
 
 func TestUsageTriggerIgnoresIrrelevantRows(t *testing.T) {
@@ -135,6 +143,24 @@ func TestUsageTriggerSkipsOrgWithoutGateSnapshot(t *testing.T) {
 	require.Empty(t, sig.Calls())
 }
 
+func TestUsageTriggerSkipsRowsWithoutUserID(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	writeTestGateRules(t, ctx, cacheImpl, "org_123")
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
+
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
+		usageRowWithEmail("org_123", "claude-code:otel:logs", "ada@acme.com"),
+	})
+
+	require.Empty(t, sig.Calls())
+}
+
 func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
 	t.Parallel()
 
@@ -158,12 +184,12 @@ func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
 		return len(sig.Calls()) == 2
 	}, 2*time.Second, 5*time.Millisecond)
 	require.ElementsMatch(t, []spendrules.ActorEvaluationSignal{
-		{OrganizationID: "org_a", UserID: "", Email: "ada@acme.com"},
-		{OrganizationID: "org_b", UserID: "", Email: "ada@acme.com"},
+		{OrganizationID: "org_a", UserID: "user_ada", Email: "ada@acme.com"},
+		{OrganizationID: "org_b", UserID: "user_ada", Email: "ada@acme.com"},
 	}, sig.Calls())
 }
 
-func TestUsageTriggerDedupesNormalizedActorWithinBatch(t *testing.T) {
+func TestUsageTriggerDedupesUserIDWithinBatch(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
@@ -175,14 +201,14 @@ func TestUsageTriggerDedupesNormalizedActorWithinBatch(t *testing.T) {
 	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
 
 	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
-		usageRowWithEmail("org_123", "claude-code:otel:logs", " Ada@Acme.com "),
-		usageRowWithEmail("org_123", "codex:usage:metrics", "ada@acme.com"),
+		usageRowWithIdentity("org_123", "claude-code:otel:logs", "user_ada", " Ada@Acme.com "),
+		usageRowWithIdentity("org_123", "codex:usage:metrics", "user_ada", "other@acme.com"),
 	})
 
 	require.Eventually(t, func() bool {
 		return len(sig.Calls()) == 1
 	}, 2*time.Second, 5*time.Millisecond)
-	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "", Email: " Ada@Acme.com "}}, sig.Calls())
+	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "user_ada", Email: " Ada@Acme.com "}}, sig.Calls())
 }
 
 func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
@@ -202,13 +228,13 @@ func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(sig.Calls()) == 1
 	}, 2*time.Second, 5*time.Millisecond)
-	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"}}, sig.Calls())
+	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "user_ada", Email: "ada@acme.com"}}, sig.Calls())
 
 	// Shutdown flushes the pending trailing signal while Temporal would
 	// still be reachable.
 	require.NoError(t, trigger.Shutdown(ctx))
 	require.Equal(t, []spendrules.ActorEvaluationSignal{
-		{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"},
-		{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"},
+		{OrganizationID: "org_123", UserID: "user_ada", Email: "ada@acme.com"},
+		{OrganizationID: "org_123", UserID: "user_ada", Email: "ada@acme.com"},
 	}, sig.Calls())
 }

--- a/server/internal/spendrules/trigger_test.go
+++ b/server/internal/spendrules/trigger_test.go
@@ -85,6 +85,11 @@ func TestUsageTriggerSignalsOrgWithGateSnapshot(t *testing.T) {
 		usageRow("org_123", "claude-code:otel:logs"),
 	})
 
+	// The leading-edge signal fires on a detached goroutine (signalAsync), so
+	// poll rather than assert synchronously.
+	require.Eventually(t, func() bool {
+		return len(sig.Calls()) == 1
+	}, 2*time.Second, 5*time.Millisecond)
 	require.Equal(t, []string{"org_123"}, sig.Calls())
 }
 
@@ -145,6 +150,10 @@ func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
 		usageRow("org_b", "cursor:usage:metrics"),
 	})
 
+	// Both leading-edge signals fire on detached goroutines; wait for both.
+	require.Eventually(t, func() bool {
+		return len(sig.Calls()) == 2
+	}, 2*time.Second, 5*time.Millisecond)
 	require.ElementsMatch(t, []string{"org_a", "org_b"}, sig.Calls())
 }
 
@@ -158,10 +167,13 @@ func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
 	sig := &usageSignalerStub{}
 	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
 
-	// Leading edge signals immediately; the second batch inside the cooldown
-	// is suppressed and left pending.
+	// Leading edge signals immediately (on a detached goroutine); the second
+	// batch inside the cooldown is suppressed and left pending.
 	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{usageRow("org_123", "claude-code:otel:logs")})
 	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{usageRow("org_123", "claude-code:otel:logs")})
+	require.Eventually(t, func() bool {
+		return len(sig.Calls()) == 1
+	}, 2*time.Second, 5*time.Millisecond)
 	require.Equal(t, []string{"org_123"}, sig.Calls())
 
 	// Shutdown flushes the pending trailing signal while Temporal would

--- a/server/internal/spendrules/trigger_test.go
+++ b/server/internal/spendrules/trigger_test.go
@@ -34,6 +34,10 @@ func (s *usageSignalerStub) Calls() []spendrules.ActorEvaluationSignal {
 }
 
 func usageRow(organizationID, urn string) telemetry.LogParams {
+	return usageRowWithEmail(organizationID, urn, "ada@acme.com")
+}
+
+func usageRowWithEmail(organizationID, urn, email string) telemetry.LogParams {
 	return telemetry.LogParams{
 		Timestamp: time.Now(),
 		ToolInfo: telemetry.ToolInfo{
@@ -45,7 +49,7 @@ func usageRow(organizationID, urn string) telemetry.LogParams {
 			DeploymentID:   "",
 			FunctionID:     nil,
 		},
-		UserInfo:   telemetry.UserInfoByEmail("ada@acme.com"),
+		UserInfo:   telemetry.UserInfoByEmail(email),
 		Attributes: nil,
 	}
 }
@@ -56,15 +60,16 @@ func writeTestGateRules(t *testing.T, ctx context.Context, cacheImpl *gateCache,
 	t.Helper()
 
 	writeGateRules(t, ctx, cacheImpl, organizationID, spendrules.GateRule{
-		RuleURN:    "spend_rule:engineering:v1",
-		RuleName:   "Engineering budget",
-		Action:     spendrules.ActionBlock,
-		TargetExpr: `department_name == "Engineering"`,
-		RuleExpr:   `used_pct >= warn_at_pct`,
-		LimitUSD:   100,
-		WarnAtPct:  80,
-		WindowKind: spendrules.WindowMonthly,
-		WindowEnd:  time.Now().UTC().AddDate(0, 0, 7),
+		RuleURN:     "spend_rule:engineering:v1",
+		RuleName:    "Engineering budget",
+		Action:      spendrules.ActionBlock,
+		TargetExpr:  `department_name == "Engineering"`,
+		RuleExpr:    `used_pct >= warn_at_pct`,
+		LimitUSD:    100,
+		WarnAtPct:   80,
+		WindowKind:  spendrules.WindowMonthly,
+		WindowStart: time.Now().UTC().Add(-time.Hour),
+		WindowEnd:   time.Now().UTC().AddDate(0, 0, 7),
 	})
 }
 
@@ -156,6 +161,28 @@ func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
 		{OrganizationID: "org_a", UserID: "", Email: "ada@acme.com"},
 		{OrganizationID: "org_b", UserID: "", Email: "ada@acme.com"},
 	}, sig.Calls())
+}
+
+func TestUsageTriggerDedupesNormalizedActorWithinBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cacheImpl := newGateCache()
+	writeTestGateRules(t, ctx, cacheImpl, "org_123")
+
+	sig := &usageSignalerStub{}
+	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
+	t.Cleanup(func() { _ = trigger.Shutdown(context.Background()) })
+
+	trigger.OnTelemetryLogsWritten(ctx, []telemetry.LogParams{
+		usageRowWithEmail("org_123", "claude-code:otel:logs", " Ada@Acme.com "),
+		usageRowWithEmail("org_123", "codex:usage:metrics", "ada@acme.com"),
+	})
+
+	require.Eventually(t, func() bool {
+		return len(sig.Calls()) == 1
+	}, 2*time.Second, 5*time.Millisecond)
+	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "", Email: " Ada@Acme.com "}}, sig.Calls())
 }
 
 func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {

--- a/server/internal/spendrules/trigger_test.go
+++ b/server/internal/spendrules/trigger_test.go
@@ -15,22 +15,22 @@ import (
 
 type usageSignalerStub struct {
 	mu    sync.Mutex
-	calls []string
+	calls []spendrules.ActorEvaluationSignal
 }
 
-func (s *usageSignalerStub) Signal(_ context.Context, organizationID string) error {
+func (s *usageSignalerStub) SignalActor(_ context.Context, signal spendrules.ActorEvaluationSignal) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.calls = append(s.calls, organizationID)
+	s.calls = append(s.calls, signal)
 	return nil
 }
 
-func (s *usageSignalerStub) Calls() []string {
+func (s *usageSignalerStub) Calls() []spendrules.ActorEvaluationSignal {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	out := make([]string, len(s.calls))
-	copy(out, s.calls)
-	return out
+	signals := make([]spendrules.ActorEvaluationSignal, len(s.calls))
+	copy(signals, s.calls)
+	return signals
 }
 
 func usageRow(organizationID, urn string) telemetry.LogParams {
@@ -50,13 +50,12 @@ func usageRow(organizationID, urn string) telemetry.LogParams {
 	}
 }
 
-// writeTestGateSnapshot puts a minimal gate snapshot in the cache so the
-// trigger sees the organization as having enabled spend rules.
-func writeTestGateSnapshot(t *testing.T, ctx context.Context, cacheImpl *gateCache, organizationID string) {
+// writeTestGateRules puts minimal rules in the cache so the trigger sees the
+// organization as having enabled spend rules.
+func writeTestGateRules(t *testing.T, ctx context.Context, cacheImpl *gateCache, organizationID string) {
 	t.Helper()
 
-	state := spendrules.NewGateState(organizationID, testActors())
-	state.Rules = append(state.Rules, spendrules.GateRule{
+	writeGateRules(t, ctx, cacheImpl, organizationID, spendrules.GateRule{
 		RuleURN:    "spend_rule:engineering:v1",
 		RuleName:   "Engineering budget",
 		Action:     spendrules.ActionBlock,
@@ -67,7 +66,6 @@ func writeTestGateSnapshot(t *testing.T, ctx context.Context, cacheImpl *gateCac
 		WindowKind: spendrules.WindowMonthly,
 		WindowEnd:  time.Now().UTC().AddDate(0, 0, 7),
 	})
-	require.NoError(t, spendrules.WriteGateState(ctx, cacheImpl, organizationID, state))
 }
 
 func TestUsageTriggerSignalsOrgWithGateSnapshot(t *testing.T) {
@@ -75,7 +73,7 @@ func TestUsageTriggerSignalsOrgWithGateSnapshot(t *testing.T) {
 
 	ctx := t.Context()
 	cacheImpl := newGateCache()
-	writeTestGateSnapshot(t, ctx, cacheImpl, "org_123")
+	writeTestGateRules(t, ctx, cacheImpl, "org_123")
 
 	sig := &usageSignalerStub{}
 	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
@@ -90,7 +88,7 @@ func TestUsageTriggerSignalsOrgWithGateSnapshot(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(sig.Calls()) == 1
 	}, 2*time.Second, 5*time.Millisecond)
-	require.Equal(t, []string{"org_123"}, sig.Calls())
+	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"}}, sig.Calls())
 }
 
 func TestUsageTriggerIgnoresIrrelevantRows(t *testing.T) {
@@ -98,7 +96,7 @@ func TestUsageTriggerIgnoresIrrelevantRows(t *testing.T) {
 
 	ctx := t.Context()
 	cacheImpl := newGateCache()
-	writeTestGateSnapshot(t, ctx, cacheImpl, "org_123")
+	writeTestGateRules(t, ctx, cacheImpl, "org_123")
 
 	sig := &usageSignalerStub{}
 	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
@@ -137,8 +135,8 @@ func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
 
 	ctx := t.Context()
 	cacheImpl := newGateCache()
-	writeTestGateSnapshot(t, ctx, cacheImpl, "org_a")
-	writeTestGateSnapshot(t, ctx, cacheImpl, "org_b")
+	writeTestGateRules(t, ctx, cacheImpl, "org_a")
+	writeTestGateRules(t, ctx, cacheImpl, "org_b")
 
 	sig := &usageSignalerStub{}
 	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
@@ -154,7 +152,10 @@ func TestUsageTriggerDedupesOrgsWithinBatch(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(sig.Calls()) == 2
 	}, 2*time.Second, 5*time.Millisecond)
-	require.ElementsMatch(t, []string{"org_a", "org_b"}, sig.Calls())
+	require.ElementsMatch(t, []spendrules.ActorEvaluationSignal{
+		{OrganizationID: "org_a", UserID: "", Email: "ada@acme.com"},
+		{OrganizationID: "org_b", UserID: "", Email: "ada@acme.com"},
+	}, sig.Calls())
 }
 
 func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
@@ -162,7 +163,7 @@ func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
 
 	ctx := t.Context()
 	cacheImpl := newGateCache()
-	writeTestGateSnapshot(t, ctx, cacheImpl, "org_123")
+	writeTestGateRules(t, ctx, cacheImpl, "org_123")
 
 	sig := &usageSignalerStub{}
 	trigger := spendrules.NewUsageTrigger(testenv.NewLogger(t), cacheImpl, sig, time.Hour)
@@ -174,10 +175,13 @@ func TestUsageTriggerThrottlesAndFlushesTrailingEdge(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(sig.Calls()) == 1
 	}, 2*time.Second, 5*time.Millisecond)
-	require.Equal(t, []string{"org_123"}, sig.Calls())
+	require.Equal(t, []spendrules.ActorEvaluationSignal{{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"}}, sig.Calls())
 
 	// Shutdown flushes the pending trailing signal while Temporal would
 	// still be reachable.
 	require.NoError(t, trigger.Shutdown(ctx))
-	require.Equal(t, []string{"org_123", "org_123"}, sig.Calls())
+	require.Equal(t, []spendrules.ActorEvaluationSignal{
+		{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"},
+		{OrganizationID: "org_123", UserID: "", Email: "ada@acme.com"},
+	}, sig.Calls())
 }

--- a/server/internal/telemetry/logger.go
+++ b/server/internal/telemetry/logger.go
@@ -53,6 +53,16 @@ func WithOTELMetadata(params LogParams, observedTimestamp time.Time, resourceAtt
 	return params
 }
 
+// LogObserver is notified after a batch of telemetry log rows is written to
+// telemetry_logs. Observers receive the caller's batch before per-org
+// feature-flag filtering, so a row is not a guarantee that it was persisted.
+// Implementations must be cheap; heavy work should be throttled or dispatched
+// asynchronously. Staged rows (LogBulkStaging) are not observed — they only
+// reach telemetry_logs later, via promotion.
+type LogObserver interface {
+	OnTelemetryLogsWritten(ctx context.Context, params []LogParams)
+}
+
 type Logger struct {
 	shutdownCtx       func() context.Context
 	logger            *slog.Logger
@@ -61,6 +71,7 @@ type Logger struct {
 	toolIOLogsEnabled FeatureChecker
 	users             *UserInfoResolver
 	logPublisher      *LogPublisher
+	observers         []LogObserver
 }
 
 func NewLogger(
@@ -91,7 +102,14 @@ func NewLogger(
 		toolIOLogsEnabled: toolIOLogsEnabled,
 		users:             users,
 		logPublisher:      logPublisher,
+		observers:         nil,
 	}
+}
+
+// AddObserver registers a LogObserver. Not safe to call concurrently with
+// logging — register observers during wiring, before traffic flows.
+func (l *Logger) AddObserver(obs LogObserver) {
+	l.observers = append(l.observers, obs)
 }
 
 // NewStub returns a Logger with feature checks hard-wired to disabled. Log
@@ -107,6 +125,7 @@ func NewStub(logger *slog.Logger) *Logger {
 		toolIOLogsEnabled: disabled,
 		users:             nil,
 		logPublisher:      NewNoopLogPublisher(logger),
+		observers:         nil,
 	}
 }
 
@@ -175,6 +194,9 @@ func (l *Logger) LogBulk(ctx context.Context, params []LogParams) error {
 	// rejected. Best-effort and non-blocking.
 	l.logPublisher.PublishLogs(ctx, logParams)
 
+	for _, obs := range l.observers {
+		obs.OnTelemetryLogsWritten(ctx, params)
+	}
 	return nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ships Budgets v1: a spend-rules API, dashboard, and a runtime that evaluates spend and enforces blocks within seconds. Enforcement is behind the Budgets flag and applies to Claude only.

- **New Features**
  - Spend rules API: create/list/get/update/archive, preview matched actors and current-window usage, list warning/breach events, overview metrics, and list actor attributes; OpenAPI, CLI, and generated `@gram/client` hooks included.
  - Dashboard: new Costs → Budgets tab with rules list, detail, editor with live preview, events feed, and overview cards; targets use the backend actor-attribute catalog.
  - Runtime: Temporal workflows schedule org sweeps and run debounced per-org evaluations; evaluator computes per-actor window spend from ClickHouse, records warning/breach events, and publishes Redis gate snapshots; telemetry logger observes Claude Code OTEL and Codex/Cursor usage on both server and worker paths and signals re-evaluation with per-org throttling; Claude hooks consult the spend gate before policy scans and block prompts and tool calls (native and MCP, even mid-turn) with a user-facing reason and block URL.

- **Bug Fixes**
  - Usage signals run off the write path in a bounded, cancellation-detached context and flush on shutdown.
  - Evaluator fails loudly without ClickHouse, retries transient event writes, and logs-and-skips per-rule logic errors.
  - Gate rejects nil cache, bounds the compiled-CEL cache, lifts blocks when windows reset, clears snapshots when the flag is off or no rules exist, and uses a longer snapshot TTL (4x the evaluation interval).
  - Debounced workflow continues-as-new when an error occurs and a signal arrived mid-run, so pending signals aren’t stranded.
  - Dedupes blocked prompt telemetry per session+prompt for clients that lack idempotency keys.
  - Key actor evaluation and gate snapshots by user ID (not email) to avoid aliasing across addresses.

<sup>Written for commit 8952dfb6fca4ed32c5a833c767e2c8f0e1c1d0d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

