### PR TITLE
feat(dashboard): share the skill picker with assistants

### DIFF
--- a/.changeset/attach-assistant-skills.md
+++ b/.changeset/attach-assistant-skills.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Use the searchable multi-select skill picker when attaching skills to assistants.

--- a/client/dashboard/src/pages/assistants/onboarding/AssistantSkillsSection.tsx
+++ b/client/dashboard/src/pages/assistants/onboarding/AssistantSkillsSection.tsx
@@ -1,6 +1,5 @@
 import { RequireScope } from "@/components/require-scope";
-import { Alert, AlertDescription, ErrorAlert } from "@/components/ui/alert";
-import { Dialog } from "@/components/ui/dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Select,
   SelectContent,
@@ -8,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Type } from "@/components/ui/type";
 import { useProject } from "@/contexts/Auth";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
@@ -21,6 +19,10 @@ import { useUndistributeSkillMutation } from "@gram/client/react-query/undistrib
 import { Badge, Button, Icon, Stack } from "@speakeasy-api/moonshine";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import {
+  SkillPickerDialog,
+  type SkillPickerResult,
+} from "../../skills/SkillPickerDialog";
 import { shouldWarnAboutSkillIndex } from "./assistant-skill-limit";
 import { useAssistantDraft } from "./useAssistantDraft";
 
