### PR TITLE
chore(hooks): bump agenthooks to v0.3.0

### DIFF
--- a/.github/workflows/release-hooks.yaml
+++ b/.github/workflows/release-hooks.yaml
@@ -47,11 +47,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          go-version-file: "go.mod"
-          # Reference: https://github.com/actions/setup-go/issues/495
-          cache: false
+          install: true
+          cache: true
+          env: false
       - name: Decide
         id: decide
         env:
@@ -65,10 +66,14 @@ jobs:
             exit 0
           fi
 
-          # A force-push or a first push leaves no usable before-sha.
+          # A force-push or a first push leaves no usable before-sha, and the
+          # push can carry more commits than HEAD's parent covers. The gate
+          # only ever suppresses a release, so an unknown range releases.
           base="${BEFORE}"
           if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
-            base="${GITHUB_SHA}^"
+            echo "No usable before-sha to diff against; releasing."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           changed=$(git diff --name-only "$base" "$GITHUB_SHA")
 

--- a/.github/workflows/release-hooks.yaml
+++ b/.github/workflows/release-hooks.yaml
@@ -12,6 +12,11 @@ on:
     paths:
       - "hooks/**"
       - ".goreleaser.hooks.yaml"
+      # The binary links the root module's dependencies, so a bump there can
+      # change it without touching hooks/. The gate job below decides whether
+      # the bump reached the binary.
+      - "go.mod"
+      - "go.sum"
   workflow_dispatch:
     inputs:
       bump:
@@ -28,8 +33,73 @@ concurrency:
   group: release-hooks
 
 jobs:
+  gate:
+    # Most root dependency bumps never reach the binary: they land in packages
+    # only the server imports. Releasing on every one of them would spend a
+    # version, a signed build, and a pin pull request on an identical binary,
+    # so the closure decides.
+    name: Decide whether to release
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.decide.outputs.release }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: "go.mod"
+          # Reference: https://github.com/actions/setup-go/issues/495
+          cache: false
+      - name: Decide
+        id: decide
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" != "push" ]; then
+            echo "Manual dispatch; releasing."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A force-push or a first push leaves no usable before-sha.
+          base="${BEFORE}"
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            base="${GITHUB_SHA}^"
+          fi
+          changed=$(git diff --name-only "$base" "$GITHUB_SHA")
+
+          if printf '%s\n' "$changed" | grep -qE '^(hooks/|\.goreleaser\.hooks\.yaml$)'; then
+            echo "The hooks sources changed; releasing."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Only the module files changed. Intersecting the bumped module paths
+          # with the binary's own dependency closure also discards the non-module
+          # tokens the diff carries (require, go, the block parens).
+          go list -deps -f '{{if .Module}}{{.Module.Path}}{{end}}' ./hooks/... | sort -u > "${RUNNER_TEMP}/linked-modules.txt"
+          git diff "$base" "$GITHUB_SHA" -- go.mod \
+            | sed -n 's/^[+-]\([^+-].*\)$/\1/p' \
+            | awk '{print $1}' | sort -u > "${RUNNER_TEMP}/bumped-modules.txt"
+          bumped=$(comm -12 "${RUNNER_TEMP}/bumped-modules.txt" "${RUNNER_TEMP}/linked-modules.txt")
+
+          if [ -z "$bumped" ]; then
+            echo "No bumped module is linked into the hooks binary; skipping the release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Linked modules bumped:"
+          printf '%s\n' "$bumped"
+          echo "release=true" >> "$GITHUB_OUTPUT"
+
   release:
     name: Release Speakeasy Hooks
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write # to push tags

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/samber/slog-multi v1.8.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
-	github.com/speakeasy-api/agenthooks v0.2.1
+	github.com/speakeasy-api/agenthooks v0.3.0
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -688,8 +688,8 @@ github.com/sorairolake/lzip-go v0.3.5 h1:ms5Xri9o1JBIWvOFAorYtUNik6HI3HgBTkISiqu
 github.com/sorairolake/lzip-go v0.3.5/go.mod h1:N0KYq5iWrMXI0ZEXKXaS9hCyOjZUQdBDEIbXfoUwbdk=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/speakeasy-api/agenthooks v0.2.1 h1:wo1APW8W5y/M6SzfDv5c2ckGAmA+LclH3txzBEACG3w=
