### PR TITLE
feat(skills): add feedback repository

### DIFF
--- a/server/internal/skills/feedback.go
+++ b/server/internal/skills/feedback.go
@@ -1,0 +1,44 @@
+package skills
+
+type FeedbackOutcome string
+
+const (
+	FeedbackOutcomeHelped          FeedbackOutcome = "helped"
+	FeedbackOutcomePartiallyHelped FeedbackOutcome = "partially_helped"
+	FeedbackOutcomeDidNotHelp      FeedbackOutcome = "did_not_help"
+	FeedbackOutcomeMisleading      FeedbackOutcome = "misleading"
+	FeedbackOutcomeHarmful         FeedbackOutcome = "harmful"
+)
+
+func (o FeedbackOutcome) Valid() bool {
+	switch o {
+	case FeedbackOutcomeHelped,
+		FeedbackOutcomePartiallyHelped,
+		FeedbackOutcomeDidNotHelp,
+		FeedbackOutcomeMisleading,
+		FeedbackOutcomeHarmful:
+		return true
+	default:
+		return false
+	}
+}
+
+type FeedbackSource string
+
+const (
+	FeedbackSourceDev       FeedbackSource = "dev"
+	FeedbackSourceAssistant FeedbackSource = "assistant"
+)
+
+func (s FeedbackSource) Valid() bool {
+	return s == FeedbackSourceDev || s == FeedbackSourceAssistant
+}
+
+type EditSuggestionStatus string
+
+const (
+	EditSuggestionStatusOpen       EditSuggestionStatus = "open"
+	EditSuggestionStatusApproved   EditSuggestionStatus = "approved"
+	EditSuggestionStatusDismissed  EditSuggestionStatus = "dismissed"
+	EditSuggestionStatusSuperseded EditSuggestionStatus = "superseded"
+)

