### PR TITLE
mig: index scoped invalid skill observations

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -497,6 +497,12 @@ CREATE INDEX IF NOT EXISTS skill_observations_pending_reconciliation_idx
 ON skill_observations (project_id, seen_at, id)
 WHERE reconciled_at IS NULL;
 
+CREATE INDEX IF NOT EXISTS skill_observations_scoped_invalid_reconciliation_idx
+ON skill_observations (project_id, seen_at, id)
+WHERE reconcile_error_code = 'invalid_name'
+  AND btrim(skill_name) ~ '^[^:]+:[[:space:]]*[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'
+  AND char_length(btrim(substring(btrim(skill_name) from '[^:]+$'))) <= 64;
+
 CREATE INDEX IF NOT EXISTS skill_observations_pending_metrics_sync_idx
 ON skill_observations (project_id, seen_at, id)
 WHERE reconciled_at IS NOT NULL AND metrics_synced_at IS NULL AND session_id IS NOT NULL AND skill_version_id IS NOT NULL;

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -500,8 +500,8 @@ WHERE reconciled_at IS NULL;
 CREATE INDEX IF NOT EXISTS skill_observations_scoped_invalid_reconciliation_idx
 ON skill_observations (project_id, seen_at, id)
 WHERE reconcile_error_code = 'invalid_name'
-  AND btrim(skill_name) ~ '^[^:]+:[[:space:]]*[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'
-  AND char_length(btrim(substring(btrim(skill_name) from '[^:]+$'))) <= 64;
+  AND regexp_replace(skill_name, '^[[:space:]]+|[[:space:]]+$', '', 'g') ~ '^[^:]+:[[:space:]]*[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'
+  AND char_length(regexp_replace(split_part(skill_name, ':', 2), '^[[:space:]]+|[[:space:]]+$', '', 'g')) <= 64;
 
 CREATE INDEX IF NOT EXISTS skill_observations_pending_metrics_sync_idx
 ON skill_observations (project_id, seen_at, id)

--- a/server/migrations/20260729221949_skills_scoped_invalid_reconciliation_index.sql
+++ b/server/migrations/20260729221949_skills_scoped_invalid_reconciliation_index.sql
@@ -1,4 +1,0 @@
--- atlas:txmode none
-
--- Create index "skill_observations_scoped_invalid_reconciliation_idx" to table: "skill_observations"
-CREATE INDEX CONCURRENTLY "skill_observations_scoped_invalid_reconciliation_idx" ON "skill_observations" ("project_id", "seen_at", "id") WHERE ((reconcile_error_code = 'invalid_name'::text) AND (btrim(skill_name) ~ '^[^:]+:[[:space:]]*[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'::text) AND (char_length(btrim("substring"(btrim(skill_name), '[^:]+$'::text))) <= 64));

--- a/server/migrations/20260729221949_skills_scoped_invalid_reconciliation_index.sql
+++ b/server/migrations/20260729221949_skills_scoped_invalid_reconciliation_index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "skill_observations_scoped_invalid_reconciliation_idx" to table: "skill_observations"
+CREATE INDEX CONCURRENTLY "skill_observations_scoped_invalid_reconciliation_idx" ON "skill_observations" ("project_id", "seen_at", "id") WHERE ((reconcile_error_code = 'invalid_name'::text) AND (btrim(skill_name) ~ '^[^:]+:[[:space:]]*[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'::text) AND (char_length(btrim("substring"(btrim(skill_name), '[^:]+$'::text))) <= 64));

