### PR TITLE
feat: remove feature-flag gate from telemetry Pub/Sub shadow write

### DIFF
--- a/.changeset/telemetry-pubsub-shadow-always-on.md
+++ b/.changeset/telemetry-pubsub-shadow-always-on.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Remove the `telemetry-logs-pubsub-shadow` PostHog killswitch from the telemetry Pub/Sub shadow dual-write; rows written to `telemetry_logs` are now always mirrored to the `gram-telemetry-v1-log-record` topic. The flag was evaluated locally with a constant distinct ID and no groups, which cannot satisfy a group-targeted release condition — evaluation failed on every batch and the fail-closed gate meant nothing was ever published (while emitting a warn log per batch). The publish path is already best-effort and non-blocking, so the extra killswitch added more failure surface than safety.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -706,7 +706,7 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to create publishers: %w", err)
 			}
 
-			telemetryLogPublisher := tm.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs, featureFlags)
+			telemetryLogPublisher := tm.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs)
 
 			telemLogger, shutdown := newTelemetryLogger(ctx, logger, tracerProvider, meterProvider, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled, telemetryLogPublisher)
 			shutdownFuncs = append(shutdownFuncs, shutdown)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -560,7 +560,7 @@ func newWorkerCommand() *cli.Command {
 				backgroundWorkOSClient = workos.NewStubClient()
 			}
 
-			telemetryLogPublisher := telemetry.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs, featureFlags)
+			telemetryLogPublisher := telemetry.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs)
 
 			telemetryLogger, shutdown := newTelemetryLogger(ctx, logger, tracerProvider, meterProvider, db, cache.NewRedisCacheAdapter(redisClient), chDB, logsEnabled, toolIOLogsEnabled, telemetryLogPublisher)
 			shutdownFuncs = append(shutdownFuncs, shutdown)

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -199,7 +199,7 @@ func NewActivities(
 		panic(fmt.Errorf("new analyze batch: %w", err))
 	}
 
-	telemetryLogPublisher := telemetry.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs, features)
+	telemetryLogPublisher := telemetry.NewLogPublisher(logger, tracerProvider, meterProvider, publishers.TelemetryLogs)
 
 	// The chat analysis judge roster. Adding a new session analysis is
 	// registering its judge here; enabling it per organization is a

--- a/server/internal/background/activities/promote_staged_telemetry_test.go
+++ b/server/internal/background/activities/promote_staged_telemetry_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	"github.com/speakeasy-api/gram/server/internal/cache"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -543,9 +542,6 @@ func TestPromoteStagedTelemetry_DedupSkipsAlreadyPromotedRows(t *testing.T) {
 func TestPromoteStagedTelemetry_ShadowPublishesPromotedRows(t *testing.T) {
 	t.Parallel()
 
-	flags := &feature.InMemory{}
-	flags.SetFlag(feature.FlagTelemetryLogsPubSubShadow, telemetry.ShadowFlagDistinctID, true)
-
 	var publishedMu sync.Mutex
 	published := make([]string, 0, 2)
 	mockPub := gcp.NewMockPublisher[*telemetryv1.LogRecord]()
@@ -556,7 +552,7 @@ func TestPromoteStagedTelemetry_ShadowPublishesPromotedRows(t *testing.T) {
 			publishedMu.Unlock()
 		}
 	})
