### PR TITLE
feat(skills): paginate skills table

### DIFF
--- a/.changeset/page-skills-server-side.md
+++ b/.changeset/page-skills-server-side.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Page the skills table and move its default search, filters, and sorting to the server.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -36686,6 +36686,49 @@ paths:
             minimum: 1
             type: integer
         - allowEmptyValue: true
+          description: Search skill names, display names, and summaries.
+          in: query
+          name: search
+          schema:
+            description: Search skill names, display names, and summaries.
+            maxLength: 256
+            type: string
+        - allowEmptyValue: true
+          description: Only return skills from these sources.
+          in: query
+          name: source_kinds
+          schema:
+            description: Only return skills from these sources.
+            items:
+              enum:
+                - manual
+                - captured
+              type: string
+            type: array
+        - allowEmptyValue: true
+          description: Only return skills with these classifications.
+          in: query
+          name: classifications
+          schema:
+            description: Only return skills with these classifications.
+            items:
+              enum:
+                - custom
+                - built_in
+              type: string
+            type: array
+        - allowEmptyValue: true
+          description: How to order skills.
+          in: query
+          name: sort
+          schema:
+            default: name
+            description: How to order skills.
+            enum:
+              - name
+              - updated
+            type: string
+        - allowEmptyValue: true
           description: Session header
           in: header
           name: Gram-Session
@@ -57581,9 +57624,14 @@ components:
           items:
             $ref: '#/components/schemas/Skill'
           description: The active skills in this page.
+        total_count:
+          type: integer
+          description: The total number of active skills matching the filters.
+          format: int64
       description: A page of active project skills.
       required:
         - skills
+        - total_count
     ListSourcesResult:
       type: object
       properties:

