### PR TITLE
feat: add claude opus 5 and make it the default model

### DIFF
--- a/.changeset/default-opus-5.md
+++ b/.changeset/default-opus-5.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Add Claude Opus 5 (`anthropic/claude-opus-5`) to the supported model catalog and make it the default for in-app chat and newly created assistants. Specialized judge, embedding, and other purpose-specific model selections remain unchanged.

--- a/client/dashboard/src/elements/lib/contextCompaction.test.ts
+++ b/client/dashboard/src/elements/lib/contextCompaction.test.ts
@@ -34,6 +34,10 @@ describe("estimateTokens", () => {
 });
 
 describe("getModelContextLimit", () => {
+  it("returns known mapping for Claude Opus 5", () => {
+    expect(getModelContextLimit("anthropic/claude-opus-5")).toBe(1_000_000);
+  });
+
   it("returns known mapping for Sonnet 4.6", () => {
     expect(getModelContextLimit("anthropic/claude-sonnet-4.6")).toBe(1_000_000);
   });

--- a/client/dashboard/src/elements/lib/contextCompaction.ts
+++ b/client/dashboard/src/elements/lib/contextCompaction.ts
@@ -32,6 +32,7 @@ export const DEFAULT_CONTEXT_LIMIT = 200_000;
  */
 const MODEL_CONTEXT_LIMITS: Partial<Record<KnownModelId, number>> = {
   // Anthropic (1M tier where available, else 200K)
+  "anthropic/claude-opus-5": 1_000_000,
   "anthropic/claude-fable-5": 1_000_000,
   "anthropic/claude-sonnet-5": 1_000_000,
   "anthropic/claude-opus-4.8": 1_000_000,

--- a/client/dashboard/src/elements/lib/models.ts
+++ b/client/dashboard/src/elements/lib/models.ts
@@ -1,6 +1,7 @@
 // List of openrouter models available to the user
 // This list should be updated to match the model whitelist on the backend side.
 export const MODELS = [
+  "anthropic/claude-opus-5",
   "anthropic/claude-fable-5",
   "anthropic/claude-sonnet-5",
   "anthropic/claude-opus-4.8",
@@ -44,5 +45,4 @@ export const MODELS = [
 // config.model.defaultModel. Kept explicit (rather than MODELS[0]) so
 // reordering MODELS — e.g. listing a premium model first — can never
 // silently change what unconfigured embeds run on.
-export const DEFAULT_MODEL: (typeof MODELS)[number] =
-  "anthropic/claude-sonnet-5";
+export const DEFAULT_MODEL: (typeof MODELS)[number] = "anthropic/claude-opus-5";

--- a/client/dashboard/src/lib/models.test.ts
+++ b/client/dashboard/src/lib/models.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MODEL as ELEMENTS_DEFAULT_MODEL,
+  MODELS,
+} from "@/elements/lib/models";
+import {
+  AVAILABLE_MODELS,
+  DEFAULT_ASSISTANT_MODEL,
+  DEFAULT_MODEL,
+} from "./models";
+
+const OPUS_5 = "anthropic/claude-opus-5";
+
+describe("model defaults", () => {
+  it("supports Claude Opus 5 across dashboard and Elements", () => {
+    expect(AVAILABLE_MODELS).toContainEqual({
+      value: OPUS_5,
+      label: "Claude Opus 5",
+      expensive: true,
+    });
+    expect(MODELS).toContain(OPUS_5);
+  });
+
+  it("defaults in-app chat and new assistants to Claude Opus 5", () => {
+    expect(DEFAULT_MODEL).toBe(OPUS_5);
+    expect(ELEMENTS_DEFAULT_MODEL).toBe(OPUS_5);
+    expect(DEFAULT_ASSISTANT_MODEL).toBe(OPUS_5);
+  });
+});

--- a/client/dashboard/src/lib/models.ts
+++ b/client/dashboard/src/lib/models.ts
@@ -9,6 +9,11 @@ export type AvailableModel = {
 
 export const AVAILABLE_MODELS: AvailableModel[] = [
   {
+    value: "anthropic/claude-opus-5",
+    label: "Claude Opus 5",
+    expensive: true,
+  },
+  {
     value: "anthropic/claude-fable-5",
     label: "Claude Fable 5",
     expensive: true,
@@ -70,9 +75,9 @@ export const AVAILABLE_MODELS: AvailableModel[] = [
 // Default model used across in-app chat surfaces (playground, MCP test chat,
 // chat window) when the user has not picked one explicitly. Kept next to
 // AVAILABLE_MODELS so the default is easy to discover and adjust.
-export const DEFAULT_MODEL: Model = "anthropic/claude-sonnet-5";
+export const DEFAULT_MODEL: Model = "anthropic/claude-opus-5";
 
 // Default model assigned to newly created assistants (onboarding flow). Tracked
 // separately from DEFAULT_MODEL so the assistant default can move independently
 // of the general in-app chat default.
-export const DEFAULT_ASSISTANT_MODEL: Model = "anthropic/claude-sonnet-5";
+export const DEFAULT_ASSISTANT_MODEL: Model = "anthropic/claude-opus-5";

--- a/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
+++ b/client/dashboard/src/pages/assistants/onboarding/systemPrompt.ts
@@ -45,19 +45,19 @@ Pass section bodies WITHOUT a leading heading — the tool adds it. Inside a sec
 - Integration — packaged toolset from the catalog. \`list_integrations\`.
 
 # Models (pass full id to \`update_assistant\`)
-- Anthropic: \`anthropic/claude-sonnet-5\` (default), \`anthropic/claude-fable-5\`, \`anthropic/claude-opus-4.8\`, \`anthropic/claude-opus-4.7\`, \`anthropic/claude-sonnet-4.6\`, \`anthropic/claude-haiku-4.5\`, \`anthropic/claude-sonnet-4.5\`, \`anthropic/claude-opus-4.6\`, \`anthropic/claude-opus-4.5\`
+- Anthropic: \`anthropic/claude-opus-5\` (default), \`anthropic/claude-fable-5\`, \`anthropic/claude-sonnet-5\`, \`anthropic/claude-opus-4.8\`, \`anthropic/claude-opus-4.7\`, \`anthropic/claude-sonnet-4.6\`, \`anthropic/claude-haiku-4.5\`, \`anthropic/claude-sonnet-4.5\`, \`anthropic/claude-opus-4.6\`, \`anthropic/claude-opus-4.5\`
 - OpenAI: \`openai/gpt-5.6-sol\`, \`openai/gpt-5.6-terra\`, \`openai/gpt-5.6-luna\`, \`openai/gpt-5.5\`, \`openai/gpt-5.5-pro\`, \`openai/gpt-5.4\`, \`openai/gpt-5.4-mini\`, \`openai/gpt-5.4-nano\`, \`openai/gpt-5.3-codex\`, \`openai/gpt-5.1\`, \`openai/gpt-5\`
 - Google: \`google/gemini-3.5-flash\`, \`google/gemini-3.1-pro-preview\`, \`google/gemini-3.1-flash-lite\`
 - Others: \`deepseek/deepseek-v4-pro\`, \`deepseek/deepseek-v4-flash\`, \`deepseek/deepseek-v3.2\`, \`meta-llama/llama-4-maverick\`, \`x-ai/grok-4.3\`, \`x-ai/grok-4.20\`, \`qwen/qwen3.7-max\`, \`qwen/qwen3-coder\`, \`moonshotai/kimi-k2.6\`, \`moonshotai/kimi-k2.5\`, \`mistralai/mistral-medium-3-5\`, \`mistralai/codestral-2508\`, \`mistralai/devstral-2512\`, \`mistralai/mistral-medium-3.1\`
 
 Recommend:
-- General default → \`anthropic/claude-sonnet-5\` (strong all-rounder, good price/performance).
-- Agentic / tool-heavy → \`anthropic/claude-sonnet-5\` or \`anthropic/claude-fable-5\` (hardest reasoning, expensive).
+- General default → \`anthropic/claude-opus-5\` (strongest all-rounder, expensive).
+- Agentic / tool-heavy → \`anthropic/claude-opus-5\` or \`anthropic/claude-fable-5\` (hardest reasoning, expensive).
 - Cheap / fast / high-volume → \`anthropic/claude-haiku-4.5\` or \`openai/gpt-5.6-luna\`.
 - Coding → \`openai/gpt-5.6-sol\`, \`openai/gpt-5.3-codex\`, \`qwen/qwen3-coder\`.
-- Deep reasoning / math → \`anthropic/claude-fable-5\` (expensive) or \`openai/gpt-5.6-sol\`.
+- Deep reasoning / math → \`anthropic/claude-opus-5\`, \`anthropic/claude-fable-5\`, or \`openai/gpt-5.6-sol\` (all expensive).
 - Fast Google → \`google/gemini-3.5-flash\`.
-- Unsure → \`anthropic/claude-sonnet-5\`.
+- Unsure → \`anthropic/claude-opus-5\`.
 
 # "How do I connect X?" decision tree
 1. \`list_docs\` — if X has a doc (currently: \`slack\`, \`cron\`), follow it. Slack: route through \`propose_slack_setup\` (the user picks capabilities + events; the tool creates a per-assistant Slack toolset and slack trigger — never reuse a catalog toolset). Then \`add_environment_keys\` → \`show_slack_app_guide\` with the returned webhook_url (skip if SLACK_BOT_TOKEN is already populated; check via \`list_environments\` → \`populated_entry_names\`) → \`request_environment_secrets\`.

--- a/server/cmd/dev-mcp/tools.go
+++ b/server/cmd/dev-mcp/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultAssistantModel = "anthropic/claude-sonnet-5"
+	defaultAssistantModel = "anthropic/claude-opus-5"
 	defaultTurnTimeout    = 300 * time.Second
 	maxTurnTimeout        = 900 * time.Second
 	turnPollInterval      = 2 * time.Second
@@ -46,7 +46,7 @@ type idInput struct {
 type createAssistantInput struct {
 	projectInput
 	Name           string         `json:"name" jsonschema:"The assistant name."`
-	Model          string         `json:"model,omitempty" jsonschema:"OpenRouter model identifier. Defaults to anthropic/claude-sonnet-5."`
+	Model          string         `json:"model,omitempty" jsonschema:"OpenRouter model identifier. Defaults to anthropic/claude-opus-5."`
 	Instructions   string         `json:"instructions" jsonschema:"System instructions for the assistant."`
 	Toolsets       []toolsetRef   `json:"toolsets,omitempty" jsonschema:"Toolsets available to the assistant. Defaults to none."`
 	MCPServers     []mcpServerRef `json:"mcp_servers,omitempty" jsonschema:"MCP servers attached directly to the assistant."`

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -32,8 +32,8 @@ var managedAssistantInstructions string
 
 const (
 	// managedAssistantModel is the default model for the platform-managed
-	// assistant. Defaulted to Sonnet 5, matching the in-app default chat model.
-	managedAssistantModel = "anthropic/claude-sonnet-5"
+	// assistant. Kept aligned with the in-app default chat model.
+	managedAssistantModel = "anthropic/claude-opus-5"
 
 	// Schema defaults for the assistants table, applied explicitly so the
 	// managed assistant's intent is visible at the call site.

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -82,6 +82,7 @@ func (k KeyType) Validate() error {
 // Just a general allowlist for models we allow to proxy through us for playground usage, chat, or agentic usecases
 // This list can stay sufficiently robust, we should just need to allow list a model before it goes through us
 var allowList = map[string]bool{
+	"anthropic/claude-opus-5":       true,
 	"anthropic/claude-fable-5":      true,
 	"anthropic/claude-sonnet-5":     true,
 	"anthropic/claude-opus-4.8":     true,

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -36,7 +36,7 @@ type TelemetryLogger interface {
 }
 
 const (
-	DefaultChatModel = "anthropic/claude-sonnet-5"
+	DefaultChatModel = "anthropic/claude-opus-5"
 )
 
 // ChatClient is the single HTTP client for all OpenRouter communication.

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -1604,7 +1604,12 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 
 func TestResolveModel_AllowedModelReturnedAsIs(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "openai/gpt-5.4", ResolveModel("openai/gpt-5.4"))
+	require.Equal(t, "anthropic/claude-opus-5", ResolveModel("anthropic/claude-opus-5"))
+}
+
+func TestDefaultChatModel_UsesClaudeOpus5(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "anthropic/claude-opus-5", DefaultChatModel)
 }
 
 func TestResolveModel_UnsupportedOpenAIFallback(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Add `anthropic/claude-opus-5` to the backend allowlist and frontend model catalogs
- Make Claude Opus 5 the default for in-app chat, new assistants, and platform-managed assistants
- Register its 1M-token context window and update onboarding model guidance
- Add regression coverage for catalog/default alignment and model resolution

## Verification
- OpenRouter catalog confirms `anthropic/claude-opus-5` with a 1,000,000-token context window
- Backend tests pass for OpenRouter, assistants, and dev MCP packages
- Dashboard: 1,120 tests pass; type-check, lint, and production build pass
- Server lint passes
- Catalog parity check confirms 38 identical backend/dashboard/Elements model IDs

## Demo
![Claude Opus 5 selected in the Playground model picker](https://cursor.com/artifacts/c/art-e6b81808-5db1-4a0f-a848-274267d848b2)

<a href="https://cursor.com/agents/bc-835cdcf3-4a4e-4549-ac52-e98402a0c7ff/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopus_5_playground_picker_verified.mp4"><img src="https://cursor.com/artifacts/c/art-e0ba716b-64cc-4b66-8854-3792a32a790c" alt="opus_5_playground_picker_verified.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-835cdcf3-4a4e-4549-ac52-e98402a0c7ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-835cdcf3-4a4e-4549-ac52-e98402a0c7ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `anthropic/claude-opus-5` the default model across in-app chat, new assistants, and the platform-managed assistant. Adds it to catalogs and allowlists, registers a 1M-token context window, and updates onboarding guidance.

- **New Features**
  - Added `anthropic/claude-opus-5` to the backend allowlist and dashboard catalogs; set as the default in `unified_client`, dashboard Elements, assistant onboarding, dev MCP tool, and managed assistant provisioning.
  - Registered a 1,000,000-token context limit and updated model recommendations in onboarding text.
  - Added regression tests to verify catalog/default alignment and model resolution (including default chat model and context limit mapping).

<sup>Written for commit ac3e48456752c1922bd8f3defbb3b0f879980e17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

