### PR TITLE
mig(skills): add feedback workflow storage

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -339,6 +339,90 @@ CREATE TABLE IF NOT EXISTS skill_version_origins (
 CREATE INDEX IF NOT EXISTS skill_version_origins_project_id_skill_id_idx
 ON skill_version_origins (project_id, skill_id);
 
+CREATE TABLE IF NOT EXISTS skill_feedback (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  skill_id uuid,
+  skill_version_id uuid,
+
+  skill_name TEXT NOT NULL,
+  source TEXT NOT NULL,
+  outcome TEXT NOT NULL,
+  note TEXT,
+  session_id TEXT,
+  user_id TEXT,
+  user_email TEXT,
+  reviewed_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skill_feedback_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_feedback_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT skill_feedback_project_id_skill_id_fkey FOREIGN KEY (project_id, skill_id) REFERENCES skills (project_id, id) ON DELETE NO ACTION,
+  CONSTRAINT skill_feedback_skill_id_skill_version_id_fkey FOREIGN KEY (skill_id, skill_version_id) REFERENCES skill_versions (skill_id, id) ON DELETE NO ACTION,
+  CONSTRAINT skill_feedback_note_size_check CHECK (note <> '' AND CHAR_LENGTH(note) <= 4000),
+  CONSTRAINT skill_feedback_skill_id_skill_version_id_check CHECK (skill_version_id IS NULL OR skill_id IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS skill_feedback_project_id_skill_name_created_at_id_idx
+ON skill_feedback (project_id, skill_name, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS skill_feedback_project_id_skill_name_created_at_unreviewed_idx
+ON skill_feedback (project_id, skill_name, created_at)
+WHERE reviewed_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_feedback_project_id_id_key
+ON skill_feedback (project_id, id);
+
+CREATE TABLE IF NOT EXISTS skill_edit_suggestions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  project_id uuid NOT NULL,
+  skill_id uuid NOT NULL,
+  base_version_id uuid NOT NULL,
+
+  proposed_diff TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'open',
+  scored_session_count bigint NOT NULL DEFAULT 0,
+  approved_by_user_id TEXT,
+  approved_at timestamptz,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skill_edit_suggestions_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_edit_suggestions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
+  CONSTRAINT skill_edit_suggestions_project_id_skill_id_fkey FOREIGN KEY (project_id, skill_id) REFERENCES skills (project_id, id) ON DELETE NO ACTION,
+  CONSTRAINT skill_edit_suggestions_skill_id_base_version_id_fkey FOREIGN KEY (skill_id, base_version_id) REFERENCES skill_versions (skill_id, id) ON DELETE NO ACTION,
+  CONSTRAINT skill_edit_suggestions_proposed_diff_size_check CHECK (octet_length(proposed_diff) <= 131072)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_edit_suggestions_skill_id_open_key
+ON skill_edit_suggestions (skill_id)
+WHERE status = 'open';
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_edit_suggestions_project_id_id_key
+ON skill_edit_suggestions (project_id, id);
+
+CREATE INDEX IF NOT EXISTS skill_edit_suggestions_project_id_skill_id_created_at_idx
+ON skill_edit_suggestions (project_id, skill_id, created_at DESC);
+
+-- Evidence linking each suggestion to the feedback rows it was generated from.
+CREATE TABLE IF NOT EXISTS skill_edit_suggestion_feedback (
+  project_id uuid NOT NULL,
+  suggestion_id uuid NOT NULL,
+  feedback_id uuid NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skill_edit_suggestion_feedback_pkey PRIMARY KEY (suggestion_id, feedback_id),
+  CONSTRAINT skill_edit_suggestion_feedback_project_id_suggestion_id_fkey FOREIGN KEY (project_id, suggestion_id) REFERENCES skill_edit_suggestions (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT skill_edit_suggestion_feedback_project_id_feedback_id_fkey FOREIGN KEY (project_id, feedback_id) REFERENCES skill_feedback (project_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS skill_edit_suggestion_feedback_project_id_feedback_id_idx
+ON skill_edit_suggestion_feedback (project_id, feedback_id);
+
 CREATE TABLE IF NOT EXISTS skill_observations (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -380,7 +380,6 @@ CREATE TABLE IF NOT EXISTS skill_edit_suggestions (
   skill_id uuid NOT NULL,
   base_version_id uuid NOT NULL,
 
-  proposed_diff TEXT NOT NULL,
   rationale TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'open',
   scored_session_count bigint NOT NULL DEFAULT 0,
@@ -393,8 +392,7 @@ CREATE TABLE IF NOT EXISTS skill_edit_suggestions (
   CONSTRAINT skill_edit_suggestions_pkey PRIMARY KEY (id),
   CONSTRAINT skill_edit_suggestions_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
   CONSTRAINT skill_edit_suggestions_project_id_skill_id_fkey FOREIGN KEY (project_id, skill_id) REFERENCES skills (project_id, id) ON DELETE NO ACTION,
-  CONSTRAINT skill_edit_suggestions_skill_id_base_version_id_fkey FOREIGN KEY (skill_id, base_version_id) REFERENCES skill_versions (skill_id, id) ON DELETE NO ACTION,
-  CONSTRAINT skill_edit_suggestions_proposed_diff_size_check CHECK (octet_length(proposed_diff) <= 131072)
+  CONSTRAINT skill_edit_suggestions_skill_id_base_version_id_fkey FOREIGN KEY (skill_id, base_version_id) REFERENCES skill_versions (skill_id, id) ON DELETE NO ACTION
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS skill_edit_suggestions_skill_id_open_key
@@ -408,18 +406,38 @@ CREATE INDEX IF NOT EXISTS skill_edit_suggestions_project_id_skill_id_created_at
 ON skill_edit_suggestions (project_id, skill_id, created_at DESC);
 
 -- Evidence linking each suggestion to the feedback rows it was generated from.
-CREATE TABLE IF NOT EXISTS skill_edit_suggestion_feedback (
+CREATE TABLE IF NOT EXISTS skill_edit_suggestion_changes (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
   project_id uuid NOT NULL,
   suggestion_id uuid NOT NULL,
+
+  proposed_diff TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  position integer NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT skill_edit_suggestion_changes_pkey PRIMARY KEY (id),
+  CONSTRAINT skill_edit_suggestion_changes_project_id_suggestion_id_fkey FOREIGN KEY (project_id, suggestion_id) REFERENCES skill_edit_suggestions (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT skill_edit_suggestion_changes_proposed_diff_size_check CHECK (octet_length(proposed_diff) <= 131072)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS skill_edit_suggestion_changes_project_id_id_key ON skill_edit_suggestion_changes (project_id, id);
+
+CREATE INDEX IF NOT EXISTS skill_edit_suggestion_changes_suggestion_position_idx ON skill_edit_suggestion_changes (project_id, suggestion_id, position);
+
+CREATE TABLE IF NOT EXISTS skill_edit_suggestion_feedback (
+  project_id uuid NOT NULL,
+  change_id uuid NOT NULL,
   feedback_id uuid NOT NULL,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
-  CONSTRAINT skill_edit_suggestion_feedback_pkey PRIMARY KEY (suggestion_id, feedback_id),
-  CONSTRAINT skill_edit_suggestion_feedback_project_id_suggestion_id_fkey FOREIGN KEY (project_id, suggestion_id) REFERENCES skill_edit_suggestions (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT skill_edit_suggestion_feedback_pkey PRIMARY KEY (change_id, feedback_id),
+  CONSTRAINT skill_edit_suggestion_feedback_project_id_change_id_fkey FOREIGN KEY (project_id, change_id) REFERENCES skill_edit_suggestion_changes (project_id, id) ON DELETE CASCADE,
   CONSTRAINT skill_edit_suggestion_feedback_project_id_feedback_id_fkey FOREIGN KEY (project_id, feedback_id) REFERENCES skill_feedback (project_id, id) ON DELETE CASCADE
 );
-
 CREATE INDEX IF NOT EXISTS skill_edit_suggestion_feedback_project_id_feedback_id_idx
 ON skill_edit_suggestion_feedback (project_id, feedback_id);
 

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1780,7 +1780,6 @@ type SkillEditSuggestion struct {
 	ProjectID          uuid.UUID
 	SkillID            uuid.UUID
 	BaseVersionID      uuid.UUID
-	ProposedDiff       string
 	Rationale          string
 	Status             string
 	ScoredSessionCount int64
@@ -1790,11 +1789,22 @@ type SkillEditSuggestion struct {
 	UpdatedAt          pgtype.Timestamptz
 }
 
-type SkillEditSuggestionFeedback struct {
+type SkillEditSuggestionChange struct {
+	ID           uuid.UUID
 	ProjectID    uuid.UUID
 	SuggestionID uuid.UUID
-	FeedbackID   uuid.UUID
+	ProposedDiff string
+	Rationale    string
+	Position     int32
 	CreatedAt    pgtype.Timestamptz
+	UpdatedAt    pgtype.Timestamptz
+}
+
+type SkillEditSuggestionFeedback struct {
+	ProjectID  uuid.UUID
+	ChangeID   uuid.UUID
+	FeedbackID uuid.UUID
+	CreatedAt  pgtype.Timestamptz
 }
 
 type SkillEfficacyEvaluation struct {

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1775,6 +1775,28 @@ type SkillDistribution struct {
 	UpdatedAt       pgtype.Timestamptz
 }
 
+type SkillEditSuggestion struct {
+	ID                 uuid.UUID
+	ProjectID          uuid.UUID
+	SkillID            uuid.UUID
+	BaseVersionID      uuid.UUID
+	ProposedDiff       string
+	Rationale          string
+	Status             string
+	ScoredSessionCount int64
+	ApprovedByUserID   pgtype.Text
+	ApprovedAt         pgtype.Timestamptz
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+}
+
+type SkillEditSuggestionFeedback struct {
+	ProjectID    uuid.UUID
+	SuggestionID uuid.UUID
+	FeedbackID   uuid.UUID
+	CreatedAt    pgtype.Timestamptz
+}
+
 type SkillEfficacyEvaluation struct {
 	ID              uuid.UUID
 	OrganizationID  string
@@ -1805,6 +1827,22 @@ type SkillEfficacySetting struct {
 	NewVersionBurst  int32
 	CreatedAt        pgtype.Timestamptz
 	UpdatedAt        pgtype.Timestamptz
+}
+
+type SkillFeedback struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	SkillID        uuid.NullUUID
+	SkillVersionID uuid.NullUUID
+	SkillName      string
+	Source         string
+	Outcome        string
+	Note           pgtype.Text
+	SessionID      pgtype.Text
+	UserID         pgtype.Text
+	UserEmail      pgtype.Text
+	ReviewedAt     pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
 }
 
 type SkillObservation struct {

--- a/server/migrations/20260728103328_dno_569_skill_feedback_schema.sql
+++ b/server/migrations/20260728103328_dno_569_skill_feedback_schema.sql
@@ -1,0 +1,82 @@
+-- Create "skill_edit_suggestions" table
+CREATE TABLE "skill_edit_suggestions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "skill_id" uuid NOT NULL,
+  "base_version_id" uuid NOT NULL,
+  "rationale" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'open',
+  "scored_session_count" bigint NOT NULL DEFAULT 0,
+  "approved_by_user_id" text NULL,
+  "approved_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skill_edit_suggestions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "skill_edit_suggestions_project_id_skill_id_fkey" FOREIGN KEY ("project_id", "skill_id") REFERENCES "skills" ("project_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "skill_edit_suggestions_skill_id_base_version_id_fkey" FOREIGN KEY ("skill_id", "base_version_id") REFERENCES "skill_versions" ("skill_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+-- Create index "skill_edit_suggestions_project_id_id_key" to table: "skill_edit_suggestions"
+CREATE UNIQUE INDEX "skill_edit_suggestions_project_id_id_key" ON "skill_edit_suggestions" ("project_id", "id");
+-- Create index "skill_edit_suggestions_project_id_skill_id_created_at_idx" to table: "skill_edit_suggestions"
+CREATE INDEX "skill_edit_suggestions_project_id_skill_id_created_at_idx" ON "skill_edit_suggestions" ("project_id", "skill_id", "created_at" DESC);
+-- Create index "skill_edit_suggestions_skill_id_open_key" to table: "skill_edit_suggestions"
+CREATE UNIQUE INDEX "skill_edit_suggestions_skill_id_open_key" ON "skill_edit_suggestions" ("skill_id") WHERE (status = 'open'::text);
+-- Create "skill_edit_suggestion_changes" table
+CREATE TABLE "skill_edit_suggestion_changes" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "suggestion_id" uuid NOT NULL,
+  "proposed_diff" text NOT NULL,
+  "rationale" text NOT NULL,
+  "position" integer NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skill_edit_suggestion_changes_project_id_suggestion_id_fkey" FOREIGN KEY ("project_id", "suggestion_id") REFERENCES "skill_edit_suggestions" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "skill_edit_suggestion_changes_proposed_diff_size_check" CHECK (octet_length(proposed_diff) <= 131072)
+);
+-- Create index "skill_edit_suggestion_changes_project_id_id_key" to table: "skill_edit_suggestion_changes"
+CREATE UNIQUE INDEX "skill_edit_suggestion_changes_project_id_id_key" ON "skill_edit_suggestion_changes" ("project_id", "id");
+-- Create index "skill_edit_suggestion_changes_suggestion_position_idx" to table: "skill_edit_suggestion_changes"
+CREATE INDEX "skill_edit_suggestion_changes_suggestion_position_idx" ON "skill_edit_suggestion_changes" ("project_id", "suggestion_id", "position");
+-- Create "skill_feedback" table
+CREATE TABLE "skill_feedback" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "project_id" uuid NOT NULL,
+  "skill_id" uuid NULL,
+  "skill_version_id" uuid NULL,
+  "skill_name" text NOT NULL,
+  "source" text NOT NULL,
+  "outcome" text NOT NULL,
+  "note" text NULL,
+  "session_id" text NULL,
+  "user_id" text NULL,
+  "user_email" text NULL,
+  "reviewed_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "skill_feedback_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "skill_feedback_project_id_skill_id_fkey" FOREIGN KEY ("project_id", "skill_id") REFERENCES "skills" ("project_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "skill_feedback_skill_id_skill_version_id_fkey" FOREIGN KEY ("skill_id", "skill_version_id") REFERENCES "skill_versions" ("skill_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "skill_feedback_note_size_check" CHECK ((note <> ''::text) AND (char_length(note) <= 4000)),
+  CONSTRAINT "skill_feedback_skill_id_skill_version_id_check" CHECK ((skill_version_id IS NULL) OR (skill_id IS NOT NULL))
+);
+-- Create index "skill_feedback_project_id_id_key" to table: "skill_feedback"
+CREATE UNIQUE INDEX "skill_feedback_project_id_id_key" ON "skill_feedback" ("project_id", "id");
+-- Create index "skill_feedback_project_id_skill_name_created_at_id_idx" to table: "skill_feedback"
+CREATE INDEX "skill_feedback_project_id_skill_name_created_at_id_idx" ON "skill_feedback" ("project_id", "skill_name", "created_at" DESC, "id" DESC);
+-- Create index "skill_feedback_project_id_skill_name_created_at_unreviewed_idx" to table: "skill_feedback"
+CREATE INDEX "skill_feedback_project_id_skill_name_created_at_unreviewed_idx" ON "skill_feedback" ("project_id", "skill_name", "created_at") WHERE (reviewed_at IS NULL);
+-- Create "skill_edit_suggestion_feedback" table
+CREATE TABLE "skill_edit_suggestion_feedback" (
+  "project_id" uuid NOT NULL,
+  "change_id" uuid NOT NULL,
+  "feedback_id" uuid NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("change_id", "feedback_id"),
+  CONSTRAINT "skill_edit_suggestion_feedback_project_id_change_id_fkey" FOREIGN KEY ("project_id", "change_id") REFERENCES "skill_edit_suggestion_changes" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "skill_edit_suggestion_feedback_project_id_feedback_id_fkey" FOREIGN KEY ("project_id", "feedback_id") REFERENCES "skill_feedback" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "skill_edit_suggestion_feedback_project_id_feedback_id_idx" to table: "skill_edit_suggestion_feedback"
+CREATE INDEX "skill_edit_suggestion_feedback_project_id_feedback_id_idx" ON "skill_edit_suggestion_feedback" ("project_id", "feedback_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:xCv1MSGKmD+dVk8e+Nl99SQ53nADzVC4AWuEA7uGazc=
+h1:g9FN8zPhUSzqzkes1Ebd53yaH03KlGqewOg4zsxcnZU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -301,3 +301,4 @@ h1:xCv1MSGKmD+dVk8e+Nl99SQ53nADzVC4AWuEA7uGazc=
 20260727224846_device-integration-tables.sql h1:ey1xakeDGhxvCTmirU8tnwHhQtcezKBf4n6lUC0+Sk8=
 20260727224939_device-agent-syncs-lower-email-idx.sql h1:3CMLuaTHwK5tJmwg00pedj5vsj0s5Q6TF4yCASaZlP0=
 20260727233742_chat-content-parts.sql h1:Z0oj3IaXFhP+YUZziMHME4AnKQgdBEkRvquoCORjBU4=
+20260728103328_dno_569_skill_feedback_schema.sql h1:TdiYFG8KGdlKTU+gjI711O9BRh3iO44xAkkyD/X9JtY=


### PR DESCRIPTION
## Summary
- add project-scoped agent feedback storage with unresolved name fallback and review watermark
- add single-open-suggestion workflow storage with immutable version references and evidence counts
- add the indexes needed for recent and unreviewed per-skill reads

Linear: DNO-569

No raw hash is stored on feedback rows; unresolved name-only feedback remains a capture-gap signal as specified by the RFC.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Postgres storage for project-scoped skill feedback and a suggestion workflow where each proposed change is first-class and evidence links to individual changes. Implements DNO-569 with indexes for recent and unreviewed reads.

- **New Features**
  - skill_feedback: required skill_name; optional skill_id/version (version implies skill_id); source/outcome; note non-empty and <=4k; session/user attribution; reviewed_at; indexes for recent and unreviewed reads; unique (project_id, id).
  - skill_edit_suggestions: base_version_id, rationale, status default open, scored_session_count; optional approver fields; enforces one open suggestion per skill (partial unique); recency index; unique (project_id, id).
  - skill_edit_suggestion_changes + skill_edit_suggestion_feedback: changes are first-class with proposed_diff (<=128KB), rationale, position; feedback links to a specific change; indexes for change ordering and reverse lookups. Invariants: suggestions aren’t versions until approved; version refs immutable; no raw hash on feedback; name-only feedback allowed for unresolved skills.

<sup>Written for commit 3fbf7091086733c6a3b715c3ae78087d6ab62cd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

