### PR TITLE
fix: improve developer toolkit widget interactions

### DIFF
--- a/client/dashboard/src/components/platform-admin-panel.test.tsx
+++ b/client/dashboard/src/components/platform-admin-panel.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const LONG_ORGANIZATION_ID =
+  "org_0000000000000000000000000000000000000000000000000000000000000000";
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({
+    id: LONG_ORGANIZATION_ID,
+    slug: "test-org",
+  }),
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({ auth: { logout: vi.fn() } }),
+}));
+
+import { PlatformAdminInfoPanel } from "./platform-admin-panel";
+
+afterEach(cleanup);
+
+describe("PlatformAdminInfoPanel", () => {
+  it("wraps a long organization ID instead of cropping it", () => {
+    render(<PlatformAdminInfoPanel />);
+
+    const organizationId = screen.getByText(LONG_ORGANIZATION_ID);
+    expect(organizationId.classList.contains("break-all")).toBe(true);
+    expect(organizationId.classList.contains("truncate")).toBe(false);
+  });
+});

--- a/client/dashboard/src/components/platform-admin-panel.tsx
+++ b/client/dashboard/src/components/platform-admin-panel.tsx
@@ -684,7 +684,7 @@ function OrgInfoSection(): ReactElement {
           {organization.slug}
         </dd>
         <dt className="text-muted-foreground">ID</dt>
-        <dd className="text-foreground truncate font-mono">
+        <dd className="text-foreground break-all font-mono">
           {organization.id}
         </dd>
       </dl>

--- a/client/dashboard/src/components/platform-admin-toolbar.test.tsx
+++ b/client/dashboard/src/components/platform-admin-toolbar.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/Auth", () => ({
+  useIsPlatformAdmin: () => true,
+  useOrganization: () => ({
+    id: "org_<ORG_ID>",
+    slug: "test-org",
+    projects: [],
+  }),
+  useSession: () => ({ session: {} }),
+}));
+
+vi.mock("@gram/client/react-query/listToolsetsForOrg.js", () => ({
+  useListToolsetsForOrg: () => ({ data: { toolsets: [] } }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("./platform-admin-panel", () => ({
+  PlatformAdminFeaturesPanel: () => <div>Features panel</div>,
+  PlatformAdminInfoPanel: () => <div>Info panel</div>,
+  PlatformAdminOnboardingPanel: () => <div>Onboarding panel</div>,
+}));
+
+vi.mock("./ui/switch", () => ({
+  Switch: () => <button type="button">Switch</button>,
+}));
+
+import { PlatformAdminToolbar } from "./platform-admin-toolbar";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("PlatformAdminToolbar", () => {
+  it("uses a wider panel without disabling text selection", () => {
+    render(<PlatformAdminToolbar />);
+
+    const title = screen.getByText("Developer Toolkit");
+    const panel = title.closest("[class~='w-96']");
+    const toolbar = title.closest("[class~='fixed']");
+
+    expect(panel).not.toBeNull();
+    expect(toolbar?.classList.contains("select-none")).toBe(false);
+  });
+
+  it("expands from the caret after the toolbar has been dragged", () => {
+    render(<PlatformAdminToolbar />);
+
+    const dragHandle = screen.getByRole("button", {
+      name: /Developer Toolkit/,
+    });
+    fireEvent.pointerDown(dragHandle, {
+      button: 0,
+      clientX: 0,
+      clientY: 0,
+    });
+    fireEvent.pointerMove(window, { clientX: 10, clientY: 0 });
+    fireEvent.pointerUp(window);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand developer toolkit" }),
+    );
+
+    expect(screen.getByText("Info panel")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Collapse developer toolkit" }),
+    ).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/platform-admin-toolbar.test.tsx
+++ b/client/dashboard/src/components/platform-admin-toolbar.test.tsx
@@ -31,9 +31,15 @@ vi.mock("./ui/switch", () => ({
 
 import { PlatformAdminToolbar } from "./platform-admin-toolbar";
 
+const initialWindowWidth = window.innerWidth;
+
 afterEach(() => {
   cleanup();
   localStorage.clear();
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: initialWindowWidth,
+  });
 });
 
 describe("PlatformAdminToolbar", () => {
@@ -46,6 +52,24 @@ describe("PlatformAdminToolbar", () => {
 
     expect(panel).not.toBeNull();
     expect(toolbar?.classList.contains("select-none")).toBe(false);
+  });
+
+  it("restores a valid dragged position on a narrow viewport", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 360,
+    });
+    localStorage.setItem(
+      "gram-rbac-dev-toolbar-pos",
+      JSON.stringify({ x: 24, y: 10 }),
+    );
+
+    render(<PlatformAdminToolbar />);
+
+    const toolbar = screen
+      .getByText("Developer Toolkit")
+      .closest<HTMLElement>("[class~='fixed']");
+    expect(toolbar?.style.left).toBe("24px");
   });
 
   it("expands from the caret after the toolbar has been dragged", () => {

--- a/client/dashboard/src/components/platform-admin-toolbar.tsx
+++ b/client/dashboard/src/components/platform-admin-toolbar.tsx
@@ -34,6 +34,8 @@ const STORAGE_KEY = "gram-rbac-dev-override";
 const HIDDEN_KEY = "gram-dev-toolbar-hidden";
 const PLATFORM_ADMIN_KEY = "gram-dev-platform-admin";
 const DEV_TOOLBAR_PORTAL_SELECTOR = "[data-rbac-dev-toolbar-portal='true']";
+const TOOLBAR_WIDTH_PX = 384;
+const TOOLBAR_VIEWPORT_GUTTER_PX = 24;
 
 // Shared className for the toolkit's top-level tabs. shrink-0 keeps tabs from
 // compressing; the tab bar scrolls horizontally when they overflow the panel.
@@ -228,7 +230,7 @@ function loadPosition(): { x: number; y: number } | null {
     if (raw) {
       const pos = JSON.parse(raw);
       return {
-        x: Math.max(0, Math.min(pos.x, window.innerWidth - 320)),
+        x: Math.max(0, Math.min(pos.x, window.innerWidth - TOOLBAR_WIDTH_PX)),
         y: Math.max(0, Math.min(pos.y, window.innerHeight - 44)),
       };
     }
@@ -441,7 +443,7 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
         hasDragged.current = true;
       }
       const el = rootRef.current;
-      const w = el ? el.offsetWidth : 320;
+      const w = el ? el.offsetWidth : TOOLBAR_WIDTH_PX;
       const h = el ? el.offsetHeight : 50;
       const newX = Math.max(0, Math.min(window.innerWidth - w, e.clientX - ox));
       const newY = Math.max(
@@ -534,20 +536,23 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
     (s) => s.enabled,
   ).length;
 
-  // Slide left of an open right panel, clamped so the toolkit (w-80 = 320px)
+  // Slide left of an open right panel, clamped so the toolkit
   // stays on screen. Only applies in the default (un-dragged) position.
   const toolbarShift =
     pos === null && panelLeft !== null
       ? Math.max(
           0,
-          Math.min(window.innerWidth - panelLeft, window.innerWidth - 344),
+          Math.min(
+            window.innerWidth - panelLeft,
+            window.innerWidth - TOOLBAR_WIDTH_PX - TOOLBAR_VIEWPORT_GUTTER_PX,
+          ),
         )
       : 0;
 
   return createPortal(
     <div
       ref={rootRef}
-      className="pointer-events-auto fixed z-[99999] transition-transform duration-300 ease-out select-none"
+      className="pointer-events-auto fixed z-[99999] transition-transform duration-300 ease-out"
       style={
         pos
           ? { left: pos.x, top: pos.y }
@@ -561,7 +566,7 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
       }
     >
       <div className={`
-          w-80 rounded-xl border shadow-2xl backdrop-blur-md transition-all
+          w-96 max-w-[calc(100vw-2rem)] rounded-xl border shadow-2xl backdrop-blur-md transition-all
           duration-200
           ${state.enabled ? "bg-background/98 border-foreground/15 dark:border-foreground/15 dark:bg-gray-950/98" : "border-border bg-white/98 dark:bg-gray-950/98"}
         `}>
@@ -593,13 +598,12 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
           <div className="ml-auto flex items-center gap-0.5">
             <button
               type="button"
-              onClick={() => {
-                if (hasDragged.current) {
-                  hasDragged.current = false;
-                  return;
-                }
-                setCollapsed((c) => !c);
-              }}
+              aria-label={
+                collapsed
+                  ? "Expand developer toolkit"
+                  : "Collapse developer toolkit"
+              }
+              onClick={() => setCollapsed((c) => !c)}
               className="text-muted-foreground hover:bg-accent hover:text-foreground rounded-full p-1 transition-colors"
             >
               {collapsed ? (

--- a/client/dashboard/src/components/platform-admin-toolbar.tsx
+++ b/client/dashboard/src/components/platform-admin-toolbar.tsx
@@ -36,6 +36,7 @@ const PLATFORM_ADMIN_KEY = "gram-dev-platform-admin";
 const DEV_TOOLBAR_PORTAL_SELECTOR = "[data-rbac-dev-toolbar-portal='true']";
 const TOOLBAR_WIDTH_PX = 384;
 const TOOLBAR_VIEWPORT_GUTTER_PX = 24;
+const TOOLBAR_HORIZONTAL_MARGIN_PX = 32;
 
 // Shared className for the toolkit's top-level tabs. shrink-0 keeps tabs from
 // compressing; the tab bar scrolls horizontally when they overflow the panel.
@@ -229,8 +230,13 @@ function loadPosition(): { x: number; y: number } | null {
     const raw = localStorage.getItem(POSITION_KEY);
     if (raw) {
       const pos = JSON.parse(raw);
+      const renderedWidth = Math.min(
+        TOOLBAR_WIDTH_PX,
+        Math.max(0, window.innerWidth - TOOLBAR_HORIZONTAL_MARGIN_PX),
+      );
+      const maxX = Math.max(0, window.innerWidth - renderedWidth);
       return {
-        x: Math.max(0, Math.min(pos.x, window.innerWidth - TOOLBAR_WIDTH_PX)),
+        x: Math.max(0, Math.min(pos.x, maxX)),
         y: Math.max(0, Math.min(pos.y, window.innerHeight - 44)),
       };
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow staff to select text inside the developer toolkit
- widen the widget and allow long organization IDs to wrap instead of cropping
- make caret expansion reliable on the first click after dragging the widget
- restore dragged positions correctly when the responsive widget is narrower than 384px
- add regression coverage for interaction, narrow viewports, and long-ID wrapping

## Testing
- `pnpm -F dashboard test platform-admin-toolbar.test.tsx platform-admin-panel.test.tsx` (4 tests passed)
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:oxlint`
- `pnpm -F dashboard lint:format`
- previous full dashboard suite: 1,128 tests passed
- manually verified the toolbar remains at a nonzero dragged position after reload in a narrow browser viewport

## Demo
<a href="https://cursor.com/agents/bc-f7130c2b-c214-4471-aafa-70f843e88134/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeveloper_toolkit_interaction_demo_clean.mp4"><img src="https://cursor.com/artifacts/c/art-b5458338-c28f-452c-b614-d1f716c5048f" alt="developer_toolkit_interaction_demo_clean.mp4" /></a>

Linear: AIS-384
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-384](https://linear.app/speakeasy/issue/AIS-384/bug-fix-developer-toolkit-widget-interaction-issues-on-the-dashboard)

<div><a href="https://cursor.com/agents/bc-f7130c2b-c214-4471-aafa-70f843e88134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7130c2b-c214-4471-aafa-70f843e88134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

