### PR TITLE
feat: animate chat suggestions into the chat bubble

### DIFF
--- a/client/dashboard/src/App.css
+++ b/client/dashboard/src/App.css
@@ -229,6 +229,90 @@
   }
 }
 
+/* Chat suggestion launch, first half: the clicked suggestion chip flies to the
+   centre of the screen and becomes the overlay card, both tagged `chat-launch`
+   (see `useChatLaunch`). The UA's default cross-fade sells the content change;
+   only the timing is tuned. The second half is NOT a view transition — the
+   user bubble lives inside the Elements shadow root, where a
+   `view-transition-name` produces no pseudo-element at all, so the card is
+   FLIP-animated onto the bubble instead. */
+::view-transition-group(chat-launch) {
+  animation-duration: 420ms;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* No cross-fade: the chip and the card show the same icon and label, so fading
+   between them just reads as the card materialising. Dropping the UA's default
+   animations leaves the chip's snapshot hidden and the card's fully opaque from
+   frame one, so the only thing that moves is the group's geometry — the chip
+   scales up and travels to the centre. */
+::view-transition-old(chat-launch) {
+  animation: none;
+  opacity: 0;
+}
+
+::view-transition-new(chat-launch) {
+  animation: none;
+  opacity: 1;
+}
+
+/* Nothing else on screen may fade while the chip flies. The page itself is
+   swapping route in the same transition, and the UA's 250ms root cross-fade
+   under an otherwise-instant card reads as the card fading in; the veil ramping
+   up reads the same way. Both are cut to an instant swap, scoped to this
+   transition by the class `useChatLaunch` sets on <html>. */
+html.chat-launching::view-transition-old(root),
+html.chat-launching::view-transition-new(root) {
+  animation-duration: 1ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(chat-launch),
+  ::view-transition-old(chat-launch),
+  ::view-transition-new(chat-launch) {
+    animation: none;
+  }
+}
+
+/* Highlight sweep over the launch card's label while it swaps the suggestion
+   title for the full message (driven from `chat-launch.ts`). A pseudo-element
+   sweep rather than a background-clip gradient, because the label keeps its own
+   colour — the shimmer passes over the text, it doesn't paint it. */
+.chat-launch-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+
+.chat-launch-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    rgb(255 255 255 / 0.45) 50%,
+    transparent 70%
+  );
+  animation: 900ms ease-out 1 both chat-launch-shimmer-sweep;
+  pointer-events: none;
+}
+
+@keyframes chat-launch-shimmer-sweep {
+  from {
+    transform: translateX(-120%);
+  }
+  to {
+    transform: translateX(120%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-launch-shimmer::after {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 /* Dotted background scroll animation for catalog cards */
 @keyframes scroll-dots {
   from {

--- a/client/dashboard/src/components/app-layout.tsx
+++ b/client/dashboard/src/components/app-layout.tsx
@@ -12,6 +12,7 @@ import { useCallback, useMemo } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
 import { AppSidebar } from "./app-sidebar.tsx";
 import { INSIGHTS_SUGGESTIONS } from "@/lib/insights-suggestions";
+import { ChatLaunchOverlay } from "./chat-launch-overlay.tsx";
 import { InsightsProvider } from "./insights-dock.tsx";
 import { OrgSidebar } from "./org-sidebar.tsx";
 import { SidebarInset, SidebarProvider } from "./ui/sidebar.tsx";
@@ -115,6 +116,9 @@ const AppLayoutContent = ({
           </GlobalInsightsWrapper>
         </SidebarInset>
       </div>
+      {/* Above the outlet so the suggestion → chat bubble morph survives the
+          navigation into the chat route. */}
+      <ChatLaunchOverlay />
     </div>
   );
 };

--- a/client/dashboard/src/components/chat-launch-overlay.tsx
+++ b/client/dashboard/src/components/chat-launch-overlay.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  CHAT_LANDING_GRADIENT,
+  CHAT_LANDING_GRADIENT_CLASS,
+} from "@/lib/chat-gradient";
+import {
+  CHAT_LAUNCH_ADORNMENT_ATTR,
+  CHAT_LAUNCH_CARD_ATTR,
+  CHAT_LAUNCH_TEXT_ATTR,
+  CHAT_LAUNCH_VEIL_ATTR,
+  useChatLaunchState,
+} from "@/lib/chat-launch";
+import { INSIGHTS_SUGGESTION_ICONS } from "@/lib/insights-suggestions";
+import { cn } from "@/lib/utils";
+
+/**
+ * The mid-flight state of a suggestion launch: the clicked chip, scaled up and
+ * centred over a dimmed page with the chat landing rainbow behind it, spinning
+ * a loader until the conversation's user bubble exists. Mounted once in
+ * <AppLayout> so it outlives the navigation into the chat route.
+ *
+ * Every part is addressed by data attribute rather than a ref, because
+ * `useChatLaunch` drives the animation imperatively from outside React (see
+ * that module for the two halves of the flight).
+ */
+export function ChatLaunchOverlay(): ReactElement | null {
+  const launch = useChatLaunchState();
+  if (!launch) return null;
+
+  const SuggestionIcon = INSIGHTS_SUGGESTION_ICONS[launch.icon];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed inset-0 z-[100] flex items-center justify-center px-6"
+    >
+      {/* Deliberately NOT given a view-transition-name. A named element is
+          lifted into its own transition group, and groups paint in name order
+          rather than DOM order — the veil would sit on top of the card for the
+          whole flight and wash it out. Unnamed, it rides in the root snapshot,
+          which swaps instantly, and every named group paints above it. */}
+      <div
+        aria-hidden="true"
+        {...{ [CHAT_LAUNCH_VEIL_ATTR]: "" }}
+        className="absolute inset-0"
+      >
+        <div className="bg-background/80 absolute inset-0 backdrop-blur-[2px]" />
+        <div
+          className={cn(
+            "pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
+            CHAT_LANDING_GRADIENT_CLASS,
+          )}
+          style={{ background: CHAT_LANDING_GRADIENT }}
+        />
+      </div>
+      <div
+        {...{ [CHAT_LAUNCH_CARD_ATTR]: "" }}
+        className="border-border bg-card text-foreground relative flex max-w-xl items-center gap-3 rounded-2xl border px-6 py-4 text-lg shadow-lg"
+      >
+        <SuggestionIcon
+          {...{ [CHAT_LAUNCH_ADORNMENT_ATTR]: "" }}
+          className="size-5 shrink-0"
+        />
+        <span {...{ [CHAT_LAUNCH_TEXT_ATTR]: "" }} className="min-w-0">
+          {launch.title}
+        </span>
+        <Loader2
+          {...{ [CHAT_LAUNCH_ADORNMENT_ATTR]: "" }}
+          className="text-muted-foreground size-4 shrink-0 animate-spin"
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/dashboard/src/lib/chat-gradient.ts
+++ b/client/dashboard/src/lib/chat-gradient.ts
@@ -1,0 +1,18 @@
+/**
+ * The Speakeasy brand rainbow used behind the chat landing header and the
+ * suggestion-launch overlay. Each blob fades to its own zero-alpha so the
+ * overlaps read as soft powder rather than muddy grey. Shared so the launch
+ * overlay's underlay is literally the same gradient the landing page shows.
+ */
+export const CHAT_LANDING_GRADIENT = [
+  "radial-gradient(38% 48% at 30% 42%, #C83228 0%, rgba(200,50,40,0) 70%)",
+  "radial-gradient(36% 46% at 48% 28%, #FB873F 0%, rgba(251,135,63,0) 70%)",
+  "radial-gradient(42% 52% at 64% 40%, #D2DC91 0%, rgba(210,220,145,0) 72%)",
+  "radial-gradient(44% 54% at 70% 60%, #5A8250 0%, rgba(90,130,80,0) 72%)",
+  "radial-gradient(42% 52% at 42% 62%, #2873D7 0%, rgba(40,115,215,0) 72%)",
+  "radial-gradient(36% 46% at 26% 54%, #9BC3FF 0%, rgba(155,195,255,0) 72%)",
+].join(",");
+
+/** Blob geometry shared by the landing backdrop and the launch overlay. */
+export const CHAT_LANDING_GRADIENT_CLASS =
+  "h-[560px] w-[920px] max-w-[140vw] opacity-60 blur-[72px] dark:opacity-40";

--- a/client/dashboard/src/lib/chat-launch.ts
+++ b/client/dashboard/src/lib/chat-launch.ts
@@ -1,0 +1,431 @@
+import { useSyncExternalStore } from "react";
+import { flushSync } from "react-dom";
+import { useNavigate } from "react-router";
+import { useInsightsState } from "@/components/insights-context";
+import type {
+  InsightsSuggestion,
+  InsightsSuggestionIcon,
+} from "@/lib/insights-suggestions";
+import { useRoutes } from "@/routes";
+
+/**
+ * "Launch" animation for chat suggestion chips, in two View Transitions:
+ *
+ *  1. `chat-launch` — the clicked chip flies to the centre of the screen as a
+ *     full-screen overlay card and spins a loader while the prompt is sent.
+ *  2. `chat-launch-bubble` — the card reverse-genies into the blue user bubble
+ *     of the conversation it started (keyframes in App.css).
+ *
+ * Two names rather than one so each half can have its own choreography, and
+ * because a name may only ever exist on ONE element per snapshot — two
+ * elements sharing a name abort the transition. Names are therefore applied
+ * imperatively at the exact moment each snapshot is taken.
+ *
+ * The overlay lives in <AppLayout>, above the router outlet, so it survives
+ * the navigation to `/chat/new` that happens mid-flight.
+ */
+
+/** Must match the ::view-transition-*() rules in App.css. */
+const VT_ARRIVE = "chat-launch";
+
+/** Marks the overlay card so the launcher can drive it without prop-drilling a
+ *  ref out of the overlay component. */
+export const CHAT_LAUNCH_CARD_ATTR = "data-chat-launch-card";
+const CARD_SELECTOR = `[${CHAT_LAUNCH_CARD_ATTR}]`;
+/** The card's icon and spinner — dropped early in the minimize, since the
+ *  bubble has neither. */
+export const CHAT_LAUNCH_ADORNMENT_ATTR = "data-chat-launch-adornment";
+const ADORNMENT_SELECTOR = `[${CHAT_LAUNCH_ADORNMENT_ATTR}]`;
+/** The dim + rainbow underlay. */
+export const CHAT_LAUNCH_VEIL_ATTR = "data-chat-launch-veil";
+const VEIL_SELECTOR = `[${CHAT_LAUNCH_VEIL_ATTR}]`;
+/** The card's label — carries the suggestion title down, then swaps to the
+ *  full prompt once the card has landed. */
+export const CHAT_LAUNCH_TEXT_ATTR = "data-chat-launch-text";
+const TEXT_SELECTOR = `[${CHAT_LAUNCH_TEXT_ATTR}]`;
+
+/** Sweeps a highlight across the label while it swaps text (see App.css). */
+const SHIMMER_CLASS = "chat-launch-shimmer";
+/** Set on <html> for the duration of the arriving transition so its App.css
+ *  rules only suppress the page cross-fade for this one transition. */
+const LAUNCHING_CLASS = "chat-launching";
+
+const FLIGHT_MS = 560;
+const FLIGHT_EASING = "cubic-bezier(0.62, 0, 0.2, 1)";
+/** Beat after landing, before the text starts changing. */
+const LAND_HOLD_MS = 140;
+const TEXT_OUT_MS = 130;
+const TEXT_IN_MS = 220;
+/** Tail of the shimmer sweep left to play before handing off. */
+const SHIMMER_TAIL_MS = 260;
+/** Cross-fade onto the real bubble, which by then holds identical text. */
+const HANDOFF_MS = 160;
+
+/** Extra beat after the chip has finished flying in, so the loader reads as a
+ *  deliberate pause rather than a flicker. */
+const LOADER_MIN_MS = 400;
+/** Give up waiting for the bubble (assistant cold start, send error) and just
+ *  drop the overlay. Generous: a cold runtime can take tens of seconds. */
+const BUBBLE_TIMEOUT_MS = 30000;
+/** Each poll walks open shadow trees, so keep the cadence modest. */
+const BUBBLE_POLL_MS = 120;
+
+/** The blue user bubble rendered by the Elements thread. */
+const USER_BUBBLE_SELECTOR = '[data-role="user"] .aui-user-message-content';
+
+export interface ChatLaunch {
+  title: string;
+  icon: InsightsSuggestionIcon;
+  prompt: string;
+}
+
+// Module-level store rather than context: the chip (a page under the outlet)
+// and the overlay (mounted in the layout shell) are in different subtrees, and
+// the chip unmounts the moment the navigation lands.
+let current: ChatLaunch | null = null;
+const listeners = new Set<() => void>();
+
+function setLaunch(next: ChatLaunch | null): void {
+  current = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** The in-flight launch, or null. Read by <ChatLaunchOverlay>. */
+export function useChatLaunchState(): ChatLaunch | null {
+  return useSyncExternalStore(
+    subscribe,
+    () => current,
+    () => null,
+  );
+}
+
+function canMorph(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    typeof document.startViewTransition === "function" &&
+    !window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Elements renders the thread inside a shadow root (see ShadowRoot.tsx), so a
+ *  plain `document.querySelector` never sees the bubble — walk open shadow
+ *  trees too. `view-transition-name` still works across the boundary: the
+ *  pseudo-elements it generates live on the document root either way. */
+function deepQuery(
+  selector: string,
+  root: Document | ShadowRoot = document,
+): HTMLElement | null {
+  const direct = root.querySelector<HTMLElement>(selector);
+  if (direct) return direct;
+  for (const element of root.querySelectorAll<HTMLElement>("*")) {
+    if (!element.shadowRoot) continue;
+    const nested = deepQuery(selector, element.shadowRoot);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+/** Polls for the user bubble carrying `prompt`. The launched message is the
+ *  first user turn of a fresh conversation, so the first match wins; the text
+ *  check guards against matching a stale thread that hasn't swapped yet. It is
+ *  a prefix match because the renderer may append trailing nodes to the text. */
+async function waitForBubble(prompt: string): Promise<HTMLElement | null> {
+  const deadline = Date.now() + BUBBLE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const bubble = deepQuery(USER_BUBBLE_SELECTOR);
+    if (bubble?.textContent?.trim().startsWith(prompt.slice(0, 40))) {
+      return bubble;
+    }
+    await delay(BUBBLE_POLL_MS);
+  }
+  return null;
+}
+
+/**
+ * Second half: hold the loader until the bubble exists, then minimize the card
+ * into it — a FLIP animation on the card itself rather than a second View
+ * Transition. It has to be FLIP: the bubble lives inside the Elements shadow
+ * root, and `view-transition-name` on a shadow-tree element produces no
+ * pseudo-element at all in Chrome, so the browser would pair the card with
+ * nothing and simply fade it out.
+ *
+ * The card is animated to the bubble's exact box while its background, text
+ * colour and radius interpolate to the bubble's computed values, so the chip
+ * styling becomes bubble styling on the way down. The real bubble is held
+ * invisible underneath until the card lands on top of it.
+ */
+async function morphIntoBubble(prompt: string): Promise<void> {
+  const bubble = await waitForBubble(prompt);
+  await delay(LOADER_MIN_MS);
+
+  const card = document.querySelector<HTMLElement>(CARD_SELECTOR);
+  if (!bubble || !card || !canMorph()) {
+    if (import.meta.env.DEV && !bubble) {
+      console.warn("[chat-launch] no user bubble found; skipping the morph");
+    }
+    setLaunch(null);
+    return;
+  }
+
+  const from = card.getBoundingClientRect();
+  const to = bubble.getBoundingClientRect();
+  const target = getComputedStyle(bubble);
+  const origin = getComputedStyle(card);
+
+  // Animate the card's real box rather than a transform: the label has to stay
+  // legible after it lands (it still has a text swap to perform), and a
+  // non-uniform scale would leave it stretched. Pin the card at its current
+  // position first so leaving the centring flex layout doesn't move it.
+  Object.assign(card.style, {
+    position: "fixed",
+    margin: "0",
+    left: `${from.left}px`,
+    top: `${from.top}px`,
+    width: `${from.width}px`,
+    height: `${from.height}px`,
+    // The card is `max-w-xl` while it's a centred card; that cap would clamp
+    // the flight short of a wider bubble and re-wrap the message.
+    maxWidth: "none",
+  });
+
+  // Hide the real bubble so it isn't a second copy of itself mid-flight.
+  bubble.style.opacity = "0";
+
+  // The icon and spinner have no counterpart in a chat bubble.
+  for (const adornment of card.querySelectorAll<HTMLElement>(
+    ADORNMENT_SELECTOR,
+  )) {
+    adornment.animate([{ opacity: 1 }, { opacity: 0 }], {
+      duration: FLIGHT_MS * 0.35,
+      easing: "ease-out",
+      fill: "forwards",
+    });
+  }
+
+  document
+    .querySelector<HTMLElement>(VEIL_SELECTOR)
+    ?.animate([{ opacity: 1 }, { opacity: 0 }], {
+      duration: FLIGHT_MS,
+      easing: "ease-in",
+      fill: "forwards",
+    });
+
+  const flight = card.animate(
+    [
+      {
+        left: `${from.left}px`,
+        top: `${from.top}px`,
+        width: `${from.width}px`,
+        height: `${from.height}px`,
+        padding: origin.padding,
+        fontSize: origin.fontSize,
+        backgroundColor: origin.backgroundColor,
+        color: origin.color,
+        borderRadius: origin.borderRadius,
+        borderColor: origin.borderColor,
+        borderWidth: origin.borderWidth,
+      },
+      {
+        left: `${to.left}px`,
+        top: `${to.top}px`,
+        width: `${to.width}px`,
+        height: `${to.height}px`,
+        padding: target.padding,
+        fontSize: target.fontSize,
+        backgroundColor: target.backgroundColor,
+        color: target.color,
+        borderRadius: target.borderRadius,
+        borderColor: target.backgroundColor,
+        // The bubble has no border. Two pixels of card border shrink the
+        // content box just enough to wrap a message that fits the bubble on
+        // one line, so the border has to go, not just change colour.
+        borderWidth: "0px",
+      },
+    ],
+    { duration: FLIGHT_MS, easing: FLIGHT_EASING, fill: "forwards" },
+  );
+  await flight.finished.catch(() => undefined);
+  // Bake the flight's end state into inline styles so the follow loop below
+  // can drive the box directly — a forwards-filled animation outranks inline
+  // styles and would ignore every write.
+  flight.commitStyles();
+  flight.cancel();
+
+  // From here the card shadows the bubble frame by frame. The transcript is
+  // still settling — the thread column widens as the assistant's turn renders,
+  // which can nearly double the bubble's width and re-wrap its text — so a
+  // one-shot re-measure always loses the race. The full message has to wrap
+  // exactly as it does in the bubble, or it spills out of the card.
+  const stopFollowing = followBubble(card, bubble);
+
+  await swapToFullPrompt(card, prompt, target);
+
+  // Hand off: the bubble underneath now holds the same text in the same box,
+  // so fading the card out is invisible.
+  bubble.style.opacity = "";
+  await card
+    .animate([{ opacity: 1 }, { opacity: 0 }], {
+      duration: HANDOFF_MS,
+      easing: "linear",
+      fill: "forwards",
+    })
+    .finished.catch(() => undefined);
+  stopFollowing();
+  setLaunch(null);
+}
+
+/** Pins the card to the bubble's box every frame until the returned stopper is
+ *  called. Cheap — one rect read and four style writes per frame, for under a
+ *  second. */
+function followBubble(card: HTMLElement, bubble: HTMLElement): () => void {
+  let frame = 0;
+  const step = () => {
+    const rect = bubble.getBoundingClientRect();
+    card.style.left = `${rect.left}px`;
+    card.style.top = `${rect.top}px`;
+    card.style.width = `${rect.width}px`;
+    card.style.height = `${rect.height}px`;
+    frame = requestAnimationFrame(step);
+  };
+  step();
+  return () => cancelAnimationFrame(frame);
+}
+
+/**
+ * With the card sitting in the bubble's box — still showing the short
+ * suggestion title — dissolve the title, put the full message in its place,
+ * and sweep a shimmer across it so the substitution reads as the message
+ * resolving rather than as a cut.
+ *
+ * The card also adopts the bubble's typography here, while the label is
+ * invisible: the thread renders inside a shadow root with its own font stack
+ * and line height, so keeping the dashboard's would wrap the message
+ * differently from the bubble it is about to become.
+ */
+async function swapToFullPrompt(
+  card: HTMLElement,
+  prompt: string,
+  target: CSSStyleDeclaration,
+): Promise<void> {
+  const label = card.querySelector<HTMLElement>(TEXT_SELECTOR);
+  if (!label) return;
+
+  await delay(LAND_HOLD_MS);
+  await label
+    .animate([{ opacity: 1 }, { opacity: 0.15 }], {
+      duration: TEXT_OUT_MS,
+      easing: "ease-in",
+      fill: "forwards",
+    })
+    .finished.catch(() => undefined);
+
+  // The overlay unmounts moments later, so writing through React here is safe.
+  label.textContent = prompt;
+  label.classList.add(SHIMMER_CLASS);
+  // The adornments are invisible by now but still occupy layout; once the card
+  // stops being a flex row they would stack above the label and push the
+  // message out of the box. Take them out entirely.
+  for (const adornment of card.querySelectorAll<HTMLElement>(
+    ADORNMENT_SELECTOR,
+  )) {
+    adornment.style.display = "none";
+  }
+
+  // Match the bubble's own text layout, and drop the flex centring the icon
+  // and spinner needed — a multi-line message has to start at the top of the
+  // box the way the bubble's does.
+  Object.assign(card.style, {
+    display: "block",
+    fontFamily: target.fontFamily,
+    fontSize: target.fontSize,
+    lineHeight: target.lineHeight,
+    fontWeight: target.fontWeight,
+    letterSpacing: target.letterSpacing,
+  });
+
+  await label
+    .animate([{ opacity: 0.15 }, { opacity: 1 }], {
+      duration: TEXT_IN_MS,
+      easing: "ease-out",
+      fill: "forwards",
+    })
+    .finished.catch(() => undefined);
+  await delay(SHIMMER_TAIL_MS);
+}
+
+/**
+ * Returns a launcher for suggestion chips. Pass the clicked element so it can
+ * be tagged as the transition's starting geometry; without it (or without View
+ * Transitions support / with reduced motion) the prompt is sent with no
+ * animation.
+ */
+export function useChatLaunch(): (
+  suggestion: InsightsSuggestion,
+  source: HTMLElement | null,
+) => void {
+  const navigate = useNavigate();
+  const routes = useRoutes();
+  const { sendPrompt } = useInsightsState();
+
+  return (suggestion, source) => {
+    const prompt = suggestion.prompt.trim();
+    if (!prompt) return;
+
+    // Start the conversation on the shared runtime, then drop into the
+    // full-page view — the queued prompt fires once the chat route mounts the
+    // runtime. The server mints the chat id on the first send.
+    const send = () => {
+      sendPrompt(prompt);
+      void navigate(routes.chat.conversation.href("new"));
+    };
+
+    if (!source || !canMorph()) {
+      send();
+      return;
+    }
+
+    source.style.viewTransitionName = VT_ARRIVE;
+    // Scopes the "no page cross-fade" rules in App.css to this transition.
+    document.documentElement.classList.add(LAUNCHING_CLASS);
+    const transition = document.startViewTransition(() => {
+      // Sending inside the same flush keeps it one atomic DOM change: the old
+      // snapshot is the chip, the new one is the overlay over the chat page.
+      flushSync(() => {
+        setLaunch({
+          title: suggestion.title,
+          icon: suggestion.icon ?? "sparkles",
+          prompt,
+        });
+        send();
+      });
+      // react-router defers the route swap past this flush, so the chip is
+      // still mounted when the new snapshot is taken — drop its name here or
+      // the browser sees two `chat-launch` elements and aborts.
+      source.style.viewTransitionName = "";
+      const card = document.querySelector<HTMLElement>(CARD_SELECTOR);
+      if (card) card.style.viewTransitionName = VT_ARRIVE;
+    });
+
+    // Wait for the flight to land before starting the second transition — an
+    // overlapping one would abort it mid-air.
+    void transition.finished
+      .catch(() => undefined)
+      .then(() => {
+        document.documentElement.classList.remove(LAUNCHING_CLASS);
+        return morphIntoBubble(prompt);
+      });
+  };
+}

--- a/client/dashboard/src/lib/insights-suggestions.ts
+++ b/client/dashboard/src/lib/insights-suggestions.ts
@@ -75,7 +75,7 @@ export const INSIGHTS_SUGGESTION_ICONS = {
   zap: Zap,
 } satisfies Record<string, LucideIcon>;
 
-type InsightsSuggestionIcon = keyof typeof INSIGHTS_SUGGESTION_ICONS;
+export type InsightsSuggestionIcon = keyof typeof INSIGHTS_SUGGESTION_ICONS;
 
 export interface InsightsSuggestion {
   /** Chip text — a short question. */

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -48,6 +48,11 @@ import {
   SLASH_COMMANDS,
   type InsightsSuggestion,
 } from "@/lib/insights-suggestions";
+import { useChatLaunch } from "@/lib/chat-launch";
+import {
+  CHAT_LANDING_GRADIENT,
+  CHAT_LANDING_GRADIENT_CLASS,
+} from "@/lib/chat-gradient";
 import { cn } from "@/lib/utils";
 import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { useRoutes } from "@/routes";
@@ -102,19 +107,11 @@ function ChatLandingBackdrop(): ReactElement {
       className="pointer-events-none absolute inset-x-0 top-0 z-0 h-[460px] overflow-hidden [mask-image:linear-gradient(to_bottom,black_30%,transparent_92%)]"
     >
       <div
-        className="absolute top-[-160px] left-1/2 h-[560px] w-[920px] max-w-[140vw] -translate-x-1/2 opacity-60 blur-[72px] dark:opacity-40"
-        style={{
-          // Brand rainbow (matches INSIGHTS_AI_RAINBOW), each blob fading to its
-          // own zero-alpha so the overlaps read as soft powder, not muddy grey.
-          background: [
-            "radial-gradient(38% 48% at 30% 42%, #C83228 0%, rgba(200,50,40,0) 70%)",
-            "radial-gradient(36% 46% at 48% 28%, #FB873F 0%, rgba(251,135,63,0) 70%)",
-            "radial-gradient(42% 52% at 64% 40%, #D2DC91 0%, rgba(210,220,145,0) 72%)",
-            "radial-gradient(44% 54% at 70% 60%, #5A8250 0%, rgba(90,130,80,0) 72%)",
-            "radial-gradient(42% 52% at 42% 62%, #2873D7 0%, rgba(40,115,215,0) 72%)",
-            "radial-gradient(36% 46% at 26% 54%, #9BC3FF 0%, rgba(155,195,255,0) 72%)",
-          ].join(","),
-        }}
+        className={cn(
+          "absolute top-[-160px] left-1/2 -translate-x-1/2",
+          CHAT_LANDING_GRADIENT_CLASS,
+        )}
+        style={{ background: CHAT_LANDING_GRADIENT }}
       />
     </div>
   );
@@ -312,7 +309,7 @@ export function ChatLanding({
 
       <ChatHomePinned />
       <ChatHomeRecents />
-      <ChatHomeSuggestions onPick={startChat} />
+      <ChatHomeSuggestions />
     </div>
   );
 }
@@ -745,11 +742,13 @@ function PinButton({
   );
 }
 
-function ChatHomeSuggestions({
-  onPick,
-}: {
-  onPick: (prompt: string) => void;
-}): ReactElement {
+/**
+ * Starter prompt chips. Clicking one hands the chip element to `useChatLaunch`,
+ * which flies it to the centre of the screen and then morphs it into the user
+ * bubble of the conversation it just started.
+ */
+function ChatHomeSuggestions(): ReactElement {
+  const launchChat = useChatLaunch();
   return (
     <section className="flex flex-col gap-3">
       <h2 className="text-muted-foreground px-3 text-sm font-medium">
@@ -763,7 +762,7 @@ function ChatHomeSuggestions({
             <button
               key={suggestion.title}
               type="button"
-              onClick={() => onPick(suggestion.prompt)}
+              onClick={(event) => launchChat(suggestion, event.currentTarget)}
               className="border-border bg-card text-foreground hover:bg-accent hover:text-accent-foreground flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors"
             >
               <SuggestionIcon className="size-4 shrink-0" />


### PR DESCRIPTION
Clicking a suggestion chip on the project home or the Project Assistant home now flies the chip into the conversation instead of cutting straight to an empty chat.

The sequence:

1. The chip travels and scales to the centre of the screen over a dimmed page with the chat landing rainbow behind it, and spins a loader while the prompt is sent.
2. Once the user bubble exists, the card minimizes onto it — its box, background, text colour and radius interpolate to the bubble's own computed values, so the chip styling becomes bubble styling on the way down.
3. Landed, the card still shows the short suggestion title; the title dissolves, the full message takes its place with a shimmer sweep, and the card fades onto the real bubble.

Reduced motion and browsers without View Transitions skip straight to the existing behaviour.

## Implementation notes

Two halves, deliberately built differently:

- **Chip → card** is a View Transition (`chat-launch`). The name is applied imperatively at each snapshot, because react-router defers the route swap past `flushSync` — the chip is still mounted when the new snapshot is taken, and two elements sharing a name abort the transition.
- **Card → bubble** is a FLIP animation, not a second View Transition. The user bubble lives inside the Elements shadow root, and a `view-transition-name` on a shadow-tree element produces no pseudo-element at all in Chrome, so the browser pairs the card with nothing and just fades it out.

The overlay is mounted in `AppLayout`, above the router outlet, so it survives the navigation to `/chat/new` that happens mid-flight.

Matching the bubble exactly took a few non-obvious corrections, all noted in comments:

- The card's `max-w-xl` clamped the animated width.
- The bubble reflows as the thread column widens, so the card shadows its rect per frame rather than re-measuring once.
- The card's 1px border shrank its content box by 2px — enough to wrap a message that fits the bubble on one line.
- The card adopts the bubble's font stack and line height; the shadow root has its own.
- The veil is deliberately unnamed: a named element becomes its own transition group, and groups paint in name order rather than DOM order, so it painted over the card and washed it out.

## Testing

Verified in the browser: box, wrapping and typography match the real bubble at handoff; no view-transition errors in console. `pnpm -F dashboard lint` and `type-check` pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Animate chat suggestion chips into the conversation: they fly to the center with a loader, then morph into the new user bubble. This replaces the abrupt jump to an empty chat and gives clear visual feedback, with reduced-motion and non–View Transitions fallbacks.

- New Features
  - Suggestion chip → centered overlay via View Transitions (`chat-launch`) over a dimmed page with the chat rainbow.
  - Overlay card → user bubble via a FLIP animation; title swaps to full prompt with a brief shimmer, then fades onto the real bubble.
  - Overlay is mounted above the router so the animation survives navigation to the new chat route.
  - Falls back to existing behavior when View Transitions aren’t supported or reduced motion is enabled.

- Refactors
  - Extracted shared chat landing gradient to `client/dashboard/src/lib/chat-gradient.ts`.
  - Introduced `useChatLaunch` and `ChatLaunchOverlay` to coordinate the animation.
  - Exported `InsightsSuggestionIcon` type from `insights-suggestions`.

<sup>Written for commit 4e1ce4cab5e80552ad68234aceba8056959c2828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

