### PR TITLE
fix: wire up MCP dotenv file import

### DIFF
--- a/.changeset/mcp-dotenv-file-import.md
+++ b/.changeset/mcp-dotenv-file-import.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Make the MCP environment variable "Import .env" control open a local file picker, populate one secret row per assignment, and report invalid files instead of doing nothing.

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
@@ -1,0 +1,83 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AddVariableSheet } from "./AddVariableSheet";
+
+afterEach(cleanup);
+
+describe("AddVariableSheet", () => {
+  it("imports variables from a selected dotenv file", async () => {
+    const onAddVariables = vi.fn();
+    render(
+      <AddVariableSheet
+        open
+        onOpenChange={() => {}}
+        attachedEnvironment={null}
+        availableEnvVarsFromAttached={[]}
+        onAddVariables={onAddVariables}
+        onLoadFromEnvironment={() => {}}
+      />,
+    );
+
+    const file = new File(
+      ["# credentials\nAPI_KEY=secret-value\nBASE_URL=https://example.test"],
+      ".env",
+      { type: "text/plain" },
+    );
+    fireEvent.change(screen.getByLabelText("Import .env file"), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("API_KEY")).toBeTruthy();
+      expect(screen.getByDisplayValue("BASE_URL")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onAddVariables).toHaveBeenCalledWith([
+      {
+        key: "API_KEY",
+        value: "secret-value",
+        state: "system",
+        isSecret: true,
+      },
+      {
+        key: "BASE_URL",
+        value: "https://example.test",
+        state: "system",
+        isSecret: true,
+      },
+    ]);
+  });
+
+  it("reports files without dotenv assignments", async () => {
+    render(
+      <AddVariableSheet
+        open
+        onOpenChange={() => {}}
+        attachedEnvironment={null}
+        availableEnvVarsFromAttached={[]}
+        onAddVariables={() => {}}
+        onLoadFromEnvironment={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Import .env file"), {
+      target: {
+        files: [new File(["API_KEY"], ".env", { type: "text/plain" })],
+      },
+    });
+
+    expect(
+      await screen.findByText(
+        "No valid environment variable assignments found.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
@@ -6,14 +6,14 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AddVariableSheet } from "./AddVariableSheet";
 
 afterEach(cleanup);
 
-describe("AddVariableSheet", () => {
-  it("imports variables from a selected dotenv file", async () => {
-    const onAddVariables = vi.fn();
-    render(
+function renderSheet(onAddVariables = vi.fn()) {
+  render(
+    <TooltipProvider>
       <AddVariableSheet
         open
         onOpenChange={() => {}}
@@ -21,8 +21,15 @@ describe("AddVariableSheet", () => {
         availableEnvVarsFromAttached={[]}
         onAddVariables={onAddVariables}
         onLoadFromEnvironment={() => {}}
-      />,
-    );
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("AddVariableSheet", () => {
+  it("imports variables from a selected dotenv file", async () => {
+    const onAddVariables = vi.fn();
+    renderSheet(onAddVariables);
 
     const file = new File(
       ["# credentials\nAPI_KEY=secret-value\nBASE_URL=https://example.test"],
@@ -57,16 +64,7 @@ describe("AddVariableSheet", () => {
   });
 
   it("reports files without dotenv assignments", async () => {
-    render(
-      <AddVariableSheet
-        open
-        onOpenChange={() => {}}
-        attachedEnvironment={null}
-        availableEnvVarsFromAttached={[]}
-        onAddVariables={() => {}}
-        onLoadFromEnvironment={() => {}}
-      />,
-    );
+    renderSheet();
 
     fireEvent.change(screen.getByLabelText("Import .env file"), {
       target: {

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
@@ -29,6 +29,14 @@ function renderSheet(onAddVariables: OnAddVariables = () => {}) {
   );
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("AddVariableSheet", () => {
   it("imports variables from a selected dotenv file", async () => {
     const onAddVariables = vi.fn<OnAddVariables>();
@@ -80,5 +88,64 @@ describe("AddVariableSheet", () => {
         "No valid environment variable assignments found.",
       ),
     ).toBeTruthy();
+  });
+
+  it("ignores an older file read after a newer import finishes", async () => {
+    const firstRead = deferred<string>();
+    const firstFile = new File([""], "first.env", { type: "text/plain" });
+    vi.spyOn(firstFile, "text").mockReturnValue(firstRead.promise);
+    renderSheet();
+
+    fireEvent.change(screen.getByLabelText("Import .env file"), {
+      target: { files: [firstFile] },
+    });
+    expect(
+      screen.getByRole("button", { name: "Save" }).hasAttribute("disabled"),
+    ).toBe(true);
+
+    fireEvent.change(screen.getByLabelText("Import .env file"), {
+      target: {
+        files: [
+          new File(["LATEST_KEY=latest-value"], "latest.env", {
+            type: "text/plain",
+          }),
+        ],
+      },
+    });
+    expect(await screen.findByDisplayValue("LATEST_KEY")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Save" }).hasAttribute("disabled"),
+    ).toBe(false);
+
+    firstRead.resolve("STALE_KEY=stale-value");
+    await firstRead.promise;
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue("STALE_KEY")).toBeNull();
+      expect(screen.getByDisplayValue("LATEST_KEY")).toBeTruthy();
+    });
+  });
+
+  it("ignores a file read that finishes after the sheet closes", async () => {
+    const fileRead = deferred<string>();
+    const file = new File([""], ".env", { type: "text/plain" });
+    vi.spyOn(file, "text").mockReturnValue(fileRead.promise);
+    renderSheet();
+
+    fireEvent.change(screen.getByLabelText("Import .env file"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    fileRead.resolve("STALE_KEY=stale-value");
+    await fileRead.promise;
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue("STALE_KEY")).toBeNull();
+      expect(
+        (screen.getByPlaceholderText("CLIENT_KEY...") as HTMLInputElement)
+          .value,
+      ).toBe("");
+    });
   });
 });

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
@@ -31,7 +31,7 @@ function renderSheet(onAddVariables: OnAddVariables = () => {}) {
 
 describe("AddVariableSheet", () => {
   it("imports variables from a selected dotenv file", async () => {
-    const onAddVariables = vi.fn();
+    const onAddVariables = vi.fn<OnAddVariables>();
     renderSheet(onAddVariables);
 
     const file = new File(

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.test.tsx
@@ -5,13 +5,16 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AddVariableSheet } from "./AddVariableSheet";
 
 afterEach(cleanup);
 
-function renderSheet(onAddVariables = vi.fn()) {
+type OnAddVariables = ComponentProps<typeof AddVariableSheet>["onAddVariables"];
+
+function renderSheet(onAddVariables: OnAddVariables = () => {}) {
   render(
     <TooltipProvider>
       <AddVariableSheet

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
@@ -119,14 +119,10 @@ export function AddVariableSheet({
     setEntries((prev) => [...prev, { ...EMPTY_ENTRY }]);
   };
 
-  const handleDotEnvPaste = (
-    index: number,
-    event: ClipboardEvent<HTMLInputElement>,
-  ) => {
-    const parsed = parseDotEnvPaste(event.clipboardData.getData("text"));
-    if (!parsed) return;
+  const importDotEnvContents = (contents: string, index: number): boolean => {
+    const parsed = parseDotEnvPaste(contents);
+    if (!parsed) return false;
 
-    event.preventDefault();
     if (parsed.entries.length > 0) {
       const importedEntries = parsed.entries.map(({ key, value }) => ({
         key: key.toUpperCase(),
@@ -148,6 +144,32 @@ export function AddVariableSheet({
       );
     } else {
       setError(null);
+    }
+
+    return true;
+  };
+
+  const handleDotEnvPaste = (
+    index: number,
+    event: ClipboardEvent<HTMLInputElement>,
+  ) => {
+    const imported = importDotEnvContents(
+      event.clipboardData.getData("text"),
+      index,
+    );
+    if (imported) event.preventDefault();
+  };
+
+  const handleDotEnvFile = async (file: File | undefined): Promise<void> => {
+    if (!file) return;
+
+    try {
+      const imported = importDotEnvContents(await file.text(), 0);
+      if (!imported) {
+        setError("No valid environment variable assignments found.");
+      }
+    } catch {
+      setError("The selected .env file could not be read.");
     }
   };
 
@@ -321,7 +343,7 @@ export function AddVariableSheet({
         </div>
 
         <SheetFooter className="flex-row items-center justify-between border-t px-6 py-4">
-          <button className="text-muted-foreground hover:text-foreground flex items-center gap-2 text-sm transition-colors">
+          <label className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-sm transition-colors">
             <svg
               className="h-4 w-4"
               fill="none"
@@ -332,7 +354,17 @@ export function AddVariableSheet({
               <path d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
             </svg>
             Import .env
-          </button>
+            <input
+              type="file"
+              accept=".env,text/plain"
+              className="sr-only"
+              aria-label="Import .env file"
+              onChange={(event) => {
+                void handleDotEnvFile(event.currentTarget.files?.[0]);
+                event.currentTarget.value = "";
+              }}
+            />
+          </label>
           <span className="text-muted-foreground text-xs">
             or paste .env contents in Key input
           </span>

--- a/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
+++ b/client/dashboard/src/pages/mcp/AddVariableSheet.tsx
@@ -15,7 +15,7 @@ import { Switch } from "@/components/ui/switch";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Button } from "@speakeasy-api/moonshine";
 import { AlertCircle, ChevronDown, Plus, X } from "lucide-react";
-import { type ClipboardEvent, useCallback, useState } from "react";
+import { type ClipboardEvent, useCallback, useRef, useState } from "react";
 import { parseDotEnvPaste } from "./dotEnvUtils";
 import { EnvVarState } from "./environmentVariableUtils";
 
@@ -63,13 +63,19 @@ export function AddVariableSheet({
     { ...EMPTY_ENTRY },
   ]);
   const [error, setError] = useState<string | null>(null);
+  const [isReadingFile, setIsReadingFile] = useState(false);
+  const fileReadSeq = useRef(0);
 
   const resetForm = useCallback(() => {
+    fileReadSeq.current += 1;
     setEntries([{ ...EMPTY_ENTRY }]);
     setError(null);
+    setIsReadingFile(false);
   }, []);
 
   const handleSave = () => {
+    if (isReadingFile) return;
+
     const keyedEntries = entries.filter((e) => e.key.trim());
     if (keyedEntries.length === 0) return;
 
@@ -157,19 +163,34 @@ export function AddVariableSheet({
       event.clipboardData.getData("text"),
       index,
     );
-    if (imported) event.preventDefault();
+    if (imported) {
+      fileReadSeq.current += 1;
+      setIsReadingFile(false);
+      event.preventDefault();
+    }
   };
 
   const handleDotEnvFile = async (file: File | undefined): Promise<void> => {
     if (!file) return;
 
+    const readSeq = ++fileReadSeq.current;
+    setIsReadingFile(true);
+
     try {
-      const imported = importDotEnvContents(await file.text(), 0);
+      const contents = await file.text();
+      if (readSeq !== fileReadSeq.current) return;
+
+      const imported = importDotEnvContents(contents, 0);
       if (!imported) {
         setError("No valid environment variable assignments found.");
       }
     } catch {
+      if (readSeq !== fileReadSeq.current) return;
       setError("The selected .env file could not be read.");
+    } finally {
+      if (readSeq === fileReadSeq.current) {
+        setIsReadingFile(false);
+      }
     }
   };
 
@@ -368,7 +389,10 @@ export function AddVariableSheet({
           <span className="text-muted-foreground text-xs">
             or paste .env contents in Key input
           </span>
-          <Button onClick={handleSave} disabled={!hasValidEntry}>
+          <Button
+            onClick={handleSave}
+            disabled={!hasValidEntry || isReadingFile}
+          >
             Save
           </Button>
         </SheetFooter>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- connect the MCP environment variable “Import .env” control to a local file picker
- reuse dotenv parsing and validation for pasted and uploaded content
- keep imported values secret by default and report unreadable or invalid files
- sequence asynchronous file reads so stale selections and closed-sheet completions are ignored, while Save stays disabled during the active read
- add component coverage for successful, invalid, superseded, and canceled file imports
- add a patch changeset for the dashboard package

## Testing
- `pnpm -F dashboard lint`
- `pnpm -F dashboard test src/pages/mcp/AddVariableSheet.test.tsx src/pages/mcp/dotEnvUtils.test.ts` (9 tests passed)
- `pnpm exec changeset status --since=main` (dashboard patch detected)
- manually re-tested the latest dashboard import flow; imported value was masked and secret, Save became available after loading, closing discarded it, and no related console errors appeared

## Walkthrough
<a href="https://cursor.com/agents/bc-98a35009-ec65-4b10-b0e5-f5dab7837f1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_dotenv_file_import.mp4"><img src="https://cursor.com/artifacts/c/art-049d32fe-9bd7-42d7-ad34-3112f1a5abca" alt="mcp_dotenv_file_import.mp4" /></a>

Linear: AIS-345
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-345](https://linear.app/speakeasy/issue/AIS-345/bug-import-env-doesnt-work-for-adding-env-vars-to-mcp-servers)

<div><a href="https://cursor.com/agents/bc-98a35009-ec65-4b10-b0e5-f5dab7837f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98a35009-ec65-4b10-b0e5-f5dab7837f1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP dashboard “Import .env” flow so users can import variables from a local file or by pasting contents. Addresses AIS-345 by adding vars to MCP servers as secrets, showing clear errors, and guarding against stale file reads.

- **Bug Fixes**
  - Wire “Import .env” to a hidden file input (`.env`, `text/plain`), reset after selection, and parse entries into rows.
  - Reuse one dotenv parser for paste/file; uppercase keys, mark values secret, set state to system.
  - Sequence async file reads to ignore stale selections and after-close completions; disable Save during an active read.
  - Show errors for unreadable files and when no valid assignments are found.
  - Add component tests for success/invalid/superseded/canceled imports; fix test callback typing and mock return types; add a changeset to publish a `dashboard` patch.

<sup>Written for commit 0abe60cba4040f9a93c6652e4947a1aad8c46464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

