### PR TITLE
fix(hooks): device-agent identity discovery — well-known paths + socket rescue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/Masterminds/squirrel v1.5.4
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/OpenRouterTeam/go-sdk v0.3.0
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.43.0
@@ -130,7 +131,6 @@ require (
 	github.com/Khan/genqlient v0.8.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/PuerkitoBio/rehttp v1.4.0 // indirect
 	github.com/STARRY-S/zip v0.2.1 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -90,6 +90,11 @@ func socketIdentityEmail(ctx context.Context) string {
 		DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
 			return dialAgentSocket(dialCtx, socket)
 		},
+		// One-shot client: without this, the transport pools the socket
+		// connection (plus its read/write goroutines) for the process
+		// lifetime — a per-invocation leak, since the transport is never
+		// reused or closed.
+		DisableKeepAlives: true,
 	}}
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, "http://speakeasy-agent/v1/identity", nil)
 	if err != nil {

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -92,7 +92,14 @@ func deviceAgentCommands() []string {
 		candidates = append(candidates, `C:\Program Files\Speakeasy\speakeasyd.exe`)
 	default:
 		if home != "" {
-			candidates = append(candidates, filepath.Join(home, ".local", "bin", "speakeasyd"))
+			candidates = append(candidates,
+				// ~/.speakeasy is the agent's conventional dotdir on Linux
+				// (its IPC socket lives there); kept as a supported install
+				// location by maintainer decision even though no packaged
+				// rollout writes it today.
+				filepath.Join(home, ".speakeasy", "bin", "speakeasyd"),
+				filepath.Join(home, ".local", "bin", "speakeasyd"),
+			)
 		}
 		candidates = append(candidates, "/usr/local/bin/speakeasyd")
 	}

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -61,16 +61,22 @@ func deviceAgentEmail(ctx context.Context) string {
 
 // deviceAgentCommands returns the device-agent commands to try, in order.
 // GRAM_DEVICE_AGENT_COMMANDS (comma-separated) replaces the default set
-// entirely. The default tries a bare PATH lookup first and then the agent's
-// well-known install locations: MDM installs place speakeasyd under the
-// per-user Speakeasy directory without touching PATH (and GUI-spawned hook
+// entirely. The default order — the device agent's HOOK_IDENTITY contract —
+// is: the path the daemon advertises about itself, then a bare PATH lookup,
+// then static well-known install locations for daemons too old to advertise.
+// speakeasyd is typically NOT on PATH (MDM installs place it under the
+// per-user Speakeasy directory without touching PATH, and GUI-spawned hook
 // hosts see a minimal PATH anyway), so a bare lookup alone silently loses
 // managed identity attribution.
 func deviceAgentCommands() []string {
 	if env := strings.TrimSpace(os.Getenv("GRAM_DEVICE_AGENT_COMMANDS")); env != "" {
 		return strings.Split(env, ",")
 	}
-	commands := []string{"speakeasyd"}
+	var commands []string
+	if advertised := advertisedAgentPath(); advertised != "" {
+		commands = append(commands, advertised)
+	}
+	commands = append(commands, "speakeasyd")
 	home, _ := os.UserHomeDir()
 	var candidates []string
 	switch runtime.GOOS {
@@ -83,25 +89,64 @@ func deviceAgentCommands() []string {
 			"/Library/Application Support/Speakeasy/speakeasyd",
 		)
 	case "windows":
-		if local := os.Getenv("LOCALAPPDATA"); local != "" {
-			candidates = append(candidates, filepath.Join(local, "Speakeasy", "bin", "speakeasyd.exe"))
-		}
 		candidates = append(candidates, `C:\Program Files\Speakeasy\speakeasyd.exe`)
 	default:
 		if home != "" {
-			candidates = append(candidates,
-				filepath.Join(home, ".speakeasy", "bin", "speakeasyd"),
-				filepath.Join(home, ".local", "bin", "speakeasyd"),
-			)
+			candidates = append(candidates, filepath.Join(home, ".local", "bin", "speakeasyd"))
 		}
 		candidates = append(candidates, "/usr/local/bin/speakeasyd")
 	}
 	for _, candidate := range candidates {
-		if executableFile(candidate) {
+		if executableFile(candidate) && candidate != commands[0] {
 			commands = append(commands, candidate)
 		}
 	}
 	return commands
+}
+
+// advertisedAgentPath reads the daemon's self-advertisement: on every startup
+// speakeasyd writes its own executable path to a fixed per-OS file (the
+// device agent's core/paths.AgentPathFile — keep the locations in sync). This
+// is the only discovery mode that works regardless of where IT installed the
+// daemon, on every OS. Windows is machine-wide (%ProgramData%) because the
+// daemon runs as LocalSystem there, whose profile dirs per-user hook
+// processes can't see. Returns "" when the file is absent (older daemon),
+// unreadable, or names something that isn't an executable file.
+func advertisedAgentPath() string {
+	var file string
+	switch runtime.GOOS {
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		file = filepath.Join(home, "Library", "Application Support", "Speakeasy", "agent-path")
+	case "windows":
+		programData := os.Getenv("PROGRAMDATA")
+		if programData == "" {
+			programData = `C:\ProgramData`
+		}
+		file = filepath.Join(programData, "Speakeasy", "agent-path")
+	default:
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return ""
+			}
+			stateHome = filepath.Join(home, ".local", "state")
+		}
+		file = filepath.Join(stateHome, "speakeasy", "agent-path")
+	}
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return ""
+	}
+	advertised := strings.TrimSpace(string(content))
+	if !filepath.IsAbs(advertised) || !executableFile(advertised) {
+		return ""
+	}
+	return advertised
 }
 
 func executableFile(path string) bool {

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -39,9 +40,8 @@ func resolveUserEmail(ctx context.Context, typed any) string {
 }
 
 func deviceAgentEmail(ctx context.Context) string {
-	commands := strings.Split(firstNonEmpty(os.Getenv("GRAM_DEVICE_AGENT_COMMANDS"), "speakeasyd"), ",")
 	timeout := tenthsDuration("GRAM_DEVICE_AGENT_TIMEOUT_TENTHS", 15)
-	for _, name := range commands {
+	for _, name := range deviceAgentCommands() {
 		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
@@ -57,6 +57,59 @@ func deviceAgentEmail(ctx context.Context) string {
 		}
 	}
 	return ""
+}
+
+// deviceAgentCommands returns the device-agent commands to try, in order.
+// GRAM_DEVICE_AGENT_COMMANDS (comma-separated) replaces the default set
+// entirely. The default tries a bare PATH lookup first and then the agent's
+// well-known install locations: MDM installs place speakeasyd under the
+// per-user Speakeasy directory without touching PATH (and GUI-spawned hook
+// hosts see a minimal PATH anyway), so a bare lookup alone silently loses
+// managed identity attribution.
+func deviceAgentCommands() []string {
+	if env := strings.TrimSpace(os.Getenv("GRAM_DEVICE_AGENT_COMMANDS")); env != "" {
+		return strings.Split(env, ",")
+	}
+	commands := []string{"speakeasyd"}
+	home, _ := os.UserHomeDir()
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		if home != "" {
+			candidates = append(candidates, filepath.Join(home, "Library", "Application Support", "Speakeasy", "bin", "speakeasyd"))
+		}
+		candidates = append(candidates,
+			"/usr/local/bin/speakeasyd",
+			"/Library/Application Support/Speakeasy/speakeasyd",
+		)
+	case "windows":
+		if local := os.Getenv("LOCALAPPDATA"); local != "" {
+			candidates = append(candidates, filepath.Join(local, "Speakeasy", "bin", "speakeasyd.exe"))
+		}
+		candidates = append(candidates, `C:\Program Files\Speakeasy\speakeasyd.exe`)
+	default:
+		if home != "" {
+			candidates = append(candidates,
+				filepath.Join(home, ".speakeasy", "bin", "speakeasyd"),
+				filepath.Join(home, ".local", "bin", "speakeasyd"),
+			)
+		}
+		candidates = append(candidates, "/usr/local/bin/speakeasyd")
+	}
+	for _, candidate := range candidates {
+		if executableFile(candidate) {
+			commands = append(commands, candidate)
+		}
+	}
+	return commands
+}
+
+func executableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return runtime.GOOS == "windows" || info.Mode()&0o111 != 0
 }
 
 func identityOutputEmail(output []byte) string {

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -6,6 +6,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,27 +59,103 @@ func deviceAgentEmail(ctx context.Context) string {
 			return email
 		}
 	}
