### PR TITLE
chore(worktree): auto-boot the dev stack on worktree creation

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -45,6 +45,12 @@ nuke = "mise run nuke"
 [list]
 url = "https://localhost:{{ vars.siteport | default('5173') }}"
 
+# `wt status` — one line per worktree: is its stack up, and where. The built-in
+# table can't express this: liveness is only in `url_active` in the JSON, not
+# in any column template.
+[aliases]
+status = "mise run git:workstatus"
+
 #
 # ## Dev server URL
 #

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -17,11 +17,33 @@
 [[pre-start]]
 workinit = "mise run git:workinit"
 
+# Background: brings the worktree's stack up on the ports workinit just
+# assigned — compose infra, migrations, dev-idp, the pitchfork daemons, then
+# seed. Non-blocking, so worktree creation returns without waiting on it;
+# `wt config state logs` has the output.
+#
+# INFRA_READINESS_TIMEOUT is raised from its 30s default because a new worktree
+# always starts from a cold volume: Postgres has to finish initdb before it
+# accepts queries, and several worktree stacks may be booting at once. At 30s
+# infra:start gives up mid-initdb and zero aborts before migrations run,
+# leaving the daemons pointed at an empty database.
+[post-start]
+stack = "INFRA_READINESS_TIMEOUT=300 ./zero --agent"
+
 # Runs inside the worktree before deletion — nuke needs this worktree's
 # COMPOSE_PROJECT_NAME (mise.local.toml) and local/ dir to tear down the right
 # compose stack. post-remove would run in the primary worktree instead.
 [[pre-remove]]
 nuke = "mise run nuke"
+
+# Dashboard URL in the `wt list` URL column, dimmed when the port isn't
+# listening — so it doubles as a "is this worktree's stack up?" indicator.
+# Ports are randomized per worktree by `zero:remap-ports`, not derived from the
+# branch, so `git:workinit` stores the assigned port as the per-branch
+# `siteport` var. The default covers the primary worktree, which keeps
+# mise.toml's port.
+[list]
+url = "https://localhost:{{ vars.siteport | default('5173') }}"
 
 #
 # ## Dev server URL

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -55,3 +55,10 @@ for line in $remap; do
 done
 
 echo ✅ Updated all port mappings for new worktree
+
+# Ports are randomized, so `wt list`'s URL column can't derive them from the
+# branch name. Store the dashboard port as a per-branch var for it to read.
+site_port=$(printf '%s\n' $remap | sed -n 's/^GRAM_SITE_PORT=//p')
+if [ -n "$site_port" ] && command -v wt &> /dev/null; then
+  wt config state vars set "siteport=${site_port}" > /dev/null
+fi

--- a/.mise-tasks/git/workinit.sh
+++ b/.mise-tasks/git/workinit.sh
@@ -58,7 +58,10 @@ echo ✅ Updated all port mappings for new worktree
 
 # Ports are randomized, so `wt list`'s URL column can't derive them from the
 # branch name. Store the dashboard port as a per-branch var for it to read.
+# Best-effort: this is display metadata, and the script runs under `set -e` as a
+# blocking pre-start hook, so a failure here must not stop the worktree from
+# being set up. stderr is left alone so the reason is still visible.
 site_port=$(printf '%s\n' $remap | sed -n 's/^GRAM_SITE_PORT=//p')
 if [ -n "$site_port" ] && command -v wt &> /dev/null; then
-  wt config state vars set "siteport=${site_port}" > /dev/null
+  wt config state vars set "siteport=${site_port}" > /dev/null || true
 fi

