### PR TITLE
mig: route custom domain root to a default MCP server

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1175,6 +1175,15 @@ CREATE TABLE IF NOT EXISTS custom_domains (
   provisioner_kind TEXT NOT NULL DEFAULT 'ingress',
   -- IP addresses or CIDR ranges allowed to access this domain. Empty array = unrestricted.
   ip_allowlist TEXT[] NOT NULL DEFAULT '{}',
+  openai_apps_challenge_token TEXT CONSTRAINT custom_domains_openai_apps_challenge_token_check CHECK (
+    openai_apps_challenge_token IS NULL
+    OR (
+      openai_apps_challenge_token <> ''
+      AND char_length(openai_apps_challenge_token) <= 256
+      AND position(chr(10) IN openai_apps_challenge_token) = 0
+      AND position(chr(13) IN openai_apps_challenge_token) = 0
+    )
+  ),
   health_status TEXT,
   health_issue TEXT,
   health_checked_at timestamptz,
@@ -3948,6 +3957,7 @@ CREATE TABLE IF NOT EXISTS mcp_endpoints (
   custom_domain_id uuid,
   mcp_server_id uuid NOT NULL,
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 128),
+  is_domain_root BOOLEAN,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -3957,7 +3967,8 @@ CREATE TABLE IF NOT EXISTS mcp_endpoints (
   CONSTRAINT mcp_endpoints_pkey PRIMARY KEY (id),
   CONSTRAINT mcp_endpoints_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE,
   CONSTRAINT mcp_endpoints_mcp_server_id_fkey FOREIGN KEY (mcp_server_id) REFERENCES mcp_servers (id) ON DELETE CASCADE,
-  CONSTRAINT mcp_endpoints_custom_domain_id_fkey FOREIGN KEY (custom_domain_id) REFERENCES custom_domains (id) ON DELETE SET NULL
+  CONSTRAINT mcp_endpoints_custom_domain_id_fkey FOREIGN KEY (custom_domain_id) REFERENCES custom_domains (id) ON DELETE SET NULL,
+  CONSTRAINT mcp_endpoints_domain_root_requires_custom_domain_check CHECK (is_domain_root IS NOT TRUE OR custom_domain_id IS NOT NULL)
 );
 
 CREATE INDEX IF NOT EXISTS mcp_endpoints_project_id_idx
@@ -3979,6 +3990,10 @@ WHERE custom_domain_id IS NOT NULL AND deleted IS FALSE;
 CREATE UNIQUE INDEX IF NOT EXISTS mcp_endpoints_slug_null_custom_domain_id_key
 ON mcp_endpoints (slug)
 WHERE custom_domain_id IS NULL AND deleted IS FALSE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS mcp_endpoints_custom_domain_id_root_key
+ON mcp_endpoints (custom_domain_id)
+WHERE is_domain_root IS TRUE AND deleted IS FALSE;
 
 -- MCP servers attached directly to an assistant. The legacy toolset
 -- attachment path lives in assistant_toolsets; this table covers

--- a/server/internal/customdomains/repo/models.go
+++ b/server/internal/customdomains/repo/models.go
@@ -10,23 +10,24 @@ import (
 )
 
 type CustomDomain struct {
-	ID                   uuid.UUID
-	OrganizationID       string
-	Domain               string
-	Verified             bool
-	Activated            bool
-	IngressName          pgtype.Text
-	CertSecretName       pgtype.Text
-	ProvisionerKind      string
-	IpAllowlist          []string
-	HealthStatus         pgtype.Text
-	HealthIssue          pgtype.Text
-	HealthCheckedAt      pgtype.Timestamptz
-	UnhealthySince       pgtype.Timestamptz
-	CertificateExpiresAt pgtype.Timestamptz
-	ConsecutiveFailures  pgtype.Int4
-	CreatedAt            pgtype.Timestamptz
-	UpdatedAt            pgtype.Timestamptz
-	DeletedAt            pgtype.Timestamptz
-	Deleted              bool
+	ID                       uuid.UUID
+	OrganizationID           string
+	Domain                   string
+	Verified                 bool
+	Activated                bool
+	IngressName              pgtype.Text
+	CertSecretName           pgtype.Text
+	ProvisionerKind          string
+	IpAllowlist              []string
+	OpenaiAppsChallengeToken pgtype.Text
+	HealthStatus             pgtype.Text
+	HealthIssue              pgtype.Text
+	HealthCheckedAt          pgtype.Timestamptz
+	UnhealthySince           pgtype.Timestamptz
+	CertificateExpiresAt     pgtype.Timestamptz
+	ConsecutiveFailures      pgtype.Int4
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
 }

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -28,7 +28,7 @@ INSERT INTO custom_domains (
     $5,
     $6
 )
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateCustomDomainParams struct {
@@ -60,6 +60,7 @@ func (q *Queries) CreateCustomDomain(ctx context.Context, arg CreateCustomDomain
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -87,7 +88,7 @@ func (q *Queries) DeleteCustomDomain(ctx context.Context, organizationID string)
 }
 
 const getCustomDomainByDomain = `-- name: GetCustomDomainByDomain :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE domain = $1
   AND deleted IS FALSE
@@ -106,6 +107,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -121,7 +123,7 @@ func (q *Queries) GetCustomDomainByDomain(ctx context.Context, domain string) (C
 }
 
 const getCustomDomainByID = `-- name: GetCustomDomainByID :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND deleted IS FALSE
@@ -140,6 +142,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -155,7 +158,7 @@ func (q *Queries) GetCustomDomainByID(ctx context.Context, id uuid.UUID) (Custom
 }
 
 const getCustomDomainByIDAndOrganization = `-- name: GetCustomDomainByIDAndOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND organization_id = $2
@@ -184,6 +187,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -199,7 +203,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganization(ctx context.Context, arg Ge
 }
 
 const getCustomDomainByIDAndOrganizationForHealthUpdate = `-- name: GetCustomDomainByIDAndOrganizationForHealthUpdate :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE id = $1
   AND organization_id = $2
@@ -225,6 +229,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganizationForHealthUpdate(ctx context.
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -240,7 +245,7 @@ func (q *Queries) GetCustomDomainByIDAndOrganizationForHealthUpdate(ctx context.
 }
 
 const getCustomDomainByOrganization = `-- name: GetCustomDomainByOrganization :one
-SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains
 WHERE organization_id = $1
   AND deleted IS FALSE
@@ -260,6 +265,7 @@ func (q *Queries) GetCustomDomainByOrganization(ctx context.Context, organizatio
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -413,7 +419,7 @@ SET
     updated_at = clock_timestamp()
 WHERE id = $6
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainParams struct {
@@ -445,6 +451,7 @@ func (q *Queries) UpdateCustomDomain(ctx context.Context, arg UpdateCustomDomain
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -472,7 +479,7 @@ SET
 WHERE id = $7
   AND organization_id = $8
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainHealthParams struct {
@@ -508,6 +515,7 @@ func (q *Queries) UpdateCustomDomainHealth(ctx context.Context, arg UpdateCustom
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,
@@ -529,7 +537,7 @@ SET
     updated_at = clock_timestamp()
 WHERE organization_id = $2
   AND deleted IS FALSE
-RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, openai_apps_challenge_token, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateCustomDomainIPAllowlistParams struct {
@@ -550,6 +558,7 @@ func (q *Queries) UpdateCustomDomainIPAllowlist(ctx context.Context, arg UpdateC
 		&i.CertSecretName,
 		&i.ProvisionerKind,
 		&i.IpAllowlist,
+		&i.OpenaiAppsChallengeToken,
 		&i.HealthStatus,
 		&i.HealthIssue,
 		&i.HealthCheckedAt,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -432,25 +432,26 @@ type ChatUserFeedback struct {
 }
 
 type CustomDomain struct {
-	ID                   uuid.UUID
-	OrganizationID       string
-	Domain               string
-	Verified             bool
-	Activated            bool
-	IngressName          pgtype.Text
-	CertSecretName       pgtype.Text
-	ProvisionerKind      string
-	IpAllowlist          []string
-	HealthStatus         pgtype.Text
-	HealthIssue          pgtype.Text
-	HealthCheckedAt      pgtype.Timestamptz
-	UnhealthySince       pgtype.Timestamptz
-	CertificateExpiresAt pgtype.Timestamptz
-	ConsecutiveFailures  pgtype.Int4
-	CreatedAt            pgtype.Timestamptz
-	UpdatedAt            pgtype.Timestamptz
-	DeletedAt            pgtype.Timestamptz
-	Deleted              bool
+	ID                       uuid.UUID
+	OrganizationID           string
+	Domain                   string
+	Verified                 bool
+	Activated                bool
+	IngressName              pgtype.Text
+	CertSecretName           pgtype.Text
+	ProvisionerKind          string
+	IpAllowlist              []string
+	OpenaiAppsChallengeToken pgtype.Text
+	HealthStatus             pgtype.Text
+	HealthIssue              pgtype.Text
+	HealthCheckedAt          pgtype.Timestamptz
+	UnhealthySince           pgtype.Timestamptz
+	CertificateExpiresAt     pgtype.Timestamptz
+	ConsecutiveFailures      pgtype.Int4
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
 }
 
 type Deployment struct {
@@ -999,6 +1000,7 @@ type McpEndpoint struct {
 	CustomDomainID uuid.NullUUID
 	McpServerID    uuid.UUID
 	Slug           string
+	IsDomainRoot   pgtype.Bool
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz
 	DeletedAt      pgtype.Timestamptz

--- a/server/internal/mcpendpoints/repo/models.go
+++ b/server/internal/mcpendpoints/repo/models.go
@@ -15,6 +15,7 @@ type McpEndpoint struct {
 	CustomDomainID uuid.NullUUID
 	McpServerID    uuid.UUID
 	Slug           string
+	IsDomainRoot   pgtype.Bool
 	CreatedAt      pgtype.Timestamptz
 	UpdatedAt      pgtype.Timestamptz
 	DeletedAt      pgtype.Timestamptz

--- a/server/internal/mcpendpoints/repo/queries.sql.go
+++ b/server/internal/mcpendpoints/repo/queries.sql.go
@@ -70,7 +70,7 @@ VALUES (
     $3,
     $4
 )
-RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateMCPEndpointParams struct {
@@ -94,6 +94,7 @@ func (q *Queries) CreateMCPEndpoint(ctx context.Context, arg CreateMCPEndpointPa
 		&i.CustomDomainID,
 		&i.McpServerID,
 		&i.Slug,
+		&i.IsDomainRoot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -106,7 +107,7 @@ const deleteMCPEndpoint = `-- name: DeleteMCPEndpoint :one
 UPDATE mcp_endpoints
 SET deleted_at = clock_timestamp()
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 `
 
 type DeleteMCPEndpointParams struct {
@@ -123,6 +124,7 @@ func (q *Queries) DeleteMCPEndpoint(ctx context.Context, arg DeleteMCPEndpointPa
 		&i.CustomDomainID,
 		&i.McpServerID,
 		&i.Slug,
+		&i.IsDomainRoot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -132,7 +134,7 @@ func (q *Queries) DeleteMCPEndpoint(ctx context.Context, arg DeleteMCPEndpointPa
 }
 
 const getMCPEndpointByCustomDomainAndSlug = `-- name: GetMCPEndpointByCustomDomainAndSlug :one
-SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 FROM mcp_endpoints
 WHERE slug = $1
   AND custom_domain_id IS NOT DISTINCT FROM $2
@@ -155,6 +157,7 @@ func (q *Queries) GetMCPEndpointByCustomDomainAndSlug(ctx context.Context, arg G
 		&i.CustomDomainID,
 		&i.McpServerID,
 		&i.Slug,
+		&i.IsDomainRoot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -164,7 +167,7 @@ func (q *Queries) GetMCPEndpointByCustomDomainAndSlug(ctx context.Context, arg G
 }
 
 const getMCPEndpointByID = `-- name: GetMCPEndpointByID :one
-SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 FROM mcp_endpoints
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -183,6 +186,7 @@ func (q *Queries) GetMCPEndpointByID(ctx context.Context, arg GetMCPEndpointByID
 		&i.CustomDomainID,
 		&i.McpServerID,
 		&i.Slug,
+		&i.IsDomainRoot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -192,7 +196,7 @@ func (q *Queries) GetMCPEndpointByID(ctx context.Context, arg GetMCPEndpointByID
 }
 
 const getMCPEndpointByProjectAndCustomDomainAndSlug = `-- name: GetMCPEndpointByProjectAndCustomDomainAndSlug :one
-SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 FROM mcp_endpoints
 WHERE project_id = $1
   AND slug = $2
@@ -218,6 +222,7 @@ func (q *Queries) GetMCPEndpointByProjectAndCustomDomainAndSlug(ctx context.Cont
 		&i.CustomDomainID,
 		&i.McpServerID,
 		&i.Slug,
+		&i.IsDomainRoot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -289,7 +294,7 @@ func (q *Queries) ListMCPEndpointsByCustomDomainID(ctx context.Context, customDo
 }
 
 const listMCPEndpointsByMCPServerID = `-- name: ListMCPEndpointsByMCPServerID :many
-SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 FROM mcp_endpoints
 WHERE project_id = $1
   AND mcp_server_id = $2
@@ -317,6 +322,7 @@ func (q *Queries) ListMCPEndpointsByMCPServerID(ctx context.Context, arg ListMCP
 			&i.CustomDomainID,
 			&i.McpServerID,
 			&i.Slug,
+			&i.IsDomainRoot,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -333,7 +339,7 @@ func (q *Queries) ListMCPEndpointsByMCPServerID(ctx context.Context, arg ListMCP
 }
 
 const listMCPEndpointsByProject = `-- name: ListMCPEndpointsByProject :many
-SELECT id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 FROM mcp_endpoints
 WHERE project_id = $1 AND deleted IS FALSE
 ORDER BY created_at DESC
@@ -354,6 +360,7 @@ func (q *Queries) ListMCPEndpointsByProject(ctx context.Context, projectID uuid.
 			&i.CustomDomainID,
 			&i.McpServerID,
 			&i.Slug,
+			&i.IsDomainRoot,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -373,7 +380,7 @@ const softDeleteMCPEndpointsByCustomDomainID = `-- name: SoftDeleteMCPEndpointsB
 UPDATE mcp_endpoints
 SET deleted_at = clock_timestamp()
 WHERE custom_domain_id = $1::uuid AND deleted IS FALSE
-RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 `
 
 // Soft-delete all endpoints registered under a given custom_domain. Used when
@@ -399,6 +406,7 @@ func (q *Queries) SoftDeleteMCPEndpointsByCustomDomainID(ctx context.Context, cu
 			&i.CustomDomainID,
 			&i.McpServerID,
 			&i.Slug,
+			&i.IsDomainRoot,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -418,7 +426,7 @@ const softDeleteMCPEndpointsByMCPServerID = `-- name: SoftDeleteMCPEndpointsByMC
 UPDATE mcp_endpoints
 SET deleted_at = clock_timestamp()
 WHERE mcp_server_id = $1 AND project_id = $2 AND deleted IS FALSE
-RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 `
 
 type SoftDeleteMCPEndpointsByMCPServerIDParams struct {
@@ -446,6 +454,7 @@ func (q *Queries) SoftDeleteMCPEndpointsByMCPServerID(ctx context.Context, arg S
 			&i.CustomDomainID,
 			&i.McpServerID,
 			&i.Slug,
+			&i.IsDomainRoot,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -469,7 +478,7 @@ SET
     slug = $3,
     updated_at = clock_timestamp()
 WHERE id = $4 AND project_id = $5 AND deleted IS FALSE
-RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, custom_domain_id, mcp_server_id, slug, is_domain_root, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateMCPEndpointParams struct {
@@ -495,6 +504,7 @@ func (q *Queries) UpdateMCPEndpoint(ctx context.Context, arg UpdateMCPEndpointPa
 		&i.CustomDomainID,
 		&i.McpServerID,
 		&i.Slug,
+		&i.IsDomainRoot,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260730125106_custom-domain-root-mcp-and-challenge.sql
+++ b/server/migrations/20260730125106_custom-domain-root-mcp-and-challenge.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Modify "custom_domains" table
+ALTER TABLE "custom_domains" ADD CONSTRAINT "custom_domains_openai_apps_challenge_token_check" CHECK ((openai_apps_challenge_token IS NULL) OR ((openai_apps_challenge_token <> ''::text) AND (char_length(openai_apps_challenge_token) <= 256) AND (POSITION((chr(10)) IN (openai_apps_challenge_token)) = 0) AND (POSITION((chr(13)) IN (openai_apps_challenge_token)) = 0))), ADD COLUMN "openai_apps_challenge_token" text NULL;
+-- Modify "mcp_endpoints" table
+ALTER TABLE "mcp_endpoints" ADD CONSTRAINT "mcp_endpoints_domain_root_requires_custom_domain_check" CHECK ((is_domain_root IS NOT TRUE) OR (custom_domain_id IS NOT NULL)), ADD COLUMN "is_domain_root" boolean NULL;
+-- Create index "mcp_endpoints_custom_domain_id_root_key" to table: "mcp_endpoints"
+CREATE UNIQUE INDEX CONCURRENTLY "mcp_endpoints_custom_domain_id_root_key" ON "mcp_endpoints" ("custom_domain_id") WHERE ((is_domain_root IS TRUE) AND (deleted IS FALSE));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:s7xHchmljdPcmyoGJC0TPwrjT0iQsOLZgYgryb5UKyc=
+h1:nl0qDGaUHyRAQ0KEMJNOwJq9p3jf6m37JpIoOliWEsE=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -308,3 +308,4 @@ h1:s7xHchmljdPcmyoGJC0TPwrjT0iQsOLZgYgryb5UKyc=
 20260728192302_dno_574_skill_version_promotion.sql h1:jQLB1IwxIj6iZr8kA9Ya/u6N6pG4jn+15RjS3+BM5+w=
 20260728201450_cimd_inbound_storage.sql h1:al8Z9FQ75jt6vp7WIIhJ8+uyTDmf51PA3zb4Anggt1w=
 20260729235455_dno643-device-agent-device-syncs.sql h1:2xYuc2B1oopRAdvkZ57ys+5kncKCyM1Zw78D/M8bCXM=
+20260730125106_custom-domain-root-mcp-and-challenge.sql h1:RBOpyM/n3XVpvcfMBEhhY2FojQ9DYg4UwVuFtqTYzno=


### PR DESCRIPTION
Schema and migrations split off https://github.com/speakeasy-api/gram/pull/4601 so the database changes can land independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds database changes to route a custom domain’s root path to a default MCP server and to store OpenAI Apps challenge tokens. Updates models and queries to read/write these fields.

- **New Features**
  - `mcp_endpoints.is_domain_root` to mark the domain root target; requires `custom_domain_id` via a check constraint and enforces one root per domain with a partial unique index.
  - `custom_domains.openai_apps_challenge_token` with validation (non-empty, <=256 chars, no newlines).
  - Repo and generated query code updated to include these fields.

- **Migration**
  - Backward-compatible: columns are nullable; unique index created concurrently; no data backfill required.

<sup>Written for commit d56246a8fc4b63b949cac89f23109ae7f981c2cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

