### PR TITLE
fix(skills): stop truncating feedback notes in suggestion prompts

### DIFF
--- a/server/internal/platformtools/skills/feedback.go
+++ b/server/internal/platformtools/skills/feedback.go
@@ -39,7 +39,7 @@ type Feedback struct {
 
 func NewAssistantFeedbackTool(db *pgxpool.Pool, recorder *feedbackrecorder.Recorder) *Feedback {
 	readOnly, destructive, idempotent, openWorld := false, false, false, false
-	minSkillLength, maxSkillLength, maxNoteLength := 1, 64, 4000
+	minSkillLength, maxSkillLength, maxNoteLength := 1, 64, domainskills.MaxFeedbackNoteRunes
 	return &Feedback{
 		db:       db,
 		recorder: recorder,
@@ -101,8 +101,8 @@ func (t *Feedback) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload i
 		return oops.E(oops.CodeBadRequest, nil, "skill must be a canonical 1-64 character skill name")
 	case !input.Outcome.Valid():
 		return oops.E(oops.CodeBadRequest, nil, "invalid feedback outcome")
-	case utf8.RuneCountInString(note) > 4000:
-		return oops.E(oops.CodeBadRequest, nil, "feedback note must be at most 4000 Unicode characters")
+	case utf8.RuneCountInString(note) > domainskills.MaxFeedbackNoteRunes:
+		return oops.E(oops.CodeBadRequest, nil, "feedback note must be at most %d Unicode characters", domainskills.MaxFeedbackNoteRunes)
 	}
 
 	principal, ok := contextvalues.GetAssistantPrincipal(ctx)

--- a/server/internal/skills/feedback.go
+++ b/server/internal/skills/feedback.go
@@ -1,5 +1,10 @@
 package skills
 
+// MaxFeedbackNoteRunes caps a feedback note everywhere it is handled: the wire
+// contract, ingest validation, and the suggestion prompt all admit the full
+// note so recorded evidence is never silently truncated downstream.
+const MaxFeedbackNoteRunes = 4000
+
 type FeedbackOutcome string
 
 const (

--- a/server/internal/skills/feedback/recorder.go
+++ b/server/internal/skills/feedback/recorder.go
@@ -54,8 +54,8 @@ func (r *Recorder) Record(ctx context.Context, input RecordInput) (repo.SkillFee
 		return repo.SkillFeedback{}, errors.New("invalid feedback source")
 	case !input.Outcome.Valid():
 		return repo.SkillFeedback{}, errors.New("invalid feedback outcome")
-	case utf8.RuneCountInString(input.Note) > 4000:
-		return repo.SkillFeedback{}, errors.New("feedback note must be at most 4000 Unicode characters")
+	case utf8.RuneCountInString(input.Note) > domainskills.MaxFeedbackNoteRunes:
+		return repo.SkillFeedback{}, fmt.Errorf("feedback note must be at most %d Unicode characters", domainskills.MaxFeedbackNoteRunes)
 	case input.SkillVersionID.Valid && !input.SkillID.Valid:
 		return repo.SkillFeedback{}, errors.New("skill version requires an exact skill")
 	}

--- a/server/internal/skills/suggest/engine_test.go
+++ b/server/internal/skills/suggest/engine_test.go
@@ -259,7 +259,7 @@ func TestBuildPromptBoundsNotesDropsOldestEvidenceAndOmitsSessionIDs(t *testing.
 	for i := range feedback {
 		feedback[i] = repo.SkillFeedback{
 			Outcome: fmt.Sprintf("outcome-%d", i), Source: "test",
-			Note:      pgtype.Text{String: strings.Repeat("\x00", 2000), Valid: true},
+			Note:      pgtype.Text{String: strings.Repeat("\x00", skills.MaxFeedbackNoteRunes+1000), Valid: true},
 			CreatedAt: pgtype.Timestamptz{Time: policyNow.Add(time.Duration(i) * time.Second), Valid: true},
 		}
 	}
@@ -284,7 +284,7 @@ func TestBuildPromptBoundsNotesDropsOldestEvidenceAndOmitsSessionIDs(t *testing.
 	require.Less(t, len(payload.Feedback), len(feedback))
 	require.Equal(t, "outcome-49", payload.Feedback[len(payload.Feedback)-1].Outcome)
 	for _, item := range payload.Feedback {
-		require.LessOrEqual(t, utf8.RuneCountInString(item.Note), maxFeedbackNoteRunes)
+		require.LessOrEqual(t, utf8.RuneCountInString(item.Note), skills.MaxFeedbackNoteRunes)
 	}
 	for _, item := range payload.Transcripts {
 		require.NotEqual(t, "oldest", item.Surface)

--- a/server/internal/skills/suggest/judge.go
+++ b/server/internal/skills/suggest/judge.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/skills"
 	"github.com/speakeasy-api/gram/server/internal/skills/efficacy"
 	"github.com/speakeasy-api/gram/server/internal/skills/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -27,10 +28,7 @@ var (
 	ErrModelFailure = efficacy.ErrModelFailure
 )
 
-const (
-	maxFeedbackNoteRunes = 1000
-	maxPromptRunes       = 240000
-)
+const maxPromptRunes = 240000
 
 const SystemPrompt = `You improve an authored skill using evidence from its recent use.
 
@@ -122,8 +120,8 @@ func BuildPrompt(config Config, in GenerateInput) ([]byte, error) {
 	feedback := make([]promptFeedback, len(in.Feedback))
 	for i, item := range in.Feedback {
 		note := []rune(item.Note.String)
-		if len(note) > maxFeedbackNoteRunes {
-			note = note[:maxFeedbackNoteRunes]
+		if len(note) > skills.MaxFeedbackNoteRunes {
+			note = note[:skills.MaxFeedbackNoteRunes]
 		}
 		feedback[i] = promptFeedback{
 			Ref:       i + 1,


### PR DESCRIPTION
## What

Skill feedback notes are validated at ingest to at most 4000 Unicode characters, but the suggestion engine's prompt builder clamped each note to 1000 runes before the model ever saw it. A long, detailed report lost its tail silently — with no truncation marker, so the model couldn't tell evidence was missing.

This removes the discrepancy by letting the prompt carry the full note:

- Export `skills.MaxFeedbackNoteRunes = 4000` as the single cap and wire it into the feedback recorder, the `skill_feedback` platform tool (schema `maxLength` + validation), and `BuildPrompt`.
- Delete the separate 1000-rune prompt clamp in `suggest/judge.go`.

## Why not just raise the local constant

Ingest and prompt caps were two unrelated literals that had already drifted. A single exported constant makes the wire contract, validation, and prompt budget move together.

## Prompt budget

Worst case is `MaxFeedback` (50) × 4000 = 200k runes against the 240k prompt budget. `BuildPrompt` already sheds transcripts, then oldest feedback, when over budget — the bounds test now uses oversized (4000+1000 rune) notes so it keeps exercising both the clamp and the shedding path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop truncating skill feedback notes in suggestion prompts. The model now sees the full note (up to 4000 runes), and we use a single cap via `skills.MaxFeedbackNoteRunes`.

- **Bug Fixes**
  - Exported `skills.MaxFeedbackNoteRunes = 4000` and applied it to ingest validation, the `skill_feedback` tool schema/validation, and `BuildPrompt`.
  - Removed the 1000-rune clamp from `suggest/judge.go`; truncation now uses `skills.MaxFeedbackNoteRunes`.
  - Updated tests to target the new cap and continue exercising prompt budget shedding.

<sup>Written for commit 67b640bd0716e38eb91983e8684686577e1bbeb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

