### PR TITLE
feat(plugins): bundle skill feedback MCP

### DIFF
--- a/hooks/cmd/speakeasy-hooks/main.go
+++ b/hooks/cmd/speakeasy-hooks/main.go
@@ -49,6 +49,17 @@ func main() {
 			os.Exit(relay.RunDrain(context.Background(), os.Stdout))
 		case "upload-skill":
 			os.Exit(relay.RunSkillUpload(context.Background(), os.Args[2:], os.Stdin))
+		case "skill-feedback":
+			// Serves the speakeasy-skill-feedback MCP server over stdio.
+			// Generated plugin .mcp.json entries invoke this through the
+			// bootstrap script with --config pointing at the plugin's
+			// speakeasy.json.
+			flagCfg, _ := relay.SplitInlineFlags(relay.Config{ServerURL: "", ProjectSlug: "", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}, os.Args[2:])
+			if err := relay.RunSkillFeedbackMCP(context.Background(), relay.LoadConfig(flagCfg)); err != nil {
+				fmt.Fprintf(os.Stderr, "speakeasy-hooks skill-feedback: %v\n", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
 		}
 	}
 

--- a/hooks/relay/skillfeedback.go
+++ b/hooks/relay/skillfeedback.go
@@ -1,0 +1,145 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
+	"github.com/speakeasy-api/gram/hooks/sdk/models/operations"
+)
+
+// skillFeedbackBudget bounds one feedback submission end to end. The agent is
+// blocked on the tool call while this runs, so the budget stays short.
+const skillFeedbackBudget = 15 * time.Second
+
+var skillNamePattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+type skillFeedbackInput struct {
+	Skill   string `json:"skill" jsonschema:"Canonical name of the skill that was used."`
+	Outcome string `json:"outcome" jsonschema:"How the skill affected the task."`
+	Note    string `json:"note,omitempty" jsonschema:"Optional concise context about the outcome."`
+}
+
+// skillFeedbackInputSchema mirrors the assistant-side skill feedback tool
+// schema so agents see identical constraints on every surface.
+func skillFeedbackInputSchema() *jsonschema.Schema {
+	schema, err := jsonschema.For[skillFeedbackInput](nil)
+	if err != nil {
+		panic(fmt.Errorf("build skill feedback schema: %w", err))
+	}
+	minSkill, maxSkill, maxNote := 1, 64, 4000
+	schema.Properties["skill"].MinLength = &minSkill
+	schema.Properties["skill"].MaxLength = &maxSkill
+	schema.Properties["skill"].Pattern = skillNamePattern.String()
+	schema.Properties["outcome"].Enum = []any{
+		string(components.OutcomeHelped),
+		string(components.OutcomePartiallyHelped),
+		string(components.OutcomeDidNotHelp),
+		string(components.OutcomeMisleading),
+		string(components.OutcomeHarmful),
+	}
+	schema.Properties["note"].MaxLength = &maxNote
+	return schema
+}
+
+// RunSkillFeedbackMCP serves the speakeasy-skill-feedback MCP server over
+// stdio. Generated plugin packages point their .mcp.json at this subcommand
+// through the bootstrap script, so the agent-facing feedback tool authenticates
+// with the same credential chain as hook ingestion instead of a key baked into
+// the MCP config.
+func RunSkillFeedbackMCP(ctx context.Context, cfg Config) error {
+	if cfg.ConfigError != "" {
+		return fmt.Errorf("load plugin config: %s", cfg.ConfigError)
+	}
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "speakeasy-skill-feedback", Version: BinaryVersion}, nil)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "skill_feedback",
+		Description: "Record feedback only after materially relying on a skill while completing a task.",
+		InputSchema: skillFeedbackInputSchema(),
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, input skillFeedbackInput) (*mcp.CallToolResult, any, error) {
+		if err := submitSkillFeedback(ctx, cfg, input); err != nil {
+			return nil, nil, err
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: `{"recorded":true}`}}}, nil, nil
+	})
+
+	// Harnesses terminate stdio servers by closing stdin, which can surface
+	// as an EOF error when it races a pending read — that is a clean shutdown.
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("serve skill feedback mcp: %w", err)
+	}
+	return nil
+}
+
+func submitSkillFeedback(ctx context.Context, cfg Config, input skillFeedbackInput) error {
+	switch {
+	case len(input.Skill) > 64 || !skillNamePattern.MatchString(input.Skill):
+		return errors.New("skill must be a canonical 1-64 character skill name")
+	case utf8.RuneCountInString(input.Note) > 4000:
+		return errors.New("note must be at most 4000 Unicode characters")
+	}
+	outcome := components.Outcome(input.Outcome)
+	switch outcome {
+	case components.OutcomeHelped, components.OutcomePartiallyHelped, components.OutcomeDidNotHelp, components.OutcomeMisleading, components.OutcomeHarmful:
+	default:
+		return errors.New("invalid feedback outcome")
+	}
+
+	c, ok := resolveAuth(cfg)
+	if !ok {
+		return errors.New("no hooks credential on this machine; sign in with the plugin's speakeasy-hooks login command")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, skillFeedbackBudget)
+	defer cancel()
+
+	body := components.SkillFeedbackPayload{
+		SchemaVersion: components.SkillFeedbackPayloadSchemaVersionHookSkillFeedbackV1,
+		Skill:         input.Skill,
+		Outcome:       outcome,
+		Note:          nil,
+	}
+	if input.Note != "" {
+		body.Note = &input.Note
+	}
+	request := operations.SkillFeedbackRequest{GramKey: nil, GramProject: nil, Body: body}
+	security := &operations.SkillFeedbackSecurity{
+		ApikeyHeaderGramKey:          &c.APIKey,
+		ProjectSlugHeaderGramProject: nil,
+	}
+	if c.Project != "" {
+		security.ProjectSlugHeaderGramProject = &c.Project
+	}
+
+	cl := newClient(c.ServerURL)
+	var response *operations.SkillFeedbackResponse
+	var err error
+	for attempt := 0; ; attempt++ {
+		response, err = cl.sdk.Hooks.SkillFeedback(ctx, request, security)
+		if err == nil {
+			break
+		}
+		if interpretError(err).statusCode != 0 || attempt >= 2 || ctx.Err() != nil {
+			return fmt.Errorf("record skill feedback: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("record skill feedback: %w", err)
+		case <-time.After(time.Duration(attempt+1) * 250 * time.Millisecond):
+		}
+	}
+	if response == nil || response.StatusCode != http.StatusNoContent {
+		return errors.New("unexpected skill feedback response status")
+	}
+	return nil
+}

--- a/hooks/relay/skillfeedback.go
+++ b/hooks/relay/skillfeedback.go
@@ -61,7 +61,11 @@ func RunSkillFeedbackMCP(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("load plugin config: %s", cfg.ConfigError)
 	}
 
-	server := mcp.NewServer(&mcp.Implementation{Name: "speakeasy-skill-feedback", Version: BinaryVersion}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "speakeasy-skill-feedback", Version: BinaryVersion}, &mcp.ServerOptions{
+		// Initialize-time instructions are the discovery nudge: harnesses
+		// surface them in model context even before the tool schema loads.
+		Instructions: "After materially relying on a distributed skill while completing a task, call skill_feedback with that skill's name and how it affected the task. One call per skill per task.",
+	})
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "skill_feedback",
 		Description: "Record feedback only after materially relying on a skill while completing a task.",

--- a/hooks/relay/skillfeedback_test.go
+++ b/hooks/relay/skillfeedback_test.go
@@ -1,0 +1,84 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitSkillFeedbackPostsWithResolvedCreds(t *testing.T) {
+	t.Setenv("GRAM_HOOKS_AUTH_FILE", filepath.Join(t.TempDir(), "hooks-auth.env"))
+	t.Setenv("GRAM_HOOKS_API_KEY", "test-hooks-key")
+
+	var calls atomic.Int32
+	var gotKey, gotProject, gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		gotKey = r.Header.Get("Gram-Key")
+		gotProject = r.Header.Get("Gram-Project")
+		gotPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := Config{ServerURL: server.URL, ProjectSlug: "acme", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}
+	note := "missed an edge case"
+	err := submitSkillFeedback(t.Context(), cfg, skillFeedbackInput{Skill: "release-notes", Outcome: "partially_helped", Note: note})
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), calls.Load())
+	require.Equal(t, "/rpc/hooks.skillFeedback", gotPath)
+	require.Equal(t, "test-hooks-key", gotKey)
+	require.Equal(t, "acme", gotProject)
+	require.Equal(t, map[string]any{
+		"schema_version": "hook.skill-feedback.v1",
+		"skill":          "release-notes",
+		"outcome":        "partially_helped",
+		"note":           note,
+	}, gotBody)
+}
+
+func TestSubmitSkillFeedbackRejectsInvalidInputBeforeSending(t *testing.T) {
+	t.Setenv("GRAM_HOOKS_AUTH_FILE", filepath.Join(t.TempDir(), "hooks-auth.env"))
+	t.Setenv("GRAM_HOOKS_API_KEY", "test-hooks-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("no request must reach the server for invalid input")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	cfg := Config{ServerURL: server.URL, ProjectSlug: "acme", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}
+
+	err := submitSkillFeedback(t.Context(), cfg, skillFeedbackInput{Skill: "Not A Slug", Outcome: "helped", Note: ""})
+	require.ErrorContains(t, err, "canonical")
+
+	err = submitSkillFeedback(t.Context(), cfg, skillFeedbackInput{Skill: "release-notes", Outcome: "changed_my_life", Note: ""})
+	require.ErrorContains(t, err, "outcome")
+}
+
+func TestSubmitSkillFeedbackWithoutCredsAsksForLogin(t *testing.T) {
+	t.Setenv("GRAM_HOOKS_AUTH_FILE", filepath.Join(t.TempDir(), "hooks-auth.env"))
+	t.Setenv("GRAM_HOOKS_API_KEY", "")
+
+	cfg := Config{ServerURL: "http://127.0.0.1:1", ProjectSlug: "acme", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}
+	err := submitSkillFeedback(t.Context(), cfg, skillFeedbackInput{Skill: "release-notes", Outcome: "helped", Note: ""})
+	require.ErrorContains(t, err, "login")
+}
+
+func TestSkillFeedbackInputSchemaConstrainsOutcome(t *testing.T) {
+	t.Parallel()
+
+	schema := skillFeedbackInputSchema()
+	raw, err := json.Marshal(schema)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "partially_helped")
+	require.Contains(t, string(raw), skillNamePattern.String())
+	require.ElementsMatch(t, []string{"skill", "outcome"}, schema.Required)
+}

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -6,14 +6,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/url"
 	"path"
 	"slices"
 	"sort"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	"github.com/speakeasy-api/gram/server/internal/plugins/naming"
