### PR TITLE
fix(dashboard): keep email domains in tool insights axis labels

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -173,6 +173,25 @@ const SHARED_TOOLTIP = {
   boxPadding: 4,
 } satisfies _BarTooltip;
 
+// Category-axis labels are mostly emails. Keep the domain — it's how you tell
+// internal from external users — and spend the character budget on the local
+// part instead. Full label is still available in the tooltip title.
+const MAX_AXIS_LABEL_CHARS = 26;
+
+function truncateAxisLabel(label: string): string {
+  if (label.length <= MAX_AXIS_LABEL_CHARS) return label;
+
+  const at = label.lastIndexOf("@");
+  if (at > 0) {
+    const domain = label.slice(at);
+    if (domain.length <= MAX_AXIS_LABEL_CHARS - 4) {
+      return `${label.slice(0, MAX_AXIS_LABEL_CHARS - 1 - domain.length)}…${domain}`;
+    }
+  }
+
+  return `${label.slice(0, MAX_AXIS_LABEL_CHARS - 1)}…`;
+}
+
 const SHARED_BAR_SCALES = {
   x: {
     stacked: true,
@@ -191,11 +210,7 @@ const SHARED_BAR_SCALES = {
       padding: 2,
       font: { size: 12 },
       callback(value) {
-        const label = this.getLabelForValue(value as number);
-        const display = label.includes("@")
-          ? label.split("@")[0]!.slice(0, 14) + "@…"
-          : label.slice(0, 14) + (label.length > 14 ? "…" : "");
-        return display;
+        return truncateAxisLabel(this.getLabelForValue(value as number));
       },
     },
   },
@@ -1121,7 +1136,7 @@ function UserEventCountsChart({
     const color = USER_SOURCE_COLORS[0]!;
     const chartDatasets = [
       {
-        label: "Events",
+        label: "Tool calls",
         barThickness: 24,
         data: sortedUsers.map((user) => user.eventCount),
         backgroundColor: color,
@@ -2096,7 +2111,7 @@ function HooksAnalytics({
         <UserEventCountsChart
           loading={sectionStatus.users.pending}
           error={sectionStatus.users.error}
-          title="User Event Counts"
+          title="Tool Calls by User"
           users={users}
           handleFilter={makeFilterHandler({ user: "row" })}
           expandedChart={expandedChart}


### PR DESCRIPTION
## What

The y-axis labels on the Tool Insights user charts are mostly email addresses. The old truncation cut at 14 characters and threw the domain away (`priya.raghunat@…`), which made rows hard to tell apart and lost the one part of the address that identifies *which* org a user belongs to.

Now the label keeps the domain and spends the character budget on the local part instead:

- `priya.raghunathan@bluefin.example` → `priya.raghun…@bluefin.example`
- non-email labels fall back to a plain 26-char truncation
- the full label is still shown in the tooltip title

## Also

Renamed the user chart from "User Event Counts" to "Tool Calls by User", and its dataset legend from "Events" to "Tool calls" — the chart only ever plotted tool calls, so "events" was misleading.

## Testing

Local dashboard against seeded tool-usage telemetry; checked long, short, and non-email labels render without clipping the axis.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep email domains in Tool Insights axis labels so users are easier to tell apart, and update chart text to match tool call data (legend: “Tool calls”, title: “Tool Calls by User”).

- **Bug Fixes**
  - Added `truncateAxisLabel` to keep the domain and truncate the local part within 26 chars; non-email labels use plain truncation.
  - Full label remains in the tooltip title.

<sup>Written for commit e880260a936562941f13a635012f42e7b140c14c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

