### PR TITLE
feat: support Anthropic model provider keys

### DIFF
--- a/.changeset/anthropic-model-provider-keys.md
+++ b/.changeset/anthropic-model-provider-keys.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Projects can now use Anthropic API keys for Claude model completions. Anthropic keys are validated before encrypted storage and route supported Claude requests directly through Anthropic's OpenAI-compatible endpoint, while other model providers continue to use the project's OpenRouter or platform key.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -55849,7 +55849,7 @@ components:
           format: uuid
         provider:
           type: string
-          description: The model provider the key authenticates with. Supported values include openrouter.
+          description: The model provider the key authenticates with. Supported values are openrouter and anthropic.
         slot:
           type: string
           description: The responsibility slot the key applies to. The 'default' slot covers every slot without a dedicated override.
@@ -66171,7 +66171,7 @@ components:
           default: true
         provider:
           type: string
-          description: The model provider the key authenticates with. Supported values include openrouter.
+          description: The model provider the key authenticates with. Supported values are openrouter and anthropic.
         slot:
           type: string
           description: The responsibility slot the key applies to. Use 'default' to cover every slot without a dedicated override.

--- a/client/dashboard/src/components/platform-admin-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-panel.tsx
@@ -348,7 +348,7 @@ function ProductFeaturesSection(): ReactElement {
 
       <FeatureToggle
         label="Custom Model Provider Keys"
-        description="Allows projects in this organization to store OpenRouter API keys for model completions."
+        description="Allows projects in this organization to store OpenRouter or Anthropic API keys for model completions."
         icon={Key}
         featureName={FeatureName.CustomModelKeys}
         enabled={features.customModelKeysEnabled}

--- a/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
+++ b/client/dashboard/src/pages/settings/ModelProviderKeysSection.tsx
@@ -1,6 +1,13 @@
 import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { Heading } from "@/components/ui/heading";
 import { SkeletonTable } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Type } from "@/components/ui/type";
 import { useProjectSlugForRequests } from "@/contexts/Sdk";
 import { HumanizeDateTime } from "@/lib/dates";
@@ -31,9 +38,10 @@ import { type ComponentProps, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
   keySourceForSlot,
-  MODEL_KEY_PROVIDER,
+  MODEL_KEY_PROVIDERS,
   MODEL_KEY_SLOTS,
   type KeySource,
+  type ModelKeyProvider,
   type ModelKeySlot,
 } from "./model-key-slots";
 
