### PR TITLE
chore(dashboard): use speakeasy branding in user facing copy

### DIFF
--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -121,7 +121,7 @@ const useChatResolution = () => useContext(ChatResolutionContext);
 
 const DangerousApiKeyWarning = () => (
   <div className="m-2 rounded-md border border-red-500 bg-red-100 px-4 py-3 text-sm text-red-800 dark:border-red-600 dark:bg-red-900/30 dark:text-red-200">
-    <strong>Danger:</strong> You are using a Gram API key directly in the
+    <strong>Danger:</strong> You are using a Speakeasy API key directly in the
     browser. This exposes your key to anyone who inspects this page. Do NOT use
     this in production.
   </div>

--- a/client/dashboard/src/lib/chat-owner.ts
+++ b/client/dashboard/src/lib/chat-owner.ts
@@ -67,10 +67,10 @@ export function chatOwnerLabel(
 
 export function unresolvedChatOwnerTooltip(chat: ChatIdentity): string {
   if (chat.externalUserId) {
-    return "This session's user couldn't be matched to a member of your organization, so the user ID reported by the AI provider is shown instead. The user may not be provisioned in Gram or may have been removed from the organization.";
+    return "This session's user couldn't be matched to a member of your organization, so the user ID reported by the AI provider is shown instead. The user may not be provisioned in Speakeasy or may have been removed from the organization.";
   }
   if (chat.userId) {
-    return "This session's user couldn't be matched to a member of your organization. The user may have been removed from the organization or may not be provisioned in Gram.";
+    return "This session's user couldn't be matched to a member of your organization. The user may have been removed from the organization or may not be provisioned in Speakeasy.";
   }
   return "The AI provider didn't report a user identity for this session.";
 }

--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -89,7 +89,7 @@ const healthIssueMessages: Record<string, string> = {
   dns_not_found:
     "We couldn't find DNS records for this domain. Check that the record still exists with your DNS provider.",
   dns_target_mismatch:
-    "This domain's DNS does not resolve to Gram's endpoint. If the domain sits behind a proxy or CDN, traffic may still work; otherwise update its DNS record to the value shown when you registered the domain.",
+    "This domain's DNS does not resolve to the platform's endpoint. If the domain sits behind a proxy or CDN, traffic may still work; otherwise update its DNS record to the value shown when you registered the domain.",
   resource_missing:
     "The routing configuration for this domain is missing. Run the check again to confirm the problem persists.",
   certificate_missing:

--- a/client/dashboard/src/pages/org/SkillContentUploadSetting.tsx
+++ b/client/dashboard/src/pages/org/SkillContentUploadSetting.tsx
@@ -41,9 +41,10 @@ export function SkillContentUploadSetting(): JSX.Element | null {
           variant="body"
           className="text-muted-foreground mr-8 ml-6 max-w-4xl text-sm"
         >
-          When enabled, Gram uploads SKILL.md content at activation so captured
-          skills can be inspected. When disabled, Gram only receives skill
-          names, source details, hashes, users, and hostnames at activation.
+          When enabled, Speakeasy uploads SKILL.md content at activation so
+          captured skills can be inspected. When disabled, Speakeasy only
+          receives skill names, source details, hashes, users, and hostnames at
+          activation.
         </Type>
       </Stack>
       <RequireScope scope="org:admin" level="component">

--- a/client/dashboard/src/pages/org/external-services/CreateExternalCredentialSheet.tsx
+++ b/client/dashboard/src/pages/org/external-services/CreateExternalCredentialSheet.tsx
@@ -134,7 +134,7 @@ export function CreateExternalCredentialSheet({
               <Input
                 value={name}
                 onChange={setName}
-                placeholder="Gram platform identity"
+                placeholder="Speakeasy platform identity"
               />
             </Stack>
 
@@ -184,8 +184,8 @@ function GcpCredentialFields({
   return (
     <Stack gap={4}>
       <Type muted small>
-        Leave blank to use Gram's ambient attached identity, or set a service
-        account for Gram to impersonate.
+        Leave blank to use the platform's ambient attached identity, or set a
+        service account for the platform to impersonate.
       </Type>
       <Stack gap={2}>
         <Label className="text-muted-foreground text-xs">

--- a/client/dashboard/src/pages/org/external-services/ExternalServices.tsx
+++ b/client/dashboard/src/pages/org/external-services/ExternalServices.tsx
@@ -114,9 +114,9 @@ function ExternalServicesOverview(): JSX.Element {
           </Button>
         </Page.Section.CTA>
         <Page.Section.Description className="max-w-2xl">
-          Gram's platform-level credentials for authenticating into external
-          services. Shared across every organization and visible to platform
-          admins only.
+          Speakeasy's platform-level credentials for authenticating into
+          external services. Shared across every organization and visible to
+          platform admins only.
         </Page.Section.Description>
         <Page.Section.Body>
           <CredentialTable

--- a/client/dashboard/src/pages/org/external-services/tabs/SettingsTab.tsx
+++ b/client/dashboard/src/pages/org/external-services/tabs/SettingsTab.tsx
@@ -114,7 +114,7 @@ export function SettingsTab({
 
       <SettingsSection
         title="GCP identity"
-        description="Leave blank to use Gram's ambient attached identity, or set a service account for Gram to impersonate."
+        description="Leave blank to use the platform's ambient attached identity, or set a service account for the platform to impersonate."
       >
         <Field
           label="Impersonate service account"


### PR DESCRIPTION
## What

Replaces the remaining **"Gram"** references in **customer-visible dashboard copy** with **"Speakeasy"** (where the product is the brand/actor) or **"the platform"** (where it reads more naturally as infrastructure). The app already brands itself as Speakeasy in its metadata (`index.html` title + OpenGraph tags); this brings the visible in-app prose in line.

There is no central copy/i18n file in the dashboard — strings are inlined at each call site — so this is a small, scattered multi-file diff.

## Changes (prose copy only, 7 files)

| File | Before → After |
|------|----------------|
| `pages/org/external-services/ExternalServices.tsx` | "Gram's platform-level credentials…" → "Speakeasy's platform-level credentials…" |
| `pages/org/external-services/CreateExternalCredentialSheet.tsx` | placeholder "Gram platform identity" → "Speakeasy platform identity"; "Gram's ambient attached identity / for Gram to impersonate" → "the platform's…" |
| `pages/org/external-services/tabs/SettingsTab.tsx` | same GCP-identity helper text → "the platform's…" |
| `pages/org/SkillContentUploadSetting.tsx` | "Gram uploads / Gram only receives…" → "Speakeasy uploads / Speakeasy only receives…" |
| `pages/org/OrgDomains.tsx` | "does not resolve to Gram's endpoint" → "…to the platform's endpoint" |
| `lib/chat-owner.ts` | "may not be provisioned in Gram" (×2 tooltips) → "…in Speakeasy" |
| `elements/components/assistant-ui/thread.tsx` | "using a Gram API key directly in the browser" → "a Speakeasy API key…" |

## Deliberately NOT changed

- **CLI snippets** (`gram upload`, `gram tunnel run`, `gram push`) — here `gram` is the literal binary name a user types; renaming the copy without renaming the CLI would break the instructions.
- **`"gram function"` source-type label** — refers to the Gram Functions feature name, not generic brand chrome.
- **LLM tool-description text** in the onboarding assistant (`useOnboardingTools.tsx`) — system-prompt text, not UI.
- Structural uses (imports, `X-Gram-Source` headers, `sessionHeaderGramSession`, telemetry attribute paths, code comments) — not user-visible.

## Verification

- Formatting confirmed against the repo's `oxfmt` config (printWidth 80) via `--stdin-filepath` — all 7 files match the formatter's output byte-for-byte.
- Pure string-literal edits: no identifiers, types, imports, or exports changed, so no new `tsc`/`knip` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5DDAAqzd6VsDLeNG9kd9L

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced remaining “Gram” references in user-facing dashboard copy with “Speakeasy” or “the platform” to match current branding. CLI commands and feature names that literally use `gram` are unchanged.

<sup>Written for commit b3c3752f7edd5269274a7e1efd96cef3af7859d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