-	return ""
+	// Rescue tier: a daemon running from a location the exec chain can't
+	// guess still owns a socket at a fixed per-OS path — ask it directly.
+	// The env override is a real off switch and silences this tier too.
+	if strings.TrimSpace(os.Getenv("GRAM_DEVICE_AGENT_COMMANDS")) != "" {
+		return ""
+	}
+	return socketIdentityEmail(ctx)
 }
 
-// deviceAgentCommands returns the device-agent commands to try, in order.
+// socketAgentTimeout bounds the whole socket-rescue request. Only a *hung*
+// daemon ever pays it — a missing socket fails the dial instantly — and hooks
+// must never hold an editor hostage to a wedged one.
+const socketAgentTimeout = 150 * time.Millisecond
+
+// socketIdentityEmail asks the running daemon for identity over its IPC
+// socket (GET /v1/identity — the device agent's api.SocketPath and
+// IdentityResponse contracts; keep the paths below in sync). This is the
+// rescue, not the primary, on purpose: `speakeasyd identity` re-reads the
+// config files per call, while the daemon serves its boot-time snapshot —
+// exec is fresher whenever both are available. One attempt, no retry.
+func socketIdentityEmail(ctx context.Context) string {
+	socket := agentSocketPath()
+	if socket == "" {
+		return ""
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, socketAgentTimeout)
+	defer cancel()
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+			return dialAgentSocket(dialCtx, socket)
+		},
+	}}
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, "http://speakeasy-agent/v1/identity", nil)
+	if err != nil {
+		return ""
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return ""
+	}
+	var identity struct {
+		V        int    `json:"v"`
+		Enrolled bool   `json:"enrolled"`
+		Email    string `json:"email"`
+	}
+	if json.Unmarshal(body, &identity) != nil {
+		return ""
+	}
+	// Contract rule: a document version newer than we understand is
+	// unreadable, same as the exec path's consumers.
+	if identity.V > 1 || !identity.Enrolled || !validEmail(identity.Email) {
+		return ""
+	}
+	return identity.Email
+}
+
+// agentSocketPath mirrors the device agent's api.SocketPath, including the
+// SPEAKEASY_SOCKET override.
+func agentSocketPath() string {
+	if v := os.Getenv("SPEAKEASY_SOCKET"); v != "" {
+		return v
+	}
+	if runtime.GOOS == "windows" {
+		return `\\.\pipe\speakeasy-agent`
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "/tmp/speakeasy-agent.sock"
+	}
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Application Support", "Speakeasy", "agent.sock")
+	}
+	return filepath.Join(home, ".speakeasy", "agent.sock")
+}
+
+// deviceAgentCommands returns the device-agent commands to exec, in order.
 // GRAM_DEVICE_AGENT_COMMANDS (comma-separated) replaces the default set
