### PR TITLE
fix(dashboard): keep mcpIsPublic untouched when disabling an MCP server

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPDetails.tsx
+++ b/client/dashboard/src/pages/mcp/MCPDetails.tsx
@@ -543,13 +543,13 @@ export function MCPStatusDropdown({
       : "private";
 
   const applyStatus = (status: ServerStatus) => {
-    // Disabling also clears mcpIsPublic: serving surfaces gate on both
-    // flags, so leaving a stale public flag behind would keep the server
-    // anonymously reachable on any surface that misses the enabled check.
-    // Re-enabling always sets mcpIsPublic explicitly.
+    // Disabling intentionally leaves mcpIsPublic untouched: flipping it
+    // would trigger UpdateToolset's visibility-flip OAuth cleanup and
+    // destroy an attached OAuth configuration. Serving is gated on
+    // mcpEnabled alone, and re-enabling sets mcpIsPublic explicitly.
     const updates =
       status === "disabled"
-        ? { mcpEnabled: false, mcpIsPublic: false }
+        ? { mcpEnabled: false }
         : { mcpEnabled: true, mcpIsPublic: status === "public" };
 
     updateToolsetMutation.mutate(


### PR DESCRIPTION
# Summary

Follow-up to #4630, addressing a review comment that landed after the PR was queued: the dashboard change that made the Disabled option send `mcpIsPublic: false` alongside `mcpEnabled: false` introduced a destructive side effect. `UpdateToolset` clears an attached OAuth configuration whenever the `mcp_is_public` value flips while an external OAuth server or OAuth proxy is attached (`server/internal/toolsets/impl.go`, visibility-flip cleanup). So disabling a public toolset with OAuth configured detached its OAuth setup, and re-enabling could not restore it.

This reverts the Disabled option to sending only `{ mcpEnabled: false }`. That flag flip is safe: it never triggers the OAuth cleanup, and since #4630 the serve path 404s on `mcp_enabled = false` across every legacy surface, so gating on the enabled flag alone is sufficient — the `mcpIsPublic` clear was defense in depth that bought nothing and cost the OAuth configuration. Re-enabling already sets `mcpIsPublic` explicitly, so re-enable behavior is unchanged.

# Testing

- Dashboard `type-check` passes.
- Server behavior is unchanged by this PR; the `mcp_enabled` serving gate added in #4630 (covered by `TestServePublic_DisabledPublicLegacyToolset_Returns404`) is what keeps a disabled-from-public server unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OAuth config loss when disabling an MCP server by leaving `mcpIsPublic` unchanged; disabled servers are still gated by `mcpEnabled`, so behavior is unchanged.

- **Bug Fixes**
  - Dashboard now sends `{ mcpEnabled: false }` only when disabling.
  - Avoids `UpdateToolset` visibility-flip cleanup that detached OAuth configs.
  - Re-enabling still sets `mcpIsPublic` explicitly; disabled servers remain unreachable.

<sup>Written for commit 5146aa413740dc9c4c31bd24258931ddd54e9e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

