### PR TITLE
fix: make shadow MCP inventory name resolution robust to tied versions

### DIFF
--- a/.changeset/shadow-mcp-name-version-ordering.md
+++ b/.changeset/shadow-mcp-name-version-ordering.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Shadow MCP inventory server names now resolve reliably after renames. Name updates written in quick succession could previously tie on their stored version and intermittently revert to an older observed name; versions are now stored at full nanosecond precision and each update is guaranteed to supersede the state it was based on.

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -351,6 +351,10 @@ type ShadowMCPInventoryURLRow struct {
 	FirstSeen          time.Time `ch:"first_seen"`
 	LastSeen           time.Time `ch:"last_seen"`
 	LastCalledUnixNano int64     `ch:"last_called_unix_nano"`
+	// UpdatedAt is aliased max_updated_at in queries: an alias equal to the
+	// base column name is substituted into sibling argMax aggregates and
+	// trips ILLEGAL_AGGREGATION.
+	UpdatedAt time.Time `ch:"max_updated_at"`
 }
 
 type ListShadowMCPInventoryUsageParams struct {
@@ -605,6 +609,11 @@ func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []Upser
 			if existing.LastSeen.After(upsert.LastSeen) {
 				upsert.LastSeen = existing.LastSeen
 			}
+			// The merged row must dominate the state read above or the
+			// argMax(_, updated_at) reads resolve names against a stale row.
+			if !upsert.UpdatedAt.After(existing.UpdatedAt) {
+				upsert.UpdatedAt = existing.UpdatedAt.Add(time.Nanosecond)
+			}
 		}
 	}
 
@@ -612,9 +621,6 @@ func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []Upser
 	for _, upsert := range upserts {
 		rows = append(rows, upsert)
 	}
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"async_insert": 0,
-	}))
 	if err := q.insertShadowMCPInventoryURLRows(ctx, rows); err != nil {
 		return fmt.Errorf("upserting shadow mcp inventory urls: %w", err)
 	}
@@ -622,7 +628,18 @@ func (q *Queries) UpsertShadowMCPInventoryURLs(ctx context.Context, args []Upser
 	return nil
 }
 
+// insertShadowMCPInventoryURLRows writes inventory rows synchronously
+// (async_insert=0): every caller is a read-merge-write cycle whose next read
+// must see the rows written here. Timestamps are sent as
+// fromUnixTimestamp64Nano expressions because clickhouse-go's positional
+// binder truncates time.Time arguments to whole seconds, which collapses
+// distinct updated_at versions written within the same second and makes the
+// argMax(_, updated_at) reads nondeterministic.
 func (q *Queries) insertShadowMCPInventoryURLRows(ctx context.Context, rows []*shadowMCPInventoryURLUpsert) error {
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert": 0,
+	}))
+
 	builder := sq.Insert("shadow_mcp_inventory_urls").
 		Columns(
 			"gram_project_id",
@@ -642,9 +659,9 @@ func (q *Queries) insertShadowMCPInventoryURLRows(ctx context.Context, rows []*s
 			row.URLHost,
 			row.ServerName,
 			row.ServerNameOverride,
-			row.FirstSeen.UTC(),
-			row.LastSeen.UTC(),
-			row.UpdatedAt.UTC(),
+			squirrel.Expr("fromUnixTimestamp64Nano(?)", row.FirstSeen.UTC().UnixNano()),
+			squirrel.Expr("fromUnixTimestamp64Nano(?)", row.LastSeen.UTC().UnixNano()),
+			squirrel.Expr("fromUnixTimestamp64Nano(?)", row.UpdatedAt.UTC().UnixNano()),
 		)
 	}
 