-// entirely. The default order — the device agent's HOOK_IDENTITY contract —
-// is: the path the daemon advertises about itself, then a bare PATH lookup,
-// then static well-known install locations for daemons too old to advertise.
-// speakeasyd is typically NOT on PATH (MDM installs place it under the
-// per-user Speakeasy directory without touching PATH, and GUI-spawned hook
-// hosts see a minimal PATH anyway), so a bare lookup alone silently loses
-// managed identity attribution.
+// entirely — and silences the socket rescue in deviceAgentEmail, so it stays
+// a complete off switch. The default is a bare PATH lookup, then static
+// well-known install locations: speakeasyd is typically NOT on PATH (MDM
+// installs place it under the per-user Speakeasy directory without touching
+// PATH, and GUI-spawned hook hosts see a minimal PATH anyway), so a bare
+// lookup alone silently loses managed identity attribution. A daemon running
+// somewhere none of these cover is handled by the socket rescue.
 func deviceAgentCommands() []string {
 	if env := strings.TrimSpace(os.Getenv("GRAM_DEVICE_AGENT_COMMANDS")); env != "" {
 		return strings.Split(env, ",")
 	}
-	var commands []string
-	if advertised := advertisedAgentPath(); advertised != "" {
-		commands = append(commands, advertised)
-	}
-	commands = append(commands, "speakeasyd")
+	commands := []string{"speakeasyd"}
 	home, _ := os.UserHomeDir()
 	var candidates []string
 	switch runtime.GOOS {
@@ -104,56 +183,11 @@ func deviceAgentCommands() []string {
 		candidates = append(candidates, "/usr/local/bin/speakeasyd")
 	}
 	for _, candidate := range candidates {
-		if executableFile(candidate) && candidate != commands[0] {
+		if executableFile(candidate) {
 			commands = append(commands, candidate)
 		}
 	}
 	return commands
-}
-
-// advertisedAgentPath reads the daemon's self-advertisement: on every startup
-// speakeasyd writes its own executable path to a fixed per-OS file (the
-// device agent's core/paths.AgentPathFile — keep the locations in sync). This
-// is the only discovery mode that works regardless of where IT installed the
-// daemon, on every OS. Windows is machine-wide (%ProgramData%) because the
-// daemon runs as LocalSystem there, whose profile dirs per-user hook
-// processes can't see. Returns "" when the file is absent (older daemon),
-// unreadable, or names something that isn't an executable file.
-func advertisedAgentPath() string {
-	var file string
-	switch runtime.GOOS {
-	case "darwin":
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return ""
-		}
-		file = filepath.Join(home, "Library", "Application Support", "Speakeasy", "agent-path")
-	case "windows":
-		programData := os.Getenv("PROGRAMDATA")
-		if programData == "" {
-			programData = `C:\ProgramData`
-		}
-		file = filepath.Join(programData, "Speakeasy", "agent-path")
-	default:
-		stateHome := os.Getenv("XDG_STATE_HOME")
-		if stateHome == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return ""
-			}
-			stateHome = filepath.Join(home, ".local", "state")
-		}
-		file = filepath.Join(stateHome, "speakeasy", "agent-path")
-	}
-	content, err := os.ReadFile(file)
-	if err != nil {
-		return ""
-	}
-	advertised := strings.TrimSpace(string(content))
-	if !filepath.IsAbs(advertised) || !executableFile(advertised) {
-		return ""
-	}
-	return advertised
 }
 
 func executableFile(path string) bool {

--- a/hooks/relay/identity_socket_unix.go
+++ b/hooks/relay/identity_socket_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package relay
+
+import (
+	"context"
+	"net"
+)
+
+func dialAgentSocket(ctx context.Context, path string) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", path)
+}

