### PR TITLE
feat(hooks): enable local file logging

### DIFF
--- a/hooks/relay/client.go
+++ b/hooks/relay/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -60,9 +61,9 @@ type ingestResult struct {
 	// org_settings effects; nil when the server sent none.
 	failOpen     *bool
 	skillCapture *skillCapture
-	// err preserves the SDK or transport failure for local diagnostics. It is
-	// never returned to providers or persisted in the offline spool.
-	err error
+	// diagnostic preserves a sanitized, length-capped SDK or transport failure
+	// for local logs. It is never returned to providers or persisted.
+	diagnostic string
 }
 
 // accepted reports a definitive 2xx exchange — the server stored (or
@@ -216,7 +217,7 @@ func (cl *client) send(ctx context.Context, c creds, body components.IngestReque
 		}
 	}
 
-	out := ingestResult{statusCode: res.StatusCode, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}
+	out := ingestResult{statusCode: res.StatusCode, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}
 	if res.IngestHookResult != nil {
 		out.decision = decision{
 			Decision: string(res.IngestHookResult.Decision),
@@ -252,7 +253,7 @@ func interpretError(err error) ingestResult {
 			authRejected: status == http.StatusUnauthorized || status == http.StatusForbidden,
 			failOpen:     nil,
 			skillCapture: nil,
-			err:          err,
+			diagnostic:   "",
 		}
 	}
 	var apiErr *apierrors.APIError
@@ -269,7 +270,7 @@ func interpretError(err error) ingestResult {
 				authRejected: false,
 				failOpen:     nil,
 				skillCapture: nil,
-				err:          err,
+				diagnostic:   truncateDiagnostic(fmt.Sprintf("%s (status %d)", apiErr.Message, apiErr.StatusCode)),
 			}
 		}
 		return ingestResult{
@@ -278,10 +279,32 @@ func interpretError(err error) ingestResult {
 			authRejected: apiErr.StatusCode == http.StatusUnauthorized || apiErr.StatusCode == http.StatusForbidden,
 			failOpen:     nil,
 			skillCapture: nil,
-			err:          err,
+			diagnostic:   "",
 		}
 	}
-	return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, err: err}
+	return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: transportDiagnostic(err)}
+}
+
+const maxDiagnosticBytes = 2048
+
+func transportDiagnostic(err error) string {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		safeURL := "<invalid URL>"
+		if _, parseErr := url.Parse(urlErr.URL); parseErr == nil {
+			safeURL = redactURL(urlErr.URL)
+		}
+		return truncateDiagnostic(fmt.Sprintf("%s %s: %v", urlErr.Op, safeURL, urlErr.Err))
+	}
+	return truncateDiagnostic(err.Error())
+}
+
+func truncateDiagnostic(message string) string {
+	if len(message) <= maxDiagnosticBytes {
+		return message
+	}
+	const suffix = "..."
+	return message[:maxDiagnosticBytes-len(suffix)] + suffix
 }
 
 func validRawSHA256(value string) bool {

--- a/hooks/relay/client.go
+++ b/hooks/relay/client.go
@@ -60,6 +60,9 @@ type ingestResult struct {
 	// org_settings effects; nil when the server sent none.
 	failOpen     *bool
 	skillCapture *skillCapture
+	// err preserves the SDK or transport failure for local diagnostics. It is
+	// never returned to providers or persisted in the offline spool.
+	err error
 }
 
 // accepted reports a definitive 2xx exchange — the server stored (or
@@ -213,7 +216,7 @@ func (cl *client) send(ctx context.Context, c creds, body components.IngestReque
 		}
 	}
 
