### PR TITLE
fix(risk): use UTC-relative dates in ClickHouse overview tests

### DIFF
--- a/server/internal/risk/overview_ch_test.go
+++ b/server/internal/risk/overview_ch_test.go
@@ -83,8 +83,9 @@ func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
 	disabledPolicyID, err := uuid.Parse(disabledPolicy.ID)
 	require.NoError(t, err)
 
-	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+	from := now.AddDate(0, 0, -30).Truncate(24 * time.Hour) // 30 days ago, well within ClickHouse TTL
+	to := from.AddDate(0, 0, 7)                             // 7-day window
 
 	aliceSecret1Chat, aliceSecret1 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
 	aliceSecret2Chat, aliceSecret2 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
@@ -186,13 +187,17 @@ func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
 	for _, point := range result.TimeSeriesFindings {
 		timeSeries[point.Category+"|"+point.BucketStart] = point.Findings
 	}
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T14:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["pii|2026-05-03T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["shadow_mcp|2026-05-04T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T13:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T14:00:00Z"])
-	require.Equal(t, int64(0), timeSeries["pii|2026-05-05T13:00:00Z"])
+
+	bucket := func(offset time.Duration) string {
+		return from.Add(offset).Truncate(time.Hour).Format(time.RFC3339)
+	}
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(36*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(38*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["pii|"+bucket(60*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["shadow_mcp|"+bucket(84*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(109*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(110*time.Hour)])
+	require.Equal(t, int64(0), timeSeries["pii|"+bucket(109*time.Hour)])
 }
 
 // TestGetRiskOverview_ClickHouseUserEmailPrecedence covers the Go-side email
@@ -210,8 +215,9 @@ func TestGetRiskOverview_ClickHouseUserEmailPrecedence(t *testing.T) {
 	projectID := *authCtx.ProjectID
 	orgID := authCtx.ActiveOrganizationID
 
-	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
+	from := now.AddDate(0, 0, -30).Truncate(24 * time.Hour) // 30 days ago, well within ClickHouse TTL
+	to := from.AddDate(0, 0, 1)                             // 1 day window
 
 	// The auth context user exists in the users table; findings attributed to
 	// that internal user id must resolve to its email even with an opaque


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing test `TestGetRiskOverview_ClickHouseUserEmailPrecedence` on main by replacing hardcoded May 2026 timestamps with UTC-relative dates.

## Problem

The ClickHouse overview tests (`TestGetRiskOverview_ClickHouseParity` and `TestGetRiskOverview_ClickHouseUserEmailPrecedence`) used hardcoded dates from May 2026:

```go
from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
```

As of July 30, 2026, these dates fall outside ClickHouse's 90-day TTL window, causing the test data to be deleted before the test could query it.

## Solution

Updated both tests to use UTC-relative dates calculated from `time.Now()`:

```go
now := time.Now().UTC()
from := now.AddDate(0, 0, -30).Truncate(24 * time.Hour) // 30 days ago, well within ClickHouse TTL
```

Also updated the time series assertions in `TestGetRiskOverview_ClickHouseParity` to use a dynamic bucket calculation based on the relative `from` date instead of hardcoded timestamps.

## Testing

- Ran both affected tests locally and verified they pass
- Ran server linter with no issues

## References

- [GitHub Actions run](https://github.com/speakeasy-api/gram/actions/runs/30539807072/job/90861747811)
- Fixes AGE-3088
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3088](https://linear.app/speakeasy/issue/AGE-3088/bug-fix-failing-gram-test-on-main)

<div><a href="https://cursor.com/agents/bc-84096709-59df-4b78-a0bb-eff212f0830b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84096709-59df-4b78-a0bb-eff212f0830b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ClickHouse risk overview tests resilient by using UTC-relative dates so data stays within the 90-day TTL. Also compute time-series bucket keys dynamically from the relative start date. Fixes AGE-3088.

- **Bug Fixes**
  - Replaced hardcoded May 2026 dates with UTC-relative windows in the parity and email precedence tests (30 days ago as start; 7-day and 1-day ranges).
  - Updated parity test assertions to build bucket keys from the `from` date instead of fixed timestamps.

<sup>Written for commit 10046bc23af0b51cef64278e3fbea5043ca3f160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

