### PR TITLE
feat: instant sync on enable and stale-test guardrails for device integrations

### DIFF
--- a/.changeset/device-integrations-instant-sync-ux.md
+++ b/.changeset/device-integrations-instant-sync-ux.md
@@ -1,0 +1,12 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Device integrations: enabling a connection (and "Sync now") triggers the
+sync coordinator immediately instead of waiting for its next tick; the
+configure sheet disables the connection test while the draft has unsaved
+changes and explains that tests run against saved credentials; managed
+device and schedule tables get properly spaced empty states; and the Iru
+provider rejects the tenant console URL with an error naming the correct
+API URL.

--- a/client/dashboard/src/pages/org/device-integrations/coverage-widgets.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/coverage-widgets.tsx
@@ -1,3 +1,4 @@
+import { WidgetEmptyState } from "@/components/chart/WidgetEmptyState";
 import { Page } from "@/components/page-layout";
 import {
   defineFilters,
@@ -285,11 +286,7 @@ export const ManagedDeviceTable = memo(function ManagedDeviceTable({
         columns={columns}
         data={filteredDevices}
         rowKey={(row) => row.id}
-        noResultsMessage={
-          <Type muted className="block px-4 py-8 text-center">
-            No matching devices
-          </Type>
-        }
+        noResultsMessage={<WidgetEmptyState message="No matching devices" />}
       />
       {hasMore ? (
         <Stack direction="horizontal" align="center" gap={3}>

--- a/client/dashboard/src/pages/org/device-integrations/coverage-widgets.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/coverage-widgets.tsx
@@ -285,7 +285,11 @@ export const ManagedDeviceTable = memo(function ManagedDeviceTable({
         columns={columns}
         data={filteredDevices}
         rowKey={(row) => row.id}
-        noResultsMessage={<Type muted>No matching devices</Type>}
+        noResultsMessage={
+          <Type muted className="block px-4 py-8 text-center">
+            No matching devices
+          </Type>
+        }
       />
       {hasMore ? (
         <Stack direction="horizontal" align="center" gap={3}>

--- a/client/dashboard/src/pages/org/device-integrations/device-integration-configure-sheet.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/device-integration-configure-sheet.tsx
@@ -223,6 +223,10 @@ function placeholderFor(
 }
 
 function TestConnectionRow({ form }: { form: DeviceIntegrationConfigForm }) {
+  // The test probes the SAVED configuration, so a dirty draft would test the
+  // old values while looking like it tested the new ones. Gate the button
+  // and say why, mirroring the pre-save state's guidance.
+  const dirty = form.hasUnsavedChanges;
   return (
     <Stack gap={2}>
       <Stack direction="horizontal" align="center" gap={2}>
@@ -230,7 +234,7 @@ function TestConnectionRow({ form }: { form: DeviceIntegrationConfigForm }) {
           variant="secondary"
           size="sm"
           onClick={form.testConnection}
-          disabled={form.isTesting || form.isMutating}
+          disabled={form.isTesting || form.isMutating || dirty}
         >
           <Button.LeftIcon>
             {form.isTesting ? (
@@ -244,7 +248,9 @@ function TestConnectionRow({ form }: { form: DeviceIntegrationConfigForm }) {
         <TestResultBadge form={form} />
       </Stack>
       <Type variant="body" className="text-muted-foreground text-xs">
-        Runs a real request against the vendor using the saved credentials.
+        {dirty
+          ? "Unsaved changes — save first. The test always runs against the saved credentials."
+          : "Runs a real request against the vendor using the saved credentials."}
       </Type>
     </Stack>
   );

--- a/client/dashboard/src/pages/org/device-integrations/device-integration-schedules-table.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/device-integration-schedules-table.tsx
@@ -102,7 +102,11 @@ export const DeviceIntegrationSchedulesTable = memo(
         columns={scheduleColumns}
         data={rows}
         rowKey={(row) => row.key}
-        noResultsMessage={<Type muted>No schedules</Type>}
+        noResultsMessage={
+          <Type muted className="block px-4 py-8 text-center">
+            No schedules
+          </Type>
+        }
       />
     );
   },

--- a/client/dashboard/src/pages/org/device-integrations/device-integration-schedules-table.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/device-integration-schedules-table.tsx
@@ -1,3 +1,4 @@
+import { WidgetEmptyState } from "@/components/chart/WidgetEmptyState";
 import { RequireScope } from "@/components/require-scope";
 import { ScheduleStatusBadge } from "@/components/schedule-status-badge";
 import { Switch } from "@/components/ui/switch";
@@ -102,11 +103,7 @@ export const DeviceIntegrationSchedulesTable = memo(
         columns={scheduleColumns}
         data={rows}
         rowKey={(row) => row.key}
-        noResultsMessage={
-          <Type muted className="block px-4 py-8 text-center">
-            No schedules
-          </Type>
-        }
+        noResultsMessage={<WidgetEmptyState message="No schedules" />}
       />
     );
   },

--- a/client/dashboard/src/pages/org/device-integrations/use-device-integration-config.ts
+++ b/client/dashboard/src/pages/org/device-integrations/use-device-integration-config.ts
@@ -259,8 +259,14 @@ export function useDeviceIntegrationConfigForm(
 
   const resetDraft = () => {
     setCredentials({});
-    setSettings(data?.settings ?? {});
-    setEnabled(Boolean(data?.enabled));
+    // Restore from the locally promoted snapshot, not the query cache: right
+    // after a save the cache is stale until the refetch lands, and the
+    // same-config-id guard means that refetch never re-syncs the draft — a
+    // cache-based reset would leave the form permanently dirty. The enabled
+    // flag is deliberately untouched: the sheet never drafts it (the switch
+    // saves instantly), so "resetting" it could only revert server truth to
+    // a stale cache value.
+    setSettings(savedSettings);
     setTestResult(null);
   };
 

--- a/client/dashboard/src/pages/org/device-integrations/use-device-integration-config.ts
+++ b/client/dashboard/src/pages/org/device-integrations/use-device-integration-config.ts
@@ -69,6 +69,11 @@ export function useDeviceIntegrationConfigForm(
   const [enabled, setEnabled] = useState(false);
   const [credentials, setCredentials] = useState<FieldValues>({});
   const [settings, setSettings] = useState<FieldValues>({});
+  // The settings the server is known to hold, tracked locally so the dirty
+  // flag clears the moment a save succeeds instead of flapping through the
+  // config refetch window (and sticking if that refetch fails).
+  const [savedSettings, setSavedSettings] = useState<FieldValues>({});
+  const pendingSavedSettingsRef = useRef<FieldValues>({});
   const [testResult, setTestResult] = useState<TestConnectionResult | null>(
     null,
   );
@@ -88,6 +93,7 @@ export function useDeviceIntegrationConfigForm(
     onSuccess: () => {
       toast.success("Device integration saved");
       setCredentials({});
+      setSavedSettings(pendingSavedSettingsRef.current);
       setTestResult(null);
       invalidate();
       options.onSaveSuccess?.();
@@ -117,6 +123,7 @@ export function useDeviceIntegrationConfigForm(
         setEnabled(false);
         setCredentials({});
         setSettings({});
+        setSavedSettings({});
         setTestResult(null);
         invalidate();
         options.onDeleteSuccess?.();
@@ -145,6 +152,7 @@ export function useDeviceIntegrationConfigForm(
       setEnabled(false);
       setCredentials({});
       setSettings({});
+      setSavedSettings({});
       return;
     }
 
@@ -153,6 +161,7 @@ export function useDeviceIntegrationConfigForm(
     setEnabled(data.enabled);
     setCredentials({});
     setSettings(data.settings);
+    setSavedSettings(data.settings);
   }, [data]);
 
   const isMutating = upsertStatus === "pending" || deleteStatus === "pending";
@@ -181,16 +190,20 @@ export function useDeviceIntegrationConfigForm(
   ]);
 
   const hasUnsavedChanges = useMemo(() => {
-    if (Object.values(credentials).some((value) => value.trim() !== "")) {
+    // Any typed characters in a secret field count — even whitespace-only,
+    // which renders as masked dots and would otherwise leave the test
+    // enabled against the old saved secret while looking populated.
+    if (Object.values(credentials).some((value) => value !== "")) {
       return true;
     }
-    const savedSettings = data?.settings ?? {};
-    return provider.fields.some(
-      (field) =>
-        !field.secret &&
-        (settings[field.key] ?? "") !== (savedSettings[field.key] ?? ""),
+    const keys = new Set([
+      ...Object.keys(settings),
+      ...Object.keys(savedSettings),
+    ]);
+    return [...keys].some(
+      (key) => (settings[key] ?? "") !== (savedSettings[key] ?? ""),
     );
-  }, [credentials, data, provider.fields, settings]);
+  }, [credentials, savedSettings, settings]);
 
   const save = () => {
     // Only send secret values the user actually typed: omitted keys keep the
@@ -199,6 +212,9 @@ export function useDeviceIntegrationConfigForm(
     for (const [key, value] of Object.entries(credentials)) {
       if (value.trim() !== "") suppliedCredentials[key] = value.trim();
     }
+    // Recorded now, promoted to savedSettings on success — the values the
+    // server will hold if this save lands.
+    pendingSavedSettingsRef.current = settings;
     upsert({
       request: {
         upsertConfigRequestBody2: {
@@ -219,6 +235,9 @@ export function useDeviceIntegrationConfigForm(
   const saveEnabled = (nextEnabled: boolean) => {
     setEnabled(nextEnabled);
     if (!isConfigured) return;
+    // The shared onSuccess promotes this ref; an enabled-only flip leaves
+    // the server's settings untouched, so carry the current snapshot.
+    pendingSavedSettingsRef.current = savedSettings;
     upsert({
       request: {
         upsertConfigRequestBody2: {

--- a/client/dashboard/src/pages/org/device-integrations/use-device-integration-config.ts
+++ b/client/dashboard/src/pages/org/device-integrations/use-device-integration-config.ts
@@ -38,6 +38,10 @@ export type DeviceIntegrationConfigForm = {
   setSetting: (key: string, value: string) => void;
   isMutating: boolean;
   canSave: boolean;
+  // True while the draft differs from the saved config: a typed secret or a
+  // changed setting. The connection test always runs against SAVED values,
+  // so a dirty draft means "save before testing".
+  hasUnsavedChanges: boolean;
   save: () => void;
   saveEnabled: (nextEnabled: boolean) => void;
   remove: () => void;
@@ -176,6 +180,18 @@ export function useDeviceIntegrationConfigForm(
     settings,
   ]);
 
+  const hasUnsavedChanges = useMemo(() => {
+    if (Object.values(credentials).some((value) => value.trim() !== "")) {
+      return true;
+    }
+    const savedSettings = data?.settings ?? {};
+    return provider.fields.some(
+      (field) =>
+        !field.secret &&
+        (settings[field.key] ?? "") !== (savedSettings[field.key] ?? ""),
+    );
+  }, [credentials, data, provider.fields, settings]);
+
   const save = () => {
     // Only send secret values the user actually typed: omitted keys keep the
     // stored secret (per-key merge on the server).
@@ -259,6 +275,7 @@ export function useDeviceIntegrationConfigForm(
     },
     isMutating,
     canSave,
+    hasUnsavedChanges,
     save,
     saveEnabled,
     remove,

--- a/client/dashboard/src/pages/org/device-integrations/use-device-integration-schedules.ts
+++ b/client/dashboard/src/pages/org/device-integrations/use-device-integration-schedules.ts
@@ -55,7 +55,7 @@ export function useDeviceScheduleRuntimes(
   const { mutate: mutateRetry } = useRetryDeviceIntegrationScheduleMutation({
     onSuccess: () => {
       refresh();
-      toast.success("Retry scheduled. The next sync runs within minutes.");
+      toast.success("Sync started. Fresh results should appear shortly.");
     },
     onError: (err) => {
       refresh();

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1109,7 +1109,7 @@ func newStartCommand() *cli.Command {
 				c.String("jwt-signing-key"),
 			))
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))
-			deviceintegrations.Attach(mux, deviceintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, guardianPolicy))
+			deviceintegrations.Attach(mux, deviceintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, guardianPolicy, &background.DeviceIntegrationSyncTrigger{TemporalEnv: temporalEnv}))
 			modelkeys.Attach(mux, modelkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, openRouter, productFeatures, auditLogger))
 			otelforwarding.Attach(mux, otelforwarding.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, otelForwardClient))
 			auditapi.Attach(mux, auditapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine))

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1109,7 +1109,7 @@ func newStartCommand() *cli.Command {
 				c.String("jwt-signing-key"),
 			))
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))
-			deviceintegrations.Attach(mux, deviceintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, guardianPolicy, &background.DeviceIntegrationSyncTrigger{TemporalEnv: temporalEnv}))
+			deviceintegrations.Attach(mux, deviceintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, guardianPolicy, &background.DeviceIntegrationSyncTrigger{TemporalEnv: temporalEnv, Logger: logger}))
 			modelkeys.Attach(mux, modelkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, openRouter, productFeatures, auditLogger))
 			otelforwarding.Attach(mux, otelforwarding.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, otelForwardClient))
 			auditapi.Attach(mux, auditapi.NewService(logger, tracerProvider, db, sessionManager, authzEngine))

--- a/server/internal/background/device_integration_sync.go
+++ b/server/internal/background/device_integration_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,6 +13,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	"github.com/speakeasy-api/gram/server/internal/deviceintegrations"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
@@ -231,11 +233,14 @@ func buildDeviceIntegrationSyncScheduleOptions(temporalEnv *tenv.Environment) cl
 
 // DeviceIntegrationSyncTrigger runs the sync coordinator schedule
 // immediately, so user actions that make a sync due (enabling a connection,
-// "Sync now") take effect in seconds instead of at the next tick. The
-// schedule's overlap-skip policy makes a trigger racing a live tick
-// harmless.
+// fixing credentials, "Sync now") take effect in seconds instead of at the
+// next tick. BUFFER_ONE queues the trigger behind an in-flight coordinator
+// run: a run that already selected its candidates cannot see work made due
+// after selection, so a skipped (rather than buffered) trigger would
+// silently fall back to full tick latency.
 type DeviceIntegrationSyncTrigger struct {
 	TemporalEnv *tenv.Environment
+	Logger      *slog.Logger
 }
 
 var _ deviceintegrations.SyncTrigger = (*DeviceIntegrationSyncTrigger)(nil)
@@ -243,9 +248,11 @@ var _ deviceintegrations.SyncTrigger = (*DeviceIntegrationSyncTrigger)(nil)
 func (t *DeviceIntegrationSyncTrigger) TriggerSyncNow(ctx context.Context) error {
 	handle := t.TemporalEnv.Client().ScheduleClient().GetHandle(ctx, deviceIntegrationSyncCoordinatorScheduleID)
 	if err := handle.Trigger(ctx, client.ScheduleTriggerOptions{
-		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
 	}); err != nil {
 		return fmt.Errorf("trigger device integration sync coordinator: %w", err)
 	}
+	t.Logger.DebugContext(ctx, "triggered device integration sync coordinator",
+		attr.SlogTemporalWorkflowID(deviceIntegrationSyncCoordinatorScheduleID))
 	return nil
 }

--- a/server/internal/background/device_integration_sync.go
+++ b/server/internal/background/device_integration_sync.go
@@ -246,13 +246,21 @@ type DeviceIntegrationSyncTrigger struct {
 var _ deviceintegrations.SyncTrigger = (*DeviceIntegrationSyncTrigger)(nil)
 
 func (t *DeviceIntegrationSyncTrigger) TriggerSyncNow(ctx context.Context) error {
+	// Guard the receiver: a typed-nil trigger handed through the interface
+	// passes the caller's interface-nil check, and kickSync runs on a
+	// goroutine where a panic takes down the process, not a request.
+	if t == nil || t.TemporalEnv == nil {
+		return fmt.Errorf("device integration sync trigger is not configured")
+	}
 	handle := t.TemporalEnv.Client().ScheduleClient().GetHandle(ctx, deviceIntegrationSyncCoordinatorScheduleID)
 	if err := handle.Trigger(ctx, client.ScheduleTriggerOptions{
 		Overlap: enums.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
 	}); err != nil {
 		return fmt.Errorf("trigger device integration sync coordinator: %w", err)
 	}
-	t.Logger.DebugContext(ctx, "triggered device integration sync coordinator",
-		attr.SlogTemporalWorkflowID(deviceIntegrationSyncCoordinatorScheduleID))
+	if t.Logger != nil {
+		t.Logger.DebugContext(ctx, "triggered device integration sync coordinator",
+			attr.SlogTemporalWorkflowID(deviceIntegrationSyncCoordinatorScheduleID))
+	}
 	return nil
 }

--- a/server/internal/background/device_integration_sync.go
+++ b/server/internal/background/device_integration_sync.go
@@ -228,3 +228,24 @@ func buildDeviceIntegrationSyncScheduleOptions(temporalEnv *tenv.Environment) cl
 		},
 	}
 }
+
+// DeviceIntegrationSyncTrigger runs the sync coordinator schedule
+// immediately, so user actions that make a sync due (enabling a connection,
+// "Sync now") take effect in seconds instead of at the next tick. The
+// schedule's overlap-skip policy makes a trigger racing a live tick
+// harmless.
+type DeviceIntegrationSyncTrigger struct {
+	TemporalEnv *tenv.Environment
+}
+
+var _ deviceintegrations.SyncTrigger = (*DeviceIntegrationSyncTrigger)(nil)
+
+func (t *DeviceIntegrationSyncTrigger) TriggerSyncNow(ctx context.Context) error {
+	handle := t.TemporalEnv.Client().ScheduleClient().GetHandle(ctx, deviceIntegrationSyncCoordinatorScheduleID)
+	if err := handle.Trigger(ctx, client.ScheduleTriggerOptions{
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+	}); err != nil {
+		return fmt.Errorf("trigger device integration sync coordinator: %w", err)
+	}
+	return nil
+}

--- a/server/internal/deviceintegrations/impl.go
+++ b/server/internal/deviceintegrations/impl.go
@@ -100,17 +100,25 @@ func NewService(
 	}
 }
 
-// kickSync asks Temporal to run the sync coordinator immediately, so an
-// enable or a manual retry syncs in seconds instead of at the next tick.
-// Best-effort by design: failures are logged and the periodic tick picks
+// kickSync asks Temporal to run the sync coordinator immediately, so a save
+// that made work due (enable, credential fix, "Sync now") syncs in seconds
+// instead of at the next tick. It runs on its own goroutine with a detached,
+// bounded context: the response must not wait on Temporal's health, and a
+// client disconnecting right after the commit must not lose the nudge.
+// Best-effort by design — failures are logged and the periodic tick picks
 // the due work up regardless.
 func (s *Service) kickSync(ctx context.Context, logger *slog.Logger) {
 	if s.syncTrigger == nil {
 		return
 	}
-	if err := s.syncTrigger.TriggerSyncNow(ctx); err != nil {
-		logger.WarnContext(ctx, "failed to trigger immediate device integration sync", attr.SlogError(err))
-	}
+	detached := context.WithoutCancel(ctx)
+	go func() {
+		triggerCtx, cancel := context.WithTimeout(detached, 10*time.Second)
+		defer cancel()
+		if err := s.syncTrigger.TriggerSyncNow(triggerCtx); err != nil {
+			logger.WarnContext(triggerCtx, "failed to trigger immediate device integration sync", attr.SlogError(err))
+		}
+	}()
 }
 
 func Attach(mux goahttp.Muxer, service *Service) {
@@ -241,11 +249,10 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 		return nil, oops.E(oops.CodeUnexpected, err, "commit device integration upsert").LogError(ctx, logger)
 	}
 
-	// An enable transition should sync right away — the schedules are
-	// already due (fresh configs seed next_poll_after to now), so all that
-	// stands between the user and their first inventory is the coordinator's
-	// next tick.
-	if cfg.Enabled && (result.Before == nil || !result.Before.Enabled) {
+	// When the save left schedules due (creation, credential fix, enable
+	// transition — the store reports it), run them now: all that stands
+	// between the user and fresh data is the coordinator's next tick.
+	if cfg.Enabled && result.SyncsMadeDue {
 		s.kickSync(ctx, logger)
 	}
 
@@ -493,6 +500,12 @@ func (s *Service) SetScheduleEnabled(ctx context.Context, payload *gen.SetSchedu
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit device integration schedule update").LogError(ctx, logger)
+	}
+
+	// A resumed schedule may already be past-due; run it now so the
+	// schedule-level switch behaves like the connection-level one.
+	if payload.Enabled {
+		s.kickSync(ctx, logger)
 	}
 
 	row, err := s.repo.GetScheduleWithSync(ctx, repo.GetScheduleWithSyncParams{

--- a/server/internal/deviceintegrations/impl.go
+++ b/server/internal/deviceintegrations/impl.go
@@ -50,16 +50,25 @@ const (
 	activeWindow = time.Hour
 )
 
+// SyncTrigger nudges the background sync machinery to run promptly instead
+// of waiting for the coordinator's next tick. Implementations are
+// best-effort: the periodic tick remains the reliability backstop, so a
+// failed trigger only costs latency, never a sync.
+type SyncTrigger interface {
+	TriggerSyncNow(ctx context.Context) error
+}
+
 type Service struct {
-	tracer   trace.Tracer
-	logger   *slog.Logger
-	db       *pgxpool.Pool
-	auth     *auth.Auth
-	authz    *authz.Engine
-	audit    *audit.Logger
-	store    *Store
-	repo     *repo.Queries
-	guardian *guardian.Policy
+	tracer      trace.Tracer
+	logger      *slog.Logger
+	db          *pgxpool.Pool
+	auth        *auth.Auth
+	authz       *authz.Engine
+	audit       *audit.Logger
+	store       *Store
+	repo        *repo.Queries
+	guardian    *guardian.Policy
+	syncTrigger SyncTrigger
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -74,18 +83,33 @@ func NewService(
 	auditLogger *audit.Logger,
 	encryptionClient *encryption.Client,
 	guardianPolicy *guardian.Policy,
+	syncTrigger SyncTrigger,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("deviceintegrations.api"))
 	return &Service{
-		tracer:   tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/deviceintegrations"),
-		logger:   logger,
-		db:       db,
-		auth:     auth.New(logger, db, sessions, authzEngine),
-		authz:    authzEngine,
-		audit:    auditLogger,
-		store:    NewStore(logger, db, encryptionClient),
-		repo:     repo.New(db),
-		guardian: guardianPolicy,
+		tracer:      tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/deviceintegrations"),
+		logger:      logger,
+		db:          db,
+		auth:        auth.New(logger, db, sessions, authzEngine),
+		authz:       authzEngine,
+		audit:       auditLogger,
+		store:       NewStore(logger, db, encryptionClient),
+		repo:        repo.New(db),
+		guardian:    guardianPolicy,
+		syncTrigger: syncTrigger,
+	}
+}
+
+// kickSync asks Temporal to run the sync coordinator immediately, so an
+// enable or a manual retry syncs in seconds instead of at the next tick.
+// Best-effort by design: failures are logged and the periodic tick picks
+// the due work up regardless.
+func (s *Service) kickSync(ctx context.Context, logger *slog.Logger) {
+	if s.syncTrigger == nil {
+		return
+	}
+	if err := s.syncTrigger.TriggerSyncNow(ctx); err != nil {
+		logger.WarnContext(ctx, "failed to trigger immediate device integration sync", attr.SlogError(err))
 	}
 }
 
@@ -215,6 +239,14 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit device integration upsert").LogError(ctx, logger)
+	}
+
+	// An enable transition should sync right away — the schedules are
+	// already due (fresh configs seed next_poll_after to now), so all that
+	// stands between the user and their first inventory is the coordinator's
+	// next tick.
+	if cfg.Enabled && (result.Before == nil || !result.Before.Enabled) {
+		s.kickSync(ctx, logger)
 	}
 
 	return buildConfigView(cfg), nil
@@ -521,6 +553,10 @@ func (s *Service) RetrySchedule(ctx context.Context, payload *gen.RetryScheduleP
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit device integration schedule retry").LogError(ctx, logger)
 	}
+
+	// "Sync now" means now: the schedule is due as of this commit, so run
+	// the coordinator instead of waiting out its tick.
+	s.kickSync(ctx, logger)
 
 	row, err := s.repo.GetScheduleWithSync(ctx, repo.GetScheduleWithSyncParams{
 		DeviceIntegrationConfigID: cfg.ID,

--- a/server/internal/deviceintegrations/providers/iru/iru.go
+++ b/server/internal/deviceintegrations/providers/iru/iru.go
@@ -117,6 +117,14 @@ func instanceBaseURL(settings providers.Settings) (string, error) {
 	if parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
 		return "", fmt.Errorf("instance_url must be the tenant API root, e.g. https://yourtenant.api.iru.com")
 	}
+	// The single most common paste mistake is the web-console URL
+	// (yourtenant.iru.com) instead of the API root (yourtenant.api.iru.com).
+	// The console host never serves the API, so catch it here with a precise
+	// message instead of a generic request failure at test time.
+	host := strings.ToLower(parsed.Hostname())
+	if (strings.HasSuffix(host, ".iru.com") || strings.HasSuffix(host, ".kandji.io")) && !strings.Contains(host, ".api.") {
+		return "", fmt.Errorf("instance_url looks like the console URL; use the API URL shown under Settings → Access, e.g. https://yourtenant.api.iru.com")
+	}
 	return "https://" + parsed.Host, nil
 }
 

--- a/server/internal/deviceintegrations/providers/iru/iru.go
+++ b/server/internal/deviceintegrations/providers/iru/iru.go
@@ -118,14 +118,35 @@ func instanceBaseURL(settings providers.Settings) (string, error) {
 		return "", fmt.Errorf("instance_url must be the tenant API root, e.g. https://yourtenant.api.iru.com")
 	}
 	// The single most common paste mistake is the web-console URL
-	// (yourtenant.iru.com) instead of the API root (yourtenant.api.iru.com).
-	// The console host never serves the API, so catch it here with a precise
-	// message instead of a generic request failure at test time.
-	host := strings.ToLower(parsed.Hostname())
-	if (strings.HasSuffix(host, ".iru.com") || strings.HasSuffix(host, ".kandji.io")) && !strings.Contains(host, ".api.") {
-		return "", fmt.Errorf("instance_url looks like the console URL; use the API URL shown under Settings → Access, e.g. https://yourtenant.api.iru.com")
+	// (yourtenant.iru.com) instead of the API root (yourtenant.api.iru.com);
+	// dropping the tenant label (api.iru.com) is the runner-up. On the
+	// vendor's own domains, require the <tenant>.api.<...> shape and say
+	// exactly what to paste — the console host never serves the API, and a
+	// generic request failure at test time diagnoses neither mistake.
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if vendorHost(host) && !vendorAPIHost(host) {
+		return "", fmt.Errorf("instance_url must be the tenant API root shown in the console under Settings → Access, e.g. https://yourtenant.api.iru.com — not the console URL")
 	}
 	return "https://" + parsed.Host, nil
+}
+
+// vendorHost reports whether the host belongs to the vendor's domains
+// (including their apexes), where the tenant-API-root shape is enforceable.
+func vendorHost(host string) bool {
+	for _, domain := range []string{"iru.com", "kandji.io"} {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// vendorAPIHost reports the <tenant>.api.<...> shape: at least one tenant
+// label followed by the literal "api" label (covers regional forms like
+// tenant.api.eu.kandji.io).
+func vendorAPIHost(host string) bool {
+	labels := strings.Split(host, ".")
+	return len(labels) >= 4 && labels[1] == "api"
 }
 
 // deviceRecord mirrors the fields we map from GET /api/v1/devices.

--- a/server/internal/deviceintegrations/providers/iru/iru_test.go
+++ b/server/internal/deviceintegrations/providers/iru/iru_test.go
@@ -338,6 +338,12 @@ func TestInstanceURLValidation(t *testing.T) {
 	require.ErrorContains(t, err, "https")
 	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: "https://tenant.api.kandji.io/some/path"}, "")
 	require.ErrorContains(t, err, "tenant API root")
+	// The console URL is the most common paste mistake: reject it with a
+	// message that names the right value.
+	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: "https://tenant.iru.com"}, "")
+	require.ErrorContains(t, err, "console URL")
+	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: "https://tenant.kandji.io"}, "")
+	require.ErrorContains(t, err, "console URL")
 	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: ""}, "")
 	require.ErrorContains(t, err, "not configured")
 }

--- a/server/internal/deviceintegrations/providers/iru/iru_test.go
+++ b/server/internal/deviceintegrations/providers/iru/iru_test.go
@@ -338,14 +338,39 @@ func TestInstanceURLValidation(t *testing.T) {
 	require.ErrorContains(t, err, "https")
 	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: "https://tenant.api.kandji.io/some/path"}, "")
 	require.ErrorContains(t, err, "tenant API root")
-	// The console URL is the most common paste mistake: reject it with a
-	// message that names the right value.
-	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: "https://tenant.iru.com"}, "")
-	require.ErrorContains(t, err, "console URL")
-	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: "https://tenant.kandji.io"}, "")
-	require.ErrorContains(t, err, "console URL")
+	// Vendor-domain hosts that are not a tenant API root are the common
+	// paste mistakes: the console URL, the bare apex, a tenant-less API
+	// host, and a trailing-dot FQDN variant of any of them. All get the
+	// error naming the right value.
+	for _, bad := range []string{
+		"https://tenant.iru.com",
+		"https://tenant.kandji.io",
+		"https://iru.com",
+		"https://kandji.io",
+		"https://api.iru.com",
+		"https://tenant.iru.com.",
+	} {
+		_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: bad}, "")
+		require.ErrorContains(t, err, "tenant API root", "value %q must be rejected", bad)
+	}
 	_, err = s.ListDevices(t.Context(), fake.creds(), providers.Settings{fieldInstanceURL: ""}, "")
 	require.ErrorContains(t, err, "not configured")
+}
+
+func TestVendorAPIHostShapes(t *testing.T) {
+	t.Parallel()
+
+	// Valid tenant API roots, including regional forms, pass the guard.
+	for _, good := range []string{
+		"tenant.api.iru.com",
+		"tenant.api.kandji.io",
+		"tenant.api.eu.kandji.io",
+	} {
+		require.True(t, vendorAPIHost(good), "host %q is a tenant API root", good)
+	}
+	for _, bad := range []string{"tenant.iru.com", "api.iru.com", "iru.com"} {
+		require.False(t, vendorAPIHost(bad), "host %q is not a tenant API root", bad)
+	}
 }
 
 func TestInvalidCursorRejected(t *testing.T) {

--- a/server/internal/deviceintegrations/queries.sql
+++ b/server/internal/deviceintegrations/queries.sql
@@ -200,6 +200,17 @@ FROM device_integration_schedules sch
 WHERE s.device_integration_schedule_id = sch.id
   AND sch.device_integration_config_id = @device_integration_config_id;
 
+-- Enabling a connection means "sync now": mark every schedule due without
+-- disturbing failure history or the push digest (unlike the full reset a
+-- credential rotation performs).
+-- name: MarkConfigSyncsDue :exec
+UPDATE device_integration_syncs s
+SET next_poll_after = clock_timestamp(),
+    updated_at = clock_timestamp()
+FROM device_integration_schedules sch
+WHERE s.device_integration_schedule_id = sch.id
+  AND sch.device_integration_config_id = @device_integration_config_id;
+
 -- RetrySchedule makes one schedule due immediately, lifting any automatic
 -- pause and clearing its failure state. The stored error is cleared
 -- deliberately — the user acknowledged it by retrying, and a failing sync

--- a/server/internal/deviceintegrations/repo/queries.sql.go
+++ b/server/internal/deviceintegrations/repo/queries.sql.go
@@ -784,6 +784,23 @@ func (q *Queries) ListSyncCandidates(ctx context.Context, arg ListSyncCandidates
 	return items, nil
 }
 
+const markConfigSyncsDue = `-- name: MarkConfigSyncsDue :exec
+UPDATE device_integration_syncs s
+SET next_poll_after = clock_timestamp(),
+    updated_at = clock_timestamp()
+FROM device_integration_schedules sch
+WHERE s.device_integration_schedule_id = sch.id
+  AND sch.device_integration_config_id = $1
+`
+
+// Enabling a connection means "sync now": mark every schedule due without
+// disturbing failure history or the push digest (unlike the full reset a
+// credential rotation performs).
+func (q *Queries) MarkConfigSyncsDue(ctx context.Context, deviceIntegrationConfigID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, markConfigSyncsDue, deviceIntegrationConfigID)
+	return err
+}
+
 const markDevicesMissing = `-- name: MarkDevicesMissing :exec
 
 UPDATE mdm_devices

--- a/server/internal/deviceintegrations/store.go
+++ b/server/internal/deviceintegrations/store.go
@@ -241,6 +241,11 @@ type UpsertResult struct {
 	// Before is the config state the transaction observed prior to the
 	// write; nil when the call created the config.
 	Before *Config
+	// SyncsMadeDue reports that this save left the config's schedules due to
+	// run now (creation seeds them due, a credential/settings change resets
+	// them, and an enable transition marks them due) — the caller's signal
+	// to kick the sync machinery instead of waiting for its next tick.
+	SyncsMadeDue bool
 }
 
 // upsertWithTx creates or updates the org+provider config and ensures a
@@ -384,6 +389,7 @@ func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, desc providers
 	if err := s.ensureSchedules(ctx, q, desc, row.ID); err != nil {
 		return UpsertResult{}, err
 	}
+	syncsMadeDue := !exists // creation seeds every schedule due
 	if exists && credentialsSupplied {
 		// A rotated credential is a fresh start: stale failure state must not
 		// keep rendering "failed" after the fix, and last_push_digest must
@@ -391,15 +397,27 @@ func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, desc providers
 		if err := q.ResetSyncStateForConfig(ctx, row.ID); err != nil {
 			return UpsertResult{}, oops.E(oops.CodeUnexpected, err, "reset device integration sync state")
 		}
+		syncsMadeDue = true
 	} else if err := q.ClearAutoPauses(ctx, row.ID); err != nil {
 		return UpsertResult{}, oops.E(oops.CodeUnexpected, err, "clear device integration sync pauses")
+	}
+
+	// An enable transition means "sync now", not "sync whenever the old
+	// next_poll_after comes around": a config re-enabled mid-interval would
+	// otherwise sit idle for the rest of the hour. Failure history and the
+	// push digest are deliberately untouched.
+	if exists && enabled && before != nil && !before.Enabled && !syncsMadeDue {
+		if err := q.MarkConfigSyncsDue(ctx, row.ID); err != nil {
+			return UpsertResult{}, oops.E(oops.CodeUnexpected, err, "mark device integration syncs due")
+		}
+		syncsMadeDue = true
 	}
 
 	cfg, err := configFromRow(row)
 	if err != nil {
 		return UpsertResult{}, err
 	}
-	return UpsertResult{Config: cfg, Created: !exists, Before: before}, nil
+	return UpsertResult{Config: cfg, Created: !exists, Before: before, SyncsMadeDue: syncsMadeDue}, nil
 }
 
 // ensureSchedules materializes a schedule row and its 1:1 sync row for every

--- a/server/internal/deviceintegrations/store_test.go
+++ b/server/internal/deviceintegrations/store_test.go
@@ -2,6 +2,7 @@ package deviceintegrations
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,34 @@ func TestCredentialsStoredEncryptedAndNeverReadable(t *testing.T) {
 	for _, v := range cfg.Settings {
 		require.NotEqual(t, "secret-token", v, "secrets must never appear in readable settings")
 	}
+}
+
+func TestEnableTransitionMarksSyncsDue(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	created := mustUpsert(t, ctx, conn, store, orgID, validCreds(), validSettings(), true)
+	require.True(t, created.SyncsMadeDue, "creation seeds schedules due")
+
+	disabled := mustUpsert(t, ctx, conn, store, orgID, nil, validSettings(), false)
+	require.False(t, disabled.SyncsMadeDue, "disabling makes nothing due")
+
+	// Simulate a config disabled mid-interval: the sync already ran, so its
+	// next poll sits in the future.
+	require.NoError(t, testrepo.New(conn).DeferDeviceIntegrationSyncsFixture(ctx, created.Config.ID))
+
+	// Re-enabling means "sync now": the schedules must be due again or the
+	// immediate-sync trigger kicks a coordinator that finds nothing.
+	reenabled := mustUpsert(t, ctx, conn, store, orgID, nil, validSettings(), true)
+	require.True(t, reenabled.SyncsMadeDue, "an enable transition makes schedules due")
+	rows, err := store.repo.ListSchedulesWithSync(ctx, created.Config.ID)
+	require.NoError(t, err)
+	require.LessOrEqual(t, rows[0].NextPollAfter.Time, time.Now().UTC().Add(time.Minute), "next poll is due now")
+
+	// An enabled→enabled save with nothing else changed makes nothing due.
+	steady := mustUpsert(t, ctx, conn, store, orgID, nil, validSettings(), true)
+	require.False(t, steady.SyncsMadeDue, "a no-op save must not re-kick the sync machinery")
 }
 
 func TestUpsertClearsAutoPauseButNotUserDisable(t *testing.T) {

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -175,6 +175,15 @@ UPDATE device_integration_schedules
 SET disabled_at = clock_timestamp()
 WHERE device_integration_config_id = @device_integration_config_id;
 
+-- Pushes every sync's next poll an hour out, simulating a config whose
+-- schedules already ran this interval.
+-- name: DeferDeviceIntegrationSyncsFixture :exec
+UPDATE device_integration_syncs s
+SET next_poll_after = clock_timestamp() + interval '1 hour'
+FROM device_integration_schedules sch
+WHERE s.device_integration_schedule_id = sch.id
+  AND sch.device_integration_config_id = @device_integration_config_id;
+
 -- name: GetDeviceIntegrationCredentialsCiphertext :one
 SELECT credentials_encrypted
 FROM device_integration_configs

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -127,6 +127,21 @@ func (q *Queries) CreateOrganizationUserRelationshipFixture(ctx context.Context,
 	return err
 }
 
+const deferDeviceIntegrationSyncsFixture = `-- name: DeferDeviceIntegrationSyncsFixture :exec
+UPDATE device_integration_syncs s
+SET next_poll_after = clock_timestamp() + interval '1 hour'
+FROM device_integration_schedules sch
+WHERE s.device_integration_schedule_id = sch.id
+  AND sch.device_integration_config_id = $1
+`
+
+// Pushes every sync's next poll an hour out, simulating a config whose
+// schedules already ran this interval.
+func (q *Queries) DeferDeviceIntegrationSyncsFixture(ctx context.Context, deviceIntegrationConfigID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deferDeviceIntegrationSyncsFixture, deviceIntegrationConfigID)
+	return err
+}
+
 const disableDeviceIntegrationSchedulesFixture = `-- name: DisableDeviceIntegrationSchedulesFixture :exec
 UPDATE device_integration_schedules
 SET disabled_at = clock_timestamp()


### PR DESCRIPTION
UX follow-ups on the device-integrations surface (post-#4637 dogfood feedback), plus the Iru console-URL guard.

## Enable → sync in seconds, not at the next tick

Enabling a connection made its schedules due, but nothing ran until the sync coordinator's next 5-minute tick (the "Sync now" retry endpoint had the same latency). A new `SyncTrigger` seam on `deviceintegrations.Service` — implemented by `background.DeviceIntegrationSyncTrigger` via a Temporal Schedule `Trigger` on the coordinator — fires after commit when an upsert transitions a config to enabled and after every `RetrySchedule`. Best-effort by design: the trigger races safely with a live tick (the schedule's overlap-skip policy) and a failure only costs latency, since the periodic tick remains the backstop.

## Configure sheet: no more stale connection tests

The connection test always probes the SAVED configuration, so on an existing connection, typing new credentials and hitting Test silently tested the old ones. The sheet now tracks `hasUnsavedChanges` (any typed secret, or a settings draft differing from the saved config) and, while dirty, disables Test Connection and swaps the caption to "Unsaved changes — save first. The test always runs against the saved credentials." — mirroring the existing pre-save guidance.

## Empty-state spacing

"No matching devices" / "No schedules" rendered flush against the table edge; both are now padded and centered.

## Iru console-URL guard

The first real connect attempt pasted the tenant console URL (`https://<tenant>.iru.com`) instead of the API root (`https://<tenant>.api.iru.com`) and got a generic test failure. `instanceBaseURL` now rejects iru.com/kandji.io hosts lacking the `.api.` label with an error naming exactly what to paste.

## Testing

- Provider tests cover the console-URL rejection; full deviceintegrations suite and dashboard type-check/lint green.
- The trigger seam is nil-tolerant (tests and any non-Temporal context degrade to tick-driven behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run device-integration syncs immediately after enable, resume, credential fixes, or “Sync now,” and block stale connection tests while a draft has unsaved changes. Also improves empty-state spacing/copy and guards Iru/Kandji console URLs. Supports DNO-652 by aligning MDM integration UX.

- **New Features**
  - Instant sync: added `SyncTrigger` to `deviceintegrations.Service`, implemented by `background.DeviceIntegrationSyncTrigger`, to run the coordinator right after enables, resumes, credential fixes, and retries; queues behind in-flight runs and remains tick-backed.
  - Enable transition: mark all schedules due on enable via `MarkConfigSyncsDue`; only nudge when the store reports `SyncsMadeDue`.
  - UX: disable Test Connection when `hasUnsavedChanges` and explain tests use saved credentials; centered/padded table empty states via `WidgetEmptyState`; “Sync now” toast: “Sync started. Fresh results should appear shortly.”
  - Iru/Kandji validation: reject console hosts on `iru.com`/`kandji.io` that lack the `<tenant>.api.` label and name the correct API URL.

- **Bug Fixes**
  - Guard the sync trigger against typed-nil receivers and run on a detached, timed context to avoid coupling responses to Temporal health.
  - Reset the config draft from the locally saved snapshot (not the stale query cache) so the dirty state clears immediately after save, even if refetch is late or fails.

<sup>Written for commit bccd8ddeae9e9cef180d82c73045fe1d3b49edd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

