### PR TITLE
chore: add impeccable CI check for UI anti-patterns

### DIFF
--- a/.github/scripts/impeccable-summary.mjs
+++ b/.github/scripts/impeccable-summary.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Turns `impeccable detect --json` output into GitHub Actions annotations and a
+// job summary, then exits non-zero if anything was found.
+//
+// Usage: node .github/scripts/impeccable-summary.mjs findings.json
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { relative } from "node:path";
+
+const [, , findingsPath] = process.argv;
+
+if (!findingsPath) {
+  console.error("usage: impeccable-summary.mjs <findings.json>");
+  process.exit(1);
+}
+
+const raw = readFileSync(findingsPath, "utf8").trim();
+const findings = raw === "" ? [] : JSON.parse(raw);
+
+const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
+const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+function writeSummary(markdown) {
+  if (summaryPath) {
+    appendFileSync(summaryPath, `${markdown}\n`);
+  } else {
+    console.log(markdown);
+  }
+}
+
+if (findings.length === 0) {
+  console.log("No UI anti-patterns detected.");
+  writeSummary("## Impeccable\n\nNo UI anti-patterns detected.");
+  process.exit(0);
+}
+
+const rows = findings.map((finding) => {
+  const file = finding.file ? relative(workspace, finding.file) : "unknown";
+  return { ...finding, file };
+});
+
+for (const row of rows) {
+  // `warning` findings are still failures — the job's job is to keep new slop
+  // out. The annotation level only controls how GitHub renders it.
+  const level = row.severity === "error" ? "error" : "warning";
+  const message = `${row.name}: ${row.description}${row.snippet ? ` (${row.snippet})` : ""}`;
+  console.log(
+    `::${level} file=${row.file},line=${row.line ?? 1},title=impeccable/${row.antipattern}::${message}`,
+  );
+}
+
+const table = rows
+  .map(
+    (row) =>
+      `| \`${row.file}:${row.line ?? 1}\` | ${row.antipattern} | ${row.severity} | ${row.name} |`,
+  )
+  .join("\n");
+
+writeSummary(
+  [
+    "## Impeccable",
+    "",
+    `Found **${rows.length}** UI anti-pattern${rows.length === 1 ? "" : "s"}.`,
+    "",
+    "| Location | Rule | Severity | Issue |",
+    "| --- | --- | --- | --- |",
+    table,
+    "",
+    "Rule catalog: <https://impeccable.style/slop>",
+  ].join("\n"),
+);
+
+process.exit(1);

--- a/.github/scripts/impeccable-summary.mjs
+++ b/.github/scripts/impeccable-summary.mjs
@@ -39,14 +39,32 @@ const rows = findings.map((finding) => {
   return { ...finding, file };
 });
 
+// Workflow commands are newline-delimited and `::`-separated, so any of those
+// characters in a finding would truncate the annotation or inject a new one.
+// See https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+// `%` goes first — it is the escape character.
+function escapeData(value) {
+  return String(value ?? "")
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+}
+
+function escapeProperty(value) {
+  return escapeData(value).replaceAll(":", "%3A").replaceAll(",", "%2C");
+}
+
 for (const row of rows) {
   // `warning` findings are still failures — the job's job is to keep new slop
   // out. The annotation level only controls how GitHub renders it.
   const level = row.severity === "error" ? "error" : "warning";
   const message = `${row.name}: ${row.description}${row.snippet ? ` (${row.snippet})` : ""}`;
-  console.log(
-    `::${level} file=${row.file},line=${row.line ?? 1},title=impeccable/${row.antipattern}::${message}`,
-  );
+  const props = [
+    `file=${escapeProperty(row.file)}`,
+    `line=${row.line ?? 1}`,
+    `title=${escapeProperty(`impeccable/${row.antipattern}`)}`,
+  ].join(",");
+  console.log(`::${level} ${props}::${escapeData(message)}`);
 }
 
 const table = rows

