### PR TITLE
fix: record vendor-data rejections as sync failures, validate URL settings at save

### DIFF
--- a/.changeset/device-integrations-data-error-handling.md
+++ b/.changeset/device-integrations-data-error-handling.md
@@ -1,0 +1,9 @@
+---
+"server": patch
+---
+
+Device integration syncs now record database rejections of vendor-supplied
+row content (for example a device record whose name carries a Unicode NUL
+escape that jsonb refuses) as visible, backed-off schedule failures instead
+of retrying them as infrastructure errors, and URL-kind integration settings
+are syntax-checked at save time.

--- a/server/internal/deviceintegrations/setup_test.go
+++ b/server/internal/deviceintegrations/setup_test.go
@@ -46,6 +46,7 @@ func TestMain(m *testing.M) {
 			// behavior through settings since the registry is process-global.
 			{Key: "devices", Label: "Devices", Kind: providers.FieldKindText, Secret: false, Required: false},
 			{Key: "fail", Label: "Fail Mode", Kind: providers.FieldKindText, Secret: false, Required: false},
+			{Key: "raw_json", Label: "Raw JSON", Kind: providers.FieldKindText, Secret: false, Required: false},
 		},
 		Schedules: []providers.ScheduleSpec{
 			{Schedule: "testmdm_inventory", Capability: providers.CapabilityInventorySource, Interval: time.Hour},
@@ -115,6 +116,13 @@ func (fakeInventorySource) ListDevices(ctx context.Context, creds providers.Cred
 	case "boom":
 		return providers.DevicePage{Devices: nil, NextCursor: ""}, errors.New("vendor exploded")
 	}
+	// raw_json overrides each device's vendor record verbatim, letting tests
+	// feed the framework payloads the database may reject (e.g. jsonb
+	// refusing a Unicode NUL escape).
+	rawRecord := []byte(`{"fake":true}`)
+	if override := settings["raw_json"]; override != "" {
+		rawRecord = []byte(override)
+	}
 	var devices []providers.Device
 	if raw := settings["devices"]; raw != "" {
 		for entry := range strings.SplitSeq(raw, ",") {
@@ -127,7 +135,7 @@ func (fakeInventorySource) ListDevices(ctx context.Context, creds providers.Cred
 				OSVersion:     "15.0",
 				UserEmail:     email,
 				LastCheckInAt: time.Now().UTC(),
-				Raw:           []byte(`{"fake":true}`),
+				Raw:           rawRecord,
 			})
 		}
 	}

--- a/server/internal/deviceintegrations/store.go
+++ b/server/internal/deviceintegrations/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"maps"
+	"net/url"
 	"strings"
 	"time"
 
@@ -215,6 +216,16 @@ func validateFields(desc providers.Descriptor, creds providers.Credentials, sett
 		}
 		if f.Required && (!supplied || strings.TrimSpace(value) == "") {
 			return oops.E(oops.CodeInvalid, nil, "%s is required for provider %s", f.Key, desc.ID)
+		}
+		// URL-kind fields get a save-time syntax check so a scheme-less or
+		// http URL is rejected at the sheet instead of surfacing an hour
+		// later as a deterministic sync failure. Providers still enforce
+		// their own stricter shape (tenant root, no path) at request time.
+		if f.Kind == providers.FieldKindURL && supplied && strings.TrimSpace(value) != "" {
+			parsed, err := url.Parse(strings.TrimSpace(value))
+			if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+				return oops.E(oops.CodeInvalid, nil, "%s must be a valid https URL", f.Key)
+			}
 		}
 	}
 	return nil

