### PR TITLE
feat(dashboard): show leaf tool name instead of mcp__ namespace in chat logs

### DIFF
--- a/.changeset/tool-call-leaf-name-display.md
+++ b/.changeset/tool-call-leaf-name-display.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Tool calls in chat logs and the assistant thread now display the leaf tool name (e.g. `resolve-library-id`) instead of the fully namespaced MCP name (e.g. `mcp__context7__resolve-library-id`), matching the tool-logs table. The raw name is still used for approval logic; name search formats identically so highlight navigation stays aligned.

--- a/client/dashboard/src/elements/components/assistant-ui/tool-fallback.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/tool-fallback.tsx
@@ -4,6 +4,7 @@ import {
   type ToolCallMessagePartComponent,
 } from "@assistant-ui/react";
 import { useToolApproval } from "@/elements/hooks/useToolApproval";
+import { formatToolName } from "@/elements/lib/humanize";
 import {
   ToolUI,
   type ToolStatus,
@@ -95,7 +96,7 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
       )}
     >
       <ToolUI
-        name={toolName}
+        name={formatToolName(toolName)}
         status={getToolStatus()}
         request={args as Record<string, unknown>}
         result={getResult()}

--- a/client/dashboard/src/elements/lib/humanize.ts
+++ b/client/dashboard/src/elements/lib/humanize.ts
@@ -1,3 +1,15 @@
+// Some agents (Cowork / claude.ai) report tool calls with the fully namespaced
+// MCP name, e.g. `mcp__<server>__send_message`. Strip through the last `__` so
+// only the leaf tool segment shows; names without a separator are unchanged.
+// Mirrors `@/components/observe/toolNameDisplay` — elements can't import app
+// code across the publish boundary.
+export function formatToolName(toolName: string): string {
+  const separator = "__";
+  const index = toolName.lastIndexOf(separator);
+  if (index === -1) return toolName;
+  return toolName.slice(index + separator.length) || toolName;
+}
+
 // humanize tool name:
 // - split camel case into words
 // - capitalize first letter of each word

--- a/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatTranscript.tsx
@@ -70,6 +70,7 @@ import {
   RevealSecretButton,
   RiskBadge,
 } from "./chatRisk";
+import { formatToolName } from "@/components/observe/toolNameDisplay";
 import {
   distinctRiskCount,
   resultsAreSensitive,
@@ -708,8 +709,12 @@ function ToolRowView({
   bare?: boolean;
 }) {
   const openExclusion = useContext(CreateExclusionContext);
-  const name =
-    row.toolCall?.function?.name || row.toolCall?.name || "Tool result";
+  // Strip the `mcp__<server>__` namespace so the row shows the leaf tool name,
+  // matching the tool-logs table (formatToolName). Search counting in
+  // rowSearchFields formats identically to keep the navigator aligned.
+  const name = formatToolName(
+    row.toolCall?.function?.name || row.toolCall?.name || "Tool result",
+  );
   const request = argsToString(row.toolCall?.function?.arguments);
   const result = row.resultMessage
     ? messageText(row.resultMessage.content)

--- a/client/dashboard/src/pages/chatLogs/transcript.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.ts
@@ -5,6 +5,7 @@ import {
   type ToolCall,
   type TraceEntryType,
 } from "./traceEntries";
+import { formatToolName } from "@/components/observe/toolNameDisplay";
 
 type MessageEntryType = Extract<
   TraceEntryType,
@@ -267,8 +268,11 @@ export function rowSearchFields(
   }
 
   const fields: RowSearchField[] = [];
-  const name =
-    row.toolCall?.function?.name || row.toolCall?.name || "Tool result";
+  // Format the name the same way the renderer does (ToolRowView) so the
+  // occurrence navigator stays in sync — see the invariant note above.
+  const name = formatToolName(
+    row.toolCall?.function?.name || row.toolCall?.name || "Tool result",
+  );
   const nameCount = findQueryRanges(name, q).length;
   if (nameCount > 0) fields.push({ key: "name", count: nameCount });
 


### PR DESCRIPTION
## What

Tool calls in chat logs and the assistant thread rendered the fully namespaced MCP name, e.g. `mcp__context7__resolve-library-id`. This strips the `mcp__<server>__` namespace so only the leaf tool name (`resolve-library-id`) shows — matching the existing behavior of the tool-logs table.

## How

Reuses the existing `formatToolName` helper (`components/observe/toolNameDisplay.ts`) — the same one the tool-logs table (`LogsTools.tsx`) already uses. It strips through the last `__` and returns names without a separator unchanged, so plain function names (`read_file`) and prefix-only names degrade gracefully.

No new parsing method and no backend change: the chat transcript only carries the flat tool name (no structured provider/server field), and `formatToolName`'s fallback makes any non-`mcp__` name a no-op.

### Applied at three call sites
- `ChatTranscript.tsx` (`ToolRowView`) — the displayed row label.
- `transcript.ts` (`rowSearchFields`) — formats identically so the search occurrence navigator stays aligned with what's rendered (the invariant noted in that file).
- `tool-fallback.tsx` (assistant thread) — display only; the raw `toolName` is still passed to `whitelistTool` for approval logic. Elements can't import app code across the publish boundary, so a small mirror of `formatToolName` lives in `elements/lib/humanize.ts`.

## Notes / tradeoff
- The `mcp__…` prefix is no longer searchable in the tool **name** field (it's boilerplate; the leaf still matches). Args/output/text search is unchanged.
- A provider/server chip (à la the tool-logs table's badge) is **not** included — that relies on structured `targetType`/`targetId` telemetry fields the chat path doesn't have. Left as a follow-up.

## Test plan
- [x] `pnpm -F dashboard type-check` passes
- [ ] Chat logs: MCP tool rows show the leaf name; plain tools unchanged; name search + prev/next highlight still line up