### PR TITLE
chore: removes unused API field

### DIFF
--- a/.changeset/drop-risk-result-replayed.md
+++ b/.changeset/drop-risk-result-replayed.md
@@ -1,0 +1,9 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Remove the unused `replayed` field from the `RiskResult` API type. The flag was
+denormalized from the scanned chat message onto every risk listing row but never
+rendered by any consumer; dropping it shrinks the listing queries ahead of
+serving the Risk Events page from ClickHouse.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -62374,9 +62374,6 @@ components:
           type: integer
           description: Policy version when this result was produced.
           format: int64
-        replayed:
-          type: boolean
-          description: True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.
         rule_id:
           type: string
           description: The matched rule identifier.
@@ -62407,7 +62404,6 @@ components:
         - chat_message_id
         - source
         - created_at
-        - replayed
     RiskResultRedacted:
       type: object
       properties:

--- a/client/dashboard/src/pages/chatLogs/chatHelpers.test.ts
+++ b/client/dashboard/src/pages/chatLogs/chatHelpers.test.ts
@@ -22,7 +22,6 @@ function result(
     createdAt: new Date("2026-07-06T00:00:00Z"),
     source,
     match,
-    replayed: false,
     ...extra,
   };
 }

--- a/client/dashboard/src/sdk/src/models/components/riskresult.ts
+++ b/client/dashboard/src/sdk/src/models/components/riskresult.ts
@@ -63,10 +63,6 @@ export type RiskResult = {
    */
   policyVersion: number;
   /**
-   * True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.
-   */
-  replayed: boolean;
-  /**
    * The matched rule identifier.
    */
   ruleId?: string | undefined;
@@ -112,7 +108,6 @@ export const RiskResult$inboundSchema: z.ZodMiniType<RiskResult, unknown> = z
       match_redacted: z.optional(z.string()),
       policy_id: z.string(),
       policy_version: z.int(),
-      replayed: z.boolean(),
       rule_id: z.optional(z.string()),
       source: z.string(),
       spans: z.optional(z.array(RiskSpan$inboundSchema)),

--- a/server/design/shared/risk.go
+++ b/server/design/shared/risk.go
@@ -283,9 +283,7 @@ var RiskResult = Type("RiskResult", func() {
 	Attribute("created_at", String, "When this result was created.", func() {
 		Format(FormatDateTime)
 	})
-	Attribute("replayed", Boolean, "True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.")
-
-	Required("id", "policy_id", "policy_version", "chat_message_id", "source", "created_at", "replayed")
+	Required("id", "policy_id", "policy_version", "chat_message_id", "source", "created_at")
 })
 
 // RiskSpan is one matched span attributed to a finding.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -62658,9 +62658,6 @@ components:
                     type: integer
                     description: Policy version when this result was produced.
                     format: int64
-                replayed:
-                    type: boolean
-                    description: True when the scanned message arrived as a replay from a device's offline spool after control-plane downtime — the finding was produced retroactively rather than from live traffic.
                 rule_id:
                     type: string
                     description: The matched rule identifier.
@@ -62691,7 +62688,6 @@ components:
                 - chat_message_id
                 - source
                 - created_at
-                - replayed
         RiskResultRedacted:
             type: object
             properties:

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -10643,7 +10643,6 @@ func unmarshalRiskResultResponseBodyToTypesRiskResult(v *RiskResultResponseBody)
 		Confidence:    v.Confidence,
 		MatchRedacted: v.MatchRedacted,
 		CreatedAt:     *v.CreatedAt,
-		Replayed:      *v.Replayed,
 	}
 	if v.Tags != nil {
 		res.Tags = make([]string, len(v.Tags))

--- a/server/gen/http/risk/client/types.go
+++ b/server/gen/http/risk/client/types.go
@@ -9508,10 +9508,6 @@ type RiskResultResponseBody struct {
 	MatchRedacted *string `form:"match_redacted,omitempty" json:"match_redacted,omitempty" xml:"match_redacted,omitempty"`
 	// When this result was created.
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
-	// True when the scanned message arrived as a replay from a device's offline
-	// spool after control-plane downtime — the finding was produced retroactively
-	// rather than from live traffic.
-	Replayed *bool `form:"replayed,omitempty" json:"replayed,omitempty" xml:"replayed,omitempty"`
 }
 
 // RiskSpanResponseBody is used to define fields on response body types.
@@ -29657,9 +29653,6 @@ func ValidateRiskResultResponseBody(body *RiskResultResponseBody) (err error) {
 	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
-	}
-	if body.Replayed == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("replayed", "body"))
 	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))