--- a/.github/workflows/impeccable.yaml
+++ b/.github/workflows/impeccable.yaml
@@ -1,0 +1,63 @@
+name: Impeccable
+
+# Scans the frontend for UI anti-patterns and "AI slop" tells (side-tab accent
+# borders, gradient headings, bounce easing, AI-favourite color palettes, ...)
+# using https://npmjs.com/package/impeccable.
+#
+# The tree is clean as of this workflow's introduction, so the whole frontend is
+# scanned rather than just the PR diff — a full scan takes ~3 seconds and also
+# catches regressions in files the PR did not touch.
+#
+# Rule waivers live in .impeccable/config.json (see `impeccable ignores --help`)
+# or as inline `impeccable-disable-next-line <rule>` comments.
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Pin the CLI so a new release cannot turn a green PR red without a commit.
+  IMPECCABLE_VERSION: "3.4.0"
+  # puppeteer is an optional dependency only used for scanning live URLs. We
+  # scan files, so skip the ~150MB Chromium download.
+  PUPPETEER_SKIP_DOWNLOAD: "1"
+
+jobs:
+  detect-ui-slop:
+    name: Detect UI anti-patterns
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout source code
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Run impeccable
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # `detect` exits 0 when clean and 2 when anti-patterns are found.
+          npx --yes "impeccable@${IMPECCABLE_VERSION}" detect --json \
+            client ts-framework functions > findings.json
+          status=$?
+
+          if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+            echo "::error::impeccable exited with unexpected status $status"
+            cat findings.json || true
+            exit "$status"
+          fi
+
+          node .github/scripts/impeccable-summary.mjs findings.json

--- a/.github/workflows/impeccable.yaml
+++ b/.github/workflows/impeccable.yaml
@@ -33,6 +33,8 @@ jobs:
   detect-ui-slop:
     name: Detect UI anti-patterns
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    # The scan itself takes ~3s; this only guards against a hung npx install.
+    timeout-minutes: 5
     steps:
       - name: Checkout source code
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ __pycache__/
 
 # Local kubernetes manifests (developer scratch)
 .local-k8s/
+
+# Personal impeccable ignores (.impeccable/config.json is shared and committed)
+.impeccable/config.local.json

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,15 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [],
+    "ignoreValues": [
+      {
+        "rule": "overused-font",
+        "value": "*",
+        "files": ["client/dashboard/src/main.tsx"],
+        "createdAt": "2026-07-29T15:25:48.973Z",
+        "reason": "Inter is the Speakeasy brand typeface"
+      }
+    ]
+  }
+}

