### PR TITLE
fix(dashboard): align tum tooltip with the public billing docs

### DIFF
--- a/.changeset/tum-definition-docs-link.md
+++ b/.changeset/tum-definition-docs-link.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Explain tokens under management on the billing page with the same definition as the public billing docs, and link the info affordances straight to that docs section.

--- a/client/dashboard/src/components/billing/token-usage-panel.tsx
+++ b/client/dashboard/src/components/billing/token-usage-panel.tsx
@@ -4,6 +4,7 @@ import { unixNanoToMs } from "@/components/chart/chartUtils";
 import { type TimeSeriesStack } from "@/components/stacked-time-series";
 import { StackedTimeSeriesPanel } from "@/components/stacked-time-series-panel";
 import { type StackMode } from "./breakdown-options";
+import { TumDefinitionHint } from "./tum-definition";
 
 // The billing page's tokens-under-management breakdown: the shared stacked
 // time-series panel fed with daily token buckets, stacked by a chosen
@@ -48,10 +49,6 @@ function formatTokensAxis(value: number): string {
 // points grid by index — the same shape the shared panel consumes, so the
 // rows (rollup flag included) pass straight through as stacks.
 export type GroupSeries = TimeSeriesStack;
-
-// The header info copy for the panel.
-const HEADER_HINT =
-  "Tokens under management — the agent traffic the platform observes from your users' sessions (including Claude Code, Cowork, Cursor, and Codex): input, output, and cache-write tokens. Cache reads are excluded (re-read cached content isn't new traffic), and so is inference the platform itself runs (risk-policy analysis, hosted chat).";
 
 // The daily stack series for the selected mode, aligned to the points grid.
 // The panel drops all-zero stacks, so modes whose series don't apply (e.g.
@@ -127,7 +124,7 @@ export function TokenUsagePanel({
   return (
     <StackedTimeSeriesPanel
       title="Token Usage Time Series"
-      headerHint={HEADER_HINT}
+      headerHint={<TumDefinitionHint />}
       bucketsMs={bucketsMs}
       stacks={stacks}
       headerControls={breakdownPicker}

--- a/client/dashboard/src/components/billing/tum-definition.tsx
+++ b/client/dashboard/src/components/billing/tum-definition.tsx
@@ -1,0 +1,69 @@
+import { Info } from "lucide-react";
+import { SimpleTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+// How the billing page explains tokens under management. The copy mirrors the
+// public docs section it links to, and every TUM affordance on the page reads
+// it from here, so the page can't drift into two competing definitions —
+// change the docs section and this copy together.
+const TUM_DOCS_URL =
+  "https://www.speakeasy.com/docs/ai-control-plane/org-admin/billing#tokens-under-management";
+
+// The tooltip body: the definition, then the two fences that decide what lands
+// in the number. It carries its own docs link because pointer users can hover
+// into tooltip content (Radix keeps the tooltip open across the gap); keyboard
+// users reach the same URL through the trigger, which is itself a link.
+export function TumDefinitionHint(): JSX.Element {
+  return (
+    <div className="flex max-w-xs flex-col gap-1.5">
+      <p>
+        The volume of agent traffic the platform observes from your users'
+        sessions each billing cycle — Claude Code, Cowork, Cursor, Codex, and
+        the rest — measured in tokens.
+      </p>
+      <p>
+        <span className="font-medium">Counted:</span> input tokens, output
+        tokens, cache writes (content written to a prompt cache for the first
+        time), and MCP tool-call traffic.
+      </p>
+      <p>
+        <span className="font-medium">Not counted:</span> cache reads — that
+        content was already counted once, as a cache write — and inference the
+        platform runs itself, such as risk-policy analysis, prompt-injection
+        scanning, the playground, hosted chat, and the dashboard assistant.
+      </p>
+      <a
+        href={TUM_DOCS_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="underline underline-offset-2"
+      >
+        Read the billing docs
+      </a>
+    </div>
+  );
+}
+
+// The info affordance beside a "Tokens Under Management" label: hover for the
+// definition, click (or focus and hit enter) to open the docs section it
+// mirrors. An anchor rather than a bare icon so the explanation and the docs
+// are both reachable without a pointer.
+export function TumDefinitionTooltip({
+  className,
+}: {
+  className?: string;
+}): JSX.Element {
+  return (
+    <SimpleTooltip tooltip={<TumDefinitionHint />}>
+      <a
+        href={TUM_DOCS_URL}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="How tokens under management is measured"
+        className="text-muted-foreground hover:text-foreground inline-flex shrink-0"
+      >
+        <Info aria-hidden className={cn("h-4 w-4", className)} />
+      </a>
+    </SimpleTooltip>
+  );
+}

--- a/client/dashboard/src/components/billing/tum-section.tsx
+++ b/client/dashboard/src/components/billing/tum-section.tsx
@@ -2,7 +2,6 @@ import { Page } from "@/components/page-layout";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
 import { useOrganization } from "@/contexts/Auth";
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
@@ -15,7 +14,7 @@ import { useListProjects } from "@gram/client/react-query/listProjects.js";
 import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
 import { Button, Stack } from "@speakeasy-api/moonshine";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Info, RotateCcw } from "lucide-react";
+import { RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { TimeRangePicker } from "@/components/DashboardTimeRangePicker";
 import { BillingCyclePicker } from "./billing-cycle-picker";
@@ -37,6 +36,7 @@ import {
 } from "./breakdown-options";
 import { BreakdownPicker } from "./breakdown-picker";
 import { type GroupSeries, TokenUsagePanel } from "./token-usage-panel";
+import { TumDefinitionTooltip } from "./tum-definition";
 import { TumDetailsTable } from "./tum-details-table";
 import { tumDetailsQuery } from "./tum-queries";
 import { TumUsageCard } from "./tum-usage-card";
@@ -320,9 +320,7 @@ export const TumUsageSection = (): JSX.Element => {
               <Type variant="body" className="font-medium">
                 Tokens Under Management
               </Type>
-              <SimpleTooltip tooltip="Counts the tokens observed in your users' agent sessions (input, output, and cache writes; cache reads excluded) during the selected billing cycle. Compared against your contracted monthly allowance.">
-                <Info className="text-muted-foreground h-4 w-4" />
-              </SimpleTooltip>
+              <TumDefinitionTooltip />
               <div className="ml-auto flex items-center gap-2">
                 <BillingCyclePicker
                   cycles={cycles}

--- a/client/dashboard/src/components/stacked-time-series-panel.tsx
+++ b/client/dashboard/src/components/stacked-time-series-panel.tsx
@@ -152,7 +152,7 @@ export function StackedTimeSeriesPanel({
 }: {
   // The panel title, with the info-tooltip copy beside it.
   title: string;
-  headerHint: string;
+  headerHint: ReactNode;
   // Gap-filled daily UTC bucket start times — the axis grid. Every stack's
   // series aligns to it by index.
   bucketsMs: number[];

--- a/client/dashboard/src/components/ui/tooltip.tsx
+++ b/client/dashboard/src/components/ui/tooltip.tsx
@@ -63,7 +63,7 @@ function SimpleTooltip({
   tooltip,
   children,
 }: {
-  tooltip: string;
+  tooltip: React.ReactNode;
   children: React.ReactNode;
 }): React.JSX.Element {
   return (


### PR DESCRIPTION
## What

The billing page defined *tokens under management* twice, in two different sets of words — the usage heading tooltip and the token-usage chart's header hint — and neither matched the [public billing docs](https://www.speakeasy.com/docs/ai-control-plane/org-admin/billing#tokens-under-management) nor linked to them.

Both affordances now read one shared definition (`client/dashboard/src/components/billing/tum-definition.tsx`) that mirrors the docs section:

- **Counted:** input tokens, output tokens, cache writes, MCP tool-call traffic
- **Not counted:** cache reads (already counted once as a cache write) and inference the platform runs itself (risk-policy analysis, prompt-injection scanning, playground, hosted chat, dashboard assistant)

Each tooltip ends with a **Read the billing docs** link to that anchor, and the heading's info icon is itself an anchor, so the docs are reachable by keyboard focus rather than only by hovering into tooltip content.

## Notes

- `SimpleTooltip`'s `tooltip` prop and `StackedTimeSeriesPanel`'s `headerHint` prop widen from `string` to `ReactNode` to carry the linked content. Existing callers (cost pages) pass strings and are unaffected.
- The old chart hint's concrete agent examples (Claude Code, Cowork, Cursor, Codex) are preserved in the shared copy.

## Verification

`tsc -b --noEmit --force`, `oxlint --type-aware`, `oxfmt --check`, and `knip` all pass. Not yet exercised in a running dashboard — the copy/link change is static, but a reviewer with a billing page in a local stack can confirm the tooltip layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X7rFsMc6FTAMpy5LsEKZQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the billing page’s “Tokens Under Management” definition with the public docs and added a direct docs link. Unified the tooltip and chart hint to use one shared, accessible component.

- **Bug Fixes**
  - Replaced duplicated copy with shared `TumDefinitionHint`/`TumDefinitionTooltip` that mirrors the docs and includes a “Read the billing docs” link.
  - Made the heading info icon an anchor to improve keyboard access.
  - Widened `SimpleTooltip` `tooltip` and `StackedTimeSeriesPanel` `headerHint` from `string` to `ReactNode` while keeping existing callers working.

<sup>Written for commit 65215b5c5d5e178c51ee2fd272a429f947dd7db0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

