### PR TITLE
feat: add GCP Cloud KMS signing client

### DIFF
--- a/.changeset/gcp-kms-signing-client.md
+++ b/.changeset/gcp-kms-signing-client.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add support for signing with GCP Cloud KMS keys, so a signing key's private half never leaves the key management service holding it. Groundwork only: no API or dashboard surface uses it yet.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ tool goa.design/goa/v3/cmd/goa
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
+	cloud.google.com/go/kms v1.26.0
 	cloud.google.com/go/pubsub/v2 v2.3.0
 	cloud.google.com/go/storage v1.62.1
 	github.com/BurntSushi/toml v1.6.0
@@ -33,6 +34,7 @@ require (
 	github.com/exaring/otelpgx v0.10.0
 	github.com/failsafe-go/failsafe-go v0.9.6
 	github.com/go-chi/chi/v5 v5.3.1
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3
 	github.com/go-redis/cache/v9 v9.0.0
 	github.com/go-redis/redis_rate/v10 v10.0.1
@@ -119,6 +121,7 @@ require (
 	cloud.google.com/go/auth v0.19.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -190,7 +193,6 @@ require (
 	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCB
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/iam v1.7.0/go.mod h1:tetWZW1PD/m6vcuY2Zj/aU0eCHNPuxedbnbRTyKXvdY=
+cloud.google.com/go/kms v1.26.0 h1:cK9mN2cf+9V63D3H1f6koxTatWy39aTI/hCjz1I+adU=
+cloud.google.com/go/kms v1.26.0/go.mod h1:pHKOdFJm63hxBsiPkYtowZPltu9dW0MWvBa6IA4HM58=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
 cloud.google.com/go/logging v1.13.2/go.mod h1:zaybliM3yun1J8mU2dVQ1/qDzjbOqEijZCn6hSBtKak=
 cloud.google.com/go/longrunning v0.9.0 h1:0EzbDEGsAvOZNbqXopgniY0w0a1phvu5IdUFq8grmqY=

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1148,7 +1148,11 @@ func newStartCommand() *cli.Command {
 			deploymentsService := deployments.NewService(logger, tracerProvider, db, temporalEnv, sessionManager, assetStorage, posthogClient, siteURL, mcpRegistryClient, authzEngine, auditLogger)
 			deployments.Attach(mux, deploymentsService)
 			keys.Attach(mux, keys.NewService(logger, tracerProvider, db, sessionManager, c.String("environment"), authzEngine, auditLogger))
-			externalcredentials.Attach(mux, externalcredentials.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, gcpauth.NewResolver()))
+			// Hoisted so services that authenticate as a customer's GCP identity
+			// share one resolver instead of each constructing their own. Only the
+			// credentials service consumes it today.
+			gcpIdentityResolver := gcpauth.NewResolver()
+			externalcredentials.Attach(mux, externalcredentials.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, gcpIdentityResolver))
 			externalkeys.Attach(mux, externalkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger))
 			cliauth.Attach(mux, cliauth.NewService(logger, tracerProvider, db, sessionManager, authzEngine, redisClient, c.String("environment")))
 			chatsessionssvc.Attach(mux, chatsessionssvc.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, authzEngine))

--- a/server/internal/externalcredentials/setup_test.go
+++ b/server/internal/externalcredentials/setup_test.go
@@ -2,12 +2,14 @@ package externalcredentials_test
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	adminecgen "github.com/speakeasy-api/gram/server/gen/admin_external_credentials"
 	gen "github.com/speakeasy-api/gram/server/gen/external_credentials"
@@ -57,8 +59,16 @@ type fakeGcpResolver struct {
 	fn func(ctx context.Context, cred gcpauth.Credential) (gcpauth.Principal, error)
 }
 
+var _ gcpauth.Resolver = (*fakeGcpResolver)(nil)
+
 func (f *fakeGcpResolver) ResolvePrincipal(ctx context.Context, cred gcpauth.Credential) (gcpauth.Principal, error) {
 	return f.fn(ctx, cred)
+}
+
+// TokenSource is unused by the credentials service, which only ever describes an
+// identity rather than calling Google APIs as it.
+func (f *fakeGcpResolver) TokenSource(context.Context, gcpauth.Credential) (oauth2.TokenSource, error) {
+	return nil, errors.New("fakeGcpResolver: TokenSource not supported")
 }
 
 // withAdmin returns ctx with the auth context's IsAdmin flag flipped to true.

--- a/server/internal/thirdparty/gcp/gcpauth/doc.go
+++ b/server/internal/thirdparty/gcp/gcpauth/doc.go
@@ -1,9 +1,13 @@
-// Package gcpauth resolves the effective identity ("who am I") behind a GCP IAM
-// external credential: given how the credential authenticates, it reports the
-// principal that identity resolves to and, in doing so, proves the identity is
-// reachable and usable.
+// Package gcpauth turns a GCP IAM external credential into the two things
+// callers need from it.
 //
-// The ambient attached identity and service-account impersonation are resolved
+// ResolvePrincipal answers "who am I": it reports the principal the credential's
+// identity resolves to and, in doing so, proves that identity is reachable and
+// usable by minting a token. TokenSource returns the oauth2.TokenSource that
+// authenticates Google API calls made as that identity, for callers that need to
+// actually use the credential rather than describe it.
+//
+// The ambient attached identity and service-account impersonation are supported
 // today. Workload Identity Federation is recognized and reported as
 // not-yet-supported (ErrUnsupportedMode) rather than silently ignored, leaving
 // the seam ready to extend.

--- a/server/internal/thirdparty/gcp/gcpauth/resolver.go
+++ b/server/internal/thirdparty/gcp/gcpauth/resolver.go
@@ -77,9 +77,9 @@ func resolveAmbient(ctx context.Context) (Principal, error) {
 	// Credentials. ADC reads the metadata server in-cluster and the local
 	// credentials off-GCP, so success means the identity can actually obtain a
 	// token, not merely that a service account is attached.
-	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
+	creds, err := ambientCredentials(ctx)
 	if err != nil {
-		return Principal{}, fmt.Errorf("resolve application default credentials: %w", err)
+		return Principal{}, err
 	}
 	if _, err := creds.TokenSource.Token(); err != nil {
 		return Principal{}, fmt.Errorf("mint token from application default credentials: %w", err)
@@ -112,9 +112,9 @@ func (r *DefaultResolver) TokenSource(ctx context.Context, cred Credential) (oau
 	case modeImpersonation:
 		return impersonatedTokenSource(ctx, cred.ImpersonateServiceAccount)
 	case modeAmbient:
-		creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
+		creds, err := ambientCredentials(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("resolve application default credentials: %w", err)
+			return nil, err
 		}
 		return creds.TokenSource, nil
 	case modeWIF:
@@ -122,6 +122,22 @@ func (r *DefaultResolver) TokenSource(ctx context.Context, cred Credential) (oau
 	default:
 		return nil, ErrUnsupportedMode
 	}
+}
+
+// ambientCredentials loads Gram's own Application Default Credentials, which
+// read the metadata server in-cluster and local credentials off-GCP.
+//
+// Both the principal probe and the token source go through it. ResolvePrincipal
+// cannot simply call TokenSource, because it also needs the credentials JSON to
+// recover a service-account email, so this is the shared point that stops the
+// two paths drifting in which credentials they load or how a failure reads.
+func ambientCredentials(ctx context.Context) (*google.Credentials, error) {
+	creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("resolve application default credentials: %w", err)
+	}
+
+	return creds, nil
 }
 
 // resolveImpersonated proves Gram's own identity can impersonate the target

--- a/server/internal/thirdparty/gcp/gcpauth/resolver.go
+++ b/server/internal/thirdparty/gcp/gcpauth/resolver.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/impersonate"
 )
@@ -27,9 +28,19 @@ const metadataProbeTimeout = 2 * time.Second
 // should surface it as a reportable outcome rather than an internal error.
 var ErrUnsupportedMode = errors.New("credential identity mode not yet supported")
 
-// Resolver resolves the effective principal behind a GCP IAM credential.
+// Resolver resolves a GCP IAM credential into the two things callers need from
+// it: who the credential's identity is, and a token source that authenticates
+// Google API calls made as that identity.
 type Resolver interface {
+	// ResolvePrincipal reports the effective principal and proves the identity is
+	// usable by minting a token.
 	ResolvePrincipal(ctx context.Context, cred Credential) (Principal, error)
+
+	// TokenSource returns a token source that authenticates calls as the
+	// credential's identity. The source is lazy: obtaining it does not prove the
+	// identity works, so callers that need that guarantee up front should use
+	// ResolvePrincipal.
+	TokenSource(ctx context.Context, cred Credential) (oauth2.TokenSource, error)
 }
 
 // DefaultResolver resolves a GCP credential's effective principal using the
@@ -89,12 +100,51 @@ func resolveAmbient(ctx context.Context) (Principal, error) {
 	return Principal{Email: serviceAccountEmail(creds.JSON), Source: SourceADC}, nil
 }
 
+// TokenSource returns a token source authenticating as the credential's
+// identity. Workload Identity Federation credentials return ErrUnsupportedMode.
+//
+// Unlike ResolvePrincipal this does not mint a token, so a credential that
+// cannot actually obtain one fails at first use rather than here. That is
+// deliberate: the returned source refreshes on its own schedule, so proving it
+// once up front would guarantee nothing about later calls.
+func (r *DefaultResolver) TokenSource(ctx context.Context, cred Credential) (oauth2.TokenSource, error) {
+	switch cred.mode() {
+	case modeImpersonation:
+		return impersonatedTokenSource(ctx, cred.ImpersonateServiceAccount)
+	case modeAmbient:
+		creds, err := google.FindDefaultCredentials(ctx, cloudPlatformScope)
+		if err != nil {
+			return nil, fmt.Errorf("resolve application default credentials: %w", err)
+		}
+		return creds.TokenSource, nil
+	case modeWIF:
+		return nil, ErrUnsupportedMode
+	default:
+		return nil, ErrUnsupportedMode
+	}
+}
+
 // resolveImpersonated proves Gram's own identity can impersonate the target
 // service account by minting a token as it. Unlike the ambient probe this is a
 // real authorization check: it only succeeds when Gram's identity holds
 // roles/iam.serviceAccountTokenCreator on the target. The effective principal is
 // the target service account itself.
 func resolveImpersonated(ctx context.Context, targetServiceAccount string) (Principal, error) {
+	tokenSource, err := impersonatedTokenSource(ctx, targetServiceAccount)
+	if err != nil {
+		return Principal{}, err
+	}
+	if _, err := tokenSource.Token(); err != nil {
+		return Principal{}, fmt.Errorf("impersonate %s: %w", targetServiceAccount, err)
+	}
+	return Principal{Email: targetServiceAccount, Source: SourceImpersonation}, nil
+}
+
+// impersonatedTokenSource builds a token source that mints tokens as the target
+// service account, using Gram's own identity (Application Default Credentials)
+// as the base. The returned source caches and refreshes tokens internally, so
+// callers should retain it rather than rebuilding it per call.
+func impersonatedTokenSource(ctx context.Context, targetServiceAccount string) (oauth2.TokenSource, error) {
 	tokenSource, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
 		TargetPrincipal: targetServiceAccount,
 		Scopes:          []string{cloudPlatformScope},
@@ -103,12 +153,9 @@ func resolveImpersonated(ctx context.Context, targetServiceAccount string) (Prin
 		Subject:         "",
 	})
 	if err != nil {
-		return Principal{}, fmt.Errorf("build impersonated token source for %s: %w", targetServiceAccount, err)
+		return nil, fmt.Errorf("build impersonated token source for %s: %w", targetServiceAccount, err)
 	}
