### PR TITLE
chore: make worktree boot resilient to a slow Temporal

### DIFF
--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -69,3 +69,14 @@ wait_for "Postgres" gram-db \
 # migration can fail with a connection EOF.
 wait_for "ClickHouse" clickhouse \
     docker compose exec -T clickhouse clickhouse-client --user "$CLICKHOUSE_USERNAME" --password "$CLICKHOUSE_PASSWORD" -q "SELECT 1"
+
+# Temporal is the last of the three to become usable, and the first thing that
+# needs it is `mise run seed`, whose deployment step starts a workflow. Without
+# this probe seed fails with `error starting deployment: context deadline
+# exceeded` — a 10s timeout on a Temporal that isn't serving yet — which on a
+# cold worktree leaves the stack up but only partially seeded.
+#
+# `cluster health` hangs rather than erroring when the dev-server's SQLite
+# persistence is wedged, so it relies on run_bounded to cap each attempt.
+wait_for "Temporal" gram-temporal \
+    docker compose exec -T gram-temporal temporal operator cluster health

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -631,7 +631,7 @@ async function deployAssets(init: {
   projectSlug: string;
   projectName: string;
   assets: Asset[];
-}): Promise<string> {
+}): Promise<string | null> {
   const { sessionId, projectSlug, projectName, assets } = init;
 
   const oapi: Array<{ assetId: string; name: string; slug: string }> = [];
@@ -763,8 +763,17 @@ async function deployAssets(init: {
     `evolve deployment for '${projectSlug}'`,
   );
 
+  // Best-effort: evolve is the first seed step that needs Temporal, so it is
+  // the one that fails when the worker or Temporal itself is briefly
+  // unavailable. Aborting here discarded every later seed step — org members,
+  // telemetry, chats — for one flaky workflow start, leaving a dashboard with
+  // nothing in it. Skipping the project instead withholds the completion
+  // marker (see seedStepFailures), so the next `mise run seed` retries it.
   if (!evolveRes.ok) {
-    abort(`Failed to evolve project \`${projectName}\``, evolveRes.error);
+    log.stepFailed(
+      `Failed to evolve project \`${projectName}\`: ${evolveRes.error}`,
+    );
+    return null;
   }
 
   const deploymentId = evolveRes.value.deployment?.id;
@@ -5096,6 +5105,11 @@ async function seed() {
       projectName: name,
       assets: seedAssets,
     });
+    if (deploymentId === null) {
+      // Toolsets below are keyed off the deployment, so this project has
+      // nothing more to seed. Later projects and seed sections still run.
+      continue;
+    }
     log.info(
       `Deployed assets into '${projectSlug}' (deployment_id = ${deploymentId})`,
     );


### PR DESCRIPTION
Creating a worktree brings up a full stack and seeds it (`post-start` → `./zero --agent`). When Temporal is slow to serve, that boot leaves a running stack with an almost-empty database — and nothing retries. Two independent gaps produced that outcome.

## `infra:start` never waited for Temporal

`wait_for` probes Postgres and ClickHouse, but the Temporal dev-server only has a compose healthcheck — nothing blocks on it. So `zero` proceeds to migrations, daemons and seed while Temporal is still unusable, and the first seed step that starts a workflow fails:

```
ERROR error starting deployment
    error.message: "error starting deployment: context deadline exceeded"
```

That's a 10s deadline on `ExecuteProcessDeploymentWorkflow`, ~10 minutes into an unattended worktree boot.

Added a third probe alongside the other two. `cluster health` _hangs_ rather than erroring when the dev-server's SQLite persistence is wedged, so it depends on the existing `run_bounded` cap per attempt — which is why the probe goes here, next to the others, rather than in `zero`.

## Seed discarded ~20 remaining steps for one flaky call

`deployAssets` called `abort()` (→ `process.exit(1)`) when evolve failed, so a single transient workflow start took out every later seed step: toolsets, org members, telemetry, chats, risk findings, RBAC. The dashboard came up on the empty-state screen, which reads as "seed still running" rather than "seed died 10 minutes ago".

It now records the failure via `log.stepFailed` and skips that project. Later projects and all subsequent seed sections still run, and the existing `seedStepFailures` path withholds the completion marker — so the next `mise run seed` retries the missing project instead of short-circuiting.

## Verification

- `mise infra:start` — passes with Temporal serving; exits 0.
- `mise run seed --force` — completes end to end (70s), marker recorded.
- Type-check clean; `hk fix` clean.

Not covered: the Temporal-unavailable path is exercised by the same bounded-probe logic as Postgres/ClickHouse, but I didn't simulate a wedged Temporal to watch the probe time out.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make dev worktree boot resilient when Temporal is slow. We now wait for Temporal before seeding and skip only the failing project instead of aborting the whole seed.

- **Bug Fixes**
  - `infra:start` now waits for Temporal health via `temporal operator cluster health` on `gram-temporal` before migrations and seeding (added third `wait_for` probe).
  - Seeding no longer exits on a flaky evolve; `deployAssets` logs the failure and skips that project (returns `null`), so later projects and sections still run and the completion marker is withheld for retry with `mise run seed`.

<sup>Written for commit 2a197026e6cc8ba37ff96365f3285eed35562971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