--- a/server/gen/http/risk/server/encode_decode.go
+++ b/server/gen/http/risk/server/encode_decode.go
@@ -10304,7 +10304,6 @@ func marshalTypesRiskResultToRiskResultResponseBody(v *types.RiskResult) *RiskRe
 		Confidence:    v.Confidence,
 		MatchRedacted: v.MatchRedacted,
 		CreatedAt:     v.CreatedAt,
-		Replayed:      v.Replayed,
 	}
 	if v.Tags != nil {
 		res.Tags = make([]string, len(v.Tags))

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -9484,10 +9484,6 @@ type RiskResultResponseBody struct {
 	MatchRedacted *string `form:"match_redacted,omitempty" json:"match_redacted,omitempty" xml:"match_redacted,omitempty"`
 	// When this result was created.
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
-	// True when the scanned message arrived as a replay from a device's offline
-	// spool after control-plane downtime — the finding was produced retroactively
-	// rather than from live traffic.
-	Replayed bool `form:"replayed" json:"replayed" xml:"replayed"`
 }
 
 // RiskSpanResponseBody is used to define fields on response body types.

--- a/server/gen/types/risk_result.go
+++ b/server/gen/types/risk_result.go
@@ -55,8 +55,4 @@ type RiskResult struct {
 	MatchRedacted *string
 	// When this result was created.
 	CreatedAt string
-	// True when the scanned message arrived as a replay from a device's offline
-	// spool after control-plane downtime — the finding was produced retroactively
-	// rather than from live traffic.
-	Replayed bool
 }

--- a/server/internal/risk/chrepo_roundtrip_test.go
+++ b/server/internal/risk/chrepo_roundtrip_test.go
@@ -26,7 +26,10 @@ func TestInsertRiskFindings_RoundTrip(t *testing.T) {
 	q := chrepo.New(conn)
 
 	orgID := "org_" + uuid.NewString()
-	createdAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	// Relative date: rows older than the table's 90-day created_at TTL expire
+	// at insert time, so a hardcoded date would silently break the round trip
+	// once the calendar catches up.
+	createdAt := time.Now().UTC().AddDate(0, 0, -1).Truncate(time.Hour)
 
 	// A plain (non-excluded) row: excluded_at / exclusion_id bind as nil into
 	// the Nullable columns.

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -1740,8 +1740,26 @@ func (s *Service) listResultsByChat(ctx context.Context, projectID uuid.UUID, ra
 	results := make([]*types.RiskResult, 0, len(rows))
 	var nextCursor *riskResultsCursor
 	for i, row := range rows {
-		cid := row.ChatID.String()
-		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID.UUID, &cid, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt, row.Replayed))
+		results = append(results, foundRowToResult(
+			row.ID,
+			row.RiskPolicyID,
+			row.RiskPolicyVersion,
+			row.BlockID,
+			row.ChatMessageID.UUID,
+			new(row.ChatID.String()),
+			row.ChatTitle,
+			row.ChatUserID,
+			row.Source,
+			row.RuleID,
+			row.Description,
+			row.Match,
+			row.StartPos,
+			row.EndPos,
+			row.Confidence,
+			row.Tags,
+			row.Spans,
+			row.MessageCreatedAt,
+		))
 		if i == pageSize {
 			nextCursor = &riskResultsCursor{MessageCreatedAt: row.MessageCreatedAt.Time, ID: row.ID}
 		}
@@ -1772,8 +1790,29 @@ func (s *Service) listResultsByProject(ctx context.Context, projectID uuid.UUID,
 	results := make([]*types.RiskResult, 0, len(rows))
 	var nextCursor *riskResultsCursor
 	for i, row := range rows {
-		chatID := row.ChatID.String()
-		results = append(results, foundRowToResult(row.ID, row.RiskPolicyID, row.RiskPolicyVersion, row.BlockID, row.ChatMessageID.UUID, &chatID, row.ChatTitle, row.ChatUserID, row.Source, row.RuleID, row.Description, row.Match, row.StartPos, row.EndPos, row.Confidence, row.Tags, row.Spans, row.MessageCreatedAt, row.Replayed))
+		results = append(
+			results,
+			foundRowToResult(
+				row.ID,
+				row.RiskPolicyID,
+				row.RiskPolicyVersion,
+				row.BlockID,
+				row.ChatMessageID.UUID,
+				new(row.ChatID.String()),
+				row.ChatTitle,
+				row.ChatUserID,
+				row.Source,
+				row.RuleID,
+				row.Description,
+				row.Match,
+				row.StartPos,
+				row.EndPos,
+				row.Confidence,
+				row.Tags,
+				row.Spans,
+				row.MessageCreatedAt,
+			),
+		)
 		if i == pageSize {
 			nextCursor = &riskResultsCursor{MessageCreatedAt: row.MessageCreatedAt.Time, ID: row.ID}
 		}
@@ -3869,7 +3908,6 @@ func foundRowToResult(
 	source string, ruleID, description, match pgtype.Text,
 	startPos, endPos pgtype.Int4,
 	confidence pgtype.Float8, tags []string, spans []byte, createdAt pgtype.Timestamptz,
-	replayed bool,
 ) *types.RiskResult {
 	return &types.RiskResult{
 		ID:            id.String(),
@@ -3893,7 +3931,6 @@ func foundRowToResult(
 		// for callers ListRiskResults decides shouldn't see raw match/spans.
 		MatchRedacted: nil,
 		CreatedAt:     createdAt.Time.Format(time.RFC3339),
-		Replayed:      replayed,
 	}
 }
 

--- a/server/internal/risk/overview_ch_test.go
+++ b/server/internal/risk/overview_ch_test.go
@@ -83,8 +83,12 @@ func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
 	disabledPolicyID, err := uuid.Parse(disabledPolicy.ID)
 	require.NoError(t, err)
 
-	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)
+	// Relative window: the risk_findings table carries a 90-day TTL on
+	// created_at, so hardcoded seed dates silently age out and expire at
+	// insert time once the calendar catches up (INC: this test broke exactly
+	// 90 days after its old fixed dates).
+	from := time.Now().UTC().AddDate(0, 0, -14).Truncate(time.Hour)
+	to := from.AddDate(0, 0, 7)
 
 	aliceSecret1Chat, aliceSecret1 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
 	aliceSecret2Chat, aliceSecret2 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
@@ -186,13 +190,16 @@ func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
 	for _, point := range result.TimeSeriesFindings {
 		timeSeries[point.Category+"|"+point.BucketStart] = point.Findings
 	}
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T14:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["pii|2026-05-03T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["shadow_mcp|2026-05-04T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T13:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T14:00:00Z"])
-	require.Equal(t, int64(0), timeSeries["pii|2026-05-05T13:00:00Z"])
+	bucket := func(category string, offset time.Duration) string {
+		return category + "|" + from.Add(offset).Format(time.RFC3339)
+	}
+	require.Equal(t, int64(1), timeSeries[bucket("secrets", 36*time.Hour)])
+	require.Equal(t, int64(1), timeSeries[bucket("secrets", 38*time.Hour)])
+	require.Equal(t, int64(1), timeSeries[bucket("pii", 60*time.Hour)])
+	require.Equal(t, int64(1), timeSeries[bucket("shadow_mcp", 84*time.Hour)])
+	require.Equal(t, int64(1), timeSeries[bucket("secrets", 109*time.Hour)])
+	require.Equal(t, int64(1), timeSeries[bucket("secrets", 110*time.Hour)])
+	require.Equal(t, int64(0), timeSeries[bucket("pii", 109*time.Hour)])
 }
 
 // TestGetRiskOverview_ClickHouseUserEmailPrecedence covers the Go-side email
@@ -210,8 +217,10 @@ func TestGetRiskOverview_ClickHouseUserEmailPrecedence(t *testing.T) {
 	projectID := *authCtx.ProjectID
 	orgID := authCtx.ActiveOrganizationID
 
-	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	// Relative window: rows older than the table's 90-day created_at TTL
+	// expire at insert time, so seed dates must track the current date.
+	from := time.Now().UTC().AddDate(0, 0, -7).Truncate(time.Hour)
+	to := from.AddDate(0, 0, 1)
 
 	// The auth context user exists in the users table; findings attributed to
 	// that internal user id must resolve to its email even with an opaque

--- a/server/internal/risk/queries.sql
+++ b/server/internal/risk/queries.sql
@@ -1025,14 +1025,14 @@ SELECT
     sub.rule_id, sub.description, sub.match, sub.start_pos, sub.end_pos,
     sub.confidence, sub.tags, sub.spans, sub.dead_letter_reason, sub.created_at,
     sub.chat_id, sub.message_created_at, sub.chat_title, sub.chat_user_id,
-    sub.block_id, sub.replayed
+    sub.block_id
 FROM (
   SELECT
       rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id,
       rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found,
       rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos,
       rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.created_at,
-      cm.chat_id, cm.created_at AS message_created_at, cm.replayed,
+      cm.chat_id, cm.created_at AS message_created_at,
       c.title AS chat_title, c.external_user_id AS chat_user_id,
       COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id,
       CASE
@@ -1155,7 +1155,7 @@ ORDER BY cm.created_at DESC, rr.id DESC
 LIMIT @page_limit;
 
 -- name: ListRiskResultsByChatFound :many
-SELECT rr.*, cm.chat_id, cm.created_at AS message_created_at, cm.replayed, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
+SELECT rr.*, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -2492,7 +2492,7 @@ func (q *Queries) ListRiskPolicyEvalReviews(ctx context.Context, arg ListRiskPol
 }
 
 const listRiskResultsByChatFound = `-- name: ListRiskResultsByChatFound :many
-SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.chat_content_part_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, cm.replayed, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
+SELECT rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id, rr.risk_policy_version, rr.chat_message_id, rr.chat_content_part_id, rr.source, rr.found, rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos, rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.excluded_at, rr.excluded_exclusion_id, rr.false_positive_at, rr.false_positive_reason, rr.created_at, cm.chat_id, cm.created_at AS message_created_at, c.title AS chat_title, c.external_user_id AS chat_user_id, COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id
 FROM risk_results rr
 JOIN chat_messages cm ON cm.id = rr.chat_message_id
 LEFT JOIN chats c ON c.id = cm.chat_id AND c.deleted IS FALSE
@@ -2549,7 +2549,6 @@ type ListRiskResultsByChatFoundRow struct {
 	CreatedAt           pgtype.Timestamptz
 	ChatID              uuid.UUID
 	MessageCreatedAt    pgtype.Timestamptz
-	Replayed            bool
 	ChatTitle           pgtype.Text
 	ChatUserID          pgtype.Text
 	BlockID             uuid.UUID
@@ -2596,7 +2595,6 @@ func (q *Queries) ListRiskResultsByChatFound(ctx context.Context, arg ListRiskRe
 			&i.CreatedAt,
 			&i.ChatID,
 			&i.MessageCreatedAt,
-			&i.Replayed,
 			&i.ChatTitle,
 			&i.ChatUserID,
 			&i.BlockID,
@@ -2741,14 +2739,14 @@ SELECT
     sub.rule_id, sub.description, sub.match, sub.start_pos, sub.end_pos,
     sub.confidence, sub.tags, sub.spans, sub.dead_letter_reason, sub.created_at,
     sub.chat_id, sub.message_created_at, sub.chat_title, sub.chat_user_id,
-    sub.block_id, sub.replayed
+    sub.block_id
 FROM (
   SELECT
       rr.id, rr.project_id, rr.organization_id, rr.risk_policy_id,
       rr.risk_policy_version, rr.chat_message_id, rr.source, rr.found,
       rr.rule_id, rr.description, rr.match, rr.start_pos, rr.end_pos,
       rr.confidence, rr.tags, rr.spans, rr.dead_letter_reason, rr.created_at,
-      cm.chat_id, cm.created_at AS message_created_at, cm.replayed,
+      cm.chat_id, cm.created_at AS message_created_at,
       c.title AS chat_title, c.external_user_id AS chat_user_id,
       COALESCE(blk.block_id, '00000000-0000-0000-0000-000000000000'::uuid) AS block_id,
       CASE
@@ -2883,7 +2881,6 @@ type ListRiskResultsByProjectFoundRow struct {
 	ChatTitle         pgtype.Text
 	ChatUserID        pgtype.Text
 	BlockID           uuid.UUID
-	Replayed          bool
 }
 
 // Sort by the underlying chat message's created_at (the event time), NOT
@@ -2956,7 +2953,6 @@ func (q *Queries) ListRiskResultsByProjectFound(ctx context.Context, arg ListRis
 			&i.ChatTitle,
 			&i.ChatUserID,
 			&i.BlockID,
-			&i.Replayed,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused `replayed` field from `RiskResult` across the API, server, and dashboard SDK, and stabilized ClickHouse risk tests with relative dates to avoid TTL flakes. No behavior changes.

- **Refactors**
  - Dropped `replayed` from OpenAPI schemas and required fields.
  - Regenerated server/client types and encode/decode; removed field plumbing from SQL and `foundRowToResult`/call sites.
  - Trimmed listing queries to reduce payload ahead of serving Risk Events from ClickHouse.

- **Migration**
  - Clients should stop reading or sending `replayed`. Regenerate SDKs to pick up the change.

<sup>Written for commit 1a06d954f1e80b64b7c09321e9d5336b936a76e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

