### PR TITLE
chore: codify NOT VALID constraint recipe in postgresql skill

### DIFF
--- a/.agents/skills/postgresql/SKILL.md
+++ b/.agents/skills/postgresql/SKILL.md
@@ -47,6 +47,7 @@ Reference these guidelines when:
   - Consider using partial indexes for specific query patterns.
   - Use appropriate index types (e.g., `B-tree`, `Hash`, `GIN`, `GiST`) based on the data and query requirements.
   - When a unique key exists mainly to be a foreign-key target (e.g. a composite `(organization_id, id)` key that a tenant-scoped child composite-FKs to for tenancy pinning), declare it as a `CREATE UNIQUE INDEX`, not a table-level `UNIQUE` constraint. Postgres accepts a non-partial, plain-column unique index as an FK target. This matters when adding the key to an existing table: `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE` takes an `ACCESS EXCLUSIVE` lock and builds the index synchronously, whereas a `CREATE UNIQUE INDEX` (which Atlas automatically emits as `CONCURRENTLY` per its `concurrent_index` policy) does not. Trade-off: a concurrent index makes the migration non-transactional (Atlas emits `-- atlas:txmode none` for you), so keep such migrations minimal.
+  - Adding a `CHECK` or `FOREIGN KEY` constraint to an existing table takes an `ACCESS EXCLUSIVE` lock while Postgres scans every existing row, blocking reads and writes for the duration. Atlas reports this as lint PG305 (`CHECK`) or PG306 (`FOREIGN KEY`) but has no diff policy that avoids it, so the online-safe two-step form has to be hand-written: see the `NOT VALID` recipe under Database migrations.
 
 - **Schema evolution:**
   - Use expand-contract pattern instead of removing existing columns from a schema. Introduce new columns instead when appropriate.
