### PR TITLE
feat: link MCP connect denials to access grants

### DIFF
--- a/.changeset/mcp-connect-access-guidance.md
+++ b/.changeset/mcp-connect-access-guidance.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Explain that MCP connection access was restricted by the `mcp:connect` permission and link users to their organization's authorization challenges grant flow.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -859,6 +859,7 @@ func newStartCommand() *cli.Command {
 				env,
 				posthogClient,
 				serverURL,
+				siteURL,
 				encryptionClient,
 				cache.NewRedisCacheAdapter(redisClient),
 				guardianPolicy,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -720,6 +720,7 @@ func newWorkerCommand() *cli.Command {
 				env,
 				posthogClient,
 				serverURL,
+				nil,
 				encryptionClient,
 				cache.NewRedisCacheAdapter(redisClient),
 				guardianPolicy,

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -98,6 +98,7 @@ type Service struct {
 	auth                   *auth.Auth
 	env                    toolconfig.EnvironmentLoader
 	serverURL              *url.URL
+	siteURL                *url.URL
 	posthog                *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
 	toolProxy              *gateway.ToolProxy
 	oauthService           OAuthService
@@ -239,6 +240,7 @@ func NewService(
 	env toolconfig.EnvironmentLoader,
 	posthog *posthog.Posthog,
 	serverURL *url.URL,
+	siteURL *url.URL,
 	enc *encryption.Client,
 	cacheImpl cache.Cache,
 	guardianPolicy *guardian.Policy,
@@ -298,6 +300,7 @@ func NewService(
 		auth:            auth.New(logger, db, sessions, authzEngine),
 		env:             env,
 		serverURL:       serverURL,
+		siteURL:         siteURL,
 		posthog:         posthog,
 		toolProxy: gateway.NewToolProxy(
 			logger,
@@ -345,6 +348,16 @@ func NewService(
 		tunnelManager:      newTunnelManager(tunnelRoutes, tunnelForwardToken, remoteProxyManager, tunnelGatewayCIDRs),
 		tunnelPublic:       newTunnelPublicRuntime(redisClient, tunnelPublicConfig),
 	}
+}
+
+func (s *Service) serverPermissionDenied(ctx context.Context, err error) error {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil {
+		return mcpaccess.ServerPermissionDenied(err, "")
+	}
+
+	requestAccessURL := mcpaccess.AuthorizationChallengesURL(s.siteURL, authCtx.OrganizationSlug)
+	return mcpaccess.ServerPermissionDenied(err, requestAccessURL)
 }
 
 func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
@@ -775,7 +788,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").LogError(ctx, s.logger)
 			}
 			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
-				return fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err))
+				return fmt.Errorf("authorize MCP server access: %w", s.serverPermissionDenied(ctx, err))
 			}
 		}
 

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -350,14 +350,13 @@ func NewService(
 	}
 }
 
-func (s *Service) serverPermissionDenied(ctx context.Context, err error) error {
+func (s *Service) authorizationChallengesURL(ctx context.Context) string {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil {
-		return mcpaccess.ServerPermissionDenied(err, "")
+		return ""
 	}
 
-	requestAccessURL := mcpaccess.AuthorizationChallengesURL(s.siteURL, authCtx.OrganizationSlug)
-	return mcpaccess.ServerPermissionDenied(err, requestAccessURL)
+	return mcpaccess.AuthorizationChallengesURL(s.siteURL, authCtx.OrganizationSlug)
 }
 
 func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
@@ -788,7 +787,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 				return oops.E(oops.CodeUnexpected, err, "failed to load access grants").LogError(ctx, s.logger)
 			}
 			if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, toolset.ID.String(), toolset.ProjectID.String())); err != nil {
-				return fmt.Errorf("authorize MCP server access: %w", s.serverPermissionDenied(ctx, err))
+				return fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err, s.authorizationChallengesURL(ctx)))
 			}
 		}
 

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
@@ -516,7 +517,7 @@ func (s *Service) prepareProxyBackendContext(
 
 		// mcp:connect covers non-tool proxy methods; tool interceptors still enforce per-tool scopes.
 		if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, mcpServer.ID.String(), endpoint.ProjectID.String())); err != nil {
-			return nil, fmt.Errorf("authorize MCP server access: %w", s.serverPermissionDenied(ctx, err))
+			return nil, fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err, s.authorizationChallengesURL(ctx)))
 		}
 	case mcpservers.VisibilityPublic:
 		// Public, no OAuth: optionally probe Gram identity if the

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -17,7 +17,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
-	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
@@ -517,7 +516,7 @@ func (s *Service) prepareProxyBackendContext(
 
 		// mcp:connect covers non-tool proxy methods; tool interceptors still enforce per-tool scopes.
 		if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, mcpServer.ID.String(), endpoint.ProjectID.String())); err != nil {
-			return nil, fmt.Errorf("authorize MCP server access: %w", mcpaccess.ServerPermissionDenied(err))
+			return nil, fmt.Errorf("authorize MCP server access: %w", s.serverPermissionDenied(ctx, err))
 		}
 	case mcpservers.VisibilityPublic:
 		// Public, no OAuth: optionally probe Gram identity if the

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -762,7 +762,8 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_RequiresC
 	var oopsErr *oops.ShareableError
 	require.ErrorAs(t, err, &oopsErr)
 	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
