### PR TITLE
fix: unify Billing chat-credit amounts and units

### DIFF
--- a/client/dashboard/src/components/billing/billing-format.test.ts
+++ b/client/dashboard/src/components/billing/billing-format.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatBillingCurrency, formatBillingQuantity } from "./billing-format";
+
+describe("billing formatting", () => {
+  it("formats fractional quantities with explicit units", () => {
+    expect(formatBillingQuantity(2.5, "chat credits")).toBe("2.5 chat credits");
+    expect(formatBillingQuantity(1, "servers")).toBe("1 server");
+  });
+
+  it("formats monetary values as USD with cents", () => {
+    expect(formatBillingCurrency(29)).toBe("$29.00");
+    expect(formatBillingCurrency(11.5)).toBe("$11.50");
+  });
+});

--- a/client/dashboard/src/components/billing/billing-format.ts
+++ b/client/dashboard/src/components/billing/billing-format.ts
@@ -1,0 +1,30 @@
+export type BillingUnit = "chat credits" | "servers" | "tool calls";
+
+const quantityFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+});
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const singularUnits: Record<BillingUnit, string> = {
+  "chat credits": "chat credit",
+  servers: "server",
+  "tool calls": "tool call",
+};
+
+export function formatBillingQuantity(
+  value: number,
+  unit: BillingUnit,
+): string {
+  const formattedUnit = value === 1 ? singularUnits[unit] : unit;
+  return `${quantityFormatter.format(value)} ${formattedUnit}`;
+}
+
+export function formatBillingCurrency(value: number): string {
+  return currencyFormatter.format(value);
+}