-	if _, err := tokenSource.Token(); err != nil {
-		return Principal{}, fmt.Errorf("impersonate %s: %w", targetServiceAccount, err)
-	}
-	return Principal{Email: targetServiceAccount, Source: SourceImpersonation}, nil
+	return tokenSource, nil
 }
 
 // serviceAccountEmail extracts the client_email from an ADC credentials JSON

--- a/server/internal/thirdparty/gcp/gcpauth/resolver_test.go
+++ b/server/internal/thirdparty/gcp/gcpauth/resolver_test.go
@@ -17,6 +17,36 @@ func TestResolvePrincipal_RejectsWIF(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnsupportedMode)
 }
 
+func TestTokenSource_RejectsWIF(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewResolver().TokenSource(t.Context(), Credential{
+		WifPoolID:        "pool",
+		WifProviderID:    "provider",
+		WifProjectNumber: "123456789",
+	})
+	require.ErrorIs(t, err, ErrUnsupportedMode)
+}
+
+// A WIF credential may also name an impersonation target, which must not
+// downgrade it to the supported impersonation path on either entry point.
+func TestTokenSource_RejectsWIFWithImpersonationHop(t *testing.T) {
+	t.Parallel()
+
+	cred := Credential{
+		ImpersonateServiceAccount: "hop@proj.iam.gserviceaccount.com",
+		WifPoolID:                 "pool",
+		WifProviderID:             "provider",
+		WifProjectNumber:          "123456789",
+	}
+
+	_, tsErr := NewResolver().TokenSource(t.Context(), cred)
+	require.ErrorIs(t, tsErr, ErrUnsupportedMode)
+
+	_, principalErr := NewResolver().ResolvePrincipal(t.Context(), cred)
+	require.ErrorIs(t, principalErr, ErrUnsupportedMode)
+}
+
 func TestServiceAccountEmail(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/gcp/gcpkms/algorithm.go
+++ b/server/internal/thirdparty/gcp/gcpkms/algorithm.go
@@ -1,0 +1,94 @@
+package gcpkms
+
+import (
+	"crypto"
+	_ "crypto/sha256" // registers SHA-256 so crypto.SHA256.New() is available
+	"errors"
+	"fmt"
+	"slices"
+
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// ErrUnsupportedAlgorithm is returned when a key signs with an algorithm Gram
+// does not publish. It is a misconfiguration rather than a fault, so callers
+// should surface it as a reportable outcome.
+var ErrUnsupportedAlgorithm = errors.New("kms key algorithm not supported")
+
+// supportedAlgorithms are the JOSE signing algorithms Gram publishes and signs
+// with. Widening this set is an interoperability decision, not a mechanical one:
+// PS256 is optional in RFC 7518 and plenty of verifiers do not implement it.
+var supportedAlgorithms = []jose.SignatureAlgorithm{jose.RS256, jose.ES256}
+
+// joseAlgorithmByKMS maps GCP KMS asymmetric-sign algorithms onto their JOSE
+// equivalents. Algorithms Gram does not support are listed deliberately: naming
+// what a key actually is makes a misconfiguration self-explanatory. RSA-PSS
+// matters most here — PS256 and RS256 are both RSA over SHA-256, but PSS and
+// PKCS#1 v1.5 produce signatures no shared verifier accepts, so a PSS key
+// silently mounted as RS256 would mint unverifiable tokens.
+//
+// Only signing algorithms appear. Encryption, HMAC, KEM and post-quantum
+// algorithms have no JOSE signature equivalent, and joseAlgorithm rejects any
+// key whose algorithm is absent from this map.
+//
+//nolint:exhaustive // signing algorithms only, per the note above
+var joseAlgorithmByKMS = map[kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm]jose.SignatureAlgorithm{
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256: jose.RS256,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256: jose.RS256,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256: jose.RS256,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512: jose.RS512,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256:   jose.PS256,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_3072_SHA256:   jose.PS256,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA256:   jose.PS256,
+	kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512:   jose.PS512,
+	kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256:        jose.ES256,
+	kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384:        jose.ES384,
+	kmspb.CryptoKeyVersion_EC_SIGN_ED25519:            jose.EdDSA,
+}
+
+// joseAlgorithm maps a KMS key-version algorithm onto the JOSE algorithm Gram
+// records, rejecting anything outside the supported set.
+func joseAlgorithm(kmsAlg kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) (jose.SignatureAlgorithm, error) {
+	alg, known := joseAlgorithmByKMS[kmsAlg]
+	if !known {
+		return "", fmt.Errorf("%w: key version signs with %s, which has no JOSE equivalent", ErrUnsupportedAlgorithm, kmsAlg)
+	}
+
+	if !slices.Contains(supportedAlgorithms, alg) {
+		return "", fmt.Errorf("%w: key version signs with %s (JOSE %s); Gram supports %v", ErrUnsupportedAlgorithm, kmsAlg, alg, supportedAlgorithms)
+	}
+
+	return alg, nil
+}
+
+// digestHash is the hash a JOSE algorithm digests its payload with before the
+// signature is computed.
+func digestHash(alg jose.SignatureAlgorithm) (crypto.Hash, error) {
+	switch alg {
+	case jose.RS256, jose.ES256:
+		return crypto.SHA256, nil
+	default:
+		return 0, fmt.Errorf("%w: no digest defined for %s", ErrUnsupportedAlgorithm, alg)
+	}
+}
+
+// digestPayload hashes a payload with the algorithm's digest. GCP KMS signs a
+// digest rather than the payload itself, so this runs on the caller's side.
+func digestPayload(alg jose.SignatureAlgorithm, payload []byte) ([]byte, error) {
+	hash, err := digestHash(alg)
+	if err != nil {
+		return nil, err
+	}
+
+	if !hash.Available() {
+		return nil, fmt.Errorf("%w: hash %s is not linked into the binary", ErrUnsupportedAlgorithm, hash)
+	}
+
+	h := hash.New()
+	if _, err := h.Write(payload); err != nil {
+		return nil, fmt.Errorf("hash payload with %s: %w", hash, err)
+	}
+
+	return h.Sum(nil), nil
+}

--- a/server/internal/thirdparty/gcp/gcpkms/algorithm_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/algorithm_test.go
@@ -1,0 +1,96 @@
+package gcpkms
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoseAlgorithm_SupportedRSA(t *testing.T) {
+	t.Parallel()
+
+	for _, kmsAlg := range []kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm{
+		kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256,
+	} {
+		alg, err := joseAlgorithm(kmsAlg)
+		require.NoError(t, err, "%s should map to RS256", kmsAlg)
+		require.Equal(t, jose.RS256, alg)
+	}
+}
+
+func TestJoseAlgorithm_SupportedECDSA(t *testing.T) {
+	t.Parallel()
+
+	alg, err := joseAlgorithm(kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256)
+	require.NoError(t, err)
+	require.Equal(t, jose.ES256, alg)
+}
+
+// RSA-PSS is the dangerous near-miss: same RSA key, same SHA-256, but PS256 not
+// RS256. Accepting it would silently mint tokens no verifier accepts, so the
+// rejection must name both the KMS algorithm and its real JOSE identity.
+func TestJoseAlgorithm_RejectsRSAPSSByName(t *testing.T) {
+	t.Parallel()
+
+	_, err := joseAlgorithm(kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+	require.ErrorContains(t, err, "RSA_SIGN_PSS_2048_SHA256")
+	require.ErrorContains(t, err, "PS256")
+}
+
+func TestJoseAlgorithm_RejectsKnownButUnsupported(t *testing.T) {
+	t.Parallel()
+
+	for _, kmsAlg := range []kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm{
+		kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512,
+		kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512,
+		kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384,
+	} {
+		_, err := joseAlgorithm(kmsAlg)
+		require.ErrorIs(t, err, ErrUnsupportedAlgorithm, "%s must not be accepted", kmsAlg)
+	}
+}
+
+func TestJoseAlgorithm_RejectsNonSigningAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	_, err := joseAlgorithm(kmspb.CryptoKeyVersion_GOOGLE_SYMMETRIC_ENCRYPTION)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+	require.ErrorContains(t, err, "no JOSE equivalent")
+}
+
+// Ed25519 signing keys DO have a JOSE equivalent (EdDSA), so they must be
+// rejected for being outside the supported set rather than for lacking a
+// mapping, which would send an operator looking for something that exists.
+func TestJoseAlgorithm_RejectsEd25519WithAccurateReason(t *testing.T) {
+	t.Parallel()
+
+	_, err := joseAlgorithm(kmspb.CryptoKeyVersion_EC_SIGN_ED25519)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+	require.ErrorContains(t, err, "EdDSA")
+	require.NotContains(t, err.Error(), "no JOSE equivalent")
+}
+
+func TestDigestPayload(t *testing.T) {
+	t.Parallel()
+
+	want := sha256.Sum256([]byte(ProbePayload))
+
+	for _, alg := range []jose.SignatureAlgorithm{jose.RS256, jose.ES256} {
+		digest, err := digestPayload(alg, []byte(ProbePayload))
+		require.NoError(t, err)
+		require.Equal(t, want[:], digest)
+	}
+}
+
+func TestDigestPayload_RejectsUnsupportedAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	_, err := digestPayload(jose.PS256, []byte(ProbePayload))
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}

--- a/server/internal/thirdparty/gcp/gcpkms/doc.go
+++ b/server/internal/thirdparty/gcp/gcpkms/doc.go
@@ -1,0 +1,23 @@
+// Package gcpkms signs with GCP Cloud KMS asymmetric keys whose private half
+// never leaves the provider.
+//
+// The package is deliberately GCP-concrete. The cross-provider seam is
+// jose.OpaqueSigner, which NewSigner returns and which every go-jose JWS and JWT
+// path already accepts, so an AWS KMS equivalent can sit beside this package
+// without either of them growing a shared abstraction.
+//
+// Only RS256 and ES256 are supported. That is an interoperability choice rather
+// than a technical limit: they are the two algorithms every OIDC and MCP
+// verifier implements. A key signing with anything else is rejected by name, so
+// a key version configured for RSA-PSS reports that it is PS256 instead of
+// silently producing signatures no verifier accepts.
+//
+// Everything here is scoped to keys whose KMS purpose is ASYMMETRIC_SIGN, which
+// is why the identifiers say "signing" and why ValidateKeyVersionName requires a
+// cryptoKeyVersions suffix. A key's purpose is fixed at creation, so symmetric
+// ENCRYPT_DECRYPT support would not extend these types: it addresses keys at the
+// cryptoKeys level (KMS picks the version, and the ciphertext records which one),
+// has no public half, and so needs its own interface and validator. The parts
+// worth sharing at that point are the token source and the authenticated
+// connection setup in NewSigningClient, not this API.
+package gcpkms

--- a/server/internal/thirdparty/gcp/gcpkms/kms_signing_client.go
+++ b/server/internal/thirdparty/gcp/gcpkms/kms_signing_client.go
@@ -1,0 +1,188 @@
+package gcpkms
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+	"hash/crc32"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	jose "github.com/go-jose/go-jose/v4"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// castagnoli is the CRC-32C polynomial GCP KMS uses for its integrity checks.
+var castagnoli = crc32.MakeTable(crc32.Castagnoli)
+
+// crc32c returns the CRC-32C of data as the int64 the KMS wrappers use. The
+// conversion is lossless: a CRC is 32 bits, so it always fits.
+func crc32c(data []byte) int64 {
+	return int64(crc32.Checksum(data, castagnoli))
+}
+
+var _ SigningClient = (*kmsSigningClient)(nil)
+
+// kmsSigningClient is the SigningClient backed by real GCP Cloud KMS.
+type kmsSigningClient struct {
+	kms *kms.KeyManagementClient
+}
+
+// NewSigningClient opens an authenticated GCP KMS client. The caller owns its
+// lifetime and MUST Close it: each client holds a gRPC connection, so a missed
+// Close leaks one silently.
+func NewSigningClient(ctx context.Context, tokenSource oauth2.TokenSource) (SigningClient, error) {
+	c, err := kms.NewKeyManagementClient(ctx, option.WithTokenSource(tokenSource))
+	if err != nil {
+		return nil, fmt.Errorf("build gcp kms client: %w", err)
+	}
+
+	return &kmsSigningClient{kms: c}, nil
+}
+
+// Close releases the underlying gRPC connection. It is not optional: each
+// client holds its own connection, so skipping Close leaks one per call site
+// with no visible symptom until the process runs out of them.
+func (c *kmsSigningClient) Close() error {
+	if err := c.kms.Close(); err != nil {
+		return fmt.Errorf("close gcp kms client: %w", err)
+	}
+
+	return nil
+}
+
+// GetPublicKey reads a key version's public half and reports the JOSE algorithm
+// it actually signs with, which is what lets callers detect a key pointed at a
+// row configured for a different algorithm.
+//
+// It fails rather than returning a key when the algorithm is one Gram does not
+// publish (ErrUnsupportedAlgorithm), when the PEM checksum does not match, or
+// when the PEM cannot be parsed. Note this is a KMS management-tier operation:
+// its quota is far below that of the cryptographic operations, so it is not
+// safe to call on a per-signature path.
+func (c *kmsSigningClient) GetPublicKey(ctx context.Context, resourceName string) (*PublicKey, error) {
+	if err := ValidateKeyVersionName(resourceName); err != nil {
+		return nil, err
+	}
+
+	// The format MUST be left unspecified. Per the API contract, specifying one
+	// (even PublicKey_PEM) routes the key into the response's public_key field
+	// instead, and leaves pem / pem_crc32c empty — which the code below reads.
+	// Unspecified is what populates pem for non-PQC algorithms.
+	resp, err := c.kms.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{
+		Name:            resourceName,
+		PublicKeyFormat: kmspb.PublicKey_PUBLIC_KEY_FORMAT_UNSPECIFIED,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get gcp kms public key: %w", err)
+	}
+
+	// GCP returns a CRC-32C over the PEM so callers can detect corruption in
+	// transit. An absent checksum means the field was not populated, which is not
+	// the same as the payload being trustworthy.
+	pemData := resp.GetPem()
+	checksum := resp.GetPemCrc32C()
+	switch {
+	case checksum == nil:
+		return nil, errors.New("get gcp kms public key: response omitted the pem checksum")
+	case checksum.GetValue() != crc32c([]byte(pemData)):
+		return nil, errors.New("get gcp kms public key: pem checksum mismatch, response corrupted in transit")
+	}
+
+	// GCP asks callers to confirm the response describes the key they requested;
+	// the checksums only prove the bytes arrived intact, not that they came from
+	// the right resource.
+	if got := resp.GetName(); got != resourceName {
+		return nil, fmt.Errorf("get gcp kms public key: response describes %q, requested %q", got, resourceName)
+	}
+
+	alg, err := joseAlgorithm(resp.GetAlgorithm())
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := parsePublicKeyPEM(pemData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublicKey{Algorithm: alg, Key: key}, nil
+}
+
+// AsymmetricSign signs a digest and returns the signature in the provider's own
+// encoding: PKCS#1 v1.5 for RSA, ASN.1 DER for ECDSA. Converting DER to the
+// fixed-width form JOSE requires is the signer's job, not this layer's.
+//
+// The digest must already be hashed with the algorithm's hash and be exactly
+// that hash's width; KMS never sees the payload. Both CRC-32C guards GCP
+// provides are enforced, so a request whose digest arrived corrupted, or a
+// response whose signature did, is an error rather than a bad signature handed
+// back to the caller.
+func (c *kmsSigningClient) AsymmetricSign(ctx context.Context, resourceName string, alg jose.SignatureAlgorithm, digest []byte) ([]byte, error) {
+	if err := ValidateKeyVersionName(resourceName); err != nil {
+		return nil, err
+	}
+
+	pbDigest, err := protoDigest(alg, digest)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.kms.AsymmetricSign(ctx, &kmspb.AsymmetricSignRequest{
+		Name:         resourceName,
+		Digest:       pbDigest,
+		DigestCrc32C: wrapperspb.Int64(crc32c(digest)),
+		Data:         nil,
+		DataCrc32C:   nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gcp kms asymmetric sign: %w", err)
+	}
+
+	// Confirm the signature came from the key version that was asked for, as GCP
+	// documents; the checksums below only prove the bytes survived the wire.
+	if got := resp.GetName(); got != resourceName {
+		return nil, fmt.Errorf("gcp kms asymmetric sign: response signed with %q, requested %q", got, resourceName)
+	}
+
+	// GCP echoes back whether it received an intact digest, plus a checksum over
+	// the signature. Both must hold, or something was corrupted on the wire.
+	if !resp.GetVerifiedDigestCrc32C() {
+		return nil, errors.New("gcp kms asymmetric sign: server could not verify the digest checksum, request corrupted in transit")
+	}
+
+	signature := resp.GetSignature()
+	sigChecksum := resp.GetSignatureCrc32C()
+	switch {
+	case sigChecksum == nil:
+		return nil, errors.New("gcp kms asymmetric sign: response omitted the signature checksum")
+	case sigChecksum.GetValue() != crc32c(signature):
+		return nil, errors.New("gcp kms asymmetric sign: signature checksum mismatch, response corrupted in transit")
+	}
+
+	return signature, nil
+}
+
+// protoDigest wraps a digest in the request field matching its hash. GCP rejects
+// a digest placed in the wrong field, so the length check here turns a remote
+// InvalidArgument into a local, explicit error.
+func protoDigest(alg jose.SignatureAlgorithm, digest []byte) (*kmspb.Digest, error) {
+	hash, err := digestHash(alg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(digest) != hash.Size() {
+		return nil, fmt.Errorf("digest is %d bytes, expected %d for %s", len(digest), hash.Size(), alg)
+	}
+
+	switch hash {
+	case crypto.SHA256:
+		return &kmspb.Digest{Digest: &kmspb.Digest_Sha256{Sha256: digest}}, nil
+	default:
+		return nil, fmt.Errorf("%w: no kms digest field for %s", ErrUnsupportedAlgorithm, alg)
+	}
+}

--- a/server/internal/thirdparty/gcp/gcpkms/kms_signing_client_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/kms_signing_client_test.go
@@ -1,0 +1,309 @@
+package gcpkms
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// GCP rejects a digest whose length does not match the field it was placed in,
+// so the width is checked locally to turn a remote InvalidArgument into a clear
+// error at the call site.
+func TestProtoDigest_RejectsWrongLengthDigest(t *testing.T) {
+	t.Parallel()
+
+	_, err := protoDigest(jose.RS256, []byte("too short"))
+	require.ErrorContains(t, err, "expected 32")
+}
+
+func TestProtoDigest_PlacesSHA256InTheSHA256Field(t *testing.T) {
+	t.Parallel()
+
+	digest := make([]byte, sha256.Size)
+	digest[0] = 0xab
+
+	pb, err := protoDigest(jose.RS256, digest)
+	require.NoError(t, err)
+	require.Equal(t, digest, pb.GetSha256(), "a SHA-256 digest must land in the sha256 oneof arm")
+}
+
+// GCP's integrity guards use CRC-32C (Castagnoli), not the far more common
+// IEEE polynomial. Substituting IEEE would leave every test in this package
+// passing while every real request was rejected for a checksum mismatch, so the
+// polynomial is pinned against the published CRC-32C check vector.
+func TestCRC32C_UsesCastagnoliPolynomial(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, int64(0xE3069283), crc32c([]byte("123456789")))
+}
+
+// fakeKMS is an in-process KeyManagementService. It exists so the real transport
+// — request construction, the integrity guards, and PEM parsing — is testable
+// without a GCP network path. Fields are set by each test to shape the response.
+type fakeKMS struct {
+	kmspb.UnimplementedKeyManagementServiceServer
+
+	publicKey    *kmspb.PublicKey
+	publicKeyErr error
+	signResponse *kmspb.AsymmetricSignResponse
+	signErr      error
+
+	gotPublicKeyRequest *kmspb.GetPublicKeyRequest
+	gotSignRequest      *kmspb.AsymmetricSignRequest
+}
+
+func (f *fakeKMS) GetPublicKey(_ context.Context, req *kmspb.GetPublicKeyRequest) (*kmspb.PublicKey, error) {
+	f.gotPublicKeyRequest = req
+	if f.publicKeyErr != nil {
+		return nil, f.publicKeyErr
+	}
+	return f.publicKey, nil
+}
+
+func (f *fakeKMS) AsymmetricSign(_ context.Context, req *kmspb.AsymmetricSignRequest) (*kmspb.AsymmetricSignResponse, error) {
+	f.gotSignRequest = req
+	if f.signErr != nil {
+		return nil, f.signErr
+	}
+	return f.signResponse, nil
+}
+
+// newFakeSigningClient wires the real signingClient to an in-process fake over
+// bufconn, so every code path except the network itself is exercised.
+func newFakeSigningClient(t *testing.T, fake *fakeKMS) SigningClient {
+	t.Helper()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	kmspb.RegisterKeyManagementServiceServer(server, fake)
+
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	raw, err := kms.NewKeyManagementClient(t.Context(), option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+
+	return &kmsSigningClient{kms: raw}
+}
+
+// testPublicKeyPEM returns a valid RSA public key PEM and its parsed form.
+func testPublicKeyPEM(t *testing.T) (string, *rsa.PublicKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Headers: nil, Bytes: der})), &key.PublicKey
+}
+
+func healthyPublicKey(t *testing.T) (*kmspb.PublicKey, *rsa.PublicKey) {
+	t.Helper()
+
+	pemData, parsed := testPublicKeyPEM(t)
+	return &kmspb.PublicKey{
+		Pem:       pemData,
+		PemCrc32C: wrapperspb.Int64(crc32c([]byte(pemData))),
+		Algorithm: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256,
+		Name:      testResourceName,
+	}, parsed
+}
+
+// The public key format MUST be left unspecified. Specifying one — even PEM —
+// makes GCP populate the response's public_key field and leave pem empty, which
+// would make every GetPublicKey call fail against real KMS while every fake in
+// this package still passed.
+func TestGetPublicKey_LeavesFormatUnspecified(t *testing.T) {
+	t.Parallel()
+
+	pk, _ := healthyPublicKey(t)
+	fake := &fakeKMS{publicKey: pk}
+	client := newFakeSigningClient(t, fake)
+
+	_, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		kmspb.PublicKey_PUBLIC_KEY_FORMAT_UNSPECIFIED,
+		fake.gotPublicKeyRequest.GetPublicKeyFormat(),
+		"specifying a format moves the key out of the pem field this client reads",
+	)
+	require.Equal(t, testResourceName, fake.gotPublicKeyRequest.GetName())
+}
+
+func TestGetPublicKey_ParsesPEMAndAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	pk, parsed := healthyPublicKey(t)
+	client := newFakeSigningClient(t, &fakeKMS{publicKey: pk})
+
+	public, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.NoError(t, err)
+	require.Equal(t, jose.RS256, public.Algorithm)
+	require.Equal(t, parsed, public.Key)
+}
+
+func TestGetPublicKey_RejectsChecksumMismatch(t *testing.T) {
+	t.Parallel()
+
+	pk, _ := healthyPublicKey(t)
+	pk.PemCrc32C = wrapperspb.Int64(crc32c([]byte("something else")))
+	client := newFakeSigningClient(t, &fakeKMS{publicKey: pk})
+
+	_, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.ErrorContains(t, err, "pem checksum mismatch")
+}
+
+func TestGetPublicKey_RejectsMissingChecksum(t *testing.T) {
+	t.Parallel()
+
+	pk, _ := healthyPublicKey(t)
+	pk.PemCrc32C = nil
+	client := newFakeSigningClient(t, &fakeKMS{publicKey: pk})
+
+	_, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.ErrorContains(t, err, "omitted the pem checksum")
+}
+
+// The checksums prove the bytes survived the wire, not that they describe the
+// key that was asked for. GCP documents the name field as the guard for that.
+func TestGetPublicKey_RejectsResponseForADifferentKey(t *testing.T) {
+	t.Parallel()
+
+	pk, _ := healthyPublicKey(t)
+	pk.Name = "projects/p/locations/l/keyRings/r/cryptoKeys/other/cryptoKeyVersions/9"
+	client := newFakeSigningClient(t, &fakeKMS{publicKey: pk})
+
+	_, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.ErrorContains(t, err, "response describes")
+}
+
+func TestGetPublicKey_RejectsUnsupportedAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	pk, _ := healthyPublicKey(t)
+	pk.Algorithm = kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256
+	client := newFakeSigningClient(t, &fakeKMS{publicKey: pk})
+
+	_, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+	require.ErrorContains(t, err, "PS256")
+}
+
+func TestAsymmetricSign_SendsDigestAndChecksum(t *testing.T) {
+	t.Parallel()
+
+	digest := sha256.Sum256([]byte(ProbePayload))
+	signature := []byte("signature-bytes")
+
+	fake := &fakeKMS{signResponse: &kmspb.AsymmetricSignResponse{
+		Name:                 testResourceName,
+		Signature:            signature,
+		SignatureCrc32C:      wrapperspb.Int64(crc32c(signature)),
+		VerifiedDigestCrc32C: true,
+	}}
+	client := newFakeSigningClient(t, fake)
+
+	got, err := client.AsymmetricSign(t.Context(), testResourceName, jose.RS256, digest[:])
+	require.NoError(t, err)
+	require.Equal(t, signature, got)
+
+	require.Equal(t, digest[:], fake.gotSignRequest.GetDigest().GetSha256())
+	require.Equal(t, crc32c(digest[:]), fake.gotSignRequest.GetDigestCrc32C().GetValue())
+}
+
+func TestAsymmetricSign_RejectsUnverifiedDigestChecksum(t *testing.T) {
+	t.Parallel()
+
+	digest := sha256.Sum256([]byte(ProbePayload))
+	signature := []byte("signature-bytes")
+
+	client := newFakeSigningClient(t, &fakeKMS{signResponse: &kmspb.AsymmetricSignResponse{
+		Name:                 testResourceName,
+		Signature:            signature,
+		SignatureCrc32C:      wrapperspb.Int64(crc32c(signature)),
+		VerifiedDigestCrc32C: false,
+	}})
+
+	_, err := client.AsymmetricSign(t.Context(), testResourceName, jose.RS256, digest[:])
+	require.ErrorContains(t, err, "could not verify the digest checksum")
+}
+
+func TestAsymmetricSign_RejectsSignatureChecksumMismatch(t *testing.T) {
+	t.Parallel()
+
+	digest := sha256.Sum256([]byte(ProbePayload))
+
+	client := newFakeSigningClient(t, &fakeKMS{signResponse: &kmspb.AsymmetricSignResponse{
+		Name:                 testResourceName,
+		Signature:            []byte("signature-bytes"),
+		SignatureCrc32C:      wrapperspb.Int64(crc32c([]byte("different"))),
+		VerifiedDigestCrc32C: true,
+	}})
+
+	_, err := client.AsymmetricSign(t.Context(), testResourceName, jose.RS256, digest[:])
+	require.ErrorContains(t, err, "signature checksum mismatch")
+}
+
+func TestAsymmetricSign_RejectsSignatureFromADifferentKey(t *testing.T) {
+	t.Parallel()
+
+	digest := sha256.Sum256([]byte(ProbePayload))
+	signature := []byte("signature-bytes")
+
+	client := newFakeSigningClient(t, &fakeKMS{signResponse: &kmspb.AsymmetricSignResponse{
+		Name:                 "projects/p/locations/l/keyRings/r/cryptoKeys/other/cryptoKeyVersions/9",
+		Signature:            signature,
+		SignatureCrc32C:      wrapperspb.Int64(crc32c(signature)),
+		VerifiedDigestCrc32C: true,
+	}})
+
+	_, err := client.AsymmetricSign(t.Context(), testResourceName, jose.RS256, digest[:])
+	require.ErrorContains(t, err, "response signed with")
+}
+
+// A gRPC status must survive the client's error wrapping, because VerifySigningKey
+// classifies on it to tell a missing IAM grant apart from a transient outage.
+func TestSigningClientErrors_PreserveGRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	client := newFakeSigningClient(t, &fakeKMS{
+		publicKeyErr: status.Error(codes.PermissionDenied, "permission denied on resource"),
+	})
+
+	_, err := client.GetPublicKey(t.Context(), testResourceName)
+	require.Error(t, err)
+
+	sts, ok := status.FromError(err)
+	require.True(t, ok, "wrapping must not hide the gRPC status")
+	require.Equal(t, codes.PermissionDenied, sts.Code())
+}

