### PR TITLE
fix: serialize ClickHouse async insert flushes

### DIFF
--- a/server/internal/testenv/clickhouse.go
+++ b/server/internal/testenv/clickhouse.go
@@ -2,6 +2,7 @@ package testenv
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -12,6 +13,10 @@ import (
 )
 
 type ClickhouseClientFunc = testinfra.ClickhouseClientFunc
+
+// The unscoped flush command in the pinned ClickHouse version is not safe to
+// overlap: a concurrent flush can return before another flush commits its rows.
+var flushClickHouseAsyncInsertsMu sync.Mutex
 
 // NewTestClickhouse creates a new ClickHouse container with the schema initialized
 // from migration files. Returns a container reference and a function to create
@@ -32,6 +37,9 @@ func NewTestClickhouse(ctx context.Context) (*clickhousecontainer.ClickHouseCont
 // visible without polling.
 func FlushClickHouseAsyncInserts(t *testing.T, conn clickhouse.Conn) {
 	t.Helper()
+
+	flushClickHouseAsyncInsertsMu.Lock()
+	defer flushClickHouseAsyncInsertsMu.Unlock()
 
 	require.NoError(t, conn.Exec(t.Context(), "SYSTEM FLUSH ASYNC INSERT QUEUE"))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- serialize test-only `SYSTEM FLUSH ASYNC INSERT QUEUE` calls
- prevent concurrent telemetry tests from observing an empty result after overlapping global flushes
- leave production telemetry write behavior unchanged

## Testing
- `GOMAXPROCS=8 mise exec -- go test ./server/internal/telemetry -run '^TestCreateLog_' -count=50`
- `GOMAXPROCS=8 mise exec -- go test -race ./server/internal/telemetry -run '^TestCreateLog_' -count=20`
- `mise lint:server`

Linear: AGE-3059
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3059](https://linear.app/speakeasy/issue/AGE-3059/bug-flaky-test-testcreatelog)

<div><a href="https://cursor.com/agents/bc-088a2902-e6bd-4da8-b21c-cfaed7eee902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-088a2902-e6bd-4da8-b21c-cfaed7eee902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize test-only ClickHouse async insert flushes to remove flakiness in concurrent telemetry tests; production write behavior is unchanged. Addresses Linear AGE-3059.

- **Bug Fixes**
  - Guard `SYSTEM FLUSH ASYNC INSERT QUEUE` with a process-wide mutex to prevent overlapping flushes returning before other inserts commit.
  - Eliminates empty reads in concurrent `TestCreateLog_*`; verified with parallel stress runs.

<sup>Written for commit 19054c8a67923dfbb8e7b7f777fa9517e59b9732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

