### PR TITLE
feat: add typed dashboard feature flag hook

### DIFF
--- a/.agents/skills/feature-flag/SKILL.md
+++ b/.agents/skills/feature-flag/SKILL.md
@@ -142,14 +142,14 @@ if (assistants.status === "missing" || assistants.status === "error") {
   return <FeatureUnavailable />;
 }
 
-const assistantsEnabled = assistants.enabled; // status is "ready"; boolean
+const assistantsEnabled = assistants.status === "enabled";
 ```
 
 Add new frontend keys to the `FEATURE_FLAGS` registry in
 `client/dashboard/src/lib/featureFlags.ts`; its values generate the hook's
-`FeatureFlag` type. The hook distinguishes loading, ready, missing, and error
-states and stays reactive as PostHog reloads flags. On localhost, the
-development telemetry provider reports every flag ready and enabled.
+`FeatureFlag` type. The hook distinguishes loading, enabled, disabled, missing,
+and error states and stays reactive as PostHog reloads flags. On localhost,
+the development telemetry provider reports every flag as enabled.
 
 PostHog flags control rollout UI only. Never use them for authorization or
 entitlement enforcement, and never import PostHog hooks directly.

--- a/.agents/skills/feature-flag/SKILL.md
+++ b/.agents/skills/feature-flag/SKILL.md
@@ -135,14 +135,24 @@ New frontend code should use the typed `useFeatureFlag()` hook from
 `client/dashboard/src/hooks/useFeatureFlag.ts`:
 
 ```tsx
-const rbacEnabled = useFeatureFlag("gram-rbac"); // defaults off while loading
-const deploymentsEnabled = useFeatureFlag("gram-deployments-page", "on");
-const tunneledMcpEnabled = useFeatureFlag("gram-tunneled-mcp", "unresolved"); // boolean | undefined
+const assistants = useFeatureFlag(FEATURE_FLAGS.assistants);
+
+if (assistants.status === "loading") return null;
+if (assistants.status === "missing" || assistants.status === "error") {
+  return <FeatureUnavailable />;
+}
+
+const assistantsEnabled = assistants.enabled; // status is "ready"; boolean
 ```
 
-Add new keys to the hook's `FeatureFlag` union. The hook stays reactive as
-PostHog flags load; on localhost, the development telemetry provider enables
-every flag. Never import PostHog hooks directly.
+Add new frontend keys to the `FEATURE_FLAGS` registry in
+`client/dashboard/src/lib/featureFlags.ts`; its values generate the hook's
+`FeatureFlag` type. The hook distinguishes loading, ready, missing, and error
+states and stays reactive as PostHog reloads flags. On localhost, the
+development telemetry provider reports every flag ready and enabled.
+
+PostHog flags control rollout UI only. Never use them for authorization or
+entitlement enforcement, and never import PostHog hooks directly.
 
 ---
 

--- a/.agents/skills/feature-flag/SKILL.md
+++ b/.agents/skills/feature-flag/SKILL.md
@@ -131,12 +131,18 @@ if err != nil || !enabled {
 
 ### Checking in the React dashboard
 
-Use the `useTelemetry()` hook from `client/dashboard/src/contexts/Telemetry.tsx` — never import PostHog hooks directly:
+New frontend code should use the typed `useFeatureFlag()` hook from
+`client/dashboard/src/hooks/useFeatureFlag.ts`:
 
 ```tsx
-const telemetry = useTelemetry();
-const myFeatureEnabled = telemetry.isFeatureEnabled("my-new-feature") ?? false;
+const rbacEnabled = useFeatureFlag("gram-rbac"); // defaults off while loading
+const deploymentsEnabled = useFeatureFlag("gram-deployments-page", "on");
+const tunneledMcpEnabled = useFeatureFlag("gram-tunneled-mcp", "unresolved"); // boolean | undefined
 ```
+
+Add new keys to the hook's `FeatureFlag` union. The hook stays reactive as
+PostHog flags load; on localhost, the development telemetry provider enables
+every flag. Never import PostHog hooks directly.
 
 ---
 

--- a/.changeset/typed-dashboard-feature-flags.md
+++ b/.changeset/typed-dashboard-feature-flags.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a typed, reactive PostHog feature-flag hook that distinguishes loading, enabled, disabled, missing, and error states. Project navigation now uses the hook as an integration proof while preserving existing opt-in and opt-out behavior.

--- a/.claude/skills/feature-flag/SKILL.md
+++ b/.claude/skills/feature-flag/SKILL.md
@@ -142,14 +142,14 @@ if (assistants.status === "missing" || assistants.status === "error") {
   return <FeatureUnavailable />;
 }
 
-const assistantsEnabled = assistants.enabled; // status is "ready"; boolean
+const assistantsEnabled = assistants.status === "enabled";
 ```
 
 Add new frontend keys to the `FEATURE_FLAGS` registry in
 `client/dashboard/src/lib/featureFlags.ts`; its values generate the hook's
-`FeatureFlag` type. The hook distinguishes loading, ready, missing, and error
-states and stays reactive as PostHog reloads flags. On localhost, the
-development telemetry provider reports every flag ready and enabled.
+`FeatureFlag` type. The hook distinguishes loading, enabled, disabled, missing,
+and error states and stays reactive as PostHog reloads flags. On localhost,
+the development telemetry provider reports every flag as enabled.
 
 PostHog flags control rollout UI only. Never use them for authorization or
 entitlement enforcement, and never import PostHog hooks directly.

--- a/.claude/skills/feature-flag/SKILL.md
+++ b/.claude/skills/feature-flag/SKILL.md
@@ -135,14 +135,24 @@ New frontend code should use the typed `useFeatureFlag()` hook from
 `client/dashboard/src/hooks/useFeatureFlag.ts`:
 
 ```tsx
-const rbacEnabled = useFeatureFlag("gram-rbac"); // defaults off while loading
-const deploymentsEnabled = useFeatureFlag("gram-deployments-page", "on");
-const tunneledMcpEnabled = useFeatureFlag("gram-tunneled-mcp", "unresolved"); // boolean | undefined
+const assistants = useFeatureFlag(FEATURE_FLAGS.assistants);
+
+if (assistants.status === "loading") return null;
+if (assistants.status === "missing" || assistants.status === "error") {
+  return <FeatureUnavailable />;
+}
+
+const assistantsEnabled = assistants.enabled; // status is "ready"; boolean
 ```
 
-Add new keys to the hook's `FeatureFlag` union. The hook stays reactive as
-PostHog flags load; on localhost, the development telemetry provider enables
-every flag. Never import PostHog hooks directly.
+Add new frontend keys to the `FEATURE_FLAGS` registry in
+`client/dashboard/src/lib/featureFlags.ts`; its values generate the hook's
+`FeatureFlag` type. The hook distinguishes loading, ready, missing, and error
+states and stays reactive as PostHog reloads flags. On localhost, the
+development telemetry provider reports every flag ready and enabled.
+
+PostHog flags control rollout UI only. Never use them for authorization or
+entitlement enforcement, and never import PostHog hooks directly.
 
 ---
 

