### PR TITLE
fix(dashboard): restore external OAuth management

### DIFF
--- a/.changeset/external-oauth-management.md
+++ b/.changeset/external-oauth-management.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Restore external OAuth configuration on eligible MCP server authentication pages.

--- a/client/dashboard/src/pages/mcp/ToolsetAuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/ToolsetAuthenticationSection.tsx
@@ -1,13 +1,18 @@
+import { useExternalMcpOAuthConfigStatus } from "@/components/sources/sources-hooks";
 import type { Toolset } from "@/lib/toolTypes";
 import { useRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
 import { Button } from "@speakeasy-api/moonshine";
 import { useState } from "react";
 import { PageSection } from "./MCPDetails";
+import { ConnectOAuthModal } from "./oauth-wizard";
 import { AttachRemoteIdentityProviderSheet } from "./x/tabs/settings/sections/authentication/AttachRemoteIdentityProviderSheet";
 import { AuthenticationSectionBody } from "./x/tabs/settings/sections/authentication/AuthenticationSection";
 import { useToolsetAuthTarget } from "./x/tabs/settings/sections/authentication/authTarget";
 import { UserSessionsList } from "./x/tabs/settings/sections/authentication/McpServerSessionsPanel";
-import { externalOauthIssuerUrl } from "./toolsetAuthSurface";
+import {
+  canConfigureExternalOAuth,
+  externalOauthIssuerUrl,
+} from "./toolsetAuthSurface";
 
 /**
  * User-sessions auth surface for toolset-backed MCP servers: the remote
@@ -20,6 +25,12 @@ export function ToolsetAuthenticationSection({
   toolset: Toolset;
 }): JSX.Element {
   const target = useToolsetAuthTarget(toolset);
+  const [externalOAuthOpen, setExternalOAuthOpen] = useState(false);
+  const externalMcpOAuthStatus = useExternalMcpOAuthConfigStatus(toolset.slug);
+  const externalOAuthAvailable = canConfigureExternalOAuth(
+    toolset,
+    externalMcpOAuthStatus === "required-unconfigured",
+  );
 
   return (
     <>
@@ -27,7 +38,19 @@ export function ToolsetAuthenticationSection({
         heading="Authentication"
         description="Configure the upstream identity provider and user session settings for clients connecting to this server."
       >
-        <AuthenticationSectionBody target={target} />
+        <AuthenticationSectionBody
+          target={target}
+          additionalSetupAction={
+            externalOAuthAvailable ? (
+              <Button
+                variant="secondary"
+                onClick={() => setExternalOAuthOpen(true)}
+              >
+                <Button.Text>Configure External OAuth</Button.Text>
+              </Button>
+            ) : undefined
+          }
+        />
       </PageSection>
       {target.userSessionIssuerId && (
         <PageSection
@@ -37,6 +60,13 @@ export function ToolsetAuthenticationSection({
           <UserSessionsList issuerId={target.userSessionIssuerId} />
         </PageSection>
       )}
+      <ConnectOAuthModal
+        isOpen={externalOAuthOpen}
+        onClose={() => setExternalOAuthOpen(false)}
+        toolsetSlug={toolset.slug}
+        toolset={toolset}
+        initialPath="external"
+      />
     </>
   );
 }

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.test.tsx
@@ -215,6 +215,14 @@ describe("OAuthWizard — rendering", () => {
     expect(screen.getByRole("button", { name: /External OAuth/ })).toBeTruthy();
   });
 
+  it("can open directly on the external OAuth management form", () => {
+    renderWizard({ initialPath: "external" });
+
+    expect(screen.getAllByText("Configure External OAuth")).toHaveLength(2);
+    expect(screen.getByPlaceholderText("my-oauth-server")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /OAuth Proxy/ })).toBeNull();
+  });
+
   it("keeps auto-configure labeled as OAuth Proxy when user-session onboarding is enabled", () => {
     mocks.isFeatureEnabled.mockReturnValue(true);
     renderWizard({ toolset: oauthToolset });

--- a/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/OAuthWizard.tsx
@@ -39,11 +39,13 @@ function OAuthWizard({
   onClose,
   toolsetSlug,
   toolset,
+  initialPath,
 }: {
   isOpen: boolean;
   onClose: () => void;
   toolsetSlug: string;
   toolset: Toolset;
+  initialPath?: Input["initialPath"];
 }) {
   // Force the inner machine to remount after the modal close animation
   // finishes (200ms). This replaces the old `dispatch RESET` pattern: it
@@ -64,6 +66,7 @@ function OAuthWizard({
           onClose={onClose}
           toolsetSlug={toolsetSlug}
           toolset={toolset}
+          initialPath={initialPath}
         />
       </Dialog.Content>
     </Dialog>
@@ -79,10 +82,12 @@ function WizardBody({
   onClose,
   toolsetSlug,
   toolset,
+  initialPath,
 }: {
   onClose: () => void;
   toolsetSlug: string;
   toolset: Toolset;
+  initialPath?: Input["initialPath"];
 }) {
   const client = useSdkClient();
   const queryClient = useQueryClient();
@@ -124,6 +129,7 @@ function WizardBody({
 
   const input: Input = {
     discovered,
+    initialPath,
     toolsetSlug,
     toolsetName: toolset.name,
     activeOrganizationId: session.activeOrganizationId,
@@ -237,11 +243,13 @@ export function ConnectOAuthModal({
   onClose,
   toolsetSlug,
   toolset,
+  initialPath,
 }: {
   isOpen: boolean;
   onClose: () => void;
   toolsetSlug: string;
   toolset: Toolset;
+  initialPath?: Input["initialPath"];
 }): JSX.Element {
   const productTier = useProductTier();
   const isAccountUpgrade = productTier.includes("base");
@@ -267,6 +275,7 @@ export function ConnectOAuthModal({
       onClose={onClose}
       toolsetSlug={toolsetSlug}
       toolset={toolset}
+      initialPath={initialPath}
     />
   );
 }

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine-types.ts
@@ -20,6 +20,7 @@ export type ProxyFormKey =
 
 export type Context = {
   discovered: DiscoveredOAuth | null;
+  initialPath?: "external";
   external: {
     slug: string;
     metadataJson: string;
@@ -53,6 +54,7 @@ export type Context = {
 
 export type Input = {
   discovered: DiscoveredOAuth | null;
+  initialPath?: "external";
   toolsetSlug: string;
   toolsetName: string;
   activeOrganizationId: string;

--- a/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
+++ b/client/dashboard/src/pages/mcp/oauth-wizard/machine.ts
@@ -38,6 +38,7 @@ function initialProxy(): Context["proxy"] {
 function initialContext(input: Input): Context {
   return {
     discovered: input.discovered,
+    initialPath: input.initialPath,
     external: { slug: "", metadataJson: "", jsonError: null, prefilled: false },
     proxy: initialProxy(),
     envSlug: null,
@@ -159,8 +160,24 @@ export const oauthWizardMachine = setup({
 }).createMachine({
   id: "oauthWizard",
   context: ({ input }) => initialContext(input),
-  initial: "pathSelection",
+  initial: "initializing",
   states: {
+    initializing: {
+      always: [
+        {
+          guard: ({ context }) => context.initialPath === "external",
+          target: "external.editing",
+          actions: assign({
+            external: ({ context }) =>
+              context.discovered && context.discovered.version === "2.1"
+                ? externalFromDiscovered(context.discovered)
+                : context.external,
+          }),
+        },
+        { target: "pathSelection" },
+      ],
+    },
+
     pathSelection: {
       meta: { title: "Connect OAuth" },
       on: {

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Toolset } from "@/lib/toolTypes";
 import {
+  canConfigureExternalOAuth,
   externalOauthIssuerUrl,
   getOAuthParadigm,
   isUserSessionIssuerWired,
@@ -92,6 +93,54 @@ describe("toolsetConvertAction", () => {
 
   it("offers no convert path without a legacy paradigm", () => {
     expect(toolsetConvertAction(null)).toBeNull();
+  });
+});
+
+describe("canConfigureExternalOAuth", () => {
+  const eligibleToolset = {
+    mcpEnabled: true,
+    mcpIsPublic: true,
+    oauthEnablementMetadata: { oauth2SecurityCount: 1 },
+  } as unknown as Toolset;
+
+  it("allows external OAuth for an enabled public server with an OAuth authorization code flow", () => {
+    expect(canConfigureExternalOAuth(eligibleToolset, false)).toBe(true);
+  });
+
+  it("allows external OAuth when an attached external MCP source requires it", () => {
+    const externalMcpToolset = {
+      ...eligibleToolset,
+      oauthEnablementMetadata: { oauth2SecurityCount: 0 },
+    } as unknown as Toolset;
+
+    expect(canConfigureExternalOAuth(externalMcpToolset, true)).toBe(true);
+  });
+
+  it("does not expose external OAuth for disabled or private servers", () => {
+    expect(
+      canConfigureExternalOAuth(
+        { ...eligibleToolset, mcpEnabled: false } as Toolset,
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      canConfigureExternalOAuth(
+        { ...eligibleToolset, mcpIsPublic: false } as Toolset,
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not expose external OAuth without an eligible tool or source", () => {
+    expect(
+      canConfigureExternalOAuth(
+        {
+          ...eligibleToolset,
+          oauthEnablementMetadata: { oauth2SecurityCount: 0 },
+        } as unknown as Toolset,
+        false,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
+++ b/client/dashboard/src/pages/mcp/toolsetAuthSurface.ts
@@ -76,6 +76,26 @@ export function toolsetConvertAction(
 }
 
 /**
+ * External OAuth is supported for enabled, public toolset servers whose tools
+ * advertise OAuth or whose attached external MCP source requires it. Keep this
+ * aligned with the legacy OAuth section so the user-sessions surface does not
+ * expose a configuration the serve path cannot use.
+ */
+export function canConfigureExternalOAuth(
+  toolset: Toolset,
+  externalMcpRequiresOAuth: boolean,
+): boolean {
+  const hasOAuthAuthorizationCodeFlow =
+    (toolset.oauthEnablementMetadata?.oauth2SecurityCount ?? 0) > 0;
+
+  return Boolean(
+    toolset.mcpEnabled &&
+    toolset.mcpIsPublic &&
+    (hasOAuthAuthorizationCodeFlow || externalMcpRequiresOAuth),
+  );
+}
+
+/**
  * Whether the public→private flip must be blocked pending OAuth conversion.
  * The backend silently clears external OAuth / OAuth proxy config on any
  * mcp_is_public flip (UpdateToolset in server/internal/toolsets/impl.go).

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthenticationSectionBody } from "./AuthenticationSection";
 import type { AuthTarget } from "./authTarget";
@@ -64,9 +65,16 @@ vi.mock("./RemoteIdentityProvidersField", () => ({
 vi.mock("./AuthenticationSetupActions", () => ({
   AuthenticationSetupActions: ({
     onUseDiscovered,
+    additionalAction,
   }: {
     onUseDiscovered: () => void;
-  }) => <button onClick={onUseDiscovered}>Use Discovered</button>,
+    additionalAction?: ReactNode;
+  }) => (
+    <>
+      <button onClick={onUseDiscovered}>Use Discovered</button>
+      {additionalAction}
+    </>
+  ),
 }));
 
 vi.mock("./DeleteRemoteIdentityProviderDialog", () => ({
@@ -160,6 +168,31 @@ describe("AuthenticationSectionBody", () => {
     expect(
       screen.getByText("https://auth.example.com|resource.read resource.write"),
     ).toBeDefined();
+  });
+
+  it("includes a target-specific setup action before a session issuer is configured", () => {
+    useUserSessionIssuer.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+    });
+    useAllRemoteSessionClients.mockReturnValue({
+      items: [],
+      isLoading: false,
+    });
+    useProtectedResourceMetadata.mockReturnValue({
+      status: "idle",
+      metadata: null,
+    });
+
+    render(
+      <AuthenticationSectionBody
+        target={remoteTargetWithoutSessionIssuer}
+        additionalSetupAction={<button>Configure External OAuth</button>}
+      />,
+    );
+
+    expect(screen.getByText("Configure External OAuth")).toBeDefined();
   });
 
   it("does not probe configured remote servers that already have a client", () => {

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSection.tsx
@@ -74,8 +74,10 @@ export function AuthenticationSection({
  */
 export function AuthenticationSectionBody({
   target,
+  additionalSetupAction,
 }: {
   target: AuthTarget;
+  additionalSetupAction?: ReactNode;
 }): JSX.Element {
   const userSessionIssuerId = target.userSessionIssuerId ?? undefined;
   const issuerConfigured = !!userSessionIssuerId;
@@ -177,6 +179,7 @@ export function AuthenticationSectionBody({
           openSheet(authorizationServer, protectedResourceScopes)
         }
         onStartManual={() => openSheet(undefined)}
+        additionalAction={additionalSetupAction}
       />
     );
   } else if (isLoadingUserSessionIssuer) {
@@ -240,11 +243,13 @@ function IdentityProviderSetupField({
   hasDiscoveredAuthorizationServer,
   onUseDiscovered,
   onStartManual,
+  additionalAction,
 }: {
   probeStatus: ProtectedResourceProbeStatus;
   hasDiscoveredAuthorizationServer: boolean;
   onUseDiscovered: () => void;
   onStartManual: () => void;
+  additionalAction?: ReactNode;
 }) {
   return (
     <Field>
@@ -258,6 +263,7 @@ function IdentityProviderSetupField({
             hasDiscoveredAuthorizationServer={hasDiscoveredAuthorizationServer}
             onUseDiscovered={onUseDiscovered}
             onStartManual={onStartManual}
+            additionalAction={additionalAction}
           />
         }
       />

--- a/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSetupActions.tsx
+++ b/client/dashboard/src/pages/mcp/x/tabs/settings/sections/authentication/AuthenticationSetupActions.tsx
@@ -5,6 +5,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Button } from "@speakeasy-api/moonshine";
+import type { ReactNode } from "react";
 import type { ProtectedResourceProbeStatus } from "./useProtectedResourceMetadata";
 
 export function AuthenticationSetupActions({
@@ -12,6 +13,7 @@ export function AuthenticationSetupActions({
   hasDiscoveredAuthorizationServer,
   onUseDiscovered,
   onStartManual,
+  additionalAction,
 }: {
   probeStatus: ProtectedResourceProbeStatus;
   // True only when the RFC 9728 probe returned at least one
@@ -20,6 +22,7 @@ export function AuthenticationSetupActions({
   hasDiscoveredAuthorizationServer: boolean;
   onUseDiscovered: () => void;
   onStartManual: () => void;
+  additionalAction?: ReactNode;
 }): JSX.Element {
   const probing = probeStatus === "loading";
   const discoverAvailable =
@@ -71,6 +74,7 @@ export function AuthenticationSetupActions({
         <Button variant="secondary" onClick={onStartManual}>
           <Button.Text>Configure Manually</Button.Text>
         </Button>
+        {additionalAction}
       </div>
     </RequireScope>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore the external OAuth setup action on the rewritten toolset authentication surface
- open the existing OAuth wizard directly on the external OAuth form
- preserve the existing eligibility rules for enabled public MCP servers
- cover the eligibility matrix, setup-action plumbing, and direct wizard entry with tests
- add a patch changeset for the dashboard package

## Testing
- `pnpm -F dashboard test toolsetAuthSurface OAuthWizard AuthenticationSection` (32 tests passed)
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint`
- `pnpm exec changeset status --since=main`
- manually verified the eligible toolset flow: action appears, opens the external OAuth form directly, validates placeholder metadata, and enables submission without submitting

## Demo
<a href="https://cursor.com/agents/bc-96961926-1adb-4c79-8951-2651a7d40b37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexternal_oauth_management_stable.webm"><img src="https://cursor.com/artifacts/c/art-2a4593df-46d6-4c96-8846-c174e512c9f1" alt="external_oauth_management_stable.webm" /></a>

Linear: AIS-364
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-364](https://linear.app/speakeasy/issue/AIS-364/bring-back-management-ui-for-external-oauth)

<div><a href="https://cursor.com/agents/bc-96961926-1adb-4c79-8951-2651a7d40b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96961926-1adb-4c79-8951-2651a7d40b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores external OAuth management on the MCP toolset Authentication screen. Adds a “Configure External OAuth” action that opens the OAuth wizard directly on the external form. Aligns with Linear AIS-364.

- **Bug Fixes**
  - Show “Configure External OAuth” only for eligible servers: `mcpEnabled` + `mcpIsPublic` and either an OAuth2 auth code flow or an attached external MCP source requiring OAuth.
  - Wizard accepts `initialPath="external"` and jumps to the external form; pre-fills when discovered metadata is v2.1.
  - Adds an `additionalSetupAction` path so the button appears before a session issuer exists.
  - Keeps legacy eligibility rules to avoid exposing unusable config on the serve path.
  - Adds tests for the new entry point and gating (`OAuthWizard`, `toolsetAuthSurface`, `AuthenticationSection`).

- **Dependencies**
  - Adds a dashboard changeset to release this as a patch.

<sup>Written for commit ef81a9d9c94872d5c35f2f69f80a5251572a6a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

