### PR TITLE
feat: shadow MCP policy disposition picker and server selector inversion

### DIFF
--- a/.changeset/shadow-mcp-disposition-ui.md
+++ b/.changeset/shadow-mcp-disposition-ui.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Shadow MCP policy creation now offers a default-disposition choice: Block all servers (allow exceptions) or Allow all servers (block exceptions). The server selector flips between picking allowed and blocked servers to match, and the disposition is shown read-only when editing since switching posture requires deleting and recreating the policy.

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPDispositionPicker.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPDispositionPicker.tsx
@@ -1,0 +1,101 @@
+import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup";
+import { Text } from "@/components/ui/Text";
+import { cn } from "@/lib/utils";
+import type { ShadowMCPDisposition } from "@/pages/security/policy-shadow-mcp-setup";
+
+const DISPOSITION_OPTIONS: {
+  value: ShadowMCPDisposition;
+  title: string;
+  description: string;
+}[] = [
+  {
+    value: "block_all",
+    title: "Block all servers",
+    description:
+      "Every Shadow MCP server is blocked unless you allow it. Best for locked-down environments.",
+  },
+  {
+    value: "allow_all",
+    title: "Allow all servers",
+    description:
+      "Every Shadow MCP server stays available unless you block it. Best for rolling out enforcement gradually.",
+  },
+];
+
+export type ShadowMCPDispositionPickerProps = {
+  value: ShadowMCPDisposition;
+  onChange: (next: ShadowMCPDisposition) => void;
+  /** Edit mode: the disposition is immutable after create, so render the
+   * choice read-only with an explanation. */
+  readOnly: boolean;
+};
+
+export function ShadowMCPDispositionPicker({
+  value,
+  onChange,
+  readOnly,
+}: ShadowMCPDispositionPickerProps): JSX.Element {
+  return (
+    <section
+      aria-labelledby="shadow-mcp-disposition-picker-title"
+      className="space-y-3"
+    >
+      <div>
+        <Text
+          id="shadow-mcp-disposition-picker-title"
+          variant="body"
+          className="font-medium"
+        >
+          Default behavior
+        </Text>
+        <Text muted small className="mt-1">
+          How this policy treats Shadow MCP servers that have no rule.
+        </Text>
+      </div>
+      <RadioGroup
+        value={value}
+        onValueChange={(next) => {
+          if (readOnly) return;
+          onChange(next as ShadowMCPDisposition);
+        }}
+        className="space-y-2.5"
+      >
+        {DISPOSITION_OPTIONS.map((opt) => {
+          const selected = value === opt.value;
+          const disabled = readOnly && !selected;
+
+          return (
+            <label
+              key={opt.value}
+              htmlFor={`shadow-mcp-disposition-${opt.value}`}
+              className={cn(
+                "grid grid-cols-[auto_1fr] items-center gap-x-3 rounded-lg border p-3.5 transition-colors",
+                disabled
+                  ? "border-border cursor-not-allowed opacity-60"
+                  : selected
+                    ? "border-foreground bg-muted/40 cursor-default"
+                    : "border-border hover:bg-muted/30 cursor-pointer",
+              )}
+            >
+              <RadioGroupItem
+                value={opt.value}
+                id={`shadow-mcp-disposition-${opt.value}`}
+                disabled={readOnly}
+              />
+              <span className="text-sm font-medium">{opt.title}</span>
+              <div className="text-muted-foreground col-start-2 mt-1.5 text-xs">
+                {opt.description}
+              </div>
+            </label>
+          );
+        })}
+      </RadioGroup>
+      {readOnly && (
+        <Text muted small>
+          The disposition is locked after a policy is created. To switch, delete
+          this policy (and its rules) and create a new one.
+        </Text>
+      )}
+    </section>
+  );
+}

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyServerSelector.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyServerSelector.tsx
@@ -20,7 +20,7 @@ import {
   type ShadowMCPInventoryStatus,
 } from "./shadowMCPInventoryStatus";
 
