### PR TITLE
mig: add shadow MCP disposition column to risk_policies

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4093,6 +4093,14 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   scope_exempt TEXT,
   action TEXT NOT NULL DEFAULT 'flag',
   audience_type TEXT NOT NULL DEFAULT 'everyone',
+  -- Default disposition for shadow MCP blocking policies (action = 'block'
+  -- with the 'shadow_mcp' source): 'block_all' blocks every non-Gram-hosted
+  -- server unless allowed, 'allow_all' permits every server unless blocked.
+  -- Both exception lists live in RBAC grants (allow list = risk_policy:bypass,
+  -- block list = risk_policy:block), not on this row. NULL means 'block_all'
+  -- (the original behavior). Immutable after create; switching posture
+  -- requires delete + recreate. Valid values enforced in application layer.
+  shadow_mcp_disposition TEXT,
   auto_name BOOLEAN NOT NULL DEFAULT TRUE,
   user_message TEXT,
   -- For policy_type = 'prompt_based': the prompt-based guardrail the LLM judge

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1644,6 +1644,7 @@ type RiskPolicy struct {
 	ScopeExempt          pgtype.Text
 	Action               string
 	AudienceType         string
+	ShadowMcpDisposition pgtype.Text
 	AutoName             bool
 	UserMessage          pgtype.Text
 	Prompt               pgtype.Text

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -60,6 +60,7 @@ type RiskPolicy struct {
 	ScopeExempt          pgtype.Text
 	Action               string
 	AudienceType         string
+	ShadowMcpDisposition pgtype.Text
 	AutoName             bool
 	UserMessage          pgtype.Text
 	Prompt               pgtype.Text

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -257,7 +257,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -286,6 +286,7 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
+		&i.ShadowMcpDisposition,
 		&i.AutoName,
 		&i.UserMessage,
 		&i.Prompt,
@@ -674,7 +675,7 @@ VALUES (
   , COALESCE($22::double precision, 5.0)
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -746,6 +747,7 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
+		&i.ShadowMcpDisposition,
 		&i.AutoName,
 		&i.UserMessage,
 		&i.Prompt,
@@ -1405,7 +1407,7 @@ func (q *Queries) GetRiskOverviewScanCounts(ctx context.Context, arg GetRiskOver
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1438,6 +1440,7 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
+		&i.ShadowMcpDisposition,
 		&i.AutoName,
 		&i.UserMessage,
 		&i.Prompt,
@@ -1493,7 +1496,7 @@ func (q *Queries) GetRiskPolicyBypassRequest(ctx context.Context, arg GetRiskPol
 }
 
 const getRiskPolicyForUpdate = `-- name: GetRiskPolicyForUpdate :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -1527,6 +1530,7 @@ func (q *Queries) GetRiskPolicyForUpdate(ctx context.Context, arg GetRiskPolicyF
 		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
+		&i.ShadowMcpDisposition,
 		&i.AutoName,
 		&i.UserMessage,
 		&i.Prompt,
@@ -1743,7 +1747,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1780,6 +1784,7 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
+			&i.ShadowMcpDisposition,
 			&i.AutoName,
 			&i.UserMessage,
 			&i.Prompt,
@@ -1853,7 +1858,7 @@ func (q *Queries) ListEnabledExclusionsForPolicy(ctx context.Context, arg ListEn
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1887,6 +1892,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
+			&i.ShadowMcpDisposition,
 			&i.AutoName,
 			&i.UserMessage,
 			&i.Prompt,
@@ -1909,7 +1915,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -1945,6 +1951,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
+			&i.ShadowMcpDisposition,
 			&i.AutoName,
 			&i.UserMessage,
 			&i.Prompt,
@@ -1967,7 +1974,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -2006,6 +2013,7 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
+			&i.ShadowMcpDisposition,
 			&i.AutoName,
 			&i.UserMessage,
 			&i.Prompt,
@@ -2312,7 +2320,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -2346,6 +2354,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.ScopeExempt,
 			&i.Action,
 			&i.AudienceType,
+			&i.ShadowMcpDisposition,
 			&i.AutoName,
 			&i.UserMessage,
 			&i.Prompt,
@@ -3855,7 +3864,7 @@ SET name = $1
 WHERE id = $19
   AND project_id = $20
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -3923,6 +3932,7 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.ScopeExempt,
 		&i.Action,
 		&i.AudienceType,
+		&i.ShadowMcpDisposition,
 		&i.AutoName,
 		&i.UserMessage,
 		&i.Prompt,

--- a/server/migrations/20260728180048_shadow-mcp-policy-gates.sql
+++ b/server/migrations/20260728180048_shadow-mcp-policy-gates.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "shadow_mcp_disposition" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:g9FN8zPhUSzqzkes1Ebd53yaH03KlGqewOg4zsxcnZU=
+h1:nK6CZpT6lanjmh8+rQULRMisESTsBmVTTCoyZhHfaiI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -302,3 +302,4 @@ h1:g9FN8zPhUSzqzkes1Ebd53yaH03KlGqewOg4zsxcnZU=
 20260727224939_device-agent-syncs-lower-email-idx.sql h1:3CMLuaTHwK5tJmwg00pedj5vsj0s5Q6TF4yCASaZlP0=
 20260727233742_chat-content-parts.sql h1:Z0oj3IaXFhP+YUZziMHME4AnKQgdBEkRvquoCORjBU4=
 20260728103328_dno_569_skill_feedback_schema.sql h1:TdiYFG8KGdlKTU+gjI711O9BRh3iO44xAkkyD/X9JtY=
+20260728180048_shadow-mcp-policy-gates.sql h1:H1/CKCAzAPKMfNb8kYnWaGseH4/DN8kIyhYazDYuiC8=


### PR DESCRIPTION
## Summary

- adds a nullable `shadow_mcp_disposition` (text) column to `risk_policies`
- regenerates SQLc models for the new column
- DDL only; a `NULL` disposition reads as `block_all` in the application layer, so existing rows keep their current behavior as-is

## Root cause

Shadow MCP blocking policies gain a creation-time default disposition: `block_all` (deny non-Gram-hosted servers unless allowed) or `allow_all` (permit servers unless blocked). Each disposition's per-URL exception rules live in RBAC grants — `risk_policy:bypass` for allow lists, `risk_policy:block` for block lists — so the disposition itself is the only new column.

Part of the Shadow MCP Policy Gates project (DNO-624–DNO-629). Application changes follow in stacked PRs.

## Test plan

- [x] `mise run db:reset` + `mise run db:migrate` apply cleanly
- [x] `mise run gen:sqlc-server` produces no drift
- [x] server builds and existing risk tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
