### PR TITLE
test: stabilize ClickHouse telemetry log visibility

### DIFF
--- a/server/internal/telemetry/create_log_test.go
+++ b/server/internal/telemetry/create_log_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -550,27 +551,29 @@ func newTestToolInfo(orgID string) telemetry.ToolInfo {
 	}
 }
 
-// flushAndGetLog drains ClickHouse's async insert queue so the row the
-// preceding Log call wrote becomes deterministically visible, then fetches
-// it. Logger.Log is synchronous up to the async insert queue, so the flush is
-// the only synchronization point needed — no polling (see
-// internal/telemetry/README.md).
+// flushAndGetLog drains ClickHouse's async insert queue, then polls the read.
+// Under full-suite load ClickHouse can acknowledge the flush just before the
+// row becomes queryable, so a single immediate read is occasionally empty.
 func flushAndGetLog(t *testing.T, ctx context.Context, ti *testInstance, projectID, urn string, timestamp time.Time) repo.TelemetryLog {
 	t.Helper()
 
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+	var logs []repo.TelemetryLog
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
-	logs, err := ti.chClient.ListTelemetryLogs(ctx, repo.ListTelemetryLogsParams{
-		GramProjectID: projectID,
-		TimeStart:     timestamp.Add(-1 * time.Minute).UnixNano(),
-		TimeEnd:       timestamp.Add(1 * time.Minute).UnixNano(),
-		GramURNs:      []string{urn},
-		SortOrder:     "desc",
-		Cursor:        "",
-		Limit:         10,
-	})
-	require.NoError(t, err)
-	require.Len(t, logs, 1, "expected 1 log in ClickHouse")
+		var err error
+		logs, err = ti.chClient.ListTelemetryLogs(ctx, repo.ListTelemetryLogsParams{
+			GramProjectID: projectID,
+			TimeStart:     timestamp.Add(-1 * time.Minute).UnixNano(),
+			TimeEnd:       timestamp.Add(1 * time.Minute).UnixNano(),
+			GramURNs:      []string{urn},
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		assert.NoError(c, err)
+		assert.Len(c, logs, 1, "expected 1 log in ClickHouse")
+	}, 10*time.Second, 50*time.Millisecond)
 
 	return logs[0]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- poll telemetry log reads after flushing ClickHouse async inserts
- allow up to 10 seconds for delayed row visibility under loaded CI runners
- retain the shared helper's exact-one-row assertion

## Testing
- `mise exec -- go test ./server/internal/telemetry -run '^TestCreateLog_ToolIOBodyContentNotPresentWhenNotRecorded$' -count=20`
- `mise exec -- go test ./server/internal/telemetry -run '^TestCreateLog_' -count=10`
- `mise exec -- go test ./server/internal/telemetry -count=1`
- `mise lint:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-378](https://linear.app/speakeasy/issue/AIS-378/flaky-test-testcreatelog-tooliobodycontentnotpresentwhennotrecorded)

<div><a href="https://cursor.com/agents/bc-3bf407fa-606b-4e7f-91c9-0f89117a3237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bf407fa-606b-4e7f-91c9-0f89117a3237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes ClickHouse telemetry log tests by polling reads after flushing async inserts, preventing empty reads under CI load. Addresses Linear issue AIS-378 by keeping the exact-one-row check while allowing brief visibility delays.

- **Bug Fixes**
  - Updated flush helper to flush then poll with `require.EventuallyWithT` (10s timeout, 50ms interval) until one log is returned.
  - Uses `assert` within the poll loop; preserves the single-row assertion and avoids flaky failures.

<sup>Written for commit 2a65e1a05e11a5d8cd63c667c3b30b21b2db9884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

