### PR TITLE
mig(skills): index open skill suggestion list

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -406,6 +406,10 @@ ON skill_edit_suggestions (project_id, id);
 CREATE INDEX IF NOT EXISTS skill_edit_suggestions_project_id_skill_id_created_at_idx
 ON skill_edit_suggestions (project_id, skill_id, created_at DESC);
 
+CREATE INDEX IF NOT EXISTS skill_edit_suggestions_project_id_created_at_id_open_idx
+ON skill_edit_suggestions (project_id, created_at DESC, id DESC)
+WHERE status = 'open';
+
 -- Evidence linking each suggestion to the feedback rows it was generated from.
 CREATE TABLE IF NOT EXISTS skill_edit_suggestion_changes (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/migrations/20260728192241_dno_573_suggestion_list_index.sql
+++ b/server/migrations/20260728192241_dno_573_suggestion_list_index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "skill_edit_suggestions_project_id_created_at_id_open_idx" to table: "skill_edit_suggestions"
+CREATE INDEX CONCURRENTLY "skill_edit_suggestions_project_id_created_at_id_open_idx" ON "skill_edit_suggestions" ("project_id", "created_at" DESC, "id" DESC) WHERE (status = 'open'::text);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:j795Lg1oCvJYoom5JA87340v9+cAW3se/yTxEYTSIPU=
+h1:t1ICEHW0ov8iHj5KSG9RuABTPK7e1VmE17qEQHnJs/0=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -304,3 +304,4 @@ h1:j795Lg1oCvJYoom5JA87340v9+cAW3se/yTxEYTSIPU=
 20260728103328_dno_569_skill_feedback_schema.sql h1:TdiYFG8KGdlKTU+gjI711O9BRh3iO44xAkkyD/X9JtY=
 20260728180048_shadow-mcp-policy-gates.sql h1:H1/CKCAzAPKMfNb8kYnWaGseH4/DN8kIyhYazDYuiC8=
 20260728192204_dno_572_suggestion_analysis_indexes.sql h1:o9BPYFE+ys9Plt7G+5qHdq+bsizeDOOgfycxaU75Fuw=
+20260728192241_dno_573_suggestion_list_index.sql h1:oi8LXZQndV4kUsIAJm/Ji3RokVt1KgFK+NC3c1+CZvA=


### PR DESCRIPTION
## Summary

- add a partial project-scoped index for open skill suggestion pagination
- generate the concurrent Atlas migration and checksum

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a partial, project-scoped index on `skill_edit_suggestions` for open items — (project_id, created_at DESC, id DESC) WHERE status = 'open' — to speed up and stabilize `skills.listSuggestions` pagination and reduce query cost. Shipped via a CREATE INDEX CONCURRENTLY Atlas migration (plus schema `IF NOT EXISTS`) to support DNO-573 review/approval and bulk-approve endpoints at scale.

<sup>Written for commit 15ca9e82cd5bc9ee5d33d6fc8b8e0c827aefec7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

