### PR TITLE
test: deflake shadow MCP inventory backfill

### DIFF
--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -660,8 +660,6 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 		ObservedAt: observedAt.Add(time.Hour),
 	})
 
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
-
 	result, err := ti.service.BackfillShadowMCPInventoryURLs(ctx, telemetry.BackfillShadowMCPInventoryURLsParams{
 		GramProjectID:      projectID,
 		Limit:              50,
@@ -678,8 +676,6 @@ func TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 1, result.InventoryURLCount)
-
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	rows, err := ti.chClient.ListShadowMCPInventoryURLs(ctx, telemetryRepo.ListShadowMCPInventoryURLsParams{
 		GramProjectID: projectID,
@@ -779,7 +775,10 @@ func insertHistoricalShadowMCPCall(t *testing.T, ctx context.Context, ti *testIn
 
 	spanID := uuid.New().String()[:16]
 	traceID := strings.ReplaceAll(uuid.NewString(), "-", "")
-	err = ti.chClient.InsertTelemetryLog(ctx, telemetryRepo.InsertTelemetryLogParams{
+	// Promotion writes live telemetry synchronously, including attached
+	// materialized views, so tests can read trace_summaries without a global
+	// async-insert queue flush.
+	err = ti.chClient.InsertPromotedTelemetryLogs(ctx, []telemetryRepo.InsertTelemetryLogParams{{
 		ID:                   uuid.NewString(),
 		TimeUnixNano:         p.ObservedAt.UnixNano(),
 		ObservedTimeUnixNano: p.ObservedAt.UnixNano(),
@@ -796,9 +795,10 @@ func insertHistoricalShadowMCPCall(t *testing.T, ctx context.Context, ti *testIn
 		ServiceName:          "gram-hooks",
 		ServiceVersion:       nil,
 		GramChatID:           nil,
-	})
+	}})
 	require.NoError(t, err)
 }
+
 func inventoryURLRows(rows []telemetryRepo.ShadowMCPInventoryURLRow) []string {
 	urls := make([]string, 0, len(rows))
 	for _, row := range rows {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- seed historical Shadow MCP telemetry synchronously in inventory tests
- remove the target test's dependency on the global async-insert queue flush
- ensure `trace_summaries` materialized-view rows are visible before backfill assertions

## Testing

- `mise exec -- go test ./internal/telemetry -race -run 'TestBackfillShadowMCPInventoryURLs_CanonicalizesAndUpserts' -count=100`
- `mise exec -- go test ./internal/telemetry -race -run 'ShadowMCP' -count=20`
- `mise lint:server`

Resolves AIS-380.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-380](https://linear.app/speakeasy/issue/AIS-380/flaky-test-testbackfillshadowmcpinventoryurls-canonicalizesandupserts)

<div><a href="https://cursor.com/agents/bc-bda63cb5-b973-4ef4-a4a6-f832021f9be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bda63cb5-b973-4ef4-a4a6-f832021f9be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes the Shadow MCP inventory backfill test by writing historical telemetry synchronously and removing reliance on the global async-insert flush, making materialized-view rows visible before assertions. Resolves AIS-380.

- Bug Fixes
  - Seed test data via InsertPromotedTelemetryLogs to write live telemetry and materialized views synchronously.
  - Remove FlushClickHouseAsyncInserts calls; inventory URL reads are now deterministic.

<sup>Written for commit 8c9ee0b7395f2fc527abc897589d697c1a271015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

