### PR TITLE
fix(mcp): treat disabled legacy toolset MCP servers as not found

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -543,9 +543,13 @@ export function MCPStatusDropdown({
       : "private";
 
   const applyStatus = (status: ServerStatus) => {
+    // Disabling also clears mcpIsPublic: serving surfaces gate on both
+    // flags, so leaving a stale public flag behind would keep the server
+    // anonymously reachable on any surface that misses the enabled check.
+    // Re-enabling always sets mcpIsPublic explicitly.
     const updates =
       status === "disabled"
-        ? { mcpEnabled: false }
+        ? { mcpEnabled: false, mcpIsPublic: false }
         : { mcpEnabled: true, mcpIsPublic: status === "public" };
 
     updateToolsetMutation.mutate(

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1001,6 +1001,11 @@ func (s *Service) checkToolsetSecurity(ctx context.Context, toolset *toolsets_re
 // strictPlatform=true to assert that the original challenge was minted
 // on the platform domain — the value is an explicit assertion rather
 // than a route inference.
+//
+// Disabled toolsets (mcp_enabled false) surface as errToolsetNotFound so
+// every legacy-routed surface (serving, well-known metadata, OAuth
+// challenges) treats them as nonexistent — mirroring how the
+// mcp_endpoints → mcp_servers path handles visibility 'disabled'.
 func (s *Service) loadToolset(ctx context.Context, mcpSlug string, customDomainID uuid.NullUUID, strictPlatform bool) (*toolsets_repo.Toolset, error) {
 	var toolset toolsets_repo.Toolset
 	var err error
@@ -1020,6 +1025,9 @@ func (s *Service) loadToolset(ctx context.Context, mcpSlug string, customDomainI
 		return nil, errToolsetNotFound
 	case err != nil:
 		return nil, fmt.Errorf("lookup toolset: %w", err)
+	}
+	if !toolset.McpEnabled {
+		return nil, errToolsetNotFound
 	}
 	return &toolset, nil
 }

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -319,6 +319,44 @@ func TestServePublic_PrivateDisabledMCP_Returns404(t *testing.T) {
 	require.Contains(t, err.Error(), "not found")
 }
 
+// TestServePublic_DisabledPublicLegacyToolset_Returns404 verifies that a
+// legacy toolset-backed MCP server (mcp_slug set, no mcp_endpoints row)
+// stops serving once disabled, even when it was public — mcp_enabled false
+// must surface as not-found on the serve path, not just on the metadata
+// surfaces.
+func TestServePublic_DisabledPublicLegacyToolset_Returns404(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "disabled-public-" + uuid.NewString()[:8]
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, slug)
+
+	// Serves anonymously while enabled.
+	w, err := servePublicHTTP(t, ctx, ti, slug, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+
+	// Disable via the same flag the dashboard/API writes, deliberately
+	// leaving mcp_is_public true — the state that kept serving anonymously
+	// before the fix.
+	err = toolsetsRepo.SetToolsetMCPEnabledByID(ctx, toolsets_repo.SetToolsetMCPEnabledByIDParams{
+		McpEnabled: false,
+		ID:         toolset.ID,
+		ProjectID:  *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	_, err = servePublicHTTP(t, ctx, ti, slug, makeInitializeBody(), "", nil)
+	require.Error(t, err, "disabled toolset must not serve")
+	require.Contains(t, err.Error(), "not found")
+}
+
 func TestServePublic_AttachedAuthErrorReturnsMCPError(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -1698,6 +1698,10 @@ func (s *Service) loadToolsetFromContextAndSlug(ctx context.Context, mcpSlug str
 		return nil, fmt.Errorf("lookup toolset: %w", toolsetErr)
 	}
 
+	if !toolset.McpEnabled {
+		return nil, fmt.Errorf("%w: mcp disabled", errToolsetNotFound)
+	}
+
 	return &toolset, nil
 }
 

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -218,6 +218,10 @@ func (s *Service) loadToolsetFromCurrentURLContext(ctx context.Context, mcpSlug 
 		return nil, "", fmt.Errorf("lookup toolset: %w", toolsetErr)
 	}
 
+	if !toolset.McpEnabled {
+		return nil, "", fmt.Errorf("%w: mcp disabled", errToolsetNotFound)
+	}
+
 	if !toolset.McpIsPublic && !toolset.OauthProxyServerID.Valid {
 		return nil, "", errOAuthUnavailable
 	}
@@ -235,6 +239,10 @@ func (s *Service) loadToolsetForProjectAndMCPSlug(ctx context.Context, projectID
 		return nil, "", fmt.Errorf("%w: %w", errToolsetNotFound, err)
 	case err != nil:
 		return nil, "", fmt.Errorf("lookup toolset: %w", err)
+	}
+
+	if !toolset.McpEnabled {
+		return nil, "", fmt.Errorf("%w: mcp disabled", errToolsetNotFound)
 	}
 
 	mcpURL := fmt.Sprintf("%s/mcp/%s", s.serverURL.String(), mcpSlug)


### PR DESCRIPTION
# Summary

Legacy toolset-backed MCP servers — a `toolsets` row with `mcp_slug` set and no `mcp_endpoints` row, predating the toolsets → mcp_servers migration — had no working off-switch. The `/mcp/{slug}` serve path, the well-known OAuth metadata handlers, the OAuth authorize/token/register surfaces, and the install page all resolved the toolset without consulting `mcp_enabled`; only the dashboard-facing metadata service enforced it. Disabling a server in the dashboard (or via the API, or even flipping the column directly in the DB) recorded an audit event while the endpoint kept serving — anonymously, when the server had been public, because the dashboard's Disabled option also left `mcp_is_public` at its previous value.

Tracked in AIS-387 (customer context lives there).

# Changes

- **`server/internal/mcp/impl.go`** — `loadToolset` now surfaces disabled toolsets as `errToolsetNotFound`, mirroring how the `mcp_endpoints` → `mcp_servers` path treats `visibility = 'disabled'`. This covers all five legacy-routed surfaces in the package: `/mcp/{slug}` serving, both well-known handlers, OAuth challenge resolution, and stored-state resume.
- **`server/internal/oauth/impl.go`** — same gate in `loadToolsetFromCurrentURLContext` (authorize/token/register) and `loadToolsetForProjectAndMCPSlug` (IDP callback).
- **`server/internal/mcpmetadata/impl.go`** — same gate in `loadToolsetFromContextAndSlug` (install pages render the not-found page).
- **`client/dashboard/src/pages/mcp/MCPDetails.tsx`** — the Disabled option now also clears `mcpIsPublic`, as defense in depth against any surface that still misses the enabled check. Re-enabling already sets `mcpIsPublic` explicitly, so no behavior change on that path.

# Testing

- New regression test `TestServePublic_DisabledPublicLegacyToolset_Returns404`: a public legacy toolset serves anonymously, then stops with not-found once `mcp_enabled` is flipped false (with `mcp_is_public` deliberately left true — the exact state that kept serving before the fix).
- Full `-race` runs pass for `mcp`, `oauth`, `mcpmetadata`, `mcpendpoints`, `mcpservers`, `toolsets`, `xmcp`; `mise lint:server` and dashboard `type-check` clean.
- The existing `TestServePublic_McpEndpoint_DisabledMcpServer_FallsBackToLegacyToolset` contract (disabled `mcp_server` falls through to an _enabled_ legacy toolset sharing the slug) is unchanged and still passes.

# Follow-up (not in this PR)

The fall-through contract above means a disabled `mcp_server` whose _backing toolset_ still has `mcp_slug` set and `mcp_enabled` true is still reachable via the legacy path. Whether the migration should clear legacy slugs (or the fallback should be retired via backfill) is noted in AIS-387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled legacy toolset-backed MCP servers now return not found on all legacy routes, stopping traffic immediately. Disabling in the dashboard also clears `mcpIsPublic` to prevent anonymous access (AIS-387).

- **Bug Fixes**
  - Gate legacy MCP slug resolution on `mcp_enabled`; `server/internal/mcp`, `server/internal/oauth`, and `server/internal/mcpmetadata` now treat disabled toolsets as not found for `/mcp/{slug}`, well-known metadata, OAuth authorize/token/register, and install pages.
  - `client/dashboard`: disabling sets `{ mcpEnabled: false, mcpIsPublic: false }`.
  - Added regression test `TestServePublic_DisabledPublicLegacyToolset_Returns404`.

<sup>Written for commit 80bd18bc13f5fe9fa6159c579f512632b083558f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

