### PR TITLE
chore(pnpm): enable global virtual store

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+enableGlobalVirtualStore: true
+
 packages:
   - client/*
   - sdks/*


### PR DESCRIPTION
https://pnpm.io/git-worktrees

Sharing a single virtual store across projects avoids duplicating package content on disk and speeds up installs across worktrees.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `pnpm`'s global virtual store across the workspace to dedupe packages and speed up installs, especially across worktrees. Sets `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml`.

<sup>Written for commit e94feaded4941aaa28d128ee3ac1f7b9774b11a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

