### PR TITLE
feat(skills): chart activations by version

### DIFF
--- a/.changeset/charted-skill-activations.md
+++ b/.changeset/charted-skill-activations.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Chart skill activations by version across the rolling 30-day window.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -56271,7 +56271,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SkillSightingTimelinePoint'
-          description: Daily activations in the adoption window.
+          description: Daily activations by attributed version in the adoption window.
         skill:
           $ref: '#/components/schemas/Skill'
       description: An active skill and its current version.
@@ -65922,7 +65922,11 @@ components:
           type: string
           description: Start of the UTC day.
           format: date-time
-      description: A UTC-day activation bucket for a skill.
+        skill_version_id:
+          type: string
+          description: The attributed skill version, absent when the observation could not be resolved to a version.
+          format: uuid
+      description: A UTC-day activation bucket for one attributed skill version.
       required:
         - bucket_start
         - activation_count

--- a/client/dashboard/src/pages/skills/SkillActivitySections.tsx
+++ b/client/dashboard/src/pages/skills/SkillActivitySections.tsx
@@ -1,18 +1,39 @@
+import { ChartCard } from "@/components/chart/ChartCard";
+import { CHART_COLORS } from "@/components/stacked-time-series";
 import { Type } from "@/components/ui/type";
 import { HumanizeDateTime } from "@/lib/dates";
 import { SettingsSection } from "@/pages/mcp/x/tabs/settings/SettingsSection";
 import type { GetSkillResult } from "@gram/client/models/components/getskillresult.js";
