### PR TITLE
feat(dashboard): show skill methodology in app

### DIFF
--- a/.changeset/skill-methodology-dialog.md
+++ b/.changeset/skill-methodology-dialog.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Show the skill efficacy methodology in the dashboard instead of linking to GitHub.

--- a/client/dashboard/src/pages/skills/SkillInsightsSection.tsx
+++ b/client/dashboard/src/pages/skills/SkillInsightsSection.tsx
@@ -8,9 +8,11 @@ import {
   ErrorAlert,
 } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
 import { Skeleton, SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { useProject } from "@/contexts/Auth";
+import { Markdown } from "@/elements/components/Markdown";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
@@ -38,6 +40,7 @@ import {
 import { Line } from "react-chartjs-2";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
+import skillEfficacyMethodology from "../../../../../docs/skills/measuring-skill-efficacy.md?raw";
 
 ChartJS.register(
   CategoryScale,
@@ -50,8 +53,6 @@ ChartJS.register(
 
 export const SKILL_INSIGHTS_SECTION_ID = "insights";
 
-const METHODOLOGY_URL =
-  "https://github.com/speakeasy-api/gram/blob/main/docs/skills/measuring-skill-efficacy.md";
 type TrendMetric = "efficacy" | "activations" | "sessionCost";
 
 function formatCount(value: number): string {
@@ -255,16 +256,7 @@ function InsightsContent({
               ? `${formatMinutes(efficacy.estimatedMinutesSavedTotal)} saved`
               : "Not estimated"
           }
-          detail={
-            <a
-              href={METHODOLOGY_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline underline-offset-2"
-            >
-              View methodology
-            </a>
-          }
+          detail={<MethodologyDialog />}
         />
       </dl>
 
@@ -318,6 +310,26 @@ function InsightsContent({
         )}
       </div>
     </div>
+  );
+}
+
+function MethodologyDialog(): JSX.Element {
+  return (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button variant="link" size="inline" className="h-auto p-0">
+          View methodology
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content className="max-h-[calc(100vh-2rem)] grid-rows-[minmax(0,1fr)] sm:max-w-3xl">
+        <Dialog.Title className="sr-only">
+          Measuring skill efficacy
+        </Dialog.Title>
+        <div className="min-h-0 overflow-y-auto pr-1">
+          <Markdown className="text-sm">{skillEfficacyMethodology}</Markdown>
+        </div>
+      </Dialog.Content>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary

- replace the external ROI methodology link with an in-app dialog
- render the canonical efficacy methodology Markdown directly from the repository documentation
- keep the dialog accessible and scrollable across desktop and mobile viewports

Closes [DNO-663](https://linear.app/speakeasy/issue/DNO-663)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the skill efficacy/ROI methodology in an in-app dialog instead of linking to GitHub, so users can read it without leaving the dashboard. Addresses DNO-663 with an accessible, scrollable dialog across desktop and mobile.

- **New Features**
  - Replaced the external “View methodology” link in Skill Insights with `MethodologyDialog`.
  - Render the canonical Markdown from `docs/skills/measuring-skill-efficacy.md?raw` via the existing `Markdown` component.
  - Keeps the doc as the single source of truth; no content duplication.

<sup>Written for commit fe9e4f681a04c9503bcc6e0f1b478da287b3d7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

