### PR TITLE
chore(remotesessions): unblock refresh handler goroutine on test failure

### DIFF
--- a/server/internal/remotesessions/tokenservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/tokenservice_invalid_grant_test.go
@@ -2,6 +2,7 @@ package remotesessions_test
 
 import (
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -87,6 +88,13 @@ func TestResolveAccessToken_InvalidGrantAdoptsConcurrentRelink(t *testing.T) {
 	refreshArrived := make(chan struct{})
 	releaseRefresh := make(chan struct{})
 
+	// Close releaseRefresh exactly once, and register a cleanup so an assertion
+	// failure between <-refreshArrived and the happy-path close still unblocks
+	// the blocked handler goroutine instead of leaking it forever.
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRefresh) }) }
+	t.Cleanup(release)
+
 	ctx, env := newSyntheticExpiryEnv(t, "invalid-grant-adopt", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -147,7 +155,7 @@ func TestResolveAccessToken_InvalidGrantAdoptsConcurrentRelink(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, env.session.ID, winner.ID, "re-link updates the row in place")
 
-	close(releaseRefresh)
+	release()
 
 	got := <-resolved
 	require.NoError(t, got.err)


### PR DESCRIPTION
Follow-up to a late cubic review comment on #4636 (merged).

In `TestResolveAccessToken_InvalidGrantAdoptsConcurrentRelink`, the blocked upstream refresh handler goroutine was only released by `close(releaseRefresh)` on the happy path. Four `require.*` assertions run between the `<-refreshArrived` signal and that close, so any assertion failure there returns early via `t.FailNow` and leaves both the handler goroutine and the resolve goroutine blocked forever.

This guards the close with a `sync.Once` and registers it via `t.Cleanup`, so the channel is always closed exactly once and the goroutines are unblocked even when a `require` assertion fails early.

Test-only change (no changeset). Verified with `mise exec -- go test ./server/internal/remotesessions -run TestResolveAccessToken_InvalidGrant -count=1 -race`.

Linear Issue: [AIS-382](https://linear.app/speakeasy/issue/AIS-382/remotesessions-dead-upstream-refresh-token-loops-mcp-clients-through)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent goroutine leaks in the `remotesessions` test TestResolveAccessToken_InvalidGrantAdoptsConcurrentRelink by closing the refresh-release channel exactly once with sync.Once and registering it in t.Cleanup. This ensures the refresh handler unblocks even on assertion failures and keeps the AIS-382 invalid_grant test reliable.

<sup>Written for commit 7fe7d1c3d6f63b2980f7c07a18c8d1c5d9014365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