--- a/server/internal/thirdparty/gcp/gcpkms/local_signing_client.go
+++ b/server/internal/thirdparty/gcp/gcpkms/local_signing_client.go
@@ -61,7 +61,15 @@ func NewLocalSigningClient(alg jose.SignatureAlgorithm) (*LocalSigningClient, er
 // client validates it, so a malformed name fails here too rather than passing in
 // tests and failing in production; beyond that the name is not otherwise used,
 // since this client holds exactly one key.
-func (c *LocalSigningClient) GetPublicKey(_ context.Context, resourceName string) (*PublicKey, error) {
+//
+// A canceled or expired context fails the call, as it would against real KMS. A
+// stand-in that kept working after the caller gave up would report a key usable
+// under conditions where production reports nothing at all.
+func (c *LocalSigningClient) GetPublicKey(ctx context.Context, resourceName string) (*PublicKey, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("get local %s public key: %w", c.alg, err)
+	}
+
 	if err := ValidateKeyVersionName(resourceName); err != nil {
 		return nil, err
 	}
@@ -93,9 +101,14 @@ func (c *LocalSigningClient) GetPublicKey(_ context.Context, resourceName string
 // verification code they would against GCP.
 //
 // The digest width and the algorithm are checked as strictly as the real client
-// checks them, so a caller cannot pass something here that KMS would reject.
+// checks them, so a caller cannot pass something here that KMS would reject, and
+// a canceled or expired context fails the call as it would against real KMS.
 // There are no checksums to verify: nothing crosses a wire.
-func (c *LocalSigningClient) AsymmetricSign(_ context.Context, resourceName string, alg jose.SignatureAlgorithm, digest []byte) ([]byte, error) {
+func (c *LocalSigningClient) AsymmetricSign(ctx context.Context, resourceName string, alg jose.SignatureAlgorithm, digest []byte) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("sign digest with local %s key: %w", c.alg, err)
+	}
+
 	if err := ValidateKeyVersionName(resourceName); err != nil {
 		return nil, err
 	}

--- a/server/internal/thirdparty/gcp/gcpkms/local_signing_client.go
+++ b/server/internal/thirdparty/gcp/gcpkms/local_signing_client.go
@@ -1,0 +1,131 @@
+package gcpkms
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// rsaLocalKeyBits matches the smallest RSA size GCP KMS offers for signing, so
+// the stand-in produces signatures the same width as production.
+const rsaLocalKeyBits = 2048
+
+var _ SigningClient = (*LocalSigningClient)(nil)
+
+// LocalSigningClient is an in-process SigningClient backed by a key pair generated at
+// construction, for use where no GCP network path exists: CI, and local
+// development without KMS access.
+//
+// It is a faithful stand-in for the transport rather than a shortcut around it.
+// Signatures come back in the provider's own encodings — PKCS#1 v1.5 for RSA,
+// ASN.1 DER for ECDSA — so callers exercise the same parsing, conversion and
+// verification code they would against real KMS. The private key is ephemeral
+// and never leaves the process.
+type LocalSigningClient struct {
+	alg jose.SignatureAlgorithm
+	key crypto.Signer
+}
+
+// NewLocalSigningClient generates a key pair for the given algorithm.
+func NewLocalSigningClient(alg jose.SignatureAlgorithm) (*LocalSigningClient, error) {
+	switch alg {
+	case jose.RS256:
+		key, err := rsa.GenerateKey(rand.Reader, rsaLocalKeyBits)
+		if err != nil {
+			return nil, fmt.Errorf("generate local rsa key: %w", err)
+		}
+		return &LocalSigningClient{alg: alg, key: key}, nil
+
+	case jose.ES256:
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("generate local ecdsa key: %w", err)
+		}
+		return &LocalSigningClient{alg: alg, key: key}, nil
+
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, alg)
+	}
+}
+
+// GetPublicKey returns the generated key pair's public half and the algorithm
+// the client was built for. The resource name is validated exactly as the real
+// client validates it, so a malformed name fails here too rather than passing in
+// tests and failing in production; beyond that the name is not otherwise used,
+// since this client holds exactly one key.
+func (c *LocalSigningClient) GetPublicKey(_ context.Context, resourceName string) (*PublicKey, error) {
+	if err := ValidateKeyVersionName(resourceName); err != nil {
+		return nil, err
+	}
+
+	// Round-trip through PKIX/PEM rather than handing back the in-memory key.
+	// GCP exports a PEM that the real client decodes and parses, and that parsing
+	// is otherwise exercised nowhere — returning the key directly would leave the
+	// one step where the two implementations genuinely differ untested.
+	der, err := x509.MarshalPKIXPublicKey(c.key.Public())
+	if err != nil {
+		return nil, fmt.Errorf("marshal local %s public key: %w", c.alg, err)
+	}
+
+	key, err := parsePublicKeyPEM(string(pem.EncodeToMemory(&pem.Block{
+		Type:    "PUBLIC KEY",
+		Headers: nil,
+		Bytes:   der,
+	})))
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublicKey{Algorithm: c.alg, Key: key}, nil
+}
+
+// AsymmetricSign signs a digest with the in-process key, returning the
+// signature in the same provider encoding real KMS would: PKCS#1 v1.5 for RSA,
+// ASN.1 DER for ECDSA. Callers therefore exercise the same conversion and
+// verification code they would against GCP.
+//
+// The digest width and the algorithm are checked as strictly as the real client
+// checks them, so a caller cannot pass something here that KMS would reject.
+// There are no checksums to verify: nothing crosses a wire.
+func (c *LocalSigningClient) AsymmetricSign(_ context.Context, resourceName string, alg jose.SignatureAlgorithm, digest []byte) ([]byte, error) {
+	if err := ValidateKeyVersionName(resourceName); err != nil {
+		return nil, err
+	}
+
+	if alg != c.alg {
+		return nil, fmt.Errorf("%w: key signs %s, caller asked for %s", ErrUnsupportedAlgorithm, c.alg, alg)
+	}
+
+	hash, err := digestHash(alg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(digest) != hash.Size() {
+		return nil, fmt.Errorf("digest is %d bytes, expected %d for %s", len(digest), hash.Size(), alg)
+	}
+
+	// crypto.Signer yields exactly the encodings GCP KMS returns: PKCS#1 v1.5 for
+	// RSA and ASN.1 DER for ECDSA.
+	signature, err := c.key.Sign(rand.Reader, digest, hash)
+	if err != nil {
+		return nil, fmt.Errorf("sign digest with local %s key: %w", alg, err)
+	}
+
+	return signature, nil
+}
+
+// Close is a no-op: the key lives in memory and there is no connection to
+// release. It exists so this client satisfies SigningClient, which lets tests
+// exercise the same caller-owns-the-lifetime pattern production uses.
+func (c *LocalSigningClient) Close() error {
+	return nil
+}

--- a/server/internal/thirdparty/gcp/gcpkms/local_signing_client_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/local_signing_client_test.go
@@ -1,0 +1,17 @@
+package gcpkms
+
+import (
+	"testing"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// The stand-in generates a real key pair, so it can only stand in for the
+// algorithms this package actually supports.
+func TestNewLocalSigningClient_RejectsUnsupportedAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewLocalSigningClient(jose.PS256)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}

--- a/server/internal/thirdparty/gcp/gcpkms/local_signing_client_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/local_signing_client_test.go
@@ -1,6 +1,8 @@
 package gcpkms
 
 import (
+	"context"
+	"crypto/sha256"
 	"testing"
 
 	jose "github.com/go-jose/go-jose/v4"
@@ -14,4 +16,23 @@ func TestNewLocalSigningClient_RejectsUnsupportedAlgorithm(t *testing.T) {
 
 	_, err := NewLocalSigningClient(jose.PS256)
 	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}
+
+// Real KMS calls fail once the caller's context is done. The stand-in has to do
+// the same, or a cancellation test would pass against production and fail here.
+func TestLocalSigningClient_HonoursCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = client.GetPublicKey(ctx, testResourceName)
+	require.ErrorIs(t, err, context.Canceled)
+
+	digest := sha256.Sum256([]byte(ProbePayload))
+	_, err = client.AsymmetricSign(ctx, testResourceName, jose.RS256, digest[:])
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/server/internal/thirdparty/gcp/gcpkms/resource.go
+++ b/server/internal/thirdparty/gcp/gcpkms/resource.go
@@ -1,0 +1,38 @@
+package gcpkms
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// ErrInvalidResourceName is returned when a stored resource name is not a
+// fully-qualified GCP KMS crypto key version.
+var ErrInvalidResourceName = errors.New("invalid gcp kms resource name")
+
+// resourceNamePattern matches a crypto key VERSION resource name. The version
+// suffix is required: asymmetric-sign keys have no primary version, so a
+// version-less `.../cryptoKeys/<key>` path cannot be resolved to something
+// signable. Rejecting it here turns a confusing runtime KMS error into a clear
+// configuration message.
+//
+// Segments are permissive beyond excluding whitespace, which no GCP resource id
+// may contain. Pinning each segment to its exact GCP grammar would risk
+// rejecting valid names (numeric project ids, the "global" location) for no
+// benefit, since KMS itself is the authority on whether the key exists.
+var resourceNamePattern = regexp.MustCompile(
+	`^projects/[^/\s]+/locations/[^/\s]+/keyRings/[^/\s]+/cryptoKeys/[^/\s]+/cryptoKeyVersions/[^/\s]+$`,
+)
+
+// ValidateKeyVersionName reports whether a resource name identifies a specific
+// crypto key version.
+func ValidateKeyVersionName(resourceName string) error {
+	if !resourceNamePattern.MatchString(resourceName) {
+		return fmt.Errorf(
+			"%w: %q is not a projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>/cryptoKeyVersions/<v> path",
+			ErrInvalidResourceName, resourceName,
+		)
+	}
+
+	return nil
+}

--- a/server/internal/thirdparty/gcp/gcpkms/resource_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/resource_test.go
@@ -1,0 +1,42 @@
+package gcpkms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testResourceName is the well-formed key version every test in this package
+// addresses. It lives here because this file owns resource-name validation.
+const testResourceName = "projects/gram-test/locations/us-central1/keyRings/signing/cryptoKeys/jwks/cryptoKeyVersions/1"
+
+func TestValidateKeyVersionName_AcceptsKeyVersion(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateKeyVersionName(testResourceName))
+}
+
+// An asymmetric-sign key has no primary version, so a key-level path cannot be
+// resolved to something signable and must be rejected up front.
+func TestValidateKeyVersionName_RejectsVersionlessKeyPath(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateKeyVersionName("projects/p/locations/l/keyRings/r/cryptoKeys/k")
+	require.ErrorIs(t, err, ErrInvalidResourceName)
+}
+
+func TestValidateKeyVersionName_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"",
+		"not-a-resource-name",
+		"projects//locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+		"projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/",
+		"projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1/extra",
+		"/projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1",
+		"projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1 ",
+	} {
+		require.ErrorIs(t, ValidateKeyVersionName(name), ErrInvalidResourceName, "should reject %q", name)
+	}
+}

