### PR TITLE
fix(mcp): rewrite external OAuth authorization-server issuer to Gram URL

### DIFF
--- a/.changeset/external-oauth-issuer.md
+++ b/.changeset/external-oauth-issuer.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+MCP servers backed by an external OAuth authorization server now serve RFC 8414 authorization-server metadata whose `issuer` matches the Gram resource URL, so spec-compliant OAuth clients no longer reject the document.

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -176,8 +176,14 @@ func (s *Service) HandleGetAuthorizationServer(w http.ResponseWriter, r *http.Re
 	}
 
 	// The legacy /mcp OAuth machinery is keyed on the toolset's mcp_slug,
-	// which equals the requested slug on this fallback path.
-	return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, mcpSlug)
+	// which equals the requested slug on this fallback path. The resource URL
+	// mirrors HandleGetProtectedResource so the served issuer matches the
+	// protected-resource metadata's authorization_servers entry.
+	resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), "mcp", mcpSlug)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build legacy resource URL").LogError(ctx, s.logger)
+	}
+	return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, mcpSlug, resourceURL)
 }
 
 // ServeWellKnownProtectedResourceForServer serves RFC 9728 protected-resource
@@ -268,7 +274,14 @@ func (s *Service) ServeWellKnownAuthorizationServerForServer(
 		if oauthSlug == "" {
 			return oops.E(oops.CodeNotFound, nil, "no OAuth configuration found")
 		}
-		return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, oauthSlug)
+		// The resource URL mirrors ServeWellKnownProtectedResourceForServer
+		// (routeBase + mcp_endpoints.slug) so the served issuer matches the
+		// protected-resource metadata's authorization_servers entry.
+		resourceURL, err := url.JoinPath(s.BaseURLForRequest(r), routeBase, mcpEndpoint.Slug)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "build resource URL").LogError(ctx, logger)
+		}
+		return s.serveLegacyToolsetAuthorizationServer(ctx, w, r, logger, toolset, oauthSlug, resourceURL)
 	default:
 		return oops.E(oops.CodeUnexpected, nil, "mcp server has no backend configured").LogError(ctx, logger)
 	}
