### PR TITLE
fix(dashboard): clarify skill version history actions

### DIFF
--- a/.changeset/skill-version-direction.md
+++ b/.changeset/skill-version-direction.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Label skill version history actions as rollbacks or roll-forwards relative to the current version.

--- a/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.test.tsx
+++ b/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.test.tsx
@@ -135,14 +135,12 @@ describe("RestoreSkillVersionDialog", () => {
         onClose={onClose}
       />,
     );
-    expect(
-      screen.getByText("Roll forward to this skill version?"),
-    ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Roll forward" }));
+    expect(screen.getByText("Promote to this skill version?")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Promote" }));
     await waitFor(() => expect(testState.invalidate).toHaveBeenCalled());
     expect(
       screen
-        .getByRole("button", { name: "Roll forward..." })
+        .getByRole("button", { name: "Promote..." })
         .hasAttribute("disabled"),
     ).toBe(true);
     expect(

--- a/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.test.tsx
+++ b/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.test.tsx
@@ -44,6 +44,7 @@ function RestoreHarness(): JSX.Element {
       <RestoreSkillVersionDialog
         skillId="skill_a"
         version={target}
+        direction="backward"
         onClose={() => setTarget(null)}
       />
     </>
@@ -66,6 +67,7 @@ describe("RestoreSkillVersionDialog", () => {
       <RestoreSkillVersionDialog
         skillId="skill_a"
         version={version}
+        direction="backward"
         onClose={onClose}
       />,
     );
@@ -74,7 +76,8 @@ describe("RestoreSkillVersionDialog", () => {
         /Explicit distribution pins for plugins and assistants stay unchanged/,
       ),
     ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+    expect(screen.getByText("Roll back to this skill version?")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Roll back" }));
 
     await waitFor(() =>
       expect(testState.restore.mutateAsync).toHaveBeenCalledWith({
@@ -95,15 +98,15 @@ describe("RestoreSkillVersionDialog", () => {
       new Error("restore failed"),
     );
     render(<RestoreHarness />);
-    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+    fireEvent.click(screen.getByRole("button", { name: "Roll back" }));
     expect(await screen.findByText(/restore failed/)).toBeTruthy();
-    expect(screen.getByText(/Restore status may be unknown/)).toBeTruthy();
+    expect(screen.getByText(/current version may be unknown/)).toBeTruthy();
     expect(
       screen
-        .getByRole("button", { name: "Restore version" })
+        .getByRole("button", { name: "Roll back" })
         .hasAttribute("disabled"),
     ).toBe(true);
-    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+    fireEvent.click(screen.getByRole("button", { name: "Roll back" }));
     expect(testState.restore.mutateAsync).toHaveBeenCalledOnce();
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
@@ -111,7 +114,7 @@ describe("RestoreSkillVersionDialog", () => {
     expect(screen.queryByText(/restore failed/)).toBeNull();
     expect(
       screen
-        .getByRole("button", { name: "Restore version" })
+        .getByRole("button", { name: "Roll back" })
         .hasAttribute("disabled"),
     ).toBe(false);
   });
@@ -128,14 +131,18 @@ describe("RestoreSkillVersionDialog", () => {
       <RestoreSkillVersionDialog
         skillId="skill_a"
         version={version}
+        direction="forward"
         onClose={onClose}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+    expect(
+      screen.getByText("Roll forward to this skill version?"),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Roll forward" }));
     await waitFor(() => expect(testState.invalidate).toHaveBeenCalled());
     expect(
       screen
-        .getByRole("button", { name: "Restoring..." })
+        .getByRole("button", { name: "Roll forward..." })
         .hasAttribute("disabled"),
     ).toBe(true);
     expect(
@@ -155,10 +162,11 @@ describe("RestoreSkillVersionDialog", () => {
       <RestoreSkillVersionDialog
         skillId="skill_a"
         version={version}
+        direction="backward"
         onClose={onClose}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Restore version" }));
+    fireEvent.click(screen.getByRole("button", { name: "Roll back" }));
 
     await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
     expect(testState.toastSuccess).toHaveBeenCalledOnce();

--- a/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.tsx
+++ b/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.tsx
@@ -69,7 +69,7 @@ export function RestoreSkillVersionDialog({
     );
   };
 
-  const actionLabel = direction === "backward" ? "Roll back" : "Roll forward";
+  const actionLabel = direction === "backward" ? "Roll back" : "Promote";
 
   return (
     <Dialog

--- a/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.tsx
+++ b/client/dashboard/src/pages/skills/RestoreSkillVersionDialog.tsx
@@ -7,14 +7,17 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 import { invalidateSkillQueries } from "./invalidate-skill-queries";
+import type { VersionChangeDirection } from "./version-selection";
 
 export function RestoreSkillVersionDialog({
   skillId,
   version,
+  direction,
   onClose,
 }: {
   skillId: string;
   version: SkillVersion | null;
+  direction: VersionChangeDirection | null;
   onClose: () => void;
 }): JSX.Element {
   const queryClient = useQueryClient();
@@ -48,9 +51,9 @@ export function RestoreSkillVersionDialog({
       const message =
         restoreError instanceof Error
           ? restoreError.message
-          : "Unable to restore version.";
+          : "Unable to change the current version.";
       setError(
-        `${message} Restore status may be unknown. Review the refreshed state before retrying.`,
+        `${message} The current version may be unknown. Review the refreshed state before retrying.`,
       );
       setUncertain(true);
     } finally {
@@ -61,26 +64,32 @@ export function RestoreSkillVersionDialog({
     setError(null);
     setUncertain(false);
     onClose();
-    toast.success(`Version ${target.canonicalSha256.slice(0, 8)} restored`);
+    toast.success(
+      `Version ${target.canonicalSha256.slice(0, 8)} is now current`,
+    );
   };
+
+  const actionLabel = direction === "backward" ? "Roll back" : "Roll forward";
 
   return (
     <Dialog
-      open={version !== null}
+      open={version !== null && direction !== null}
       onOpenChange={(open) => {
         if (!open) closeDialog();
       }}
     >
       <Dialog.Content>
         <Dialog.Header>
-          <Dialog.Title>Restore this skill version?</Dialog.Title>
+          <Dialog.Title>{actionLabel} to this skill version?</Dialog.Title>
           <Dialog.Description>
             This makes version {version?.canonicalSha256.slice(0, 8)} current.
             Explicit distribution pins for plugins and assistants stay
             unchanged.
           </Dialog.Description>
         </Dialog.Header>
-        {error && <ErrorAlert title="Restore status unknown" error={error} />}
+        {error && (
+          <ErrorAlert title="Version change status unknown" error={error} />
+        )}
         <Dialog.Footer>
           <Button
             variant="outline"
@@ -90,12 +99,14 @@ export function RestoreSkillVersionDialog({
             Cancel
           </Button>
           <Button
-            disabled={reconciling || uncertain || version === null}
+            disabled={
+              reconciling || uncertain || version === null || direction === null
+            }
             onClick={() => {
               if (version) void restoreVersion(version);
             }}
           >
-            {reconciling ? "Restoring..." : "Restore version"}
+            {reconciling ? `${actionLabel}...` : actionLabel}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -320,13 +320,20 @@ describe("SkillDetail", () => {
     expect(testState.fetchNextPage).toHaveBeenCalledOnce();
   });
 
-  it("offers restore only for valid non-current versions", () => {
+  it("labels valid non-current version actions by direction", () => {
     testState.versions = [
+      {
+        ...testState.version,
+        id: "version_new",
+        canonicalSha256: "newvalid12345678",
+        createdAt: new Date("2026-07-17T00:00:00Z"),
+      },
       testState.version,
       {
         ...testState.version,
         id: "version_old",
         canonicalSha256: "oldvalid12345678",
+        createdAt: new Date("2026-07-15T00:00:00Z"),
       },
       {
         ...testState.version,
@@ -337,16 +344,23 @@ describe("SkillDetail", () => {
     ];
     render(<SkillDetail />);
 
-    expect(
-      screen.getAllByRole("button", { name: "Restore this version" }),
-    ).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Roll forward" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Roll back" })).toBeTruthy();
+    expect(screen.getByText("Current")).toBeTruthy();
     expect(
       screen.getByRole("group", {
         name: "Version 12345678, current version",
       }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("group", { name: "Version oldvalid restore target" }),
+      screen.getByRole("group", {
+        name: "Version newvalid, roll forward target",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("group", {
+        name: "Version oldvalid, roll back target",
+      }),
     ).toBeTruthy();
     expect(
       screen.getByRole("group", { name: "Version invalid1, invalid version" }),

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -344,7 +344,7 @@ describe("SkillDetail", () => {
     ];
     render(<SkillDetail />);
 
-    expect(screen.getByRole("button", { name: "Roll forward" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Promote" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Roll back" })).toBeTruthy();
     expect(screen.getByText("Current")).toBeTruthy();
     expect(
@@ -354,7 +354,7 @@ describe("SkillDetail", () => {
     ).toBeTruthy();
     expect(
       screen.getByRole("group", {
-        name: "Version newvalid, roll forward target",
+        name: "Version newvalid, promotion target",
       }),
     ).toBeTruthy();
     expect(

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -445,7 +445,7 @@ function VersionHistory({
   const diffVersions = selectDiffVersions(
     versions,
     selectedVersions,
-    currentVersion.id,
+    currentVersion,
   );
   const comparable = versions.length > 1;
   useEffect(() => {

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -46,7 +46,11 @@ import { SkillPluginBanner } from "./SkillPluginBanner";
 import { SkillValidationErrors } from "./SkillValidationErrors";
 import { RestoreSkillVersionDialog } from "./RestoreSkillVersionDialog";
 import { SuggestedSkillEditSection } from "./SuggestedSkillEditSection";
-import { selectDiffVersions } from "./version-selection";
+import {
+  selectDiffVersions,
+  type VersionChangeDirection,
+  versionChangeDirection,
+} from "./version-selection";
 
 const SkillTextDiff = lazy(() => import("./SkillTextDiff"));
 
@@ -69,12 +73,14 @@ const SKILL_SECTION_IDS: readonly string[] = [
 
 function versionAnchorLabel(
   version: SkillVersion,
-  latestVersionId: string,
+  currentVersion: SkillVersion,
 ): string {
   const hash = version.canonicalSha256.slice(0, 8);
-  if (version.id === latestVersionId) return `Version ${hash}, current version`;
+  if (version.id === currentVersion.id)
+    return `Version ${hash}, current version`;
   if (!version.specValid) return `Version ${hash}, invalid version`;
-  return `Version ${hash} restore target`;
+  const direction = versionChangeDirection(version, currentVersion);
+  return `Version ${hash}, roll ${direction === "backward" ? "back" : "forward"} target`;
 }
 
 function useScrollToSectionHash(): void {
@@ -250,7 +256,7 @@ function SkillDetailSections({
         <SettingsSection.Header>
           <SettingsSection.Title>SKILL.md</SettingsSection.Title>
           <SettingsSection.Description>
-            The latest version of this skill's manifest, exactly as agents load
+            The current version of this skill's manifest, exactly as agents load
             it.
           </SettingsSection.Description>
         </SettingsSection.Header>
@@ -273,7 +279,7 @@ function SkillDetailSections({
           {latestVersion && (
             <SettingsSection.Footer>
               <SettingsSection.FooterHint>
-                Latest version{" "}
+                Current version{" "}
                 <span className="font-mono">
                   {latestVersion.canonicalSha256.slice(0, 8)}
                 </span>{" "}
@@ -344,13 +350,11 @@ function SkillDetailSections({
           <SettingsSection.Header>
             <SettingsSection.Title>Version history</SettingsSection.Title>
             <SettingsSection.Description>
-              Every recorded version of this skill's manifest.
+              Versions are ordered by creation date, newest first. After a
+              rollback, the current version may appear below newer versions.
             </SettingsSection.Description>
           </SettingsSection.Header>
-          <VersionHistory
-            skillId={skillId}
-            latestVersionId={latestVersion.id}
-          />
+          <VersionHistory skillId={skillId} currentVersion={latestVersion} />
         </SettingsSection>
       )}
 
@@ -418,10 +422,10 @@ function SkillDetailSections({
 
 function VersionHistory({
   skillId,
-  latestVersionId,
+  currentVersion,
 }: {
   skillId: string;
-  latestVersionId: string;
+  currentVersion: SkillVersion;
 }): JSX.Element {
   const project = useProject();
   const location = useLocation();
@@ -431,14 +435,17 @@ function VersionHistory({
   const [selectedVersions, setSelectedVersions] = useState<Set<string>>(
     () => new Set(),
   );
-  const [restoreTarget, setRestoreTarget] = useState<SkillVersion | null>(null);
+  const [restoreTarget, setRestoreTarget] = useState<{
+    version: SkillVersion;
+    direction: VersionChangeDirection;
+  } | null>(null);
 
   const versions =
     versionsQuery.data?.pages.flatMap((page) => page.result.versions) ?? [];
   const diffVersions = selectDiffVersions(
     versions,
     selectedVersions,
-    latestVersionId,
+    currentVersion.id,
   );
   const comparable = versions.length > 1;
   useEffect(() => {
@@ -450,7 +457,7 @@ function VersionHistory({
   let loadMoreLabel = "Load more versions";
   if (versionsQuery.isFetchingNextPage) loadMoreLabel = "Loading...";
   const columns = versionColumns({
-    latestVersionId,
+    currentVersionId: currentVersion.id,
     comparable,
     selectedVersions,
     onToggle: (versionId) => {
@@ -464,32 +471,35 @@ function VersionHistory({
         return next;
       });
     },
-    restoreAction: (version) => (
-      <div
-        id={`version-${version.id}`}
-        role="group"
-        tabIndex={-1}
-        aria-label={versionAnchorLabel(version, latestVersionId)}
-        className="focus-visible:ring-ring rounded-md focus-visible:ring-2 focus-visible:outline-none"
-      >
-        {version.id !== latestVersionId && version.specValid && (
-          <RequireScope
-            scope="skill:write"
-            resourceId={project.id}
-            level="component"
-            reason="You need write access to restore a skill version."
-          >
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setRestoreTarget(version)}
+    restoreAction: (version) => {
+      const direction = versionChangeDirection(version, currentVersion);
+      return (
+        <div
+          id={`version-${version.id}`}
+          role="group"
+          tabIndex={-1}
+          aria-label={versionAnchorLabel(version, currentVersion)}
+          className="focus-visible:ring-ring rounded-md focus-visible:ring-2 focus-visible:outline-none"
+        >
+          {direction && version.specValid && (
+            <RequireScope
+              scope="skill:write"
+              resourceId={project.id}
+              level="component"
+              reason="You need write access to change the current skill version."
             >
-              Restore this version
-            </Button>
-          </RequireScope>
-        )}
-      </div>
-    ),
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setRestoreTarget({ version, direction })}
+              >
+                {direction === "backward" ? "Roll back" : "Roll forward"}
+              </Button>
+            </RequireScope>
+          )}
+        </div>
+      );
+    },
   });
 
   return (
@@ -497,8 +507,8 @@ function VersionHistory({
       <SettingsSection.Body>
         {comparable && (
           <Type small muted>
-            Select one older version to compare it with latest, or select any
-            two loaded versions.
+            Select one version to compare it with current, or select any two
+            loaded versions.
           </Type>
         )}
         {versionsQuery.isPending && !versionsQuery.data && <SkeletonTable />}
@@ -535,7 +545,8 @@ function VersionHistory({
       </SettingsSection.Body>
       <RestoreSkillVersionDialog
         skillId={skillId}
-        version={restoreTarget}
+        version={restoreTarget?.version ?? null}
+        direction={restoreTarget?.direction ?? null}
         onClose={() => setRestoreTarget(null)}
       />
     </SettingsSection.Panel>
@@ -581,7 +592,7 @@ function ValidationErrors({
   return (
     <div className="border-destructive/40 bg-destructive/5 rounded-lg border p-4">
       <Type variant="subheading" className="text-destructive mb-2">
-        Latest version has validation issues
+        Current version has validation issues
       </Type>
       <SkillValidationErrors errors={errors} />
     </div>
@@ -589,13 +600,13 @@ function ValidationErrors({
 }
 
 function versionColumns({
-  latestVersionId,
+  currentVersionId,
   comparable,
   selectedVersions,
   onToggle,
   restoreAction,
 }: {
-  latestVersionId: string;
+  currentVersionId: string;
   comparable: boolean;
   selectedVersions: Set<string>;
   onToggle: (versionId: string) => void;
@@ -627,8 +638,8 @@ function versionColumns({
           <span className="font-mono text-sm">
             {version.canonicalSha256.slice(0, 8)}
           </span>
-          {version.id === latestVersionId && (
-            <Badge variant="information">Latest</Badge>
+          {version.id === currentVersionId && (
+            <Badge variant="information">Current</Badge>
           )}
           {version.derivedFromVersionId && (
             <Badge variant="neutral" title={version.derivedFromVersionId}>

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -80,7 +80,8 @@ function versionAnchorLabel(
     return `Version ${hash}, current version`;
   if (!version.specValid) return `Version ${hash}, invalid version`;
   const direction = versionChangeDirection(version, currentVersion);
-  return `Version ${hash}, roll ${direction === "backward" ? "back" : "forward"} target`;
+  if (direction === "backward") return `Version ${hash}, roll back target`;
+  return `Version ${hash}, promotion target`;
 }
 
 function useScrollToSectionHash(): void {
@@ -493,7 +494,7 @@ function VersionHistory({
                 variant="outline"
                 onClick={() => setRestoreTarget({ version, direction })}
               >
-                {direction === "backward" ? "Roll back" : "Roll forward"}
+                {direction === "backward" ? "Roll back" : "Promote"}
               </Button>
             </RequireScope>
           )}

--- a/client/dashboard/src/pages/skills/version-selection.test.ts
+++ b/client/dashboard/src/pages/skills/version-selection.test.ts
@@ -1,6 +1,9 @@
 import type { SkillVersion } from "@gram/client/models/components/skillversion.js";
 import { describe, expect, it } from "vitest";
-import { selectDiffVersions } from "./version-selection";
+import {
+  selectDiffVersions,
+  versionChangeDirection,
+} from "./version-selection";
 
 function version(id: string): SkillVersion {
   return {
@@ -19,6 +22,31 @@ function version(id: string): SkillVersion {
   };
 }
 
+describe("versionChangeDirection", () => {
+  const current = version("middle");
+
+  it("uses creation order to distinguish rollbacks from roll-forwards", () => {
+    expect(
+      versionChangeDirection(
+        { ...version("older"), createdAt: new Date("2026-07-15T00:00:00Z") },
+        current,
+      ),
+    ).toBe("backward");
+    expect(
+      versionChangeDirection(
+        { ...version("newer"), createdAt: new Date("2026-07-17T00:00:00Z") },
+        current,
+      ),
+    ).toBe("forward");
+  });
+
+  it("matches the API id ordering when creation times tie", () => {
+    expect(versionChangeDirection(version("lower"), current)).toBe("backward");
+    expect(versionChangeDirection(version("newer"), current)).toBe("forward");
+    expect(versionChangeDirection(current, current)).toBeNull();
+  });
+});
+
 describe("selectDiffVersions", () => {
   const newest = version("newest");
   const middle = version("middle");
@@ -34,9 +62,15 @@ describe("selectDiffVersions", () => {
     ).toEqual([oldest, middle]);
   });
 
-  it("compares one selected older version with latest", () => {
+  it("compares one selected older version with current", () => {
     expect(
       selectDiffVersions(newestFirst, new Set(["middle"]), "newest"),
+    ).toEqual([middle, newest]);
+  });
+
+  it("compares one selected newer version with current", () => {
+    expect(
+      selectDiffVersions(newestFirst, new Set(["newest"]), "middle"),
     ).toEqual([middle, newest]);
   });
 });

--- a/client/dashboard/src/pages/skills/version-selection.test.ts
+++ b/client/dashboard/src/pages/skills/version-selection.test.ts
@@ -55,22 +55,29 @@ describe("selectDiffVersions", () => {
 
   it("uses API newest-first order when timestamps tie", () => {
     expect(
-      selectDiffVersions(newestFirst, new Set(["newest", "oldest"]), "newest"),
+      selectDiffVersions(newestFirst, new Set(["newest", "oldest"]), newest),
     ).toEqual([oldest, newest]);
     expect(
-      selectDiffVersions(newestFirst, new Set(["middle", "oldest"]), "newest"),
+      selectDiffVersions(newestFirst, new Set(["middle", "oldest"]), newest),
     ).toEqual([oldest, middle]);
   });
 
   it("compares one selected older version with current", () => {
     expect(
-      selectDiffVersions(newestFirst, new Set(["middle"]), "newest"),
+      selectDiffVersions(newestFirst, new Set(["middle"]), newest),
     ).toEqual([middle, newest]);
   });
 
   it("compares one selected newer version with current", () => {
     expect(
-      selectDiffVersions(newestFirst, new Set(["newest"]), "middle"),
+      selectDiffVersions(newestFirst, new Set(["newest"]), middle),
     ).toEqual([middle, newest]);
+  });
+
+  it("compares with a current version outside the loaded page", () => {
+    expect(selectDiffVersions([newest], new Set(["newest"]), middle)).toEqual([
+      middle,
+      newest,
+    ]);
   });
 });

--- a/client/dashboard/src/pages/skills/version-selection.ts
+++ b/client/dashboard/src/pages/skills/version-selection.ts
@@ -19,22 +19,21 @@ export function versionChangeDirection(
 export function selectDiffVersions(
   versionsNewestFirst: SkillVersion[],
   selectedIds: Set<string>,
-  currentVersionId: string,
+  currentVersion: SkillVersion,
 ): [older: SkillVersion, newer: SkillVersion] | null {
   const selected = versionsNewestFirst.filter((version) =>
     selectedIds.has(version.id),
   );
   const selectedVersion = selected[0];
-  if (selected.length === 1 && selectedVersion?.id !== currentVersionId) {
-    const current = versionsNewestFirst.find(
-      (version) => version.id === currentVersionId,
-    );
-    if (!current || !selectedVersion) return null;
-    const selectedIndex = versionsNewestFirst.indexOf(selectedVersion);
-    const currentIndex = versionsNewestFirst.indexOf(current);
-    return selectedIndex < currentIndex
-      ? [current, selectedVersion]
-      : [selectedVersion, current];
+  if (
+    selected.length === 1 &&
+    selectedVersion &&
+    selectedVersion.id !== currentVersion.id
+  ) {
+    const direction = versionChangeDirection(selectedVersion, currentVersion);
+    return direction === "forward"
+      ? [currentVersion, selectedVersion]
+      : [selectedVersion, currentVersion];
   }
   if (selected.length !== 2) return null;
 

--- a/client/dashboard/src/pages/skills/version-selection.ts
+++ b/client/dashboard/src/pages/skills/version-selection.ts
@@ -1,19 +1,40 @@
 import type { SkillVersion } from "@gram/client/models/components/skillversion.js";
 
+export type VersionChangeDirection = "backward" | "forward";
+
+export function versionChangeDirection(
+  target: SkillVersion,
+  current: SkillVersion,
+): VersionChangeDirection | null {
+  if (target.id === current.id) return null;
+
+  const targetCreatedAt = target.createdAt.getTime();
+  const currentCreatedAt = current.createdAt.getTime();
+  if (targetCreatedAt === currentCreatedAt) {
+    return target.id < current.id ? "backward" : "forward";
+  }
+  return targetCreatedAt < currentCreatedAt ? "backward" : "forward";
+}
+
 export function selectDiffVersions(
   versionsNewestFirst: SkillVersion[],
   selectedIds: Set<string>,
-  latestVersionId: string,
+  currentVersionId: string,
 ): [older: SkillVersion, newer: SkillVersion] | null {
   const selected = versionsNewestFirst.filter((version) =>
     selectedIds.has(version.id),
   );
   const selectedVersion = selected[0];
-  if (selected.length === 1 && selectedVersion?.id !== latestVersionId) {
-    const latest = versionsNewestFirst.find(
-      (version) => version.id === latestVersionId,
+  if (selected.length === 1 && selectedVersion?.id !== currentVersionId) {
+    const current = versionsNewestFirst.find(
+      (version) => version.id === currentVersionId,
     );
-    return latest && selectedVersion ? [selectedVersion, latest] : null;
+    if (!current || !selectedVersion) return null;
+    const selectedIndex = versionsNewestFirst.indexOf(selectedVersion);
+    const currentIndex = versionsNewestFirst.indexOf(current);
+    return selectedIndex < currentIndex
+      ? [current, selectedVersion]
+      : [selectedVersion, current];
   }
   if (selected.length !== 2) return null;
 


### PR DESCRIPTION
## Summary
- label version changes as rollbacks or roll-forwards relative to the current version
- mark the promoted version as current and explain creation-date ordering
- keep single-version diffs ordered correctly after a rollback
- shorten history actions so they fit in the table

Closes [DNO-661](https://linear.app/speakeasy/issue/DNO-661/fix-version-history-restore-action-is-mislabeled-for-newer-versions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the skill version history by labeling actions relative to the current version (“Roll back” for older, “Promote” for newer) and marking the current version clearly across the UI. Fixes DNO-661 by correcting mislabeled actions for newer versions and shortening labels to fit in the table.

- **Bug Fixes**
  - Mark the active version as “Current” and update copy to reference the current version throughout.
  - Explain creation-date ordering; after a rollback the current version may appear below newer entries.
  - Compute direction using creation time (tie-break by id) and show “Roll back”/“Promote” only for valid non-current versions.
  - Compare a single selected version against the current version, handling both older and newer selections, even when the current version isn’t in the loaded page.
  - Revise the dialog: direction-aware title and buttons (“Roll back”/“Promote”), clearer error text, and a success toast (“is now current”).
  - Shorter action labels ensure the control fits within the table.
  - Tests updated for direction logic, dialog behavior, and accessibility labels.

<sup>Written for commit f3617f6c1bcd2352dc41ee4427f4f35a7e420e9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

