### PR TITLE
fix: label chat session access events in audit UI

### DIFF
--- a/client/dashboard/src/components/project/ActivityTimelineCard.tsx
+++ b/client/dashboard/src/components/project/ActivityTimelineCard.tsx
@@ -7,6 +7,7 @@ import {
   Globe,
   KeyRound,
   Link2,
+  MessageSquare,
   Package,
   Puzzle,
   Rocket,
@@ -222,6 +223,13 @@ function getActionMeta(action: string): ActionMeta {
       fg: "text-violet-600 dark:text-violet-400",
     };
   }
+  if (action.startsWith("chat_session:")) {
+    return {
+      icon: MessageSquare,
+      bg: "bg-cyan-100 dark:bg-cyan-950",
+      fg: "text-cyan-600 dark:text-cyan-400",
+    };
+  }
   if (action.startsWith("plugin:")) {
     return {
       icon: Puzzle,
@@ -279,6 +287,7 @@ const ACTION_LABELS: Record<string, string> = {
   "plugin:server_remove": "removed server from plugin",
   "plugin:assignments_set": "updated plugin access",
   "plugin:publish": "published plugins",
+  "chat_session:access": "accessed chat session",
 };
 
 function recordString(value: unknown, key: string): string | undefined {

--- a/client/dashboard/src/lib/audit-log-format.ts
+++ b/client/dashboard/src/lib/audit-log-format.ts
@@ -215,6 +215,8 @@ export function renderVerb(log: AuditLog): string {
       return "updated plugin access assignments";
     case "plugin:publish":
       return "published plugins";
+    case "chat_session:access":
+      return "accessed chat session";
     case "organization:webhooks_enabled":
       return "enabled webhooks delivery";
     case "organization:webhooks_disabled":


### PR DESCRIPTION
## What

Chat session access events rendered with a raw action string in the audit UI:

> `<user> chat_session:access <chat title>`

Now they read as a sentence:

> `<user> accessed chat session <chat title>`

## Why

`chat_session:access` was missing from both action-label maps, so each fell through to its default:

- `ActivityTimelineCard.tsx` (project home) printed `log.action` verbatim and used the generic clock icon.
- `lib/audit-log-format.ts` (org audit log) split on `:` and produced "access chat session".

## Changes

- Add `chat_session:access` → "accessed chat session" to both label maps.
- Give `chat_session:*` a `MessageSquare` icon in the activity timeline instead of the fallback clock.

Subject links were already wired (`subject-href.ts` routes `chat_session` to `agent-sessions?chatId=…`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat session access events in the audit UI to use a readable label and proper icon instead of the raw action string. Applies to both the project activity timeline and the org audit log.

- **Bug Fixes**
  - Map `chat_session:access` to "accessed chat session" in both label formatters.
  - Use a `MessageSquare` icon for all `chat_session:*` actions in the activity timeline.

<sup>Written for commit cdaf995671b1c49595cfd3315c0649da7bc4fd2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