--- a/server/internal/thirdparty/gcp/gcpkms/signature.go
+++ b/server/internal/thirdparty/gcp/gcpkms/signature.go
@@ -1,0 +1,56 @@
+package gcpkms
+
+import (
+	"crypto/ecdsa"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// ecdsaDERToJOSE converts the ASN.1 DER ECDSA signature GCP KMS returns into the
+// fixed-width R || S concatenation JOSE requires (RFC 7515 section 3.4).
+//
+// The left-padding is what makes this correct rather than a plain
+// concatenation. DER encodes integers minimally, so a small R or S occupies
+// fewer bytes than the curve width; joining those directly yields a short
+// signature that every verifier rejects. Only about one signature in 256 has a
+// short component, so an implementation that skipped the padding would fail
+// intermittently and pass casual testing. FillBytes pads explicitly below, and
+// TestECDSADERToJOSE_LeftPadsShortComponents pins the behaviour.
+func ecdsaDERToJOSE(der []byte, coordinateBytes int) ([]byte, error) {
+	var parsed struct {
+		R, S *big.Int
+	}
+
+	rest, err := asn1.Unmarshal(der, &parsed)
+	if err != nil {
+		return nil, fmt.Errorf("parse ecdsa der signature: %w", err)
+	}
+	if len(rest) > 0 {
+		return nil, fmt.Errorf("parse ecdsa der signature: %d trailing bytes", len(rest))
+	}
+
+	// A DER ECDSA signature encodes two integers in [1, n-1]. Zero is never
+	// valid, and a negative value would make FillBytes panic below.
+	if parsed.R.Sign() <= 0 || parsed.S.Sign() <= 0 {
+		return nil, errors.New("ecdsa signature component is zero or negative")
+	}
+
+	maxBits := coordinateBytes * 8
+	if parsed.R.BitLen() > maxBits || parsed.S.BitLen() > maxBits {
+		return nil, fmt.Errorf("ecdsa signature component exceeds the %d-byte curve width", coordinateBytes)
+	}
+
+	out := make([]byte, 2*coordinateBytes)
+	parsed.R.FillBytes(out[:coordinateBytes])
+	parsed.S.FillBytes(out[coordinateBytes:])
+
+	return out, nil
+}
+
+// coordinateBytes is the byte width of a single ECDSA signature component for a
+// public key's curve.
+func coordinateBytes(pub *ecdsa.PublicKey) int {
+	return (pub.Curve.Params().BitSize + 7) / 8
+}

--- a/server/internal/thirdparty/gcp/gcpkms/signature_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/signature_test.go
@@ -1,0 +1,130 @@
+package gcpkms
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type derSignature struct {
+	R, S *big.Int
+}
+
+// A DER integer is encoded minimally, so a small R or S produces a shorter
+// signature. JOSE requires both halves left-padded to the curve width; getting
+// this wrong yields tokens that fail verification roughly one time in 256.
+func TestECDSADERToJOSE_LeftPadsShortComponents(t *testing.T) {
+	t.Parallel()
+
+	der, err := asn1.Marshal(derSignature{R: big.NewInt(1), S: big.NewInt(2)})
+	require.NoError(t, err)
+
+	raw, err := ecdsaDERToJOSE(der, 32)
+	require.NoError(t, err)
+	require.Len(t, raw, 64, "both halves must occupy the full curve width")
+
+	require.Equal(t, make([]byte, 31), raw[:31], "R must be left-padded with zeros")
+	require.Equal(t, byte(1), raw[31])
+	require.Equal(t, make([]byte, 31), raw[32:63], "S must be left-padded with zeros")
+	require.Equal(t, byte(2), raw[63])
+}
+
+func TestECDSADERToJOSE_FullWidthComponentsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	r := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)) // 32 bytes of 0xff
+	der, err := asn1.Marshal(derSignature{R: r, S: big.NewInt(7)})
+	require.NoError(t, err)
+
+	raw, err := ecdsaDERToJOSE(der, 32)
+	require.NoError(t, err)
+	require.Len(t, raw, 64)
+	require.Equal(t, r.FillBytes(make([]byte, 32)), raw[:32])
+}
+
+// Real signatures from a P-256 key must always convert to exactly 64 bytes. The
+// loop is what catches the short-component case, which appears only in a
+// minority of signatures.
+func TestECDSADERToJOSE_RealSignaturesAreAlwaysFullWidth(t *testing.T) {
+	t.Parallel()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	digest := make([]byte, 32)
+	for i := range 256 {
+		digest[0] = byte(i)
+		digest[1] = byte(i >> 8)
+
+		der, err := ecdsa.SignASN1(rand.Reader, key, digest)
+		require.NoError(t, err)
+
+		raw, err := ecdsaDERToJOSE(der, 32)
+		require.NoError(t, err)
+		require.Len(t, raw, 64)
+	}
+}
+
+func TestECDSADERToJOSE_RejectsTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	der, err := asn1.Marshal(derSignature{R: big.NewInt(1), S: big.NewInt(2)})
+	require.NoError(t, err)
+
+	_, err = ecdsaDERToJOSE(append(der, 0x00), 32)
+	require.ErrorContains(t, err, "trailing bytes")
+}
+
+func TestECDSADERToJOSE_RejectsOversizedComponent(t *testing.T) {
+	t.Parallel()
+
+	tooBig := new(big.Int).Lsh(big.NewInt(1), 256) // 33 bytes, wider than P-256
+	der, err := asn1.Marshal(derSignature{R: tooBig, S: big.NewInt(1)})
+	require.NoError(t, err)
+
+	_, err = ecdsaDERToJOSE(der, 32)
+	require.ErrorContains(t, err, "exceeds the 32-byte curve width")
+}
+
+// R and S are integers in [1, n-1]; zero is never valid, and a negative value
+// would make FillBytes panic.
+func TestECDSADERToJOSE_RejectsZeroAndNegativeComponents(t *testing.T) {
+	t.Parallel()
+
+	for _, sig := range []derSignature{
+		{R: big.NewInt(0), S: big.NewInt(1)},
+		{R: big.NewInt(1), S: big.NewInt(0)},
+		{R: big.NewInt(-1), S: big.NewInt(1)},
+		{R: big.NewInt(1), S: big.NewInt(-1)},
+	} {
+		der, err := asn1.Marshal(sig)
+		require.NoError(t, err)
+
+		_, err = ecdsaDERToJOSE(der, 32)
+		require.ErrorContains(t, err, "zero or negative", "R=%s S=%s", sig.R, sig.S)
+	}
+}
+
+func TestECDSADERToJOSE_RejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	_, err := ecdsaDERToJOSE([]byte("not der"), 32)
+	require.ErrorContains(t, err, "parse ecdsa der signature")
+}
+
+func TestCoordinateBytes(t *testing.T) {
+	t.Parallel()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	require.Equal(t, 32, coordinateBytes(&key.PublicKey))
+
+	key384, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+	require.Equal(t, 48, coordinateBytes(&key384.PublicKey))
+}

