### PR TITLE
fix: default employee table sort to enrolled-first

### DIFF
--- a/client/dashboard/src/components/observe/InsightsEmployees.tsx
+++ b/client/dashboard/src/components/observe/InsightsEmployees.tsx
@@ -607,7 +607,11 @@ function EmployeeTable({
 }) {
   const showDeviceAgent = deviceStatus !== "hidden";
   const [page, setPage] = useState(0);
-  const [sort, setSort] = useState<SortDescriptor | null>(initialSort);
+  // Default to enrolled-first when no explicit sort was seeded via URL. Status
+  // labels sort "Enrolled" before "Not Enrolled" ascending.
+  const [sort, setSort] = useState<SortDescriptor | null>(
+    initialSort ?? { id: "status", direction: "asc" },
+  );
   // Only ticks once statuses are actually resolvable; disabled (0) otherwise so
   // the memo stays stable (deviceAgentState is only called when "ready").
   const now = useNow(deviceStatus === "ready" ? AGENT_STATUS_TICK_MS : 0);


### PR DESCRIPTION
## What

The Employee Enrollment table sorted **not-enrolled** members to the top by default. Flip the default so **enrolled** members lead.

## How

`EmployeeTable` now seeds its sort state to `{ id: "status", direction: "asc" }` when no sort is supplied via the `?sort=` URL param. The status column's `sortValue` returns the label, and "Enrolled" sorts before "Not Enrolled" ascending.

Header clicks and `?sort=` links still override the default exactly as before.