### PR TITLE
fix: doesn't challenge dead letter results (AIS-390)

### DIFF
--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -117,6 +117,13 @@ type ScanResult struct {
 	// acknowledging one command clears only an identical retry, not every call
 	// of the same tool under the same policy. Not sensitive (a one-way digest).
 	CallFingerprint string
+
+	// DeadLetterReason is non-empty when the "match" is a scanner dead-letter
+	// sentinel (the analyzer failed after exhausting retries, e.g. rule
+	// pii.dead_letter) rather than an actual finding. A warn policy must not
+	// challenge the user over an analyzer outage, so ScanForEnforcement skips
+	// the challenge for such results; block policies still deny (fail closed).
+	DeadLetterReason string
 }
 
 // callFingerprint is the stable per-call key for a warn acknowledgement: a hex
@@ -361,6 +368,18 @@ func (s *Scanner) ScanForEnforcement(
 				}
 				return nil
 			}
+			// A warn match that is really a dead-letter sentinel (the analyzer
+			// failed, e.g. pii.dead_letter) must not challenge the user: the
+			// challenge would report an analyzer outage as a policy violation.
+			// Skipping the CAS also keeps the sentinel from shadowing a genuine
+			// warn match from a sibling policy.
+			if result.DeadLetterReason != "" {
+				s.logger.WarnContext(gctx, "skipping warn challenge for dead-letter sentinel",
+					attr.SlogRiskPolicyID(result.PolicyID),
+					attr.SlogRiskRuleID(result.RuleID),
+				)
+				return nil
+			}
 			warnWinner.CompareAndSwap(nil, result)
 			return nil
 		})
@@ -558,17 +577,18 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 			findings := categoryScope.FilterFindings(view, filter(gitleaksFindings))
 			if len(findings) > 0 {
 				return &ScanResult{
-					Action:          policy.Action,
-					PolicyID:        policy.ID.String(),
-					PolicyName:      policy.Name,
-					Source:          ra.SourceGitleaks,
-					MessageType:     messageType,
-					RuleID:          findings[0].RuleID,
-					Description:     findings[0].Description,
-					UserMessage:     conv.FromPGText[string](policy.UserMessage),
-					MatchedValue:    findings[0].Match,
-					Entity:          findings[0].RuleID,
-					CallFingerprint: "",
+					Action:           policy.Action,
+					PolicyID:         policy.ID.String(),
+					PolicyName:       policy.Name,
+					Source:           ra.SourceGitleaks,
+					MessageType:      messageType,
+					RuleID:           findings[0].RuleID,
+					Description:      findings[0].Description,
+					UserMessage:      conv.FromPGText[string](policy.UserMessage),
+					MatchedValue:     findings[0].Match,
+					Entity:           findings[0].RuleID,
+					CallFingerprint:  "",
+					DeadLetterReason: "",
 				}, nil
 			}
 		case ra.SourcePresidio:
@@ -588,19 +608,31 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 			if len(batchResults) > 0 {
 				filtered := categoryScope.FilterFindings(view, filter(batchResults[0]))
 				if len(filtered) > 0 {
+					// A Presidio failure surfaces as a dead-letter sentinel finding
+					// (DeadLetterReason set) rather than an error. Prefer a real
+					// finding when one is present so the sentinel never shadows
+					// actual PII; a sentinel-only result propagates with
+					// DeadLetterReason set and the warn path skips the challenge.
 					f := filtered[0]
+					for _, cand := range filtered {
+						if cand.DeadLetterReason == "" {
+							f = cand
+							break
+						}
+					}
 					return &ScanResult{
-						Action:          policy.Action,
-						PolicyID:        policy.ID.String(),
-						PolicyName:      policy.Name,
-						Source:          ra.SourcePresidio,
-						MessageType:     messageType,
-						RuleID:          f.RuleID,
-						Description:     f.Description,
-						UserMessage:     conv.FromPGText[string](policy.UserMessage),
-						MatchedValue:    f.Match,
-						Entity:          f.RuleID,
-						CallFingerprint: "",
+						Action:           policy.Action,
+						PolicyID:         policy.ID.String(),
+						PolicyName:       policy.Name,
+						Source:           ra.SourcePresidio,
+						MessageType:      messageType,
+						RuleID:           f.RuleID,
+						Description:      f.Description,
+						UserMessage:      conv.FromPGText[string](policy.UserMessage),
+						MatchedValue:     f.Match,
+						Entity:           f.RuleID,
+						CallFingerprint:  "",
+						DeadLetterReason: f.DeadLetterReason,
 					}, nil
 				}
 			}