--- a/server/internal/deviceintegrations/store_test.go
+++ b/server/internal/deviceintegrations/store_test.go
@@ -56,6 +56,22 @@ func TestUpsertRejectsUnknownAndMisroutedFields(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUpsertRejectsMalformedURLSetting(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	// URL-kind fields are syntax-checked at save time so a typo'd instance
+	// URL fails at the sheet, not as a deterministic sync failure an hour
+	// later.
+	for _, bad := range []string{"tenant.example.test", "http://tenant.example.test", "https://"} {
+		_, err := upsertTx(t, ctx, conn, store, orgID, validCreds(), providers.Settings{"instance_url": bad}, true)
+		require.ErrorContains(t, err, "https URL", "value %q must be rejected", bad)
+	}
+
+	mustUpsert(t, ctx, conn, store, orgID, validCreds(), validSettings(), true)
+}
+
 func TestUpsertKeepsCredentialsWhenOmitted(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/deviceintegrations/sync.go
+++ b/server/internal/deviceintegrations/sync.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -69,6 +71,17 @@ func asInfra(err error) error {
 func isInfra(err error) bool {
 	var ie *infraError
 	return errors.As(err, &ie)
+}
+
+// isVendorDataError reports whether the database rejected the row CONTENT
+// rather than failing operationally: SQLSTATE class 22 (data exception),
+// e.g. jsonb refusing a Unicode NUL escape inside a vendor-supplied record.
+// Retrying cannot succeed until the vendor data changes, so these must
+// surface as visible, backed-off schedule failures — classifying them as
+// infra would hot-loop the Temporal retry with nothing on the dashboard.
+func isVendorDataError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && strings.HasPrefix(pgErr.Code, "22")
 }
 
 // SyncCandidate is one due schedule the coordinator should run.
@@ -263,6 +276,9 @@ func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTarget
 			}
 			userID, err := s.resolveMember(ctx, memberCache, target.OrganizationID, device.UserEmail)
 			if err != nil {
+				if isVendorDataError(err) {
+					return fmt.Errorf("resolve member for device %s: %w", device.ExternalID, err)
+				}
 				return asInfra(err)
 			}
 			raw := device.Raw
@@ -288,6 +304,9 @@ func (s *Syncer) runInventorySync(ctx context.Context, target repo.GetSyncTarget
 				ConfigUpdatedAt:           target.ConfigUpdatedAt,
 			})
 			if err != nil {
+				if isVendorDataError(err) {
+					return fmt.Errorf("upsert mdm device %s: %w", device.ExternalID, err)
+				}
 				return asInfra(oops.E(oops.CodeUnexpected, err, "upsert mdm device"))
 			}
 			if rows == 0 {

--- a/server/internal/deviceintegrations/sync_test.go
+++ b/server/internal/deviceintegrations/sync_test.go
@@ -141,6 +141,31 @@ func TestRunSyncMarksMissingOnlyOnCompletedSnapshot(t *testing.T) {
 	require.Equal(t, int32(1), state.ConsecutiveFailures)
 }
 
+func TestRunSyncVendorDataErrorRecordsFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, syncer, orgID := newSyncTestEnv(t)
+
+	// A vendor record whose content the database itself rejects (jsonb
+	// refuses the Unicode NUL escape). Deterministic vendor data, not an
+	// infrastructure blip: RunSync must record a visible, backed-off
+	// failure and return nil rather than hot-looping the Temporal retry.
+	created := mustUpsert(t, ctx, conn, store, orgID, validCreds(), providers.Settings{
+		"instance_url": "https://example.test",
+		"devices":      "dev-1",
+		"raw_json":     `{"name":"\u0000"}`,
+	}, true)
+	syncID := findSyncID(t, ctx, store, orgID, testProviderID)
+
+	require.NoError(t, syncer.RunSync(ctx, syncID), "data rejection is a recorded failure, not an infra error")
+
+	state := scheduleStateFor(t, ctx, store, created.Config.ID, "testmdm_inventory")
+	require.True(t, state.LastPollFailedAt.Valid, "failure recorded")
+	require.Equal(t, int32(1), state.ConsecutiveFailures)
+	require.Contains(t, state.LastPollError.String, "upsert mdm device dev-1", "the error names the offending device")
+	require.False(t, state.AutoPausedAt.Valid, "data errors are not credential rejections")
+}
+
 func TestRunSyncAuthFailuresAutoPause(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Two device-integrations framework fixes surfaced by the Iru provider code review (DNO-644), targeting main directly since #4558 merged while the review was in flight.

## Vendor-data DB rejections hot-looped as infra errors

`runInventorySync` classified every `UpsertMdmDevice` error as infrastructure, which routes it to Temporal's activity retry. But a database rejection of the row _content_ — e.g. jsonb refusing a Unicode NUL escape inside a vendor-supplied device record (device names and user fields are end-user-controlled MDM data) — is deterministic: retrying can never succeed. The result was an org's whole inventory sync hot-looping invisibly: no `last_poll_error`, no backoff, no mark-missing, coverage silently stale.

SQLSTATE class 22 (data exception) errors on the resolve/upsert path now surface as recorded, backed-off schedule failures naming the offending device's external id. Regression test drives a NUL-escape record through the real fake-provider → sync → Postgres path.

## URL settings validated at save time

`FieldKindURL` settings (Jamf/Iru `instance_url`) were only presence-checked at save; URL syntax was enforced at request time inside the provider. A scheme-less or `http://` URL saved fine and surfaced an hour later as a deterministic hourly sync failure (non-auth, so it never pauses). Save now rejects values that don't parse as an https URL with a host; providers keep their stricter tenant-root shape checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record vendor-data DB rejections as visible, backed-off sync failures instead of infra retries, and validate integration URL settings at save. Addresses issues from the Iru provider review (DNO-644) to prevent hot loops and deterministic hourly failures.

- **Bug Fixes**
  - Treat SQLSTATE class 22 (data exceptions) during member resolve/upsert as recorded schedule failures that name the offending device, avoiding Temporal retry hot-loops; tests cover a NUL-escape record through the provider → sync → Postgres path.
  - Validate URL-kind settings at save: require an https scheme and host; rejects bad values immediately while providers keep stricter tenant-root checks.

<sup>Written for commit 80b5cc09cf8cb9d35211908880a62587cfaeaf79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

