### PR TITLE
feat(remotesessions): look up identity providers by upstream issuer URL

### DIFF
--- a/.changeset/ais-333-resolve-issuer-by-url.md
+++ b/.changeset/ais-333-resolve-issuer-by-url.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": minor
+---
+
+`remoteSessionIssuers.get` can now look an identity provider up by its upstream issuer URL, returning the one the project would use (preferring project over organization over platform) or 404 when nothing describes that URL yet. The dashboard's automatic setup flows use it to decide whether to reuse an existing provider instead of scanning the provider list in the browser, which also lets them reuse platform-catalog providers for the first time.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -30664,7 +30664,12 @@ paths:
         name: FetchRemoteSessionIssuerMetadata
   /rpc/remoteSessionIssuers.get:
     get:
-      description: Get a remote_session_issuer by id or by slug. Provide exactly one.
+      description: |-
+        Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+
+        Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+
+        The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.
       operationId: getRemoteSessionIssuer
       parameters:
         - allowEmptyValue: true
@@ -30681,6 +30686,13 @@ paths:
           name: slug
           schema:
             description: The remote_session_issuer slug.
+            type: string
+        - allowEmptyValue: true
+          description: The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer this project would use for that URL, or 404 when none describes it.
+          in: query
+          name: issuer
+          schema:
+            description: The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer this project would use for that URL, or 404 when none describes it.
             type: string
         - allowEmptyValue: true
           description: Session header

--- a/client/dashboard/src/lib/errors.tsx
+++ b/client/dashboard/src/lib/errors.tsx
@@ -26,6 +26,15 @@ export function toError(error: unknown): Error {
   }
 }
 
+// isNotFoundError reports whether an SDK call failed with a 404. Some lookups
+// treat "not found" as a normal answer rather than a failure — asking whether a
+// record exists before creating it — so they catch the rejection and branch on
+// this instead of surfacing an error.
+export function isNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return "statusCode" in error && error.statusCode === 404;
+}
+
 export function handleError(
   error: unknown,
   options: ErrorHandlerOptions = {},

--- a/client/dashboard/src/pages/mcp/wire-user-session-issuer/services.ts
+++ b/client/dashboard/src/pages/mcp/wire-user-session-issuer/services.ts
@@ -12,6 +12,7 @@ import { buildMigrateLegacyGramRegistrationsMutation } from "@gram/client/react-
 import { buildSetToolsetUserSessionIssuerMutation } from "@gram/client/react-query/setToolsetUserSessionIssuer.js";
 import { fromPromise } from "xstate";
 
+import { isNotFoundError } from "@/lib/errors";
 import {
   type AuthedFetch,
   proxyRegisterUpstreamClient,
@@ -71,7 +72,7 @@ function createMigrationServicesImpl(
           fetchOptions({ signal }).options,
         );
       } catch (error) {
-        if (isNotFound(error)) return null;
+        if (isNotFoundError(error)) return null;
         throw error;
       }
     },
@@ -94,7 +95,7 @@ function createMigrationServicesImpl(
           fetchOptions({ signal }).options,
         );
       } catch (error) {
-        if (isNotFound(error)) return null;
+        if (isNotFoundError(error)) return null;
         throw error;
       }
     },