@@ -612,34 +644,36 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 			findings = categoryScope.FilterFindings(view, filter(findings))
 			if len(findings) > 0 {
 				return &ScanResult{
-					Action:          policy.Action,
-					PolicyID:        policy.ID.String(),
-					PolicyName:      policy.Name,
-					Source:          ra.SourcePromptInjection,
-					MessageType:     messageType,
-					RuleID:          findings[0].RuleID,
-					Description:     findings[0].Description,
-					UserMessage:     conv.FromPGText[string](policy.UserMessage),
-					MatchedValue:    findings[0].Match,
-					Entity:          findings[0].RuleID,
-					CallFingerprint: "",
+					Action:           policy.Action,
+					PolicyID:         policy.ID.String(),
+					PolicyName:       policy.Name,
+					Source:           ra.SourcePromptInjection,
+					MessageType:      messageType,
+					RuleID:           findings[0].RuleID,
+					Description:      findings[0].Description,
+					UserMessage:      conv.FromPGText[string](policy.UserMessage),
+					MatchedValue:     findings[0].Match,
+					Entity:           findings[0].RuleID,
+					CallFingerprint:  "",
+					DeadLetterReason: "",
 				}, nil
 			}
 		}
 	}
 	if denyFindings := filter(customFindings); len(denyFindings) > 0 {
 		return &ScanResult{
-			Action:          policy.Action,
-			PolicyID:        policy.ID.String(),
-			PolicyName:      policy.Name,
-			Source:          ra.SourceCustom,
-			MessageType:     messageType,
-			RuleID:          denyFindings[0].RuleID,
-			Description:     denyFindings[0].Description,
-			UserMessage:     conv.FromPGText[string](policy.UserMessage),
-			MatchedValue:    denyFindings[0].Match,
-			Entity:          denyFindings[0].RuleID,
-			CallFingerprint: "",
+			Action:           policy.Action,
+			PolicyID:         policy.ID.String(),
+			PolicyName:       policy.Name,
+			Source:           ra.SourceCustom,
+			MessageType:      messageType,
+			RuleID:           denyFindings[0].RuleID,
+			Description:      denyFindings[0].Description,
+			UserMessage:      conv.FromPGText[string](policy.UserMessage),
+			MatchedValue:     denyFindings[0].Match,
+			Entity:           denyFindings[0].RuleID,
+			CallFingerprint:  "",
+			DeadLetterReason: "",
 		}, nil
 	}
 	return nil, nil
@@ -683,9 +717,10 @@ func (s *Scanner) scanPromptPolicy(ctx context.Context, policy repo.RiskPolicy, 
 		Description: finding.Description,
 		UserMessage: conv.FromPGText[string](policy.UserMessage),
 		// Judge findings have no literal matched substring; Entity mirrors RuleID.
-		MatchedValue:    finding.Match,
-		Entity:          finding.RuleID,
-		CallFingerprint: "",
+		MatchedValue:     finding.Match,
+		Entity:           finding.RuleID,
+		CallFingerprint:  "",
+		DeadLetterReason: "",
 	}
 }
 

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -564,6 +564,10 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 		}
 	}
 
+	// Sentinel-only presidio result held back so the remaining sources still
+	// run; returned only when no real finding matches (see the presidio case).
+	var deadLetterResult *ScanResult
+
 	for _, source := range policy.Sources {
 		if !categoryScope.SourceInScope(view, source) {
 			continue
@@ -611,8 +615,11 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 					// A Presidio failure surfaces as a dead-letter sentinel finding
 					// (DeadLetterReason set) rather than an error. Prefer a real
 					// finding when one is present so the sentinel never shadows
-					// actual PII; a sentinel-only result propagates with
-					// DeadLetterReason set and the warn path skips the challenge.
+					// actual PII. A sentinel-only result must not short-circuit the
+					// policy either: hold it and keep scanning the remaining sources
+					// so a healthy detector (e.g. gitleaks) can still match; it is
+					// returned only when nothing real matches, and the warn path
+					// then skips the challenge.
 					f := filtered[0]
 					for _, cand := range filtered {
 						if cand.DeadLetterReason == "" {
@@ -620,7 +627,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 							break
 						}
 					}
-					return &ScanResult{
+					result := &ScanResult{
 						Action:           policy.Action,
 						PolicyID:         policy.ID.String(),
 						PolicyName:       policy.Name,
@@ -633,7 +640,14 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 						Entity:           f.RuleID,
 						CallFingerprint:  "",
 						DeadLetterReason: f.DeadLetterReason,
-					}, nil
+					}
+					if f.DeadLetterReason != "" {
+						if deadLetterResult == nil {
+							deadLetterResult = result
+						}
+						continue
+					}
+					return result, nil
 				}
 			}
 		case ra.SourcePromptInjection:
