### PR TITLE
fix: sensitivity slider placement (AIS-338)

### DIFF
--- a/.changeset/sensitivity-slider-detect-step.md
+++ b/.changeset/sensitivity-slider-detect-step.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Move the detection sensitivity slider from its own policy-editor stage into the Detect stage. The slider now appears as a card below the detector categories, only while a confidence-scored category (Financial, PII, Government IDs, Healthcare, or Off-Policy) is enabled, and the standard policy flow shrinks to Detect → Scope → Action → Review. The slider help text no longer references internal engine names.

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -196,11 +196,6 @@ const STANDARD_STEPS: Step[] = [
     description: "Turn on detector categories and custom rules.",
   },
   {
-    id: "sensitivity",
-    title: "Sensitivity",
-    description: "Tune detection confidence.",
-  },
-  {
     id: "scope",
     title: "Scope",
     description: "Narrow where the policy applies.",
@@ -1835,11 +1830,12 @@ function SeveritySection({
   );
 }
 
-// ── Sensitivity step (Presidio match-confidence threshold) ───────────────────
+// ── Sensitivity section (Presidio match-confidence threshold) ────────────────
 // The minimum confidence a Presidio PII match must clear to be flagged. Applies
 // to every Presidio-backed detector in a standard policy and is only persisted
 // while at least one such category is active (see `presidioActive` in the
-// editor). Non-Presidio policies don't carry a stray threshold.
+// editor). Non-Presidio policies don't carry a stray threshold. Rendered inside
+// the Detect step, and only while a confidence-scored category is on.
 const PRESIDIO_THRESHOLD_MIN = 0;
 const PRESIDIO_THRESHOLD_MAX = 1;
 const PRESIDIO_THRESHOLD_STEP = 0.05;
@@ -1847,58 +1843,47 @@ const PRESIDIO_THRESHOLD_TICKS = [0, 0.25, 0.5, 0.75, 1];
 const DEFAULT_PRESIDIO_THRESHOLD = 0.5;
 const EMPTY_SHADOW_MCP_URLS: ReadonlySet<string> = new Set<string>();
 
-function SensitivityStep({
-  active,
+function SensitivitySection({
   threshold,
   setThreshold,
 }: {
-  active: boolean;
   threshold: number;
   setThreshold: React.Dispatch<React.SetStateAction<number>>;
 }): JSX.Element {
   return (
     <Card>
-      <SectionHeader description="Tune the confidence a match must clear before it's flagged." />
-      {active ? (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <Label className="text-sm font-medium">Detection sensitivity</Label>
-            <Type small mono>
-              {threshold.toFixed(2)}
-              {threshold === DEFAULT_PRESIDIO_THRESHOLD ? " · default" : ""}
-            </Type>
-          </div>
-          <Type small muted>
-            Minimum confidence a match must clear to be flagged, from{" "}
-            {PRESIDIO_THRESHOLD_MIN} to {PRESIDIO_THRESHOLD_MAX}. Higher means
-            fewer false positives but may miss borderline matches. Applies to
-            all Presidio-backed detectors in this policy.
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">Detection sensitivity</Label>
+          <Type small mono>
+            {threshold.toFixed(2)}
+            {threshold === DEFAULT_PRESIDIO_THRESHOLD ? " · default" : ""}
           </Type>
-          <div className="pt-3">
-            <Slider
-              value={threshold}
-              onChange={(v) =>
-                setThreshold(
-                  Math.max(
-                    PRESIDIO_THRESHOLD_MIN,
-                    Math.min(PRESIDIO_THRESHOLD_MAX, Math.round(v * 20) / 20),
-                  ),
-                )
-              }
-              min={PRESIDIO_THRESHOLD_MIN}
-              max={PRESIDIO_THRESHOLD_MAX}
-              step={PRESIDIO_THRESHOLD_STEP}
-              ticks={PRESIDIO_THRESHOLD_TICKS}
-            />
-          </div>
         </div>
-      ) : (
         <Type small muted>
-          Sensitivity applies to confidence-scored detectors. Turn on a
-          PII-style category (Financial, PII, Government IDs, Healthcare, or
-          Off-Policy) in the Detect step to adjust it.
+          Minimum confidence a match must clear to be flagged, from{" "}
+          {PRESIDIO_THRESHOLD_MIN} to {PRESIDIO_THRESHOLD_MAX}. Higher means
+          fewer false positives but may miss borderline matches. Applies to all
+          confidence-scored detectors in this policy.
         </Type>
-      )}
+        <div className="pt-3">
+          <Slider
+            value={threshold}
+            onChange={(v) =>
+              setThreshold(
+                Math.max(
+                  PRESIDIO_THRESHOLD_MIN,
+                  Math.min(PRESIDIO_THRESHOLD_MAX, Math.round(v * 20) / 20),
+                ),
+              )
+            }
+            min={PRESIDIO_THRESHOLD_MIN}
+            max={PRESIDIO_THRESHOLD_MAX}
+            step={PRESIDIO_THRESHOLD_STEP}
+            ticks={PRESIDIO_THRESHOLD_TICKS}
+          />
+        </div>
+      </div>
     </Card>
   );
 }
@@ -3814,75 +3799,77 @@ export function StandardPolicyEditor({
         onStep={setStep}
       >
         {step === 0 && (
-          <Card>
-            <SectionHeader description="Turn on detector categories and attach your organization's custom rules." />
-            <Stack gap={5}>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <Label className="text-sm font-medium">Built-in rules</Label>
-                  <span className="text-muted-foreground text-xs">
-                    {
-                      ALL_CATEGORIES.filter((c) => selectedCategories.has(c))
-                        .length
-                    }{" "}
-                    on
-                  </span>
+          <>
+            <Card>
+              <SectionHeader description="Turn on detector categories and attach your organization's custom rules." />
+              <Stack gap={5}>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-sm font-medium">
+                      Built-in rules
+                    </Label>
+                    <span className="text-muted-foreground text-xs">
+                      {
+                        ALL_CATEGORIES.filter((c) => selectedCategories.has(c))
+                          .length
+                      }{" "}
+                      on
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    {ALL_CATEGORIES.map((cat) => (
+                      <DetectorCard
+                        key={cat}
+                        category={cat}
+                        selected={selectedCategories.has(cat)}
+                        disabledRules={disabledRules}
+                        disabledReason={builtInRuleDisabledReason(
+                          cat,
+                          selectedCategories,
+                        )}
+                        onToggle={(checked) => toggleCategory(cat, checked)}
+                        onCustomize={() => setCustomizeCategory(cat)}
+                      />
+                    ))}
+                  </div>
                 </div>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  {ALL_CATEGORIES.map((cat) => (
-                    <DetectorCard
-                      key={cat}
-                      category={cat}
-                      selected={selectedCategories.has(cat)}
-                      disabledRules={disabledRules}
-                      disabledReason={builtInRuleDisabledReason(
-                        cat,
-                        selectedCategories,
-                      )}
-                      onToggle={(checked) => toggleCategory(cat, checked)}
-                      onCustomize={() => setCustomizeCategory(cat)}
-                    />
-                  ))}
-                </div>
-              </div>
-              {customRules.length > 0 && (
-                <RuleSelectList
-                  title="Custom Rules"
-                  description={
-                    <>
-                      Attach your organization's custom rules as{" "}
-                      <span className="text-foreground font-medium">
-                        detectors
-                      </span>{" "}
-                      — a match records a finding.
-                    </>
-                  }
-                  idPrefix="detector"
-                  customRules={customRules}
-                  selectedRuleIds={selectedCustomRuleIds}
-                  onToggleRule={toggleDetector}
-                  expanded={detectionExpanded}
-                  onToggle={() => setDetectionExpanded((v) => !v)}
-                />
-              )}
-              {!hasEnabledDetector && (
-                <Type small className="text-destructive">
-                  Turn on at least one detector or attach a custom rule.
-                </Type>
-              )}
-            </Stack>
-          </Card>
+                {customRules.length > 0 && (
+                  <RuleSelectList
+                    title="Custom Rules"
+                    description={
+                      <>
+                        Attach your organization's custom rules as{" "}
+                        <span className="text-foreground font-medium">
+                          detectors
+                        </span>{" "}
+                        — a match records a finding.
+                      </>
+                    }
+                    idPrefix="detector"
+                    customRules={customRules}
+                    selectedRuleIds={selectedCustomRuleIds}
+                    onToggleRule={toggleDetector}
+                    expanded={detectionExpanded}
+                    onToggle={() => setDetectionExpanded((v) => !v)}
+                  />
+                )}
+                {!hasEnabledDetector && (
+                  <Type small className="text-destructive">
+                    Turn on at least one detector or attach a custom rule.
+                  </Type>
+                )}
+              </Stack>
+            </Card>
+            {presidioActive && (
+              <SensitivitySection
+                threshold={presidioThreshold}
+                setThreshold={setPresidioThreshold}
+              />
+            )}
+          </>
         )}
 
         {step === 1 && (
-          <SensitivityStep
-            active={presidioActive}
-            threshold={presidioThreshold}
-            setThreshold={setPresidioThreshold}
-          />
-        )}
-
-        {step === 2 && (
           <ScopeStep
             description="Apply everywhere, or narrow the scope to reduce noise and cost."
             selectedCategories={selectedCategories}
@@ -3892,7 +3879,7 @@ export function StandardPolicyEditor({
           />
         )}
 
-        {step === 3 && (
+        {step === 2 && (
           <ActionStep
             action={action}
             setAction={setAction}
@@ -3921,7 +3908,7 @@ export function StandardPolicyEditor({
           />
         )}
 
-        {step === 4 && (
+        {step === 3 && (
           <StandardReview
             name={name}
             categories={selectedCategories}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the sensitivity slider into the Detect stage and show it only when confidence‑scored detectors are enabled, removing an extra step in the setup flow (AIS-338).

- **Refactors**
  - Removed the “Sensitivity” step from `STANDARD_STEPS`; flow is now Detect → Scope → Action → Review.
  - Replaced `SensitivityStep` with `SensitivitySection` card below detector categories in Detect; renders only when `presidioActive` is true and the threshold persists while any such category is on.
  - Updated help text to reference confidence-scored detectors and removed internal engine names.
  - Kept behavior: 0–1 range, 0.05 step, default 0.5, rounded to 0.05.

- **Dependencies**
  - Added dashboard changeset for this patch.

<sup>Written for commit b1e609c7116c842d6fe91c8b2a8127f93746a1e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