-	logPublisher := telemetry.NewLogPublisher(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), mockPub, flags)
+	logPublisher := telemetry.NewLogPublisher(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), mockPub)
 
 	ctx, act, queries, cacheAdapter := newPromoteStagedTelemetryHarness(t, logPublisher)
 	chConn, err := infra.NewClickhouseClient(t)

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -18,12 +18,6 @@ const (
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
 
-	// FlagTelemetryLogsPubSubShadow gates the best-effort shadow dual-write of
-	// telemetry_logs rows onto Pub/Sub (gram-telemetry-v1-log-record). It is
-	// evaluated globally with a constant distinct ID, not per-org: this is an
-	// infrastructure cutover killswitch, not a product rollout.
-	FlagTelemetryLogsPubSubShadow Flag = "telemetry-logs-pubsub-shadow"
-
 	// FlagHooksRollout gates the phased rollout of new observability (hooks)
 	// plugin generator versions. Unlike the other flags it is consulted via its
 	// PAYLOAD, not its boolean state: the flag carries a JSON payload

--- a/server/internal/telemetry/log_publisher.go
+++ b/server/internal/telemetry/log_publisher.go
@@ -14,7 +14,6 @@ import (
 	telemetryv1 "github.com/speakeasy-api/gram/infra/gen/gram/telemetry/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
@@ -24,11 +23,6 @@ const (
 	// publish spans.
 	pubsubOperationPublishLogs = "publish_telemetry_logs_pubsub"
 
-	// ShadowFlagDistinctID pins flag evaluation to a single constant identity
-	// so percentage rollouts collapse to all-or-nothing: the shadow dual-write
-	// is an infrastructure killswitch, not a per-user rollout.
-	ShadowFlagDistinctID = "global"
-
 	// publishAckAwaitTimeout bounds the detached goroutine that drains publish
 	// acks for one batch. The broker publish itself is bounded separately by
 	// PublishSettings.Timeout, configured where the telemetry publisher is
@@ -37,15 +31,14 @@ const (
 )
 
 // NewNoopLogPublisher returns an inert LogPublisher: a noop Pub/Sub
-// publisher, all flags off, and noop tracing/metrics. For the stub logger and
-// for tests and processes that do not exercise the shadow dual-write.
+// publisher and noop tracing/metrics. For the stub logger and for tests and
+// processes that do not exercise the shadow dual-write.
 func NewNoopLogPublisher(logger *slog.Logger) *LogPublisher {
 	return NewLogPublisher(
 		logger,
 		tracenoop.NewTracerProvider(),
 		metricnoop.NewMeterProvider(),
 		gcp.NewNoopPublisher[*telemetryv1.LogRecord](),
-		&feature.InMemory{},
 	)
 }
 
@@ -58,7 +51,6 @@ type LogPublisher struct {
 	logger *slog.Logger
 	tracer trace.Tracer
 	pub    gcp.Publisher[*telemetryv1.LogRecord]
-	flags  feature.Provider
 
 	// drains tracks in-flight ack-drain goroutines so tests can await them
 	// deterministically (see WaitForPublishDrains in export_test.go).
@@ -67,27 +59,24 @@ type LogPublisher struct {
 
 // NewLogPublisher constructs a LogPublisher. Callers must always pass a
 // publisher — a real Pub/Sub publisher, gcp.NewNoopPublisher where the shadow
-// write is not wanted, or a mock in tests — and a feature provider. The meter
-// provider is currently unused (publish metrics were pulled pending a rethink)
-// but stays in the signature so reintroducing them is not a wiring change.
+// write is not wanted, or a mock in tests. The meter provider is currently
+// unused (publish metrics were pulled pending a rethink) but stays in the
+// signature so reintroducing them is not a wiring change.
 func NewLogPublisher(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	_ metric.MeterProvider,
 	pub gcp.Publisher[*telemetryv1.LogRecord],
-	flags feature.Provider,
 ) *LogPublisher {
 	inv.Require(
 		"telemetry log publisher",
 		"publisher set", pub != nil,
-		"feature provider set", flags != nil,
 	)
 
 	return &LogPublisher{
 		logger: logger.With(attr.SlogComponent("telemetry_log_publisher")),
 		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/telemetry"),
 		pub:    pub,
-		flags:  flags,
 		drains: sync.WaitGroup{},
 	}
 }
@@ -95,7 +84,7 @@ func NewLogPublisher(
 // PublishLogs mirrors rows just written to telemetry_logs onto the shadow
 // topic. It is best-effort and non-blocking: it never blocks on broker acks
 // (results are drained on a detached goroutine) and must never affect the
-// ClickHouse write path. The flag check fails closed.
+// ClickHouse write path.
 func (p *LogPublisher) PublishLogs(ctx context.Context, rows []repo.InsertTelemetryLogParams) {
 	if len(rows) == 0 {
 		return
@@ -109,15 +98,6 @@ func (p *LogPublisher) PublishLogs(ctx context.Context, rows []repo.InsertTeleme
 	// PublishSettings.Timeout and publishAckAwaitTimeout bound the work
 	// instead.
 	ctx = context.WithoutCancel(ctx)
-
-	enabled, err := p.flags.IsFlagEnabledLocal(ctx, feature.FlagTelemetryLogsPubSubShadow, ShadowFlagDistinctID, nil, nil)
-	if err != nil {
-		p.logger.WarnContext(ctx, "failed to evaluate telemetry pubsub shadow flag", attr.SlogError(err))
-		return
-	}
-	if !enabled {
-		return
-	}
 
 	ctx, span := p.tracer.Start(ctx, "telemetry.publishLogs", trace.WithAttributes(
 		attr.TelemetryCHOperation(pubsubOperationPublishLogs),

--- a/server/internal/telemetry/log_publisher_test.go
+++ b/server/internal/telemetry/log_publisher_test.go
@@ -12,7 +12,6 @@ import (
 
 	telemetryv1 "github.com/speakeasy-api/gram/infra/gen/gram/telemetry/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
-	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -52,21 +51,15 @@ func newCapturingMockPublisher(result any) (*gcp.MockPublisher[*telemetryv1.LogR
 	return mockPub, capture
 }
 
-func shadowFlagsOn() *feature.InMemory {
-	flags := &feature.InMemory{}
-	flags.SetFlag(feature.FlagTelemetryLogsPubSubShadow, telemetry.ShadowFlagDistinctID, true)
-	return flags
-}
-
 // newShadowTestLogger builds a Logger backed by the shared test ClickHouse
-// whose shadow publisher uses the given publisher and flags. The LogPublisher
-// is returned alongside so tests can await its ack drains.
-func newShadowTestLogger(t *testing.T, ctx context.Context, ti *testInstance, pub gcp.Publisher[*telemetryv1.LogRecord], flags feature.Provider) (*telemetry.Logger, *telemetry.LogPublisher) {
+// whose shadow publisher uses the given publisher. The LogPublisher is
+// returned alongside so tests can await its ack drains.
+func newShadowTestLogger(t *testing.T, ctx context.Context, ti *testInstance, pub gcp.Publisher[*telemetryv1.LogRecord]) (*telemetry.Logger, *telemetry.LogPublisher) {
 	t.Helper()
 
 	logger := testenv.NewLogger(t)
 	enabled := func(context.Context, string) (bool, error) { return true, nil }
-	logPub := telemetry.NewLogPublisher(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), pub, flags)
+	logPub := telemetry.NewLogPublisher(logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), pub)
 	return telemetry.NewLogger(ctx, logger, testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.chConn, enabled, enabled, nil, logPub), logPub
 }
 
@@ -99,7 +92,7 @@ func TestLogPublisher_MirrorsRowsToPubSub(t *testing.T) {
 	ctx, ti := newTestLogsService(t)
 
 	mockPub, capture := newCapturingMockPublisher(gcp.NewSuccessPublishResult())
-	telemLogger, logPub := newShadowTestLogger(t, ctx, ti, mockPub, shadowFlagsOn())
+	telemLogger, logPub := newShadowTestLogger(t, ctx, ti, mockPub)
 
 	toolInfoA := newTestToolInfo(ti.orgID)
 	toolInfoB := newTestToolInfo(ti.orgID)
@@ -154,32 +147,6 @@ func TestLogPublisher_MirrorsRowsToPubSub(t *testing.T) {
 	logPub.WaitForPublishDrains()
 }
 
-// TestLogPublisher_FlagOffPublishesNothing verifies the killswitch: with the
-// shadow flag off (the fail-closed default), rows land in ClickHouse and
-// nothing is published.
-func TestLogPublisher_FlagOffPublishesNothing(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTestLogsService(t)
-
-	mockPub := gcp.NewMockPublisher[*telemetryv1.LogRecord]()
-	telemLogger, _ := newShadowTestLogger(t, ctx, ti, mockPub, &feature.InMemory{})
-
-	attrs := telemetry.HTTPLogAttributes{}
-	attrs.RecordMethod("GET")
-	attrs.RecordStatusCode(200)
-
-	toolInfo := newTestToolInfo(ti.orgID)
-	timestamp := time.Now().UTC()
-	require.NoError(t, telemLogger.LogBulk(ctx, []telemetry.LogParams{
-		{Timestamp: timestamp, ToolInfo: toolInfo, Attributes: attrs},
-	}))
-
-	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
-	fetchLog(t, ctx, ti.chClient, toolInfo.ProjectID, toolInfo.URN, timestamp)
-	mockPub.AssertNotCalled(t, "Publish", mock.Anything, mock.Anything)
-}
-
 // TestLogPublisher_PublishesDespiteCanceledContext verifies that caller
 // cancellation does not drop the shadow copy. PublishLogs runs after ClickHouse
 // accepted the rows, and a row skipped at that point is never re-published: a
@@ -194,7 +161,6 @@ func TestLogPublisher_PublishesDespiteCanceledContext(t *testing.T) {
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		mockPub,
-		shadowFlagsOn(),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -233,7 +199,7 @@ func TestLogPublisher_PublishFailureDoesNotAffectWrite(t *testing.T) {
 	ctx, ti := newTestLogsService(t)
 
 	mockPub, capture := newCapturingMockPublisher(errors.New("broker unavailable"))
-	telemLogger, logPub := newShadowTestLogger(t, ctx, ti, mockPub, shadowFlagsOn())
+	telemLogger, logPub := newShadowTestLogger(t, ctx, ti, mockPub)
 
 	attrs := telemetry.HTTPLogAttributes{}
 	attrs.RecordMethod("GET")


### PR DESCRIPTION
## Summary

Follow-up to #4468. The shadow dual-write of `telemetry_logs` rows to Pub/Sub never fired in prod: the `telemetry-logs-pubsub-shadow` PostHog flag was created with a group-targeted release condition, but the code evaluates it locally with a constant distinct ID (`"global"`) and no groups. The posthog-go SDK cannot locally evaluate a group-aggregated flag without group names, so every evaluation errored, the fail-closed gate skipped the publish, and `gram-server`/`gram-worker` emitted ~30k `failed to evaluate telemetry pubsub shadow flag` warn logs per hour.

Rather than reconfiguring the flag, this removes the killswitch entirely — it's overkill here:

- The publish path is already best-effort and non-blocking: it runs only after ClickHouse accepts the rows, drains acks on a detached bounded goroutine, and can never affect the write path or add request latency.
- A misconfigured flag was a bigger operational hazard (silent no-op + log spam) than the failure mode it guarded against.

Changes:

- `telemetry.LogPublisher` now publishes unconditionally; dropped the `feature.Provider` dependency, the `ShadowFlagDistinctID` constant, and the flag check.
- Removed `feature.FlagTelemetryLogsPubSubShadow` from the flag registry.
- Updated wiring in `start.go`, `worker.go`, and background activities; processes that don't want the shadow write keep passing a noop Pub/Sub publisher.
- Dropped the now-meaningless flag-off test; the remaining publisher tests (id fidelity, canceled-context, publish-failure isolation, promotion-path publishing) are unchanged in intent.

## Test plan

- [x] `go build ./server/...` and `go vet` on affected packages
- [x] `go test -race` on `server/internal/telemetry` and `server/internal/background/activities` (publisher + promotion shadow tests)
- [x] `mise lint:server` clean
- [ ] After deploy: confirm `telemetry.publishLogs` spans appear and no `failed to publish telemetry logs to pubsub` errors (would indicate topic/permission issues)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `telemetry-logs-pubsub-shadow` killswitch and publishes telemetry logs to Pub/Sub unconditionally. Fixes the broken local flag evaluation that disabled the shadow write and spammed warn logs.

- Bug Fixes
  - Always mirror `telemetry_logs` rows to the `gram-telemetry-v1-log-record` topic; publish stays best-effort and non-blocking.
  - Dropped the `telemetry-logs-pubsub-shadow` flag and plumbing from `LogPublisher`/`NewLogPublisher`; updated `start.go`, `worker.go`, background activities, and tests. Processes that don’t want the shadow write continue to pass a noop publisher.
  - Eliminates warn log spam and ensures the Pub/Sub shadow write actually runs.

<sup>Written for commit 82e88432cafe4402c4186280ba9d094dd06b4d23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

