### PR TITLE
feat: sources risk events via CH with feature flag

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2111,7 +2111,15 @@ async function seedRiskFindingsClickHouse(init: {
           WHEN rr.source = 'presidio' THEN 'pii'
           ELSE 'custom'
         END,
-        COALESCE(rr.match, ''),
+        -- ClickHouse must never hold a plaintext match. Catalog matches are
+        -- already redacted display strings and pass through; anything else
+        -- (e.g. account_identity emails, stored verbatim in Postgres only)
+        -- collapses to a length-only placeholder, mirroring the writer.
+        CASE
+          WHEN COALESCE(rr.match, '') = '' THEN ''
+          WHEN rr.match LIKE '<redacted%' THEN rr.match
+          ELSE '<redacted len=' || length(rr.match) || '>'
+        END,
         rr.excluded_at,
         rr.false_positive_at
       FROM risk_results rr

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2051,6 +2051,123 @@ async function seedRiskFindings(init: {
   }
 }
 
+// Mirrors the project's Postgres risk_results into the ClickHouse
+// risk_findings table the way the enriched FindingCHWriter would have written
+// them: denormalized chat/user attribution, category from the shared
+// classifier's rules, and the already-redacted match display string. This is
+// what the ClickHouse-backed Risk Overview read path (the
+// risk-overview-from-clickhouse flag) reads locally. Must run AFTER every
+// risk_results writer (seedRiskFindings, seedNonCorporateAccountFindings) so
+// the copy sees the final Postgres state.
+async function seedRiskFindingsClickHouse(init: {
+  projectId: string;
+}): Promise<void> {
+  const { projectId } = init;
+  const dbUser = process.env.DB_USER || "gram";
+  const dbName = process.env.DB_NAME || "gram";
+
+  // The CASE mirrors internal/risk/categories Classify (the single source of
+  // truth the CH writer stamps categories with): source-owned categories
+  // first, then rule-id lists/prefixes, then scanner-source fallbacks.
+  const copySQL = `
+    COPY (
+      SELECT
+        rr.id,
+        rr.created_at,
+        rr.organization_id,
+        rr.project_id::text,
+        COALESCE(rr.chat_message_id::text, ''),
+        COALESCE(rr.risk_policy_id::text, ''),
+        COALESCE(rr.risk_policy_version, 1),
+        COALESCE(rr.rule_id, ''),
+        COALESCE(rr.description, ''),
+        rr.source,
+        COALESCE(rr.confidence, 0),
+        COALESCE(cm.chat_id::text, ''),
+        COALESCE(NULLIF(cm.user_id, ''), NULLIF(c.user_id, ''), ''),
+        COALESCE(NULLIF(cm.external_user_id, ''), NULLIF(c.external_user_id, ''), ''),
+        CASE
+          WHEN rr.source = 'shadow_mcp' THEN 'shadow_mcp'
+          WHEN rr.source = 'destructive_tool' THEN 'destructive_tool'
+          WHEN rr.source = 'cli_destructive' THEN 'cli_destructive'
+          WHEN rr.source = 'account_identity' THEN 'account_identity'
+          WHEN rr.source = 'llm_judge' THEN 'prompt_policy'
+          WHEN rr.source = 'prompt_injection' THEN 'prompt_injection'
+          WHEN rr.rule_id LIKE 'secret.%' THEN 'secrets'
+          WHEN rr.rule_id IN ('pii.credit_card','pii.iban_code','pii.us_bank_number','pii.crypto') THEN 'financial'
+          WHEN rr.rule_id IN (
+            'pii.us_ssn','pii.us_passport','pii.us_itin','pii.uk_nhs','pii.uk_nino','pii.uk_passport',
+            'pii.es_nif','pii.it_fiscal_code','pii.au_tfn','pii.in_pan','pii.in_aadhaar','pii.sg_nric_fin'
+          ) THEN 'government_ids'
+          WHEN rr.rule_id IN (
+            'pii.medical_license','pii.us_mbi','pii.us_npi','pii.medical_disease_disorder','pii.medical_medication',
+            'pii.medical_therapeutic_procedure','pii.medical_clinical_event','pii.medical_biological_attribute','pii.medical_family_history'
+          ) THEN 'healthcare'
+          WHEN rr.rule_id IN (
+            'pii.harmful_content_request','pii.policy_violation','pii.unauthorized_action','pii.topic_boundary_violation'
+          ) THEN 'off_policy'
+          WHEN rr.rule_id LIKE 'pii.%' THEN 'pii'
+          WHEN rr.source = 'gitleaks' THEN 'secrets'
+          WHEN rr.source = 'presidio' THEN 'pii'
+          ELSE 'custom'
+        END,
+        COALESCE(rr.match, ''),
+        rr.excluded_at,
+        rr.false_positive_at
+      FROM risk_results rr
+      LEFT JOIN chat_messages cm ON cm.id = rr.chat_message_id
+      LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
+      WHERE rr.project_id = '${projectId}' AND rr.found IS TRUE
+        -- risk_findings has a 90-day TTL; older rows would be dropped on
+        -- insert anyway, and skipping them keeps the daily partition count of
+        -- a single insert under ClickHouse's per-block limit.
+        AND rr.created_at >= now() - interval '90 days'
+    ) TO STDOUT WITH (FORMAT csv, NULL '\\N')`;
+
+  const insertSQL = `
+    INSERT INTO risk_findings (
+      id, created_at, organization_id, project_id, chat_message_id,
+      risk_policy_id, risk_policy_version, rule_id, description, source,
+      confidence, chat_id, user_id, external_user_id, category,
+      match_redacted, excluded_at, false_positive_at
+    ) FORMAT CSV`;
+
+  try {
+    // Idempotent reset scoped to this project (lightweight delete, applied
+    // synchronously enough for a local seed).
+    await runClickHouseSQL(
+      `DELETE FROM risk_findings WHERE project_id = '${projectId}';`,
+    );
+
+    const copied = await $({
+      input: copySQL,
+    })`docker compose exec -T gram-db psql -U ${dbUser} -d ${dbName} -f -`.quiet();
+
+    const rows = copied.stdout.trim();
+    if (rows === "") {
+      log.info("No Postgres risk findings to mirror into ClickHouse");
+      return;
+    }
+
+    // psql renders timestamptz with a trailing offset (e.g. "+00");
+    // best_effort parsing accepts it. The partition limit stays raised as a
+    // safety net: the 90-day copy window keeps a single insert just under the
+    // default limit of 100 daily partitions.
+    await $({
+      input: rows + "\n",
+    })`docker compose exec -T clickhouse clickhouse-client --date_time_input_format=best_effort --max_partitions_per_insert_block=1000 --query ${insertSQL}`.quiet();
+
+    log.info(
+      `Mirrored ${rows.split("\n").length} risk findings into ClickHouse for the flagged Risk Overview read path`,
+    );
+  } catch (e: unknown) {
+    const err = e as { stderr?: string; stdout?: string; message?: string };
+    log.stepFailed(
+      `Failed to mirror risk findings into ClickHouse: ${err.message || err.stderr || err.stdout || JSON.stringify(e)}`,
+    );
+  }
+}
+
 // Inserts an account_identity ("Non-Corporate Accounts") policy plus the risk
 // events it would produce over the personal-account chats seeded by
 // seedPersonalAccounts. Mirrors the scanner's real semantics: findings are
@@ -4874,6 +4991,10 @@ async function seed() {
       projectId: firstProject.id,
       organizationId: activeOrgID,
     });
+    // Mirror the final risk_results state into ClickHouse risk_findings so
+    // the ClickHouse-backed Risk Overview read path has matching data. Must
+    // stay last among the risk seeders.
+    await seedRiskFindingsClickHouse({ projectId: firstProject.id });
   }
 
   // Give the local dev user the "see all org sessions" admin view that the

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -102,6 +102,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/resources"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	riskchrepo "github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
@@ -1219,6 +1220,7 @@ func newStartCommand() *cli.Command {
 					}
 					return urls, nil
 				},
