### PR TITLE
chore: make personal-account seed idempotent across org flips

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -2640,6 +2640,15 @@ async function seedPersonalAccounts(init: {
     ${usersValues.join(",\n")}
     ON CONFLICT (email) DO UPDATE SET display_name = EXCLUDED.display_name, workos_id = EXCLUDED.workos_id;
 
+    -- workos_membership_id is derived from the employee email only, but the row
+    -- also carries organization_id, which ./zero flips between runs. A prior
+    -- run can therefore leave a row with the same membership id under a
+    -- different org, which collides on the global
+    -- organization_user_relationships_workos_membership_id_key partial unique
+    -- index (not the (organization_id, user_id) arbiter below). Clear any prior
+    -- seeded rows for these users by their stable uid first, matching the
+    -- by-uid cleanup used for user_accounts/chats below.
+    DELETE FROM organization_user_relationships WHERE user_id IN (${uidList});
     INSERT INTO organization_user_relationships (organization_id, user_id, workos_user_id, workos_membership_id) VALUES
     ${orgRelValues.join(",\n")}
     ON CONFLICT (organization_id, user_id) DO NOTHING;
@@ -2649,14 +2658,26 @@ async function seedPersonalAccounts(init: {
     ON CONFLICT (organization_id, provider, device_id) WHERE deleted_at IS NULL
     DO UPDATE SET linked_user_id = EXCLUDED.linked_user_id, last_seen_at = clock_timestamp();
 
-    DELETE FROM user_accounts WHERE organization_id = ${sqlStr(organizationId)} AND user_id IN (${uidList});
+    -- Account ids derive from (provider, email) and are org-independent, but
+    -- ./zero flips organization_id between runs. Scoping this cleanup to the
+    -- current org would strand a prior run's row (same id, old org) that then
+    -- collides on user_accounts_pkey (id) — which the (org, provider,
+    -- external_account_uuid) arbiter below does not cover. Delete by uid across
+    -- every org so re-seeds are idempotent regardless of the active org.
+    DELETE FROM user_accounts WHERE user_id IN (${uidList});
     INSERT INTO user_accounts (id, organization_id, user_id, provider, external_org_id, external_account_uuid, external_account_id, email, account_type) VALUES
     ${accountValues.join(",\n")}
     ON CONFLICT (organization_id, provider, external_account_uuid) WHERE deleted_at IS NULL
     DO UPDATE SET user_id = EXCLUDED.user_id, account_type = EXCLUDED.account_type, email = EXCLUDED.email, external_org_id = EXCLUDED.external_org_id, last_seen_at = clock_timestamp();
 
-    DELETE FROM chat_messages WHERE chat_id IN (SELECT id FROM chats WHERE project_id = ${sqlStr(projectId)} AND user_id IN (${uidList}));
-    DELETE FROM chats WHERE project_id = ${sqlStr(projectId)} AND user_id IN (${uidList});
+    -- Chat ids derive from the account key and are project/org-independent, but
+    -- projectId (like organizationId) flips between ./zero runs. Scoping this
+    -- cleanup to the current project would strand a prior run's chats (same id,
+    -- old project) that then collide on chats_pkey (id) — the chats INSERT below
+    -- has no ON CONFLICT. Delete by uid across every project so re-seeds are
+    -- idempotent. Restricted to the seed employee uids, so no real chats match.
+    DELETE FROM chat_messages WHERE chat_id IN (SELECT id FROM chats WHERE user_id IN (${uidList}));
+    DELETE FROM chats WHERE user_id IN (${uidList});
     INSERT INTO chats (id, project_id, organization_id, user_id, external_user_id, user_account_id, title, created_at, updated_at) VALUES
     ${chatValues.join(",\n")};
     INSERT INTO chat_messages (chat_id, project_id, role, content, model, created_at) VALUES


### PR DESCRIPTION
## Problem

Re-running `mise run seed` after `./zero` reassigns the local org/project id fails
on unique-constraint violations in `seedPersonalAccounts`. The seeded row ids are
derived from stable inputs (employee email, provider+email, account key) and are
therefore org/project-independent, but the cleanup `DELETE`s were scoped to the
*current* org/project. A prior run's rows survive under the old org, then collide
on constraints the `ON CONFLICT` arbiters don't cover:

| Table | Stranded row collides on | Arbiter in use |
| --- | --- | --- |
| `organization_user_relationships` | `..._workos_membership_id_key` (global partial unique) | `(organization_id, user_id)` |
| `user_accounts` | `user_accounts_pkey (id)` | `(organization_id, provider, external_account_uuid)` |
| `chats` | `chats_pkey (id)` | none — plain `INSERT` |

## Fix

Delete by the stable seed uid across all orgs/projects instead of scoping to the
active one, plus a new `DELETE` for `organization_user_relationships` (previously
had no cleanup at all). Each delete is restricted to the seed employee uid list,
so no real rows are in range.

Comments added at each site explaining which constraint the scoping missed.

## Testing

Re-ran the seed twice against a local stack with an org id change in between —
now idempotent.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the personal-account seed idempotent across org/project flips by deleting seeded rows by stable user ID across all orgs/projects before re-inserting. Prevents unique-constraint collisions when rerunning `mise run seed` after `./zero`.

- **Bug Fixes**
  - Delete prior seeded rows by `user_id` across all orgs/projects for `organization_user_relationships`, `user_accounts`, and `chats`/`chat_messages` to avoid collisions.
  - Added inline comments explaining the missed constraints and why cleanup must be global.

<sup>Written for commit 04c64df442134a80b0f7dcd2dd994026b3b07d16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