+	domainskills "github.com/speakeasy-api/gram/server/internal/skills"
 )
 
 // ServerEnvConfig represents a user-facing environment variable required by a server.
@@ -70,13 +74,13 @@ type GenerateConfig struct {
 	// APIKey is the plaintext consumer-scoped Gram API key to inject into
 	// MCP server configs. If empty, configs will use placeholder variables.
 	APIKey string
-	// HooksAPIKey controls whether the observability plugin is emitted. Runtime
-	// hook senders authenticate with explicit env credentials or a local cached
-	// hooks key, then fall back to this org-wide key embedded in speakeasy.json.
+	// HooksAPIKey controls whether the observability plugin and distributed-skill
+	// feedback MCP servers are emitted. Both authenticate with this hooks-scoped
+	// key.
 	HooksAPIKey string
 	// ProjectSlug is the publishing project's slug. The Cursor hooks endpoint
-	// requires it via the Gram-Project header (Claude's does not), and it scopes
-	// the default marketplace name for non-default projects.
+	// and skill feedback MCP server require it via the Gram-Project header, and
+	// it scopes the default marketplace name for non-default projects.
 	ProjectSlug string
 	// IsDefaultProject reports whether this is the org's default project (its
 	// oldest, by id ASC). The default project keeps the bare org-derived
@@ -345,7 +349,7 @@ func storedHooksConfigHash(stored []byte) string {
 // MCP plugins on the next run, even when a project's generated MCP output is
 // byte-identical — for generator changes that alter MCP behaviour in ways the
 // placeholder fingerprint pass can't observe.
-const mcpGeneratorVersion = "9"
+const mcpGeneratorVersion = "10"
 
 // hooksGeneratorVersion is the sole rollout signal for the observability (hooks)
 // plugin. It is stamped into the hooks plugin.json version (see
@@ -362,7 +366,7 @@ const hooksGeneratorVersion = "22"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits
-// the observability plugin entirely (see GenerateConfig.HooksAPIKey), which
+// hooks and skill feedback MCP output (see GenerateConfig.HooksAPIKey), which
 // would make the fingerprint blind to it. Constant values keep the generated
 // bytes stable across publishes while the real keys rotate.
 const (
@@ -386,15 +390,14 @@ const mcpSharedFingerprintKey = "__shared__"
 // Fingerprints are stored per plugin (rather than as one aggregate) so a future
 // per-plugin publish flow can decide independently which plugins have unpublished
 // changes without a schema migration; today the rollout treats the MCP component
-// as changed when any entry differs. Per-publish fields (manifest version, the
-// injected MCP API key) are normalized out so the same MCP configuration and
+// as changed when any entry differs. Per-publish fields (manifest version and
+// injected API keys) are normalized out so the same MCP configuration and
 // mcpGeneratorVersion always produce the same fingerprints.
 func MCPFingerprints(plugins []PluginInfo, cfg GenerateConfig) (map[string]string, error) {
 	cfg.Version = ""
 	cfg.APIKey = fingerprintAPIKeySentinel
-	// HooksAPIKey affects only the shared files here (whether the observability
-	// entry is listed in marketplace.json). Published repos always carry a hooks
-	// key, so pin a stable non-empty sentinel to keep that entry in the hash.
+	// Published repos carry a hooks key. Normalize it so skill feedback MCP
+	// entries are fingerprinted without rotating the hash on every publish.
 	cfg.HooksAPIKey = fingerprintHooksKeySentinel
 
 	out := make(map[string]string, len(plugins)+1)
@@ -573,6 +576,7 @@ func writeHooksRuntimeFiles(files map[string][]byte, subdir string, cfg Generate
 // verbatim from the existing repo when only the hooks component changed.
 func mcpFilePaths(plugins []PluginInfo, cfg GenerateConfig) ([]string, error) {
 	cfg.APIKey = fingerprintAPIKeySentinel
+	cfg.HooksAPIKey = fingerprintHooksKeySentinel
 	files, err := generateMCPFiles(plugins, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("enumerate mcp file paths: %w", err)
@@ -898,7 +902,7 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 		taken[key] = true
 	}
 
-	mcpServers := make(map[string]codexMCPServer, len(p.Servers))
+	mcpServers := make(map[string]codexMCPServer, len(p.Servers)+1)
 	for i, s := range p.Servers {
 		if keys[i] == "" {
 			continue
@@ -927,6 +931,16 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 		}
 
 		mcpServers[keys[i]] = entry
+	}
+	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
+			mcpServers[skillFeedbackMCPServerName] = codexMCPServer{
+				URL:               feedbackURL,
+				BearerTokenEnvVar: "",
+				HTTPHeaders:       headers,
+				EnvHTTPHeaders:    nil,
+			}
+		}
 	}
 	mcpJSON, err := marshalJSON(codexMCPConfig{MCPServers: mcpServers})
 	if err != nil {
@@ -1654,7 +1668,7 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	}
 	files[path.Join(subdir, ".claude-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]claudeMCPServer)
+	mcpServers := make(map[string]claudeMCPServer, len(p.Servers)+1)
 	for _, s := range p.Servers {
 		var headers map[string]string
 
@@ -1677,6 +1691,15 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 			Headers: headers,
 		}
 	}
+	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
+			mcpServers[skillFeedbackMCPServerName] = claudeMCPServer{
+				Type:    "http",
+				URL:     feedbackURL,
+				Headers: headers,
+			}
+		}
+	}
 	mcpJSON, err := marshalJSON(claudeMCPConfig{MCPServers: mcpServers})
 	if err != nil {
 		return fmt.Errorf("marshal .mcp.json: %w", err)
@@ -1696,32 +1719,55 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 // than trust the invariant across the DB boundary.
 func emitPluginSkills(files map[string][]byte, subdir string, p PluginInfo) {
 	for _, sk := range p.Skills {
-		if !validSkillDirName(sk.Name) {
+		if !domainskills.ValidSpecName(sk.Name) {
 			continue
 		}
 		files[path.Join(subdir, "skills", sk.Name, "SKILL.md")] = []byte(sk.Content)
 	}
 }
 
-// validSkillDirName reports whether a skill name is safe to use as a package
-// directory: 1-64 chars of lowercase alphanumerics and single interior
-// hyphens, mirroring the skill spec's name rules.
-func validSkillDirName(name string) bool {
-	if len(name) == 0 || len(name) > 64 || name[0] == '-' || name[len(name)-1] == '-' {
-		return false
-	}
-	previousHyphen := false
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z' || r >= '0' && r <= '9':
-			previousHyphen = false
-		case r == '-' && !previousHyphen:
-			previousHyphen = true
-		default:
-			return false
+const skillFeedbackMCPServerName = "speakeasy-skill-feedback"
+
+// skillFeedbackMCPConfig uses the same name predicate as emitPluginSkills, so
+// feedback is bundled exactly when this feature package carries a skill.
+func skillFeedbackMCPConfig(p PluginInfo, cfg GenerateConfig) (string, map[string]string, bool) {
+	hasSkill := false
+	for _, skill := range p.Skills {
+		if domainskills.ValidSpecName(skill.Name) {
+			hasSkill = true
+			break
 		}
 	}
-	return true
+	if !hasSkill {
+		return "", nil, false
+	}
+	for _, server := range p.Servers {
+		if server.DisplayName == skillFeedbackMCPServerName {
+			return "", nil, false
+		}
+	}
+
+	hooksKey := strings.TrimSpace(cfg.HooksAPIKey)
+	projectSlug := strings.TrimSpace(cfg.ProjectSlug)
+	base, err := url.Parse(strings.TrimSpace(cfg.ServerURL))
+	if hooksKey == "" || projectSlug == "" || err != nil || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") {
+		return "", nil, false
+	}
+
+	return platformtools.PlatformToolsetURL(base, platformtools.SkillFeedbackPlatformToolsetSlug), map[string]string{
+		"Authorization":         "Bearer " + hooksKey,
+		constants.ProjectHeader: projectSlug,
+	}, true
+}
+
+func needsSkillFeedbackMCPKey(plugins []PluginInfo, cfg GenerateConfig) bool {
+	cfg.HooksAPIKey = fingerprintHooksKeySentinel
+	for _, plugin := range plugins {
+		if _, _, ok := skillFeedbackMCPConfig(plugin, cfg); ok {
+			return true
+		}
+	}
+	return false
 }
 
 func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p PluginInfo, cfg GenerateConfig) error {
@@ -1743,7 +1789,7 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 	}
 	files[path.Join(subdir, ".cursor-plugin/plugin.json")] = pluginJSON
 
-	mcpServers := make(map[string]cursorMCPServer)
+	mcpServers := make(map[string]cursorMCPServer, len(p.Servers)+1)
 	for _, s := range p.Servers {
 		var headers map[string]string
 
@@ -1763,6 +1809,14 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 		mcpServers[s.DisplayName] = cursorMCPServer{
 			URL:     s.MCPURL,
 			Headers: headers,
+		}
+	}
+	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
+			mcpServers[skillFeedbackMCPServerName] = cursorMCPServer{
+				URL:     feedbackURL,
+				Headers: headers,
+			}
 		}
 	}
 	mcpJSON, err := marshalJSON(cursorMCPConfig{MCPServers: mcpServers})

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -6,17 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"net"
-	"net/url"
 	"path"
 	"slices"
 	"sort"
 	"strings"
 	"unicode/utf8"
 
-	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	"github.com/speakeasy-api/gram/server/internal/plugins/naming"
 	domainskills "github.com/speakeasy-api/gram/server/internal/skills"
 )
@@ -910,6 +906,8 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 		}
 
 		entry := codexMCPServer{
+			Command:           "",
+			Args:              nil,
 			URL:               s.MCPURL,
 			BearerTokenEnvVar: "",
 			HTTPHeaders:       nil,
@@ -933,15 +931,20 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 
 		mcpServers[keys[i]] = entry
 	}
