### PR TITLE
feat(dashboard): search addable plugin skills

### DIFF
--- a/.changeset/search-addable-plugin-skills.md
+++ b/.changeset/search-addable-plugin-skills.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Prioritize addable skills and add search to the plugin skill picker.

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -1,4 +1,5 @@
 import { RequireScope } from "@/components/require-scope";
+import { Page } from "@/components/page-layout";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Button as UiButton } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -27,6 +28,10 @@ import { Sparkles, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
+import {
+  filterSkills,
+  prioritizeAddableSkills,
+} from "../skills/skills-list-helpers";
 import { SectionEmptyState } from "./SectionEmptyState";
 
 /**
@@ -51,6 +56,7 @@ export function PluginSkillsSection({
   const project = useProject();
   const queryClient = useQueryClient();
   const [isAddSkillOpen, setIsAddSkillOpen] = useState(false);
+  const [skillSearch, setSkillSearch] = useState("");
 
   const distributionsQuery = useSkillDistributionsInfinite(
     { pluginId, limit: 50 },
@@ -92,10 +98,30 @@ export function PluginSkillsSection({
   // endpoint rejects them, so the picker explains why and links to the fix.
   const availableSkills = useMemo(() => {
     const distributedSkillIds = new Set(distributions.map((d) => d.skillId));
-    return (
-      skillsQuery.data?.pages.flatMap((page) => page.result.skills) ?? []
-    ).filter((skill) => !distributedSkillIds.has(skill.id));
+    return prioritizeAddableSkills(
+      (
+        skillsQuery.data?.pages.flatMap((page) => page.result.skills) ?? []
+      ).filter((skill) => !distributedSkillIds.has(skill.id)),
+    );
   }, [distributions, skillsQuery.data?.pages]);
+  const visibleSkills = useMemo(
+    () => filterSkills(availableSkills, skillSearch, [], []),
+    [availableSkills, skillSearch],
+  );
+  const unavailableSkillCount = availableSkills.filter(
+    (skill) => !skill.hasValidVersion,
+  ).length;
+  const hiddenSkillCount = availableSkills.length - visibleSkills.length;
+  const skillListSummary = [
+    hiddenSkillCount > 0
+      ? `${hiddenSkillCount} skill${hiddenSkillCount === 1 ? "" : "s"} hidden by search`
+      : "",
+    unavailableSkillCount > 0
+      ? `${unavailableSkillCount} unavailable skill${unavailableSkillCount === 1 ? "" : "s"}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   const distribute = useDistributeSkillMutation();
   const undistribute = useUndistributeSkillMutation();
@@ -109,7 +135,10 @@ export function PluginSkillsSection({
     // failed-only retry selection.
     if (!open && isBatchAdding) return;
     setIsAddSkillOpen(open);
-    if (open) setSelectedSkillIds([]);
+    if (open) {
+      setSelectedSkillIds([]);
+      setSkillSearch("");
+    }
   };
 
   const toggleSkill = (skillId: string) => {
@@ -182,6 +211,37 @@ export function PluginSkillsSection({
       },
     );
   };
+
+  let skillPickerContent: JSX.Element;
+  if (isSkillListLoading) {
+    skillPickerContent = <Skeleton className="h-24 w-full" />;
+  } else if (visibleSkills.length > 0) {
+    skillPickerContent = (
+      <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-md border p-1">
+        {visibleSkills.map((skill) => (
+          <AddSkillOption
+            key={skill.id}
+            skill={skill}
+            checked={selectedSkillIds.includes(skill.id)}
+            disabled={isBatchAdding}
+            onToggle={() => toggleSkill(skill.id)}
+          />
+        ))}
+      </div>
+    );
+  } else if (availableSkills.length > 0) {
+    skillPickerContent = (
+      <Type muted small>
+        No skills match your search.
+      </Type>
+    );
+  } else {
+    skillPickerContent = (
+      <Type muted small>
+        No skills available to add. Record a skill in this project first.
+      </Type>
+    );
+  }
 
   // Precomputed list body keeps the JSX below free of nested ternaries while
   // distinguishing "nothing distributed yet" from "no search matches".
@@ -295,26 +355,19 @@ export function PluginSkillsSection({
           </Dialog.Header>
           <div className="flex flex-col gap-2">
             <label className="text-sm font-medium">Skills</label>
-            {isSkillListLoading ? (
-              <Skeleton className="h-24 w-full" />
-            ) : availableSkills.length > 0 ? (
-              <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-md border p-1">
-                {availableSkills.map((skill) => (
-                  <AddSkillOption
-                    key={skill.id}
-                    skill={skill}
-                    checked={selectedSkillIds.includes(skill.id)}
-                    disabled={isBatchAdding}
-                    onToggle={() => toggleSkill(skill.id)}
-                  />
-                ))}
-              </div>
-            ) : (
+            <Page.Toolbar.Search
+              value={skillSearch}
+              onChange={setSkillSearch}
+              debounceMs={150}
+              placeholder="Search skills"
+              className="w-full"
+            />
+            {!isSkillListLoading && skillListSummary && (
               <Type muted small>
-                No skills available to add. Record a skill in this project
-                first.
+                {skillListSummary}
               </Type>
             )}
+            {skillPickerContent}
           </div>
           <Dialog.Footer>
             <Button

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -25,7 +25,7 @@ import { useUndistributeSkillMutation } from "@gram/client/react-query/undistrib
 import { Badge, Button, cn, Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Sparkles, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import {
@@ -126,6 +126,10 @@ export function PluginSkillsSection({
   const distribute = useDistributeSkillMutation();
   const undistribute = useUndistributeSkillMutation();
   const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  useEffect(() => {
+    setSkillSearch("");
+    setSelectedSkillIds([]);
+  }, [pluginId]);
   // Shared mutation observers only reflect their latest call, so a local flag
   // covers the whole allSettled batch to keep the dialog locked until it ends.
   const [isBatchAdding, setIsBatchAdding] = useState(false);

--- a/client/dashboard/src/pages/skills/SkillsList.test.ts
+++ b/client/dashboard/src/pages/skills/SkillsList.test.ts
@@ -2,6 +2,7 @@ import type { Skill } from "@gram/client/models/components/skill.js";
 import { describe, expect, it } from "vitest";
 import {
   filterSkills,
+  prioritizeAddableSkills,
   skillCountLabel,
   sortSkills,
 } from "./skills-list-helpers";
@@ -57,6 +58,22 @@ describe("SkillsList filtering", () => {
       ),
     ).toEqual(["b"]);
     expect(filterSkills(skills, "", ["manual"], ["built_in"])).toEqual([]);
+  });
+
+  it("prioritizes addable skills without reordering either group", () => {
+    const unavailableFirst = skill({ id: "a", hasValidVersion: false });
+    const availableFirst = skill({ id: "b" });
+    const unavailableSecond = skill({ id: "c", hasValidVersion: false });
+    const availableSecond = skill({ id: "d" });
+
+    expect(
+      prioritizeAddableSkills([
+        unavailableFirst,
+        availableFirst,
+        unavailableSecond,
+        availableSecond,
+      ]).map((item) => item.id),
+    ).toEqual(["b", "d", "a", "c"]);
   });
 
   it("never labels loaded pages as the project-wide total", () => {

--- a/client/dashboard/src/pages/skills/skills-list-helpers.ts
+++ b/client/dashboard/src/pages/skills/skills-list-helpers.ts
@@ -28,6 +28,13 @@ export function filterSkills(
   });
 }
 
+export function prioritizeAddableSkills(skills: Skill[]): Skill[] {
+  return skills.toSorted(
+    (left, right) =>
+      Number(right.hasValidVersion) - Number(left.hasValidVersion),
+  );
+}
+
 export function sortSkills(
   skills: Skill[],
   metricsBySkill: ReadonlyMap<string, SkillInsightMetrics>,


### PR DESCRIPTION
## Summary

- prioritize distributable skills in the plugin Add Skills picker
- add 150 ms debounced name and slug search with hidden/unavailable counts
- preserve stable ordering within addable and unavailable groups

Closes [DNO-666](https://linear.app/speakeasy/issue/DNO-666/feat-search-and-prioritize-addable-skills-in-the-plugin-add-skill)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes addable (distributable) skills and adds a 150 ms debounced search to the plugin Add Skill picker so users can quickly find valid skills. Also shows hidden/unavailable counts, keeps order within groups, and resets search/selection when reopening the dialog or switching plugins.

- **New Features**
  - Addable skills listed first without reordering within groups via `prioritizeAddableSkills`.
  - Name/slug search with 150 ms debounce using `Page.Toolbar.Search` and `filterSkills`; search and selection reset on reopen or plugin change.
  - Summary line shows hidden-by-search and unavailable counts; clearer empty and loading states.
  - Satisfies DNO-666 by prioritizing distributable skills, adding debounced search, and surfacing availability.

<sup>Written for commit 9bd1cc5a32d69b62bb32800ed0e4831b81104840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

