### PR TITLE
feat(domains): auto-disable custom domains after a week of failed health checks

### DIFF
--- a/.changeset/custom-domain-auto-disable.md
+++ b/.changeset/custom-domain-auto-disable.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Custom domains that stay unhealthy for over a week (7+ consecutive failed daily checks) are now automatically disabled: their routing and TLS certificate are removed, and the dashboard explains what went wrong and walks admins through fixing the issue and reverifying the domain. Gram-side check failures never count toward disabling.

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -115,16 +115,32 @@ function customDomainHealthMessage(issue?: string): string {
 // not a customer-actionable problem; only surface it once it has persisted
 // across consecutive checks.
 function showCustomDomainUnhealthy(domain: {
+  verified: boolean;
   healthStatus?: string;
   healthIssue?: string;
   consecutiveFailures?: number;
 }): boolean {
-  if (domain.healthStatus !== "unhealthy") {
+  if (!domain.verified || domain.healthStatus !== "unhealthy") {
     return false;
   }
   return (
     domain.healthIssue !== "check_failed" ||
     (domain.consecutiveFailures ?? 0) >= 2
+  );
+}
+
+// A domain that carries unhealthy state but is no longer verified was
+// auto-disabled by the health sweep: its routing was torn down after a week of
+// continuous failures and it must go back through the reverify flow.
+function showCustomDomainAutoDisabled(domain: {
+  verified: boolean;
+  healthStatus?: string;
+  unhealthySince?: unknown;
+}): boolean {
+  return (
+    !domain.verified &&
+    domain.healthStatus === "unhealthy" &&
+    Boolean(domain.unhealthySince)
   );
 }
 
@@ -411,6 +427,10 @@ function OrgDomainsInner() {
                   <SimpleTooltip tooltip="Your domain is being verified. This may take a few minutes.">
                     <Loader2 className="h-4 w-4 animate-spin text-blue-500" />
                   </SimpleTooltip>
+                ) : showCustomDomainAutoDisabled(domain) ? (
+                  <SimpleTooltip tooltip="This domain was disabled after failing health checks for over a week">
+                    <X className="h-4 w-4 stroke-3 text-red-500" />
+                  </SimpleTooltip>
                 ) : showCustomDomainUnhealthy(domain) ? (
                   <SimpleTooltip tooltip="The latest health check found a problem">
                     <AlertTriangle className="h-4 w-4 text-amber-500" />
@@ -490,6 +510,41 @@ function OrgDomainsInner() {
               </Stack>
             </RequireScope>
           </Stack>
+          {showCustomDomainAutoDisabled(domain) && (
+            <Alert variant="error" dismissible={false} className="mt-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="space-y-1">
+                  <Type variant="body" className="font-medium">
+                    This custom domain was disabled
+                  </Type>
+                  <Type variant="body" className="text-sm">
+                    It failed health checks continuously for over a week, so its
+                    routing and TLS certificate were removed.{" "}
+                    {customDomainHealthMessage(domain.healthIssue)}
+                  </Type>
+                  {domain.unhealthySince && (
+                    <Type variant="body" className="text-sm opacity-80">
+                      Unhealthy since{" "}
+                      <HumanizeDateTime date={domain.unhealthySince} />
+                    </Type>
+                  )}
+                  <Type variant="body" className="text-sm">
+                    Fix the issue above, then reverify the domain to provision
+                    it again.
+                  </Type>
+                </div>
+                <RequireScope scope="org:admin" level="component">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setIsAddDomainDialogOpen(true)}
+                  >
+                    Reverify domain
+                  </Button>
+                </RequireScope>
+              </div>
+            </Alert>
+          )}
           {showCustomDomainUnhealthy(domain) && (
             <Alert variant="warning" dismissible={false} className="mt-4">
               <div className="flex flex-wrap items-center justify-between gap-3">

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -129,9 +129,8 @@ function showCustomDomainUnhealthy(domain: {
   );
 }
 
-// A domain that carries unhealthy state but is no longer verified was
-// auto-disabled by the health sweep: its routing was torn down after a week of
-// continuous failures and it must go back through the reverify flow.
+// Unhealthy state on an unverified domain means the health sweep auto-disabled
+// it: routing was torn down and it must go back through the reverify flow.
 function showCustomDomainAutoDisabled(domain: {
   verified: boolean;
   healthStatus?: string;

--- a/server/internal/background/activities/custom_domain_health.go
+++ b/server/internal/background/activities/custom_domain_health.go
@@ -197,6 +197,7 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 
 	var notification NotifyCustomDomainUnhealthyArgs
 	var next customdomains.HealthState
+	autoDisabled := false
 	if err := pgx.BeginFunc(ctx, c.db, func(tx pgx.Tx) error {
 		repository := customdomainsrepo.New(tx)
 		lockedDomain, err := repository.GetCustomDomainByIDAndOrganizationForHealthUpdate(ctx, customdomainsrepo.GetCustomDomainByIDAndOrganizationForHealthUpdateParams{
@@ -249,6 +250,17 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		if err != nil {
 			return fmt.Errorf("update custom domain health: %w", err)
 		}
+		if customdomains.ShouldAutoDisable(next, args.CheckedAt) {
+			// Disable under the same row lock that persisted the decision so
+			// a recovery cannot commit in between; k8s teardown waits for commit.
+			if _, err := repository.DisableCustomDomainForHealth(ctx, customdomainsrepo.DisableCustomDomainForHealthParams{
+				ID:             domain.ID,
+				OrganizationID: args.OrganizationID,
+			}); err != nil {
+				return fmt.Errorf("disable custom domain after failed health checks: %w", err)
+			}
+			autoDisabled = true
+		}
 		return nil
 	}); err != nil {
 		return noNotification, fmt.Errorf("save custom domain health: %w", err)
@@ -265,37 +277,22 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		)
 	}
 
-	if customdomains.ShouldAutoDisable(next, args.CheckedAt) {
-		if err := c.autoDisable(ctx, domain); err != nil {
-			return noNotification, fmt.Errorf("auto-disable custom domain: %w", err)
+	if autoDisabled {
+		// Retries reuse CheckedAt, so the reconcile no-ops and this idempotent
+		// teardown re-runs until it succeeds.
+		if domain.IngressName.String != "" {
+			provisioner := c.infrastructure.Provisioner(k8s.ProvisionerKind(domain.ProvisionerKind))
+			if err := provisioner.Delete(ctx, domain.IngressName.String, domain.CertSecretName.String); err != nil {
+				return noNotification, fmt.Errorf("tear down auto-disabled custom domain resources: %w", err)
+			}
 		}
+		c.logger.WarnContext(ctx, "auto-disabled custom domain after prolonged failed health checks",
+			attr.SlogURLDomain(domain.Domain),
+			attr.SlogOrganizationID(args.OrganizationID),
+		)
 	}
 
 	return notification, nil
-}
-
-// autoDisable tears down the domain's Kubernetes resources and returns the row
-// to the unverified state after prolonged unhealthiness, putting the domain
-// back into the dashboard's reverify flow. Every step is idempotent so a retry
-// after a partial failure converges.
-func (c *CustomDomainHealth) autoDisable(ctx context.Context, domain customdomainsrepo.CustomDomain) error {
-	if domain.IngressName.String != "" {
-		provisioner := c.infrastructure.Provisioner(k8s.ProvisionerKind(domain.ProvisionerKind))
-		if err := provisioner.Delete(ctx, domain.IngressName.String, domain.CertSecretName.String); err != nil {
-			return fmt.Errorf("tear down custom domain resources: %w", err)
-		}
-	}
-	if _, err := customdomainsrepo.New(c.db).DisableCustomDomainForHealth(ctx, customdomainsrepo.DisableCustomDomainForHealthParams{
-		ID:             domain.ID,
-		OrganizationID: domain.OrganizationID,
-	}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return fmt.Errorf("disable custom domain after failed health checks: %w", err)
-	}
-	c.logger.WarnContext(ctx, "auto-disabled custom domain after prolonged failed health checks",
-		attr.SlogURLDomain(domain.Domain),
-		attr.SlogOrganizationID(domain.OrganizationID),
-	)
-	return nil
 }
 
 // NotifyOrgAdmins returns delivery failures for Temporal retry; recipient keys make retries idempotent.

--- a/server/internal/background/activities/custom_domain_health.go
+++ b/server/internal/background/activities/custom_domain_health.go
@@ -34,6 +34,7 @@ const CustomDomainHealthCheckMaxAttempts = 3
 type CustomDomainInfrastructureChecker interface {
 	CheckCustomDomainInfrastructure(ctx context.Context, check k8s.CustomDomainInfrastructureCheck) (k8s.CustomDomainInfrastructureHealth, error)
 	ListManagedCustomDomainResources(ctx context.Context) ([]k8s.ManagedCustomDomainResource, error)
+	Provisioner(kind k8s.ProvisionerKind) k8s.CustomDomainProvisioner
 }
 
 type CustomDomainHealth struct {
@@ -264,7 +265,37 @@ func (c *CustomDomainHealth) Check(ctx context.Context, args CheckCustomDomainHe
 		)
 	}
 
+	if customdomains.ShouldAutoDisable(next, args.CheckedAt) {
+		if err := c.autoDisable(ctx, domain); err != nil {
+			return noNotification, fmt.Errorf("auto-disable custom domain: %w", err)
+		}
+	}
+
 	return notification, nil
+}
+
+// autoDisable tears down the domain's Kubernetes resources and returns the row
+// to the unverified state after prolonged unhealthiness, putting the domain
+// back into the dashboard's reverify flow. Every step is idempotent so a retry
+// after a partial failure converges.
+func (c *CustomDomainHealth) autoDisable(ctx context.Context, domain customdomainsrepo.CustomDomain) error {
+	if domain.IngressName.String != "" {
+		provisioner := c.infrastructure.Provisioner(k8s.ProvisionerKind(domain.ProvisionerKind))
+		if err := provisioner.Delete(ctx, domain.IngressName.String, domain.CertSecretName.String); err != nil {
+			return fmt.Errorf("tear down custom domain resources: %w", err)
+		}
+	}
+	if _, err := customdomainsrepo.New(c.db).DisableCustomDomainForHealth(ctx, customdomainsrepo.DisableCustomDomainForHealthParams{
+		ID:             domain.ID,
+		OrganizationID: domain.OrganizationID,
+	}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("disable custom domain after failed health checks: %w", err)
+	}
+	c.logger.WarnContext(ctx, "auto-disabled custom domain after prolonged failed health checks",
+		attr.SlogURLDomain(domain.Domain),
+		attr.SlogOrganizationID(domain.OrganizationID),
+	)
+	return nil
 }
 
 // NotifyOrgAdmins returns delivery failures for Temporal retry; recipient keys make retries idempotent.

--- a/server/internal/background/activities/custom_domain_health_test.go
+++ b/server/internal/background/activities/custom_domain_health_test.go
@@ -36,7 +36,12 @@ func noopEmailService(t *testing.T) *email.Service {
 }
 
 type stubInfrastructureChecker struct {
-	resources []k8s.ManagedCustomDomainResource
+	resources   []k8s.ManagedCustomDomainResource
+	provisioner k8s.CustomDomainProvisioner
+}
+
+func (s *stubInfrastructureChecker) Provisioner(kind k8s.ProvisionerKind) k8s.CustomDomainProvisioner {
+	return s.provisioner
 }
 
 func createActivatedCustomDomainResource(
@@ -142,7 +147,7 @@ func TestCustomDomainHealthCheckProbeRescuesDNSMismatch(t *testing.T) {
 	repository := customdomainsrepo.New(conn)
 	domainID := createActivatedCustomDomain(t, repository, "test-organization", "proxied.example.com")
 
-	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
 	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("proxied.example.com")))
 	checker.SetProbe(func(context.Context, string) error { return nil })
 
@@ -170,7 +175,7 @@ func TestCustomDomainHealthCheckProbeFailureKeepsDNSMismatch(t *testing.T) {
 	repository := customdomainsrepo.New(conn)
 	domainID := createActivatedCustomDomain(t, repository, "test-organization", "broken.example.com")
 
-	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
 	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("broken.example.com")))
 	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
 
@@ -199,7 +204,7 @@ func TestCustomDomainHealthCheckRetryReemitsNotification(t *testing.T) {
 	repository := customdomainsrepo.New(conn)
 	domainID := createActivatedCustomDomain(t, repository, "test-organization", "retry.example.com")
 
-	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: nil}, "custom-domain.example.com", noopEmailService(t), nil, nil)
 	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("retry.example.com")))
 	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
 
@@ -285,7 +290,7 @@ func TestCustomDomainNotifyOrgAdminsSendsIdempotentEmail(t *testing.T) {
 	captured := &captureLoopsClient{sent: nil, failNext: 0}
 	siteURL, err := url.Parse("https://app.example.com")
 	require.NoError(t, err)
-	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil}, "custom-domain.example.com", email.NewService(testenv.NewLogger(t), captured), siteURL, nil)
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: nil}, "custom-domain.example.com", email.NewService(testenv.NewLogger(t), captured), siteURL, nil)
 
 	err = checker.NotifyOrgAdmins(t.Context(), activities.NotifyCustomDomainUnhealthyArgs{
 		CustomDomainID: uuid.New(),
@@ -302,6 +307,141 @@ func TestCustomDomainNotifyOrgAdminsSendsIdempotentEmail(t *testing.T) {
 	require.NotEmpty(t, sent[0].IdempotencyKey)
 }
 
+func TestCustomDomainHealthCheckAutoDisablesAfterProlongedFailure(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "custom_domain_auto_disable")
+	require.NoError(t, err)
+	repository := customdomainsrepo.New(conn)
+	domainID := createActivatedCustomDomain(t, repository, "test-organization", "prolonged.example.com")
+
+	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
+	unhealthySince := checkedAt.Add(-8 * 24 * time.Hour)
+	// One failure short of the threshold; this check crosses it.
+	_, err = repository.UpdateCustomDomainHealth(t.Context(), customdomainsrepo.UpdateCustomDomainHealthParams{
+		HealthStatus:         conv.ToPGText("unhealthy"),
+		HealthIssue:          conv.ToPGTextEmpty("dns_target_mismatch"),
+		CheckedAt:            conv.ToPGTimestamptz(checkedAt.Add(-24 * time.Hour)),
+		UnhealthySince:       conv.PtrToPGTimestamptz(&unhealthySince),
+		CertificateExpiresAt: conv.PtrToPGTimestamptz(nil),
+		ConsecutiveFailures:  pgtype.Int4{Int32: customdomains.AutoDisableConsecutiveFailures - 1, Valid: true},
+		ID:                   domainID,
+		OrganizationID:       "test-organization",
+	})
+	require.NoError(t, err)
+
+	stubProvisioner := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, testenv.NewLogger(t))
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: stubProvisioner}, "custom-domain.example.com", noopEmailService(t), nil, nil)
+	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("prolonged.example.com")))
+	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
+
+	notification, err := checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
+		CustomDomainID: domainID,
+		OrganizationID: "test-organization",
+		CheckedAt:      checkedAt,
+	})
+	require.NoError(t, err)
+	require.Empty(t, notification.Issue, "an old transition must not re-notify on disable")
+
+	calls := stubProvisioner.Calls()
+	require.Len(t, calls, 1)
+	require.Equal(t, "Delete", calls[0].Method)
+	require.Equal(t, "prolonged.example.com-resource", calls[0].ResourceName)
+
+	domain, err := repository.GetCustomDomainByDomain(t.Context(), "prolonged.example.com")
+	require.NoError(t, err)
+	require.False(t, domain.Verified, "auto-disable returns the domain to the reverify flow")
+	require.False(t, domain.Activated, "auto-disable removes the domain from health sweeps")
+	require.Equal(t, "unhealthy", domain.HealthStatus.String, "health state stays visible for the dashboard")
+}
+
+func TestCustomDomainHealthCheckNoAutoDisableBelowFailureThreshold(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "custom_domain_no_auto_disable")
+	require.NoError(t, err)
+	repository := customdomainsrepo.New(conn)
+	domainID := createActivatedCustomDomain(t, repository, "test-organization", "belowbar.example.com")
+
+	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
+	unhealthySince := checkedAt.Add(-8 * 24 * time.Hour)
+	// Two failures short of the threshold; this check leaves it one short.
+	_, err = repository.UpdateCustomDomainHealth(t.Context(), customdomainsrepo.UpdateCustomDomainHealthParams{
+		HealthStatus:         conv.ToPGText("unhealthy"),
+		HealthIssue:          conv.ToPGTextEmpty("dns_target_mismatch"),
+		CheckedAt:            conv.ToPGTimestamptz(checkedAt.Add(-24 * time.Hour)),
+		UnhealthySince:       conv.PtrToPGTimestamptz(&unhealthySince),
+		CertificateExpiresAt: conv.PtrToPGTimestamptz(nil),
+		ConsecutiveFailures:  pgtype.Int4{Int32: customdomains.AutoDisableConsecutiveFailures - 2, Valid: true},
+		ID:                   domainID,
+		OrganizationID:       "test-organization",
+	})
+	require.NoError(t, err)
+
+	stubProvisioner := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, testenv.NewLogger(t))
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: stubProvisioner}, "custom-domain.example.com", noopEmailService(t), nil, nil)
+	checker.SetResolver(dns.NewMockResolver(mismatchResolverConfig("belowbar.example.com")))
+	checker.SetProbe(func(context.Context, string) error { return errors.New("connection refused") })
+
+	_, err = checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
+		CustomDomainID: domainID,
+		OrganizationID: "test-organization",
+		CheckedAt:      checkedAt,
+	})
+	require.NoError(t, err)
+	require.Empty(t, stubProvisioner.Calls())
+
+	domain, err := repository.GetCustomDomainByDomain(t.Context(), "belowbar.example.com")
+	require.NoError(t, err)
+	require.True(t, domain.Verified)
+	require.True(t, domain.Activated)
+}
+
+func TestCustomDomainHealthCheckFailedNeverAutoDisables(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "custom_domain_checkfailed_no_disable")
+	require.NoError(t, err)
+	repository := customdomainsrepo.New(conn)
+	domainID := createActivatedCustomDomain(t, repository, "test-organization", "gramside.example.com")
+
+	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
+	unhealthySince := checkedAt.Add(-30 * 24 * time.Hour)
+	// Far past both thresholds, but the issue is Gram-side.
+	_, err = repository.UpdateCustomDomainHealth(t.Context(), customdomainsrepo.UpdateCustomDomainHealthParams{
+		HealthStatus:         conv.ToPGText("unhealthy"),
+		HealthIssue:          conv.ToPGTextEmpty("check_failed"),
+		CheckedAt:            conv.ToPGTimestamptz(checkedAt.Add(-24 * time.Hour)),
+		UnhealthySince:       conv.PtrToPGTimestamptz(&unhealthySince),
+		CertificateExpiresAt: conv.PtrToPGTimestamptz(nil),
+		ConsecutiveFailures:  pgtype.Int4{Int32: 30, Valid: true},
+		ID:                   domainID,
+		OrganizationID:       "test-organization",
+	})
+	require.NoError(t, err)
+
+	stubProvisioner := k8s.NewStubProvisioner(k8s.ProvisionerKindIngress, testenv.NewLogger(t))
+	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, &stubInfrastructureChecker{resources: nil, provisioner: stubProvisioner}, "custom-domain.example.com", noopEmailService(t), nil, nil)
+	checker.SetResolver(dns.NewMockResolver(dns.MockResolverConfig{
+		LookupCNAMEFunc: func(context.Context, string) (string, error) { return "", errors.New("dns timeout") },
+		LookupHostFunc:  func(context.Context, string) ([]string, error) { return nil, errors.New("dns timeout") },
+		LookupTXTFunc:   func(context.Context, string) ([]string, error) { return nil, nil },
+	}))
+
+	_, err = checker.Check(t.Context(), activities.CheckCustomDomainHealthArgs{
+		CustomDomainID: domainID,
+		OrganizationID: "test-organization",
+		CheckedAt:      checkedAt,
+	})
+	require.NoError(t, err)
+	require.Empty(t, stubProvisioner.Calls())
+
+	domain, err := repository.GetCustomDomainByDomain(t.Context(), "gramside.example.com")
+	require.NoError(t, err)
+	require.True(t, domain.Activated)
+	require.Equal(t, "check_failed", domain.HealthIssue.String)
+}
+
 func TestFindOrphanCustomDomainResourcesFlagsUnknownDomains(t *testing.T) {
 	t.Parallel()
 
@@ -309,7 +449,7 @@ func TestFindOrphanCustomDomainResourcesFlagsUnknownDomains(t *testing.T) {
 	require.NoError(t, err)
 	createActivatedCustomDomainResource(t, customdomainsrepo.New(conn), "test-organization", "active.example.com", "active-example-com", k8s.ProvisionerKindIngress)
 
-	stub := &stubInfrastructureChecker{resources: []k8s.ManagedCustomDomainResource{
+	stub := &stubInfrastructureChecker{provisioner: nil, resources: []k8s.ManagedCustomDomainResource{
 		{Kind: k8s.ProvisionerKindIngress, Name: "active-example-com", Domain: "active.example.com"},
 		{Kind: k8s.ProvisionerKindIngress, Name: "orphan-example-com", Domain: "orphan.example.com"},
 	}}
@@ -329,7 +469,7 @@ func TestFindOrphanCustomDomainResourcesAllResourcesAccountedFor(t *testing.T) {
 	require.NoError(t, err)
 	createActivatedCustomDomainResource(t, customdomainsrepo.New(conn), "test-organization", "active.example.com", "active-example-com", k8s.ProvisionerKindIngress)
 
-	stub := &stubInfrastructureChecker{resources: []k8s.ManagedCustomDomainResource{
+	stub := &stubInfrastructureChecker{provisioner: nil, resources: []k8s.ManagedCustomDomainResource{
 		{Kind: k8s.ProvisionerKindIngress, Name: "active-example-com", Domain: "active.example.com"},
 	}}
 	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, stub, "custom-domain.example.com", noopEmailService(t), nil, nil)
@@ -352,7 +492,7 @@ func TestFindOrphanCustomDomainResourcesFlagsUnactivatedDomain(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stub := &stubInfrastructureChecker{resources: []k8s.ManagedCustomDomainResource{
+	stub := &stubInfrastructureChecker{provisioner: nil, resources: []k8s.ManagedCustomDomainResource{
 		{Kind: k8s.ProvisionerKindIngress, Name: "pending-example-com", Domain: "pending.example.com"},
 	}}
 	checker := activities.NewCustomDomainHealth(testenv.NewLogger(t), conn, stub, "custom-domain.example.com", noopEmailService(t), nil, nil)
@@ -370,7 +510,7 @@ func TestFindOrphanCustomDomainResourcesFlagsMismatchedIdentity(t *testing.T) {
 	require.NoError(t, err)
 	createActivatedCustomDomainResource(t, customdomainsrepo.New(conn), "test-organization", "active.example.com", "active-example-com", k8s.ProvisionerKindIngress)
 
-	stub := &stubInfrastructureChecker{resources: []k8s.ManagedCustomDomainResource{
+	stub := &stubInfrastructureChecker{provisioner: nil, resources: []k8s.ManagedCustomDomainResource{
 		{Kind: k8s.ProvisionerKindIngress, Name: "active-example-com", Domain: "active.example.com"},
 		{Kind: k8s.ProvisionerKindIngress, Name: "duplicate-active-example-com", Domain: "active.example.com"},
 	}}

--- a/server/internal/background/activities/custom_domain_health_test.go
+++ b/server/internal/background/activities/custom_domain_health_test.go
@@ -317,7 +317,6 @@ func TestCustomDomainHealthCheckAutoDisablesAfterProlongedFailure(t *testing.T) 
 
 	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
 	unhealthySince := checkedAt.Add(-8 * 24 * time.Hour)
-	// One failure short of the threshold; this check crosses it.
 	_, err = repository.UpdateCustomDomainHealth(t.Context(), customdomainsrepo.UpdateCustomDomainHealthParams{
 		HealthStatus:         conv.ToPGText("unhealthy"),
 		HealthIssue:          conv.ToPGTextEmpty("dns_target_mismatch"),
@@ -365,7 +364,6 @@ func TestCustomDomainHealthCheckNoAutoDisableBelowFailureThreshold(t *testing.T)
 
 	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
 	unhealthySince := checkedAt.Add(-8 * 24 * time.Hour)
-	// Two failures short of the threshold; this check leaves it one short.
 	_, err = repository.UpdateCustomDomainHealth(t.Context(), customdomainsrepo.UpdateCustomDomainHealthParams{
 		HealthStatus:         conv.ToPGText("unhealthy"),
 		HealthIssue:          conv.ToPGTextEmpty("dns_target_mismatch"),
@@ -407,7 +405,6 @@ func TestCustomDomainHealthCheckFailedNeverAutoDisables(t *testing.T) {
 
 	checkedAt := time.Now().UTC().Truncate(time.Microsecond)
 	unhealthySince := checkedAt.Add(-30 * 24 * time.Hour)
-	// Far past both thresholds, but the issue is Gram-side.
 	_, err = repository.UpdateCustomDomainHealth(t.Context(), customdomainsrepo.UpdateCustomDomainHealthParams{
 		HealthStatus:         conv.ToPGText("unhealthy"),
 		HealthIssue:          conv.ToPGTextEmpty("check_failed"),

--- a/server/internal/customdomains/health.go
+++ b/server/internal/customdomains/health.go
@@ -61,19 +61,16 @@ func HealthIssueMessage(issue HealthIssue) string {
 	}
 }
 
-// Auto-disable thresholds: a domain must be continuously unhealthy for at
-// least this long AND this many consecutive checks before its Kubernetes
-// resources are torn down. Both must hold so a burst of rapid manual rechecks
-// cannot disable a domain in under a week, and a long-forgotten domain that
-// only just resumed daily checks gets a full week of signal first.
+// Both thresholds must hold: rapid manual rechecks alone cannot reach a week,
+// and a week of wall-clock unhealthiness alone is not enough without sustained
+// failing checks.
 const (
 	AutoDisableConsecutiveFailures int32         = 7
 	AutoDisableUnhealthyFor        time.Duration = 7 * 24 * time.Hour
 )
 
-// ShouldAutoDisable reports whether a just-persisted health state has crossed
-// the auto-disable thresholds. Gram-side probe failures (check_failed) never
-// count toward disabling a customer's domain.
+// ShouldAutoDisable reports whether both auto-disable thresholds are crossed.
+// check_failed is excluded: a Gram-side probe failure is not a customer fault.
 func ShouldAutoDisable(state HealthState, now time.Time) bool {
 	if state.Status != HealthStatusUnhealthy || state.Issue == HealthIssueCheckFailed {
 		return false

--- a/server/internal/customdomains/health.go
+++ b/server/internal/customdomains/health.go
@@ -61,6 +61,30 @@ func HealthIssueMessage(issue HealthIssue) string {
 	}
 }
 
+// Auto-disable thresholds: a domain must be continuously unhealthy for at
+// least this long AND this many consecutive checks before its Kubernetes
+// resources are torn down. Both must hold so a burst of rapid manual rechecks
+// cannot disable a domain in under a week, and a long-forgotten domain that
+// only just resumed daily checks gets a full week of signal first.
+const (
+	AutoDisableConsecutiveFailures int32         = 7
+	AutoDisableUnhealthyFor        time.Duration = 7 * 24 * time.Hour
+)
+
+// ShouldAutoDisable reports whether a just-persisted health state has crossed
+// the auto-disable thresholds. Gram-side probe failures (check_failed) never
+// count toward disabling a customer's domain.
+func ShouldAutoDisable(state HealthState, now time.Time) bool {
+	if state.Status != HealthStatusUnhealthy || state.Issue == HealthIssueCheckFailed {
+		return false
+	}
+	if state.ConsecutiveFailures < AutoDisableConsecutiveFailures {
+		return false
+	}
+	return state.UnhealthySince != nil &&
+		now.UTC().Sub(state.UnhealthySince.UTC()) >= AutoDisableUnhealthyFor
+}
+
 func ShouldNotifyUnhealthyTransition(current, next HealthState) bool {
 	// Probe failures are Gram-side and not customer-actionable.
 	if next.Status != HealthStatusUnhealthy || next.Issue == HealthIssueCheckFailed {

--- a/server/internal/customdomains/health_test.go
+++ b/server/internal/customdomains/health_test.go
@@ -262,3 +262,41 @@ func TestHealthIssueMessageCertificateProblemsAreManagedByGram(t *testing.T) {
 		)
 	}
 }
+
+func TestShouldAutoDisableRequiresAllThresholds(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	eightDaysAgo := now.Add(-8 * 24 * time.Hour)
+	sixDaysAgo := now.Add(-6 * 24 * time.Hour)
+
+	eligible := HealthState{
+		Status:               HealthStatusUnhealthy,
+		Issue:                HealthIssueDNSTargetMismatch,
+		CheckedAt:            &now,
+		UnhealthySince:       &eightDaysAgo,
+		CertificateExpiresAt: nil,
+		ConsecutiveFailures:  AutoDisableConsecutiveFailures,
+	}
+	require.True(t, ShouldAutoDisable(eligible, now))
+
+	belowFailures := eligible
+	belowFailures.ConsecutiveFailures = AutoDisableConsecutiveFailures - 1
+	require.False(t, ShouldAutoDisable(belowFailures, now), "needs the full failure count")
+
+	tooRecent := eligible
+	tooRecent.UnhealthySince = &sixDaysAgo
+	require.False(t, ShouldAutoDisable(tooRecent, now), "needs a full week unhealthy")
+
+	gramSide := eligible
+	gramSide.Issue = HealthIssueCheckFailed
+	require.False(t, ShouldAutoDisable(gramSide, now), "check_failed never disables")
+
+	healthy := eligible
+	healthy.Status = HealthStatusHealthy
+	require.False(t, ShouldAutoDisable(healthy, now))
+
+	noAnchor := eligible
+	noAnchor.UnhealthySince = nil
+	require.False(t, ShouldAutoDisable(noAnchor, now))
+}

--- a/server/internal/customdomains/queries.sql
+++ b/server/internal/customdomains/queries.sql
@@ -135,9 +135,8 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE;
 
 -- name: DisableCustomDomainForHealth :one
--- Auto-disable after prolonged unhealthiness: the Kubernetes resources are
--- torn down by the caller and the domain drops out of health sweeps
--- (activated) and back into the reverify flow (verified).
+-- Clearing activated drops the domain from health sweeps; clearing verified
+-- puts it back into the dashboard reverify flow. Caller tears down k8s.
 UPDATE custom_domains
 SET
     verified = FALSE,

--- a/server/internal/customdomains/queries.sql
+++ b/server/internal/customdomains/queries.sql
@@ -133,3 +133,17 @@ UPDATE custom_domains
 SET deleted_at = clock_timestamp()
 WHERE organization_id = @organization_id
   AND deleted IS FALSE;
+
+-- name: DisableCustomDomainForHealth :one
+-- Auto-disable after prolonged unhealthiness: the Kubernetes resources are
+-- torn down by the caller and the domain drops out of health sweeps
+-- (activated) and back into the reverify flow (verified).
+UPDATE custom_domains
+SET
+    verified = FALSE,
+    activated = FALSE,
+    updated_at = clock_timestamp()
+WHERE id = @id
+  AND organization_id = @organization_id
+  AND deleted IS FALSE
+RETURNING id;

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -86,6 +86,33 @@ func (q *Queries) DeleteCustomDomain(ctx context.Context, organizationID string)
 	return err
 }
 
+const disableCustomDomainForHealth = `-- name: DisableCustomDomainForHealth :one
+UPDATE custom_domains
+SET
+    verified = FALSE,
+    activated = FALSE,
+    updated_at = clock_timestamp()
+WHERE id = $1
+  AND organization_id = $2
+  AND deleted IS FALSE
+RETURNING id
+`
+
+type DisableCustomDomainForHealthParams struct {
+	ID             uuid.UUID
+	OrganizationID string
+}
+
+// Auto-disable after prolonged unhealthiness: the Kubernetes resources are
+// torn down by the caller and the domain drops out of health sweeps
+// (activated) and back into the reverify flow (verified).
+func (q *Queries) DisableCustomDomainForHealth(ctx context.Context, arg DisableCustomDomainForHealthParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, disableCustomDomainForHealth, arg.ID, arg.OrganizationID)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getCustomDomainByDomain = `-- name: GetCustomDomainByDomain :one
 SELECT id, organization_id, domain, verified, activated, ingress_name, cert_secret_name, provisioner_kind, ip_allowlist, health_status, health_issue, health_checked_at, unhealthy_since, certificate_expires_at, consecutive_failures, created_at, updated_at, deleted_at, deleted
 FROM custom_domains

--- a/server/internal/customdomains/repo/queries.sql.go
+++ b/server/internal/customdomains/repo/queries.sql.go
@@ -103,9 +103,8 @@ type DisableCustomDomainForHealthParams struct {
 	OrganizationID string
 }
 
-// Auto-disable after prolonged unhealthiness: the Kubernetes resources are
-// torn down by the caller and the domain drops out of health sweeps
-// (activated) and back into the reverify flow (verified).
+// Clearing activated drops the domain from health sweeps; clearing verified
+// puts it back into the dashboard reverify flow. Caller tears down k8s.
 func (q *Queries) DisableCustomDomainForHealth(ctx context.Context, arg DisableCustomDomainForHealthParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, disableCustomDomainForHealth, arg.ID, arg.OrganizationID)
 	var id uuid.UUID

--- a/server/internal/k8s/ingress_provisioner.go
+++ b/server/internal/k8s/ingress_provisioner.go
@@ -57,12 +57,16 @@ func (p *IngressProvisioner) Get(ctx context.Context, resourceName string) error
 }
 
 func (p *IngressProvisioner) Delete(ctx context.Context, resourceName, secretName string) error {
-	if err := p.clientset.NetworkingV1().Ingresses(p.namespace).Delete(ctx, resourceName, metav1.DeleteOptions{}); err != nil {
+	// NotFound counts as success so retries after a partial teardown converge.
+	if err := p.clientset.NetworkingV1().Ingresses(p.namespace).Delete(ctx, resourceName, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("delete ingress %s: %w", resourceName, err)
 	}
 	p.logger.InfoContext(ctx, "ingress deleted", attr.SlogIngressName(resourceName))
 
-	if err := p.clientset.CoreV1().Secrets(p.namespace).Delete(ctx, secretName, metav1.DeleteOptions{}); err != nil {
+	if secretName == "" {
+		return nil
+	}
+	if err := p.clientset.CoreV1().Secrets(p.namespace).Delete(ctx, secretName, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("delete secret %s: %w", secretName, err)
 	}
 	p.logger.InfoContext(ctx, "secret deleted", attr.SlogSecretName(secretName))

--- a/server/internal/k8s/ingress_provisioner_test.go
+++ b/server/internal/k8s/ingress_provisioner_test.go
@@ -155,3 +155,23 @@ func TestIngressProvisioner_Delete(t *testing.T) {
 	_, err = cs.CoreV1().Secrets(ingressTestNamespace).Get(ctx, result.SecretName, metav1.GetOptions{})
 	require.True(t, k8serrors.IsNotFound(err))
 }
+func TestIngressProvisioner_Delete_MissingResourcesIsNoop(t *testing.T) {
+	t.Parallel()
+	p, _ := newIngressProvisioner(t)
+
+	// Models a retry after the previous attempt already deleted both resources.
+	require.NoError(t, p.Delete(t.Context(), "never-created", "never-created-tls"))
+}
+
+func TestIngressProvisioner_Delete_EmptySecretNameSkipsSecret(t *testing.T) {
+	t.Parallel()
+	p, cs := newIngressProvisioner(t)
+
+	result, err := p.Setup(t.Context(), "nosecret.example.com", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, p.Delete(t.Context(), result.ResourceName, ""))
+
+	_, err = cs.NetworkingV1().Ingresses(ingressTestNamespace).Get(t.Context(), result.ResourceName, metav1.GetOptions{})
+	require.True(t, k8serrors.IsNotFound(err))
+}


### PR DESCRIPTION
## Why

Stacked on #4603. The production dry run surfaced domains that stay broken indefinitely — including orgs with nobody left to email. Without intervention their Ingress and cert secrets linger forever and cert-manager grinds failed ACME renewals daily. Tracked as AIS-383.

## What

- **Auto-disable**: when a health check leaves a domain unhealthy for **≥7 days AND ≥7 consecutive failures** (`customdomains.ShouldAutoDisable`), the check activity tears down the domain's Ingress + TLS secret (idempotent provisioner delete) and flips the row to `verified=false, activated=false`. That removes it from future health sweeps and puts it back into the dashboard's existing reverify flow. `check_failed` (Gram-side) episodes never count toward disabling.
- **No schema change**: `activated`/`verified` plus the already-persisted health columns encode the disabled state, so this ships without a migration.
- **Dashboard**: a destructive alert explains the domain was disabled, shows the underlying issue + unhealthy-since date, and offers "Reverify domain" — which reuses the existing registration dialog to re-provision once the customer fixes DNS/certs. The unhealthy warning alert is now gated to verified domains so the two states don't stack.

## Safety

- Both thresholds must hold, so rapid manual rechecks can't burn through the failure count in under a week.
- Teardown → DB flip ordering with idempotent steps; a Temporal retry after partial failure converges.
- Health state is left intact for the dashboard to display.

## Verification

- New activity tests: crosses-threshold disables (provisioner Delete recorded, row flipped, health state retained), below-threshold and `check_failed` never disable.
- `ShouldAutoDisable` unit tests cover each threshold in isolation.
- Existing health/notify/orphan tests all pass; `mise lint:server`, dashboard lint + type-check clean.

Demo GIF in comments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically disables custom domains that stay unhealthy for 7+ days to stop lingering Ingress/cert resources and daily ACME churn, and guides admins to reverify. Addresses AIS-383 by cleaning up long-broken domains and reducing cert-manager noise.

- **New Features**
  - Auto-disable after ≥7 consecutive failures and ≥7 days; `check_failed` never counts.
  - On disable: tear down Ingress and TLS via provisioner (idempotent; NotFound OK; empty secret skipped) and flip `verified=false` and `activated=false` inside the row-locked health transaction; keep health state for display.
  - `dashboard`: new “domain was disabled” alert with issue and “unhealthy since” date, plus “Reverify domain” action; unhealthy warning now only shows for verified domains.

<sup>Written for commit b15fda3c141feaef2fe8b87464e7b59a1a10865c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

