### PR TITLE
mig(skills): support skill version promotion

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -302,6 +302,7 @@ CREATE TABLE IF NOT EXISTS skill_versions (
   validation_errors JSONB NOT NULL DEFAULT '[]'::jsonb,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  promoted_at timestamptz,
   created_by_user_id TEXT NOT NULL,
 
   CONSTRAINT skill_versions_pkey PRIMARY KEY (id),
@@ -312,6 +313,7 @@ CREATE TABLE IF NOT EXISTS skill_versions (
 CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_canonical_sha256_key ON skill_versions (skill_id, canonical_sha256);
 CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_id_key ON skill_versions (skill_id, id);
 CREATE INDEX IF NOT EXISTS skill_versions_skill_id_created_at_id_idx ON skill_versions (skill_id, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS skill_versions_skill_id_effective_at_id_idx ON skill_versions (skill_id, COALESCE(promoted_at, created_at) DESC, id DESC);
 
 CREATE TABLE IF NOT EXISTS skill_version_lineages (
   skill_version_id uuid NOT NULL,
@@ -371,6 +373,10 @@ ON skill_feedback (project_id, skill_name, created_at DESC, id DESC);
 CREATE INDEX IF NOT EXISTS skill_feedback_project_id_skill_name_created_at_unreviewed_idx
 ON skill_feedback (project_id, skill_name, created_at)
 WHERE reviewed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS skill_feedback_project_id_skill_id_created_at_id_idx
+ON skill_feedback (project_id, skill_id, created_at DESC, id DESC)
+WHERE skill_id IS NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS skill_feedback_project_id_id_key
 ON skill_feedback (project_id, id);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1922,6 +1922,7 @@ type SkillVersion struct {
 	SpecValid        bool
 	ValidationErrors []byte
 	CreatedAt        pgtype.Timestamptz
+	PromotedAt       pgtype.Timestamptz
 	CreatedByUserID  string
 }
 

--- a/server/internal/skills/repo/models.go
+++ b/server/internal/skills/repo/models.go
@@ -165,6 +165,7 @@ type SkillVersion struct {
 	SpecValid        bool
 	ValidationErrors []byte
 	CreatedAt        pgtype.Timestamptz
+	PromotedAt       pgtype.Timestamptz
 	CreatedByUserID  string
 }
 

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -1144,7 +1144,7 @@ WHERE s.project_id = $9
   AND s.archived_at IS NULL
 ON CONFLICT (skill_id, canonical_sha256)
 DO NOTHING
-RETURNING id, skill_id, content, canonical_sha256, raw_sha256, description, metadata, spec_valid, validation_errors, created_at, created_by_user_id
+RETURNING id, skill_id, content, canonical_sha256, raw_sha256, description, metadata, spec_valid, validation_errors, created_at, promoted_at, created_by_user_id
 `
 
 type CreateSkillVersionParams struct {
@@ -1185,6 +1185,7 @@ func (q *Queries) CreateSkillVersion(ctx context.Context, arg CreateSkillVersion
 		&i.SpecValid,
 		&i.ValidationErrors,
 		&i.CreatedAt,
+		&i.PromotedAt,
 		&i.CreatedByUserID,
 	)
 	return i, err
@@ -1757,7 +1758,7 @@ func (q *Queries) GetPluginForDistribution(ctx context.Context, arg GetPluginFor
 }
 
 const getProjectSkillVersion = `-- name: GetProjectSkillVersion :one
-SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.created_by_user_id
+SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
 FROM skill_versions sv
 JOIN skills s ON s.id = sv.skill_id
 WHERE s.project_id = $1
@@ -1783,6 +1784,7 @@ func (q *Queries) GetProjectSkillVersion(ctx context.Context, arg GetProjectSkil
 		&i.SpecValid,
 		&i.ValidationErrors,
 		&i.CreatedAt,
+		&i.PromotedAt,
 		&i.CreatedByUserID,
 	)
 	return i, err
@@ -2503,7 +2505,7 @@ func (q *Queries) GetSkillState(ctx context.Context, arg GetSkillStateParams) (G
 }
 
 const getSkillVersionByHash = `-- name: GetSkillVersionByHash :one
-SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.created_by_user_id
+SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
 FROM skill_versions sv
 JOIN skills s ON s.id = sv.skill_id
 WHERE s.project_id = $1
@@ -2532,6 +2534,7 @@ func (q *Queries) GetSkillVersionByHash(ctx context.Context, arg GetSkillVersion
 		&i.SpecValid,
 		&i.ValidationErrors,
 		&i.CreatedAt,
+		&i.PromotedAt,
 		&i.CreatedByUserID,
 	)
 	return i, err
@@ -2539,7 +2542,7 @@ func (q *Queries) GetSkillVersionByHash(ctx context.Context, arg GetSkillVersion
 
 const getSkillVersionDetails = `-- name: GetSkillVersionDetails :one
 SELECT
-  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.created_by_user_id,
+  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id,
   svl.derived_from_version_id,
   sightings.first_seen_at,
   sightings.last_seen_at,
@@ -2595,6 +2598,7 @@ func (q *Queries) GetSkillVersionDetails(ctx context.Context, arg GetSkillVersio
 		&i.SkillVersion.SpecValid,
 		&i.SkillVersion.ValidationErrors,
 		&i.SkillVersion.CreatedAt,
+		&i.SkillVersion.PromotedAt,
 		&i.SkillVersion.CreatedByUserID,
 		&i.DerivedFromVersionID,
 		&i.FirstSeenAt,
@@ -4257,7 +4261,7 @@ func (q *Queries) ListSkillSuggestionProjects(ctx context.Context, arg ListSkill
 
 const listSkillVersions = `-- name: ListSkillVersions :many
 SELECT
-  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.created_by_user_id,
+  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id,
   svl.derived_from_version_id,
   sightings.first_seen_at,
   sightings.last_seen_at,
@@ -4335,6 +4339,7 @@ func (q *Queries) ListSkillVersions(ctx context.Context, arg ListSkillVersionsPa
 			&i.SkillVersion.SpecValid,
 			&i.SkillVersion.ValidationErrors,
 			&i.SkillVersion.CreatedAt,
+			&i.SkillVersion.PromotedAt,
 			&i.SkillVersion.CreatedByUserID,
 			&i.DerivedFromVersionID,
 			&i.FirstSeenAt,
@@ -5112,7 +5117,7 @@ func (q *Queries) ResolveSkillObservationVersions(ctx context.Context, arg Resol
 
 const resolveSkillSuggestionBase = `-- name: ResolveSkillSuggestionBase :one
 WITH base AS (
-  SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.created_by_user_id
+  SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
   FROM skills s
   JOIN skill_versions sv ON sv.skill_id = s.id
   LEFT JOIN skill_version_origins svo

--- a/server/migrations/20260728192302_dno_574_skill_version_promotion.sql
+++ b/server/migrations/20260728192302_dno_574_skill_version_promotion.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Create index "skill_feedback_project_id_skill_id_created_at_id_idx" to table: "skill_feedback"
+CREATE INDEX CONCURRENTLY "skill_feedback_project_id_skill_id_created_at_id_idx" ON "skill_feedback" ("project_id", "skill_id", "created_at" DESC, "id" DESC) WHERE (skill_id IS NOT NULL);
+-- Modify "skill_versions" table
+ALTER TABLE "skill_versions" ADD COLUMN "promoted_at" timestamptz NULL;
+-- Create index "skill_versions_skill_id_effective_at_id_idx" to table: "skill_versions"
+CREATE INDEX CONCURRENTLY "skill_versions_skill_id_effective_at_id_idx" ON "skill_versions" ("skill_id", (COALESCE(promoted_at, created_at)) DESC, "id" DESC);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:t1ICEHW0ov8iHj5KSG9RuABTPK7e1VmE17qEQHnJs/0=
+h1:f0Opv31InrLIn0Lwjyplbmx06eX7O21BOKjdTaDZCEw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -305,3 +305,4 @@ h1:t1ICEHW0ov8iHj5KSG9RuABTPK7e1VmE17qEQHnJs/0=
 20260728180048_shadow-mcp-policy-gates.sql h1:H1/CKCAzAPKMfNb8kYnWaGseH4/DN8kIyhYazDYuiC8=
 20260728192204_dno_572_suggestion_analysis_indexes.sql h1:o9BPYFE+ys9Plt7G+5qHdq+bsizeDOOgfycxaU75Fuw=
 20260728192241_dno_573_suggestion_list_index.sql h1:oi8LXZQndV4kUsIAJm/Ji3RokVt1KgFK+NC3c1+CZvA=
+20260728192302_dno_574_skill_version_promotion.sql h1:jQLB1IwxIj6iZr8kA9Ya/u6N6pG4jn+15RjS3+BM5+w=


### PR DESCRIPTION
## Summary

- add an optional promotion timestamp for restoring an existing immutable skill version without duplicating canonical content
- index effective version ordering for current-version resolution
- index project and skill scoped feedback pagination

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add skill version promotion via optional `promoted_at` on `skill_versions` to restore an existing version without duplicating canonical content. Create concurrent indexes for effective ordering by `COALESCE(promoted_at, created_at)` and for project+skill feedback pagination (`project_id, skill_id, created_at DESC, id DESC`), and thread `promoted_at` through DB/repo models and query responses so current-following distributions observe restored content (DNO-574).

<sup>Written for commit 19b12c2e88f328014af47081a76414d021edf47b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

