### PR TITLE
feat: add loading indicator while plugin distribution banner refetches

### DIFF
--- a/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
+++ b/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
@@ -88,11 +88,11 @@ export function PluginStatusBanner({
   // detail page shouldn't crash the whole page via the error boundary when
   // it does. The existing `if (!data) return null` below already degrades
   // gracefully on a failed fetch.
-  const { data } = usePlugins(undefined, undefined, { throwOnError: false });
+  const { data, isFetching: isPluginsFetching } = usePlugins(undefined, undefined, { throwOnError: false });
   const [isInstallDialogOpen, setIsInstallDialogOpen] = useState(false);
   // Polled so the banner picks up the Temporal generator-rollout schedule's
   // auto-sync without a manual refresh.
-  const { data: publishStatus } = usePublishStatus(undefined, undefined, {
+  const { data: publishStatus, isFetching: isPublishStatusFetching } = usePublishStatus(undefined, undefined, {
     refetchInterval: 5_000,
   });
   const [selectedPluginIds, setSelectedPluginIds] = useState<string[]>([]);
@@ -124,6 +124,7 @@ export function PluginStatusBanner({
   if (!data) return null;
 
   const plugins = data.plugins;
+  const isRefetching = (isPluginsFetching || isPublishStatusFetching) && !!data;
   const memberPlugins = plugins.filter((plugin) =>
     plugin.servers?.some((s) => serverMatchesRef(s, server)),
   );
@@ -265,6 +266,9 @@ export function PluginStatusBanner({
                     ? "Marketplace needs setup"
                     : "Not published to any plugin"}
               </Type>
+              {isRefetching && (
+                <Spinner className="text-muted-foreground ml-1 h-3.5 w-3.5" />
+              )}
             </div>
             <Type variant="small" className="text-muted-foreground/90">
               Plugins are the preferred way to distribute MCP servers to your

--- a/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
+++ b/client/dashboard/src/pages/mcp/overview/PluginStatusBanner.tsx
@@ -88,13 +88,18 @@ export function PluginStatusBanner({
   // detail page shouldn't crash the whole page via the error boundary when
   // it does. The existing `if (!data) return null` below already degrades
   // gracefully on a failed fetch.
-  const { data, isFetching: isPluginsFetching } = usePlugins(undefined, undefined, { throwOnError: false });
+  const { data, isFetching: isPluginsFetching } = usePlugins(
+    undefined,
+    undefined,
+    { throwOnError: false },
+  );
   const [isInstallDialogOpen, setIsInstallDialogOpen] = useState(false);
   // Polled so the banner picks up the Temporal generator-rollout schedule's
   // auto-sync without a manual refresh.
-  const { data: publishStatus, isFetching: isPublishStatusFetching } = usePublishStatus(undefined, undefined, {
-    refetchInterval: 5_000,
-  });
+  const { data: publishStatus, isFetching: isPublishStatusFetching } =
+    usePublishStatus(undefined, undefined, {
+      refetchInterval: 5_000,
+    });
   const [selectedPluginIds, setSelectedPluginIds] = useState<string[]>([]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 

--- a/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
+++ b/client/dashboard/src/pages/skills/SkillPluginBanner.tsx
@@ -201,6 +201,8 @@ export function SkillPluginBanner({
       ? "This skill has no recorded versions yet. Record a SKILL.md manifest before it can be distributed."
       : "None of this skill's versions pass validation. Fix the validation errors in SKILL.md before it can be distributed.";
 
+  const isRefetching = distributionsQuery.isFetching && isMembershipLoaded;
+
   let headline: JSX.Element;
   if (isBlocked) {
     headline = (
@@ -257,7 +259,12 @@ export function SkillPluginBanner({
       />
       <div className="relative flex items-center justify-between gap-8 p-6">
         <div className="flex max-w-md flex-col gap-3">
-          <div className="flex items-center gap-2">{headline}</div>
+          <div className="flex items-center gap-2">
+            {headline}
+            {isRefetching && (
+              <Spinner className="text-muted-foreground ml-1 h-3.5 w-3.5" />
+            )}
+          </div>
           <Type variant="small" className="text-muted-foreground/90">
             {isBlocked
               ? blockedReason


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small loading indicator to the plugin distribution banners on the skills and MCPs screens to show when data is being refetched.

## Changes

- Added `isRefetching` state detection to both `SkillPluginBanner` and `PluginStatusBanner`
- Display a small muted spinner next to the headline text when refetching is in progress
- Spinner uses `h-3.5 w-3.5` size with `ml-1` spacing and `text-muted-foreground` color for subtle indication

## Testing

- Verified type-checking passes with `pnpm -F dashboard type-check`
- Verified linting passes with `pnpm -F dashboard lint`
- The changes preserve existing state during refetch (current behavior) while adding visual feedback

## Related Issue

Closes DNO-554
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-554](https://linear.app/speakeasy/issue/DNO-554/feat-add-loading-indicator-while-plugin-distribution-banner-refetches)

<div><a href="https://cursor.com/agents/bc-4f35f63b-c704-4746-8a91-17eb6f5104e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f35f63b-c704-4746-8a91-17eb6f5104e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a small muted spinner to the plugin distribution banners on the Skills and MCP pages to indicate when data is refetching. Meets DNO-554 by providing clear loading feedback without changing or interrupting the current state.

<sup>Written for commit f5c6a8a85b2ca5546603f8d4956cee6b7f371205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

