### PR TITLE
fix(playground): persist tool edits from manage dialog

### DIFF
--- a/.changeset/age-3031-playground-tool-edits.md
+++ b/.changeset/age-3031-playground-tool-edits.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Persist edits made from the Playground's Add/Manage Tools dialog. Failed edits remain open for retry instead of reporting success before the update is saved.

--- a/client/dashboard/src/pages/playground/EditToolDialog.tsx
+++ b/client/dashboard/src/pages/playground/EditToolDialog.tsx
@@ -71,7 +71,7 @@ interface EditToolDialogProps {
   documentIdToName?: Record<string, string>;
   functionIdToName?: Record<string, string>;
   onSave: (updates: ToolUpdatePayload) => void | Promise<void>;
-  onRemove: () => void;
+  onRemove?: () => void;
 }
 
 export function EditToolDialog({
@@ -93,6 +93,7 @@ export function EditToolDialog({
   // TODO: extend tag variations to prompt tools once they support tags.
   const [tags, setTags] = useState<string[] | undefined>(undefined);
   const [saving, setSaving] = useState(false);
+  const savingRef = useRef(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const hasAnnotations = tool ? toolSupportsAnnotations(tool) : false;
@@ -104,6 +105,30 @@ export function EditToolDialog({
     [tool],
   );
   const origTags = supportsTags ? tool?.variation?.tags : undefined;
+  const origTitle = tool?.variation?.title ?? tool?.annotations?.title ?? "";
+  const origReadOnly = tool
+    ? getAnnotationValue(tool, "readOnlyHint")
+    : undefined;
+  const origDestructive = tool
+    ? getAnnotationValue(tool, "destructiveHint")
+    : undefined;
+  const origIdempotent = tool
+    ? getAnnotationValue(tool, "idempotentHint")
+    : undefined;
+  const origOpenWorld = tool
+    ? getAnnotationValue(tool, "openWorldHint")
+    : undefined;
+
+  const hasChanges =
+    !!tool &&
+    (name !== tool.name ||
+      title !== origTitle ||
+      description !== (tool.description || "") ||
+      readOnlyHint !== origReadOnly ||
+      destructiveHint !== origDestructive ||
+      idempotentHint !== origIdempotent ||
+      openWorldHint !== origOpenWorld ||
+      (supportsTags && !tagsEqual(tags, origTags)));
 
   // Reset form when tool changes
   useEffect(() => {
@@ -161,7 +186,8 @@ export function EditToolDialog({
   ]);
 
   const handleSave = async () => {
-    if (!tool) return;
+    if (!tool || !hasChanges || savingRef.current) return;
+    savingRef.current = true;
     setSaving(true);
     try {
       await onSave({
@@ -181,18 +207,27 @@ export function EditToolDialog({
         ...(supportsTags && { tags }),
       });
       onOpenChange(false);
+    } catch {
+      // The mutation owner reports the error. Keep the editor open for retry.
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   };
 
   const handleRemove = () => {
-    onRemove();
+    if (savingRef.current) return;
+    onRemove?.();
     onOpenChange(false);
   };
 
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && savingRef.current) return;
+    onOpenChange(nextOpen);
+  };
+
   const handleClose = () => {
-    onOpenChange(false);
+    handleDialogOpenChange(false);
   };
 
   if (!tool) return null;
@@ -204,24 +239,8 @@ export function EditToolDialog({
   });
   const typeLabel = getToolTypeLabel(tool);
 
-  const origTitle = tool.variation?.title ?? tool.annotations?.title ?? "";
-  const origReadOnly = getAnnotationValue(tool, "readOnlyHint");
-  const origDestructive = getAnnotationValue(tool, "destructiveHint");
-  const origIdempotent = getAnnotationValue(tool, "idempotentHint");
-  const origOpenWorld = getAnnotationValue(tool, "openWorldHint");
-
-  const hasChanges =
-    name !== tool.name ||
-    title !== origTitle ||
-    description !== (tool.description || "") ||
-    readOnlyHint !== origReadOnly ||
-    destructiveHint !== origDestructive ||
-    idempotentHint !== origIdempotent ||
-    openWorldHint !== origOpenWorld ||
-    (supportsTags && !tagsEqual(tags, origTags));
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <Dialog.Content className="max-w-3xl min-w-2xl">
         <Dialog.Header>
           <Dialog.Title className="flex items-center gap-2">
@@ -352,11 +371,17 @@ export function EditToolDialog({
 
         {/* Actions */}
         <div className="flex items-center justify-between border-t pt-4">
-          <Button variant="destructive-secondary" onClick={handleRemove}>
-            Remove
-          </Button>
-          <div className="flex items-center gap-2">
-            <Button variant="secondary" onClick={handleClose}>
+          {onRemove && (
+            <Button
+              variant="destructive-secondary"
+              onClick={handleRemove}
+              disabled={saving}
+            >
+              Remove
+            </Button>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="secondary" onClick={handleClose} disabled={saving}>
               Cancel
             </Button>
             <Button

--- a/client/dashboard/src/pages/playground/ManageToolsDialog.test.tsx
+++ b/client/dashboard/src/pages/playground/ManageToolsDialog.test.tsx
@@ -1,0 +1,233 @@
+import { CommandPaletteProvider } from "@/contexts/CommandPaletteProvider";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Tool, Toolset } from "@/lib/toolTypes";
+import { PromptTemplateKind } from "@gram/client/models/components/prompttemplate.js";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import type { ToolUpdatePayload } from "./EditToolDialog";
+import { ManageToolsDialog } from "./ManageToolsDialog";
+
+const testState = vi.hoisted(() => ({
+  listTools: {
+    data: undefined as { tools: Tool[] } | undefined,
+    isLoading: false,
+  },
+}));
+
+vi.mock("@/hooks/toolTypes", () => ({
+  useListTools: () => testState.listTools,
+  useLatestDeployment: () => ({ data: undefined }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const promptTool = {
+  type: "prompt",
+  canonicalName: "weather_lookup",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  description: "Look up the weather",
+  engine: "mustache",
+  historyId: "history_id",
+  id: "tool_id",
+  kind: PromptTemplateKind.Prompt,
+  name: "weather_lookup",
+  projectId: "project_id",
+  prompt: "Weather for {{city}}",
+  schema: JSON.stringify({
+    type: "object",
+    properties: { city: { type: "string" } },
+  }),
+  toolUrn: "tools:weather_lookup",
+  toolsHint: [],
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+} satisfies Tool;
+
+const toolset = {
+  accountType: "free",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  id: "toolset_id",
+  name: "Weather tools",
+  oauthEnablementMetadata: { oauth2SecurityCount: 0 },
+  organizationId: "organization_id",
+  projectId: "project_id",
+  promptTemplates: [],
+  rawTools: [],
+  resourceUrns: [],
+  resources: [],
+  slug: "weather-tools",
+  toolSelectionMode: "manual",
+  toolUrns: [],
+  tools: [],
+  toolsetVersion: 1,
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+} satisfies Toolset;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"];
+  let reject!: Deferred<T>["reject"];
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function renderDialog({
+  currentTools = [],
+  initialGroup,
+  onToolUpdate,
+  onRemoveTools = vi.fn(),
+}: {
+  currentTools?: Tool[];
+  initialGroup?: string;
+  onToolUpdate: (tool: Tool, updates: ToolUpdatePayload) => Promise<void>;
+  onRemoveTools?: (toolUrns: string[]) => void;
+}) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    toolset: { ...toolset, tools: currentTools },
+    currentTools,
+    onAddTools: vi.fn(),
+    onRemoveTools,
+    initialGroup,
+    onToolUpdate,
+  };
+
+  render(
+    <TooltipProvider>
+      <CommandPaletteProvider>
+        <ManageToolsDialog {...props} />
+      </CommandPaletteProvider>
+    </TooltipProvider>,
+  );
+
+  return { onRemoveTools };
+}
+
+beforeEach(() => {
+  testState.listTools.data = { tools: [promptTool] };
+  vi.mocked(toast.success).mockClear();
+  vi.mocked(toast.error).mockClear();
+});
+
+afterEach(cleanup);
+
+describe("ManageToolsDialog tool editing", () => {
+  it("waits for the supplied update before reporting success and closing", async () => {
+    const update = deferred<void>();
+    const onToolUpdate = vi.fn(() => update.promise);
+
+    renderDialog({ onToolUpdate });
+    fireEvent.click(screen.getByText("weather_lookup"));
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Save/ }));
+
+    expect(onToolUpdate).toHaveBeenCalledWith(promptTool, {
+      name: "weather_lookup",
+      description: "Updated description",
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+
+    update.resolve();
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Tool updated");
+    });
+    expect(screen.queryByLabelText("Description")).toBeNull();
+  });
+
+  it("reports a rejected update and keeps the editor open", async () => {
+    const onToolUpdate = vi.fn().mockRejectedValue(new Error("request failed"));
+
+    renderDialog({ onToolUpdate });
+    fireEvent.click(screen.getByText("weather_lookup"));
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Save/ }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to update tool");
+    });
+    expect(screen.getByLabelText("Description")).toBeTruthy();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("submits only once when the save shortcut repeats while pending", () => {
+    const update = deferred<void>();
+    const onToolUpdate = vi.fn(() => update.promise);
+
+    renderDialog({ onToolUpdate });
+    fireEvent.click(screen.getByText("weather_lookup"));
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Updated description" },
+    });
+
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+
+    expect(onToolUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the active editor open while its save is pending", async () => {
+    const update = deferred<void>();
+    const onToolUpdate = vi.fn(() => update.promise);
+
+    renderDialog({ onToolUpdate });
+    fireEvent.click(screen.getByText("weather_lookup"));
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Updated description" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Save/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByLabelText("Description")).toBeTruthy();
+
+    update.resolve();
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Description")).toBeNull();
+    });
+  });
+
+  it("hides Remove while editing a tool that is not in the toolset", () => {
+    renderDialog({ currentTools: [], onToolUpdate: vi.fn() });
+    fireEvent.click(screen.getByText("weather_lookup"));
+
+    expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+  });
+
+  it("offers Remove while editing a tool already in the toolset", () => {
+    const { onRemoveTools } = renderDialog({
+      currentTools: [promptTool],
+      initialGroup: "Prompts",
+      onToolUpdate: vi.fn(),
+    });
+    fireEvent.click(screen.getByText("weather_lookup"));
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(onRemoveTools).toHaveBeenCalledWith(["tools:weather_lookup"]);
+    expect(screen.queryByLabelText("Description")).toBeNull();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/client/dashboard/src/pages/playground/ManageToolsDialog.tsx
+++ b/client/dashboard/src/pages/playground/ManageToolsDialog.tsx
@@ -13,7 +13,7 @@ import { Tool, Toolset, getToolSourceLabel } from "@/lib/toolTypes";
 import { Button } from "@speakeasy-api/moonshine";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { EditToolDialog } from "./EditToolDialog";
+import { EditToolDialog, ToolUpdatePayload } from "./EditToolDialog";
 
 interface ManageToolsDialogProps {
   open: boolean;
@@ -22,6 +22,7 @@ interface ManageToolsDialogProps {
   currentTools: Tool[];
   onAddTools: (toolUrns: string[]) => void;
   onRemoveTools: (toolUrns: string[]) => void;
+  onToolUpdate: (tool: Tool, updates: ToolUpdatePayload) => Promise<void>;
   initialGroup?: string; // If provided, filter to this source initially
 }
 
@@ -32,6 +33,7 @@ export function ManageToolsDialog({
   currentTools,
   onAddTools,
   onRemoveTools,
+  onToolUpdate,
   initialGroup,
 }: ManageToolsDialogProps): JSX.Element {
   const [search, setSearch] = useState("");
@@ -248,17 +250,26 @@ export function ManageToolsDialog({
         tool={editingTool}
         documentIdToName={documentIdToName}
         functionIdToName={functionIdToName}
-        onSave={(updates) => {
-          // TODO: Implement save functionality
-          console.log("Save tool:", editingTool?.name, updates);
-          toast.success("Tool updated");
-        }}
-        onRemove={() => {
-          if (editingTool?.toolUrn) {
-            onRemoveTools([editingTool.toolUrn]);
-            toast.success("Tool removed");
+        onSave={async (updates) => {
+          if (!editingTool) return;
+
+          try {
+            await onToolUpdate(editingTool, updates);
+            toast.success("Tool updated");
+          } catch (error) {
+            toast.error("Failed to update tool");
+            throw error;
           }
         }}
+        onRemove={
+          mode === "manage"
+            ? () => {
+                if (editingTool?.toolUrn) {
+                  onRemoveTools([editingTool.toolUrn]);
+                }
+              }
+            : undefined
+        }
       />
     </Dialog>
   );

--- a/client/dashboard/src/pages/playground/Playground.tsx
+++ b/client/dashboard/src/pages/playground/Playground.tsx
@@ -29,7 +29,6 @@ import {
 } from "@gram/client/react-query/listToolsets.js";
 import { useMcpServers } from "@gram/client/react-query/mcpServers.js";
 import { invalidateTemplate } from "@gram/client/react-query/template.js";
-import { invalidateAllToolset } from "@gram/client/react-query/toolset.js";
 import { useUpdateToolsetMutation } from "@gram/client/react-query/updateToolset.js";
 import { ResizablePanel } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
@@ -47,6 +46,7 @@ import { PlaygroundElements } from "./PlaygroundElements";
 import { PlaygroundLogsPanel } from "./PlaygroundLogsPanel";
 import { PlaygroundProxiedChat } from "./PlaygroundProxiedChat";
 import { ShareChatButton } from "./ShareChatButton";
+import { invalidatePlaygroundToolQueries } from "./playgroundToolQueries";
 import { useProxiedMcpConnection } from "./useProxiedMcpConnection";
 
 // A single selectable server in the playground. Toolset-backed and
@@ -506,7 +506,7 @@ function ToolsetPanel({
           ...updates,
         },
       });
-      void invalidateTemplate(queryClient, [{ name: tool.name }]);
+      await invalidateTemplate(queryClient, [{ name: tool.name }]);
     } else {
       const form = {
         ...tool.variation,
@@ -520,11 +520,7 @@ function ToolsetPanel({
       });
     }
 
-    // Invalidate to refresh tool data in the sidebar
-    void invalidateAllToolset(queryClient);
-    void queryClient.invalidateQueries({
-      queryKey: queryKeyInstance({ toolsetSlug }),
-    });
+    await invalidatePlaygroundToolQueries(queryClient, toolsetSlug);
   };
 
   return (
@@ -596,6 +592,7 @@ function ToolsetPanel({
           currentTools={toolset.tools}
           onAddTools={(toolUrns) => handleAddTools(toolUrns)}
           onRemoveTools={(toolUrns) => handleRemoveTools(toolUrns)}
+          onToolUpdate={handleToolUpdate}
           initialGroup={manageToolsGroup}
         />
       )}

--- a/client/dashboard/src/pages/playground/playgroundToolQueries.test.ts
+++ b/client/dashboard/src/pages/playground/playgroundToolQueries.test.ts
@@ -1,0 +1,28 @@
+import { queryKeyInstance } from "@gram/client/react-query/instance.js";
+import { queryKeyListTools } from "@gram/client/react-query/listTools.js";
+import { queryKeyToolset } from "@gram/client/react-query/toolset.js";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { invalidatePlaygroundToolQueries } from "./playgroundToolQueries";
+
+describe("invalidatePlaygroundToolQueries", () => {
+  it("invalidates the global tools list and both toolset views", async () => {
+    const queryClient = new QueryClient();
+    const queryKeys = [
+      queryKeyListTools({}),
+      queryKeyToolset({ slug: "weather-tools" }),
+      queryKeyInstance({ toolsetSlug: "weather-tools" }),
+    ];
+
+    for (const queryKey of queryKeys) {
+      queryClient.setQueryData(queryKey, { cached: true });
+      expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(false);
+    }
+
+    await invalidatePlaygroundToolQueries(queryClient, "weather-tools");
+
+    for (const queryKey of queryKeys) {
+      expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    }
+  });
+});

--- a/client/dashboard/src/pages/playground/playgroundToolQueries.ts
+++ b/client/dashboard/src/pages/playground/playgroundToolQueries.ts
@@ -1,0 +1,17 @@
+import { queryKeyInstance } from "@gram/client/react-query/instance.js";
+import { invalidateAllListTools } from "@gram/client/react-query/listTools.js";
+import { invalidateAllToolset } from "@gram/client/react-query/toolset.js";
+import type { QueryClient } from "@tanstack/react-query";
+
+export async function invalidatePlaygroundToolQueries(
+  queryClient: QueryClient,
+  toolsetSlug: string,
+): Promise<void> {
+  await Promise.all([
+    invalidateAllListTools(queryClient),
+    invalidateAllToolset(queryClient),
+    queryClient.invalidateQueries({
+      queryKey: queryKeyInstance({ toolsetSlug }),
+    }),
+  ]);
+}

--- a/client/dashboard/src/pages/toolBuilder/ToolBuilder.test.ts
+++ b/client/dashboard/src/pages/toolBuilder/ToolBuilder.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parsePrompt } from "./toolBuilderState";
+
+describe("parsePrompt", () => {
+  it("normalizes legacy step IDs without adding runtime callbacks", () => {
+    const parsed = parsePrompt(
+      JSON.stringify({
+        toolName: "weather_summary",
+        purpose: "Summarize weather",
+        inputs: [{ name: "city" }],
+        steps: [
+          {
+            tool: "weather_lookup",
+            instructions: "Look up {{city}}",
+          },
+        ],
+      }),
+    );
+
+    expect(parsed.purpose).toBe("Summarize weather");
+    expect(parsed.inputs).toEqual([{ name: "city" }]);
+    expect(parsed.steps).toHaveLength(1);
+    expect(parsed.steps[0]?.id).toEqual(expect.any(String));
+    expect(parsed.steps[0]).not.toHaveProperty("update");
+  });
+});

--- a/client/dashboard/src/pages/toolBuilder/ToolBuilder.tsx
+++ b/client/dashboard/src/pages/toolBuilder/ToolBuilder.tsx
@@ -51,22 +51,14 @@ import { ChatProvider } from "../playground/ChatContext";
 import { useChatContext } from "../playground/useChatContext";
 import { ChatConfig, ChatWindow } from "../playground/ChatWindow";
 import { ToolsetDropdown } from "../toolsets/ToolsetDropown";
+import {
+  CustomTool,
+  Input,
+  parsePrompt,
+  SerializableStep,
+  Step,
+} from "./toolBuilderState";
 import { useToolifyContext } from "./useToolifyContext";
-
-type Input = {
-  name: string;
-  description?: string;
-};
-
-type Step = {
-  id: string;
-  tool?: string;
-  canonicalTool?: string;
-  toolUrn?: string;
-  instructions: string;
-  inputs?: string[];
-  update: (step: Step) => void;
-};
 
 function higherOrderToolToJSON(tool: CustomTool): string {
   return JSON.stringify(tool, null, 2);
@@ -74,17 +66,6 @@ function higherOrderToolToJSON(tool: CustomTool): string {
 
 const instructionsPlaceholder =
   "Interpret what to do with this tool based on the <purpose />, the chat history, and the output of previous steps.";
-
-// Type for steps without the update function (used for JSON serialization)
-type SerializableStep = Omit<Step, "update">;
-
-// Needs to stay aligned with server/internal/templates/impl.go:CustomToolJSONV1
-type CustomTool = {
-  toolName: string;
-  purpose: string;
-  inputs: Input[];
-  steps: SerializableStep[];
-};
 
 export function ToolBuilderNew(): React.JSX.Element {
   const ctx = useToolifyContext();
@@ -110,7 +91,6 @@ export function ToolBuilderNew(): React.JSX.Element {
       ...step,
       id: uuidv7(),
       canonicalTool: step.tool,
-      update: () => {}, // Set later
     }));
   }
 
@@ -176,7 +156,7 @@ type ToolBuilderState = {
   description: string;
   purpose: string;
   inputs: Input[];
-  steps: Step[];
+  steps: SerializableStep[];
   toolset?: ToolsetEntry;
 };
 
@@ -216,7 +196,7 @@ function ToolBuilder({ initial }: { initial: ToolBuilderState }) {
   tools = tools.filter((t) => t.id !== initial.id); // Make sure you can't create recursive tools
 
   // Ensures that the canonical tool, tool URN, and update function is set for the step
-  const makeStep = (step: Step) => {
+  const makeStep = (step: SerializableStep): Step => {
     if (!step.tool || !tools.length) {
       return {
         ...step,
@@ -370,7 +350,7 @@ function ToolBuilder({ initial }: { initial: ToolBuilderState }) {
         setDescription(initial.description);
         setPurpose(initial.purpose);
         setInputs(initial.inputs);
-        setSteps(initial.steps);
+        setSteps(initial.steps.map(makeStep));
       }}
     >
       Revert
@@ -885,26 +865,6 @@ const StepSeparator = () => {
   return (
     <div className="h-4 w-1/2 border-r-2 border-dashed border-stone-400 dark:border-stone-600" />
   );
-};
-
-const parsePrompt = (
-  prompt: string,
-): { purpose: string; inputs: Input[]; steps: Step[] } => {
-  const customTool = JSON.parse(prompt) as CustomTool;
-
-  const steps: Step[] = customTool.steps.map((step) => ({
-    ...step,
-    id: step.id || uuidv7(), // Ensure steps have IDs
-    update: () => {
-      console.error("update not implemented");
-    }, // This will be replaced by the component when used
-  }));
-
-  return {
-    purpose: customTool.purpose,
-    inputs: customTool.inputs,
-    steps,
-  };
 };
 
 const customToolSystemPrompt = [

--- a/client/dashboard/src/pages/toolBuilder/toolBuilderState.ts
+++ b/client/dashboard/src/pages/toolBuilder/toolBuilderState.ts
@@ -1,0 +1,50 @@
+import { v7 as uuidv7 } from "uuid";
+
+export type Input = {
+  name: string;
+  description?: string;
+};
+
+export type SerializableStep = {
+  id: string;
+  tool?: string;
+  canonicalTool?: string;
+  toolUrn?: string;
+  instructions: string;
+  inputs?: string[];
+};
+
+export type Step = SerializableStep & {
+  update: (step: Step) => void;
+};
+
+// Needs to stay aligned with server/internal/templates/impl.go:CustomToolJSONV1
+export type CustomTool = {
+  toolName: string;
+  purpose: string;
+  inputs: Input[];
+  steps: SerializableStep[];
+};
+
+type ParsedCustomTool = Omit<CustomTool, "steps"> & {
+  steps: Array<Omit<SerializableStep, "id"> & { id?: string }>;
+};
+
+export function parsePrompt(prompt: string): {
+  purpose: string;
+  inputs: Input[];
+  steps: SerializableStep[];
+} {
+  const customTool = JSON.parse(prompt) as ParsedCustomTool;
+
+  const steps: SerializableStep[] = customTool.steps.map((step) => ({
+    ...step,
+    id: step.id || uuidv7(),
+  }));
+
+  return {
+    purpose: customTool.purpose,
+    inputs: customTool.inputs,
+    steps,
+  };
+}


### PR DESCRIPTION
Playground tool edits opened from Add/Manage Tools currently report success without persisting, so users can unknowingly lose their changes. This PR routes that entry point through the existing mutation path and removes the related Tool Builder placeholder callback.

## Summary
- persist tool edits opened from the Playground Add/Manage Tools dialog through the existing update mutation
- keep failed or pending edits safe, prevent duplicate submissions, and refresh every affected tool cache
- remove Tool Builder placeholder update callbacks by separating serialized steps from runtime state

## Testing
- `pnpm -F dashboard test` (140 files, 1,146 tests)
- `pnpm -F dashboard lint`
- `git diff --check`

Linear: AGE-3031

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist tool edits from the Playground Add/Manage Tools dialog by routing saves to the real update mutation, with accurate success/error handling and cache refresh. Addresses Linear AGE-3031 so edits no longer show fake success or get lost.

- **Bug Fixes**
  - Wire Manage Tools edits to the provided update mutation; show success only after it resolves, and show an error while keeping the editor open on failure.
  - Prevent accidental loss by saving only when there are changes, blocking duplicate submissions and dialog close while saving, disabling buttons during save, and showing Remove only for tools already in the toolset.
  - Refresh all affected tool data using `invalidatePlaygroundToolQueries` and await `invalidateTemplate` for updated tools.

- **Refactors**
  - Move Tool Builder parsing and types to `toolBuilderState.ts` (`parsePrompt`, step types), remove placeholder update callbacks from serialized steps, and ensure stable step IDs.

<sup>Written for commit 59c9cce34e37f9d24961dddb6a44d14231fa26a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