--- a/.claude/skills/feature-flag/SKILL.md
+++ b/.claude/skills/feature-flag/SKILL.md
@@ -131,12 +131,18 @@ if err != nil || !enabled {
 
 ### Checking in the React dashboard
 
-Use the `useTelemetry()` hook from `client/dashboard/src/contexts/Telemetry.tsx` — never import PostHog hooks directly:
+New frontend code should use the typed `useFeatureFlag()` hook from
+`client/dashboard/src/hooks/useFeatureFlag.ts`:
 
 ```tsx
-const telemetry = useTelemetry();
-const myFeatureEnabled = telemetry.isFeatureEnabled("my-new-feature") ?? false;
+const rbacEnabled = useFeatureFlag("gram-rbac"); // defaults off while loading
+const deploymentsEnabled = useFeatureFlag("gram-deployments-page", "on");
+const tunneledMcpEnabled = useFeatureFlag("gram-tunneled-mcp", "unresolved"); // boolean | undefined
 ```
+
+Add new keys to the hook's `FeatureFlag` union. The hook stays reactive as
+PostHog flags load; on localhost, the development telemetry provider enables
+every flag. Never import PostHog hooks directly.
 
 ---
 

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -21,14 +21,12 @@ import { SidebarFooterAction } from "./sidebar-footer-action";
 import { SidebarUserMenu } from "./sidebar-user-menu";
 import { useSidebar } from "@/components/ui/Sidebar/sidebar-context";
 import { useSlugs } from "@/contexts/Sdk";
-import { useTelemetry } from "@/contexts/Telemetry";
 import { useRBAC } from "@/hooks/useRBAC";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { SidebarNavSkeleton } from "./sidebar-nav-skeleton";
 import { useProductTier } from "@/hooks/useProductTier";
 import { useProjectNavRoutes } from "@/hooks/useProjectNavRoutes";
 import type { ProjectNavRoute } from "@/hooks/useProjectNavRoutes";
-import { useOrgMemoryDeveloperToggle } from "@/hooks/useOrgMemoryDeveloperToggle";
 import { AppRoute, useOrgRoutes, useRoutes } from "@/routes";
 import { useGetPeriodUsage } from "@gram/client/react-query/getPeriodUsage.js";
 import { Icon } from "@/components/ui/Icon";
@@ -76,14 +74,19 @@ export function AppSidebar({
   // While grants reload (e.g. right after switching projects, when the query
   // cache is cleared), show a skeleton so the scope-gated nav doesn't flash empty.
   const { isLoading: rbacLoading } = useRBAC();
-  const telemetry = useTelemetry();
-  const [isOrgMemoryEnabled] = useOrgMemoryDeveloperToggle();
   const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
 
-  const isAssistantsEnabled = telemetry.isFeatureEnabled("assistants") ?? false;
-  // Default true: opt-out via PostHog org-group targeting on `gram-deployments-page`.
-  const isDeploymentsPageEnabled =
-    telemetry.isFeatureEnabled("gram-deployments-page") ?? true;
+  // useProjectNavRoutes owns feature-flag and scope decisions for both the
+  // sidebar and command palette so the two surfaces cannot drift.
+  const allNavRoutes = useProjectNavRoutes();
+  const navAccess = useMemo(() => {
+    const map = new Map<string, ProjectNavRoute>();
+    for (const entry of allNavRoutes) map.set(entry.route.url, entry);
+    return map;
+  }, [allNavRoutes]);
+  const isAssistantsEnabled = navAccess.has(routes.assistants.url);
+  const isOrgMemoryEnabled = navAccess.has(routes.orgMemory.url);
+  const isDeploymentsPageEnabled = navAccess.has(routes.deployments.url);
 
   const connectActive = [
     routes.sources,
@@ -131,15 +134,7 @@ export function AppSidebar({
 
   // Find the specific active route title for the sliding highlight. Shared with
   // the command palette via useProjectNavRoutes so the two stay in sync.
-  const allNavRoutes = useProjectNavRoutes();
   const activeRoute = allNavRoutes.find((entry) => entry.route.active)?.route;
-  // Single source of truth for per-page scopes, shared with the command palette
-  // via useProjectNavRoutes so nav visibility and palette visibility can't drift.
-  const navAccess = useMemo(() => {
-    const map = new Map<string, ProjectNavRoute>();
-    for (const entry of allNavRoutes) map.set(entry.route.url, entry);
-    return map;
-  }, [allNavRoutes]);
   const accessFor = (
     route: AppRoute,
   ): Pick<ProjectNavRoute, "scope" | "resourceId"> => {

--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -1,5 +1,12 @@
 import type { PostHog } from "posthog-js";
-import { createContext, useContext, useEffect, useReducer } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+} from "react";
+import type { ReactNode } from "react";
 import type { User } from "./Auth";
 
 export type Telemetry = Pick<
@@ -56,9 +63,82 @@ export const testTelemetry: Telemetry = {
   },
 };
 
-export const TelemetryContext = createContext<Telemetry>(
-  import.meta.env.DEV ? devTelemetry : nullTelemetry,
-);
+export type FeatureFlagsStatus = "loading" | "ready" | "error";
+
+export type FeatureFlagsSnapshot = {
+  status: FeatureFlagsStatus;
+  revision: number;
+};
+
+export type TelemetryContextValue = {
+  telemetry: Telemetry;
+  featureFlags: FeatureFlagsSnapshot;
+};
+
+const defaultTelemetry = import.meta.env.DEV ? devTelemetry : nullTelemetry;
+
+export const TelemetryContext = createContext<TelemetryContextValue>({
+  telemetry: defaultTelemetry,
+  featureFlags: { status: "ready", revision: 0 },
+});
+
+function updateFeatureFlags(
+  current: FeatureFlagsSnapshot,
+  errorsLoading: boolean,
+): FeatureFlagsSnapshot {
+  return {
+    status: errorsLoading ? "error" : "ready",
+    revision: current.revision + 1,
+  };
+}
+
+/**
+ * Owns the single PostHog feature-flag subscription for the dashboard.
+ *
+ * Updating the context snapshot re-renders existing `useTelemetry` consumers
+ * as well as the typed feature-flag hook, without registering one PostHog
+ * listener per consumer.
+ */
+export function TelemetryStateProvider({
+  children,
+  telemetry,
+  featureFlagsInitiallyAvailable = false,
+}: {
+  children: ReactNode;
+  telemetry: Telemetry;
+  featureFlagsInitiallyAvailable?: boolean;
+}): JSX.Element {
+  const [featureFlags, onFlagsChanged] = useReducer(
+    updateFeatureFlags,
+    featureFlagsInitiallyAvailable
+      ? { status: "ready", revision: 0 }
+      : { status: "loading", revision: 0 },
+  );
+
+  useEffect(() => {
+    if (featureFlagsInitiallyAvailable) {
+      return undefined;
+    }
+
+    return telemetry.onFeatureFlags((_flags, _variants, context) => {
+      onFlagsChanged(context?.errorsLoading === true);
+    });
+  }, [featureFlagsInitiallyAvailable, telemetry]);
+
+  const value = useMemo<TelemetryContextValue>(
+    () => ({ telemetry, featureFlags }),
+    [featureFlags, telemetry],
+  );
+
+  return (
+    <TelemetryContext.Provider value={value}>
+      {children}
+    </TelemetryContext.Provider>
+  );
+}
+
+export const useTelemetryContext = (): TelemetryContextValue =>
+  useContext(TelemetryContext);
 
 /**
  * Access telemetry, re-rendering the consumer when PostHog feature flags
@@ -69,23 +149,10 @@ export const TelemetryContext = createContext<Telemetry>(
  * on `group()`/`identify()`), so a component that reads a flag during render
  * would otherwise be stuck on the pre-load value — most notably opt-in gates
  * (`?? false`) staying hidden forever even once the flag turns on. Subscribing
- * to `onFeatureFlags` here makes every `isFeatureEnabled` call site reactive,
- * so there's a single way to read a flag and it just works.
+ * at the context provider makes every `isFeatureEnabled` call site reactive,
+ * so there is one PostHog listener and a single way to read a flag.
  */
-export const useTelemetry = (): Telemetry => {
-  const telemetry = useContext(TelemetryContext);
-  const [, onFlagsChanged] = useReducer((version: number) => version + 1, 0);
-
-  useEffect(() => {
-    // onFeatureFlags fires once flags are loaded (immediately if already
-    // loaded when we subscribe) and again on any reload. Returns an
-    // unsubscribe fn. Bumping local state re-renders this consumer so its
-    // isFeatureEnabled reads re-evaluate against the latest flags.
-    return telemetry.onFeatureFlags(() => onFlagsChanged());
-  }, [telemetry]);
-
-  return telemetry;
-};
+export const useTelemetry = (): Telemetry => useTelemetryContext().telemetry;
 
 export function useIdentifyUserForTelemetry(user: User | undefined): void {
   const telemetry = useTelemetry();

--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -63,9 +63,9 @@ export const testTelemetry: Telemetry = {
   },
 };
 
-export type FeatureFlagsStatus = "loading" | "ready" | "error";
+type FeatureFlagsStatus = "loading" | "ready" | "error";
 
-export type FeatureFlagsSnapshot = {
+type FeatureFlagsSnapshot = {
   status: FeatureFlagsStatus;
   revision: number;
 };
@@ -77,7 +77,7 @@ export type TelemetryContextValue = {
 
 const defaultTelemetry = import.meta.env.DEV ? devTelemetry : nullTelemetry;
 
-export const TelemetryContext = createContext<TelemetryContextValue>({
+const TelemetryContext = createContext<TelemetryContextValue>({
   telemetry: defaultTelemetry,
   featureFlags: { status: "ready", revision: 0 },
 });

--- a/client/dashboard/src/contexts/TelemetryProvider.tsx
+++ b/client/dashboard/src/contexts/TelemetryProvider.tsx
@@ -3,7 +3,7 @@ import posthog from "posthog-js";
 import { type ReactNode, useEffect } from "react";
 import { datadogRum } from "@datadog/browser-rum";
 import {
-  TelemetryContext,
+  TelemetryStateProvider,
   nullTelemetry,
   testTelemetry,
   devTelemetry,
@@ -80,8 +80,11 @@ export const TelemetryProvider = (props: {
   }
 
   return (
-    <TelemetryContext.Provider value={value}>
+    <TelemetryStateProvider
+      telemetry={value}
+      featureFlagsInitiallyAvailable={value !== ph}
+    >
       {props.children}
-    </TelemetryContext.Provider>
+    </TelemetryStateProvider>
   );
 };

--- a/client/dashboard/src/hooks/useFeatureFlag.test.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { useFeatureFlag } from "./useFeatureFlag";
+
+const testState = vi.hoisted(() => ({
+  flagValue: undefined as boolean | undefined,
+  lastFlag: undefined as string | undefined,
+}));
+
+vi.mock("@/contexts/Telemetry", () => ({
+  useTelemetry: () => ({
+    isFeatureEnabled: (flag: string) => {
+      testState.lastFlag = flag;
+      return testState.flagValue;
+    },
+  }),
+}));
+
+afterEach(() => {
+  testState.flagValue = undefined;
+  testState.lastFlag = undefined;
+});
+
+describe("useFeatureFlag", () => {
+  it("treats an unresolved flag as off in off mode", () => {
+    const { result } = renderHook(() => useFeatureFlag("gram-rbac", "off"));
+
+    expect(result.current).toBe(false);
+    expect(testState.lastFlag).toBe("gram-rbac");
+  });
+
+  it("defaults to off mode", () => {
+    const { result } = renderHook(() => useFeatureFlag("gram-rbac"));
+
+    expect(result.current).toBe(false);
+  });
+
+  it("treats an unresolved flag as on in on mode", () => {
+    const { result } = renderHook(() => useFeatureFlag("gram-rbac", "on"));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("preserves an unresolved flag in unresolved mode", () => {
+    const { result } = renderHook(() =>
+      useFeatureFlag("gram-rbac", "unresolved"),
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it.each([true, false])(
+    "returns the resolved value %s regardless of loading mode",
+    (flagValue) => {
+      testState.flagValue = flagValue;
+
+      const { result } = renderHook(() =>
+        useFeatureFlag("gram-rbac", "unresolved"),
+      );
+
+      expect(result.current).toBe(flagValue);
+    },
+  );
+
+  it("exposes mode-specific return types", () => {
+    const off = () => useFeatureFlag("gram-rbac", "off");
+    const unresolved = () => useFeatureFlag("gram-rbac", "unresolved");
+
+    expectTypeOf(off).returns.toEqualTypeOf<boolean>();
+    expectTypeOf(unresolved).returns.toEqualTypeOf<boolean | undefined>();
+  });
+});

--- a/client/dashboard/src/hooks/useFeatureFlag.test.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.test.ts
@@ -1,78 +1,154 @@
-import { renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  nullTelemetry,
+  TelemetryStateProvider,
+  type Telemetry,
+} from "@/contexts/Telemetry";
 import { useFeatureFlag } from "./useFeatureFlag";
 
-const testState = vi.hoisted(() => ({
-  flagValue: undefined as boolean | undefined,
-  lastFlag: undefined as string | undefined,
-}));
+type FeatureFlagsCallback = Parameters<Telemetry["onFeatureFlags"]>[0];
+type FeatureFlagOptions = Parameters<Telemetry["isFeatureEnabled"]>[1];
 
-vi.mock("@/contexts/Telemetry", () => ({
-  useTelemetry: () => ({
-    isFeatureEnabled: (flag: string) => {
-      testState.lastFlag = flag;
-      return testState.flagValue;
+function renderFeatureFlag({
+  initiallyAvailable = false,
+  initialValue,
+}: {
+  initiallyAvailable?: boolean;
+  initialValue?: boolean;
+} = {}) {
+  let flagValue = initialValue;
+  let featureFlagsCallback: FeatureFlagsCallback | undefined;
+  const unsubscribe = vi.fn();
+  const isFeatureEnabled = vi.fn(
+    (_flag: string, _options?: FeatureFlagOptions) => flagValue,
+  );
+  const onFeatureFlags = vi.fn((callback: FeatureFlagsCallback) => {
+    featureFlagsCallback = callback;
+    return unsubscribe;
+  });
+  const telemetry: Telemetry = {
+    ...nullTelemetry,
+    isFeatureEnabled,
+    onFeatureFlags,
+  };
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      TelemetryStateProvider,
+      {
+        telemetry,
+        featureFlagsInitiallyAvailable: initiallyAvailable,
+      },
+      children,
+    );
+  }
+
+  const hook = renderHook(() => useFeatureFlag("gram-rbac"), {
+    wrapper: Wrapper,
+  });
+
+  return {
+    ...hook,
+    isFeatureEnabled,
+    onFeatureFlags,
+    unsubscribe,
+    emitFlagResult(value: boolean | undefined) {
+      act(() => {
+        flagValue = value;
+        featureFlagsCallback?.([], {}, { errorsLoading: false });
+      });
     },
-  }),
-}));
-
-afterEach(() => {
-  testState.flagValue = undefined;
-  testState.lastFlag = undefined;
-});
+    emitFlagError() {
+      act(() => {
+        featureFlagsCallback?.([], {}, { errorsLoading: true });
+      });
+    },
+  };
+}
 
 describe("useFeatureFlag", () => {
-  it("treats an unresolved flag as off in off mode", () => {
-    const { result } = renderHook(() => useFeatureFlag("gram-rbac", "off"));
+  it("reports loading before PostHog provides flags", () => {
+    const { result, isFeatureEnabled, onFeatureFlags } = renderFeatureFlag();
 
-    expect(result.current).toBe(false);
-    expect(testState.lastFlag).toBe("gram-rbac");
+    expect(result.current).toEqual({
+      status: "loading",
+      enabled: undefined,
+    });
+    expect(isFeatureEnabled).not.toHaveBeenCalled();
+    expect(onFeatureFlags).toHaveBeenCalledOnce();
   });
 
-  it("defaults to off mode", () => {
-    const { result } = renderHook(() => useFeatureFlag("gram-rbac"));
+  it("reports a fresh enabled value after flags load", () => {
+    const { result, emitFlagResult, isFeatureEnabled } = renderFeatureFlag();
 
-    expect(result.current).toBe(false);
+    emitFlagResult(true);
+
+    expect(result.current).toEqual({ status: "ready", enabled: true });
+    expect(isFeatureEnabled).toHaveBeenCalledWith("gram-rbac", {
+      fresh: true,
+    });
   });
 
-  it("treats an unresolved flag as on in on mode", () => {
-    const { result } = renderHook(() => useFeatureFlag("gram-rbac", "on"));
+  it("reports a fresh disabled value after flags load", () => {
+    const { result, emitFlagResult } = renderFeatureFlag();
 
-    expect(result.current).toBe(true);
+    emitFlagResult(false);
+
+    expect(result.current).toEqual({ status: "ready", enabled: false });
   });
 
-  it("preserves an unresolved flag in unresolved mode", () => {
-    const { result } = renderHook(() =>
-      useFeatureFlag("gram-rbac", "unresolved"),
-    );
+  it("distinguishes a missing flag from loading", () => {
+    const { result, emitFlagResult } = renderFeatureFlag();
 
-    expect(result.current).toBeUndefined();
+    emitFlagResult(undefined);
+
+    expect(result.current).toEqual({
+      status: "missing",
+      enabled: undefined,
+    });
   });
 
-  it.each([true, false])(
-    "returns the resolved value %s regardless of loading mode",
-    (flagValue) => {
-      testState.flagValue = flagValue;
+  it("reports flag loading errors without using a cached value", () => {
+    const { result, emitFlagError, isFeatureEnabled } = renderFeatureFlag({
+      initialValue: true,
+    });
 
-      const { result } = renderHook(() =>
-        useFeatureFlag("gram-rbac", "unresolved"),
-      );
+    emitFlagError();
 
-      expect(result.current).toBe(flagValue);
-    },
-  );
+    expect(result.current).toEqual({
+      status: "error",
+      enabled: undefined,
+    });
+    expect(isFeatureEnabled).not.toHaveBeenCalled();
+  });
 
-  it("exposes mode-specific return types", () => {
-    function useOffResult() {
-      return useFeatureFlag("gram-rbac", "off");
-    }
-    function useUnresolvedResult() {
-      return useFeatureFlag("gram-rbac", "unresolved");
-    }
+  it("reacts when PostHog reloads a flag", () => {
+    const { result, emitFlagResult } = renderFeatureFlag();
 
-    expectTypeOf(useOffResult).returns.toEqualTypeOf<boolean>();
-    expectTypeOf(useUnresolvedResult).returns.toEqualTypeOf<
-      boolean | undefined
-    >();
+    emitFlagResult(true);
+    expect(result.current).toEqual({ status: "ready", enabled: true });
+
+    emitFlagResult(false);
+    expect(result.current).toEqual({ status: "ready", enabled: false });
+  });
+
+  it("uses deterministic telemetry providers without subscribing", () => {
+    const { result, onFeatureFlags } = renderFeatureFlag({
+      initiallyAvailable: true,
+      initialValue: true,
+    });
+
+    expect(result.current).toEqual({ status: "ready", enabled: true });
+    expect(onFeatureFlags).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes the shared listener when the provider unmounts", () => {
+    const { unmount, unsubscribe } = renderFeatureFlag();
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 });

--- a/client/dashboard/src/hooks/useFeatureFlag.test.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.test.ts
@@ -40,8 +40,8 @@ function renderFeatureFlag({
       {
         telemetry,
         featureFlagsInitiallyAvailable: initiallyAvailable,
+        children,
       },
-      children,
     );
   }
 
@@ -54,13 +54,13 @@ function renderFeatureFlag({
     isFeatureEnabled,
     onFeatureFlags,
     unsubscribe,
-    emitFlagResult(value: boolean | undefined) {
+    emitFlagResult: (value: boolean | undefined) => {
       act(() => {
         flagValue = value;
         featureFlagsCallback?.([], {}, { errorsLoading: false });
       });
     },
-    emitFlagError() {
+    emitFlagError: () => {
       act(() => {
         featureFlagsCallback?.([], {}, { errorsLoading: true });
       });

--- a/client/dashboard/src/hooks/useFeatureFlag.test.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.test.ts
@@ -63,10 +63,16 @@ describe("useFeatureFlag", () => {
   );
 
   it("exposes mode-specific return types", () => {
-    const off = () => useFeatureFlag("gram-rbac", "off");
-    const unresolved = () => useFeatureFlag("gram-rbac", "unresolved");
+    function useOffResult() {
+      return useFeatureFlag("gram-rbac", "off");
+    }
+    function useUnresolvedResult() {
+      return useFeatureFlag("gram-rbac", "unresolved");
+    }
 
-    expectTypeOf(off).returns.toEqualTypeOf<boolean>();
-    expectTypeOf(unresolved).returns.toEqualTypeOf<boolean | undefined>();
+    expectTypeOf(useOffResult).returns.toEqualTypeOf<boolean>();
+    expectTypeOf(useUnresolvedResult).returns.toEqualTypeOf<
+      boolean | undefined
+    >();
   });
 });

--- a/client/dashboard/src/hooks/useFeatureFlag.test.tsx
+++ b/client/dashboard/src/hooks/useFeatureFlag.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { createElement, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import {
   nullTelemetry,
@@ -35,13 +35,13 @@ function renderFeatureFlag({
   };
 
   function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(
-      TelemetryStateProvider,
-      {
-        telemetry,
-        featureFlagsInitiallyAvailable: initiallyAvailable,
-        children,
-      },
+    return (
+      <TelemetryStateProvider
+        telemetry={telemetry}
+        featureFlagsInitiallyAvailable={initiallyAvailable}
+      >
+        {children}
+      </TelemetryStateProvider>
     );
   }
 

--- a/client/dashboard/src/hooks/useFeatureFlag.test.tsx
+++ b/client/dashboard/src/hooks/useFeatureFlag.test.tsx
@@ -74,7 +74,6 @@ describe("useFeatureFlag", () => {
 
     expect(result.current).toEqual({
       status: "loading",
-      enabled: undefined,
     });
     expect(isFeatureEnabled).not.toHaveBeenCalled();
     expect(onFeatureFlags).toHaveBeenCalledOnce();
@@ -85,7 +84,7 @@ describe("useFeatureFlag", () => {
 
     emitFlagResult(true);
 
-    expect(result.current).toEqual({ status: "ready", enabled: true });
+    expect(result.current).toEqual({ status: "enabled" });
     expect(isFeatureEnabled).toHaveBeenCalledWith("gram-rbac", {
       fresh: true,
     });
@@ -96,7 +95,7 @@ describe("useFeatureFlag", () => {
 
     emitFlagResult(false);
 
-    expect(result.current).toEqual({ status: "ready", enabled: false });
+    expect(result.current).toEqual({ status: "disabled" });
   });
 
   it("distinguishes a missing flag from loading", () => {
@@ -106,7 +105,6 @@ describe("useFeatureFlag", () => {
 
     expect(result.current).toEqual({
       status: "missing",
-      enabled: undefined,
     });
   });
 
@@ -119,7 +117,6 @@ describe("useFeatureFlag", () => {
 
     expect(result.current).toEqual({
       status: "error",
-      enabled: undefined,
     });
     expect(isFeatureEnabled).not.toHaveBeenCalled();
   });
@@ -128,10 +125,10 @@ describe("useFeatureFlag", () => {
     const { result, emitFlagResult } = renderFeatureFlag();
 
     emitFlagResult(true);
-    expect(result.current).toEqual({ status: "ready", enabled: true });
+    expect(result.current).toEqual({ status: "enabled" });
 
     emitFlagResult(false);
-    expect(result.current).toEqual({ status: "ready", enabled: false });
+    expect(result.current).toEqual({ status: "disabled" });
   });
 
   it("uses deterministic telemetry providers without subscribing", () => {
@@ -140,7 +137,7 @@ describe("useFeatureFlag", () => {
       initialValue: true,
     });
 
-    expect(result.current).toEqual({ status: "ready", enabled: true });
+    expect(result.current).toEqual({ status: "enabled" });
     expect(onFeatureFlags).not.toHaveBeenCalled();
   });
 

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -19,12 +19,20 @@ export type FeatureFlag =
 type WhileLoading = "off" | "on" | "unresolved";
 
 /**
- * Read a typed PostHog feature flag and explicitly choose its loading behavior.
+ * Read a typed PostHog feature flag.
  *
- * The default `"off"` mode is appropriate for opt-in gates. Use `"on"` for
- * kill switches, or `"unresolved"` when the caller needs to handle loading
- * separately. The underlying telemetry hook re-renders when PostHog resolves
- * or reloads flags.
+ * Once PostHog resolves the flag, this hook always returns its actual boolean
+ * value. `whileLoading` controls only the value returned before then:
+ *
+ * - `"off"` (default) returns `false`, hiding an opt-in feature until PostHog
+ *   confirms that it is enabled.
+ * - `"on"` returns `true`, keeping a kill-switched feature visible unless
+ *   PostHog confirms that it is disabled.
+ * - `"unresolved"` returns `undefined`, allowing the caller to distinguish
+ *   loading from an enabled or disabled flag and render its own loading state.
+ *
+ * The underlying telemetry hook re-renders when PostHog resolves or reloads
+ * flags.
  *
  * In local development, the telemetry provider enables every feature flag.
  */

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,61 @@
+import { useTelemetry } from "@/contexts/Telemetry";
+
+export type FeatureFlag =
+  | "gram-rbac"
+  | "gram-device-agent"
+  | "gram-device-integrations"
+  | "org-memory"
+  | "assistants"
+  | "gram-functions"
+  | "gram-tunneled-mcp"
+  | "user-sessions-dashboard"
+  | "gram-deployments-page"
+  | "gram-budgets"
+  | "gram-new-costs-page"
+  | "gram-prompt-policies"
+  | "gram-experimental-chat"
+  | "onboard-external-mcp-to-user-sessions";
+
+type WhileLoading = "off" | "on" | "unresolved";
+
+/**
+ * Read a typed PostHog feature flag and explicitly choose its loading behavior.
+ *
+ * The default `"off"` mode is appropriate for opt-in gates. Use `"on"` for
+ * kill switches, or `"unresolved"` when the caller needs to handle loading
+ * separately. The underlying telemetry hook re-renders when PostHog resolves
+ * or reloads flags.
+ *
+ * In local development, the telemetry provider enables every feature flag.
+ */
+export function useFeatureFlag(
+  flag: FeatureFlag,
+  whileLoading: "unresolved",
+): boolean | undefined;
+export function useFeatureFlag(
+  flag: FeatureFlag,
+  whileLoading?: "off" | "on",
+): boolean;
+export function useFeatureFlag(
+  flag: FeatureFlag,
+  whileLoading: WhileLoading,
+): boolean | undefined;
+export function useFeatureFlag(
+  flag: FeatureFlag,
+  whileLoading: WhileLoading = "off",
+): boolean | undefined {
+  const enabled = useTelemetry().isFeatureEnabled(flag);
+
+  if (enabled !== undefined) {
+    return enabled;
+  }
+
+  switch (whileLoading) {
+    case "off":
+      return false;
+    case "on":
+      return true;
+    case "unresolved":
+      return undefined;
+  }
+}

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -4,18 +4,19 @@ import type { FeatureFlag } from "@/lib/featureFlags";
 export type { FeatureFlag } from "@/lib/featureFlags";
 
 export type FeatureFlagResult =
-  | {
-      status: "loading" | "missing" | "error";
-      enabled: undefined;
-    }
-  | {
-      status: "ready";
-      enabled: boolean;
-    };
+  | { status: "loading" }
+  | { status: "enabled" }
+  | { status: "disabled" }
+  | { status: "missing" }
+  | { status: "error" };
 
-const LOADING_RESULT = { status: "loading", enabled: undefined } as const;
-const MISSING_RESULT = { status: "missing", enabled: undefined } as const;
-const ERROR_RESULT = { status: "error", enabled: undefined } as const;
+export type FeatureFlagStatus = FeatureFlagResult["status"];
+
+const LOADING_RESULT = { status: "loading" } as const;
+const ENABLED_RESULT = { status: "enabled" } as const;
+const DISABLED_RESULT = { status: "disabled" } as const;
+const MISSING_RESULT = { status: "missing" } as const;
+const ERROR_RESULT = { status: "error" } as const;
 
 function assertNever(value: never): never {
   throw new Error(`Unhandled feature flag status: ${String(value)}`);
@@ -28,14 +29,15 @@ function assertNever(value: never): never {
  * The result makes each state explicit:
  *
  * - `"loading"`: PostHog has not completed its first flag request.
- * - `"ready"`: `enabled` contains the fresh boolean value from PostHog.
+ * - `"enabled"`: PostHog resolved the flag to enabled.
+ * - `"disabled"`: PostHog resolved the flag to disabled.
  * - `"missing"`: flags loaded successfully, but PostHog has no value for this
  *   registered key. Treat this as a configuration error rather than as off.
  * - `"error"`: PostHog reported that its flag request failed.
  *
- * Local development uses a deterministic provider where every flag is ready
- * and enabled. PostHog flags are rollout controls only; never use them as
- * authorization checks or entitlement enforcement.
+ * Local development uses a deterministic provider where every flag is
+ * immediately enabled. PostHog flags are rollout controls only; never use them
+ * as authorization checks or entitlement enforcement.
  */
 export function useFeatureFlag(flag: FeatureFlag): FeatureFlagResult {
   const { telemetry, featureFlags } = useTelemetryContext();
@@ -52,7 +54,7 @@ export function useFeatureFlag(flag: FeatureFlag): FeatureFlagResult {
         return MISSING_RESULT;
       }
 
-      return { status: "ready", enabled };
+      return enabled ? ENABLED_RESULT : DISABLED_RESULT;
     }
     default:
       return assertNever(status);

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -1,75 +1,60 @@
-import { useTelemetry } from "@/contexts/Telemetry";
+import { useTelemetryContext } from "@/contexts/Telemetry";
+import type { FeatureFlag } from "@/lib/featureFlags";
 
-export type FeatureFlag =
-  | "gram-rbac"
-  | "gram-device-agent"
-  | "gram-device-integrations"
-  | "org-memory"
-  | "assistants"
-  | "gram-functions"
-  | "gram-tunneled-mcp"
-  | "user-sessions-dashboard"
-  | "gram-deployments-page"
-  | "gram-budgets"
-  | "gram-new-costs-page"
-  | "gram-prompt-policies"
-  | "gram-experimental-chat"
-  | "onboard-external-mcp-to-user-sessions";
+export type { FeatureFlag } from "@/lib/featureFlags";
 
-type WhileLoading = "off" | "on" | "unresolved";
+export type FeatureFlagResult =
+  | {
+      status: "loading" | "missing" | "error";
+      enabled: undefined;
+    }
+  | {
+      status: "ready";
+      enabled: boolean;
+    };
+
+const LOADING_RESULT = { status: "loading", enabled: undefined } as const;
+const MISSING_RESULT = { status: "missing", enabled: undefined } as const;
+const ERROR_RESULT = { status: "error", enabled: undefined } as const;
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled feature flag status: ${String(value)}`);
+}
 
 /**
- * Read a typed PostHog feature flag.
+ * Read a typed PostHog feature flag without guessing when its value is
+ * unavailable.
  *
- * PostHog returns `undefined` while flags are loading, then `true` or `false`
- * once the requested flag has resolved. `whileLoading` does not affect the
- * flag itself; it selects the temporary value this hook returns in place of
- * that initial `undefined`:
+ * The result makes each state explicit:
  *
- * - `"off"` (default) temporarily returns `false`. Use it for new or opt-in
- *   features that must remain hidden until PostHog explicitly enables them.
- *   The feature may briefly appear hidden while the flag loads.
- * - `"on"` temporarily returns `true`. Use it when the flag is a rollback
- *   switch for an established feature that should remain visible unless
- *   PostHog explicitly disables it. The feature may briefly appear visible
- *   while the flag loads.
- * - `"unresolved"` preserves `undefined`. Use it when showing either enabled
- *   or disabled UI before the flag loads would be incorrect. The caller must
- *   handle `undefined`, typically by rendering a placeholder or nothing.
+ * - `"loading"`: PostHog has not completed its first flag request.
+ * - `"ready"`: `enabled` contains the fresh boolean value from PostHog.
+ * - `"missing"`: flags loaded successfully, but PostHog has no value for this
+ *   registered key. Treat this as a configuration error rather than as off.
+ * - `"error"`: PostHog reported that its flag request failed.
  *
- * After the flag resolves, all modes return its actual boolean value. The
- * underlying telemetry hook re-renders when PostHog resolves or reloads flags.
- *
- * In local development, the telemetry provider enables every feature flag.
+ * Local development uses a deterministic provider where every flag is ready
+ * and enabled. PostHog flags are rollout controls only; never use them as
+ * authorization checks or entitlement enforcement.
  */
-export function useFeatureFlag(
-  flag: FeatureFlag,
-  whileLoading: "unresolved",
-): boolean | undefined;
-export function useFeatureFlag(
-  flag: FeatureFlag,
-  whileLoading?: "off" | "on",
-): boolean;
-export function useFeatureFlag(
-  flag: FeatureFlag,
-  whileLoading: WhileLoading,
-): boolean | undefined;
-export function useFeatureFlag(
-  flag: FeatureFlag,
-  whileLoading: WhileLoading = "off",
-): boolean | undefined {
-  const enabled = useTelemetry().isFeatureEnabled(flag);
+export function useFeatureFlag(flag: FeatureFlag): FeatureFlagResult {
+  const { telemetry, featureFlags } = useTelemetryContext();
+  const status = featureFlags.status;
 
-  if (enabled !== undefined) {
-    return enabled;
-  }
+  switch (status) {
+    case "loading":
+      return LOADING_RESULT;
+    case "error":
+      return ERROR_RESULT;
+    case "ready": {
+      const enabled = telemetry.isFeatureEnabled(flag, { fresh: true });
+      if (enabled === undefined) {
+        return MISSING_RESULT;
+      }
 
-  switch (whileLoading) {
-    case "off":
-      return false;
-    case "on":
-      return true;
-    case "unresolved":
-      return undefined;
+      return { status: "ready", enabled };
+    }
+    default:
+      return assertNever(status);
   }
 }

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -10,8 +10,6 @@ export type FeatureFlagResult =
   | { status: "missing" }
   | { status: "error" };
 
-export type FeatureFlagStatus = FeatureFlagResult["status"];
-
 const LOADING_RESULT = { status: "loading" } as const;
 const ENABLED_RESULT = { status: "enabled" } as const;
 const DISABLED_RESULT = { status: "disabled" } as const;

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -21,18 +21,24 @@ type WhileLoading = "off" | "on" | "unresolved";
 /**
  * Read a typed PostHog feature flag.
  *
- * Once PostHog resolves the flag, this hook always returns its actual boolean
- * value. `whileLoading` controls only the value returned before then:
+ * PostHog returns `undefined` while flags are loading, then `true` or `false`
+ * once the requested flag has resolved. `whileLoading` does not affect the
+ * flag itself; it selects the temporary value this hook returns in place of
+ * that initial `undefined`:
  *
- * - `"off"` (default) returns `false`, hiding an opt-in feature until PostHog
- *   confirms that it is enabled.
- * - `"on"` returns `true`, keeping a kill-switched feature visible unless
- *   PostHog confirms that it is disabled.
- * - `"unresolved"` returns `undefined`, allowing the caller to distinguish
- *   loading from an enabled or disabled flag and render its own loading state.
+ * - `"off"` (default) temporarily returns `false`. Use it for new or opt-in
+ *   features that must remain hidden until PostHog explicitly enables them.
+ *   The feature may briefly appear hidden while the flag loads.
+ * - `"on"` temporarily returns `true`. Use it when the flag is a rollback
+ *   switch for an established feature that should remain visible unless
+ *   PostHog explicitly disables it. The feature may briefly appear visible
+ *   while the flag loads.
+ * - `"unresolved"` preserves `undefined`. Use it when showing either enabled
+ *   or disabled UI before the flag loads would be incorrect. The caller must
+ *   handle `undefined`, typically by rendering a placeholder or nothing.
  *
- * The underlying telemetry hook re-renders when PostHog resolves or reloads
- * flags.
+ * After the flag resolves, all modes return its actual boolean value. The
+ * underlying telemetry hook re-renders when PostHog resolves or reloads flags.
  *
  * In local development, the telemetry provider enables every feature flag.
  */

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -1,5 +1,7 @@
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FeatureFlagResult } from "@/hooks/useFeatureFlag";
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import type { AppRoute } from "@/routes";
 import { useProjectNavRoutes } from "./useProjectNavRoutes";
 
@@ -10,6 +12,7 @@ const testState = vi.hoisted(() => ({
   projectId: "project_a",
   skillsEnabled: false,
   orgMemoryEnabled: false,
+  featureFlags: {} as Record<string, FeatureFlagResult>,
 }));
 
 function route(title: string, url: string): AppRoute {
@@ -56,10 +59,8 @@ vi.mock("@/routes", async () => {
   };
 });
 
-vi.mock("@/contexts/Telemetry", () => ({
-  useTelemetry: () => ({
-    isFeatureEnabled: () => false,
-  }),
+vi.mock("@/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: (flag: string) => testState.featureFlags[flag],
 }));
 
 vi.mock("@/contexts/Auth", () => ({
@@ -80,6 +81,23 @@ vi.mock("@gram/client/react-query/productFeatures.js", () => ({
     return { data: { skillsEnabled: testState.skillsEnabled } };
   },
 }));
+
+function unavailableFeatureFlag(
+  status: "loading" | "missing" | "error",
+): FeatureFlagResult {
+  return { status, enabled: undefined };
+}
+
+beforeEach(() => {
+  testState.productFeatureOptions = undefined;
+  testState.projectId = "project_a";
+  testState.skillsEnabled = false;
+  testState.orgMemoryEnabled = false;
+  testState.featureFlags = {
+    [FEATURE_FLAGS.assistants]: unavailableFeatureFlag("loading"),
+    [FEATURE_FLAGS.deploymentsPage]: unavailableFeatureFlag("loading"),
+  };
+});
 
 describe("useProjectNavRoutes", () => {
   it("uses Shadow MCP as the sidebar destination while leaving Approval Requests out of nav", () => {
@@ -131,5 +149,34 @@ describe("useProjectNavRoutes", () => {
     expect(
       result.current.some((entry) => entry.route === routes.orgMemory),
     ).toBe(true);
+  });
+
+  it.each(["loading", "missing", "error"] as const)(
+    "preserves opt-in and opt-out navigation while flags are %s",
+    (status) => {
+      testState.featureFlags = {
+        [FEATURE_FLAGS.assistants]: unavailableFeatureFlag(status),
+        [FEATURE_FLAGS.deploymentsPage]: unavailableFeatureFlag(status),
+      };
+
+      const { result } = renderHook(() => useProjectNavRoutes());
+      const navRoutes = result.current.map((entry) => entry.route);
+
+      expect(navRoutes).not.toContain(routes.assistants);
+      expect(navRoutes).toContain(routes.deployments);
+    },
+  );
+
+  it("uses resolved values for feature-gated navigation", () => {
+    testState.featureFlags = {
+      [FEATURE_FLAGS.assistants]: { status: "ready", enabled: true },
+      [FEATURE_FLAGS.deploymentsPage]: { status: "ready", enabled: false },
+    };
+
+    const { result } = renderHook(() => useProjectNavRoutes());
+    const navRoutes = result.current.map((entry) => entry.route);
+
+    expect(navRoutes).toContain(routes.assistants);
+    expect(navRoutes).not.toContain(routes.deployments);
   });
 });

--- a/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.test.tsx
@@ -85,7 +85,7 @@ vi.mock("@gram/client/react-query/productFeatures.js", () => ({
 function unavailableFeatureFlag(
   status: "loading" | "missing" | "error",
 ): FeatureFlagResult {
-  return { status, enabled: undefined };
+  return { status };
 }
 
 beforeEach(() => {
@@ -169,8 +169,8 @@ describe("useProjectNavRoutes", () => {
 
   it("uses resolved values for feature-gated navigation", () => {
     testState.featureFlags = {
-      [FEATURE_FLAGS.assistants]: { status: "ready", enabled: true },
-      [FEATURE_FLAGS.deploymentsPage]: { status: "ready", enabled: false },
+      [FEATURE_FLAGS.assistants]: { status: "enabled" },
+      [FEATURE_FLAGS.deploymentsPage]: { status: "disabled" },
     };
 
     const { result } = renderHook(() => useProjectNavRoutes());

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -46,12 +46,10 @@ export function useProjectNavRoutes(): ProjectNavRoute[] {
   });
 
   // Assistants is opt-in: unavailable flags remain hidden.
-  const isAssistantsEnabled =
-    assistantsFlag.status === "ready" && assistantsFlag.enabled;
+  const isAssistantsEnabled = assistantsFlag.status === "enabled";
   // Deployments is opt-out: it remains visible unless PostHog explicitly
   // resolves the flag to disabled.
-  const isDeploymentsPageEnabled =
-    deploymentsPageFlag.status !== "ready" || deploymentsPageFlag.enabled;
+  const isDeploymentsPageEnabled = deploymentsPageFlag.status !== "disabled";
   const isSkillsEnabled = productFeatures?.skillsEnabled === true;
 
   return useMemo<ProjectNavRoute[]>(() => {

--- a/client/dashboard/src/hooks/useProjectNavRoutes.ts
+++ b/client/dashboard/src/hooks/useProjectNavRoutes.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useProject } from "@/contexts/Auth";
-import { useTelemetry } from "@/contexts/Telemetry";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { Scope } from "@gram/client/models/components/rolegrant.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 import { AppRoute, useRoutes } from "@/routes";
@@ -36,17 +37,21 @@ export interface ProjectNavRoute {
 export function useProjectNavRoutes(): ProjectNavRoute[] {
   const routes = useRoutes();
   const { id: projectId } = useProject();
-  const telemetry = useTelemetry();
+  const assistantsFlag = useFeatureFlag(FEATURE_FLAGS.assistants);
+  const deploymentsPageFlag = useFeatureFlag(FEATURE_FLAGS.deploymentsPage);
   const [isOrgMemoryEnabled] = useOrgMemoryDeveloperToggle();
   const { data: productFeatures } = useProductFeatures(undefined, undefined, {
     staleTime: 30_000,
     throwOnError: false,
   });
 
-  const isAssistantsEnabled = telemetry.isFeatureEnabled("assistants") ?? false;
-  // Default true: opt-out via PostHog org-group targeting on `gram-deployments-page`.
+  // Assistants is opt-in: unavailable flags remain hidden.
+  const isAssistantsEnabled =
+    assistantsFlag.status === "ready" && assistantsFlag.enabled;
+  // Deployments is opt-out: it remains visible unless PostHog explicitly
+  // resolves the flag to disabled.
   const isDeploymentsPageEnabled =
-    telemetry.isFeatureEnabled("gram-deployments-page") ?? true;
+    deploymentsPageFlag.status !== "ready" || deploymentsPageFlag.enabled;
   const isSkillsEnabled = productFeatures?.skillsEnabled === true;
 
   return useMemo<ProjectNavRoute[]>(() => {

--- a/client/dashboard/src/lib/externalMcpUserSessions.ts
+++ b/client/dashboard/src/lib/externalMcpUserSessions.ts
@@ -1,8 +1,9 @@
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { randomSlugSuffix } from "@/lib/slug";
 import { getServerURL } from "@/lib/utils";
 
 export const ONBOARD_EXTERNAL_MCP_TO_USER_SESSIONS_FLAG =
-  "onboard-external-mcp-to-user-sessions";
+  FEATURE_FLAGS.externalMcpUserSessions;
 
 export const DEFAULT_USER_SESSION_DURATION_HOURS = 24 * 14;
 

--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -1,0 +1,18 @@
+export const FEATURE_FLAGS = {
+  assistants: "assistants",
+  budgets: "gram-budgets",
+  deploymentsPage: "gram-deployments-page",
+  deviceAgent: "gram-device-agent",
+  deviceIntegrations: "gram-device-integrations",
+  experimentalChat: "gram-experimental-chat",
+  externalMcpUserSessions: "onboard-external-mcp-to-user-sessions",
+  functions: "gram-functions",
+  newCostsPage: "gram-new-costs-page",
+  orgMemory: "org-memory",
+  promptPolicies: "gram-prompt-policies",
+  rbac: "gram-rbac",
+  tunneledMcp: "gram-tunneled-mcp",
+  userSessionsDashboard: "user-sessions-dashboard",
+} as const;
+
+export type FeatureFlag = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];

--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -9,7 +9,6 @@ export const FEATURE_FLAGS = {
   externalMcpUserSessions: "onboard-external-mcp-to-user-sessions",
   functions: "gram-functions",
   newCostsPage: "gram-new-costs-page",
-  orgMemory: "org-memory",
   promptPolicies: "gram-prompt-policies",
   rbac: "gram-rbac",
   tunneledMcp: "gram-tunneled-mcp",

--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -4,6 +4,7 @@ export const FEATURE_FLAGS = {
   deploymentsPage: "gram-deployments-page",
   deviceAgent: "gram-device-agent",
   deviceIntegrations: "gram-device-integrations",
+  enterpriseTrials: "enterprise-trials",
   experimentalChat: "gram-experimental-chat",
   externalMcpUserSessions: "onboard-external-mcp-to-user-sessions",
   functions: "gram-functions",

--- a/client/dashboard/src/lib/tunneledMcp.ts
+++ b/client/dashboard/src/lib/tunneledMcp.ts
@@ -1,1 +1,3 @@
-export const TUNNELED_MCP_FEATURE_FLAG = "gram-tunneled-mcp";
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
+
+export const TUNNELED_MCP_FEATURE_FLAG = FEATURE_FLAGS.tunneledMcp;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Give new dashboard code one typed, reactive way to read PostHog flags while distinguishing loading, missing, and failed evaluations from enabled or disabled flags. Existing feature-flag behavior is preserved, with project navigation migrated as a contained integration proof.

- add a typed `useFeatureFlag` dashboard hook backed by a single frontend flag registry, including `enterprise-trials`
- return mutually exclusive `loading`, `enabled`, `disabled`, `missing`, and `error` states, making common checks a single status comparison
- read fresh PostHog values and keep deterministic local/null telemetry behavior explicit
- move flag reactivity to one provider-level subscription shared by all consumers
- migrate `useProjectNavRoutes` to the typed hook and make `AppSidebar` derive visibility from that shared route set, guaranteeing sidebar/command-palette parity
- preserve opt-in behavior for Assistants and Org Memory and opt-out behavior for Deployments across loading, missing, and error states
- derive existing frontend flag constants from the registry and document that PostHog flags are rollout controls, not authorization or entitlements
- add a patch changeset for the dashboard package

## Migration scope

This PR intentionally migrates only project navigation as an integration proof. The remaining raw `isFeatureEnabled` call sites keep their existing behavior and can be migrated in focused follow-ups by feature group.

## Testing
- `pnpm -F dashboard test` (1,197 tests passed)
- `pnpm -F dashboard test src/hooks/useFeatureFlag.test.tsx src/hooks/useProjectNavRoutes.test.tsx` (15 tests passed)
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:format`
- `pnpm -F dashboard lint:oxlint`
- `pnpm -F dashboard knip`
- `pnpm changeset status --since=main` (`dashboard` patch detected)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3079](https://linear.app/speakeasy/issue/AGE-3079/feat-add-usefeatureflag-hook-for-posthog-flags-in-the-dashboard)

<div><a href="https://cursor.com/agents/bc-66610d9c-8504-4b3c-b9cc-0c3d48c52f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66610d9c-8504-4b3c-b9cc-0c3d48c52f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed `useFeatureFlag` hook and a shared `TelemetryStateProvider` to make PostHog flags reactive and explicit, then migrates project navigation and sidebar to use the typed flags. Addresses Linear AGE-3079.

- **New Features**
  - `TelemetryStateProvider` centralizes a single PostHog subscription and exposes `{ telemetry, featureFlags }` with an “initially available” mode for deterministic providers.
  - `useFeatureFlag(flag)` returns `"loading" | "enabled" | "disabled" | "missing" | "error"` using fresh values; reactivity comes from the shared provider snapshot.
  - Central `FEATURE_FLAGS` registry defines keys and the `FeatureFlag` union; added `enterprise-trials` and replaced hardcoded keys in `tunneledMcp` and `externalMcpUserSessions`.
  - `useProjectNavRoutes` gates `assistants` (opt-in) and `gram-deployments-page` (opt-out) via typed flags; `AppSidebar` now derives visibility from these routes for command-palette parity.

- **Migration**
  - Replace `useTelemetry().isFeatureEnabled(...)` with `useFeatureFlag(...)` and handle `"loading" | "enabled" | "disabled" | "missing" | "error"`.
  - Add new flags to `FEATURE_FLAGS`; never import PostHog hooks directly.

<sup>Written for commit 923c9ecfff812f5dc27eaeec6acd652e6551b5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