--- a/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
@@ -20,6 +20,9 @@ const testState = vi.hoisted(() => ({
   insightsError: null as Error | null,
   insightsData: { insights: [] } as { insights: unknown[] } | undefined,
   insightsRefetch: vi.fn().mockResolvedValue(undefined),
+  skillRequests: [] as unknown[],
+  metricSkillRequests: [] as unknown[],
+  searchValue: "example",
   skills: [] as Array<Record<string, unknown>>,
   unknownActivations: [] as Array<Record<string, unknown>>,
   suggestionFetchNextPage: vi.fn().mockResolvedValue(undefined),
@@ -71,17 +74,62 @@ vi.mock("@/routes", () => ({
   }),
 }));
 vi.mock("@gram/client/react-query/skills.js", () => ({
-  useSkillsInfinite: () => ({
-    data: { pages: [{ result: { skills: testState.skills } }] },
-    isPending: false,
-    isFetching: false,
-    isFetchingNextPage: false,
-    isFetchNextPageError: testState.isFetchNextPageError,
-    hasNextPage: testState.hasNextPage,
-    error: testState.error,
-    fetchNextPage: testState.fetchNextPage,
-    refetch: vi.fn(),
-  }),
+  useSkills: (request: {
+    cursor?: string;
+    limit?: number;
+    search?: string;
+  }) => {
+    testState.skillRequests.push(request);
+    const matchingSkills = request.search
+      ? testState.skills.filter((skill) =>
+          String(skill.displayName).toLowerCase().includes(request.search!),
+        )
+      : testState.skills;
+    const start = Number(request.cursor ?? 0);
+    const limit = request.limit ?? 50;
+    const next = start + limit;
+    return {
+      data: {
+        result: {
+          skills: matchingSkills.slice(start, next),
+          totalCount: matchingSkills.length,
+          nextCursor: next < matchingSkills.length ? String(next) : undefined,
+        },
+      },
+      isPending: false,
+      isFetching: false,
+      error: testState.error,
+      refetch: vi.fn(),
+    };
+  },
+  useSkillsInfinite: (request: { search?: string }) => {
+    testState.metricSkillRequests.push(request);
+    const matchingSkills = request.search
+      ? testState.skills.filter((skill) =>
+          String(skill.displayName).toLowerCase().includes(request.search!),
+        )
+      : testState.skills;
+    return {
+      data: {
+        pages: [
+          {
+            result: {
+              skills: matchingSkills,
+              totalCount: matchingSkills.length,
+            },
+          },
+        ],
+      },
+      isPending: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isFetchNextPageError: testState.isFetchNextPageError,
+      hasNextPage: testState.hasNextPage,
+      error: testState.error,
+      fetchNextPage: testState.fetchNextPage,
+      refetch: vi.fn(),
+    };
+  },
   invalidateAllSkills: testState.invalidateSkills,
 }));
 vi.mock("@gram/client/react-query/skillSuggestions.js", () => ({
@@ -164,12 +212,17 @@ vi.mock("@/components/page-layout", () => {
     <div>{children}</div>
   );
   const Search = ({ onChange }: { onChange: (value: string) => void }) => (
-    <button onClick={() => onChange("example")}>Apply search</button>
+    <button onClick={() => onChange(testState.searchValue)}>
+      Apply search
+    </button>
+  );
+  const SortBy = ({ onChange }: { onChange: (value: string) => void }) => (
+    <button onClick={() => onChange("activations")}>Apply metric sort</button>
   );
   const Toolbar = Object.assign(Wrapper, {
     Search,
     Filters: () => null,
-    SortBy: () => null,
+    SortBy,
     Count: Wrapper,
     Actions: Wrapper,
     Refresh: () => null,
@@ -254,6 +307,9 @@ beforeEach(() => {
   testState.insightsData = { insights: [] };
   testState.insightsRefetch.mockReset();
   testState.insightsRefetch.mockResolvedValue(undefined);
+  testState.skillRequests = [];
+  testState.metricSkillRequests = [];
+  testState.searchValue = "example";
   testState.skills = makeSkills(250);
   testState.unknownActivations = [];
   testState.suggestionFetchNextPage.mockReset().mockResolvedValue(undefined);
@@ -284,14 +340,16 @@ describe("SkillsList pagination surfaces", () => {
     expect(testState.suggestionRequests[0]).toEqual({ limit: 50 });
   });
 
-  it("bounds rendered rows and resets the bound when search changes", async () => {
+  it("pages rendered rows and resets to the first page when search changes", async () => {
     render(<SkillsList />);
-    expect(screen.getAllByTestId("skill-row")).toHaveLength(200);
-    fireEvent.click(screen.getByRole("button", { name: "Show more results" }));
-    expect(screen.getAllByTestId("skill-row")).toHaveLength(250);
+    expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
+    expect(screen.getByText("Example 0")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
+    expect(screen.getByText("Example 50")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Apply search" }));
     await waitFor(() => {
-      expect(screen.getAllByTestId("skill-row")).toHaveLength(200);
+      expect(screen.getByText("Example 0")).toBeTruthy();
     });
   });
 
@@ -300,19 +358,22 @@ describe("SkillsList pagination surfaces", () => {
     testState.isFetchNextPageError = true;
     testState.error = new Error("next page failed");
     render(<SkillsList />);
+    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
 
-    expect(screen.getAllByTestId("skill-row")).toHaveLength(200);
+    expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
     expect(screen.getByText("Unable to load more skills.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(testState.fetchNextPage).toHaveBeenCalledOnce();
   });
 
   it("does not claim an incomplete failed search has no matches", () => {
-    testState.skills = [];
+    testState.searchValue = "missing";
     testState.hasNextPage = true;
     testState.isFetchNextPageError = true;
     testState.error = new Error("next page failed");
     render(<SkillsList />);
+    fireEvent.click(screen.getByRole("button", { name: "Apply search" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
 
     expect(
       screen.getByText("Search incomplete. Retry to check remaining skills."),
@@ -348,10 +409,13 @@ describe("SkillsList pagination surfaces", () => {
     expect(screen.getByText("unmatched-skill")).toBeTruthy();
   });
 
-  it("loads every skill page before presenting a sorted view", async () => {
+  it("only drains skill pages when a metric sort is selected", async () => {
     testState.hasNextPage = true;
     render(<SkillsList />);
 
+    expect(testState.fetchNextPage).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
+    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
     await waitFor(() => expect(testState.fetchNextPage).toHaveBeenCalledOnce());
     expect(
       screen.getByText("Loading all skills to finish this view..."),
@@ -365,7 +429,7 @@ describe("SkillsList pagination surfaces", () => {
     render(<SkillsList />);
 
     expect(screen.getByText("Unable to load skill insights")).toBeTruthy();
-    expect(screen.getAllByTestId("skill-row")).toHaveLength(200);
+    expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
     fireEvent.click(screen.getByRole("button", { name: "Retry insights" }));
     expect(testState.insightsRefetch).toHaveBeenCalledOnce();
   });

--- a/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
@@ -20,6 +20,7 @@ const testState = vi.hoisted(() => ({
   insightsError: null as Error | null,
   insightsData: { insights: [] } as { insights: unknown[] } | undefined,
   insightsRefetch: vi.fn().mockResolvedValue(undefined),
+  metricTotalCount: undefined as number | undefined,
   skillRequests: [] as unknown[],
   metricSkillRequests: [] as unknown[],
   searchValue: "example",
@@ -115,7 +116,7 @@ vi.mock("@gram/client/react-query/skills.js", () => ({
           {
             result: {
               skills: matchingSkills,
-              totalCount: matchingSkills.length,
+              totalCount: testState.metricTotalCount ?? matchingSkills.length,
             },
           },
         ],
@@ -307,6 +308,7 @@ beforeEach(() => {
   testState.insightsData = { insights: [] };
   testState.insightsRefetch.mockReset();
   testState.insightsRefetch.mockResolvedValue(undefined);
+  testState.metricTotalCount = undefined;
   testState.skillRequests = [];
   testState.metricSkillRequests = [];
   testState.searchValue = "example";
@@ -354,6 +356,8 @@ describe("SkillsList pagination surfaces", () => {
   });
 
   it("keeps loaded rows visible and exposes an explicit retry after a page failure", () => {
+    testState.skills = makeSkills(100);
+    testState.metricTotalCount = 1000;
     testState.hasNextPage = true;
     testState.isFetchNextPageError = true;
     testState.error = new Error("next page failed");
@@ -362,6 +366,11 @@ describe("SkillsList pagination surfaces", () => {
 
     expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
     expect(screen.getByText("Unable to load more skills.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
+    expect(
+      screen.getByRole("button", { name: "Next" }).hasAttribute("disabled"),
+    ).toBe(true);
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(testState.fetchNextPage).toHaveBeenCalledOnce();
   });
@@ -432,6 +441,20 @@ describe("SkillsList pagination surfaces", () => {
     expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
     fireEvent.click(screen.getByRole("button", { name: "Retry insights" }));
     expect(testState.insightsRefetch).toHaveBeenCalledOnce();
+  });
+
+  it("returns to paginated skills when metric insights are unavailable", async () => {
+    testState.hasNextPage = true;
+    testState.insightsData = undefined;
+    testState.insightsError = new Error("insights unavailable");
+    render(<SkillsList />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("skill-row")).toHaveLength(50),
+    );
+    expect(testState.fetchNextPage).not.toHaveBeenCalled();
   });
 
   it("badges skills with open suggestions and drains suggestion pages", async () => {

--- a/client/dashboard/src/pages/skills/SkillsList.test.ts
+++ b/client/dashboard/src/pages/skills/SkillsList.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   filterSkills,
   prioritizeAddableSkills,
-  skillCountLabel,
   sortSkills,
 } from "./skills-list-helpers";
 
@@ -74,45 +73,6 @@ describe("SkillsList filtering", () => {
         availableSecond,
       ]).map((item) => item.id),
     ).toEqual(["b", "d", "a", "c"]);
-  });
-
-  it("never labels loaded pages as the project-wide total", () => {
-    expect(
-      skillCountLabel({
-        active: false,
-        hasNextPage: true,
-        incomplete: false,
-        loadedCount: 200,
-        resultCount: 200,
-      }),
-    ).toBe("200 loaded");
-    expect(
-      skillCountLabel({
-        active: true,
-        hasNextPage: true,
-        incomplete: false,
-        loadedCount: 200,
-        resultCount: 3,
-      }),
-    ).toBe("Searching 200 loaded");
-    expect(
-      skillCountLabel({
-        active: true,
-        hasNextPage: false,
-        incomplete: false,
-        loadedCount: 240,
-        resultCount: 3,
-      }),
-    ).toBe("3 skills");
-    expect(
-      skillCountLabel({
-        active: true,
-        hasNextPage: true,
-        incomplete: true,
-        loadedCount: 200,
-        resultCount: 0,
-      }),
-    ).toBe("0 matching loaded");
   });
 
   it("sorts sampled metrics ahead of missing values", () => {

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -22,7 +22,7 @@ import {
 import { Badge, type Column, Icon, Table } from "@speakeasy-api/moonshine";
 import { useRoutes } from "@/routes";
 import { useQueryState } from "nuqs";
-import { useDeferredValue, useMemo, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { ApproveAllSkillSuggestions } from "./ApproveAllSkillSuggestions";
@@ -128,15 +128,15 @@ export default function SkillsList(): JSX.Element {
       [],
     [metricQuery.data?.pages],
   );
-  const skills = metricSort
+  const insightSkills = metricSort
     ? metricSkills
     : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
   const insightsQuery = useSkillEfficacyInsights(
-    metricSort ? {} : { skillIds: skills.map((skill) => skill.id) },
+    metricSort ? {} : { skillIds: insightSkills.map((skill) => skill.id) },
     undefined,
     {
       throwOnError: false,
-      enabled: skills.length > 0,
+      enabled: insightSkills.length > 0,
     },
   );
   const openSuggestions = useOpenSkillSuggestions();
@@ -155,42 +155,61 @@ export default function SkillsList(): JSX.Element {
     filters.values.sourceKind.length > 0 ||
     filters.values.classification.length > 0;
   const insightsUnavailable = !!insightsQuery.error && !insightsQuery.data;
+  const effectiveMetricSort = metricSort && !insightsUnavailable;
   const effectiveSort = insightsUnavailable ? "updated" : sort;
+  const skills = effectiveMetricSort
+    ? metricSkills
+    : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
   const visibleSkills = useMemo(
     () =>
-      metricSort ? sortSkills(skills, metricsBySkill, effectiveSort) : skills,
-    [effectiveSort, metricSort, metricsBySkill, skills],
+      effectiveMetricSort
+        ? sortSkills(skills, metricsBySkill, effectiveSort)
+        : skills,
+    [effectiveMetricSort, effectiveSort, metricsBySkill, skills],
   );
 
+  useEffect(() => {
+    if (!insightsUnavailable || sort === "updated") return;
+    setSort("updated");
+    setPage(0);
+    setPageCursors([undefined]);
+  }, [insightsUnavailable, sort]);
+
   useDrainSkillPages({
-    active: metricSort,
+    active: effectiveMetricSort,
     hasNextPage: metricQuery.hasNextPage,
     isFetchingNextPage: metricQuery.isFetchingNextPage,
     isFetchNextPageError: metricQuery.isFetchNextPageError,
     fetchNextPage: metricQuery.fetchNextPage,
   });
 
-  const displayedSkills = metricSort
+  const displayedSkills = effectiveMetricSort
     ? visibleSkills.slice(
         page * RESULT_PAGE_SIZE,
         (page + 1) * RESULT_PAGE_SIZE,
       )
     : visibleSkills;
-  const totalCount = metricSort
+  const totalCount = effectiveMetricSort
     ? (metricQuery.data?.pages[0]?.result.totalCount ?? 0)
     : (pageQuery.data?.result.totalCount ?? 0);
-  const totalPages = Math.ceil(totalCount / RESULT_PAGE_SIZE);
-  const query = metricSort ? metricQuery : pageQuery;
+  const paginationCount =
+    effectiveMetricSort && metricQuery.isFetchNextPageError
+      ? visibleSkills.length
+      : totalCount;
+  const totalPages = Math.ceil(paginationCount / RESULT_PAGE_SIZE);
+  const query = effectiveMetricSort ? metricQuery : pageQuery;
   const isEmptyProject =
     !!query.data && totalCount === 0 && !active && !query.isFetching;
   const draining =
-    metricSort && metricQuery.hasNextPage && !metricQuery.isFetchNextPageError;
+    effectiveMetricSort &&
+    metricQuery.hasNextPage &&
+    !metricQuery.isFetchNextPageError;
   const resetPage = () => {
     setPage(0);
     setPageCursors([undefined]);
   };
   const nextPage = () => {
-    if (metricSort) {
+    if (effectiveMetricSort) {
       setPage((current) => current + 1);
       return;
     }
@@ -420,7 +439,7 @@ export default function SkillsList(): JSX.Element {
                   <Page.Toolbar.Refresh
                     onRefresh={() => {
                       void Promise.all([
-                        metricSort
+                        effectiveMetricSort
                           ? metricQuery.refetch()
                           : pageQuery.refetch(),
                         insightsQuery.refetch(),
@@ -507,13 +526,13 @@ export default function SkillsList(): JSX.Element {
                     className="min-w-[1100px]"
                     noResultsMessage={noResultsMessage(
                       active,
-                      metricSort && metricQuery.isFetchNextPageError,
+                      effectiveMetricSort && metricQuery.isFetchNextPageError,
                     )}
                   />
                 </div>
               )}
 
-              {metricSort && metricQuery.isFetchNextPageError && (
+              {effectiveMetricSort && metricQuery.isFetchNextPageError && (
                 <LoadMoreError
                   onRetry={() => void metricQuery.fetchNextPage()}
                 />

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -10,8 +10,15 @@ import { Type } from "@/components/ui/type";
 import { useProject } from "@/contexts/Auth";
 import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
 import type { Skill } from "@gram/client/models/components/skill.js";
+import type {
+  Classifications,
+  SourceKinds,
+} from "@gram/client/models/operations/listskills.js";
 import { useSkillEfficacyInsights } from "@gram/client/react-query/skillEfficacyInsights.js";
-import { useSkillsInfinite } from "@gram/client/react-query/skills.js";
+import {
+  useSkills,
+  useSkillsInfinite,
+} from "@gram/client/react-query/skills.js";
 import { Badge, type Column, Icon, Table } from "@speakeasy-api/moonshine";
 import { useRoutes } from "@/routes";
 import { useQueryState } from "nuqs";
@@ -26,12 +33,7 @@ import {
   SKILL_SOURCE_OPTIONS,
 } from "./skill-badge-options";
 import { SkillClassificationBadge, SkillSourceBadge } from "./skill-badges";
-import {
-  filterSkills,
-  skillCountLabel,
-  type SkillSort,
-  sortSkills,
-} from "./skills-list-helpers";
+import { type SkillSort, sortSkills } from "./skills-list-helpers";
 import { UnknownSkillActivationsSection } from "./UnknownSkillActivationsSection";
 import { useDrainSkillPages } from "./use-drain-skill-pages";
 import { useOpenSkillSuggestions } from "./use-open-skill-suggestions";
@@ -51,7 +53,9 @@ const FILTER_OPTIONS = {
   classification: SKILL_CLASSIFICATION_OPTIONS,
 };
 
-const RESULT_PAGE_SIZE = 200;
+const RESULT_PAGE_SIZE = 50;
+const METRIC_SORT_BATCH_SIZE = 200;
+const EMPTY_SKILLS: Skill[] = [];
 const INSIGHT_SORT_OPTIONS = [
   { value: "updated", label: "Recently updated" },
   { value: "activations", label: "Most activated" },
@@ -68,12 +72,7 @@ function formatSavings(minutes: number): string {
   return `${(minutes / 60).toFixed(1)} hr`;
 }
 
-function noResultsMessage(
-  draining: boolean,
-  active: boolean,
-  incomplete: boolean,
-): string {
-  if (draining) return "Loading remaining skills...";
+function noResultsMessage(active: boolean, incomplete: boolean): string {
   if (incomplete) return "Search incomplete. Retry to check remaining skills.";
   if (active) return "No matching skills.";
   return "No skills yet.";
@@ -90,18 +89,56 @@ export default function SkillsList(): JSX.Element {
   // Legacy deep links opened the skill as a sheet via ?skill=<id>; redirect
   // them to the dedicated detail page.
   const [legacySkillId] = useQueryState("skill");
-  const [displayCount, setDisplayCount] = useState(RESULT_PAGE_SIZE);
-  const query = useSkillsInfinite({ limit: 200 }, undefined, {
-    throwOnError: false,
-  });
-  const skills = useMemo(
-    () => query.data?.pages.flatMap((page) => page.result.skills) ?? [],
-    [query.data?.pages],
+  const [page, setPage] = useState(0);
+  const [pageCursors, setPageCursors] = useState<(string | undefined)[]>([
+    undefined,
+  ]);
+  const metricSort = sort !== "updated";
+  const searchQuery = deferredSearch.trim() || undefined;
+  const sourceKinds = filters.values.sourceKind as SourceKinds[];
+  const classifications = filters.values.classification as Classifications[];
+  const pageQuery = useSkills(
+    {
+      cursor: pageCursors[page],
+      limit: RESULT_PAGE_SIZE,
+      search: searchQuery,
+      sourceKinds,
+      classifications,
+      sort: "updated",
+    },
+    undefined,
+    { throwOnError: false, enabled: !metricSort },
   );
-  const insightsQuery = useSkillEfficacyInsights({}, undefined, {
-    throwOnError: false,
-    enabled: skills.length > 0,
-  });
+  const metricQuery = useSkillsInfinite(
+    {
+      limit: METRIC_SORT_BATCH_SIZE,
+      search: searchQuery,
+      sourceKinds,
+      classifications,
+    },
+    undefined,
+    {
+      throwOnError: false,
+      enabled: metricSort,
+    },
+  );
+  const metricSkills = useMemo(
+    () =>
+      metricQuery.data?.pages.flatMap((skillPage) => skillPage.result.skills) ??
+      [],
+    [metricQuery.data?.pages],
+  );
+  const skills = metricSort
+    ? metricSkills
+    : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
+  const insightsQuery = useSkillEfficacyInsights(
+    metricSort ? {} : { skillIds: skills.map((skill) => skill.id) },
+    undefined,
+    {
+      throwOnError: false,
+      enabled: skills.length > 0,
+    },
+  );
   const openSuggestions = useOpenSkillSuggestions();
   const metricsBySkill = useMemo(
     () =>
@@ -121,37 +158,47 @@ export default function SkillsList(): JSX.Element {
   const effectiveSort = insightsUnavailable ? "updated" : sort;
   const visibleSkills = useMemo(
     () =>
-      sortSkills(
-        filterSkills(
-          skills,
-          deferredSearch,
-          filters.values.sourceKind,
-          filters.values.classification,
-        ),
-        metricsBySkill,
-        effectiveSort,
-      ),
-    [
-      deferredSearch,
-      filters.values.classification,
-      filters.values.sourceKind,
-      metricsBySkill,
-      skills,
-      effectiveSort,
-    ],
+      metricSort ? sortSkills(skills, metricsBySkill, effectiveSort) : skills,
+    [effectiveSort, metricSort, metricsBySkill, skills],
   );
 
   useDrainSkillPages({
-    active: true,
-    hasNextPage: query.hasNextPage,
-    isFetchingNextPage: query.isFetchingNextPage,
-    isFetchNextPageError: query.isFetchNextPageError,
-    fetchNextPage: query.fetchNextPage,
+    active: metricSort,
+    hasNextPage: metricQuery.hasNextPage,
+    isFetchingNextPage: metricQuery.isFetchingNextPage,
+    isFetchNextPageError: metricQuery.isFetchNextPageError,
+    fetchNextPage: metricQuery.fetchNextPage,
   });
 
-  const displayedSkills = visibleSkills.slice(0, displayCount);
+  const displayedSkills = metricSort
+    ? visibleSkills.slice(
+        page * RESULT_PAGE_SIZE,
+        (page + 1) * RESULT_PAGE_SIZE,
+      )
+    : visibleSkills;
+  const totalCount = metricSort
+    ? (metricQuery.data?.pages[0]?.result.totalCount ?? 0)
+    : (pageQuery.data?.result.totalCount ?? 0);
+  const totalPages = Math.ceil(totalCount / RESULT_PAGE_SIZE);
+  const query = metricSort ? metricQuery : pageQuery;
   const isEmptyProject =
-    !!query.data && skills.length === 0 && !active && !query.hasNextPage;
+    !!query.data && totalCount === 0 && !active && !query.isFetching;
+  const draining =
+    metricSort && metricQuery.hasNextPage && !metricQuery.isFetchNextPageError;
+  const resetPage = () => {
+    setPage(0);
+    setPageCursors([undefined]);
+  };
+  const nextPage = () => {
+    if (metricSort) {
+      setPage((current) => current + 1);
+      return;
+    }
+    const nextCursor = pageQuery.data?.result.nextCursor;
+    if (!nextCursor) return;
+    setPageCursors((current) => [...current.slice(0, page + 1), nextCursor]);
+    setPage((current) => current + 1);
+  };
 
   const columns: Column<Skill>[] = [
     {
@@ -299,14 +346,7 @@ export default function SkillsList(): JSX.Element {
     },
   ];
 
-  const countLabel = skillCountLabel({
-    active,
-    hasNextPage: query.hasNextPage,
-    incomplete: query.isFetchNextPageError,
-    loadedCount: skills.length,
-    resultCount: visibleSkills.length,
-  });
-  const draining = query.hasNextPage && !query.isFetchNextPageError;
+  const countLabel = `${totalCount} skill${totalCount === 1 ? "" : "s"}`;
 
   if (legacySkillId) {
     return <Navigate to={routes.skills.detail.href(legacySkillId)} replace />;
@@ -334,7 +374,7 @@ export default function SkillsList(): JSX.Element {
                     value={search}
                     onChange={(value) => {
                       setSearch(value);
-                      setDisplayCount(RESULT_PAGE_SIZE);
+                      resetPage();
                     }}
                     debounceMs={150}
                     placeholder="Search skills"
@@ -350,15 +390,15 @@ export default function SkillsList(): JSX.Element {
                           value: FilterValue,
                         ) => void
                       )(id, value);
-                      setDisplayCount(RESULT_PAGE_SIZE);
+                      resetPage();
                     }}
                     onClear={(id) => {
                       (filters.clearValue as (id: string) => void)(id);
-                      setDisplayCount(RESULT_PAGE_SIZE);
+                      resetPage();
                     }}
                     onClearAll={() => {
                       filters.clearAll();
-                      setDisplayCount(RESULT_PAGE_SIZE);
+                      resetPage();
                     }}
                   />
                   <Page.Toolbar.Count>{countLabel}</Page.Toolbar.Count>
@@ -366,7 +406,7 @@ export default function SkillsList(): JSX.Element {
                     value={effectiveSort}
                     onChange={(value) => {
                       setSort(value as SkillSort);
-                      setDisplayCount(RESULT_PAGE_SIZE);
+                      resetPage();
                     }}
                     options={INSIGHT_SORT_OPTIONS}
                   />
@@ -380,13 +420,16 @@ export default function SkillsList(): JSX.Element {
                   <Page.Toolbar.Refresh
                     onRefresh={() => {
                       void Promise.all([
-                        query.refetch(),
+                        metricSort
+                          ? metricQuery.refetch()
+                          : pageQuery.refetch(),
                         insightsQuery.refetch(),
                         openSuggestions.query.refetch(),
                       ]);
                     }}
                     isRefreshing={
-                      (query.isFetching && !query.isFetchingNextPage) ||
+                      pageQuery.isFetching ||
+                      metricQuery.isFetching ||
                       insightsQuery.isFetching ||
                       openSuggestions.query.isFetching
                     }
@@ -463,28 +506,44 @@ export default function SkillsList(): JSX.Element {
                     }
                     className="min-w-[1100px]"
                     noResultsMessage={noResultsMessage(
-                      draining,
                       active,
-                      query.isFetchNextPageError,
+                      metricSort && metricQuery.isFetchNextPageError,
                     )}
                   />
                 </div>
               )}
 
-              {query.isFetchNextPageError && (
-                <LoadMoreError onRetry={() => void query.fetchNextPage()} />
+              {metricSort && metricQuery.isFetchNextPageError && (
+                <LoadMoreError
+                  onRetry={() => void metricQuery.fetchNextPage()}
+                />
               )}
 
-              {!draining && displayedSkills.length < visibleSkills.length && (
-                <div className="flex justify-center">
-                  <Button
-                    variant="outline"
-                    onClick={() =>
-                      setDisplayCount((count) => count + RESULT_PAGE_SIZE)
-                    }
-                  >
-                    Show more results
-                  </Button>
+              {!draining && totalPages > 1 && (
+                <div className="flex items-center justify-between border-t px-4 py-3">
+                  <Type small muted>
+                    {page * RESULT_PAGE_SIZE + 1}-
+                    {Math.min((page + 1) * RESULT_PAGE_SIZE, totalCount)} of{" "}
+                    {totalCount}
+                  </Type>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setPage((current) => current - 1)}
+                      disabled={page === 0}
+                    >
+                      Previous
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={nextPage}
+                      disabled={page >= totalPages - 1}
+                    >
+                      Next
+                    </Button>
+                  </div>
                 </div>
               )}
 

--- a/client/dashboard/src/pages/skills/skills-list-helpers.ts
+++ b/client/dashboard/src/pages/skills/skills-list-helpers.ts
@@ -67,25 +67,3 @@ export function sortSkills(
     return difference || left.displayName.localeCompare(right.displayName);
   });
 }
-
-export function skillCountLabel({
-  active,
-  hasNextPage,
-  incomplete,
-  loadedCount,
-  resultCount,
-}: {
-  active: boolean;
-  hasNextPage: boolean;
-  incomplete: boolean;
-  loadedCount: number;
-  resultCount: number;
-}): string {
-  if (active && incomplete) {
-    return `${resultCount} matching loaded`;
-  }
-  if (hasNextPage) {
-    return active ? `Searching ${loadedCount} loaded` : `${loadedCount} loaded`;
-  }
-  return `${resultCount} skill${resultCount === 1 ? "" : "s"}`;
-}

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -5959,9 +5959,10 @@ examples:
       parameters:
         query:
           limit: 50
+          sort: "name"
       responses:
         "200":
-          application/json: {"skills": [{"classification": "<value>", "created_at": "2025-12-01T14:04:14.090Z", "display_name": "Ted_Medhurst44", "has_valid_version": false, "id": "a629e09f-919e-4d88-8c05-cebb47ad66a9", "latest_version_id": "77214f80-c570-4870-b5c3-21f19e9fee9e", "name": "<value>", "project_id": "e35c924f-8388-4d55-a06c-1f5093920091", "seen_count": 708579, "source_kind": "<value>", "updated_at": "2025-12-29T20:39:39.995Z", "version_count": 665804}]}
+          application/json: {"skills": [{"classification": "<value>", "created_at": "2025-12-01T14:04:14.090Z", "display_name": "Ted_Medhurst44", "has_valid_version": false, "id": "a629e09f-919e-4d88-8c05-cebb47ad66a9", "latest_version_id": "77214f80-c570-4870-b5c3-21f19e9fee9e", "name": "<value>", "project_id": "e35c924f-8388-4d55-a06c-1f5093920091", "seen_count": 708579, "source_kind": "<value>", "updated_at": "2025-12-29T20:39:39.995Z", "version_count": 665804}], "total_count": 708579}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": true}
         "500":

--- a/client/dashboard/src/sdk/src/funcs/skillsList.ts
+++ b/client/dashboard/src/sdk/src/funcs/skillsList.ts
@@ -117,8 +117,12 @@ async function $do(
   const path = pathToFunc("/rpc/skills.list")();
 
   const query = encodeFormQuery({
+    "classifications": payload?.classifications,
     "cursor": payload?.cursor,
     "limit": payload?.limit,
+    "search": payload?.search,
+    "sort": payload?.sort,
+    "source_kinds": payload?.source_kinds,
   });
 
   const headers = new Headers(compactMap({

--- a/client/dashboard/src/sdk/src/models/components/listskillsresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/listskillsresult.ts
@@ -21,6 +21,10 @@ export type ListSkillsResult = {
    * The active skills in this page.
    */
   skills: Array<Skill>;
+  /**
+   * The total number of active skills matching the filters.
+   */
+  totalCount: number;
 };
 
 /** @internal */
@@ -31,10 +35,12 @@ export const ListSkillsResult$inboundSchema: z.ZodMiniType<
   z.object({
     next_cursor: z.optional(z.string()),
     skills: z.array(Skill$inboundSchema),
+    total_count: z.int(),
   }),
   z.transform((v) => {
     return remap$(v, {
       "next_cursor": "nextCursor",
+      "total_count": "totalCount",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/models/operations/listskills.ts
+++ b/client/dashboard/src/sdk/src/models/operations/listskills.ts
@@ -5,6 +5,7 @@
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
 import { safeParse } from "../../lib/schemas.js";
+import { ClosedEnum } from "../../types/enums.js";
 import { Result as SafeParseResult } from "../../types/fp.js";
 import {
   ListSkillsResult,
@@ -27,6 +28,30 @@ export type ListSkillsSecurity = {
   option2?: ListSkillsSecurityOption2 | undefined;
 };
 
+export const SourceKinds = {
+  Manual: "manual",
+  Captured: "captured",
+} as const;
+export type SourceKinds = ClosedEnum<typeof SourceKinds>;
+
+export const Classifications = {
+  Custom: "custom",
+  BuiltIn: "built_in",
+} as const;
+export type Classifications = ClosedEnum<typeof Classifications>;
+
+/**
+ * How to order skills.
+ */
+export const Sort = {
+  Name: "name",
+  Updated: "updated",
+} as const;
+/**
+ * How to order skills.
+ */
+export type Sort = ClosedEnum<typeof Sort>;
+
 export type ListSkillsRequest = {
   /**
    * Cursor for the next page of skills.
@@ -36,6 +61,22 @@ export type ListSkillsRequest = {
    * The number of skills to return per page.
    */
   limit?: number | undefined;
+  /**
+   * Search skill names, display names, and summaries.
+   */
+  search?: string | undefined;
+  /**
+   * Only return skills from these sources.
+   */
+  sourceKinds?: Array<SourceKinds> | undefined;
+  /**
+   * Only return skills with these classifications.
+   */
+  classifications?: Array<Classifications> | undefined;
+  /**
+   * How to order skills.
+   */
+  sort?: Sort | undefined;
   /**
    * Session header
    */
@@ -148,9 +189,25 @@ export function listSkillsSecurityToJSON(
 }
 
 /** @internal */
+export const SourceKinds$outboundSchema: z.ZodMiniEnum<typeof SourceKinds> = z
+  .enum(SourceKinds);
+
+/** @internal */
+export const Classifications$outboundSchema: z.ZodMiniEnum<
+  typeof Classifications
+> = z.enum(Classifications);
+
+/** @internal */
+export const Sort$outboundSchema: z.ZodMiniEnum<typeof Sort> = z.enum(Sort);
+
+/** @internal */
 export type ListSkillsRequest$Outbound = {
   cursor?: string | undefined;
   limit: number;
+  search?: string | undefined;
+  source_kinds?: Array<string> | undefined;
+  classifications?: Array<string> | undefined;
+  sort: string;
   "Gram-Session"?: string | undefined;
   "Gram-Key"?: string | undefined;
   "Gram-Project"?: string | undefined;
@@ -164,12 +221,17 @@ export const ListSkillsRequest$outboundSchema: z.ZodMiniType<
   z.object({
     cursor: z.optional(z.string()),
     limit: z._default(z.int(), 50),
+    search: z.optional(z.string()),
+    sourceKinds: z.optional(z.array(SourceKinds$outboundSchema)),
+    classifications: z.optional(z.array(Classifications$outboundSchema)),
+    sort: z._default(Sort$outboundSchema, "name"),
     gramSession: z.optional(z.string()),
     gramKey: z.optional(z.string()),
     gramProject: z.optional(z.string()),
   }),
   z.transform((v) => {
     return remap$(v, {
+      sourceKinds: "source_kinds",
       gramSession: "Gram-Session",
       gramKey: "Gram-Key",
       gramProject: "Gram-Project",

--- a/client/dashboard/src/sdk/src/react-query/skills.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/skills.core.ts
@@ -12,9 +12,12 @@ import { skillsList } from "../funcs/skillsList.js";
 import { combineSignals } from "../lib/primitives.js";
 import { RequestOptions } from "../lib/sdks.js";
 import {
+  Classifications,
   ListSkillsRequest,
   ListSkillsResponse,
   ListSkillsSecurity,
+  Sort,
+  SourceKinds,
 } from "../models/operations/listskills.js";
 import { unwrapAsync } from "../types/fp.js";
 import { PageIterator, unwrapResultIterator } from "../types/operations.js";
@@ -81,6 +84,10 @@ export function buildSkillsQuery(
     queryKey: queryKeySkills({
       cursor: request?.cursor,
       limit: request?.limit,
+      search: request?.search,
+      sourceKinds: request?.sourceKinds,
+      classifications: request?.classifications,
+      sort: request?.sort,
       gramSession: request?.gramSession,
       gramKey: request?.gramKey,
       gramProject: request?.gramProject,
@@ -122,6 +129,10 @@ export function buildSkillsInfiniteQuery(
     queryKey: queryKeySkillsInfinite({
       cursor: request?.cursor,
       limit: request?.limit,
+      search: request?.search,
+      sourceKinds: request?.sourceKinds,
+      classifications: request?.classifications,
+      sort: request?.sort,
       gramSession: request?.gramSession,
       gramKey: request?.gramKey,
       gramProject: request?.gramProject,
@@ -160,6 +171,10 @@ export function queryKeySkills(
   parameters: {
     cursor?: string | undefined;
     limit?: number | undefined;
+    search?: string | undefined;
+    sourceKinds?: Array<SourceKinds> | undefined;
+    classifications?: Array<Classifications> | undefined;
+    sort?: Sort | undefined;
     gramSession?: string | undefined;
     gramKey?: string | undefined;
     gramProject?: string | undefined;
@@ -172,6 +187,10 @@ export function queryKeySkillsInfinite(
   parameters: {
     cursor?: string | undefined;
     limit?: number | undefined;
+    search?: string | undefined;
+    sourceKinds?: Array<SourceKinds> | undefined;
+    classifications?: Array<Classifications> | undefined;
+    sort?: Sort | undefined;
     gramSession?: string | undefined;
     gramKey?: string | undefined;
     gramProject?: string | undefined;

--- a/client/dashboard/src/sdk/src/react-query/skills.ts
+++ b/client/dashboard/src/sdk/src/react-query/skills.ts
@@ -28,8 +28,11 @@ import { ResponseValidationError } from "../models/errors/responsevalidationerro
 import { SDKValidationError } from "../models/errors/sdkvalidationerror.js";
 import { ServiceError } from "../models/errors/serviceerror.js";
 import {
+  Classifications,
   ListSkillsRequest,
   ListSkillsSecurity,
+  Sort,
+  SourceKinds,
 } from "../models/operations/listskills.js";
 import { useGramContext } from "./_context.js";
 import {
@@ -196,6 +199,10 @@ export function setSkillsData(
     parameters: {
       cursor?: string | undefined;
       limit?: number | undefined;
+      search?: string | undefined;
+      sourceKinds?: Array<SourceKinds> | undefined;
+      classifications?: Array<Classifications> | undefined;
+      sort?: Sort | undefined;
       gramSession?: string | undefined;
       gramKey?: string | undefined;
       gramProject?: string | undefined;
@@ -214,6 +221,10 @@ export function invalidateSkills(
     [parameters: {
       cursor?: string | undefined;
       limit?: number | undefined;
+      search?: string | undefined;
+      sourceKinds?: Array<SourceKinds> | undefined;
+      classifications?: Array<Classifications> | undefined;
+      sort?: Sort | undefined;
       gramSession?: string | undefined;
       gramKey?: string | undefined;
       gramProject?: string | undefined;

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -141,6 +141,13 @@ var _ = Service("skills", func() {
 				Minimum(1)
 				Maximum(200)
 			})
+			Attribute("search", String, "Search skill names, display names, and summaries.", func() { MaxLength(256) })
+			Attribute("source_kinds", ArrayOf(String, func() { Enum("manual", "captured") }), "Only return skills from these sources.")
+			Attribute("classifications", ArrayOf(String, func() { Enum("custom", "built_in") }), "Only return skills with these classifications.")
+			Attribute("sort", String, "How to order skills.", func() {
+				Enum("name", "updated")
+				Default("name")
+			})
 			security.SessionPayload()
 			security.ByKeyPayload()
 			security.ProjectPayload()
@@ -152,6 +159,10 @@ var _ = Service("skills", func() {
 			GET("/rpc/skills.list")
 			Param("cursor")
 			Param("limit")
+			Param("search")
+			Param("source_kinds")
+			Param("classifications")
+			Param("sort")
 			security.SessionHeader()
 			security.ByKeyHeader()
 			security.ProjectHeader()
@@ -1113,8 +1124,9 @@ var ListSkillsResult = Type("ListSkillsResult", func() {
 	Description("A page of active project skills.")
 
 	Attribute("skills", ArrayOf(Skill), "The active skills in this page.")
+	Attribute("total_count", Int64, "The total number of active skills matching the filters.")
 	Attribute("next_cursor", String, "Cursor for the next page; absent when exhausted.")
-	Required("skills")
+	Required("skills", "total_count")
 })
 
 var ListSkillVersionsResult = Type("ListSkillVersionsResult", func() {

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -2262,6 +2262,10 @@ func ParseEndpoint(
 		skillsListFlags                = flag.NewFlagSet("list", flag.ExitOnError)
 		skillsListCursorFlag           = skillsListFlags.String("cursor", "", "")
 		skillsListLimitFlag            = skillsListFlags.String("limit", "50", "")
+		skillsListSearchFlag           = skillsListFlags.String("search", "", "")
+		skillsListSourceKindsFlag      = skillsListFlags.String("source-kinds", "", "")
+		skillsListClassificationsFlag  = skillsListFlags.String("classifications", "", "")
+		skillsListSortFlag             = skillsListFlags.String("sort", "name", "")
 		skillsListSessionTokenFlag     = skillsListFlags.String("session-token", "", "")
 		skillsListApikeyTokenFlag      = skillsListFlags.String("apikey-token", "", "")
 		skillsListProjectSlugInputFlag = skillsListFlags.String("project-slug-input", "", "")
@@ -6878,7 +6882,7 @@ func ParseEndpoint(
 				data, err = skillsc.BuildUpdatePayload(*skillsUpdateBodyFlag, *skillsUpdateSessionTokenFlag, *skillsUpdateApikeyTokenFlag, *skillsUpdateProjectSlugInputFlag)
 			case "list":
 				endpoint = c.List()
-				data, err = skillsc.BuildListPayload(*skillsListCursorFlag, *skillsListLimitFlag, *skillsListSessionTokenFlag, *skillsListApikeyTokenFlag, *skillsListProjectSlugInputFlag)
+				data, err = skillsc.BuildListPayload(*skillsListCursorFlag, *skillsListLimitFlag, *skillsListSearchFlag, *skillsListSourceKindsFlag, *skillsListClassificationsFlag, *skillsListSortFlag, *skillsListSessionTokenFlag, *skillsListApikeyTokenFlag, *skillsListProjectSlugInputFlag)
 			case "list-suggestions":
 				endpoint = c.ListSuggestions()
 				data, err = skillsc.BuildListSuggestionsPayload(*skillsListSuggestionsSkillIDFlag, *skillsListSuggestionsCursorFlag, *skillsListSuggestionsLimitFlag, *skillsListSuggestionsSessionTokenFlag, *skillsListSuggestionsApikeyTokenFlag, *skillsListSuggestionsProjectSlugInputFlag)
@@ -16617,6 +16621,10 @@ func skillsListUsage() {
 	fmt.Fprintf(os.Stderr, "%s [flags] skills list", os.Args[0])
 	fmt.Fprint(os.Stderr, " -cursor STRING")
 	fmt.Fprint(os.Stderr, " -limit INT")
+	fmt.Fprint(os.Stderr, " -search STRING")
+	fmt.Fprint(os.Stderr, " -source-kinds JSON")
+	fmt.Fprint(os.Stderr, " -classifications JSON")
+	fmt.Fprint(os.Stderr, " -sort STRING")
 	fmt.Fprint(os.Stderr, " -session-token STRING")
 	fmt.Fprint(os.Stderr, " -apikey-token STRING")
 	fmt.Fprint(os.Stderr, " -project-slug-input STRING")
@@ -16629,13 +16637,17 @@ func skillsListUsage() {
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -cursor STRING: `)
 	fmt.Fprintln(os.Stderr, `    -limit INT: `)
+	fmt.Fprintln(os.Stderr, `    -search STRING: `)
+	fmt.Fprintln(os.Stderr, `    -source-kinds JSON: `)
+	fmt.Fprintln(os.Stderr, `    -classifications JSON: `)
+	fmt.Fprintln(os.Stderr, `    -sort STRING: `)
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
 	fmt.Fprintln(os.Stderr, `    -project-slug-input STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills list --cursor \"abc123\" --limit 2 --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skills list --cursor \"abc123\" --limit 2 --search \"aaa\" --source-kinds '[\n      \"captured\"\n   ]' --classifications '[\n      \"built_in\"\n   ]' --sort \"updated\" --session-token \"abc123\" --apikey-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 func skillsListSuggestionsUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -37086,6 +37086,49 @@ paths:
                     minimum: 1
                     type: integer
                 - allowEmptyValue: true
+                  description: Search skill names, display names, and summaries.
+                  in: query
+                  name: search
+                  schema:
+                    description: Search skill names, display names, and summaries.
+                    maxLength: 256
+                    type: string
+                - allowEmptyValue: true
+                  description: Only return skills from these sources.
+                  in: query
+                  name: source_kinds
+                  schema:
+                    description: Only return skills from these sources.
+                    items:
+                        enum:
+                            - manual
+                            - captured
+                        type: string
+                    type: array
+                - allowEmptyValue: true
+                  description: Only return skills with these classifications.
+                  in: query
+                  name: classifications
+                  schema:
+                    description: Only return skills with these classifications.
+                    items:
+                        enum:
+                            - custom
+                            - built_in
+                        type: string
+                    type: array
+                - allowEmptyValue: true
+                  description: How to order skills.
+                  in: query
+                  name: sort
+                  schema:
+                    default: name
+                    description: How to order skills.
+                    enum:
+                        - name
+                        - updated
+                    type: string
+                - allowEmptyValue: true
                   description: Session header
                   in: header
                   name: Gram-Session
@@ -57866,9 +57909,14 @@ components:
                     items:
                         $ref: '#/components/schemas/Skill'
                     description: The active skills in this page.
+                total_count:
+                    type: integer
+                    description: The total number of active skills matching the filters.
+                    format: int64
             description: A page of active project skills.
             required:
                 - skills
+                - total_count
         ListSourcesResult:
             type: object
             properties:

--- a/server/gen/http/skills/client/cli.go
+++ b/server/gen/http/skills/client/cli.go
@@ -208,7 +208,7 @@ func BuildUpdatePayload(skillsUpdateBody string, skillsUpdateSessionToken string
 
 // BuildListPayload builds the payload for the skills list endpoint from CLI
 // flags.
-func BuildListPayload(skillsListCursor string, skillsListLimit string, skillsListSessionToken string, skillsListApikeyToken string, skillsListProjectSlugInput string) (*skills.ListPayload, error) {
+func BuildListPayload(skillsListCursor string, skillsListLimit string, skillsListSearch string, skillsListSourceKinds string, skillsListClassifications string, skillsListSort string, skillsListSessionToken string, skillsListApikeyToken string, skillsListProjectSlugInput string) (*skills.ListPayload, error) {
 	var err error
 	var cursor *string
 	{
@@ -236,6 +236,64 @@ func BuildListPayload(skillsListCursor string, skillsListLimit string, skillsLis
 			}
 		}
 	}
+	var search *string
+	{
+		if skillsListSearch != "" {
+			search = &skillsListSearch
+			if utf8.RuneCountInString(*search) > 256 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("search", *search, utf8.RuneCountInString(*search), 256, false))
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	var sourceKinds []string
+	{
+		if skillsListSourceKinds != "" {
+			err = json.Unmarshal([]byte(skillsListSourceKinds), &sourceKinds)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for sourceKinds, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"captured\"\n   ]'")
+			}
+			for _, e := range sourceKinds {
+				if !(e == "manual" || e == "captured") {
+					err = goa.MergeErrors(err, goa.InvalidEnumValueError("source_kinds[*]", e, []any{"manual", "captured"}))
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	var classifications []string
+	{
+		if skillsListClassifications != "" {
+			err = json.Unmarshal([]byte(skillsListClassifications), &classifications)
+			if err != nil {
+				return nil, fmt.Errorf("invalid JSON for classifications, \nerror: %s, \nexample of valid JSON:\n%s", err, "'[\n      \"built_in\"\n   ]'")
+			}
+			for _, e := range classifications {
+				if !(e == "custom" || e == "built_in") {
+					err = goa.MergeErrors(err, goa.InvalidEnumValueError("classifications[*]", e, []any{"custom", "built_in"}))
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	var sort string
+	{
+		if skillsListSort != "" {
+			sort = skillsListSort
+			if !(sort == "name" || sort == "updated") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("sort", sort, []any{"name", "updated"}))
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
 	var sessionToken *string
 	{
 		if skillsListSessionToken != "" {
@@ -257,6 +315,10 @@ func BuildListPayload(skillsListCursor string, skillsListLimit string, skillsLis
 	v := &skills.ListPayload{}
 	v.Cursor = cursor
 	v.Limit = limit
+	v.Search = search
+	v.SourceKinds = sourceKinds
+	v.Classifications = classifications
+	v.Sort = sort
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
 	v.ProjectSlugInput = projectSlugInput

--- a/server/gen/http/skills/client/encode_decode.go
+++ b/server/gen/http/skills/client/encode_decode.go
@@ -1028,6 +1028,16 @@ func EncodeListRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.R
 			values.Add("cursor", *p.Cursor)
 		}
 		values.Add("limit", fmt.Sprintf("%v", p.Limit))
+		if p.Search != nil {
+			values.Add("search", *p.Search)
+		}
+		for _, value := range p.SourceKinds {
+			values.Add("source_kinds", value)
+		}
+		for _, value := range p.Classifications {
+			values.Add("classifications", value)
+		}
+		values.Add("sort", p.Sort)
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -214,6 +214,8 @@ type UpdateResponseBody struct {
 type ListResponseBody struct {
 	// The active skills in this page.
 	Skills []*SkillResponseBody `form:"skills,omitempty" json:"skills,omitempty" xml:"skills,omitempty"`
+	// The total number of active skills matching the filters.
+	TotalCount *int64 `form:"total_count,omitempty" json:"total_count,omitempty" xml:"total_count,omitempty"`
 	// Cursor for the next page; absent when exhausted.
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
 }
@@ -5310,6 +5312,7 @@ func NewUpdateGatewayError(body *UpdateGatewayErrorResponseBody) *goa.ServiceErr
 // a HTTP "OK" response.
 func NewListSkillsResultOK(body *ListResponseBody) *skills.ListSkillsResult {
 	v := &skills.ListSkillsResult{
+		TotalCount: *body.TotalCount,
 		NextCursor: body.NextCursor,
 	}
 	v.Skills = make([]*types.Skill, len(body.Skills))
@@ -8239,6 +8242,9 @@ func ValidateUpdateResponseBody(body *UpdateResponseBody) (err error) {
 func ValidateListResponseBody(body *ListResponseBody) (err error) {
 	if body.Skills == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("skills", "body"))
+	}
+	if body.TotalCount == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("total_count", "body"))
 	}
 	for _, e := range body.Skills {
 		if e != nil {

--- a/server/gen/http/skills/server/encode_decode.go
+++ b/server/gen/http/skills/server/encode_decode.go
@@ -990,6 +990,10 @@ func DecodeListRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.De
 		var (
 			cursor           *string
 			limit            int
+			search           *string
+			sourceKinds      []string
+			classifications  []string
+			sort             string
 			sessionToken     *string
 			apikeyToken      *string
 			projectSlugInput *string
@@ -1018,6 +1022,36 @@ func DecodeListRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.De
 		if limit > 200 {
 			err = goa.MergeErrors(err, goa.InvalidRangeError("limit", limit, 200, false))
 		}
+		searchRaw := qp.Get("search")
+		if searchRaw != "" {
+			search = &searchRaw
+		}
+		if search != nil {
+			if utf8.RuneCountInString(*search) > 256 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("search", *search, utf8.RuneCountInString(*search), 256, false))
+			}
+		}
+		sourceKinds = qp["source_kinds"]
+		for _, e := range sourceKinds {
+			if !(e == "manual" || e == "captured") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("source_kinds[*]", e, []any{"manual", "captured"}))
+			}
+		}
+		classifications = qp["classifications"]
+		for _, e := range classifications {
+			if !(e == "custom" || e == "built_in") {
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("classifications[*]", e, []any{"custom", "built_in"}))
+			}
+		}
+		sortRaw := qp.Get("sort")
+		if sortRaw != "" {
+			sort = sortRaw
+		} else {
+			sort = "name"
+		}
+		if !(sort == "name" || sort == "updated") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("sort", sort, []any{"name", "updated"}))
+		}
 		sessionTokenRaw := r.Header.Get("Gram-Session")
 		if sessionTokenRaw != "" {
 			sessionToken = &sessionTokenRaw
@@ -1033,7 +1067,7 @@ func DecodeListRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.De
 		if err != nil {
 			return payload, err
 		}
-		payload = NewListPayload(cursor, limit, sessionToken, apikeyToken, projectSlugInput)
+		payload = NewListPayload(cursor, limit, search, sourceKinds, classifications, sort, sessionToken, apikeyToken, projectSlugInput)
 		if payload.SessionToken != nil {
 			if strings.Contains(*payload.SessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -216,6 +216,8 @@ type UpdateResponseBody struct {
 type ListResponseBody struct {
 	// The active skills in this page.
 	Skills []*SkillResponseBody `form:"skills" json:"skills" xml:"skills"`
+	// The total number of active skills matching the filters.
+	TotalCount int64 `form:"total_count" json:"total_count" xml:"total_count"`
 	// Cursor for the next page; absent when exhausted.
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
 }
@@ -4600,6 +4602,7 @@ func NewUpdateResponseBody(res *types.Skill) *UpdateResponseBody {
 // "list" endpoint of the "skills" service.
 func NewListResponseBody(res *skills.ListSkillsResult) *ListResponseBody {
 	body := &ListResponseBody{
+		TotalCount: res.TotalCount,
 		NextCursor: res.NextCursor,
 	}
 	if res.Skills != nil {
@@ -7928,10 +7931,14 @@ func NewUpdatePayload(body *UpdateRequestBody, sessionToken *string, apikeyToken
 }
 
 // NewListPayload builds a skills service list endpoint payload.
-func NewListPayload(cursor *string, limit int, sessionToken *string, apikeyToken *string, projectSlugInput *string) *skills.ListPayload {
+func NewListPayload(cursor *string, limit int, search *string, sourceKinds []string, classifications []string, sort string, sessionToken *string, apikeyToken *string, projectSlugInput *string) *skills.ListPayload {
 	v := &skills.ListPayload{}
 	v.Cursor = cursor
 	v.Limit = limit
+	v.Search = search
+	v.SourceKinds = sourceKinds
+	v.Classifications = classifications
+	v.Sort = sort
 	v.SessionToken = sessionToken
 	v.ApikeyToken = apikeyToken
 	v.ProjectSlugInput = projectSlugInput

--- a/server/gen/skills/service.go
+++ b/server/gen/skills/service.go
@@ -284,7 +284,15 @@ type ListPayload struct {
 	// Cursor for the next page of skills.
 	Cursor *string
 	// The number of skills to return per page.
-	Limit            int
+	Limit int
+	// Search skill names, display names, and summaries.
+	Search *string
+	// Only return skills from these sources.
+	SourceKinds []string
+	// Only return skills with these classifications.
+	Classifications []string
+	// How to order skills.
+	Sort             string
 	SessionToken     *string
 	ApikeyToken      *string
 	ProjectSlugInput *string
@@ -339,6 +347,8 @@ type ListSkillVersionsResult struct {
 type ListSkillsResult struct {
 	// The active skills in this page.
 	Skills []*types.Skill
+	// The total number of active skills matching the filters.
+	TotalCount int64
 	// Cursor for the next page; absent when exhausted.
 	NextCursor *string
 }

--- a/server/internal/platformtools/skills/insights.go
+++ b/server/internal/platformtools/skills/insights.go
@@ -179,7 +179,10 @@ func (t *Insights) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload i
 			versionCreatedAt[version.ID] = version.CreatedAt
 		}
 	} else {
-		listed, err := t.skills.List(ctx, &genskills.ListPayload{Cursor: nil, Limit: 200, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+		listed, err := t.skills.List(ctx, &genskills.ListPayload{
+			Cursor: nil, Limit: 200, Search: nil, SourceKinds: nil, Classifications: nil, Sort: "name",
+			SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+		})
 		if err != nil {
 			return fmt.Errorf("list skills: %w", err)
 		}

--- a/server/internal/platformtools/skills/tools.go
+++ b/server/internal/platformtools/skills/tools.go
@@ -53,6 +53,10 @@ func (t *List) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Re
 	result, err := t.skills.List(ctx, &genskills.ListPayload{
 		Cursor:           input.Cursor,
 		Limit:            input.Limit,
+		Search:           nil,
+		SourceKinds:      nil,
+		Classifications:  nil,
+		Sort:             "name",
 		SessionToken:     nil,
 		ApikeyToken:      nil,
 		ProjectSlugInput: nil,

--- a/server/internal/skillefficacy/impl.go
+++ b/server/internal/skillefficacy/impl.go
@@ -122,7 +122,9 @@ func (s *Service) QueryInsights(ctx context.Context, payload *gen.QueryInsightsP
 	responseSkillIDs := skillIDs
 	if len(responseSkillIDs) == 0 {
 		activeSkills, err := skillsrepo.New(s.db).ListSkills(ctx, skillsrepo.ListSkillsParams{
-			ProjectID: *authCtx.ProjectID, CursorName: pgtype.Text{String: "", Valid: false}, PageLimit: math.MaxInt32,
+			ProjectID: *authCtx.ProjectID, Search: pgtype.Text{String: "", Valid: false}, SourceKinds: nil, Classifications: nil, SortOrder: "name",
+			CursorName: pgtype.Text{String: "", Valid: false}, CursorUpdatedAt: pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false},
+			CursorID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, PageLimit: math.MaxInt32,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "list active project skills").LogError(ctx, logger)

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -762,19 +762,40 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 		return nil, err
 	}
 
+	sortOrder := payload.Sort
+	if sortOrder == "" {
+		sortOrder = "name"
+	}
 	cursorName := pgtype.Text{String: "", Valid: false}
+	cursorUpdatedAt := pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}
+	cursorID := uuid.NullUUID{UUID: uuid.Nil, Valid: false}
 	if payload.Cursor != nil {
-		name, decodeErr := decodeSkillCursor(*payload.Cursor)
-		if decodeErr != nil {
-			return nil, oops.E(oops.CodeBadRequest, nil, "invalid skill cursor")
+		if sortOrder == "updated" {
+			updatedAt, id, decodeErr := decodeCreatedAtIDCursor(*payload.Cursor)
+			if decodeErr != nil {
+				return nil, oops.E(oops.CodeBadRequest, nil, "invalid skill cursor")
+			}
+			cursorUpdatedAt = conv.ToPGTimestamptz(updatedAt)
+			cursorID = uuid.NullUUID{UUID: id, Valid: true}
+		} else {
+			name, decodeErr := decodeSkillCursor(*payload.Cursor)
+			if decodeErr != nil {
+				return nil, oops.E(oops.CodeBadRequest, nil, "invalid skill cursor")
+			}
+			cursorName = conv.ToPGText(name)
 		}
-		cursorName = conv.ToPGText(name)
 	}
 
 	rows, err := repo.New(s.db).ListSkills(ctx, repo.ListSkillsParams{
-		ProjectID:  *authCtx.ProjectID,
-		CursorName: cursorName,
-		PageLimit:  conv.SafeInt32(payload.Limit + 1),
+		ProjectID:       *authCtx.ProjectID,
+		Search:          conv.PtrToPGTextEmpty(payload.Search),
+		SourceKinds:     payload.SourceKinds,
+		Classifications: payload.Classifications,
+		SortOrder:       sortOrder,
+		CursorName:      cursorName,
+		CursorUpdatedAt: cursorUpdatedAt,
+		CursorID:        cursorID,
+		PageLimit:       conv.SafeInt32(payload.Limit + 1),
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list skills").LogError(ctx, logger)
@@ -786,12 +807,21 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	}
 	var nextCursor *string
 	if hasMore {
-		encoded := encodeSkillCursor(rows[len(rows)-1].Skill.Name)
+		last := rows[len(rows)-1].Skill
+		encoded := encodeSkillCursor(last.Name)
+		if sortOrder == "updated" {
+			encoded = encodeCreatedAtIDCursor(last.UpdatedAt.Time, last.ID)
+		}
 		nextCursor = &encoded
+	}
+	totalCount := int64(0)
+	if len(rows) > 0 {
+		totalCount = rows[0].TotalCount
 	}
 
 	return &gen.ListSkillsResult{
 		Skills:     mv.BuildSkillListView(rows),
+		TotalCount: totalCount,
 		NextCursor: nextCursor,
 	}, nil
 }

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -786,7 +786,8 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 		}
 	}
 
-	rows, err := repo.New(s.db).ListSkills(ctx, repo.ListSkillsParams{
+	queries := repo.New(s.db)
+	rows, err := queries.ListSkills(ctx, repo.ListSkillsParams{
 		ProjectID:       *authCtx.ProjectID,
 		Search:          conv.PtrToPGTextEmpty(payload.Search),
 		SourceKinds:     payload.SourceKinds,
@@ -817,6 +818,16 @@ func (s *Service) List(ctx context.Context, payload *gen.ListPayload) (*gen.List
 	totalCount := int64(0)
 	if len(rows) > 0 {
 		totalCount = rows[0].TotalCount
+	} else {
+		totalCount, err = queries.CountSkills(ctx, repo.CountSkillsParams{
+			ProjectID:       *authCtx.ProjectID,
+			Search:          conv.PtrToPGTextEmpty(payload.Search),
+			SourceKinds:     payload.SourceKinds,
+			Classifications: payload.Classifications,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "count skills").LogError(ctx, logger)
+		}
 	}
 
 	return &gen.ListSkillsResult{

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -1250,6 +1250,8 @@ WHERE s.project_id = @project_id
   AND s.id = @skill_id
   AND s.archived_at IS NULL;
 
+-- CountSkills handles empty cursor pages. Keep its filters in sync with ListSkills
+-- so normal pages avoid a second query.
 -- name: CountSkills :one
 SELECT COUNT(*)
 FROM skills

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -1250,6 +1250,26 @@ WHERE s.project_id = @project_id
   AND s.id = @skill_id
   AND s.archived_at IS NULL;
 
+-- name: CountSkills :one
+SELECT COUNT(*)
+FROM skills
+WHERE project_id = @project_id
+  AND archived_at IS NULL
+  AND (
+    sqlc.narg(search)::text IS NULL
+    OR name ILIKE '%' || sqlc.narg(search)::text || '%'
+    OR display_name ILIKE '%' || sqlc.narg(search)::text || '%'
+    OR COALESCE(summary, '') ILIKE '%' || sqlc.narg(search)::text || '%'
+  )
+  AND (
+    COALESCE(cardinality(@source_kinds::text[]), 0) = 0
+    OR source_kind = ANY(@source_kinds::text[])
+  )
+  AND (
+    COALESCE(cardinality(@classifications::text[]), 0) = 0
+    OR classification = ANY(@classifications::text[])
+  );
+
 -- name: ListSkills :many
 SELECT
   sqlc.embed(s),

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -1259,7 +1259,27 @@ SELECT
   EXISTS (
     SELECT 1 FROM skill_versions sv
     WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
-  )::boolean AS has_valid_version
+  )::boolean AS has_valid_version,
+  (
+    SELECT COUNT(*)
+    FROM skills counted
+    WHERE counted.project_id = @project_id
+      AND counted.archived_at IS NULL
+      AND (
+        sqlc.narg(search)::text IS NULL
+        OR counted.name ILIKE '%' || sqlc.narg(search)::text || '%'
+        OR counted.display_name ILIKE '%' || sqlc.narg(search)::text || '%'
+        OR COALESCE(counted.summary, '') ILIKE '%' || sqlc.narg(search)::text || '%'
+      )
+      AND (
+        COALESCE(cardinality(@source_kinds::text[]), 0) = 0
+        OR counted.source_kind = ANY(@source_kinds::text[])
+      )
+      AND (
+        COALESCE(cardinality(@classifications::text[]), 0) = 0
+        OR counted.classification = ANY(@classifications::text[])
+      )
+  )::bigint AS total_count
 FROM skills s
 LEFT JOIN LATERAL (
   SELECT
@@ -1276,10 +1296,42 @@ LEFT JOIN skill_share_links l
 WHERE s.project_id = @project_id
   AND s.archived_at IS NULL
   AND (
-    sqlc.narg(cursor_name)::text IS NULL
-    OR s.name > sqlc.narg(cursor_name)::text
+    sqlc.narg(search)::text IS NULL
+    OR s.name ILIKE '%' || sqlc.narg(search)::text || '%'
+    OR s.display_name ILIKE '%' || sqlc.narg(search)::text || '%'
+    OR COALESCE(s.summary, '') ILIKE '%' || sqlc.narg(search)::text || '%'
   )
-ORDER BY s.name ASC
+  AND (
+    COALESCE(cardinality(@source_kinds::text[]), 0) = 0
+    OR s.source_kind = ANY(@source_kinds::text[])
+  )
+  AND (
+    COALESCE(cardinality(@classifications::text[]), 0) = 0
+    OR s.classification = ANY(@classifications::text[])
+  )
+  AND (
+    (
+      COALESCE(NULLIF(@sort_order::text, ''), 'name') = 'name'
+      AND (
+        sqlc.narg(cursor_name)::text IS NULL
+        OR s.name > sqlc.narg(cursor_name)::text
+      )
+    )
+    OR (
+      COALESCE(NULLIF(@sort_order::text, ''), 'name') = 'updated'
+      AND (
+        sqlc.narg(cursor_updated_at)::timestamptz IS NULL
+        OR (s.updated_at, s.id) < (
+          sqlc.narg(cursor_updated_at)::timestamptz,
+          sqlc.narg(cursor_id)::uuid
+        )
+      )
+    )
+  )
+ORDER BY
+  CASE WHEN COALESCE(NULLIF(@sort_order::text, ''), 'name') = 'name' THEN s.name END ASC,
+  CASE WHEN COALESCE(NULLIF(@sort_order::text, ''), 'name') = 'updated' THEN s.updated_at END DESC,
+  CASE WHEN COALESCE(NULLIF(@sort_order::text, ''), 'name') = 'updated' THEN s.id END DESC
 LIMIT @page_limit;
 
 -- name: ListSkillVersions :many

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -4499,7 +4499,27 @@ SELECT
   EXISTS (
     SELECT 1 FROM skill_versions sv
     WHERE sv.skill_id = s.id AND sv.spec_valid IS TRUE
-  )::boolean AS has_valid_version
+  )::boolean AS has_valid_version,
+  (
+    SELECT COUNT(*)
+    FROM skills counted
+    WHERE counted.project_id = $1
+      AND counted.archived_at IS NULL
+      AND (
+        $2::text IS NULL
+        OR counted.name ILIKE '%' || $2::text || '%'
+        OR counted.display_name ILIKE '%' || $2::text || '%'
+        OR COALESCE(counted.summary, '') ILIKE '%' || $2::text || '%'
+      )
+      AND (
+        COALESCE(cardinality($3::text[]), 0) = 0
+        OR counted.source_kind = ANY($3::text[])
+      )
+      AND (
+        COALESCE(cardinality($4::text[]), 0) = 0
+        OR counted.classification = ANY($4::text[])
+      )
+  )::bigint AS total_count
 FROM skills s
 LEFT JOIN LATERAL (
   SELECT
@@ -4517,16 +4537,54 @@ WHERE s.project_id = $1
   AND s.archived_at IS NULL
   AND (
     $2::text IS NULL
-    OR s.name > $2::text
+    OR s.name ILIKE '%' || $2::text || '%'
+    OR s.display_name ILIKE '%' || $2::text || '%'
+    OR COALESCE(s.summary, '') ILIKE '%' || $2::text || '%'
   )
-ORDER BY s.name ASC
-LIMIT $3
+  AND (
+    COALESCE(cardinality($3::text[]), 0) = 0
+    OR s.source_kind = ANY($3::text[])
+  )
+  AND (
+    COALESCE(cardinality($4::text[]), 0) = 0
+    OR s.classification = ANY($4::text[])
+  )
+  AND (
+    (
+      COALESCE(NULLIF($5::text, ''), 'name') = 'name'
+      AND (
+        $6::text IS NULL
+        OR s.name > $6::text
+      )
+    )
+    OR (
+      COALESCE(NULLIF($5::text, ''), 'name') = 'updated'
+      AND (
+        $7::timestamptz IS NULL
+        OR (s.updated_at, s.id) < (
+          $7::timestamptz,
+          $8::uuid
+        )
+      )
+    )
+  )
+ORDER BY
+  CASE WHEN COALESCE(NULLIF($5::text, ''), 'name') = 'name' THEN s.name END ASC,
+  CASE WHEN COALESCE(NULLIF($5::text, ''), 'name') = 'updated' THEN s.updated_at END DESC,
+  CASE WHEN COALESCE(NULLIF($5::text, ''), 'name') = 'updated' THEN s.id END DESC
+LIMIT $9
 `
 
 type ListSkillsParams struct {
-	ProjectID  uuid.UUID
-	CursorName pgtype.Text
-	PageLimit  int32
+	ProjectID       uuid.UUID
+	Search          pgtype.Text
+	SourceKinds     []string
+	Classifications []string
+	SortOrder       string
+	CursorName      pgtype.Text
+	CursorUpdatedAt pgtype.Timestamptz
+	CursorID        uuid.NullUUID
+	PageLimit       int32
 }
 
 type ListSkillsRow struct {
@@ -4535,10 +4593,21 @@ type ListSkillsRow struct {
 	LatestVersionID uuid.UUID
 	VersionCount    int64
 	HasValidVersion bool
+	TotalCount      int64
 }
 
 func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListSkillsRow, error) {
-	rows, err := q.db.Query(ctx, listSkills, arg.ProjectID, arg.CursorName, arg.PageLimit)
+	rows, err := q.db.Query(ctx, listSkills,
+		arg.ProjectID,
+		arg.Search,
+		arg.SourceKinds,
+		arg.Classifications,
+		arg.SortOrder,
+		arg.CursorName,
+		arg.CursorUpdatedAt,
+		arg.CursorID,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -4564,6 +4633,7 @@ func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListS
 			&i.LatestVersionID,
 			&i.VersionCount,
 			&i.HasValidVersion,
+			&i.TotalCount,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -592,6 +592,46 @@ func (q *Queries) CountSkillFeedbackOutcomes(ctx context.Context, arg CountSkill
 	return i, err
 }
 
+const countSkills = `-- name: CountSkills :one
+SELECT COUNT(*)
+FROM skills
+WHERE project_id = $1
+  AND archived_at IS NULL
+  AND (
+    $2::text IS NULL
+    OR name ILIKE '%' || $2::text || '%'
+    OR display_name ILIKE '%' || $2::text || '%'
+    OR COALESCE(summary, '') ILIKE '%' || $2::text || '%'
+  )
+  AND (
+    COALESCE(cardinality($3::text[]), 0) = 0
+    OR source_kind = ANY($3::text[])
+  )
+  AND (
+    COALESCE(cardinality($4::text[]), 0) = 0
+    OR classification = ANY($4::text[])
+  )
+`
+
+type CountSkillsParams struct {
+	ProjectID       uuid.UUID
+	Search          pgtype.Text
+	SourceKinds     []string
+	Classifications []string
+}
+
+func (q *Queries) CountSkills(ctx context.Context, arg CountSkillsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countSkills,
+		arg.ProjectID,
+		arg.Search,
+		arg.SourceKinds,
+		arg.Classifications,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countUnreviewedSkillFeedback = `-- name: CountUnreviewedSkillFeedback :one
 SELECT COUNT(*)
 FROM skill_feedback

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -620,6 +620,8 @@ type CountSkillsParams struct {
 	Classifications []string
 }
 
+// CountSkills handles empty cursor pages. Keep its filters in sync with ListSkills
+// so normal pages avoid a second query.
 func (q *Queries) CountSkills(ctx context.Context, arg CountSkillsParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countSkills,
 		arg.ProjectID,

--- a/server/internal/skills/service_test.go
+++ b/server/internal/skills/service_test.go
@@ -471,6 +471,56 @@ func TestSkillsPaginationAndInvalidCursors(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
 
+func TestSkillsListSearchFiltersAndUpdatedPagination(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	alpha := createSkill(t, ctx, ti, "alpha", "Alpha summary")
+	createSkill(t, ctx, ti, "bravo", "Bravo summary")
+	_, err := skillservice.CaptureSkillContent(ctx, ti.conn, ti.projectID, skillManifest("captured", "Captured summary", "body"))
+	require.NoError(t, err)
+	_, err = ti.service.Update(ctx, &gen.UpdatePayload{
+		ID: alpha.Skill.ID, Name: alpha.Skill.Name, DisplayName: "Alpha updated", Summary: alpha.Skill.Summary,
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	first, err := ti.service.List(ctx, &gen.ListPayload{
+		Cursor: nil, Limit: 1, Search: nil, SourceKinds: []string{"manual"}, Classifications: nil, Sort: "updated",
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), first.TotalCount)
+	require.Equal(t, "alpha", first.Skills[0].Name)
+	require.NotNil(t, first.NextCursor)
+
+	second, err := ti.service.List(ctx, &gen.ListPayload{
+		Cursor: first.NextCursor, Limit: 1, Search: nil, SourceKinds: []string{"manual"}, Classifications: nil, Sort: "updated",
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), second.TotalCount)
+	require.Equal(t, "bravo", second.Skills[0].Name)
+	require.Nil(t, second.NextCursor)
+
+	search := "bravo summary"
+	searched, err := ti.service.List(ctx, &gen.ListPayload{
+		Cursor: nil, Limit: 10, Search: &search, SourceKinds: nil, Classifications: nil, Sort: "name",
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), searched.TotalCount)
+	require.Equal(t, "bravo", searched.Skills[0].Name)
+
+	captured, err := ti.service.List(ctx, &gen.ListPayload{
+		Cursor: nil, Limit: 10, Search: nil, SourceKinds: []string{"captured"}, Classifications: []string{"custom"}, Sort: "name",
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), captured.TotalCount)
+	require.Equal(t, "captured", captured.Skills[0].Name)
+}
+
 func TestSkillsReadAndWriteRBACExpansion(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/skills/service_test.go
+++ b/server/internal/skills/service_test.go
@@ -476,7 +476,7 @@ func TestSkillsListSearchFiltersAndUpdatedPagination(t *testing.T) {
 
 	ctx, ti := newTestService(t)
 	alpha := createSkill(t, ctx, ti, "alpha", "Alpha summary")
-	createSkill(t, ctx, ti, "bravo", "Bravo summary")
+	bravo := createSkill(t, ctx, ti, "bravo", "Bravo summary")
 	_, err := skillservice.CaptureSkillContent(ctx, ti.conn, ti.projectID, skillManifest("captured", "Captured summary", "body"))
 	require.NoError(t, err)
 	_, err = ti.service.Update(ctx, &gen.UpdatePayload{
@@ -519,6 +519,18 @@ func TestSkillsListSearchFiltersAndUpdatedPagination(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(1), captured.TotalCount)
 	require.Equal(t, "captured", captured.Skills[0].Name)
+
+	err = ti.service.Archive(ctx, &gen.ArchivePayload{
+		ID: bravo.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	empty, err := ti.service.List(ctx, &gen.ListPayload{
+		Cursor: first.NextCursor, Limit: 1, Search: nil, SourceKinds: []string{"manual"}, Classifications: nil, Sort: "updated",
+		SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, empty.Skills)
+	require.Equal(t, int64(1), empty.TotalCount)
 }
 
 func TestSkillsReadAndWriteRBACExpansion(t *testing.T) {


### PR DESCRIPTION
## Summary

- paginate the Skills table through `skills.list` instead of draining every skill up front
- move search, source/classification filtering, updated sorting, and total counts to the server
- preserve exact ClickHouse metric sorting by draining only when a metric sort is selected
- fetch insights for the current page during normal pagination

[Linear: DNO-667](https://linear.app/speakeasy/issue/DNO-667)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated the Skills table with server-side search, filters, sorting, and total counts to cut load time and API usage. Metric sorts (e.g., activations) still drain all skills to preserve exact ClickHouse ordering. Addresses DNO-667.

- **New Features**
  - Server `skills.list`: added `search`, `source_kinds`, `classifications`, and `sort` (`name`|`updated`); returns `total_count` and `next_cursor`; supports name and updated-at+id cursors.
  - Dashboard: page-based fetch (50 per page) via `useSkills` with Previous/Next; server-side search/filters/sort; metric sorts drain via `useSkillsInfinite` in 200-item batches; insights queried only for the visible page during normal pagination.
  - OpenAPI/SDK/CLI: updated models and queries; `ListSkillsResult.total_count` is required; CLI `skills list` adds `--search`, `--source-kinds`, `--classifications`, `--sort`.

- **Bug Fixes**
  - Metric-drain failures: keep loaded rows visible, disable Next, show Retry; pagination counts fall back to loaded rows.
  - If insights are unavailable, automatically revert to `updated` sort and return to paginated mode.
  - Empty/search states no longer claim “no matches” while a search is incomplete.

<sup>Written for commit 10aca4264c8661e47f26f3f2a62c84e698594b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

