### PR TITLE
chore: confine internal org chat analysis to a single project

### DIFF
--- a/server/internal/chat/analysis/settings.go
+++ b/server/internal/chat/analysis/settings.go
@@ -15,6 +15,16 @@ import (
 // column is NOT NULL), and a judge with no row is off.
 const DefaultJudgeDailyCap int32 = 100
 
+// projectOnlyOrgs confines an organization's chat analysis to a single
+// project: every other project resolves with no judges enabled, so nothing is
+// enqueued and no budget is reserved for it. Hardcoded rather than configured
+// — this is a one-off carve-out for Speakeasy's own organization, whose
+// hundreds of internal projects would otherwise spend judge budget on noise.
+var projectOnlyOrgs = map[string]uuid.UUID{
+	// speakeasy-team → its "default" project.
+	"5a25158b-24dc-4d49-b03d-e85acfbea59c": uuid.MustParse("0196cbd1-9328-74e7-b7bb-6e5357565573"),
+}
+
 // Settings are the effective per-organization budgets: the daily cap for each
 // enabled judge. A judge absent from the map is off for the organization.
 type Settings struct {
@@ -42,6 +52,9 @@ func settingsForProject(ctx context.Context, queries *repo.Queries, judges *Judg
 	settings := Settings{OrganizationID: "", JudgeDailyCaps: make(map[string]int32)}
 	for _, row := range rows {
 		settings.OrganizationID = row.OrganizationID
+		if only, ok := projectOnlyOrgs[row.OrganizationID]; ok && only != projectID {
+			continue
+		}
 		if !row.Judge.Valid || !row.Enabled.Valid || !row.Enabled.Bool {
 			continue
 		}


### PR DESCRIPTION
Extremely minimal change specifically to make chat analysis _only_ run on the default project (for `speakeasy-team`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Confine chat analysis for `speakeasy-team` to its default project to avoid judge budget being spent on noise across internal projects. Other projects in that org now resolve with no judges enabled, so no tasks are enqueued and no budget is reserved.

<sup>Written for commit a3850fbbdbb5111510be289ed3376419bae5116f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