-	out := ingestResult{statusCode: res.StatusCode, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil}
+	out := ingestResult{statusCode: res.StatusCode, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}
 	if res.IngestHookResult != nil {
 		out.decision = decision{
 			Decision: string(res.IngestHookResult.Decision),
@@ -249,6 +252,7 @@ func interpretError(err error) ingestResult {
 			authRejected: status == http.StatusUnauthorized || status == http.StatusForbidden,
 			failOpen:     nil,
 			skillCapture: nil,
+			err:          err,
 		}
 	}
 	var apiErr *apierrors.APIError
@@ -265,6 +269,7 @@ func interpretError(err error) ingestResult {
 				authRejected: false,
 				failOpen:     nil,
 				skillCapture: nil,
+				err:          err,
 			}
 		}
 		return ingestResult{
@@ -273,9 +278,10 @@ func interpretError(err error) ingestResult {
 			authRejected: apiErr.StatusCode == http.StatusUnauthorized || apiErr.StatusCode == http.StatusForbidden,
 			failOpen:     nil,
 			skillCapture: nil,
+			err:          err,
 		}
 	}
-	return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil}
+	return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, err: err}
 }
 
 func validRawSHA256(value string) bool {

--- a/hooks/relay/codextools_lock_windows.go
+++ b/hooks/relay/codextools_lock_windows.go
@@ -2,11 +2,18 @@
 
 package relay
 
-import "os"
+import (
+	"os"
 
-// Windows has no flock; the queue operates unlocked there, the bash sender's
-// posture. Mis-correlation needs concurrent same-tool codex hooks on Windows,
-// and the queue self-heals as entries drain.
-func lockFile(*os.File) error { return nil }
+	"golang.org/x/sys/windows"
+)
 
-func unlockFile(*os.File) {}
+func lockFile(f *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped)
+}
+
+func unlockFile(f *os.File) {
+	var overlapped windows.Overlapped
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &overlapped)
+}

