### PR TITLE
fix: canonicalize plugin-scoped skill names at hook ingest

### DIFF
--- a/.changeset/canonical-scoped-skill-names.md
+++ b/.changeset/canonical-scoped-skill-names.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Plugin-scoped skill activations now record under the skill's canonical name, so the same skill attributes consistently across plugins instead of being rejected as invalid.

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -177,7 +177,7 @@ func (s *Service) recordSkillActivation(ctx context.Context, payload *gen.Ingest
 		return nil, false, nil
 	}
 	skill := payload.Data.Skill
-	name := strings.TrimSpace(skill.Name)
+	name := canonicalSkillName(payload)
 	if name == "" || !isExplicitSkillActivation(payload) && blockReason != "" {
 		return nil, false, nil
 	}
@@ -1508,11 +1508,18 @@ func canonicalMessageText(payload *gen.IngestPayload) string {
 	return ""
 }
 
+// canonicalSkillName strips a single `<scope>:` plugin prefix from the
+// reported skill name so activations attribute to one canonical skill no
+// matter which plugin distributed it.
 func canonicalSkillName(payload *gen.IngestPayload) string {
-	if payload != nil && payload.Data != nil && payload.Data.Skill != nil {
-		return strings.TrimSpace(payload.Data.Skill.Name)
+	if payload == nil || payload.Data == nil || payload.Data.Skill == nil {
+		return ""
 	}
-	return ""
+	name := strings.TrimSpace(payload.Data.Skill.Name)
+	if scope, rest, scoped := strings.Cut(name, ":"); scoped && strings.TrimSpace(scope) != "" && !strings.Contains(rest, ":") {
+		name = strings.TrimSpace(rest)
+	}
+	return name
 }
 
 func canonicalChatTitle(payload *gen.IngestPayload, fallback string) string {

--- a/server/internal/hooks/skill_capture_test.go
+++ b/server/internal/hooks/skill_capture_test.go
@@ -125,6 +125,22 @@ func TestIngest_RecordsExplicitAndInferredSkillObservations(t *testing.T) {
 	require.False(t, rows[1].RawSha256.Valid, "malformed hashes degrade to name-only observations")
 }
 
+func TestIngest_ScopedSkillNameStoredCanonically(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	payload := skillPayload("claude", eventTypeSkillActivated, "scoped-session", "vendor-plugin: repo-review", "")
+	_, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+
+	rows, err := ti.service.repo.ListSkillObservations(ctx, *authCtx.ProjectID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "repo-review", rows[0].SkillName)
+}
+
 func TestIngest_SkillObservationDurableIdempotencyIgnoresRedisDuplicate(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)

--- a/server/internal/skills/reconcile.go
+++ b/server/internal/skills/reconcile.go
@@ -101,7 +101,7 @@ func ReconcileSkillObservations(ctx context.Context, db *pgxpool.Pool, projectID
 			failedIDs[errorCode] = append(failedIDs[errorCode], row.ID)
 			continue
 		}
-		displayName, name, normalizeErr := normalizeObservedSkillName(row.SkillName, row.Source.String, row.SourceLevel.String, row.Provider)
+		displayName, name, normalizeErr := normalizeObservedSkillName(row.SkillName)
 		if normalizeErr != nil {
 			failedIDs[reconcileErrorInvalidName] = append(failedIDs[reconcileErrorInvalidName], row.ID)
 			continue
@@ -185,16 +185,10 @@ func ReconcileSkillObservations(ctx context.Context, db *pgxpool.Pool, projectID
 	return &ReconcileSkillObservationsResult{Processed: processed, HasMore: len(rows) == int(batchSize)}, nil
 }
 
-func normalizeObservedSkillName(observedName, source, sourceLevel, provider string) (string, string, error) {
+func normalizeObservedSkillName(observedName string) (string, string, error) {
 	displayName := strings.TrimSpace(observedName)
-	if strings.EqualFold(strings.TrimSpace(sourceLevel), "plugin") ||
-		strings.EqualFold(strings.TrimSpace(source), "marketplace") ||
-		strings.EqualFold(strings.TrimSpace(source), "plugin") ||
-		strings.EqualFold(strings.TrimSpace(provider), "marketplace") ||
-		strings.EqualFold(strings.TrimSpace(provider), "plugin") {
-		if separator := strings.LastIndexByte(displayName, ':'); separator >= 0 {
-			displayName = strings.TrimSpace(displayName[separator+1:])
-		}
+	if scope, name, scoped := strings.Cut(displayName, ":"); scoped && strings.TrimSpace(scope) != "" && !strings.Contains(name, ":") {
+		displayName = strings.TrimSpace(name)
 	}
 	name, err := normalizeSkillName(displayName)
 	return displayName, name, err

--- a/server/internal/skills/reconcile_test.go
+++ b/server/internal/skills/reconcile_test.go
@@ -215,7 +215,7 @@ func TestReconcileSkillObservations_RawHashResolvesExactHistoricalVersionBeforeN
 	newVersion, err := skills.CaptureSkillContent(ctx, ti.conn, ti.projectID, capturedManifest("hash-first", "New.", "new body"))
 	require.NoError(t, err)
 	require.NotEqual(t, oldVersion.SkillVersionID, newVersion.SkillVersionID)
-	insertSkillObservation(t, ti, "renamed-copy", "", "project", contentSHA256(oldContent), time.Now().UTC())
+	insertSkillObservation(t, ti, "plugin:renamed-copy", "", "project", contentSHA256(oldContent), time.Now().UTC())
 
 	result, err := skills.ReconcileSkillObservations(ctx, ti.conn, ti.projectID, 10)
 	require.NoError(t, err)
@@ -224,6 +224,7 @@ func TestReconcileSkillObservations_RawHashResolvesExactHistoricalVersionBeforeN
 	require.NoError(t, err)
 	require.Equal(t, oldVersion.SkillID, observations[0].SkillID.UUID)
 	require.Equal(t, oldVersion.SkillVersionID, observations[0].SkillVersionID.UUID)
+	require.Equal(t, "plugin:renamed-copy", observations[0].SkillName)
 	_, err = ti.repo.GetSkillByNameForUpdate(ctx, repo.GetSkillByNameForUpdateParams{ProjectID: ti.projectID, Name: "renamed-copy"})
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
@@ -396,10 +397,10 @@ func TestReconcileSkillObservations_ClassifiesExternalPluginAsBuiltIn(t *testing
 	require.Equal(t, "built_in", skill.Classification)
 }
 
-func TestReconcileSkillObservations_StripsPluginPrefixWithoutSourceLevel(t *testing.T) {
+func TestReconcileSkillObservations_StripsScopedPrefixWithoutSourceMetadata(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
-	insertSkillObservation(t, ti, "vendor:external-plugin", "marketplace", "", "", time.Now().UTC())
+	insertSkillObservationForProject(t, ti, ti.projectID, "claude", "vendor:external-plugin", "", "", "", time.Now().UTC())
 
 	result, err := skills.ReconcileSkillObservations(ctx, ti.conn, ti.projectID, 10)
 	require.NoError(t, err)
@@ -409,6 +410,10 @@ func TestReconcileSkillObservations_StripsPluginPrefixWithoutSourceLevel(t *test
 		Name:      "external-plugin",
 	})
 	require.NoError(t, err)
+	observations, err := hooksrepo.New(ti.conn).ListSkillObservations(ctx, ti.projectID)
+	require.NoError(t, err)
+	require.Equal(t, "vendor:external-plugin", observations[0].SkillName)
+	require.True(t, observations[0].SkillID.Valid)
 }
 
 func TestReconcileSkillObservations_ProviderAloneRemainsCustom(t *testing.T) {


### PR DESCRIPTION
## Summary

- canonicalize `<scope>:<name>` skill reports at hook ingest: `canonicalSkillName` strips a single plugin scope prefix, so both the stored observation row and the derived telemetry rows carry the canonical skill name
- with the canonical name on the wire everywhere, activations of the same skill attribute to one skill regardless of which plugin distributed it
- reconciliation keeps a metadata-independent scope strip for observations already in flight, but the retroactive `invalid_name` requeue (regexp scans in the pending-project and claim queries) is gone — prior failed rows are left as-is

Closes [DNO-668](https://linear.app/speakeasy/issue/DNO-668/fix-plugin-scoped-skill-activations-are-rejected-as-invalid-name)