@@ -313,8 +326,8 @@ func (s *Service) serveLegacyToolsetProtectedResource(ctx context.Context, w htt
 // result means the toolset carries no OAuth configuration — 404. oauthSlug
 // keys the emitted issuer / endpoint URLs onto the legacy /oauth/{slug}
 // surface.
-func (s *Service) serveLegacyToolsetAuthorizationServer(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, oauthSlug string) error {
-	result, err := wellknown.ResolveOAuthServerMetadataFromToolset(ctx, logger, s.db, s.oauthRepo, &s.toolsetCache, toolset, s.BaseURLForRequest(r), oauthSlug)
+func (s *Service) serveLegacyToolsetAuthorizationServer(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, toolset *toolsets_repo.Toolset, oauthSlug, resourceURL string) error {
+	result, err := wellknown.ResolveOAuthServerMetadataFromToolset(ctx, logger, s.db, s.oauthRepo, &s.toolsetCache, toolset, s.BaseURLForRequest(r), oauthSlug, resourceURL)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to resolve OAuth server metadata").LogError(ctx, logger)
 	}

--- a/server/internal/mcp/servepublic_clientdance_test.go
+++ b/server/internal/mcp/servepublic_clientdance_test.go
@@ -555,11 +555,18 @@ func TestClientDance_ExternalOAuth_FullFlow(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
+	upstreamMetadata := idp.OAuth21Metadata(t)
 	result := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
 		Slug:     "ext-dance",
 		IsPublic: true,
-		Metadata: idp.OAuth21Metadata(t),
+		Metadata: upstreamMetadata,
 	})
+
+	var upstreamMeta map[string]any
+	require.NoError(t, json.Unmarshal(upstreamMetadata, &upstreamMeta))
+	upstreamIssuer, ok := upstreamMeta["issuer"].(string)
+	require.True(t, ok, "upstream metadata must carry an issuer")
+	require.NotEmpty(t, upstreamIssuer)
 
 	mcpSlug := result.Toolset.McpSlug.String
 
@@ -599,6 +606,34 @@ func TestClientDance_ExternalOAuth_FullFlow(t *testing.T) {
 	authServers, ok := prMeta["authorization_servers"].([]any)
 	require.True(t, ok, "authorization_servers should be an array")
 	require.NotEmpty(t, authServers, "authorization_servers should not be empty")
+
+	// 7. Fetch the RFC 8414 authorization-server metadata. Gram re-serves the
+	//    captured upstream document from its own well-known URL, so per
+	//    RFC 8414 §3.3 the served issuer must equal the resource URL the
+	//    protected-resource metadata advertises (the Gram URL), NOT the
+	//    upstream issuer. The upstream's own endpoints stay verbatim.
+	asReq := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
+	asRctx := chi.NewRouteContext()
+	asRctx.URLParams.Add("mcpSlug", mcpSlug)
+	asReq = asReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, asRctx))
+
+	asW := httptest.NewRecorder()
+	err = ti.service.HandleGetAuthorizationServer(asW, asReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, asW.Code)
+
+	var asMeta map[string]any
+	err = json.Unmarshal(asW.Body.Bytes(), &asMeta)
+	require.NoError(t, err)
+
+	servedIssuer, ok := asMeta["issuer"].(string)
+	require.True(t, ok, "authorization-server metadata must carry an issuer")
+	require.Equal(t, resource, servedIssuer, "served issuer must equal the protected-resource URL (RFC 8414 §3.3)")
+	require.NotEqual(t, upstreamIssuer, servedIssuer, "served issuer must not be the raw upstream issuer")
+
+	// The upstream's own endpoints must be preserved verbatim.
+	require.Equal(t, upstreamMeta["authorization_endpoint"], asMeta["authorization_endpoint"], "authorization_endpoint must stay upstream")
+	require.Equal(t, upstreamMeta["token_endpoint"], asMeta["token_endpoint"], "token_endpoint must stay upstream")
 }
 
 // TestClientDance_ProxyOAuth_WWWAuthenticateChain verifies the

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -175,10 +175,16 @@ func TestHandleGetAuthorizationServer_ToolsetBackendWithExternalOAuth(t *testing
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
 
-	// External OAuth toolsets surface the upstream provider's metadata verbatim.
+	// External OAuth toolsets re-serve the upstream provider's captured
+	// metadata, but the issuer is rewritten to the Gram resource URL so the
+	// document satisfies RFC 8414 §3.3 (served issuer must equal the URL the
+	// client fetched it under, i.e. the /mcp/{slug} surface). The upstream's
+	// own authorization/token endpoints are preserved verbatim.
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
-	require.Equal(t, "https://test-oauth-server.example.com", metadata["issuer"])
+	require.Equal(t, "http://0.0.0.0/mcp/"+slug, metadata["issuer"])
+	require.Equal(t, "https://test-oauth-server.example.com/authorize", metadata["authorization_endpoint"])
+	require.Equal(t, "https://test-oauth-server.example.com/token", metadata["token_endpoint"])
 }
 
 // TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend is the primary