--- a/hooks/relay/identity_socket_windows.go
+++ b/hooks/relay/identity_socket_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package relay
+
+import (
+	"context"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func dialAgentSocket(ctx context.Context, path string) (net.Conn, error) {
+	return winio.DialPipeContext(ctx, path)
+}

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -101,7 +101,7 @@ func TestDeviceAgentEmailFindsAgentOffPATH(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "Library", "Application Support", "Speakeasy", "bin")
 	if runtime.GOOS != "darwin" {
-		binDir = filepath.Join(home, ".speakeasy", "bin")
+		binDir = filepath.Join(home, ".local", "bin")
 	}
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	agent := filepath.Join(binDir, "speakeasyd")

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -34,6 +34,63 @@ func TestDeviceAgentCommandsEnvOverrideIsExclusive(t *testing.T) {
 	require.Equal(t, []string{"one", "two"}, deviceAgentCommands())
 }
 
+func TestDeviceAgentEmailUsesAdvertisedPath(t *testing.T) {
+	// The daemon advertises its own executable path on startup (the device
+	// agent's HOOK_IDENTITY contract), so discovery works from an arbitrary
+	// IT-chosen install dir with nothing on PATH.
+	if runtime.GOOS == "windows" {
+		t.Skip("executable shell fixture is POSIX-only")
+	}
+	installDir := t.TempDir() // deliberately NOT a well-known location
+	agent := filepath.Join(installDir, "speakeasyd")
+	require.NoError(t, os.WriteFile(agent, []byte("#!/bin/sh\nprintf '%s' '{\"email\":\"advertised@example.com\"}'\n"), 0o700))
+
+	home := t.TempDir()
+	advertDir := filepath.Join(home, "Library", "Application Support", "Speakeasy")
+	if runtime.GOOS != "darwin" {
+		advertDir = filepath.Join(home, ".local", "state", "speakeasy")
+	}
+	require.NoError(t, os.MkdirAll(advertDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(advertDir, "agent-path"), []byte(agent+"\n"), 0o644))
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "")
+	t.Setenv("GRAM_DEVICE_AGENT_TIMEOUT_TENTHS", "20")
+
+	require.Equal(t, agent, deviceAgentCommands()[0])
+	require.Equal(t, "advertised@example.com", deviceAgentEmail(t.Context()))
+}
+
+func TestAdvertisedAgentPathIgnoresBogusContent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture layout is POSIX-only")
+	}
+	home := t.TempDir()
+	advertDir := filepath.Join(home, "Library", "Application Support", "Speakeasy")
+	if runtime.GOOS != "darwin" {
+		advertDir = filepath.Join(home, ".local", "state", "speakeasy")
+	}
+	require.NoError(t, os.MkdirAll(advertDir, 0o755))
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	advert := filepath.Join(advertDir, "agent-path")
+
+	// Relative path: refused.
+	require.NoError(t, os.WriteFile(advert, []byte("speakeasyd\n"), 0o644))
+	require.Empty(t, advertisedAgentPath())
+
+	// Absolute but nonexistent: refused.
+	require.NoError(t, os.WriteFile(advert, []byte(filepath.Join(home, "gone")+"\n"), 0o644))
+	require.Empty(t, advertisedAgentPath())
+
+	// Absent file (an older daemon): refused without error.
+	require.NoError(t, os.Remove(advert))
+	require.Empty(t, advertisedAgentPath())
+}
+
 func TestDeviceAgentEmailFindsAgentOffPATH(t *testing.T) {
 	// The MDM install layout: speakeasyd lives under the per-user Speakeasy
 	// dir and is NOT on PATH. Managed attribution must still resolve via the

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -52,7 +52,14 @@ func startIdentitySocket(t *testing.T, status int, body string) string {
 	ln, err := net.Listen("unix", socket)
 	require.NoError(t, err)
 	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/identity", r.URL.Path)
+		// Not require: FailNow from a non-test goroutine can hang the test.
+		// t.Errorf is goroutine-safe, and the 404 makes the client-side
+		// assertion fail loudly too.
+		if r.URL.Path != "/v1/identity" {
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
 	})}

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -29,6 +29,36 @@ func TestDeviceAgentEmail(t *testing.T) {
 	require.Equal(t, "device@example.com", deviceAgentEmail(t.Context()))
 }
 