--- a/hooks/relay/config.go
+++ b/hooks/relay/config.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -48,8 +49,9 @@ type Config struct {
 	// the fail-open posture (unreachable/5xx allow); explicit deny decisions
 	// and credential failures enforce regardless. New plugins never set it.
 	Nonblocking bool
-	// DebugLog, when set, appends one diagnostic line per event. It travels as a
-	// command flag so it survives providers that scrub the hook environment.
+	// DebugLog is the file that receives hook and runner diagnostics. LoadConfig
+	// defaults it beneath the per-user hooks state directory; the command flag
+	// remains available for providers that scrub the hook environment.
 	DebugLog string
 	// ConfigPath records the speakeasy.json the config was loaded from, so the
 	// login nudge can point the sign-in command at the same deployment identity
@@ -182,7 +184,21 @@ func LoadConfig(defaults Config) Config {
 	if os.Getenv("GRAM_HOOKS_NONBLOCKING") != "" || os.Getenv("GRAM_HOOKS_OBSERVABILITY_MODE") != "" {
 		cfg.Nonblocking = true
 	}
+	if v := strings.TrimSpace(os.Getenv("GRAM_HOOKS_DEBUG_LOG")); v != "" {
+		cfg.DebugLog = v
+	}
+	if cfg.DebugLog == "" {
+		cfg.DebugLog = defaultDebugLogPath()
+	}
 	cfg.ServerURL = strings.TrimRight(cfg.ServerURL, "/")
 	cfg.SiteURL = strings.TrimRight(cfg.SiteURL, "/")
 	return cfg
+}
+
+func defaultDebugLogPath() string {
+	stateDir := hooksStateDir()
+	if stateDir == "" {
+		return ""
+	}
+	return filepath.Join(stateDir, "speakeasy-hooks.log")
 }

--- a/hooks/relay/logging.go
+++ b/hooks/relay/logging.go
@@ -60,8 +60,14 @@ func (w debugLogWriter) Write(p []byte) (int, error) {
 	)
 	withFileLock(w.path, func() {
 		if info, err := os.Stat(w.path); err == nil && info.Size()+int64(len(p)) > maxDebugLogBytes {
-			_ = os.Remove(w.path + ".1")
-			_ = os.Rename(w.path, w.path+".1")
+			if err := os.Remove(w.path + ".1"); err != nil && !os.IsNotExist(err) {
+				writeErr = fmt.Errorf("remove previous hooks log: %w", err)
+				return
+			}
+			if err := os.Rename(w.path, w.path+".1"); err != nil {
+				writeErr = fmt.Errorf("rotate hooks log: %w", err)
+				return
+			}
 		}
 
 		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
@@ -69,7 +75,7 @@ func (w debugLogWriter) Write(p []byte) (int, error) {
 			writeErr = fmt.Errorf("open hooks log: %w", err)
 			return
 		}
-		if err := file.Chmod(0o600); err != nil {
+		if err := secureLogFile(file); err != nil {
 			_ = file.Close()
 			writeErr = fmt.Errorf("secure hooks log permissions: %w", err)
 			return

--- a/hooks/relay/logging.go
+++ b/hooks/relay/logging.go
@@ -1,0 +1,67 @@
+package relay
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+const maxDebugLogBytes = 10 << 20
+
+type debugLogWriter struct {
+	path string
+}
+
+func newDebugLogger(path string) *slog.Logger {
+	var writer io.Writer = io.Discard
+	if path != "" {
+		writer = debugLogWriter{path: path}
+	}
+	return slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})).With(
+		"component", "speakeasy-hooks",
+		"version", BinaryVersion,
+		"pid", os.Getpid(),
+	)
+}
+
+// Write appends one complete slog record. Hook invocations are separate
+// processes, so the sibling lock keeps their records intact and serializes
+// rotation. One previous file is retained to bound diagnostics to about 20 MiB.
+func (w debugLogWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	parent := filepath.Dir(w.path)
+	if parent != "." {
+		if err := os.MkdirAll(parent, 0o700); err != nil {
+			return 0, fmt.Errorf("create hooks log directory: %w", err)
+		}
+	}
+
+	var (
+		written  int
+		writeErr error
+	)
+	withFileLock(w.path, func() {
+		if info, err := os.Stat(w.path); err == nil && info.Size()+int64(len(p)) > maxDebugLogBytes {
+			_ = os.Remove(w.path + ".1")
+			_ = os.Rename(w.path, w.path+".1")
+		}
+
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			writeErr = fmt.Errorf("open hooks log: %w", err)
+			return
+		}
+		written, writeErr = file.Write(p)
+		if closeErr := file.Close(); writeErr == nil && closeErr != nil {
+			writeErr = fmt.Errorf("close hooks log: %w", closeErr)
+		}
+	})
+	return written, writeErr
+}

--- a/hooks/relay/logging.go
+++ b/hooks/relay/logging.go
@@ -8,7 +8,10 @@ import (
 	"path/filepath"
 )
 
-const maxDebugLogBytes = 10 << 20
+const (
+	maxDebugLogBytes       = 10 << 20
+	maxDebugLogRecordBytes = 64 << 10
+)
 
 type debugLogWriter struct {
 	path string
@@ -35,6 +38,14 @@ func (w debugLogWriter) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+	requested := len(p)
+	if len(p) > maxDebugLogRecordBytes {
+		const suffix = "... record truncated\n"
+		truncated := make([]byte, 0, maxDebugLogRecordBytes)
+		truncated = append(truncated, p[:maxDebugLogRecordBytes-len(suffix)]...)
+		truncated = append(truncated, suffix...)
+		p = truncated
+	}
 
 	parent := filepath.Dir(w.path)
 	if parent != "." {
@@ -58,10 +69,18 @@ func (w debugLogWriter) Write(p []byte) (int, error) {
 			writeErr = fmt.Errorf("open hooks log: %w", err)
 			return
 		}
+		if err := file.Chmod(0o600); err != nil {
+			_ = file.Close()
+			writeErr = fmt.Errorf("secure hooks log permissions: %w", err)
+			return
+		}
 		written, writeErr = file.Write(p)
 		if closeErr := file.Close(); writeErr == nil && closeErr != nil {
 			writeErr = fmt.Errorf("close hooks log: %w", closeErr)
 		}
 	})
+	if writeErr == nil && written == len(p) {
+		return requested, nil
+	}
 	return written, writeErr
 }

