### PR TITLE
fix(dashboard): carry sort and time range through project home links

### DIFF
--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -63,6 +63,17 @@ import { HooksSetupDialog } from "@/pages/hooks/HooksSetupDialog";
 type EmployeeView = "employees" | "unattributed";
 
 const VIEW_SEARCH_PARAM = "view";
+const SORT_SEARCH_PARAM = "sort";
+
+// `?sort=tokenCount:desc` seeds the table's initial sort so links into this page
+// (e.g. the Top Users card on the project home) land on the same ordering the
+// card showed. Sorting stays table-local afterwards; the param is read once.
+function parseSortParam(raw: string | null): SortDescriptor | null {
+  if (!raw) return null;
+  const [id, direction] = raw.split(":");
+  if (!id) return null;
+  return { id, direction: direction === "asc" ? "asc" : "desc" };
+}
 
 const EMPLOYEE_VIEWS: EmployeeView[] = ["employees", "unattributed"];
 const VIEW_LABELS: Record<EmployeeView, string> = {
@@ -261,6 +272,7 @@ export function InsightsEmployeesContent(): JSX.Element {
       ? "unattributed"
       : "employees";
   const isUnattributedView = view === "unattributed";
+  const initialSort = parseSortParam(searchParams.get(SORT_SEARCH_PARAM));
 
   const selectedStatuses = values.status;
   const selectedRoleId = values.role;
@@ -562,6 +574,7 @@ export function InsightsEmployeesContent(): JSX.Element {
                 key={view}
                 employees={employees}
                 search={search}
+                initialSort={initialSort}
                 onSelectUser={openUser}
                 deviceSyncByEmail={deviceSyncByEmail}
                 deviceStatus={deviceStatus}
@@ -580,19 +593,21 @@ const PAGE_SIZE = 10;
 function EmployeeTable({
   employees,
   search,
+  initialSort,
   onSelectUser,
   deviceSyncByEmail,
   deviceStatus,
 }: {
   employees: Employee[];
   search: string;
+  initialSort: SortDescriptor | null;
   onSelectUser: (employee: Employee) => void;
   deviceSyncByEmail: Map<string, Date>;
   deviceStatus: DeviceAgentColumnStatus;
 }) {
   const showDeviceAgent = deviceStatus !== "hidden";
   const [page, setPage] = useState(0);
-  const [sort, setSort] = useState<SortDescriptor | null>(null);
+  const [sort, setSort] = useState<SortDescriptor | null>(initialSort);
   // Only ticks once statuses are actually resolvable; disabled (0) otherwise so
   // the memo stays stable (deviceAgentState is only called when "ready").
   const now = useNow(deviceStatus === "ready" ? AGENT_STATUS_TICK_MS : 0);
@@ -788,7 +803,7 @@ function EmployeeTable({
 
   const NoResultsMessage = () => {
     return (
-      <div className="flex h-full items-center justify-center">
+      <div className="flex h-full items-center justify-center py-10">
         <p className="text-muted-foreground text-sm">
           {search
             ? `No employees matching "${search}".`

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -37,6 +37,7 @@ import {
   formatDateRangeLabel,
   useDateRangeFilter,
 } from "@/components/observe/useDateRangeFilter";
+import { safeBase64Encode } from "@/components/observe/observeFilterUtils";
 import { ActivityTimelineCard } from "./ActivityTimelineCard";
 import { buildProjectOverviewQuery } from "./projectOverviewQuery";
 
@@ -61,6 +62,28 @@ export function ProjectDashboard(): JSX.Element {
   const rangeLabel = useMemo(
     () => formatDateRangeLabel(dateRange, customRangeLabel),
     [dateRange, customRangeLabel],
+  );
+
+  // "View all" links carry the selected window so the destination opens on the
+  // same data the card summarized. The range is spelled out rather than left to
+  // the destination: every target reads the shared range/from/to/label params,
+  // but their default presets differ (7d here and on MCP & Tools, 30d on the
+  // employee and agent-session tables), so an absent param silently widens it.
+  const withRange = useCallback(
+    (href: string, extra?: Record<string, string>) => {
+      const params = new URLSearchParams(extra);
+      if (customRange) {
+        params.set("from", customRange.from.toISOString());
+        params.set("to", customRange.to.toISOString());
+        if (customRangeLabel) {
+          params.set("label", safeBase64Encode(customRangeLabel));
+        }
+      } else {
+        params.set("range", dateRange);
+      }
+      return `${href}?${params.toString()}`;
+    },
+    [customRange, customRangeLabel, dateRange],
   );
 
   const {
@@ -547,7 +570,11 @@ export function ProjectDashboard(): JSX.Element {
                           })
                         }
                       />
-                      <ViewAllLink to={routes.employees.href()} />
+                      <ViewAllLink
+                        to={withRange(routes.employees.href(), {
+                          sort: "tokenCount:desc",
+                        })}
+                      />
                     </CardActions>
                   }
                 >
@@ -582,7 +609,7 @@ export function ProjectDashboard(): JSX.Element {
                           })
                         }
                       />
-                      <ViewAllLink to={routes.insights.href()} />
+                      <ViewAllLink to={withRange(routes.insights.href())} />
                     </CardActions>
                   }
                 >
@@ -628,17 +655,17 @@ export function ProjectDashboard(): JSX.Element {
                             }
                           />
                           <ViewAllLink
-                            to={
+                            to={withRange(
                               // no hooks data and no chat sessions
                               isProjectEmpty &&
-                              overview?.summary.totalChats === 0
+                                overview?.summary.totalChats === 0
                                 ? routes.insights.href()
                                 : // has hooks data but no chat sessions
                                   !isProjectEmpty &&
                                     overview?.summary.totalChats === 0
                                   ? routes.insights.href()
-                                  : routes.agentSessions.href()
-                            }
+                                  : routes.agentSessions.href(),
+                            )}
                           />
                         </CardActions>
                       }
@@ -698,7 +725,7 @@ export function ProjectDashboard(): JSX.Element {
                               })
                             }
                           />
-                          <ViewAllLink to={routes.insights.href()} />
+                          <ViewAllLink to={withRange(routes.insights.href())} />
                         </CardActions>
                       }
                     >
@@ -718,7 +745,7 @@ export function ProjectDashboard(): JSX.Element {
                       tooltip="Tools ranked by the number of MCP calls they served in the selected period."
                       action={
                         <CardActions>
-                          <ViewAllLink to={routes.insights.href()} />
+                          <ViewAllLink to={withRange(routes.insights.href())} />
                         </CardActions>
                       }
                     >
@@ -736,7 +763,7 @@ export function ProjectDashboard(): JSX.Element {
                       tooltip="Tools with the highest share of failed MCP calls (HTTP 4xx/5xx) in the selected period. Only tools with at least one failure are shown."
                       action={
                         <CardActions>
-                          <ViewAllLink to={routes.insights.href()} />
+                          <ViewAllLink to={withRange(routes.insights.href())} />
                         </CardActions>
                       }
                     >


### PR DESCRIPTION
## Problem

Clicking "View all" on the **Top Users** card on the project home dropped both the ranking and the selected time window. You'd leave a card showing the top five employees by token count over the last 7 days and land on the Employee Enrollment table sorted by name over the last 30 days — no obvious relationship to what you just clicked.

Two separate causes:

1. **Sort.** The employee table's sort was local `useState(null)` with no way for a link to seed it.
2. **Time range.** Every destination reads the same shared `range` / `from` / `to` / `label` params, but their default presets differ — 7d on the project home and MCP & Tools, 30d on the employee and agent-session tables. The links carried no query string, so an absent param silently widened the window.

## Changes

- `InsightsEmployees.tsx` — support `?sort=<columnId>:<asc|desc>`, parsed once and used to seed the table's initial `SortDescriptor`. Sorting stays table-local afterwards, so user clicks aren't fighting the URL. An unknown column id degrades to unsorted (`sortTableData` returns the input unchanged).
- `ProjectDashboard.tsx` — new `withRange()` helper that spells the current window out into each outbound link, applied to all six "View all" links. Top Users additionally passes `sort=tokenCount:desc`.
- Padding fix on the employee table's empty state, which collapsed to a single cramped line (`h-full` inside a zero-height container).

## Testing

- `pnpm -F dashboard type-check` clean.
- Not yet exercised in a browser.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve the selected sort and time range when clicking “View all” from Project Home, so detailed views match what the cards show. This removes confusing jumps in ordering and date window.

- **Bug Fixes**
  - Employee table reads `?sort=<columnId>:<asc|desc>` once to seed initial sort; unknown columns fall back to unsorted.
  - Added `withRange()` to append the current date range to all “View all” links; Top Users also passes `sort=tokenCount:desc`.
  - Fixed cramped padding in the employee table empty state.

<sup>Written for commit 98afcf92184679f0385814fa481b5b144bb3fccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