@@ -64,6 +72,9 @@ function ModelProviderKeysTable({
     { throwOnError: false },
   );
   const [draftValues, setDraftValues] = useState<Record<string, string>>({});
+  const [draftProviders, setDraftProviders] = useState<
+    Record<string, ModelKeyProvider>
+  >({});
 
   const keysBySlot = useMemo(
     () => new Map((data?.keys ?? []).map((key) => [key.slot, key] as const)),
@@ -118,13 +129,15 @@ function ModelProviderKeysTable({
   const handleSave = (slot: ModelKeySlot, key?: ModelProviderKey) => {
     const apiKey = draftValues[slot.slot]?.trim();
     if (!apiKey || isSaving) return;
+    const provider =
+      draftProviders[slot.slot] ?? providerForSlot(slot.slot, keysBySlot);
 
     upsertKey(
       {
         request: {
           upsertKeyRequestBody: {
             slot: slot.slot,
-            provider: MODEL_KEY_PROVIDER,
+            provider,
             apiKey,
             enabled: key?.enabled ?? true,
           },
@@ -140,6 +153,16 @@ function ModelProviderKeysTable({
 
   const handleValueChange = (slot: ModelKeySlot, value: string) => {
     setDraftValues((values) => ({ ...values, [slot.slot]: value }));
+  };
+
+  const handleProviderChange = (
+    slot: ModelKeySlot,
+    provider: ModelKeyProvider,
+  ) => {
+    setDraftProviders((providers) => ({
+      ...providers,
+      [slot.slot]: provider,
+    }));
   };
 
   const handleSetEnabled = (key: ModelProviderKey) => {
@@ -179,19 +202,55 @@ function ModelProviderKeysTable({
       ),
     },
     {
+      key: "provider",
+      header: "Provider",
+      width: "150px",
+      render: (slot) => {
+        const provider =
+          draftProviders[slot.slot] ?? providerForSlot(slot.slot, keysBySlot);
+        return (
+          <Select
+            value={provider}
+            onValueChange={(value) =>
+              handleProviderChange(slot, value as ModelKeyProvider)
+            }
+            disabled={isMutating || !customModelKeysEnabled}
+          >
+            <SelectTrigger
+              className="h-9 w-full"
+              aria-label={`${slot.name} key provider`}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MODEL_KEY_PROVIDERS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      },
+    },
+    {
       key: "value",
       header: "Value",
       width: "260px",
       render: (slot) => {
         const key = keysBySlot.get(slot.slot);
         const draftValue = draftValues[slot.slot] ?? "";
+        const provider =
+          draftProviders[slot.slot] ?? providerForSlot(slot.slot, keysBySlot);
         const isDirty = draftValue.length > 0;
         return (
           <div className="relative">
             <Input
               type="password"
               value={draftValue}
-              placeholder={key ? "••••••••••••" : "Enter key"}
+              placeholder={
+                key ? "••••••••••••" : keyPlaceholderForProvider(provider)
+              }
               className="h-9 py-0 pr-10"
               onChange={(event) => handleValueChange(slot, event.target.value)}
               onKeyDown={(event) => {
@@ -331,15 +390,39 @@ function ModelProviderKeysTable({
           <ReleaseStageBadge stage="preview" />
         </Stack>
         <Type muted small>
-          Bring your own OpenRouter API key for model completions. Set a project
-          default for all surfaces, or override individual surfaces. Keys are
-          write-only and never displayed after saving.
+          Bring your own OpenRouter or Anthropic API key for model completions.
+          Set a project default for all surfaces, or override individual
+          surfaces. Keys are write-only and never displayed after saving.
         </Type>
       </div>
 
       {keyList}
     </Stack>
   );
+}
+
+function providerForKey(key?: ModelProviderKey): ModelKeyProvider {
+  if (key?.provider === "anthropic") return "anthropic";
+  return "openrouter";
+}
+
+function providerForSlot(
+  slot: string,
+  keysBySlot: Map<string, ModelProviderKey>,
+): ModelKeyProvider {
+  const ownKey = keysBySlot.get(slot);
+  if (ownKey) return providerForKey(ownKey);
+  if (slot !== "default") return providerForKey(keysBySlot.get("default"));
+  return "openrouter";
+}
+
+function keyPlaceholderForProvider(provider: ModelKeyProvider): string {
+  switch (provider) {
+    case "anthropic":
+      return "sk-ant-…";
+    case "openrouter":
+      return "sk-or-…";
+  }
 }
 
 const KEY_SOURCE_BADGE: Record<

--- a/client/dashboard/src/pages/settings/model-key-slots.ts
+++ b/client/dashboard/src/pages/settings/model-key-slots.ts
@@ -1,7 +1,13 @@
 import type { ModelProviderKey } from "@gram/client/models/components/modelproviderkey.js";
 
 const PROJECT_DEFAULT_SLOT = "default";
-export const MODEL_KEY_PROVIDER = "openrouter";
+
+export const MODEL_KEY_PROVIDERS = [
+  { value: "openrouter", label: "OpenRouter" },
+  { value: "anthropic", label: "Anthropic" },
+] as const;
+
+export type ModelKeyProvider = (typeof MODEL_KEY_PROVIDERS)[number]["value"];
 
 export type ModelKeySlot = {
   slot: string;

--- a/client/dashboard/src/sdk/src/models/components/modelproviderkey.ts
+++ b/client/dashboard/src/sdk/src/models/components/modelproviderkey.ts
@@ -29,7 +29,7 @@ export type ModelProviderKey = {
    */
   projectId: string;
   /**
-   * The model provider the key authenticates with. Supported values include openrouter.
+   * The model provider the key authenticates with. Supported values are openrouter and anthropic.
    */
   provider: string;
   /**

--- a/client/dashboard/src/sdk/src/models/components/upsertkeyrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/upsertkeyrequestbody.ts
@@ -15,7 +15,7 @@ export type UpsertKeyRequestBody = {
    */
   enabled?: boolean | undefined;
   /**
-   * The model provider the key authenticates with. Supported values include openrouter.
+   * The model provider the key authenticates with. Supported values are openrouter and anthropic.
    */
   provider: string;
   /**

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -118,6 +118,7 @@ import (
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/templates"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/anthropic"
 	ghclient "github.com/speakeasy-api/gram/server/internal/thirdparty/github"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -1097,7 +1098,7 @@ func newStartCommand() *cli.Command {
 				c.String("jwt-signing-key"),
 			))
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))
-			modelkeys.Attach(mux, modelkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, openRouter, productFeatures, auditLogger))
+			modelkeys.Attach(mux, modelkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, openRouter, anthropic.New(guardianPolicy), productFeatures, auditLogger))
 			otelforwarding.Attach(mux, otelforwarding.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, otelForwardClient))
 			auditapi.Attach(mux, auditapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine))
 			auth.Attach(mux, auth.NewService(

--- a/server/design/modelkeys/design.go
+++ b/server/design/modelkeys/design.go
@@ -18,7 +18,7 @@ var ModelProviderKey = Type("ModelProviderKey", func() {
 		Format(FormatUUID)
 	})
 	Attribute("slot", String, "The responsibility slot the key applies to. The 'default' slot covers every slot without a dedicated override.")
-	Attribute("provider", String, "The model provider the key authenticates with. Supported values include openrouter.")
+	Attribute("provider", String, "The model provider the key authenticates with. Supported values are openrouter and anthropic.")
 	Attribute("enabled", Boolean, "Whether the key participates in key resolution.")
 	Attribute("created_at", String, "ISO 8601 timestamp when the key was created.", func() {
 		Format(FormatDateTime)
@@ -70,7 +70,7 @@ var _ = Service("modelKeys", func() {
 
 		Payload(func() {
 			Attribute("slot", String, "The responsibility slot the key applies to. Use 'default' to cover every slot without a dedicated override.")
-			Attribute("provider", String, "The model provider the key authenticates with. Supported values include openrouter.")
+			Attribute("provider", String, "The model provider the key authenticates with. Supported values are openrouter and anthropic.")
 			Attribute("api_key", String, "The provider API key. Stored encrypted at rest; never returned on reads.")
 			Attribute("enabled", Boolean, "Whether the key participates in key resolution.", func() {
 				Default(true)

--- a/server/gen/http/model_keys/client/types.go
+++ b/server/gen/http/model_keys/client/types.go
@@ -19,8 +19,8 @@ type UpsertKeyRequestBody struct {
 	// The responsibility slot the key applies to. Use 'default' to cover every
 	// slot without a dedicated override.
 	Slot string `form:"slot" json:"slot" xml:"slot"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider string `form:"provider" json:"provider" xml:"provider"`
 	// The provider API key. Stored encrypted at rest; never returned on reads.
 	APIKey string `form:"api_key" json:"api_key" xml:"api_key"`
@@ -54,8 +54,8 @@ type UpsertKeyResponseBody struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot *string `form:"slot,omitempty" json:"slot,omitempty" xml:"slot,omitempty"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// Whether the key participates in key resolution.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
@@ -75,8 +75,8 @@ type SetKeyEnabledResponseBody struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot *string `form:"slot,omitempty" json:"slot,omitempty" xml:"slot,omitempty"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// Whether the key participates in key resolution.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`
@@ -820,8 +820,8 @@ type ModelProviderKeyResponseBody struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot *string `form:"slot,omitempty" json:"slot,omitempty" xml:"slot,omitempty"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// Whether the key participates in key resolution.
 	Enabled *bool `form:"enabled,omitempty" json:"enabled,omitempty" xml:"enabled,omitempty"`

--- a/server/gen/http/model_keys/server/types.go
+++ b/server/gen/http/model_keys/server/types.go
@@ -19,8 +19,8 @@ type UpsertKeyRequestBody struct {
 	// The responsibility slot the key applies to. Use 'default' to cover every
 	// slot without a dedicated override.
 	Slot *string `form:"slot,omitempty" json:"slot,omitempty" xml:"slot,omitempty"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider *string `form:"provider,omitempty" json:"provider,omitempty" xml:"provider,omitempty"`
 	// The provider API key. Stored encrypted at rest; never returned on reads.
 	APIKey *string `form:"api_key,omitempty" json:"api_key,omitempty" xml:"api_key,omitempty"`
@@ -54,8 +54,8 @@ type UpsertKeyResponseBody struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot string `form:"slot" json:"slot" xml:"slot"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider string `form:"provider" json:"provider" xml:"provider"`
 	// Whether the key participates in key resolution.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
@@ -75,8 +75,8 @@ type SetKeyEnabledResponseBody struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot string `form:"slot" json:"slot" xml:"slot"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider string `form:"provider" json:"provider" xml:"provider"`
 	// Whether the key participates in key resolution.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`
@@ -820,8 +820,8 @@ type ModelProviderKeyResponseBody struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot string `form:"slot" json:"slot" xml:"slot"`
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider string `form:"provider" json:"provider" xml:"provider"`
 	// Whether the key participates in key resolution.
 	Enabled bool `form:"enabled" json:"enabled" xml:"enabled"`

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -56157,7 +56157,7 @@ components:
                     format: uuid
                 provider:
                     type: string
-                    description: The model provider the key authenticates with. Supported values include openrouter.
+                    description: The model provider the key authenticates with. Supported values are openrouter and anthropic.
                 slot:
                     type: string
                     description: The responsibility slot the key applies to. The 'default' slot covers every slot without a dedicated override.
@@ -66479,7 +66479,7 @@ components:
                     default: true
                 provider:
                     type: string
-                    description: The model provider the key authenticates with. Supported values include openrouter.
+                    description: The model provider the key authenticates with. Supported values are openrouter and anthropic.
                 slot:
                     type: string
                     description: The responsibility slot the key applies to. Use 'default' to cover every slot without a dedicated override.

--- a/server/gen/model_keys/service.go
+++ b/server/gen/model_keys/service.go
@@ -94,8 +94,8 @@ type UpsertKeyPayload struct {
 	// The responsibility slot the key applies to. Use 'default' to cover every
 	// slot without a dedicated override.
 	Slot string
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider string
 	// The provider API key. Stored encrypted at rest; never returned on reads.
 	APIKey string

--- a/server/gen/types/model_provider_key.go
+++ b/server/gen/types/model_provider_key.go
@@ -17,8 +17,8 @@ type ModelProviderKey struct {
 	// The responsibility slot the key applies to. The 'default' slot covers every
 	// slot without a dedicated override.
 	Slot string
-	// The model provider the key authenticates with. Supported values include
-	// openrouter.
+	// The model provider the key authenticates with. Supported values are
+	// openrouter and anthropic.
 	Provider string
 	// Whether the key participates in key resolution.
 	Enabled bool

--- a/server/internal/modelkeys/impl.go
+++ b/server/internal/modelkeys/impl.go
@@ -36,16 +36,21 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+type AnthropicKeyValidator interface {
+	ValidateAPIKey(ctx context.Context, apiKey string) error
+}
+
 type Service struct {
-	tracer      trace.Tracer
-	logger      *slog.Logger
-	db          *pgxpool.Pool
-	auth        *auth.Auth
-	authz       *authz.Engine
-	enc         *encryption.Client
-	provisioner openrouter.Provisioner
-	features    *productfeatures.Client
-	audit       *audit.Logger
+	tracer             trace.Tracer
+	logger             *slog.Logger
+	db                 *pgxpool.Pool
+	auth               *auth.Auth
+	authz              *authz.Engine
+	enc                *encryption.Client
+	provisioner        openrouter.Provisioner
+	anthropicValidator AnthropicKeyValidator
+	features           *productfeatures.Client
+	audit              *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -59,21 +64,23 @@ func NewService(
 	authzEngine *authz.Engine,
 	enc *encryption.Client,
 	provisioner openrouter.Provisioner,
+	anthropicValidator AnthropicKeyValidator,
 	features *productfeatures.Client,
 	auditLogger *audit.Logger,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("modelkeys"))
 
 	return &Service{
-		tracer:      tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/modelkeys"),
-		logger:      logger,
-		db:          db,
-		auth:        auth.New(logger, db, sessions, authzEngine),
-		authz:       authzEngine,
-		enc:         enc,
-		provisioner: provisioner,
-		features:    features,
-		audit:       auditLogger,
+		tracer:             tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/modelkeys"),
+		logger:             logger,
+		db:                 db,
+		auth:               auth.New(logger, db, sessions, authzEngine),
+		authz:              authzEngine,
+		enc:                enc,
+		provisioner:        provisioner,
+		anthropicValidator: anthropicValidator,
+		features:           features,
+		audit:              auditLogger,
 	}
 }
 
@@ -144,7 +151,7 @@ func (s *Service) UpsertKey(ctx context.Context, payload *gen.UpsertKeyPayload) 
 	}
 
 	provider := strings.ToLower(strings.TrimSpace(payload.Provider))
-	if provider != ProviderOpenRouter {
+	if provider != ProviderOpenRouter && provider != ProviderAnthropic {
 		return nil, oops.E(oops.CodeInvalid, nil, "unsupported model provider: %s", provider)
 	}
 
@@ -153,8 +160,15 @@ func (s *Service) UpsertKey(ctx context.Context, payload *gen.UpsertKeyPayload) 
 		return nil, oops.E(oops.CodeInvalid, nil, "api_key is required")
 	}
 
-	if _, _, err := s.provisioner.GetKeyUsage(ctx, apiKey); err != nil {
-		return nil, oops.E(oops.CodeBadRequest, err, "the model provider rejected the API key").LogError(ctx, logger)
+	var validationErr error
+	switch provider {
+	case ProviderOpenRouter:
+		_, _, validationErr = s.provisioner.GetKeyUsage(ctx, apiKey)
+	case ProviderAnthropic:
+		validationErr = s.anthropicValidator.ValidateAPIKey(ctx, apiKey)
+	}
+	if validationErr != nil {
+		return nil, oops.E(oops.CodeBadRequest, validationErr, "the model provider rejected the API key").LogError(ctx, logger)
 	}
 
 	encrypted, err := s.enc.Encrypt([]byte(apiKey))

--- a/server/internal/modelkeys/queries.sql
+++ b/server/internal/modelkeys/queries.sql
@@ -1,9 +1,10 @@
 -- name: GetKeyForResolution :one
-SELECT api_key_encrypted
+SELECT provider
+     , api_key_encrypted
 FROM model_provider_keys
 WHERE project_id = @project_id
   AND slot = ANY (@slots::text[])
-  AND provider = @provider
+  AND provider = ANY (@providers::text[])
   AND enabled
   AND deleted IS FALSE
 ORDER BY (slot = @preferred_slot::text) DESC

--- a/server/internal/modelkeys/repo/queries.sql.go
+++ b/server/internal/modelkeys/repo/queries.sql.go
@@ -45,11 +45,12 @@ func (q *Queries) GetKeyByIDForUpdate(ctx context.Context, arg GetKeyByIDForUpda
 }
 
 const getKeyForResolution = `-- name: GetKeyForResolution :one
-SELECT api_key_encrypted
+SELECT provider
+     , api_key_encrypted
 FROM model_provider_keys
 WHERE project_id = $1
   AND slot = ANY ($2::text[])
-  AND provider = $3
+  AND provider = ANY ($3::text[])
   AND enabled
   AND deleted IS FALSE
 ORDER BY (slot = $4::text) DESC
@@ -59,20 +60,25 @@ LIMIT 1
 type GetKeyForResolutionParams struct {
 	ProjectID     uuid.UUID
 	Slots         []string
-	Provider      string
+	Providers     []string
 	PreferredSlot string
 }
 
-func (q *Queries) GetKeyForResolution(ctx context.Context, arg GetKeyForResolutionParams) (string, error) {
+type GetKeyForResolutionRow struct {
+	Provider        string
+	ApiKeyEncrypted string
+}
+
+func (q *Queries) GetKeyForResolution(ctx context.Context, arg GetKeyForResolutionParams) (GetKeyForResolutionRow, error) {
 	row := q.db.QueryRow(ctx, getKeyForResolution,
 		arg.ProjectID,
 		arg.Slots,
-		arg.Provider,
+		arg.Providers,
 		arg.PreferredSlot,
 	)
-	var api_key_encrypted string
-	err := row.Scan(&api_key_encrypted)
-	return api_key_encrypted, err
+	var i GetKeyForResolutionRow
+	err := row.Scan(&i.Provider, &i.ApiKeyEncrypted)
+	return i, err
 }
 
 const insertKey = `-- name: InsertKey :one

--- a/server/internal/modelkeys/resolver.go
+++ b/server/internal/modelkeys/resolver.go
@@ -19,9 +19,8 @@ import (
 )
 
 const (
-	// ProviderOpenRouter is the only supported key provider: BYOK egress stays
-	// on OpenRouter (passthrough), so customer keys are OpenRouter keys.
-	ProviderOpenRouter = "openrouter"
+	ProviderOpenRouter = string(openrouter.KeyProviderOpenRouter)
+	ProviderAnthropic  = string(openrouter.KeyProviderAnthropic)
 
 	// SlotDefault is the project-wide key slot. It applies to every
 	// responsibility slot that has no dedicated override row.
@@ -50,7 +49,7 @@ func ValidSlots() []string {
 	return slots
 }
 
-// Resolver picks the OpenRouter API key a completion bills to. Precedence:
+// Resolver picks the provider API key a completion bills to. Precedence:
 // slot-override key, then the project's default-slot key, then the org's
 // provisioned platform key (delegated to the Provisioner, unchanged).
 //
@@ -64,6 +63,7 @@ type Resolver struct {
 }
 
 var _ openrouter.KeyResolver = (*Resolver)(nil)
+var _ openrouter.ModelAwareKeyResolver = (*Resolver)(nil)
 
 func NewResolver(db *pgxpool.Pool, enc *encryption.Client, provisioner openrouter.Provisioner) *Resolver {
 	return &Resolver{
@@ -74,6 +74,10 @@ func NewResolver(db *pgxpool.Pool, enc *encryption.Client, provisioner openroute
 }
 
 func (r *Resolver) ResolveKey(ctx context.Context, orgID string, projectID string, slot billing.ModelUsageSource, keyType openrouter.KeyType) (openrouter.ResolvedKey, error) {
+	return r.ResolveKeyForModel(ctx, orgID, projectID, slot, keyType, "")
+}
+
+func (r *Resolver) ResolveKeyForModel(ctx context.Context, orgID string, projectID string, slot billing.ModelUsageSource, keyType openrouter.KeyType, model string) (openrouter.ResolvedKey, error) {
 	// Callers without a project (e.g. embeddings) resolve straight to the
 	// platform key. KeyTypeInternal marks platform-initiated inference; only
 	// the slots exposed for it (the risk-analysis judges) consult customer
@@ -93,11 +97,16 @@ func (r *Resolver) ResolveKey(ctx context.Context, orgID string, projectID strin
 		return openrouter.ResolvedKey{}, fmt.Errorf("invalid project id for key resolution: %w", err)
 	}
 
-	encryptedKey, err := repo.New(r.db).GetKeyForResolution(ctx, repo.GetKeyForResolutionParams{
+	providers := []string{ProviderOpenRouter}
+	if openrouter.KeyProviderAnthropic.SupportsModel(model) {
+		providers = append(providers, ProviderAnthropic)
+	}
+
+	storedKey, err := repo.New(r.db).GetKeyForResolution(ctx, repo.GetKeyForResolutionParams{
 		ProjectID:     projectUUID,
 		Slots:         []string{string(slot), SlotDefault},
+		Providers:     providers,
 		PreferredSlot: string(slot),
-		Provider:      ProviderOpenRouter,
 	})
 	switch {
 	// An absent table means BYOK is not deployed in this environment yet
@@ -114,11 +123,12 @@ func (r *Resolver) ResolveKey(ctx context.Context, orgID string, projectID strin
 		return openrouter.ResolvedKey{}, fmt.Errorf("read model provider keys: %w", err)
 	}
 
-	key, err := r.enc.Decrypt(encryptedKey)
+	provider := openrouter.KeyProvider(storedKey.Provider)
+	key, err := r.enc.Decrypt(storedKey.ApiKeyEncrypted)
 	if err != nil {
 		return openrouter.ResolvedKey{}, fmt.Errorf("decrypt model provider key: %w", err)
 	}
-	return openrouter.ResolvedKey{Key: key, Customer: true}, nil
+	return openrouter.ResolvedKey{Key: key, Provider: provider, Customer: true}, nil
 }
 
 // internalBYOKSlots lists the platform-initiated (KeyTypeInternal) slots a

--- a/server/internal/modelkeys/resolver_test.go
+++ b/server/internal/modelkeys/resolver_test.go
@@ -35,6 +35,51 @@ func upsertTestKey(t *testing.T, ctx context.Context, ti *testInstance, slot str
 	require.NoError(t, err)
 }
 
+func TestResolveKey_ReturnsAnthropicProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	enableCustomModelKeys(t, ctx, ti.conn)
+	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
+
+	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(p *gen.UpsertKeyPayload) {
+		p.Provider = modelkeys.ProviderAnthropic
+		p.APIKey = "sk-ant-project-default"
+	}))
+	require.NoError(t, err)
+
+	resolved, err := resolver.ResolveKeyForModel(ctx, orgID, projectID, billing.ModelUsageSourceAssistants, openrouter.KeyTypeChat, openrouter.DefaultChatModel)
+	require.NoError(t, err)
+	require.Equal(t, "sk-ant-project-default", resolved.Key)
+	require.Equal(t, openrouter.KeyProviderAnthropic, resolved.Provider)
+	require.True(t, resolved.Customer)
+}
+
+func TestResolveKeyForModel_IncompatibleOverrideUsesCompatibleDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	enableCustomModelKeys(t, ctx, ti.conn)
+	resolver, orgID, projectID := newResolverUnderTest(t, ctx, ti)
+
+	upsertTestKey(t, ctx, ti, modelkeys.SlotDefault, "sk-or-project-default")
+	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(string(billing.ModelUsageSourceAssistants), func(p *gen.UpsertKeyPayload) {
+		p.Provider = modelkeys.ProviderAnthropic
+		p.APIKey = "sk-ant-assistants"
+	}))
+	require.NoError(t, err)
+
+	resolved, err := resolver.ResolveKeyForModel(ctx, orgID, projectID, billing.ModelUsageSourceAssistants, openrouter.KeyTypeChat, "openai/gpt-5.4")
+	require.NoError(t, err)
+	require.Equal(t, "sk-or-project-default", resolved.Key)
+	require.Equal(t, openrouter.KeyProviderOpenRouter, resolved.Provider)
+
+	resolved, err = resolver.ResolveKeyForModel(ctx, orgID, projectID, billing.ModelUsageSourceAssistants, openrouter.KeyTypeChat, openrouter.DefaultChatModel)
+	require.NoError(t, err)
+	require.Equal(t, "sk-ant-assistants", resolved.Key)
+	require.Equal(t, openrouter.KeyProviderAnthropic, resolved.Provider)
+}
+
 func TestResolveKey_NoCustomerKeysFallsBackToPlatform(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -84,12 +84,23 @@ func (p *stubProvisioner) GetModelUsage(ctx context.Context, generationID string
 	return nil, errors.New("not implemented")
 }
 
+type stubAnthropicKeyValidator struct {
+	err   error
+	calls int
+}
+
+func (v *stubAnthropicKeyValidator) ValidateAPIKey(context.Context, string) error {
+	v.calls++
+	return v.err
+}
+
 type testInstance struct {
-	service     *modelkeys.Service
-	conn        *pgxpool.Pool
-	enc         *encryption.Client
-	provisioner *stubProvisioner
-	features    *productfeatures.Client
+	service            *modelkeys.Service
+	conn               *pgxpool.Pool
+	enc                *encryption.Client
+	provisioner        *stubProvisioner
+	anthropicValidator *stubAnthropicKeyValidator
+	features           *productfeatures.Client
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
@@ -128,6 +139,7 @@ func newTestServiceWithRedisDB(t *testing.T, redisDB int) (context.Context, *tes
 	require.NoError(t, err)
 
 	provisioner := &stubProvisioner{platformKey: "platform-key", usageErr: nil, usageCalls: 0}
+	anthropicValidator := &stubAnthropicKeyValidator{err: nil, calls: 0}
 	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
 
 	svc := modelkeys.NewService(
@@ -138,16 +150,18 @@ func newTestServiceWithRedisDB(t *testing.T, redisDB int) (context.Context, *tes
 		authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient()),
 		enc,
 		provisioner,
+		anthropicValidator,
 		features,
 		audit.NewLogger(),
 	)
 
 	return ctx, &testInstance{
-		service:     svc,
-		conn:        conn,
-		enc:         enc,
-		provisioner: provisioner,
-		features:    features,
+		service:            svc,
+		conn:               conn,
+		enc:                enc,
+		provisioner:        provisioner,
+		anthropicValidator: anthropicValidator,
+		features:           features,
 	}
 }
 

--- a/server/internal/modelkeys/upsertkey_test.go
+++ b/server/internal/modelkeys/upsertkey_test.go
@@ -115,9 +115,39 @@ func TestUpsertKey_RejectsUnknownProvider(t *testing.T) {
 	enableCustomModelKeys(t, ctx, ti.conn)
 
 	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(p *gen.UpsertKeyPayload) {
-		p.Provider = "anthropic"
+		p.Provider = "not-a-provider"
 	}))
 	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+func TestUpsertKey_CreatesAnthropicKey(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	enableCustomModelKeys(t, ctx, ti.conn)
+
+	key, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(p *gen.UpsertKeyPayload) {
+		p.Provider = modelkeys.ProviderAnthropic
+		p.APIKey = "sk-ant-test-key"
+	}))
+	require.NoError(t, err)
+	require.Equal(t, modelkeys.ProviderAnthropic, key.Provider)
+	require.Equal(t, 1, ti.anthropicValidator.calls)
+	require.Equal(t, 0, ti.provisioner.usageCalls)
+}
+
+func TestUpsertKey_RejectsAnthropicKeyTheProviderRejects(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	enableCustomModelKeys(t, ctx, ti.conn)
+	ti.anthropicValidator.err = errors.New("401 unauthorized")
+
+	_, err := ti.service.UpsertKey(ctx, newUpsertPayload(modelkeys.SlotDefault, func(p *gen.UpsertKeyPayload) {
+		p.Provider = modelkeys.ProviderAnthropic
+		p.APIKey = "invalid-anthropic-key"
+	}))
+	requireOopsCode(t, err, oops.CodeBadRequest)
 }
 
 func TestUpsertKey_RejectsKeyTheProviderRejects(t *testing.T) {

--- a/server/internal/telemetry/create_log_test.go
+++ b/server/internal/telemetry/create_log_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -550,27 +551,29 @@ func newTestToolInfo(orgID string) telemetry.ToolInfo {
 	}
 }
 
-// flushAndGetLog drains ClickHouse's async insert queue so the row the
-// preceding Log call wrote becomes deterministically visible, then fetches
-// it. Logger.Log is synchronous up to the async insert queue, so the flush is
-// the only synchronization point needed — no polling (see
-// internal/telemetry/README.md).
+// flushAndGetLog drains ClickHouse's async insert queue, then polls the read.
+// Under full-suite load ClickHouse can acknowledge the flush just before the
+// row becomes queryable, so a single immediate read is occasionally empty.
 func flushAndGetLog(t *testing.T, ctx context.Context, ti *testInstance, projectID, urn string, timestamp time.Time) repo.TelemetryLog {
 	t.Helper()
 
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+	var logs []repo.TelemetryLog
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
-	logs, err := ti.chClient.ListTelemetryLogs(ctx, repo.ListTelemetryLogsParams{
-		GramProjectID: projectID,
-		TimeStart:     timestamp.Add(-1 * time.Minute).UnixNano(),
-		TimeEnd:       timestamp.Add(1 * time.Minute).UnixNano(),
-		GramURNs:      []string{urn},
-		SortOrder:     "desc",
-		Cursor:        "",
-		Limit:         10,
-	})
-	require.NoError(t, err)
-	require.Len(t, logs, 1, "expected 1 log in ClickHouse")
+		var err error
+		logs, err = ti.chClient.ListTelemetryLogs(ctx, repo.ListTelemetryLogsParams{
+			GramProjectID: projectID,
+			TimeStart:     timestamp.Add(-1 * time.Minute).UnixNano(),
+			TimeEnd:       timestamp.Add(1 * time.Minute).UnixNano(),
+			GramURNs:      []string{urn},
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		assert.NoError(c, err)
+		assert.Len(c, logs, 1, "expected 1 log in ClickHouse")
+	}, 10*time.Second, 50*time.Millisecond)
 
 	return logs[0]
 }

--- a/server/internal/thirdparty/anthropic/client.go
+++ b/server/internal/thirdparty/anthropic/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
 const (
@@ -64,6 +65,36 @@ func New(guardianPolicy *guardian.Policy, opts ...Option) *Client {
 		opt(c)
 	}
 	return c
+}
+
+// ValidateAPIKey verifies that a standard Anthropic API key can access the
+// Models API. The key is supplied per call because model-provider keys are
+// project-scoped and must never be retained on this shared client.
+func (c *Client) ValidateAPIKey(ctx context.Context, apiKey string) error {
+	endpoint, err := c.endpoint("/v1/models")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return fmt.Errorf("create anthropic API key validation request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", apiVersion)
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("validate anthropic API key: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return res.Body.Close() })
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return &HTTPError{StatusCode: res.StatusCode, Status: res.Status}
+	}
+
+	return nil
 }
 
 // ListActivitiesParams filters and paginates the activities feed. The feed

--- a/server/internal/thirdparty/anthropic/client_test.go
+++ b/server/internal/thirdparty/anthropic/client_test.go
@@ -14,6 +14,37 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
+func TestValidateAPIKey(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/models", r.URL.Path)
+		require.Equal(t, "anthropic-key", r.Header.Get("x-api-key"))
+		require.Equal(t, apiVersion, r.Header.Get("anthropic-version"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(testGuardianPolicy(t), WithBaseURL(server.URL))
+	require.NoError(t, client.ValidateAPIKey(t.Context(), "anthropic-key"))
+}
+
+func TestValidateAPIKeyRejectsUnauthorizedKey(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	client := New(testGuardianPolicy(t), WithBaseURL(server.URL))
+	err := client.ValidateAPIKey(t.Context(), "invalid-key")
+
+	var httpErr *HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusUnauthorized, httpErr.StatusCode)
+}
+
 func TestListActivitiesSendsAuthAndFilters(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/anthropic/client_test.go
+++ b/server/internal/thirdparty/anthropic/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -18,9 +19,9 @@ func TestValidateAPIKey(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/models", r.URL.Path)
-		require.Equal(t, "anthropic-key", r.Header.Get("x-api-key"))
-		require.Equal(t, apiVersion, r.Header.Get("anthropic-version"))
+		assert.Equal(t, "/v1/models", r.URL.Path)
+		assert.Equal(t, "anthropic-key", r.Header.Get("x-api-key"))
+		assert.Equal(t, apiVersion, r.Header.Get("anthropic-version"))
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(server.Close)

--- a/server/internal/thirdparty/openrouter/key_resolver.go
+++ b/server/internal/thirdparty/openrouter/key_resolver.go
@@ -3,9 +3,35 @@ package openrouter
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
 )
+
+type KeyProvider string
+
+const (
+	KeyProviderOpenRouter KeyProvider = "openrouter"
+	KeyProviderAnthropic  KeyProvider = "anthropic"
+)
+
+func (p KeyProvider) OrDefault() KeyProvider {
+	if p == "" {
+		return KeyProviderOpenRouter
+	}
+	return p
+}
+
+func (p KeyProvider) SupportsModel(model string) bool {
+	switch p.OrDefault() {
+	case KeyProviderOpenRouter:
+		return true
+	case KeyProviderAnthropic:
+		return strings.HasPrefix(model, "anthropic/")
+	default:
+		return false
+	}
+}
 
 // ResolvedKey is the outcome of key resolution. Customer marks a
 // customer-supplied (BYOK) key: platform-side key maintenance — generation
@@ -13,15 +39,22 @@ import (
 // callers must skip it when the flag is set.
 type ResolvedKey struct {
 	Key      string
+	Provider KeyProvider
 	Customer bool
 }
 
-// KeyResolver resolves the OpenRouter API key a completion should bill to,
-// given the requesting org, project, and responsibility slot (usage source).
+// KeyResolver resolves the provider API key a completion should bill to,
+// given the requesting org, project, and responsibility slot.
 // Implementations fall back to the org's provisioned platform key when no
 // customer-supplied key applies.
 type KeyResolver interface {
 	ResolveKey(ctx context.Context, orgID string, projectID string, slot billing.ModelUsageSource, keyType KeyType) (ResolvedKey, error)
+}
+
+// ModelAwareKeyResolver can apply provider compatibility while evaluating a
+// slot and its project-default fallback.
+type ModelAwareKeyResolver interface {
+	ResolveKeyForModel(ctx context.Context, orgID string, projectID string, slot billing.ModelUsageSource, keyType KeyType, model string) (ResolvedKey, error)
 }
 
 // PlatformKeyResolver resolves every slot to the org's provisioned platform
@@ -37,5 +70,5 @@ func (r *PlatformKeyResolver) ResolveKey(ctx context.Context, orgID string, _ st
 	if err != nil {
 		return ResolvedKey{}, fmt.Errorf("provision platform key: %w", err)
 	}
-	return ResolvedKey{Key: key, Customer: false}, nil
+	return ResolvedKey{Key: key, Provider: KeyProviderOpenRouter, Customer: false}, nil
 }

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -36,11 +36,14 @@ type TelemetryLogger interface {
 }
 
 const (
-	DefaultChatModel = "anthropic/claude-sonnet-5"
+	DefaultChatModel    = "anthropic/claude-sonnet-5"
+	AnthropicAPIBaseURL = "https://api.anthropic.com"
+	anthropicAPIVersion = "2023-06-01"
 )
 
-// ChatClient is the single HTTP client for all OpenRouter communication.
-// It applies pluggable strategies for message capture and usage tracking.
+// ChatClient is the single OpenAI-compatible completion client. It routes
+// platform and OpenRouter BYOK keys through OpenRouter, and Anthropic BYOK keys
+// directly to Anthropic while sharing capture and usage tracking strategies.
 type ChatClient struct {
 	logger                 *slog.Logger
 	httpClient             *guardian.HTTPClient
@@ -77,6 +80,7 @@ func NewUnifiedClient(
 
 type initializeRequestResult struct {
 	apiKey         string
+	provider       KeyProvider
 	customerKey    bool
 	requestBody    OpenAIChatRequest
 	captureSession CaptureSession
@@ -111,10 +115,6 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 	if keySlot == "" {
 		keySlot = req.UsageSource
 	}
-	resolvedKey, err := c.keyResolver.ResolveKey(ctx, req.OrgID, req.ProjectID, keySlot, req.KeyType.OrDefault())
-	if err != nil {
-		return nil, fmt.Errorf("resolve OpenRouter key: %w", err)
-	}
 
 	// Set defaults
 	temp := float32(1.0)
@@ -138,6 +138,34 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 		}
 	} else {
 		return nil, fmt.Errorf("model %s is not allowed and no fallback is available for its provider", model)
+	}
+
+	var (
+		resolvedKey ResolvedKey
+		err         error
+	)
+	if resolver, ok := c.keyResolver.(ModelAwareKeyResolver); ok {
+		resolvedKey, err = resolver.ResolveKeyForModel(ctx, req.OrgID, req.ProjectID, keySlot, req.KeyType.OrDefault(), model)
+	} else {
+		resolvedKey, err = c.keyResolver.ResolveKey(ctx, req.OrgID, req.ProjectID, keySlot, req.KeyType.OrDefault())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve model provider key: %w", err)
+	}
+
+	// A provider-specific key only applies to models that provider serves. A
+	// project may still select other models, which continue through the
+	// platform OpenRouter key.
+	if !resolvedKey.Provider.SupportsModel(model) {
+		platformKey, err := c.provisioner.ProvisionAPIKey(ctx, req.OrgID, req.KeyType.OrDefault())
+		if err != nil {
+			return nil, fmt.Errorf("resolve platform key for model %s: %w", model, err)
+		}
+		resolvedKey = ResolvedKey{
+			Key:      platformKey,
+			Provider: KeyProviderOpenRouter,
+			Customer: false,
+		}
 	}
 
 	outboundMessages := req.Messages
@@ -195,20 +223,45 @@ func (c *ChatClient) initializeRequest(ctx context.Context, req CompletionReques
 
 	return &initializeRequestResult{
 		apiKey:         resolvedKey.Key,
+		provider:       resolvedKey.Provider.OrDefault(),
 		customerKey:    resolvedKey.Customer,
 		requestBody:    reqBody,
 		captureSession: captureSession,
 	}, nil
 }
 
-// makeHTTPRequest creates and executes an HTTP request to OpenRouter.
-func (c *ChatClient) makeHTTPRequest(ctx context.Context, apiKey string, reqBody OpenAIChatRequest) (*http.Response, error) {
+// makeHTTPRequest creates and executes an OpenAI-compatible completion
+// request against the provider selected by key resolution.
+func (c *ChatClient) makeHTTPRequest(ctx context.Context, provider KeyProvider, apiKey string, reqBody OpenAIChatRequest) (*http.Response, error) {
 	if !IsModelAllowed(reqBody.Model) {
 		return nil, fmt.Errorf("model %s is not allowed", reqBody.Model)
 	}
 
+	endpoint := fmt.Sprintf("%s/v1/chat/completions", OpenRouterBaseURL)
+	outboundBody := reqBody
+	switch provider.OrDefault() {
+	case KeyProviderOpenRouter:
+	case KeyProviderAnthropic:
+		model, ok := strings.CutPrefix(reqBody.Model, "anthropic/")
+		if !ok {
+			return nil, fmt.Errorf("model %s is not supported by Anthropic", reqBody.Model)
+		}
+		endpoint = fmt.Sprintf("%s/v1/chat/completions", AnthropicAPIBaseURL)
+		outboundBody.Model = model
+		// These fields are OpenRouter extensions rather than OpenAI Chat
+		// Completions fields. Gram records the same context in its own
+		// telemetry, so omit them from direct Anthropic requests.
+		outboundBody.Reasoning = nil
+		outboundBody.CacheControl = nil
+		outboundBody.SessionID = ""
+		outboundBody.Metadata = nil
+		outboundBody.Trace = nil
+	default:
+		return nil, fmt.Errorf("unsupported key provider %q", provider)
+	}
+
 	// Marshal request
-	data, err := json.Marshal(reqBody)
+	data, err := json.Marshal(outboundBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
@@ -217,7 +270,7 @@ func (c *ChatClient) makeHTTPRequest(ctx context.Context, apiKey string, reqBody
 	httpReq, err := http.NewRequestWithContext(
 		ctx,
 		"POST",
-		fmt.Sprintf("%s/v1/chat/completions", OpenRouterBaseURL),
+		endpoint,
 		bytes.NewReader(data),
 	)
 	if err != nil {
@@ -226,6 +279,9 @@ func (c *ChatClient) makeHTTPRequest(ctx context.Context, apiKey string, reqBody
 
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+	if provider.OrDefault() == KeyProviderAnthropic {
+		httpReq.Header.Set("anthropic-version", anthropicAPIVersion)
+	}
 
 	// Make HTTP call
 	httpResp, err := c.httpClient.Do(httpReq)
@@ -317,8 +373,8 @@ func (c *ChatClient) onMessageComplete(ctx context.Context, session CaptureSessi
 // requestCompletion issues a single non-streaming completion request and
 // returns the parsed response alongside the raw body (kept for diagnostics).
 // The response body lifetime is fully contained here so callers can retry.
-func (c *ChatClient) requestCompletion(ctx context.Context, apiKey string, reqBody OpenAIChatRequest) (OpenAIChatResponse, []byte, error) {
-	httpResp, err := c.makeHTTPRequest(ctx, apiKey, reqBody)
+func (c *ChatClient) requestCompletion(ctx context.Context, provider KeyProvider, apiKey string, reqBody OpenAIChatRequest) (OpenAIChatResponse, []byte, error) {
+	httpResp, err := c.makeHTTPRequest(ctx, provider, apiKey, reqBody)
 	if err != nil {
 		return OpenAIChatResponse{}, nil, err
 	}
@@ -364,7 +420,7 @@ func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (
 	)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		var err error
-		chatResp, body, err = c.requestCompletion(ctx, initResult.apiKey, reqBody)
+		chatResp, body, err = c.requestCompletion(ctx, initResult.provider, initResult.apiKey, reqBody)
 		if err != nil {
 			return nil, err
 		}
@@ -461,7 +517,7 @@ func (c *ChatClient) GetCompletionStream(ctx context.Context, req CompletionRequ
 	reqBody.Stream = true
 
 	// Make HTTP request
-	httpResp, err := c.makeHTTPRequest(ctx, initResult.apiKey, reqBody)
+	httpResp, err := c.makeHTTPRequest(ctx, initResult.provider, initResult.apiKey, reqBody)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -1803,6 +1803,7 @@ type recordingKeyResolver struct {
 	project string
 	slot    billing.ModelUsageSource
 	keyType KeyType
+	result  ResolvedKey
 }
 
 var _ KeyResolver = (*recordingKeyResolver)(nil)
@@ -1811,7 +1812,10 @@ func (r *recordingKeyResolver) ResolveKey(_ context.Context, orgID string, proje
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.orgID, r.project, r.slot, r.keyType = orgID, projectID, slot, keyType
-	return ResolvedKey{Key: "recorded-key", Customer: false}, nil
+	if r.result.Key != "" {
+		return r.result, nil
+	}
+	return ResolvedKey{Key: "recorded-key", Provider: KeyProviderOpenRouter, Customer: false}, nil
 }
 
 func TestChatClient_InitializeRequest_KeySlotOverridesUsageSourceForResolution(t *testing.T) {
@@ -1859,4 +1863,75 @@ func TestChatClient_InitializeRequest_EmptyKeySlotFallsBackToUsageSource(t *test
 	require.NoError(t, err)
 	require.Equal(t, billing.ModelUsageSourceSlack, resolver.slot,
 		"trusted callers set UsageSource server-side; it doubles as the slot when KeySlot is unset")
+}
+
+func TestChatClient_InitializeRequest_NonAnthropicModelUsesPlatformKey(t *testing.T) {
+	t.Parallel()
+
+	resolver := &recordingKeyResolver{
+		result: ResolvedKey{
+			Key:      "anthropic-key",
+			Provider: KeyProviderAnthropic,
+			Customer: true,
+		},
+	}
+	provisioner := &mockProvisioner{apiKey: "platform-key"}
+	client := &ChatClient{
+		logger:      testenv.NewLogger(t),
+		provisioner: provisioner,
+		keyResolver: resolver,
+	}
+
+	result, err := client.initializeRequest(t.Context(), CompletionRequest{
+		OrgID:     "test-org",
+		ProjectID: uuid.NewString(),
+		Model:     "openai/gpt-5.4",
+		Messages:  []or.ChatMessages{CreateMessageUser("hi")},
+		KeyType:   KeyTypeChat,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "platform-key", result.apiKey)
+	require.Equal(t, KeyProviderOpenRouter, result.provider)
+	require.False(t, result.customerKey)
+	require.Equal(t, []KeyType{KeyTypeChat}, provisioner.ProvisionedKeyTypes())
+}
+
+func TestChatClient_MakeHTTPRequest_AnthropicCompatibilityEndpoint(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/chat/completions", r.URL.Path)
+		require.Equal(t, "Bearer anthropic-key", r.Header.Get("Authorization"))
+		require.Equal(t, anthropicAPIVersion, r.Header.Get("anthropic-version"))
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "claude-sonnet-5", body["model"])
+		require.NotContains(t, body, "session_id")
+		require.NotContains(t, body, "metadata")
+		require.NotContains(t, body, "trace")
+		require.NotContains(t, body, "reasoning")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &ChatClient{
+		httpClient: &http.Client{Transport: &testTransport{server: server}},
+	}
+	response, err := client.makeHTTPRequest(t.Context(), KeyProviderAnthropic, "anthropic-key", OpenAIChatRequest{
+		Model:          DefaultChatModel,
+		Messages:       []or.ChatMessages{CreateMessageUser("hi")},
+		Stream:         false,
+		Tools:          nil,
+		Temperature:    1,
+		ResponseFormat: nil,
+		Reasoning:      &Reasoning{Effort: "none", MaxTokens: nil, Exclude: nil, Enabled: nil},
+		CacheControl:   nil,
+		SessionID:      uuid.NewString(),
+		User:           "test-org",
+		Metadata:       map[string]string{"source": "assistants"},
+		Trace:          &TraceConfig{TraceID: "trace", TraceName: "", SpanName: "", GenerationName: "", ParentSpanID: ""},
+	})
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
 }

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -1900,17 +1900,19 @@ func TestChatClient_MakeHTTPRequest_AnthropicCompatibilityEndpoint(t *testing.T)
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v1/chat/completions", r.URL.Path)
-		require.Equal(t, "Bearer anthropic-key", r.Header.Get("Authorization"))
-		require.Equal(t, anthropicAPIVersion, r.Header.Get("anthropic-version"))
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		assert.Equal(t, "Bearer anthropic-key", r.Header.Get("Authorization"))
+		assert.Equal(t, anthropicAPIVersion, r.Header.Get("anthropic-version"))
 
 		var body map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		require.Equal(t, "claude-sonnet-5", body["model"])
-		require.NotContains(t, body, "session_id")
-		require.NotContains(t, body, "metadata")
-		require.NotContains(t, body, "trace")
-		require.NotContains(t, body, "reasoning")
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			return
+		}
+		assert.Equal(t, "claude-sonnet-5", body["model"])
+		assert.NotContains(t, body, "session_id")
+		assert.NotContains(t, body, "metadata")
+		assert.NotContains(t, body, "trace")
+		assert.NotContains(t, body, "reasoning")
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(server.Close)

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -937,7 +937,7 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 		{
 			name:             "provisioner error",
 			provisionerError: fmt.Errorf("failed to provision key"),
-			expectedError:    "resolve OpenRouter key",
+			expectedError:    "resolve model provider key",
 		},
 		{
 			name:               "start or resume error",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- validate and encrypt customer-supplied Anthropic API keys
- route Claude completions directly through Anthropic's OpenAI-compatible endpoint
- preserve provider-aware slot/default fallback to OpenRouter
- add an OpenRouter/Anthropic provider selector to project settings
- stabilize ClickHouse telemetry assertions by polling post-flush visibility under full-suite load

## Testing
- `mise run test:server ./internal/modelkeys/... ./internal/thirdparty/anthropic/... ./internal/thirdparty/openrouter/...` (149 tests)
- `mise run test:server ./internal/telemetry -count=3` (852 tests)
- previously failing telemetry tests: 20/20 focused stress runs
- previously observed local resource-contention tool tests: 12/12 focused stress runs
- `mise lint:server`
- `mise run build:server`
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint`
- `GOTOOLCHAIN=go1.26.5 mise run gen:sdk`
- browser walkthrough: provider selector offers OpenRouter and Anthropic, and selecting Anthropic updates the key placeholder without exposing key material

## Demo
<a href="https://cursor.com/agents/bc-ded1463d-e0f0-4a12-a34e-71696215d8fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanthropic_provider_selection.mp4"><img src="https://cursor.com/artifacts/c/art-375e3c54-2539-420a-afa7-3a4f9ef3459f" alt="anthropic_provider_selection.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-646](https://linear.app/speakeasy/issue/DNO-646/feat-byok-for-anthropic-api-access)

<div><a href="https://cursor.com/agents/bc-ded1463d-e0f0-4a12-a34e-71696215d8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ded1463d-e0f0-4a12-a34e-71696215d8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BYOK support for Anthropic with validated key storage and model-aware routing to meet DNO-646. Claude requests use Anthropic when an Anthropic key is available; all others stay on OpenRouter.

- **New Features**
  - Validate Anthropic API keys via the Models API before encrypted storage.
  - Provider- and model-aware key resolution: use a compatible provider key; if an override is incompatible, fall back to a compatible project default or the platform `openrouter` key.
  - Route Anthropic BYOK chat completions directly to Anthropic’s OpenAI-compatible endpoint, set `anthropic-version`, and strip OpenRouter-only fields; non-Anthropic models continue through OpenRouter.
  - Dashboard: add a provider selector per slot with provider-specific placeholders (`sk-or-…`/`sk-ant-…`); OpenAPI/schema and SDK now list supported providers `openrouter` and `anthropic`.

- **Bug Fixes**
  - Stabilized ClickHouse telemetry tests by waiting for row visibility after async insert flush.

<sup>Written for commit b443d9049c44cc48eeea63996843517668878fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