--- a/hooks/relay/logging_permissions_unix.go
+++ b/hooks/relay/logging_permissions_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package relay
+
+import "os"
+
+func secureLogFile(file *os.File) error {
+	return file.Chmod(0o600)
+}

--- a/hooks/relay/logging_permissions_windows.go
+++ b/hooks/relay/logging_permissions_windows.go
@@ -34,8 +34,10 @@ func secureLogFile(file *os.File) error {
 		return err
 	}
 
-	return windows.SetSecurityInfo(
-		windows.Handle(file.Fd()),
+	// SetNamedSecurityInfo opens the file with WRITE_DAC itself. The append
+	// handle returned by os.OpenFile intentionally does not carry that access.
+	return windows.SetNamedSecurityInfo(
+		file.Name(),
 		windows.SE_FILE_OBJECT,
 		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
 		nil,

--- a/hooks/relay/logging_permissions_windows.go
+++ b/hooks/relay/logging_permissions_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package relay
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func secureLogFile(file *os.File) error {
+	token, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return err
+	}
+	user, err := token.GetTokenUser()
+	closeErr := token.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	acl, err := windows.ACLFromEntries([]windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.GRANT_ACCESS,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}, nil)
+	if err != nil {
+		return err
+	}
+
+	return windows.SetSecurityInfo(
+		windows.Handle(file.Fd()),
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		acl,
+		nil,
+	)
+}

--- a/hooks/relay/logging_test.go
+++ b/hooks/relay/logging_test.go
@@ -1,0 +1,83 @@
+package relay
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/speakeasy-api/agenthooks"
+	"github.com/speakeasy-api/agenthooks/agenthookstest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigEnablesDefaultDebugLog(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("GRAM_HOOKS_DEBUG_LOG", "")
+
+	cfg := LoadConfig(Config{
+		ServerURL:    "",
+		SiteURL:      "",
+		ProjectSlug:  "",
+		OrgID:        "",
+		HooksAPIKey:  "",
+		BrowserLogin: false,
+		Nonblocking:  false,
+		DebugLog:     "",
+		ConfigPath:   "",
+		ConfigError:  "",
+	})
+
+	require.Equal(t, filepath.Join(stateHome, "gram", "hooks", "speakeasy-hooks.log"), cfg.DebugLog)
+}
+
+func TestLoadConfigUsesDebugLogEnvironmentOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom-hooks.log")
+	t.Setenv("GRAM_HOOKS_DEBUG_LOG", path)
+
+	cfg := LoadConfig(Config{
+		ServerURL:    "",
+		SiteURL:      "",
+		ProjectSlug:  "",
+		OrgID:        "",
+		HooksAPIKey:  "",
+		BrowserLogin: false,
+		Nonblocking:  false,
+		DebugLog:     "",
+		ConfigPath:   "",
+		ConfigError:  "",
+	})
+
+	require.Equal(t, path, cfg.DebugLog)
+}
+
+func TestDebugLogCapturesRelayAndAgenthooksDiagnostics(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "speakeasy-hooks.log")
+	cfg := Config{
+		ServerURL:    DefaultServerURL,
+		SiteURL:      "",
+		ProjectSlug:  "",
+		OrgID:        "",
+		HooksAPIKey:  "",
+		BrowserLogin: false,
+		Nonblocking:  false,
+		DebugLog:     path,
+		ConfigPath:   "",
+		ConfigError:  "",
+	}
+
+	NewRelay(cfg).debugf("connectivity diagnostic: %s", "dial tcp")
+	result := agenthookstest.Invoke(t, NewRunner(cfg), agenthooks.ProviderClaudeCode, []byte("{"))
+	require.Zero(t, result.ExitCode)
+
+	logData, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(logData), "connectivity diagnostic: dial tcp")
+	require.Contains(t, string(logData), "agenthooks: decode failed")
+	require.Contains(t, string(logData), "level=DEBUG")
+	require.Contains(t, string(logData), "level=ERROR")
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}