--- a/server/migrations/20260729223725_skills_scoped_invalid_reconciliation_index.sql
+++ b/server/migrations/20260729223725_skills_scoped_invalid_reconciliation_index.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "skill_observations_scoped_invalid_reconciliation_idx" to table: "skill_observations"
+CREATE INDEX CONCURRENTLY "skill_observations_scoped_invalid_reconciliation_idx" ON "skill_observations" ("project_id", "seen_at", "id") WHERE ((reconcile_error_code = 'invalid_name'::text) AND (regexp_replace(skill_name, '^[[:space:]]+|[[:space:]]+$'::text, ''::text, 'g'::text) ~ '^[^:]+:[[:space:]]*[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$'::text) AND (char_length(regexp_replace(split_part(skill_name, ':'::text, 2), '^[[:space:]]+|[[:space:]]+$'::text, ''::text, 'g'::text)) <= 64));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/K1ioXUBJ2LJl3OHoe923MXaHL8IU9zfS8/ESG0krK4=
+h1:1TztkEypYaJtMhHF9CTI8cEIUk17PDJnImruY4otHsU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -307,3 +307,4 @@ h1:/K1ioXUBJ2LJl3OHoe923MXaHL8IU9zfS8/ESG0krK4=
 20260728192241_dno_573_suggestion_list_index.sql h1:oi8LXZQndV4kUsIAJm/Ji3RokVt1KgFK+NC3c1+CZvA=
 20260728192302_dno_574_skill_version_promotion.sql h1:jQLB1IwxIj6iZr8kA9Ya/u6N6pG4jn+15RjS3+BM5+w=
 20260728201450_cimd_inbound_storage.sql h1:al8Z9FQ75jt6vp7WIIhJ8+uyTDmf51PA3zb4Anggt1w=
+20260729221949_skills_scoped_invalid_reconciliation_index.sql h1:Htoj3PQTTJSFqnRMu2KMvr21qPwM/xzaw7rMLGjZ2Wg=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:1TztkEypYaJtMhHF9CTI8cEIUk17PDJnImruY4otHsU=
+h1:PfT4P+t/mNz8cU/J3dByuOnpP6Cnxsib2Z9uKgkhy40=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -307,4 +307,4 @@ h1:1TztkEypYaJtMhHF9CTI8cEIUk17PDJnImruY4otHsU=
 20260728192241_dno_573_suggestion_list_index.sql h1:oi8LXZQndV4kUsIAJm/Ji3RokVt1KgFK+NC3c1+CZvA=
 20260728192302_dno_574_skill_version_promotion.sql h1:jQLB1IwxIj6iZr8kA9Ya/u6N6pG4jn+15RjS3+BM5+w=
 20260728201450_cimd_inbound_storage.sql h1:al8Z9FQ75jt6vp7WIIhJ8+uyTDmf51PA3zb4Anggt1w=
-20260729221949_skills_scoped_invalid_reconciliation_index.sql h1:Htoj3PQTTJSFqnRMu2KMvr21qPwM/xzaw7rMLGjZ2Wg=
+20260729223725_skills_scoped_invalid_reconciliation_index.sql h1:lu2a4rcUVOY/RYtTn4ytB9KIaC2MHQ9A2rv72/vSq/o=


### PR DESCRIPTION
## Summary

- add a partial index for scoped `invalid_name` skill observations awaiting re-drive
- keep the index predicate aligned with the reconciliation eligibility predicate in #4715
- build the index concurrently to avoid blocking observation ingestion

Supports [DNO-668](https://linear.app/speakeasy/issue/DNO-668/fix-plugin-scoped-skill-activations-are-rejected-as-invalid-name)

Prerequisite for #4715.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a partial index to speed up re-driving scoped `invalid_name` skill observations without blocking ingestion. This supports DNO-668 by making eligible, plugin-scoped activations easier to find for reconciliation.

- **Migration**
  - Creates `skill_observations_scoped_invalid_reconciliation_idx` on `(project_id, seen_at, id)` with a predicate for `reconcile_error_code = 'invalid_name'`, a `scope:name` regex that trims whitespace around parts, and a 64-char tail cap.
  - Built CONCURRENTLY (`atlas:txmode none`) and added to `server/database/schema.sql`; no app changes.
  - Predicate aligns with reconciliation eligibility used in #4715.

<sup>Written for commit a14101b16fccb19826241e2070fba6bbec6401a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

