### PR TITLE
fix: make rich Google Doc creation discoverable

### DIFF
--- a/.changeset/curate-rich-google-docs.md
+++ b/.changeset/curate-rich-google-docs.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Remote MCP servers now apply configured tool variations to live `tools/list` responses and translate varied aliases back to canonical upstream tool names on `tools/call`. Google Workspace catalog installs use this support to expose rich HTML document import as `create_rich_doc`, while preserving `create_doc` for plain-text documents and documenting the connector's editing tiers.

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -5,6 +5,7 @@ import { Type } from "@/components/ui/type";
 import { ManualSetupBadge } from "@/pages/catalog/ManualSetupBadge";
 import { useSdkClient } from "@/contexts/Sdk";
 import { AddServerDialog } from "@/pages/catalog/AddServerDialog";
+import { GOOGLE_WORKSPACE_REGISTRY_SPECIFIER } from "@/pages/catalog/toolCurations";
 import {
   PulseMCPServer,
   useIsCatalogServerInstalled,
@@ -329,6 +330,11 @@ export default function CatalogDetail(): JSX.Element {
               </Card.Content>
             </Card>
 
+            {server.registrySpecifier ===
+              GOOGLE_WORKSPACE_REGISTRY_SPECIFIER && (
+              <GoogleWorkspaceRichDocsGuide />
+            )}
+
             {/* Available Tools */}
             {detailTools.length > 0 && <ToolsSection tools={detailTools} />}
           </div>
@@ -481,6 +487,35 @@ export default function CatalogDetail(): JSX.Element {
         />
       </Page.Body>
     </Page>
+  );
+}
+
+function GoogleWorkspaceRichDocsGuide() {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title>Creating rich Google Docs</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <div className="space-y-3">
+          <Type>
+            For documents with headings, formatted text, lists, or tables, use{" "}
+            <code className="font-mono">import_to_google_doc</code> with{" "}
+            <code className="font-mono">source_format: &quot;html&quot;</code>.
+            Catalog installs expose this as{" "}
+            <code className="font-mono">create_rich_doc</code> so assistants
+            select it for structured-document requests.{" "}
+            <code className="font-mono">create_doc</code> remains available for
+            plain text.
+          </Type>
+          <Type muted>
+            Rich import is included in the Core tier. In-place table and
+            paragraph styling requires Extended; batch updates and advanced
+            table editing require Complete.
+          </Type>
+        </div>
+      </Card.Content>
+    </Card>
   );
 }
 