@@ -675,6 +689,9 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 			CallFingerprint:  "",
 			DeadLetterReason: "",
 		}, nil
+	}
+	if deadLetterResult != nil {
+		return deadLetterResult, nil
 	}
 	return nil, nil
 }

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -570,10 +570,11 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 
 	// failWithHeldSentinel prefers a held dead-letter sentinel over a later
 	// source error: propagating the error would discard the whole policy and
-	// fail a block policy open. Cancellation still propagates so the fan-out
-	// in ScanForEnforcement can discard the scan.
+	// fail a block policy open. Cancellation and deadline expiry still
+	// propagate so the fan-out in ScanForEnforcement discards the scan
+	// instead of enforcing a stale sentinel after the request is gone.
 	failWithHeldSentinel := func(err error) (*ScanResult, error) {
-		if deadLetterResult == nil || errors.Is(err, context.Canceled) {
+		if deadLetterResult == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
 		s.logger.WarnContext(ctx, "source scan failed after presidio dead-letter; enforcing sentinel",

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -568,6 +568,21 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 	// run; returned only when no real finding matches (see the presidio case).
 	var deadLetterResult *ScanResult
 
+	// failWithHeldSentinel prefers a held dead-letter sentinel over a later
+	// source error: propagating the error would discard the whole policy and
+	// fail a block policy open. Cancellation still propagates so the fan-out
+	// in ScanForEnforcement can discard the scan.
+	failWithHeldSentinel := func(err error) (*ScanResult, error) {
+		if deadLetterResult == nil || errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		s.logger.WarnContext(ctx, "source scan failed after presidio dead-letter; enforcing sentinel",
+			attr.SlogError(err),
+			attr.SlogRiskPolicyID(policy.ID.String()),
+		)
+		return deadLetterResult, nil
+	}
+
 	for _, source := range policy.Sources {
 		if !categoryScope.SourceInScope(view, source) {
 			continue
@@ -576,7 +591,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 		case ra.SourceGitleaks:
 			gitleaksFindings, err := s.scanGitleaks(ctx, text)
 			if err != nil {
-				return nil, fmt.Errorf("gitleaks scan: %w", err)
+				return failWithHeldSentinel(fmt.Errorf("gitleaks scan: %w", err))
 			}
 			findings := categoryScope.FilterFindings(view, filter(gitleaksFindings))
 			if len(findings) > 0 {
@@ -607,7 +622,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 				func() {},
 			)
 			if err != nil {
-				return nil, fmt.Errorf("presidio scan: %w", err)
+				return failWithHeldSentinel(fmt.Errorf("presidio scan: %w", err))
 			}
 			if len(batchResults) > 0 {
 				filtered := categoryScope.FilterFindings(view, filter(batchResults[0]))
@@ -653,7 +668,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 		case ra.SourcePromptInjection:
 			findings, err := s.piScanner.Scan(ctx, text, policy.OrganizationID, policy.ProjectID.String(), userID, judgemessage.New(messageType, toolName, text))
 			if err != nil {
-				return nil, fmt.Errorf("prompt injection scan: %w", err)
+				return failWithHeldSentinel(fmt.Errorf("prompt injection scan: %w", err))
 			}
 			findings = categoryScope.FilterFindings(view, filter(findings))
 			if len(findings) > 0 {

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -766,14 +766,19 @@ func TestScanner_PresidioDeadLetterDoesNotSkipLaterSources(t *testing.T) {
 }
 
 // deadLetterThenErrorPIIScanner dead-letters the first AnalyzeBatch call and
-// errors on subsequent ones, so a policy listing presidio twice exercises the
-// "later source errors after a sentinel was held" path.
+// errors on subsequent ones (with err, defaulting to a generic failure), so a
+// policy listing presidio twice exercises the "later source errors after a
+// sentinel was held" path.
 type deadLetterThenErrorPIIScanner struct {
 	calls atomic.Int32
+	err   error
 }
 
 func (d *deadLetterThenErrorPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
 	if d.calls.Add(1) > 1 {
+		if d.err != nil {
+			return nil, d.err
+		}
 		return nil, errors.New("presidio unavailable")
 	}
 	out := make([][]scanners.Finding, len(texts))
@@ -833,6 +838,50 @@ func TestScanner_PresidioDeadLetterSurvivesLaterSourceError(t *testing.T) {
 	require.Equal(t, "block", result.Action)
 	require.Equal(t, risk_analysis.DeadLetterRuleID, result.RuleID)
 	require.GreaterOrEqual(t, pii.calls.Load(), int32(2), "second presidio source must have run")
+}
+
+// TestScanner_PresidioDeadLetterDiscardedOnDeadline pins that a held sentinel
+// is NOT enforced when the later source fails with a deadline error: the scan
+// is stale and must be discarded, not converted into a block.
+func TestScanner_PresidioDeadLetterDiscardedOnDeadline(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	require.NotNil(t, authCtx.ProjectID)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:               policyID,
+		ProjectID:        *authCtx.ProjectID,
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Name:             "pii twice deadline",
+		Sources:          []string{"presidio", "presidio"},
+		PresidioEntities: []string{"EMAIL_ADDRESS"},
+		Enabled:          true,
+		Action:           "block",
+		AudienceType:     "everyone",
+		AutoName:         false,
+	})
+	require.NoError(t, err)
+	grantRiskPolicyToAllUsers(t, ti, ctx, authCtx.ActiveOrganizationID, policyID)
+
+	pii := &deadLetterThenErrorPIIScanner{err: fmt.Errorf("presidio scan: %w", context.DeadlineExceeded)}
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		newTestCustomRuleAnalyzer(t, ti.conn),
+		pii,
+		nil,
+		nil,
+		nil,
+		testCELEngine(t),
+	)
+	require.NoError(t, err)
+
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "some text", message.User, "")
+	require.NoError(t, err)
+	require.Nil(t, result, "deadline-expired scan must be discarded, not enforce the sentinel")
 }
 
 // TestScanner_PresidioDeadLetterBlockStillDenies pins the fail-closed side:

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -729,6 +729,41 @@ func TestScanner_PresidioDeadLetterWarnKeepsRealFindings(t *testing.T) {
 	require.Empty(t, result.DeadLetterReason)
 }
 
+// TestScanner_PresidioDeadLetterDoesNotSkipLaterSources verifies a sentinel
+// does not short-circuit the policy's remaining sources: with sources
+// [presidio, gitleaks] and Presidio dead-lettering, a real secret must still
+// be caught by gitleaks and fire under its own rule.
+func TestScanner_PresidioDeadLetterDoesNotSkipLaterSources(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	require.NotNil(t, authCtx.ProjectID)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:               policyID,
+		ProjectID:        *authCtx.ProjectID,
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Name:             "pii then secrets",
+		Sources:          []string{risk_analysis.SourcePresidio, risk_analysis.SourceGitleaks},
+		PresidioEntities: []string{"EMAIL_ADDRESS"},
+		Enabled:          true,
+		Action:           "warn",
+		AudienceType:     "everyone",
+		AutoName:         false,
+	})
+	require.NoError(t, err)
+	grantRiskPolicyToAllUsers(t, ti, ctx, authCtx.ActiveOrganizationID, policyID)
+
+	scanner := newDeadLetterScanner(t, ti, &deadLetterPIIScanner{})
+
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "export GITHUB_TOKEN=ghp_R2D2C3POLuk3Skywalker1234567890ab", message.User, "")
+	require.NoError(t, err)
+	require.NotNil(t, result, "gitleaks must still run when presidio dead-letters")
+	require.Equal(t, risk_analysis.SourceGitleaks, result.Source)
+	require.Equal(t, "warn", result.Action)
+	require.Empty(t, result.DeadLetterReason)
+}
+
 // TestScanner_PresidioDeadLetterBlockStillDenies pins the fail-closed side:
 // a block policy still denies on a dead-letter sentinel (the message could not
 // be scanned), carrying DeadLetterReason so callers can tell outage from match.

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -622,3 +622,128 @@ func TestScanner_RecommendedScopesToolOnlySourcesNonToolRequest(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, result)
 }
