### PR TITLE
feat(domains): take custom-domain health checks live

### DIFF
--- a/.changeset/custom-domain-health-live.md
+++ b/.changeset/custom-domain-health-live.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Custom-domain health checks go live: daily check results are now persisted and shown in organization settings, and organization admins receive an email the first time a domain turns unhealthy. This removes the observation-only dry-run mode used to validate detection accuracy in production.

--- a/server/internal/background/activities/custom_domain_health.go
+++ b/server/internal/background/activities/custom_domain_health.go
@@ -45,7 +45,6 @@ type CustomDomainHealth struct {
 	expectedTarget string
 	emails         *email.Service
 	siteURL        *url.URL
-	dryRun         bool
 }
 
 type ListCustomDomainsForHealthCheckArgs struct {
@@ -90,12 +89,6 @@ func NewCustomDomainHealth(logger *slog.Logger, db *pgxpool.Pool, infrastructure
 		expectedTarget: expectedTarget,
 		emails:         emails,
 		siteURL:        siteURL,
-		// The first release observes only: checks run and log their findings,
-		// including the admin notifications that would be sent, but no health
-		// state is persisted and no email goes out. Because dry run leaves no
-		// trace in the database, flipping this to false later lets the next
-		// sweep re-derive state and notify as if it were the first ever check.
-		dryRun: true,
 	}
 }
 
@@ -106,11 +99,6 @@ func (c *CustomDomainHealth) SetResolver(resolver dns.Resolver) {
 // SetProbe replaces the HTTPS probe. Intended for testing.
 func (c *CustomDomainHealth) SetProbe(probe func(ctx context.Context, domain string) error) {
 	c.probe = probe
-}
-
-// SetDryRun toggles observation-only mode. Intended for testing.
-func (c *CustomDomainHealth) SetDryRun(dryRun bool) {
-	c.dryRun = dryRun
 }
 
 func (c *CustomDomainHealth) List(ctx context.Context, args ListCustomDomainsForHealthCheckArgs) ([]CustomDomainHealthCheckTarget, error) {
@@ -206,36 +194,8 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		}
 	}
 
-	if c.dryRun {
-		// Observation-only release: report what a live check would have done
-		// without flipping status, bumping consecutive_failures, or touching
-		// checked_at. Since nothing persists, an unhealthy domain re-reports a
-		// would-be transition on every sweep — that recurring log line is the
-		// point of the dry run.
-		current := customDomainHealthState(domain)
-		if preserveCertificateExpiry {
-			observation.CertificateExpiresAt = current.CertificateExpiresAt
-		}
-		next := customdomains.ReconcileHealthState(current, observation, args.CheckedAt)
-		c.logger.InfoContext(ctx, "dry run: observed custom domain health",
-			attr.SlogURLDomain(domain.Domain),
-			attr.SlogOrganizationID(args.OrganizationID),
-			attr.SlogCustomDomainHealthStatus(string(next.Status)),
-			attr.SlogCustomDomainHealthIssue(string(next.Issue)),
-		)
-		if customdomains.ShouldNotifyUnhealthyTransition(current, next) {
-			return NotifyCustomDomainUnhealthyArgs{
-				CustomDomainID: domain.ID,
-				OrganizationID: args.OrganizationID,
-				Domain:         domain.Domain,
-				Issue:          next.Issue,
-				CheckedAt:      args.CheckedAt,
-			}, nil
-		}
-		return noNotification, nil
-	}
-
 	var notification NotifyCustomDomainUnhealthyArgs