@@ -29,7 +31,7 @@ export function AssistantSkillsSection(): JSX.Element {
   const project = useProject();
   const [addOpen, setAddOpen] = useState(false);
   const attached = draft.assistant?.skills ?? [];
-  const shouldLoadSkills = addOpen || attached.length > 0;
+  const shouldLoadSkills = attached.length > 0;
   const skillsQuery = useSkillsInfinite({ limit: 200 }, undefined, {
     throwOnError: false,
     enabled: shouldLoadSkills,
@@ -44,8 +46,6 @@ export function AssistantSkillsSection(): JSX.Element {
     () => new Map(skills.map((skill) => [skill.id, skill])),
     [skills],
   );
-  const attachedIds = new Set(attached.map((ref) => ref.skillId));
-  const available = skills.filter((skill) => !attachedIds.has(skill.id));
   const distribute = useDistributeSkillMutation();
   const undistribute = useUndistributeSkillMutation();
 
@@ -54,34 +54,31 @@ export function AssistantSkillsSection(): JSX.Element {
     await draft.refetchAssistant();
   };
 
-  const addSkill: React.FormEventHandler<HTMLFormElement> = (event) => {
-    event.preventDefault();
-    if (!draft.assistantId) return;
-    const skillId = new FormData(event.currentTarget).get("skillId");
-    if (typeof skillId !== "string" || !skillId) return;
-    distribute.mutate(
-      {
-        request: {
-          distributeSkillRequestBody: {
-            id: skillId,
-            assistantId: draft.assistantId,
-          },
-        },
-      },
-      {
-        onSuccess: () => {
-          setAddOpen(false);
-          void refresh()
-            .then(() => toast.success("Skill attached"))
-            .catch(() => {
-              draft.invalidateAll();
-              toast.error("Skill attached, but the assistant did not refresh");
-            });
-        },
-        onError: () => {
-          toast.error("Unable to attach skill");
-        },
-      },
+  const handleAddSkillsComplete = async ({
+    addedCount,
+    failedCount,
+  }: SkillPickerResult) => {
+    if (addedCount > 0) {
+      try {
+        await refresh();
+      } catch {
+        draft.invalidateAll();
+        toast.error(
+          `${addedCount > 1 ? "Skills attached" : "Skill attached"}, but the assistant did not refresh`,
+        );
+        return;
+      }
+    }
+    if (failedCount > 0) {
+      toast.error(
+        addedCount > 0
+          ? `Attached ${addedCount} skill${addedCount > 1 ? "s" : ""}, ${failedCount} failed`
+          : `Unable to attach skill${failedCount > 1 ? "s" : ""}`,
+      );
+      return;
+    }
+    toast.success(
+      addedCount > 1 ? `${addedCount} skills attached` : "Skill attached",
     );
   };
 
@@ -166,12 +163,9 @@ export function AssistantSkillsSection(): JSX.Element {
       </div>
 
       {shouldWarnAboutSkillIndex(attached.length) && (
-        <Alert variant="warning" className="mb-3 px-3 py-2">
-          <AlertDescription>
-            With this many skills, the skill index adds roughly 2k tokens to
-            every thread.
-          </AlertDescription>
-        </Alert>
+        <div className="mb-3">
+          <SkillIndexWarning />
+        </div>
       )}
 
       {attached.length === 0 ? (
@@ -193,61 +187,36 @@ export function AssistantSkillsSection(): JSX.Element {
         </Stack>
       )}
 
-      <Dialog open={addOpen} onOpenChange={setAddOpen}>
-        <Dialog.Content>
-          <Dialog.Header>
-            <Dialog.Title>Attach skill</Dialog.Title>
-            <Dialog.Description>
-              Add a project skill to this assistant. It will track the latest
-              valid version by default.
-            </Dialog.Description>
-          </Dialog.Header>
-          <form className="flex flex-col gap-4" onSubmit={addSkill}>
-            {skillsQuery.error && !skillsQuery.data ? (
-              <ErrorAlert
-                title="Unable to load skills"
-                error={skillsQuery.error}
-              />
-            ) : skillsQuery.isPending || skillsQuery.hasNextPage ? (
-              <Skeleton className="h-9 w-full" />
-            ) : available.length === 0 ? (
-              <Type small muted>
-                No skills available to attach.
-              </Type>
-            ) : (
-              <select
-                name="skillId"
-                required
-                className="bg-background rounded-md border px-3 py-2 text-sm"
-                aria-label="Skill"
-              >
-                <option value="">Select a skill</option>
-                {available.map((skill) => (
-                  <option key={skill.id} value={skill.id}>
-                    {skill.displayName}
-                  </option>
-                ))}
-              </select>
-            )}
-            <Dialog.Footer>
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={() => setAddOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                disabled={distribute.isPending || available.length === 0}
-              >
-                Attach
-              </Button>
-            </Dialog.Footer>
-          </form>
-        </Dialog.Content>
-      </Dialog>
+      {draft.assistantId && (
+        <SkillPickerDialog
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          excludedSkillIds={attached.map((item) => item.skillId)}
+          target={{ assistantId: draft.assistantId }}
+          title="Attach Skills"
+          description="Add project skills to this assistant. They will track the latest valid version by default."
+          actionLabel="Attach"
+          emptyMessage="No skills available to attach. Record a skill in this project first."
+          renderSelectionNotice={(selectedCount) =>
+            shouldWarnAboutSkillIndex(attached.length + selectedCount) ? (
+              <SkillIndexWarning />
+            ) : null
+          }
+          onBatchComplete={handleAddSkillsComplete}
+        />
+      )}
     </div>
+  );
+}
+
+function SkillIndexWarning(): JSX.Element {
+  return (
+    <Alert variant="warning" className="px-3 py-2">
+      <AlertDescription>
+        With this many skills, the skill index adds roughly 2k tokens to every
+        thread.
+      </AlertDescription>
+    </Alert>
   );
 }
 

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -1,9 +1,6 @@
 import { RequireScope } from "@/components/require-scope";
-import { Page } from "@/components/page-layout";
 import { ErrorAlert } from "@/components/ui/alert";
 import { Button as UiButton } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Dialog } from "@/components/ui/dialog";
 import { DotCard } from "@/components/ui/dot-card";
 import { DotRow } from "@/components/ui/dot-row";
 import { DotTable } from "@/components/ui/dot-table";
@@ -13,25 +10,22 @@ import type { ViewMode } from "@/components/ui/use-view-mode";
 import { useProject } from "@/contexts/Auth";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { useRoutes } from "@/routes";
-import type { Skill } from "@gram/client/models/components/skill.js";
 import type { SkillDistribution } from "@gram/client/models/components/skilldistribution.js";
-import { useDistributeSkillMutation } from "@gram/client/react-query/distributeSkill.js";
 import {
   invalidateAllSkillDistributions,
   useSkillDistributionsInfinite,
 } from "@gram/client/react-query/skillDistributions.js";
-import { useSkillsInfinite } from "@gram/client/react-query/skills.js";
 import { useUndistributeSkillMutation } from "@gram/client/react-query/undistributeSkill.js";
-import { Badge, Button, cn, Icon } from "@speakeasy-api/moonshine";
+import { Badge, Button, Icon } from "@speakeasy-api/moonshine";
 import { useQueryClient } from "@tanstack/react-query";
 import { Sparkles, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import {
-  filterSkills,
-  prioritizeAddableSkills,
-} from "../skills/skills-list-helpers";
+  SkillPickerDialog,
+  type SkillPickerResult,
+} from "../skills/SkillPickerDialog";
 import { SectionEmptyState } from "./SectionEmptyState";
 
 /**
@@ -56,7 +50,6 @@ export function PluginSkillsSection({
   const project = useProject();
   const queryClient = useQueryClient();
   const [isAddSkillOpen, setIsAddSkillOpen] = useState(false);
-  const [skillSearch, setSkillSearch] = useState("");
 
   const distributionsQuery = useSkillDistributionsInfinite(
     { pluginId, limit: 50 },
@@ -88,110 +81,28 @@ export function PluginSkillsSection({
     );
   }, [distributions, normalizedSearch]);
 
-  const skillsQuery = useSkillsInfinite({ limit: 200 }, undefined, {
-    throwOnError: false,
-    enabled: isAddSkillOpen,
-  });
-  useDrainInfiniteQuery(skillsQuery, isAddSkillOpen);
-  const isSkillListLoading = skillsQuery.isPending || skillsQuery.hasNextPage;
-  // Skills without a valid version stay listed but disabled: the distribute
-  // endpoint rejects them, so the picker explains why and links to the fix.
-  const availableSkills = useMemo(() => {
-    const distributedSkillIds = new Set(distributions.map((d) => d.skillId));
-    return prioritizeAddableSkills(
-      (
-        skillsQuery.data?.pages.flatMap((page) => page.result.skills) ?? []
-      ).filter((skill) => !distributedSkillIds.has(skill.id)),
-    );
-  }, [distributions, skillsQuery.data?.pages]);
-  const visibleSkills = useMemo(
-    () => filterSkills(availableSkills, skillSearch, [], []),
-    [availableSkills, skillSearch],
-  );
-  const unavailableSkillCount = availableSkills.filter(
-    (skill) => !skill.hasValidVersion,
-  ).length;
-  const hiddenSkillCount = availableSkills.length - visibleSkills.length;
-  const skillListSummary = [
-    hiddenSkillCount > 0
-      ? `${hiddenSkillCount} skill${hiddenSkillCount === 1 ? "" : "s"} hidden by search`
-      : "",
-    unavailableSkillCount > 0
-      ? `${unavailableSkillCount} unavailable skill${unavailableSkillCount === 1 ? "" : "s"}`
-      : "",
-  ]
-    .filter(Boolean)
-    .join(" · ");
-
-  const distribute = useDistributeSkillMutation();
   const undistribute = useUndistributeSkillMutation();
-  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
-  useEffect(() => {
-    setSkillSearch("");
-    setSelectedSkillIds([]);
-  }, [pluginId]);
-  // Shared mutation observers only reflect their latest call, so a local flag
-  // covers the whole allSettled batch to keep the dialog locked until it ends.
-  const [isBatchAdding, setIsBatchAdding] = useState(false);
 
-  const openAddSkillDialog = (open: boolean) => {
-    // Closing mid-batch would hide in-flight requests and drop the
-    // failed-only retry selection.
-    if (!open && isBatchAdding) return;
-    setIsAddSkillOpen(open);
-    if (open) {
-      setSelectedSkillIds([]);
-      setSkillSearch("");
+  const handleAddSkillsComplete = async ({
+    addedCount,
+    failedCount,
+  }: SkillPickerResult) => {
+    // Some mutations may succeed even when others fail, so always refresh the
+    // cache before offering a failed-only retry.
+    await invalidateAllSkillDistributions(queryClient);
+    if (failedCount === 0) {
+      onMutated(
+        addedCount > 1
+          ? `${addedCount} skills added to plugin`
+          : "Skill added to plugin",
+      );
+      return;
     }
-  };
-
-  const toggleSkill = (skillId: string) => {
-    setSelectedSkillIds((prev) =>
-      prev.includes(skillId)
-        ? prev.filter((id) => id !== skillId)
-        : [...prev, skillId],
+    toast.error(
+      addedCount > 0
+        ? `Added ${addedCount} skill${addedCount > 1 ? "s" : ""}, ${failedCount} failed`
+        : `Unable to add skill${failedCount > 1 ? "s" : ""} to plugin`,
     );
-  };
-
-  const handleAddSkills = async () => {
-    if (selectedSkillIds.length === 0 || isBatchAdding) return;
-    setIsBatchAdding(true);
-    try {
-      // allSettled + unconditional invalidation: some mutations in the batch
-      // may succeed even when others fail, and the cache must reflect what the
-      // server actually committed.
-      const results = await Promise.allSettled(
-        selectedSkillIds.map((skillId) =>
-          distribute.mutateAsync({
-            request: { distributeSkillRequestBody: { id: skillId, pluginId } },
-          }),
-        ),
-      );
-      await invalidateAllSkillDistributions(queryClient);
-      const failedIds = selectedSkillIds.filter(
-        (_, index) => results[index]?.status === "rejected",
-      );
-      const addedCount = selectedSkillIds.length - failedIds.length;
-      if (failedIds.length === 0) {
-        setIsAddSkillOpen(false);
-        onMutated(
-          addedCount > 1
-            ? `${addedCount} skills added to plugin`
-            : "Skill added to plugin",
-        );
-        return;
-      }
-      // Keep only the failures selected so a retry doesn't re-add the skills
-      // the server already committed.
-      setSelectedSkillIds(failedIds);
-      toast.error(
-        addedCount > 0
-          ? `Added ${addedCount} skill${addedCount > 1 ? "s" : ""}, ${failedIds.length} failed`
-          : `Unable to add skill${failedIds.length > 1 ? "s" : ""} to plugin`,
-      );
-    } finally {
-      setIsBatchAdding(false);
-    }
   };
 
   const handleRemoveSkill = (distribution: SkillDistribution) => {
@@ -215,37 +126,6 @@ export function PluginSkillsSection({
       },
     );
   };
-
-  let skillPickerContent: JSX.Element;
-  if (isSkillListLoading) {
-    skillPickerContent = <Skeleton className="h-24 w-full" />;
-  } else if (visibleSkills.length > 0) {
-    skillPickerContent = (
-      <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-md border p-1">
-        {visibleSkills.map((skill) => (
-          <AddSkillOption
-            key={skill.id}
-            skill={skill}
-            checked={selectedSkillIds.includes(skill.id)}
-            disabled={isBatchAdding}
-            onToggle={() => toggleSkill(skill.id)}
-          />
-        ))}
-      </div>
-    );
-  } else if (availableSkills.length > 0) {
-    skillPickerContent = (
-      <Type muted small>
-        No skills match your search.
-      </Type>
-    );
-  } else {
-    skillPickerContent = (
-      <Type muted small>
-        No skills available to add. Record a skill in this project first.
-      </Type>
-    );
-  }
 
   // Precomputed list body keeps the JSX below free of nested ternaries while
   // distinguishing "nothing distributed yet" from "no search matches".
@@ -337,7 +217,7 @@ export function PluginSkillsSection({
             variant="secondary"
             size="sm"
             disabled={!isMembershipLoaded}
-            onClick={() => openAddSkillDialog(true)}
+            onClick={() => setIsAddSkillOpen(true)}
           >
             <Button.LeftIcon>
               <Icon name="plus" className="h-4 w-4" />
@@ -348,107 +228,18 @@ export function PluginSkillsSection({
       </div>
       <div className="mb-8">{listContent}</div>
 
-      {/* Add Skill Dialog */}
-      <Dialog open={isAddSkillOpen} onOpenChange={openAddSkillDialog}>
-        <Dialog.Content>
-          <Dialog.Header>
-            <Dialog.Title>Add Skills</Dialog.Title>
-            <Dialog.Description>
-              Distribute project skills to this plugin bundle.
-            </Dialog.Description>
-          </Dialog.Header>
-          <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium">Skills</label>
-            <Page.Toolbar.Search
-              value={skillSearch}
-              onChange={setSkillSearch}
-              debounceMs={150}
-              placeholder="Search skills"
-              className="w-full"
-            />
-            {!isSkillListLoading && skillListSummary && (
-              <Type muted small>
-                {skillListSummary}
-              </Type>
-            )}
-            {skillPickerContent}
-          </div>
-          <Dialog.Footer>
-            <Button
-              variant="secondary"
-              disabled={isBatchAdding}
-              onClick={() => openAddSkillDialog(false)}
-              type="button"
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              disabled={
-                isBatchAdding ||
-                isSkillListLoading ||
-                selectedSkillIds.length === 0
-              }
-              onClick={() => void handleAddSkills()}
-            >
-              {selectedSkillIds.length > 1
-                ? `Add ${selectedSkillIds.length} skills`
-                : "Add"}
-            </Button>
-          </Dialog.Footer>
-        </Dialog.Content>
-      </Dialog>
-    </>
-  );
-}
-
-function AddSkillOption({
-  skill,
-  checked,
-  disabled,
-  onToggle,
-}: {
-  skill: Skill;
-  checked: boolean;
-  disabled: boolean;
-  onToggle: () => void;
-}): JSX.Element {
-  const routes = useRoutes();
-  const isDistributable = skill.hasValidVersion;
-
-  return (
-    <label
-      className={cn(
-        "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
-        isDistributable ? "hover:bg-accent cursor-pointer" : "opacity-70",
-      )}
-    >
-      <Checkbox
-        checked={checked}
-        disabled={disabled || !isDistributable}
-        onCheckedChange={onToggle}
+      <SkillPickerDialog
+        open={isAddSkillOpen}
+        onOpenChange={setIsAddSkillOpen}
+        excludedSkillIds={distributions.map((item) => item.skillId)}
+        target={{ pluginId }}
+        title="Add Skills"
+        description="Distribute project skills to this plugin bundle."
+        actionLabel="Add"
+        emptyMessage="No skills available to add. Record a skill in this project first."
+        onBatchComplete={handleAddSkillsComplete}
       />
-      <div className="flex min-w-0 flex-col">
-        <span className="truncate">{skill.displayName}</span>
-        <span className="text-muted-foreground truncate font-mono text-xs">
-          {skill.name}
-        </span>
-        {!isDistributable && (
-          <span className="text-muted-foreground text-xs">
-            {skill.versionCount === 0
-              ? "No versions recorded"
-              : "No valid version"}
-            {" · "}
-            <Link
-              to={routes.skills.detail.href(skill.id)}
-              className="text-foreground underline underline-offset-2"
-            >
-              Fix
-            </Link>
-          </span>
-        )}
-      </div>
-    </label>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/skills/SkillPickerDialog.tsx
+++ b/client/dashboard/src/pages/skills/SkillPickerDialog.tsx
@@ -1,0 +1,265 @@
+import { Page } from "@/components/page-layout";
+import { ErrorAlert } from "@/components/ui/alert";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog } from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Type } from "@/components/ui/type";
+import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
+import { useRoutes } from "@/routes";
+import type { Skill } from "@gram/client/models/components/skill.js";
+import { useDistributeSkillMutation } from "@gram/client/react-query/distributeSkill.js";
+import { useSkillsInfinite } from "@gram/client/react-query/skills.js";
+import { Button, cn } from "@speakeasy-api/moonshine";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { Link } from "react-router";
+import { filterSkills, prioritizeAddableSkills } from "./skills-list-helpers";
+
+type SkillDistributionTarget =
+  | { assistantId: string; pluginId?: never }
+  | { assistantId?: never; pluginId: string };
+
+export type SkillPickerResult = {
+  addedCount: number;
+  failedCount: number;
+};
+
+export function SkillPickerDialog({
+  open,
+  onOpenChange,
+  excludedSkillIds,
+  target,
+  title,
+  description,
+  actionLabel,
+  emptyMessage,
+  renderSelectionNotice,
+  onBatchComplete,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  excludedSkillIds: string[];
+  target: SkillDistributionTarget;
+  title: string;
+  description: string;
+  actionLabel: string;
+  emptyMessage: string;
+  renderSelectionNotice?: (selectedCount: number) => ReactNode;
+  onBatchComplete: (result: SkillPickerResult) => void | Promise<void>;
+}): JSX.Element {
+  const [search, setSearch] = useState("");
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  const [isBatchAdding, setIsBatchAdding] = useState(false);
+  const skillsQuery = useSkillsInfinite({ limit: 200 }, undefined, {
+    throwOnError: false,
+    enabled: open,
+  });
+  useDrainInfiniteQuery(skillsQuery, open);
+  const isLoading = skillsQuery.isPending || skillsQuery.hasNextPage;
+  const availableSkills = useMemo(() => {
+    const excluded = new Set(excludedSkillIds);
+    return prioritizeAddableSkills(
+      (
+        skillsQuery.data?.pages.flatMap((page) => page.result.skills) ?? []
+      ).filter((skill) => !excluded.has(skill.id)),
+    );
+  }, [excludedSkillIds, skillsQuery.data?.pages]);
+  const visibleSkills = useMemo(
+    () => filterSkills(availableSkills, search, [], []),
+    [availableSkills, search],
+  );
+  const unavailableSkillCount = availableSkills.filter(
+    (skill) => !skill.hasValidVersion,
+  ).length;
+  const hiddenSkillCount = availableSkills.length - visibleSkills.length;
+  const listSummary = [
+    hiddenSkillCount > 0
+      ? `${hiddenSkillCount} skill${hiddenSkillCount === 1 ? "" : "s"} hidden by search`
+      : "",
+    unavailableSkillCount > 0
+      ? `${unavailableSkillCount} unavailable skill${unavailableSkillCount === 1 ? "" : "s"}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const distribute = useDistributeSkillMutation();
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isBatchAdding) return;
+    onOpenChange(nextOpen);
+    if (nextOpen) {
+      setSearch("");
+      setSelectedSkillIds([]);
+    }
+  };
+
+  const toggleSkill = (skillId: string) => {
+    setSelectedSkillIds((current) =>
+      current.includes(skillId)
+        ? current.filter((id) => id !== skillId)
+        : [...current, skillId],
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (selectedSkillIds.length === 0 || isBatchAdding) return;
+    setIsBatchAdding(true);
+    try {
+      const results = await Promise.allSettled(
+        selectedSkillIds.map((skillId) =>
+          distribute.mutateAsync({
+            request: {
+              distributeSkillRequestBody: { id: skillId, ...target },
+            },
+          }),
+        ),
+      );
+      const failedIds = selectedSkillIds.filter(
+        (_, index) => results[index]?.status === "rejected",
+      );
+      const result = {
+        addedCount: selectedSkillIds.length - failedIds.length,
+        failedCount: failedIds.length,
+      };
+      setSelectedSkillIds(failedIds);
+      await onBatchComplete(result);
+      if (failedIds.length === 0) onOpenChange(false);
+    } finally {
+      setIsBatchAdding(false);
+    }
+  };
+
+  let pickerContent: JSX.Element;
+  if (skillsQuery.error && !skillsQuery.data) {
+    pickerContent = (
+      <ErrorAlert title="Unable to load skills" error={skillsQuery.error} />
+    );
+  } else if (isLoading) {
+    pickerContent = <Skeleton className="h-24 w-full" />;
+  } else if (visibleSkills.length > 0) {
+    pickerContent = (
+      <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto rounded-md border p-1">
+        {visibleSkills.map((skill) => (
+          <SkillOption
+            key={skill.id}
+            skill={skill}
+            checked={selectedSkillIds.includes(skill.id)}
+            disabled={isBatchAdding}
+            onToggle={() => toggleSkill(skill.id)}
+          />
+        ))}
+      </div>
+    );
+  } else if (availableSkills.length > 0) {
+    pickerContent = (
+      <Type muted small>
+        No skills match your search.
+      </Type>
+    );
+  } else {
+    pickerContent = (
+      <Type muted small>
+        {emptyMessage}
+      </Type>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>{title}</Dialog.Title>
+          <Dialog.Description>{description}</Dialog.Description>
+        </Dialog.Header>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium">Skills</label>
+          <Page.Toolbar.Search
+            value={search}
+            onChange={setSearch}
+            debounceMs={150}
+            placeholder="Search skills"
+            className="w-full"
+          />
+          {!isLoading && listSummary && (
+            <Type muted small>
+              {listSummary}
+            </Type>
+          )}
+          {pickerContent}
+          {renderSelectionNotice?.(selectedSkillIds.length)}
+        </div>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            disabled={isBatchAdding}
+            onClick={() => handleOpenChange(false)}
+            type="button"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={
+              isBatchAdding || isLoading || selectedSkillIds.length === 0
+            }
+            onClick={() => void handleSubmit()}
+          >
+            {selectedSkillIds.length > 1
+              ? `${actionLabel} ${selectedSkillIds.length} skills`
+              : actionLabel}
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+function SkillOption({
+  skill,
+  checked,
+  disabled,
+  onToggle,
+}: {
+  skill: Skill;
+  checked: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}): JSX.Element {
+  const routes = useRoutes();
+  const isDistributable = skill.hasValidVersion;
+
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+        isDistributable ? "hover:bg-accent cursor-pointer" : "opacity-70",
+      )}
+    >
+      <Checkbox
+        checked={checked}
+        disabled={disabled || !isDistributable}
+        onCheckedChange={onToggle}
+      />
+      <div className="flex min-w-0 flex-col">
+        <span className="truncate">{skill.displayName}</span>
+        <span className="text-muted-foreground truncate font-mono text-xs">
+          {skill.name}
+        </span>
+        {!isDistributable && (
+          <span className="text-muted-foreground text-xs">
+            {skill.versionCount === 0
+              ? "No versions recorded"
+              : "No valid version"}
+            {" · "}
+            <Link
+              to={routes.skills.detail.href(skill.id)}
+              className="text-foreground underline underline-offset-2"
+            >
+              Fix
+            </Link>
+          </span>
+        )}
+      </div>
+    </label>
+  );
+}

--- a/client/dashboard/src/pages/skills/SkillPickerDialog.tsx
+++ b/client/dashboard/src/pages/skills/SkillPickerDialog.tsx
@@ -131,7 +131,10 @@ export function SkillPickerDialog({
   };
 
   let pickerContent: JSX.Element;
-  if (skillsQuery.error) {
+  if (
+    skillsQuery.error &&
+    (!skillsQuery.data || skillsQuery.isFetchNextPageError)
+  ) {
     pickerContent = (
       <ErrorAlert title="Unable to load skills" error={skillsQuery.error} />
     );

--- a/client/dashboard/src/pages/skills/SkillPickerDialog.tsx
+++ b/client/dashboard/src/pages/skills/SkillPickerDialog.tsx
@@ -11,7 +11,7 @@ import { useDistributeSkillMutation } from "@gram/client/react-query/distributeS
 import { useSkillsInfinite } from "@gram/client/react-query/skills.js";
 import { Button, cn } from "@speakeasy-api/moonshine";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
 import { filterSkills, prioritizeAddableSkills } from "./skills-list-helpers";
 
@@ -50,6 +50,11 @@ export function SkillPickerDialog({
   const [search, setSearch] = useState("");
   const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
   const [isBatchAdding, setIsBatchAdding] = useState(false);
+  useEffect(() => {
+    if (!open) return;
+    setSearch("");
+    setSelectedSkillIds([]);
+  }, [open, target.assistantId, target.pluginId]);
   const skillsQuery = useSkillsInfinite({ limit: 200 }, undefined, {
     throwOnError: false,
     enabled: open,
@@ -87,10 +92,6 @@ export function SkillPickerDialog({
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen && isBatchAdding) return;
     onOpenChange(nextOpen);
-    if (nextOpen) {
-      setSearch("");
-      setSelectedSkillIds([]);
-    }
   };
 
   const toggleSkill = (skillId: string) => {
@@ -130,7 +131,7 @@ export function SkillPickerDialog({
   };
 
   let pickerContent: JSX.Element;
-  if (skillsQuery.error && !skillsQuery.data) {
+  if (skillsQuery.error) {
     pickerContent = (
       <ErrorAlert title="Unable to load skills" error={skillsQuery.error} />
     );


### PR DESCRIPTION
## Summary

- extract the plugin skill picker into a shared dialog with search, availability states, batch distribution, and failed-only retries
- adopt the shared picker for assistant skill attachments while preserving version pinning and projected skill-index warnings
- keep plugin behavior unchanged through caller-specific cache refresh and feedback

Closes [DNO-669](https://linear.app/speakeasy/issue/DNO-669)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the searchable multi‑select skill picker between plugins and assistants to make attaching skills faster and clearer. Implements DNO-669 by replacing the assistant “Attach skill” select with the shared picker while preserving version pinning and skill‑index warnings.

- **New Features**
  - Shared, searchable multi-select dialog with availability states, addable-first ordering, batch attach, and failed-only retry.
  - Assistants now use the shared picker; version pinning is preserved; the skill‑index warning evaluates against the final selection; assistant refresh and clear toasts for partial failures.
  - Plugins now use the shared picker; the distributions cache is invalidated after batch adds to reflect partial success.

- **Bug Fixes**
  - Reset search and selection on open/target change, block closing mid-batch, surface skill list load errors in-dialog, and preserve cached results on refetch errors.

<sup>Written for commit 2ec68cae5e9622b3bf903fd78995d4a4611f0931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