--- a/client/dashboard/src/components/billing/usage-controls.test.tsx
+++ b/client/dashboard/src/components/billing/usage-controls.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { UsageProgress } from "./usage-controls";
+
+afterEach(cleanup);
+
+describe("UsageProgress", () => {
+  it("labels consumed, included, and additional fractional chat credits", () => {
+    render(<UsageProgress value={27.5} included={25} unit="chat credits" />);
+
+    expect(screen.getByText("Consumed: 27.5 chat credits")).toBeTruthy();
+    expect(screen.getByText("Included: 25 chat credits")).toBeTruthy();
+    expect(screen.getByText("Additional: 2.5 chat credits")).toBeTruthy();
+  });
+
+  it("labels non-credit quantities with their units", () => {
+    render(
+      <UsageProgress
+        value={250}
+        included={1000}
+        overageIncrement={1000}
+        unit="tool calls"
+      />,
+    );
+
+    expect(screen.getByText("Consumed: 250 tool calls")).toBeTruthy();
+    expect(screen.getByText("Included: 1,000 tool calls")).toBeTruthy();
+    expect(screen.queryByText(/Additional:/)).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/billing/usage-controls.tsx
+++ b/client/dashboard/src/components/billing/usage-controls.tsx
@@ -3,6 +3,7 @@ import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Button, cn } from "@speakeasy-api/moonshine";
 import { useCallback, useState } from "react";
+import { formatBillingQuantity, type BillingUnit } from "./billing-format";
 
 export const TopUpCTA = (): JSX.Element => {
   const client = useSdkClient();
@@ -30,7 +31,7 @@ export const TopUpCTA = (): JSX.Element => {
   return (
     <Page.Section.CTA>
       <Button onClick={() => void handleClick()} disabled={busy}>
-        TOP UP CREDITS
+        TOP UP CHAT CREDITS
       </Button>
     </Page.Section.CTA>
   );
@@ -41,29 +42,37 @@ export const UsageProgress = ({
   included,
   overageIncrement,
   noMax,
+  unit,
 }: {
   value: number;
   included: number;
-  overageIncrement: number;
+  overageIncrement?: number;
   noMax?: boolean;
+  unit: BillingUnit;
 }): JSX.Element => {
-  if (noMax) {
-    included = Math.max(1, value * 1.5);
+  const effectiveIncluded = noMax ? Math.max(1, value * 1.5) : included;
+
+  const anyOverage = value > effectiveIncluded;
+  const additional = Math.max(0, value - effectiveIncluded);
+  let overageMax = 0;
+  if (anyOverage) {
+    overageMax = overageIncrement
+      ? Math.ceil(additional / overageIncrement) * overageIncrement
+      : additional;
   }
+  const totalMax = Math.max(1, effectiveIncluded + overageMax);
 
-  const anyOverage = value > included;
-  const overageMax = anyOverage
-    ? Math.ceil((value - included + 1) / overageIncrement) * overageIncrement
-    : 0;
-  const totalMax = included + overageMax;
-
-  const includedWidth = (included / totalMax) * 100;
+  const includedWidth = (effectiveIncluded / totalMax) * 100;
   const overageWidth = (overageMax / totalMax) * 100;
+  const includedProgressWidth =
+    effectiveIncluded > 0
+      ? Math.min((value / effectiveIncluded) * 100, 100)
+      : 0;
 
   const includedProgress = (
     <div
       className={cn(
-        "bg-muted relative h-4 overflow-hidden rounded-md dark:bg-neutral-800",
+        "bg-muted relative h-4 overflow-hidden rounded-md",
         anyOverage && "rounded-r-none",
       )}
       style={{ width: `${includedWidth}%` }}
@@ -71,7 +80,7 @@ export const UsageProgress = ({
       <div
         className="bg-success-default h-full transition-all duration-300"
         style={{
-          width: `${Math.min((value / included) * 100, 100)}%`,
+          width: `${includedProgressWidth}%`,
         }}
       />
     </div>
@@ -79,13 +88,13 @@ export const UsageProgress = ({
 
   const overageProgress = anyOverage ? (
     <div
-      className="bg-muted relative h-4 overflow-hidden rounded-r-md dark:bg-neutral-800"
+      className="bg-muted relative h-4 overflow-hidden rounded-r-md"
       style={{ width: `${overageWidth}%` }}
     >
       <div
         className="bg-warning-default h-full transition-all duration-300"
         style={{
-          width: `${Math.min(((value - included) / overageMax) * 100, 100)}%`,
+          width: `${Math.min((additional / overageMax) * 100, 100)}%`,
         }}
       />
     </div>
@@ -97,47 +106,42 @@ export const UsageProgress = ({
         {includedProgress}
         {overageProgress}
       </div>
-      <div
-        className="text-muted-foreground absolute top-6 text-xs whitespace-nowrap"
-        style={{ right: `${101 - includedWidth}%` }}
-      >
-        {anyOverage
-          ? `Included: ${included.toLocaleString()}`
-          : `${value.toLocaleString()} / ${
-              noMax ? "No limit" : included.toLocaleString()
-            }`}
+      <div className="text-muted-foreground mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        <span>Consumed: {formatBillingQuantity(value, unit)}</span>
+        <span>
+          Included: {noMax ? "No limit" : formatBillingQuantity(included, unit)}
+        </span>
+        {anyOverage ? (
+          <span>Additional: {formatBillingQuantity(additional, unit)}</span>
+        ) : null}
       </div>
 
-      {anyOverage && (
+      {anyOverage ? (
         <>
           <div
-            className="absolute top-0 h-8 w-[2px] bg-neutral-600"
+            className="bg-border absolute top-0 h-4 w-[2px]"
             style={{ left: `${includedWidth}%` }}
           />
-          <div
-            className="text-muted-foreground absolute top-6 text-xs whitespace-nowrap"
-            style={{ left: `${includedWidth + 1}%` }}
-          >
-            Extra: {(value - included).toLocaleString()}
-          </div>
 
-          {Array.from(
-            { length: Math.floor((value - included) / overageIncrement) },
-            (_, index) => {
-              const incrementPosition =
-                includedWidth +
-                (((index + 1) * overageIncrement) / totalMax) * 100;
-              return (
-                <div
-                  key={index}
-                  className="absolute top-0 h-5 w-[2px] bg-neutral-600"
-                  style={{ left: `${incrementPosition}%` }}
-                />
-              );
-            },
-          )}
+          {overageIncrement
+            ? Array.from(
+                { length: Math.floor(additional / overageIncrement) },
+                (_, index) => {
+                  const incrementPosition =
+                    includedWidth +
+                    (((index + 1) * overageIncrement) / totalMax) * 100;
+                  return (
+                    <div
+                      key={index}
+                      className="bg-border absolute top-0 h-4 w-[2px]"
+                      style={{ left: `${incrementPosition}%` }}
+                    />
+                  );
+                },
+              )
+            : null}
         </>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/client/dashboard/src/components/billing/usage-controls.tsx
+++ b/client/dashboard/src/components/billing/usage-controls.tsx
@@ -1,9 +1,8 @@
 import { Page } from "@/components/page-layout";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
-import { Button, cn } from "@speakeasy-api/moonshine";
+import { Button } from "@speakeasy-api/moonshine";
 import { useCallback, useState } from "react";
-import { formatBillingQuantity, type BillingUnit } from "./billing-format";
 
 export const TopUpCTA = (): JSX.Element => {
   const client = useSdkClient();
@@ -34,114 +33,5 @@ export const TopUpCTA = (): JSX.Element => {
         TOP UP CHAT CREDITS
       </Button>
     </Page.Section.CTA>
-  );
-};
-
-export const UsageProgress = ({
-  value,
-  included,
-  overageIncrement,
-  noMax,
-  unit,
-}: {
-  value: number;
-  included: number;
-  overageIncrement?: number;
-  noMax?: boolean;
-  unit: BillingUnit;
-}): JSX.Element => {
-  const effectiveIncluded = noMax ? Math.max(1, value * 1.5) : included;
-
-  const anyOverage = value > effectiveIncluded;
-  const additional = Math.max(0, value - effectiveIncluded);
-  let overageMax = 0;
-  if (anyOverage) {
-    overageMax = overageIncrement
-      ? Math.ceil(additional / overageIncrement) * overageIncrement
-      : additional;
-  }
-  const totalMax = Math.max(1, effectiveIncluded + overageMax);
-
-  const includedWidth = (effectiveIncluded / totalMax) * 100;
-  const overageWidth = (overageMax / totalMax) * 100;
-  const includedProgressWidth =
-    effectiveIncluded > 0
-      ? Math.min((value / effectiveIncluded) * 100, 100)
-      : 0;
-
-  const includedProgress = (
-    <div
-      className={cn(
-        "bg-muted relative h-4 overflow-hidden rounded-md",
-        anyOverage && "rounded-r-none",
-      )}
-      style={{ width: `${includedWidth}%` }}
-    >
-      <div
-        className="bg-success-default h-full transition-all duration-300"
-        style={{
-          width: `${includedProgressWidth}%`,
-        }}
-      />
-    </div>
-  );
-
-  const overageProgress = anyOverage ? (
-    <div
-      className="bg-muted relative h-4 overflow-hidden rounded-r-md"
-      style={{ width: `${overageWidth}%` }}
-    >
-      <div
-        className="bg-warning-default h-full transition-all duration-300"
-        style={{
-          width: `${Math.min((additional / overageMax) * 100, 100)}%`,
-        }}
-      />
-    </div>
-  ) : null;
-
-  return (
-    <div className="relative">
-      <div className="flex w-full">
-        {includedProgress}
-        {overageProgress}
-      </div>
-      <div className="text-muted-foreground mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-        <span>Consumed: {formatBillingQuantity(value, unit)}</span>
-        <span>
-          Included: {noMax ? "No limit" : formatBillingQuantity(included, unit)}
-        </span>
-        {anyOverage ? (
-          <span>Additional: {formatBillingQuantity(additional, unit)}</span>
-        ) : null}
-      </div>
-
-      {anyOverage ? (
-        <>
-          <div
-            className="bg-border absolute top-0 h-4 w-[2px]"
-            style={{ left: `${includedWidth}%` }}
-          />
-
-          {overageIncrement
-            ? Array.from(
-                { length: Math.floor(additional / overageIncrement) },
-                (_, index) => {
-                  const incrementPosition =
-                    includedWidth +
-                    (((index + 1) * overageIncrement) / totalMax) * 100;
-                  return (
-                    <div
-                      key={index}
-                      className="bg-border absolute top-0 h-4 w-[2px]"
-                      style={{ left: `${incrementPosition}%` }}
-                    />
-                  );
-                },
-              )
-            : null}
-        </>
-      ) : null}
-    </div>
   );
 };

--- a/client/dashboard/src/components/billing/usage-progress.test.tsx
+++ b/client/dashboard/src/components/billing/usage-progress.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { UsageProgress } from "./usage-controls";
+import { UsageProgress } from "./usage-progress";
 
 afterEach(cleanup);
 

--- a/client/dashboard/src/components/billing/usage-progress.tsx
+++ b/client/dashboard/src/components/billing/usage-progress.tsx
@@ -1,0 +1,111 @@
+import { cn } from "@speakeasy-api/moonshine";
+import { formatBillingQuantity, type BillingUnit } from "./billing-format";
+
+export function UsageProgress({
+  value,
+  included,
+  overageIncrement,
+  noMax,
+  unit,
+}: {
+  value: number;
+  included: number;
+  overageIncrement?: number;
+  noMax?: boolean;
+  unit: BillingUnit;
+}): JSX.Element {
+  const effectiveIncluded = noMax ? Math.max(1, value * 1.5) : included;
+
+  const anyOverage = value > effectiveIncluded;
+  const additional = Math.max(0, value - effectiveIncluded);
+  let overageMax = 0;
+  if (anyOverage) {
+    overageMax = overageIncrement
+      ? Math.ceil(additional / overageIncrement) * overageIncrement
+      : additional;
+  }
+  const totalMax = Math.max(1, effectiveIncluded + overageMax);
+
+  const includedWidth = (effectiveIncluded / totalMax) * 100;
+  const overageWidth = (overageMax / totalMax) * 100;
+  const includedProgressWidth =
+    effectiveIncluded > 0
+      ? Math.min((value / effectiveIncluded) * 100, 100)
+      : 0;
+
+  const includedProgress = (
+    <div
+      className={cn(
+        "bg-muted relative h-4 overflow-hidden rounded-md",
+        anyOverage && "rounded-r-none",
+      )}
+      style={{ width: `${includedWidth}%` }}
+    >
+      <div
+        className="bg-success-default h-full transition-all duration-300"
+        style={{
+          width: `${includedProgressWidth}%`,
+        }}
+      />
+    </div>
+  );
+
+  const overageProgress = anyOverage ? (
+    <div
+      className="bg-muted relative h-4 overflow-hidden rounded-r-md"
+      style={{ width: `${overageWidth}%` }}
+    >
+      <div
+        className="bg-warning-default h-full transition-all duration-300"
+        style={{
+          width: `${Math.min((additional / overageMax) * 100, 100)}%`,
+        }}
+      />
+    </div>
+  ) : null;
+
+  return (
+    <div className="relative">
+      <div className="flex w-full">
+        {includedProgress}
+        {overageProgress}
+      </div>
+      <div className="text-muted-foreground mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        <span>Consumed: {formatBillingQuantity(value, unit)}</span>
+        <span>
+          Included: {noMax ? "No limit" : formatBillingQuantity(included, unit)}
+        </span>
+        {anyOverage ? (
+          <span>Additional: {formatBillingQuantity(additional, unit)}</span>
+        ) : null}
+      </div>
+
+      {anyOverage ? (
+        <>
+          <div
+            className="bg-border absolute top-0 h-4 w-[2px]"
+            style={{ left: `${includedWidth}%` }}
+          />
+
+          {overageIncrement
+            ? Array.from(
+                { length: Math.floor(additional / overageIncrement) },
+                (_, index) => {
+                  const incrementPosition =
+                    includedWidth +
+                    (((index + 1) * overageIncrement) / totalMax) * 100;
+                  return (
+                    <div
+                      key={index}
+                      className="bg-border absolute top-0 h-4 w-[2px]"
+                      style={{ left: `${incrementPosition}%` }}
+                    />
+                  );
+                },
+              )
+            : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/billing/Billing.test.tsx
+++ b/client/dashboard/src/pages/billing/Billing.test.tsx
@@ -2,10 +2,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
 import type { UsageTiers } from "@gram/client/models/components/usagetiers.js";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  getChatCreditEntitlement,
-  TierIncludedItems,
-} from "./billing-entitlements";
+import { getChatCreditEntitlement } from "./billing-entitlement";
+import { TierIncludedItems } from "./billing-entitlements";
 
 afterEach(cleanup);
 

--- a/client/dashboard/src/pages/billing/Billing.test.tsx
+++ b/client/dashboard/src/pages/billing/Billing.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
+import type { UsageTiers } from "@gram/client/models/components/usagetiers.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { getChatCreditEntitlement, TierIncludedItems } from "./Billing";
+
+afterEach(cleanup);
+
+function tierLimits(includedCredits: number): TierLimits {
+  return {
+    basePrice: 29,
+    includedToolCalls: 10_000,
+    includedServers: 3,
+    includedCredits,
+    pricePerAdditionalToolCall: 0,
+    pricePerAdditionalServer: 0,
+    featureBullets: [],
+    includedBullets: [],
+    addOnBullets: [],
+  };
+}
+
+describe("Billing chat-credit entitlement", () => {
+  it("uses the Pro pricing configuration for the Pro usage entitlement", () => {
+    const usageTiers: UsageTiers = {
+      free: tierLimits(5),
+      pro: tierLimits(25),
+      enterprise: tierLimits(0),
+    };
+
+    expect(getChatCreditEntitlement("__deprecated__pro", usageTiers)).toBe(
+      usageTiers.pro.includedCredits,
+    );
+  });
+
+  it("renders the pricing entitlement with the same explicit unit", () => {
+    render(<TierIncludedItems tierLimits={tierLimits(25)} />);
+
+    expect(screen.getByText("25 chat credits / month")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/billing/Billing.test.tsx
+++ b/client/dashboard/src/pages/billing/Billing.test.tsx
@@ -2,7 +2,10 @@ import { cleanup, render, screen } from "@testing-library/react";
 import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
 import type { UsageTiers } from "@gram/client/models/components/usagetiers.js";
 import { afterEach, describe, expect, it } from "vitest";
-import { getChatCreditEntitlement, TierIncludedItems } from "./Billing";
+import {
+  getChatCreditEntitlement,
+  TierIncludedItems,
+} from "./billing-entitlements";
 
 afterEach(cleanup);
 

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -12,7 +12,6 @@ import { useTelemetry } from "@/contexts/Telemetry";
 import { type ProductTier, useProductTier } from "@/hooks/useProductTier";
 import { getServerURL } from "@/lib/utils";
 import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
-import type { UsageTiers as UsageTiersModel } from "@gram/client/models/components/usagetiers.js";
 import { useGetCreditUsage } from "@gram/client/react-query/getCreditUsage.js";
 import { useGetPeriodUsage } from "@gram/client/react-query/getPeriodUsage.js";
 import { useGetUsageTiers } from "@gram/client/react-query/getUsageTiers.js";
@@ -21,16 +20,20 @@ import { Button, cn, Stack } from "@speakeasy-api/moonshine";
 import { Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { RequireScope } from "@/components/require-scope";
-import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
+import { TopUpCTA } from "@/components/billing/usage-controls";
+import { UsageProgress } from "@/components/billing/usage-progress";
 import {
   TumAdminSection,
   TumUsageSection,
 } from "@/components/billing/tum-section";
 import {
   formatBillingCurrency,
-  formatBillingQuantity,
   type BillingUnit,
 } from "@/components/billing/billing-format";
+import {
+  getChatCreditEntitlement,
+  TierIncludedItems,
+} from "./billing-entitlements";
 
 export default function Billing(): JSX.Element {
   return (
@@ -70,64 +73,6 @@ function BillingInner() {
         <UsageTiers />
       )}
     </>
-  );
-}
-
-export function getChatCreditEntitlement(
-  productTier: ProductTier,
-  usageTiers: UsageTiersModel | undefined,
-): number | undefined {
-  if (!usageTiers) {
-    return undefined;
-  }
-
-  switch (productTier) {
-    case "__deprecated__pro":
-      return usageTiers.pro.includedCredits;
-    case "enterprise":
-      return usageTiers.enterprise.includedCredits;
-    default:
-      return usageTiers.free.includedCredits;
-  }
-}
-
-export function TierIncludedItems({
-  tierLimits,
-}: {
-  tierLimits: TierLimits;
-}): JSX.Element | null {
-  const hasIncludedItems =
-    tierLimits.includedBullets.length > 0 || tierLimits.includedCredits > 0;
-  if (!hasIncludedItems) {
-    return null;
-  }
-
-  return (
-    <Stack gap={1}>
-      <Type
-        mono
-        muted
-        small
-        variant="subheading"
-        className="font-medium uppercase"
-      >
-        Included
-      </Type>
-      <ul className="list-inside space-y-1">
-        {tierLimits.includedCredits > 0 ? (
-          <li>
-            <span className="text-muted-foreground/60">✓</span>{" "}
-            {formatBillingQuantity(tierLimits.includedCredits, "chat credits")}{" "}
-            / month
-          </li>
-        ) : null}
-        {tierLimits.includedBullets.map((bullet) => (
-          <li key={bullet}>
-            <span className="text-muted-foreground/60">✓</span> {bullet}
-          </li>
-        ))}
-      </ul>
-    </Stack>
   );
 }
 

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -30,10 +30,8 @@ import {
   formatBillingCurrency,
   type BillingUnit,
 } from "@/components/billing/billing-format";
-import {
-  getChatCreditEntitlement,
-  TierIncludedItems,
-} from "./billing-entitlements";
+import { TierIncludedItems } from "./billing-entitlements";
+import { getChatCreditEntitlement } from "./billing-entitlement";
 
 export default function Billing(): JSX.Element {
   return (

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -9,9 +9,10 @@ import { Type } from "@/components/ui/type";
 import { useIsPlatformAdmin } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
-import { ProductTier, useProductTier } from "@/hooks/useProductTier";
+import { type ProductTier, useProductTier } from "@/hooks/useProductTier";
 import { getServerURL } from "@/lib/utils";
-import { TierLimits } from "@gram/client/models/components/tierlimits.js";
+import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
+import type { UsageTiers as UsageTiersModel } from "@gram/client/models/components/usagetiers.js";
 import { useGetCreditUsage } from "@gram/client/react-query/getCreditUsage.js";
 import { useGetPeriodUsage } from "@gram/client/react-query/getPeriodUsage.js";
 import { useGetUsageTiers } from "@gram/client/react-query/getUsageTiers.js";
@@ -25,6 +26,11 @@ import {
   TumAdminSection,
   TumUsageSection,
 } from "@/components/billing/tum-section";
+import {
+  formatBillingCurrency,
+  formatBillingQuantity,
+  type BillingUnit,
+} from "@/components/billing/billing-format";
 
 export default function Billing(): JSX.Element {
   return (
@@ -67,50 +73,114 @@ function BillingInner() {
   );
 }
 
+export function getChatCreditEntitlement(
+  productTier: ProductTier,
+  usageTiers: UsageTiersModel | undefined,
+): number | undefined {
+  if (!usageTiers) {
+    return undefined;
+  }
+
+  switch (productTier) {
+    case "__deprecated__pro":
+      return usageTiers.pro.includedCredits;
+    case "enterprise":
+      return usageTiers.enterprise.includedCredits;
+    default:
+      return usageTiers.free.includedCredits;
+  }
+}
+
+export function TierIncludedItems({
+  tierLimits,
+}: {
+  tierLimits: TierLimits;
+}): JSX.Element | null {
+  const hasIncludedItems =
+    tierLimits.includedBullets.length > 0 || tierLimits.includedCredits > 0;
+  if (!hasIncludedItems) {
+    return null;
+  }
+
+  return (
+    <Stack gap={1}>
+      <Type
+        mono
+        muted
+        small
+        variant="subheading"
+        className="font-medium uppercase"
+      >
+        Included
+      </Type>
+      <ul className="list-inside space-y-1">
+        {tierLimits.includedCredits > 0 ? (
+          <li>
+            <span className="text-muted-foreground/60">✓</span>{" "}
+            {formatBillingQuantity(tierLimits.includedCredits, "chat credits")}{" "}
+            / month
+          </li>
+        ) : null}
+        {tierLimits.includedBullets.map((bullet) => (
+          <li key={bullet}>
+            <span className="text-muted-foreground/60">✓</span> {bullet}
+          </li>
+        ))}
+      </ul>
+    </Stack>
+  );
+}
+
+function UsageItem({
+  label,
+  tooltip,
+  value,
+  included,
+  overageIncrement,
+  noMax,
+  unit,
+}: {
+  label: string;
+  tooltip: string;
+  value: number;
+  included: number;
+  overageIncrement?: number;
+  noMax?: boolean;
+  unit: BillingUnit;
+}) {
+  return (
+    <Stack gap={3} className="mb-6">
+      <Stack direction="horizontal" align="center" gap={1}>
+        <Type variant="body" className="font-medium">
+          {label}
+        </Type>
+        <SimpleTooltip tooltip={tooltip}>
+          <Info className="text-muted-foreground h-4 w-4" />
+        </SimpleTooltip>
+      </Stack>
+      <UsageProgress
+        value={value}
+        included={included}
+        overageIncrement={overageIncrement}
+        noMax={noMax}
+        unit={unit}
+      />
+    </Stack>
+  );
+}
+
 const UsageSection = () => {
   const productTier = useProductTier();
 
-  const isAdmin = useIsPlatformAdmin();
-
   const { data: creditUsage } = useGetCreditUsage();
+  const { data: usageTiers } = useGetUsageTiers();
   const { data: periodUsage } = useGetPeriodUsage(undefined, undefined, {
     throwOnError: !getServerURL().includes("localhost"),
   });
-
-  const UsageItem = ({
-    label,
-    tooltip,
-    value,
-    included,
-    overageIncrement,
-    noMax,
-  }: {
-    label: string;
-    tooltip: string;
-    value: number;
-    included: number;
-    overageIncrement: number;
-    noMax?: boolean;
-  }) => {
-    return (
-      <Stack gap={3} className="mb-6">
-        <Stack direction="horizontal" align="center" gap={1}>
-          <Type variant="body" className="font-medium">
-            {label}
-          </Type>
-          <SimpleTooltip tooltip={tooltip}>
-            <Info className="text-muted-foreground h-4 w-4" />
-          </SimpleTooltip>
-        </Stack>
-        <UsageProgress
-          value={value}
-          included={included}
-          overageIncrement={overageIncrement}
-          noMax={noMax}
-        />
-      </Stack>
-    );
-  };
+  const chatCreditEntitlement = getChatCreditEntitlement(
+    productTier,
+    usageTiers,
+  );
 
   return (
     <Page.Section>
@@ -133,6 +203,7 @@ const UsageSection = () => {
                 included={periodUsage.includedToolCalls || 1000}
                 overageIncrement={periodUsage.includedToolCalls}
                 noMax={productTier === "enterprise"}
+                unit="tool calls"
               />
               <UsageItem
                 label="Servers"
@@ -141,17 +212,8 @@ const UsageSection = () => {
                 included={periodUsage.includedServers || 1}
                 overageIncrement={1}
                 noMax={productTier === "enterprise"}
+                unit="servers"
               />
-              {isAdmin && (
-                <UsageItem
-                  label="Chat Based Credits (Polar) (ADMIN VIEW ONLY)"
-                  tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
-                  value={periodUsage.credits}
-                  included={periodUsage.includedCredits}
-                  overageIncrement={periodUsage.includedCredits}
-                  noMax={productTier === "enterprise"}
-                />
-              )}
             </>
           ) : (
             <>
@@ -161,13 +223,13 @@ const UsageSection = () => {
               <Skeleton className="h-4 w-full" />
             </>
           )}
-          {creditUsage ? (
+          {creditUsage && chatCreditEntitlement !== undefined ? (
             <UsageItem
-              label="Chat Based Credits"
-              tooltip="The number of credits used this month for chat based products and other AI-powered dashboard experiences."
+              label="Chat credits"
+              tooltip="Chat credits consumed this month by chat-based products and other AI-powered dashboard experiences."
               value={creditUsage.creditsUsed}
-              included={creditUsage.monthlyCredits}
-              overageIncrement={creditUsage.monthlyCredits}
+              included={chatCreditEntitlement}
+              unit="chat credits"
             />
           ) : (
             <>
@@ -322,7 +384,7 @@ const UsageTiers = () => {
     const price =
       tier === "enterprise"
         ? "Tailored pricing"
-        : `$${tierLimits.basePrice.toLocaleString()}`;
+        : `${formatBillingCurrency(tierLimits.basePrice)} / month`;
 
     const ringColor = productTierColors(tier).ring;
 
@@ -358,28 +420,7 @@ const UsageTiers = () => {
                 ))}
               </ul>
             </Stack>
-            {tierLimits.includedBullets &&
-              tierLimits.includedBullets.length > 0 && (
-                <Stack gap={1}>
-                  <Type
-                    mono
-                    muted
-                    small
-                    variant="subheading"
-                    className="font-medium uppercase"
-                  >
-                    Included
-                  </Type>
-                  <ul className="list-inside space-y-1">
-                    {tierLimits.includedBullets.map((bullet) => (
-                      <li key={bullet}>
-                        <span className="text-muted-foreground/60">✓</span>{" "}
-                        {bullet}
-                      </li>
-                    ))}
-                  </ul>
-                </Stack>
-              )}
+            <TierIncludedItems tierLimits={tierLimits} />
             {tierLimits.addOnBullets && tierLimits.addOnBullets.length > 0 && (
               <Stack gap={1}>
                 <Type

--- a/client/dashboard/src/pages/billing/billing-entitlement.ts
+++ b/client/dashboard/src/pages/billing/billing-entitlement.ts
@@ -1,0 +1,21 @@
+import type { ProductTier } from "@/hooks/useProductTier";
+import type { UsageTiers } from "@gram/client/models/components/usagetiers.js";
+
+export function getChatCreditEntitlement(
+  productTier: ProductTier,
+  usageTiers: UsageTiers | undefined,
+): number | undefined {
+  if (!usageTiers) {
+    return undefined;
+  }
+
+  switch (productTier) {
+    case "__deprecated__pro":
+      return usageTiers.pro.includedCredits;
+    case "enterprise":
+      return usageTiers.enterprise.includedCredits;
+    case "base":
+    case "base_PAID":
+      return usageTiers.free.includedCredits;
+  }
+}

--- a/client/dashboard/src/pages/billing/billing-entitlements.tsx
+++ b/client/dashboard/src/pages/billing/billing-entitlements.tsx
@@ -1,27 +1,7 @@
 import { formatBillingQuantity } from "@/components/billing/billing-format";
 import { Type } from "@/components/ui/type";
-import type { ProductTier } from "@/hooks/useProductTier";
 import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
-import type { UsageTiers } from "@gram/client/models/components/usagetiers.js";
 import { Stack } from "@speakeasy-api/moonshine";
-
-export function getChatCreditEntitlement(
-  productTier: ProductTier,
-  usageTiers: UsageTiers | undefined,
-): number | undefined {
-  if (!usageTiers) {
-    return undefined;
-  }
-
-  switch (productTier) {
-    case "__deprecated__pro":
-      return usageTiers.pro.includedCredits;
-    case "enterprise":
-      return usageTiers.enterprise.includedCredits;
-    default:
-      return usageTiers.free.includedCredits;
-  }
-}
 
 export function TierIncludedItems({
   tierLimits,

--- a/client/dashboard/src/pages/billing/billing-entitlements.tsx
+++ b/client/dashboard/src/pages/billing/billing-entitlements.tsx
@@ -1,0 +1,64 @@
+import { formatBillingQuantity } from "@/components/billing/billing-format";
+import { Type } from "@/components/ui/type";
+import type { ProductTier } from "@/hooks/useProductTier";
+import type { TierLimits } from "@gram/client/models/components/tierlimits.js";
+import type { UsageTiers } from "@gram/client/models/components/usagetiers.js";
+import { Stack } from "@speakeasy-api/moonshine";
+
+export function getChatCreditEntitlement(
+  productTier: ProductTier,
+  usageTiers: UsageTiers | undefined,
+): number | undefined {
+  if (!usageTiers) {
+    return undefined;
+  }
+
+  switch (productTier) {
+    case "__deprecated__pro":
+      return usageTiers.pro.includedCredits;
+    case "enterprise":
+      return usageTiers.enterprise.includedCredits;
+    default:
+      return usageTiers.free.includedCredits;
+  }
+}
+
+export function TierIncludedItems({
+  tierLimits,
+}: {
+  tierLimits: TierLimits;
+}): JSX.Element | null {
+  const hasIncludedItems =
+    tierLimits.includedBullets.length > 0 || tierLimits.includedCredits > 0;
+  if (!hasIncludedItems) {
+    return null;
+  }
+
+  return (
+    <Stack gap={1}>
+      <Type
+        mono
+        muted
+        small
+        variant="subheading"
+        className="font-medium uppercase"
+      >
+        Included
+      </Type>
+      <ul className="list-inside space-y-1">
+        {tierLimits.includedCredits > 0 ? (
+          <li>
+            <span className="text-muted-foreground/60">✓</span>{" "}
+            {formatBillingQuantity(tierLimits.includedCredits, "chat credits")}{" "}
+            / month
+          </li>
+        ) : null}
+        {tierLimits.includedBullets.map((bullet) => (
+          <li key={bullet}>
+            <span className="text-muted-foreground/60">✓</span> {bullet}
+          </li>
+        ))}
+      </ul>
+    </Stack>
+  );
+}

--- a/server/internal/billing/stub.go
+++ b/server/internal/billing/stub.go
@@ -191,7 +191,6 @@ func (s *StubClient) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error)
 			IncludedBullets: []string{
 				"3 MCP servers (public or private)",
 				"10000 tool calls / month",
-				"25 chat based credits / month",
 				"Slack community support",
 			},
 			AddOnBullets: []string{},
@@ -211,13 +210,12 @@ func (s *StubClient) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error)
 			IncludedBullets: []string{
 				"50 MCP servers (public or private)",
 				"100000000 tool calls / month",
-				"25 chat based credits / month",
 				"Email support",
 			},
 			AddOnBullets: []string{
 				"$0.50 / month / additional MCP server",
 				"$0.05 / month / additional 5000 tool calls",
-				"$11 per 10 additional chat based credits",
+				AdditionalChatCreditsBullet("$11", 10),
 			},
 		},
 		Enterprise: &gen.TierLimits{

--- a/server/internal/billing/terminology.go
+++ b/server/internal/billing/terminology.go
@@ -1,0 +1,9 @@
+package billing
+
+import "fmt"
+
+const ChatCreditsUnit = "chat credits"
+
+func AdditionalChatCreditsBullet(price string, quantity int) string {
+	return fmt.Sprintf("%s per %d additional %s", price, quantity, ChatCreditsUnit)
+}

--- a/server/internal/billing/terminology_test.go
+++ b/server/internal/billing/terminology_test.go
@@ -1,0 +1,15 @@
+package billing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdditionalChatCreditsBullet(t *testing.T) {
+	require.Equal(
+		t,
+		"$11 per 10 additional chat credits",
+		AdditionalChatCreditsBullet("$11", 10),
+	)
+}

--- a/server/internal/billing/terminology_test.go
+++ b/server/internal/billing/terminology_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestAdditionalChatCreditsBullet(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(
 		t,
 		"$11 per 10 additional chat credits",

--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -1088,13 +1088,12 @@ func (p *Client) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error) {
 			IncludedBullets: []string{
 				fmt.Sprintf("%d MCP %s (public or private)", freeTierLimits.Servers, conv.Ternary(freeTierLimits.Servers == 1, "server", "servers")),
 				fmt.Sprintf("%d tool calls / month", freeTierLimits.ToolCalls),
-				fmt.Sprintf("%d LLM credits / month", freeTierLimits.Credits),
 				"Slack community support",
 			},
 			AddOnBullets: []string{
 				fmt.Sprintf("%s / month / additional MCP server", formatPrice(mcpServerPrice)),
 				fmt.Sprintf("%s / additional tool call", formatPrice(toolCallPrice)),
-				fmt.Sprintf("%s / 10 additional LLM credits", formatPrice(10*creditsPrice)), // 1.10 per credit in polar, but this is how we want to label from a marketing perspective
+				billing.AdditionalChatCreditsBullet(formatPrice(10*creditsPrice), 10),
 			},
 		},
 		Pro: &gen.TierLimits{
@@ -1112,13 +1111,12 @@ func (p *Client) GetUsageTiers(ctx context.Context) (*gen.UsageTiers, error) {
 			IncludedBullets: []string{
 				fmt.Sprintf("%d MCP %s (public or private)", proTierLimits.Servers, conv.Ternary(proTierLimits.Servers == 1, "server", "servers")),
 				fmt.Sprintf("%d tool calls / month", proTierLimits.ToolCalls),
-				fmt.Sprintf("%d LLM credits / month", proTierLimits.Credits),
 				"Email support",
 			},
 			AddOnBullets: []string{
 				fmt.Sprintf("%s / month / additional MCP server", formatPrice(mcpServerPrice)),
 				fmt.Sprintf("%s / additional tool call", formatPrice(toolCallPrice)),
-				"$11 per 10 additional LLM credits", // 1.10 per credit in polar, but this is how we want to label from a marketing perspective
+				billing.AdditionalChatCreditsBullet("$11", 10),
 			},
 		},
 		Enterprise: &gen.TierLimits{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- derive the Billing usage entitlement from the same Polar tier configuration used by pricing
- label consumed, included, and additional quantities with explicit units and format plan prices as USD per month
- standardize pricing and top-up terminology on “chat credits”
- add isolated frontend and Go coverage for entitlement selection, rendered units, fractional values, currency, and add-on copy

## Testing
- `pnpm -F dashboard test src/components/billing/billing-format.test.ts src/components/billing/usage-progress.test.tsx src/pages/billing/Billing.test.tsx` ✅ (6 tests)
- `pnpm -F dashboard type-check` ✅
- `pnpm -F dashboard lint` ✅
- `mise exec -- go test ./server/internal/billing ./server/internal/thirdparty/polar` ✅
- `mise lint:server` ✅
- manually verified Pro Billing usage and pricing both show 25 included chat credits with explicit units ✅

## Walkthrough
<a href="https://cursor.com/agents/bc-9e4c318f-5ac5-428e-a6d5-b0cf431c9658/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbilling_chat_credit_consistency.mp4"><img src="https://cursor.com/artifacts/c/art-56048f7c-daaa-46a4-b5f7-1e8b2b198d31" alt="billing_chat_credit_consistency.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-682](https://linear.app/speakeasy/issue/DNO-682/fix-inconsistent-pro-chat-credit-amounts-and-units-on-billing)

<div><a href="https://cursor.com/agents/bc-9e4c318f-5ac5-428e-a6d5-b0cf431c9658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e4c318f-5ac5-428e-a6d5-b0cf431c9658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies chat‑credit amounts and units across Billing by deriving entitlements from Polar usage tiers and standardizing labels, pricing, and copy across app and API. Addresses Linear DNO-682 by fixing inconsistent Pro chat‑credit amounts and units.

- **Bug Fixes**
  - Derive chat‑credit entitlement from Polar usage tiers so Free/Pro/Enterprise match pricing; pricing cards render included chat credits “/ month”.
  - Standardize on “chat credits” (replaces “LLM credits” and “chat based credits”); update button to “TOP UP CHAT CREDITS”; backend add‑on bullet uses consistent “per 10 additional chat credits”.
  - Usage bar labels Consumed/Included/Additional with explicit units; supports fractional values and “No limit”; overage markers respect increments.
  - Format plan prices as USD with cents and show “/ month”.
  - Extract display/formatting and entitlement selection into small components with tests for entitlements, unit rendering (singular/plural, fractional), currency, progress labels, and add‑on copy (frontend and Go).

<sup>Written for commit a99680083eaa4da23441b38d0fec1bb07fed6f57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

