### PR TITLE
feat: add official Google Drive and Docs MCP servers

### DIFF
--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -20,6 +20,7 @@ import {
   X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
 import {
   type CompletePhase,
   type ConfigurePhase,
@@ -1254,6 +1255,10 @@ function NextSteps({
   releaseState: CompletePhase;
 }) {
   const routes = useTargetRoutes(releaseState);
+  const settingsHref = routes.mcp.x.settings.href(status.mcpServerParam!);
+  const configureHref = status.authSetupRequired
+    ? `${settingsHref}#authentication`
+    : settingsHref;
 
   return (
     <div>
@@ -1292,22 +1297,26 @@ function NextSteps({
             </div>
           </a>
         )}
-        <routes.mcp.x.Link
-          params={[status.mcpServerParam!]}
-          className="no-underline hover:no-underline"
-        >
+        <Link to={configureHref} className="no-underline hover:no-underline">
           <div className="group hover:border-foreground/20 hover:bg-muted/30 flex h-full items-center gap-3 rounded-lg border p-3 transition-all [&_*]:no-underline">
             <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-orange-500/10 dark:bg-orange-500/20">
               <Settings className="h-4 w-4 text-orange-600 dark:text-orange-400" />
             </div>
             <div className="flex-1">
               <Type className="text-sm font-medium no-underline">
-                Configure MCP settings
+                {status.authSetupRequired
+                  ? "Configure authentication"
+                  : "Configure MCP settings"}
               </Type>
+              {status.authSetupRequired && (
+                <Type small muted>
+                  Add your OAuth client credentials
+                </Type>
+              )}
             </div>
             <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />
           </div>
-        </routes.mcp.x.Link>
+        </Link>
       </div>
     </div>
   );

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -3,6 +3,7 @@ import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { ManualSetupBadge } from "@/pages/catalog/ManualSetupBadge";
+import { GoogleWorkspaceSetupGuide } from "@/pages/catalog/GoogleWorkspaceSetupGuide";
 import { useSdkClient } from "@/contexts/Sdk";
 import { AddServerDialog } from "@/pages/catalog/AddServerDialog";
 import {
@@ -38,6 +39,8 @@ const SERVER_WEBSITE_MAP: Record<string, string> = {
   "io.github.getsentry/sentry-mcp": "sentry.io",
   "io.github.github/github-mcp-server": "github.com",
   "com.notion/mcp": "notion.so",
+  "com.google.workspace/drive": "drive.google.com",
+  "com.google.workspace/docs": "docs.google.com",
 };
 
 export function CatalogDetailRoot(): JSX.Element {
@@ -328,6 +331,8 @@ export default function CatalogDetail(): JSX.Element {
                 </Type>
               </Card.Content>
             </Card>
+
+            <GoogleWorkspaceSetupGuide server={server} />
 
             {/* Available Tools */}
             {detailTools.length > 0 && <ToolsSection tools={detailTools} />}

--- a/client/dashboard/src/pages/catalog/GoogleWorkspaceSetupGuide.tsx
+++ b/client/dashboard/src/pages/catalog/GoogleWorkspaceSetupGuide.tsx
@@ -1,0 +1,125 @@
+import { CopyButton } from "@/components/ui/copy-button";
+import { Card } from "@/components/ui/card";
+import { Type } from "@/components/ui/type";
+import { getServerURL } from "@/lib/utils";
+import type { PulseMCPServer } from "@/pages/catalog/hooks";
+import { ExternalLink } from "lucide-react";
+import type { ReactNode } from "react";
+
+const GOOGLE_WORKSPACE_PROVIDER = "google-workspace";
+
+export function GoogleWorkspaceSetupGuide({
+  server,
+}: {
+  server: PulseMCPServer;
+}): JSX.Element | null {
+  const setup = server.meta?.["com.getgram/catalog"];
+  if (setup?.provider !== GOOGLE_WORKSPACE_PROVIDER) return null;
+
+  const requiredServices = [
+    ...(setup.requiredApis ?? []),
+    ...(setup.requiredMcpServices ?? []),
+  ];
+  const enableCommand = `gcloud services enable ${requiredServices.join(" ")} --project=<PROJECT_ID>`;
+  const redirectURI = `${getServerURL()}/mcp/remote_login_callback`;
+
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title>Google Workspace setup</Card.Title>
+      </Card.Header>
+      <Card.Content className="space-y-5">
+        <SetupStep number={1} title="Enable the Google Cloud services">
+          <Type small muted>
+            Enable the product API and its MCP service in the Google Cloud
+            project that will own the OAuth client.
+          </Type>
+          <CopyableCode value={enableCommand} />
+        </SetupStep>
+
+        <SetupStep number={2} title="Configure OAuth consent scopes">
+          <Type small muted>
+            Add these scopes in Google Auth Platform → Data Access:
+          </Type>
+          <ul className="space-y-1">
+            {(setup.requiredScopes ?? []).map((scope) => (
+              <li key={scope}>
+                <code className="text-xs break-all">{scope}</code>
+              </li>
+            ))}
+          </ul>
+        </SetupStep>
+
+        <SetupStep number={3} title="Create a customer-owned OAuth client">
+          <Type small muted>
+            In Google Auth Platform, create a Web application OAuth client. Your
+            organization owns the client ID and secret; Gram does not create or
+            own them. Register this authorized redirect URI:
+          </Type>
+          <CopyableCode value={redirectURI} />
+        </SetupStep>
+
+        <SetupStep number={4} title="Install and authenticate">
+          <Type small muted>
+            Add this server, then open its Settings → Authentication section.
+            Start with the discovered Google configuration, choose Manual, paste
+            the customer-owned client ID and secret, and authenticate.
+          </Type>
+        </SetupStep>
+
+        <div className="border-t pt-5">
+          <Type className="mb-1 font-medium">
+            Migrating from the community Workspace connector
+          </Type>
+          <Type small muted>
+            {setup.migrationFromCommunityMcp} Add both official Drive and Docs
+            servers to the same assistant when a workflow needs file creation
+            and rich document editing. Gram namespaces tools by server, so their
+            tools remain distinct. Read the finished document with{" "}
+            <code>read_doc</code> before removing the community connector.
+          </Type>
+        </div>
+
+        {setup.setupDocumentationUrl && (
+          <a
+            href={setup.setupDocumentationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary inline-flex items-center gap-1 text-sm hover:underline"
+          >
+            Google&apos;s complete setup guide
+            <ExternalLink className="size-3.5" />
+          </a>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}
+
+function SetupStep({
+  number,
+  title,
+  children,
+}: {
+  number: number;
+  title: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <div className="space-y-2">
+      <Type className="font-medium">
+        {number}. {title}
+      </Type>
+      {children}
+    </div>
+  );
+}
+
+function CopyableCode({ value }: { value: string }): JSX.Element {
+  return (
+    <div className="bg-muted/50 flex items-center justify-between gap-3 rounded-lg p-3">
+      <code className="text-xs break-all">{value}</code>
+      <CopyButton size="inline" text={value} tooltip="Copy" />
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/catalog/hooks.ts
+++ b/client/dashboard/src/pages/catalog/hooks.ts
@@ -29,6 +29,16 @@ interface ServerMeta {
       }[];
     };
   };
+  "com.getgram/catalog"?: {
+    provider?: string;
+    setupDocumentationUrl?: string;
+    requiredApis?: string[];
+    requiredMcpServices?: string[];
+    requiredScopes?: string[];
+    oauthClientOwnership?: string;
+    migrationFromCommunityMcp?: string;
+    supportsCombinedAssistants?: boolean;
+  };
 }
 
 // The catalog list returns `ExternalMCPServerEntry` (no tools). `tools` is

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts
@@ -8,6 +8,8 @@ const mockDiscoverProtectedResourceMetadata = vi.fn();
 const mockMcpServersCreate = vi.fn();
 const mockMcpEndpointsCreate = vi.fn();
 const mockAuthedFetch = vi.fn();
+const mockDiscoverRemoteSessionIssuer = vi.fn();
+const mockListRemoteSessionIssuers = vi.fn();
 
 // Return a stable client reference to avoid re-render loops from useCallback deps
 const mockClient = {
@@ -22,6 +24,10 @@ const mockClient = {
   },
   mcpEndpoints: {
     create: mockMcpEndpointsCreate,
+  },
+  remoteSessionIssuers: {
+    discover: mockDiscoverRemoteSessionIssuer,
+    list: mockListRemoteSessionIssuers,
   },
 };
 
@@ -132,6 +138,11 @@ describe("useRemoteMcpInstallWorkflow", () => {
       id: "endpoint-1",
       slug: "test-org-abc123",
     });
+    mockListRemoteSessionIssuers.mockResolvedValue(
+      (async function* () {
+        yield { result: { items: [] } };
+      })(),
+    );
     mockDeleteServer.mockResolvedValue(undefined);
   });
 
@@ -334,6 +345,52 @@ describe("useRemoteMcpInstallWorkflow", () => {
       mcpServerParam: "mcp-server-slug",
     });
     expect(state.statuses[0]!.mcpEndpointUrl).toContain("/mcp/test-org-abc123");
+  });
+
+  it("marks customer-managed OAuth as a required next step", async () => {
+    mockMcpServersCreate.mockResolvedValue({
+      id: "mcp-server-1",
+      slug: "google-drive",
+      projectId: "proj-1",
+      userSessionIssuerId: "usi-1",
+    });
+    mockDiscoverProtectedResourceMetadata.mockResolvedValue({
+      available: true,
+      metadata: {
+        authorizationServers: ["https://accounts.google.com/"],
+        scopesSupported: [
+          "https://www.googleapis.com/auth/drive.readonly",
+          "https://www.googleapis.com/auth/drive.file",
+        ],
+      },
+    });
+    mockDiscoverRemoteSessionIssuer.mockResolvedValue({
+      issuer: "https://accounts.google.com",
+      authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenEndpoint: "https://oauth2.googleapis.com/token",
+      registrationEndpoint: undefined,
+      scopesSupported: ["openid"],
+    });
+    const servers = [
+      makeServer({
+        title: "Google Drive",
+        registrySpecifier: "com.google.workspace/drive",
+        remotes: [remote("https://drivemcp.googleapis.com/mcp/v1")],
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useRemoteMcpInstallWorkflow({ servers }),
+    );
+
+    await startInstall(result);
+
+    await waitFor(() => expect(result.current.phase).toBe("complete"));
+    const state = result.current;
+    if (state.phase !== "complete") throw new Error("unexpected phase");
+    expect(state.statuses[0]).toMatchObject({
+      status: "completed",
+      authSetupRequired: true,
+    });
   });
 
   it("sends gram-project request options for cross-project installs", async () => {

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
@@ -64,6 +64,8 @@ export interface ServerInstallStatus {
   mcpServerParam?: string;
   /** Public URL of the pre-staged default MCP endpoint, when one was created. */
   mcpEndpointUrl?: string;
+  /** OAuth was discovered but requires customer-managed client credentials. */
+  authSetupRequired?: boolean;
   error?: string;
 }
 
@@ -520,6 +522,8 @@ export function useRemoteMcpInstallWorkflow({
           ? `${getServerURL()}/mcp/${endpoint.slug}`
           : undefined,
         authConfigured: authAutoConfig.status === "configured",
+        authSetupRequired:
+          authAutoConfig.status === "skipped" && authAutoConfig.warn,
       };
     },
     [authedFetch, client, orgSlug],
@@ -580,6 +584,7 @@ export function useRemoteMcpInstallWorkflow({
           mcpServerId: result.mcpServer.id,
           mcpServerParam: mcpServerRouteParam(result.mcpServer),
           mcpEndpointUrl: result.mcpEndpointUrl,
+          authSetupRequired: result.authSetupRequired,
         });
       } catch (err) {
         setStatusAt(index, {

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
@@ -406,6 +406,7 @@ export function useRemoteMcpInstallWorkflow({
       mcpServer: McpServer;
       mcpEndpointUrl?: string;
       authConfigured: boolean;
+      authSetupRequired: boolean;
     }> => {
       const remoteMcpServer = await client.remoteMcp.createServer(
         {

--- a/docs/google-workspace-mcp.md
+++ b/docs/google-workspace-mcp.md
@@ -1,0 +1,108 @@
+# Google Drive and Docs MCP setup
+
+Gram's catalog includes Google's official Google Drive and Google Docs remote
+MCP servers:
+
+| Source       | Endpoint                                 | Purpose                                                                       |
+| ------------ | ---------------------------------------- | ----------------------------------------------------------------------------- |
+| Google Drive | `https://drivemcp.googleapis.com/mcp/v1` | Find, read, and create files, including converting HTML to native Google Docs |
+| Google Docs  | `https://docsmcp.googleapis.com/mcp/v1`  | Read document structure and apply rich `documents.batchUpdate` edits          |
+
+Install both sources when an assistant needs to create and richly edit
+documents. Gram gives each MCP server a distinct slug and namespaces its tools,
+so Drive and Docs tools remain unambiguous when attached to the same assistant.
+
+## Google Cloud configuration
+
+Use a Google Cloud project owned by your organization. Enable the product APIs
+and their MCP services:
+
+```bash
+gcloud services enable \
+  drive.googleapis.com \
+  docs.googleapis.com \
+  drivemcp.googleapis.com \
+  docsmcp.googleapis.com \
+  --project=<PROJECT_ID>
+```
+
+In Google Auth Platform, configure the OAuth consent screen and add the scopes
+for each server you install.
+
+Drive:
+
+```text
+https://www.googleapis.com/auth/drive.readonly
+https://www.googleapis.com/auth/drive.file
+```
+
+Docs:
+
+```text
+https://www.googleapis.com/auth/drive.readonly
+https://www.googleapis.com/auth/drive.file
+https://www.googleapis.com/auth/documents.readonly
+https://www.googleapis.com/auth/documents
+```
+
+If the app uses the External audience while it is in testing, add every person
+who will authenticate as a test user.
+
+Create an OAuth 2.0 client with application type **Web application**. The client
+ID and secret are customer-managed: they remain owned by your organization and
+must not be shared outside the Gram authentication settings. Add Gram's callback
+as an authorized redirect URI:
+
+```text
+https://<YOUR_GRAM_HOST>/mcp/remote_login_callback
+```
+
+The catalog detail page displays the exact callback for the current Gram
+environment.
+
+## Connect in Gram
+
+1. In **Catalog**, add **Google Drive** and **Google Docs** to the project.
+2. Open each new MCP server and go to **Settings → Authentication**.
+3. Select **Start With Discovered Configuration**. Gram discovers Google's
+   authorization and token endpoints from the official MCP endpoint.
+4. Choose **Manual** client configuration, then enter the customer-owned client
+   ID and secret.
+5. Confirm that the scope override matches the scopes listed above, save, and
+   complete Google authorization.
+6. Attach both MCP servers to the same assistant.
+
+Google does not expose dynamic client registration for these servers, so Gram
+cannot create the OAuth client automatically.
+
+## Verify rich document creation
+
+Ask the assistant:
+
+```text
+Create a Google Doc with example tables for a basic RBAC permissions structure
+and dummy text organized into sections with headings.
+```
+
+The intended flow is:
+
+1. Drive `create_file` creates a native Google Doc. It can accept `textContent`
+   with `contentMimeType` (including HTML) and convert supported content.
+2. Docs `update_doc` applies headings, text styles, and table requests using
+   `documents.batchUpdate`.
+3. Docs `read_doc` reads the finished document back. Verify that its structural
+   response includes the expected headings, styled ranges, and table rows and
+   cells.
+
+## Migrate from the community Workspace connector
+
+1. Add and authenticate the two official sources without removing the existing
+   connector.
+2. Attach Drive and Docs to the assistant and run the verification prompt.
+3. Read the created document back with `read_doc` and confirm its structure.
+4. Update any saved instructions that refer to community-specific tool names to
+   use `create_file`, `update_doc`, and `read_doc`.
+5. Remove the community connector after dependent workflows have been verified.
+
+See [Google's Workspace MCP configuration guide](https://developers.google.com/workspace/guides/configure-mcp-servers)
+for current Google Cloud and OAuth requirements.

--- a/server/internal/externalmcp/builtin_catalog.go
+++ b/server/internal/externalmcp/builtin_catalog.go
@@ -1,0 +1,213 @@
+package externalmcp
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+// builtInRegistryID identifies catalog entries maintained by Gram rather than
+// fetched from an external registry. It is stable so catalog detail links and
+// client-side selection keys remain valid across requests.
+var builtInRegistryID = uuid.MustParse("7d86f4d1-a510-4b79-bd32-91633968970d")
+
+const (
+	googleDriveRegistrySpecifier = "com.google.workspace/drive"
+	googleDocsRegistrySpecifier  = "com.google.workspace/docs"
+)
+
+type builtInCatalogDefinition struct {
+	specifier        string
+	title            string
+	description      string
+	iconURL          string
+	remoteURL        string
+	setupAPI         string
+	setupMCPService  string
+	scopes           []string
+	migrationSummary string
+	tools            []*types.ExternalMCPTool
+}
+
+var builtInCatalogDefinitions = []builtInCatalogDefinition{
+	{
+		specifier:       googleDriveRegistrySpecifier,
+		title:           "Google Drive",
+		description:     "Google's official remote MCP server for searching, reading, creating, and managing files in Google Drive.",
+		iconURL:         "https://www.gstatic.com/images/branding/product/2x/drive_2020q4_48dp.png",
+		remoteURL:       "https://drivemcp.googleapis.com/mcp/v1",
+		setupAPI:        "drive.googleapis.com",
+		setupMCPService: "drivemcp.googleapis.com",
+		scopes: []string{
+			"https://www.googleapis.com/auth/drive.readonly",
+			"https://www.googleapis.com/auth/drive.file",
+		},
+		migrationSummary: "Use Drive for file discovery and creation. Its create_file tool accepts textContent and contentMimeType and converts supported content, including HTML, to Google-native files.",
+		tools: []*types.ExternalMCPTool{
+			builtInTool("copy_file", "Copy an existing file in Google Drive.", false),
+			builtInTool("create_file", "Create or upload a file, optionally converting supported content to a Google-native file.", false),
+			builtInTool("download_file_content", "Download a file's content.", true),
+			builtInTool("get_file_metadata", "Get metadata for a Drive file.", true),
+			builtInTool("get_file_permissions", "List permissions for a Drive file.", true),
+			builtInTool("list_recent_files", "List recently used Drive files.", true),
+			builtInTool("read_file_content", "Read a natural-language representation of a Drive file.", true),
+			builtInTool("search_files", "Search for files in Google Drive.", true),
+		},
+	},
+	{
+		specifier:       googleDocsRegistrySpecifier,
+		title:           "Google Docs",
+		description:     "Google's official remote MCP server for reading and richly editing native Google Docs.",
+		iconURL:         "https://www.gstatic.com/images/branding/product/2x/docs_2020q4_48dp.png",
+		remoteURL:       "https://docsmcp.googleapis.com/mcp/v1",
+		setupAPI:        "docs.googleapis.com",
+		setupMCPService: "docsmcp.googleapis.com",
+		scopes: []string{
+			"https://www.googleapis.com/auth/drive.readonly",
+			"https://www.googleapis.com/auth/drive.file",
+			"https://www.googleapis.com/auth/documents.readonly",
+			"https://www.googleapis.com/auth/documents",
+		},
+		migrationSummary: "Use Docs after Drive creates the native document. Its update_doc tool accepts documents.batchUpdate requests for headings, text styles, tables, images, headers, footers, and document styles.",
+		tools: []*types.ExternalMCPTool{
+			builtInTool("read_doc", "Read a Google Doc's text and structural representation.", true),
+			builtInTool("update_doc", "Apply Google Docs documents.batchUpdate requests to a document.", false),
+		},
+	},
+}
+
+func builtInTool(name, description string, readOnly bool) *types.ExternalMCPTool {
+	return &types.ExternalMCPTool{
+		Name:        &name,
+		Description: &description,
+		InputSchema: nil,
+		Annotations: map[string]any{
+			"readOnlyHint": readOnly,
+		},
+	}
+}
+
+func listBuiltInCatalog(search string) []*types.ExternalMCPServerEntry {
+	registryID := builtInRegistryID.String()
+	needle := strings.ToLower(strings.TrimSpace(search))
+	servers := make([]*types.ExternalMCPServerEntry, 0, len(builtInCatalogDefinitions))
+
+	for _, definition := range builtInCatalogDefinitions {
+		if needle != "" &&
+			!strings.Contains(strings.ToLower(definition.specifier), needle) &&
+			!strings.Contains(strings.ToLower(definition.title), needle) &&
+			!strings.Contains(strings.ToLower(definition.description), needle) {
+			continue
+		}
+
+		title := definition.title
+		iconURL := definition.iconURL
+		meta := builtInCatalogMeta(definition)
+		servers = append(servers, &types.ExternalMCPServerEntry{
+			RegistrySpecifier:                   definition.specifier,
+			Version:                             "1.0.0",
+			Description:                         definition.description,
+			ToolsetID:                           nil,
+			McpServerID:                         nil,
+			RegistryID:                          &registryID,
+			OrganizationMcpCollectionRegistryID: nil,
+			Title:                               &title,
+			IconURL:                             &iconURL,
+			Meta:                                meta,
+			ToolCount:                           len(definition.tools),
+			IsReadOnly:                          false,
+			SupportsDcr:                         false,
+			Remotes: []*types.ExternalMCPRemote{
+				{
+					URL:           definition.remoteURL,
+					TransportType: "streamable-http",
+					Headers:       nil,
+					Variables:     nil,
+				},
+			},
+		})
+	}
+
+	return servers
+}
+
+func getBuiltInCatalogDetails(specifier string) *types.ExternalMCPServer {
+	registryID := builtInRegistryID.String()
+	for _, definition := range builtInCatalogDefinitions {
+		if definition.specifier != specifier {
+			continue
+		}
+
+		title := definition.title
+		iconURL := definition.iconURL
+		return &types.ExternalMCPServer{
+			RegistrySpecifier:                   definition.specifier,
+			Version:                             "1.0.0",
+			Description:                         definition.description,
+			ToolsetID:                           nil,
+			McpServerID:                         nil,
+			RegistryID:                          &registryID,
+			OrganizationMcpCollectionRegistryID: nil,
+			Title:                               &title,
+			IconURL:                             &iconURL,
+			Meta:                                builtInCatalogMeta(definition),
+			Tools:                               definition.tools,
+			Remotes: []*types.ExternalMCPRemote{
+				{
+					URL:           definition.remoteURL,
+					TransportType: "streamable-http",
+					Headers:       nil,
+					Variables:     nil,
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+func builtInCatalogMeta(definition builtInCatalogDefinition) map[string]any {
+	return map[string]any{
+		"com.pulsemcp/server": map[string]any{
+			"isOfficial": true,
+		},
+		"com.pulsemcp/server-version": map[string]any{
+			"source":   "https://developers.google.com/workspace/guides/configure-mcp-servers",
+			"status":   "active",
+			"isLatest": true,
+			"remotes[0]": map[string]any{
+				"authOptions": []map[string]any{
+					{"type": "oauth"},
+				},
+			},
+		},
+		"com.getgram/catalog": map[string]any{
+			"provider":                   "google-workspace",
+			"setupDocumentationUrl":      "https://developers.google.com/workspace/guides/configure-mcp-servers",
+			"requiredApis":               []string{definition.setupAPI},
+			"requiredMcpServices":        []string{definition.setupMCPService},
+			"requiredScopes":             definition.scopes,
+			"oauthClientOwnership":       "customer",
+			"migrationFromCommunityMcp":  definition.migrationSummary,
+			"supportsCombinedAssistants": true,
+		},
+	}
+}
+
+func mergeBuiltInCatalog(registryServers []*types.ExternalMCPServerEntry, search string) []*types.ExternalMCPServerEntry {
+	builtIns := listBuiltInCatalog(search)
+	seen := make(map[string]struct{}, len(builtIns)+len(registryServers))
+	result := make([]*types.ExternalMCPServerEntry, 0, len(builtIns)+len(registryServers))
+
+	for _, server := range append(builtIns, registryServers...) {
+		if _, ok := seen[server.RegistrySpecifier]; ok {
+			continue
+		}
+		seen[server.RegistrySpecifier] = struct{}{}
+		result = append(result, server)
+	}
+
+	return result
+}

--- a/server/internal/externalmcp/builtin_catalog_test.go
+++ b/server/internal/externalmcp/builtin_catalog_test.go
@@ -1,0 +1,114 @@
+package externalmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+func TestListBuiltInCatalogIncludesOfficialGoogleDriveAndDocs(t *testing.T) {
+	t.Parallel()
+
+	servers := listBuiltInCatalog("")
+	require.Len(t, servers, 2)
+
+	drive := servers[0]
+	require.Equal(t, googleDriveRegistrySpecifier, drive.RegistrySpecifier)
+	require.Equal(t, "Google Drive", *drive.Title)
+	require.Equal(t, "https://drivemcp.googleapis.com/mcp/v1", drive.Remotes[0].URL)
+	require.Equal(t, 8, drive.ToolCount)
+	require.False(t, drive.IsReadOnly)
+	require.False(t, drive.SupportsDcr)
+	require.Equal(t, builtInRegistryID.String(), *drive.RegistryID)
+
+	docs := servers[1]
+	require.Equal(t, googleDocsRegistrySpecifier, docs.RegistrySpecifier)
+	require.Equal(t, "Google Docs", *docs.Title)
+	require.Equal(t, "https://docsmcp.googleapis.com/mcp/v1", docs.Remotes[0].URL)
+	require.Equal(t, 2, docs.ToolCount)
+	require.False(t, docs.IsReadOnly)
+	require.False(t, docs.SupportsDcr)
+}
+
+func TestListBuiltInCatalogFiltersBySearch(t *testing.T) {
+	t.Parallel()
+
+	servers := listBuiltInCatalog("richly editing")
+	require.Len(t, servers, 1)
+	require.Equal(t, googleDocsRegistrySpecifier, servers[0].RegistrySpecifier)
+}
+
+func TestGetBuiltInCatalogDetailsIncludesToolsAndSetupMetadata(t *testing.T) {
+	t.Parallel()
+
+	details := getBuiltInCatalogDetails(googleDocsRegistrySpecifier)
+	require.NotNil(t, details)
+	require.Equal(t, []string{"read_doc", "update_doc"}, toolNames(details.Tools))
+
+	meta, ok := details.Meta.(map[string]any)
+	require.True(t, ok)
+	setup, ok := meta["com.getgram/catalog"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "customer", setup["oauthClientOwnership"])
+	require.Equal(t, []string{"docs.googleapis.com"}, setup["requiredApis"])
+	require.Equal(t, []string{"docsmcp.googleapis.com"}, setup["requiredMcpServices"])
+	require.Equal(t, []string{
+		"https://www.googleapis.com/auth/drive.readonly",
+		"https://www.googleapis.com/auth/drive.file",
+		"https://www.googleapis.com/auth/documents.readonly",
+		"https://www.googleapis.com/auth/documents",
+	}, setup["requiredScopes"])
+}
+
+func TestMergeBuiltInCatalogPrefersGramDefinitions(t *testing.T) {
+	t.Parallel()
+
+	duplicate := &types.ExternalMCPServerEntry{
+		RegistrySpecifier:                   googleDriveRegistrySpecifier,
+		Version:                             "9.9.9",
+		Description:                         "registry duplicate",
+		ToolsetID:                           nil,
+		McpServerID:                         nil,
+		RegistryID:                          nil,
+		OrganizationMcpCollectionRegistryID: nil,
+		Title:                               nil,
+		IconURL:                             nil,
+		Meta:                                nil,
+		ToolCount:                           0,
+		IsReadOnly:                          true,
+		SupportsDcr:                         true,
+		Remotes:                             nil,
+	}
+	other := &types.ExternalMCPServerEntry{
+		RegistrySpecifier:                   "example/other",
+		Version:                             "1.0.0",
+		Description:                         "other",
+		ToolsetID:                           nil,
+		McpServerID:                         nil,
+		RegistryID:                          nil,
+		OrganizationMcpCollectionRegistryID: nil,
+		Title:                               nil,
+		IconURL:                             nil,
+		Meta:                                nil,
+		ToolCount:                           0,
+		IsReadOnly:                          false,
+		SupportsDcr:                         false,
+		Remotes:                             nil,
+	}
+
+	servers := mergeBuiltInCatalog([]*types.ExternalMCPServerEntry{duplicate, other}, "")
+	require.Len(t, servers, 3)
+	require.Equal(t, "1.0.0", servers[0].Version)
+	require.Equal(t, googleDocsRegistrySpecifier, servers[1].RegistrySpecifier)
+	require.Equal(t, "example/other", servers[2].RegistrySpecifier)
+}
+
+func toolNames(tools []*types.ExternalMCPTool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, *tool.Name)
+	}
+	return names
+}

--- a/server/internal/externalmcp/catalog_test.go
+++ b/server/internal/externalmcp/catalog_test.go
@@ -1,0 +1,58 @@
+package externalmcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/mcp_registries"
+)
+
+func TestExternalMCP_BuiltInGoogleCatalogEntries(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestExternalMCPService(t)
+	result, err := ti.service.ListCatalog(ctx, &gen.ListCatalogPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		RegistryID:       nil,
+		Search:           nil,
+		Cursor:           nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Servers, 2)
+	require.Equal(t, "com.google.workspace/drive", result.Servers[0].RegistrySpecifier)
+	require.Equal(t, "com.google.workspace/docs", result.Servers[1].RegistrySpecifier)
+	require.NotNil(t, result.Servers[1].RegistryID)
+
+	details, err := ti.service.GetServerDetails(ctx, &gen.GetServerDetailsPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		RegistryID:       *result.Servers[1].RegistryID,
+		ServerSpecifier:  result.Servers[1].RegistrySpecifier,
+	})
+	require.NoError(t, err)
+	require.Len(t, details.Tools, 2)
+	require.Equal(t, "read_doc", *details.Tools[0].Name)
+	require.Equal(t, "update_doc", *details.Tools[1].Name)
+}
+
+func TestExternalMCP_BuiltInGoogleCatalogSearch(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestExternalMCPService(t)
+	search := "Drive"
+	result, err := ti.service.ListCatalog(ctx, &gen.ListCatalogPayload{
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		RegistryID:       nil,
+		Search:           &search,
+		Cursor:           nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Servers, 1)
+	require.Equal(t, "com.google.workspace/drive", result.Servers[0].RegistrySpecifier)
+}

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -162,6 +162,17 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 			return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
 		}
 
+		if registryID == builtInRegistryID {
+			search := ""
+			if payload.Search != nil {
+				search = *payload.Search
+			}
+			return &gen.ListCatalogResult{
+				Servers:    listBuiltInCatalog(search),
+				NextCursor: nil,
+			}, nil
+		}
+
 		registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -212,6 +223,12 @@ func (s *Service) ListCatalog(ctx context.Context, payload *gen.ListCatalogPaylo
 		allServers = append(allServers, result.Servers...)
 	}
 
+	search := ""
+	if payload.Search != nil {
+		search = *payload.Search
+	}
+	allServers = mergeBuiltInCatalog(allServers, search)
+
 	// Cap at 100 servers for v0. Multi-registry pagination is tracked in
 	// AGE-2153; until then anything past the cap is silently dropped, so warn.
 	if len(allServers) > 100 {
@@ -241,6 +258,14 @@ func (s *Service) GetServerDetails(ctx context.Context, payload *gen.GetServerDe
 	registryID, err := uuid.Parse(payload.RegistryID)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid registry_id").LogError(ctx, s.logger)
+	}
+
+	if registryID == builtInRegistryID {
+		details := getBuiltInCatalogDetails(payload.ServerSpecifier)
+		if details == nil {
+			return nil, oops.C(oops.CodeNotFound)
+		}
+		return details, nil
 	}
 
 	registry, err := s.repo.GetMCPRegistryByID(ctx, registryID)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Gram-owned catalog entries for Google's official Drive and Docs remote MCP endpoints
- surface customer-managed OAuth setup requirements, scopes, redirect URI, and migration guidance in the catalog
- direct users to authentication setup when an upstream supports OAuth but not dynamic client registration
- document dual-server assistant usage and rich document creation/read-back verification

## Testing
- `mise exec -- go test ./server/internal/externalmcp -run 'BuiltIn|MergeBuiltIn' -count=1`
- `mise exec -- go test ./server/internal/externalmcp -run 'ExternalMCP_BuiltIn' -count=1`
- `mise lint:server`
- `pnpm -F dashboard test -- src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts` (1,121 tests passed)
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:format`
- `pnpm -F dashboard lint:oxlint`
- probed both official endpoints live: `tools/list`, RFC 9728 protected-resource metadata, and Google issuer discovery returned the expected tools/scopes/endpoints
- manually verified both catalog cards, setup guides, scopes, redirect URI, migration copy, and tool lists with zero browser console errors

A live document create/update/read requires a customer-owned Google OAuth client, so that credentialed external write was not performed in the development environment.

## Demo
<a href="https://cursor.com/agents/bc-efdb6b08-335b-432e-bfda-7b6ea769e669/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoogle_drive_catalog_setup.webm"><img src="https://cursor.com/artifacts/c/art-f9954711-289f-45cc-a389-df75e4290784" alt="google_drive_catalog_setup.webm" /></a>

<a href="https://cursor.com/agents/bc-efdb6b08-335b-432e-bfda-7b6ea769e669/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoogle_docs_catalog_setup.webm"><img src="https://cursor.com/artifacts/c/art-cee4fd4b-c697-4d84-be34-ecc8c1eeeae3" alt="google_docs_catalog_setup.webm" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-374](https://linear.app/speakeasy/issue/AIS-374/feat-add-googles-official-drive-and-docs-remote-mcp-servers-to-gram)

<div><a href="https://cursor.com/agents/bc-efdb6b08-335b-432e-bfda-7b6ea769e669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efdb6b08-335b-432e-bfda-7b6ea769e669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gram-owned catalog entries for Google’s official Google Drive and Google Docs MCP servers, with a guided, customer-managed OAuth flow and an auth-first install that deep-links to authentication. Aligns with AIS-374 by enabling official Workspace endpoints with clear scopes, redirect URI, and migration guidance.

- **New Features**
  - Catalog: Adds `com.google.workspace/drive` and `com.google.workspace/docs` as built-ins with remotes, tools, and scopes; merged into search and details via a stable internal registry.
  - Install flow: Detects OAuth support without DCR, flags `authSetupRequired`, and routes Next Steps directly to Settings → Authentication.
  - Dashboard: New Google Workspace setup card with `gcloud services enable` command, required scopes, and the exact redirect URI; Drive/Docs website mapping added.
  - Docs & tests: New `docs/google-workspace-mcp.md`; server tests cover built-in catalog list/search/details; client tests cover customer-managed OAuth detection.

- **Migration**
  - Enable required Google APIs and MCP services, then create a Web OAuth client with Gram’s callback.
  - Install both Drive and Docs, open Settings → Authentication, start with discovered endpoints, enter your client ID/secret, and authorize.
  - Attach both servers to the same assistant; verify by creating a Doc (Drive) and applying rich edits (Docs) before removing the community connector.

<sup>Written for commit 4bcab0e884d72c3096883327dedb56bb4f9176d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

