### PR TITLE
feat: batch apply selected skill edit suggestion changes

### DIFF
--- a/.changeset/batch-apply-skill-suggestion-changes.md
+++ b/.changeset/batch-apply-skill-suggestion-changes.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+Skill edit suggestions now support batch apply: select individual proposed changes and apply them together as a single new version. The batch controls moved from the per-change comment box to a control bar above the diff.

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -4847,11 +4847,27 @@ async function seedSkillEditSuggestion(init: {
     (change, position) =>
       `(${position}, $seedskill$${change.diff}$seedskill$, $seedskill$${change.rationale}$seedskill$)`,
   ).join(",\n    ");
+  // The change diffs are anchored to the seeded content, so a suggestion is
+  // only inserted while that version is still the one approvals resolve as
+  // the base (mirroring ResolveSkillSuggestionBase). Once the skill advances
+  // — e.g. edits were applied while demoing — re-seeding leaves it alone
+  // instead of planting a stale suggestion.
   const sql = `
 INSERT INTO skill_edit_suggestions (project_id, skill_id, base_version_id, rationale, scored_session_count)
 SELECT s.project_id, s.id, '${baseVersionId}', 'Recurring friction in refund sessions points at the same missing steps.', 7
 FROM skills s
 WHERE s.id = '${skillId}'
+  AND '${baseVersionId}' = (
+    SELECT sv.id
+    FROM skill_versions sv
+    LEFT JOIN skill_version_origins svo
+      ON svo.project_id = s.project_id
+      AND svo.skill_id = sv.skill_id
+      AND svo.skill_version_id = sv.id
+    WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
+    ORDER BY (svo.origin IS DISTINCT FROM 'captured') DESC, COALESCE(sv.promoted_at, sv.created_at) DESC, sv.id DESC
+    LIMIT 1
+  )
   AND NOT EXISTS (
     SELECT 1 FROM skill_edit_suggestions e
     WHERE e.skill_id = s.id AND e.status = 'open'
@@ -4878,7 +4894,7 @@ WHERE e.skill_id = '${skillId}'
   })`docker compose exec -T gram-db psql -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -tA -f -`.quiet();
 
   log.info(
-    `Seeded skill 'support-refunds' with an open edit suggestion (${SEED_SKILL_SUGGESTION_CHANGES.length} changes) in '${projectSlug}'`,
+    `Seeded skill 'support-refunds' in '${projectSlug}' (an open edit suggestion with ${SEED_SKILL_SUGGESTION_CHANGES.length} changes is added while the skill is at its seeded base version)`,
   );
 }
 

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -25,6 +25,7 @@ import { keysValidate } from "#gram/client/funcs/keysValidate.js";
 import { projectsCreate } from "#gram/client/funcs/projectsCreate.js";
 import { projectsRead } from "#gram/client/funcs/projectsRead.js";
 import { resourcesList } from "#gram/client/funcs/resourcesList.js";
+import { skillsCreate } from "#gram/client/funcs/skillsCreate.js";
 import { toolsList } from "#gram/client/funcs/toolsList.js";
 import { toolsetsCreate } from "#gram/client/funcs/toolsetsCreate.js";
 import { toolsetsUpdateBySlug } from "#gram/client/funcs/toolsetsUpdateBySlug.js";
@@ -4737,6 +4738,150 @@ function abort(message: string, ...values: unknown[]): never {
   process.exit(1);
 }
 
+// The suggest engine only produces edit suggestions from real agent feedback,
+// so local seeding writes an open suggestion directly. Each change's diff is
+// incremental (diffed against what the changes before it produce), matching
+// what the engine stores — regenerate them with skilldiff.Unified if the base
+// content changes.
+const SEED_SKILL_CONTENT = `---
+name: support-refunds
+description: Handle customer refund requests end to end.
+---
+
+Verify the order exists before promising anything.
+Match the request to the original payment method.
+Check the payment status in the billing dashboard.
+Confirm the item was returned or the claim is valid.
+Apply the refund policy for the product category.
+Issue the refund through the payments console.
+Record the refund reason in the order notes.
+Watch for duplicate refund attempts on the order.
+Notify the customer with the expected settlement window.
+Escalate disputed chargebacks to the billing team.
+Attach the conversation transcript to the ticket.
+Close the support ticket with a summary.
+`;
+
+// Diff lines are stored as arrays because unified-diff context lines carry a
+// leading space — a blank context line is a single space that whitespace
+// trimming would otherwise destroy inside a template literal.
+const SEED_SKILL_SUGGESTION_CHANGES = [
+  {
+    rationale:
+      "Refunds were promised for orders still in transit, which support then had to walk back.",
+    diff: [
+      "--- a/SKILL.md",
+      "+++ b/SKILL.md",
+      "@@ -3,7 +3,7 @@",
+      " description: Handle customer refund requests end to end.",
+      " ---",
+      " ",
+      "-Verify the order exists before promising anything.",
+      "+Verify the order exists and its fulfillment state before promising anything.",
+      " Match the request to the original payment method.",
+      " Check the payment status in the billing dashboard.",
+      " Confirm the item was returned or the claim is valid.",
+      "",
+    ].join("\n"),
+  },
+  {
+    rationale:
+      "Refunds issued to a different payment method fail compliance review and get reversed.",
+    diff: [
+      "--- a/SKILL.md",
+      "+++ b/SKILL.md",
+      "@@ -8,7 +8,7 @@",
+      " Check the payment status in the billing dashboard.",
+      " Confirm the item was returned or the claim is valid.",
+      " Apply the refund policy for the product category.",
+      "-Issue the refund through the payments console.",
+      "+Issue the refund through the payments console using the original payment method.",
+      " Record the refund reason in the order notes.",
+      " Watch for duplicate refund attempts on the order.",
+      " Notify the customer with the expected settlement window.",
+      "",
+    ].join("\n"),
+  },
+  {
+    rationale:
+      "Follow-up conversations could not locate the refund without its id in the ticket.",
+    diff: [
+      "--- a/SKILL.md",
+      "+++ b/SKILL.md",
+      "@@ -14,4 +14,4 @@",
+      " Notify the customer with the expected settlement window.",
+      " Escalate disputed chargebacks to the billing team.",
+      " Attach the conversation transcript to the ticket.",
+      "-Close the support ticket with a summary.",
+      "+Close the support ticket with a summary and the refund id.",
+      "",
+    ].join("\n"),
+  },
+];
+
+async function seedSkillEditSuggestion(init: {
+  gram: GramCore;
+  sessionId: string;
+  projectSlug: string;
+}): Promise<void> {
+  const { gram, sessionId, projectSlug } = init;
+
+  const created = await skillsCreate(
+    gram,
+    { createSkillRequestBody: { content: SEED_SKILL_CONTENT } },
+    {
+      option1: {
+        projectSlugHeaderGramProject: projectSlug,
+        sessionHeaderGramSession: sessionId,
+      },
+    },
+  );
+  if (!created.ok) {
+    log.stepFailed(`Failed to create seed skill: ${created.error}`);
+    return;
+  }
+  const skillId = created.value.skill.id;
+  const baseVersionId = created.value.version.id;
+
+  const changeValues = SEED_SKILL_SUGGESTION_CHANGES.map(
+    (change, position) =>
+      `(${position}, $seedskill$${change.diff}$seedskill$, $seedskill$${change.rationale}$seedskill$)`,
+  ).join(",\n    ");
+  const sql = `
+INSERT INTO skill_edit_suggestions (project_id, skill_id, base_version_id, rationale, scored_session_count)
+SELECT s.project_id, s.id, '${baseVersionId}', 'Recurring friction in refund sessions points at the same missing steps.', 7
+FROM skills s
+WHERE s.id = '${skillId}'
+  AND NOT EXISTS (
+    SELECT 1 FROM skill_edit_suggestions e
+    WHERE e.skill_id = s.id AND e.status = 'open'
+  );
+
+INSERT INTO skill_edit_suggestion_changes (project_id, suggestion_id, proposed_diff, rationale, position)
+SELECT e.project_id, e.id, x.diff, x.rationale, x.position
+FROM skill_edit_suggestions e
+CROSS JOIN (
+  VALUES
+    ${changeValues}
+) AS x(position, diff, rationale)
+WHERE e.skill_id = '${skillId}'
+  AND e.status = 'open'
+  AND e.base_version_id = '${baseVersionId}'
+  AND NOT EXISTS (
+    SELECT 1 FROM skill_edit_suggestion_changes c WHERE c.suggestion_id = e.id
+  );
+`;
+  const dbUser = process.env.DB_USER || "gram";
+  const dbName = process.env.DB_NAME || "gram";
+  await $({
+    input: sql,
+  })`docker compose exec -T gram-db psql -U ${dbUser} -d ${dbName} -v ON_ERROR_STOP=1 -tA -f -`.quiet();
+
+  log.info(
+    `Seeded skill 'support-refunds' with an open edit suggestion (${SEED_SKILL_SUGGESTION_CHANGES.length} changes) in '${projectSlug}'`,
+  );
+}
+
 async function seed() {
   let success = false;
   intro("Seeding local development environment...");
@@ -4882,9 +5027,11 @@ async function seed() {
     const redisPassword = process.env.GRAM_REDIS_CACHE_PASSWORD || "xi9XILbY";
     // session_capture gates Claude hook chat persistence; without it,
     // hooks.ingest accepts events but silently skips writing chat_messages.
-    await $`docker compose exec gram-db psql -U ${dbUser} -d ${dbName} -c "INSERT INTO organization_features (organization_id, feature_name) VALUES ('${activeOrgID}', 'logs'), ('${activeOrgID}', 'tool_io_logs'), ('${activeOrgID}', 'session_capture') ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE DO NOTHING;"`.quiet();
-    await $`docker compose exec gram-cache redis-cli -p 35299 -a ${redisPassword} DEL feature:${activeOrgID}:logs: feature:${activeOrgID}:tool_io_logs: feature:${activeOrgID}:session_capture:`.quiet();
-    log.info("Enabled local logs, tool_io_logs, and session_capture features");
+    await $`docker compose exec gram-db psql -U ${dbUser} -d ${dbName} -c "INSERT INTO organization_features (organization_id, feature_name) VALUES ('${activeOrgID}', 'logs'), ('${activeOrgID}', 'tool_io_logs'), ('${activeOrgID}', 'session_capture'), ('${activeOrgID}', 'skills') ON CONFLICT (organization_id, feature_name) WHERE deleted IS FALSE DO NOTHING;"`.quiet();
+    await $`docker compose exec gram-cache redis-cli -p 35299 -a ${redisPassword} DEL feature:${activeOrgID}:logs: feature:${activeOrgID}:tool_io_logs: feature:${activeOrgID}:session_capture: feature:${activeOrgID}:skills:`.quiet();
+    log.info(
+      "Enabled local logs, tool_io_logs, session_capture, and skills features",
+    );
   } catch (e: unknown) {
     const err = e as { stderr?: string; message?: string };
     log.stepFailed(
@@ -4992,6 +5139,12 @@ async function seed() {
       `${env.created ? "Created" : "Found existing"} environment '${env.slug}' for project '${projectSlug}'`,
     );
   }
+  await seedSkillEditSuggestion({
+    gram,
+    sessionId,
+    projectSlug: SEED_PROJECTS[0].slug,
+  });
+
   await seedTunnel();
 
   // Seed observability data for the E-Commerce project.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -36698,7 +36698,7 @@ paths:
         name: ApproveAllSkillSuggestions
   /rpc/skills.approveSuggestion:
     post:
-      description: Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.
+      description: Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.
       operationId: approveSkillSuggestion
       parameters:
         - allowEmptyValue: true
@@ -50406,10 +50406,12 @@ components:
     ApproveSkillSuggestionRequestBody:
       type: object
       properties:
-        change_id:
-          type: string
-          description: Optional ID of the single proposed change to take. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.
-          format: uuid
+        change_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Optional IDs of the proposed changes to take together as one new version. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.
         content:
           type: string
           description: Optional edited complete SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.

--- a/client/dashboard/src/pages/skills/SkillSuggestionComment.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillSuggestionComment.test.tsx
@@ -52,7 +52,6 @@ const actions = {
   disabled: false,
   approving: false,
   onApply: vi.fn(),
-  onApplyAll: vi.fn(),
 };
 
 describe("SkillSuggestionComment", () => {
@@ -63,13 +62,7 @@ describe("SkillSuggestionComment", () => {
   });
 
   it("leads with the session count the suggestion was built from", () => {
-    render(
-      <SkillSuggestionComment
-        change={change()}
-        changeCount={1}
-        actions={actions}
-      />,
-    );
+    render(<SkillSuggestionComment change={change()} actions={actions} />);
 
     expect(screen.getByText(/Requested in 11 sessions\./)).toBeTruthy();
     expect(
@@ -81,7 +74,6 @@ describe("SkillSuggestionComment", () => {
     render(
       <SkillSuggestionComment
         change={change({ feedbackSessionCount: 0 })}
-        changeCount={1}
         actions={actions}
       />,
     );
@@ -98,13 +90,7 @@ describe("SkillSuggestionComment", () => {
         createdAt: new Date("2026-07-01T00:00:00Z"),
       },
     ];
-    render(
-      <SkillSuggestionComment
-        change={change()}
-        changeCount={1}
-        actions={actions}
-      />,
-    );
+    render(<SkillSuggestionComment change={change()} actions={actions} />);
 
     expect(testState.enabled).toBe(false);
     fireEvent.click(
@@ -118,7 +104,6 @@ describe("SkillSuggestionComment", () => {
     render(
       <SkillSuggestionComment
         change={change({ feedbackCount: 0 })}
-        changeCount={1}
         actions={actions}
       />,
     );
@@ -130,43 +115,17 @@ describe("SkillSuggestionComment", () => {
 describe("SkillSuggestionComment actions", () => {
   afterEach(cleanup);
 
-  it("offers applying everything only when more than one change is proposed", () => {
-    const { rerender } = render(
-      <SkillSuggestionComment
-        change={change()}
-        changeCount={1}
-        actions={actions}
-      />,
-    );
-    expect(screen.queryByRole("button", { name: "Apply all" })).toBeNull();
-
-    rerender(
-      <SkillSuggestionComment
-        change={change()}
-        changeCount={3}
-        actions={actions}
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Apply all" })).toBeTruthy();
-  });
-
-  it("keeps applying one change separate from applying them all", () => {
+  it("applies only the change the comment is attached to", () => {
     const onApply = vi.fn<() => void>();
-    const onApplyAll = vi.fn<() => void>();
     render(
       <SkillSuggestionComment
         change={change()}
-        changeCount={2}
-        actions={{ ...actions, onApply, onApplyAll }}
+        actions={{ ...actions, onApply }}
       />,
     );
 
+    expect(screen.queryByRole("button", { name: "Apply all" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
-    expect(onApply).toHaveBeenCalledTimes(1);
-    expect(onApplyAll).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Apply all" }));
-    expect(onApplyAll).toHaveBeenCalledTimes(1);
     expect(onApply).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/dashboard/src/pages/skills/SkillSuggestionComment.tsx
+++ b/client/dashboard/src/pages/skills/SkillSuggestionComment.tsx
@@ -16,8 +16,6 @@ export type SkillSuggestionActions = {
   approving: boolean;
   /** Applies just the change this comment is attached to. */
   onApply: () => void;
-  /** Opens the review of every change the suggestion still proposes. */
-  onApplyAll: () => void;
 };
 
 /** Collapsed marker for one proposed change in the diff. */
@@ -46,12 +44,9 @@ export function SkillSuggestionMarker({
 
 export function SkillSuggestionComment({
   change,
-  changeCount,
   actions,
 }: {
   change: SkillEditSuggestionChange;
-  /** How many changes the suggestion still proposes across the manifest. */
-  changeCount: number;
   actions: SkillSuggestionActions;
 }): JSX.Element {
   const project = useProject();
@@ -91,25 +86,13 @@ export function SkillSuggestionComment({
           level="component"
           reason="You need write access to review suggested edits."
         >
-          <div className="flex flex-wrap gap-2">
-            {changeCount > 1 && (
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={actions.disabled}
-                onClick={actions.onApplyAll}
-              >
-                Apply all
-              </Button>
-            )}
-            <Button
-              size="sm"
-              disabled={actions.disabled}
-              onClick={actions.onApply}
-            >
-              {actions.approving ? "Applying..." : "Apply"}
-            </Button>
-          </div>
+          <Button
+            size="sm"
+            disabled={actions.disabled}
+            onClick={actions.onApply}
+          >
+            {actions.approving ? "Applying..." : "Apply"}
+          </Button>
         </RequireScope>
       </div>
     </div>

--- a/client/dashboard/src/pages/skills/SuggestedSkillEditSection.tsx
+++ b/client/dashboard/src/pages/skills/SuggestedSkillEditSection.tsx
@@ -1,7 +1,10 @@
+import { RequireScope } from "@/components/require-scope";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
+import { useProject } from "@/contexts/Auth";
 import { SettingsSection } from "@/pages/mcp/x/tabs/settings/SettingsSection";
 import type { SkillVersion } from "@gram/client/models/components/skillversion.js";
 import { lazy, Suspense, useMemo, useState } from "react";
@@ -20,6 +23,15 @@ const SkillTextDiff = lazy(() => import("./SkillTextDiff")) as (
   props: SkillTextDiffProps<SkillDiffAnchor>,
 ) => JSX.Element;
 
+function toggled(
+  current: ReadonlySet<string>,
+  id: string,
+): ReadonlySet<string> {
+  const next = new Set(current);
+  if (!next.delete(id)) next.add(id);
+  return next;
+}
+
 export function SuggestedSkillEditSection({
   skillId,
   latestVersion,
@@ -27,10 +39,14 @@ export function SuggestedSkillEditSection({
   skillId: string;
   latestVersion: SkillVersion;
 }): JSX.Element | null {
+  const project = useProject();
   const review = useSkillSuggestionReview(skillId);
   const [editOpen, setEditOpen] = useState(false);
   const [reviewOpen, setReviewOpen] = useState(false);
   const [openChanges, setOpenChanges] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const [selectedChanges, setSelectedChanges] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
 
@@ -49,14 +65,20 @@ export function SuggestedSkillEditSection({
     });
   }, [suggestion, latestVersion.content]);
 
+  // The suggestion shrinks as changes are taken, so the batch only ever
+  // counts changes the diff still shows.
+  const selectedIds = anchors
+    .map((anchor) => anchor.change.id)
+    .filter((id) => selectedChanges.has(id));
+
   if (!review.isPending && !review.loadError && !suggestion) return null;
 
   const toggleChange = (changeId: string): void => {
-    setOpenChanges((current) => {
-      const next = new Set(current);
-      if (!next.delete(changeId)) next.add(changeId);
-      return next;
-    });
+    setOpenChanges((current) => toggled(current, changeId));
+  };
+
+  const toggleSelected = (changeId: string): void => {
+    setSelectedChanges((current) => toggled(current, changeId));
   };
 
   // A change is applied on its own, so a comment only ever speaks for the
@@ -67,19 +89,27 @@ export function SuggestedSkillEditSection({
 
     return (
       <div className="space-y-1 px-4 py-1.5">
-        <SkillSuggestionMarker
-          open={open}
-          onToggle={() => toggleChange(anchor.change.id)}
-        />
+        <div className="flex items-center gap-2">
+          {anchors.length > 1 && (
+            <Checkbox
+              checked={selectedChanges.has(anchor.change.id)}
+              onCheckedChange={() => toggleSelected(anchor.change.id)}
+              disabled={review.actionsDisabled}
+              aria-label="Select change to apply as a batch"
+            />
+          )}
+          <SkillSuggestionMarker
+            open={open}
+            onToggle={() => toggleChange(anchor.change.id)}
+          />
+        </div>
         {open && (
           <SkillSuggestionComment
             change={anchor.change}
-            changeCount={anchors.length}
             actions={{
               disabled: review.actionsDisabled,
               approving: review.approving,
-              onApply: () => void review.approve(anchor.change.id),
-              onApplyAll: () => setReviewOpen(true),
+              onApply: () => void review.approve([anchor.change.id]),
             }}
           />
         )}
@@ -93,7 +123,8 @@ export function SuggestedSkillEditSection({
         <SettingsSection.Title>Suggested edit</SettingsSection.Title>
         <SettingsSection.Description>
           Analysis of agent feedback proposed these changes. Open the comment
-          beside a change to see why it was proposed and apply it on its own.
+          beside a change to see why it was proposed, and select changes to
+          apply together as one new version.
         </SettingsSection.Description>
       </SettingsSection.Header>
       <SettingsSection.Panel>
@@ -132,6 +163,41 @@ export function SuggestedSkillEditSection({
                 </Button>
               )}
             </div>
+          )}
+          {suggestion?.appliesCleanly && anchors.length > 1 && (
+            <RequireScope
+              scope="skill:write"
+              resourceId={project.id}
+              level="component"
+              reason="You need write access to review suggested edits."
+            >
+              <div className="border-border bg-card flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3">
+                <Type small muted>
+                  {`${selectedIds.length} of ${anchors.length} changes selected`}
+                </Type>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={review.actionsDisabled}
+                    onClick={() => setReviewOpen(true)}
+                  >
+                    Apply all
+                  </Button>
+                  <Button
+                    size="sm"
+                    disabled={
+                      review.actionsDisabled || selectedIds.length === 0
+                    }
+                    onClick={() => void review.approve(selectedIds)}
+                  >
+                    {review.approving
+                      ? "Applying..."
+                      : `Apply selected (${selectedIds.length})`}
+                  </Button>
+                </div>
+              </div>
+            </RequireScope>
           )}
           {suggestion?.appliesCleanly && (
             <Suspense

--- a/client/dashboard/src/pages/skills/SuggestedSkillEditSection.tsx
+++ b/client/dashboard/src/pages/skills/SuggestedSkillEditSection.tsx
@@ -95,7 +95,7 @@ export function SuggestedSkillEditSection({
               checked={selectedChanges.has(anchor.change.id)}
               onCheckedChange={() => toggleSelected(anchor.change.id)}
               disabled={review.actionsDisabled}
-              aria-label="Select change to apply as a batch"
+              aria-label={`Select change at line ${anchor.line} to apply as a batch`}
             />
           )}
           <SkillSuggestionMarker

--- a/client/dashboard/src/pages/skills/use-skill-suggestion.ts
+++ b/client/dashboard/src/pages/skills/use-skill-suggestion.ts
@@ -17,8 +17,8 @@ export type SkillSuggestionReview = {
   actionsDisabled: boolean;
   approving: boolean;
   dismissing: boolean;
-  /** Applies one proposed change by id, or every change when omitted. */
-  approve: (changeId?: string) => Promise<void>;
+  /** Applies the proposed changes with the given ids, or every change when omitted. */
+  approve: (changeIds?: string[]) => Promise<void>;
   dismiss: () => Promise<void>;
   refresh: () => Promise<void>;
   retry: () => void;
@@ -44,14 +44,14 @@ export function useSkillSuggestionReview(
   const loaded = query.data?.result.suggestions[0];
   const suggestion = loaded?.id === hiddenSuggestionId ? undefined : loaded;
 
-  const approve = async (changeId?: string): Promise<void> => {
+  const approve = async (changeIds?: string[]): Promise<void> => {
     if (!suggestion) return;
     setActionError(null);
     setReconciling(true);
     try {
       const result = await approveMutation.mutateAsync({
         request: {
-          approveSkillSuggestionRequestBody: { id: suggestion.id, changeId },
+          approveSkillSuggestionRequestBody: { id: suggestion.id, changeIds },
         },
       });
       // A partial apply leaves the suggestion open carrying the rest, so it
@@ -64,7 +64,7 @@ export function useSkillSuggestionReview(
           toast.success("Suggested edit applied as a new version");
           break;
         case "partially_applied":
-          toast.success("Change applied as a new version");
+          toast.success("Selected changes applied as a new version");
           break;
         case "superseded":
           toast.info("Suggestion was superseded because the skill changed");

--- a/client/dashboard/src/sdk/src/funcs/skillsApproveSuggestion.ts
+++ b/client/dashboard/src/sdk/src/funcs/skillsApproveSuggestion.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * approveSuggestion skills
  *
  * @remarks
- * Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.
+ * Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.
  */
 export function skillsApproveSuggestion(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/models/components/approveskillsuggestionrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/approveskillsuggestionrequestbody.ts
@@ -7,9 +7,9 @@ import { remap as remap$ } from "../../lib/primitives.js";
 
 export type ApproveSkillSuggestionRequestBody = {
   /**
-   * Optional ID of the single proposed change to take. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.
+   * Optional IDs of the proposed changes to take together as one new version. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.
    */
-  changeId?: string | undefined;
+  changeIds?: Array<string> | undefined;
   /**
    * Optional edited complete SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.
    */
@@ -22,7 +22,7 @@ export type ApproveSkillSuggestionRequestBody = {
 
 /** @internal */
 export type ApproveSkillSuggestionRequestBody$Outbound = {
-  change_id?: string | undefined;
+  change_ids?: Array<string> | undefined;
   content?: string | undefined;
   id: string;
 };
@@ -33,13 +33,13 @@ export const ApproveSkillSuggestionRequestBody$outboundSchema: z.ZodMiniType<
   ApproveSkillSuggestionRequestBody
 > = z.pipe(
   z.object({
-    changeId: z.optional(z.string()),
+    changeIds: z.optional(z.array(z.string())),
     content: z.optional(z.string()),
     id: z.string(),
   }),
   z.transform((v) => {
     return remap$(v, {
-      changeId: "change_id",
+      changeIds: "change_ids",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/react-query/approveSkillSuggestion.ts
+++ b/client/dashboard/src/sdk/src/react-query/approveSkillSuggestion.ts
@@ -54,7 +54,7 @@ export type ApproveSkillSuggestionMutationError =
  * approveSuggestion skills
  *
  * @remarks
- * Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.
+ * Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.
  */
 export function useApproveSkillSuggestionMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/skills.ts
+++ b/client/dashboard/src/sdk/src/sdk/skills.ts
@@ -169,7 +169,7 @@ export class Skills extends ClientSDK {
    * approveSuggestion skills
    *
    * @remarks
-   * Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.
+   * Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.
    */
   async approveSuggestion(
     request: ApproveSkillSuggestionRequest,

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -236,12 +236,12 @@ var _ = Service("skills", func() {
 	})
 
 	Method("approveSuggestion", func() {
-		Description("Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.")
+		Description("Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.")
 
 		Payload(func() {
 			Attribute("id", String, "The suggestion ID.", func() { Format(FormatUUID) })
 			Attribute("content", String, "Optional edited complete SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.")
-			Attribute("change_id", String, "Optional ID of the single proposed change to take. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.", func() { Format(FormatUUID) })
+			Attribute("change_ids", ArrayOf(String, func() { Format(FormatUUID) }), "Optional IDs of the proposed changes to take together as one new version. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.")
 			Required("id")
 			security.SessionPayload()
 			security.ByKeyPayload()
@@ -688,7 +688,7 @@ var ApproveSkillSuggestionRequestBody = Type("ApproveSkillSuggestionRequestBody"
 
 	Attribute("id", String, "The suggestion ID.", func() { Format(FormatUUID) })
 	Attribute("content", String, "Optional edited complete SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.")
-	Attribute("change_id", String, "Optional ID of the single proposed change to take. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.", func() { Format(FormatUUID) })
+	Attribute("change_ids", ArrayOf(String, func() { Format(FormatUUID) }), "Optional IDs of the proposed changes to take together as one new version. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.")
 	Required("id")
 })
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -16775,7 +16775,7 @@ func skillsUsage() {
 	fmt.Fprintln(os.Stderr, `    list: List active skills in the project. The implementation requires the skills product feature and skill read scope.`)
 	fmt.Fprintln(os.Stderr, `    list-suggestions: List open skill edit suggestions in the project, newest first. The implementation requires the skills product feature and skill read scope.`)
 	fmt.Fprintln(os.Stderr, `    list-feedback: List all-time outcome counts and recent resolved feedback for a skill. Name-only feedback is excluded.`)
-	fmt.Fprintln(os.Stderr, `    approve-suggestion: Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.`)
+	fmt.Fprintln(os.Stderr, `    approve-suggestion: Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.`)
 	fmt.Fprintln(os.Stderr, `    dismiss-suggestion: Idempotently dismiss an open skill edit suggestion. Approved and superseded suggestions conflict.`)
 	fmt.Fprintln(os.Stderr, `    list-suggestion-feedback: List the agent feedback cited as the reason for one proposed change, newest first.`)
 	fmt.Fprintln(os.Stderr, `    approve-all-suggestions: Snapshot and independently process selected skill edit suggestions, or every open suggestion when no IDs are supplied. One conflict or failure does not stop the remaining approvals.`)
@@ -16982,7 +16982,7 @@ func skillsApproveSuggestionUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.`)
+	fmt.Fprintln(os.Stderr, `Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)
@@ -16992,7 +16992,7 @@ func skillsApproveSuggestionUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills approve-suggestion --body '{\n      \"change_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"content\": \"abc123\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }' --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills approve-suggestion --body '{\n      \"change_ids\": [\n         \"550e8400-e29b-41d4-a716-446655440000\"\n      ],\n      \"content\": \"abc123\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }' --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func skillsDismissSuggestionUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -37096,7 +37096,7 @@ paths:
                 name: ApproveAllSkillSuggestions
     /rpc/skills.approveSuggestion:
         post:
-            description: Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only one of its proposed changes. Stale suggestions are superseded instead.
+            description: Approve an open skill edit suggestion, optionally replacing its proposed SKILL.md content or taking only a subset of its proposed changes. Stale suggestions are superseded instead.
             operationId: approveSkillSuggestion
             parameters:
                 - allowEmptyValue: true
@@ -50684,10 +50684,12 @@ components:
         ApproveSkillSuggestionRequestBody:
             type: object
             properties:
-                change_id:
-                    type: string
-                    description: Optional ID of the single proposed change to take. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.
-                    format: uuid
+                change_ids:
+                    type: array
+                    items:
+                        type: string
+                        format: uuid
+                    description: Optional IDs of the proposed changes to take together as one new version. The suggestion stays open carrying whatever is left. Cannot be combined with edited content.
                 content:
                     type: string
                     description: Optional edited complete SKILL.md content. Handlers enforce a maximum size of 65,536 UTF-8 bytes.

--- a/server/gen/http/skills/client/cli.go
+++ b/server/gen/http/skills/client/cli.go
@@ -408,11 +408,11 @@ func BuildApproveSuggestionPayload(skillsApproveSuggestionBody string, skillsApp
 	{
 		err = json.Unmarshal([]byte(skillsApproveSuggestionBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"change_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"content\": \"abc123\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"change_ids\": [\n         \"550e8400-e29b-41d4-a716-446655440000\"\n      ],\n      \"content\": \"abc123\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\"\n   }'")
 		}
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", body.ID, goa.FormatUUID))
-		if body.ChangeID != nil {
-			err = goa.MergeErrors(err, goa.ValidateFormat("body.change_id", *body.ChangeID, goa.FormatUUID))
+		for _, e := range body.ChangeIds {
+			err = goa.MergeErrors(err, goa.ValidateFormat("body.change_ids[*]", e, goa.FormatUUID))
 		}
 		if err != nil {
 			return nil, err
@@ -437,9 +437,14 @@ func BuildApproveSuggestionPayload(skillsApproveSuggestionBody string, skillsApp
 		}
 	}
 	v := &skills.ApproveSuggestionPayload{
-		ID:       body.ID,
-		Content:  body.Content,
-		ChangeID: body.ChangeID,
+		ID:      body.ID,
+		Content: body.Content,
+	}
+	if body.ChangeIds != nil {
+		v.ChangeIds = make([]string, len(body.ChangeIds))
+		for i, val := range body.ChangeIds {
+			v.ChangeIds[i] = val
+		}
 	}
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -63,9 +63,10 @@ type ApproveSuggestionRequestBody struct {
 	// Optional edited complete SKILL.md content. Handlers enforce a maximum size
 	// of 65,536 UTF-8 bytes.
 	Content *string `form:"content,omitempty" json:"content,omitempty" xml:"content,omitempty"`
-	// Optional ID of the single proposed change to take. The suggestion stays open
-	// carrying whatever is left. Cannot be combined with edited content.
-	ChangeID *string `form:"change_id,omitempty" json:"change_id,omitempty" xml:"change_id,omitempty"`
+	// Optional IDs of the proposed changes to take together as one new version.
+	// The suggestion stays open carrying whatever is left. Cannot be combined with
+	// edited content.
+	ChangeIds []string `form:"change_ids,omitempty" json:"change_ids,omitempty" xml:"change_ids,omitempty"`
 }
 
 // DismissSuggestionRequestBody is the type of the "skills" service
@@ -4564,9 +4565,14 @@ func NewUpdateRequestBody(p *skills.UpdatePayload) *UpdateRequestBody {
 // payload of the "approveSuggestion" endpoint of the "skills" service.
 func NewApproveSuggestionRequestBody(p *skills.ApproveSuggestionPayload) *ApproveSuggestionRequestBody {
 	body := &ApproveSuggestionRequestBody{
-		ID:       p.ID,
-		Content:  p.Content,
-		ChangeID: p.ChangeID,
+		ID:      p.ID,
+		Content: p.Content,
+	}
+	if p.ChangeIds != nil {
+		body.ChangeIds = make([]string, len(p.ChangeIds))
+		for i, val := range p.ChangeIds {
+			body.ChangeIds[i] = val
+		}
 	}
 	return body
 }

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -65,9 +65,10 @@ type ApproveSuggestionRequestBody struct {
 	// Optional edited complete SKILL.md content. Handlers enforce a maximum size
 	// of 65,536 UTF-8 bytes.
 	Content *string `form:"content,omitempty" json:"content,omitempty" xml:"content,omitempty"`
-	// Optional ID of the single proposed change to take. The suggestion stays open
-	// carrying whatever is left. Cannot be combined with edited content.
-	ChangeID *string `form:"change_id,omitempty" json:"change_id,omitempty" xml:"change_id,omitempty"`
+	// Optional IDs of the proposed changes to take together as one new version.
+	// The suggestion stays open carrying whatever is left. Cannot be combined with
+	// edited content.
+	ChangeIds []string `form:"change_ids,omitempty" json:"change_ids,omitempty" xml:"change_ids,omitempty"`
 }
 
 // DismissSuggestionRequestBody is the type of the "skills" service
@@ -7966,9 +7967,14 @@ func NewListFeedbackPayload(id string, cursor *string, limit int, sessionToken *
 // endpoint payload.
 func NewApproveSuggestionPayload(body *ApproveSuggestionRequestBody, sessionToken *string, apikeyToken *string, projectSlugInput *string) *skills.ApproveSuggestionPayload {
 	v := &skills.ApproveSuggestionPayload{
-		ID:       *body.ID,
-		Content:  body.Content,
-		ChangeID: body.ChangeID,
+		ID:      *body.ID,
+		Content: body.Content,
+	}
+	if body.ChangeIds != nil {
+		v.ChangeIds = make([]string, len(body.ChangeIds))
+		for i, val := range body.ChangeIds {
+			v.ChangeIds[i] = val
+		}
 	}
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
@@ -8230,8 +8236,8 @@ func ValidateApproveSuggestionRequestBody(body *ApproveSuggestionRequestBody) (e
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))
 	}
-	if body.ChangeID != nil {
-		err = goa.MergeErrors(err, goa.ValidateFormat("body.change_id", *body.ChangeID, goa.FormatUUID))
+	for _, e := range body.ChangeIds {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.change_ids[*]", e, goa.FormatUUID))
 	}
 	return
 }

--- a/server/gen/skills/service.go
+++ b/server/gen/skills/service.go
@@ -42,7 +42,7 @@ type Service interface {
 	// Name-only feedback is excluded.
 	ListFeedback(context.Context, *ListFeedbackPayload) (res *ListSkillFeedbackResult, err error)
 	// Approve an open skill edit suggestion, optionally replacing its proposed
-	// SKILL.md content or taking only one of its proposed changes. Stale
+	// SKILL.md content or taking only a subset of its proposed changes. Stale
 	// suggestions are superseded instead.
 	ApproveSuggestion(context.Context, *ApproveSuggestionPayload) (res *ApproveSkillSuggestionResult, err error)
 	// Idempotently dismiss an open skill edit suggestion. Approved and superseded
@@ -163,9 +163,10 @@ type ApproveSuggestionPayload struct {
 	// Optional edited complete SKILL.md content. Handlers enforce a maximum size
 	// of 65,536 UTF-8 bytes.
 	Content *string
-	// Optional ID of the single proposed change to take. The suggestion stays open
-	// carrying whatever is left. Cannot be combined with edited content.
-	ChangeID         *string
+	// Optional IDs of the proposed changes to take together as one new version.
+	// The suggestion stays open carrying whatever is left. Cannot be combined with
+	// edited content.
+	ChangeIds        []string
 	SessionToken     *string
 	ApikeyToken      *string
 	ProjectSlugInput *string

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -543,6 +543,11 @@ DELETE FROM skill_edit_suggestion_changes
 WHERE project_id = @project_id
   AND id = @id;
 
+-- name: DeleteSkillEditSuggestionChangesByIDs :exec
+DELETE FROM skill_edit_suggestion_changes
+WHERE project_id = @project_id
+  AND id = ANY (@ids::uuid[]);
+
 -- name: RebaseSkillEditSuggestionChange :exec
 UPDATE skill_edit_suggestion_changes
 SET proposed_diff = @proposed_diff,

--- a/server/internal/skills/rbac_test.go
+++ b/server/internal/skills/rbac_test.go
@@ -67,7 +67,7 @@ func TestSkillsFeatureDisabledRejectsEveryEndpoint(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeForbidden)
 	_, err = ti.service.ListSuggestions(ctx, &gen.ListSuggestionsPayload{SkillID: nil, Cursor: nil, Limit: 10, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
 	requireOopsCode(t, err, oops.CodeForbidden)
-	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{ID: suggestion.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{ID: suggestion.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	_, err = ti.service.DismissSuggestion(ctx, &gen.DismissSuggestionPayload{ID: suggestion.ID.String(), SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
 	requireOopsCode(t, err, oops.CodeForbidden)

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -1295,6 +1295,22 @@ func (q *Queries) DeleteSkillEditSuggestionChanges(ctx context.Context, arg Dele
 	return err
 }
 
+const deleteSkillEditSuggestionChangesByIDs = `-- name: DeleteSkillEditSuggestionChangesByIDs :exec
+DELETE FROM skill_edit_suggestion_changes
+WHERE project_id = $1
+  AND id = ANY ($2::uuid[])
+`
+
+type DeleteSkillEditSuggestionChangesByIDsParams struct {
+	ProjectID uuid.UUID
+	Ids       []uuid.UUID
+}
+
+func (q *Queries) DeleteSkillEditSuggestionChangesByIDs(ctx context.Context, arg DeleteSkillEditSuggestionChangesByIDsParams) error {
+	_, err := q.db.Exec(ctx, deleteSkillEditSuggestionChangesByIDs, arg.ProjectID, arg.Ids)
+	return err
+}
+
 const deleteSkillVersionOrigin = `-- name: DeleteSkillVersionOrigin :exec
 DELETE FROM skill_version_origins
 WHERE project_id = $1

--- a/server/internal/skills/suggestion_management.go
+++ b/server/internal/skills/suggestion_management.go
@@ -110,10 +110,10 @@ func (s *Service) approveSuggestion(
 	logger *slog.Logger,
 	suggestionID uuid.UUID,
 	editedContent *string,
-	changeID *uuid.UUID,
+	changeIDs []uuid.UUID,
 ) (approval suggestionApproval, err error) {
-	if changeID != nil && editedContent != nil {
-		return approval, oops.E(oops.CodeBadRequest, nil, "cannot take a single proposed change and edited content together")
+	if len(changeIDs) > 0 && editedContent != nil {
+		return approval, oops.E(oops.CodeBadRequest, nil, "cannot take a subset of proposed changes and edited content together")
 	}
 
 	dbtx, err := s.db.Begin(ctx)
@@ -161,7 +161,7 @@ func (s *Service) approveSuggestion(
 			return approval, oops.E(oops.CodeUnexpected, listErr, "load skill suggestion changes for approval").LogError(ctx, logger)
 		}
 		approval.evidence.Changes = changes
-		content, _, err = approvalContent(details.BaseContent, changes, changeID)
+		content, _, err = approvalContent(details.BaseContent, changes, changeIDs)
 		if err != nil {
 			return approval, err
 		}
@@ -246,7 +246,7 @@ func (s *Service) approveSuggestion(
 	approval.evidence.Changes = changes
 	var remaining []repo.ListSkillEditSuggestionChangesRow
 	if editedContent == nil {
-		content, remaining, err = approvalContent(base.BaseContent, changes, changeID)
+		content, remaining, err = approvalContent(base.BaseContent, changes, changeIDs)
 		if err != nil {
 			return approval, err
 		}
@@ -265,19 +265,19 @@ func (s *Service) approveSuggestion(
 		return approval, oops.E(oops.CodeUnexpected, err, "parse validated skill suggestion").LogError(ctx, logger)
 	}
 
-	// Taking one change leaves the suggestion open carrying the rest. Writing
+	// Taking a subset leaves the suggestion open carrying the rest. Writing
 	// the remainder before the version exists lets recordVersion's replay
 	// repoint it at the version this creates; closing it first, as a whole
 	// approval does, is what keeps that replay off an approval's own work.
 	var approved repo.SkillEditSuggestion
 	if len(remaining) > 0 {
-		// Drop only the change being taken. The rest keep their own rationale
+		// Drop only the changes being taken. The rest keep their own rationale
 		// and evidence, and recordVersion's replay rebases them onto the
 		// version this creates.
-		if err := queries.DeleteSkillEditSuggestionChange(ctx, repo.DeleteSkillEditSuggestionChangeParams{
-			ProjectID: *authCtx.ProjectID, ID: *changeID,
+		if err := queries.DeleteSkillEditSuggestionChangesByIDs(ctx, repo.DeleteSkillEditSuggestionChangesByIDsParams{
+			ProjectID: *authCtx.ProjectID, Ids: changeIDs,
 		}); err != nil {
-			return approval, oops.E(oops.CodeUnexpected, err, "drop the approved skill suggestion change").LogError(ctx, logger)
+			return approval, oops.E(oops.CodeUnexpected, err, "drop the approved skill suggestion changes").LogError(ctx, logger)
 		}
 		approved = suggestion
 	} else {
@@ -362,47 +362,51 @@ func (s *Service) approveSuggestion(
 }
 
 // approvalContent resolves what a reviewer is taking from a suggestion: every
-// proposed change, or a single one with the rest left to propose. Each change
-// applies to what the changes before it produce, so taking one on its own
-// replays only that edit onto the current manifest.
+// proposed change, or a subset with the rest left to propose. Each change
+// applies to what the changes before it produce, so a subset replays only the
+// taken edits, in their proposed order, onto the current manifest.
 func approvalContent(
 	baseContent string,
 	changes []repo.ListSkillEditSuggestionChangesRow,
-	changeID *uuid.UUID,
+	changeIDs []uuid.UUID,
 ) (string, []repo.ListSkillEditSuggestionChangesRow, error) {
 	if len(changes) == 0 {
 		return "", nil, oops.E(oops.CodeConflict, nil, "skill suggestion no longer proposes any changes")
 	}
 
-	if changeID == nil {
-		content := baseContent
+	requested := make(map[uuid.UUID]struct{}, len(changeIDs))
+	for _, id := range changeIDs {
+		requested[id] = struct{}{}
+	}
+
+	taken := changes
+	var remaining []repo.ListSkillEditSuggestionChangesRow
+	if len(changeIDs) > 0 {
+		taken = make([]repo.ListSkillEditSuggestionChangesRow, 0, len(requested))
+		remaining = make([]repo.ListSkillEditSuggestionChangesRow, 0, len(changes))
 		for _, change := range changes {
-			applied, err := skilldiff.Apply(content, change.ProposedDiff)
-			if err != nil {
-				return "", nil, oops.E(oops.CodeConflict, nil, "skill suggestion no longer applies to its base version")
+			if _, ok := requested[change.ID]; ok {
+				taken = append(taken, change)
+				delete(requested, change.ID)
+				continue
 			}
-			content = applied
+			remaining = append(remaining, change)
 		}
-
-		return content, nil, nil
-	}
-
-	var taken *repo.ListSkillEditSuggestionChangesRow
-	remaining := make([]repo.ListSkillEditSuggestionChangesRow, 0, len(changes))
-	for i, change := range changes {
-		if change.ID == *changeID {
-			taken = &changes[i]
-			continue
+		if len(requested) > 0 {
+			return "", nil, oops.E(oops.CodeConflict, nil, "a selected proposed change is no longer part of this suggestion")
 		}
-		remaining = append(remaining, change)
-	}
-	if taken == nil {
-		return "", nil, oops.E(oops.CodeConflict, nil, "that proposed change is no longer part of this suggestion")
 	}
 
-	content, err := skilldiff.Apply(baseContent, taken.ProposedDiff)
-	if err != nil {
-		return "", nil, oops.E(oops.CodeConflict, nil, "that proposed change no longer applies to the current skill")
+	content := baseContent
+	for _, change := range taken {
+		applied, err := skilldiff.Apply(content, change.ProposedDiff)
+		if err != nil {
+			if len(changeIDs) > 0 {
+				return "", nil, oops.E(oops.CodeConflict, nil, "a selected proposed change no longer applies to the current skill")
+			}
+			return "", nil, oops.E(oops.CodeConflict, nil, "skill suggestion no longer applies to its base version")
+		}
+		content = applied
 	}
 
 	return content, remaining, nil
@@ -418,16 +422,18 @@ func (s *Service) ApproveSuggestion(ctx context.Context, payload *gen.ApproveSug
 		return nil, oops.E(oops.CodeBadRequest, nil, "invalid skill suggestion id")
 	}
 
-	var changeID *uuid.UUID
-	if payload.ChangeID != nil {
-		parsed, parseErr := uuid.Parse(*payload.ChangeID)
+	// Duplicates are harmless: approvalContent resolves membership through a
+	// set and the taken changes are deleted with an ANY match.
+	changeIDs := make([]uuid.UUID, 0, len(payload.ChangeIds))
+	for _, value := range payload.ChangeIds {
+		parsed, parseErr := uuid.Parse(value)
 		if parseErr != nil {
 			return nil, oops.E(oops.CodeBadRequest, nil, "invalid skill suggestion change id")
 		}
-		changeID = &parsed
+		changeIDs = append(changeIDs, parsed)
 	}
 
-	approval, err := s.approveSuggestion(ctx, authCtx, logger, suggestionID, payload.Content, changeID)
+	approval, err := s.approveSuggestion(ctx, authCtx, logger, suggestionID, payload.Content, changeIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/skills/suggestion_management_test.go
+++ b/server/internal/skills/suggestion_management_test.go
@@ -142,7 +142,7 @@ func TestSkillsApproveSuggestionHappyEditedAndAuditPrivacy(t *testing.T) {
 
 	edited := skillManifest(created.Skill.Name, "Edited.", editedMarker)
 	result, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: &edited, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: &edited, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "applied", result.Outcome)
@@ -192,7 +192,7 @@ func TestSkillsApproveSuggestionStaleAndHistoricalDuplicate(t *testing.T) {
 	})
 	require.NoError(t, err)
 	staleResult, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: stale.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: stale.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "superseded", staleResult.Outcome)
@@ -208,7 +208,7 @@ func TestSkillsApproveSuggestionStaleAndHistoricalDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	duplicate := createSuggestion(t, ti, current, firstContent, "duplicate rationale")
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: duplicate.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: duplicate.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeConflict)
 	preserved, err := ti.repo.GetSkillEditSuggestionForUpdate(ctx, repo.GetSkillEditSuggestionForUpdateParams{
@@ -241,7 +241,7 @@ func TestSkillsApproveSuggestionRejectsConcurrentSuggestionUpdate(t *testing.T) 
 	finished := make(chan approveResult, 1)
 	go func() {
 		result, approveErr := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-			ID: suggestion.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+			ID: suggestion.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 		})
 		finished <- approveResult{result: result, err: approveErr}
 	}()
@@ -305,7 +305,7 @@ func TestSkillsDismissSuggestionIdempotentAndConflicts(t *testing.T) {
 	approvedSkill := createSkill(t, ctx, ti, "suggestion-dismiss-approved", "Base.")
 	approvedSuggestion := createSuggestion(t, ti, approvedSkill, skillManifest(approvedSkill.Skill.Name, "Proposed.", "proposal"), "rationale")
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: approvedSuggestion.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: approvedSuggestion.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	require.NoError(t, err)
 	_, err = ti.service.DismissSuggestion(ctx, &gen.DismissSuggestionPayload{
@@ -498,7 +498,7 @@ func TestSkillsSuggestionManagementRBACDenied(t *testing.T) {
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	_, err = ti.service.ApproveSuggestion(deniedCtx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	_, err = ti.service.DismissSuggestion(deniedCtx, &gen.DismissSuggestionPayload{
@@ -516,7 +516,7 @@ func TestSkillsSuggestionManagementRBACDenied(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = ti.service.ApproveSuggestion(readOnlyCtx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
 	_, err = ti.service.DismissSuggestion(readOnlyCtx, &gen.DismissSuggestionPayload{
@@ -545,23 +545,23 @@ func TestSkillsApproveSuggestionNonOpenConflicts(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeConflict)
 
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: uuid.NewString(), Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: uuid.NewString(), Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeNotFound)
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: "not-a-uuid", Content: nil, ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: "not-a-uuid", Content: nil, ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeBadRequest)
 	openSkill := createSkill(t, ctx, ti, "suggestion-invalid-edit", "Base.")
 	openSuggestion := createSuggestion(t, ti, openSkill, skillManifest(openSkill.Skill.Name, "Proposed.", "proposal"), "rationale")
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
 		ID: openSuggestion.ID.String(), Content: conv.PtrEmpty(strings.Repeat("x", 65537)),
-		ChangeID: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ChangeIds: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
@@ -611,7 +611,7 @@ func TestSkillsApproveSuggestionTakesOneChangeAndKeepsTheRestOpen(t *testing.T) 
 	require.Len(t, changeIDs, 2)
 	first := changeIDs[0].String()
 	partial, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: nil, ChangeID: &first, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: []string{first}, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "partially_applied", partial.Outcome)
@@ -632,7 +632,104 @@ func TestSkillsApproveSuggestionTakesOneChangeAndKeepsTheRestOpen(t *testing.T) 
 
 	second := suggestionChangeIDs(t, ti, suggestion.ID)[0].String()
 	final, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: nil, ChangeID: &second, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: []string{second}, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "applied", final.Outcome)
+	require.NotNil(t, final.Version)
+	require.Equal(t, proposed, final.Version.Content)
+	require.Equal(t, string(skills.EditSuggestionStatusApproved), final.Suggestion.Status)
+}
+
+func TestSkillsApproveSuggestionTakesSelectedChangesAsOneVersion(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	created, err := ti.service.Create(ctx, &gen.CreatePayload{
+		Content:          skillManifest("suggestion-approve-selected", "Runbook.", twoChangeBody),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	announce := strings.Replace(twoChangeBody, "Announce the window in the release channel.", "Announce the window in the release channel and page the on-call.", 1)
+	budget := strings.Replace(announce, "Watch the canary for ten minutes.", "Watch the canary for twenty minutes.", 1)
+	all := strings.Replace(budget, "Close the window.", "Close the window and record the duration.", 1)
+	afterAnnounce := skillManifest(created.Skill.Name, "Runbook.", announce)
+	afterBudget := skillManifest(created.Skill.Name, "Runbook.", budget)
+	proposed := skillManifest(created.Skill.Name, "Runbook.", all)
+
+	suggestion := createSuggestion(t, ti, created, afterAnnounce, "page the on-call")
+	_, err = ti.repo.CreateSkillEditSuggestionChange(ctx, repo.CreateSkillEditSuggestionChangeParams{
+		ProposedDiff: diffTo(t, afterAnnounce, afterBudget),
+		Rationale:    "watch longer",
+		Position:     1,
+		ProjectID:    ti.projectID,
+		SuggestionID: suggestion.ID,
+	})
+	require.NoError(t, err)
+	_, err = ti.repo.CreateSkillEditSuggestionChange(ctx, repo.CreateSkillEditSuggestionChangeParams{
+		ProposedDiff: diffTo(t, afterBudget, proposed),
+		Rationale:    "record the duration",
+		Position:     2,
+		ProjectID:    ti.projectID,
+		SuggestionID: suggestion.ID,
+	})
+	require.NoError(t, err)
+
+	changeIDs := suggestionChangeIDs(t, ti, suggestion.ID)
+	require.Len(t, changeIDs, 3)
+	selected := []string{changeIDs[0].String(), changeIDs[2].String()}
+	partial, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: selected, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "partially_applied", partial.Outcome)
+	require.NotNil(t, partial.Version)
+	// One version carries both selected edits; the unselected one is untouched.
+	require.Contains(t, partial.Version.Content, "page the on-call")
+	require.Contains(t, partial.Version.Content, "record the duration")
+	require.NotContains(t, partial.Version.Content, "twenty minutes")
+
+	require.Equal(t, string(skills.EditSuggestionStatusOpen), partial.Suggestion.Status)
+	require.Equal(t, partial.Version.ID, partial.Suggestion.BaseVersionID)
+	require.Len(t, partial.Suggestion.Changes, 1)
+	require.Equal(t, "watch longer", partial.Suggestion.Changes[0].Rationale)
+	require.True(t, partial.Suggestion.Changes[0].AppliesCleanly)
+}
+
+func TestSkillsApproveSuggestionSelectingEveryChangeApprovesFully(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	created, err := ti.service.Create(ctx, &gen.CreatePayload{
+		Content:          skillManifest("suggestion-approve-select-all", "Runbook.", twoChangeBody),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	budget := strings.Replace(twoChangeBody, "Check the error budget.", "Check the error budget and page the on-call.", 1)
+	both := strings.Replace(budget, "Close the window.", "Close the window and record the duration.", 1)
+	afterBudget := skillManifest(created.Skill.Name, "Runbook.", budget)
+	proposed := skillManifest(created.Skill.Name, "Runbook.", both)
+
+	suggestion := createSuggestion(t, ti, created, afterBudget, "page the on-call")
+	_, err = ti.repo.CreateSkillEditSuggestionChange(ctx, repo.CreateSkillEditSuggestionChangeParams{
+		ProposedDiff: diffTo(t, afterBudget, proposed),
+		Rationale:    "record the duration",
+		Position:     1,
+		ProjectID:    ti.projectID,
+		SuggestionID: suggestion.ID,
+	})
+	require.NoError(t, err)
+
+	changeIDs := suggestionChangeIDs(t, ti, suggestion.ID)
+	require.Len(t, changeIDs, 2)
+	// Duplicated IDs collapse instead of double-applying a change.
+	selected := []string{changeIDs[0].String(), changeIDs[1].String(), changeIDs[0].String()}
+	final, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: selected, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	require.NoError(t, err)
 	require.Equal(t, "applied", final.Outcome)
@@ -649,7 +746,7 @@ func TestSkillsApproveSuggestionRejectsUnknownChangeAndEditedCombination(t *test
 
 	missing := uuid.NewString()
 	_, err := ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: nil, ChangeID: &missing, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: nil, ChangeIds: []string{missing}, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	require.ErrorContains(t, err, "no longer part of this suggestion")
 	requireOopsCode(t, err, oops.CodeConflict)
@@ -657,7 +754,7 @@ func TestSkillsApproveSuggestionRejectsUnknownChangeAndEditedCombination(t *test
 	edited := skillManifest(created.Skill.Name, "Edited.", "edited")
 	only := suggestionChangeIDs(t, ti, suggestion.ID)[0].String()
 	_, err = ti.service.ApproveSuggestion(ctx, &gen.ApproveSuggestionPayload{
-		ID: suggestion.ID.String(), Content: &edited, ChangeID: &only, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		ID: suggestion.ID.String(), Content: &edited, ChangeIds: []string{only}, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }


### PR DESCRIPTION
## Summary

- `skills.approveSuggestion` now accepts `change_ids` (replacing the single `change_id`), so a reviewer can take any subset of a suggestion's proposed changes together as **one new skill version** — GitHub add-to-batch style. Selecting every change behaves exactly like a full approval; a partial selection leaves the suggestion open carrying the rest.
- Taken changes are dropped in a single bulk delete (`id = ANY`) inside the approval transaction.
- Dashboard: each proposed change in the diff gets a selection checkbox, and a control bar above the diff shows `n of m changes selected` with **Apply all** (opens the existing review dialog) and **Apply selected (n)**. The misplaced **Apply all** button is removed from the per-change comment box, which now only applies its own change.

Closes [DNO-659](https://linear.app/speakeasy/issue/DNO-659)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch apply selected skill edit suggestion changes as one version. API now accepts `change_ids`; the dashboard adds batch controls with accessible checkboxes; local seed adds a multi-change suggestion and skips reseeding once the skill advances. Addresses DNO-659.

- **New Features**
  - API: `skills.approveSuggestion` accepts `change_ids` (array). Selecting all equals full approval; partial keeps the rest open. Cannot combine with edited content.
  - Dashboard: per-change selection checkboxes (unique accessible names) and a control bar above the diff with “Apply all” and “Apply selected (n)”. The per-change comment’s “Apply” only applies that single change; the old “Apply all” there is removed.
  - Dev: local seed creates a sample skill with an open multi-change suggestion, enables the `skills` feature, and skips suggestion seeding once the skill advances past its base version.

- **Migration**
  - Replace `change_id` with `change_ids` (array). In the TS SDK, use `changeIds` instead of `changeId`. Example: `approveSkillSuggestion({ id, changeIds: [id1, id2] })`.
  - CLI: `skills approve-suggestion` now expects `change_ids` (array) in the JSON body. OpenAPI/clients are updated.

<sup>Written for commit af308dd508520081d1e2f42187450ff9b6e81e34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