-	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+	if bundleSkillFeedbackMCP(p) {
 		// Codex trims invalid edge characters when forming keys, so a
 		// non-exact display name can still occupy the reserved key.
 		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
 			mcpServers[skillFeedbackMCPServerName] = codexMCPServer{
-				URL:               feedbackURL,
+				Command:           "bash",
+				Args:              skillFeedbackMCPArgs(`${PLUGIN_ROOT}`),
+				URL:               "",
 				BearerTokenEnvVar: "",
-				HTTPHeaders:       headers,
+				HTTPHeaders:       nil,
 				EnvHTTPHeaders:    nil,
+			}
+			if err := writeHooksRuntimeFiles(files, subdir, cfg); err != nil {
+				return err
 			}
 		}
 	}
@@ -1690,15 +1693,22 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 
 		mcpServers[s.DisplayName] = claudeMCPServer{
 			Type:    "http",
+			Command: "",
+			Args:    nil,
 			URL:     s.MCPURL,
 			Headers: headers,
 		}
 	}
-	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+	if bundleSkillFeedbackMCP(p) {
 		mcpServers[skillFeedbackMCPServerName] = claudeMCPServer{
-			Type:    "http",
-			URL:     feedbackURL,
-			Headers: headers,
+			Type:    "stdio",
+			Command: "bash",
+			Args:    skillFeedbackMCPArgs(`${CLAUDE_PLUGIN_ROOT}`),
+			URL:     "",
+			Headers: nil,
+		}
+		if err := writeHooksRuntimeFiles(files, subdir, cfg); err != nil {
+			return err
 		}
 	}
 	mcpJSON, err := marshalJSON(claudeMCPConfig{MCPServers: mcpServers})
@@ -1719,19 +1729,29 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 // published repo — refuse anything that isn't a plain lowercase slug rather
 // than trust the invariant across the DB boundary.
 func emitPluginSkills(files map[string][]byte, subdir string, p PluginInfo) {
+	footer := ""
+	if bundleSkillFeedbackMCP(p) {
+		footer = skillFeedbackFooter
+	}
 	for _, sk := range p.Skills {
 		if !domainskills.ValidSpecName(sk.Name) {
 			continue
 		}
-		files[path.Join(subdir, "skills", sk.Name, "SKILL.md")] = []byte(sk.Content)
+		files[path.Join(subdir, "skills", sk.Name, "SKILL.md")] = []byte(strings.TrimRight(sk.Content, "\n") + footer + "\n")
 	}
 }
 
 const skillFeedbackMCPServerName = "speakeasy-skill-feedback"
 
