### PR TITLE
fix(triggers): record real trigger-instance URNs and trace context in delivery telemetry

### DIFF
--- a/.changeset/trigger-telemetry-urns.md
+++ b/.changeset/trigger-telemetry-urns.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Trigger delivery telemetry logs now record a proper `trigger-instance:<uuid>` URN and the active trace context instead of a generic `urn:uuid:` identifier with empty trace and span ids.

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -76,6 +76,7 @@ import (
 	sv "github.com/speakeasy-api/gram/server/internal/thirdparty/svix"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/tracking"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 func noopShutdown(context.Context) error { return nil }
@@ -822,7 +823,7 @@ func newTriggersApp(
 				Timestamp: entry.Timestamp,
 				ToolInfo: telemetry.ToolInfo{
 					ID:             entry.Instance.ID.String(),
-					URN:            "urn:uuid:" + entry.Instance.ID.String(),
+					URN:            urn.NewTriggerInstance(entry.Instance.ID).String(),
 					Name:           "trigger:" + entry.Instance.DefinitionSlug,
 					ProjectID:      entry.Instance.ProjectID.String(),
 					DeploymentID:   "",

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
@@ -63,7 +64,7 @@ type EnvironmentLoader interface {
 }
 
 type DeliveryLogger interface {
-	LogTriggerDelivery(triggerrepo.TriggerInstance, EventEnvelope, DeliveryStatus, string, error)
+	LogTriggerDelivery(context.Context, triggerrepo.TriggerInstance, EventEnvelope, DeliveryStatus, string, error)
 }
 
 type Dispatcher interface {
@@ -86,6 +87,7 @@ func NewTriggerDeliveryLogger(write func(context.Context, TriggerDeliveryLog)) D
 }
 
 func (l *triggerDeliveryLogger) LogTriggerDelivery(
+	ctx context.Context,
 	instance triggerrepo.TriggerInstance,
 	envelope EventEnvelope,
 	status DeliveryStatus,
@@ -121,8 +123,14 @@ func (l *triggerDeliveryLogger) LogTriggerDelivery(
 	if err != nil {
 		attributes[attr.ErrorMessageKey] = err.Error()
 	}
+	// telemetry.HTTPLogAttributes.RecordTraceContext is off-limits here (import
+	// cycle through platformtools), so stamp the trace context directly.
+	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
+		attributes[attr.TraceIDKey] = spanCtx.TraceID().String()
+		attributes[attr.SpanIDKey] = spanCtx.SpanID().String()
+	}
 
-	l.write(context.Background(), TriggerDeliveryLog{
+	l.write(ctx, TriggerDeliveryLog{
 		Timestamp:  conv.Default(envelope.ReceivedAt, time.Now().UTC()),
 		Attributes: attributes,
 		Instance:   instance,
@@ -872,33 +880,33 @@ func boundAssistantKey(id string) string {
 func (a *App) ProcessEvent(ctx context.Context, instance triggerrepo.TriggerInstance, envelope EventEnvelope) (*Task, error) {
 	rawConfig, err := configJSONToMap(instance.ConfigJson)
 	if err != nil {
-		a.emitDeliveryLog(instance, envelope, DeliveryStatusFailed, "decode trigger config", err)
+		a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusFailed, "decode trigger config", err)
 		return nil, fmt.Errorf("decode trigger config: %w", err)
 	}
 
 	_, config, err := a.validateInstance(ctx, instance.ProjectID, nullUUIDToUUID(instance.EnvironmentID), instance.DefinitionSlug, rawConfig)
 	if err != nil {
-		a.emitDeliveryLog(instance, envelope, DeliveryStatusFailed, "validate trigger instance", err)
+		a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusFailed, "validate trigger instance", err)
 		return nil, fmt.Errorf("validate trigger instance: %w", err)
 	}
 
 	if instance.Status != StatusActive {
-		a.emitDeliveryLog(instance, envelope, DeliveryStatusSkipped, "trigger is paused", nil)
+		a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusSkipped, "trigger is paused", nil)
 		return nil, nil
 	}
 
 	match, err := config.Filter(envelope.Event)
 	if err != nil {
-		a.emitDeliveryLog(instance, envelope, DeliveryStatusFailed, "evaluate filter", err)
+		a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusFailed, "evaluate filter", err)
 		return nil, fmt.Errorf("evaluate filter: %w", err)
 	}
 	if !match {
-		a.emitDeliveryLog(instance, envelope, DeliveryStatusSkipped, "filter did not match", nil)
+		a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusSkipped, "filter did not match", nil)
 		return nil, nil
 	}
 
 	if err := ValidateTargetKind(instance.TargetKind); err != nil {
-		a.emitDeliveryLog(instance, envelope, DeliveryStatusFailed, "trigger target is not supported", err)
+		a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusFailed, "trigger target is not supported", err)
 		return nil, fmt.Errorf("validate trigger target kind: %w", err)
 	}
 
@@ -916,13 +924,13 @@ func (a *App) ProcessEvent(ctx context.Context, instance triggerrepo.TriggerInst
 	if envelope.Event != nil {
 		eventJSON, err := json.Marshal(envelope.Event)
 		if err != nil {
-			a.emitDeliveryLog(instance, envelope, DeliveryStatusFailed, "marshal event payload", err)
+			a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusFailed, "marshal event payload", err)
 			return nil, fmt.Errorf("marshal event payload: %w", err)
 		}
 		task.EventJSON = eventJSON
 	}
 
-	a.emitDeliveryLog(instance, envelope, DeliveryStatusSent, "trigger event enqueued", nil)
+	a.deliveryLogger.LogTriggerDelivery(ctx, instance, envelope, DeliveryStatusSent, "trigger event enqueued", nil)
 	return task, nil
 }
 
@@ -1079,10 +1087,6 @@ func (a *App) loadEnvironmentMap(ctx context.Context, projectID uuid.UUID, envir
 		return map[string]string{}, nil
 	}
 	return envMap, nil
-}
-
-func (a *App) emitDeliveryLog(instance triggerrepo.TriggerInstance, envelope EventEnvelope, status DeliveryStatus, reason string, err error) {
-	a.deliveryLogger.LogTriggerDelivery(instance, envelope, status, reason, err)
 }
 
 func ValidateTargetKind(targetKind string) error {

--- a/server/internal/background/triggers/app_test.go
+++ b/server/internal/background/triggers/app_test.go
@@ -6,7 +6,12 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	triggerrepo "github.com/speakeasy-api/gram/server/internal/triggers/repo"
 )
 
 func TestBoundAssistantKey(t *testing.T) {
@@ -101,4 +106,46 @@ func TestAppCreateRejectsDirectIngressDefinition(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrBadRequest)
 	require.ErrorContains(t, err, "system-managed")
+}
+
+func TestLogTriggerDeliveryStampsTraceContext(t *testing.T) {
+	t.Parallel()
+
+	var captured TriggerDeliveryLog
+	logger := NewTriggerDeliveryLogger(func(_ context.Context, entry TriggerDeliveryLog) {
+		captured = entry
+	})
+
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:  trace.SpanID{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18},
+	})
+	ctx := trace.ContextWithSpanContext(t.Context(), spanCtx)
+
+	logger.LogTriggerDelivery(ctx, triggerrepo.TriggerInstance{
+		ID:             uuid.New(),
+		DefinitionSlug: DefinitionSlugSlack,
+		TargetKind:     TargetKindAssistant,
+	}, EventEnvelope{EventID: "event-123", CorrelationID: "corr-123"}, DeliveryStatusSent, "", nil)
+
+	require.Equal(t, spanCtx.TraceID().String(), captured.Attributes[attr.TraceIDKey])
+	require.Equal(t, spanCtx.SpanID().String(), captured.Attributes[attr.SpanIDKey])
+}
+
+func TestLogTriggerDeliveryOmitsTraceContextWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	var captured TriggerDeliveryLog
+	logger := NewTriggerDeliveryLogger(func(_ context.Context, entry TriggerDeliveryLog) {
+		captured = entry
+	})
+
+	logger.LogTriggerDelivery(t.Context(), triggerrepo.TriggerInstance{
+		ID:             uuid.New(),
+		DefinitionSlug: DefinitionSlugSlack,
+		TargetKind:     TargetKindAssistant,
+	}, EventEnvelope{EventID: "event-123", CorrelationID: "corr-123"}, DeliveryStatusSent, "", nil)
+
+	require.NotContains(t, captured.Attributes, attr.TraceIDKey)
+	require.NotContains(t, captured.Attributes, attr.SpanIDKey)
 }

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -1509,9 +1509,11 @@ func (q *Queries) ListToolTraces(ctx context.Context, arg ListToolTracesParams) 
 		havingParts = append(havingParts, "event_source = ?")
 		havingArgs = append(havingArgs, arg.EventSource)
 	} else {
-		// Exclude hooks logs by default when no event_source filter is specified
-		havingParts = append(havingParts, "event_source != ?")
-		havingArgs = append(havingArgs, "hook")
+		// Exclude hook logs and trigger delivery logs by default when no
+		// event_source filter is specified. Trigger delivery rows carry a
+		// tool_name (trigger:<slug>) and a trace id but are not tool calls.
+		havingParts = append(havingParts, "event_source NOT IN (?, ?)")
+		havingArgs = append(havingArgs, "hook", "trigger")
 	}
 
 	// Combine all HAVING conditions with explicit AND to ensure proper filtering