+
+// deadLetterPIIScanner simulates an unavailable Presidio analyzer: every text
+// comes back as a dead-letter sentinel finding (plus optionally one real
+// finding) the way PresidioClient.AnalyzeBatch reports an exhausted retry
+// budget.
+type deadLetterPIIScanner struct {
+	alsoRealFinding bool
+}
+
+func (d *deadLetterPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+	out := make([][]scanners.Finding, len(texts))
+	for i := range texts {
+		out[i] = []scanners.Finding{{
+			Source:           risk_analysis.SourcePresidio,
+			RuleID:           risk_analysis.DeadLetterRuleID,
+			Description:      "Presidio could not analyze this message after exhausting its retry budget.",
+			DeadLetterReason: "presidio returned status 500",
+		}}
+		if d.alsoRealFinding {
+			out[i] = append(out[i], scanners.Finding{
+				Source:      risk_analysis.SourcePresidio,
+				RuleID:      "pii.email_address",
+				Description: "Identified an email address.",
+				Match:       "user@example.com",
+				Tags:        []string{"pii"},
+				Confidence:  1,
+			})
+		}
+	}
+	return out, nil
+}
+
+// insertPresidioWarnPolicy is insertPresidioBlockPolicy with action=warn.
+func insertPresidioWarnPolicy(t *testing.T, ti *testInstance, ctx context.Context, name string, entities []string) {
+	t.Helper()
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	require.NotNil(t, authCtx.ProjectID)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:               policyID,
+		ProjectID:        *authCtx.ProjectID,
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Name:             name,
+		Sources:          []string{"presidio"},
+		PresidioEntities: entities,
+		Enabled:          true,
+		Action:           "warn",
+		AudienceType:     "everyone",
+		AutoName:         false,
+	})
+	require.NoError(t, err)
+	grantRiskPolicyToAllUsers(t, ti, ctx, authCtx.ActiveOrganizationID, policyID)
+}
+
+func newDeadLetterScanner(t *testing.T, ti *testInstance, pii *deadLetterPIIScanner) *risk.Scanner {
+	t.Helper()
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		newTestCustomRuleAnalyzer(t, ti.conn),
+		pii,
+		nil,
+		nil,
+		nil,
+		testCELEngine(t),
+	)
+	require.NoError(t, err)
+	return scanner
+}
+
+// TestScanner_PresidioDeadLetterSkipsWarnChallenge is a regression test: a
+// Presidio dead-letter sentinel (analysis failed after retries) must not fire
+// a warn challenge. Before the fix, a warn policy would challenge users with
+// rule pii.dead_letter whenever Presidio was down.
+func TestScanner_PresidioDeadLetterSkipsWarnChallenge(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	insertPresidioWarnPolicy(t, ti, ctx, "pii warn policy", []string{"EMAIL_ADDRESS"})
+	scanner := newDeadLetterScanner(t, ti, &deadLetterPIIScanner{})
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "some text", message.User, "")
+	require.NoError(t, err)
+	require.Nil(t, result, "dead-letter sentinel must not fire a warn challenge")
+}
+
+// TestScanner_PresidioDeadLetterWarnKeepsRealFindings verifies a genuine
+// finding returned alongside the sentinel still challenges under its own rule.
+func TestScanner_PresidioDeadLetterWarnKeepsRealFindings(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	insertPresidioWarnPolicy(t, ti, ctx, "pii warn policy", []string{"EMAIL_ADDRESS"})
+	scanner := newDeadLetterScanner(t, ti, &deadLetterPIIScanner{alsoRealFinding: true})
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "reach me at user@example.com", message.User, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "warn", result.Action)
+	require.Equal(t, "pii.email_address", result.RuleID)
+	require.Empty(t, result.DeadLetterReason)
+}
+
+// TestScanner_PresidioDeadLetterBlockStillDenies pins the fail-closed side:
+// a block policy still denies on a dead-letter sentinel (the message could not
+// be scanned), carrying DeadLetterReason so callers can tell outage from match.
+func TestScanner_PresidioDeadLetterBlockStillDenies(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	insertPresidioBlockPolicy(t, ti, ctx, "pii block policy", []string{"EMAIL_ADDRESS"})
+	scanner := newDeadLetterScanner(t, ti, &deadLetterPIIScanner{})
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "some text", message.User, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "block", result.Action)
+	require.Equal(t, risk_analysis.DeadLetterRuleID, result.RuleID)
+	require.NotEmpty(t, result.DeadLetterReason)
+}

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -2,6 +2,7 @@ package risk_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -762,6 +763,76 @@ func TestScanner_PresidioDeadLetterDoesNotSkipLaterSources(t *testing.T) {
 	require.Equal(t, risk_analysis.SourceGitleaks, result.Source)
 	require.Equal(t, "warn", result.Action)
 	require.Empty(t, result.DeadLetterReason)
+}
+
+// deadLetterThenErrorPIIScanner dead-letters the first AnalyzeBatch call and
+// errors on subsequent ones, so a policy listing presidio twice exercises the
+// "later source errors after a sentinel was held" path.
+type deadLetterThenErrorPIIScanner struct {
+	calls atomic.Int32
+}
+
+func (d *deadLetterThenErrorPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+	if d.calls.Add(1) > 1 {
+		return nil, errors.New("presidio unavailable")
+	}
+	out := make([][]scanners.Finding, len(texts))
+	for i := range texts {
+		out[i] = []scanners.Finding{{
+			Source:           risk_analysis.SourcePresidio,
+			RuleID:           risk_analysis.DeadLetterRuleID,
+			Description:      "Presidio could not analyze this message after exhausting its retry budget.",
+			DeadLetterReason: "presidio returned status 500",
+		}}
+	}
+	return out, nil
+}
+
+// TestScanner_PresidioDeadLetterSurvivesLaterSourceError pins that a held
+// sentinel is still enforced when a later source errors: a block policy must
+// not fail open just because another detector broke after the dead-letter.
+func TestScanner_PresidioDeadLetterSurvivesLaterSourceError(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	require.NotNil(t, authCtx.ProjectID)
+	policyID := uuid.New()
+	_, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:               policyID,
+		ProjectID:        *authCtx.ProjectID,
+		OrganizationID:   authCtx.ActiveOrganizationID,
+		Name:             "pii twice",
+		Sources:          []string{"presidio", "presidio"},
+		PresidioEntities: []string{"EMAIL_ADDRESS"},
+		Enabled:          true,
+		Action:           "block",
+		AudienceType:     "everyone",
+		AutoName:         false,
+	})
+	require.NoError(t, err)
+	grantRiskPolicyToAllUsers(t, ti, ctx, authCtx.ActiveOrganizationID, policyID)
+
+	pii := &deadLetterThenErrorPIIScanner{}
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		newTestCustomRuleAnalyzer(t, ti.conn),
+		pii,
+		nil,
+		nil,
+		nil,
+		testCELEngine(t),
+	)
+	require.NoError(t, err)
+
+	result, err := scanner.ScanForEnforcement(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "some text", message.User, "")
+	require.NoError(t, err)
+	require.NotNil(t, result, "held sentinel must survive a later source error")
+	require.Equal(t, "block", result.Action)
+	require.Equal(t, risk_analysis.DeadLetterRuleID, result.RuleID)
+	require.GreaterOrEqual(t, pii.calls.Load(), int32(2), "second presidio source must have run")
 }
 
 // TestScanner_PresidioDeadLetterBlockStillDenies pins the fail-closed side:


### PR DESCRIPTION
Fixes dead letter challenge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops warn challenges on Presidio dead-letter sentinels (`pii.dead_letter`) and ensures outages never hide real matches or fail policies open. Addresses Linear AIS-390; block policies stay fail-closed.

- **Bug Fixes**
  - Skip warn challenge when a result has `DeadLetterReason`; log and continue. Block policies still deny.
  - Hold Presidio sentinel-only matches so other sources still run; prefer real findings; return the sentinel only if nothing else matches.
  - If a later source errors after a held sentinel, return the sentinel—except on cancellation or deadline expiry—to avoid failing a policy open.

<sup>Written for commit 283032472faf58f3265f8c761938068ecfae8558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