--- a/server/internal/thirdparty/gcp/gcpkms/signer.go
+++ b/server/internal/thirdparty/gcp/gcpkms/signer.go
@@ -1,0 +1,153 @@
+package gcpkms
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"fmt"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// signer adapts a KMS key to go-jose's OpaqueSigner, so every JWS and JWT path
+// in go-jose can sign with a key whose private half never leaves the provider.
+type signer struct {
+	// ctx bounds the KMS calls made by SignPayload. go-jose's OpaqueSigner takes
+	// no context, so it has to live here; a signer is therefore request-scoped and
+	// must not be cached across requests.
+	//
+	//nolint:containedctx // forced by jose.OpaqueSigner, whose SignPayload has no context parameter
+	ctx          context.Context
+	client       SigningClient
+	resourceName string
+	alg          jose.SignatureAlgorithm
+	public       *jose.JSONWebKey
+}
+
+var _ jose.OpaqueSigner = (*signer)(nil)
+
+// NewSigner builds a jose.OpaqueSigner backed by a KMS key version.
+//
+// The public key is supplied rather than fetched. GetPublicKey is a KMS
+// management-tier operation whose quota sits far below that of the cryptographic
+// operations, so a signer that fetched on construction would throttle on a
+// per-signature path. Callers that do not already hold the public half can read
+// it once via SigningClient.GetPublicKey and cache it.
+//
+// The returned signer is request-scoped: it captures ctx for the signing calls,
+// and its client must outlive it.
+func NewSigner(ctx context.Context, client SigningClient, resourceName, keyID string, public PublicKey) (jose.OpaqueSigner, error) {
+	if err := ValidateKeyVersionName(resourceName); err != nil {
+		return nil, err
+	}
+
+	if err := checkKeyMatchesAlgorithm(public); err != nil {
+		return nil, err
+	}
+
+	return &signer{
+		ctx:          ctx,
+		client:       client,
+		resourceName: resourceName,
+		alg:          public.Algorithm,
+		public: &jose.JSONWebKey{
+			Key:                         public.Key,
+			KeyID:                       keyID,
+			Algorithm:                   string(public.Algorithm),
+			Use:                         "sig",
+			Certificates:                nil,
+			CertificatesURL:             nil,
+			CertificateThumbprintSHA1:   nil,
+			CertificateThumbprintSHA256: nil,
+		},
+	}, nil
+}
+
+// checkKeyMatchesAlgorithm rejects a PublicKey whose key material could not have
+// produced signatures for its stated algorithm.
+//
+// Callers are told to cache the public half separately from the configured
+// algorithm, so the two can drift apart — and the consequence is silent: a
+// mismatched pair would sign with one encoding while advertising another,
+// producing tokens that fail verification everywhere with no error at mint time.
+// Checking once at construction turns that into an immediate, obvious failure.
+func checkKeyMatchesAlgorithm(public PublicKey) error {
+	switch public.Algorithm {
+	case jose.RS256:
+		if _, ok := public.Key.(*rsa.PublicKey); !ok {
+			return fmt.Errorf("%s key must be an *rsa.PublicKey, got %T", public.Algorithm, public.Key)
+		}
+		return nil
+
+	case jose.ES256:
+		pub, ok := public.Key.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("%s key must be an *ecdsa.PublicKey, got %T", public.Algorithm, public.Key)
+		}
+		// ES256 is P-256 by definition. A larger curve would produce wider R and S
+		// halves than the algorithm's verifiers expect.
+		if pub.Curve != elliptic.P256() {
+			return fmt.Errorf("%s key must be on P-256, got %s", public.Algorithm, pub.Curve.Params().Name)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, public.Algorithm)
+	}
+}
+
+// Public returns the JWK go-jose publishes alongside the signature, which is
+// where the `kid` in a JWS protected header comes from.
+func (s *signer) Public() *jose.JSONWebKey {
+	return s.public
+}
+
+// Algs reports the single algorithm this key signs with. A KMS key version has
+// exactly one, so go-jose is never given a choice to get wrong.
+func (s *signer) Algs() []jose.SignatureAlgorithm {
+	return []jose.SignatureAlgorithm{s.alg}
+}
+
+// SignPayload hashes the payload, has KMS sign the digest, and returns the
+// signature in the encoding JOSE expects. The payload itself never leaves the
+// process — KMS only ever sees a digest.
+func (s *signer) SignPayload(payload []byte, alg jose.SignatureAlgorithm) ([]byte, error) {
+	if alg != s.alg {
+		return nil, fmt.Errorf("%w: key signs %s, caller asked for %s", ErrUnsupportedAlgorithm, s.alg, alg)
+	}
+
+	digest, err := digestPayload(s.alg, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	signature, err := s.client.AsymmetricSign(s.ctx, s.resourceName, s.alg, digest)
+	if err != nil {
+		return nil, fmt.Errorf("sign payload with %s: %w", s.resourceName, err)
+	}
+
+	// Dispatch on the algorithm rather than the key's Go type, so a signer can
+	// never quietly fall through to the wrong encoding.
+	switch s.alg {
+	case jose.RS256:
+		// RSA PKCS#1 v1.5 signatures are already in the encoding JOSE expects.
+		return signature, nil
+
+	case jose.ES256:
+		// The provider returns ASN.1 DER; JOSE requires fixed-width R || S.
+		pub, ok := s.public.Key.(*ecdsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("%s signer holds a %T public key", s.alg, s.public.Key)
+		}
+
+		joseSignature, err := ecdsaDERToJOSE(signature, coordinateBytes(pub))
+		if err != nil {
+			return nil, fmt.Errorf("convert ecdsa signature for %s: %w", s.resourceName, err)
+		}
+		return joseSignature, nil
+
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedAlgorithm, s.alg)
+	}
+}

