### PR TITLE
fix: hide sidebar nav groups with no permitted items

### DIFF
--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -1,9 +1,5 @@
-import {
-  CollapsibleNavGroup,
-  CollapsibleNavItem,
-  NavButton,
-  NavGroupProvider,
-} from "@/components/nav-menu";
+import { NavButton, NavGroupProvider } from "@/components/nav-menu";
+import { ScopeGatedNavGroup } from "@/components/scope-gated-nav-group";
 import {
   Sidebar,
   SidebarContent,
@@ -43,22 +39,6 @@ import { RequireScope } from "./require-scope";
 import { FeatureRequestModal } from "./FeatureRequestModal";
 import { Button } from "./ui/button";
 import { Type } from "./ui/type";
-
-function ScopeGatedNavItem({
-  item,
-  scope,
-  resourceId,
-}: {
-  item: AppRoute;
-  scope: Scope | Scope[];
-  resourceId?: string;
-}) {
-  return (
-    <RequireScope scope={scope} resourceId={resourceId} level="section">
-      <CollapsibleNavItem item={item} />
-    </RequireScope>
-  );
-}
 
 function ScopeGatedTopLevelItem({
   item,
@@ -218,117 +198,74 @@ export function AppSidebar({
           </li>
 
           {/* Observe group */}
-          <CollapsibleNavGroup
+          <ScopeGatedNavGroup
             label="Observe"
             Icon={(p) => <Icon {...p} name="eye" />}
-            defaultHref={routes.costs.href()}
-          >
-            <ScopeGatedNavItem
-              item={routes.costs}
-              {...accessFor(routes.costs)}
-            />
-            <ScopeGatedNavItem
-              item={routes.insights}
-              {...accessFor(routes.insights)}
-            />
-            <ScopeGatedNavItem
-              item={routes.agentSessions}
-              {...accessFor(routes.agentSessions)}
-            />
-            {isOrgMemoryEnabled && (
-              <ScopeGatedNavItem
-                item={routes.orgMemory}
-                {...accessFor(routes.orgMemory)}
-              />
-            )}
-            <ScopeGatedNavItem item={routes.logs} {...accessFor(routes.logs)} />
-            <ScopeGatedNavItem
-              item={routes.employees}
-              {...accessFor(routes.employees)}
-            />
-          </CollapsibleNavGroup>
+            items={[
+              { item: routes.costs, ...accessFor(routes.costs) },
+              { item: routes.insights, ...accessFor(routes.insights) },
+              {
+                item: routes.agentSessions,
+                ...accessFor(routes.agentSessions),
+              },
+              ...(isOrgMemoryEnabled
+                ? [{ item: routes.orgMemory, ...accessFor(routes.orgMemory) }]
+                : []),
+              { item: routes.logs, ...accessFor(routes.logs) },
+              { item: routes.employees, ...accessFor(routes.employees) },
+            ]}
+          />
 
           {/* Secure group */}
-          <CollapsibleNavGroup
+          <ScopeGatedNavGroup
             label="Secure"
             Icon={(p) => <Icon {...p} name="shield" />}
-            defaultHref={routes.riskOverview.href()}
             stage="beta"
-          >
-            <ScopeGatedNavItem
-              item={routes.riskOverview}
-              {...accessFor(routes.riskOverview)}
-            />
-            <ScopeGatedNavItem
-              item={routes.policyCenter}
-              {...accessFor(routes.policyCenter)}
-            />
-            <ScopeGatedNavItem
-              item={routes.riskEvents}
-              {...accessFor(routes.riskEvents)}
-            />
-            <ScopeGatedNavItem
-              item={routes.shadowMCP}
-              {...accessFor(routes.shadowMCP)}
-            />
-            <ScopeGatedNavItem
-              item={routes.detectionRules}
-              {...accessFor(routes.detectionRules)}
-            />
-          </CollapsibleNavGroup>
+            items={[
+              { item: routes.riskOverview, ...accessFor(routes.riskOverview) },
+              { item: routes.policyCenter, ...accessFor(routes.policyCenter) },
+              { item: routes.riskEvents, ...accessFor(routes.riskEvents) },
+              { item: routes.shadowMCP, ...accessFor(routes.shadowMCP) },
+              {
+                item: routes.detectionRules,
+                ...accessFor(routes.detectionRules),
+              },
+            ]}
+          />
 
           {/* Connect group */}
-          <CollapsibleNavGroup
+          <ScopeGatedNavGroup
             label="Connect"
             Icon={(p) => <Icon {...p} name="plug" />}
-            defaultHref={routes.sources.href()}
-          >
-            <ScopeGatedNavItem
-              item={routes.sources}
-              {...accessFor(routes.sources)}
-            />
-            <ScopeGatedNavItem
-              item={routes.catalog}
-              {...accessFor(routes.catalog)}
-            />
-            <ScopeGatedNavItem
-              item={routes.playground}
-              {...accessFor(routes.playground)}
-            />
-            {isDeploymentsPageEnabled && (
-              <ScopeGatedNavItem
-                item={routes.deployments}
-                {...accessFor(routes.deployments)}
-              />
-            )}
-          </CollapsibleNavGroup>
+            items={[
+              { item: routes.sources, ...accessFor(routes.sources) },
+              { item: routes.catalog, ...accessFor(routes.catalog) },
+              { item: routes.playground, ...accessFor(routes.playground) },
+              ...(isDeploymentsPageEnabled
+                ? [
+                    {
+                      item: routes.deployments,
+                      ...accessFor(routes.deployments),
+                    },
+                  ]
+                : []),
+            ]}
+          />
 
           {/* Distribute group */}
-          <CollapsibleNavGroup
+          <ScopeGatedNavGroup
             label="Distribute"
             Icon={(p) => <Icon {...p} name="hammer" />}
-            defaultHref={routes.mcp.href()}
-          >
-            <ScopeGatedNavItem item={routes.mcp} {...accessFor(routes.mcp)} />
-            {isAssistantsEnabled && (
-              <ScopeGatedNavItem
-                item={routes.assistants}
-                {...accessFor(routes.assistants)}
-              />
-            )}
-            <ScopeGatedNavItem
-              item={routes.skills}
-              {...accessFor(routes.skills)}
-            />
-            <ScopeGatedNavItem
-              item={routes.plugins}
-              {...accessFor(routes.plugins)}
-            />
-            <ScopeGatedNavItem
-              item={routes.environments}
-              {...accessFor(routes.environments)}
-            />
-          </CollapsibleNavGroup>
+            items={[
+              { item: routes.mcp, ...accessFor(routes.mcp) },
+              ...(isAssistantsEnabled
+                ? [{ item: routes.assistants, ...accessFor(routes.assistants) }]
+                : []),
+              { item: routes.skills, ...accessFor(routes.skills) },
+              { item: routes.plugins, ...accessFor(routes.plugins) },
+              { item: routes.environments, ...accessFor(routes.environments) },
+            ]}
+          />
 
           {/* Settings — top-level, no group */}
           <ScopeGatedTopLevelItem

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -1,10 +1,6 @@
-import {
-  CollapsibleNavGroup,
-  CollapsibleNavItem,
-  NavButton,
-  NavGroupProvider,
-} from "@/components/nav-menu";
+import { NavButton, NavGroupProvider } from "@/components/nav-menu";
 import { RequireScope } from "@/components/require-scope";
+import { ScopeGatedNavGroup } from "@/components/scope-gated-nav-group";
 import {
   Sidebar,
   SidebarContent,
@@ -29,19 +25,8 @@ import { OnboardingResumeButton } from "./onboarding-resume-button";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { WorkspaceSwitcher } from "./workspace-switcher";
 
-function ScopeGatedNavItem({
-  item,
-  scope,
-}: {
-  item: AppRoute;
-  scope: Scope | Scope[];
-}) {
-  return (
-    <RequireScope scope={scope} level="section">
-      <CollapsibleNavItem item={item} />
-    </RequireScope>
-  );
-}
+/** Scopes that make an org-level nav item visible. */
+const orgReadOrAdmin: Scope[] = ["org:read", "org:admin"];
 
 function ScopeGatedTopLevelItem({
   item,
@@ -176,91 +161,58 @@ export function OrgSidebar({
               />
 
               {/* Settings group */}
-              <CollapsibleNavGroup
+              <ScopeGatedNavGroup
                 label="Settings"
                 Icon={(p) => <Icon {...p} name="settings" />}
-                defaultHref={orgRoutes.billing.href()}
-              >
-                <ScopeGatedNavItem
-                  item={orgRoutes.billing}
-                  scope={["org:read", "org:admin"]}
-                />
-                <ScopeGatedNavItem item={orgRoutes.apiKeys} scope="org:admin" />
-                <ScopeGatedNavItem
-                  item={orgRoutes.domains}
-                  scope={["org:read", "org:admin"]}
-                />
-                <ScopeGatedNavItem
-                  item={orgRoutes.logs}
-                  scope={["org:read", "org:admin"]}
-                />
-                {productFeatures?.skillsEnabled === true && (
-                  <ScopeGatedNavItem
-                    item={orgRoutes.skills}
-                    scope="org:admin"
-                  />
-                )}
-                <ScopeGatedNavItem
-                  item={orgRoutes.aiIntegrations}
-                  scope={["org:read", "org:admin"]}
-                />
-                <ScopeGatedNavItem
-                  item={orgRoutes.webhooks}
-                  scope={["org:read", "org:admin"]}
-                />
-                {/* Platform-admin only for now; gated on the platform-admin
-                    flag rather than an org RBAC scope. Later expands to org
-                    admins managing their own external credentials. */}
-                {isPlatformAdmin && (
-                  <CollapsibleNavItem item={orgRoutes.externalServices} />
-                )}
-              </CollapsibleNavGroup>
+                items={[
+                  { item: orgRoutes.billing, scope: orgReadOrAdmin },
+                  { item: orgRoutes.apiKeys, scope: "org:admin" },
+                  { item: orgRoutes.domains, scope: orgReadOrAdmin },
+                  { item: orgRoutes.logs, scope: orgReadOrAdmin },
+                  ...(productFeatures?.skillsEnabled === true
+                    ? [{ item: orgRoutes.skills, scope: "org:admin" as Scope }]
+                    : []),
+                  { item: orgRoutes.aiIntegrations, scope: orgReadOrAdmin },
+                  { item: orgRoutes.webhooks, scope: orgReadOrAdmin },
+                  // Platform-admin only for now; gated on the platform-admin
+                  // flag rather than an org RBAC scope. Later expands to org
+                  // admins managing their own external credentials.
+                  ...(isPlatformAdmin
+                    ? [{ item: orgRoutes.externalServices }]
+                    : []),
+                ]}
+              />
 
               {/* Secure group */}
-              <CollapsibleNavGroup
+              <ScopeGatedNavGroup
                 label="Secure"
                 Icon={(p) => <Icon {...p} name="shield-check" />}
-                defaultHref={orgRoutes.auditLogs.href()}
-              >
-                <ScopeGatedNavItem
-                  item={orgRoutes.auditLogs}
-                  scope={["org:read", "org:admin"]}
-                />
-                {isDeviceAgentEnabled && (
-                  <ScopeGatedNavItem
-                    item={orgRoutes.deviceAgent}
-                    scope={["org:read", "org:admin"]}
-                  />
-                )}
-                {isRbacEnabled && (
-                  <ScopeGatedNavItem
-                    item={orgRoutes.access}
-                    scope={["org:read", "org:admin"]}
-                  />
-                )}
-              </CollapsibleNavGroup>
+                items={[
+                  { item: orgRoutes.auditLogs, scope: orgReadOrAdmin },
+                  ...(isDeviceAgentEnabled
+                    ? [{ item: orgRoutes.deviceAgent, scope: orgReadOrAdmin }]
+                    : []),
+                  ...(isRbacEnabled
+                    ? [{ item: orgRoutes.access, scope: orgReadOrAdmin }]
+                    : []),
+                ]}
+              />
 
               {/* Identity group */}
-              <CollapsibleNavGroup
+              <ScopeGatedNavGroup
                 label="Identity"
                 Icon={(p) => <Icon {...p} name="fingerprint" />}
-                defaultHref={orgRoutes.identity.href()}
-              >
-                {isUserSessionsEnabled && (
-                  <ScopeGatedNavItem
-                    item={orgRoutes.userSessions}
-                    scope={["org:read", "org:admin"]}
-                  />
-                )}
-                <ScopeGatedNavItem
-                  item={orgRoutes.identity}
-                  scope={["org:read", "org:admin"]}
-                />
-                <ScopeGatedNavItem
-                  item={orgRoutes.remoteIdentityProviders}
-                  scope={["org:read", "org:admin"]}
-                />
-              </CollapsibleNavGroup>
+                items={[
+                  ...(isUserSessionsEnabled
+                    ? [{ item: orgRoutes.userSessions, scope: orgReadOrAdmin }]
+                    : []),
+                  { item: orgRoutes.identity, scope: orgReadOrAdmin },
+                  {
+                    item: orgRoutes.remoteIdentityProviders,
+                    scope: orgReadOrAdmin,
+                  },
+                ]}
+              />
             </SidebarMenu>
           </NavGroupProvider>
         )}

--- a/client/dashboard/src/components/scope-gated-nav-group.tsx
+++ b/client/dashboard/src/components/scope-gated-nav-group.tsx
@@ -1,0 +1,61 @@
+import { CollapsibleNavGroup, CollapsibleNavItem } from "@/components/nav-menu";
+import { ReleaseStage } from "@/components/release-stage-badge";
+import { useRBAC } from "@/hooks/useRBAC";
+import { AppRoute } from "@/routes";
+import { Scope } from "@gram/client/models/components/rolegrant.js";
+import React from "react";
+
+/** A nav sub-item plus the scopes that make it visible. */
+export interface ScopeGatedNavEntry {
+  item: AppRoute;
+  /** Any one scope grants visibility. Omit for items gated by something else. */
+  scope?: Scope | Scope[];
+  /** Optional resource ID to check the scopes against. */
+  resourceId?: string;
+}
+
+/**
+ * A collapsible sidebar group whose items are scope-gated as data rather than
+ * by wrapping each child in `RequireScope`.
+ *
+ * Gating per child can't hide the group itself — the parent has no way to know
+ * its children rendered nothing — so a user with none of the group's scopes
+ * still saw an empty, expandable group. Filtering up front lets the group
+ * disappear entirely, and lets the group header link to the first item the user
+ * can actually open instead of a fixed (possibly forbidden) page.
+ */
+export function ScopeGatedNavGroup({
+  label,
+  Icon,
+  items,
+  stage,
+}: {
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  items: ScopeGatedNavEntry[];
+  stage?: ReleaseStage;
+}): React.JSX.Element | null {
+  const { hasAnyScope } = useRBAC();
+
+  const visible = items.filter((entry) => {
+    if (entry.scope === undefined) return true;
+    const scopes = Array.isArray(entry.scope) ? entry.scope : [entry.scope];
+    return hasAnyScope(scopes, entry.resourceId);
+  });
+
+  const first = visible[0];
+  if (!first) return null;
+
+  return (
+    <CollapsibleNavGroup
+      label={label}
+      Icon={Icon}
+      defaultHref={first.item.href()}
+      stage={stage}
+    >
+      {visible.map((entry) => (
+        <CollapsibleNavItem key={entry.item.url} item={entry.item} />
+      ))}
+    </CollapsibleNavGroup>
+  );
+}


### PR DESCRIPTION
## Problem

Sidebar nav groups (`Observe`, `Secure`, `Connect`, `Distribute` in the project sidebar; `Settings`, `Secure`, `Identity` in the org sidebar) rendered even when RBAC hid every item inside them, leaving empty expandable groups.

Cause: each sub-item was wrapped in `RequireScope level="section"`, which returns `null` at its own render time. The parent `CollapsibleNavGroup` has no way to observe that its children rendered nothing, so it always rendered the header.

## Fix

Move gating from render-time to data-time. New `ScopeGatedNavGroup` takes items as `{ item, scope, resourceId }[]`, filters them with `useRBAC().hasAnyScope`, and returns `null` when nothing survives.

Also fixes a latent bug: the group header's `defaultHref` was hardcoded (e.g. Observe → Costs), so clicking a group could navigate to a page the user is blocked from. It now points at the first visible item.

## Notes

- No behaviour change when RBAC is disabled — `hasScope` returns `true` for everything, so all items stay visible.
- Feature-flagged items (org memory, deployments, assistants, device agent, user sessions, skills, external services) are filtered into the array by the caller as before.
- Top-level items (Home, Chat, Settings, Team…) keep using `RequireScope` — they have no group to hide.

## Testing

`pnpm -F dashboard type-check` passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide empty sidebar nav groups when users lack permission for all items, and update group headers to link to the first accessible page. Adds a RBAC-aware `ScopeGatedNavGroup` and updates app/org sidebars to use it.

- **Bug Fixes**
  - Empty groups no longer render when all items are hidden by RBAC.
  - Group header link now points to the first visible item, avoiding blocked pages.

- **Refactors**
  - Introduced `ScopeGatedNavGroup` that filters items via `useRBAC().hasAnyScope` and returns null when empty.
  - Migrated `app-sidebar.tsx` and `org-sidebar.tsx` to use it; top-level items still use `RequireScope`. Behavior when RBAC is disabled and feature-flag filtering are unchanged.

<sup>Written for commit e6dcd217ca170c7f0bc817aa3f7aa916ab518819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