--- a/client/dashboard/src/pages/catalog/toolCurations.test.ts
+++ b/client/dashboard/src/pages/catalog/toolCurations.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  catalogToolCurations,
+  GOOGLE_WORKSPACE_REGISTRY_SPECIFIER,
+} from "./toolCurations";
+
+describe("catalogToolCurations", () => {
+  it("steers rich Google Doc creation to the HTML import tool", () => {
+    const curations = catalogToolCurations(
+      GOOGLE_WORKSPACE_REGISTRY_SPECIFIER,
+      "019c97bd-067f-78c6-aac1-72bb82546f9b",
+    );
+
+    expect(curations).toEqual([
+      expect.objectContaining({
+        srcToolName: "import_to_google_doc",
+        srcToolUrn:
+          "tools:externalmcp:019c97bd-067f-78c6-aac1-72bb82546f9b:import_to_google_doc",
+        name: "create_rich_doc",
+      }),
+      expect.objectContaining({
+        srcToolName: "create_doc",
+        srcToolUrn:
+          "tools:externalmcp:019c97bd-067f-78c6-aac1-72bb82546f9b:create_doc",
+      }),
+    ]);
+    expect(curations[0]?.description).toContain('source_format: "html"');
+    expect(curations[0]?.description).toContain("tables");
+    expect(curations[1]?.description).toContain("plain text only");
+  });
+
+  it("does not alter unrelated catalog servers", () => {
+    expect(catalogToolCurations("example/server", "remote-id")).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/catalog/toolCurations.ts
+++ b/client/dashboard/src/pages/catalog/toolCurations.ts
@@ -1,0 +1,43 @@
+import type { UpsertGlobalToolVariationForm } from "@gram/client/models/components/upsertglobaltoolvariationform.js";
+
+export const GOOGLE_WORKSPACE_REGISTRY_SPECIFIER =
+  "io.github.taylorwilsdon/workspace-mcp";
+
+type CatalogToolCuration = Omit<
+  UpsertGlobalToolVariationForm,
+  "srcToolName" | "srcToolUrn"
+> & {
+  sourceName: string;
+};
+
+const GOOGLE_WORKSPACE_TOOL_CURATIONS: CatalogToolCuration[] = [
+  {
+    sourceName: "import_to_google_doc",
+    name: "create_rich_doc",
+    title: "Create rich Google Doc",
+    description:
+      'Use this to create a native Google Doc with headings, formatted text, lists, or tables. Pass the complete document as HTML with source_format: "html". Prefer this over create_doc whenever the request asks for structure or formatting.',
+  },
+  {
+    sourceName: "create_doc",
+    description:
+      "Create a Google Doc from plain text only. Use create_rich_doc instead when the request includes headings, formatted text, lists, tables, or other rich structure.",
+  },
+];
+
+export function catalogToolCurations(
+  registrySpecifier: string,
+  remoteMcpServerId: string,
+): UpsertGlobalToolVariationForm[] {
+  if (registrySpecifier !== GOOGLE_WORKSPACE_REGISTRY_SPECIFIER) {
+    return [];
+  }
+
+  return GOOGLE_WORKSPACE_TOOL_CURATIONS.map(
+    ({ sourceName, ...variation }) => ({
+      ...variation,
+      srcToolName: sourceName,
+      srcToolUrn: `tools:externalmcp:${remoteMcpServerId}:${sourceName}`,
+    }),
+  );
+}

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts
@@ -7,6 +7,8 @@ const mockCreateServerHeader = vi.fn();
 const mockDiscoverProtectedResourceMetadata = vi.fn();
 const mockMcpServersCreate = vi.fn();
 const mockMcpEndpointsCreate = vi.fn();
+const mockUpsertGlobalVariation = vi.fn();
+const mockDeleteGlobalVariation = vi.fn();
 const mockAuthedFetch = vi.fn();
 
 // Return a stable client reference to avoid re-render loops from useCallback deps
@@ -22,6 +24,10 @@ const mockClient = {
   },
   mcpEndpoints: {
     create: mockMcpEndpointsCreate,
+  },
+  variations: {
+    upsertGlobal: mockUpsertGlobalVariation,
+    deleteGlobal: mockDeleteGlobalVariation,
   },
 };
 
@@ -132,6 +138,14 @@ describe("useRemoteMcpInstallWorkflow", () => {
       id: "endpoint-1",
       slug: "test-org-abc123",
     });
+    mockUpsertGlobalVariation
+      .mockResolvedValueOnce({
+        variation: { id: "variation-1", groupId: "group-1" },
+      })
+      .mockResolvedValueOnce({
+        variation: { id: "variation-2", groupId: "group-1" },
+      });
+    mockDeleteGlobalVariation.mockResolvedValue(undefined);
     mockDeleteServer.mockResolvedValue(undefined);
   });
 
@@ -429,6 +443,44 @@ describe("useRemoteMcpInstallWorkflow", () => {
     if (state.phase !== "complete") throw new Error("unexpected phase");
     expect(state.statuses[0]).toMatchObject({ status: "failed" });
     expect(state.statuses[0]!.error).toContain("boom");
+  });
+
+  it("installs curated rich-document tools for Google Workspace", async () => {
+    const servers = [
+      makeServer({
+        registrySpecifier: "io.github.taylorwilsdon/workspace-mcp",
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useRemoteMcpInstallWorkflow({ servers }),
+    );
+
+    await startInstall(result);
+
+    await waitFor(() => expect(result.current.phase).toBe("complete"));
+    expect(mockUpsertGlobalVariation).toHaveBeenCalledTimes(2);
+    expect(mockUpsertGlobalVariation).toHaveBeenNthCalledWith(
+      1,
+      {
+        upsertGlobalToolVariationForm: expect.objectContaining({
+          srcToolName: "import_to_google_doc",
+          srcToolUrn: "tools:externalmcp:rms-1:import_to_google_doc",
+          name: "create_rich_doc",
+        }),
+      },
+      undefined,
+      undefined,
+    );
+    expect(mockMcpServersCreate).toHaveBeenCalledWith(
+      {
+        createMcpServerForm: expect.objectContaining({
+          remoteMcpServerId: "rms-1",
+          toolVariationsGroupId: "group-1",
+        }),
+      },
+      undefined,
+      undefined,
+    );
   });
 
   it("continues installing remaining servers after one fails", async () => {

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
@@ -12,6 +12,7 @@ import {
   getRemoteDisplayInfo,
   normalizeRemoteUrl,
 } from "@/pages/catalog/remotes";
+import { catalogToolCurations } from "@/pages/catalog/toolCurations";
 import { autoConfigureRemoteMcpAuth } from "@/pages/sources/remote-mcp/autoConfigureAuth";
 import type { RequestOptions } from "@gram/client/lib/sdks.js";
 import type { ExternalMCPRemote } from "@gram/client/models/components/externalmcpremote.js";
@@ -418,12 +419,28 @@ export function useRemoteMcpInstallWorkflow({
       );
 
       let mcpServer: McpServer;
+      const variationIds: string[] = [];
       try {
+        let toolVariationsGroupId: string | undefined;
+        for (const variation of catalogToolCurations(
+          target.server.registrySpecifier,
+          remoteMcpServer.id,
+        )) {
+          const result = await client.variations.upsertGlobal(
+            { upsertGlobalToolVariationForm: variation },
+            undefined,
+            reqOpts,
+          );
+          variationIds.push(result.variation.id);
+          toolVariationsGroupId = result.variation.groupId;
+        }
+
         mcpServer = await client.mcpServers.create(
           {
             createMcpServerForm: {
               name: target.name,
               remoteMcpServerId: remoteMcpServer.id,
+              toolVariationsGroupId,
               // Private (user-session gated) rather than the sources flow's
               // "disabled": catalog installs promise a usable server, and the
               // pre-staged endpoint must actually serve. Public would expose
@@ -435,6 +452,11 @@ export function useRemoteMcpInstallWorkflow({
           reqOpts,
         );
       } catch (linkError) {
+        const variationRollbacks = await Promise.allSettled(
+          variationIds.map((variationId) =>
+            client.variations.deleteGlobal({ variationId }, undefined, reqOpts),
+          ),
+        );
         try {
           await client.remoteMcp.deleteServer(
             { id: remoteMcpServer.id },
@@ -448,8 +470,11 @@ export function useRemoteMcpInstallWorkflow({
             rollbackError instanceof Error
               ? rollbackError.message
               : String(rollbackError);
+          const failedVariationRollbacks = variationRollbacks.filter(
+            (result) => result.status === "rejected",
+          ).length;
           throw new Error(
-            `Created remote MCP server ${remoteMcpServer.id} but failed to link an MCP server, and the rollback also failed. Delete it manually before retrying. Cause: ${linkMsg}. Rollback: ${rollbackMsg}.`,
+            `Created remote MCP server ${remoteMcpServer.id} but failed to configure and link it, and the rollback also failed. Delete it manually before retrying. Cause: ${linkMsg}. Remote rollback: ${rollbackMsg}. Variation rollbacks failed: ${failedVariationRollbacks}.`,
           );
         }
         throw linkError instanceof Error

--- a/docs/google-workspace-rich-docs.md
+++ b/docs/google-workspace-rich-docs.md
@@ -1,0 +1,42 @@
+# Rich Google Docs with the Workspace MCP
+
+Gram installs `io.github.taylorwilsdon/workspace-mcp` from the Pulse registry's
+latest version; it does not pin a connector release. The catalog detail page
+shows the version and live tool list returned by Pulse. The upstream tier
+manifest includes `import_to_google_doc` in Core alongside the plain-text
+`create_doc` tool.
+
+For a new document with headings, formatted text, lists, or tables, call
+`import_to_google_doc` with the full document body as HTML and
+`source_format: "html"`. Catalog installs expose this tool to assistants as
+`create_rich_doc`. Continue to use `create_doc` when the initial content is
+genuinely plain text.
+
+The rich import is available in Core. In-place editing has separate tier
+requirements:
+
+- Extended: `insert_doc_elements`, `update_paragraph_style`, and related
+  paragraph/table operations.
+- Complete: `batch_update_doc`, `create_table_with_data`, and advanced table
+  inspection or editing.
+
+## Repeatable assistant check
+
+1. Add Google Workspace from the Gram catalog and complete Google
+   authentication.
+2. Create an assistant with that MCP server attached.
+3. Send:
+
+   > Create me a Google Doc with example tables, a basic RBAC permissions
+   > structure, dummy text, and sections with headings.
+
+4. Inspect the chat transcript. The first creation call must be
+   `create_rich_doc` and its forwarded upstream call must be
+   `import_to_google_doc` with `source_format: "html"`. It must not use
+   `create_doc`.
+5. Ask the assistant to read the document back with `get_doc_content`.
+6. Verify the returned native Google Doc contains at least two heading
+   sections, formatted text, and a table with role and permission columns.
+
+For local testing, the `assistants-dev` MCP server's `run_turn` and `load_chat`
+tools expose the tool calls and read-back messages needed for steps 3–6.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -834,6 +834,7 @@ func newStartCommand() *cli.Command {
 				logger,
 				tracerProvider,
 				meterProvider,
+				db,
 				guardianPolicy,
 				authzEngine,
 				posthogClient,

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -386,7 +386,17 @@ func (s *Service) serveRemoteBackend(
 		return oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
 	}
 
-	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, endpoint.ProjectID.String(), upstreamAuth, wwwAuthenticate)
+	p := s.remoteProxyManager.Build(
+		logger,
+		&server,
+		mcpServer.ID.String(),
+		headers,
+		mcpServer.Visibility,
+		endpoint.ProjectID,
+		mcpServer.ToolVariationsGroupID,
+		upstreamAuth,
+		wwwAuthenticate,
+	)
 
 	return serveProxyBackend(w, r.WithContext(ctx), p)
 }

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -199,7 +199,7 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub)
+	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub)
 	managedLogsTools := platformtoolsruntime.ManagedAssistantLogsTools(telemService)
 	platformToolsets := platformtools.BuildToolsets(platformtools.ToolsetDependencies{
 		AssistantMemoryTools:          nil,

--- a/server/internal/remotemcp/proxy/tools_call_request.go
+++ b/server/internal/remotemcp/proxy/tools_call_request.go
@@ -106,3 +106,25 @@ func (r *ToolsCallRequest) SetArguments(arguments json.RawMessage) error {
 	r.UserRequest.dirty = true
 	return nil
 }
+
+// SetName replaces the tool name on a tools/call request. This lets a
+// tools/list interceptor expose a curated alias while the proxy still invokes
+// the upstream tool's canonical name.
+func (r *ToolsCallRequest) SetName(name string) error {
+	rpcReq, ok := r.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request)
+	if !ok {
+		return &MutationError{Op: "set name", Cause: fmt.Errorf("underlying message is %T, want *jsonrpc.Request", r.UserRequest.JSONRPCMessages[0])}
+	}
+
+	staged := *r.Params
+	staged.Name = name
+	payload, err := json.Marshal(&staged)
+	if err != nil {
+		return &MutationError{Op: "set name", Cause: fmt.Errorf("marshal mutated CallToolParamsRaw: %w", err)}
+	}
+
+	r.Params.Name = name
+	rpcReq.Params = payload
+	r.UserRequest.dirty = true
+	return nil
+}

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -3,6 +3,8 @@ package remotemcp
 import (
 	"log/slog"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
@@ -16,6 +18,7 @@ import (
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
+	variationsrepo "github.com/speakeasy-api/gram/server/internal/variations/repo"
 )
 
 // ProxyManager builds configured remote-MCP proxies wired up with the
@@ -31,6 +34,7 @@ import (
 type ProxyManager struct {
 	logger         *slog.Logger
 	tracer         trace.Tracer
+	db             *pgxpool.Pool
 	guardianPolicy *guardian.Policy
 	authz          *authz.Engine
 	posthog        *posthog.Posthog
@@ -53,6 +57,7 @@ func NewProxyManager(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
+	db *pgxpool.Pool,
 	guardianPolicy *guardian.Policy,
 	authzEngine *authz.Engine,
 	posthogClient *posthog.Posthog,
@@ -66,6 +71,7 @@ func NewProxyManager(
 	return &ProxyManager{
 		logger:                                logger,
 		tracer:                                tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/remotemcp"),
+		db:                                    db,
 		guardianPolicy:                        guardianPolicy,
 		authz:                                 authzEngine,
 		posthog:                               posthogClient,
@@ -106,7 +112,8 @@ func (f *ProxyManager) Build(
 	mcpServerID string,
 	headers []remotemcprepo.RemoteMcpServerHeader,
 	visibility string,
-	projectID string,
+	projectID uuid.UUID,
+	toolVariationsGroupID uuid.NullUUID,
 	upstreamAuth string,
 	wwwAuthenticate string,
 ) *proxy.Proxy {
@@ -120,11 +127,27 @@ func (f *ProxyManager) Build(
 		})
 	}
 
-	return f.BuildTarget(logger, proxy.ServerIdentity{
+	identity := proxy.ServerIdentity{
 		RemoteMCPServerID:   server.ID.String(),
 		TunneledMCPServerID: "",
 		McpServerID:         mcpServerID,
-	}, server.Url, configured, visibility, projectID, upstreamAuth, wwwAuthenticate)
+	}
+	p := f.BuildTarget(logger, identity, server.Url, configured, visibility, projectID.String(), upstreamAuth, wwwAuthenticate)
+
+	if toolVariationsGroupID.Valid {
+		variationInterceptor := NewToolsVariationInterceptor(
+			variationsrepo.New(f.db),
+			toolVariationsGroupID.UUID,
+			projectID,
+			identity,
+		)
+		// Authorize against upstream canonical names first, then expose aliases
+		// in tools/list and restore them after tools/call authorization.
+		p.ToolsListResponseInterceptors = append(p.ToolsListResponseInterceptors, variationInterceptor)
+		p.ToolsCallRequestInterceptors = append(p.ToolsCallRequestInterceptors, variationInterceptor)
+	}
+
+	return p
 }
 
 func (f *ProxyManager) BuildTarget(

--- a/server/internal/remotemcp/proxymanager.go
+++ b/server/internal/remotemcp/proxymanager.go
@@ -142,9 +142,13 @@ func (f *ProxyManager) Build(
 			identity,
 		)
 		// Authorize against upstream canonical names first, then expose aliases
-		// in tools/list and restore them after tools/call authorization.
+		// in tools/list. Restore aliases before the request-side interceptors so
+		// tools/call authorization uses that same canonical name.
 		p.ToolsListResponseInterceptors = append(p.ToolsListResponseInterceptors, variationInterceptor)
-		p.ToolsCallRequestInterceptors = append(p.ToolsCallRequestInterceptors, variationInterceptor)
+		p.ToolsCallRequestInterceptors = append(
+			[]proxy.ToolsCallRequestInterceptor{variationInterceptor},
+			p.ToolsCallRequestInterceptors...,
+		)
 	}
 
 	return p

--- a/server/internal/remotemcp/tools_variation_interceptor.go
+++ b/server/internal/remotemcp/tools_variation_interceptor.go
@@ -134,7 +134,13 @@ func applyRemoteToolVariation(tool *mcp.Tool, variation variationsrepo.ToolVaria
 		return
 	}
 	if tool.Annotations == nil {
-		tool.Annotations = &mcp.ToolAnnotations{}
+		tool.Annotations = &mcp.ToolAnnotations{
+			DestructiveHint: nil,
+			IdempotentHint:  false,
+			OpenWorldHint:   nil,
+			ReadOnlyHint:    false,
+			Title:           "",
+		}
 	}
 	if variation.Title.Valid && variation.Title.String != "" {
 		tool.Annotations.Title = variation.Title.String

--- a/server/internal/remotemcp/tools_variation_interceptor.go
+++ b/server/internal/remotemcp/tools_variation_interceptor.go
@@ -1,0 +1,154 @@
+package remotemcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	variationsrepo "github.com/speakeasy-api/gram/server/internal/variations/repo"
+)
+
+type toolVariationLoader interface {
+	ListByGroupIDAndToolSource(context.Context, variationsrepo.ListByGroupIDAndToolSourceParams) ([]variationsrepo.ToolVariation, error)
+}
+
+// ToolsVariationInterceptor applies configured tool variations to a remote
+// MCP's live tools/list response and translates aliases back to upstream names
+// on tools/call.
+type ToolsVariationInterceptor struct {
+	loader    toolVariationLoader
+	groupID   uuid.UUID
+	projectID uuid.UUID
+	identity  proxy.ServerIdentity
+}
+
+var (
+	_ proxy.ToolsListResponseInterceptor = (*ToolsVariationInterceptor)(nil)
+	_ proxy.ToolsCallRequestInterceptor  = (*ToolsVariationInterceptor)(nil)
+)
+
+func NewToolsVariationInterceptor(
+	loader toolVariationLoader,
+	groupID uuid.UUID,
+	projectID uuid.UUID,
+	identity proxy.ServerIdentity,
+) *ToolsVariationInterceptor {
+	return &ToolsVariationInterceptor{
+		loader:    loader,
+		groupID:   groupID,
+		projectID: projectID,
+		identity:  identity,
+	}
+}
+
+func (i *ToolsVariationInterceptor) Name() string {
+	return "tools-variation"
+}
+
+func (i *ToolsVariationInterceptor) InterceptToolsListResponse(ctx context.Context, list *proxy.ToolsListResponse) error {
+	if list == nil || list.Result == nil || len(list.Result.Tools) == 0 {
+		return nil
+	}
+
+	variations, err := i.load(ctx)
+	if err != nil {
+		return err
+	}
+	if len(variations) == 0 {
+		return nil
+	}
+
+	bySourceName := make(map[string]variationsrepo.ToolVariation, len(variations))
+	for _, variation := range variations {
+		bySourceName[variation.SrcToolUrn.Name] = variation
+	}
+
+	for _, tool := range list.Result.Tools {
+		if tool == nil {
+			continue
+		}
+		variation, ok := bySourceName[tool.Name]
+		if !ok {
+			continue
+		}
+		applyRemoteToolVariation(tool, variation)
+	}
+
+	if err := list.SetTools(list.Result.Tools); err != nil {
+		return fmt.Errorf("commit varied tools/list result: %w", err)
+	}
+	return nil
+}
+
+func (i *ToolsVariationInterceptor) InterceptToolsCallRequest(ctx context.Context, call *proxy.ToolsCallRequest) error {
+	if call == nil || call.Params == nil {
+		return nil
+	}
+
+	variations, err := i.load(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, variation := range variations {
+		if variation.Name.Valid && variation.Name.String != "" && variation.Name.String == call.Params.Name {
+			if err := call.SetName(variation.SrcToolUrn.Name); err != nil {
+				return fmt.Errorf("restore upstream tool name: %w", err)
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func (i *ToolsVariationInterceptor) load(ctx context.Context) ([]variationsrepo.ToolVariation, error) {
+	variations, err := i.loader.ListByGroupIDAndToolSource(ctx, variationsrepo.ListByGroupIDAndToolSourceParams{
+		GroupID:     i.groupID,
+		ProjectID:   i.projectID,
+		KindValue:   i.identity.ToolURNKind(),
+		SourceValue: i.identity.SourceID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load remote MCP tool variations: %w", err)
+	}
+	return variations, nil
+}
+
+func applyRemoteToolVariation(tool *mcp.Tool, variation variationsrepo.ToolVariation) {
+	if variation.Name.Valid && variation.Name.String != "" {
+		tool.Name = variation.Name.String
+	}
+	if variation.Description.Valid && variation.Description.String != "" {
+		tool.Description = variation.Description.String
+	}
+
+	hasAnnotationOverride := (variation.Title.Valid && variation.Title.String != "") ||
+		variation.ReadOnlyHint.Valid ||
+		variation.DestructiveHint.Valid ||
+		variation.IdempotentHint.Valid ||
+		variation.OpenWorldHint.Valid
+	if !hasAnnotationOverride {
+		return
+	}
+	if tool.Annotations == nil {
+		tool.Annotations = &mcp.ToolAnnotations{}
+	}
+	if variation.Title.Valid && variation.Title.String != "" {
+		tool.Annotations.Title = variation.Title.String
+	}
+	if variation.ReadOnlyHint.Valid {
+		tool.Annotations.ReadOnlyHint = variation.ReadOnlyHint.Bool
+	}
+	if variation.DestructiveHint.Valid {
+		tool.Annotations.DestructiveHint = &variation.DestructiveHint.Bool
+	}
+	if variation.IdempotentHint.Valid {
+		tool.Annotations.IdempotentHint = variation.IdempotentHint.Bool
+	}
+	if variation.OpenWorldHint.Valid {
+		tool.Annotations.OpenWorldHint = &variation.OpenWorldHint.Bool
+	}
+}

--- a/server/internal/remotemcp/tools_variation_interceptor_test.go
+++ b/server/internal/remotemcp/tools_variation_interceptor_test.go
@@ -1,0 +1,117 @@
+package remotemcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	variationsrepo "github.com/speakeasy-api/gram/server/internal/variations/repo"
+)
+
+type staticToolVariationLoader struct {
+	variations []variationsrepo.ToolVariation
+	err        error
+	params     variationsrepo.ListByGroupIDAndToolSourceParams
+}
+
+func (l *staticToolVariationLoader) ListByGroupIDAndToolSource(
+	_ context.Context,
+	params variationsrepo.ListByGroupIDAndToolSourceParams,
+) ([]variationsrepo.ToolVariation, error) {
+	l.params = params
+	return l.variations, l.err
+}
+
+func TestToolsVariationInterceptor_VariesRemoteToolsList(t *testing.T) {
+	t.Parallel()
+
+	groupID := uuid.New()
+	projectID := uuid.New()
+	sourceID := uuid.NewString()
+	loader := &staticToolVariationLoader{
+		variations: []variationsrepo.ToolVariation{
+			{
+				SrcToolUrn:      urn.NewTool(urn.ToolKindExternalMCP, sourceID, "import_to_google_doc"),
+				Name:            pgtype.Text{String: "create_rich_doc", Valid: true},
+				Description:     pgtype.Text{String: "Create a native Google Doc from rich HTML.", Valid: true},
+				Title:           pgtype.Text{String: "Create rich document", Valid: true},
+				ReadOnlyHint:    pgtype.Bool{Bool: false, Valid: true},
+				DestructiveHint: pgtype.Bool{Bool: false, Valid: true},
+				OpenWorldHint:   pgtype.Bool{Bool: true, Valid: true},
+			},
+		},
+	}
+	interceptor := remotemcp.NewToolsVariationInterceptor(
+		loader,
+		groupID,
+		projectID,
+		proxy.ServerIdentity{RemoteMCPServerID: sourceID},
+	)
+	resp := newToolsListResponse(t, []*mcp.Tool{
+		{Name: "create_doc", Description: "Create plain text.", InputSchema: map[string]any{"type": "object"}},
+		{Name: "import_to_google_doc", Description: "Import a file.", InputSchema: map[string]any{"type": "object"}},
+	})
+
+	require.NoError(t, interceptor.InterceptToolsListResponse(t.Context(), resp))
+	require.Equal(t, groupID, loader.params.GroupID)
+	require.Equal(t, projectID, loader.params.ProjectID)
+	require.Equal(t, "externalmcp", loader.params.KindValue)
+	require.Equal(t, sourceID, loader.params.SourceValue)
+	require.Equal(t, "create_doc", resp.Result.Tools[0].Name)
+	require.Equal(t, "create_rich_doc", resp.Result.Tools[1].Name)
+	require.Equal(t, "Create a native Google Doc from rich HTML.", resp.Result.Tools[1].Description)
+	require.Equal(t, "Create rich document", resp.Result.Tools[1].Annotations.Title)
+	require.False(t, resp.Result.Tools[1].Annotations.ReadOnlyHint)
+	require.NotNil(t, resp.Result.Tools[1].Annotations.DestructiveHint)
+	require.False(t, *resp.Result.Tools[1].Annotations.DestructiveHint)
+	require.NotNil(t, resp.Result.Tools[1].Annotations.OpenWorldHint)
+	require.True(t, *resp.Result.Tools[1].Annotations.OpenWorldHint)
+}
+
+func TestToolsVariationInterceptor_RestoresAliasBeforeUpstreamCall(t *testing.T) {
+	t.Parallel()
+
+	sourceID := uuid.NewString()
+	loader := &staticToolVariationLoader{
+		variations: []variationsrepo.ToolVariation{
+			{
+				SrcToolUrn: urn.NewTool(urn.ToolKindExternalMCP, sourceID, "import_to_google_doc"),
+				Name:       pgtype.Text{String: "create_rich_doc", Valid: true},
+			},
+		},
+	}
+	interceptor := remotemcp.NewToolsVariationInterceptor(
+		loader,
+		uuid.New(),
+		uuid.New(),
+		proxy.ServerIdentity{RemoteMCPServerID: sourceID},
+	)
+	params := json.RawMessage(`{"name":"create_rich_doc","arguments":{"source_format":"html"}}`)
+	rpcReq := &jsonrpc.Request{Params: params}
+	call := &proxy.ToolsCallRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Name:      "create_rich_doc",
+			Arguments: json.RawMessage(`{"source_format":"html"}`),
+		},
+		UserRequest: &proxy.UserRequest{
+			JSONRPCMessages: []jsonrpc.Message{rpcReq},
+		},
+	}
+
+	require.NoError(t, interceptor.InterceptToolsCallRequest(t.Context(), call))
+	require.Equal(t, "import_to_google_doc", call.Params.Name)
+
+	var forwarded mcp.CallToolParamsRaw
+	require.NoError(t, json.Unmarshal(rpcReq.Params, &forwarded))
+	require.Equal(t, "import_to_google_doc", forwarded.Name)
+	require.JSONEq(t, `{"source_format":"html"}`, string(forwarded.Arguments))
+}

--- a/server/internal/variations/queries.sql
+++ b/server/internal/variations/queries.sql
@@ -127,6 +127,20 @@ WHERE
   AND tool_variations.src_tool_urn = ANY(@tool_urns::text[])
   AND tool_variations.deleted IS FALSE;
 
+-- name: ListByGroupIDAndToolSource :many
+-- Loads every variation for one remote tool source so tools/list aliases can be
+-- reversed before forwarding a later tools/call request upstream.
+SELECT tool_variations.*
+FROM tool_variations
+INNER JOIN tool_variations_groups
+  ON tool_variations.group_id = tool_variations_groups.id
+WHERE
+  tool_variations.group_id = @group_id
+  AND tool_variations_groups.project_id = @project_id
+  AND split_part(tool_variations.src_tool_urn, ':', 2)::varchar = @kind_value::varchar
+  AND split_part(tool_variations.src_tool_urn, ':', 3)::varchar = @source_value::varchar
+  AND tool_variations.deleted IS FALSE;
+
 -- name: FindGlobalVariationsForProjects :many
 -- Batch-resolves variation name overrides across multiple projects.
 WITH global_groups AS (

--- a/server/internal/variations/repo/queries.sql.go
+++ b/server/internal/variations/repo/queries.sql.go
@@ -207,6 +207,74 @@ func (q *Queries) InitGlobalToolVariationsGroup(ctx context.Context, arg InitGlo
 	return id, err
 }
 
+const listByGroupIDAndToolSource = `-- name: ListByGroupIDAndToolSource :many
+SELECT tool_variations.id, tool_variations.group_id, tool_variations.src_tool_urn, tool_variations.src_tool_name, tool_variations.confirm, tool_variations.confirm_prompt, tool_variations.name, tool_variations.summary, tool_variations.description, tool_variations.tags, tool_variations.summarizer, tool_variations.title, tool_variations.read_only_hint, tool_variations.destructive_hint, tool_variations.idempotent_hint, tool_variations.open_world_hint, tool_variations.created_at, tool_variations.updated_at, tool_variations.deleted_at, tool_variations.deleted
+FROM tool_variations
+INNER JOIN tool_variations_groups
+  ON tool_variations.group_id = tool_variations_groups.id
+WHERE
+  tool_variations.group_id = $1
+  AND tool_variations_groups.project_id = $2
+  AND split_part(tool_variations.src_tool_urn, ':', 2)::varchar = $3::varchar
+  AND split_part(tool_variations.src_tool_urn, ':', 3)::varchar = $4::varchar
+  AND tool_variations.deleted IS FALSE
+`
+
+type ListByGroupIDAndToolSourceParams struct {
+	GroupID     uuid.UUID
+	ProjectID   uuid.UUID
+	KindValue   string
+	SourceValue string
+}
+
+// Loads every variation for one remote tool source so tools/list aliases can be
+// reversed before forwarding a later tools/call request upstream.
+func (q *Queries) ListByGroupIDAndToolSource(ctx context.Context, arg ListByGroupIDAndToolSourceParams) ([]ToolVariation, error) {
+	rows, err := q.db.Query(ctx, listByGroupIDAndToolSource,
+		arg.GroupID,
+		arg.ProjectID,
+		arg.KindValue,
+		arg.SourceValue,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ToolVariation
+	for rows.Next() {
+		var i ToolVariation
+		if err := rows.Scan(
+			&i.ID,
+			&i.GroupID,
+			&i.SrcToolUrn,
+			&i.SrcToolName,
+			&i.Confirm,
+			&i.ConfirmPrompt,
+			&i.Name,
+			&i.Summary,
+			&i.Description,
+			&i.Tags,
+			&i.Summarizer,
+			&i.Title,
+			&i.ReadOnlyHint,
+			&i.DestructiveHint,
+			&i.IdempotentHint,
+			&i.OpenWorldHint,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listByGroupIDAndToolURNs = `-- name: ListByGroupIDAndToolURNs :many
 SELECT tool_variations.id, tool_variations.group_id, tool_variations.src_tool_urn, tool_variations.src_tool_name, tool_variations.confirm, tool_variations.confirm_prompt, tool_variations.name, tool_variations.summary, tool_variations.description, tool_variations.tags, tool_variations.summarizer, tool_variations.title, tool_variations.read_only_hint, tool_variations.destructive_hint, tool_variations.idempotent_hint, tool_variations.open_world_hint, tool_variations.created_at, tool_variations.updated_at, tool_variations.deleted_at, tool_variations.deleted
 FROM tool_variations

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -155,7 +155,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	auditLogger := audit.NewLogger()
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
-	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient)
+	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient)
 	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil)
 
 	svc := xmcp.NewService(logger, conn, enc, mcpService)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- apply configured tool variations to remote MCP `tools/list` and translate aliases back to canonical upstream names on `tools/call`
- curate Google Workspace catalog installs so rich requests see `create_rich_doc` backed by `import_to_google_doc`, while `create_doc` remains plain-text only
- document HTML import usage, tier requirements, and a repeatable assistant/read-back check

## Demo
<a href="https://cursor.com/agents/bc-ce2c13af-7a4b-4fc3-b216-a8b07f3aa536/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoogle_workspace_rich_docs_guide.mp4"><img src="https://cursor.com/artifacts/c/art-3ffbe476-4315-4a61-b6f1-bbffa0f8e8a4" alt="google_workspace_rich_docs_guide.mp4" /></a>

## Testing
- `mise exec -- go test ./server/internal/remotemcp/... ./server/internal/mcp/... ./server/internal/xmcp/... ./server/internal/variations/...`
- `mise lint:server`
- `pnpm -F dashboard test -- src/pages/catalog/toolCurations.test.ts src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts` (full dashboard suite: 1,123 tests)
- `pnpm -F dashboard lint`
- manual dashboard verification with a local registry fixture; no application errors

Linear: AGE-3061
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-373](https://linear.app/speakeasy/issue/AIS-373/fix-make-rich-google-doc-creation-discoverable-in-the-workspace-mcp)

<div><a href="https://cursor.com/agents/bc-ce2c13af-7a4b-4fc3-b216-a8b07f3aa536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce2c13af-7a4b-4fc3-b216-a8b07f3aa536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes rich Google Doc creation easy to discover. Curates the Google Workspace catalog and adds server-side tool aliasing so assistants prefer `create_rich_doc` (HTML import) for structured docs, while `create_doc` stays plain-text. Satisfies Linear AIS-373.

- New Features
  - Server: Applies configured tool variations to `tools/list` and remaps alias names back to upstream on `tools/call`. Adds a tools-variation interceptor, new repo query, and wires group/project IDs through the proxy manager.
  - Catalog: For `io.github.taylorwilsdon/workspace-mcp`, installs a curated alias `create_rich_doc` backed by `import_to_google_doc`, and retains `create_doc` for plain text. The install workflow creates variations, links the group to the server, and rolls back on failure.
  - Dashboard: Shows a short “Creating rich Google Docs” guide on the catalog detail page to explain when to use HTML import and tier capabilities.
  - Docs: Adds `docs/google-workspace-rich-docs.md` with examples and a repeatable assistant/read-back check.

- Bug Fixes
  - Server: Corrects interceptor order so authorization runs against upstream canonical tool names; aliases are applied on `tools/list` and restored before forwarding `tools/call`.

<sup>Written for commit 257d140d32d7f86f037b86d7af0c2df7a692010e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