+func TestDeviceAgentCommandsEnvOverrideIsExclusive(t *testing.T) {
+	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "one,two")
+	require.Equal(t, []string{"one", "two"}, deviceAgentCommands())
+}
+
+func TestDeviceAgentEmailFindsAgentOffPATH(t *testing.T) {
+	// The MDM install layout: speakeasyd lives under the per-user Speakeasy
+	// dir and is NOT on PATH. Managed attribution must still resolve via the
+	// well-known install locations.
+	if runtime.GOOS == "windows" {
+		t.Skip("executable shell fixture is POSIX-only")
+	}
+	home := t.TempDir()
+	binDir := filepath.Join(home, "Library", "Application Support", "Speakeasy", "bin")
+	if runtime.GOOS != "darwin" {
+		binDir = filepath.Join(home, ".speakeasy", "bin")
+	}
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	agent := filepath.Join(binDir, "speakeasyd")
+	require.NoError(t, os.WriteFile(agent, []byte("#!/bin/sh\nprintf '%s' '{\"email\":\"managed@example.com\"}'\n"), 0o700))
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // bare "speakeasyd" resolves nowhere
+	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "")
+	t.Setenv("GRAM_DEVICE_AGENT_TIMEOUT_TENTHS", "20")
+
+	require.Contains(t, deviceAgentCommands(), agent)
+	require.Equal(t, "managed@example.com", deviceAgentEmail(t.Context()))
+}
+
 func TestTopLevelPayloadEmailIgnoresNestedValues(t *testing.T) {
 	require.Equal(t, "cursor@example.com", topLevelPayloadEmail([]byte(`{"user_email":"cursor@example.com","tool_input":{"user_email":"nested@example.com"}}`)))
 	require.Empty(t, topLevelPayloadEmail([]byte(`{"tool_input":{"user_email":"nested@example.com"}}`)))

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -101,7 +101,9 @@ func TestDeviceAgentEmailFindsAgentOffPATH(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "Library", "Application Support", "Speakeasy", "bin")
 	if runtime.GOOS != "darwin" {
-		binDir = filepath.Join(home, ".local", "bin")
+		// The supported legacy dotdir location — regression coverage for
+		// keeping it in the candidate list.
+		binDir = filepath.Join(home, ".speakeasy", "bin")
 	}
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	agent := filepath.Join(binDir, "speakeasyd")

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -2,6 +2,8 @@ package relay
 
 import (
 	"encoding/base64"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -34,61 +36,80 @@ func TestDeviceAgentCommandsEnvOverrideIsExclusive(t *testing.T) {
 	require.Equal(t, []string{"one", "two"}, deviceAgentCommands())
 }
 
-func TestDeviceAgentEmailUsesAdvertisedPath(t *testing.T) {
-	// The daemon advertises its own executable path on startup (the device
-	// agent's HOOK_IDENTITY contract), so discovery works from an arbitrary
-	// IT-chosen install dir with nothing on PATH.
+// startIdentitySocket serves body for GET /v1/identity on a unix socket and
+// returns its path. status lets tests exercise non-200 handling.
+func startIdentitySocket(t *testing.T, status int, body string) string {
+	t.Helper()
 	if runtime.GOOS == "windows" {
-		t.Skip("executable shell fixture is POSIX-only")
+		t.Skip("unix-socket fixture is POSIX-only")
 	}
-	installDir := t.TempDir() // deliberately NOT a well-known location
-	agent := filepath.Join(installDir, "speakeasyd")
-	require.NoError(t, os.WriteFile(agent, []byte("#!/bin/sh\nprintf '%s' '{\"email\":\"advertised@example.com\"}'\n"), 0o700))
-
-	home := t.TempDir()
-	advertDir := filepath.Join(home, "Library", "Application Support", "Speakeasy")
-	if runtime.GOOS != "darwin" {
-		advertDir = filepath.Join(home, ".local", "state", "speakeasy")
-	}
-	require.NoError(t, os.MkdirAll(advertDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(advertDir, "agent-path"), []byte(agent+"\n"), 0o644))
-
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_STATE_HOME", "")
-	t.Setenv("PATH", t.TempDir())
-	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "")
-	t.Setenv("GRAM_DEVICE_AGENT_TIMEOUT_TENTHS", "20")
-
-	require.Equal(t, agent, deviceAgentCommands()[0])
-	require.Equal(t, "advertised@example.com", deviceAgentEmail(t.Context()))
+	// Not t.TempDir(): it embeds the test name and can blow the ~104-byte
+	// sockaddr_un path limit on macOS.
+	dir, err := os.MkdirTemp("", "sk")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "agent.sock")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/identity", r.URL.Path)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return socket
 }
 
-func TestAdvertisedAgentPathIgnoresBogusContent(t *testing.T) {
+func TestDeviceAgentEmailSocketRescue(t *testing.T) {
+	// A daemon running from a location the exec chain can't guess (no PATH
+	// entry, no well-known dir) is still reachable at its fixed socket path.
+	socket := startIdentitySocket(t, http.StatusOK, `{"v":1,"enrolled":true,"email":"socket@example.com","source":"managed"}`)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+	t.Setenv("HOME", t.TempDir()) // no well-known installs
+	t.Setenv("PATH", t.TempDir()) // bare "speakeasyd" resolves nowhere
+	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "")
+
+	require.Equal(t, "socket@example.com", deviceAgentEmail(t.Context()))
+}
+
+func TestDeviceAgentEmailEnvOverrideSilencesSocket(t *testing.T) {
+	// The env override is a complete off switch: even a live, answering
+	// socket must not be consulted.
+	socket := startIdentitySocket(t, http.StatusOK, `{"v":1,"enrolled":true,"email":"socket@example.com","source":"managed"}`)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+	t.Setenv("GRAM_DEVICE_AGENT_COMMANDS", "speakeasy-hooks-test-missing-device-agent")
+
+	require.Empty(t, deviceAgentEmail(t.Context()))
+}
+
+func TestSocketIdentityEmailRejectsUnusableResponses(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"contract version too new", http.StatusOK, `{"v":2,"enrolled":true,"email":"new@example.com"}`},
+		{"not enrolled", http.StatusOK, `{"v":1,"enrolled":false}`},
+		{"invalid email", http.StatusOK, `{"v":1,"enrolled":true,"email":"not-an-email"}`},
+		{"http error", http.StatusInternalServerError, `boom`},
+		{"garbage body", http.StatusOK, `not json`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			socket := startIdentitySocket(t, tc.status, tc.body)
+			t.Setenv("SPEAKEASY_SOCKET", socket)
+			require.Empty(t, socketIdentityEmail(t.Context()))
+		})
+	}
+}
+
+func TestSocketIdentityEmailAbsentSocket(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("fixture layout is POSIX-only")
+		t.Skip("unix-socket fixture is POSIX-only")
 	}