+				riskchrepo.New(chDB),
 			)
 			chatWriter.AddObserver(riskService)
 			risk.Attach(mux, riskService)

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -17,6 +17,10 @@ const (
 
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
+	// FlagRiskOverviewFromClickHouse serves the risk overview endpoint from
+	// ClickHouse risk_findings instead of Postgres risk_results. Per-org
+	// rollout gate; removed once the ClickHouse read path is GA.
+	FlagRiskOverviewFromClickHouse Flag = "risk-overview-from-clickhouse"
 
 	// FlagTelemetryLogsPubSubShadow gates the best-effort shadow dual-write of
 	// telemetry_logs rows onto Pub/Sub (gram-telemetry-v1-log-record). It is

--- a/server/internal/risk/chrepo/overview.go
+++ b/server/internal/risk/chrepo/overview.go
@@ -1,0 +1,218 @@
+package chrepo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Masterminds/squirrel"
+)
+
+// RiskOverviewWindowParams scopes every overview read to one tenant and a
+// half-open [From, To) time window. Callers cap the window (the API allows at
+// most 31 days), which combines with the table's daily partitioning and
+// (organization_id, project_id, created_at, id) sort key to keep these direct
+// queries cheap without materialized views.
+type RiskOverviewWindowParams struct {
+	OrganizationID string
+	ProjectID      string
+	From           time.Time
+	To             time.Time
+}
+
+// overviewFindings returns the base builder every overview read shares:
+// tenant + window scoped, live findings only. Dead-letter sentinel rows and
+// insert-time exclusion annotations are filtered here; false_positive_at is
+// filtered for forward-compatibility (post-hoc marks are not mirrored to
+// ClickHouse yet, so the column is NULL on every row today).
+//
+// Counts use uniqExact(id), never count(): findings arrive over Pub/Sub with
+// at-least-once delivery and the table is a plain append-only MergeTree, so
+// redelivered rows sharing an id are expected.
+func overviewFindings(p RiskOverviewWindowParams, columns ...string) squirrel.SelectBuilder {
+	return sq.Select(columns...).
+		From("risk_findings").
+		Where("organization_id = ?", p.OrganizationID).
+		Where("project_id = ?", p.ProjectID).
+		Where("created_at >= ?", p.From).
+		Where("created_at < ?", p.To).
+		Where("dead_letter_reason = ''").
+		Where("excluded_at IS NULL").
+		Where("false_positive_at IS NULL")
+}
+
+// RiskOverviewFindingCounts are the window-wide headline stats.
+type RiskOverviewFindingCounts struct {
+	Findings        uint64
+	FlaggedSessions uint64
+}
+
+// GetRiskOverviewFindingCounts returns the deduplicated finding count and the
+// number of distinct chats with at least one finding. Rows with an empty
+// chat_id (attribution unresolved at ingest) count as findings but not as
+// flagged sessions.
+func (q *Queries) GetRiskOverviewFindingCounts(ctx context.Context, p RiskOverviewWindowParams) (RiskOverviewFindingCounts, error) {
+	var counts RiskOverviewFindingCounts
+
+	query, args, err := overviewFindings(p,
+		"uniqExact(id) AS findings",
+		"uniqExactIf(chat_id, chat_id != '') AS flagged_sessions",
+	).ToSql()
+	if err != nil {
+		return counts, fmt.Errorf("build risk overview finding counts query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return counts, fmt.Errorf("query risk overview finding counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	if rows.Next() {
+		if err := rows.Scan(&counts.Findings, &counts.FlaggedSessions); err != nil {
+			return counts, fmt.Errorf("scan risk overview finding counts: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return counts, fmt.Errorf("read risk overview finding counts: %w", err)
+	}
+
+	return counts, nil
+}
+
+// RiskOverviewRuleCount is one (rule, source) group's finding count.
+type RiskOverviewRuleCount struct {
+	RuleID   string
+	Source   string
+	Findings uint64
+}
+
+// ListRiskOverviewTopRules returns per-(rule_id, source) finding counts,
+// most findings first.
+func (q *Queries) ListRiskOverviewTopRules(ctx context.Context, p RiskOverviewWindowParams, limit uint64) ([]RiskOverviewRuleCount, error) {
+	query, args, err := overviewFindings(p,
+		"rule_id",
+		"source",
+		"uniqExact(id) AS findings",
+	).
+		GroupBy("rule_id", "source").
+		OrderBy("findings DESC", "rule_id ASC").
+		Limit(limit).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build risk overview top rules query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query risk overview top rules: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []RiskOverviewRuleCount
+	for rows.Next() {
+		var row RiskOverviewRuleCount
+		if err := rows.Scan(&row.RuleID, &row.Source, &row.Findings); err != nil {
+			return nil, fmt.Errorf("scan risk overview top rules row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read risk overview top rules: %w", err)
+	}
+
+	return out, nil
+}
+
+// RiskOverviewCategoryBucket is one non-empty (hour, category) cell of the
+// findings time series. Empty cells are absent: the caller gap-fills the full
+// hour x category grid (the Postgres path does this with a generate_series
+// cross join; the ClickHouse path does it in Go).
+type RiskOverviewCategoryBucket struct {
+	BucketStart time.Time
+	Category    string
+	Findings    uint64
+}
+
+// ListRiskOverviewCategoryTimeSeries returns hourly finding counts grouped by
+// the category column stamped at ingest.
+func (q *Queries) ListRiskOverviewCategoryTimeSeries(ctx context.Context, p RiskOverviewWindowParams) ([]RiskOverviewCategoryBucket, error) {
+	query, args, err := overviewFindings(p,
+		"toStartOfHour(created_at, 'UTC') AS bucket_start",
+		"category",
+		"uniqExact(id) AS findings",
+	).
+		GroupBy("bucket_start", "category").
+		OrderBy("bucket_start ASC", "category ASC").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build risk overview category time series query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query risk overview category time series: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []RiskOverviewCategoryBucket
+	for rows.Next() {
+		var row RiskOverviewCategoryBucket
+		if err := rows.Scan(&row.BucketStart, &row.Category, &row.Findings); err != nil {
+			return nil, fmt.Errorf("scan risk overview category time series row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read risk overview category time series: %w", err)
+	}
+
+	return out, nil
+}
+
+// RiskOverviewUserCount is one (user_id, external_user_id) group's finding
+// count. Email resolution happens in Go against Postgres afterwards, so this
+// stays a pure ClickHouse aggregate.
+type RiskOverviewUserCount struct {
+	UserID         string
+	ExternalUserID string
+	Findings       uint64
+}
+
+// ListRiskOverviewTopUsers returns per-user finding counts, most findings
+// first. Ordering within equal counts is (user_id, external_user_id) purely
+// for determinism; the caller re-sorts after resolving display emails.
+func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, p RiskOverviewWindowParams, limit uint64) ([]RiskOverviewUserCount, error) {
+	query, args, err := overviewFindings(p,
+		"user_id",
+		"external_user_id",
+		"uniqExact(id) AS findings",
+	).
+		GroupBy("user_id", "external_user_id").
+		OrderBy("findings DESC", "user_id ASC", "external_user_id ASC").
+		Limit(limit).
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build risk overview top users query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query risk overview top users: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []RiskOverviewUserCount
+	for rows.Next() {
+		var row RiskOverviewUserCount
+		if err := rows.Scan(&row.UserID, &row.ExternalUserID, &row.Findings); err != nil {
+			return nil, fmt.Errorf("scan risk overview top users row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read risk overview top users: %w", err)
+	}
+
+	return out, nil
+}

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -49,6 +49,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
 	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
@@ -123,6 +124,10 @@ type Service struct {
 	// the realtime scanner uses. Optional: when nil the eval endpoint returns
 	// un-matched verdicts (judge unavailable).
 	promptJudge promptpolicy.Evaluator
+	// findingsCH reads the ClickHouse risk_findings table for the overview
+	// endpoint when FlagRiskOverviewFromClickHouse is on for the org.
+	// Optional: when nil the overview always serves from Postgres.
+	findingsCH *chrepo.Queries
 }
 
 var _ chat.MessageObserver = (*Service)(nil)
@@ -162,6 +167,7 @@ func NewObserver(
 		celEng:                       nil,
 		builtinPresets:               nil,
 		promptJudge:                  nil,
+		findingsCH:                   nil,
 	}
 }
 
@@ -187,6 +193,7 @@ func NewService(
 	promptJudge promptpolicy.Evaluator,
 	reconcileShadowMCPPolicyURLs ShadowMCPPolicyURLReconciler,
 	shadowMCPInventoryURLLookup ShadowMCPInventoryURLLookup,
+	findingsCH *chrepo.Queries,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("risk"))
 
@@ -214,6 +221,7 @@ func NewService(
 		celEng:                       celEng,
 		builtinPresets:               builtinPresets,
 		promptJudge:                  promptJudge,
+		findingsCH:                   findingsCH,
 	}
 }
 
@@ -1484,6 +1492,10 @@ func (s *Service) GetRiskOverview(ctx context.Context, payload *gen.GetRiskOverv
 		return nil, oops.E(oops.CodeInvalid, err, "invalid overview window").LogError(ctx, s.logger)
 	}
 
+	if s.overviewFromClickHouse(ctx, authCtx) {
+		return s.getRiskOverviewFromClickHouse(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, from, to)
+	}
+
 	window := riskOverviewWindowParams(from, to)
 	scanCounts, err := s.repo.GetRiskOverviewScanCounts(ctx, repo.GetRiskOverviewScanCountsParams{
 		ProjectID: *authCtx.ProjectID,
@@ -1626,13 +1638,19 @@ func riskOverviewWindowParams(from, to time.Time) riskOverviewWindow {
 }
 
 func riskOverviewTopCategories(rows []repo.ListRiskOverviewTimeSeriesFindingsRow, limit int) []*gen.RiskOverviewCategory {
-	if limit <= 0 {
-		return nil
-	}
-
 	counts := make(map[string]int64)
 	for _, row := range rows {
 		counts[row.Category] += row.Findings
+	}
+
+	return topCategoriesFromCounts(counts, limit)
+}
+
+// topCategoriesFromCounts is the shared tail of the Postgres and ClickHouse
+// top-categories derivations: rank per-category totals, drop empty ones.
+func topCategoriesFromCounts(counts map[string]int64, limit int) []*gen.RiskOverviewCategory {
+	if limit <= 0 {
+		return nil
 	}
 
 	categories := make([]*gen.RiskOverviewCategory, 0, len(counts))

--- a/server/internal/risk/overview_ch.go
+++ b/server/internal/risk/overview_ch.go
@@ -85,12 +85,16 @@ func (s *Service) getRiskOverviewFromClickHouse(ctx context.Context, projectID u
 		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview time series from clickhouse").LogError(ctx, s.logger)
 	}
 
-	userRows, err := s.findingsCH.ListRiskOverviewTopUsers(ctx, chWindow, riskOverviewRowLimit)
+	// Fetch raw (user_id, external_user_id) groups with headroom: email
+	// resolution can merge several raw groups into one display identity, so
+	// limiting at the display cap here could undercount a merged user near the
+	// boundary. The display-level cap applies after merging.
+	userRows, err := s.findingsCH.ListRiskOverviewTopUsers(ctx, chWindow, riskOverviewRowLimit*5)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top users from clickhouse").LogError(ctx, s.logger)
 	}
 
-	topUsers, err := s.resolveOverviewUserEmails(ctx, userRows)
+	topUsers, err := s.resolveOverviewUserEmails(ctx, organizationID, userRows)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "resolve risk overview user emails").LogError(ctx, s.logger)
 	}
@@ -127,8 +131,8 @@ func (s *Service) getRiskOverviewFromClickHouse(ctx context.Context, projectID u
 // groups into display rows, replicating the Postgres query's email precedence
 // in Go: users.email, else an @-containing external id, else "Unknown user".
 // Groups that resolve to the same (external_user_id, email) merge, mirroring
-// the Postgres GROUP BY.
-func (s *Service) resolveOverviewUserEmails(ctx context.Context, rows []chrepo.RiskOverviewUserCount) ([]*gen.RiskOverviewUser, error) {
+// the Postgres GROUP BY. The email lookup is tenant-bound to organizationID.
+func (s *Service) resolveOverviewUserEmails(ctx context.Context, organizationID string, rows []chrepo.RiskOverviewUserCount) ([]*gen.RiskOverviewUser, error) {
 	ids := make([]string, 0, len(rows))
 	seen := make(map[string]struct{}, len(rows))
 	for _, row := range rows {
@@ -144,7 +148,10 @@ func (s *Service) resolveOverviewUserEmails(ctx context.Context, rows []chrepo.R
 
 	emails := make(map[string]string, len(ids))
 	if len(ids) > 0 {
-		userRows, err := s.repo.ListUserEmailsByIDs(ctx, ids)
+		userRows, err := s.repo.ListUserEmailsByIDs(ctx, repo.ListUserEmailsByIDsParams{
+			OrganizationID: organizationID,
+			Ids:            ids,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("list user emails by ids: %w", err)
 		}
@@ -185,6 +192,9 @@ func (s *Service) resolveOverviewUserEmails(ctx context.Context, rows []chrepo.R
 		}
 		return cmp.Compare(a.Email, b.Email)
 	})
+	if len(out) > riskOverviewRowLimit {
+		out = out[:riskOverviewRowLimit]
+	}
 
 	return out, nil
 }

--- a/server/internal/risk/overview_ch.go
+++ b/server/internal/risk/overview_ch.go
@@ -1,0 +1,245 @@
+package risk
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	gen "github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+// riskOverviewRowLimit caps the top-users and top-rules lists. Enough rows for
+// the "view all" pages to show the full long-tail without pagination; the main
+// /risk-overview widget only renders the top 10.
+const riskOverviewRowLimit = 200
+
+// overviewFromClickHouse reports whether GetRiskOverview should serve from
+// ClickHouse for this org. Per-org PostHog rollout flag, targeted by org and
+// slug groups the same way the dashboard evaluates flags. A nil provider,
+// missing ClickHouse connection, or a failed lookup degrades to the Postgres
+// path.
+func (s *Service) overviewFromClickHouse(ctx context.Context, authCtx *contextvalues.AuthContext) bool {
+	if s.findingsCH == nil || s.flags == nil {
+		return false
+	}
+	groups := feature.OrgProjectGroups(authCtx.OrganizationSlug, conv.PtrValOr(authCtx.ProjectSlug, ""))
+	on, err := s.flags.IsFlagEnabled(ctx, feature.FlagRiskOverviewFromClickHouse, authCtx.ActiveOrganizationID, groups)
+	if err != nil {
+		s.logger.WarnContext(ctx, "risk-overview-from-clickhouse flag check failed; serving from postgres",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(authCtx.ActiveOrganizationID),
+		)
+		return false
+	}
+	return on
+}
+
+// getRiskOverviewFromClickHouse serves GetRiskOverview from the ClickHouse
+// risk_findings table instead of Postgres risk_results, relieving the
+// autovacuum pressure the PG queries create. Events Scanned and Active
+// Policies stay on Postgres: ClickHouse stores only true positives (clean
+// scans are never written) and policies are current-state config.
+func (s *Service) getRiskOverviewFromClickHouse(ctx context.Context, projectID uuid.UUID, organizationID string, from, to time.Time) (*gen.RiskOverviewResult, error) {
+	window := riskOverviewWindowParams(from, to)
+	scanCounts, err := s.repo.GetRiskOverviewScanCounts(ctx, repo.GetRiskOverviewScanCountsParams{
+		ProjectID: projectID,
+		FromTime:  window.from,
+		ToTime:    window.to,
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview scan counts").LogError(ctx, s.logger)
+	}
+
+	chWindow := chrepo.RiskOverviewWindowParams{
+		OrganizationID: organizationID,
+		ProjectID:      projectID.String(),
+		From:           from,
+		To:             to,
+	}
+
+	findingCounts, err := s.findingsCH.GetRiskOverviewFindingCounts(ctx, chWindow)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "get risk overview finding counts from clickhouse").LogError(ctx, s.logger)
+	}
+
+	ruleRows, err := s.findingsCH.ListRiskOverviewTopRules(ctx, chWindow, riskOverviewRowLimit)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top rules from clickhouse").LogError(ctx, s.logger)
+	}
+
+	buckets, err := s.findingsCH.ListRiskOverviewCategoryTimeSeries(ctx, chWindow)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview time series from clickhouse").LogError(ctx, s.logger)
+	}
+
+	userRows, err := s.findingsCH.ListRiskOverviewTopUsers(ctx, chWindow, riskOverviewRowLimit)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list risk overview top users from clickhouse").LogError(ctx, s.logger)
+	}
+
+	topUsers, err := s.resolveOverviewUserEmails(ctx, userRows)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "resolve risk overview user emails").LogError(ctx, s.logger)
+	}
+
+	topRules := make([]*gen.RiskRuleBreakdownEntry, 0, len(ruleRows))
+	for _, row := range ruleRows {
+		topRules = append(topRules, &gen.RiskRuleBreakdownEntry{
+			RuleID:   row.RuleID,
+			Source:   row.Source,
+			Findings: safeCount(row.Findings),
+		})
+	}
+
+	categoryCounts := make(map[string]int64, len(buckets))
+	for _, bucket := range buckets {
+		categoryCounts[bucket.Category] += safeCount(bucket.Findings)
+	}
+
+	return &gen.RiskOverviewResult{
+		From:               from.UTC().Format(time.RFC3339),
+		To:                 to.UTC().Format(time.RFC3339),
+		MessagesScanned:    scanCounts.MessagesScanned,
+		Findings:           safeCount(findingCounts.Findings),
+		FlaggedSessions:    safeCount(findingCounts.FlaggedSessions),
+		ActivePolicies:     scanCounts.ActivePolicies,
+		TopCategories:      topCategoriesFromCounts(categoryCounts, 10),
+		TopUsers:           topUsers,
+		TopRules:           topRules,
+		TimeSeriesFindings: fillCategoryTimeSeries(from, to, buckets),
+	}, nil
+}
+
+// resolveOverviewUserEmails turns ClickHouse (user_id, external_user_id)
+// groups into display rows, replicating the Postgres query's email precedence
+// in Go: users.email, else an @-containing external id, else "Unknown user".
+// Groups that resolve to the same (external_user_id, email) merge, mirroring
+// the Postgres GROUP BY.
+func (s *Service) resolveOverviewUserEmails(ctx context.Context, rows []chrepo.RiskOverviewUserCount) ([]*gen.RiskOverviewUser, error) {
+	ids := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		if row.UserID == "" {
+			continue
+		}
+		if _, ok := seen[row.UserID]; ok {
+			continue
+		}
+		seen[row.UserID] = struct{}{}
+		ids = append(ids, row.UserID)
+	}
+
+	emails := make(map[string]string, len(ids))
+	if len(ids) > 0 {
+		userRows, err := s.repo.ListUserEmailsByIDs(ctx, ids)
+		if err != nil {
+			return nil, fmt.Errorf("list user emails by ids: %w", err)
+		}
+		for _, user := range userRows {
+			if user.Email != "" {
+				emails[user.ID] = user.Email
+			}
+		}
+	}
+
+	type userKey struct {
+		externalUserID string
+		email          string
+	}
+	merged := make(map[userKey]int64, len(rows))
+	for _, row := range rows {
+		email := emails[row.UserID]
+		if email == "" && strings.Contains(row.ExternalUserID, "@") {
+			email = row.ExternalUserID
+		}
+		if email == "" {
+			email = "Unknown user"
+		}
+		merged[userKey{externalUserID: row.ExternalUserID, email: email}] += safeCount(row.Findings)
+	}
+
+	out := make([]*gen.RiskOverviewUser, 0, len(merged))
+	for key, findings := range merged {
+		out = append(out, &gen.RiskOverviewUser{
+			Email:          key.email,
+			ExternalUserID: key.externalUserID,
+			Findings:       findings,
+		})
+	}
+	slices.SortFunc(out, func(a, b *gen.RiskOverviewUser) int {
+		if a.Findings != b.Findings {
+			return cmp.Compare(b.Findings, a.Findings)
+		}
+		return cmp.Compare(a.Email, b.Email)
+	})
+
+	return out, nil
+}
+
+// fillCategoryTimeSeries expands the sparse (hour, category) cells ClickHouse
+// returns into the dense hour x category grid the dashboard chart expects,
+// replicating the Postgres generate_series cross-join: one row per window hour
+// per category observed in the window, zero-filled, ordered by bucket then
+// category. No categories in the window yields an empty series.
+func fillCategoryTimeSeries(from, to time.Time, buckets []chrepo.RiskOverviewCategoryBucket) []*gen.RiskOverviewTimeSeriesFinding {
+	out := make([]*gen.RiskOverviewTimeSeriesFinding, 0, len(buckets))
+	if len(buckets) == 0 {
+		return out
+	}
+
+	type cell struct {
+		hourUnix int64
+		category string
+	}
+	counts := make(map[cell]int64, len(buckets))
+	categories := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, bucket := range buckets {
+		hour := bucket.BucketStart.UTC().Truncate(time.Hour)
+		counts[cell{hourUnix: hour.Unix(), category: bucket.Category}] += safeCount(bucket.Findings)
+		if _, ok := seen[bucket.Category]; !ok {
+			seen[bucket.Category] = struct{}{}
+			categories = append(categories, bucket.Category)
+		}
+	}
+	slices.Sort(categories)
+
+	start := from.UTC().Truncate(time.Hour)
+	// Mirror the Postgres bucket series: the last bucket is the hour containing
+	// to minus one microsecond, so an exact-hour to does not add an extra
+	// empty trailing bucket.
+	end := to.UTC().Add(-time.Microsecond).Truncate(time.Hour)
+	for hour := start; !hour.After(end); hour = hour.Add(time.Hour) {
+		for _, category := range categories {
+			out = append(out, &gen.RiskOverviewTimeSeriesFinding{
+				BucketStart: hour.Format(time.RFC3339),
+				Category:    category,
+				Findings:    counts[cell{hourUnix: hour.Unix(), category: category}],
+			})
+		}
+	}
+
+	return out
+}
+
+// safeCount narrows a ClickHouse UInt64 aggregate to the int64 the API types
+// use, clamping instead of overflowing.
+func safeCount(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}

--- a/server/internal/risk/overview_ch_test.go
+++ b/server/internal/risk/overview_ch_test.go
@@ -1,0 +1,247 @@
+package risk_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
+	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// chOverviewFinding mirrors what the enriched FindingCHWriter writes for one
+// seeded overview finding: category from the shared classifier, chat-level
+// attribution (seedChatWithUser chats carry only an external user id).
+func chOverviewFinding(t *testing.T, projectID uuid.UUID, orgID string, chatID, msgID uuid.UUID, createdAt time.Time, source, ruleID, externalUserID string) chrepo.RiskFindingRow {
+	t.Helper()
+
+	return chrepo.RiskFindingRow{
+		ID:                       uuid.Must(uuid.NewV7()),
+		CreatedAt:                createdAt,
+		OrganizationID:           orgID,
+		ProjectID:                projectID.String(),
+		RequestID:                "",
+		ChatMessageID:            msgID.String(),
+		RiskPolicyID:             "",
+		RiskPolicyVersion:        1,
+		RuleID:                   ruleID,
+		Description:              "",
+		Source:                   source,
+		Confidence:               1,
+		Tags:                     []string{},
+		StartPos:                 0,
+		EndPos:                   0,
+		DeadLetterReason:         "",
+		ChatID:                   chatID.String(),
+		UserID:                   "",
+		ExternalUserID:           externalUserID,
+		Category:                 string(categories.Classify(source, ruleID)),
+		MatchLen:                 0,
+		MatchRedacted:            "",
+		FingerprintPepperVersion: "",
+		FingerprintGlobalHS256:   "",
+		FingerprintTenantHS256:   "",
+		ExcludedAt:               nil,
+		ExclusionID:              nil,
+	}
+}
+
+// TestGetRiskOverview_ClickHouseParity seeds Postgres and ClickHouse with
+// equivalent findings and asserts the ClickHouse read path returns the same
+// numbers TestGetRiskOverview_CustomWindowAggregates asserts for the Postgres
+// path (kept adjacent on purpose: if the expectations there change, they must
+// change here identically). On top of the shared expectations, ClickHouse-only
+// rows probe the read-path filters: a redelivered duplicate id, an
+// insert-time-excluded row, a dead-letter sentinel, a post-hoc false positive,
+// and a foreign-tenant row must all leave the numbers untouched.
+func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ti.flags.SetFlag(feature.FlagRiskOverviewFromClickHouse, authCtx.ActiveOrganizationID, true)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Overview CH Active")})
+	require.NoError(t, err)
+	disabledPolicy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Overview CH Disabled"), Enabled: new(false)})
+	require.NoError(t, err)
+
+	policyID, err := uuid.Parse(policy.ID)
+	require.NoError(t, err)
+	disabledPolicyID, err := uuid.Parse(disabledPolicy.ID)
+	require.NoError(t, err)
+
+	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)
+
+	aliceSecret1Chat, aliceSecret1 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+	aliceSecret2Chat, aliceSecret2 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+	alicePIIChat, alicePII := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+	bobShadowChat, bobShadow := seedChatWithUser(t, ti, projectID, orgID, "bob@example.com")
+	_, opaqueNoFinding := seedChatWithUser(t, ti, projectID, orgID, "opaque-user-id")
+	opaqueFindingChat, opaqueFinding := seedChatWithUser(t, ti, projectID, orgID, "opaque-user-id")
+	outsideWindowChat, outsideWindow := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+	disabledPolicyChat, disabledPolicyFinding := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
+
+	// Postgres side: identical to the Postgres-path test. MessagesScanned and
+	// ActivePolicies are served from Postgres on both paths.
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, aliceSecret1, from.Add(36*time.Hour), "gitleaks", "secret.github_pat", true)
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, aliceSecret2, from.Add(38*time.Hour), "gitleaks", "secret.aws_access_token", true)
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, alicePII, from.Add(60*time.Hour), "presidio", "pii.email_address", true)
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, bobShadow, from.Add(84*time.Hour), "shadow_mcp", "", true)
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, opaqueNoFinding, from.Add(108*time.Hour), "gitleaks", "", false)
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, opaqueFinding, from.Add(109*time.Hour), "gitleaks", "secret.github_pat", true)
+	seedRiskOverviewResult(t, ti, projectID, orgID, policyID, outsideWindow, to.Add(24*time.Hour), "gitleaks", "secret.github_pat", true)
+	seedRiskOverviewResult(t, ti, projectID, orgID, disabledPolicyID, disabledPolicyFinding, from.Add(110*time.Hour), "gitleaks", "secret.github_pat", true)
+
+	// ClickHouse side: the found=true findings as the enriched writer stores
+	// them. The found=false scan row never becomes a finding message, so it has
+	// no ClickHouse counterpart.
+	rows := []chrepo.RiskFindingRow{
+		chOverviewFinding(t, projectID, orgID, aliceSecret1Chat, aliceSecret1, from.Add(36*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com"),
+		chOverviewFinding(t, projectID, orgID, aliceSecret2Chat, aliceSecret2, from.Add(38*time.Hour), "gitleaks", "secret.aws_access_token", "alice@example.com"),
+		chOverviewFinding(t, projectID, orgID, alicePIIChat, alicePII, from.Add(60*time.Hour), "presidio", "pii.email_address", "alice@example.com"),
+		chOverviewFinding(t, projectID, orgID, bobShadowChat, bobShadow, from.Add(84*time.Hour), "shadow_mcp", "", "bob@example.com"),
+		chOverviewFinding(t, projectID, orgID, opaqueFindingChat, opaqueFinding, from.Add(109*time.Hour), "gitleaks", "secret.github_pat", "opaque-user-id"),
+		chOverviewFinding(t, projectID, orgID, outsideWindowChat, outsideWindow, to.Add(24*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com"),
+		chOverviewFinding(t, projectID, orgID, disabledPolicyChat, disabledPolicyFinding, from.Add(110*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com"),
+	}
+
+	// Redelivered duplicate: same row id inserted twice; uniqExact must count
+	// it once.
+	rows = append(rows, rows[0])
+
+	// Insert-time-excluded row and a dead-letter sentinel: filtered by every
+	// overview query.
+	excludedAt := from.Add(37 * time.Hour)
+	excludedRow := chOverviewFinding(t, projectID, orgID, aliceSecret1Chat, aliceSecret1, from.Add(37*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com")
+	excludedRow.ExcludedAt = &excludedAt
+	exclusionID := uuid.Must(uuid.NewV7())
+	excludedRow.ExclusionID = &exclusionID
+	rows = append(rows, excludedRow)
+
+	deadLetterRow := chOverviewFinding(t, projectID, orgID, aliceSecret1Chat, aliceSecret1, from.Add(37*time.Hour), "gitleaks", "", "alice@example.com")
+	deadLetterRow.DeadLetterReason = "could-not-analyze"
+	deadLetterRow.Category = ""
+	rows = append(rows, deadLetterRow)
+
+	// Foreign tenant: same window, different org/project.
+	foreignRow := chOverviewFinding(t, uuid.New(), "org_"+uuid.NewString(), aliceSecret1Chat, aliceSecret1, from.Add(37*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com")
+	rows = append(rows, foreignRow)
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, rows))
+
+	// Post-hoc false positive: inserted directly with false_positive_at set
+	// (the live writer never stamps it; the mark path mirrors it later).
+	require.NoError(t, ti.chConn.Exec(ctx, `
+		INSERT INTO risk_findings (id, created_at, organization_id, project_id, rule_id, source, category, chat_id, false_positive_at)
+		VALUES (?, ?, ?, ?, 'secret.github_pat', 'gitleaks', 'secrets', ?, ?)
+	`, uuid.Must(uuid.NewV7()), from.Add(37*time.Hour), orgID, projectID.String(), aliceSecret1Chat.String(), from.Add(40*time.Hour)))
+
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	result, err := ti.service.GetRiskOverview(ctx, &gen.GetRiskOverviewPayload{
+		From: new(from.Format(time.RFC3339)),
+		To:   new(to.Format(time.RFC3339)),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, int64(7), result.MessagesScanned)
+	require.Equal(t, int64(6), result.Findings)
+	require.Equal(t, int64(6), result.FlaggedSessions)
+	require.Equal(t, int64(1), result.ActivePolicies)
+
+	categoryCounts := map[string]int64{}
+	for _, category := range result.TopCategories {
+		categoryCounts[category.Category] = category.Findings
+	}
+	require.Equal(t, int64(4), categoryCounts["secrets"])
+	require.Equal(t, int64(1), categoryCounts["pii"])
+	require.Equal(t, int64(1), categoryCounts["shadow_mcp"])
+
+	users := map[string]int64{}
+	for _, user := range result.TopUsers {
+		users[user.Email] = user.Findings
+	}
+	require.Equal(t, int64(4), users["alice@example.com"])
+	require.Equal(t, int64(1), users["bob@example.com"])
+	require.Equal(t, int64(1), users["Unknown user"])
+	require.NotContains(t, users, "opaque-user-id")
+
+	require.Len(t, result.TimeSeriesFindings, 504)
+	timeSeries := map[string]int64{}
+	for _, point := range result.TimeSeriesFindings {
+		timeSeries[point.Category+"|"+point.BucketStart] = point.Findings
+	}
+	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T12:00:00Z"])
+	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T14:00:00Z"])
+	require.Equal(t, int64(1), timeSeries["pii|2026-05-03T12:00:00Z"])
+	require.Equal(t, int64(1), timeSeries["shadow_mcp|2026-05-04T12:00:00Z"])
+	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T13:00:00Z"])
+	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T14:00:00Z"])
+	require.Equal(t, int64(0), timeSeries["pii|2026-05-05T13:00:00Z"])
+}
+
+// TestGetRiskOverview_ClickHouseUserEmailPrecedence covers the Go-side email
+// resolution that replaces the Postgres users join: a resolvable internal user
+// id wins over the external id, and the users lookup result merges groups.
+func TestGetRiskOverview_ClickHouseUserEmailPrecedence(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ti.flags.SetFlag(feature.FlagRiskOverviewFromClickHouse, authCtx.ActiveOrganizationID, true)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	// The auth context user exists in the users table; findings attributed to
+	// that internal user id must resolve to its email even with an opaque
+	// external id.
+	chatID, msgID := seedChatWithUser(t, ti, projectID, orgID, "opaque-external")
+	internalUser := chOverviewFinding(t, projectID, orgID, chatID, msgID, from.Add(2*time.Hour), "gitleaks", "secret.github_pat", "opaque-external")
+	internalUser.UserID = authCtx.UserID
+
+	// Unknown internal user id + opaque external id: falls through to the
+	// "Unknown user" bucket.
+	unknownUser := chOverviewFinding(t, projectID, orgID, chatID, msgID, from.Add(3*time.Hour), "gitleaks", "secret.github_pat", "opaque-external")
+	unknownUser.UserID = "user-that-does-not-exist"
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{internalUser, unknownUser}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	require.NotNil(t, authCtx.Email)
+	userEmail := *authCtx.Email
+
+	result, err := ti.service.GetRiskOverview(ctx, &gen.GetRiskOverviewPayload{
+		From: new(from.Format(time.RFC3339)),
+		To:   new(to.Format(time.RFC3339)),
+	})
+	require.NoError(t, err)
+
+	users := map[string]int64{}
+	for _, user := range result.TopUsers {
+		users[user.Email] = user.Findings
+	}
+	require.Equal(t, int64(1), users[userEmail])
+	require.Equal(t, int64(1), users["Unknown user"])
+}

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -1543,6 +1543,15 @@ WHERE project_id = @project_id
   AND deleted IS FALSE
 RETURNING *;
 
+-- name: ListUserEmailsByIDs :many
+-- Display-email lookup for the ClickHouse-backed overview top-users list. The
+-- ids come from findings already scoped to the caller's project; mirroring the
+-- Postgres overview query, no deleted filter is applied so findings from
+-- since-removed users keep a resolvable email.
+SELECT id, email
+FROM users
+WHERE id = ANY(@ids::text[]);
+
 -- name: GetChatMessageAttribution :many
 -- Resolves the denormalized attribution (chat id, user ids) the ClickHouse
 -- finding writer stamps on risk_findings rows at ingest. Message-level ids win

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -1544,13 +1544,17 @@ WHERE project_id = @project_id
 RETURNING *;
 
 -- name: ListUserEmailsByIDs :many
--- Display-email lookup for the ClickHouse-backed overview top-users list. The
--- ids come from findings already scoped to the caller's project; mirroring the
--- Postgres overview query, no deleted filter is applied so findings from
--- since-removed users keep a resolvable email.
-SELECT id, email
-FROM users
-WHERE id = ANY(@ids::text[]);
+-- Display-email lookup for the ClickHouse-backed overview top-users list,
+-- tenant-bound through org membership so a caller can never resolve emails of
+-- users outside its organization. Soft-deleted memberships are intentionally
+-- included: findings from since-removed org members keep a resolvable email,
+-- mirroring the Postgres overview query's unconditional users join.
+SELECT u.id, u.email
+FROM users u
+JOIN organization_user_relationships our
+  ON our.user_id = u.id
+  AND our.organization_id = @organization_id
+WHERE u.id = ANY(@ids::text[]);
 
 -- name: GetChatMessageAttribution :many
 -- Resolves the denormalized attribution (chat id, user ids) the ClickHouse

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -3273,6 +3273,41 @@ func (q *Queries) ListRiskUserRuleBreakdown(ctx context.Context, arg ListRiskUse
 	return items, nil
 }
 
+const listUserEmailsByIDs = `-- name: ListUserEmailsByIDs :many
+SELECT id, email
+FROM users
+WHERE id = ANY($1::text[])
+`
+
+type ListUserEmailsByIDsRow struct {
+	ID    string
+	Email string
+}
+
+// Display-email lookup for the ClickHouse-backed overview top-users list. The
+// ids come from findings already scoped to the caller's project; mirroring the
+// Postgres overview query, no deleted filter is applied so findings from
+// since-removed users keep a resolvable email.
+func (q *Queries) ListUserEmailsByIDs(ctx context.Context, ids []string) ([]ListUserEmailsByIDsRow, error) {
+	rows, err := q.db.Query(ctx, listUserEmailsByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUserEmailsByIDsRow
+	for rows.Next() {
+		var i ListUserEmailsByIDsRow
+		if err := rows.Scan(&i.ID, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markMessagesRiskAnalyzed = `-- name: MarkMessagesRiskAnalyzed :exec
 UPDATE chat_messages
 SET risk_analyzed_at = clock_timestamp()

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -3274,22 +3274,31 @@ func (q *Queries) ListRiskUserRuleBreakdown(ctx context.Context, arg ListRiskUse
 }
 
 const listUserEmailsByIDs = `-- name: ListUserEmailsByIDs :many
-SELECT id, email
-FROM users
-WHERE id = ANY($1::text[])
+SELECT u.id, u.email
+FROM users u
+JOIN organization_user_relationships our
+  ON our.user_id = u.id
+  AND our.organization_id = $1
+WHERE u.id = ANY($2::text[])
 `
+
+type ListUserEmailsByIDsParams struct {
+	OrganizationID string
+	Ids            []string
+}
 
 type ListUserEmailsByIDsRow struct {
 	ID    string
 	Email string
 }
 
-// Display-email lookup for the ClickHouse-backed overview top-users list. The
-// ids come from findings already scoped to the caller's project; mirroring the
-// Postgres overview query, no deleted filter is applied so findings from
-// since-removed users keep a resolvable email.
-func (q *Queries) ListUserEmailsByIDs(ctx context.Context, ids []string) ([]ListUserEmailsByIDsRow, error) {
-	rows, err := q.db.Query(ctx, listUserEmailsByIDs, ids)
+// Display-email lookup for the ClickHouse-backed overview top-users list,
+// tenant-bound through org membership so a caller can never resolve emails of
+// users outside its organization. Soft-deleted memberships are intentionally
+// included: findings from since-removed org members keep a resolvable email,
+// mirroring the Postgres overview query's unconditional users join.
+func (q *Queries) ListUserEmailsByIDs(ctx context.Context, arg ListUserEmailsByIDsParams) ([]ListUserEmailsByIDsRow, error) {
+	rows, err := q.db.Query(ctx, listUserEmailsByIDs, arg.OrganizationID, arg.Ids)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
@@ -172,6 +174,7 @@ type testInstance struct {
 	shadowMCPInventoryURLLookup  risk.ShadowMCPInventoryURLLookup
 	completionClient             openrouter.CompletionClient
 	cacheDeletes                 *countingCache
+	chConn                       clickhouse.Conn
 }
 
 func newTestRiskService(t *testing.T, configure ...func(*testInstance)) (context.Context, *testInstance) {
@@ -223,6 +226,7 @@ func newTestRiskService(t *testing.T, configure ...func(*testInstance)) (context
 		},
 		completionClient: nil,
 		cacheDeletes:     cacheAdapter,
+		chConn:           chConn,
 	}
 	for _, configureInstance := range configure {
 		configureInstance(ti)
@@ -231,7 +235,7 @@ func newTestRiskService(t *testing.T, configure ...func(*testInstance)) (context
 		return ti.reconcileShadowMCPPolicyURLs(ctx, db, input)
 	}, func(ctx context.Context, projectID uuid.UUID, canonicalURLs []string) ([]string, error) {
 		return ti.shadowMCPInventoryURLLookup(ctx, projectID, canonicalURLs)
-	})
+	}, chrepo.New(chConn))
 
 	return ctx, ti
 }


### PR DESCRIPTION
This PR switches over to ClickHouse for sourcing risk events dashboard data depending on feature flag setting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the Risk Overview from ClickHouse `risk_findings` behind the org-scoped `risk-overview-from-clickhouse` flag to reduce Postgres load while matching current metrics. Events Scanned and Active Policies still come from Postgres.

- **New Features**
  - Added ClickHouse read path for findings count, flagged sessions, top rules, top users, and category time series (deduped via `uniqExact`; filters dead letters, excluded rows, and false positives).
  - Top users now resolve emails via an org-bound Postgres lookup, merge duplicate identities, then cap results for accuracy and privacy.
  - Added `FlagRiskOverviewFromClickHouse` and wired `chrepo` into the service/startup; overview selects ClickHouse or Postgres by flag.
  - Local seed mirrors Postgres `risk_results` into ClickHouse `risk_findings` with redacted matches only and a 90-day window.

- **Migration**
  - Enable per org by turning on `risk-overview-from-clickhouse`.
  - For local dev, run the seed after risk seeds to mirror data into ClickHouse and ensure ClickHouse is running.

<sup>Written for commit 97ba85028e31fa03260aff620aa3d1911af8c8fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