-export type ShadowMCPPolicyServerSelectorMode = "allow" | "block";
+type ShadowMCPPolicyServerSelectorMode = "allow" | "block";
 
 export type ShadowMCPPolicyServerSelectorProps = {
   servers: ShadowMCPInventoryServer[];

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyServerSelector.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyServerSelector.tsx
@@ -20,6 +20,8 @@ import {
   type ShadowMCPInventoryStatus,
 } from "./shadowMCPInventoryStatus";
 
+export type ShadowMCPPolicyServerSelectorMode = "allow" | "block";
+
 export type ShadowMCPPolicyServerSelectorProps = {
   servers: ShadowMCPInventoryServer[];
   originalURLs: ReadonlySet<string>;
@@ -28,6 +30,44 @@ export type ShadowMCPPolicyServerSelectorProps = {
   isLoading: boolean;
   error: Error | null;
   onRetry: () => void;
+  /** "allow" (block_all policies — pick servers that stay available) or
+   * "block" (allow_all policies — pick servers that get denied). */
+  mode?: ShadowMCPPolicyServerSelectorMode;
+};
+
+const SELECTOR_COPY: Record<
+  ShadowMCPPolicyServerSelectorMode,
+  {
+    title: string;
+    subtitle: string;
+    emptyTitle: string;
+    emptySubtitle: string;
+    dialogTitle: string;
+    dialogDescription: string;
+  }
+> = {
+  allow: {
+    title: "Servers allowed by this policy",
+    subtitle:
+      "These Shadow MCP servers remain available when the policy blocks access.",
+    emptyTitle: "No servers allowed yet",
+    emptySubtitle:
+      "Select any Shadow MCP servers that should remain available when this policy blocks access.",
+    dialogTitle: "Select allowed servers",
+    dialogDescription:
+      "Choose which Shadow MCP servers remain available when this policy blocks access.",
+  },
+  block: {
+    title: "Servers blocked by this policy",
+    subtitle:
+      "These Shadow MCP servers are denied while every other server stays available.",
+    emptyTitle: "No servers blocked yet",
+    emptySubtitle:
+      "Select any Shadow MCP servers that should be denied while this policy allows everything else.",
+    dialogTitle: "Select blocked servers",
+    dialogDescription:
+      "Choose which Shadow MCP servers are denied while this policy allows everything else.",
+  },
 };
 
 type PolicyServerAction = "add" | "remove" | "no-change";
@@ -104,9 +144,17 @@ function StatusCell({ server }: { server: ShadowMCPInventoryServer }) {
   );
 }
 
-function EmptyServerSelection({ onSelect }: { onSelect: () => void }) {
+function EmptyServerSelection({
+  onSelect,
+  title,
+  subtitle,
+}: {
+  onSelect: () => void;
+  title: string;
+  subtitle: string;
+}) {
   return (
-    <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-8 py-10 text-center">
+    <div className="bg-muted/20 flex flex-col items-center justify-center rounded-xl border border-dashed px-6 py-8 text-center">
       <div className="bg-muted/50 mb-4 flex h-12 w-12 items-center justify-center rounded-full">
         <Icon
           aria-hidden="true"
@@ -115,11 +163,10 @@ function EmptyServerSelection({ onSelect }: { onSelect: () => void }) {
         />
       </div>
       <Text variant="subheading" className="mb-1">
-        No servers allowed yet
+        {title}
       </Text>
       <Text small muted className="mb-4 max-w-md">
-        Select any Shadow MCP servers that should remain available when this
-        policy blocks access.
+        {subtitle}
       </Text>
       <Button type="button" variant="primary" onClick={onSelect}>
         Select servers
@@ -234,7 +281,9 @@ export function ShadowMCPPolicyServerSelector({
   isLoading,
   error,
   onRetry,
+  mode = "allow",
 }: ShadowMCPPolicyServerSelectorProps): JSX.Element {
+  const copy = SELECTOR_COPY[mode];
   const [open, setOpen] = useState(false);
   const [draftURLs, setDraftURLs] = useState<Set<string>>(
     () => new Set(selectedURLs),
@@ -398,7 +447,11 @@ export function ShadowMCPPolicyServerSelector({
     );
   } else if (!hasAppliedRows) {
     selectionContent = (
-      <EmptyServerSelection onSelect={() => handleOpenChange(true)} />
+      <EmptyServerSelection
+        onSelect={() => handleOpenChange(true)}
+        title={copy.emptyTitle}
+        subtitle={copy.emptySubtitle}
+      />
     );
   } else {
     selectionContent = <AppliedServerTable rows={appliedRows} />;
@@ -416,11 +469,10 @@ export function ShadowMCPPolicyServerSelector({
             variant="body"
             className="font-medium"
           >
-            Servers allowed by this policy
+            {copy.title}
           </Text>
           <Text muted small className="mt-1">
-            These Shadow MCP servers remain available when the policy blocks
-            access.
+            {copy.subtitle}
           </Text>
         </div>
         {showHeaderAction && (
@@ -456,11 +508,8 @@ export function ShadowMCPPolicyServerSelector({
           }}
         >
           <Dialog.Header>
-            <Dialog.Title>Select allowed servers</Dialog.Title>
-            <Dialog.Description>
-              Choose which Shadow MCP servers remain available when this policy
-              blocks access.
-            </Dialog.Description>
+            <Dialog.Title>{copy.dialogTitle}</Dialog.Title>
+            <Dialog.Description>{copy.dialogDescription}</Dialog.Description>
           </Dialog.Header>
 
           <Input

--- a/client/dashboard/src/components/shadow-mcp/useShadowMCPPolicyInventory.ts
+++ b/client/dashboard/src/components/shadow-mcp/useShadowMCPPolicyInventory.ts
@@ -67,3 +67,14 @@ export function initialShadowMCPPolicyURLs(
       .map((server) => server.canonicalServerUrl),
   );
 }
+
+export function initialShadowMCPBlockedPolicyURLs(
+  servers: readonly ShadowMCPInventoryServer[],
+  policyID: string,
+): Set<string> {
+  return new Set(
+    servers
+      .filter((server) => server.blockedPolicyIds.includes(policyID))
+      .map((server) => server.canonicalServerUrl),
+  );
+}

--- a/client/dashboard/src/pages/security/PolicyDetail.shadow-mcp.test.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.shadow-mcp.test.tsx
@@ -12,6 +12,7 @@ import { StandardPolicyEditor } from "./PolicyDetail";
 const mocks = vi.hoisted(() => ({
   saveDisabledRenders: [] as boolean[],
   selectionRenders: [] as string[][],
+  modeRenders: [] as string[],
   step: "action" as string | null,
   mutateCreate: vi.fn(),
   mutateUpdate: vi.fn(),
@@ -40,10 +41,13 @@ vi.mock("nuqs", () => ({
 vi.mock("@/components/shadow-mcp/ShadowMCPPolicyServerSelector", () => ({
   ShadowMCPPolicyServerSelector: ({
     selectedURLs,
+    mode = "allow",
   }: {
     selectedURLs: ReadonlySet<string>;
+    mode?: string;
   }) => {
     mocks.selectionRenders.push([...selectedURLs].sort());
+    mocks.modeRenders.push(mode);
     return null;
   },
 }));
@@ -128,7 +132,9 @@ vi.mock("@/components/ui/Button", async (importOriginal) => {
   return { ...actual, Button: TestButton };
 });
 
-function inventoryServer(): ShadowMCPInventoryServer {
+function inventoryServer(
+  overrides: Partial<ShadowMCPInventoryServer> = {},
+): ShadowMCPInventoryServer {
   return {
     access: "allowed",
     allowedPolicyIds: ["policy-1"],
@@ -144,6 +150,7 @@ function inventoryServer(): ShadowMCPInventoryServer {
     topUsers: [],
     urlHost: "github.example.com",
     userCount: 1,
+    ...overrides,
   };
 }
 
@@ -179,6 +186,7 @@ describe("StandardPolicyEditor cached Shadow MCP inventory", () => {
   beforeEach(() => {
     mocks.saveDisabledRenders.length = 0;
     mocks.selectionRenders.length = 0;
+    mocks.modeRenders.length = 0;
     mocks.step = "action";
     vi.clearAllMocks();
     vi.mocked(useSdkClient).mockReturnValue({
@@ -210,5 +218,46 @@ describe("StandardPolicyEditor cached Shadow MCP inventory", () => {
     });
     expect(mocks.saveDisabledRenders[0]).toBe(true);
     expect(mocks.selectionRenders[0]).toEqual([]);
+    expect(mocks.modeRenders.at(-1)).toBe("allow");
+  });
+
+  it("seeds an allow_all policy's selection from its blocked-URL grants", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(shadowMCPPolicyInventoryQueryKey("project-1"), [
+      inventoryServer(),
+      inventoryServer({
+        access: "blocked",
+        allowedPolicyIds: [],
+        blockedPolicyIds: ["policy-1"],
+        canonicalServerUrl: "https://sketchy.example.com/mcp",
+        serverName: "Sketchy",
+        serverSlug: "sketchy-11111111",
+        urlHost: "sketchy.example.com",
+      }),
+    ]);
+
+    const allowAllPolicy: RiskPolicy = {
+      ...blockingPolicyWithDirtyDraftName(),
+      shadowMcpDisposition: "allow_all",
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <StandardPolicyEditor policy={allowAllPolicy} />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      // The selection comes from the inventory's per-URL block-grant view
+      // (blockedPolicyIds), and the selector flips to block mode.
+      expect(mocks.selectionRenders.at(-1)).toEqual([
+        "https://sketchy.example.com/mcp",
+      ]);
+      expect(mocks.modeRenders.at(-1)).toBe("block");
+    });
   });
 });

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -1,7 +1,9 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import { ShadowMCPDispositionPicker } from "@/components/shadow-mcp/ShadowMCPDispositionPicker";
 import { ShadowMCPPolicyServerSelector } from "@/components/shadow-mcp/ShadowMCPPolicyServerSelector";
 import {
+  initialShadowMCPBlockedPolicyURLs,
   initialShadowMCPPolicyURLs,
   invalidateShadowMCPPolicyInventory,
   useShadowMCPPolicyInventory,
@@ -83,9 +85,11 @@ import {
   isBlockingShadowMCPPolicy,
   isShadowMCPBlockConfiguration,
   shadowMCPAllowedURLsForMutation,
+  shadowMCPBlockedURLsForMutation,
   shadowMCPSelectionBaselineForUpdate,
   shadowMCPSelectionIsDirty,
   shadowMCPSelectionIsInitialized,
+  type ShadowMCPDisposition,
 } from "./policy-shadow-mcp-setup";
 import { type Step } from "@/pages/setup/components/onboarding-stepper";
 import {
@@ -3500,11 +3504,19 @@ export function StandardPolicyEditor({
   const [action, setAction] = useState<PolicyAction>(
     (policy?.action as PolicyAction) ?? "flag",
   );
+  // Under block_all the URL set holds allowed servers; under allow_all it
+  // holds blocked servers. The disposition is immutable after create, so the
+  // meaning never flips for an existing policy.
   const [selectedShadowMCPURLs, setSelectedShadowMCPURLs] = useState<
     Set<string>
   >(() => new Set());
   const [originalShadowMCPURLs, setOriginalShadowMCPURLs] =
     useState<Set<string> | null>(null);
+  const [shadowMCPDisposition, setShadowMCPDisposition] =
+    useState<ShadowMCPDisposition>(
+      () =>
+        (policy?.shadowMcpDisposition as ShadowMCPDisposition) ?? "block_all",
+    );
   const [userMessage, setUserMessage] = useState(policy?.userMessage ?? "");
   const [audienceType, setAudienceType] = useState<"everyone" | "targeted">(
     policy?.audienceType === "targeted" ? "targeted" : "everyone",
@@ -3554,10 +3566,16 @@ export function StandardPolicyEditor({
       return;
     }
 
-    const initialURLs =
-      policyID && originalHasShadowMCPBlockConfiguration
-        ? initialShadowMCPPolicyURLs(inventoryQuery.data, policyID)
-        : new Set<string>();
+    let initialURLs: ReadonlySet<string> = new Set<string>();
+    if (policyID && originalHasShadowMCPBlockConfiguration) {
+      // Both dispositions derive their URL set from per-URL grants surfaced
+      // on the inventory: bypass grants (allowed) for block_all policies,
+      // block grants (blocked) for allow_all policies.
+      initialURLs =
+        policy?.shadowMcpDisposition === "allow_all"
+          ? initialShadowMCPBlockedPolicyURLs(inventoryQuery.data, policyID)
+          : initialShadowMCPPolicyURLs(inventoryQuery.data, policyID);
+    }
     setSelectedShadowMCPURLs(new Set(initialURLs));
     setOriginalShadowMCPURLs(new Set(initialURLs));
     setInitializedInventoryForPolicy(editorIdentity);
@@ -3566,6 +3584,7 @@ export function StandardPolicyEditor({
     initializedInventoryForPolicy,
     inventoryQuery.data,
     originalHasShadowMCPBlockConfiguration,
+    policy,
     policyID,
     targetIsShadowMCPBlock,
   ]);
@@ -3714,9 +3733,18 @@ export function StandardPolicyEditor({
       selectedCategories,
       selectedURLs: selectedShadowMCPURLs,
       originalPolicy: policy,
+      disposition: shadowMCPDisposition,
     });
-    const setupFields =
-      shadowMcpAllowedUrls === undefined ? {} : { shadowMcpAllowedUrls };
+    const shadowMcpBlockedUrls = shadowMCPBlockedURLsForMutation({
+      action: resolvedAction,
+      selectedCategories,
+      selectedURLs: selectedShadowMCPURLs,
+      disposition: shadowMCPDisposition,
+    });
+    const setupFields = {
+      ...(shadowMcpAllowedUrls === undefined ? {} : { shadowMcpAllowedUrls }),
+      ...(shadowMcpBlockedUrls === undefined ? {} : { shadowMcpBlockedUrls }),
+    };
 
     if (policy) {
       updateMutation.mutate({
@@ -3771,6 +3799,11 @@ export function StandardPolicyEditor({
               ? { presidioScoreThreshold: presidioThreshold }
               : {}),
             ...setupFields,
+            // The disposition only exists on blocking shadow MCP policies and
+            // is immutable after create, so it is never sent on update.
+            ...(isBlockingShadowMCPPolicy(true, sources, resolvedAction)
+              ? { shadowMcpDisposition: shadowMCPDisposition }
+              : {}),
             ...(identityActive ? { approvedEmailDomains } : {}),
           },
         },
@@ -3896,15 +3929,36 @@ export function StandardPolicyEditor({
             flagOnlySelected={flagOnlySelected}
             shadowMCPAllowedServers={
               targetIsShadowMCPBlock ? (
-                <ShadowMCPPolicyServerSelector
-                  servers={inventoryQuery.data ?? []}
-                  originalURLs={originalShadowMCPURLs ?? EMPTY_SHADOW_MCP_URLS}
-                  selectedURLs={selectedShadowMCPURLs}
-                  onSelectionChange={setSelectedShadowMCPURLs}
-                  isLoading={inventoryQuery.isPending}
-                  error={inventoryQuery.error}
-                  onRetry={() => void inventoryQuery.refetch()}
-                />
+                <div className="grid gap-5 lg:grid-cols-3 lg:items-start">
+                  <ShadowMCPDispositionPicker
+                    value={shadowMCPDisposition}
+                    onChange={(next) => {
+                      if (next === shadowMCPDisposition) return;
+                      // The URL set's meaning flips with the disposition
+                      // (allowed vs blocked servers), so a stale selection
+                      // must not carry across.
+                      setShadowMCPDisposition(next);
+                      setSelectedShadowMCPURLs(new Set());
+                    }}
+                    readOnly={policy !== null}
+                  />
+                  <div className="lg:col-span-2">
+                    <ShadowMCPPolicyServerSelector
+                      servers={inventoryQuery.data ?? []}
+                      originalURLs={
+                        originalShadowMCPURLs ?? EMPTY_SHADOW_MCP_URLS
+                      }
+                      selectedURLs={selectedShadowMCPURLs}
+                      onSelectionChange={setSelectedShadowMCPURLs}
+                      isLoading={inventoryQuery.isPending}
+                      error={inventoryQuery.error}
+                      onRetry={() => void inventoryQuery.refetch()}
+                      mode={
+                        shadowMCPDisposition === "allow_all" ? "block" : "allow"
+                      }
+                    />
+                  </div>
+                </div>
               ) : undefined
             }
           />

--- a/client/dashboard/src/pages/security/policy-shadow-mcp-setup.test.ts
+++ b/client/dashboard/src/pages/security/policy-shadow-mcp-setup.test.ts
@@ -4,6 +4,7 @@ import {
   isBlockingShadowMCPPolicy,
   isShadowMCPBlockConfiguration,
   shadowMCPAllowedURLsForMutation,
+  shadowMCPBlockedURLsForMutation,
   shadowMCPSelectionBaselineForUpdate,
   shadowMCPSelectionIsDirty,
   shadowMCPSelectionIsInitialized,
@@ -147,5 +148,76 @@ describe("shadowMCPSelectionBaselineForUpdate", () => {
 
   it("does not invent a baseline when the field was omitted", () => {
     expect(shadowMCPSelectionBaselineForUpdate({})).toBeUndefined();
+  });
+});
+
+describe("shadowMCPAllowedURLsForMutation with allow_all disposition", () => {
+  it("never sends allowed URLs for an allow_all target", () => {
+    expect(
+      shadowMCPAllowedURLsForMutation({
+        action: "block",
+        selectedCategories: new Set(["shadow_mcp"]),
+        selectedURLs: new Set(["https://github.example.com/mcp"]),
+        originalPolicy: null,
+        disposition: "allow_all",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("shadowMCPBlockedURLsForMutation", () => {
+  it("returns sorted selected URLs for an allow_all blocking Shadow MCP target", () => {
+    expect(
+      shadowMCPBlockedURLsForMutation({
+        action: "block",
+        selectedCategories: new Set(["shadow_mcp"]),
+        selectedURLs: new Set([
+          "https://sketchy.example.com/mcp",
+          "https://bad.example.com/sse",
+        ]),
+        disposition: "allow_all",
+      }),
+    ).toEqual([
+      "https://bad.example.com/sse",
+      "https://sketchy.example.com/mcp",
+    ]);
+  });
+
+  it("omits blocked URLs under the block_all disposition", () => {
+    expect(
+      shadowMCPBlockedURLsForMutation({
+        action: "block",
+        selectedCategories: new Set(["shadow_mcp"]),
+        selectedURLs: new Set(["https://sketchy.example.com/mcp"]),
+        disposition: "block_all",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("omits blocked URLs when the target is not a blocking Shadow MCP policy", () => {
+    expect(
+      shadowMCPBlockedURLsForMutation({
+        action: "flag",
+        selectedCategories: new Set(["shadow_mcp"]),
+        selectedURLs: new Set(["https://sketchy.example.com/mcp"]),
+        disposition: "allow_all",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("shadowMCPSelectionBaselineForUpdate with blocked URLs", () => {
+  it("returns the explicitly submitted blocked URL set", () => {
+    expect(
+      shadowMCPSelectionBaselineForUpdate({
+        shadowMcpBlockedUrls: ["https://sketchy.example.com/mcp"],
+      }),
+    ).toEqual(new Set(["https://sketchy.example.com/mcp"]));
+  });
+
+  it("returns an empty baseline for an explicit blocked-list clear", () => {
+    expect(
+      shadowMCPSelectionBaselineForUpdate({ shadowMcpBlockedUrls: [] }),
+    ).toEqual(new Set());
   });
 });

--- a/client/dashboard/src/pages/security/policy-shadow-mcp-setup.ts
+++ b/client/dashboard/src/pages/security/policy-shadow-mcp-setup.ts
@@ -2,6 +2,12 @@ import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
 
 type OriginalPolicy = Pick<RiskPolicy, "action" | "enabled" | "sources">;
 
+/** Default disposition of a shadow MCP blocking policy. block_all denies every
+ * server unless allowed (the original behavior); allow_all permits every
+ * server unless it appears on the policy's blocked-URL list. Immutable after
+ * create. */
+export type ShadowMCPDisposition = "block_all" | "allow_all";
+
 export function isShadowMCPBlockConfiguration(
   sources: readonly string[],
   action: string,
@@ -22,12 +28,19 @@ export function shadowMCPAllowedURLsForMutation({
   selectedCategories,
   selectedURLs,
   originalPolicy,
+  disposition = "block_all",
 }: {
   action: string;
   selectedCategories: ReadonlySet<string>;
   selectedURLs: ReadonlySet<string>;
   originalPolicy: OriginalPolicy | null;
+  disposition?: ShadowMCPDisposition;
 }): string[] | undefined {
+  // Allowed URLs are a block_all concept; an allow_all policy carries a
+  // blocked list instead (shadowMCPBlockedURLsForMutation) and the server
+  // rejects allowed URLs on it.
+  if (disposition === "allow_all") return undefined;
+
   const targetIsShadowMCPBlock = isBlockingShadowMCPPolicy(
     true,
     [...selectedCategories],
@@ -43,6 +56,31 @@ export function shadowMCPAllowedURLsForMutation({
   }
 
   return undefined;
+}
+
+export function shadowMCPBlockedURLsForMutation({
+  action,
+  selectedCategories,
+  selectedURLs,
+  disposition,
+}: {
+  action: string;
+  selectedCategories: ReadonlySet<string>;
+  selectedURLs: ReadonlySet<string>;
+  disposition: ShadowMCPDisposition;
+}): string[] | undefined {
+  // The blocked list only exists on allow_all blocking shadow MCP policies.
+  // There is no clear-on-morph branch like the allowed-URL helper has: the
+  // server rejects source/action changes on a policy with a stored
+  // disposition, so an allow_all policy can never stop being one.
+  if (disposition !== "allow_all") return undefined;
+  const targetIsShadowMCPBlock = isBlockingShadowMCPPolicy(
+    true,
+    [...selectedCategories],
+    action,
+  );
+  if (!targetIsShadowMCPBlock) return undefined;
+  return [...selectedURLs].sort();
 }
 
 export function shadowMCPSelectionIsDirty(
@@ -71,7 +109,12 @@ export function shadowMCPSelectionIsInitialized(
 
 export function shadowMCPSelectionBaselineForUpdate(body: {
   shadowMcpAllowedUrls?: readonly string[];
+  shadowMcpBlockedUrls?: readonly string[];
 }): Set<string> | undefined {
+  // The two lists are disposition-exclusive, so at most one key is present.
+  if (Object.prototype.hasOwnProperty.call(body, "shadowMcpBlockedUrls")) {
+    return new Set(body.shadowMcpBlockedUrls ?? []);
+  }
   if (!Object.prototype.hasOwnProperty.call(body, "shadowMcpAllowedUrls")) {
     return undefined;
   }

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCPServerDetail.test.tsx
@@ -824,6 +824,7 @@ describe("ShadowMCPServerDetail", () => {
       data: inventoryServer({
         access: "none",
         allowedPolicyIds: [],
+        blockedPolicyIds: [],
       }),
       error: null,
       isLoading: false,
@@ -964,6 +965,7 @@ describe("ShadowMCPServerDetail", () => {
       data: inventoryServer({
         access: "none",
         allowedPolicyIds: [],
+        blockedPolicyIds: [],
         latestRequest: {
           id: "request-1",
           policyId: "cached-policy",


### PR DESCRIPTION
## Summary

- adds a disposition radio-card picker (`Block by default` / `Allow by default`) to shadow MCP policy creation
- picker is read-only when editing an existing policy, with copy explaining delete + recreate to switch
- server selector inverts under allow-all: selection builds the blocked list, with block-mode titles, dialog copy, and empty states
- editing an allow-all policy seeds the selection from the inventory's `blockedPolicyIds` (per-URL block-grant attribution) — the same pattern block-all uses for allowed URLs via `allowedPolicyIds`
- disposition is sent on create only, and only for blocking shadow MCP policies

https://github.com/user-attachments/assets/36835ba9-ed93-49d4-9a9a-8e415f56fb85

## Root cause

With dispositions in the API (DNO-624/625), the policy editor needs to let users choose the default posture at creation time and repurpose the server selector for block rules under allow-all, while keeping the disposition immutable in the edit flow.

DNO-627. Stacked on DNO-626. Frontend only.

## Test plan

- [x] unit tests for `shadowMCPBlockedURLsForMutation` / selection baseline handling in `policy-shadow-mcp-setup.test.ts`
- [x] `PolicyDetail.shadow-mcp.test.tsx` covers allow-all seeding from inventory block-grant attribution
- [x] `pnpm tsc -p tsconfig.app.json --noEmit` and `pnpm lint` clean
- [x] manual dashboard pass (create both dispositions, verify read-only picker on edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