@@ -155,6 +156,22 @@ function createMigrationServicesImpl(
       const discoverMutation =
         buildFetchRemoteSessionIssuerMetadataMutation(client);
       const createMutation = buildCreateRemoteSessionIssuerMutation(client);
+
+      // Look for an identity provider that already describes this upstream — in
+      // the project, inherited from the organization, or in the platform catalog
+      // — before creating one. This is an automatic setup path, so a duplicate
+      // here is unwanted; the manual attach form is the surface where a
+      // deliberate duplicate is legitimate, and it still creates unconditionally.
+      try {
+        const existing = await client.remoteSessionIssuers.get(
+          { issuer: input.issuerUrl },
+          undefined,
+          fetchOptions({ signal }).options,
+        );
+        return existing;
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error;
+      }
 
       let draft: {
         authorizationEndpoint?: string;
@@ -360,9 +377,4 @@ export function createMigrationServices(
   authedFetch: AuthedFetch,
 ): ReturnType<typeof createMigrationServicesImpl> {
   return createMigrationServicesImpl(client, authedFetch);
-}
-
-function isNotFound(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return "statusCode" in error && error.statusCode === 404;
 }

--- a/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.test.ts
+++ b/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.test.ts
@@ -14,6 +14,13 @@ vi.mock("@/lib/proxyRegisterUpstreamClient", () => ({
 
 const proxyRegisterMock = vi.mocked(proxyRegisterUpstreamClient);
 
+// Which issuer an upstream URL maps to — the project's own, one inherited from
+// the organization, or one from the platform catalog — is decided server-side by
+// remoteSessionIssuers.get({issuer}), and a 404 there means "nothing describes
+// this URL yet". These tests cover what this module still owns: the order of the
+// guards, the get-then-create branch, and what happens to a created issuer when
+// a later step fails. Tier precedence and URL normalization are covered
+// server-side.
 describe("autoConfigureRemoteMcpAuth", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -24,8 +31,8 @@ describe("autoConfigureRemoteMcpAuth", () => {
     });
   });
 
-  it("registers a fresh client under the server's own USI when no matching issuer exists", async () => {
-    const client = mockClient({ issuers: [] });
+  it("creates an issuer from the discovered draft when none exists and attaches a client under the server's own USI", async () => {
+    const client = mockClient();
 
     const result = await autoConfigureRemoteMcpAuth({
       client: client as unknown as Gram,
@@ -41,6 +48,12 @@ describe("autoConfigureRemoteMcpAuth", () => {
     });
     // The server already owns its USI from setup — auto-config never makes one.
     expect(client.userSessionIssuers.create).not.toHaveBeenCalled();
+    // The lookup is by URL, never by scanning the issuer list.
+    expect(client.remoteSessionIssuers.get).toHaveBeenCalledWith(
+      { issuer: "https://idp.example.com" },
+      undefined,
+      undefined,
+    );
     expect(client.remoteSessionIssuers.create).toHaveBeenCalledWith(
       {
         createRemoteSessionIssuerForm: expect.objectContaining({
@@ -83,19 +96,13 @@ describe("autoConfigureRemoteMcpAuth", () => {
     ).not.toHaveProperty("userSessionIssuerId");
   });
 
-  it("reuses a project issuer over an org issuer and stores resource scopes", async () => {
-    const orgIssuer = remoteSessionIssuer({
-      id: "org-issuer",
-      projectId: "",
-      issuer: "https://idp.example.com/",
-    });
-    const projectIssuer = remoteSessionIssuer({
-      id: "project-issuer",
-      projectId: "project-1",
-      issuer: "https://idp.example.com",
-    });
+  it("reuses the issuer the lookup returns instead of creating one", async () => {
     const client = mockClient({
-      issuers: [orgIssuer, projectIssuer],
+      existingIssuer: remoteSessionIssuer({
+        id: "existing-issuer",
+        projectId: "project-1",
+        issuer: "https://idp.example.com",
+      }),
     });
 
     const result = await autoConfigureRemoteMcpAuth({
@@ -105,9 +112,59 @@ describe("autoConfigureRemoteMcpAuth", () => {
       mcpServer: mcpServer(),
     });
 
-    expect(result.status).toBe("configured");
+    expect(result).toMatchObject({
+      status: "configured",
+      remoteSessionIssuerId: "existing-issuer",
+    });
     expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
-    expect(client.userSessionIssuers.create).not.toHaveBeenCalled();
+    expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
+      {
+        createRemoteSessionClientForm: expect.objectContaining({
+          remoteSessionIssuerId: "existing-issuer",
+        }),
+      },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("attaches the client to an issuer the project does not own, such as a platform-catalog one", async () => {
+    // A platform-catalog issuer comes back with no project and no organization.
+    // The tenant still hangs its own client off it.
+    const client = mockClient({
+      existingIssuer: remoteSessionIssuer({
+        id: "platform-issuer",
+        projectId: "",
+        organizationId: "",
+        issuer: "https://idp.example.com",
+      }),
+    });
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result).toMatchObject({
+      status: "configured",
+      remoteSessionIssuerId: "platform-issuer",
+    });
+    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
+  });
+
+  it("prefers the protected resource's scopes over the authorization server's", async () => {
+    const client = mockClient();
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result.status).toBe("configured");
     expect(proxyRegisterMock).toHaveBeenCalledWith(expect.any(Function), {
       registrationEndpoint: "https://idp.example.com/register",
       scope: "resource.read resource.write",
@@ -116,125 +173,7 @@ describe("autoConfigureRemoteMcpAuth", () => {
     expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
       {
         createRemoteSessionClientForm: expect.objectContaining({
-          remoteSessionIssuerId: "project-issuer",
-          userSessionIssuerIds: ["server-usi"],
-          clientId: "client-from-dcr",
-          clientSecret: "secret-from-dcr",
-          tokenEndpointAuthMethod: "client_secret_post",
           scope: ["resource.read", "resource.write"],
-        }),
-      },
-      undefined,
-      undefined,
-    );
-    expect(client.mcpServers.update).toHaveBeenCalledWith(
-      {
-        updateMcpServerForm: expect.objectContaining({
-          id: "mcp-server-1",
-          visibility: "private",
-        }),
-      },
-      undefined,
-      undefined,
-    );
-  });
-
-  it("reuses an org issuer over a platform issuer for the same URL", async () => {
-    // Both match the discovered URL and neither is project-scoped; tier
-    // precedence must prefer the organization issuer over the shared platform
-    // one regardless of list order.
-    const platformIssuer = remoteSessionIssuer({
-      id: "platform-issuer",
-      projectId: "",
-      organizationId: "",
-      issuer: "https://idp.example.com/",
-    });
-    const orgIssuer = remoteSessionIssuer({
-      id: "org-issuer",
-      projectId: "",
-      organizationId: "org-1",
-      issuer: "https://idp.example.com",
-    });
-    const client = mockClient({
-      issuers: [platformIssuer, orgIssuer],
-    });
-
-    const result = await autoConfigureRemoteMcpAuth({
-      client: client as unknown as Gram,
-      authedFetch: vi.fn(),
-      remoteMcpServer: remoteMcpServer(),
-      mcpServer: mcpServer(),
-    });
-
-    expect(result.status).toBe("configured");
-    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
-    expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
-      {
-        createRemoteSessionClientForm: expect.objectContaining({
-          remoteSessionIssuerId: "org-issuer",
-        }),
-      },
-      undefined,
-      undefined,
-    );
-  });
-
-  it("reuses a platform issuer when no tenant issuer matches", async () => {
-    const platformIssuer = remoteSessionIssuer({
-      id: "platform-issuer",
-      projectId: "",
-      organizationId: "",
-      issuer: "https://idp.example.com",
-    });
-    const client = mockClient({
-      issuers: [platformIssuer],
-    });
-
-    const result = await autoConfigureRemoteMcpAuth({
-      client: client as unknown as Gram,
-      authedFetch: vi.fn(),
-      remoteMcpServer: remoteMcpServer(),
-      mcpServer: mcpServer(),
-    });
-
-    expect(result.status).toBe("configured");
-    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
-    expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
-      {
-        createRemoteSessionClientForm: expect.objectContaining({
-          remoteSessionIssuerId: "platform-issuer",
-        }),
-      },
-      undefined,
-      undefined,
-    );
-  });
-
-  it("does not normalize issuer matches beyond trailing slashes", async () => {
-    const client = mockClient({
-      issuers: [
-        remoteSessionIssuer({
-          id: "space-prefixed-issuer",
-          projectId: "project-1",
-          issuer: " https://idp.example.com",
-        }),
-      ],
-    });
-
-    const result = await autoConfigureRemoteMcpAuth({
-      client: client as unknown as Gram,
-      authedFetch: vi.fn(),
-      remoteMcpServer: remoteMcpServer(),
-      mcpServer: mcpServer(),
-    });
-
-    expect(result.status).toBe("configured");
-    expect(client.remoteSessionIssuers.create).toHaveBeenCalled();
-    expect(client.remoteSessionClients.create).toHaveBeenCalledWith(
-      {
-        createRemoteSessionClientForm: expect.objectContaining({
-          remoteSessionIssuerId: "created-issuer",
-          userSessionIssuerIds: ["server-usi"],
         }),
       },
       undefined,
@@ -262,7 +201,11 @@ describe("autoConfigureRemoteMcpAuth", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("skips when issuer discovery does not advertise DCR", async () => {
+  // Guard ordering, and the reason it is load-bearing: a lookup miss creates the
+  // issuer, and one created for an upstream that cannot do dynamic client
+  // registration could never receive a client. The DCR check has to come first
+  // so nothing is written for such a server.
+  it("skips without looking up an issuer when discovery does not advertise DCR", async () => {
     const client = mockClient({
       issuerDraft: {
         issuer: "https://idp.example.com",
@@ -289,24 +232,45 @@ describe("autoConfigureRemoteMcpAuth", () => {
         "OAuth metadata was found, but automatic authentication setup requires dynamic client registration.",
       warn: true,
     });
+    expect(client.remoteSessionIssuers.get).not.toHaveBeenCalled();
+    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
     expect(proxyRegisterMock).not.toHaveBeenCalled();
     expect(client.remoteSessionClients.create).not.toHaveBeenCalled();
     expect(client.mcpServers.update).not.toHaveBeenCalled();
   });
 
-  it("skips when a matching issuer exists but discovery lacks DCR", async () => {
+  it("skips when a reused issuer is missing OAuth endpoints", async () => {
     const client = mockClient({
-      issuers: [
-        remoteSessionIssuer({
-          id: "project-issuer",
-          projectId: "project-1",
-          issuer: "https://idp.example.com",
-        }),
-      ],
+      existingIssuer: {
+        ...remoteSessionIssuer({ id: "endpointless-issuer" }),
+        authorizationEndpoint: undefined,
+        tokenEndpoint: undefined,
+      },
+    });
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result).toEqual({
+      status: "skipped",
+      message:
+        "A matching identity provider already exists, but it is missing OAuth endpoints.",
+      warn: true,
+    });
+    // Bailing out before DCR means no stray client registration upstream.
+    expect(proxyRegisterMock).not.toHaveBeenCalled();
+    expect(client.remoteSessionClients.create).not.toHaveBeenCalled();
+  });
+
+  it("skips when nothing matches and the draft itself lacks OAuth endpoints", async () => {
+    const client = mockClient({
       issuerDraft: {
         issuer: "https://idp.example.com",
-        authorizationEndpoint: "https://idp.example.com/authorize",
-        tokenEndpoint: "https://idp.example.com/token",
+        registrationEndpoint: "https://idp.example.com/register",
         scopesSupported: [],
         tokenEndpointAuthMethodsSupported: [],
         oidc: false,
@@ -325,11 +289,58 @@ describe("autoConfigureRemoteMcpAuth", () => {
     expect(result).toEqual({
       status: "skipped",
       message:
-        "OAuth metadata was found, but automatic authentication setup requires dynamic client registration.",
+        "OAuth metadata was found, but it is missing required OAuth endpoints.",
       warn: true,
     });
-    expect(client.remoteSessionClients.create).not.toHaveBeenCalled();
-    expect(client.mcpServers.update).not.toHaveBeenCalled();
+    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
+    expect(proxyRegisterMock).not.toHaveBeenCalled();
+  });
+
+  // Only a 404 means "nothing describes this URL". Any other failure is a real
+  // error and must not be mistaken for a miss that then creates a duplicate.
+  it("skips without creating when the issuer lookup fails for a reason other than not-found", async () => {
+    const client = mockClient();
+    client.remoteSessionIssuers.get.mockRejectedValue(
+      Object.assign(new Error("boom"), { statusCode: 500 }),
+    );
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result).toEqual({
+      status: "skipped",
+      message:
+        "OAuth metadata was found, but existing identity providers could not be checked.",
+      warn: true,
+    });
+    expect(client.remoteSessionIssuers.create).not.toHaveBeenCalled();
+    expect(proxyRegisterMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when the issuer cannot be created", async () => {
+    const client = mockClient();
+    client.remoteSessionIssuers.create.mockRejectedValueOnce(
+      new Error("create failed"),
+    );
+
+    const result = await autoConfigureRemoteMcpAuth({
+      client: client as unknown as Gram,
+      authedFetch: vi.fn(),
+      remoteMcpServer: remoteMcpServer(),
+      mcpServer: mcpServer(),
+    });
+
+    expect(result).toEqual({
+      status: "skipped",
+      message:
+        "OAuth metadata was found, but an identity provider for it could not be created.",
+      warn: true,
+    });
+    expect(proxyRegisterMock).not.toHaveBeenCalled();
   });
 
   it("silently skips when protected-resource metadata is unavailable", async () => {
@@ -355,8 +366,11 @@ describe("autoConfigureRemoteMcpAuth", () => {
     expect(client.remoteSessionIssuers.fetchMetadata).not.toHaveBeenCalled();
   });
 
-  it("cleans up a newly-created issuer but keeps the USI when client registration fails", async () => {
-    const client = mockClient({ issuers: [] });
+  // A created issuer is deliberately left behind. The lookup is keyed on the
+  // upstream URL, so the next attempt finds this same issuer and reuses it;
+  // deleting it would force a re-create on every retry.
+  it("keeps a newly created issuer and the USI when client registration fails", async () => {
+    const client = mockClient();
     client.remoteSessionClients.create.mockRejectedValueOnce(
       new Error("client create failed"),
     );
@@ -374,22 +388,19 @@ describe("autoConfigureRemoteMcpAuth", () => {
         "Automatic authentication setup failed. You can configure it from the Authentication tab.",
       warn: true,
     });
-    // The freshly-created issuer is rolled back; the server's permanent USI is
-    // never deleted.
-    expect(client.remoteSessionIssuers.delete).toHaveBeenCalledWith(
-      {
-        id: "created-issuer",
-      },
-      undefined,
-      undefined,
-    );
+    expect(client.remoteSessionIssuers.delete).not.toHaveBeenCalled();
     expect(client.userSessionIssuers.delete).not.toHaveBeenCalled();
     expect(client.mcpServers.update).not.toHaveBeenCalled();
   });
 });
 
 function mockClient({
-  issuers = [],
+  existingIssuer = null,
+  createdIssuer = remoteSessionIssuer({
+    id: "created-issuer",
+    projectId: "project-1",
+    issuer: "https://idp.example.com",
+  }),
   protectedResource = {
     available: true,
     discoveryWarnings: [],
@@ -410,7 +421,8 @@ function mockClient({
     discoveryWarnings: [],
   },
 }: {
-  issuers?: RemoteSessionIssuer[];
+  existingIssuer?: RemoteSessionIssuer | null;
+  createdIssuer?: RemoteSessionIssuer;
   protectedResource?: unknown;
   issuerDraft?: unknown;
 } = {}) {
@@ -422,14 +434,10 @@ function mockClient({
     },
     remoteSessionIssuers: {
       fetchMetadata: vi.fn().mockResolvedValue(issuerDraft),
-      list: vi.fn().mockResolvedValue(pageIterator(issuers)),
-      create: vi.fn().mockResolvedValue(
-        remoteSessionIssuer({
-          id: "created-issuer",
-          projectId: "project-1",
-          issuer: "https://idp.example.com",
-        }),
-      ),
+      get: existingIssuer
+        ? vi.fn().mockResolvedValue(existingIssuer)
+        : vi.fn().mockRejectedValue(notFound()),
+      create: vi.fn().mockResolvedValue(createdIssuer),
       delete: vi.fn().mockResolvedValue(undefined),
     },
     userSessionIssuers: {
@@ -449,14 +457,9 @@ function mockClient({
   };
 }
 
-function pageIterator<T>(items: T[]) {
-  return {
-    result: { items },
-    next: () => null,
-    [Symbol.asyncIterator]: async function* () {
-      yield { result: { items }, next: () => null };
-    },
-  };
+// Shaped like the SDK's 404 rejection, which is what isNotFoundError keys on.
+function notFound(): Error {
+  return Object.assign(new Error("not found"), { statusCode: 404 });
 }
 
 function remoteSessionIssuer(

--- a/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.ts
+++ b/client/dashboard/src/pages/sources/remote-mcp/autoConfigureAuth.ts
@@ -14,10 +14,8 @@ import {
   type AuthedFetch,
   proxyRegisterUpstreamClient,
 } from "@/lib/proxyRegisterUpstreamClient";
-import {
-  deriveRemoteSessionIssuerNameFromUrl,
-  resolveRemoteSessionIssuerByTierPrecedence,
-} from "@/lib/sources";
+import { isNotFoundError } from "@/lib/errors";
+import { deriveRemoteSessionIssuerNameFromUrl } from "@/lib/sources";
 import {
   narrowTokenEndpointAuthMethod,
   pickPreferredAuthMethod,
@@ -116,44 +114,106 @@ export async function autoConfigureRemoteMcpAuth({
     );
   }
 
-  let existingIssuer: RemoteSessionIssuer | null;
-  try {
-    existingIssuer = await findMatchingIssuer(client, draft.issuer, options);
-  } catch (error) {
-    console.info("Remote MCP matching issuer lookup failed.", {
-      remoteMcpServerId: remoteMcpServer.id,
-      issuer: draft.issuer,
-      error,
-    });
-    return skipped(
-      "OAuth metadata was found, but existing identity providers could not be checked.",
-      true,
-    );
-  }
-  if (
-    existingIssuer &&
-    (!existingIssuer.authorizationEndpoint || !existingIssuer.tokenEndpoint)
-  ) {
-    return skipped(
-      "A matching identity provider already exists, but it is missing OAuth endpoints.",
-      true,
-    );
-  }
-
+  // Checked before the issuer is looked up, not after. A miss below creates the
+  // issuer, and one created for an upstream that cannot do dynamic client
+  // registration could never receive a client — so a server without DCR must
+  // bail out before anything is written.
   if (!draft.registrationEndpoint) {
     return skipped(
       "OAuth metadata was found, but automatic authentication setup requires dynamic client registration.",
       true,
     );
   }
+
+  // Ask the server whether this upstream already has an identity provider — in
+  // this project, inherited from the organization, or in the platform catalog.
+  // A 404 is the normal answer for a new upstream and means "create one". The
+  // lookup lives server-side so that the tier precedence and the URL
+  // normalization behind it have a single definition, rather than every caller
+  // scanning the issuer list and matching URLs itself.
+  const resourceSlug = buildUserSessionResourceSlug(mcpServer.slug ?? "mcp");
+  let remoteSessionIssuer: RemoteSessionIssuer | null;
+  try {
+    remoteSessionIssuer = await client.remoteSessionIssuers.get(
+      { issuer: draft.issuer },
+      undefined,
+      options,
+    );
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      console.info("Remote MCP identity provider lookup failed.", {
+        remoteMcpServerId: remoteMcpServer.id,
+        issuer: draft.issuer,
+        error,
+      });
+      return skipped(
+        "OAuth metadata was found, but existing identity providers could not be checked.",
+        true,
+      );
+    }
+    remoteSessionIssuer = null;
+  }
+
+  // An issuer that predates discovery may carry no endpoints, and reusing one
+  // that cannot authorize would produce a client that never works.
   if (
-    !existingIssuer &&
+    remoteSessionIssuer &&
+    (!remoteSessionIssuer.authorizationEndpoint ||
+      !remoteSessionIssuer.tokenEndpoint)
+  ) {
+    return skipped(
+      "A matching identity provider already exists, but it is missing OAuth endpoints.",
+      true,
+    );
+  }
+  if (
+    !remoteSessionIssuer &&
     (!draft.authorizationEndpoint || !draft.tokenEndpoint)
   ) {
     return skipped(
       "OAuth metadata was found, but it is missing required OAuth endpoints.",
       true,
     );
+  }
+
+  if (!remoteSessionIssuer) {
+    try {
+      remoteSessionIssuer = await client.remoteSessionIssuers.create(
+        {
+          createRemoteSessionIssuerForm: {
+            slug: resourceSlug,
+            issuer: draft.issuer,
+            name:
+              deriveRemoteSessionIssuerNameFromUrl(draft.issuer) ?? undefined,
+            authorizationEndpoint: draft.authorizationEndpoint,
+            tokenEndpoint: draft.tokenEndpoint,
+            registrationEndpoint: draft.registrationEndpoint,
+            jwksUri: draft.jwksUri,
+            scopesSupported: draft.scopesSupported ?? [],
+            grantTypesSupported: draft.grantTypesSupported ?? [],
+            responseTypesSupported: draft.responseTypesSupported ?? [],
+            tokenEndpointAuthMethodsSupported:
+              draft.tokenEndpointAuthMethodsSupported ?? [],
+            clientIdMetadataDocumentSupported:
+              draft.clientIdMetadataDocumentSupported,
+            oidc: draft.oidc,
+            passthrough: draft.passthrough,
+          },
+        },
+        undefined,
+        options,
+      );
+    } catch (error) {
+      console.info("Remote MCP identity provider creation failed.", {
+        remoteMcpServerId: remoteMcpServer.id,
+        issuer: draft.issuer,
+        error,
+      });
+      return skipped(
+        "OAuth metadata was found, but an identity provider for it could not be created.",
+        true,
+      );
+    }
   }
 
   const scopes = preferredScopes(
@@ -183,42 +243,12 @@ export async function autoConfigureRemoteMcpAuth({
     );
   }
 
-  const resourceSlug = buildUserSessionResourceSlug(mcpServer.slug ?? "mcp");
-  let createdRemoteSessionIssuerId: string | undefined;
-
+  // No rollback of a newly created issuer if the steps below fail. The lookup
+  // above is keyed on the upstream URL, so an issuer left behind is exactly what
+  // the next attempt finds and reuses; deleting it would force a re-create on
+  // every retry. The trade is that an abandoned install can leave an issuer with
+  // no clients in the project's list, which is deletable from the UI.
   try {
-    const remoteSessionIssuer =
-      existingIssuer ??
-      (await client.remoteSessionIssuers.create(
-        {
-          createRemoteSessionIssuerForm: {
-            slug: resourceSlug,
-            issuer: draft.issuer,
-            name:
-              deriveRemoteSessionIssuerNameFromUrl(draft.issuer) ?? undefined,
-            authorizationEndpoint: draft.authorizationEndpoint,
-            tokenEndpoint: draft.tokenEndpoint,
-            registrationEndpoint: draft.registrationEndpoint,
-            jwksUri: draft.jwksUri,
-            scopesSupported: draft.scopesSupported ?? [],
-            grantTypesSupported: draft.grantTypesSupported ?? [],
-            responseTypesSupported: draft.responseTypesSupported ?? [],
-            tokenEndpointAuthMethodsSupported:
-              draft.tokenEndpointAuthMethodsSupported ?? [],
-            clientIdMetadataDocumentSupported:
-              draft.clientIdMetadataDocumentSupported,
-            oidc: draft.oidc,
-            passthrough: draft.passthrough,
-          },
-        },
-        undefined,
-        options,
-      ));
-
-    if (!existingIssuer) {
-      createdRemoteSessionIssuerId = remoteSessionIssuer.id;
-    }
-
     // Attach the freshly-registered upstream client to the server's permanent
     // USI.
     await client.remoteSessionClients.create(
@@ -256,13 +286,6 @@ export async function autoConfigureRemoteMcpAuth({
       remoteMcpServerId: remoteMcpServer.id,
       error,
     });
-    // Clean up only a newly-created issuer. The USI is the server's permanent
-    // identity and must survive a failed client registration.
-    await cleanupCreatedRemoteSessionIssuer(
-      client,
-      createdRemoteSessionIssuerId,
-      options,
-    );
     return skipped(
       "Automatic authentication setup failed. You can configure it from the Authentication tab.",
       true,
@@ -295,36 +318,6 @@ async function setMcpServerVisibility(
   );
 }
 
-// findMatchingIssuer resolves the issuer a discovered authorization-server URL
-// should reuse. The listing is project-scoped, so any project-tier match belongs
-// to this project; resolution is by tier precedence — project > organization >
-// platform — never by list order, which is by creation time and would otherwise
-// pick an organization or platform issuer over an equally-valid project one
-// depending on when each was created.
-async function findMatchingIssuer(
-  client: Gram,
-  discoveredIssuer: string,
-  options?: RequestOptions,
-): Promise<RemoteSessionIssuer | null> {
-  const normalized = normalizeIssuerURL(discoveredIssuer);
-  const matches: RemoteSessionIssuer[] = [];
-  const pages = await client.remoteSessionIssuers.list(
-    { limit: 100 },
-    undefined,
-    options,
-  );
-
-  for await (const page of pages) {
-    for (const issuer of page.result.items) {
-      if (normalizeIssuerURL(issuer.issuer) === normalized) {
-        matches.push(issuer);
-      }
-    }
-  }
-
-  return resolveRemoteSessionIssuerByTierPrecedence(matches) ?? null;
-}
-
 function preferredScopes(
   protectedResourceScopes: string[] | undefined,
   authorizationServerScopes: string[] | undefined,
@@ -338,30 +331,6 @@ function nonEmptyStrings(values: string[] | undefined): string[] {
   return (values ?? [])
     .map((value) => value.trim())
     .filter((value) => value.length > 0);
-}
-
-function normalizeIssuerURL(value: string): string {
-  return value.replace(/\/+$/g, "");
-}
-
-async function cleanupCreatedRemoteSessionIssuer(
-  client: Gram,
-  remoteSessionIssuerId: string | undefined,
-  options?: RequestOptions,
-): Promise<void> {
-  if (!remoteSessionIssuerId) return;
-  try {
-    await client.remoteSessionIssuers.delete(
-      { id: remoteSessionIssuerId },
-      undefined,
-      options,
-    );
-  } catch (error) {
-    console.info("Failed to clean up auto-created remote session issuer.", {
-      remoteSessionIssuerId,
-      error,
-    });
-  }
 }
 
 function skipped(

--- a/client/dashboard/src/sdk/src/funcs/remoteSessionIssuersGet.ts
+++ b/client/dashboard/src/sdk/src/funcs/remoteSessionIssuersGet.ts
@@ -42,7 +42,11 @@ import { Result } from "../types/fp.js";
  * getRemoteSessionIssuer remoteSessionIssuers
  *
  * @remarks
- * Get a remote_session_issuer by id or by slug. Provide exactly one.
+ * Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+ *
+ * Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+ *
+ * The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.
  */
 export function remoteSessionIssuersGet(
   client: GramCore,
@@ -109,6 +113,7 @@ async function $do(
 
   const query = encodeFormQuery({
     "id": payload?.id,
+    "issuer": payload?.issuer,
     "slug": payload?.slug,
   });
 

--- a/client/dashboard/src/sdk/src/models/operations/getremotesessionissuer.ts
+++ b/client/dashboard/src/sdk/src/models/operations/getremotesessionissuer.ts
@@ -30,6 +30,10 @@ export type GetRemoteSessionIssuerRequest = {
    */
   slug?: string | undefined;
   /**
+   * The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer this project would use for that URL, or 404 when none describes it.
+   */
+  issuer?: string | undefined;
+  /**
    * Session header
    */
   gramSession?: string | undefined;
@@ -152,6 +156,7 @@ export function getRemoteSessionIssuerSecurityToJSON(
 export type GetRemoteSessionIssuerRequest$Outbound = {
   id?: string | undefined;
   slug?: string | undefined;
+  issuer?: string | undefined;
   "Gram-Session"?: string | undefined;
   "Gram-Key"?: string | undefined;
   "Gram-Project"?: string | undefined;
@@ -165,6 +170,7 @@ export const GetRemoteSessionIssuerRequest$outboundSchema: z.ZodMiniType<
   z.object({
     id: z.optional(z.string()),
     slug: z.optional(z.string()),
+    issuer: z.optional(z.string()),
     gramSession: z.optional(z.string()),
     gramKey: z.optional(z.string()),
     gramProject: z.optional(z.string()),

--- a/client/dashboard/src/sdk/src/react-query/remoteSessionIssuer.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/remoteSessionIssuer.core.ts
@@ -51,6 +51,7 @@ export function buildRemoteSessionIssuerQuery(
     queryKey: queryKeyRemoteSessionIssuer({
       id: request?.id,
       slug: request?.slug,
+      issuer: request?.issuer,
       gramSession: request?.gramSession,
       gramKey: request?.gramKey,
       gramProject: request?.gramProject,
@@ -83,6 +84,7 @@ export function queryKeyRemoteSessionIssuer(
   parameters: {
     id?: string | undefined;
     slug?: string | undefined;
+    issuer?: string | undefined;
     gramSession?: string | undefined;
     gramKey?: string | undefined;
     gramProject?: string | undefined;

--- a/client/dashboard/src/sdk/src/react-query/remoteSessionIssuer.ts
+++ b/client/dashboard/src/sdk/src/react-query/remoteSessionIssuer.ts
@@ -59,7 +59,11 @@ export type RemoteSessionIssuerQueryError =
  * getRemoteSessionIssuer remoteSessionIssuers
  *
  * @remarks
- * Get a remote_session_issuer by id or by slug. Provide exactly one.
+ * Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+ *
+ * Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+ *
+ * The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.
  */
 export function useRemoteSessionIssuer(
   request?: GetRemoteSessionIssuerRequest | undefined,
@@ -85,7 +89,11 @@ export function useRemoteSessionIssuer(
  * getRemoteSessionIssuer remoteSessionIssuers
  *
  * @remarks
- * Get a remote_session_issuer by id or by slug. Provide exactly one.
+ * Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+ *
+ * Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+ *
+ * The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.
  */
 export function useRemoteSessionIssuerSuspense(
   request?: GetRemoteSessionIssuerRequest | undefined,
@@ -116,6 +124,7 @@ export function setRemoteSessionIssuerData(
     parameters: {
       id?: string | undefined;
       slug?: string | undefined;
+      issuer?: string | undefined;
       gramSession?: string | undefined;
       gramKey?: string | undefined;
       gramProject?: string | undefined;
@@ -134,6 +143,7 @@ export function invalidateRemoteSessionIssuer(
     [parameters: {
       id?: string | undefined;
       slug?: string | undefined;
+      issuer?: string | undefined;
       gramSession?: string | undefined;
       gramKey?: string | undefined;
       gramProject?: string | undefined;

--- a/client/dashboard/src/sdk/src/sdk/remotesessionissuers.ts
+++ b/client/dashboard/src/sdk/src/sdk/remotesessionissuers.ts
@@ -107,7 +107,11 @@ export class RemoteSessionIssuers extends ClientSDK {
    * getRemoteSessionIssuer remoteSessionIssuers
    *
    * @remarks
-   * Get a remote_session_issuer by id or by slug. Provide exactly one.
+   * Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+   *
+   * Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+   *
+   * The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.
    */
   async get(
     request?: GetRemoteSessionIssuerRequest | undefined,

--- a/hooks/sdk/.speakeasy/gen.lock
+++ b/hooks/sdk/.speakeasy/gen.lock
@@ -6,8 +6,8 @@ management:
   generationVersion: 2.916.4
   releaseVersion: 0.1.0
 persistentEdits:
-  generation_id: bade27a4-12fe-449d-b210-39f46b2a6412
-  pristine_commit_hash: e85bc2c0d683eb533c99ae0fea5b85d2fb99b4e9
+  generation_id: 7c0754ab-cf46-4642-97f8-81bc371413ac
+  pristine_commit_hash: 36f4bb7d1a873cd7b04ba78f81727a1334f0c6d7
   pristine_tree_hash: 8620a45800ff2e081a2675968363289d0bf62d85
 features:
   go:

--- a/server/design/remotesessionissuers/design.go
+++ b/server/design/remotesessionissuers/design.go
@@ -149,13 +149,14 @@ var _ = Service("remoteSessionIssuers", func() {
 	})
 
 	Method("getRemoteSessionIssuer", func() {
-		Description("Get a remote_session_issuer by id or by slug. Provide exactly one.")
+		Description("Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.\n\nLooking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.\n\nThe issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.")
 
 		Payload(func() {
 			Attribute("id", String, "The remote_session_issuer id.", func() {
 				Format(FormatUUID)
 			})
 			Attribute("slug", String, "The remote_session_issuer slug.")
+			Attribute("issuer", String, "The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer this project would use for that URL, or 404 when none describes it.")
 			security.SessionPayload()
 			security.ByKeyPayload()
 			security.ProjectPayload()
@@ -167,6 +168,7 @@ var _ = Service("remoteSessionIssuers", func() {
 			GET("/rpc/remoteSessionIssuers.get")
 			Param("id")
 			Param("slug")
+			Param("issuer")
 			security.SessionHeader()
 			security.ByKeyHeader()
 			security.ProjectHeader()

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -1865,6 +1865,7 @@ func ParseEndpoint(
 		remoteSessionIssuersGetRemoteSessionIssuerFlags                = flag.NewFlagSet("get-remote-session-issuer", flag.ExitOnError)
 		remoteSessionIssuersGetRemoteSessionIssuerIDFlag               = remoteSessionIssuersGetRemoteSessionIssuerFlags.String("id", "", "")
 		remoteSessionIssuersGetRemoteSessionIssuerSlugFlag             = remoteSessionIssuersGetRemoteSessionIssuerFlags.String("slug", "", "")
+		remoteSessionIssuersGetRemoteSessionIssuerIssuerFlag           = remoteSessionIssuersGetRemoteSessionIssuerFlags.String("issuer", "", "")
 		remoteSessionIssuersGetRemoteSessionIssuerSessionTokenFlag     = remoteSessionIssuersGetRemoteSessionIssuerFlags.String("session-token", "", "")
 		remoteSessionIssuersGetRemoteSessionIssuerApikeyTokenFlag      = remoteSessionIssuersGetRemoteSessionIssuerFlags.String("apikey-token", "", "")
 		remoteSessionIssuersGetRemoteSessionIssuerProjectSlugInputFlag = remoteSessionIssuersGetRemoteSessionIssuerFlags.String("project-slug-input", "", "")
@@ -6732,7 +6733,7 @@ func ParseEndpoint(
 				data, err = remotesessionissuersc.BuildListRemoteSessionIssuersPayload(*remoteSessionIssuersListRemoteSessionIssuersCursorFlag, *remoteSessionIssuersListRemoteSessionIssuersLimitFlag, *remoteSessionIssuersListRemoteSessionIssuersSessionTokenFlag, *remoteSessionIssuersListRemoteSessionIssuersApikeyTokenFlag, *remoteSessionIssuersListRemoteSessionIssuersProjectSlugInputFlag)
 			case "get-remote-session-issuer":
 				endpoint = c.GetRemoteSessionIssuer()
-				data, err = remotesessionissuersc.BuildGetRemoteSessionIssuerPayload(*remoteSessionIssuersGetRemoteSessionIssuerIDFlag, *remoteSessionIssuersGetRemoteSessionIssuerSlugFlag, *remoteSessionIssuersGetRemoteSessionIssuerSessionTokenFlag, *remoteSessionIssuersGetRemoteSessionIssuerApikeyTokenFlag, *remoteSessionIssuersGetRemoteSessionIssuerProjectSlugInputFlag)
+				data, err = remotesessionissuersc.BuildGetRemoteSessionIssuerPayload(*remoteSessionIssuersGetRemoteSessionIssuerIDFlag, *remoteSessionIssuersGetRemoteSessionIssuerSlugFlag, *remoteSessionIssuersGetRemoteSessionIssuerIssuerFlag, *remoteSessionIssuersGetRemoteSessionIssuerSessionTokenFlag, *remoteSessionIssuersGetRemoteSessionIssuerApikeyTokenFlag, *remoteSessionIssuersGetRemoteSessionIssuerProjectSlugInputFlag)
 			case "delete-remote-session-issuer":
 				endpoint = c.DeleteRemoteSessionIssuer()
 				data, err = remotesessionissuersc.BuildDeleteRemoteSessionIssuerPayload(*remoteSessionIssuersDeleteRemoteSessionIssuerIDFlag, *remoteSessionIssuersDeleteRemoteSessionIssuerSessionTokenFlag, *remoteSessionIssuersDeleteRemoteSessionIssuerApikeyTokenFlag, *remoteSessionIssuersDeleteRemoteSessionIssuerProjectSlugInputFlag)
@@ -14911,7 +14912,11 @@ func remoteSessionIssuersUsage() {
 	fmt.Fprintln(os.Stderr, `    create-remote-session-issuer: Create a new remote_session_issuer.`)
 	fmt.Fprintln(os.Stderr, `    update-remote-session-issuer: Update fields on an existing remote_session_issuer.`)
 	fmt.Fprintln(os.Stderr, `    list-remote-session-issuers: List remote_session_issuers in the caller's project.`)
-	fmt.Fprintln(os.Stderr, `    get-remote-session-issuer: Get a remote_session_issuer by id or by slug. Provide exactly one.`)
+	fmt.Fprintln(os.Stderr, `    get-remote-session-issuer: Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+	
+	Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+	
+	The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.`)
 	fmt.Fprintln(os.Stderr, `    delete-remote-session-issuer: Soft-delete a remote_session_issuer. Blocked if any remote_session_clients still reference it.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
@@ -15044,6 +15049,7 @@ func remoteSessionIssuersGetRemoteSessionIssuerUsage() {
 	fmt.Fprintf(os.Stderr, "%s [flags] remote-session-issuers get-remote-session-issuer", os.Args[0])
 	fmt.Fprint(os.Stderr, " -id STRING")
 	fmt.Fprint(os.Stderr, " -slug STRING")
+	fmt.Fprint(os.Stderr, " -issuer STRING")
 	fmt.Fprint(os.Stderr, " -session-token STRING")
 	fmt.Fprint(os.Stderr, " -apikey-token STRING")
 	fmt.Fprint(os.Stderr, " -project-slug-input STRING")
@@ -15051,18 +15057,23 @@ func remoteSessionIssuersGetRemoteSessionIssuerUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Get a remote_session_issuer by id or by slug. Provide exactly one.`)
+	fmt.Fprintln(os.Stderr, `Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+	
+	Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+	
+	The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -id STRING: `)
 	fmt.Fprintln(os.Stderr, `    -slug STRING: `)
+	fmt.Fprintln(os.Stderr, `    -issuer STRING: `)
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -project-slug-input STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "remote-session-issuers get-remote-session-issuer --id \"550e8400-e29b-41d4-a716-446655440000\" --slug \"abc123\" --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "remote-session-issuers get-remote-session-issuer --id \"550e8400-e29b-41d4-a716-446655440000\" --slug \"abc123\" --issuer \"abc123\" --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func remoteSessionIssuersDeleteRemoteSessionIssuerUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -31117,7 +31117,12 @@ paths:
                 name: FetchRemoteSessionIssuerMetadata
     /rpc/remoteSessionIssuers.get:
         get:
-            description: Get a remote_session_issuer by id or by slug. Provide exactly one.
+            description: |-
+                Get a remote_session_issuer by id, by slug, or by upstream issuer URL. Provide exactly one.
+
+                Looking up by issuer is how an automatic setup flow decides whether an upstream authorization server already has an identity provider before creating one: a 404 means nothing describes that URL yet, so create it. Unlike id and slug, which address at most one record, several issuers may legitimately describe the same URL — a project may keep its own alongside one inherited from its organization or from the platform catalog. This returns the one this project would use, preferring project over organization over platform and, within a tier, the oldest.
+
+                The issuer URL is canonicalized before matching: scheme and host are lowercased, the scheme's default port is dropped, and trailing slashes are stripped. http and https are deliberately NOT equated, path case is significant, and a URL carrying a query or fragment is rejected (RFC 8414 forbids both on issuer identifiers). Canonicalization applies to the supplied URL only, never to stored values, so an issuer recorded with an unusual spelling may not be found and a duplicate is created instead, which is the safe direction to fail.
             operationId: getRemoteSessionIssuer
             parameters:
                 - allowEmptyValue: true
@@ -31134,6 +31139,13 @@ paths:
                   name: slug
                   schema:
                     description: The remote_session_issuer slug.
+                    type: string
+                - allowEmptyValue: true
+                  description: The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer this project would use for that URL, or 404 when none describes it.
+                  in: query
+                  name: issuer
+                  schema:
+                    description: The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer this project would use for that URL, or 404 when none describes it.
                     type: string
                 - allowEmptyValue: true
                   description: Session header

--- a/server/gen/http/remote_session_issuers/client/cli.go
+++ b/server/gen/http/remote_session_issuers/client/cli.go
@@ -320,7 +320,7 @@ func BuildListRemoteSessionIssuersPayload(remoteSessionIssuersListRemoteSessionI
 
 // BuildGetRemoteSessionIssuerPayload builds the payload for the
 // remoteSessionIssuers getRemoteSessionIssuer endpoint from CLI flags.
-func BuildGetRemoteSessionIssuerPayload(remoteSessionIssuersGetRemoteSessionIssuerID string, remoteSessionIssuersGetRemoteSessionIssuerSlug string, remoteSessionIssuersGetRemoteSessionIssuerSessionToken string, remoteSessionIssuersGetRemoteSessionIssuerApikeyToken string, remoteSessionIssuersGetRemoteSessionIssuerProjectSlugInput string) (*remotesessionissuers.GetRemoteSessionIssuerPayload, error) {
+func BuildGetRemoteSessionIssuerPayload(remoteSessionIssuersGetRemoteSessionIssuerID string, remoteSessionIssuersGetRemoteSessionIssuerSlug string, remoteSessionIssuersGetRemoteSessionIssuerIssuer string, remoteSessionIssuersGetRemoteSessionIssuerSessionToken string, remoteSessionIssuersGetRemoteSessionIssuerApikeyToken string, remoteSessionIssuersGetRemoteSessionIssuerProjectSlugInput string) (*remotesessionissuers.GetRemoteSessionIssuerPayload, error) {
 	var err error
 	var id *string
 	{
@@ -336,6 +336,12 @@ func BuildGetRemoteSessionIssuerPayload(remoteSessionIssuersGetRemoteSessionIssu
 	{
 		if remoteSessionIssuersGetRemoteSessionIssuerSlug != "" {
 			slug = &remoteSessionIssuersGetRemoteSessionIssuerSlug
+		}
+	}
+	var issuer *string
+	{
+		if remoteSessionIssuersGetRemoteSessionIssuerIssuer != "" {
+			issuer = &remoteSessionIssuersGetRemoteSessionIssuerIssuer
 		}
 	}
 	var sessionToken *string
@@ -359,6 +365,7 @@ func BuildGetRemoteSessionIssuerPayload(remoteSessionIssuersGetRemoteSessionIssu
 	v := &remotesessionissuers.GetRemoteSessionIssuerPayload{}
 	v.ID = id
 	v.Slug = slug
+	v.Issuer = issuer
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
 	v.ProjectSlugInput = projectSlugInput

--- a/server/gen/http/remote_session_issuers/client/encode_decode.go
+++ b/server/gen/http/remote_session_issuers/client/encode_decode.go
@@ -1291,6 +1291,9 @@ func EncodeGetRemoteSessionIssuerRequest(encoder func(*http.Request) goahttp.Enc
 		if p.Slug != nil {
 			values.Add("slug", *p.Slug)
 		}
+		if p.Issuer != nil {
+			values.Add("issuer", *p.Issuer)
+		}
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}

--- a/server/gen/http/remote_session_issuers/server/encode_decode.go
+++ b/server/gen/http/remote_session_issuers/server/encode_decode.go
@@ -1233,6 +1233,7 @@ func DecodeGetRemoteSessionIssuerRequest(mux goahttp.Muxer, decoder func(*http.R
 		var (
 			id               *string
 			slug             *string
+			issuer           *string
 			sessionToken     *string
 			apikeyToken      *string
 			projectSlugInput *string
@@ -1250,6 +1251,10 @@ func DecodeGetRemoteSessionIssuerRequest(mux goahttp.Muxer, decoder func(*http.R
 		if slugRaw != "" {
 			slug = &slugRaw
 		}
+		issuerRaw := qp.Get("issuer")
+		if issuerRaw != "" {
+			issuer = &issuerRaw
+		}
 		sessionTokenRaw := r.Header.Get("Gram-Session")
 		if sessionTokenRaw != "" {
 			sessionToken = &sessionTokenRaw
@@ -1265,7 +1270,7 @@ func DecodeGetRemoteSessionIssuerRequest(mux goahttp.Muxer, decoder func(*http.R
 		if err != nil {
 			return payload, err
 		}
-		payload = NewGetRemoteSessionIssuerPayload(id, slug, sessionToken, apikeyToken, projectSlugInput)
+		payload = NewGetRemoteSessionIssuerPayload(id, slug, issuer, sessionToken, apikeyToken, projectSlugInput)
 		if payload.SessionToken != nil {
 			if strings.Contains(*payload.SessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/remote_session_issuers/server/types.go
+++ b/server/gen/http/remote_session_issuers/server/types.go
@@ -3175,10 +3175,11 @@ func NewListRemoteSessionIssuersPayload(cursor *string, limit *int, sessionToken
 
 // NewGetRemoteSessionIssuerPayload builds a remoteSessionIssuers service
 // getRemoteSessionIssuer endpoint payload.
-func NewGetRemoteSessionIssuerPayload(id *string, slug *string, sessionToken *string, apikeyToken *string, projectSlugInput *string) *remotesessionissuers.GetRemoteSessionIssuerPayload {
+func NewGetRemoteSessionIssuerPayload(id *string, slug *string, issuer *string, sessionToken *string, apikeyToken *string, projectSlugInput *string) *remotesessionissuers.GetRemoteSessionIssuerPayload {
 	v := &remotesessionissuers.GetRemoteSessionIssuerPayload{}
 	v.ID = id
 	v.Slug = slug
+	v.Issuer = issuer
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
 	v.ProjectSlugInput = projectSlugInput

--- a/server/gen/remote_session_issuers/service.go
+++ b/server/gen/remote_session_issuers/service.go
@@ -36,7 +36,26 @@ type Service interface {
 	UpdateRemoteSessionIssuer(context.Context, *UpdateRemoteSessionIssuerPayload) (res *types.RemoteSessionIssuer, err error)
 	// List remote_session_issuers in the caller's project.
 	ListRemoteSessionIssuers(context.Context, *ListRemoteSessionIssuersPayload) (res *ListRemoteSessionIssuersResult, err error)
-	// Get a remote_session_issuer by id or by slug. Provide exactly one.
+	// Get a remote_session_issuer by id, by slug, or by upstream issuer URL.
+	// Provide exactly one.
+
+	// Looking up by issuer is how an automatic setup flow decides whether an
+	// upstream authorization server already has an identity provider before
+	// creating one: a 404 means nothing describes that URL yet, so create it.
+	// Unlike id and slug, which address at most one record, several issuers may
+	// legitimately describe the same URL — a project may keep its own alongside
+	// one inherited from its organization or from the platform catalog. This
+	// returns the one this project would use, preferring project over organization
+	// over platform and, within a tier, the oldest.
+
+	// The issuer URL is canonicalized before matching: scheme and host are
+	// lowercased, the scheme's default port is dropped, and trailing slashes are
+	// stripped. http and https are deliberately NOT equated, path case is
+	// significant, and a URL carrying a query or fragment is rejected (RFC 8414
+	// forbids both on issuer identifiers). Canonicalization applies to the
+	// supplied URL only, never to stored values, so an issuer recorded with an
+	// unusual spelling may not be found and a duplicate is created instead, which
+	// is the safe direction to fail.
 	GetRemoteSessionIssuer(context.Context, *GetRemoteSessionIssuerPayload) (res *types.RemoteSessionIssuer, err error)
 	// Soft-delete a remote_session_issuer. Blocked if any remote_session_clients
 	// still reference it.
@@ -146,7 +165,10 @@ type GetRemoteSessionIssuerPayload struct {
 	// The remote_session_issuer id.
 	ID *string
 	// The remote_session_issuer slug.
-	Slug             *string
+	Slug *string
+	// The upstream issuer URL (e.g. https://login.linear.app). Returns the issuer
+	// this project would use for that URL, or 404 when none describes it.
+	Issuer           *string
 	SessionToken     *string
 	ApikeyToken      *string
 	ProjectSlugInput *string

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -303,6 +303,34 @@ func (s *Service) CreateRemoteSessionIssuer(ctx context.Context, payload *gen.Cr
 	return mv.BuildRemoteSessionIssuerView(issuer), nil
 }
 
+// resolveIssuerByPrecedence picks the single issuer a project should use out of
+// every tier-visible candidate matching one upstream URL.
+//
+// Precedence is project > organization > platform, ranked by scopeOf so the
+// ladder has one definition shared with issuer migration. Row order carries no
+// tier information, so it can never stand in for this.
+//
+// Within a tier the oldest issuer wins. That tie-break is load-bearing rather
+// than cosmetic: several project-tier rows on one URL are normal, because the
+// manual attach form creates unconditionally and always has. Without it the
+// endpoint would return whichever row the planner happened to emit first and
+// two identical calls could disagree. Candidates arrive ordered oldest-first by
+// created_at, so keeping the first of the best tier is "oldest" — see the query
+// for why id ordering is not a substitute.
+func resolveIssuerByPrecedence(candidates []repo.RemoteSessionIssuer) (repo.RemoteSessionIssuer, bool) {
+	var best repo.RemoteSessionIssuer
+	found := false
+
+	for _, candidate := range candidates {
+		if !found || scopeOf(candidate) < scopeOf(best) {
+			best = candidate
+			found = true
+		}
+	}
+
+	return best, found
+}
+
 // UpdateRemoteSessionIssuer applies an optional patch to an existing
 // remote_session_issuer.
 func (s *Service) UpdateRemoteSessionIssuer(ctx context.Context, payload *gen.UpdateRemoteSessionIssuerPayload) (*types.RemoteSessionIssuer, error) {
@@ -489,8 +517,15 @@ func (s *Service) ListRemoteSessionIssuers(ctx context.Context, payload *gen.Lis
 	}, nil
 }
 
-// GetRemoteSessionIssuer resolves a single issuer by either id or slug.
-// Exactly one of the two must be supplied.
+// GetRemoteSessionIssuer resolves a single issuer by id, slug, or upstream
+// issuer URL. Exactly one of the three must be supplied.
+//
+// The not-found returns are logged at warn rather than error on purpose. A miss
+// is a client-fault 404, and .LogError would also mark the OpenTelemetry span as
+// errored — which matters most for the issuer arm, where a miss is the normal
+// path: automatic setup asks "does an identity provider already describe this
+// upstream?" and creates one when the answer is no. See AGE-3082 for the
+// codebase-wide migration of the remaining CodeNotFound .LogError call sites.
 func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRemoteSessionIssuerPayload) (*types.RemoteSessionIssuer, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
@@ -501,8 +536,9 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 
 	hasID := payload.ID != nil && *payload.ID != ""
 	hasSlug := payload.Slug != nil && *payload.Slug != ""
-	if hasID == hasSlug {
-		return nil, oops.E(oops.CodeBadRequest, nil, "exactly one of id or slug is required").LogError(ctx, logger)
+	hasIssuer := payload.Issuer != nil && strings.TrimSpace(*payload.Issuer) != ""
+	if conv.Ternary(hasID, 1, 0)+conv.Ternary(hasSlug, 1, 0)+conv.Ternary(hasIssuer, 1, 0) != 1 {
+		return nil, oops.E(oops.CodeBadRequest, nil, "exactly one of id, slug, or issuer is required").LogError(ctx, logger)
 	}
 
 	var issuer repo.RemoteSessionIssuer
@@ -524,10 +560,42 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
+				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogWarn(ctx, logger)
 			}
 			return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 		}
+	case hasIssuer:
+		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
+			return nil, err
+		}
+
+		canonical, err := parseCanonicalIssuerURL(*payload.Issuer)
+		if err != nil {
+			return nil, oops.E(oops.CodeBadRequest, err, "%s", err.Error()).LogError(ctx, logger)
+		}
+
+		// Both inherited tiers are in scope: an organization-level or platform
+		// issuer describing this upstream is one the project may attach its own
+		// client to, so it counts as found.
+		candidates, err := repo.New(s.db).ListRemoteSessionIssuersByIssuerURL(ctx, repo.ListRemoteSessionIssuersByIssuerURLParams{
+			Issuers:               canonical.matchCandidates(),
+			ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+			IncludeOrganizational: true,
+			OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
+			IncludeGlobal:         true,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "list remote session issuers by issuer url").LogError(ctx, logger)
+		}
+
+		// Unlike id and slug, an issuer URL can match several rows: duplicates
+		// across tiers are legitimate by design. Precedence decides which one the
+		// project should use.
+		match, found := resolveIssuerByPrecedence(candidates)
+		if !found {
+			return nil, oops.E(oops.CodeNotFound, nil, "remote session issuer not found").LogWarn(ctx, logger)
+		}
+		issuer = match
 	default: // hasSlug
 		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: authCtx.ProjectID.String(), Dimensions: nil}); err != nil {
 			return nil, err
@@ -539,7 +607,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogError(ctx, logger)
+				return nil, oops.E(oops.CodeNotFound, err, "remote session issuer not found").LogWarn(ctx, logger)
 			}
 			return nil, oops.E(oops.CodeUnexpected, err, "get remote session issuer").LogError(ctx, logger)
 		}

--- a/server/internal/remotesessions/issuerhandlers_test.go
+++ b/server/internal/remotesessions/issuerhandlers_test.go
@@ -1,6 +1,7 @@
 package remotesessions_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/dev-idp/pkg/devidptest"
@@ -17,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -262,6 +265,253 @@ func TestGetRemoteSessionIssuer_BothIDAndSlug(t *testing.T) {
 	})
 	require.Error(t, err)
 	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// getByIssuerURL is the lookup automatic setup performs before deciding whether
+// to create an identity provider for a freshly discovered upstream.
+func getByIssuerURL(issuerURL string) *gen.GetRemoteSessionIssuerPayload {
+	return &gen.GetRemoteSessionIssuerPayload{
+		ID:               nil,
+		Slug:             nil,
+		Issuer:           &issuerURL,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	}
+}
+
+func projectAndOrgID(t *testing.T, ctx context.Context) (uuid.UUID, string) {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	return *authCtx.ProjectID, authCtx.ActiveOrganizationID
+}
+
+// A miss is the normal path for a new upstream, not an error condition: the
+// caller reads the 404 as "nothing describes this URL yet" and creates one.
+func TestGetRemoteSessionIssuerByURL_NotFoundWhenNothingMatches(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	_, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL("https://miss.example.com"))
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestGetRemoteSessionIssuerByURL_FindsProjectIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	existing := seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "byurl-existing", "https://reuse.example.com")
+
+	found, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL("https://reuse.example.com"))
+	require.NoError(t, err)
+	require.Equal(t, existing.String(), found.ID)
+	require.Equal(t, "byurl-existing", found.Slug)
+}
+
+// The canonical form collapses trailing slashes, the scheme's default port, and
+// host case, so a caller spelling the upstream any of these ways finds the same
+// stored row.
+func TestGetRemoteSessionIssuerByURL_MatchesEquivalentSpellings(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	existing := seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "byurl-spelling", "https://spelling.example.com/oauth")
+
+	for _, spelling := range []string{
+		"https://spelling.example.com/oauth",
+		"https://spelling.example.com/oauth/",
+		"https://spelling.example.com:443/oauth",
+		"https://SPELLING.example.com/oauth",
+		"  https://spelling.example.com/oauth  ",
+	} {
+		found, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL(spelling))
+		require.NoError(t, err, spelling)
+		require.Equal(t, existing.String(), found.ID, spelling)
+	}
+}
+
+// http and https on one host are different upstreams and must not be equated.
+func TestGetRemoteSessionIssuerByURL_DoesNotMatchAcrossSchemes(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "byurl-https", "https://scheme.example.com")
+
+	_, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL("http://scheme.example.com"))
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// Precedence is project > organization > platform. All three tiers describe the
+// same upstream here, and the project's own issuer has to win.
+func TestGetRemoteSessionIssuerByURL_PrefersProjectOverInheritedTiers(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	const issuerURL = "https://tiers.example.com"
+
+	// Seeded platform-first so creation order is the opposite of tier order: if
+	// resolution ever fell back to row order this test would fail.
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, uuid.NullUUID{}, pgtype.Text{String: "", Valid: false}, "tiers-platform", issuerURL)
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, uuid.NullUUID{}, conv.ToPGText(orgID), "tiers-org", issuerURL)
+	projectIssuer := seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "tiers-project", issuerURL)
+
+	found, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL(issuerURL))
+	require.NoError(t, err)
+	require.Equal(t, projectIssuer.String(), found.ID)
+}
+
+func TestGetRemoteSessionIssuerByURL_PrefersOrganizationOverPlatform(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	_, orgID := projectAndOrgID(t, ctx)
+
+	const issuerURL = "https://orgwins.example.com"
+
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, uuid.NullUUID{}, pgtype.Text{String: "", Valid: false}, "orgwins-platform", issuerURL)
+	orgIssuer := seedRemoteIssuerWithURL(t, ctx, ti.conn, uuid.NullUUID{}, conv.ToPGText(orgID), "orgwins-org", issuerURL)
+
+	found, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL(issuerURL))
+	require.NoError(t, err)
+	require.Equal(t, orgIssuer.String(), found.ID)
+}
+
+// The platform catalog is the point of the inheritance work: an install against
+// an upstream a platform admin already curated must find that issuer rather than
+// fork a tenant copy of it, and must then accept a tenant-owned client.
+func TestGetRemoteSessionIssuerByURL_FindsSeededPlatformIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	platformIssuer := seedGlobalRemoteIssuer(t, ctx, ti.conn, "platformseed")
+
+	found, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL("https://platformseed.example.com"))
+	require.NoError(t, err)
+	require.Equal(t, platformIssuer.String(), found.ID)
+	require.Empty(t, found.ProjectID)
+	require.Empty(t, found.OrganizationID)
+
+	requirePlatformIssuerUnchanged(t, ctx, ti.conn, platformIssuer)
+
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "platformseed-usi")
+	clientID := createRemoteClient(t, ctx, ti, platformIssuer.String(), userIssuerID.String(), "platformseed-client")
+	require.NotEmpty(t, clientID)
+}
+
+// Several project-tier rows on one URL are normal, because the manual attach
+// form creates unconditionally. The answer has to be deterministic anyway.
+func TestGetRemoteSessionIssuerByURL_BreaksIntraTierTiesByOldest(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	const issuerURL = "https://tiebreak.example.com"
+
+	oldest := seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "tiebreak-first", issuerURL)
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "tiebreak-second", issuerURL)
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "tiebreak-third", issuerURL)
+
+	// Repeated because a non-deterministic pick would still agree with the
+	// expected answer some of the time.
+	for range 5 {
+		found, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL(issuerURL))
+		require.NoError(t, err)
+		require.Equal(t, oldest.String(), found.ID)
+	}
+}
+
+// Another organization's issuer for the same upstream must stay invisible.
+func TestGetRemoteSessionIssuerByURL_IgnoresOtherOrganizations(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	otherOrgID := createOrganization(t, ctx, ti.conn, "byurl-other-org")
+	seedRemoteIssuerWithURL(t, ctx, ti.conn, uuid.NullUUID{}, conv.ToPGText(otherOrgID), "byurl-foreign", "https://foreign.example.com")
+
+	_, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL("https://foreign.example.com"))
+	require.Error(t, err)
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestGetRemoteSessionIssuerByURL_RejectsInvalidIssuerURL(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	for _, issuerURL := range []string{
+		"idp.example.com",
+		"ftp://idp.example.com",
+		"https://idp.example.com?tenant=acme",
+		"https://idp.example.com#fragment",
+	} {
+		_, err := ti.service.GetRemoteSessionIssuer(ctx, getByIssuerURL(issuerURL))
+		require.Error(t, err, issuerURL)
+		requireOopsCode(t, err, oops.CodeBadRequest)
+	}
+}
+
+// The three selectors are mutually exclusive, and a blank issuer counts as
+// absent so it cannot silently become a fourth "match everything" mode.
+func TestGetRemoteSessionIssuerByURL_RejectsAmbiguousSelectors(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	existing := seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "byurl-ambiguous", "https://ambiguous.example.com")
+
+	id := existing.String()
+	slug := "byurl-ambiguous"
+	issuerURL := "https://ambiguous.example.com"
+	blank := "   "
+
+	for _, payload := range []*gen.GetRemoteSessionIssuerPayload{
+		{ID: &id, Slug: nil, Issuer: &issuerURL, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil},
+		{ID: nil, Slug: &slug, Issuer: &issuerURL, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil},
+		{ID: &id, Slug: &slug, Issuer: &issuerURL, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil},
+		{ID: nil, Slug: nil, Issuer: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil},
+		{ID: nil, Slug: nil, Issuer: &blank, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil},
+	} {
+		_, err := ti.service.GetRemoteSessionIssuer(ctx, payload)
+		require.Error(t, err)
+		requireOopsCode(t, err, oops.CodeBadRequest)
+	}
+}
+
+// A lookup is a read, so project:read is enough. This is the scope that lets a
+// read-only principal answer "does an issuer for this URL exist?".
+func TestGetRemoteSessionIssuerByURL_AllowsProjectRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	projectID, orgID := projectAndOrgID(t, ctx)
+
+	existing := seedRemoteIssuerWithURL(t, ctx, ti.conn, conv.ToNullUUID(projectID), conv.ToPGText(orgID), "byurl-readonly", "https://readonly.example.com")
+
+	readOnlyCtx := withExactAccessGrants(t, ctx, ti.conn, authz.Grant{
+		Scope:    authz.ScopeProjectRead,
+		Selector: authz.NewSelector(authz.ScopeProjectRead, projectID.String()),
+	})
+
+	found, err := ti.service.GetRemoteSessionIssuer(readOnlyCtx, getByIssuerURL("https://readonly.example.com"))
+	require.NoError(t, err)
+	require.Equal(t, existing.String(), found.ID)
 }
 
 func TestListRemoteSessionIssuers(t *testing.T) {

--- a/server/internal/remotesessions/issuerurl.go
+++ b/server/internal/remotesessions/issuerurl.go
@@ -1,0 +1,193 @@
+package remotesessions
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// Issuer URL canonicalization, used by resolveRemoteSessionIssuer to decide
+// whether two spellings name the same upstream authorization server.
+//
+// The canonical form lowercases the scheme and host, drops the scheme's default
+// port, and strips trailing slashes. Everything else is left alone, and the
+// omissions are the point: this function decides whether a customer silently
+// lands on an issuer somebody else curated, so treating fewer things as equal
+// fails safe. Over-matching attaches a tenant to the wrong upstream;
+// under-matching costs one duplicate row.
+//
+// Deliberately treated as DISTINCT:
+//
+//   - http and https. Same host, different security properties, and an
+//     authorization server reachable over both is a misconfiguration Gram should
+//     not paper over.
+//   - Path case. Hosts are case-insensitive per RFC 3986; paths are not, and
+//     some issuers do route on path case.
+//   - Percent-encoding variance in the path (%7E vs ~), repeated inner slashes,
+//     and dot segments. Decoding or collapsing these means re-implementing RFC
+//     3986 normalization, which is far more machinery than the payoff.
+//   - Unicode vs punycode hosts. Equating them needs IDNA processing, whose
+//     mapping rules are themselves a source of confusable-domain bugs.
+//
+// Rejected outright: a missing or non-http(s) scheme, a missing host, userinfo,
+// a query string, and a fragment. RFC 8414 §2 requires an issuer identifier to
+// be an https URL with no query or fragment, so anything carrying one is not an
+// issuer identifier and should not become a lookup key.
+//
+// This is NOT issuerURLsEqual. That one compares a fetched metadata document's
+// self-declared issuer against the URL Gram asked for, which is a trust check on
+// a discovery response, and it stays strict on purpose. Widening it would let an
+// upstream claim an identity it does not have. Keep the two separate.
+type canonicalIssuerURL struct {
+	// raw is the caller-supplied spelling with surrounding whitespace trimmed.
+	// Kept so matchCandidates can probe for a stored row written exactly the way
+	// this caller writes it.
+	raw string
+
+	scheme string
+	// host is lowercased and, for an IPv6 literal, re-bracketed.
+	host string
+	// port is empty when the scheme's default port applies, so that
+	// https://x and https://x:443 produce one canonical form.
+	port string
+	// path has trailing slashes stripped and may be empty.
+	path string
+}
+
+// parseCanonicalIssuerURL validates raw as an issuer identifier and reduces it
+// to its canonical parts.
+func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return canonicalIssuerURL{}, fmt.Errorf("issuer url is empty")
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return canonicalIssuerURL{}, fmt.Errorf("parse issuer url: %w", err)
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return canonicalIssuerURL{}, fmt.Errorf("issuer url must use http or https, got %q", u.Scheme)
+	}
+	if u.User != nil {
+		return canonicalIssuerURL{}, fmt.Errorf("issuer url must not carry userinfo")
+	}
+	// Both are checked on the raw string rather than on the parsed fields,
+	// because the parsed fields do not reliably report an empty component:
+	// net/url leaves Fragment and RawFragment empty for a bare "#", and the
+	// query case only works at all because ForceQuery happens to exist. The
+	// delimiters themselves are the dependable signal. A literal "?" or "#"
+	// always starts a query or fragment, and an encoded one stays percent-
+	// encoded in the path, so neither check can false-positive.
+	if strings.Contains(trimmed, "?") {
+		return canonicalIssuerURL{}, fmt.Errorf("issuer url must not carry a query string")
+	}
+	if strings.Contains(trimmed, "#") {
+		return canonicalIssuerURL{}, fmt.Errorf("issuer url must not carry a fragment")
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return canonicalIssuerURL{}, fmt.Errorf("issuer url has no host")
+	}
+	// url.Hostname strips the brackets from an IPv6 literal; put them back so the
+	// canonical form is a URL that can be parsed again.
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+
+	// An explicit default port is the same authority as no port at all, so drop
+	// it. Any other port is significant and stays.
+	port := u.Port()
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+
+	return canonicalIssuerURL{
+		raw:    trimmed,
+		scheme: scheme,
+		host:   host,
+		port:   port,
+		path:   strings.TrimRight(u.EscapedPath(), "/"),
+	}, nil
+}
+
+// String renders the canonical form. It is the advisory-lock key for a resolve,
+// so two spellings that name one upstream also serialize against each other.
+func (c canonicalIssuerURL) String() string {
+	authority := c.host
+	if c.port != "" {
+		authority += ":" + c.port
+	}
+
+	return c.scheme + "://" + authority + c.path
+}
+
+// matchCandidates returns every literal spelling a stored issuer may carry that
+// this URL should match.
+//
+// Lookup compares the raw `issuer` column against this set rather than
+// normalizing the column, because the index it rides on
+// (remote_session_issuers_issuer_idx) is on the raw column: wrapping `issuer` in
+// any expression makes the index unusable and turns the lookup into a
+// sequential scan. Expanding one canonical form back into its spellings keeps
+// the query a handful of index probes.
+//
+// The consequence, and the accepted limitation of this whole approach, is that
+// canonicalization applies to the SUPPLIED url only, never to what is already
+// stored. A row written as https://LOGIN.example.com will not be found by a
+// caller supplying https://login.example.com, and a duplicate is created
+// instead. That is the safe direction to fail, and it is why the raw spelling is
+// probed too: the common case of a second install discovering the same odd URL
+// as the first still matches.
+//
+// The set is deliberately CLOSED at five entries and must stay that way. It
+// covers exactly the two axes canonicalization collapses (trailing slash,
+// default port) plus the caller's own spelling. Do not extend it to cover host
+// case, punycode, or percent-encoding: those axes are unbounded, and enumerating
+// them is a combinatorial explosion. If input-side matching ever proves
+// insufficient, the fix is a stored canonical column that normalizes both sides,
+// not a longer candidate list.
+func (c canonicalIssuerURL) matchCandidates() []string {
+	canonical := c.String()
+
+	spellings := []string{canonical, canonical + "/"}
+
+	// The default-port spellings exist only when no explicit port survived
+	// canonicalization: those are precisely the URLs whose default port was
+	// implicit and may have been written out in full when the row was stored. A
+	// URL on an explicit non-default port has no such alternative spelling.
+	if withPort := c.withDefaultPort(); withPort != "" {
+		spellings = append(spellings, withPort, withPort+"/")
+	}
+
+	spellings = append(spellings, c.raw)
+
+	candidates := make([]string, 0, len(spellings))
+	for _, spelling := range spellings {
+		if !slices.Contains(candidates, spelling) {
+			candidates = append(candidates, spelling)
+		}
+	}
+
+	return candidates
+}
+
+// withDefaultPort renders the canonical form with the scheme's default port
+// written out explicitly, or "" when an explicit non-default port is present
+// (in which case no default-port spelling of this URL exists).
+func (c canonicalIssuerURL) withDefaultPort() string {
+	if c.port != "" {
+		return ""
+	}
+
+	port := "443"
+	if c.scheme == "http" {
+		port = "80"
+	}
+
+	return c.scheme + "://" + c.host + ":" + port + c.path
+}

--- a/server/internal/remotesessions/issuerurl_test.go
+++ b/server/internal/remotesessions/issuerurl_test.go
@@ -1,0 +1,166 @@
+package remotesessions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The canonical form collapses exactly three things: scheme case, host case,
+// the scheme's default port, and trailing slashes. Each case below names which.
+func TestParseCanonicalIssuerURL_Canonicalizes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "already canonical", in: "https://idp.example.com", want: "https://idp.example.com"},
+		{name: "trailing slash", in: "https://idp.example.com/", want: "https://idp.example.com"},
+		{name: "repeated trailing slashes", in: "https://idp.example.com///", want: "https://idp.example.com"},
+		{name: "trailing slash after path", in: "https://idp.example.com/oauth/", want: "https://idp.example.com/oauth"},
+		{name: "surrounding whitespace", in: "  https://idp.example.com  ", want: "https://idp.example.com"},
+		{name: "uppercase scheme", in: "HTTPS://idp.example.com", want: "https://idp.example.com"},
+		{name: "uppercase host", in: "https://IDP.Example.COM", want: "https://idp.example.com"},
+		{name: "https default port", in: "https://idp.example.com:443/oauth", want: "https://idp.example.com/oauth"},
+		{name: "http default port", in: "http://idp.example.com:80/oauth", want: "http://idp.example.com/oauth"},
+		{name: "everything at once", in: " HTTPS://IDP.Example.com:443/OAuth/ ", want: "https://idp.example.com/OAuth"},
+		{name: "ipv6 literal stays bracketed", in: "https://[2001:DB8::1]:443/oauth", want: "https://[2001:db8::1]/oauth"},
+		// The query and fragment rejections test the raw string for a literal "?"
+		// or "#". An encoded delimiter is part of the path, not a delimiter, and
+		// must survive rather than trip those checks.
+		{name: "percent-encoded delimiters stay in the path", in: "https://idp.example.com/p%23q%3Fr", want: "https://idp.example.com/p%23q%3Fr"},
+	}
+
+	for _, tc := range cases {
+		canonical, err := parseCanonicalIssuerURL(tc.in)
+		require.NoError(t, err, tc.name)
+		require.Equal(t, tc.want, canonical.String(), tc.name)
+	}
+}
+
+// Everything here is deliberately NOT collapsed. Over-matching would attach a
+// tenant to somebody else's upstream, so each of these stays a distinct issuer
+// even though a more aggressive normalizer would equate them.
+func TestParseCanonicalIssuerURL_PreservesDistinctions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{name: "http is not https", a: "http://idp.example.com", b: "https://idp.example.com"},
+		{name: "path case is significant", a: "https://idp.example.com/OAuth", b: "https://idp.example.com/oauth"},
+		{name: "non-default port is significant", a: "https://idp.example.com:8443", b: "https://idp.example.com"},
+		{name: "http default port is not the https one", a: "http://idp.example.com:443", b: "http://idp.example.com"},
+		{name: "percent-encoding is not decoded", a: "https://idp.example.com/%7Euser", b: "https://idp.example.com/~user"},
+		{name: "inner slashes are not collapsed", a: "https://idp.example.com/a//b", b: "https://idp.example.com/a/b"},
+		{name: "dot segments are not resolved", a: "https://idp.example.com/a/../b", b: "https://idp.example.com/b"},
+		{name: "punycode is not equated to unicode", a: "https://xn--bcher-kva.example.com", b: "https://bücher.example.com"},
+		{name: "subdomain is not the apex", a: "https://idp.example.com", b: "https://example.com"},
+	}
+
+	for _, tc := range cases {
+		a, err := parseCanonicalIssuerURL(tc.a)
+		require.NoError(t, err, tc.name)
+		b, err := parseCanonicalIssuerURL(tc.b)
+		require.NoError(t, err, tc.name)
+		require.NotEqual(t, a.String(), b.String(), tc.name)
+	}
+}
+
+func TestParseCanonicalIssuerURL_Rejects(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{name: "empty", in: ""},
+		{name: "whitespace only", in: "   "},
+		{name: "relative", in: "idp.example.com/oauth"},
+		{name: "scheme relative", in: "//idp.example.com"},
+		{name: "no host", in: "https:///oauth"},
+		{name: "not http", in: "ftp://idp.example.com"},
+		{name: "javascript scheme", in: "javascript:alert(1)"},
+		{name: "mailto", in: "mailto:someone@example.com"},
+		{name: "userinfo", in: "https://user:pass@idp.example.com"},
+		// RFC 8414 §2 forbids both on an issuer identifier, so a URL carrying one
+		// is not an issuer and must not become a lookup key. The empty forms are
+		// the interesting ones: net/url reports no fragment at all for a bare "#",
+		// so a check on the parsed fields alone would let it through and quietly
+		// canonicalize it to the fragment-free URL.
+		{name: "query string", in: "https://idp.example.com?tenant=acme"},
+		{name: "empty query string", in: "https://idp.example.com?"},
+		{name: "fragment", in: "https://idp.example.com#section"},
+		{name: "empty fragment", in: "https://idp.example.com#"},
+		{name: "empty fragment after path", in: "https://idp.example.com/oauth#"},
+		{name: "fragment and query", in: "https://idp.example.com?a=b#c"},
+	}
+
+	for _, tc := range cases {
+		_, err := parseCanonicalIssuerURL(tc.in)
+		require.Error(t, err, tc.name)
+	}
+}
+
+// The candidate set is what the lookup query probes against the raw issuer
+// column. It must stay closed: these assertions pin both its contents and its
+// size so a future change that starts enumerating host-case or encoding
+// variants fails here rather than silently making the lookup unbounded.
+func TestCanonicalIssuerURL_MatchCandidates(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := parseCanonicalIssuerURL("https://idp.example.com/oauth")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		"https://idp.example.com/oauth",
+		"https://idp.example.com/oauth/",
+		"https://idp.example.com:443/oauth",
+		"https://idp.example.com:443/oauth/",
+	}, canonical.matchCandidates())
+}
+
+// A non-default port has no default-port spelling, so the set shrinks rather
+// than emitting a nonsensical https://host:8443:443 entry.
+func TestCanonicalIssuerURL_MatchCandidatesExplicitPort(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := parseCanonicalIssuerURL("https://idp.example.com:8443/oauth")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		"https://idp.example.com:8443/oauth",
+		"https://idp.example.com:8443/oauth/",
+	}, canonical.matchCandidates())
+}
+
+// The caller's own spelling is probed alongside the canonical ones. This is what
+// lets a second install that discovers the same oddly-spelled URL as the first
+// still find that row, even though canonicalization never touches stored values.
+func TestCanonicalIssuerURL_MatchCandidatesIncludesRawSpelling(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := parseCanonicalIssuerURL("https://IDP.Example.com/oauth")
+	require.NoError(t, err)
+	require.Contains(t, canonical.matchCandidates(), "https://IDP.Example.com/oauth")
+	require.Contains(t, canonical.matchCandidates(), "https://idp.example.com/oauth")
+}
+
+// A raw spelling that is already canonical must not be emitted twice, or the
+// lookup would probe the same value repeatedly.
+func TestCanonicalIssuerURL_MatchCandidatesDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := parseCanonicalIssuerURL("https://idp.example.com/oauth")
+	require.NoError(t, err)
+
+	candidates := canonical.matchCandidates()
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		_, duplicate := seen[candidate]
+		require.False(t, duplicate, "duplicate candidate %q", candidate)
+		seen[candidate] = struct{}{}
+	}
+}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -142,6 +142,43 @@ WHERE (
 ORDER BY id DESC
 LIMIT sqlc.arg('limit_value');
 
+-- name: ListRemoteSessionIssuersByIssuerURL :many
+-- Every issuer a project may resolve an upstream authorization server URL onto:
+-- its own, plus each inherited tier the caller opts in to, using the same
+-- three-arm tenancy predicate as ListRemoteSessionIssuersByProjectID.
+--
+-- Matching is literal equality against a caller-supplied candidate set rather
+-- than a normalizing expression, because the index this rides on
+-- (remote_session_issuers_issuer_idx) is on the raw column: any expression
+-- around `issuer` would make it unusable and turn this into a sequential scan.
+-- The caller canonicalizes the URL in Go and expands it back into the closed set
+-- of raw spellings that canonicalize to the same thing, so `= ANY` stays a
+-- series of index probes. See matchCandidates for the exact set and for the
+-- spellings deliberately left unmatched.
+--
+-- Returns every candidate rather than picking one: precedence is project >
+-- organization > platform and cannot be expressed by row order here, and the
+-- caller applies it (plus the oldest-first tie-break within a tier) through
+-- resolveIssuerByPrecedence.
+--
+-- Ordered by created_at, NOT by id. generate_uuidv7 overlays only a
+-- millisecond-resolution timestamp onto an otherwise random gen_random_uuid, so
+-- two rows written in the same millisecond sort randomly by id: stable for a
+-- given set of rows, but not chronological. created_at is clock_timestamp() at
+-- microsecond resolution, which makes "oldest" mean what it says. id remains the
+-- final tie-break so the order is still total if two rows somehow share a
+-- created_at.
+SELECT *
+FROM remote_session_issuers
+WHERE issuer = ANY(@issuers::text[])
+  AND (
+    project_id = @project_id
+    OR (@include_organizational::boolean AND project_id IS NULL AND organization_id = @organization_id)
+    OR (@include_global::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
+  AND deleted IS FALSE
+ORDER BY created_at ASC, id ASC;
+
 -- name: UpdateRemoteSessionIssuer :one
 -- Three-state semantics on the nullable endpoint columns: an omitted narg
 -- (NULL) keeps the existing value, an explicit empty string clears the

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -2481,6 +2481,105 @@ func (q *Queries) ListRemoteSessionClientsForUserSessionIssuer(ctx context.Conte
 	return items, nil
 }
 
+const listRemoteSessionIssuersByIssuerURL = `-- name: ListRemoteSessionIssuersByIssuerURL :many
+SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, client_id_metadata_document_supported, oidc, passthrough, name, logo_asset_id, client_setup_documentation_url, created_at, updated_at, deleted_at, deleted
+FROM remote_session_issuers
+WHERE issuer = ANY($1::text[])
+  AND (
+    project_id = $2
+    OR ($3::boolean AND project_id IS NULL AND organization_id = $4)
+    OR ($5::boolean AND project_id IS NULL AND organization_id IS NULL)
+  )
+  AND deleted IS FALSE
+ORDER BY created_at ASC, id ASC
+`
+
+type ListRemoteSessionIssuersByIssuerURLParams struct {
+	Issuers               []string
+	ProjectID             uuid.NullUUID
+	IncludeOrganizational bool
+	OrganizationID        pgtype.Text
+	IncludeGlobal         bool
+}
+
+// Every issuer a project may resolve an upstream authorization server URL onto:
+// its own, plus each inherited tier the caller opts in to, using the same
+// three-arm tenancy predicate as ListRemoteSessionIssuersByProjectID.
+//
+// Matching is literal equality against a caller-supplied candidate set rather
+// than a normalizing expression, because the index this rides on
+// (remote_session_issuers_issuer_idx) is on the raw column: any expression
+// around `issuer` would make it unusable and turn this into a sequential scan.
+// The caller canonicalizes the URL in Go and expands it back into the closed set
+// of raw spellings that canonicalize to the same thing, so `= ANY` stays a
+// series of index probes. See matchCandidates for the exact set and for the
+// spellings deliberately left unmatched.
+//
+// Returns every candidate rather than picking one: precedence is project >
+// organization > platform and cannot be expressed by row order here, and the
+// caller applies it (plus the oldest-first tie-break within a tier) through
+// resolveIssuerByPrecedence.
+//
+// Ordered by created_at, NOT by id. generate_uuidv7 overlays only a
+// millisecond-resolution timestamp onto an otherwise random gen_random_uuid, so
+// two rows written in the same millisecond sort randomly by id: stable for a
+// given set of rows, but not chronological. created_at is clock_timestamp() at
+// microsecond resolution, which makes "oldest" mean what it says. id remains the
+// final tie-break so the order is still total if two rows somehow share a
+// created_at.
+func (q *Queries) ListRemoteSessionIssuersByIssuerURL(ctx context.Context, arg ListRemoteSessionIssuersByIssuerURLParams) ([]RemoteSessionIssuer, error) {
+	rows, err := q.db.Query(ctx, listRemoteSessionIssuersByIssuerURL,
+		arg.Issuers,
+		arg.ProjectID,
+		arg.IncludeOrganizational,
+		arg.OrganizationID,
+		arg.IncludeGlobal,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []RemoteSessionIssuer
+	for rows.Next() {
+		var i RemoteSessionIssuer
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.OrganizationID,
+			&i.Slug,
+			&i.Issuer,
+			&i.AuthorizationEndpoint,
+			&i.TokenEndpoint,
+			&i.RegistrationEndpoint,
+			&i.JwksUri,
+			&i.ServiceDocumentation,
+			&i.OpPolicyUri,
+			&i.OpTosUri,
+			&i.ScopesSupported,
+			&i.GrantTypesSupported,
+			&i.ResponseTypesSupported,
+			&i.TokenEndpointAuthMethodsSupported,
+			&i.ClientIDMetadataDocumentSupported,
+			&i.Oidc,
+			&i.Passthrough,
+			&i.Name,
+			&i.LogoAssetID,
+			&i.ClientSetupDocumentationUrl,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRemoteSessionIssuersByProjectID = `-- name: ListRemoteSessionIssuersByProjectID :many
 SELECT id, project_id, organization_id, slug, issuer, authorization_endpoint, token_endpoint, registration_endpoint, jwks_uri, service_documentation, op_policy_uri, op_tos_uri, scopes_supported, grant_types_supported, response_types_supported, token_endpoint_auth_methods_supported, client_id_metadata_document_supported, oidc, passthrough, name, logo_asset_id, client_setup_documentation_url, created_at, updated_at, deleted_at, deleted
 FROM remote_session_issuers

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -353,6 +353,31 @@ func seedGlobalRemoteIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Poo
 	return issuer.ID
 }
 
+// seedRemoteIssuerWithURL creates a remote session issuer at a chosen tenancy
+// tier carrying a specific upstream URL. The tier-specific seeders above all
+// hardcode their issuer URL, which is exactly the column resolveRemoteSessionIssuer
+// matches on, so resolution tests need to set it per row.
+//
+// Pass a valid projectID for the project tier, a zero projectID plus an
+// organizationID for the organization tier, and neither for the platform tier.
+func seedRemoteIssuerWithURL(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.NullUUID, organizationID pgtype.Text, slug, issuerURL string) uuid.UUID {
+	t.Helper()
+	issuer, err := repo.New(conn).CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
+		ProjectID:                         projectID,
+		OrganizationID:                    organizationID,
+		Slug:                              slug,
+		Issuer:                            issuerURL,
+		AuthorizationEndpoint:             conv.ToPGText(issuerURL + "/authorize"),
+		TokenEndpoint:                     conv.ToPGText(issuerURL + "/token"),
+		ScopesSupported:                   []string{"openid"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic"},
+	})
+	require.NoError(t, err)
+	return issuer.ID
+}
+
 // seedOrgLevelRemoteClient creates an organization-level (project_id IS NULL,
 // organization_id set) remote_session_client referencing remoteIssuerID and
 // attaches it to each userSessionIssuerID through the join table. Org-level


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-333/feat-resolve-remote-session-issuers-by-url-server-side

`remoteSessionIssuers.get` accepts an `issuer` selector alongside `id` and `slug`. It returns the identity provider a project would use for an upstream authorization server, preferring project over organization over platform and breaking ties within a tier by the oldest issuer, and returns 404 when nothing describes that URL.

Reuse previously happened in the browser. SDK and direct RPC callers got none of it, the platform catalog was invisible to it, and every caller had to reimplement the normalization and precedence rules to behave the same way.

Issuer URLs are canonicalized before matching: scheme and host lowercased, the scheme's default port dropped, trailing slashes stripped. `http` and `https` stay distinct, path case is significant, and a URL carrying a query or fragment is rejected per RFC 8414. Canonicalization applies to the supplied URL only, so a row stored with an unusual spelling is not found and a duplicate is created instead, which is the safe direction to fail. Matching expands the canonical form back into a closed set of raw spellings so the non-unique index on `issuer` stays usable.

Candidates are ordered by `created_at`, not by id. `generate_uuidv7` overlays only a millisecond timestamp onto an otherwise random uuid, so rows written in the same millisecond sort randomly by id, which would make the oldest-first tie-break untrue.

Both automatic setup paths in the dashboard look up before creating and no longer scan the issuer list client-side. The manual attach form still creates unconditionally, since a deliberate duplicate is legitimate there. The rollback that deleted a newly created issuer on failure is gone: the lookup is keyed on the upstream URL, so an issuer left behind is what the next attempt finds and reuses.

Not-found returns from the get handler moved from `.LogError` to `.LogWarn`. A miss is the normal path for a new upstream, and error level would also mark the OpenTelemetry span as errored. AGE-3082 covers the remaining 166 call sites.

Concurrent duplicate creation is deliberately not addressed. No in-app path fans out installs concurrently: the batch install loop is sequential and the single-server path is one submit at a time. The residual window is a cross-tab or scripted-caller race of a few hundred milliseconds, and a duplicate is clutter rather than corruption.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side lookup of identity providers by upstream issuer URL via `remoteSessionIssuers.get`, applying project > organization > platform precedence with an oldest-first tie-break. Replaces dashboard-side scans and enables reuse of org/platform issuers (AIS-333).

- **New Features**
  - `remoteSessionIssuers.get` now accepts an `issuer` URL and returns the issuer this project would use, or 404 if none.
  - URL canonicalization: lowercase scheme/host, drop default port, strip trailing slashes; `http` vs `https` stay distinct; query/fragment rejected.
  - Deterministic selection: new issuer-URL query ordered by `created_at ASC, id ASC`; candidate matching uses a closed set of raw spellings to keep the `issuer` index usable.
  - OpenAPI, SDK, `react-query`, CLI updated to support `issuer`.

- **Refactors**
  - Dashboard auto-setup and user-session flows use lookup-then-create; removed client-side scan and created-issuer rollback.
  - 404s treated as non-errors via `isNotFoundError`; not-found logs downgraded to warn.
  - Added server-side canonicalization and precedence helpers with unit tests.

<sup>Written for commit 178dfe6b7c6ae75540a959bc27cfa74bfe909e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

