### PR TITLE
feat(dashboard): redesign switch-org and no-access gate on the auth shell

### DIFF
--- a/.changeset/switch-org-gate-redesign.md
+++ b/.changeset/switch-org-gate-redesign.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Redesign the switch-organization screen and the no-access gate on the new auth shell. The dropdown is replaced with a selectable organization list that pins the current org under a "Current" chip, the gate variant shows a no-access banner for the blocked org above the switchable list, and both screens get a Log out link in the shell header.

--- a/client/dashboard/src/pages/demo/SwitchOrg.tsx
+++ b/client/dashboard/src/pages/demo/SwitchOrg.tsx
@@ -1,20 +1,79 @@
 import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
-import { AuthLayout } from "@/pages/login/components/login-section";
-import { JourneyDemo } from "@/pages/login/components/journey-demo";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Button } from "@speakeasy-api/moonshine";
-import { LogOutIcon, AlertCircleIcon, BuildingIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AUTH_BUTTON_CLASSES } from "@/pages/login/components/auth-constants";
+import { AuthShell } from "@/pages/login/components/auth-shell";
 import { useState } from "react";
 
 interface SwitchOrgProps {
   gate?: boolean;
+}
+
+interface OrgRowData {
+  id: string;
+  name: string;
+  slug: string;
+  projects: readonly unknown[];
+}
+
+// One selectable organization row: avatar square with the org initial, name +
+// slug/project-count meta, and either the pinned "Current" chip or a checkmark
+// when selected ("2C Switch organization" frame in the design project).
+function OrgRow({
+  org,
+  current,
+  selected,
+  onSelect,
+}: {
+  org: OrgRowData;
+  current: boolean;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const displayName = org.name || org.slug;
+  const projectCount = org.projects.length;
+
+  return (
+    <button
+      type="button"
+      disabled={current}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-md border px-3.5 py-3 text-left transition-colors",
+        current
+          ? "cursor-default border-[var(--edge)] bg-[var(--surface)]"
+          : selected
+            ? "border-[var(--cta)] bg-[hsl(0,0%,97%)]"
+            : "border-[var(--edge)] bg-[var(--card)] hover:border-[hsl(0,0%,60%)]",
+      )}
+    >
+      <span
+        className={cn(
+          "auth-mono-text flex h-7 w-7 flex-none items-center justify-center rounded-md text-[12px]",
+          current || selected
+            ? "bg-[var(--cta)] text-white"
+            : "bg-[var(--edge-soft)] text-[var(--muted-strong)]",
+        )}
+      >
+        {displayName.charAt(0).toUpperCase()}
+      </span>
+      <span className="flex flex-1 flex-col gap-px">
+        <span className="text-[15px]">{displayName}</span>
+        <span className="auth-mono-text text-[11px] text-[var(--muted)]">
+          {org.slug} · {projectCount}{" "}
+          {projectCount === 1 ? "project" : "projects"}
+        </span>
+      </span>
+      {current && (
+        <span className="auth-mono rounded-full bg-[var(--moss)] px-2.5 py-[3px] text-[10px] text-white">
+          Current
+        </span>
+      )}
+      {selected && !current && (
+        <span className="auth-mono-text text-[13px] text-black">✓</span>
+      )}
+    </button>
+  );
 }
 
 export default function SwitchOrg({
@@ -23,14 +82,21 @@ export default function SwitchOrg({
   const client = useSdkClient();
   const { session } = useSessionData();
 
+  const currentOrgId = session?.activeOrganizationId;
   const allOrgs = session?.organizations ?? [];
+  // The gate frames the list as the way through, so the blocked org only
+  // appears in the no-access banner; the switcher pins it first instead.
+  const orgs = gate
+    ? allOrgs.filter((org) => org.id !== currentOrgId)
+    : [...allOrgs].sort(
+        (a, b) => Number(b.id === currentOrgId) - Number(a.id === currentOrgId),
+      );
 
   const [selectedOrgId, setSelectedOrgId] = useState<string>("");
   const [isSwitching, setIsSwitching] = useState(false);
 
   const handleSwitch = async () => {
-    if (!selectedOrgId || selectedOrgId === session?.activeOrganizationId)
-      return;
+    if (!selectedOrgId || selectedOrgId === currentOrgId) return;
     setIsSwitching(true);
     try {
       await client.auth.switchScopes({ organizationId: selectedOrgId });
@@ -45,83 +111,72 @@ export default function SwitchOrg({
     window.location.href = "/login";
   };
 
-  const currentOrgName = session?.organization?.name ?? "This organization";
+  const currentOrg = allOrgs.find((org) => org.id === currentOrgId);
+  const currentOrgName =
+    currentOrg?.name || currentOrg?.slug || "This organization";
 
   return (
-    <main className="flex min-h-screen flex-col md:flex-row">
-      <JourneyDemo />
+    <AuthShell
+      page={gate ? "Organization access" : "Switch organization"}
+      contentClassName="max-w-[400px]"
+      showTerms={false}
+      headerAction={
+        <button
+          type="button"
+          onClick={() => void handleLogout()}
+          className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+        >
+          Log out
+        </button>
+      }
+    >
+      <div className="text-center">
+        <p className="text-[16px] tracking-[0.0025em]">
+          {gate
+            ? `${currentOrgName} doesn't have platform access.`
+            : "Switch organization."}
+        </p>
+        <p className="mt-1.5 text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
+          {gate
+            ? "Switch to another organization to continue, or contact your admin."
+            : "Select which organization you'd like to work in."}
+        </p>
+      </div>
 
-      <AuthLayout
-        topRight={
-          gate ? (
-            <button
-              onClick={() => void handleLogout()}
-              className="flex items-center gap-1.5 text-xs text-[#8B8684] transition-colors hover:text-slate-600"
-            >
-              <LogOutIcon className="h-3.5 w-3.5" />
-              Log out
-            </button>
-          ) : undefined
-        }
+      {gate && (
+        <div className="flex w-full items-center gap-2.5 rounded-md border border-[var(--ember)] bg-[hsl(23,96%,97%)] px-3.5 py-2.5">
+          <span className="auth-mono flex-none rounded-full bg-[var(--ember)] px-2.5 py-[3px] text-[10px] text-black">
+            No access
+          </span>
+          <span className="auth-mono-text text-[12px] text-[var(--muted-strong)]">
+            {currentOrg?.slug ?? "this organization"} · MCP platform not enabled
+          </span>
+        </div>
+      )}
+
+      <div className="flex w-full flex-col gap-2">
+        {orgs.map((org) => (
+          <OrgRow
+            key={org.id}
+            org={org}
+            current={org.id === currentOrgId}
+            selected={org.id === selectedOrgId}
+            onSelect={() => setSelectedOrgId(org.id)}
+          />
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => void handleSwitch()}
+        disabled={!selectedOrgId || isSwitching}
+        className={cn(
+          AUTH_BUTTON_CLASSES,
+          "w-full disabled:cursor-not-allowed disabled:opacity-50",
+        )}
       >
-        <div className="flex flex-col items-center gap-3 text-center">
-          <div
-            className={`flex h-12 w-12 items-center justify-center rounded-full ${gate ? "bg-amber-50" : "bg-blue-50"}`}
-          >
-            {gate ? (
-              <AlertCircleIcon className="h-6 w-6 text-amber-500" />
-            ) : (
-              <BuildingIcon className="h-6 w-6 text-blue-500" />
-            )}
-          </div>
-          <h1 className="text-2xl font-bold tracking-tight text-gray-900">
-            {gate ? `No access for ${currentOrgName}` : "Switch organization"}
-          </h1>
-          <p className="text-sm leading-relaxed text-[#8B8684]">
-            {gate
-              ? "This organization doesn't have access to the MCP platform. Switch to another organization to continue."
-              : "Select which organization you'd like to work in."}
-          </p>
-        </div>
-
-        <div className="flex w-full flex-col gap-3">
-          <Select value={selectedOrgId} onValueChange={setSelectedOrgId}>
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Select an organization" />
-            </SelectTrigger>
-            <SelectContent>
-              {allOrgs.map((org) => {
-                const isCurrent = org.id === session?.activeOrganizationId;
-                return (
-                  <SelectItem key={org.id} value={org.id} disabled={isCurrent}>
-                    <span className="flex items-center gap-2">
-                      {org.name || org.slug}
-                      {isCurrent && (
-                        <span className="rounded-sm bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600">
-                          current
-                        </span>
-                      )}
-                    </span>
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
-
-          <Button
-            variant="brand"
-            className="w-full"
-            onClick={() => void handleSwitch()}
-            disabled={
-              !selectedOrgId ||
-              selectedOrgId === session?.activeOrganizationId ||
-              isSwitching
-            }
-          >
-            {isSwitching ? "Switching…" : "Switch organization"}
-          </Button>
-        </div>
-      </AuthLayout>
-    </main>
+        {isSwitching ? "Switching…" : "Switch organization"}
+      </button>
+    </AuthShell>
   );
 }

--- a/client/dashboard/src/pages/login/components/auth-shell.tsx
+++ b/client/dashboard/src/pages/login/components/auth-shell.tsx
@@ -1,5 +1,6 @@
 import speakeasyIcon from "@/assets/speakeasy-icon.svg";
 import { BrandGradientLine } from "@/components/brand-gradient-line";
+import { cn } from "@/lib/utils";
 import { AgentSessionShowcase } from "./agent-session-showcase";
 import { SpeakeasyWordmark } from "./speakeasy-wordmark";
 import { TermsFooter } from "./terms-footer";
@@ -74,9 +75,17 @@ function BrandLockup() {
 
 export function AuthShell({
   page,
+  headerAction,
+  contentClassName,
+  showTerms = true,
   children,
 }: {
-  page: "Login" | "Register";
+  page: string;
+  /** Extra control on the right of the header, e.g. a Log out link. */
+  headerAction?: React.ReactNode;
+  /** Overrides the right-pane column width (default max-w-[380px]). */
+  contentClassName?: string;
+  showTerms?: boolean;
   children: React.ReactNode;
 }): JSX.Element {
   return (
@@ -90,8 +99,11 @@ export function AuthShell({
           <img src={speakeasyIcon} alt="" className="h-[22px] w-[22px]" />
           Speakeasy AI Control Plane
         </span>
-        <span className="auth-mono text-[13px] text-[var(--muted)]">
-          {page}
+        <span className="flex items-center gap-6">
+          <span className="auth-mono text-[13px] text-[var(--muted)]">
+            {page}
+          </span>
+          {headerAction}
         </span>
       </header>
 
@@ -99,14 +111,21 @@ export function AuthShell({
         <AgentSessionShowcase />
 
         <section className="relative flex flex-col items-center justify-center border-[var(--edge-soft)] bg-[var(--card)] px-8 pt-16 pb-28 xl:border-l">
-          <div className="flex w-full max-w-[380px] flex-col items-center gap-6">
+          <div
+            className={cn(
+              "flex w-full max-w-[380px] flex-col items-center gap-6",
+              contentClassName,
+            )}
+          >
             <BrandLockup />
             {children}
           </div>
-          <TermsFooter
-            className="absolute right-12 bottom-7 left-12 text-[var(--muted-strong)]"
-            linkClassName="text-[var(--link)] hover:text-[var(--focus)]"
-          />
+          {showTerms && (
+            <TermsFooter
+              className="absolute right-12 bottom-7 left-12 text-[var(--muted-strong)]"
+              linkClassName="text-[var(--link)] hover:text-[var(--focus)]"
+            />
+          )}
         </section>
       </div>
     </main>


### PR DESCRIPTION
Implements the **2C Switch organization** and **2D No-access gate** frames from the login-screen design project — the follow-up to #4534, which shipped the login/register redesign (frames 2A/2B).

## What changed

- **Switch organization** (`/switch-org`): the Moonshine dropdown is replaced with a selectable organization list. The current org is pinned first under a moss `CURRENT` chip and is not clickable; picking another row shows a dark border + checkmark and enables the pill CTA. Row meta shows `slug · N projects`.
- **No-access gate** (rendered by `AuthProvider` when the active org isn't whitelisted and the user belongs to >1 org): same list framed as the way through — an ember `NO ACCESS` banner names the blocked org, which is excluded from the list. Header label becomes `Organization access`.
- **Log out** moves into the shell header as a mono link on both screens (previously gate-only, floating over the pane).
- `AuthShell` gains three small props to host these screens: `headerAction`, `contentClassName`, and `showTerms`; `page` widens from a union to `string`.

## Behavior

Switch/logout logic is unchanged: same `auth.switchScopes` → `window.location.replace("/")` flow, same `auth.logout` → `/login`, same disabled-until-selection guard. Only the selection UI changed (dropdown → list rows).

## Screenshots

See the [screenshots comment](https://github.com/speakeasy-api/gram/pull/4576#issuecomment-5086153127) — 2C switch-org with a row selected and the 2D no-access gate, captured from the dev stack with a mocked 3-org session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbvGYbqZx1QNVy5i4qQnQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the organization switcher and no‑access gate in the auth shell to use a selectable org list with the current org pinned, plus a header Log out link. Clarifies blocked orgs and unifies the login flow UI without changing auth behavior.

- New Features
  - Switch org: dropdown replaced with list rows showing name, `slug · N projects`; current org pinned first with a "Current" chip; selection shows border + checkmark; CTA enabled on selection.
  - No‑access gate: shows a "No access" banner naming the blocked org and excludes it from the list; header label reads "Organization access".
  - Log out link moved to the shell header on both screens; switch/logout flows unchanged.

- Refactors
  - `AuthShell` adds `headerAction`, `contentClassName`, and `showTerms`; `page` prop widened to `string`.

<sup>Written for commit 48704580c8522d4a779608032f0d2356a9684a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