--- a/server/internal/thirdparty/gcp/gcpkms/signer_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/signer_test.go
@@ -1,0 +1,163 @@
+package gcpkms
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// The signer is only useful if go-jose can actually drive it. Signing a JWS and
+// verifying it against the key's own public half exercises the whole chain:
+// digest, provider signature, and the JOSE encoding conversion.
+func TestSigner_RS256RoundTripsThroughGoJose(t *testing.T) {
+	t.Parallel()
+
+	requireJWSRoundTrip(t, jose.RS256)
+}
+
+// ES256 is the case that can silently produce malformed tokens, because the
+// provider returns ASN.1 DER where JOSE wants R || S. Repeating the round trip
+// exercises the short-component path that appears only in some signatures.
+func TestSigner_ES256RoundTripsThroughGoJose(t *testing.T) {
+	t.Parallel()
+
+	for range 64 {
+		requireJWSRoundTrip(t, jose.ES256)
+	}
+}
+
+func requireJWSRoundTrip(t *testing.T, alg jose.SignatureAlgorithm) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	client, err := NewLocalSigningClient(alg)
+	require.NoError(t, err)
+
+	public, err := client.GetPublicKey(ctx, testResourceName)
+	require.NoError(t, err)
+
+	opaque, err := NewSigner(ctx, client, testResourceName, "test-kid", *public)
+	require.NoError(t, err)
+	require.Equal(t, []jose.SignatureAlgorithm{alg}, opaque.Algs())
+
+	joseSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: opaque}, nil)
+	require.NoError(t, err)
+
+	payload := []byte(`{"iss":"gram","sub":"round-trip"}`)
+	jws, err := joseSigner.Sign(payload)
+	require.NoError(t, err)
+
+	compact, err := jws.CompactSerialize()
+	require.NoError(t, err)
+
+	parsed, err := jose.ParseSigned(compact, []jose.SignatureAlgorithm{alg})
+	require.NoError(t, err)
+
+	// Assert on the serialized header rather than reading the value back off the
+	// signer: this proves kid actually reaches the JWS a verifier will see.
+	require.Equal(t, "test-kid", parsed.Signatures[0].Header.KeyID)
+
+	verified, err := parsed.Verify(public.Key)
+	require.NoError(t, err, "signature produced via the opaque signer must verify against the key's public half")
+	require.Equal(t, payload, verified)
+}
+
+// The public key is supplied separately from the algorithm and callers are told
+// to cache it, so the two can drift apart. A mismatched pair must fail at
+// construction rather than silently emitting one encoding under another's label.
+func TestNewSigner_RejectsKeyThatDoesNotMatchAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	rsaClient, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+	rsaPublic, err := rsaClient.GetPublicKey(ctx, testResourceName)
+	require.NoError(t, err)
+
+	ecClient, err := NewLocalSigningClient(jose.ES256)
+	require.NoError(t, err)
+	ecPublic, err := ecClient.GetPublicKey(ctx, testResourceName)
+	require.NoError(t, err)
+
+	_, err = NewSigner(ctx, rsaClient, testResourceName, "kid", PublicKey{Algorithm: jose.ES256, Key: rsaPublic.Key})
+	require.ErrorContains(t, err, "must be an *ecdsa.PublicKey")
+
+	_, err = NewSigner(ctx, ecClient, testResourceName, "kid", PublicKey{Algorithm: jose.RS256, Key: ecPublic.Key})
+	require.ErrorContains(t, err, "must be an *rsa.PublicKey")
+
+	_, err = NewSigner(ctx, rsaClient, testResourceName, "kid", PublicKey{Algorithm: jose.ES256, Key: nil})
+	require.ErrorContains(t, err, "must be an *ecdsa.PublicKey")
+}
+
+// ES256 is P-256 by definition; a wider curve would produce R and S halves that
+// no ES256 verifier expects.
+func TestNewSigner_RejectsES256OnTheWrongCurve(t *testing.T) {
+	t.Parallel()
+
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+
+	client, err := NewLocalSigningClient(jose.ES256)
+	require.NoError(t, err)
+
+	_, err = NewSigner(t.Context(), client, testResourceName, "kid", PublicKey{
+		Algorithm: jose.ES256,
+		Key:       &key.PublicKey,
+	})
+	require.ErrorContains(t, err, "must be on P-256")
+}
+
+func TestNewSigner_RejectsInvalidResourceName(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	client, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	public, err := client.GetPublicKey(ctx, testResourceName)
+	require.NoError(t, err)
+
+	_, err = NewSigner(ctx, client, "projects/p/locations/l/keyRings/r/cryptoKeys/k", "kid", *public)
+	require.ErrorIs(t, err, ErrInvalidResourceName)
+}
+
+func TestNewSigner_RejectsUnsupportedAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	client, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	public, err := client.GetPublicKey(ctx, testResourceName)
+	require.NoError(t, err)
+	public.Algorithm = jose.PS256
+
+	_, err = NewSigner(ctx, client, testResourceName, "kid", *public)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}
+
+func TestSigner_RejectsMismatchedAlgorithmAtSignTime(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	client, err := NewLocalSigningClient(jose.ES256)
+	require.NoError(t, err)
+
+	public, err := client.GetPublicKey(ctx, testResourceName)
+	require.NoError(t, err)
+
+	opaque, err := NewSigner(ctx, client, testResourceName, "kid", *public)
+	require.NoError(t, err)
+
+	_, err = opaque.SignPayload([]byte("payload"), jose.RS256)
+	require.ErrorIs(t, err, ErrUnsupportedAlgorithm)
+}