-	home := t.TempDir()
-	advertDir := filepath.Join(home, "Library", "Application Support", "Speakeasy")
-	if runtime.GOOS != "darwin" {
-		advertDir = filepath.Join(home, ".local", "state", "speakeasy")
-	}
-	require.NoError(t, os.MkdirAll(advertDir, 0o755))
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_STATE_HOME", "")
-
-	advert := filepath.Join(advertDir, "agent-path")
-
-	// Relative path: refused.
-	require.NoError(t, os.WriteFile(advert, []byte("speakeasyd\n"), 0o644))
-	require.Empty(t, advertisedAgentPath())
-
-	// Absolute but nonexistent: refused.
-	require.NoError(t, os.WriteFile(advert, []byte(filepath.Join(home, "gone")+"\n"), 0o644))
-	require.Empty(t, advertisedAgentPath())
-
-	// Absent file (an older daemon): refused without error.
-	require.NoError(t, os.Remove(advert))
-	require.Empty(t, advertisedAgentPath())
+	t.Setenv("SPEAKEASY_SOCKET", filepath.Join(t.TempDir(), "nope.sock"))
+	require.Empty(t, socketIdentityEmail(t.Context()))
 }
 
 func TestDeviceAgentEmailFindsAgentOffPATH(t *testing.T) {


### PR DESCRIPTION
## Why

`deviceAgentEmail` resolves the device agent with a bare `speakeasyd` (PATH lookup) — but `speakeasyd` is typically **not on PATH**. MDM installs place it under the per-user Speakeasy dir without touching PATH, and GUI-spawned hook hosts see a minimal PATH regardless. Net effect: managed-identity attribution silently fails on standard installs and every event falls through to the weaker fallbacks (Codex app-server, payload email).

Verified live on an MDM-managed machine: `"$HOME/Library/Application Support/Speakeasy/bin/speakeasyd" identity` answers `{"enrolled": true, "email": ..., "source": "managed"}` while `which speakeasyd` finds nothing.

## What

Discovery order (the device agent's HOOK_IDENTITY contract — documented on their side in speakeasy-api/device-agent#102):

1. **`GRAM_DEVICE_AGENT_COMMANDS`** (comma-separated), when set, replaces everything below — **including the socket rescue** — so it stays a complete off switch for tests and nonstandard layouts.
2. **Exec chain**: bare `speakeasyd` on PATH (unchanged existing behavior), then static per-OS well-known install locations (macOS MDM dir, `~/.speakeasy/bin` + `~/.local/bin` + `/usr/local/bin` on Linux, `Program Files` on Windows). Exec is primary on purpose: `speakeasyd identity` re-reads the config files per call (fresh after an MDM config push) and answers with **no running daemon** — hooks fire during exactly those windows (mid-auto-update restarts).
3. **Socket rescue**: when no binary was found, one `GET /v1/identity` over the daemon's IPC socket (`api.SocketPath` semantics incl. the `SPEAKEASY_SOCKET` override; named pipe via `go-winio` on Windows — same lib the agent's own client uses, already in the module graph). 150ms budget, no retry — a missing socket fails the dial instantly, so the daemon-down cost is ~nil. Covers a daemon running from a location the exec chain can't guess. Response is contract-gated: `v > 1` unreadable, `enrolled:false`/invalid email rejected. Keep-alives disabled — one-shot client, no pooled-connection leak.

## Design history (thread above)

An earlier revision of this PR read a daemon-written path-advertisement file first. Dropped in favor of the socket rescue (Daniel's suggestion): the socket is a contract that **already exists** and helps fleets immediately, where the advertisement was a new cross-repo contract requiring a fleet-wide daemon release before helping anyone — and architecturally the Option-A breadcrumb file the device agent's ADR-0006 had already rejected. The corresponding device-agent PR (#100) is closed; ADR-0006/HOOK_IDENTITY are updated in speakeasy-api/device-agent#102. Exec-first (not dial-first) preserves the freshness semantics above; flipping the order is trivial if we later prefer it.

## Test plan

- Off-PATH reproduction: fake agent at a well-known path, empty PATH — fails against the old code.
- Socket rescue: unix-socket `/v1/identity` fixture — rescue resolves email with nothing on PATH; env override silences the socket too; table-driven contract-gating cases (`v:2`, not-enrolled, bad email, HTTP error, garbage body); absent socket.
- Suites run on darwin and linux (docker); `GOOS=windows go vet` for the pipe-dial file.
- The exact rescue request also exercised against a live production daemon socket (150ms cap): answers the frozen `v:1` document.

## Rollout

Needs a `speakeasy-hooks` release + bundle pin bump to reach devices. No device-agent release required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
