### PR TITLE
feat: backfill with denormalised fields

### DIFF
--- a/server/cmd/tools/migrations/RISK_RESULTS_MIGRATION.md
+++ b/server/cmd/tools/migrations/RISK_RESULTS_MIGRATION.md
@@ -26,13 +26,15 @@ rule_id IS NOT NULL`, mirroring the live outbox emission
 through the live path — are excluded, and the backfill cannot inflate risk-event
 counts with non-findings.
 
-**False positives are excluded** (`false_positive_at IS NULL`). Rows the Presidio
+**False positives are migrated with their mark.** Rows the Presidio
 false-positive sweep has classified as noise (reserved IPs, placeholder emails,
-…) are dropped. ClickHouse is becoming the source of truth for risk findings and
-has no false-positive column, so importing known noise would leave permanently
-unannotated junk in the store — we keep the backfilled set clean instead. If
-false-positive tracking is needed later, a dedicated column can be added to
-`risk_findings` and this filter revisited.
+…) are written to ClickHouse with their `false_positive_at` timestamp preserved
+in the matching Nullable column. Every read query filters
+`false_positive_at IS NULL`, so these rows never inflate counts — but the
+pre-cutover marks survive the migration, which matters while the live
+false-positive mutation path (PR 3) is deferred. When validating row counts
+after a run, compare against Postgres **without** a `false_positive_at IS NULL`
+filter (or apply it on both sides).
 
 The Postgres and ClickHouse shapes differ — this is **not** a column-for-column
 copy:
@@ -47,9 +49,15 @@ copy:
   HKDF key. Dead-letter sentinels and empty matches are left un-fingerprinted.
 - **Derived / dropped columns.** `request_id` is not recorded in `risk_results`
   and is left empty; `inserted_at` is stamped by ClickHouse's `DEFAULT now64(9)`.
-  Postgres-only columns without a ClickHouse home (`found`, `spans`,
-  `false_positive_*`) are dropped. Postgres `excluded_exclusion_id` maps to
-  ClickHouse `exclusion_id`.
+  Postgres-only columns without a ClickHouse home (`found`, `spans`) are
+  dropped. Postgres `excluded_exclusion_id` maps to ClickHouse `exclusion_id`;
+  `false_positive_at` carries over as-is.
+- **Denormalized attribution and category.** The source LEFT JOINs
+  `chat_messages`/`chats` to stamp `chat_id`, `user_id`, and `external_user_id`
+  (message-level user ids win over chat-level, everything collapsing to `''`
+  when the message or chat is gone), mirroring the live writer's
+  `GetChatMessageAttribution` lookup. `category` is computed from
+  `(source, rule_id)` via `internal/risk/categories`, same as the live writer.
 
 ## Flags
 

--- a/server/cmd/tools/migrations/riskfindings/sink.go
+++ b/server/cmd/tools/migrations/riskfindings/sink.go
@@ -21,10 +21,11 @@ const DefaultSinkBatchSize = 5000
 // columns by their ch tags.
 const insertStatement = `INSERT INTO risk_findings (
 	id, created_at, organization_id, project_id, request_id, chat_message_id,
+	chat_id, user_id, external_user_id,
 	risk_policy_id, risk_policy_version, rule_id, description, source, confidence,
-	tags, start_pos, end_pos, dead_letter_reason, match_len, match_redacted,
+	category, tags, start_pos, end_pos, dead_letter_reason, match_len, match_redacted,
 	fingerprint_pepper_version, fingerprint_global_hs256, fingerprint_tenant_hs256,
-	excluded_at, exclusion_id
+	excluded_at, exclusion_id, false_positive_at
 )`
 
 // Sink batches FindingRow values and inserts them into the ClickHouse

--- a/server/cmd/tools/migrations/riskfindings/source.go
+++ b/server/cmd/tools/migrations/riskfindings/source.go
@@ -54,6 +54,15 @@ type SourceRow struct {
 	DeadLetterReason  *string
 	ExcludedAt        *time.Time
 	ExclusionID       *uuid.UUID
+	FalsePositiveAt   *time.Time
+
+	// Denormalized attribution resolved by the source's LEFT JOINs, mirroring
+	// the live writer's GetChatMessageAttribution lookup: message-level user
+	// ids win over chat-level ones. All empty when the chat message no longer
+	// resolves (deleted chat, missing message).
+	ChatID         string
+	UserID         string
+	ExternalUserID string
 }
 
 // selectPage walks risk_results in id order (uuidv7). The id is used ONLY as a
@@ -73,28 +82,39 @@ type SourceRow struct {
 // dead-letter rows — which never reach ClickHouse through the live path — are
 // excluded here too.
 //
-// false_positive_at IS NULL additionally drops rows the Presidio false-positive
-// sweep has classified as noise. ClickHouse is becoming the source of truth for
-// risk findings and has no false-positive column, so importing known noise would
-// leave permanently-unannotated junk in the store. We keep the backfilled set
-// clean; if false-positive tracking is needed later, a dedicated column can be
-// added.
+// Rows the Presidio false-positive sweep has marked are migrated WITH their
+// false_positive_at timestamp rather than dropped: risk_findings mirrors the
+// mark in its own Nullable column and every read query filters
+// false_positive_at IS NULL, so backfilling them preserves pre-cutover marks
+// (the live FP mutation path — PR 3 — is deferred) without inflating counts.
+//
+// The LEFT JOINs denormalize attribution the same way the live writer's
+// GetChatMessageAttribution query does (risk/queries.sql): chat id plus
+// resolved user ids, message-level values winning over chat-level ones,
+// everything collapsing to ” when the message or chat is gone.
 const selectPage = `
