### PR TITLE
fix: keep mock OIDC emulator in sync with remapped admin port

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -294,9 +294,11 @@ GRAM_ADMIN_OIDC_EMULATOR_URL = "http://{{env.GRAM_ADMIN_OIDC_EMULATOR_HOST}}:{{e
 GRAM_ADMIN_OIDC_CLIENT_ID = "gram-local.apps.googleusercontent.com"
 GRAM_ADMIN_OIDC_CLIENT_SECRET = "GOCSPX-example_secret"
 GRAM_ADMIN_ALLOWED_HDS = "speakeasyapi.dev,speakeasy.com"
-## Used for admin local development as a fake Google IDP
-MOCK_OIDC_PORT = "4000"
-MOCK_OIDC_ADDRESS = ":{{env.MOCK_OIDC_PORT}}"
+## Used for admin local development as a fake Google IDP. Derived from the
+## admin emulator vars (not a standalone *_PORT) so zero:remap-ports cannot
+## randomize the listen port and issuer out of sync with the admin client.
+MOCK_OIDC_ADDRESS = ":{{env.GRAM_ADMIN_OIDC_EMULATOR_PORT}}"
+MOCK_OIDC_ISSUER = "{{env.GRAM_ADMIN_OIDC_EMULATOR_URL}}"
 
 ########################
 ## Svix configuration ##


### PR DESCRIPTION
In git worktrees, `zero:remap-ports` randomizes every `*_PORT` env var independently, so `MOCK_OIDC_PORT` and `GRAM_ADMIN_OIDC_EMULATOR_PORT` (both meant to be the same port) drift apart. The admin server then dials a port nobody listens on, crash-loops with "connection refused" on OIDC discovery, and `./zero --agent` fails.

- Drop the standalone `MOCK_OIDC_PORT` and derive `MOCK_OIDC_ADDRESS` from `GRAM_ADMIN_OIDC_EMULATOR_PORT`, so remapping cannot split them.
- Add `MOCK_OIDC_ISSUER` derived from `GRAM_ADMIN_OIDC_EMULATOR_URL`; previously the emulator fell back to its built-in default issuer, which also breaks under remapped ports.

Verified in a worktree: admin starts cleanly and `./zero --agent` completes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the mock OIDC emulator in sync with the admin emulator when `zero:remap-ports` randomizes ports, preventing connection-refused loops in local dev. `MOCK_OIDC_ADDRESS` and issuer now derive from `GRAM_ADMIN_OIDC_EMULATOR_PORT`/`GRAM_ADMIN_OIDC_EMULATOR_URL`.

- **Bug Fixes**
  - Removed standalone `MOCK_OIDC_PORT`; `MOCK_OIDC_ADDRESS` now uses `GRAM_ADMIN_OIDC_EMULATOR_PORT`.
  - Added `MOCK_OIDC_ISSUER` from `GRAM_ADMIN_OIDC_EMULATOR_URL` to keep issuer and port aligned.
  - Verified: admin starts cleanly and `./zero --agent` completes in worktrees.

<sup>Written for commit 9e5f95178767b0ac03a377430eb3c067aedf63ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