--- a/server/internal/oauth/wellknown/wellknown.go
+++ b/server/internal/oauth/wellknown/wellknown.go
@@ -101,6 +101,13 @@ type OAuthRepo interface {
 // also passes `toolset.mcp_slug` here even though its protected-resource
 // URL uses an `mcp_endpoints.slug` instead — see the companion
 // resourceURL argument on [ResolveOAuthProtectedResourceFromToolset].
+//
+// resourceURL is the absolute URL of the protected resource — the same value
+// [ResolveOAuthProtectedResourceFromToolset] emits as `resource` and
+// `authorization_servers`. For the external-OAuth-server case it becomes the
+// served document's `issuer` so the metadata satisfies RFC 8414 §3.3 (the
+// served `issuer` must equal the issuer identifier the client fetched it
+// under); the proxy case ignores it and keys its issuer off oauthSlug.
 func ResolveOAuthServerMetadataFromToolset(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -110,6 +117,7 @@ func ResolveOAuthServerMetadataFromToolset(
 	toolset *toolsets_repo.Toolset,
 	baseURL string,
 	oauthSlug string,
+	resourceURL string,
 ) (*OAuthServerMetadataResult, error) {
 	if toolset.OauthProxyServerID.Valid {
 		providers, err := oauthRepo.ListOAuthProxyProvidersByServer(ctx, repo.ListOAuthProxyProvidersByServerParams{
@@ -166,15 +174,61 @@ func ResolveOAuthServerMetadataFromToolset(
 			return nil, fmt.Errorf("get external oauth server metadata: %w", err)
 		}
 
+		// The captured upstream document's `issuer` identifies the upstream
+		// authorization server, but Gram re-serves that document from its own
+		// `/.well-known/oauth-authorization-server/...` URL. RFC 8414 §3.3
+		// requires the served `issuer` to equal the issuer identifier the
+		// client used to fetch the document — here the Gram resource URL that
+		// the protected-resource metadata advertises in
+		// `authorization_servers` — so a spec-compliant MCP client does not
+		// reject the metadata on a mismatch. The upstream's own
+		// authorization/token/registration endpoints are preserved verbatim;
+		// RFC 8414 does not require those to share the issuer's origin.
+		rewritten, err := rewriteMetadataIssuer(externalOAuthServer.Metadata, resourceURL)
+		if err != nil {
+			return nil, fmt.Errorf("rewrite external oauth server issuer: %w", err)
+		}
+
 		return &OAuthServerMetadataResult{
 			Kind:     OAuthServerMetadataResultKindRaw,
 			Static:   nil,
-			Raw:      externalOAuthServer.Metadata,
+			Raw:      rewritten,
 			ProxyURL: "",
 		}, nil
 	}
 
 	return nil, nil
+}
+
+// rewriteMetadataIssuer returns raw with its top-level "issuer" field set to
+// issuer, leaving every other field untouched. Used to reconcile a captured
+// upstream OAuth authorization-server metadata document with the Gram URL it
+// is re-served from (RFC 8414 §3.3). Preserving the raw form of every other
+// field keeps upstream-specific extensions (e.g. userinfo/introspection
+// endpoints, claims_supported) that Gram's typed structs do not model.
+func rewriteMetadataIssuer(raw json.RawMessage, issuer string) (json.RawMessage, error) {
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, fmt.Errorf("decode oauth server metadata: %w", err)
+	}
+	// A JSON `null` payload unmarshals into a nil map without error; guard
+	// against it (and any non-object that decoded to nil) so the issuer
+	// assignment below does not panic on a nil map.
+	if fields == nil {
+		return nil, fmt.Errorf("decode oauth server metadata: expected a JSON object")
+	}
+
+	issuerJSON, err := json.Marshal(issuer)
+	if err != nil {
+		return nil, fmt.Errorf("encode issuer: %w", err)
+	}
+	fields["issuer"] = issuerJSON
+
+	out, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("encode oauth server metadata: %w", err)
+	}
+	return out, nil
 }
 
 // ResolveOAuthProtectedResourceFromToolset returns OAuth Protected Resource

--- a/server/internal/oauth/wellknown/wellknown_rewrite_test.go
+++ b/server/internal/oauth/wellknown/wellknown_rewrite_test.go
@@ -1,0 +1,34 @@
+package wellknown
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRewriteMetadataIssuer_Object rewrites the top-level issuer while leaving
+// every other field of the captured upstream document untouched.
+func TestRewriteMetadataIssuer_Object(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"issuer":"https://upstream.example.com","token_endpoint":"https://upstream.example.com/token"}`)
+	out, err := rewriteMetadataIssuer(raw, "https://gram.example.com/mcp/foo")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Equal(t, "https://gram.example.com/mcp/foo", got["issuer"])
+	require.Equal(t, "https://upstream.example.com/token", got["token_endpoint"])
+}
+
+// TestRewriteMetadataIssuer_NullPayload verifies a JSON null document, which
+// unmarshals into a nil map, returns an error rather than panicking on the
+// issuer assignment.
+func TestRewriteMetadataIssuer_NullPayload(t *testing.T) {
+	t.Parallel()
+
+	_, err := rewriteMetadataIssuer(json.RawMessage("null"), "https://gram.example.com/mcp/foo")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected a JSON object")
+}

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -233,11 +233,16 @@ func TestHandleWellKnownOAuthServerMetadata_ToolsetBackendWithExternalOAuth(t *t
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Header().Get("Content-Type"), "application/json")
 
-	// External OAuth toolsets surface the upstream provider's metadata
-	// verbatim — confirm we passed the stored JSON through unmodified.
+	// External OAuth toolsets re-serve the upstream provider's captured
+	// metadata, but the issuer is rewritten to the Gram resource URL so the
+	// document satisfies RFC 8414 §3.3 (served issuer must equal the URL the
+	// client fetched it under, i.e. the /x/mcp/{slug} surface). The upstream's
+	// own authorization/token endpoints are preserved verbatim.
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
-	require.Equal(t, "https://test-oauth-server.example.com", metadata["issuer"])
+	require.Equal(t, "http://0.0.0.0/x/mcp/"+slug, metadata["issuer"])
+	require.Equal(t, "https://test-oauth-server.example.com/authorize", metadata["authorization_endpoint"])
+	require.Equal(t, "https://test-oauth-server.example.com/token", metadata["token_endpoint"])
 }
 
 // TestHandleWellKnownOAuthServerMetadata_IssuerGatedRemoteBackend verifies


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-365/external-oauth-mcp-servers-served-rfc-8414-issuer-violates-33

External OAuth server toolsets re-served the captured upstream RFC 8414 authorization-server metadata verbatim, keeping the upstream `issuer` value. Gram serves that document from its own well-known URL and the protected-resource metadata advertises Gram as the authorization server, so the served `issuer` did not match the identifier the client fetched it under, violating RFC 8414 §3.3. Spec-compliant MCP clients reject such metadata; only lenient clients worked.

Rewrite only the `issuer` field to the Gram resource URL, preserving the upstream `authorization_endpoint`, `token_endpoint`, and `registration_endpoint` verbatim (§3.3 does not require those to share the issuer origin).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an RFC 8414 §3.3 mismatch by rewriting the served authorization-server `issuer` to the Gram resource URL for external OAuth MCP servers. Spec-compliant clients now accept discovery; upstream auth/token/registration endpoints stay upstream.

- **Bug Fixes**
  - Rewrites only `issuer` for `external_oauth_server` toolsets to the Gram `resource` URL on `/.well-known/oauth-authorization-server/mcp/{slug}` and `/x/mcp/{slug}`; preserves upstream `authorization_endpoint`/`token_endpoint`/`registration_endpoint`.
  - Builds and passes `resourceURL` in `HandleGetAuthorizationServer` and `ServeWellKnownAuthorizationServerForServer`, through `serveLegacyToolsetAuthorizationServer` into `ResolveOAuthServerMetadataFromToolset`.
  - Adds `rewriteMetadataIssuer` helper that sets top-level `issuer` on JSON-object payloads, errors on `null`, and leaves all other fields verbatim.
  - Extends tests to assert issuer equals the Gram resource URL and upstream endpoints remain upstream; adds a null-payload unit test.
  - Addresses Linear AIS-365 (issuer mismatch blocking strict MCP clients).

<sup>Written for commit 8ff18d510c8baa15de9bc6c9113e5b3988a37555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