@@ -719,6 +736,11 @@ func (q *Queries) UpdateShadowMCPInventoryURLNameOverride(
 	updatedAt := arg.UpdatedAt
 	if updatedAt.IsZero() {
 		updatedAt = time.Now()
+	}
+	// The new row must dominate the state read above or the argMax(_,
+	// updated_at) reads resolve the override against a stale row.
+	if !updatedAt.After(existing.UpdatedAt) {
+		updatedAt = existing.UpdatedAt.Add(time.Nanosecond)
 	}
 
 	err = q.insertShadowMCPInventoryURLRows(ctx, []*shadowMCPInventoryURLUpsert{{
@@ -795,6 +817,7 @@ func (q *Queries) listShadowMCPInventoryURLRowsByURLs(ctx context.Context, proje
 		"argMax(server_name_override, updated_at) AS server_name_override",
 		"min(first_seen) AS first_seen",
 		"max(last_seen) AS last_seen",
+		"max(updated_at) AS max_updated_at",
 	).
 		From("shadow_mcp_inventory_urls").
 		Where("gram_project_id = ?", projectID).
@@ -835,6 +858,7 @@ func (q *Queries) getShadowMCPInventoryURL(ctx context.Context, projectID string
 		"argMax(server_name_override, updated_at) AS server_name_override",
 		"min(first_seen) AS first_seen",
 		"max(last_seen) AS last_seen",
+		"max(updated_at) AS max_updated_at",
 	).
 		From("shadow_mcp_inventory_urls").
 		Where("gram_project_id = ?", projectID).
@@ -943,15 +967,18 @@ func (q *Queries) ListShadowMCPInventoryURLs(ctx context.Context, arg ListShadow
 		Limit(limit)
 
 	if arg.Cursor != "" {
-		lastSeen := time.Unix(0, cursor.LastSeenUnixNano).UTC()
+		// last_seen comparisons are bound as fromUnixTimestamp64Nano
+		// expressions: binding a time.Time positionally truncates it to whole
+		// seconds, which breaks the equality tie-break against DateTime64(9)
+		// values.
 		sb = sb.Where(squirrel.Or{
 			squirrel.Expr("last_called_unix_nano < ?", cursor.LastCalledUnixNano),
 			squirrel.And{
 				squirrel.Expr("last_called_unix_nano = ?", cursor.LastCalledUnixNano),
 				squirrel.Or{
-					squirrel.Expr("last_seen < ?", lastSeen),
+					squirrel.Expr("last_seen < fromUnixTimestamp64Nano(?)", cursor.LastSeenUnixNano),
 					squirrel.And{
-						squirrel.Expr("last_seen = ?", lastSeen),
+						squirrel.Expr("last_seen = fromUnixTimestamp64Nano(?)", cursor.LastSeenUnixNano),
 						squirrel.Expr("canonical_server_url > ?", cursor.CanonicalServerURL),
 					},
 				},

--- a/server/internal/telemetry/shadow_mcp_inventory_test.go
+++ b/server/internal/telemetry/shadow_mcp_inventory_test.go
@@ -179,6 +179,95 @@ func TestShadowMCPInventoryURLs_NameOverrideCanBeCleared(t *testing.T) {
 	require.Empty(t, rows[0].ServerNameOverride)
 }
 
+// Regression test for the flake in
+// TestService_UpdateShadowMCPInventoryServerName_ClearsOverrideAndFallsBackToLatestObservedName:
+// every write below carries an updated_at at or before the state it read, the
+// way tied wall-clock stamps (or a clock regression) produced tied
+// ReplacingMergeTree versions and let argMax resolve the name against a stale
+// row. Causally-later writes must still win.
+func TestShadowMCPInventoryURLs_NameOverrideClearDominatesRegressingClock(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	serverURL := "https://github.example.com/mcp"
+	seenAt := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+		URLHost:            "github.example.com",
+		ServerName:         "GitHub MCP",
+		SeenAt:             seenAt,
+		UpdatedAt:          seenAt,
+	}}))
+
+	updated, err := ti.chClient.UpdateShadowMCPInventoryURLNameOverride(ctx, telemetryRepo.UpdateShadowMCPInventoryURLNameOverrideParams{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+		ServerNameOverride: "Engineering GitHub",
+		UpdatedAt:          seenAt,
+	})
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+		URLHost:            "github.example.com",
+		ServerName:         "GitHub Enterprise MCP",
+		SeenAt:             seenAt.Add(time.Minute),
+		UpdatedAt:          seenAt.Add(-time.Second),
+	}}))
+
+	updated, err = ti.chClient.UpdateShadowMCPInventoryURLNameOverride(ctx, telemetryRepo.UpdateShadowMCPInventoryURLNameOverrideParams{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+		ServerNameOverride: "",
+		UpdatedAt:          seenAt.Add(-time.Second),
+	})
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	row, err := ti.chClient.GetShadowMCPInventoryURL(ctx, telemetryRepo.GetShadowMCPInventoryURLParams{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.Equal(t, "GitHub Enterprise MCP", row.ServerName)
+	require.Empty(t, row.ServerNameOverride)
+	require.True(t, row.UpdatedAt.After(seenAt), "read-merge-write must stamp a version above the state it read")
+}
+
+func TestShadowMCPInventoryURLs_UpdatedAtNanosecondRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	projectID := uuid.NewString()
+	serverURL := "https://github.example.com/mcp"
+	seenAt := time.Date(2026, 7, 14, 12, 30, 45, 123456789, time.UTC)
+
+	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+		URLHost:            "github.example.com",
+		ServerName:         "GitHub MCP",
+		SeenAt:             seenAt,
+		UpdatedAt:          seenAt,
+	}}))
+
+	row, err := ti.chClient.GetShadowMCPInventoryURL(ctx, telemetryRepo.GetShadowMCPInventoryURLParams{
+		GramProjectID:      projectID,
+		CanonicalServerURL: serverURL,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.Equal(t, seenAt.UnixNano(), row.UpdatedAt.UnixNano())
+	require.Equal(t, seenAt.UnixNano(), row.LastSeen.UnixNano())
+	require.Equal(t, seenAt.UnixNano(), row.FirstSeen.UnixNano())
+}
+
 func TestShadowMCPInventoryURLs_ListBySlugHash(t *testing.T) {
 	t.Parallel()
 
@@ -249,7 +338,9 @@ func TestShadowMCPInventoryURLs_PaginatesLastSeen(t *testing.T) {
 
 	ctx, ti := newTestLogsService(t)
 	projectID := uuid.NewString()
-	base := time.Date(2026, 6, 29, 12, 30, 0, 0, time.UTC)
+	// Nonzero nanoseconds: the cursor's last_seen equality tie-break only
+	// works if sub-second precision survives the round trip.
+	base := time.Date(2026, 6, 29, 12, 30, 0, 123456789, time.UTC)
 
 	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{
 		{GramProjectID: projectID, CanonicalServerURL: "https://gamma.example.com/mcp", URLHost: "gamma.example.com", ServerName: "Gamma", SeenAt: base.Add(3 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},
@@ -293,7 +384,7 @@ func TestShadowMCPInventoryURLs_PaginatesLastCalledThenLastSeen(t *testing.T) {
 
 	ctx, ti := newTestLogsService(t)
 	projectID := uuid.NewString()
-	base := time.Date(2026, 6, 29, 12, 45, 0, 0, time.UTC)
+	base := time.Date(2026, 6, 29, 12, 45, 0, 987654321, time.UTC)
 
 	require.NoError(t, ti.chClient.UpsertShadowMCPInventoryURLs(ctx, []telemetryRepo.UpsertShadowMCPInventoryURLParams{
 		{GramProjectID: projectID, CanonicalServerURL: "https://never-called.example.com/mcp", URLHost: "never-called.example.com", ServerName: "Never Called", SeenAt: base.Add(5 * time.Minute), FirstSeen: time.Time{}, LastSeen: time.Time{}, UpdatedAt: time.Time{}},


### PR DESCRIPTION
## Summary

Fixes the flaky `server-test` failure that ejected an unrelated merge-group run ([example failure](https://github.com/speakeasy-api/gram/actions/runs/30457355180/job/90594400302)):

```
FAIL: server/internal/access TestService_UpdateShadowMCPInventoryServerName_ClearsOverrideAndFallsBackToLatestObservedName
    expected: "GitHub Enterprise MCP"
    actual  : "GitHub MCP"
```

## Root cause

`shadow_mcp_inventory_urls` is `ReplacingMergeTree(updated_at)` with `DateTime64(9)` columns, and "current" state is resolved with `argMax(..., updated_at)` aggregates. Two defects compounded:

1. **clickhouse-go truncates positional `time.Time` arguments to whole seconds** (`format(tz, Seconds, v)` on the `Exec` bind path emits `toDateTime('<unix>')`). The name-override write, the observed-name upsert, and the override-clear write — issued milliseconds apart — therefore routinely persisted **identical** `updated_at` versions.
2. With tied versions, `argMax` is nondeterministic (and `argMaxIf(server_name, ...)` / `argMax(server_name_override, ...)` keep separate aggregate states, so a resolved "row" can mix fields from different physical rows). The override-clear read-merge-write cycle then re-persisted a stale name with the newest version — visible in CI as the flake, and in production as a rename/clear silently reverting a server's display name.

The `invalid cursor` ERROR attached to the CI failure output is stdout interleaving from `TestService_ListShadowMCPInventory_InvalidCursorIsBadRequest` running in parallel — noise, not part of the failure.

## Fix

- Send `first_seen` / `last_seen` / `updated_at` as `fromUnixTimestamp64Nano(?)` expressions so nanosecond precision survives the driver's positional bind; declare `async_insert: 0` in the shared insert helper (every caller is a read-merge-write whose next read must see these rows).
- Expose `max(updated_at)` on the merged-row reads (aliased `max_updated_at` — a bare `updated_at` alias is substituted into the sibling `argMax` aggregates and trips `ILLEGAL_AGGREGATION`).
- Stamp both read-merge-write paths with a version strictly above the state they read (`existing + 1ns` when the wall clock does not already dominate), so causally-later writes win regardless of clock behavior.
- Fix the list cursor's `last_seen` comparisons to bind `fromUnixTimestamp64Nano(cursor.LastSeenUnixNano)` — the previous `time.Time` bind would break the equality tie-break against nanosecond-precision stored values.

## Testing

- New `TestShadowMCPInventoryURLs_NameOverrideClearDominatesRegressingClock` reproduces the failure deterministically with tied/regressing stamps — verified red without the version bump, green with it.
- New `TestShadowMCPInventoryURLs_UpdatedAtNanosecondRoundTrip` asserts exact nanosecond round-trips for all three timestamps.
- Pagination test bases now carry nonzero nanoseconds so the cursor tie-break fix is regression-protected.
- Full `internal/telemetry`, `internal/telemetry/repo`, and `internal/access` packages green; previously-flaky tests green at `-count=5`; `mise lint:server` clean.

Follow-up (intentionally not in this PR): `UpsertShadowMCPInventoryURLs` in-batch coalescing picks `server_name` by slice order while `updated_at` is maxed independently, so a duplicate-URL batch can attach an older name to a newer version. Same family, needs explicit latest-observation semantics.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nondeterministic Shadow MCP inventory name resolution by preserving nanosecond timestamps and ensuring later writes always win. This removes a flaky test and prevents names from reverting to older observations.

- **Bug Fixes**
  - Preserve nanoseconds for `first_seen`, `last_seen`, and `updated_at` using `fromUnixTimestamp64Nano(?)` to avoid `clickhouse-go` truncation.
  - Write rows synchronously (`async_insert: 0`) so read-merge-write cycles see their own inserts.
  - Return `max(updated_at)` as `max_updated_at` on merged reads to avoid `ILLEGAL_AGGREGATION`.
  - Bump `updated_at` above the read state when needed (+1ns) so causally later writes dominate.
  - Bind pagination cursor `last_seen` with `fromUnixTimestamp64Nano` to keep equality tie-breaks correct.

- **Testing**
  - Added deterministic regression test for tied/regressing versions and override clear.
  - Added nanosecond round-trip test and updated pagination tests to use nonzero nanos.

<sup>Written for commit a13271333b83d5732b6e153f6ba8e563d0bbc807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