--- a/.mise-tasks/git/workstatus.sh
+++ b/.mise-tasks/git/workstatus.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#MISE description="Show each worktree's stack state and dashboard URL"
+#MISE dir="{{ config_root }}"
+#MISE alias="gwst"
+#MISE quiet=true
+
+set -e
+
+if ! command -v wt &> /dev/null; then
+    echo "worktrunk (wt) not found. See https://worktrunk.dev" >&2
+    exit 1
+fi
+
+# `wt list` renders the URL as an OSC-8 hyperlink showing only `:port`, and its
+# up/down signal is a dimmed cell that no column template can read -- liveness
+# lives solely in `url_active` in the JSON. So render it here instead.
+#
+# json-schema is pinned per-invocation because a future release switches the
+# default to schema 2, which wraps the array in an envelope this jq would miss.
+rows=$(wt --config-set 'list.json-schema=1' list --format json \
+    | jq -r '.[] | select(.url // "" != "")
+             | [(if .is_current then "@" else "+" end), .branch, (.url_active | tostring), .url]
+             | @tsv')
+
+if [ -z "$rows" ]; then
+    echo "No worktree URLs yet — ports are assigned by \`mise run git:workinit\`."
+    exit 0
+fi
+
+width=$(printf '%s\n' "$rows" | cut -f2 | awk '{ if (length($0) > m) m = length($0) } END { print m }')
+
+printf '  \033[1m%-*s  %-6s %s\033[0m\n' "$width" "Branch" "State" "URL"
+
+printf '%s\n' "$rows" | while IFS=$'\t' read -r marker branch active url; do
+    if [ "$active" = "true" ]; then
+        state=$'\033[32m● up\033[0m  '
+    else
+        state=$'\033[31m○ down\033[0m'
+    fi
+    printf '%s %-*s  %b %s\n' "$marker" "$width" "$branch" "$state" "$url"
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,56 @@ The Gram server uses the same code paths as production — only `GRAM_IDP_BASE_U
 
 </details>
 
+### Parallel worktrees
+
+Each git worktree can run its own full stack — server, worker, dashboard, databases — side by side with the others. Ports and the Docker Compose project name are remapped per worktree, so nothing collides with your primary checkout.
+
+The flow is driven by [worktrunk](https://worktrunk.dev), configured in `.config/wt.toml`:
+
+```bash
+wt switch --create my-feature   # create the worktree and boot its stack
+wt status                       # which stacks are up, and on which URL
+wt remove                       # tear the stack down and delete the worktree
+```
+
+Creating a worktree runs two hooks:
+
+- **`pre-start`** runs `mise run git:workinit`, which copies `mise.local.toml` and `local/` from the primary worktree, installs dependencies, and assigns this worktree a free port for every `*_PORT` variable plus its own `COMPOSE_PROJECT_NAME`.
+- **`post-start`** runs `./zero --agent` in the background to bring up infra, apply migrations, start the daemons, and seed.
+
+> [!NOTE]
+> `INFRA_READINESS_TIMEOUT` is raised for the `post-start` hook. A new worktree always starts from a cold volume, so Postgres has to finish `initdb` before it accepts queries — well past the 30s default that `mise infra:start` uses elsewhere.
+
+Because `post-start` is backgrounded, `wt switch` returns before the stack is ready — expect a couple of minutes. Use `wt status` to see when it comes up, and `wt config state logs` if it doesn't:
+
+```
+  Branch          State  URL
+@ main            ● up   https://localhost:5173
++ my-feature      ● up   https://localhost:52495
++ old-experiment  ○ down https://localhost:62875
+```
+
+`wt remove` runs `mise run nuke` inside the worktree first, so the right Compose stack is torn down before the directory disappears. Removing a worktree by hand (`git worktree remove`) skips that and leaves its containers and volumes running.
+
+#### Recommended shell setup
+
+Worktrunk needs a shell wrapper to change directory on your behalf. Install it once:
+
+```bash
+wt config shell install
+```
+
+If you already have aliases for the branch commands this flow replaces, pointing them at `wt` makes worktrees the default without learning new muscle memory:
+
+```bash
+alias nb='wt switch --create'   # new branch, in its own worktree
+alias gco='wt switch'           # switch; no argument opens a picker
+alias gbd='wt remove'           # tear down the stack, remove the worktree
+alias wts='wt status'           # which stacks are up
+```
+
+`wt switch` also takes shortcuts in place of a branch name: `^` for the default branch, `-` for the previous worktree, and `pr:123` to check out a pull request. Prefer `^` over hardcoding `main` — it resolves correctly in any repo.
+
 ### CLI development
 
 Quickstart:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,13 @@ Once everything is running, seed the local database with sample data:
 mise seed
 ```
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for more detail on local development, auth, and the CLI.
+To work on several branches at once, each git worktree can run its own full stack on its own ports:
+
+```bash
+wt switch --create my-feature
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more detail on local development, auth, worktrees, and the CLI.
 
 ## Contributing
 


### PR DESCRIPTION
Creating a worktree now brings up a complete, isolated dev stack — infra, migrations, daemons and seed data — so a new branch is ready to work on without running `./zero` by hand.

Builds on the hooks added in #4650.

## What changed

`post-start` runs `./zero --agent`. That's the whole thing — `zero` already does exactly the right work in a worktree, including detecting one and running `git:worksync --no-migrate` to pick up newly-added ports without re-randomizing the ones `workinit` just assigned.

The one adjustment it needs is `INFRA_READINESS_TIMEOUT=300`.

## Why the timeout

`infra/start.sh` bounds readiness at 30s so headless callers fail fast instead of hanging. That's the right default for a human watching a terminal, running once against a warm volume. A worktree inverts all three assumptions: it always starts from a cold volume, so Postgres is still partway through `initdb` when the probe gives up, and several stacks may be booting at once.

When that happens `infra:start` exits 1 and `set -e` aborts `zero` before the migrations run. Because `post-start` is backgrounded, it fails **silently** — you get a shell prompt and a worktree, and the breakage only surfaces later as the server logging `relation "projects" does not exist` against an empty database.

Raised at this call site rather than as the task default, so other headless callers keep failing fast.

## URL column

`wt list` can now show each worktree's dashboard URL, dimmed when the port isn't listening — so it doubles as a "is this stack up?" indicator, which also covers some of the silent-failure gap above.

Ports are randomized by `zero:remap-ports` rather than derived from the branch, so the documented `{{ branch | hash_port }}` would render a URL pointing at nothing. `workinit` records the assigned port as the per-branch `siteport` var instead, at the point the ports are actually assigned.

## Testing

Verified end to end on a fresh worktree created with `wt switch --create`, no manual steps:

- worktree gets its own compose project, isolated from the primary stack
- all 12 pitchfork daemons running; dashboard serves HTTP 200
- seed completes, including the org whitelist step
- **zero `relation ... does not exist` errors in the server log** — the original symptom

Roughly 2.5 min before the databases are migrated, then another 1–2 min for daemons and seed.

## Note for reviewers

`.mise-tasks` changes only take effect once merged. Project hooks are read from the worktree `wt` runs in, but `mise run git:workinit` executes inside the _new_ worktree, which is a checkout of the commit — so `siteport` won't self-record from an uncommitted edit.


## `wt status`

A `git:workstatus` task, exposed as the `wt status` alias, shows one line per worktree — whether its stack is up, and on which URL:

```
  Branch          State  URL
@ main            ● up   https://localhost:5173
+ my-feature      ● up   https://localhost:52495
+ old-experiment  ○ down https://localhost:62875
```

This can't be done with `wt list` configuration. Its URL cell renders as an OSC-8 hyperlink whose display text is only `:port`, and liveness lives solely in `url_active` in the JSON — no column template can read it. (`list.custom-columns` and `list.json-schema` are also user-config-only, so neither can be set for the repo.) The task pins the JSON schema per invocation, so it behaves identically regardless of what each developer has configured.

## Docs

`CONTRIBUTING.md` gains a **Parallel worktrees** section: what each hook does, why the stack lags behind worktree creation, a recommended shell alias setup, and why removing a worktree by hand leaves its containers and volumes running. `README.md` gets a pointer from *Running locally*.