-import type { SkillSightingTimelinePoint } from "@gram/client/models/components/skillsightingtimelinepoint.js";
-import { type Column, Table } from "@speakeasy-api/moonshine";
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
+  type ChartOptions,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+);
 
 export const SKILL_ADOPTION_SECTION_ID = "adoption";
 export const SKILL_TIMELINE_SECTION_ID = "timeline";
 
 const utcMonthDayFormatter = new Intl.DateTimeFormat(undefined, {
-  month: "long",
+  month: "short",
   day: "numeric",
   timeZone: "UTC",
 });
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function metricValue(value: number): string {
   return new Intl.NumberFormat().format(value);
@@ -24,23 +45,80 @@ function machineLabel(count: number): string {
 
 export function SkillActivitySections({
   data,
+  versionLabels,
+  versionsLoading,
 }: {
   data: GetSkillResult;
+  versionLabels: Map<string, string>;
+  versionsLoading: boolean;
 }): JSX.Element {
   const { skill, adoption, drift, sightingTimeline } = data;
-  const timelineColumns: Column<SkillSightingTimelinePoint>[] = [
-    {
-      key: "day",
-      header: "Day",
-      render: (point) => utcMonthDayFormatter.format(point.bucketStart),
-    },
-    {
-      key: "activations",
-      header: "Activations",
-      width: "140px",
-      render: (point) => metricValue(point.activationCount),
-    },
+  const firstBucket = Date.UTC(
+    adoption.windowStart.getUTCFullYear(),
+    adoption.windowStart.getUTCMonth(),
+    adoption.windowStart.getUTCDate(),
+  );
+  const lastBucket = Date.UTC(
+    adoption.windowEnd.getUTCFullYear(),
+    adoption.windowEnd.getUTCMonth(),
+    adoption.windowEnd.getUTCDate(),
+  );
+  const buckets = Array.from(
+    { length: Math.floor((lastBucket - firstBucket) / MS_PER_DAY) + 1 },
+    (_, index) => firstBucket + index * MS_PER_DAY,
+  );
+  const pointsByVersion = new Map<string, Map<number, number>>();
+  for (const point of sightingTimeline) {
+    const versionID = point.skillVersionId ?? "";
+    const points = pointsByVersion.get(versionID) ?? new Map<number, number>();
+    points.set(point.bucketStart.getTime(), point.activationCount);
+    pointsByVersion.set(versionID, points);
+  }
+  const knownVersionIDs = [...versionLabels.keys()].filter((versionID) =>
+    pointsByVersion.has(versionID),
+  );
+  const unresolvedVersionIDs = [...pointsByVersion.keys()]
+    .filter((versionID) => versionID && !versionLabels.has(versionID))
+    .sort();
+  const versionIDs = [
+    ...knownVersionIDs,
+    ...unresolvedVersionIDs,
+    ...(pointsByVersion.has("") ? [""] : []),
   ];
+  const datasets = versionIDs.map((versionID, index) => {
+    const color = CHART_COLORS[index % CHART_COLORS.length];
+    const label = versionID
+      ? (versionLabels.get(versionID) ?? `Version ${versionID.slice(0, 8)}`)
+      : "Unknown version";
+    const points = pointsByVersion.get(versionID);
+    return {
+      label,
+      data: buckets.map((bucket) => points?.get(bucket) ?? 0),
+      borderColor: color,
+      backgroundColor: color,
+      pointRadius: 2,
+      tension: 0.25,
+    };
+  });
+  const chartOptions: ChartOptions<"line"> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: "index", intersect: false },
+    plugins: {
+      legend: { position: "bottom" },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            if (context.parsed.y === null) return context.dataset.label ?? "";
+            return `${context.dataset.label}: ${metricValue(context.parsed.y)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: { beginAtZero: true, ticks: { precision: 0 } },
+    },
+  };
 
   return (
     <>
@@ -120,17 +198,35 @@ export function SkillActivitySections({
         </SettingsSection.Header>
         <SettingsSection.Panel>
           <SettingsSection.Body>
-            {sightingTimeline.length === 0 ? (
-              <Type small muted>
-                No activations captured in the last 30 days.
-              </Type>
-            ) : (
-              <Table
-                columns={timelineColumns}
-                data={sightingTimeline}
-                rowKey={(point) => point.bucketStart.toISOString()}
-              />
-            )}
+            <ChartCard
+              title="Activations by version"
+              chartId="skill-activation-timeline"
+              expandedChart={null}
+              onExpand={() => undefined}
+              expandable={false}
+              hasData={sightingTimeline.length > 0}
+              loading={versionsLoading}
+            >
+              {sightingTimeline.length === 0 ? (
+                <div className="flex h-56 items-center justify-center">
+                  <Type small muted>
+                    No activations captured in the last 30 days.
+                  </Type>
+                </div>
+              ) : (
+                <div className="h-64">
+                  <Line
+                    data={{
+                      labels: buckets.map((bucket) =>
+                        utcMonthDayFormatter.format(bucket),
+                      ),
+                      datasets,
+                    }}
+                    options={chartOptions}
+                  />
+                </div>
+              )}
+            </ChartCard>
           </SettingsSection.Body>
         </SettingsSection.Panel>
       </SettingsSection>

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -28,6 +28,11 @@ const testState = vi.hoisted(() => ({
   isFetchNextPageError: false,
   versionError: null as Error | null,
   versions: [] as Array<Record<string, unknown>>,
+  sightingTimeline: [] as Array<{
+    bucketStart: Date;
+    skillVersionId?: string;
+    activationCount: number;
+  }>,
   latestVersion: undefined as Record<string, unknown> | undefined,
   version: {
     id: "version_latest",
@@ -122,7 +127,7 @@ vi.mock("@gram/client/react-query/skill.js", () => ({
         windowStart: new Date("2026-06-16T00:00:00Z"),
         windowEnd: new Date("2026-07-16T00:00:00Z"),
       },
-      sightingTimeline: [],
+      sightingTimeline: testState.sightingTimeline,
     },
   }),
   invalidateAllSkill: testState.invalidateSkill,
@@ -162,6 +167,21 @@ vi.mock("@gram/client/react-query/shareSkill.js", () => ({
 }));
 vi.mock("@gram/client/react-query/unshareSkill.js", () => ({
   useUnshareSkillMutation: () => testState.unshare,
+}));
+vi.mock("react-chartjs-2", () => ({
+  Line: ({
+    data,
+  }: {
+    data: { datasets: Array<{ label: string; data: number[] }> };
+  }) => (
+    <div data-testid="activation-chart">
+      {data.datasets.map((dataset) => (
+        <span key={dataset.label}>
+          {dataset.label}:{dataset.data.reduce((sum, value) => sum + value, 0)}
+        </span>
+      ))}
+    </div>
+  ),
 }));
 vi.mock("@/components/require-scope", () => ({
   RequireScope: ({
@@ -205,6 +225,8 @@ vi.mock("@speakeasy-api/moonshine", () => ({
   Button: ({ children }: { children: ReactNode }) => (
     <button>{children}</button>
   ),
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
   Icon: () => <span />,
   Table: ({
     columns,
@@ -248,12 +270,33 @@ beforeEach(() => {
   testState.isFetchNextPageError = false;
   testState.versionError = null;
   testState.versions = [testState.version];
+  testState.sightingTimeline = [];
   testState.latestVersion = testState.version;
 });
 
 afterEach(cleanup);
 
 describe("SkillDetail", () => {
+  it("charts activation counts by known and unknown version", () => {
+    testState.sightingTimeline = [
+      {
+        bucketStart: new Date("2026-07-15T00:00:00Z"),
+        skillVersionId: "version_latest",
+        activationCount: 3,
+      },
+      {
+        bucketStart: new Date("2026-07-15T00:00:00Z"),
+        activationCount: 2,
+      },
+    ];
+
+    render(<SkillDetail />);
+
+    const chart = screen.getByTestId("activation-chart");
+    expect(chart.textContent).toContain("v1 (12345678):3");
+    expect(chart.textContent).toContain("Unknown version:2");
+  });
+
   it("project-scopes every write affordance", () => {
     render(<SkillDetail />);
     const gates = screen.getAllByTestId("write-gate");

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -26,6 +26,7 @@ const testState = vi.hoisted(() => ({
   toastError: vi.fn(),
   fetchNextPage: vi.fn(),
   isFetchNextPageError: false,
+  hasNextPage: false,
   versionError: null as Error | null,
   versions: [] as Array<Record<string, unknown>>,
   sightingTimeline: [] as Array<{
@@ -135,9 +136,10 @@ vi.mock("@gram/client/react-query/skill.js", () => ({
 vi.mock("@gram/client/react-query/skillVersions.js", () => ({
   useSkillVersionsInfinite: () => ({
     isPending: false,
+    isError: testState.versionError !== null,
     error: testState.versionError,
     data: { pages: [{ result: { versions: testState.versions } }] },
-    hasNextPage: false,
+    hasNextPage: testState.hasNextPage,
     isFetchingNextPage: false,
     isFetchNextPageError: testState.isFetchNextPageError,
     fetchNextPage: testState.fetchNextPage,
@@ -268,6 +270,7 @@ beforeEach(() => {
   testState.toastError.mockReset();
   testState.fetchNextPage.mockReset();
   testState.isFetchNextPageError = false;
+  testState.hasNextPage = false;
   testState.versionError = null;
   testState.versions = [testState.version];
   testState.sightingTimeline = [];
@@ -354,10 +357,19 @@ describe("SkillDetail", () => {
 
   it("keeps loaded versions visible and retries a next-page failure explicitly", () => {
     testState.isFetchNextPageError = true;
+    testState.hasNextPage = true;
     testState.versionError = new Error("next page failed");
+    testState.sightingTimeline = [
+      {
+        bucketStart: new Date("2026-07-15T00:00:00Z"),
+        skillVersionId: "version_latest",
+        activationCount: 3,
+      },
+    ];
     render(<SkillDetail />);
 
     expect(screen.getAllByText("Version table").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("activation-chart")).toBeTruthy();
     expect(screen.getByText("Unable to load more versions.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(testState.fetchNextPage).toHaveBeenCalledOnce();

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -10,6 +10,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton, SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { useProject } from "@/contexts/Auth";
+import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { Markdown } from "@/elements/components/Markdown";
 import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
 import { isNotFoundError } from "@/lib/route-errors";
@@ -186,6 +187,26 @@ function SkillDetailSections({
   useScrollToSectionHash();
 
   const { skill, latestVersion } = skillQueryData;
+  const versionsQuery = useSkillVersionsInfinite({ id: skill.id }, undefined, {
+    throwOnError: false,
+  });
+  useDrainInfiniteQuery(versionsQuery);
+  const versionsLoading =
+    versionsQuery.isPending ||
+    versionsQuery.hasNextPage ||
+    versionsQuery.isFetchingNextPage;
+  const versions =
+    versionsQuery.data?.pages.flatMap((page) => page.result.versions) ?? [];
+  const versionLabels = new Map(
+    [...versions]
+      .sort(
+        (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
+      )
+      .map((version, index) => [
+        version.id,
+        `v${skill.versionCount - versions.length + index + 1} (${version.canonicalSha256.slice(0, 8)})`,
+      ]),
+  );
   const body = latestVersion
     ? stripSkillFrontmatter(latestVersion.content)
     : "";
@@ -242,7 +263,11 @@ function SkillDetailSections({
         </SettingsSection.Panel>
       </SettingsSection>
 
-      <SkillActivitySections data={skillQueryData} />
+      <SkillActivitySections
+        data={skillQueryData}
+        versionLabels={versionLabels}
+        versionsLoading={versionsLoading}
+      />
 
       {latestVersion && (
         <SuggestedSkillEditSection
@@ -251,7 +276,12 @@ function SkillDetailSections({
         />
       )}
 
-      <SkillInsightsSection data={skillQueryData} />
+      <SkillInsightsSection
+        data={skillQueryData}
+        versionLabels={versionLabels}
+        versionsLoading={versionsLoading}
+        versionsError={versionsQuery.error}
+      />
 
       <SettingsSection id={SKILL_MANIFEST_SECTION_ID}>
         <SettingsSection.Header>

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -192,9 +192,10 @@ function SkillDetailSections({
   });
   useDrainInfiniteQuery(versionsQuery);
   const versionsLoading =
-    versionsQuery.isPending ||
-    versionsQuery.hasNextPage ||
-    versionsQuery.isFetchingNextPage;
+    !versionsQuery.error &&
+    (versionsQuery.isPending ||
+      versionsQuery.hasNextPage ||
+      versionsQuery.isFetchingNextPage);
   const versions =
     versionsQuery.data?.pages.flatMap((page) => page.result.versions) ?? [];
   const versionLabels = new Map(

--- a/client/dashboard/src/pages/skills/SkillInsightsSection.tsx
+++ b/client/dashboard/src/pages/skills/SkillInsightsSection.tsx
@@ -12,7 +12,6 @@ import { Skeleton, SkeletonTable } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { useProject } from "@/contexts/Auth";
 import { useRBAC } from "@/hooks/useRBAC";
-import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
 import { SettingsSection } from "@/pages/mcp/x/tabs/settings/SettingsSection";
 import { useRoutes } from "@/routes";
@@ -23,7 +22,6 @@ import type { SkillInsightPoint } from "@gram/client/models/components/skillinsi
 import type { SkillVersionInsight } from "@gram/client/models/components/skillversioninsight.js";
 import type { GetSkillResult } from "@gram/client/models/components/getskillresult.js";
 import { useSkillEfficacyInsights } from "@gram/client/react-query/skillEfficacyInsights.js";
-import { useSkillVersionsInfinite } from "@gram/client/react-query/skillVersions.js";
 import { Badge, type Column, Icon, Table } from "@speakeasy-api/moonshine";
 import {
   CategoryScale,
@@ -101,8 +99,14 @@ function formatChartValue(value: number, metric: TrendMetric): string {
 
 export function SkillInsightsSection({
   data,
+  versionLabels,
+  versionsLoading,
+  versionsError,
 }: {
   data: GetSkillResult;
+  versionLabels: Map<string, string>;
+  versionsLoading: boolean;
+  versionsError: Error | null;
 }): JSX.Element {
   const project = useProject();
   const { hasScope, isLoading: isRBACLoading, isRbacEnabled } = useRBAC();
@@ -117,29 +121,6 @@ export function SkillInsightsSection({
     undefined,
     { throwOnError: false, enabled: !isRBACLoading },
   );
-  const versionsQuery = useSkillVersionsInfinite(
-    { id: data.skill.id },
-    undefined,
-    { throwOnError: false },
-  );
-  useDrainInfiniteQuery(versionsQuery);
-  const versionsLoading =
-    versionsQuery.isPending ||
-    versionsQuery.hasNextPage ||
-    versionsQuery.isFetchingNextPage;
-  const versions =
-    versionsQuery.data?.pages.flatMap((page) => page.result.versions) ?? [];
-  const versionLabels = new Map(
-    [...versions]
-      .sort(
-        (left, right) => left.createdAt.getTime() - right.createdAt.getTime(),
-      )
-      .map((version, index) => [
-        version.id,
-        `v${data.skill.versionCount - versions.length + index + 1} (${version.canonicalSha256.slice(0, 8)})`,
-      ]),
-  );
-
   return (
     <SettingsSection id={SKILL_INSIGHTS_SECTION_ID}>
       <SettingsSection.Header>
@@ -157,16 +138,16 @@ export function SkillInsightsSection({
               error={query.error}
             />
           )}
-          {versionsQuery.error && (
+          {versionsError && (
             <ErrorAlert
               title="Unable to load skill versions"
-              error={versionsQuery.error}
+              error={versionsError}
             />
           )}
           {(query.isPending || (query.data && versionsLoading)) && (
             <InsightsLoading />
           )}
-          {query.data && !versionsLoading && !versionsQuery.error && (
+          {query.data && !versionsLoading && !versionsError && (
             <InsightsContent
               insight={query.data.insights[0]}
               skillId={data.skill.id}

--- a/client/dashboard/src/sdk/src/models/components/getskillresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/getskillresult.ts
@@ -37,7 +37,7 @@ export type GetSkillResult = {
    */
   latestVersion?: SkillVersion | undefined;
   /**
-   * Daily activations in the adoption window.
+   * Daily activations by attributed version in the adoption window.
    */
   sightingTimeline: Array<SkillSightingTimelinePoint>;
   /**

--- a/client/dashboard/src/sdk/src/models/components/skillsightingtimelinepoint.ts
+++ b/client/dashboard/src/sdk/src/models/components/skillsightingtimelinepoint.ts
@@ -9,7 +9,7 @@ import { Result as SafeParseResult } from "../../types/fp.js";
 import { SDKValidationError } from "../errors/sdkvalidationerror.js";
 
 /**
- * A UTC-day activation bucket for a skill.
+ * A UTC-day activation bucket for one attributed skill version.
  */
 export type SkillSightingTimelinePoint = {
   /**
@@ -20,6 +20,10 @@ export type SkillSightingTimelinePoint = {
    * Start of the UTC day.
    */
   bucketStart: Date;
+  /**
+   * The attributed skill version, absent when the observation could not be resolved to a version.
+   */
+  skillVersionId?: string | undefined;
 };
 
 /** @internal */
@@ -33,11 +37,13 @@ export const SkillSightingTimelinePoint$inboundSchema: z.ZodMiniType<
       z.iso.datetime({ offset: true }),
       z.transform(v => new Date(v)),
     ),
+    skill_version_id: z.optional(z.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
       "activation_count": "activationCount",
       "bucket_start": "bucketStart",
+      "skill_version_id": "skillVersionId",
     });
   }),
 );

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -999,8 +999,9 @@ var SkillAdoption = Type("SkillAdoption", func() {
 })
 
 var SkillSightingTimelinePoint = Type("SkillSightingTimelinePoint", func() {
-	Description("A UTC-day activation bucket for a skill.")
+	Description("A UTC-day activation bucket for one attributed skill version.")
 	Attribute("bucket_start", String, "Start of the UTC day.", func() { Format(FormatDateTime) })
+	Attribute("skill_version_id", String, "The attributed skill version, absent when the observation could not be resolved to a version.", func() { Format(FormatUUID) })
 	Attribute("activation_count", Int64, "Activations observed during the day.")
 	Required("bucket_start", "activation_count")
 })
@@ -1102,7 +1103,7 @@ var GetSkillResult = Type("GetSkillResult", func() {
 	Attribute("skill", Skill, "The skill.")
 	Attribute("latest_version", SkillVersion, "The current immutable version by effective promotion time.")
 	Attribute("adoption", SkillAdoption, "Activation adoption metrics.")
-	Attribute("sighting_timeline", ArrayOf(SkillSightingTimelinePoint), "Daily activations in the adoption window.")
+	Attribute("sighting_timeline", ArrayOf(SkillSightingTimelinePoint), "Daily activations by attributed version in the adoption window.")
 	Attribute("drift", SkillDrift, "Active-machine version convergence.")
 	Attribute("assistant_count", Int64, "The number of active, non-deleted assistants using the skill.")
 	Required("skill", "adoption", "sighting_timeline", "drift", "assistant_count")

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -56548,7 +56548,7 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/SkillSightingTimelinePoint'
-                    description: Daily activations in the adoption window.
+                    description: Daily activations by attributed version in the adoption window.
                 skill:
                     $ref: '#/components/schemas/Skill'
             description: An active skill and its current version.
@@ -66199,7 +66199,11 @@ components:
                     type: string
                     description: Start of the UTC day.
                     format: date-time
-            description: A UTC-day activation bucket for a skill.
+                skill_version_id:
+                    type: string
+                    description: The attributed skill version, absent when the observation could not be resolved to a version.
+                    format: uuid
+            description: A UTC-day activation bucket for one attributed skill version.
             required:
                 - bucket_start
                 - activation_count

--- a/server/gen/http/skills/client/encode_decode.go
+++ b/server/gen/http/skills/client/encode_decode.go
@@ -5292,6 +5292,7 @@ func unmarshalSkillAdoptionResponseBodyToSkillsSkillAdoption(v *SkillAdoptionRes
 func unmarshalSkillSightingTimelinePointResponseBodyToSkillsSkillSightingTimelinePoint(v *SkillSightingTimelinePointResponseBody) *skills.SkillSightingTimelinePoint {
 	res := &skills.SkillSightingTimelinePoint{
 		BucketStart:     *v.BucketStart,
+		SkillVersionID:  v.SkillVersionID,
 		ActivationCount: *v.ActivationCount,
 	}
 

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -312,7 +312,7 @@ type GetResponseBody struct {
 	LatestVersion *SkillVersionResponseBody `form:"latest_version,omitempty" json:"latest_version,omitempty" xml:"latest_version,omitempty"`
 	// Activation adoption metrics.
 	Adoption *SkillAdoptionResponseBody `form:"adoption,omitempty" json:"adoption,omitempty" xml:"adoption,omitempty"`
-	// Daily activations in the adoption window.
+	// Daily activations by attributed version in the adoption window.
 	SightingTimeline []*SkillSightingTimelinePointResponseBody `form:"sighting_timeline,omitempty" json:"sighting_timeline,omitempty" xml:"sighting_timeline,omitempty"`
 	// Active-machine version convergence.
 	Drift *SkillDriftResponseBody `form:"drift,omitempty" json:"drift,omitempty" xml:"drift,omitempty"`
@@ -4444,6 +4444,9 @@ type SkillAdoptionResponseBody struct {
 type SkillSightingTimelinePointResponseBody struct {
 	// Start of the UTC day.
 	BucketStart *string `form:"bucket_start,omitempty" json:"bucket_start,omitempty" xml:"bucket_start,omitempty"`
+	// The attributed skill version, absent when the observation could not be
+	// resolved to a version.
+	SkillVersionID *string `form:"skill_version_id,omitempty" json:"skill_version_id,omitempty" xml:"skill_version_id,omitempty"`
 	// Activations observed during the day.
 	ActivationCount *int64 `form:"activation_count,omitempty" json:"activation_count,omitempty" xml:"activation_count,omitempty"`
 }
@@ -14061,6 +14064,9 @@ func ValidateSkillSightingTimelinePointResponseBody(body *SkillSightingTimelineP
 	}
 	if body.BucketStart != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.bucket_start", *body.BucketStart, goa.FormatDateTime))
+	}
+	if body.SkillVersionID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.skill_version_id", *body.SkillVersionID, goa.FormatUUID))
 	}
 	return
 }

--- a/server/gen/http/skills/server/encode_decode.go
+++ b/server/gen/http/skills/server/encode_decode.go
@@ -5260,6 +5260,7 @@ func marshalSkillsSkillAdoptionToSkillAdoptionResponseBody(v *skills.SkillAdopti
 func marshalSkillsSkillSightingTimelinePointToSkillSightingTimelinePointResponseBody(v *skills.SkillSightingTimelinePoint) *SkillSightingTimelinePointResponseBody {
 	res := &SkillSightingTimelinePointResponseBody{
 		BucketStart:     v.BucketStart,
+		SkillVersionID:  v.SkillVersionID,
 		ActivationCount: v.ActivationCount,
 	}
 

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -314,7 +314,7 @@ type GetResponseBody struct {
 	LatestVersion *SkillVersionResponseBody `form:"latest_version,omitempty" json:"latest_version,omitempty" xml:"latest_version,omitempty"`
 	// Activation adoption metrics.
 	Adoption *SkillAdoptionResponseBody `form:"adoption" json:"adoption" xml:"adoption"`
-	// Daily activations in the adoption window.
+	// Daily activations by attributed version in the adoption window.
 	SightingTimeline []*SkillSightingTimelinePointResponseBody `form:"sighting_timeline" json:"sighting_timeline" xml:"sighting_timeline"`
 	// Active-machine version convergence.
 	Drift *SkillDriftResponseBody `form:"drift" json:"drift" xml:"drift"`
@@ -4446,6 +4446,9 @@ type SkillAdoptionResponseBody struct {
 type SkillSightingTimelinePointResponseBody struct {
 	// Start of the UTC day.
 	BucketStart string `form:"bucket_start" json:"bucket_start" xml:"bucket_start"`
+	// The attributed skill version, absent when the observation could not be
+	// resolved to a version.
+	SkillVersionID *string `form:"skill_version_id,omitempty" json:"skill_version_id,omitempty" xml:"skill_version_id,omitempty"`
 	// Activations observed during the day.
 	ActivationCount int64 `form:"activation_count" json:"activation_count" xml:"activation_count"`
 }

--- a/server/gen/skills/service.go
+++ b/server/gen/skills/service.go
@@ -241,7 +241,7 @@ type GetSkillResult struct {
 	LatestVersion *types.SkillVersion
 	// Activation adoption metrics.
 	Adoption *SkillAdoption
-	// Daily activations in the adoption window.
+	// Daily activations by attributed version in the adoption window.
 	SightingTimeline []*SkillSightingTimelinePoint
 	// Active-machine version convergence.
 	Drift *SkillDrift
@@ -526,10 +526,13 @@ type SkillFeedbackOutcome string
 // Where skill feedback was recorded.
 type SkillFeedbackSource string
 
-// A UTC-day activation bucket for a skill.
+// A UTC-day activation bucket for one attributed skill version.
 type SkillSightingTimelinePoint struct {
 	// Start of the UTC day.
 	BucketStart string
+	// The attributed skill version, absent when the observation could not be
+	// resolved to a version.
+	SkillVersionID *string
 	// Activations observed during the day.
 	ActivationCount int64
 }

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -926,7 +926,9 @@ func (s *Service) Get(ctx context.Context, payload *gen.GetPayload) (*gen.GetSki
 	timeline := make([]*gen.SkillSightingTimelinePoint, len(timelineRows))
 	for i, row := range timelineRows {
 		timeline[i] = &gen.SkillSightingTimelinePoint{
-			BucketStart: conv.FromPGTimestamptz(row.BucketStart), ActivationCount: row.ActivationCount,
+			BucketStart:     conv.FromPGTimestamptz(row.BucketStart),
+			SkillVersionID:  conv.FromNullableUUID(row.SkillVersionID),
+			ActivationCount: row.ActivationCount,
 		}
 	}
 	targetVersionIDs := make([]string, len(targetVersions))

--- a/server/internal/skills/insights_test.go
+++ b/server/internal/skills/insights_test.go
@@ -68,8 +68,20 @@ func TestSkillInsightsReportsVersionAdoptionAndDrift(t *testing.T) {
 	require.Equal(t, int64(1), details.Drift.OnTargetMachines)
 	require.Equal(t, int64(1), details.Drift.DriftedMachines)
 	require.Equal(t, int64(1), details.Drift.IndeterminateMachines)
-	require.Len(t, details.SightingTimeline, 1)
-	require.Equal(t, int64(4), details.SightingTimeline[0].ActivationCount)
+	require.Len(t, details.SightingTimeline, 3)
+	timelineCounts := make(map[string]int64, len(details.SightingTimeline))
+	for _, point := range details.SightingTimeline {
+		versionID := "unknown"
+		if point.SkillVersionID != nil {
+			versionID = *point.SkillVersionID
+		}
+		timelineCounts[versionID] = point.ActivationCount
+	}
+	require.Equal(t, map[string]int64{
+		oldVersion.SkillVersionID.String(): 2,
+		newVersion.SkillVersionID.String(): 1,
+		"unknown":                          1,
+	}, timelineCounts)
 
 	versions, err := ti.service.ListVersions(ctx, &gen.ListVersionsPayload{
 		ID: newVersion.SkillID.String(), Limit: 20, Cursor: nil, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -1363,6 +1363,7 @@ WHERE so.project_id = @project_id
 -- name: ListSkillSightingTimeline :many
 SELECT
   (date_trunc('day', so.seen_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::timestamptz AS bucket_start,
+  so.skill_version_id,
   COUNT(*)::bigint AS activation_count
 FROM skill_observations so
 WHERE so.project_id = @project_id
@@ -1371,8 +1372,8 @@ WHERE so.project_id = @project_id
   AND so.reconcile_error_code IS NULL
   AND so.seen_at >= @window_start
   AND so.seen_at < @window_end
-GROUP BY bucket_start
-ORDER BY bucket_start ASC;
+GROUP BY bucket_start, so.skill_version_id
+ORDER BY bucket_start ASC, so.skill_version_id ASC NULLS LAST;
 
 -- name: ListActiveMachineLatestVersions :many
 WITH latest AS (

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -4294,6 +4294,7 @@ func (q *Queries) ListSkillFeedbackByID(ctx context.Context, arg ListSkillFeedba
 const listSkillSightingTimeline = `-- name: ListSkillSightingTimeline :many
 SELECT
   (date_trunc('day', so.seen_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::timestamptz AS bucket_start,
+  so.skill_version_id,
   COUNT(*)::bigint AS activation_count
 FROM skill_observations so
 WHERE so.project_id = $1
@@ -4302,8 +4303,8 @@ WHERE so.project_id = $1
   AND so.reconcile_error_code IS NULL
   AND so.seen_at >= $3
   AND so.seen_at < $4
-GROUP BY bucket_start
-ORDER BY bucket_start ASC
+GROUP BY bucket_start, so.skill_version_id
+ORDER BY bucket_start ASC, so.skill_version_id ASC NULLS LAST
 `
 
 type ListSkillSightingTimelineParams struct {
@@ -4315,6 +4316,7 @@ type ListSkillSightingTimelineParams struct {
 
 type ListSkillSightingTimelineRow struct {
 	BucketStart     pgtype.Timestamptz
+	SkillVersionID  uuid.NullUUID
 	ActivationCount int64
 }
 
@@ -4332,7 +4334,7 @@ func (q *Queries) ListSkillSightingTimeline(ctx context.Context, arg ListSkillSi
 	var items []ListSkillSightingTimelineRow
 	for rows.Next() {
 		var i ListSkillSightingTimelineRow
-		if err := rows.Scan(&i.BucketStart, &i.ActivationCount); err != nil {
+		if err := rows.Scan(&i.BucketStart, &i.SkillVersionID, &i.ActivationCount); err != nil {
 			return nil, err
 		}
 		items = append(items, i)


### PR DESCRIPTION
## Summary
- group raw skill activations by UTC day and attributed version
- replace the activation table with a gap-filled 30-day Chart.js timeline
- share version labels across activity and efficacy insights, with an explicit unknown-version series

Closes [DNO-664](https://linear.app/speakeasy/issue/DNO-664/feat-replace-the-activation-timeline-table-with-a-30-day-per-version)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the activation timeline table with a gap‑filled 30‑day per‑version line chart to show rollout and adoption at a glance. The chart stops loading if version fetching fails, and the API now attributes each daily activation bucket to a `skill_version_id` for version‑labeled series and an explicit Unknown series. Closes DNO-664.

- **New Features**
  - Added a 30‑day line chart with one series per version; gaps filled across the window.
  - Shared version labels across activity and efficacy insights; shows “Unknown version” when attribution is missing.

- **Refactors**
  - `SkillSightingTimelinePoint` now includes `skill_version_id`; `ListSkillSightingTimeline` groups by day and version with stable ordering.
  - Updated OpenAPI and regenerated SDK; adjusted server/client wiring, chart rendering with `chart.js`, and tests.
  - Stopped chart loading when the versions query errors; surfaced the error in insights.

<sup>Written for commit 94c6a137a4570913588df4c4dad65f7d095d94d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

