### PR TITLE
feat(dashboard): show required scopes on the access-restricted page

### DIFF
--- a/.changeset/rbac-gate-required-scopes.md
+++ b/.changeset/rbac-gate-required-scopes.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Show the required permission on the page-level access-restricted screen. A "What access do I need?" disclosure expands into a bordered panel naming the scopes an organization admin can grant, so a blocked user knows what to ask for instead of just being told they lack access.

--- a/client/dashboard/src/components/require-scope.tsx
+++ b/client/dashboard/src/components/require-scope.tsx
@@ -3,6 +3,11 @@ import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { cn } from "@/lib/utils";
 import { Icon } from "@speakeasy-api/moonshine";
 import React from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 type RenderFn = (props: { disabled: boolean }) => React.ReactNode;
@@ -74,7 +79,9 @@ export function RequireScope(
 
   switch (level) {
     case "page":
-      return <>{props.fallback ?? <Unauthorized />}</>;
+      return (
+        <>{props.fallback ?? <Unauthorized scopes={scopes} all={all} />}</>
+      );
 
     case "section":
       return <>{props.fallback ?? null}</>;
@@ -160,10 +167,16 @@ function ScopeDisabled({
 function Unauthorized({
   title = "Access restricted",
   description = "You don't have permission to view this page. Contact your organization admin to request access.",
+  scopes,
+  all,
 }: {
   title?: string;
   description?: string;
+  scopes: Scope[];
+  all: boolean;
 }) {
+  const [open, setOpen] = React.useState(false);
+
   return (
     <div className="flex h-full min-h-[400px] w-full items-center justify-center">
       <div className="flex max-w-sm flex-col items-center gap-3 text-center">
@@ -172,6 +185,55 @@ function Unauthorized({
         </div>
         <h2 className="text-lg font-medium">{title}</h2>
         <p className="text-muted-foreground text-sm">{description}</p>
+        {scopes.length > 0 && (
+          /* The wrapper keeps the collapsed height (h-7 == trigger height) in
+             flow while the card is absolutely positioned on top of it, so
+             expanding grows downward instead of re-centring the whole block. */
+          <div className="relative h-7 w-full">
+            <Collapsible
+              open={open}
+              onOpenChange={setOpen}
+              className="absolute inset-x-0 top-0"
+            >
+              <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex w-full cursor-pointer items-center justify-center gap-1 px-3 py-1.5 text-xs transition-colors">
+                <Icon
+                  name="chevron-right"
+                  className={cn(
+                    "size-3.5 transition-transform",
+                    open && "rotate-90",
+                  )}
+                />
+                What access do I need?
+              </CollapsibleTrigger>
+              <CollapsibleContent className="pt-2">
+                <div className="bg-muted/25 rounded-lg border px-3 py-5">
+                  <p className="text-muted-foreground text-center text-xs">
+                    {scopes.length === 1 || !all
+                      ? "Your account is missing a permission."
+                      : "Your account is missing permissions."}
+                  </p>
+                  <p className="text-muted-foreground mt-1 text-center text-xs">
+                    {scopes.length === 1
+                      ? "An organization admin can grant you:"
+                      : all
+                        ? "An organization admin can grant you all of:"
+                        : "An organization admin can grant you any of:"}
+                  </p>
+                  <ul className="mt-2 flex flex-wrap justify-center gap-1.5">
+                    {scopes.map((s) => (
+                      <li
+                        key={s}
+                        className="bg-background text-foreground rounded border px-1.5 py-0.5 font-mono text-xs"
+                      >
+                        {s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

The page-level access-restricted screen now tells a blocked user _which_ permission they are missing, instead of only that they are missing one.

Under the existing message, a "What access do I need?" disclosure expands into a bordered panel:

> Your account is missing a permission.
> An organization admin can grant you:
> `org:read`

Copy varies with the check: singular for one scope, "all of" when `RequireScope` is called with `all`, "any of" otherwise. The scopes render as monospace chips so they can be copied verbatim when asking an admin.

## Why

"You don't have permission to view this page" gives the user nothing to act on — they cannot tell an admin what to grant. The scope name is the exact token an admin needs, and `RequireScope` already has it.

## Notes

- Deliberately avoids RBAC jargon in the prose ("permission", not "scope"); the raw scope string stays on the chip because that is what an admin searches for.
- The disclosure is anchored so expanding it does not shift the vertically-centred block: a fixed-height wrapper holds the collapsed footprint in flow while the panel is absolutely positioned on top, growing downward only.
- Component-level `RequireScope` already surfaced the same information in its tooltip; this brings the page-level fallback to parity.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the exact required permission(s) on the access-restricted page so blocked users know what to ask an organization admin for. A “What access do I need?” toggle reveals copyable scope chips with clear one/all/any wording, without shifting the centered layout.

<sup>Written for commit 2d8a8a6fbf4d6a29ad457226d69f9f2b567e00b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