-	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage, oopsErr.Error())
+	requestAccessURL := mcpaccess.AuthorizationChallengesURL(ti.siteURL, authCtx.OrganizationSlug)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage+"\n\nRequest access:\n"+requestAccessURL, oopsErr.Error())
 
 	select {
 	case <-upstreamHit:

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -225,7 +225,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 		ManagedAssistantInsightsTools: managedLogsTools,
 	})
 	tunnelRoutes := route.NewRouteTable()
-	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig)
+	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, siteURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig)
 
 	authnCache := cache.NewTypedObjectCache[mcp.AuthnChallengeState](logger, cacheAdapter, cache.SuffixNone)
 

--- a/server/internal/mcpaccess/errors.go
+++ b/server/internal/mcpaccess/errors.go
@@ -2,26 +2,44 @@ package mcpaccess
 
 import (
 	"errors"
+	"net/url"
+	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 // ServerPermissionDeniedMessage is the user-facing MCP server access denial.
-const ServerPermissionDeniedMessage = "you do not have permission to use this MCP server. Contact your organization's administrator to request access."
+const ServerPermissionDeniedMessage = "access to this MCP server was restricted because your permissions do not include mcp:connect. Ask an organization administrator to grant access."
 
 // ToolPermissionDeniedMessage is the user-facing MCP tool access denial.
 const ToolPermissionDeniedMessage = "you do not have permission to use this MCP tool. Contact your organization's administrator to request access."
 
 // ServerPermissionDenied replaces a generic forbidden error at an MCP server
-// access boundary while preserving all other errors.
-func ServerPermissionDenied(err error) error {
-	return permissionDenied(err, ServerPermissionDeniedMessage)
+// access boundary while preserving all other errors. When requestAccessURL is
+// present, the message links directly to the authorization challenge grant flow.
+func ServerPermissionDenied(err error, requestAccessURL string) error {
+	message := ServerPermissionDeniedMessage
+	if requestAccessURL = strings.TrimSpace(requestAccessURL); requestAccessURL != "" {
+		message += "\n\nRequest access:\n" + requestAccessURL
+	}
+
+	return permissionDenied(err, message)
 }
 
 // ToolPermissionDenied replaces a generic forbidden error at an MCP tool-call
 // boundary while preserving all other errors.
 func ToolPermissionDenied(err error) error {
 	return permissionDenied(err, ToolPermissionDeniedMessage)
+}
+
+// AuthorizationChallengesURL returns the organization-scoped grant flow used
+// to resolve the authorization challenge recorded by a denied mcp:connect.
+func AuthorizationChallengesURL(siteURL *url.URL, organizationSlug string) string {
+	if siteURL == nil || strings.TrimSpace(organizationSlug) == "" {
+		return ""
+	}
+
+	return siteURL.JoinPath(organizationSlug, "access", "challenges").String()
 }
 
 func permissionDenied(err error, message string) error {

--- a/server/internal/mcpaccess/errors_test.go
+++ b/server/internal/mcpaccess/errors_test.go
@@ -2,6 +2,7 @@ package mcpaccess_test
 
 import (
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ func TestServerPermissionDeniedRewritesForbiddenError(t *testing.T) {
 	t.Parallel()
 
 	cause := oops.C(oops.CodeForbidden)
-	err := mcpaccess.ServerPermissionDenied(cause)
+	err := mcpaccess.ServerPermissionDenied(cause, "")
 
 	var shareableErr *oops.ShareableError
 	require.ErrorAs(t, err, &shareableErr)
@@ -41,6 +42,42 @@ func TestPermissionDeniedPreservesNonForbiddenError(t *testing.T) {
 
 	cause := errors.New("temporary failure")
 
-	require.ErrorIs(t, mcpaccess.ServerPermissionDenied(cause), cause)
+	require.ErrorIs(t, mcpaccess.ServerPermissionDenied(cause, "https://app.example.com/acme/access/challenges"), cause)
 	require.ErrorIs(t, mcpaccess.ToolPermissionDenied(cause), cause)
+}
+
+func TestServerPermissionDeniedIncludesRequestAccessURL(t *testing.T) {
+	t.Parallel()
+
+	cause := oops.C(oops.CodeForbidden)
+	requestAccessURL := "https://app.example.com/acme/access/challenges"
+	err := mcpaccess.ServerPermissionDenied(cause, requestAccessURL)
+
+	var shareableErr *oops.ShareableError
+	require.ErrorAs(t, err, &shareableErr)
+	require.Equal(t, mcpaccess.ServerPermissionDeniedMessage+"\n\nRequest access:\n"+requestAccessURL, shareableErr.Error())
+	require.ErrorIs(t, err, cause)
+}
+
+func TestAuthorizationChallengesURL(t *testing.T) {
+	t.Parallel()
+
+	siteURL, err := url.Parse("https://app.example.com/base/")
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		"https://app.example.com/base/acme/access/challenges",
+		mcpaccess.AuthorizationChallengesURL(siteURL, "acme"),
+	)
+}
+
+func TestAuthorizationChallengesURLRequiresInputs(t *testing.T) {
+	t.Parallel()
+
+	siteURL, err := url.Parse("https://app.example.com")
+	require.NoError(t, err)
+
+	require.Empty(t, mcpaccess.AuthorizationChallengesURL(nil, "acme"))
+	require.Empty(t, mcpaccess.AuthorizationChallengesURL(siteURL, " "))
 }

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -98,7 +98,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	// Authorization mirrors the runtime gate: minting a bearer grants runtime
 	// access, so the endpoint requires the same mcp:connect permission.
 	if err := s.authz.Require(ctx, authz.MCPCheck(authz.ScopeMCPConnect, target.resourceID, authCtx.ProjectID.String())); err != nil {
-		return nil, fmt.Errorf("authorize MCP session mint: %w", mcpaccess.ServerPermissionDenied(err))
+		return nil, fmt.Errorf("authorize MCP session mint: %w", mcpaccess.ServerPermissionDenied(err, ""))
 	}
 
 	issuer, err := repo.New(s.db).GetUserSessionIssuerByID(ctx, repo.GetUserSessionIssuerByIDParams{

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -157,7 +157,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient)
-	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
+	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- explain that MCP server access is restricted by the missing `mcp:connect` permission
- include an organization-scoped link to Authorization Challenges in connection-time denial responses
- preserve the existing denial behavior when dashboard URL context is unavailable

## Testing
- `mise run test:server ./internal/mcpaccess/... -count=1` (6 tests passed)
- `mise run test:server ./internal/mcp/... -run TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_RequiresConnectForInitialize -count=1` (passed; upstream remained untouched)
- `mise run test:server ./internal/usersessions/... -run MCPConnect -count=1` (4 tests passed)
- `mise run test:server ./cmd/gram ./internal/xmcp/... -run '^$' -count=1` (constructor call sites compiled)
- `mise lint:server` (passed)

Fixes AIS-393.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-393](https://linear.app/speakeasy/issue/AIS-393/feat-explain-restricted-access-and-request-access-flow-for-mcp-connect)

<div><a href="https://cursor.com/agents/bc-a9750248-ed13-4425-9e18-517a1aaab6f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9750248-ed13-4425-9e18-517a1aaab6f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

