### PR TITLE
fix: resolve Billing relative date filters locally

### DIFF
--- a/.changeset/billing-relative-date-ranges.md
+++ b/.changeset/billing-relative-date-ranges.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Make common relative date ranges on the Billing page work without an AI request, including "this month", "this year", and "since July 1".

--- a/client/dashboard/src/elements/components/ui/time-range-picker.test.ts
+++ b/client/dashboard/src/elements/components/ui/time-range-picker.test.ts
@@ -26,13 +26,79 @@ vi.mock("@/elements/lib/errorTracking", () => ({ trackError: vi.fn() }));
 
 import {
   getPresetRange,
+  parseRelativeTimeRange,
   parseWithAI,
   resolveParsedRange,
 } from "./time-range-picker";
 
+describe("parseRelativeTimeRange", () => {
+  const now = new Date(2026, 6, 27, 15, 30);
+
+  it("parses this month from the first day through now", () => {
+    expect(parseRelativeTimeRange("this month", now)).toEqual({
+      type: "custom",
+      range: {
+        from: new Date(2026, 6, 1),
+        to: now,
+      },
+      label: "Jul",
+    });
+  });
+
+  it("parses this year from January 1 through now", () => {
+    expect(parseRelativeTimeRange("this year", now)).toEqual({
+      type: "custom",
+      range: {
+        from: new Date(2026, 0, 1),
+        to: now,
+      },
+      label: "2026",
+    });
+  });
+
+  it("parses a since date through now", () => {
+    expect(parseRelativeTimeRange("since July 1", now)).toEqual({
+      type: "custom",
+      range: {
+        from: new Date(2026, 6, 1),
+        to: now,
+      },
+      label: "7/1-7/27",
+    });
+  });
+
+  it("uses the most recent matching date when no year is provided", () => {
+    expect(parseRelativeTimeRange("since Dec 1st", now)).toEqual({
+      type: "custom",
+      range: {
+        from: new Date(2025, 11, 1),
+        to: now,
+      },
+      label: "12/1-7/27",
+    });
+  });
+
+  it("rejects invalid and future explicit dates", () => {
+    expect(parseRelativeTimeRange("since February 30", now)).toBeNull();
+    expect(parseRelativeTimeRange("since August 1, 2026", now)).toBeNull();
+  });
+});
+
 describe("parseWithAI request auth", () => {
   beforeEach(() => {
     createOpenRouterMock.mockClear();
+  });
+
+  it("resolves common relative ranges without an API request", async () => {
+    const parsed = await parseWithAI(
+      "this month",
+      "https://app.getgram.ai",
+      "proj-slug",
+      { "Gram-Session": "test-token" },
+    );
+
+    expect(parsed?.type).toBe("custom");
+    expect(createOpenRouterMock).not.toHaveBeenCalled();
   });
 
   // Root-cause regression test: the /chat/completions proxy authenticates from

--- a/client/dashboard/src/elements/components/ui/time-range-picker.tsx
+++ b/client/dashboard/src/elements/components/ui/time-range-picker.tsx
@@ -171,6 +171,102 @@ type ParseResult =
   | { type: "custom"; range: TimeRange; label?: string }
   | null;
 
+const MONTH_INDEX_BY_NAME: Readonly<Record<string, number>> = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11,
+};
+const SINCE_DATE_PATTERN =
+  /^since\s+([a-z]+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(\d{4}))?$/i;
+
+/**
+ * Resolve common calendar-relative ranges locally.
+ *
+ * These inputs are deterministic and should not depend on the availability of
+ * the AI parsing endpoint. More flexible natural-language input still falls
+ * through to parseWithAI.
+ */
+export function parseRelativeTimeRange(
+  input: string,
+  now = new Date(),
+): ParseResult {
+  const normalizedInput = input.trim().replace(/\s+/g, " ").toLowerCase();
+
+  if (normalizedInput === "this month") {
+    const from = new Date(now.getFullYear(), now.getMonth(), 1);
+    return {
+      type: "custom",
+      range: { from, to: new Date(now) },
+      label: from.toLocaleDateString("en-US", { month: "short" }),
+    };
+  }
+
+  if (normalizedInput === "this year") {
+    return {
+      type: "custom",
+      range: {
+        from: new Date(now.getFullYear(), 0, 1),
+        to: new Date(now),
+      },
+      label: String(now.getFullYear()),
+    };
+  }
+
+  const sinceMatch = SINCE_DATE_PATTERN.exec(normalizedInput);
+  if (!sinceMatch) return null;
+
+  const month = MONTH_INDEX_BY_NAME[sinceMatch[1]!];
+  const day = Number(sinceMatch[2]);
+  const explicitYear = sinceMatch[3] ? Number(sinceMatch[3]) : null;
+  if (month === undefined || day < 1 || day > 31) return null;
+
+  let year = explicitYear ?? now.getFullYear();
+  let from = new Date(year, month, day);
+
+  // Without a year, "since Dec 1" in July means the most recent Dec 1.
+  if (explicitYear === null && from.getTime() > now.getTime()) {
+    year -= 1;
+    from = new Date(year, month, day);
+  }
+
+  // Reject invalid dates (e.g. February 30) and explicit future ranges.
+  if (
+    from.getFullYear() !== year ||
+    from.getMonth() !== month ||
+    from.getDate() !== day ||
+    from.getTime() > now.getTime()
+  ) {
+    return null;
+  }
+
+  return {
+    type: "custom",
+    range: { from, to: new Date(now) },
+    label: `${month + 1}/${day}-${now.getMonth() + 1}/${now.getDate()}`,
+  };
+}
+
 // Exported for unit testing. Decides how a successful parse is applied given
 // the picker's available presets: `availablePresets` only limits the
 // quick-pick options, so typed input that the AI normalizes to a preset
@@ -240,6 +336,9 @@ export async function parseWithAI(
   projectSlug?: string,
   authHeaders?: Record<string, string>,
 ): Promise<ParseResult> {
+  const relativeRange = parseRelativeTimeRange(input);
+  if (relativeRange) return relativeRange;
+
   try {
     const now = new Date();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- parse `this month`, `this year`, and `since <month> <day>` deterministically in the shared time-range picker
- avoid the project-scoped AI request for these common ranges, so organization-level Billing filters do not silently fail when that endpoint is unavailable
- handle omitted years as the most recent matching date and reject invalid/future explicit dates
- add focused regression coverage and a dashboard patch changeset

## Verification
- `pnpm -F dashboard test` — 1,126 tests passed
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:format`
- `pnpm -F dashboard lint:oxlint`
- manual Billing walkthrough: all three reported inputs update the date window and chart, with Reset restoring the billing cycle between inputs

<a href="https://cursor.com/agents/bc-efc7cc59-c817-4100-86c8-50f6182c2150/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbilling_relative_date_filters.mp4"><img src="https://cursor.com/artifacts/c/art-a8f8ad96-bb37-4dce-a491-d3ab7360cb36" alt="billing_relative_date_filters.mp4" /></a>

Issue: DNO-650
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-650](https://linear.app/speakeasy/issue/DNO-650/bug-billing-page-date-range-custom-filters-are-broken)

<div><a href="https://cursor.com/agents/bc-efc7cc59-c817-4100-86c8-50f6182c2150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efc7cc59-c817-4100-86c8-50f6182c2150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