-SELECT id, created_at, organization_id, project_id, risk_policy_id,
-       risk_policy_version, chat_message_id, source, found, rule_id, description,
-       match, start_pos, end_pos, confidence, tags, dead_letter_reason,
-       excluded_at, excluded_exclusion_id
-FROM risk_results
-WHERE ($1::text IS NULL OR organization_id = $1)
-  AND ($2::uuid IS NULL OR project_id = $2)
-  AND ($3::uuid IS NULL OR risk_policy_id = $3)
-  AND ($4::timestamptz IS NULL OR created_at >= $4)
-  AND ($5::timestamptz IS NULL OR created_at < $5)
-  AND id > $6
-  AND found IS TRUE
-  AND rule_id IS NOT NULL
-  AND false_positive_at IS NULL
-ORDER BY id
+SELECT r.id, r.created_at, r.organization_id, r.project_id, r.risk_policy_id,
+       r.risk_policy_version, r.chat_message_id, r.source, r.found, r.rule_id, r.description,
+       r.match, r.start_pos, r.end_pos, r.confidence, r.tags, r.dead_letter_reason,
+       r.excluded_at, r.excluded_exclusion_id, r.false_positive_at,
+       COALESCE(cm.chat_id::text, '') AS chat_id,
+       COALESCE(NULLIF(cm.user_id, ''), NULLIF(c.user_id, ''), '')::text AS user_id,
+       COALESCE(NULLIF(cm.external_user_id, ''), NULLIF(c.external_user_id, ''), '')::text AS external_user_id
+FROM risk_results r
+LEFT JOIN chat_messages cm
+  ON cm.id = r.chat_message_id
+LEFT JOIN chats c
+  ON c.id = cm.chat_id
+  AND c.deleted IS FALSE
+WHERE ($1::text IS NULL OR r.organization_id = $1)
+  AND ($2::uuid IS NULL OR r.project_id = $2)
+  AND ($3::uuid IS NULL OR r.risk_policy_id = $3)
+  AND ($4::timestamptz IS NULL OR r.created_at >= $4)
+  AND ($5::timestamptz IS NULL OR r.created_at < $5)
+  AND r.id > $6
+  AND r.found IS TRUE
+  AND r.rule_id IS NOT NULL
+ORDER BY r.id
 LIMIT $7
 `
 
@@ -177,7 +197,8 @@ func (s *Source) Read(ctx context.Context, criteria pipeline.Criteria, out chan<
 				&r.ID, &r.CreatedAt, &r.OrganizationID, &r.ProjectID, &r.RiskPolicyID,
 				&r.RiskPolicyVersion, &r.ChatMessageID, &r.Source, &r.Found, &r.RuleID, &r.Description,
 				&r.Match, &r.StartPos, &r.EndPos, &r.Confidence, &r.Tags, &r.DeadLetterReason,
-				&r.ExcludedAt, &r.ExclusionID,
+				&r.ExcludedAt, &r.ExclusionID, &r.FalsePositiveAt,
+				&r.ChatID, &r.UserID, &r.ExternalUserID,
 			); err != nil {
 				rows.Close()
 				return fmt.Errorf("scan row after %s: %w", cursor, err)

--- a/server/cmd/tools/migrations/riskfindings/transform.go
+++ b/server/cmd/tools/migrations/riskfindings/transform.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 )
 
 // FindingRow is one risk_findings row ready to insert into ClickHouse. The ch
@@ -35,6 +36,10 @@ type FindingRow struct {
 	StartPos                 int32      `ch:"start_pos"`
 	EndPos                   int32      `ch:"end_pos"`
 	DeadLetterReason         string     `ch:"dead_letter_reason"`
+	ChatID                   string     `ch:"chat_id"`
+	UserID                   string     `ch:"user_id"`
+	ExternalUserID           string     `ch:"external_user_id"`
+	Category                 string     `ch:"category"`
 	MatchLen                 uint32     `ch:"match_len"`
 	MatchRedacted            string     `ch:"match_redacted"`
 	FingerprintPepperVersion string     `ch:"fingerprint_pepper_version"`
@@ -42,6 +47,7 @@ type FindingRow struct {
 	FingerprintTenantHS256   string     `ch:"fingerprint_tenant_hs256"`
 	ExcludedAt               *time.Time `ch:"excluded_at"`
 	ExclusionID              *uuid.UUID `ch:"exclusion_id"`
+	FalsePositiveAt          *time.Time `ch:"false_positive_at"`
 }
 
 // Transformer maps a Postgres SourceRow to a ClickHouse FindingRow, mirroring the
@@ -108,6 +114,11 @@ func (t *Transformer) Transform(_ context.Context, in SourceRow) ([]FindingRow, 
 		tags = []string{}
 	}
 
+	// Rows surviving the found/rule guard above are never dead-letter
+	// sentinels, so classification always applies — same canonical
+	// (source, rule_id) mapping the live writer stamps at ingest.
+	category := string(categories.Classify(in.Source, conv.PtrValOr(in.RuleID, "")))
+
 	return []FindingRow{{
 		ID:                in.ID,
 		CreatedAt:         in.CreatedAt,
@@ -125,6 +136,10 @@ func (t *Transformer) Transform(_ context.Context, in SourceRow) ([]FindingRow, 
 		StartPos:          conv.PtrValOr(in.StartPos, 0),
 		EndPos:            conv.PtrValOr(in.EndPos, 0),
 		DeadLetterReason:  conv.PtrValOr(in.DeadLetterReason, ""),
+		ChatID:            in.ChatID,
+		UserID:            in.UserID,
+		ExternalUserID:    in.ExternalUserID,
+		Category:          category,
 		MatchLen:          uint32(len(match)), //nolint:gosec // match length cannot exceed uint32 in practice
 		// Redact every source (no shadow_mcp/account_identity passthrough) via the
 		// shared helper, so backfilled match_redacted stays byte-identical to what
@@ -135,5 +150,6 @@ func (t *Transformer) Transform(_ context.Context, in SourceRow) ([]FindingRow, 
 		FingerprintTenantHS256:   tenantFP,
 		ExcludedAt:               in.ExcludedAt,
 		ExclusionID:              in.ExclusionID,
+		FalsePositiveAt:          in.FalsePositiveAt,
 	}}, nil
 }

--- a/server/cmd/tools/migrations/riskfindings/transform_test.go
+++ b/server/cmd/tools/migrations/riskfindings/transform_test.go
@@ -47,6 +47,10 @@ func TestTransformComputesFingerprintsAndRedaction(t *testing.T) {
 		DeadLetterReason:  nil,
 		ExcludedAt:        nil,
 		ExclusionID:       nil,
+		FalsePositiveAt:   nil,
+		ChatID:            "",
+		UserID:            "",
+		ExternalUserID:    "",
 	}
 
 	out, err := tf.Transform(t.Context(), in)
@@ -69,6 +73,59 @@ func TestTransformComputesFingerprintsAndRedaction(t *testing.T) {
 	require.Equal(t, uint32(len("alice@example.com")), row.MatchLen)
 	require.Contains(t, row.MatchRedacted, "<redacted len=17 sha=")
 	require.NotContains(t, row.MatchRedacted, "alice@example.com")
+}
+
+func TestTransformMapsAttributionCategoryAndFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	tf := NewTransformer(testFingerprinter(t))
+	falsePositiveAt := time.Now().UTC()
+	chatID := uuid.New()
+	in := SourceRow{
+		ID: uuid.New(), CreatedAt: time.Now().UTC(), OrganizationID: "org_123",
+		ProjectID: uuid.New(), RiskPolicyID: uuid.New(), ChatMessageID: uuid.New(),
+		Source: "presidio", Found: true, RuleID: conv.PtrEmpty("pii.email_address"),
+		Match: conv.PtrEmpty("alice@example.com"), Tags: []string{"pii"},
+		FalsePositiveAt: &falsePositiveAt,
+		ChatID:          chatID.String(),
+		UserID:          "user_1",
+		ExternalUserID:  "ext_1",
+	}
+
+	out, err := tf.Transform(t.Context(), in)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	row := out[0]
+
+	require.Equal(t, chatID.String(), row.ChatID)
+	require.Equal(t, "user_1", row.UserID)
+	require.Equal(t, "ext_1", row.ExternalUserID)
+	require.Equal(t, "pii", row.Category)
+	require.NotNil(t, row.FalsePositiveAt)
+	require.Equal(t, falsePositiveAt, *row.FalsePositiveAt)
+}
+
+func TestTransformUnresolvedAttributionStaysEmpty(t *testing.T) {
+	t.Parallel()
+
+	// A finding whose chat message no longer resolves (deleted chat, missing
+	// message) carries empty attribution rather than being dropped.
+	tf := NewTransformer(testFingerprinter(t))
+	in := SourceRow{
+		ID: uuid.New(), CreatedAt: time.Now().UTC(), OrganizationID: "org_123",
+		ProjectID: uuid.New(), RiskPolicyID: uuid.New(), ChatMessageID: uuid.New(),
+		Source: "gitleaks", Found: true, RuleID: conv.PtrEmpty("generic-api-key"),
+		Match: conv.PtrEmpty("tok-123"), Tags: []string{},
+	}
+
+	out, err := tf.Transform(t.Context(), in)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Empty(t, out[0].ChatID)
+	require.Empty(t, out[0].UserID)
+	require.Empty(t, out[0].ExternalUserID)
+	require.Nil(t, out[0].FalsePositiveAt)
+	require.Equal(t, "secrets", out[0].Category)
 }
 
 func TestTransformIsDeterministic(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backfill now writes denormalized attribution (`chat_id`, `user_id`, `external_user_id`), computes a `category`, and migrates `false_positive_at` into ClickHouse to mirror the live writer and keep read counts correct.

- **New Features**
  - Source LEFT JOINs `chat_messages`/`chats` to resolve attribution (message-level IDs override chat-level; missing data becomes empty strings) and includes false positives, carrying `false_positive_at`.
  - Transformer computes `category` from `(source, rule_id)` and propagates attribution and `false_positive_at`.
  - Sink insert writes `chat_id`, `user_id`, `external_user_id`, `category`, and `false_positive_at`.
  - Tests cover attribution mapping, category, false-positive propagation, and determinism.

- **Migration**
  - Ensure ClickHouse `risk_findings` has Nullable columns: `chat_id`, `user_id`, `external_user_id`, `category`, `false_positive_at`.
  - Reads should filter `false_positive_at IS NULL`; when validating counts, compare without that filter or apply it on both sides.

<sup>Written for commit 5a3ce840298037dbf9a2b714d56cc73c610b468c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