-github.com/speakeasy-api/agenthooks v0.2.1/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
+github.com/speakeasy-api/agenthooks v0.3.0 h1:LuRWmr/uNbizUgVOi6XUydKZCX6KLq3G4d1CzLI4v+Q=
+github.com/speakeasy-api/agenthooks v0.3.0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/speakeasy-api/openapi v1.24.0 h1:opoD27rupX7zBVPq1HkIGLeMOzNNA7JalhYP8q34i04=


### PR DESCRIPTION
Bumps `github.com/speakeasy-api/agenthooks` from v0.2.1 to [v0.3.0](https://github.com/speakeasy-api/agenthooks/releases/tag/v0.3.0).

## What v0.3.0 changes

MCP transport attribution now honors how the coding agent was launched, instead of reading config files as if the agent had been started bare:

- **Claude**: launch flags recovered through `CLAUDE_PID` shape the inventory — `--mcp-config`, `--strict-mcp-config`, plugin dirs, and safe mode are respected, and launch-only servers resolve instead of falling through unattributed.
- **Codex**: `-c`/`--config` overrides and `--profile` are carried to the detached worker over stdin and replayed into a context-keyed `codex mcp list --json` snapshot; `--ignore-user-config` is treated as unreplayable rather than mis-attributed.
- Both inventories are warmed by a detached worker at session start, so the first MCP tool call waits on an in-flight probe rather than paying for a cold `mcp list`.
- **Cursor** MCP events keep the server identity the payload carries, so attribution no longer depends on exactly one configured server.
- **Gemini** payload-borne `mcp_context` is authoritative, including transports the URL/Command model cannot represent.

No source changes needed on our side — the exported surface (`Main`, `WithDedupDir`, `MCPCall`) is unchanged. Note `WithDedupDir` now also roots the MCP inventory snapshots, so the relay's per-install dedup dir scopes those too.

## Verification

- `mise run test:hooks` — 336 tests pass.
- `mise run hooks:e2e --suites shadow-mcp` against a local server, all three providers: codex passes 16/16 (the provider whose resolution path changed most); claude and cursor pass every shadow-MCP block, telemetry, access-request, and exemption check.
- The remaining `gram_hosted_*` failures are **pre-existing on `main`** — a baseline run of the same suite on `main` (v0.2.1) reproduces the claude failures exactly and fails a cursor gram-hosted check too. Claude's non-interactive session can't authorize the Gram-hosted fixture server ("requires authentication ... can't be authorized in this non-interactive session"), so it never issues the call; cursor's is agent-behavior flake (the model echoes the scripted reply instead of invoking the tool). Neither is affected by this bump.

## Release trigger

The release workflow only watched `hooks/**` and `.goreleaser.hooks.yaml`, so a bump like this one would land on `main` and never reach a released binary — no tag, no build, no pin PR. The second commit adds `go.mod`/`go.sum` to the trigger and gates the release on whether the bump actually reached the binary: a `gate` job intersects the bumped module paths with `go list -deps ./hooks/...`, so an unrelated root bump does not spend a version, a signed build, and a pin pull request on an identical binary.

Verified the gate against real commit ranges from `main`:

| Commit | Gate |
| --- | --- |
| this PR's agenthooks bump | release (`github.com/speakeasy-api/agenthooks`) |
| `golang.org/x/sys` bump | release (genuinely in the closure) |
| `pgvector-go` bump | skip |
| hooks source change | release (path match, closure not consulted) |
| server-only change, `go.mod` untouched | skip |