+	var next customdomains.HealthState
 	if err := pgx.BeginFunc(ctx, c.db, func(tx pgx.Tx) error {
 		repository := customdomainsrepo.New(tx)
 		lockedDomain, err := repository.GetCustomDomainByIDAndOrganizationForHealthUpdate(ctx, customdomainsrepo.GetCustomDomainByIDAndOrganizationForHealthUpdateParams{
@@ -252,7 +212,7 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		if preserveCertificateExpiry {
 			observation.CertificateExpiresAt = current.CertificateExpiresAt
 		}
-		next := customdomains.ReconcileHealthState(current, observation, args.CheckedAt)
+		next = customdomains.ReconcileHealthState(current, observation, args.CheckedAt)
 		switch {
 		case customdomains.ShouldNotifyUnhealthyTransition(current, next):
 			notification = NotifyCustomDomainUnhealthyArgs{
@@ -291,6 +251,17 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		return nil
 	}); err != nil {
 		return noNotification, fmt.Errorf("save custom domain health: %w", err)
+	}
+
+	// One line per check keeps the Datadog health breakdown that the dry-run
+	// phase established. CheckedAt is nil only when the locked row vanished.
+	if next.CheckedAt != nil {
+		c.logger.InfoContext(ctx, "observed custom domain health",
+			attr.SlogURLDomain(domain.Domain),
+			attr.SlogOrganizationID(args.OrganizationID),
+			attr.SlogCustomDomainHealthStatus(string(next.Status)),
+			attr.SlogCustomDomainHealthIssue(string(next.Issue)),
+		)
 	}
 
 	return notification, nil
@@ -344,9 +315,6 @@ func (c *CustomDomainHealth) NotifyOrgAdmins(ctx context.Context, args NotifyCus
 			continue
 		}
 		seen[emailKey] = struct{}{}
-		if c.dryRun {
-			continue
-		}
 		tmpl := email.CustomDomainUnhealthy{
 			Email:        user.Email,
 			Domain:       args.Domain,
@@ -363,17 +331,16 @@ func (c *CustomDomainHealth) NotifyOrgAdmins(ctx context.Context, args NotifyCus
 	if err := errors.Join(notificationErrors...); err != nil {
 		return err
 	}
-	if c.dryRun {
-		// Aggregate line only after every recipient resolved cleanly, so a
-		// retried activity cannot log a misleading partial count. Addresses
-		// stay out of the logs.
-		c.logger.InfoContext(ctx, "dry run: would email org admins about unhealthy custom domain",
-			attr.SlogURLDomain(args.Domain),
-			attr.SlogOrganizationID(organizationID),
-			attr.SlogCustomDomainHealthIssue(string(args.Issue)),
-			attr.SlogCustomDomainNotifyRecipientCount(len(seen)),
-		)
-	}
+	// Aggregate line only after every recipient resolved cleanly, so a retried
+	// activity cannot log a misleading partial count. Addresses stay out of the
+	// logs. A zero count is the dead-org signal: nobody holds org:admin, so the
+	// alert reached no one.
+	c.logger.InfoContext(ctx, "emailed org admins about unhealthy custom domain",
+		attr.SlogURLDomain(args.Domain),
+		attr.SlogOrganizationID(organizationID),
+		attr.SlogCustomDomainHealthIssue(string(args.Issue)),
+		attr.SlogCustomDomainNotifyRecipientCount(len(seen)),
+	)
 	return nil
 }
 

--- a/server/internal/background/activities/custom_domain_health_test.go
+++ b/server/internal/background/activities/custom_domain_health_test.go
@@ -145,7 +145,6 @@ func TestCustomDomainHealthCheckProbeRescuesDNSMismatch(t *testing.T) {
 	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
 	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("proxied.example.com")))
 	checker.SetProbe(func(context.Context, string) error { return nil })
-	checker.SetDryRun(false)
 
 	notification, err := checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
 		CustomDomainID: domainID,
@@ -174,7 +173,6 @@ func TestCustomDomainHealthCheckProbeFailureKeepsDNSMismatch(t *testing.T) {
 	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
 	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("broken.example.com")))
 	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
-	checker.SetDryRun(false)
 
 	notification, err := checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
 		CustomDomainID: domainID,
@@ -204,7 +202,6 @@ func TestCustomDomainHealthCheckRetryReemitsNotification(t *testing.T) {
 	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
 	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("retry.example.com")))
 	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
-	checker.SetDryRun(false)
 
 	// Match the workflow's pinned timestamp precision.
 	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
@@ -231,39 +228,6 @@ func TestCustomDomainHealthCheckRetryReemitsNotification(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, third.Issue)
-}
-
-func TestCustomDomainHealthCheckDryRunObservesWithoutPersisting(t *testing.T) {
-	t.Parallel()
-
-	conn, err := infra.CloneTestDatabase(t, "custom_domain_health_dry_run")
-	require.NoError(t, err)
-	repository := customdomainsrepo.New(conn)
-	domainID := createActivatedCustomDomain(t, repository, "test-organization", "dryrun.example.com")
-
-	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
-	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("dryrun.example.com")))
-	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
-
-	notification, err := checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
-		CustomDomainID: domainID,
-		OrganizationID: "test-organization",
-		CheckedAt:      time.Now().UTC(),
-	})
-	require.NoError(t, err)
-	require.Equal(t, customdomains.HealthIssueDNSTargetMismatch, notification.Issue)
-	require.Equal(t, "dryrun.example.com", notification.Domain)
-
-	domain, err := repository.GetCustomDomainByIDAndOrganization(t.Context(), customdomainsrepo.GetCustomDomainByIDAndOrganizationParams{
-		ID:             domainID,
-		OrganizationID: "test-organization",
-	})
-	require.NoError(t, err)
-	require.False(t, domain.HealthStatus.Valid)
-	require.False(t, domain.HealthIssue.Valid)
-	require.False(t, domain.HealthCheckedAt.Valid)
-	require.False(t, domain.UnhealthySince.Valid)
-	require.False(t, domain.ConsecutiveFailures.Valid)
 }
 
 // seedCustomDomainAdminRecipient creates an organization with one member who
