### PR TITLE
fix(dashboard): point Platform Status link at status.speakeasy.com

### DIFF
--- a/.changeset/platform-status-link-domain.md
+++ b/.changeset/platform-status-link-domain.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Point the profile menu's "Platform Status" link at `https://status.speakeasy.com/`, matching the domain the status page now lives on (the neighbouring Roadmap link already uses `speakeasy.com`).

--- a/client/dashboard/src/components/sidebar-user-menu.test.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.test.tsx
@@ -80,13 +80,11 @@ describe("SidebarUserMenu", () => {
     expect(screen.queryByText(/Bug or Feature Request/)).toBeNull();
   });
 
-  it("links Platform Status to status.speakeasyapi.dev in a new tab", () => {
+  it("links Platform Status to status.speakeasy.com in a new tab", () => {
     render(<SidebarUserMenu />);
     fireEvent.click(screen.getByTestId("user-menu-trigger"));
     const status = screen.getByText("Platform Status").closest("a");
-    expect(status?.getAttribute("href")).toBe(
-      "https://status.speakeasyapi.dev/",
-    );
+    expect(status?.getAttribute("href")).toBe("https://status.speakeasy.com/");
     expect(status?.getAttribute("target")).toBe("_blank");
     expect(status?.getAttribute("rel")).toBe("noopener noreferrer");
   });

--- a/client/dashboard/src/components/sidebar-user-menu.tsx
+++ b/client/dashboard/src/components/sidebar-user-menu.tsx
@@ -203,7 +203,7 @@ export function SidebarUserMenu(): JSX.Element {
             </DropdownMenuItem>
             <DropdownMenuItem asChild>
               <a
-                href="https://status.speakeasyapi.dev/"
+                href="https://status.speakeasy.com/"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## What

The **Platform Status** item in the sidebar profile menu still pointed at the old `status.speakeasyapi.dev` host. It now points at `https://status.speakeasy.com/`.

## Notes

- The URL is dual-sourced: `sidebar-user-menu.test.tsx` pins the exact `href`, so the test was updated alongside the component (it would otherwise fail).
- This brings the item onto the same `speakeasy.com` domain as the neighbouring **Roadmap** link.
- `target="_blank"` / `rel="noopener noreferrer"` are unchanged and still asserted by the test.

## Verification

`vitest run src/components/sidebar-user-menu.test.tsx` → 3/3 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y17YAzziwgvz4MfD133FM3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Platform Status link in the dashboard profile menu to `https://status.speakeasy.com/` so users land on the current status page. Updated the test to pin the new `href`; `target="_blank"` and `rel="noopener noreferrer"` remain unchanged.

<sup>Written for commit d8fdbb4802f4f8d6dc6e370a06f2f162f0fe56a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