--- a/server/internal/skills/feedback_test.go
+++ b/server/internal/skills/feedback_test.go
@@ -188,6 +188,13 @@ func TestListSkillFeedbackDeterministicAndBounded(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, recent[:2], recentPage)
+	recentNegative, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: -1,
+	})
+	require.NoError(t, err)
+	require.Empty(t, recentNegative)
 
 	unreviewed, err := ti.repo.ListUnreviewedSkillFeedback(t.Context(), repo.ListUnreviewedSkillFeedbackParams{
 		ProjectID: ti.projectID,
@@ -206,6 +213,13 @@ func TestListSkillFeedbackDeterministicAndBounded(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, unreviewed[:2], unreviewedPage)
+	unreviewedNegative, err := ti.repo.ListUnreviewedSkillFeedback(t.Context(), repo.ListUnreviewedSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: -1,
+	})
+	require.NoError(t, err)
+	require.Empty(t, unreviewedNegative)
 }
 
 func TestMarkSkillFeedbackReviewedSelectiveAndIdempotent(t *testing.T) {

--- a/server/internal/skills/feedback_test.go
+++ b/server/internal/skills/feedback_test.go
@@ -1,0 +1,264 @@
+package skills_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/skills"
+	"github.com/speakeasy-api/gram/server/internal/skills/repo"
+)
+
+func createSkillFeedback(t *testing.T, ti *testInstance, projectID uuid.UUID, skillName, note string) repo.SkillFeedback {
+	t.Helper()
+
+	feedback, err := ti.repo.CreateSkillFeedback(t.Context(), repo.CreateSkillFeedbackParams{
+		ProjectID:      projectID,
+		SkillID:        uuid.NullUUID{},
+		SkillVersionID: uuid.NullUUID{},
+		SkillName:      skillName,
+		Source:         string(skills.FeedbackSourceDev),
+		Outcome:        string(skills.FeedbackOutcomeHelped),
+		Note:           pgtype.Text{String: note, Valid: note != ""},
+		SessionID:      pgtype.Text{},
+		UserID:         pgtype.Text{},
+		UserEmail:      pgtype.Text{},
+	})
+	require.NoError(t, err)
+
+	return feedback
+}
+
+func TestSkillFeedbackValues(t *testing.T) {
+	t.Parallel()
+
+	outcomes := []skills.FeedbackOutcome{
+		skills.FeedbackOutcomeHelped,
+		skills.FeedbackOutcomePartiallyHelped,
+		skills.FeedbackOutcomeDidNotHelp,
+		skills.FeedbackOutcomeMisleading,
+		skills.FeedbackOutcomeHarmful,
+	}
+	for _, outcome := range outcomes {
+		require.True(t, outcome.Valid())
+	}
+	require.False(t, skills.FeedbackOutcome("unknown").Valid())
+
+	require.True(t, skills.FeedbackSourceDev.Valid())
+	require.True(t, skills.FeedbackSourceAssistant.Valid())
+	require.False(t, skills.FeedbackSource("unknown").Valid())
+
+	require.Equal(t, skills.EditSuggestionStatusOpen, skills.EditSuggestionStatus("open"))
+	require.Equal(t, skills.EditSuggestionStatusApproved, skills.EditSuggestionStatus("approved"))
+	require.Equal(t, skills.EditSuggestionStatusDismissed, skills.EditSuggestionStatus("dismissed"))
+	require.Equal(t, skills.EditSuggestionStatusSuperseded, skills.EditSuggestionStatus("superseded"))
+}
+
+func TestCreateSkillFeedbackUnresolvedNameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+	feedback, err := ti.repo.CreateSkillFeedback(t.Context(), repo.CreateSkillFeedbackParams{
+		ProjectID:      ti.projectID,
+		SkillID:        uuid.NullUUID{},
+		SkillVersionID: uuid.NullUUID{},
+		SkillName:      "unresolved-skill",
+		Source:         string(skills.FeedbackSourceAssistant),
+		Outcome:        string(skills.FeedbackOutcomePartiallyHelped),
+		Note:           pgtype.Text{String: "Useful, but incomplete", Valid: true},
+		SessionID:      pgtype.Text{String: "session-1", Valid: true},
+		UserID:         pgtype.Text{String: "user-1", Valid: true},
+		UserEmail:      pgtype.Text{String: "user@example.test", Valid: true},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ti.projectID, feedback.ProjectID)
+	require.False(t, feedback.SkillID.Valid)
+	require.False(t, feedback.SkillVersionID.Valid)
+	require.Equal(t, "unresolved-skill", feedback.SkillName)
+	require.Equal(t, string(skills.FeedbackSourceAssistant), feedback.Source)
+	require.Equal(t, string(skills.FeedbackOutcomePartiallyHelped), feedback.Outcome)
+	require.Equal(t, "Useful, but incomplete", feedback.Note.String)
+	require.Equal(t, "session-1", feedback.SessionID.String)
+	require.Equal(t, "user-1", feedback.UserID.String)
+	require.Equal(t, "user@example.test", feedback.UserEmail.String)
+	require.False(t, feedback.ReviewedAt.Valid)
+	require.True(t, feedback.CreatedAt.Valid)
+}
+
+func TestSkillFeedbackSameNameTenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	_, otherProjectID := createProjectContext(t, ctx, ti)
+	createSkillFeedback(t, ti, ti.projectID, "shared-name", "first project")
+	createSkillFeedback(t, ti, otherProjectID, "shared-name", "second project")
+
+	first, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "shared-name",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, "first project", first[0].Note.String)
+
+	second, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: otherProjectID,
+		SkillName: "shared-name",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	require.Equal(t, "second project", second[0].Note.String)
+}
+
+func TestCreateSkillFeedbackResolvedSkillVersionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "resolved-skill", "Resolved skill")
+	skillID := uuid.MustParse(created.Skill.ID)
+	versionID := uuid.MustParse(created.Version.ID)
+
+	feedback, err := ti.repo.CreateSkillFeedback(t.Context(), repo.CreateSkillFeedbackParams{
+		ProjectID:      ti.projectID,
+		SkillID:        uuid.NullUUID{UUID: skillID, Valid: true},
+		SkillVersionID: uuid.NullUUID{UUID: versionID, Valid: true},
+		SkillName:      created.Skill.Name,
+		Source:         string(skills.FeedbackSourceDev),
+		Outcome:        string(skills.FeedbackOutcomeDidNotHelp),
+		Note:           pgtype.Text{},
+		SessionID:      pgtype.Text{},
+		UserID:         pgtype.Text{},
+		UserEmail:      pgtype.Text{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, skillID, feedback.SkillID.UUID)
+	require.Equal(t, versionID, feedback.SkillVersionID.UUID)
+	require.False(t, feedback.Note.Valid)
+	require.False(t, feedback.SessionID.Valid)
+	require.False(t, feedback.UserID.Valid)
+	require.False(t, feedback.UserEmail.Valid)
+
+	_, otherProjectID := createProjectContext(t, ctx, ti)
+	_, err = ti.repo.CreateSkillFeedback(t.Context(), repo.CreateSkillFeedbackParams{
+		ProjectID:      otherProjectID,
+		SkillID:        uuid.NullUUID{UUID: skillID, Valid: true},
+		SkillVersionID: uuid.NullUUID{UUID: versionID, Valid: true},
+		SkillName:      created.Skill.Name,
+		Source:         string(skills.FeedbackSourceDev),
+		Outcome:        string(skills.FeedbackOutcomeHarmful),
+		Note:           pgtype.Text{},
+		SessionID:      pgtype.Text{},
+		UserID:         pgtype.Text{},
+		UserEmail:      pgtype.Text{},
+	})
+	require.Error(t, err)
+}
+
+func TestListSkillFeedbackDeterministicAndBounded(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+	for _, note := range []string{"first", "second", "third", "fourth"} {
+		createSkillFeedback(t, ti, ti.projectID, "ordered-skill", note)
+	}
+	createSkillFeedback(t, ti, ti.projectID, "other-skill", "excluded")
+
+	recent, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, recent, 4)
+	recentAgain, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, recent, recentAgain)
+	recentPage, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, recent[:2], recentPage)
+
+	unreviewed, err := ti.repo.ListUnreviewedSkillFeedback(t.Context(), repo.ListUnreviewedSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, unreviewed, 4)
+	for i := range recent {
+		require.Equal(t, recent[len(recent)-1-i].ID, unreviewed[i].ID)
+	}
+	unreviewedPage, err := ti.repo.ListUnreviewedSkillFeedback(t.Context(), repo.ListUnreviewedSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "ordered-skill",
+		PageLimit: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, unreviewed[:2], unreviewedPage)
+}
+
+func TestMarkSkillFeedbackReviewedSelectiveAndIdempotent(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+	selected := createSkillFeedback(t, ti, ti.projectID, "reviewed-skill", "selected")
+	unselected := createSkillFeedback(t, ti, ti.projectID, "reviewed-skill", "unselected")
+	otherName := createSkillFeedback(t, ti, ti.projectID, "other-skill", "other name")
+	params := repo.MarkSkillFeedbackReviewedParams{
+		ProjectID: ti.projectID,
+		SkillName: "reviewed-skill",
+		Ids:       []uuid.UUID{selected.ID, otherName.ID, uuid.New()},
+	}
+
+	marked, err := ti.repo.MarkSkillFeedbackReviewed(t.Context(), params)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, marked)
+	marked, err = ti.repo.MarkSkillFeedbackReviewed(t.Context(), params)
+	require.NoError(t, err)
+	require.Zero(t, marked)
+
+	recent, err := ti.repo.ListRecentSkillFeedback(t.Context(), repo.ListRecentSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "reviewed-skill",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, recent, 2)
+	for _, feedback := range recent {
+		if feedback.ID == selected.ID {
+			require.True(t, feedback.ReviewedAt.Valid)
+		} else {
+			require.Equal(t, unselected.ID, feedback.ID)
+			require.False(t, feedback.ReviewedAt.Valid)
+		}
+	}
+
+	unreviewed, err := ti.repo.ListUnreviewedSkillFeedback(t.Context(), repo.ListUnreviewedSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "reviewed-skill",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, unreviewed, 1)
+	require.Equal(t, unselected.ID, unreviewed[0].ID)
+
+	other, err := ti.repo.ListUnreviewedSkillFeedback(t.Context(), repo.ListUnreviewedSkillFeedbackParams{
+		ProjectID: ti.projectID,
+		SkillName: "other-skill",
+		PageLimit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, other, 1)
+	require.Equal(t, otherName.ID, other[0].ID)
+}

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -4,6 +4,57 @@ SELECT pg_advisory_xact_lock(hashtextextended('skill:' || (@project_id::uuid)::t
 -- name: LockSkillObservationReconciliation :exec
 SELECT pg_advisory_xact_lock(hashtextextended('skill-observations:' || (@project_id::uuid)::text, 0));
 
+-- name: CreateSkillFeedback :one
+INSERT INTO skill_feedback (
+  project_id,
+  skill_id,
+  skill_version_id,
+  skill_name,
+  source,
+  outcome,
+  note,
+  session_id,
+  user_id,
+  user_email
+) VALUES (
+  @project_id,
+  sqlc.narg(skill_id)::uuid,
+  sqlc.narg(skill_version_id)::uuid,
+  @skill_name,
+  @source,
+  @outcome,
+  sqlc.narg(note)::text,
+  sqlc.narg(session_id)::text,
+  sqlc.narg(user_id)::text,
+  sqlc.narg(user_email)::text
+)
+RETURNING *;
+
+-- name: ListRecentSkillFeedback :many
+SELECT *
+FROM skill_feedback
+WHERE project_id = @project_id
+  AND skill_name = @skill_name
+ORDER BY created_at DESC, id DESC
+LIMIT @page_limit;
+
+-- name: ListUnreviewedSkillFeedback :many
+SELECT *
+FROM skill_feedback
+WHERE project_id = @project_id
+  AND skill_name = @skill_name
+  AND reviewed_at IS NULL
+ORDER BY created_at, id
+LIMIT @page_limit;
+
+-- name: MarkSkillFeedbackReviewed :execrows
+UPDATE skill_feedback
+SET reviewed_at = clock_timestamp()
+WHERE project_id = @project_id
+  AND skill_name = @skill_name
+  AND id = ANY(@ids::uuid[])
+  AND reviewed_at IS NULL;
+
 -- name: GetSkillByNameForUpdate :one
 SELECT *
 FROM skills

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -36,7 +36,7 @@ FROM skill_feedback
 WHERE project_id = @project_id
   AND skill_name = @skill_name
 ORDER BY created_at DESC, id DESC
-LIMIT @page_limit;
+LIMIT GREATEST(@page_limit::int, 0);
 
 -- name: ListUnreviewedSkillFeedback :many
 SELECT *
@@ -45,7 +45,7 @@ WHERE project_id = @project_id
   AND skill_name = @skill_name
   AND reviewed_at IS NULL
 ORDER BY created_at, id
-LIMIT @page_limit;
+LIMIT GREATEST(@page_limit::int, 0);
 
 -- name: MarkSkillFeedbackReviewed :execrows
 UPDATE skill_feedback

--- a/server/internal/skills/repo/models.go
+++ b/server/internal/skills/repo/models.go
@@ -71,6 +71,22 @@ type SkillEfficacySetting struct {
 	UpdatedAt        pgtype.Timestamptz
 }
 
+type SkillFeedback struct {
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	SkillID        uuid.NullUUID
+	SkillVersionID uuid.NullUUID
+	SkillName      string
+	Source         string
+	Outcome        string
+	Note           pgtype.Text
+	SessionID      pgtype.Text
+	UserID         pgtype.Text
+	UserEmail      pgtype.Text
+	ReviewedAt     pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+}
+
 type SkillObservation struct {
 	ID                 uuid.UUID
 	ProjectID          uuid.UUID

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -2754,7 +2754,7 @@ FROM skill_feedback
 WHERE project_id = $1
   AND skill_name = $2
 ORDER BY created_at DESC, id DESC
-LIMIT $3
+LIMIT GREATEST($3::int, 0)
 `
 
 type ListRecentSkillFeedbackParams struct {
@@ -3268,7 +3268,7 @@ WHERE project_id = $1
   AND skill_name = $2
   AND reviewed_at IS NULL
 ORDER BY created_at, id
-LIMIT $3
+LIMIT GREATEST($3::int, 0)
 `
 
 type ListUnreviewedSkillFeedbackParams struct {

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -646,6 +646,78 @@ func (q *Queries) CreateSkillDistribution(ctx context.Context, arg CreateSkillDi
 	return i, err
 }
 
+const createSkillFeedback = `-- name: CreateSkillFeedback :one
+INSERT INTO skill_feedback (
+  project_id,
+  skill_id,
+  skill_version_id,
+  skill_name,
+  source,
+  outcome,
+  note,
+  session_id,
+  user_id,
+  user_email
+) VALUES (
+  $1,
+  $2::uuid,
+  $3::uuid,
+  $4,
+  $5,
+  $6,
+  $7::text,
+  $8::text,
+  $9::text,
+  $10::text
+)
+RETURNING id, project_id, skill_id, skill_version_id, skill_name, source, outcome, note, session_id, user_id, user_email, reviewed_at, created_at
+`
+
+type CreateSkillFeedbackParams struct {
+	ProjectID      uuid.UUID
+	SkillID        uuid.NullUUID
+	SkillVersionID uuid.NullUUID
+	SkillName      string
+	Source         string
+	Outcome        string
+	Note           pgtype.Text
+	SessionID      pgtype.Text
+	UserID         pgtype.Text
+	UserEmail      pgtype.Text
+}
+
+func (q *Queries) CreateSkillFeedback(ctx context.Context, arg CreateSkillFeedbackParams) (SkillFeedback, error) {
+	row := q.db.QueryRow(ctx, createSkillFeedback,
+		arg.ProjectID,
+		arg.SkillID,
+		arg.SkillVersionID,
+		arg.SkillName,
+		arg.Source,
+		arg.Outcome,
+		arg.Note,
+		arg.SessionID,
+		arg.UserID,
+		arg.UserEmail,
+	)
+	var i SkillFeedback
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.SkillID,
+		&i.SkillVersionID,
+		&i.SkillName,
+		&i.Source,
+		&i.Outcome,
+		&i.Note,
+		&i.SessionID,
+		&i.UserID,
+		&i.UserEmail,
+		&i.ReviewedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const createSkillVersion = `-- name: CreateSkillVersion :one
 INSERT INTO skill_versions (
   skill_id,
@@ -2676,6 +2748,55 @@ func (q *Queries) ListProjectsWithPendingSkillObservations(ctx context.Context, 
 	return items, nil
 }
 
+const listRecentSkillFeedback = `-- name: ListRecentSkillFeedback :many
+SELECT id, project_id, skill_id, skill_version_id, skill_name, source, outcome, note, session_id, user_id, user_email, reviewed_at, created_at
+FROM skill_feedback
+WHERE project_id = $1
+  AND skill_name = $2
+ORDER BY created_at DESC, id DESC
+LIMIT $3
+`
+
+type ListRecentSkillFeedbackParams struct {
+	ProjectID uuid.UUID
+	SkillName string
+	PageLimit int32
+}
+
+func (q *Queries) ListRecentSkillFeedback(ctx context.Context, arg ListRecentSkillFeedbackParams) ([]SkillFeedback, error) {
+	rows, err := q.db.Query(ctx, listRecentSkillFeedback, arg.ProjectID, arg.SkillName, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SkillFeedback
+	for rows.Next() {
+		var i SkillFeedback
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.SkillID,
+			&i.SkillVersionID,
+			&i.SkillName,
+			&i.Source,
+			&i.Outcome,
+			&i.Note,
+			&i.SessionID,
+			&i.UserID,
+			&i.UserEmail,
+			&i.ReviewedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSkillDistributionTargetVersions = `-- name: ListSkillDistributionTargetVersions :many
 SELECT DISTINCT resolved.id
 FROM skill_distributions sd
@@ -3140,6 +3261,56 @@ func (q *Queries) ListUnknownSkillActivations(ctx context.Context, arg ListUnkno
 	return items, nil
 }
 
+const listUnreviewedSkillFeedback = `-- name: ListUnreviewedSkillFeedback :many
+SELECT id, project_id, skill_id, skill_version_id, skill_name, source, outcome, note, session_id, user_id, user_email, reviewed_at, created_at
+FROM skill_feedback
+WHERE project_id = $1
+  AND skill_name = $2
+  AND reviewed_at IS NULL
+ORDER BY created_at, id
+LIMIT $3
+`
+
+type ListUnreviewedSkillFeedbackParams struct {
+	ProjectID uuid.UUID
+	SkillName string
+	PageLimit int32
+}
+
+func (q *Queries) ListUnreviewedSkillFeedback(ctx context.Context, arg ListUnreviewedSkillFeedbackParams) ([]SkillFeedback, error) {
+	rows, err := q.db.Query(ctx, listUnreviewedSkillFeedback, arg.ProjectID, arg.SkillName, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SkillFeedback
+	for rows.Next() {
+		var i SkillFeedback
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.SkillID,
+			&i.SkillVersionID,
+			&i.SkillName,
+			&i.Source,
+			&i.Outcome,
+			&i.Note,
+			&i.SessionID,
+			&i.UserID,
+			&i.UserEmail,
+			&i.ReviewedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const loadReservedSkillEfficacyEvaluations = `-- name: LoadReservedSkillEfficacyEvaluations :many
 UPDATE skill_efficacy_evaluations e
 SET claim_token = $1::uuid,
@@ -3303,6 +3474,29 @@ type MarkSkillEfficacyEvaluationScoredParams struct {
 
 func (q *Queries) MarkSkillEfficacyEvaluationScored(ctx context.Context, arg MarkSkillEfficacyEvaluationScoredParams) (int64, error) {
 	result, err := q.db.Exec(ctx, markSkillEfficacyEvaluationScored, arg.ProjectID, arg.ID, arg.ClaimToken)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const markSkillFeedbackReviewed = `-- name: MarkSkillFeedbackReviewed :execrows
+UPDATE skill_feedback
+SET reviewed_at = clock_timestamp()
+WHERE project_id = $1
+  AND skill_name = $2
+  AND id = ANY($3::uuid[])
+  AND reviewed_at IS NULL
+`
+
+type MarkSkillFeedbackReviewedParams struct {
+	ProjectID uuid.UUID
+	SkillName string
+	Ids       []uuid.UUID
+}
+
+func (q *Queries) MarkSkillFeedbackReviewed(ctx context.Context, arg MarkSkillFeedbackReviewedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markSkillFeedbackReviewed, arg.ProjectID, arg.SkillName, arg.Ids)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary
- define the canonical feedback outcome, source, and suggestion status vocabularies
- add project-scoped feedback creation, bounded reads, and explicit review-watermark updates
- cover resolved and unresolved feedback, tenant isolation, ordering, and selective marking

Linear: DNO-569

Stacked on #4559 so the additive migration deploys before query code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a project-scoped repository and SQL queries to store and review skill feedback: create, list (recent/unreviewed), and mark selected items reviewed idempotently. Implements `skill_feedback` for DNO-569 with tenant isolation and deterministic reads.

- **New Features**
  - Canonical enums with validation for feedback outcome, source, and edit-suggestion status.
  - Queries: `CreateSkillFeedback`, `ListRecentSkillFeedback`, `ListUnreviewedSkillFeedback`, `MarkSkillFeedbackReviewed`; accept unresolved names or resolved `skill_id`/`skill_version_id`, with tenant isolation and deterministic ordering (recent: newest first; unreviewed: oldest first).

- **Bug Fixes**
  - Clamp list query limits to >= 0; negative limits return empty results.

<sup>Written for commit 4da5aa407ab595228f76d7d9297dbb3c68cedc22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

