### PR TITLE
fix: anchor risk ClickHouse test dates relative to now

### DIFF
--- a/server/internal/risk/chrepo_roundtrip_test.go
+++ b/server/internal/risk/chrepo_roundtrip_test.go
@@ -26,7 +26,9 @@ func TestInsertRiskFindings_RoundTrip(t *testing.T) {
 	q := chrepo.New(conn)
 
 	orgID := "org_" + uuid.NewString()
-	createdAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	// Relative: the risk_findings table has a 90-day TTL, so a fixed date
+	// eventually expires and the read-back finds nothing.
+	createdAt := time.Now().UTC().Truncate(time.Hour).AddDate(0, 0, -1)
 
 	// A plain (non-excluded) row: excluded_at / exclusion_id bind as nil into
 	// the Nullable columns.

--- a/server/internal/risk/overview_ch_test.go
+++ b/server/internal/risk/overview_ch_test.go
@@ -83,8 +83,10 @@ func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
 	disabledPolicyID, err := uuid.Parse(disabledPolicy.ID)
 	require.NoError(t, err)
 
-	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC)
+	// Relative window: the risk_findings table has a 90-day TTL, so fixed
+	// dates silently expire and rows vanish mid-flight.
+	from := time.Now().UTC().Truncate(time.Hour).AddDate(0, 0, -8)
+	to := from.Add(7 * 24 * time.Hour)
 
 	aliceSecret1Chat, aliceSecret1 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
 	aliceSecret2Chat, aliceSecret2 := seedChatWithUser(t, ti, projectID, orgID, "alice@example.com")
@@ -186,13 +188,16 @@ func TestGetRiskOverview_ClickHouseParity(t *testing.T) {
 	for _, point := range result.TimeSeriesFindings {
 		timeSeries[point.Category+"|"+point.BucketStart] = point.Findings
 	}
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-02T14:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["pii|2026-05-03T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["shadow_mcp|2026-05-04T12:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T13:00:00Z"])
-	require.Equal(t, int64(1), timeSeries["secrets|2026-05-05T14:00:00Z"])
-	require.Equal(t, int64(0), timeSeries["pii|2026-05-05T13:00:00Z"])
+	bucket := func(offset time.Duration) string {
+		return from.Add(offset).Format(time.RFC3339)
+	}
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(36*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(38*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["pii|"+bucket(60*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["shadow_mcp|"+bucket(84*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(109*time.Hour)])
+	require.Equal(t, int64(1), timeSeries["secrets|"+bucket(110*time.Hour)])
+	require.Equal(t, int64(0), timeSeries["pii|"+bucket(109*time.Hour)])
 }
 
 // TestGetRiskOverview_ClickHouseUserEmailPrecedence covers the Go-side email
@@ -210,8 +215,10 @@ func TestGetRiskOverview_ClickHouseUserEmailPrecedence(t *testing.T) {
 	projectID := *authCtx.ProjectID
 	orgID := authCtx.ActiveOrganizationID
 
-	from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	// Relative window: the risk_findings table has a 90-day TTL, so fixed
+	// dates silently expire and rows vanish mid-flight.
+	from := time.Now().UTC().Truncate(time.Hour).AddDate(0, 0, -7)
+	to := from.Add(24 * time.Hour)
 
 	// The auth context user exists in the users table; findings attributed to
 	// that internal user id must resolve to its email even with an opaque


### PR DESCRIPTION
server-test has been failing on ~half of all runs (main included) since 2026-07-30 02:00 UTC on `TestGetRiskOverview_ClickHouseUserEmailPrecedence` (`expected: 1, actual: 0`).

Root cause: `risk_findings` has a 90-day ClickHouse TTL (`server/clickhouse/schema.sql`), and the overview tests seed rows at fixed `2026-05-01` timestamps. 2026-05-01 + 90 days = 2026-07-30, so the seeded rows are now past TTL and whether the freshly flushed async-insert part gets TTL-filtered before the overview query reads it is timing-dependent — hence the intermittency. `TestGetRiskOverview_ClickHouseParity` (seeded from 2026-05-02) hits the same wall on 2026-07-31, and `TestInsertRiskFindings_RoundTrip` (2026-07-20) in October.

Fix: anchor the test windows relative to `time.Now` and derive the time-series bucket assertions from the window start. The Postgres-path overview tests keep their fixed dates (no TTL there), and `finding_ch_test.go` uses a fake inserter so it is unaffected.

Verified locally: the precedence test failed with `-count=3` before the change and all three tests pass with `-count=4` after; full `./server/internal/risk/...` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky ClickHouse risk tests by anchoring test dates relative to now so seeded rows don’t expire under the 90‑day TTL. Restores stable results for the overview and round‑trip tests.

- **Bug Fixes**
  - `overview_ch_test.go`: Use dynamic `from`/`to` based on `time.Now()` and compute time-series bucket keys from the window start.
  - `chrepo_roundtrip_test.go`: Set `createdAt` to a recent timestamp to ensure read-back.
  - Postgres overview tests remain with fixed dates; `finding_ch_test.go` unchanged.

<sup>Written for commit c03d8aab073094eccfa6cfb9431fc4032af415e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