@@ -310,30 +274,6 @@ func seedCustomDomainAdminRecipient(t *testing.T, conn *pgxpool.Pool, organizati
 	return adminEmail
 }
 
-func TestCustomDomainNotifyOrgAdminsDryRunSendsNoEmail(t *testing.T) {
-	t.Parallel()
-
-	conn, err := infra.CloneTestDatabase(t, "custom_domain_notify_dry_run")
-	require.NoError(t, err)
-	organizationID := "org-custom-domain-health-dry"
-	seedCustomDomainAdminRecipient(t, conn, organizationID)
-
-	captured := &captureLoopsClient{sent: nil, failNext: 0}
-	siteURL, err := url.Parse("https://app.example.com")
-	require.NoError(t, err)
-	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", email.NewService(testenv.NewLogger(t), captured), siteURL, nil)
-
-	err = checker.NotifyOrgAdmins(t.Context(), activities.NotifyCustomDomainUnhealthyArgs{
-		CustomDomainID: uuid.New(),
-		OrganizationID: organizationID,
-		Domain:         "dryrun.example.com",
-		Issue:          customdomains.HealthIssueDNSNotFound,
-		CheckedAt:      time.Now().UTC().Truncate(time.Microsecond),
-	})
-	require.NoError(t, err)
-	require.Empty(t, captured.Sent())
-}
-
 func TestCustomDomainNotifyOrgAdminsSendsIdempotentEmail(t *testing.T) {
 	t.Parallel()
 
@@ -346,7 +286,6 @@ func TestCustomDomainNotifyOrgAdminsSendsIdempotentEmail(t *testing.T) {
 	siteURL, err := url.Parse("https://app.example.com")
 	require.NoError(t, err)
 	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", email.NewService(testenv.NewLogger(t), captured), siteURL, nil)
-	checker.SetDryRun(false)
 
 	err = checker.NotifyOrgAdmins(t.Context(), activities.NotifyCustomDomainUnhealthyArgs{
 		CustomDomainID: uuid.New(),


### PR DESCRIPTION
## Why

The custom-domain health feature shipped observation-only (#4404, #4585): checks ran and logged, but nothing persisted and nobody was emailed. A full production sweep has now validated detection accuracy — every healthy domain reported healthy (including proxied/CDN setups rescued by the HTTPS probe), the sweep and orphan scan completed cleanly, and the only unhealthy results were genuine customer-side DNS/certificate faults with zero Gram-side `check_failed` false positives.

## What

- Remove the `dryRun` field, its constructor default, and the `SetDryRun` test hook — the persistence + notification path is now the only path.
- Health state persists on every check (status, issue, checked_at, unhealthy_since, certificate expiry, consecutive_failures) and surfaces in organization settings.
- Org admins get one email per unhealthy transition (Loops idempotency-keyed; `check_failed` never notifies).
- Keep the per-check `observed custom domain health` log line so the Datadog breakdown established during dry run keeps working, and add an `emailed org admins…` aggregate with `recipient_count` — a zero count flags orgs with no resolvable admins.

## Verification

- All `TestCustomDomain*` / `TestFindOrphan*` tests pass (persistence, transition dedupe, retry re-emit, idempotent email with real RBAC fixtures).
- `mise lint:server` clean.

Follow-up: auto-disable of persistently unhealthy domains is tracked in AIS-383.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned custom-domain health checks live. Results now persist, show in org settings, and org admins get one email when a domain first becomes unhealthy.

- **New Features**
  - Persist full health state on each check (status, issue, checked_at, unhealthy_since, certificate expiry, consecutive_failures).
  - Email org admins once per unhealthy transition; idempotent and deduped. No notifications on `check_failed`.
  - Keep per-check health observation log and add an aggregate “emailed org admins” log with recipient_count (0 flags orgs with no admins).
  - Supports AIS-383 follow-up for auto-disabling persistently unhealthy domains.

- **Refactors**
  - Removed dry-run mode and its test hook; persistence + notifications is now the only path.
  - Deleted dry-run tests and related code paths.

<sup>Written for commit 2cbb4ba649f67c9cd4cbc99be23efe7bcfc68eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