--- a/server/internal/thirdparty/gcp/gcpkms/signing_client.go
+++ b/server/internal/thirdparty/gcp/gcpkms/signing_client.go
@@ -1,0 +1,74 @@
+package gcpkms
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"golang.org/x/oauth2"
+)
+
+// PublicKey is the public half of a KMS signing key.
+type PublicKey struct {
+	// Algorithm is the JOSE algorithm the key version actually signs with,
+	// derived from the provider rather than from anything Gram stored. Comparing
+	// it against the stored algorithm is what catches a key pointed at the wrong
+	// row.
+	Algorithm jose.SignatureAlgorithm
+
+	// Key is the parsed public half: *rsa.PublicKey or *ecdsa.PublicKey.
+	Key crypto.PublicKey
+}
+
+// SigningClient is the transport for keys whose purpose is ASYMMETRIC_SIGN. It
+// is an interface so consumers can substitute LocalSigningClient (or their own
+// stand-in) in tests, where no GCP network path is reachable.
+//
+// The name is deliberate: a KMS key's purpose is fixed at creation, so a key
+// that encrypts cannot sign and vice versa. An encryption counterpart would be a
+// separate interface over Encrypt/Decrypt rather than more methods here.
+//
+// Signatures are returned in the provider's own encoding — PKCS#1 v1.5 for RSA,
+// ASN.1 DER for ECDSA — not the JOSE encoding. Converting is the signer's job,
+// which keeps this layer a faithful transport and lets verification use the
+// standard library directly.
+type SigningClient interface {
+	// GetPublicKey fetches the key version's public half and algorithm.
+	GetPublicKey(ctx context.Context, resourceName string) (*PublicKey, error)
+
+	// AsymmetricSign signs a digest produced by the algorithm's hash.
+	AsymmetricSign(ctx context.Context, resourceName string, alg jose.SignatureAlgorithm, digest []byte) ([]byte, error)
+
+	// Close releases the underlying connection. Every client must be closed.
+	io.Closer
+}
+
+// SigningClientFactory builds a SigningClient authenticated as some identity.
+// Services hold one of these rather than a SigningClient, because the identity
+// varies per credential and each client owns a connection that must be closed
+// after use.
+type SigningClientFactory func(ctx context.Context, tokenSource oauth2.TokenSource) (SigningClient, error)
+
+var _ SigningClientFactory = NewSigningClient
+
+// parsePublicKeyPEM decodes the SubjectPublicKeyInfo PEM a KMS key version
+// exports into a usable public key. Both implementations of SigningClient go
+// through it, so the stand-in exercises the same parsing the real client does.
+func parsePublicKeyPEM(pemData string) (crypto.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, errors.New("parse gcp kms public key: pem contained no block")
+	}
+
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse gcp kms public key: %w", err)
+	}
+
+	return key, nil
+}

--- a/server/internal/thirdparty/gcp/gcpkms/verify.go
+++ b/server/internal/thirdparty/gcp/gcpkms/verify.go
@@ -1,0 +1,196 @@
+package gcpkms
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ProbePayload is the payload signed during verification.
+//
+// It is deliberately self-describing. A verification probe performs a real
+// signing operation, which lands in the key owner's Cloud Audit Log, so an
+// operator investigating an unexplained signing event needs a way to recognise
+// it as ours.
+const ProbePayload = "gram-key-verification-probe"
+
+// VerifyReason is the machine-readable outcome of a verification probe. It
+// exists so callers can tell the three cases apart that Detail alone conflates:
+// something the key's owner must fix, something that will pass on retry, and
+// something that is Gram's fault.
+type VerifyReason string
+
+const (
+	// ReasonVerified means the key signed and the signature validated.
+	ReasonVerified VerifyReason = "verified"
+
+	// ReasonInvalidResourceName means the stored resource name is not a
+	// fully-qualified key version. Gram's own record is wrong; no call was made.
+	ReasonInvalidResourceName VerifyReason = "invalid_resource_name"
+
+	// ReasonKeyNotFound means the key version does not exist.
+	ReasonKeyNotFound VerifyReason = "key_not_found"
+
+	// ReasonPermissionDenied means the credential's identity cannot use the key.
+	// Usually a missing roles/cloudkms.signerVerifier grant.
+	ReasonPermissionDenied VerifyReason = "permission_denied"
+
+	// ReasonKeyUnusable means the key version exists but cannot sign right now:
+	// DISABLED, DESTROYED, or still PENDING_GENERATION.
+	ReasonKeyUnusable VerifyReason = "key_unusable"
+
+	// ReasonUnsupportedAlgorithm means the key signs with an algorithm Gram does
+	// not publish, such as RSA-PSS.
+	ReasonUnsupportedAlgorithm VerifyReason = "unsupported_algorithm"
+
+	// ReasonAlgorithmMismatch means the key is healthy but signs with a different
+	// algorithm than the one configured against it.
+	ReasonAlgorithmMismatch VerifyReason = "algorithm_mismatch"
+
+	// ReasonSignatureInvalid means the key produced a signature that does not
+	// validate against its own public half. This should not happen; treat it as
+	// corruption or a provider fault rather than a configuration problem.
+	ReasonSignatureInvalid VerifyReason = "signature_invalid"
+
+	// ReasonUnavailable means the probe could not complete for a transient
+	// reason: a timeout, a rate limit, or KMS being briefly unreachable. It is
+	// the one reason worth retrying; every other failure is stable.
+	ReasonUnavailable VerifyReason = "unavailable"
+
+	// ReasonUnexpected means the probe failed in a way this package does not
+	// recognise. Worth investigating rather than showing to a customer as
+	// something they can fix.
+	ReasonUnexpected VerifyReason = "unexpected"
+)
+
+// VerifyResult reports whether a key is usable for signing. It is a value rather
+// than an error because most negative outcomes here are normal, reportable
+// states a human can act on, and callers surface them rather than treating them
+// as faults. Reason distinguishes those from the ones that are not.
+type VerifyResult struct {
+	// Verified is true only when the key produced a signature that validated
+	// against its own public half.
+	Verified bool
+
+	// Reason is the machine-readable outcome. Callers should branch on this
+	// rather than on Detail.
+	Reason VerifyReason
+
+	// Algorithm is the JOSE algorithm the key actually signs with. It is set
+	// whenever the public key was readable, including on an algorithm mismatch,
+	// so callers can report what the key really is.
+	Algorithm jose.SignatureAlgorithm
+
+	// Detail explains a negative result in terms a human can act on. It may carry
+	// provider error text, so treat it as diagnostic output rather than copy to
+	// show a customer verbatim. Empty when Verified is true.
+	Detail string
+}
+
+// VerifySigningKey proves end to end that a credential can reach a key AND use
+// it to sign: it reads the public half, confirms the key's algorithm matches the
+// one expected, signs a probe digest, and verifies that signature locally
+// against the fetched public key.
+//
+// Nothing is persisted. Two KMS calls are made, one of which is a real signing
+// operation.
+func VerifySigningKey(ctx context.Context, client SigningClient, resourceName string, want jose.SignatureAlgorithm) VerifyResult {
+	public, err := client.GetPublicKey(ctx, resourceName)
+	if err != nil {
+		return failedVerify(verifyReasonFor(err), "", err)
+	}
+
+	// The stored algorithm drives how Gram advertises and signs with this key, so
+	// a mismatch is fatal even though the key itself is perfectly healthy: signing
+	// RS256 with an RSA-PSS key mints tokens no verifier accepts.
+	if public.Algorithm != want {
+		return VerifyResult{
+			Verified:  false,
+			Reason:    ReasonAlgorithmMismatch,
+			Algorithm: public.Algorithm,
+			Detail: fmt.Sprintf(
+				"key signs with %s but is configured as %s; update the configured algorithm or point at a %s key",
+				public.Algorithm, want, want,
+			),
+		}
+	}
+
+	digest, err := digestPayload(public.Algorithm, []byte(ProbePayload))
+	if err != nil {
+		return failedVerify(verifyReasonFor(err), public.Algorithm, err)
+	}
+
+	signature, err := client.AsymmetricSign(ctx, resourceName, public.Algorithm, digest)
+	if err != nil {
+		return failedVerify(verifyReasonFor(err), public.Algorithm, err)
+	}
+
+	if err := verifySignature(public.Key, digest, signature); err != nil {
+		return failedVerify(ReasonSignatureInvalid, public.Algorithm, err)
+	}
+
+	return VerifyResult{Verified: true, Reason: ReasonVerified, Algorithm: public.Algorithm, Detail: ""}
+}
+
+// failedVerify builds a negative result, keeping the error's text as the detail
+// so a negative outcome always explains itself.
+func failedVerify(reason VerifyReason, alg jose.SignatureAlgorithm, err error) VerifyResult {
+	return VerifyResult{Verified: false, Reason: reason, Algorithm: alg, Detail: err.Error()}
+}
+
+// verifyReasonFor maps a probe failure onto the reason a caller acts on. Google
+// API errors arrive as gRPC statuses even through the REST transport, so the
+// status code carries the distinction between "the customer must fix something"
+// and "try again".
+func verifyReasonFor(err error) VerifyReason {
+	switch {
+	case errors.Is(err, ErrInvalidResourceName):
+		return ReasonInvalidResourceName
+	case errors.Is(err, ErrUnsupportedAlgorithm):
+		return ReasonUnsupportedAlgorithm
+	}
+
+	sts, ok := status.FromError(err)
+	if !ok {
+		return ReasonUnexpected
+	}
+
+	switch sts.Code() {
+	case codes.PermissionDenied, codes.Unauthenticated:
+		return ReasonPermissionDenied
+	case codes.NotFound:
+		return ReasonKeyNotFound
+	case codes.FailedPrecondition:
+		return ReasonKeyUnusable
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return ReasonUnavailable
+	default:
+		return ReasonUnexpected
+	}
+}
+
+// verifySignature checks a provider-encoded signature against the public key
+// that should have produced it: PKCS#1 v1.5 for RSA, ASN.1 DER for ECDSA.
+func verifySignature(public crypto.PublicKey, digest, signature []byte) error {
+	switch pub := public.(type) {
+	case *rsa.PublicKey:
+		if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest, signature); err != nil {
+			return fmt.Errorf("signature did not verify against the key's own public half: %w", err)
+		}
+		return nil
+	case *ecdsa.PublicKey:
+		if !ecdsa.VerifyASN1(pub, digest, signature) {
+			return errors.New("signature did not verify against the key's own public half")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported public key type %T", public)
+	}
+}