### PR DESCRIPTION
## Summary

- Trigger delivery telemetry rows wrote `gram_urn = urn:uuid:<instance-id>` — a URN that identifies nothing. They now use the canonical `trigger-instance:<uuid>` URN from the `urn` package (already used by the audit log path).
- `LogTriggerDelivery` dropped the caller's context and logged with `context.Background()`, so every trigger row landed in `telemetry_logs` with empty trace and span ids. The delivery logger now takes the caller's context and stamps `trace_id`/`span_id` from the active span (webhook request, Temporal activity), so delivery logs correlate with server traces.
- With real trace ids and a non-`urn:uuid:` URN, trigger rows now flow into the `trace_summaries` MV; `ListToolTraces` excludes `event_source = 'trigger'` by default (alongside the existing `hook` exclusion) so delivery logs don't surface as tool-call traces. The tool-usage fast path already excludes them via its `tools:`-prefix/hook-only condition, and `deriveEventURN` classifies trigger rows by `gram.event.source`, so event-URN classification is unchanged.

Closes [DNO-675](https://linear.app/speakeasy/issue/DNO-675/investigation-malformed-urns-in-telemetry-logs-from-assistant-triggers)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes malformed trigger delivery URNs and missing trace context in telemetry logs so entries correlate with server traces, and hides trigger delivery logs from tool trace views. Addresses DNO-675.

- **Bug Fixes**
  - Write `trigger-instance:<uuid>` using `urn.NewTriggerInstance(...)` instead of `urn:uuid:<uuid>`.
  - Change `LogTriggerDelivery` to accept `context.Context` and record `trace_id`/`span_id` from the active span.
  - Update `ListToolTraces` to exclude `event_source` in `('hook', 'trigger')` by default.
  - Add tests to verify trace context stamping and omission when absent.

<sup>Written for commit d465c128a7a7f4158555d3669cdf8b4c9908e717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

