### PR TITLE
feat: enforce canonical warn challenges

### DIFF
--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -429,11 +429,16 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 		ev := hookevents.NewUserPromptSubmit(event, hookevents.UserPromptSubmitParams{
 			Prompt: canonicalPromptText(payload),
 		})
-		// A warn (challenge) is never blocked here: the canonical ingest
-		// transport has no native confirmation primitive, and hard-denying
-		// would clobber the ask a dedicated ask-capable hook (Claude
-		// PreToolUse) surfaces for the same event. Defer to that transport.
-		if scanResult := s.scanUserPromptForEnforcement(ctx, ev); scanResult != nil && scanResult.Action != "warn" {
+		if scanResult := s.scanUserPromptForEnforcement(ctx, ev); scanResult != nil {
+			if scanResult.Action == "warn" {
+				if s.warnAcknowledged(ctx, ev.Event, scanResult, "") {
+					return "", ""
+				}
+				if _, userReason, ok := s.warnDenyReason(ctx, ev.Event, scanResult, ""); ok {
+					auditReason := fmt.Sprintf("Speakeasy challenged this prompt: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
+					return auditReason, userReason
+				}
+			}
 			auditReason := fmt.Sprintf("Speakeasy blocked this prompt: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
 			return auditReason, renderUserBlockReason(scanResult.UserMessage, auditReason)
 		}
@@ -446,7 +451,16 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 				ToolInput:      toolInput,
 				PermissionType: permissionType,
 			})
-			if scanResult := s.scanPermissionRequestForEnforcement(ctx, ev); scanResult != nil && scanResult.Action != "warn" {
+			if scanResult := s.scanPermissionRequestForEnforcement(ctx, ev); scanResult != nil {
+				if scanResult.Action == "warn" {
+					if s.warnAcknowledged(ctx, ev.Event, scanResult, toolName) {
+						return "", ""
+					}
+					if _, userReason, ok := s.warnDenyReason(ctx, ev.Event, scanResult, toolName); ok {
+						auditReason := fmt.Sprintf("Speakeasy challenged this permission request: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
+						return auditReason, userReason
+					}
+				}
 				auditReason := fmt.Sprintf("Speakeasy blocked this permission request: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
 				userReason := renderUserBlockReason(scanResult.UserMessage, auditReason)
 				return auditReason, s.appendCanonicalBlockURL(ctx, authCtx, actor, payload, auditReason, toolName, scanResult.PolicyID, userReason)
@@ -457,7 +471,16 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 				ToolName:  toolName,
 				ToolInput: toolInput,
 			})
-			if scanResult := s.scanMCPRequestForEnforcement(ctx, ev); scanResult != nil && scanResult.Action != "warn" {
+			if scanResult := s.scanMCPRequestForEnforcement(ctx, ev); scanResult != nil {
+				if scanResult.Action == "warn" {
+					if s.warnAcknowledged(ctx, ev.Event, scanResult, toolName) {
+						return s.evaluateCanonicalShadowMCP(ctx, authCtx, actor, payload, toolName, toolInput)
+					}
+					if _, userReason, ok := s.warnDenyReason(ctx, ev.Event, scanResult, toolName); ok {
+						auditReason := fmt.Sprintf("Speakeasy challenged this tool call: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
+						return auditReason, userReason
+					}
+				}
 				auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
 				userReason := renderUserBlockReason(scanResult.UserMessage, auditReason)
 				return auditReason, s.appendCanonicalBlockURL(ctx, authCtx, actor, payload, auditReason, toolName, scanResult.PolicyID, userReason)
@@ -468,8 +491,16 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 			ToolName:  toolName,
 			ToolInput: toolInput,
 		})
-		// warn defers to the ask-capable transport (see prompt.submitted note).
-		if scanResult := s.scanToolRequestForEnforcement(ctx, ev); scanResult != nil && scanResult.Action != "warn" {
+		if scanResult := s.scanToolRequestForEnforcement(ctx, ev); scanResult != nil {
+			if scanResult.Action == "warn" {
+				if s.warnAcknowledged(ctx, ev.Event, scanResult, toolName) {
+					return "", ""
+				}
+				if _, userReason, ok := s.warnDenyReason(ctx, ev.Event, scanResult, toolName); ok {
+					auditReason := fmt.Sprintf("Speakeasy challenged this tool call: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
+					return auditReason, userReason
+				}
+			}
 			auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
 			userReason := renderUserBlockReason(scanResult.UserMessage, auditReason)
 			return auditReason, s.appendCanonicalBlockURL(ctx, authCtx, actor, payload, auditReason, toolName, scanResult.PolicyID, userReason)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -451,11 +451,14 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 				ToolInput:      toolInput,
 				PermissionType: permissionType,
 			})
-			if scanResult := s.scanPermissionRequestForEnforcement(ctx, ev); scanResult != nil {
+			// An acknowledged permission warn clears only this risk challenge; it
+			// must still fall through to the MCP/shadow-MCP guard below, never
+			// short-circuit the tool call (mirrors the Claude PreToolUse handler).
+			// So exclude acknowledged warns from the block condition rather than
+			// returning early on them.
+			if scanResult := s.scanPermissionRequestForEnforcement(ctx, ev); scanResult != nil &&
+				(scanResult.Action != "warn" || !s.warnAcknowledged(ctx, ev.Event, scanResult, toolName)) {
 				if scanResult.Action == "warn" {
-					if s.warnAcknowledged(ctx, ev.Event, scanResult, toolName) {
-						return "", ""
-					}
 					if _, userReason, ok := s.warnDenyReason(ctx, ev.Event, scanResult, toolName); ok {
 						auditReason := fmt.Sprintf("Speakeasy challenged this permission request: matched policy %q (%s)", scanResult.PolicyName, scanResult.Description)
 						return auditReason, userReason

--- a/server/internal/hooks/warn_challenge_test.go
+++ b/server/internal/hooks/warn_challenge_test.go
@@ -257,3 +257,141 @@ func TestClaude_UserPromptSubmit_Block_Blocks(t *testing.T) {
 	require.NotNil(t, result.Reason)
 	assert.Contains(t, *result.Reason, "secret policy")
 }
+
+func TestIngest_CanonicalWarnChallengesEveryAdapterAndEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	adapters := []string{"claude", "cursor", "codex", "opencode"}
+	eventKinds := []string{"prompt", "tool", "mcp", "permission"}
+
+	for _, adapter := range adapters {
+		for _, eventKind := range eventKinds {
+			scanner := &stubResultScanner{result: &risk.ScanResult{
+				Action:          "warn",
+				PolicyID:        uuid.NewString(),
+				PolicyName:      "danger",
+				Description:     "requires review",
+				RuleID:          "dangerous-operation",
+				Entity:          "destructive",
+				MatchedValue:    "rm -rf /tmp/warn",
+				CallFingerprint: "canonical-warn-fingerprint",
+			}}
+			ti.service.riskScanner = scanner
+			payload := canonicalWarnTestPayload(t, adapter, eventKind, adapter+"-"+eventKind+"-"+uuid.NewString())
+
+			result, err := ti.service.Ingest(ctx, payload)
+			require.NoErrorf(t, err, "%s %s warn request", adapter, eventKind)
+			require.NotNilf(t, result, "%s %s warn request", adapter, eventKind)
+			require.Equalf(t, "deny", result.Decision, "%s %s warn request", adapter, eventKind)
+			require.NotNilf(t, result.Message, "%s %s warn request", adapter, eventKind)
+			require.Containsf(t, *result.Message, "risk-policy-challenge/acknowledge", "%s %s warn request", adapter, eventKind)
+			require.Containsf(t, *result.Message, "ack_token=", "%s %s warn request", adapter, eventKind)
+			require.Truef(t, scanner.recordedChallenge, "%s %s warn request", adapter, eventKind)
+
+			scanner.acknowledged = true
+			scanner.recordedChallenge = false
+
+			retryResult, err := ti.service.Ingest(ctx, payload)
+			require.NoErrorf(t, err, "%s %s acknowledged retry", adapter, eventKind)
+			require.NotNilf(t, retryResult, "%s %s acknowledged retry", adapter, eventKind)
+			require.Equalf(t, "allow", retryResult.Decision, "%s %s acknowledged retry", adapter, eventKind)
+			require.Nilf(t, retryResult.Message, "%s %s acknowledged retry", adapter, eventKind)
+			require.Falsef(t, scanner.recordedChallenge, "%s %s acknowledged retry", adapter, eventKind)
+		}
+	}
+}
+
+func TestIngest_CanonicalWarnFallsBackToBlockWithoutAckLink(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.siteURL = nil
+	ti.service.riskScanner = &stubResultScanner{result: &risk.ScanResult{
+		Action:          "warn",
+		PolicyID:        uuid.NewString(),
+		PolicyName:      "danger",
+		Description:     "requires review",
+		RuleID:          "dangerous-operation",
+		Entity:          "destructive",
+		MatchedValue:    "rm -rf /tmp/warn",
+		CallFingerprint: "canonical-warn-fallback",
+	}}
+	payload := canonicalWarnTestPayload(t, "opencode", "prompt", "warn-fallback-"+uuid.NewString())
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision)
+	require.NotNil(t, result.Message)
+	require.NotContains(t, *result.Message, "risk-policy-challenge/acknowledge")
+	require.NotContains(t, *result.Message, "ack_token=")
+}
+
+func TestIngest_CanonicalBlockBehaviorUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = &stubResultScanner{result: &risk.ScanResult{
+		Action:      "block",
+		PolicyID:    uuid.NewString(),
+		PolicyName:  "hard block",
+		Description: "must not run",
+	}}
+	payload := canonicalWarnTestPayload(t, "opencode", "prompt", "block-regression-"+uuid.NewString())
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision)
+	require.NotNil(t, result.Message)
+	require.Contains(t, *result.Message, "hard block")
+	require.NotContains(t, *result.Message, "ack_token=")
+}
+
+func canonicalWarnTestPayload(t *testing.T, adapter, eventKind, sessionID string) *gen.IngestPayload {
+	t.Helper()
+
+	payload := canonicalIngestPayload(adapter, "tool.requested", sessionID)
+	toolName := "Bash"
+	toolInput := map[string]any{"command": "rm -rf /tmp/warn"}
+
+	switch eventKind {
+	case "prompt":
+		prompt := "remove everything under /tmp/warn"
+		payload.Event.Type = "prompt.submitted"
+		payload.Data = &gen.HookIngestData{
+			Prompt: &gen.HookPromptData{Text: &prompt},
+		}
+	case "tool":
+		payload.Data = &gen.HookIngestData{
+			ToolCall: &gen.HookToolCallData{
+				Name:  &toolName,
+				Input: toolInput,
+			},
+		}
+	case "mcp":
+		toolName = "mcp__filesystem__remove"
+		serverIdentity := "filesystem"
+		payload.Data = &gen.HookIngestData{
+			ToolCall: &gen.HookToolCallData{
+				Name:  &toolName,
+				Input: toolInput,
+			},
+			Mcp: &gen.HookMCPData{ServerIdentity: &serverIdentity},
+		}
+	case "permission":
+		permissionType := "exec"
+		payload.Data = &gen.HookIngestData{
+			ToolCall: &gen.HookToolCallData{
+				Name:           &toolName,
+				Input:          toolInput,
+				PermissionType: &permissionType,
+			},
+		}
+	default:
+		require.FailNow(t, "unsupported canonical warn event kind", eventKind)
+	}
+
+	return payload
+}

--- a/server/internal/hooks/warn_challenge_test.go
+++ b/server/internal/hooks/warn_challenge_test.go
@@ -17,6 +17,7 @@ import (
 // result, letting the warn (challenge) branches be exercised deterministically.
 type stubResultScanner struct {
 	result            *risk.ScanResult
+	shadowPolicy      *risk.ShadowMCPPolicy
 	acknowledged      bool
 	recordedChallenge bool
 }
@@ -26,7 +27,7 @@ func (s *stubResultScanner) ScanForEnforcement(_ context.Context, _ string, _ uu
 }
 
 func (s *stubResultScanner) LookupShadowMCPBlockingPolicy(_ context.Context, _ string, _ uuid.UUID, _ string) (*risk.ShadowMCPPolicy, error) {
-	return nil, nil
+	return s.shadowPolicy, nil
 }
 
 func (s *stubResultScanner) HasEnabledShadowMCPPolicy(_ context.Context, _ uuid.UUID) (bool, error) {
@@ -300,6 +301,55 @@ func TestIngest_CanonicalWarnChallengesEveryAdapterAndEvent(t *testing.T) {
 			require.Falsef(t, scanner.recordedChallenge, "%s %s acknowledged retry", adapter, eventKind)
 		}
 	}
+}
+
+// An acknowledged permission warn clears only that risk challenge — it must
+// still flow into the shadow-MCP guard, never let the tool call skip it. This
+// is the regression guard for the fix where an acknowledged permission warn
+// returned early instead of falling through: with the bug the guard is skipped
+// and the call is allowed; with the fix the unapproved MCP server is denied.
+func TestIngest_CanonicalAcknowledgedPermissionWarn_StillRunsShadowMCPGuard(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = &stubResultScanner{
+		acknowledged: true,
+		result: &risk.ScanResult{
+			Action:          "warn",
+			PolicyID:        uuid.NewString(),
+			PolicyName:      "danger",
+			Description:     "requires review",
+			RuleID:          "dangerous-operation",
+			Entity:          "destructive",
+			MatchedValue:    "rm -rf /tmp/warn",
+			CallFingerprint: "canonical-perm-warn-shadow",
+		},
+		// A shadow-MCP blocking policy is enabled; with no bypass grant and a
+		// non-Gram-hosted server the guard must deny.
+		shadowPolicy: &risk.ShadowMCPPolicy{ID: uuid.NewString(), Name: "shadow guard"},
+	}
+
+	// tool.requested for an MCP tool that also carries a permission type, so the
+	// permission block runs first and control must still reach the MCP guard.
+	toolName := "mcp__filesystem__remove"
+	permissionType := "exec"
+	serverIdentity := "filesystem"
+	payload := canonicalIngestPayload("claude", "tool.requested", "perm-warn-shadow-"+uuid.NewString())
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			Name:           &toolName,
+			Input:          map[string]any{"command": "rm -rf /tmp/warn"},
+			PermissionType: &permissionType,
+		},
+		Mcp: &gen.HookMCPData{ServerIdentity: &serverIdentity},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision, "acknowledged permission warn must not bypass the shadow-MCP guard")
+	require.NotNil(t, result.Message)
+	require.Contains(t, *result.Message, "shadow guard")
 }
 
 func TestIngest_CanonicalWarnFallsBackToBlockWithoutAckLink(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enforce warn policies as deny-with-ack challenges on canonical prompt, tool, MCP, and permission events
- honor acknowledged retries while retaining shadow-MCP enforcement
- fail closed to existing block behavior when an acknowledgement link cannot be generated
- cover Claude, Cursor, Codex, and OpenCode canonical adapters

## Testing
- `mise exec -- go test ./server/internal/hooks -run 'TestIngest_Canonical(Warn|Block)' -count=1`
- `mise exec -- go test ./server/internal/hooks -count=1`
- `mise lint:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-648](https://linear.app/speakeasy/issue/DNO-648/feat-enforce-warn-challenge-verdicts-on-the-canonical-ingest-path-for)

<div><a href="https://cursor.com/agents/bc-08e2d3c8-07cc-44f7-a39e-cb5424b4938d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08e2d3c8-07cc-44f7-a39e-cb5424b4938d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


Tested w/ a PII Warn policy in Claude Code, works
