### PR TITLE
mig: add device_agent_device_syncs for per-device agent heartbeats

### DIFF
--- a/.changeset/dno643-device-agent-device-syncs.md
+++ b/.changeset/dno643-device-agent-device-syncs.md
@@ -1,0 +1,9 @@
+---
+"server": minor
+---
+
+mig: add device_agent_device_syncs for per-device agent heartbeats
+
+Sibling of device_agent_syncs, keyed on (organization_id, serial_number)
+instead of email, plus the case-insensitive serial indexes both sides of the
+coverage join will need. Schema only — nothing reads or writes the table yet.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -785,6 +785,57 @@ CREATE TABLE IF NOT EXISTS device_agent_syncs (
 CREATE INDEX IF NOT EXISTS device_agent_syncs_organization_id_lower_email_idx
 ON device_agent_syncs (organization_id, LOWER(email));
 
+-- Per-DEVICE agent heartbeats, the sibling of device_agent_syncs. Both are
+-- written by the same agent.getPlugins poll: that table answers "does this
+-- user run the agent somewhere", this one answers "does THIS machine run
+-- it". They are separate tables rather than one widened table because
+-- (organization_id, email) remains a correct and independently useful key —
+-- the product-feature probe and the synced-users list both read it, and the
+-- coverage join still falls back to it for devices whose agent predates
+-- hardware reporting or cannot read a serial.
+--
+-- Keyed on the hardware serial because that is the one identifier both sides
+-- of the coverage join can supply without a human maintaining it: every MDM
+-- reads it off the hardware, whereas an assigned-user email is frequently
+-- absent or disagrees between systems. email here is descriptive (the user
+-- whose agent last checked in from this machine), not part of the key.
+CREATE TABLE IF NOT EXISTS device_agent_device_syncs (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+
+  organization_id TEXT NOT NULL,
+  serial_number TEXT NOT NULL,
+
+  email TEXT NOT NULL,
+  hostname TEXT,
+
+  first_seen_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  last_seen_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT device_agent_device_syncs_pkey PRIMARY KEY (id),
+  CONSTRAINT device_agent_device_syncs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+
+-- The dedup key, and deliberately an EXPRESSION index rather than a
+-- UNIQUE (organization_id, serial_number) table constraint: vendors and agent
+-- read-paths disagree on serial casing (macOS ioreg vs Windows WMI, and any
+-- change between agent builds), and every consumer matches on
+-- LOWER(serial_number). A raw-column key would let 'abc123' and 'ABC123'
+-- coexist for one machine, and because the coverage joins are case-insensitive
+-- BOTH rows would match the same device and fan it out — inflating counts and
+-- breaking evidence pushes that reject duplicate device ids. Keying on the
+-- same expression the readers use is what makes that state unrepresentable.
+--
+-- It also lets Postgres prove the join yields at most one row, so the planner
+-- can drop it entirely for organizations not on device-level matching.
+--
+-- Postgres cannot express an expression key as a table constraint, hence the
+-- standalone CREATE UNIQUE INDEX. The upsert infers this index via
+-- ON CONFLICT (organization_id, LOWER(serial_number)).
+CREATE UNIQUE INDEX IF NOT EXISTS device_agent_device_syncs_org_lower_serial_key
+ON device_agent_device_syncs (organization_id, LOWER(serial_number));
+
 CREATE TABLE IF NOT EXISTS deployments_openapiv3_assets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   deployment_id uuid NOT NULL,
@@ -5312,6 +5363,15 @@ ON mdm_devices (organization_id, user_id);
 -- device_agent_syncs_organization_id_lower_email_idx on the agent side.
 CREATE INDEX IF NOT EXISTS mdm_devices_organization_id_lower_user_email_idx
 ON mdm_devices (organization_id, LOWER(user_email))
+WHERE missing_since IS NULL;
+
+-- Serves the coverage join's primary serial match against present devices,
+-- pairing with device_agent_device_syncs_organization_id_lower_serial_idx on
+-- the agent side. Deliberately NOT unique: one physical machine enrolled in
+-- two MDMs (a Jamf-to-Intune migration, say) legitimately yields two rows
+-- carrying the same serial, so uniqueness here would reject real inventory.
+CREATE INDEX IF NOT EXISTS mdm_devices_organization_id_lower_serial_number_idx
+ON mdm_devices (organization_id, LOWER(serial_number))
 WHERE missing_since IS NULL;
 
 -- Backs the user FK's ON DELETE SET NULL, which must match every row for

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -539,6 +539,18 @@ type DeploymentsPackage struct {
 	VersionID    uuid.UUID
 }
 
+type DeviceAgentDeviceSync struct {
+	ID             uuid.UUID
+	OrganizationID string
+	SerialNumber   string
+	Email          string
+	Hostname       pgtype.Text
+	FirstSeenAt    pgtype.Timestamptz
+	LastSeenAt     pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
 type DeviceAgentSync struct {
 	ID             uuid.UUID
 	OrganizationID string

--- a/server/migrations/20260729235455_dno643-device-agent-device-syncs.sql
+++ b/server/migrations/20260729235455_dno643-device-agent-device-syncs.sql
@@ -1,0 +1,20 @@
+-- atlas:txmode none
+
+-- Create index "mdm_devices_organization_id_lower_serial_number_idx" to table: "mdm_devices"
+CREATE INDEX CONCURRENTLY "mdm_devices_organization_id_lower_serial_number_idx" ON "mdm_devices" ("organization_id", (lower(serial_number))) WHERE (missing_since IS NULL);
+-- Create "device_agent_device_syncs" table
+CREATE TABLE "device_agent_device_syncs" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "serial_number" text NOT NULL,
+  "email" text NOT NULL,
+  "hostname" text NULL,
+  "first_seen_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "last_seen_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "device_agent_device_syncs_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "device_agent_device_syncs_org_lower_serial_key" to table: "device_agent_device_syncs"
+CREATE UNIQUE INDEX "device_agent_device_syncs_org_lower_serial_key" ON "device_agent_device_syncs" ("organization_id", (lower(serial_number)));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/K1ioXUBJ2LJl3OHoe923MXaHL8IU9zfS8/ESG0krK4=
+h1:s7xHchmljdPcmyoGJC0TPwrjT0iQsOLZgYgryb5UKyc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -307,3 +307,4 @@ h1:/K1ioXUBJ2LJl3OHoe923MXaHL8IU9zfS8/ESG0krK4=
 20260728192241_dno_573_suggestion_list_index.sql h1:oi8LXZQndV4kUsIAJm/Ji3RokVt1KgFK+NC3c1+CZvA=
 20260728192302_dno_574_skill_version_promotion.sql h1:jQLB1IwxIj6iZr8kA9Ya/u6N6pG4jn+15RjS3+BM5+w=
 20260728201450_cimd_inbound_storage.sql h1:al8Z9FQ75jt6vp7WIIhJ8+uyTDmf51PA3zb4Anggt1w=
+20260729235455_dno643-device-agent-device-syncs.sql h1:2xYuc2B1oopRAdvkZ57ys+5kncKCyM1Zw78D/M8bCXM=


### PR DESCRIPTION
Part 1 of the DNO-643 stack (device-level coverage). Schema only — no reader, no writer, no behavior change.

## Why

Coverage can only attest per **user** today: `device_agent_syncs` is keyed `(organization_id, email)`, so a user running the agent on one of two enrolled machines makes **both** read as covered.

## What

`device_agent_device_syncs`, keyed on the hardware serial. Its sibling stays exactly as-is.

**Why a sibling table rather than widening the existing one:**

- `(organization_id, email)` remains correct and independently useful — the product-feature probe (`HasDeviceAgentSync`) and the synced-users list both read it.
- The coverage join keeps falling back to it for agents that predate hardware reporting, or that run on hardware with no readable serial.
- The existing upsert's `ON CONFLICT` keys on that exact constraint, so changing it would have to change the write path too.

**Serial as the key** is the one identifier both sides of the coverage join can supply without a human maintaining it — every MDM reads it off the hardware. `email` on this table is descriptive (which user's agent last checked in from this machine), not part of the key.

**Indexes:** case-insensitive serial on both sides of the future join. On `mdm_devices` it is deliberately **not** unique — one physical machine enrolled in two MDMs (a Jamf-to-Intune migration) legitimately yields two rows carrying the same serial, so uniqueness there would reject real inventory.

## Verification

Generated with `mise db:diff` (not hand-edited); applied locally via `mise db:migrate`; `mise lint:migrations` clean; `mise gen:sqlc-server` re-run and `models.go` committed.

DDL only — no DML, no backfill, per the migrations-ship-alone rule.

Linear: DNO-643

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-device agent heartbeat table with a case-insensitive, unique serial key and a matching MDM index to enable device-level coverage for DNO-643. Schema only; no behavior change.

- **Migration**
  - Create `device_agent_device_syncs` keyed by `(organization_id, serial_number)` with `email`, `hostname`, and timestamps.
  - Add UNIQUE expression index `(organization_id, LOWER(serial_number))` on `device_agent_device_syncs` and a non-unique partial index `(organization_id, LOWER(serial_number))` on `mdm_devices` (present devices only).
  - Keep `device_agent_syncs` unchanged; future coverage will prefer serial and fall back to email. No readers/writers, no DML/backfill.

<sup>Written for commit 5d6ab0830acc445b09db67ca3922f49a5cf0dd10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

