### PR TITLE
ci: run atlas-push on every PR so preview migration tags always exist

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -924,8 +924,17 @@ jobs:
   atlas-push:
     name: Push migrations to Atlas Registry
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes, server-build-lint]
-    if: needs.changes.outputs.server == 'true' && github.event_name != 'merge_group'
+    # Preview environments pin AtlasMigration resources to the
+    # pr-<number>-<8-char head sha> tag, so this must run for every PR head
+    # commit regardless of changed paths (adding the preview label does not
+    # re-run the workflow). Pushing a dir whose content is unchanged from
+    # main deduplicates server-side into a tag alias of the existing
+    # registry version. Forks are excluded because they cannot read
+    # ATLAS_TOKEN, and a skipped job passes ci-gate while a failed one
+    # would not.
+    if: |
+      github.event_name != 'merge_group' &&
+      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Problem

Preview environments fail to deploy for PRs that don't touch server code. Example: pr-4598.dev.getgram.ai returned `403 invalid domain` because the preview env never came up, so the request fell through the `*.dev.getgram.ai` wildcard to the main dev server's custom-domains middleware.

The chain:

1. The preview ApplicationSet pins `AtlasMigration` resources to the `pr-<number>-<8-char head sha>` registry tag.
2. That tag is only pushed by the `atlas-push` job, which was gated on `needs.changes.outputs.server == 'true'` (since #2158).
3. Frontend-only PR → `atlas-push` skipped → tag missing → ArgoCD sync fails with `AtlasMigration ... tag "pr-4598-b1e609c7" of directory "gram" not found` → no namespace, no ingress.

Docker images already handle this (`preview-image-tags` aliases main images for unchanged components), but Atlas registry tags had no equivalent.

## Fix

Run `atlas-push` for every PR head commit instead of only when server paths change:

- Dropped `needs: [changes, server-build-lint]` and the `server == 'true'` gate. The lint ordering wasn't load-bearing: migration dir validity is checked by atlas itself (dev-url replay) plus the dedicated `atlas-lint` / `lint-migrations` jobs.
- When a PR doesn't touch migrations, the pushed dir content is identical to main, so Atlas Cloud deduplicates the push into a tag alias of the existing version.
- Added a fork guard: forks can't read `ATLAS_TOKEN`, and since `atlas-push` feeds `ci-gate`, a hard failure there would block fork PRs entirely (a skipped job passes the gate). This also fixes the pre-existing failure mode for fork PRs that touch server code.
- Runs on every head push rather than gating on the `preview` label for the same reason as `preview-image-tags`: adding a label does not re-run the workflow.

Note: `atlas-push` failures now surface on frontend-only PRs too (via `ci-gate`). Merge-queue behavior unchanged (`merge_group` still excluded).

## Verification

- `actionlint` passes (only pre-existing blacksmith runner-label warnings).
- Existing broken preview PRs (e.g. #4598) need a new head commit after this merges, or a manual `atlas migrate push` with their tag.