--- a/hooks/relay/logging_test.go
+++ b/hooks/relay/logging_test.go
@@ -1,8 +1,11 @@
 package relay
 
 import (
+	"errors"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/speakeasy-api/agenthooks"
@@ -80,4 +83,44 @@ func TestDebugLogCapturesRelayAndAgenthooksDiagnostics(t *testing.T) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestDebugLogSecuresExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "speakeasy-hooks.log")
+	require.NoError(t, os.WriteFile(path, []byte("existing\n"), 0o644))
+	require.NoError(t, os.Chmod(path, 0o644))
+
+	logger := newDebugLogger(path)
+	logger.ErrorContext(t.Context(), "diagnostic")
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestDebugLogCapsIndividualRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "speakeasy-hooks.log")
+	logger := newDebugLogger(path)
+	logger.ErrorContext(t.Context(), strings.Repeat("x", maxDebugLogRecordBytes*2))
+
+	logData, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(logData), maxDebugLogRecordBytes)
+	require.Contains(t, string(logData), "record truncated")
+}
+
+func TestTransportDiagnosticRedactsAndCapsURLErrors(t *testing.T) {
+	err := &url.Error{
+		Op:  "Post",
+		URL: "https://user:password@example.com/hooks?token=secret",
+		Err: errors.New(strings.Repeat("connection failure ", 256)),
+	}
+
+	diagnostic := transportDiagnostic(err)
+
+	require.LessOrEqual(t, len(diagnostic), maxDiagnosticBytes)
+	require.NotContains(t, diagnostic, "password")
+	require.NotContains(t, diagnostic, "secret")
+	require.Contains(t, diagnostic, "example.com")
+	require.Contains(t, diagnostic, "connection failure")
 }