--- a/client/dashboard/src/components/ui/multi-select.tsx
+++ b/client/dashboard/src/components/ui/multi-select.tsx
@@ -32,7 +32,7 @@ import {
  */
 interface AnimationConfig {
   /** Badge animation type */
-  badgeAnimation?: "bounce" | "pulse" | "wiggle" | "fade" | "slide" | "none";
+  badgeAnimation?: "lift" | "pulse" | "wiggle" | "fade" | "slide" | "none";
   /** Popover animation type */
   popoverAnimation?: "scale" | "slide" | "fade" | "flip" | "none";
   /** Option hover animation type */
@@ -58,7 +58,7 @@ const multiSelectVariants = cva("m-1 transition-all duration-300 ease-in-out", {
       inverted: "inverted",
     },
     badgeAnimation: {
-      bounce: "hover:-translate-y-1 hover:scale-110",
+      lift: "hover:-translate-y-1 hover:scale-110",
       pulse: "hover:animate-pulse",
       wiggle: "hover:animate-wiggle",
       fade: "hover:opacity-80",
@@ -68,7 +68,7 @@ const multiSelectVariants = cva("m-1 transition-all duration-300 ease-in-out", {
   },
   defaultVariants: {
     variant: "default",
-    badgeAnimation: "bounce",
+    badgeAnimation: "lift",
   },
 });
 
@@ -512,9 +512,9 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
     const getBadgeAnimationClass = () => {
       if (animationConfig?.badgeAnimation) {
         switch (animationConfig.badgeAnimation) {
-          case "bounce":
+          case "lift":
             return isAnimating
-              ? "animate-bounce"
+              ? "animate-pulse"
               : "hover:-translate-y-1 hover:scale-110";
           case "pulse":
             return "hover:animate-pulse";
@@ -530,7 +530,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
             return "";
         }
       }
-      return isAnimating ? "animate-bounce" : "";
+      return isAnimating ? "animate-pulse" : "";
     };
 
     const getPopoverAnimationClass = () => {

--- a/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
+++ b/client/dashboard/src/pages/deployments/deployment/LogsTabContent.tsx
@@ -74,6 +74,9 @@ const TIMESTAMP_PATTERNS = [
 
 const LEVEL_PATTERN = /^\[?(WARN|WARNING|INFO|DEBUG|ERROR|OK)\]?\s+(.*)$/i;
 
+/** Marks the log line targeted by j/k keyboard navigation. */
+const HIGHLIGHTED_LOG_CLASS = "ring-foreground/40 ring-1 ring-inset";
+
 function formatLogTimestamp(createdAt: string): string {
   const date = new Date(createdAt);
   return dateTimeFormatters.logTimestamp.format(date);
@@ -802,8 +805,7 @@ export const LogsTabContent = ({
                           isError && "bg-destructive/10 text-destructive",
                           isWarn && "bg-warning/10 text-warning",
                           isSkipped && "bg-muted/50 text-muted-foreground",
-                          isHighlighted &&
-                            "border-l-foreground border-l-4 pl-2",
+                          isHighlighted && HIGHLIGHTED_LOG_CLASS,
                         )}
                       >
                         <div className="flex min-w-0 items-center gap-2.5">
@@ -866,7 +868,7 @@ export const LogsTabContent = ({
                     isError && "bg-destructive/10 text-destructive",
                     isWarn && "bg-warning/10 text-warning",
                     isSkipped && "bg-muted/50 text-muted-foreground",
-                    isHighlighted && "border-l-foreground border-l-4 pl-2",
+                    isHighlighted && HIGHLIGHTED_LOG_CLASS,
                   )}
                 >
                   <div className="flex min-w-0 items-center gap-2.5">

--- a/client/dashboard/src/pages/elements/Elements.tsx
+++ b/client/dashboard/src/pages/elements/Elements.tsx
@@ -1728,7 +1728,7 @@ function SearchPreview() {
       </div>
       {/* Results */}
       <div className="flex-1 space-y-1.5">
-        <div className="rounded border-l-2 border-violet-400 bg-violet-50 p-1.5">
+        <div className="rounded bg-violet-50 p-1.5 ring-1 ring-violet-300">
           <div className="mb-1 h-1.5 w-full rounded bg-slate-400" />
           <div className="h-1.5 w-3/4 rounded bg-slate-300" />
         </div>
@@ -1773,7 +1773,7 @@ function NotificationsPreview() {
           </div>
         </div>
         <div className="flex gap-1.5 rounded p-1">
-          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-purple-400 to-pink-500" />
+          <div className="h-4 w-4 shrink-0 rounded-full bg-linear-to-br from-sky-400 to-blue-500" />
           <div className="flex-1">
             <div className="mb-1 h-1.5 w-full rounded bg-slate-300" />
             <div className="h-1.5 w-3/4 rounded bg-slate-200" />

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -206,6 +206,9 @@ function hasDiff(log: AuditLog): boolean {
   return log.beforeSnapshot != null || log.afterSnapshot != null;
 }
 
+/** Marks the row targeted by j/k keyboard navigation. */
+const HIGHLIGHTED_ROW_CLASS = "ring-foreground/40 ring-1 ring-inset";
+
 function AuditLogRow({
   log,
   orgSlug,
@@ -271,10 +274,7 @@ function AuditLogRow({
 
   if (showDiff && diffExpanded) {
     return (
-      <div
-        ref={rowRef}
-        className={cn(isHighlighted && "border-l-foreground border-l-4")}
-      >
+      <div ref={rowRef} className={cn(isHighlighted && HIGHLIGHTED_ROW_CLASS)}>
         <div
           className={cn(
             "rounded-t-lg border border-b-0",
@@ -296,7 +296,7 @@ function AuditLogRow({
       className={cn(
         "rounded-none transition-colors",
         isOdd ? "bg-muted/30" : "bg-background",
-        isHighlighted && "border-l-foreground border-l-4",
+        isHighlighted && HIGHLIGHTED_ROW_CLASS,
       )}
     >
       {rowContent}


### PR DESCRIPTION
Adds a CI check using [`impeccable`](https://www.npmjs.com/package/impeccable) to detect UI anti-patterns and "AI slop" tells — side-tab accent borders, purple/violet gradients, bounce easing, overused typefaces — across the frontend.

## The check

New `Impeccable` workflow (`.github/workflows/impeccable.yaml`), one job, runs on PRs to `main`, in the merge queue, and on demand.

- Scans `client`, `ts-framework`, and `functions` in full — **~3s warm, ~6s cold**, so there was no reason to scope it to the diff. A full scan also catches regressions in files the PR didn't touch.
- `impeccable@3.4.0` is pinned via env so a CLI release can't turn a green PR red without a commit.
- `PUPPETEER_SKIP_DOWNLOAD=1` — puppeteer is an optional dep only needed for scanning live URLs, and skipping it avoids a ~150MB Chromium pull.
- `.github/scripts/impeccable-summary.mjs` converts `detect --json` into inline PR annotations plus a job-summary table, and fails the job when anything is found.

## Waivers

Two documented escape hatches, in preference order:

1. `.impeccable/config.json` — checked in and shared. Manage with `npx impeccable ignores --help`.
2. Inline `// impeccable-disable-next-line <rule>` comments, scoped to a line.

`.impeccable/config.local.json` is gitignored for personal, unshared waivers.

One waiver is in place: `overused-font` is suppressed for `client/dashboard/src/main.tsx`, since Inter is our brand typeface. It's file-scoped, so the rule still fires for Roboto/Geist/etc. anywhere else.

> Note: `impeccable ignores add-value overused-font Inter` looks like the right command but silently does nothing — the CLI's value extractor only parses `Primary font:`-style snippets, not the `Google Fonts: inter` form we hit. The file-scoped wildcard (`value: "*"` + `files: [...]`) is the working path and is what's committed.

## Pre-existing findings fixed

The tree had 9 real findings, all fixed here so the check can run on the whole tree instead of only the diff:

| File                      | Was                                    | Now                                  |
| ------------------------- | -------------------------------------- | ------------------------------------ |
| `OrgAuditLogs.tsx` (×2)   | `border-l-foreground border-l-4`       | `HIGHLIGHTED_ROW_CLASS` — inset ring |
| `LogsTabContent.tsx` (×2) | `border-l-foreground border-l-4 pl-2`  | `HIGHLIGHTED_LOG_CLASS` — inset ring |
| `Elements.tsx`            | `border-l-2 border-violet-400`         | `ring-1 ring-violet-300`             |
| `Elements.tsx`            | `from-purple-400 to-pink-500`          | `from-sky-400 to-blue-500`           |
| `multi-select.tsx` (×3)   | `animate-bounce`, cva variant `bounce` | `animate-pulse`, cva variant `lift`  |

All four side-tab hits were the same latent pattern: a thick left border marking the row under `j`/`k` keyboard navigation, where the `pl-2` existed only to offset the 4px border. An inset ring reads as "current" without stealing layout width, so the padding compensation goes away too.

The `multi-select.tsx` rename is file-local — `animationConfig` has no callers and `AnimationConfig` isn't exported. `lift` is also just the accurate name: that variant renders `hover:-translate-y-1 hover:scale-110`, with no bounce keyframe involved.

## Verification

- `impeccable detect` clean on `client`, `ts-framework`, `functions`
- `pnpm -F dashboard type-check` — pass
- `pnpm -F dashboard lint` — exit 0 (remaining warnings are pre-existing, in generated `src/sdk/`)
- `pnpm -F dashboard test` — 1185/1185 pass
- CI step simulated locally end to end, both the clean (exit 0) and findings (exit 1) paths

## Follow-up, not in scope

`Elements.tsx` uses hardcoded Tailwind palette colors (`violet-500`, `slate-300`) throughout its miniature preview mockups, which our frontend guidelines steer away from in favor of Moonshine tokens. Pre-existing, left alone here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI workflow using `impeccable` to block UI anti-patterns across the frontend with inline PR annotations and a job summary. Cleaned up existing findings and added an Inter font waiver so the check runs on the full tree.

- **New Features**
  - New “Impeccable” GitHub Actions workflow scans `client`, `ts-framework`, and `functions` on PRs to `main`, merge queue, and manual runs.
  - Pins `impeccable@3.4.0` via npx; skips `puppeteer` download to keep the job light.
  - `.github/scripts/impeccable-summary.mjs` converts `detect --json` output into annotations and a job summary, and fails on findings.
  - Escapes workflow-command data to prevent truncated/invalid annotations, and sets a 5-minute job timeout.
  - Waivers via `.impeccable/config.json` or `// impeccable-disable-next-line <rule>`; file-scoped ignore allows Inter in `client/dashboard/src/main.tsx`. `.impeccable/config.local.json` is gitignored for personal waivers.

- **Refactors**
  - Replaced thick left-border highlights with inset rings for selected rows/log lines.
  - Tweaked preview gradients and accents in `Elements.tsx` to avoid flagged patterns.
  - Renamed `bounce` badge animation to `lift`, made it the default, and swapped any `animate-bounce` usage for `animate-pulse` where needed.

<sup>Written for commit b675916edb9556b5d46112c4feb9a0629a6f8e29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