-// skillFeedbackMCPConfig uses the same name predicate as emitPluginSkills, so
-// feedback is bundled exactly when this feature package carries a skill.
-func skillFeedbackMCPConfig(p PluginInfo, cfg GenerateConfig) (string, map[string]string, bool) {
+// skillFeedbackFooter is appended to every distributed SKILL.md that ships
+// alongside the bundled feedback MCP server. Discovery otherwise depends on
+// the agent noticing the tool in tools/list on its own.
+const skillFeedbackFooter = "\n\nAfter materially relying on this skill, record the outcome with the `skill_feedback` tool (speakeasy-skill-feedback MCP server)."
+
+// bundleSkillFeedbackMCP uses the same name predicate as emitPluginSkills, so
+// feedback is bundled exactly when this feature package carries a skill. A
+// customer server that already claims the reserved name wins.
+func bundleSkillFeedbackMCP(p PluginInfo) bool {
 	hasSkill := false
 	for _, skill := range p.Skills {
 		if domainskills.ValidSpecName(skill.Name) {
@@ -1740,41 +1760,31 @@ func skillFeedbackMCPConfig(p PluginInfo, cfg GenerateConfig) (string, map[strin
 		}
 	}
 	if !hasSkill {
-		return "", nil, false
+		return false
 	}
 	for _, server := range p.Servers {
 		if server.DisplayName == skillFeedbackMCPServerName {
-			return "", nil, false
+			return false
 		}
 	}
-
-	hooksKey := strings.TrimSpace(cfg.HooksAPIKey)
-	projectSlug := strings.TrimSpace(cfg.ProjectSlug)
-	base, err := url.Parse(strings.TrimSpace(cfg.ServerURL))
-	if hooksKey == "" || projectSlug == "" || err != nil || base.Host == "" || base.Hostname() == "" {
-		return "", nil, false
-	}
-	if base.Scheme != "https" {
-		ip := net.ParseIP(base.Hostname())
-		if base.Scheme != "http" || (base.Hostname() != "localhost" && (ip == nil || !ip.IsLoopback())) {
-			return "", nil, false
-		}
-	}
-
-	return platformtools.PlatformToolsetURL(base, platformtools.SkillFeedbackPlatformToolsetSlug), map[string]string{
-		"Authorization":         "Bearer " + hooksKey,
-		constants.ProjectHeader: projectSlug,
-	}, true
+	return true
 }
 
-func needsSkillFeedbackMCPKey(plugins []PluginInfo, cfg GenerateConfig) bool {
-	cfg.HooksAPIKey = fingerprintHooksKeySentinel
-	for _, plugin := range plugins {
-		if _, _, ok := skillFeedbackMCPConfig(plugin, cfg); ok {
-			return true
-		}
+// skillFeedbackMCPArgs builds the argv for the bundled stdio feedback server:
+// the plugin-root bootstrap script downloads the pinned hooks binary and
+// forwards to its skill-feedback subcommand. root is the harness's plugin-root
+// placeholder (e.g. ${CLAUDE_PLUGIN_ROOT}), which the harness substitutes when
+// it spawns the server, so the entry works wherever the plugin is installed.
+func skillFeedbackMCPArgs(root string) []string {
+	return []string{
+		root + "/hooks/bootstrap.sh",
+		"--config=" + root + "/speakeasy.json",
+		"skill-feedback",
 	}
-	return false
+}
+
+func needsSkillFeedbackHooksKey(plugins []PluginInfo) bool {
+	return slices.ContainsFunc(plugins, bundleSkillFeedbackMCP)
 }
 
 func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p PluginInfo, cfg GenerateConfig) error {
@@ -1814,14 +1824,21 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 		}
 
 		mcpServers[s.DisplayName] = cursorMCPServer{
+			Command: "",
+			Args:    nil,
 			URL:     s.MCPURL,
 			Headers: headers,
 		}
 	}
-	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+	if bundleSkillFeedbackMCP(p) {
 		mcpServers[skillFeedbackMCPServerName] = cursorMCPServer{
-			URL:     feedbackURL,
-			Headers: headers,
+			Command: "bash",
+			Args:    skillFeedbackMCPArgs(`${CURSOR_PLUGIN_ROOT}`),
+			URL:     "",
+			Headers: nil,
+		}
+		if err := writeHooksRuntimeFiles(files, subdir, cfg); err != nil {
+			return err
 		}
 	}
 	mcpJSON, err := marshalJSON(cursorMCPConfig{MCPServers: mcpServers})
@@ -1889,7 +1906,9 @@ type claudeMCPConfig struct {
 
 type claudeMCPServer struct {
 	Type    string            `json:"type"`
-	URL     string            `json:"url"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
@@ -1915,7 +1934,9 @@ type cursorMCPConfig struct {
 }
 
 type cursorMCPServer struct {
-	URL     string            `json:"url"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
@@ -2020,7 +2041,9 @@ type codexMCPConfig struct {
 }
 
 type codexMCPServer struct {
-	URL               string            `json:"url"`
+	Command           string            `json:"command,omitempty"`
+	Args              []string          `json:"args,omitempty"`
+	URL               string            `json:"url,omitempty"`
 	BearerTokenEnvVar string            `json:"bearer_token_env_var,omitempty"`
 	HTTPHeaders       map[string]string `json:"http_headers,omitempty"`
 	EnvHTTPHeaders    map[string]string `json:"env_http_headers,omitempty"`

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net"
 	"net/url"
 	"path"
 	"slices"
@@ -933,6 +934,8 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 		mcpServers[keys[i]] = entry
 	}
 	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
+		// Codex trims invalid edge characters when forming keys, so a
+		// non-exact display name can still occupy the reserved key.
 		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
 			mcpServers[skillFeedbackMCPServerName] = codexMCPServer{
 				URL:               feedbackURL,
@@ -1692,12 +1695,10 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 		}
 	}
 	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
-		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
-			mcpServers[skillFeedbackMCPServerName] = claudeMCPServer{
-				Type:    "http",
-				URL:     feedbackURL,
-				Headers: headers,
-			}
+		mcpServers[skillFeedbackMCPServerName] = claudeMCPServer{
+			Type:    "http",
+			URL:     feedbackURL,
+			Headers: headers,
 		}
 	}
 	mcpJSON, err := marshalJSON(claudeMCPConfig{MCPServers: mcpServers})
@@ -1750,8 +1751,14 @@ func skillFeedbackMCPConfig(p PluginInfo, cfg GenerateConfig) (string, map[strin
 	hooksKey := strings.TrimSpace(cfg.HooksAPIKey)
 	projectSlug := strings.TrimSpace(cfg.ProjectSlug)
 	base, err := url.Parse(strings.TrimSpace(cfg.ServerURL))
-	if hooksKey == "" || projectSlug == "" || err != nil || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") {
+	if hooksKey == "" || projectSlug == "" || err != nil || base.Host == "" || base.Hostname() == "" {
 		return "", nil, false
+	}
+	if base.Scheme != "https" {
+		ip := net.ParseIP(base.Hostname())
+		if base.Scheme != "http" || (base.Hostname() != "localhost" && (ip == nil || !ip.IsLoopback())) {
+			return "", nil, false
+		}
 	}
 
 	return platformtools.PlatformToolsetURL(base, platformtools.SkillFeedbackPlatformToolsetSlug), map[string]string{
@@ -1812,11 +1819,9 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 		}
 	}
 	if feedbackURL, headers, ok := skillFeedbackMCPConfig(p, cfg); ok {
-		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
-			mcpServers[skillFeedbackMCPServerName] = cursorMCPServer{
-				URL:     feedbackURL,
-				Headers: headers,
-			}
+		mcpServers[skillFeedbackMCPServerName] = cursorMCPServer{
+			URL:     feedbackURL,
+			Headers: headers,
 		}
 	}
 	mcpJSON, err := marshalJSON(cursorMCPConfig{MCPServers: mcpServers})

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -937,7 +937,7 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 		if _, exists := mcpServers[skillFeedbackMCPServerName]; !exists {
 			mcpServers[skillFeedbackMCPServerName] = codexMCPServer{
 				Command:           "bash",
-				Args:              skillFeedbackMCPArgs(`${PLUGIN_ROOT}`),
+				Args:              codexSkillFeedbackMCPArgs(name, cfg),
 				URL:               "",
 				BearerTokenEnvVar: "",
 				HTTPHeaders:       nil,
@@ -1729,24 +1729,15 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 // published repo — refuse anything that isn't a plain lowercase slug rather
 // than trust the invariant across the DB boundary.
 func emitPluginSkills(files map[string][]byte, subdir string, p PluginInfo) {
-	footer := ""
-	if bundleSkillFeedbackMCP(p) {
-		footer = skillFeedbackFooter
-	}
 	for _, sk := range p.Skills {
 		if !domainskills.ValidSpecName(sk.Name) {
 			continue
 		}
-		files[path.Join(subdir, "skills", sk.Name, "SKILL.md")] = []byte(strings.TrimRight(sk.Content, "\n") + footer + "\n")
+		files[path.Join(subdir, "skills", sk.Name, "SKILL.md")] = []byte(sk.Content)
 	}
 }
 
 const skillFeedbackMCPServerName = "speakeasy-skill-feedback"
-
-// skillFeedbackFooter is appended to every distributed SKILL.md that ships
-// alongside the bundled feedback MCP server. Discovery otherwise depends on
-// the agent noticing the tool in tools/list on its own.
-const skillFeedbackFooter = "\n\nAfter materially relying on this skill, record the outcome with the `skill_feedback` tool (speakeasy-skill-feedback MCP server)."
 
 // bundleSkillFeedbackMCP uses the same name predicate as emitPluginSkills, so
 // feedback is bundled exactly when this feature package carries a skill. A
@@ -1773,13 +1764,29 @@ func bundleSkillFeedbackMCP(p PluginInfo) bool {
 // skillFeedbackMCPArgs builds the argv for the bundled stdio feedback server:
 // the plugin-root bootstrap script downloads the pinned hooks binary and
 // forwards to its skill-feedback subcommand. root is the harness's plugin-root
-// placeholder (e.g. ${CLAUDE_PLUGIN_ROOT}), which the harness substitutes when
-// it spawns the server, so the entry works wherever the plugin is installed.
+// placeholder (${CLAUDE_PLUGIN_ROOT} or ${CURSOR_PLUGIN_ROOT}), which those
+// harnesses substitute in plugin MCP configs when they spawn the server, so
+// the entry works wherever the plugin is installed.
 func skillFeedbackMCPArgs(root string) []string {
+	// The subcommand must precede the flags: the binary dispatches on its
+	// first argument.
 	return []string{
 		root + "/hooks/bootstrap.sh",
-		"--config=" + root + "/speakeasy.json",
 		"skill-feedback",
+		"--config=" + root + "/speakeasy.json",
+	}
+}
+
+// codexSkillFeedbackMCPArgs is the Codex variant: codex-cli does not
+// substitute ${PLUGIN_ROOT} in plugin MCP server configs (verified against
+// 0.145.0), so the entry addresses the deterministic plugin cache path —
+// <codex home>/plugins/cache/<marketplace>/<plugin>/<version> — and lets bash
+// expand the home from the process environment at spawn.
+func codexSkillFeedbackMCPArgs(pluginName string, cfg GenerateConfig) []string {
+	root := "${CODEX_HOME:-$HOME/.codex}/plugins/cache/" + path.Join(resolveMarketplaceName(cfg), pluginName, pluginManifestVersion(cfg))
+	return []string{
+		"-c",
+		fmt.Sprintf(`exec "%s/hooks/bootstrap.sh" skill-feedback "--config=%s/speakeasy.json"`, root, root),
 	}
 }
 

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1916,42 +1916,80 @@ func TestGenerateMCPFilesEmitsDistributedSkills(t *testing.T) {
 	files, err := generateMCPFiles(plugins, cfg)
 	require.NoError(t, err)
 
-	require.Equal(t, []byte(content), files["engineering-tools/skills/release-notes/SKILL.md"])
-	require.Equal(t, []byte(content), files[cursorPluginRoot+"/engineering-tools-cursor/skills/release-notes/SKILL.md"])
-	require.Equal(t, []byte(content), files["engineering-tools-codex/skills/release-notes/SKILL.md"])
+	distributed := strings.TrimRight(content, "\n") + skillFeedbackFooter + "\n"
+	require.Equal(t, []byte(distributed), files["engineering-tools/skills/release-notes/SKILL.md"])
+	require.Equal(t, []byte(distributed), files[cursorPluginRoot+"/engineering-tools-cursor/skills/release-notes/SKILL.md"])
+	require.Equal(t, []byte(distributed), files["engineering-tools-codex/skills/release-notes/SKILL.md"])
 	for p := range files {
 		require.NotContains(t, p, "escape", "invalid skill names must be dropped, not emitted as paths")
 	}
 
-	expectedURL := "https://app.getgram.ai/platform/mcp/skill-feedback"
-	expectedHeaders := map[string]string{
-		"Authorization": "Bearer gram_hooks_feedback",
-		"Gram-Project":  "acme",
-	}
-
 	var claude claudeMCPConfig
 	require.NoError(t, json.Unmarshal(files["engineering-tools/.mcp.json"], &claude))
-	require.Equal(t, claudeMCPServer{Type: "http", URL: expectedURL, Headers: expectedHeaders}, claude.MCPServers[skillFeedbackMCPServerName])
+	require.Equal(t, claudeMCPServer{
+		Type:    "stdio",
+		Command: "bash",
+		Args:    skillFeedbackMCPArgs("${CLAUDE_PLUGIN_ROOT}"),
+		URL:     "",
+		Headers: nil,
+	}, claude.MCPServers[skillFeedbackMCPServerName])
 
 	var cursor cursorMCPConfig
 	require.NoError(t, json.Unmarshal(files[cursorPluginRoot+"/engineering-tools-cursor/mcp.json"], &cursor))
-	require.Equal(t, cursorMCPServer{URL: expectedURL, Headers: expectedHeaders}, cursor.MCPServers[skillFeedbackMCPServerName])
+	require.Equal(t, cursorMCPServer{
+		Command: "bash",
+		Args:    skillFeedbackMCPArgs("${CURSOR_PLUGIN_ROOT}"),
+		URL:     "",
+		Headers: nil,
+	}, cursor.MCPServers[skillFeedbackMCPServerName])
 
 	var codex codexMCPConfig
 	require.NoError(t, json.Unmarshal(files["engineering-tools-codex/.mcp.json"], &codex))
 	require.Equal(t, codexMCPServer{
-		URL:               expectedURL,
+		Command:           "bash",
+		Args:              skillFeedbackMCPArgs("${PLUGIN_ROOT}"),
+		URL:               "",
 		BearerTokenEnvVar: "",
-		HTTPHeaders:       expectedHeaders,
+		HTTPHeaders:       nil,
 		EnvHTTPHeaders:    nil,
 	}, codex.MCPServers[skillFeedbackMCPServerName])
 	feedbackJSON, err := json.Marshal(codex.MCPServers[skillFeedbackMCPServerName])
 	require.NoError(t, err)
+	require.NotContains(t, string(feedbackJSON), "url")
 	require.NotContains(t, string(feedbackJSON), "bearer_token_env_var")
-	require.NotContains(t, string(feedbackJSON), "env_http_headers")
+	require.NotContains(t, string(feedbackJSON), "http_headers")
+
+	// The stdio server rides the plugin-local bootstrap script and deployment
+	// identity, so skill-carrying feature plugins ship both.
+	for _, subdir := range []string{"engineering-tools", cursorPluginRoot + "/engineering-tools-cursor", "engineering-tools-codex"} {
+		require.Contains(t, files, subdir+"/hooks/bootstrap.sh")
+		require.Contains(t, string(files[subdir+"/speakeasy.json"]), "gram_hooks_feedback")
+	}
 }
 
-func TestGenerateMCPFilesOmitsSkillFeedbackWithoutSkillOrKey(t *testing.T) {
+func TestGenerateMCPFilesOmitsSkillFeedbackWithoutSkill(t *testing.T) {
+	t.Parallel()
+	withoutSkill := PluginInfo{
+		Name:   "Engineering Tools",
+		Slug:   "engineering-tools",
+		Skills: []PluginSkillInfo{{Name: "../escape", Content: "invalid"}},
+	}
+	files, err := generateMCPFiles([]PluginInfo{withoutSkill}, GenerateConfig{
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_hooks_feedback",
+		ProjectSlug: "acme",
+	})
+	require.NoError(t, err)
+	for p, content := range files {
+		require.NotContains(t, string(content), skillFeedbackMCPServerName)
+		require.NotContains(t, p, "speakeasy.json", "plugins without skills must not carry the hooks runtime")
+	}
+}
+
+// The ZIP download path generates with no hooks key. The stdio server still
+// ships — the binary falls back to cached or browser-login credentials — so
+// downloaded packages keep the feedback loop.
+func TestGenerateSinglePluginPackageBundlesSkillFeedbackWithoutKey(t *testing.T) {
 	t.Parallel()
 	withSkill := PluginInfo{
 		Name:   "Engineering Tools",
@@ -1964,70 +2002,13 @@ func TestGenerateMCPFilesOmitsSkillFeedbackWithoutSkillOrKey(t *testing.T) {
 			ProjectSlug: "acme",
 		}, platform)
 		require.NoError(t, err)
-		for _, content := range files {
-			require.NotContains(t, string(content), skillFeedbackMCPServerName)
+		mcpPath := ".mcp.json"
+		if platform == "cursor" {
+			mcpPath = "mcp.json"
 		}
-	}
-
-	withoutSkill := withSkill
-	withoutSkill.Skills = []PluginSkillInfo{{Name: "../escape", Content: "invalid"}}
-	files, err := generateMCPFiles([]PluginInfo{withoutSkill}, GenerateConfig{
-		ServerURL:   "https://app.getgram.ai",
-		HooksAPIKey: "gram_hooks_feedback",
-		ProjectSlug: "acme",
-	})
-	require.NoError(t, err)
-	for _, content := range files {
-		require.NotContains(t, string(content), skillFeedbackMCPServerName)
-	}
-}
-
-func TestGenerateSinglePluginPackageOmitsSkillFeedbackForUnsafeServerURLs(t *testing.T) {
-	t.Parallel()
-	plugin := PluginInfo{
-		Name:   "Engineering Tools",
-		Slug:   "engineering-tools",
-		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
-	}
-	for _, serverURL := range []string{
-		"http://example.com",
-		"https:///missing-host",
-		"ftp://localhost",
-	} {
-		files, err := GenerateSinglePluginPackage(plugin, GenerateConfig{
-			ServerURL:   serverURL,
-			HooksAPIKey: "gram_hooks_feedback",
-			ProjectSlug: "acme",
-		}, "claude")
-		require.NoError(t, err)
-
-		var config claudeMCPConfig
-		require.NoError(t, json.Unmarshal(files[".mcp.json"], &config))
-		require.NotContains(t, config.MCPServers, skillFeedbackMCPServerName, serverURL)
-	}
-}
-
-func TestGenerateSinglePluginPackageEmitsSkillFeedbackForLoopbackHTTP(t *testing.T) {
-	t.Parallel()
-	plugin := PluginInfo{
-		Name:   "Engineering Tools",
-		Slug:   "engineering-tools",
-		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
-	}
-	for serverURL, expectedURL := range map[string]string{
-		"http://localhost:8080///": "http://localhost:8080/platform/mcp/skill-feedback",
-		"http://127.0.0.1:8080///": "http://127.0.0.1:8080/platform/mcp/skill-feedback",
-	} {
-		files, err := GenerateSinglePluginPackage(plugin, GenerateConfig{
-			ServerURL:   serverURL,
-			HooksAPIKey: "gram_hooks_feedback",
-			ProjectSlug: "acme",
-		}, "claude")
-		require.NoError(t, err)
-
-		var config claudeMCPConfig
-		require.NoError(t, json.Unmarshal(files[".mcp.json"], &config))
-		require.Equal(t, expectedURL, config.MCPServers[skillFeedbackMCPServerName].URL)
+		require.Contains(t, string(files[mcpPath]), skillFeedbackMCPServerName, platform)
+		require.Contains(t, files, "hooks/bootstrap.sh", platform)
+		require.Contains(t, files, "speakeasy.json", platform)
 	}
 }
 

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1916,10 +1916,9 @@ func TestGenerateMCPFilesEmitsDistributedSkills(t *testing.T) {
 	files, err := generateMCPFiles(plugins, cfg)
 	require.NoError(t, err)
 
-	distributed := strings.TrimRight(content, "\n") + skillFeedbackFooter + "\n"
-	require.Equal(t, []byte(distributed), files["engineering-tools/skills/release-notes/SKILL.md"])
-	require.Equal(t, []byte(distributed), files[cursorPluginRoot+"/engineering-tools-cursor/skills/release-notes/SKILL.md"])
-	require.Equal(t, []byte(distributed), files["engineering-tools-codex/skills/release-notes/SKILL.md"])
+	require.Equal(t, []byte(content), files["engineering-tools/skills/release-notes/SKILL.md"])
+	require.Equal(t, []byte(content), files[cursorPluginRoot+"/engineering-tools-cursor/skills/release-notes/SKILL.md"])
+	require.Equal(t, []byte(content), files["engineering-tools-codex/skills/release-notes/SKILL.md"])
 	for p := range files {
 		require.NotContains(t, p, "escape", "invalid skill names must be dropped, not emitted as paths")
 	}
@@ -1947,12 +1946,13 @@ func TestGenerateMCPFilesEmitsDistributedSkills(t *testing.T) {
 	require.NoError(t, json.Unmarshal(files["engineering-tools-codex/.mcp.json"], &codex))
 	require.Equal(t, codexMCPServer{
 		Command:           "bash",
-		Args:              skillFeedbackMCPArgs("${PLUGIN_ROOT}"),
+		Args:              codexSkillFeedbackMCPArgs("engineering-tools-codex", cfg),
 		URL:               "",
 		BearerTokenEnvVar: "",
 		HTTPHeaders:       nil,
 		EnvHTTPHeaders:    nil,
 	}, codex.MCPServers[skillFeedbackMCPServerName])
+	require.Contains(t, codex.MCPServers[skillFeedbackMCPServerName].Args[1], "${CODEX_HOME:-$HOME/.codex}/plugins/cache/")
 	feedbackJSON, err := json.Marshal(codex.MCPServers[skillFeedbackMCPServerName])
 	require.NoError(t, err)
 	require.NotContains(t, string(feedbackJSON), "url")

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1837,10 +1837,12 @@ func TestMCPFingerprintsIsStableAcrossCalls(t *testing.T) {
 func TestMCPFingerprintsIgnoresPerPublishFields(t *testing.T) {
 	t.Parallel()
 	plugins := fingerprintTestPlugins()
+	plugins[0].Skills = []PluginSkillInfo{{Name: "release-notes", Content: "v1"}}
 
 	base, err := MCPFingerprints(plugins, GenerateConfig{
-		OrgName:   "Acme Corp",
-		ServerURL: "https://app.getgram.ai",
+		OrgName:     "Acme Corp",
+		ServerURL:   "https://app.getgram.ai",
+		ProjectSlug: "acme",
 	})
 	require.NoError(t, err)
 
@@ -1849,6 +1851,7 @@ func TestMCPFingerprintsIgnoresPerPublishFields(t *testing.T) {
 	withNoise, err := MCPFingerprints(plugins, GenerateConfig{
 		OrgName:     "Acme Corp",
 		ServerURL:   "https://app.getgram.ai",
+		ProjectSlug: "acme",
 		Version:     "1750000000",
 		APIKey:      "gram_live_realkey",
 		HooksAPIKey: "gram_live_realhookskey",
@@ -1889,7 +1892,12 @@ func TestMCPFingerprintsIsolatesChangePerPlugin(t *testing.T) {
 
 func TestGenerateMCPFilesEmitsDistributedSkills(t *testing.T) {
 	t.Parallel()
-	cfg := GenerateConfig{OrgName: "Acme Corp", ServerURL: "https://app.getgram.ai"}
+	cfg := GenerateConfig{
+		OrgName:     "Acme Corp",
+		ServerURL:   "https://app.getgram.ai///",
+		HooksAPIKey: "gram_hooks_feedback",
+		ProjectSlug: "acme",
+	}
 	content := "---\nname: release-notes\ndescription: d\n---\n\nbody\n"
 	plugins := []PluginInfo{{
 		Name:        "Engineering Tools",
@@ -1914,6 +1922,99 @@ func TestGenerateMCPFilesEmitsDistributedSkills(t *testing.T) {
 	for p := range files {
 		require.NotContains(t, p, "escape", "invalid skill names must be dropped, not emitted as paths")
 	}
+
+	expectedURL := "https://app.getgram.ai/platform/mcp/skill-feedback"
+	expectedHeaders := map[string]string{
+		"Authorization": "Bearer gram_hooks_feedback",
+		"Gram-Project":  "acme",
+	}
+
+	var claude claudeMCPConfig
+	require.NoError(t, json.Unmarshal(files["engineering-tools/.mcp.json"], &claude))
+	require.Equal(t, claudeMCPServer{Type: "http", URL: expectedURL, Headers: expectedHeaders}, claude.MCPServers[skillFeedbackMCPServerName])
+
+	var cursor cursorMCPConfig
+	require.NoError(t, json.Unmarshal(files[cursorPluginRoot+"/engineering-tools-cursor/mcp.json"], &cursor))
+	require.Equal(t, cursorMCPServer{URL: expectedURL, Headers: expectedHeaders}, cursor.MCPServers[skillFeedbackMCPServerName])
+
+	var codex codexMCPConfig
+	require.NoError(t, json.Unmarshal(files["engineering-tools-codex/.mcp.json"], &codex))
+	require.Equal(t, codexMCPServer{
+		URL:               expectedURL,
+		BearerTokenEnvVar: "",
+		HTTPHeaders:       expectedHeaders,
+		EnvHTTPHeaders:    nil,
+	}, codex.MCPServers[skillFeedbackMCPServerName])
+	feedbackJSON, err := json.Marshal(codex.MCPServers[skillFeedbackMCPServerName])
+	require.NoError(t, err)
+	require.NotContains(t, string(feedbackJSON), "bearer_token_env_var")
+	require.NotContains(t, string(feedbackJSON), "env_http_headers")
+}
+
+func TestGenerateMCPFilesOmitsSkillFeedbackWithoutSkillOrKey(t *testing.T) {
+	t.Parallel()
+	withSkill := PluginInfo{
+		Name:   "Engineering Tools",
+		Slug:   "engineering-tools",
+		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
+	}
+	for _, platform := range []string{"claude", "cursor", "codex"} {
+		files, err := GenerateSinglePluginPackage(withSkill, GenerateConfig{
+			ServerURL:   "https://app.getgram.ai",
+			ProjectSlug: "acme",
+		}, platform)
+		require.NoError(t, err)
+		for _, content := range files {
+			require.NotContains(t, string(content), skillFeedbackMCPServerName)
+		}
+	}
+
+	withoutSkill := withSkill
+	withoutSkill.Skills = []PluginSkillInfo{{Name: "../escape", Content: "invalid"}}
+	files, err := generateMCPFiles([]PluginInfo{withoutSkill}, GenerateConfig{
+		ServerURL:   "https://app.getgram.ai",
+		HooksAPIKey: "gram_hooks_feedback",
+		ProjectSlug: "acme",
+	})
+	require.NoError(t, err)
+	for _, content := range files {
+		require.NotContains(t, string(content), skillFeedbackMCPServerName)
+	}
+}
+
+func TestGenerateMCPFilesPreservesSkillFeedbackServerCollision(t *testing.T) {
+	t.Parallel()
+	plugin := PluginInfo{
+		Name: "Engineering Tools",
+		Slug: "engineering-tools",
+		Servers: []PluginServerInfo{{
+			DisplayName: skillFeedbackMCPServerName,
+			MCPURL:      "https://user.example.com/mcp",
+		}},
+		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
+	}
+	files, err := generateMCPFiles([]PluginInfo{plugin}, GenerateConfig{
+		ServerURL:   "https://app.getgram.ai",
+		APIKey:      "gram_consumer_key",
+		HooksAPIKey: "gram_hooks_feedback",
+		ProjectSlug: "acme",
+	})
+	require.NoError(t, err)
+
+	var claude claudeMCPConfig
+	require.NoError(t, json.Unmarshal(files["engineering-tools/.mcp.json"], &claude))
+	require.Equal(t, "https://user.example.com/mcp", claude.MCPServers[skillFeedbackMCPServerName].URL)
+	require.Equal(t, "Bearer gram_consumer_key", claude.MCPServers[skillFeedbackMCPServerName].Headers["Authorization"])
+
+	var cursor cursorMCPConfig
+	require.NoError(t, json.Unmarshal(files[cursorPluginRoot+"/engineering-tools-cursor/mcp.json"], &cursor))
+	require.Equal(t, "https://user.example.com/mcp", cursor.MCPServers[skillFeedbackMCPServerName].URL)
+	require.Equal(t, "Bearer gram_consumer_key", cursor.MCPServers[skillFeedbackMCPServerName].Headers["Authorization"])
+
+	var codex codexMCPConfig
+	require.NoError(t, json.Unmarshal(files["engineering-tools-codex/.mcp.json"], &codex))
+	require.Equal(t, "https://user.example.com/mcp", codex.MCPServers[skillFeedbackMCPServerName].URL)
+	require.Equal(t, "Bearer gram_consumer_key", codex.MCPServers[skillFeedbackMCPServerName].HTTPHeaders["Authorization"])
 }
 
 // Distributing a skill (or changing its resolved content) must move the

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1982,6 +1982,55 @@ func TestGenerateMCPFilesOmitsSkillFeedbackWithoutSkillOrKey(t *testing.T) {
 	}
 }
 
+func TestGenerateSinglePluginPackageOmitsSkillFeedbackForUnsafeServerURLs(t *testing.T) {
+	t.Parallel()
+	plugin := PluginInfo{
+		Name:   "Engineering Tools",
+		Slug:   "engineering-tools",
+		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
+	}
+	for _, serverURL := range []string{
+		"http://example.com",
+		"https:///missing-host",
+		"ftp://localhost",
+	} {
+		files, err := GenerateSinglePluginPackage(plugin, GenerateConfig{
+			ServerURL:   serverURL,
+			HooksAPIKey: "gram_hooks_feedback",
+			ProjectSlug: "acme",
+		}, "claude")
+		require.NoError(t, err)
+
+		var config claudeMCPConfig
+		require.NoError(t, json.Unmarshal(files[".mcp.json"], &config))
+		require.NotContains(t, config.MCPServers, skillFeedbackMCPServerName, serverURL)
+	}
+}
+
+func TestGenerateSinglePluginPackageEmitsSkillFeedbackForLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+	plugin := PluginInfo{
+		Name:   "Engineering Tools",
+		Slug:   "engineering-tools",
+		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
+	}
+	for serverURL, expectedURL := range map[string]string{
+		"http://localhost:8080///": "http://localhost:8080/platform/mcp/skill-feedback",
+		"http://127.0.0.1:8080///": "http://127.0.0.1:8080/platform/mcp/skill-feedback",
+	} {
+		files, err := GenerateSinglePluginPackage(plugin, GenerateConfig{
+			ServerURL:   serverURL,
+			HooksAPIKey: "gram_hooks_feedback",
+			ProjectSlug: "acme",
+		}, "claude")
+		require.NoError(t, err)
+
+		var config claudeMCPConfig
+		require.NoError(t, json.Unmarshal(files[".mcp.json"], &config))
+		require.Equal(t, expectedURL, config.MCPServers[skillFeedbackMCPServerName].URL)
+	}
+}
+
 func TestGenerateMCPFilesPreservesSkillFeedbackServerCollision(t *testing.T) {
 	t.Parallel()
 	plugin := PluginInfo{
@@ -2015,6 +2064,30 @@ func TestGenerateMCPFilesPreservesSkillFeedbackServerCollision(t *testing.T) {
 	require.NoError(t, json.Unmarshal(files["engineering-tools-codex/.mcp.json"], &codex))
 	require.Equal(t, "https://user.example.com/mcp", codex.MCPServers[skillFeedbackMCPServerName].URL)
 	require.Equal(t, "Bearer gram_consumer_key", codex.MCPServers[skillFeedbackMCPServerName].HTTPHeaders["Authorization"])
+}
+
+func TestGenerateCodexPluginPreservesNormalizedSkillFeedbackServerCollision(t *testing.T) {
+	t.Parallel()
+	plugin := PluginInfo{
+		Name: "Engineering Tools",
+		Slug: "engineering-tools",
+		Servers: []PluginServerInfo{{
+			DisplayName: "!" + skillFeedbackMCPServerName,
+			MCPURL:      "https://user.example.com/mcp",
+		}},
+		Skills: []PluginSkillInfo{{Name: "release-notes", Content: "v1"}},
+	}
+	files, err := GenerateSinglePluginPackage(plugin, GenerateConfig{
+		ServerURL:   "https://app.getgram.ai",
+		APIKey:      "gram_consumer_key",
+		HooksAPIKey: "gram_hooks_feedback",
+		ProjectSlug: "acme",
+	}, "codex")
+	require.NoError(t, err)
+
+	var config codexMCPConfig
+	require.NoError(t, json.Unmarshal(files[".mcp.json"], &config))
+	require.Equal(t, "https://user.example.com/mcp", config.MCPServers[skillFeedbackMCPServerName].URL)
 }
 
 // Distributing a skill (or changing its resolved content) must move the

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1922,11 +1922,10 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 	}
 	firstPublish := errors.Is(connErr, pgx.ErrNoRows)
 
-	// Decide which components to (re)generate. The hooks subtree changes only on
-	// a hooksGeneratorVersion bump, so an MCP publish never touches it. A human
-	// publish (SkipIfUnchanged == false) always refreshes MCP so installed copies
-	// pick up a new manifest version, but still leaves hooks alone unless its
-	// version bumped.
+	// Decide which components to (re)generate. A human publish
+	// (SkipIfUnchanged == false) always refreshes MCP so installed copies pick up
+	// a new manifest version. Hooks change independently based on their version
+	// and output-affecting config.
 	mcpChanged := firstPublish || !input.SkipIfUnchanged ||
 		!maps.Equal(mcpFingerprints, decodeMCPFingerprints(existing.PublishedMcpFingerprints))
 
@@ -2019,6 +2018,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 
 	files := make(map[string][]byte)
 	var candidates []pluginAPIKeyCandidate
+	var hooksCandidate *pluginAPIKeyCandidate
 
 	// MCP component: carry when unchanged, otherwise regenerate with a fresh key.
 	carriedMCP := false
@@ -2035,6 +2035,15 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 			return nil, oops.E(oops.CodeUnexpected, err, "build plugin mcp api key").LogError(ctx, s.logger)
 		}
 		cfg.APIKey = mcpCandidate.fullKey
+		if needsSkillFeedbackMCPKey(pluginInfos, cfg) {
+			candidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks")
+			if err != nil {
+				return nil, oops.E(oops.CodeUnexpected, err, "build plugin hooks api key").LogError(ctx, s.logger)
+			}
+			hooksCandidate = &candidate
+			cfg.HooksAPIKey = candidate.fullKey
+			candidates = append(candidates, candidate)
+		}
 		mcpFiles, err := generateMCPFiles(pluginInfos, cfg)
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "generate mcp files").LogError(ctx, s.logger)
@@ -2055,9 +2064,13 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 		carriedHooksOrgName, carriedHooks = carryHooksSubtree(files, existingFiles, targetHooksConfigJSON, cfg.OrgName)
 	}
 	if !carriedHooks {
-		hooksCandidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks")
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "build plugin hooks api key").LogError(ctx, s.logger)
+		if hooksCandidate == nil {
+			candidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks")
+			if err != nil {
+				return nil, oops.E(oops.CodeUnexpected, err, "build plugin hooks api key").LogError(ctx, s.logger)
+			}
+			hooksCandidate = &candidate
+			candidates = append(candidates, candidate)
 		}
 		cfg.HooksAPIKey = hooksCandidate.fullKey
 		hooksFiles, err := generateHooksFiles(cfg)
@@ -2065,7 +2078,6 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 			return nil, oops.E(oops.CodeUnexpected, err, "generate hooks files").LogError(ctx, s.logger)
 		}
 		maps.Copy(files, hooksFiles)
-		candidates = append(candidates, hooksCandidate)
 		// What lands in the repo is the CURRENT generator's output; persist that
 		// truthfully even when the rollout gate had pinned an older published
 		// version — recording the stale version would make every subsequent

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -2035,7 +2035,7 @@ func (s *Service) publishProject(ctx context.Context, input publishProjectInput)
 			return nil, oops.E(oops.CodeUnexpected, err, "build plugin mcp api key").LogError(ctx, s.logger)
 		}
 		cfg.APIKey = mcpCandidate.fullKey
-		if needsSkillFeedbackMCPKey(pluginInfos, cfg) {
+		if needsSkillFeedbackHooksKey(pluginInfos) {
 			candidate, err := s.buildPluginAPIKeyCandidate(auth.APIKeyScopeHooks, "hooks")
 			if err != nil {
 				return nil, oops.E(oops.CodeUnexpected, err, "build plugin hooks api key").LogError(ctx, s.logger)

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -85,17 +85,17 @@ func distributeTestSkill(t *testing.T, ctx context.Context, ti *testInstance, pl
 	require.NoError(t, err)
 }
 
-func skillFeedbackAuthorization(t *testing.T, files map[string][]byte, configPath string) string {
+// skillFeedbackHooksKey reads the hooks key from a feature plugin's bundled
+// speakeasy.json — the deployment identity the stdio feedback server runs with.
+func skillFeedbackHooksKey(t *testing.T, files map[string][]byte, configPath string) string {
 	t.Helper()
+	require.Contains(t, files, configPath)
 	var config struct {
-		MCPServers map[string]struct {
-			Headers map[string]string `json:"headers"`
-		} `json:"mcpServers"`
+		HooksAPIKey string `json:"hooks_api_key"`
 	}
 	require.NoError(t, json.Unmarshal(files[configPath], &config))
-	server, ok := config.MCPServers["speakeasy-skill-feedback"]
-	require.True(t, ok)
-	return server.Headers["Authorization"]
+	require.NotEmpty(t, config.HooksAPIKey)
+	return config.HooksAPIKey
 }
 
 func (m *mockGitHubPublisher) CreateRepo(_ context.Context, _ int64, _, _ string, _ bool) error {
@@ -1189,16 +1189,18 @@ func TestPluginsService_PublishPlugins_CreatesAPIKeyWithCorrectScope(t *testing.
 	require.Contains(t, string(mcpJSON), "gram_local_")
 	require.NotContains(t, string(mcpJSON), "user_config")
 
-	feedbackAuthorization := skillFeedbackAuthorization(t, mock.lastPushedFiles, "key-test/.mcp.json")
-	require.Contains(t, feedbackAuthorization, hooksKey.KeyPrefix)
-	require.NotContains(t, feedbackAuthorization, mcpKey.KeyPrefix)
+	feedbackKey := skillFeedbackHooksKey(t, mock.lastPushedFiles, "key-test/speakeasy.json")
+	require.Contains(t, feedbackKey, hooksKey.KeyPrefix)
+	require.NotContains(t, feedbackKey, mcpKey.KeyPrefix)
+	require.Contains(t, string(mcpJSON), "hooks/bootstrap.sh")
+	require.NotContains(t, string(mcpJSON), hooksKey.KeyPrefix, "the hooks key must not leak into the MCP config")
 
 	claudeObservability, _ := orgObservabilitySlugs(t, ctx, ti)
 	var hooksConfig struct {
 		HooksAPIKey string `json:"hooks_api_key"`
 	}
 	require.NoError(t, json.Unmarshal(mock.lastPushedFiles[claudeObservability+"/speakeasy.json"], &hooksConfig))
-	require.Equal(t, "Bearer "+hooksConfig.HooksAPIKey, feedbackAuthorization, "MCP and hooks generation must reuse one hooks key")
+	require.Equal(t, hooksConfig.HooksAPIKey, feedbackKey, "MCP and hooks generation must reuse one hooks key")
 }
 
 func TestPluginsService_PublishPlugins_RePublishCreatesAdditionalKey(t *testing.T) {
@@ -2062,7 +2064,7 @@ func TestPluginsService_PublishProject_MCPChangeCarriesHooksVerbatim(t *testing.
 
 	hooksBefore := hooksFilesOf(mock.lastPushedFiles)
 	require.NotEmpty(t, hooksBefore, "first publish must emit hooks files")
-	feedbackAuthorizationBefore := skillFeedbackAuthorization(t, mock.lastPushedFiles, "carry-hooks/.mcp.json")
+	feedbackKeyBefore := skillFeedbackHooksKey(t, mock.lastPushedFiles, "carry-hooks/speakeasy.json")
 	orgID := publishOrgID(t, ctx, ti.conn, *authCtx.ProjectID)
 	hooksKeysBefore := countPluginHooksKeys(t, ctx, ti.conn, orgID)
 
@@ -2085,7 +2087,7 @@ func TestPluginsService_PublishProject_MCPChangeCarriesHooksVerbatim(t *testing.
 	hooksAfter := hooksFilesOf(mock.lastPushedFiles)
 	require.Equal(t, hooksBefore, hooksAfter, "hooks subtree must be carried verbatim across an MCP-only publish")
 	require.Equal(t, hooksKeysBefore+1, countPluginHooksKeys(t, ctx, ti.conn, orgID), "MCP regeneration with distributed skills mints one new hooks key")
-	require.NotEqual(t, feedbackAuthorizationBefore, skillFeedbackAuthorization(t, mock.lastPushedFiles, "carry-hooks/.mcp.json"), "regenerated MCP must use its fresh hooks key")
+	require.NotEqual(t, feedbackKeyBefore, skillFeedbackHooksKey(t, mock.lastPushedFiles, "carry-hooks/speakeasy.json"), "regenerated MCP must use its fresh hooks key")
 }
 
 // phasedRolloutFixture creates a published project and rewinds its stored hooks

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	productfeaturesrepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	skillsrepo "github.com/speakeasy-api/gram/server/internal/skills/repo"
 	ghclient "github.com/speakeasy-api/gram/server/internal/thirdparty/github"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
@@ -44,6 +45,57 @@ type mockGitHubPublisher struct {
 	createRepoErr   error
 	pushFilesErr    error
 	getRepoFilesErr error
+}
+
+func distributeTestSkill(t *testing.T, ctx context.Context, ti *testInstance, pluginID, name string) {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	skills := skillsrepo.New(ti.conn)
+	skill, err := skills.CreateSkill(ctx, skillsrepo.CreateSkillParams{
+		ProjectID:   *authCtx.ProjectID,
+		Name:        name,
+		DisplayName: name,
+		Summary:     pgtype.Text{},
+	})
+	require.NoError(t, err)
+	_, err = skills.CreateSkillVersion(ctx, skillsrepo.CreateSkillVersionParams{
+		Content:          "---\nname: " + name + "\ndescription: d\n---\n\nbody\n",
+		CanonicalSha256:  uuid.NewString(),
+		RawSha256:        uuid.NewString(),
+		Description:      pgtype.Text{},
+		Metadata:         []byte(`{}`),
+		SpecValid:        true,
+		ValidationErrors: []byte(`[]`),
+		CreatedByUserID:  authCtx.UserID,
+		ProjectID:        *authCtx.ProjectID,
+		SkillID:          skill.ID,
+	})
+	require.NoError(t, err)
+	_, err = skills.CreateSkillDistribution(ctx, skillsrepo.CreateSkillDistributionParams{
+		PluginID:        uuid.NullUUID{UUID: uuid.MustParse(pluginID), Valid: true},
+		AssistantID:     uuid.NullUUID{},
+		PinnedVersionID: uuid.NullUUID{},
+		Channel:         "plugin",
+		CreatedByUserID: authCtx.UserID,
+		ProjectID:       *authCtx.ProjectID,
+		SkillID:         skill.ID,
+	})
+	require.NoError(t, err)
+}
+
+func skillFeedbackAuthorization(t *testing.T, files map[string][]byte, configPath string) string {
+	t.Helper()
+	var config struct {
+		MCPServers map[string]struct {
+			Headers map[string]string `json:"headers"`
+		} `json:"mcpServers"`
+	}
+	require.NoError(t, json.Unmarshal(files[configPath], &config))
+	server, ok := config.MCPServers["speakeasy-skill-feedback"]
+	require.True(t, ok)
+	return server.Headers["Authorization"]
 }
 
 func (m *mockGitHubPublisher) CreateRepo(_ context.Context, _ int64, _, _ string, _ bool) error {
@@ -878,6 +930,7 @@ func TestPluginsService_PublishPlugins_ReclaimsStaleConnectionFromDeletedProject
 		SortOrder:   0,
 	})
 	require.NoError(t, err)
+
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
 
@@ -1026,7 +1079,6 @@ func TestPluginsService_PublishPlugins_McpServerBacked(t *testing.T) {
 		SortOrder:   0,
 	})
 	require.NoError(t, err)
-
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
 
@@ -1099,6 +1151,7 @@ func TestPluginsService_PublishPlugins_CreatesAPIKeyWithCorrectScope(t *testing.
 		SortOrder:   0,
 	})
 	require.NoError(t, err)
+	distributeTestSkill(t, ctx, ti, plugin.ID, "key-test-skill")
 
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
@@ -1109,14 +1162,19 @@ func TestPluginsService_PublishPlugins_CreatesAPIKeyWithCorrectScope(t *testing.
 	require.NoError(t, err)
 
 	var mcpKey, hooksKey *keysrepo.ApiKey
+	var mcpKeyCount, hooksKeyCount int
 	for i := range keys {
 		switch {
 		case strings.HasPrefix(keys[i].Name, "plugins-mcp-"):
 			mcpKey = &keys[i]
+			mcpKeyCount++
 		case strings.HasPrefix(keys[i].Name, "plugins-hooks-"):
 			hooksKey = &keys[i]
+			hooksKeyCount++
 		}
 	}
+	require.Equal(t, 1, mcpKeyCount)
+	require.Equal(t, 1, hooksKeyCount, "MCP and hooks generation must share one hooks candidate")
 	require.NotNil(t, mcpKey, "expected a plugins-mcp-* API key")
 	require.Contains(t, mcpKey.Scopes, "consumer")
 	require.True(t, strings.HasPrefix(mcpKey.KeyPrefix, "gram_local_"))
@@ -1130,6 +1188,17 @@ func TestPluginsService_PublishPlugins_CreatesAPIKeyWithCorrectScope(t *testing.
 	require.NotNil(t, mcpJSON)
 	require.Contains(t, string(mcpJSON), "gram_local_")
 	require.NotContains(t, string(mcpJSON), "user_config")
+
+	feedbackAuthorization := skillFeedbackAuthorization(t, mock.lastPushedFiles, "key-test/.mcp.json")
+	require.Contains(t, feedbackAuthorization, hooksKey.KeyPrefix)
+	require.NotContains(t, feedbackAuthorization, mcpKey.KeyPrefix)
+
+	claudeObservability, _ := orgObservabilitySlugs(t, ctx, ti)
+	var hooksConfig struct {
+		HooksAPIKey string `json:"hooks_api_key"`
+	}
+	require.NoError(t, json.Unmarshal(mock.lastPushedFiles[claudeObservability+"/speakeasy.json"], &hooksConfig))
+	require.Equal(t, "Bearer "+hooksConfig.HooksAPIKey, feedbackAuthorization, "MCP and hooks generation must reuse one hooks key")
 }
 
 func TestPluginsService_PublishPlugins_RePublishCreatesAdditionalKey(t *testing.T) {
@@ -1206,6 +1275,7 @@ func TestPluginsService_PublishPlugins_NoOrphanedKeyOnGitHubFailure(t *testing.T
 		SortOrder:   0,
 	})
 	require.NoError(t, err)
+	distributeTestSkill(t, ctx, ti, plugin.ID, "failed-publish-skill")
 
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.Error(t, err, "publish must fail when GitHub does")
@@ -1977,6 +2047,7 @@ func TestPluginsService_PublishProject_MCPChangeCarriesHooksVerbatim(t *testing.
 		SortOrder:   0,
 	})
 	require.NoError(t, err)
+	distributeTestSkill(t, ctx, ti, plugin.ID, "carry-hooks-skill")
 
 	input := plugins.PublishProjectInput{
 		ProjectID:       *authCtx.ProjectID,
@@ -1991,6 +2062,9 @@ func TestPluginsService_PublishProject_MCPChangeCarriesHooksVerbatim(t *testing.
 
 	hooksBefore := hooksFilesOf(mock.lastPushedFiles)
 	require.NotEmpty(t, hooksBefore, "first publish must emit hooks files")
+	feedbackAuthorizationBefore := skillFeedbackAuthorization(t, mock.lastPushedFiles, "carry-hooks/.mcp.json")
+	orgID := publishOrgID(t, ctx, ti.conn, *authCtx.ProjectID)
+	hooksKeysBefore := countPluginHooksKeys(t, ctx, ti.conn, orgID)
 
 	// Change the plugin set — an MCP-only change; hooksGeneratorVersion is untouched.
 	toolset2 := createTestToolset(t, ctx, ti.conn, "carry-toolset-2")
@@ -2010,6 +2084,8 @@ func TestPluginsService_PublishProject_MCPChangeCarriesHooksVerbatim(t *testing.
 
 	hooksAfter := hooksFilesOf(mock.lastPushedFiles)
 	require.Equal(t, hooksBefore, hooksAfter, "hooks subtree must be carried verbatim across an MCP-only publish")
+	require.Equal(t, hooksKeysBefore+1, countPluginHooksKeys(t, ctx, ti.conn, orgID), "MCP regeneration with distributed skills mints one new hooks key")
+	require.NotEqual(t, feedbackAuthorizationBefore, skillFeedbackAuthorization(t, mock.lastPushedFiles, "carry-hooks/.mcp.json"), "regenerated MCP must use its fresh hooks key")
 }
 
 // phasedRolloutFixture creates a published project and rewinds its stored hooks


### PR DESCRIPTION
## Summary
- bundle the generated skill feedback MCP server into Claude, Cursor, and Codex packages that distribute skills
- authenticate feedback with hooks-scoped generated keys while reusing one candidate when MCP and hooks regenerate together
- preserve user server collisions, direct-download behavior, and independent hooks rollout semantics
- bump the MCP generator version for automatic republishing

## Upstream Codex limitation

Codex does not substitute `${PLUGIN_ROOT}` (or any env) in plugin MCP server `command`/`args` config, so the Codex entry targets the deterministic plugin cache path instead of the placeholder the other harnesses use. Reported upstream: openai/codex#35762 — if that lands, the Codex variant can collapse into the shared plugin-root form.

## Stack
- depends on #4561

Linear: DNO-571

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundles the `speakeasy-skill-feedback` stdio MCP server into generated Claude, Cursor, and Codex plugin packages that ship at least one valid skill. It runs `speakeasy-hooks skill-feedback` via each plugin’s bootstrap and shared hooks credential chain; fulfills Linear DNO-571 and bumps the MCP generator to v10.

- New Features
  - Adds a `speakeasy-skill-feedback` MCP entry to `.mcp.json`/`mcp.json` that runs `bash` with `hooks/bootstrap.sh skill-feedback --config=<plugin>/speakeasy.json`; bundles `hooks/bootstrap.sh` and `speakeasy.json` with a hooks-scoped key on publish; ZIP builds still include the server without a key.
  - Emits only when the package contains a valid skill; preserves user collisions by never overwriting an existing `speakeasy-skill-feedback` entry (Codex key normalization included) and requires HTTPS if a user-provided server URL uses the reserved name.
  - Claude/Cursor use stdio with plugin-root placeholders; Codex targets a deterministic plugin cache path and fixes argv ordering (subcommand before flags). The stdio server validates input, enforces a ~15s timeout, and sets initialize-time instructions to nudge outcome recording.
  - Fingerprints normalize the hooks key and set the MCP generator to `10`; the publish flow mints one hooks-scoped key when bundling feedback and reuses it if hooks also regenerate, while MCP-only publishes carry the hooks subtree unchanged and refresh the plugin-local `speakeasy.json` with a new hooks key.

<sup>Written for commit 610f32668b6c873bcc7aa0a0e17ce214eacf263d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