--- a/hooks/relay/logging_test.go
+++ b/hooks/relay/logging_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -82,7 +83,9 @@ func TestDebugLogCapturesRelayAndAgenthooksDiagnostics(t *testing.T) {
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 }
 
 func TestDebugLogSecuresExistingFile(t *testing.T) {
@@ -95,7 +98,9 @@ func TestDebugLogSecuresExistingFile(t *testing.T) {
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 }
 
 func TestDebugLogCapsIndividualRecords(t *testing.T) {
@@ -123,4 +128,36 @@ func TestTransportDiagnosticRedactsAndCapsURLErrors(t *testing.T) {
 	require.NotContains(t, diagnostic, "secret")
 	require.Contains(t, diagnostic, "example.com")
 	require.Contains(t, diagnostic, "connection failure")
+}
+
+func TestDeliveryLogRedactsConfiguredServerURL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "speakeasy-hooks.log")
+	cfg := Config{
+		ServerURL:    "http://user:password@example.com/hooks?token=secret",
+		SiteURL:      "",
+		ProjectSlug:  "",
+		OrgID:        "",
+		HooksAPIKey:  "",
+		BrowserLogin: false,
+		Nonblocking:  false,
+		DebugLog:     path,
+		ConfigPath:   "",
+		ConfigError:  "",
+	}
+	event := &agenthooks.PromptEvent{
+		Event: agenthooks.Event{
+			Provider:   agenthooks.ProviderClaudeCode,
+			Kind:       agenthooks.KindPromptSubmitted,
+			NativeName: "UserPromptSubmit",
+		},
+		Prompt: "hello",
+	}
+
+	NewRelay(cfg).deliver(t.Context(), event)
+
+	logData, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(logData), "example.com")
+	require.NotContains(t, string(logData), "password")
+	require.NotContains(t, string(logData), "secret")
 }

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,6 +38,7 @@ type Relay struct {
 	cfg    Config
 	client *client
 	login  *loginFlow
+	logger *slog.Logger
 	// backfillDeny carries a blocked verdict from a reporting-only backfilled
 	// prompt (agenthooks discards its decision) to the decision-capable event
 	// that triggered the backfill in this same process. It was the turn's
@@ -46,10 +48,15 @@ type Relay struct {
 
 // NewRelay builds a Relay from the resolved config.
 func NewRelay(cfg Config) *Relay {
+	return newRelay(cfg, newDebugLogger(cfg.DebugLog))
+}
+
+func newRelay(cfg Config, logger *slog.Logger) *Relay {
 	return &Relay{
 		cfg:          cfg,
 		client:       newClient(cfg.ServerURL),
 		login:        newLoginFlow(cfg),
+		logger:       logger,
 		backfillDeny: "",
 	}
 }
@@ -67,14 +74,19 @@ func (r *Relay) Login(ctx context.Context, force bool) error {
 // hook must never wedge the agent — and the credential ratchet governs the
 // unauthenticated case.
 func NewRunner(cfg Config) *agenthooks.Runner {
-	r := NewRelay(cfg)
-	runner := agenthooks.New(agenthooks.WithPolicy(agenthooks.Policy{
+	logger := newDebugLogger(cfg.DebugLog)
+	r := newRelay(cfg, logger)
+	options := []agenthooks.Option{agenthooks.WithPolicy(agenthooks.Policy{
 		Fail:            agenthooks.FailOpen,
 		Unsupported:     agenthooks.Degrade,
 		AskFallback:     agenthooks.FallbackNoDecision,
 		ContinuationCap: 0,
 		Timeout:         0,
-	}))
+	})}
+	if cfg.DebugLog != "" {
+		options = append(options, agenthooks.WithLogger(logger))
+	}
+	runner := agenthooks.New(options...)
 
 	runner.OnPromptSubmitted(r.onPrompt)
 	runner.OnToolPre(r.onToolPre)
@@ -130,9 +142,9 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		r.debugf("event=%s config-error path=%s err=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ConfigPath, r.cfg.ConfigError)
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks cannot read the plugin config at %q. Reinstall the Speakeasy hooks plugin.", r.cfg.ConfigPath)
-			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateBroken
 		}
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateNeverAuthed
 	}
 
 	// Refuse to send credentials over plaintext HTTP before resolving them,
@@ -142,23 +154,23 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		r.debugf("event=%s insecure-server-url server=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ServerURL)
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks refused insecure Gram server URL %q; use https:// (or an http://localhost dev server).", r.cfg.ServerURL)
-			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateBroken
 		}
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateNeverAuthed
 	}
 
 	c, ok := resolveAuth(r.cfg)
 	if !ok {
 		if reauthNeeded() {
 			r.debugf("event=%s no-creds state=reauth-needed authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateReauthNeeded
+			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateReauthNeeded
 		}
 		if authEstablished() {
 			r.debugf("event=%s no-creds state=broken authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateBroken
 		}
 		r.debugf("event=%s no-creds state=never-authed authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateNeverAuthed
 	}
 
 	payload := buildEnvelope(typed, hostname())
@@ -199,6 +211,9 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	res := r.send(ctx, c, payload, idemKey)
 	finalCreds := c
 	state := stateReady
+	if res.err != nil {
+		r.debugf("event=%s ingest-error: %v", agenthooks.EventOf(typed).NativeName, res.err)
+	}
 	r.debugf("event=%s type=%s server=%s authfile=%s status=%d denied=%t", agenthooks.EventOf(typed).NativeName, payload.Event.Type, r.cfg.ServerURL, authFilePath(), res.statusCode, res.decision.denied())
 	if res.authRejected && c.Source == credEnv {
 		// The configured key is authoritative and a re-login can never replace
@@ -479,12 +494,7 @@ func (r *Relay) debugf(format string, args ...any) {
 	if r.cfg.DebugLog == "" {
 		return
 	}
-	f, err := os.OpenFile(r.cfg.DebugLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-	fmt.Fprintf(f, format+"\n", args...)
+	r.logger.DebugContext(context.Background(), fmt.Sprintf(format, args...))
 }
 
 // loginCommand renders the shell command the nudge asks the agent to run to

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -142,9 +142,9 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		r.debugf("event=%s config-error path=%s err=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ConfigPath, r.cfg.ConfigError)
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks cannot read the plugin config at %q. Reinstall the Speakeasy hooks plugin.", r.cfg.ConfigPath)
-			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateBroken
 		}
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateNeverAuthed
 	}
 
 	// Refuse to send credentials over plaintext HTTP before resolving them,
@@ -154,23 +154,23 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		r.debugf("event=%s insecure-server-url server=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ServerURL)
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks refused insecure Gram server URL %q; use https:// (or an http://localhost dev server).", r.cfg.ServerURL)
-			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateBroken
 		}
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateNeverAuthed
 	}
 
 	c, ok := resolveAuth(r.cfg)
 	if !ok {
 		if reauthNeeded() {
 			r.debugf("event=%s no-creds state=reauth-needed authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateReauthNeeded
+			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateReauthNeeded
 		}
 		if authEstablished() {
 			r.debugf("event=%s no-creds state=broken authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateBroken
 		}
 		r.debugf("event=%s no-creds state=never-authed authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateNeverAuthed
 	}
 
 	payload := buildEnvelope(typed, hostname())
@@ -211,8 +211,8 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	res := r.send(ctx, c, payload, idemKey)
 	finalCreds := c
 	state := stateReady
-	if res.err != nil {
-		r.debugf("event=%s ingest-error: %v", agenthooks.EventOf(typed).NativeName, res.err)
+	if res.diagnostic != "" {
+		r.debugf("event=%s ingest-error: %s", agenthooks.EventOf(typed).NativeName, res.diagnostic)
 	}
 	r.debugf("event=%s type=%s server=%s authfile=%s status=%d denied=%t", agenthooks.EventOf(typed).NativeName, payload.Event.Type, r.cfg.ServerURL, authFilePath(), res.statusCode, res.decision.denied())
 	if res.authRejected && c.Source == credEnv {
@@ -246,6 +246,9 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 			finalCreds = orgCreds
 			res = r.send(ctx, orgCreds, payload, idemKey)
 			state = stateReady
+			if res.diagnostic != "" {
+				r.debugf("event=%s auth-retry=org ingest-error: %s", agenthooks.EventOf(typed).NativeName, res.diagnostic)
+			}
 			r.debugf("event=%s auth-retry=org status=%d denied=%t", agenthooks.EventOf(typed).NativeName, res.statusCode, res.decision.denied())
 		}
 	}

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -151,7 +151,7 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	// with the ratchet's usual split: never-authenticated machines skip the
 	// network silently, established machines fail closed.
 	if insecureServerURL(r.cfg.ServerURL) {
-		r.debugf("event=%s insecure-server-url server=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ServerURL)
+		r.debugf("event=%s insecure-server-url server=%s", agenthooks.EventOf(typed).NativeName, redactURL(r.cfg.ServerURL))
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks refused insecure Gram server URL %q; use https:// (or an http://localhost dev server).", r.cfg.ServerURL)
 			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}, stateBroken
@@ -214,7 +214,7 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	if res.diagnostic != "" {
 		r.debugf("event=%s ingest-error: %s", agenthooks.EventOf(typed).NativeName, res.diagnostic)
 	}
-	r.debugf("event=%s type=%s server=%s authfile=%s status=%d denied=%t", agenthooks.EventOf(typed).NativeName, payload.Event.Type, r.cfg.ServerURL, authFilePath(), res.statusCode, res.decision.denied())
+	r.debugf("event=%s type=%s server=%s authfile=%s status=%d denied=%t", agenthooks.EventOf(typed).NativeName, payload.Event.Type, redactURL(r.cfg.ServerURL), authFilePath(), res.statusCode, res.decision.denied())
 	if res.authRejected && c.Source == credEnv {
 		// The configured key is authoritative and a re-login can never replace
 		// it, so name it in the failure instead of pointing at the cache flow.

--- a/hooks/relay/skillupload_test.go
+++ b/hooks/relay/skillupload_test.go
@@ -304,6 +304,6 @@ func acceptedSkillUploadResult(rawSHA256 string, contentRequired bool) ingestRes
 		authRejected: false,
 		failOpen:     nil,
 		skillCapture: &skillCapture{rawSHA256: rawSHA256, contentRequired: contentRequired},
-		err:          nil,
+		diagnostic:   "",
 	}
 }

--- a/hooks/relay/skillupload_test.go
+++ b/hooks/relay/skillupload_test.go
@@ -304,5 +304,6 @@ func acceptedSkillUploadResult(rawSHA256 string, contentRequired bool) ingestRes
 		authRejected: false,
 		failOpen:     nil,
 		skillCapture: &skillCapture{rawSHA256: rawSHA256, contentRequired: contentRequired},
+		err:          nil,
 	}
 }

--- a/hooks/relay/spool_test.go
+++ b/hooks/relay/spool_test.go
@@ -139,7 +139,7 @@ func TestUnsentPredicate(t *testing.T) {
 		http.StatusTooManyRequests: true, http.StatusRequestTimeout: true,
 		200: false, 400: false, 401: false, 403: false, 404: false,
 	} {
-		got := ingestResult{statusCode: status, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false}.unsent()
+		got := ingestResult{statusCode: status, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}.unsent()
 		require.Equal(t, want, got, "unsent(status=%d)", status)
 	}
 }

--- a/hooks/relay/spool_test.go
+++ b/hooks/relay/spool_test.go
@@ -139,7 +139,7 @@ func TestUnsentPredicate(t *testing.T) {
 		http.StatusTooManyRequests: true, http.StatusRequestTimeout: true,
 		200: false, 400: false, 401: false, 403: false, 404: false,
 	} {
-		got := ingestResult{statusCode: status, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, err: nil}.unsent()
+		got := ingestResult{statusCode: status, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, diagnostic: ""}.unsent()
 		require.Equal(t, want, got, "unsent(status=%d)", status)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enable structured diagnostics by default at the per-user hooks state directory
- capture relay and agenthooks runtime errors, including sanitized connectivity details
- redact configured URLs and cap individual records to avoid persisting credentials or oversized responses
- enforce owner-only Unix permissions and a protected current-user Windows ACL
- serialize cross-process writes/rotation and retain one bounded rotated file
- allow overriding the destination with `GRAM_HOOKS_DEBUG_LOG` or `--debug-log`

## Test plan
- `env -u GRAM_HOOKS_API_KEY mise run test:hooks`
- focused logging tests with the race detector
- Windows cross-compilation of the relay tests
- `mise lint:server`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-691](https://linear.app/speakeasy/issue/DNO-691/feat-enable-file-based-logging-in-the-go-hooks-binary)

<div><a href="https://cursor.com/agents/bc-3910046b-cf97-4c70-8ac6-2d6edc71e64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3910046b-cf97-4c70-8ac6-2d6edc71e64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable default local file logging for the hooks relay and runner with structured DEBUG output, stronger URL redaction, and safe rotation. Implements DNO-691 with cross‑platform locking.

- **New Features**
  - Default log file in the per-user hooks state dir (`speakeasy-hooks.log`); 0600 perms on Unix and protected current-user ACL on Windows; rotation at ~10 MiB with one backup; cross-process writes and rotation serialized on Unix and Windows.
  - Structured logging via `slog`; spans relay and `agenthooks` (runner passes the logger); caps each record at 64 KiB.
  - Transport/SDK errors captured on ingestResult, redacted and trimmed (2 KiB cap); delivery logs also redact the configured server URL.
  - Override path with `GRAM_HOOKS_DEBUG_LOG` or `--debug-log`.

- **Bug Fixes**
  - Windows: apply the log ACL by path to reliably secure existing and newly created files.

<sup>Written for commit 3baf831390ae933491a8235ac3cc4db96bae19dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