@@ -155,12 +156,37 @@ Gram uses [Atlas](https://atlasgo.io) in versioned mode. Two file kinds are invo
 Rules:
 
 - **Migrations ship in their own PR.** No application/business-logic code, no backfills, no unrelated changes alongside. Shipping migrations with business logic risks outages — the server can query a schema that has not rolled out yet — and makes the PR hard to revert.
-- **Migration files and `atlas.sum` are produced only by the Atlas CLI (`mise db:diff`).** Never hand-edit, rename, or rehash them.
+- **Migration files and `atlas.sum` are produced only by the Atlas CLI (`mise run db:diff`).** Never hand-edit, rename, or rehash them. There is exactly one sanctioned exception: the `NOT VALID` constraint pattern in the last rule below.
 - **Migration files contain only DDL — never DML.** Backfills and other data manipulation (`INSERT` / `UPDATE` / `DELETE`) do not belong in a migration file. Data migrations live in application code, not migrations.
 - **Follow expand-contract.** Never drop a column or table in the same migration that adds others. If a column is unwanted, mark it nullable with a comment and leave it for a later contract migration; sticking around for a few days is fine.
 - **Never run agents (or any tooling) against dev or prod databases.** Local databases only.
 - **Out-of-order timestamps:** if `mise lint:migrations` (or CI) reports a migration timestamp at or before the latest on `main`, do NOT rename the file. Delete the offending migration on your branch, rebase/merge `main`, then re-run `mise db:diff <name>` so the migration is regenerated on top with a fresh timestamp.
 - **Migration merge conflicts:** never resolve them by hand. Delete your migrations, rebase/merge `main`, then re-run `mise db:diff` so your changes are recreated on top.
+- **Adding a `CHECK` or `FOREIGN KEY` constraint to an existing table** triggers Atlas lint PG305 / PG306: the plain `ADD CONSTRAINT` scans the whole table under an `ACCESS EXCLUSIVE` lock, blocking reads and writes for the duration of the scan. Both are warnings and do not fail CI. Whether to avoid the scan is a question of table size and nothing else. A constraint over a column added in the same migration still triggers the same scan, it just cannot fail (unless that column has a `DEFAULT`, in which case existing rows are checked against the default value). For small or empty tables, accept the warning and say so in the PR description. For large or hot tables, use the two-step `NOT VALID` pattern:
+
+  1. Edit `server/database/schema.sql` and run `mise run db:diff <name>` as usual.
+  2. Append `NOT VALID` to each generated `ADD CONSTRAINT` clause in place, leaving Atlas's combined `ALTER TABLE` intact, then add one `ALTER TABLE ... VALIDATE CONSTRAINT ...;` statement per constraint after it. Do not break the generated `ALTER TABLE` into separate statements: each statement takes its own `ACCESS EXCLUSIVE` lock, and splitting a paired `DROP CONSTRAINT` / `ADD CONSTRAINT` opens a window where the table has no constraint at all.
+  3. Make `-- atlas:txmode none` the first line of the file. The two statements must not share a transaction: inside one transaction the `ACCESS EXCLUSIVE` lock taken by the `ADD` is held until commit, so the validation scan runs under the full lock anyway and the split gains nothing. `mise lint:migrations` enforces this directive.
+  4. Run `mise run db:hash` to re-hash `atlas.sum`. Until you do, every Atlas command fails on a checksum mismatch.
+
+  ```sql
+  -- atlas:txmode none
+
+  -- Atlas generates:
+  --   ALTER TABLE "t" ADD CONSTRAINT "t_x_check" CHECK (...), ADD COLUMN "y" text NULL;
+  ALTER TABLE "t" ADD CONSTRAINT "t_x_check" CHECK (...) NOT VALID, ADD COLUMN "y" text NULL;
+  ALTER TABLE "t" VALIDATE CONSTRAINT "t_x_check";
+  ```
+
+  The end state is identical to the one-step form, so later `mise run db:diff` runs see no drift (CI verifies this). `VALIDATE CONSTRAINT` scans under `SHARE UPDATE EXCLUSIVE`, which allows concurrent reads and writes.
+
+  Three things the pattern does not buy you:
+
+  - **`NOT VALID` does not mean unenforced.** It skips the scan of existing rows only. Every subsequent `INSERT` and `UPDATE` is checked immediately, including updates to rows that already violate the constraint. Because migrations ship ahead of application code, only add a constraint that currently deployed code already satisfies.
+  - **A failed validation is expensive to recover from.** Production applies migrations through the Atlas Operator, and agents may never touch dev or prod databases, so a failed `VALIDATE` blocks every later migration until someone repairs the data by hand. Confirm there are no violating rows before shipping instead of planning to fix them afterwards.
+  - **Regenerating the migration silently reverts the edit.** The out-of-order and merge-conflict rules above both regenerate the file, which brings back the plain one-step form. Re-apply steps 2 through 4 every time you regenerate.
+
+  A constraint declared inside a brand-new `CREATE TABLE` does not trigger PG305 / PG306 and needs no change.
 
 ## Writing queries with SQLc
 

--- a/.mise-tasks/lint/migrations.sh
+++ b/.mise-tasks/lint/migrations.sh
@@ -145,32 +145,55 @@ while IFS= read -r line; do
   [ -n "$line" ] && pg_files+=("$line")
 done < <(collect_pg_modified)
 
-# Check for concurrent index creation statements without -- atlas:txmode none.
-# Postgres-only: ClickHouse has no CREATE INDEX CONCURRENTLY.
+# Check for statements that must not run inside a transaction but are missing the
+# -- atlas:txmode none directive. Postgres-only: ClickHouse has neither statement.
+#
+#   CREATE [UNIQUE] INDEX CONCURRENTLY  Postgres rejects it inside a transaction.
+#   VALIDATE CONSTRAINT                 Only useful once the preceding
+#                                       ADD CONSTRAINT ... NOT VALID has committed.
+#                                       Sharing a transaction holds the ACCESS
+#                                       EXCLUSIVE lock taken by the ADD through the
+#                                       validation scan, so the split gains nothing.
 if [ ${#pg_files[@]} -gt 0 ]; then
-  invalid_indexes=false
-  echo -e "\n🔎 Checking for concurrent index creation statements without -- atlas:txmode none..."
+  missing_txmode=false
+  echo -e "\n🔎 Checking for statements requiring -- atlas:txmode none..."
   for file in "${pg_files[@]}"; do
+    # Matched on the raw file, so a comment quoting one of these statements is
+    # enough to require the directive. Adding it to such a file is harmless.
+    statement=""
     if grep -i -q "CREATE INDEX CONCURRENTLY" "$file" || grep -i -q "CREATE UNIQUE INDEX CONCURRENTLY" "$file"; then
-      # Check if the first line contains --atlas:txmode none
-      first_line=$(head -n 1 "$file")
-      if [ "$first_line" != "-- atlas:txmode none" ]; then
-        invalid_indexes=true
-        echo "❌ $file"
-        gh_error "$file" "Migration uses CREATE [UNIQUE] INDEX CONCURRENTLY but does not have '-- atlas:txmode none' as the first line."
-      else
-        echo "✅ $file"
-      fi
+      statement="CREATE [UNIQUE] INDEX CONCURRENTLY"
+    elif grep -i -q "VALIDATE CONSTRAINT" "$file"; then
+      statement="VALIDATE CONSTRAINT"
+    fi
+
+    if [ -z "$statement" ]; then
+      continue
+    fi
+
+    # Check if the first line contains --atlas:txmode none
+    first_line=$(head -n 1 "$file")
+    if [ "$first_line" != "-- atlas:txmode none" ]; then
+      missing_txmode=true
+      echo "❌ $file ($statement)"
+      gh_error "$file" "Migration uses $statement but does not have '-- atlas:txmode none' as the first line."
+    else
+      echo "✅ $file ($statement)"
     fi
   done
 
-  if [ "$invalid_indexes" = true ]; then
+  if [ "$missing_txmode" = true ]; then
     echo "
-🚨 Migration files contain CREATE [UNIQUE] INDEX CONCURRENTLY statements but do
-🚨 not have -- atlas:txmode none as the first line.
+🚨 Migration files contain statements that must not run inside a transaction but
+🚨 do not have -- atlas:txmode none as the first line.
 🚨
 🚨 If you are creating migrations to add/remove indexes then ensure these are
 🚨 are isolated to their own files and disable transaction mode.
+🚨
+🚨 If you are adding a CHECK or FOREIGN KEY constraint as ADD CONSTRAINT ... NOT
+🚨 VALID followed by VALIDATE CONSTRAINT, the two statements must commit
+🚨 separately, otherwise the validation scan runs under the ACCESS EXCLUSIVE lock
+🚨 taken by the ADD and the split gains nothing.
 "
     exit 1
   fi

--- a/.mise-tasks/lint/migrations.sh
+++ b/.mise-tasks/lint/migrations.sh
@@ -154,16 +154,26 @@ done < <(collect_pg_modified)
 #                                       Sharing a transaction holds the ACCESS
 #                                       EXCLUSIVE lock taken by the ADD through the
 #                                       validation scan, so the split gains nothing.
+#
+executable_sql() {
+  # Drop line comments, then fold the file to one whitespace-normalized line so a
+  # statement split across lines still matches. Block comments, string literals
+  # and dollar-quoted bodies are not parsed; a statement named inside one is
+  # matched as if it were executable, which asks for a directive that is not
+  # needed. Real DDL never hits that, and Atlas does not generate it.
+  sed 's/--.*$//' "$1" | tr '\n' ' ' | tr -s ' '
+}
+
 if [ ${#pg_files[@]} -gt 0 ]; then
   missing_txmode=false
   echo -e "\n🔎 Checking for statements requiring -- atlas:txmode none..."
   for file in "${pg_files[@]}"; do
-    # Matched on the raw file, so a comment quoting one of these statements is
-    # enough to require the directive. Adding it to such a file is harmless.
+    sql=$(executable_sql "$file")
+
     statement=""
-    if grep -i -q "CREATE INDEX CONCURRENTLY" "$file" || grep -i -q "CREATE UNIQUE INDEX CONCURRENTLY" "$file"; then
+    if echo "$sql" | grep -i -q "CREATE INDEX CONCURRENTLY" || echo "$sql" | grep -i -q "CREATE UNIQUE INDEX CONCURRENTLY"; then
       statement="CREATE [UNIQUE] INDEX CONCURRENTLY"
-    elif grep -i -q "VALIDATE CONSTRAINT" "$file"; then
+    elif echo "$sql" | grep -i -q "VALIDATE CONSTRAINT"; then
       statement="VALIDATE CONSTRAINT"
     fi
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-395/postgresql-skill-not-valid-validate-recipe-for-check-constraints-on

Atlas lint reports PG305 / PG306 whenever a `CHECK` or `FOREIGN KEY` constraint is added to an existing table: the plain `ADD CONSTRAINT` scans every row under an `ACCESS EXCLUSIVE` lock, blocking reads and writes. Atlas has no diff policy that emits `NOT VALID` ([ariga/atlas#3740](https://github.com/ariga/atlas/issues/3740) confirms declarative apply drops it), so the online-safe form has to be hand-written, which the skill previously forbade unconditionally.

Add the two-step `NOT VALID` plus `VALIDATE CONSTRAINT` recipe as the last rule under **Database migrations**, scoped as the one sanctioned hand-edit, and reword the Atlas CLI rule to name that exception. Add a self-contained bullet under **Indexing**, next to the existing `UNIQUE` lock rule, so the cost is visible at schema design time.

The recipe is explicit about what the pattern does not buy you:

* `NOT VALID` enforces every new `INSERT` and `UPDATE` immediately, so a constraint that currently deployed code violates starts rejecting production writes as soon as the migration lands.
* A failed `VALIDATE` blocks later migrations until someone repairs data by hand, which agents may not do against dev or prod.
* Regenerating the migration after a rebase brings back the plain form and silently drops the edit.

Extend the concurrent-index check in `.mise-tasks/lint/migrations.sh` from "uses CONCURRENTLY" to "uses a statement that must not run in a transaction", so `VALIDATE CONSTRAINT` also requires `-- atlas:txmode none`. Without the directive both statements share a transaction, the `ACCESS EXCLUSIVE` lock taken by the `ADD` is held through the validation scan, and the split gains nothing. All seven existing `VALIDATE CONSTRAINT` migrations already pass, so this ratchets without a backfill.

The pattern already has precedent in `server/migrations`: 20260422120000, 20260429084759, 20260601092138, 20260626112524, 20260713113216, 20260602133246 and 20260727233742.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codifies the safe `NOT VALID` + `VALIDATE CONSTRAINT` pattern for adding `CHECK`/`FOREIGN KEY` to existing tables and tightens migration lint to enforce `-- atlas:txmode none` only for executable SQL. Addresses Linear AIS-395 to avoid `ACCESS EXCLUSIVE` scans flagged by PG305/PG306.

- **Migration**
  - Skill: one sanctioned hand-edit to add `NOT VALID`, then `VALIDATE CONSTRAINT`, with `-- atlas:txmode none`; for small tables, you can accept PG305/PG306 and note it in the PR.
  - Lint: fails when a migration uses `CREATE [UNIQUE] INDEX CONCURRENTLY` or `VALIDATE CONSTRAINT` without `-- atlas:txmode none`; detection now strips line comments and normalizes whitespace so comments or split lines don’t trigger or evade the check.

<sup>Written for commit 60463c0fd0130a650d92942fef99c2291ce0e0c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