--- a/server/internal/thirdparty/gcp/gcpkms/verify.go
+++ b/server/internal/thirdparty/gcp/gcpkms/verify.go
@@ -155,6 +155,12 @@ func verifyReasonFor(err error) VerifyReason {
 		return ReasonInvalidResourceName
 	case errors.Is(err, ErrUnsupportedAlgorithm):
 		return ReasonUnsupportedAlgorithm
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		// A bare context error carries no gRPC status, so without this it would
+		// fall through to ReasonUnexpected and callers would not retry something
+		// that is purely transient. gRPC returns a proper DeadlineExceeded status
+		// for in-call expiry, but the retry layer can surface the raw error.
+		return ReasonUnavailable
 	}
 
 	sts, ok := status.FromError(err)

--- a/server/internal/thirdparty/gcp/gcpkms/verify_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/verify_test.go
@@ -1,0 +1,138 @@
+package gcpkms
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestVerifySigningKey_RS256(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	result := VerifySigningKey(t.Context(), client, testResourceName, jose.RS256)
+	require.True(t, result.Verified, "detail: %s", result.Detail)
+	require.Equal(t, ReasonVerified, result.Reason)
+	require.Equal(t, jose.RS256, result.Algorithm)
+	require.Empty(t, result.Detail)
+}
+
+func TestVerifySigningKey_ES256(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewLocalSigningClient(jose.ES256)
+	require.NoError(t, err)
+
+	result := VerifySigningKey(t.Context(), client, testResourceName, jose.ES256)
+	require.True(t, result.Verified, "detail: %s", result.Detail)
+	require.Equal(t, ReasonVerified, result.Reason)
+	require.Equal(t, jose.ES256, result.Algorithm)
+}
+
+// The stored algorithm drives how Gram advertises the key, so a healthy key
+// configured as the wrong algorithm must fail loudly and report what it is.
+func TestVerifySigningKey_ReportsAlgorithmMismatch(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewLocalSigningClient(jose.ES256)
+	require.NoError(t, err)
+
+	result := VerifySigningKey(t.Context(), client, testResourceName, jose.RS256)
+	require.False(t, result.Verified)
+	require.Equal(t, ReasonAlgorithmMismatch, result.Reason)
+	require.Equal(t, jose.ES256, result.Algorithm, "the key's real algorithm must be reported")
+	require.Contains(t, result.Detail, "ES256")
+	require.Contains(t, result.Detail, "RS256")
+}
+
+func TestVerifySigningKey_ReportsInvalidResourceName(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	result := VerifySigningKey(t.Context(), client, "not-a-resource-name", jose.RS256)
+	require.False(t, result.Verified)
+	require.Equal(t, ReasonInvalidResourceName, result.Reason)
+	require.Empty(t, result.Algorithm)
+	require.Contains(t, result.Detail, "invalid gcp kms resource name")
+}
+
+// tamperingClient returns a signature that does not correspond to the digest,
+// standing in for a key whose public half no longer matches what signs.
+type tamperingClient struct {
+	SigningClient
+}
+
+func (c tamperingClient) AsymmetricSign(ctx context.Context, resourceName string, alg jose.SignatureAlgorithm, digest []byte) ([]byte, error) {
+	signature, err := c.SigningClient.AsymmetricSign(ctx, resourceName, alg, digest)
+	if err != nil {
+		return nil, fmt.Errorf("tampering client: %w", err)
+	}
+
+	signature[len(signature)-1] ^= 0xff
+	return signature, nil
+}
+
+func TestVerifySigningKey_RejectsSignatureThatDoesNotValidate(t *testing.T) {
+	t.Parallel()
+
+	local, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	result := VerifySigningKey(t.Context(), tamperingClient{SigningClient: local}, testResourceName, jose.RS256)
+	require.False(t, result.Verified)
+	require.Equal(t, ReasonSignatureInvalid, result.Reason)
+	require.Contains(t, result.Detail, "did not verify against the key's own public half")
+}
+
+// unreachableClient fails GetPublicKey with a caller-supplied error, standing in
+// for the ways a real key can be out of reach. The error is wrapped, mirroring
+// the real client, so classification is exercised through the wrapping too.
+type unreachableClient struct {
+	SigningClient
+	err error
+}
+
+func (c unreachableClient) GetPublicKey(context.Context, string) (*PublicKey, error) {
+	return nil, fmt.Errorf("get gcp kms public key: %w", c.err)
+}
+
+// The reason is what lets a caller tell "the customer must fix their IAM" apart
+// from "retry this". Collapsing both into Detail would have the dashboard tell a
+// customer to change their permissions during a transient outage.
+func TestVerifySigningKey_ClassifiesProviderFailures(t *testing.T) {
+	t.Parallel()
+
+	local, err := NewLocalSigningClient(jose.RS256)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		err  error
+		want VerifyReason
+	}{
+		{status.Error(codes.PermissionDenied, "permission denied on resource"), ReasonPermissionDenied},
+		{status.Error(codes.Unauthenticated, "invalid credentials"), ReasonPermissionDenied},
+		{status.Error(codes.NotFound, "key version not found"), ReasonKeyNotFound},
+		{status.Error(codes.FailedPrecondition, "key version is not enabled"), ReasonKeyUnusable},
+		{status.Error(codes.Unavailable, "backend unavailable"), ReasonUnavailable},
+		{status.Error(codes.DeadlineExceeded, "context deadline exceeded"), ReasonUnavailable},
+		{status.Error(codes.ResourceExhausted, "quota exceeded"), ReasonUnavailable},
+		{status.Error(codes.InvalidArgument, "malformed request"), ReasonUnexpected},
+		{ErrUnsupportedAlgorithm, ReasonUnsupportedAlgorithm},
+	} {
+		client := unreachableClient{SigningClient: local, err: tc.err}
+
+		result := VerifySigningKey(t.Context(), client, testResourceName, jose.RS256)
+		require.False(t, result.Verified)
+		require.Equal(t, tc.want, result.Reason, "classifying %v", tc.err)
+		require.NotEmpty(t, result.Detail, "a negative result must always explain itself")
+	}
+}

--- a/server/internal/thirdparty/gcp/gcpkms/verify_test.go
+++ b/server/internal/thirdparty/gcp/gcpkms/verify_test.go
@@ -34,6 +34,7 @@ func TestVerifySigningKey_ES256(t *testing.T) {
 	require.True(t, result.Verified, "detail: %s", result.Detail)
 	require.Equal(t, ReasonVerified, result.Reason)
 	require.Equal(t, jose.ES256, result.Algorithm)
+	require.Empty(t, result.Detail)
 }
 
 // The stored algorithm drives how Gram advertises the key, so a healthy key
@@ -127,6 +128,11 @@ func TestVerifySigningKey_ClassifiesProviderFailures(t *testing.T) {
 		{status.Error(codes.ResourceExhausted, "quota exceeded"), ReasonUnavailable},
 		{status.Error(codes.InvalidArgument, "malformed request"), ReasonUnexpected},
 		{ErrUnsupportedAlgorithm, ReasonUnsupportedAlgorithm},
+
+		// Bare context errors carry no gRPC status. Without explicit handling they
+		// would classify as unexpected, and a caller would not retry a timeout.
+		{context.DeadlineExceeded, ReasonUnavailable},
+		{context.Canceled, ReasonUnavailable},
 	} {
 		client := unreachableClient{SigningClient: local, err: tc.err}
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-2870/feat-gcpkms-gcp-kms-signing-client-go-jose-opaquesigner-gcpauth-token

Adds `gcpkms`, which signs with GCP Cloud KMS keys whose private half never leaves the provider. It reads a key version's public half and algorithm, signs digests, exposes the key as a `go-jose` `jose.OpaqueSigner` that any JWS or JWT path can drive, and provides an end-to-end verification probe that signs a self-identifying payload and validates the result locally against the key's own public key. A KMS key's purpose is fixed at creation, so the signing-specific names (`SigningClient`, `kmsSigningClient`, `ValidateKeyVersionName`) leave room for encrypt and decrypt counterparts to sit alongside them later.

`jose.OpaqueSigner` is the standard interface for KMS-backed JOSE signing, and `jose.JSONWebKey` also supplies the `public_jwk` and RFC 7638 thumbprint that organization JWKS will need. Only RS256 and ES256 are supported.

Supporting this, `gcpauth.Resolver` adds a `TokenSource` method that authenticates Google API calls as a credential's identity, alongside the existing principal resolution. Both resolve paths still mint a token, so credential verify keeps proving an identity is usable rather than merely reachable.

## Notes for reviewers

`cloud.google.com/go/kms` is pinned to **v1.26.0 deliberately**. The current release pulls `grpc`, `otelgrpc`, and `google.golang.org/api` upgrades across the whole module, while v1.26.0 adds one indirect dependency (`longrunning`) and nothing else. `go-jose/v4` was already an indirect dependency via `coreos/go-oidc`, so promoting it to direct downloads nothing new.

`GetPublicKeyRequest.PublicKeyFormat` **must** stay `PUBLIC_KEY_FORMAT_UNSPECIFIED`. Per the API contract, specifying any format (including `PublicKey_PEM`) routes the key into the response's `public_key` field and leaves `pem` / `pem_crc32c` empty, which is what the client reads. An earlier revision of this branch set `PublicKey_PEM` and would have failed against every real key; `TestGetPublicKey_LeavesFormatUnspecified` now pins it.

Nothing consumes the package yet, so there is no behaviour change to observe. The organization key verify endpoint and Encryption Keys dashboard follow in AGE-3067, and organization JWKS in AIS-240.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gcpkms` for signing with GCP Cloud KMS keys (private key never leaves KMS) and exposes a `go-jose` `jose.OpaqueSigner`, plus a verification probe; `gcpauth` now provides a token source for Google API calls. Supports RS256 and ES256; improves error classification and context handling; groundwork for AGE-2870 and future JWKS work; no user-visible behavior yet.

- **New Features**
  - `server/internal/thirdparty/gcp/gcpkms`
    - `SigningClient` over GCP KMS with CRC32C integrity checks; validates versioned resource names.
    - `GetPublicKey` returns parsed key and actual JOSE alg; rejects unsupported or mismatched algs.
    - `NewSigner` returns `jose.OpaqueSigner`; converts ECDSA DER to JOSE R||S; payloads are locally hashed.
    - `VerifySigningKey` probe signs a self-identifying payload and validates locally; classifies provider errors; `LocalSigningClient` for tests/local use.
  - `gcpauth.Resolver` adds `TokenSource(ctx, Credential)`; resolver construction is hoisted so services share a single instance.

- **Bug Fixes**
  - Context timeouts and cancellations now classify as “unavailable” in verification; `LocalSigningClient` respects canceled/expired contexts.
  - `gcpauth` shares ambient ADC loading between principal resolution and token source to avoid drift and ensure consistent errors.

<sup>Written for commit 84c1aaf5798fcfe4e9a2903fa02f5f00b8eb63ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

