### PR TITLE
mig(skills): index suggestion analysis

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -287,6 +287,7 @@ CREATE TABLE IF NOT EXISTS skills (
 CREATE INDEX IF NOT EXISTS skills_project_id_idx ON skills (project_id);
 CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_id_key ON skills (project_id, id);
 CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_name_key ON skills (project_id, name) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS skills_suggestion_sweep_idx ON skills (project_id, last_seen_at DESC, id DESC) WHERE archived_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS skill_versions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
@@ -652,6 +653,10 @@ WHERE reserved_on IS NOT NULL;
 CREATE INDEX IF NOT EXISTS skill_efficacy_evaluations_stale_reserved_idx
 ON skill_efficacy_evaluations (project_id, updated_at, id)
 WHERE state = 'reserved';
+
+CREATE INDEX IF NOT EXISTS skill_efficacy_evaluations_suggestion_scored_idx
+ON skill_efficacy_evaluations (project_id, skill_id, skill_version_id, scored_at DESC, id DESC)
+WHERE state = 'scored';
 
 CREATE TABLE IF NOT EXISTS packages (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260728192204_dno_572_suggestion_analysis_indexes.sql
+++ b/server/migrations/20260728192204_dno_572_suggestion_analysis_indexes.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Create index "skill_efficacy_evaluations_suggestion_scored_idx" to table: "skill_efficacy_evaluations"
+CREATE INDEX CONCURRENTLY "skill_efficacy_evaluations_suggestion_scored_idx" ON "skill_efficacy_evaluations" ("project_id", "skill_id", "skill_version_id", "scored_at" DESC, "id" DESC) WHERE (state = 'scored'::text);
+-- Create index "skills_suggestion_sweep_idx" to table: "skills"
+CREATE INDEX CONCURRENTLY "skills_suggestion_sweep_idx" ON "skills" ("project_id", "last_seen_at" DESC, "id" DESC) WHERE (archived_at IS NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:nK6CZpT6lanjmh8+rQULRMisESTsBmVTTCoyZhHfaiI=
+h1:j795Lg1oCvJYoom5JA87340v9+cAW3se/yTxEYTSIPU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -303,3 +303,4 @@ h1:nK6CZpT6lanjmh8+rQULRMisESTsBmVTTCoyZhHfaiI=
 20260727233742_chat-content-parts.sql h1:Z0oj3IaXFhP+YUZziMHME4AnKQgdBEkRvquoCORjBU4=
 20260728103328_dno_569_skill_feedback_schema.sql h1:TdiYFG8KGdlKTU+gjI711O9BRh3iO44xAkkyD/X9JtY=
 20260728180048_shadow-mcp-policy-gates.sql h1:H1/CKCAzAPKMfNb8kYnWaGseH4/DN8kIyhYazDYuiC8=
+20260728192204_dno_572_suggestion_analysis_indexes.sql h1:o9BPYFE+ys9Plt7G+5qHdq+bsizeDOOgfycxaU75Fuw=


### PR DESCRIPTION
## Summary
- index active-skill sweep pagination by project and last-seen time
- index scored efficacy evidence reads by project, skill, version, and score time
- create both indexes concurrently before the DNO-572 analyzer rollout

## Stack
- depends on #4562
- prerequisite for #4563

Linear: DNO-572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two DB indexes to support the per-skill suggestion analyzer (Linear DNO-572). Speeds up sweep pagination and scored-evidence reads; shipped via CONCURRENTLY migration and mirrored in schema.sql.

- **Migration**
  - Create skills_suggestion_sweep_idx on skills (project_id, last_seen_at DESC, id DESC) where archived_at IS NULL.
  - Create skill_efficacy_evaluations_suggestion_scored_idx on skill_efficacy_evaluations (project_id, skill_id, skill_version_id, scored_at DESC, id DESC) where state = 'scored'.

<sup>Written for commit b12a3340ab9c232bb3590373ddb84dc6de536991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

