### PR TITLE
feat: inbound CIMD support for Gram Session OAuth

### DIFF
--- a/.changeset/ais-217-inbound-cimd-user-session-oauth.md
+++ b/.changeset/ais-217-inbound-cimd-user-session-oauth.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Support OAuth Client ID Metadata Documents (CIMD) on the Gram Session OAuth authorization server, gated per organization behind the `gram-user-session-cimd` feature flag. MCP clients that identify themselves with a URL-shaped `client_id`, such as Claude Code and VS Code, can now complete the OAuth flow without Dynamic Client Registration, including loopback redirects on any port.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -858,6 +858,7 @@ func newStartCommand() *cli.Command {
 				chatSessionsManager,
 				env,
 				posthogClient,
+				posthogClient,
 				serverURL,
 				siteURL,
 				encryptionClient,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -717,6 +717,7 @@ func newWorkerCommand() *cli.Command {
 				chatSessionsManager,
 				env,
 				posthogClient,
+				posthogClient,
 				serverURL,
 				nil,
 				encryptionClient,

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -35,6 +35,14 @@ const (
 
 	FlagRiskFindingAnalytics Flag = "risk-finding-analytics"
 	FlagRiskAsyncScanShadow  Flag = "risk-async-scan-shadow"
+
+	// FlagUserSessionCIMD gates inbound OAuth Client ID Metadata Document
+	// (CIMD) support on the user-session authorization server: URL-shaped
+	// client_id values on /mcp/{slug}/authorize are resolved by fetching the
+	// metadata document instead of requiring RFC 7591 DCR. Evaluated
+	// server-side per organization with distinctID = the issuer's org ID and
+	// no groups.
+	FlagUserSessionCIMD Flag = "gram-user-session-cimd"
 	// FlagRiskOverviewFromClickHouse serves the risk overview endpoint from
 	// ClickHouse risk_findings instead of Postgres risk_results. Per-org
 	// rollout gate; removed once the ClickHouse read path is GA.

--- a/server/internal/guardian/policy.go
+++ b/server/internal/guardian/policy.go
@@ -28,6 +28,8 @@ package guardian
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"net"
@@ -185,6 +187,7 @@ type Policy struct {
 	resolver          dns.Resolver
 	limiter           Limiter
 	breaker           Breaker
+	tlsRootCAs        *x509.CertPool
 }
 
 // WithResolver is a functional option that sets the Policy's resolver.
@@ -193,6 +196,16 @@ type Policy struct {
 func WithResolver(resolver dns.Resolver) func(*Policy) {
 	return func(p *Policy) {
 		p.resolver = resolver
+	}
+}
+
+// WithTLSRootCAs is a functional option that replaces the root CA pool used
+// by clients built from this Policy. This is intended for tests that fetch
+// from httptest.NewTLSServer instances (whose certificates are self-signed);
+// production code should rely on the system pool by leaving this unset.
+func WithTLSRootCAs(pool *x509.CertPool) func(*Policy) {
+	return func(p *Policy) {
+		p.tlsRootCAs = pool
 	}
 }
 
@@ -238,6 +251,7 @@ func newPolicy(tracerProvider trace.TracerProvider, blockedCIDRBlocks []*net.IPN
 		resolver:          dns.NewNetResolver(),
 		limiter:           nil,
 		breaker:           nil,
+		tlsRootCAs:        nil,
 	}
 
 	for _, option := range options {
@@ -309,6 +323,17 @@ func (p *Policy) clientWithBaseTransport(transport *http.Transport, options ...f
 		dialOpts = append(dialOpts, WithDialerAllowedCIDRBlocks(opts.allowedCIDRBlocks))
 	}
 	transport.DialContext = p.Dialer(dialOpts...).DialContext
+
+	// Merge into any existing transport TLS config rather than replacing
+	// it, so a future option that sets client certificates or pinning is
+	// not silently discarded when a root pool is also configured.
+	if p.tlsRootCAs != nil {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{RootCAs: p.tlsRootCAs, MinVersion: tls.VersionTLS12}
+		} else {
+			transport.TLSClientConfig.RootCAs = p.tlsRootCAs
+		}
+	}
 
 	otelOpts := []otelhttp.Option{otelhttp.WithTracerProvider(p.tracerProvider)}
 	otelOpts = append(otelOpts, opts.otelHTTPOptions...)

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -91,6 +91,13 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 			logger.InfoContext(ctx, "cimd document fetch failed", attr.SlogError(err))
 			return writeAuthorizeError(ctx, w, logger, http.StatusServiceUnavailable, "temporarily_unavailable", "failed to fetch client metadata document")
 		}
+		if errors.Is(err, errCIMDDisabled) {
+			// Same wire response as an unknown client so the rejection does
+			// not leak per-organization flag state; the log line is what
+			// distinguishes a kill-switch rejection during an incident.
+			logger.InfoContext(ctx, "rejecting url-shaped client_id while cimd flag is disabled")
+			return writeAuthorizeError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
+		}
 		if errors.Is(err, pgx.ErrNoRows) {
 			return writeAuthorizeError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"slices"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -23,7 +22,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
-	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
 // HandleAuthorize implements the OAuth 2.1 authorization endpoint (RFC 6749
@@ -71,17 +69,34 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		return writeAuthorizeOAuthError(ctx, w, logger, http.StatusBadRequest, err)
 	}
 
-	client, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		ClientID:            req.ClientID,
-	})
+	// URL-shaped client_ids resolve via CIMD here (flag-gated, inside the
+	// resolver). All resolution failures render inline per RFC 6749
+	// §4.1.2.1 — the redirect_uri of an unresolved client cannot be
+	// trusted — and a document fetch failure aborts the request per
+	// draft-ietf-oauth-client-id-metadata-document-02 §5.1 (fail closed,
+	// no stale fallback).
+	client, err := s.resolveUserSessionClient(ctx, logger, endpoint, req.ClientID, resolveClientCIMD)
 	if err != nil {
+		if oauthErr, ok := errors.AsType[*usersessions.OAuthError](err); ok {
+			return writeAuthorizeError(ctx, w, logger, http.StatusBadRequest, oauthErr.Code, oauthErr.Description)
+		}
+		if errors.Is(err, errCIMDFetchFailed) {
+			// The cause may name internal network conditions (SSRF denials,
+			// DNS failures); log it and keep the wire response generic. A
+			// fetch failure is transient from the client's perspective — the
+			// document host may just be briefly unreachable — so signal
+			// retry-later (temporarily_unavailable, RFC 6749 §4.1.2.1)
+			// rather than a permanent invalid_client that would make SDKs
+			// stop retrying.
+			logger.InfoContext(ctx, "cimd document fetch failed", attr.SlogError(err))
+			return writeAuthorizeError(ctx, w, logger, http.StatusServiceUnavailable, "temporarily_unavailable", "failed to fetch client metadata document")
+		}
 		if errors.Is(err, pgx.ErrNoRows) {
 			return writeAuthorizeError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
 		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 	}
-	if !slices.Contains(client.RedirectUris, req.RedirectURI) {
+	if !redirectURIMatches(client, req.RedirectURI) {
 		return writeAuthorizeError(ctx, w, logger, http.StatusBadRequest, "invalid_request", "redirect_uri is not registered for this client")
 	}
 

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -599,3 +599,19 @@ func TestOAuthCIMD_LoopbackFragmentRejected(t *testing.T) {
 	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback#frag", pkceChallenge(pkceVerifier(t)))
 	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
 }
+
+// TestOAuthCIMD_LoopbackEmptyFragmentRegistrationRejected: a registered URI
+// carrying an explicit empty fragment ("...#") must not satisfy the
+// variable-port exception for a fragment-less request. URL.String() drops a
+// bare "#", so without the raw-string fragment guard the two would compare
+// equal despite differing by more than the port.
+func TestOAuthCIMD_LoopbackEmptyFragmentRegistrationRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["redirect_uris"] = []any{"http://127.0.0.1:33418/callback#"}
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -571,3 +571,31 @@ func TestOAuthCIMD_ConsentNoLoopbackWarningForSameOriginRedirect(t *testing.T) {
 	require.Contains(t, cw.Body.String(), "Client verified from")
 	require.NotContains(t, cw.Body.String(), "local address on your")
 }
+
+// TestOAuthCIMD_LoopbackEncodedPathRejected: the variable-port exception
+// compares escaped components, so a percent-encoding variant of a registered
+// path must not match.
+func TestOAuthCIMD_LoopbackEncodedPathRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	// The document registers /callback; /%63allback decodes to the same
+	// path but is a different URI byte-for-byte.
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/%63allback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}
+
+// TestOAuthCIMD_LoopbackFragmentRejected: a fragment on the requested
+// redirect_uri (prohibited by RFC 6749 section 3.1.2) must not match a
+// registered URI without one.
+func TestOAuthCIMD_LoopbackFragmentRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback#frag", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}

--- a/server/internal/mcp/authnchallenge_cimd_test.go
+++ b/server/internal/mcp/authnchallenge_cimd_test.go
@@ -1,0 +1,573 @@
+// Integration tests for inbound CIMD (Client ID Metadata Documents) on the
+// user-session OAuth surface: a URL-shaped client_id presented to
+// /mcp/{slug}/authorize is resolved by fetching the metadata document from
+// an httptest TLS server, gated by the gram-user-session-cimd flag.
+
+package mcp_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// cimdDocServer hosts a Client ID Metadata Document at
+// <TLS server>/oauth/client.json. Tests mutate doc before issuing requests.
+type cimdDocServer struct {
+	srv      *httptest.Server
+	clientID string
+	doc      map[string]any
+}
+
+func startCIMDDocServer(t *testing.T) *cimdDocServer {
+	t.Helper()
+
+	ds := &cimdDocServer{srv: nil, clientID: "", doc: nil}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/client.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ds.doc); err != nil {
+			t.Errorf("encode cimd document: %v", err)
+		}
+	})
+	ds.srv = httptest.NewTLSServer(mux)
+	t.Cleanup(ds.srv.Close)
+
+	ds.clientID = ds.srv.URL + "/oauth/client.json"
+	ds.doc = map[string]any{
+		"client_id":                  ds.clientID,
+		"client_name":                "CIMD Integration Client",
+		"redirect_uris":              []any{"http://127.0.0.1:33418/callback"},
+		"token_endpoint_auth_method": "none",
+	}
+	return ds
+}
+
+func (ds *cimdDocServer) certPool() *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(ds.srv.Certificate())
+	return pool
+}
+
+// newTestCIMDService builds a doc server plus an mcp service whose guardian
+// policy trusts the doc server's TLS certificate, seeds a public
+// issuer-gated toolset, and returns the org id used as the flag distinctID.
+// The flag is NOT enabled here — tests opt in via ti.features.SetFlag.
+func newTestCIMDService(t *testing.T) (context.Context, *testInstance, *cimdDocServer, toolsets_repo.Toolset, string) {
+	t.Helper()
+
+	ds := startCIMDDocServer(t)
+	ctx, ti := newTestMCPServiceWithGuardianOptions(t, guardian.WithTLSRootCAs(ds.certPool()))
+
+	toolset, _, _ := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	toolset, err := toolsets_repo.New(ti.conn).UpdateToolset(ctx, toolsets_repo.UpdateToolsetParams{
+		Name:                   toolset.Name,
+		Description:            toolset.Description,
+		DefaultEnvironmentSlug: toolset.DefaultEnvironmentSlug,
+		McpSlug:                toolset.McpSlug,
+		McpIsPublic:            true,
+		McpEnabled:             toolset.McpEnabled,
+		Slug:                   toolset.Slug,
+		ProjectID:              toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	return ctx, ti, ds, toolset, authCtx.ActiveOrganizationID
+}
+
+func doCIMDAuthorize(t *testing.T, ti *testInstance, mcpSlug, clientID, redirectURI, codeChallenge string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	q := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/authorize?"+q.Encode(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleAuthorize(w, req))
+	return w
+}
+
+func requireAuthorizeOAuthError(t *testing.T, w *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+
+	require.Equal(t, status, w.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, code, body["error"])
+}
+
+// TestOAuthCIMD_FullFlow drives the complete authorize → consent → token
+// flow with a URL-shaped client_id. The request's loopback redirect_uri
+// deliberately uses a different port (51423) than the document registers
+// (33418) — the Claude Code shape, where RFC 8252 §7.3 requires the AS to
+// accept variable loopback ports.
+func TestOAuthCIMD_FullFlow(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:51423/callback"
+	verifier := pkceVerifier(t)
+
+	// Authorize: resolves the document, upserts the client row, redirects
+	// to consent.
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(verifier))
+	require.Equal(t, http.StatusFound, w.Code)
+	consentLoc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Contains(t, consentLoc.Path, "/connect")
+	stateID := consentLoc.Query().Get("state")
+	require.NotEmpty(t, stateID)
+
+	// The lazily-upserted row is a CIMD row carrying the fetch stamp.
+	clientRow, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		ClientID:            ds.clientID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, ds.clientID, clientRow.ClientIDMetadataUri.String)
+	require.True(t, clientRow.ClientIDMetadataFetchedAt.Valid)
+	require.Equal(t, "CIMD Integration Client", clientRow.ClientName)
+	require.False(t, clientRow.ClientSecretHash.Valid)
+
+	// Consent GET: shows the document host as the verifiable trust anchor
+	// plus the loopback-redirect caution.
+	consentReq := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/connect?state="+stateID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	consentReq = consentReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	cw := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(cw, consentReq))
+	require.Equal(t, http.StatusOK, cw.Code)
+	docHost := strings.TrimPrefix(ds.srv.URL, "https://")
+	require.Contains(t, cw.Body.String(), "Client verified from")
+	require.Contains(t, cw.Body.String(), docHost)
+	require.Contains(t, cw.Body.String(), "local address on your")
+	require.Contains(t, cw.Body.String(), "CIMD Integration Client")
+
+	// Consent POST (approve): mints the authorization code.
+	stored, err := ti.authnChallengeCache.Get(ctx, "authnChallenge:"+stateID)
+	require.NoError(t, err)
+	form := url.Values{}
+	form.Set("state", stateID)
+	form.Set("csrf_token", stored.CSRFToken)
+	form.Set("action", "approve")
+	approveReq := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug+"/connect", strings.NewReader(form.Encode()))
+	approveReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx = chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	approveReq = approveReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	aw := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(aw, approveReq))
+	require.Equal(t, http.StatusSeeOther, aw.Code)
+	codeLoc, err := url.Parse(aw.Header().Get("Location"))
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(aw.Header().Get("Location"), redirectURI), "code must be delivered to the variable-port loopback redirect")
+	code := codeLoc.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	// Token: public-client exchange with form client_id and PKCE only.
+	tokenForm := url.Values{}
+	tokenForm.Set("grant_type", "authorization_code")
+	tokenForm.Set("code", code)
+	tokenForm.Set("redirect_uri", redirectURI)
+	tokenForm.Set("client_id", ds.clientID)
+	tokenForm.Set("code_verifier", verifier)
+	tokenReq := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug+"/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx = chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	tokenReq = tokenReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	tw := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleToken(tw, tokenReq))
+	require.Equal(t, http.StatusOK, tw.Code, "token response: %s", tw.Body.String())
+	var tokenBody map[string]any
+	require.NoError(t, json.Unmarshal(tw.Body.Bytes(), &tokenBody))
+	require.NotEmpty(t, tokenBody["access_token"])
+}
+
+func TestOAuthCIMD_FlagOff_RejectsURLClientID(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, _ := newTestCIMDService(t)
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusUnauthorized, "invalid_client")
+}
+
+// TestOAuthCIMD_FlagOffAfterResolution_RejectsAtAuthorize pins the
+// kill-switch semantics: once the flag is disabled, even a
+// previously-resolved CIMD client is rejected on new authorize flows.
+func TestOAuthCIMD_FlagOffAfterResolution_RejectsAtAuthorize(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	redirectURI := "http://127.0.0.1:33418/callback"
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, false)
+	w = doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusUnauthorized, "invalid_client")
+}
+
+func TestOAuthCIMD_ConfidentialAuthMethodRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["token_endpoint_auth_method"] = "client_secret_basic"
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthCIMD_DocumentClientIDMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["client_id"] = ds.srv.URL + "/oauth/other.json"
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthCIMD_CrossOriginRedirectURIRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["redirect_uris"] = []any{"https://elsewhere.example.com/callback"}
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "https://elsewhere.example.com/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_redirect_uri")
+}
+
+func TestOAuthCIMD_UnregisteredRedirectURIRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/other-path", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}
+
+// TestOAuthCIMD_NonLoopbackPortVarianceRejected: the loopback variable-port
+// exception must not leak to non-loopback hosts — a same-origin https
+// redirect registered in the document does not match a request that only
+// differs by port.
+func TestOAuthCIMD_NonLoopbackPortVarianceRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["redirect_uris"] = []any{ds.srv.URL + "/callback"}
+
+	docURL, err := url.Parse(ds.srv.URL)
+	require.NoError(t, err)
+	variedPort := "https://" + docURL.Hostname() + ":1/callback"
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, variedPort, pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}
+
+func TestOAuthCIMD_UnknownExtensionFieldsAccepted(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["software_statement"] = "eyJhbGciOiJub25lIn0.e30."
+	ds.doc["client_id_expires_at"] = 4102444800
+	ds.doc["x_vendor_extension"] = map[string]any{"nested": true}
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code, "documents with unrecognized extension fields must be accepted: %s", w.Body.String())
+}
+
+// TestOAuthCIMD_TokenRejectsSecretForCIMDClient: a CIMD row is public by
+// construction; presenting any client secret at /token is rejected even
+// though the row exists and the secret column is NULL.
+func TestOAuthCIMD_TokenRejectsSecretForCIMDClient(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	tokenForm := url.Values{}
+	tokenForm.Set("grant_type", "authorization_code")
+	tokenForm.Set("code", "any-code")
+	tokenForm.Set("redirect_uri", "http://127.0.0.1:33418/callback")
+	tokenForm.Set("client_id", ds.clientID)
+	tokenForm.Set("client_secret", "not-a-real-secret")
+	tokenForm.Set("code_verifier", pkceVerifier(t))
+	tokenReq := httptest.NewRequest(http.MethodPost, "/mcp/"+mcpSlug+"/token", strings.NewReader(tokenForm.Encode()))
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	tokenReq = tokenReq.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	tw := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleToken(tw, tokenReq))
+	require.Equal(t, http.StatusUnauthorized, tw.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(tw.Body.Bytes(), &body))
+	require.Equal(t, "invalid_client", body["error"])
+}
+
+func TestOAuthCIMD_ASMetadataAdvertisesSupportWhenFlagOn(t *testing.T) {
+	t.Parallel()
+
+	_, ti, _, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleGetAuthorizationServer(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &meta))
+	require.Equal(t, true, meta["client_id_metadata_document_supported"])
+}
+
+func TestOAuthCIMD_ASMetadataOmitsSupportWhenFlagOff(t *testing.T) {
+	t.Parallel()
+
+	_, ti, _, toolset, _ := newTestCIMDService(t)
+
+	mcpSlug := toolset.McpSlug.String
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleGetAuthorizationServer(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &meta))
+	require.NotContains(t, meta, "client_id_metadata_document_supported")
+}
+
+func doCIMDConsentGet(t *testing.T, ti *testInstance, mcpSlug, stateID string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/connect?state="+stateID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(w, req))
+	return w
+}
+
+// TestOAuthCIMD_RepeatAuthorizeRefreshesClient exercises the ON CONFLICT DO
+// UPDATE branch of the lazy upsert — the path every returning user hits: the
+// second authorize must reuse the same row (stable id for consent/session
+// FKs) while replacing the mutable metadata from the refetched document.
+func TestOAuthCIMD_RepeatAuthorizeRefreshesClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	mcpSlug := toolset.McpSlug.String
+	redirectURI := "http://127.0.0.1:33418/callback"
+
+	w := doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	first, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		ClientID:            ds.clientID,
+	})
+	require.NoError(t, err)
+
+	ds.doc["client_name"] = "Renamed CIMD Client"
+	ds.doc["redirect_uris"] = []any{redirectURI, "http://localhost:3000/other"}
+
+	w = doCIMDAuthorize(t, ti, mcpSlug, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	second, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		ClientID:            ds.clientID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, first.ID, second.ID, "repeat authorize must update the existing row, not create a new one")
+	require.Equal(t, "Renamed CIMD Client", second.ClientName)
+	require.Equal(t, []string{redirectURI, "http://localhost:3000/other"}, second.RedirectUris)
+	require.True(t, second.ClientIDMetadataFetchedAt.Time.After(first.ClientIDMetadataFetchedAt.Time), "fetch stamp must be refreshed")
+}
+
+// TestOAuthCIMD_SecretBearingCollisionRejected pins the upsert guard: a
+// pre-existing row sharing the client_id but carrying a secret hash must
+// surface as invalid_client, not as a CHECK-constraint 500 and not as a
+// silent rewrite of a confidential client into a CIMD one.
+func TestOAuthCIMD_SecretBearingCollisionRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	_, err := usersessions_repo.New(ti.conn).CreateUserSessionClient(ctx, usersessions_repo.CreateUserSessionClientParams{
+		UserSessionIssuerID:   toolset.UserSessionIssuerID.UUID,
+		ClientID:              ds.clientID,
+		ClientSecretHash:      conv.ToPGText("bcrypt-hash-placeholder"),
+		ClientName:            "Confidential DCR Client",
+		RedirectUris:          []string{"http://127.0.0.1:33418/callback"},
+		ClientSecretExpiresAt: pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusUnauthorized, "invalid_client")
+
+	row, err := usersessions_repo.New(ti.conn).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		ClientID:            ds.clientID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Confidential DCR Client", row.ClientName, "the secret-bearing row must be left untouched")
+	require.False(t, row.ClientIDMetadataUri.Valid)
+}
+
+// TestOAuthCIMD_LoopbackQueryInjectionRejected: the loopback carve-out may
+// vary ONLY the port — extra query parameters on the requested redirect_uri
+// must not match a registered URI without them.
+func TestOAuthCIMD_LoopbackQueryInjectionRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:51423/callback?injected=1", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}
+
+// TestOAuthCIMD_LoopbackUserinfoRejected: userinfo in the requested
+// redirect_uri must never match — it would make the victim's browser send
+// attacker-chosen Basic credentials to the local listener.
+func TestOAuthCIMD_LoopbackUserinfoRejected(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://user:pass@127.0.0.1:51423/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}
+
+// TestOAuthDCR_LoopbackPortVarianceRejected: the loopback variable-port
+// carve-out is CIMD-only; DCR-registered rows keep byte-exact matching.
+func TestOAuthDCR_LoopbackPortVarianceRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+
+	// The seeded DCR client registers http://localhost:3000/callback.
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, client.ClientID, "http://localhost:9999/callback", pkceChallenge(pkceVerifier(t)))
+	requireAuthorizeOAuthError(t, w, http.StatusBadRequest, "invalid_request")
+}
+
+// TestOAuthCIMD_FetchFailureReturns503 pins the fetch-failure wire contract:
+// retryable status + code (a document host blip must not read as a permanent
+// invalid_client) and a generic description with no internal error detail.
+func TestOAuthCIMD_FetchFailureReturns503(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+
+	missingDocURL := ds.srv.URL + "/missing.json"
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, missingDocURL, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, "temporarily_unavailable", body["error"])
+	require.Equal(t, "failed to fetch client metadata document", body["error_description"])
+}
+
+// TestOAuthCIMD_ConsentEscapesHostileClientName: client_name is
+// attacker-chosen for any accepted document; the consent page must render it
+// inert.
+func TestOAuthCIMD_ConsentEscapesHostileClientName(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	ds.doc["client_name"] = `<img src=x onerror=alert(1)> Client`
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, "http://127.0.0.1:33418/callback", pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	consentLoc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+
+	cw := doCIMDConsentGet(t, ti, toolset.McpSlug.String, consentLoc.Query().Get("state"))
+	require.Equal(t, http.StatusOK, cw.Code)
+	require.NotContains(t, cw.Body.String(), "<img src=x")
+	require.Contains(t, cw.Body.String(), "&lt;img src=x onerror=alert(1)&gt; Client")
+}
+
+// TestOAuthCIMD_ConsentNoLoopbackWarningForSameOriginRedirect: the loopback
+// caution is scoped to loopback redirects; a same-origin https redirect
+// shows the trust anchor without the warning.
+func TestOAuthCIMD_ConsentNoLoopbackWarningForSameOriginRedirect(t *testing.T) {
+	t.Parallel()
+
+	_, ti, ds, toolset, orgID := newTestCIMDService(t)
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, orgID, true)
+	redirectURI := ds.srv.URL + "/callback"
+	ds.doc["redirect_uris"] = []any{redirectURI}
+
+	w := doCIMDAuthorize(t, ti, toolset.McpSlug.String, ds.clientID, redirectURI, pkceChallenge(pkceVerifier(t)))
+	require.Equal(t, http.StatusFound, w.Code)
+	consentLoc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+
+	cw := doCIMDConsentGet(t, ti, toolset.McpSlug.String, consentLoc.Query().Get("state"))
+	require.Equal(t, http.StatusOK, cw.Code)
+	require.Contains(t, cw.Body.String(), "Client verified from")
+	require.NotContains(t, cw.Body.String(), "local address on your")
+}

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	users_repo "github.com/speakeasy-api/gram/server/internal/users/repo"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
 	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -86,6 +87,17 @@ type consentTemplateData struct {
 	// completion message: a first-party challenge has no MCP client to grant
 	// to, so linking the cards is the whole job.
 	FirstParty bool
+	// ClientIDOrigin is the host of the client_id URL for CIMD-resolved
+	// clients, empty otherwise. Surfaced because a metadata document's
+	// client_name (and logo) are attacker-chosen for any accepted document;
+	// the origin is the trust anchor a human can actually verify
+	// (draft-ietf-oauth-client-id-metadata-document-02 §8.5).
+	ClientIDOrigin string
+	// LoopbackRedirectWarning is set when a CIMD client will receive the
+	// authorization code on a loopback redirect: any process on the user's
+	// machine can bind the same port, so the page shows a caution (MCP
+	// SHOULD).
+	LoopbackRedirectWarning bool
 	// AutoClose marks a fully completed first-party connection: every bound
 	// remote_session_client is connected. The consent script closes only this
 	// terminal state; partially-linked connections (some cards still
@@ -195,11 +207,10 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	// user's own upstream sessions. Skip the client lookup and label the page
 	// generically.
 	clientName := "Gram"
+	clientIDOrigin := ""
+	loopbackRedirectWarning := false
 	if !challengeState.FirstParty {
-		client, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
-			UserSessionIssuerID: endpoint.UserSessionIssuerID,
-			ClientID:            challengeState.ClientID,
-		})
+		client, err := s.resolveUserSessionClient(ctx, logger, endpoint, challengeState.ClientID, lookupClientOnly)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return oops.E(oops.CodeUnauthorized, err, "user session client revoked").LogError(ctx, logger)
@@ -207,6 +218,14 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 			return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 		}
 		clientName = client.ClientName
+		if client.ClientIDMetadataUri.Valid {
+			if u, err := url.Parse(client.ClientIDMetadataUri.String); err == nil {
+				clientIDOrigin = u.Host
+			}
+			if u, err := url.Parse(challengeState.RedirectURI); err == nil && cimd.IsLoopbackRedirectURI(u) {
+				loopbackRedirectWarning = true
+			}
+		}
 	}
 
 	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
@@ -230,18 +249,20 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	consentEnabled := len(cards) == 0 || hasConnectedCard
 
 	data := consentTemplateData{
-		ClientName:         clientName,
-		MCPSlug:            endpoint.Slug,
-		MCPRouteBase:       endpoint.RouteBase,
-		State:              stateID,
-		CSRFToken:          challengeState.CSRFToken,
-		SubjectDisplay:     subjectDisplay,
-		RedirectURI:        challengeState.RedirectURI,
-		ScriptURL:          consentScriptURL,
-		RemoteSessionCards: cards,
-		ConsentEnabled:     consentEnabled,
-		FirstParty:         challengeState.FirstParty,
-		AutoClose:          shouldAutoCloseFirstParty(challengeState.FirstParty, cards),
+		ClientName:              clientName,
+		MCPSlug:                 endpoint.Slug,
+		MCPRouteBase:            endpoint.RouteBase,
+		State:                   stateID,
+		CSRFToken:               challengeState.CSRFToken,
+		SubjectDisplay:          subjectDisplay,
+		RedirectURI:             challengeState.RedirectURI,
+		ScriptURL:               consentScriptURL,
+		RemoteSessionCards:      cards,
+		ConsentEnabled:          consentEnabled,
+		FirstParty:              challengeState.FirstParty,
+		ClientIDOrigin:          clientIDOrigin,
+		LoopbackRedirectWarning: loopbackRedirectWarning,
+		AutoClose:               shouldAutoCloseFirstParty(challengeState.FirstParty, cards),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -331,10 +352,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	subject := *challengeState.Subject
 
 	// Resolve the user_session_clients row id for the consent FK.
-	clientRow, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		ClientID:            challengeState.ClientID,
-	})
+	clientRow, err := s.resolveUserSessionClient(ctx, logger, endpoint, challengeState.ClientID, lookupClientOnly)
 	if err != nil {
 		// Client revoked mid-flow (config change) or DB error — either way the
 		// approved flow can't complete.

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -86,16 +86,25 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "missing_client_id")
 		return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "client_id is required")
 	}
-	clientRow, err := usersessions_repo.New(s.db).GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
-		UserSessionIssuerID: endpoint.UserSessionIssuerID,
-		ClientID:            clientID,
-	})
+	// lookupClientOnly: any CIMD row was persisted at authorize time, and
+	// mid-flow token legs must keep working even if the CIMD flag flips off.
+	clientRow, err := s.resolveUserSessionClient(ctx, logger, endpoint, clientID, lookupClientOnly)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "unknown_client_id")
 			return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", "unknown client_id")
 		}
 		return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
+	}
+	// CIMD-resolved clients are public by construction (the AS only accepts
+	// documents declaring token_endpoint_auth_method "none", and the schema
+	// forbids a secret on CIMD rows). Reject any attempt to authenticate
+	// one with credentials per RFC 6749 §5.2 — a URL-shaped client_id
+	// cannot travel via HTTP Basic (r.BasicAuth does no percent-decoding),
+	// so a legitimate CIMD client always presents form client_id + none.
+	if clientRow.ClientIDMetadataUri.Valid && presentedAuthMethod != "none" {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth token client authentication rejected", clientID, presentedAuthMethod, grantType, "cimd_client_presented_credentials")
+		return writeTokenError(ctx, w, logger, http.StatusUnauthorized, "invalid_client", `client_id metadata document clients must use token_endpoint_auth_method "none"`)
 	}
 	// Public clients (token_endpoint_auth_method=none) have a NULL hash:
 	// PKCE / refresh-token possession is the integrity proof, no secret check.
@@ -114,9 +123,9 @@ func (s *Service) ServeToken(w http.ResponseWriter, r *http.Request, endpoint *R
 
 	switch grantType {
 	case "authorization_code":
-		return s.handleTokenAuthorizationCodeGrant(ctx, w, r, endpoint, &clientRow, baseURL, presentedAuthMethod, logger)
+		return s.handleTokenAuthorizationCodeGrant(ctx, w, r, endpoint, clientRow, baseURL, presentedAuthMethod, logger)
 	case "refresh_token":
-		return s.handleTokenRefreshTokenGrant(ctx, w, r, endpoint, &clientRow, baseURL, presentedAuthMethod, logger)
+		return s.handleTokenRefreshTokenGrant(ctx, w, r, endpoint, clientRow, baseURL, presentedAuthMethod, logger)
 	default:
 		logOAuthClientCredentialEvent(ctx, logger, r, "oauth token request rejected", clientID, presentedAuthMethod, grantType, "unsupported_grant_type")
 		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "unsupported_grant_type", "unsupported grant_type")

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	mcpendpoints_repo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
@@ -69,6 +70,11 @@ type oauthAuthorizationServerMetadata struct {
 	GrantTypesSupported               []string `json:"grant_types_supported"`
 	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
 	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	// ClientIDMetadataDocumentSupported advertises inbound CIMD support
+	// (draft-ietf-oauth-client-id-metadata-document-02 §6). Emitted as true
+	// only when the issuer organization's gram-user-session-cimd flag is
+	// on; omitted otherwise.
+	ClientIDMetadataDocumentSupported *bool `json:"client_id_metadata_document_supported,omitempty"`
 }
 
 // HandleGetProtectedResource serves RFC 9728 protected-resource metadata at
@@ -403,6 +409,12 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build OAuth server URLs").LogError(ctx, s.logger)
 	}
+	// The response is served with cache headers (writeJSONMetadata), so a
+	// flag flip propagates to clients only after their cached copy expires.
+	var cimdSupported *bool
+	if s.userSessionCIMDEnabled(ctx, s.logger, endpoint) {
+		cimdSupported = conv.PtrEmpty(true)
+	}
 	return writeJSONMetadata(ctx, w, r, s.logger, oauthAuthorizationServerMetadata{
 		Issuer:                            urls.Issuer,
 		AuthorizationEndpoint:             urls.Authorize,
@@ -414,6 +426,7 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 		GrantTypesSupported:               usersessions.SupportedGrantTypes,
 		TokenEndpointAuthMethodsSupported: usersessions.SupportedAuthMethods,
 		CodeChallengeMethodsSupported:     usersessions.SupportedCodeChallengeMethods,
+		ClientIDMetadataDocumentSupported: cimdSupported,
 	})
 }
 

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -143,11 +143,11 @@ func (s *Service) userSessionCIMDEnabled(ctx context.Context, logger *slog.Logge
 // loopback redirects, the port is ignored. RFC 8252 requires the AS to allow
 // variable loopback ports for native apps — Claude Code binds an OS-assigned
 // ephemeral port per invocation — and RFC 9700 preserves that carve-out. The
-// port is the ONLY component allowed to vary: host, path, and query must
-// match, and neither side may carry userinfo — otherwise an attacker-crafted
-// authorize URL could inject extra query parameters (or browser-sent Basic
-// credentials) into the legitimate client's local callback. DCR rows keep
-// byte-exact matching.
+// port is the ONLY component allowed to vary: every other component must
+// match in escaped form, and neither side may carry userinfo — otherwise an
+// attacker-crafted authorize URL could inject extra query parameters, an
+// encoding-variant path, or browser-sent Basic credentials into the
+// legitimate client's local callback. DCR rows keep byte-exact matching.
 func redirectURIMatches(client *usersessions_repo.UserSessionClient, requested string) bool {
 	if slices.Contains(client.RedirectUris, requested) {
 		return true
@@ -165,11 +165,25 @@ func redirectURIMatches(client *usersessions_repo.UserSessionClient, requested s
 		if err != nil || registeredURL.User != nil || !cimd.IsLoopbackRedirectURI(registeredURL) {
 			continue
 		}
-		if strings.EqualFold(registeredURL.Hostname(), requestedURL.Hostname()) &&
-			registeredURL.Path == requestedURL.Path &&
-			registeredURL.RawQuery == requestedURL.RawQuery {
+		if loopbackRedirectEqualIgnoringPort(registeredURL, requestedURL) {
 			return true
 		}
 	}
 	return false
+}
+
+// loopbackRedirectEqualIgnoringPort reports whether two parsed loopback
+// redirect URIs are identical except for the port. Rebuilding each URI with
+// the port stripped and the host lowercased, then comparing the resulting
+// strings, covers every component in escaped form — scheme, host, path,
+// query, and fragment — so a percent-encoding variant (e.g. /%63allback for
+// a registered /callback) or an added fragment cannot slip through the
+// variable-port exception.
+func loopbackRedirectEqualIgnoringPort(a, b *url.URL) bool {
+	stripPort := func(u *url.URL) string {
+		c := *u
+		c.Host = strings.ToLower(c.Hostname())
+		return c.String()
+	}
+	return stripPort(a) == stripPort(b)
 }

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -156,11 +156,22 @@ func redirectURIMatches(client *usersessions_repo.UserSessionClient, requested s
 		return false
 	}
 
+	// Fragments disqualify the exception on either side: RFC 6749 §3.1.2
+	// forbids fragments in redirect URIs, and url.Parse cannot distinguish
+	// an absent fragment from an explicit empty one ("...#") — URL.String()
+	// drops the latter, which would let a malformed registered URI match a
+	// fragment-less request. A raw-string check is the only reliable guard.
+	if strings.Contains(requested, "#") {
+		return false
+	}
 	requestedURL, err := url.Parse(requested)
 	if err != nil || requestedURL.User != nil || !cimd.IsLoopbackRedirectURI(requestedURL) {
 		return false
 	}
 	for _, registered := range client.RedirectUris {
+		if strings.Contains(registered, "#") {
+			continue
+		}
 		registeredURL, err := url.Parse(registered)
 		if err != nil || registeredURL.User != nil || !cimd.IsLoopbackRedirectURI(registeredURL) {
 			continue
@@ -175,10 +186,11 @@ func redirectURIMatches(client *usersessions_repo.UserSessionClient, requested s
 // loopbackRedirectEqualIgnoringPort reports whether two parsed loopback
 // redirect URIs are identical except for the port. Rebuilding each URI with
 // the port stripped and the host lowercased, then comparing the resulting
-// strings, covers every component in escaped form — scheme, host, path,
-// query, and fragment — so a percent-encoding variant (e.g. /%63allback for
-// a registered /callback) or an added fragment cannot slip through the
-// variable-port exception.
+// strings, covers every remaining component in escaped form — scheme, host,
+// path, and query — so a percent-encoding variant (e.g. /%63allback for a
+// registered /callback) cannot slip through the variable-port exception.
+// Callers must have rejected fragments on both sides already: URL.String()
+// cannot represent an explicit empty fragment.
 func loopbackRedirectEqualIgnoringPort(a, b *url.URL) bool {
 	stripPort := func(u *url.URL) string {
 		c := *u

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -53,6 +53,14 @@ const (
 // rather than echoing it to the client.
 var errCIMDFetchFailed = errors.New("cimd document fetch failed")
 
+// errCIMDDisabled marks a URL-shaped client_id rejected because the issuer
+// organization's gram-user-session-cimd flag is off. Handlers must render it
+// exactly like an unknown client (invalid_client, "unknown client_id") so
+// the wire response does not leak per-organization flag state; the dedicated
+// sentinel exists so the kill-switch path is loggable and is not conflated
+// with pgx.ErrNoRows from a lookup that actually ran.
+var errCIMDDisabled = errors.New("cimd disabled for organization")
+
 // resolveUserSessionClient resolves the user_session_clients row behind a
 // presented client_id. Error contract, in the order callers should check:
 //
@@ -60,17 +68,18 @@ var errCIMDFetchFailed = errors.New("cimd document fetch failed")
 //     client-safe code + description (resolveClientCIMD only)
 //   - errCIMDFetchFailed: document fetch failure; log, render generic
 //     (resolveClientCIMD only)
-//   - pgx.ErrNoRows: unknown client — includes URL-shaped ids while the
-//     flag is off, which deliberately fail closed as unknown even when a
-//     previously-resolved row exists, so disabling the flag is a real kill
-//     switch for new authorize flows
+//   - errCIMDDisabled: URL-shaped client_id while the flag is off; render
+//     as unknown client (resolveClientCIMD only). Deliberately fails closed
+//     even when a previously-resolved row exists, so disabling the flag is
+//     a real kill switch for new authorize flows
+//   - pgx.ErrNoRows: unknown client
 //   - anything else: infrastructure failure
 func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint, clientID string, mode clientIDResolveMode) (*usersessions_repo.UserSessionClient, error) {
 	queries := usersessions_repo.New(s.db)
 
 	if mode == resolveClientCIMD && cimd.IsClientIDURL(clientID) {
 		if !s.userSessionCIMDEnabled(ctx, logger, endpoint) {
-			return nil, pgx.ErrNoRows
+			return nil, errCIMDDisabled
 		}
 
 		doc, err := cimd.Resolve(ctx, cimd.NewFetchClient(s.guardianPolicy), clientID)

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -1,0 +1,175 @@
+// Client resolution seam for the issuer-gated OAuth surface. Every handler
+// that resolves a user_session_clients row from a presented client_id —
+// authorize, token, consent GET/POST — funnels through
+// resolveUserSessionClient, so inbound CIMD resolution (and its future
+// layers: document caching, per-origin rate limits, admission control) has
+// exactly one home instead of per-handler branches.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// clientIDResolveMode selects how resolveUserSessionClient treats a
+// URL-shaped client_id.
+type clientIDResolveMode string
+
+const (
+	// lookupClientOnly resolves strictly from the database. Used by the
+	// token and consent handlers: by the time they run, the authorize leg
+	// has already persisted any CIMD row, and mid-flow requests (a code
+	// exchange or refresh) must keep working even if the CIMD flag flips
+	// off between legs.
+	lookupClientOnly clientIDResolveMode = "lookup_only"
+
+	// resolveClientCIMD additionally treats a URL-shaped client_id as a
+	// Client ID Metadata Document reference when the issuer organization's
+	// gram-user-session-cimd flag is on: the document is fetched and
+	// validated on every call (no caching) and the row lazily
+	// upserted. Authorize-time only — the consent GET/POST re-resolve the
+	// client by client_id, so the row must exist before the flow leaves
+	// /authorize.
+	resolveClientCIMD clientIDResolveMode = "resolve_cimd"
+)
+
+// errCIMDFetchFailed marks a transport-level document fetch failure. The
+// wrapped cause may name internal network conditions (guardian SSRF denials,
+// DNS errors), so handlers must log it and render a generic OAuth error
+// rather than echoing it to the client.
+var errCIMDFetchFailed = errors.New("cimd document fetch failed")
+
+// resolveUserSessionClient resolves the user_session_clients row behind a
+// presented client_id. Error contract, in the order callers should check:
+//
+//   - *usersessions.OAuthError: a CIMD spec/policy rejection with a
+//     client-safe code + description (resolveClientCIMD only)
+//   - errCIMDFetchFailed: document fetch failure; log, render generic
+//     (resolveClientCIMD only)
+//   - pgx.ErrNoRows: unknown client — includes URL-shaped ids while the
+//     flag is off, which deliberately fail closed as unknown even when a
+//     previously-resolved row exists, so disabling the flag is a real kill
+//     switch for new authorize flows
+//   - anything else: infrastructure failure
+func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint, clientID string, mode clientIDResolveMode) (*usersessions_repo.UserSessionClient, error) {
+	queries := usersessions_repo.New(s.db)
+
+	if mode == resolveClientCIMD && cimd.IsClientIDURL(clientID) {
+		if !s.userSessionCIMDEnabled(ctx, logger, endpoint) {
+			return nil, pgx.ErrNoRows
+		}
+
+		doc, err := cimd.Resolve(ctx, cimd.NewFetchClient(s.guardianPolicy), clientID)
+		if err != nil {
+			var oauthErr *usersessions.OAuthError
+			if errors.As(err, &oauthErr) {
+				return nil, fmt.Errorf("resolve cimd client: %w", err)
+			}
+			return nil, fmt.Errorf("%w: %w", errCIMDFetchFailed, err)
+		}
+
+		row, err := queries.UpsertUserSessionClientFromCIMD(ctx, usersessions_repo.UpsertUserSessionClientFromCIMDParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			ClientID:            clientID,
+			ClientName:          doc.ClientName,
+			RedirectUris:        doc.RedirectURIs,
+		})
+		if err != nil {
+			// No-rows here means the DO UPDATE guard refused to rewrite a
+			// secret-bearing row sharing this client_id; surface it as an
+			// unknown client rather than a 500.
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, pgx.ErrNoRows
+			}
+			return nil, fmt.Errorf("upsert cimd user session client: %w", err)
+		}
+		return &row, nil
+	}
+
+	row, err := queries.GetUserSessionClientByClientID(ctx, usersessions_repo.GetUserSessionClientByClientIDParams{
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		ClientID:            clientID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("lookup user session client: %w", err)
+	}
+	return &row, nil
+}
+
+// userSessionCIMDEnabled evaluates the inbound-CIMD rollout flag for the
+// endpoint's organization. distinctID is the organization ID with no groups
+// (matching the flag's PostHog targeting). Successful evaluations are
+// remembered per organization so a flag-provider outage degrades to the
+// last known state instead of failing closed — this runs on unauthenticated
+// endpoints (/authorize and the well-known metadata), where fail-closed
+// would turn a PostHog outage into an OAuth login outage for every
+// CIMD-enabled organization. Fresh evaluations always win, so flag flips
+// propagate immediately; the map holds one bool per organization that
+// touches the OAuth surface, so growth is bounded by tenant count.
+func (s *Service) userSessionCIMDEnabled(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint) bool {
+	enabled, err := s.features.IsFlagEnabled(ctx, feature.FlagUserSessionCIMD, endpoint.OrganizationID, nil)
+	if err != nil {
+		s.cimdOrgFlagMu.RLock()
+		lastKnown, ok := s.cimdOrgFlagLastKnown[endpoint.OrganizationID]
+		s.cimdOrgFlagMu.RUnlock()
+		logger.WarnContext(ctx, "evaluate user session cimd flag", attr.SlogError(err))
+		return ok && lastKnown
+	}
+
+	s.cimdOrgFlagMu.Lock()
+	s.cimdOrgFlagLastKnown[endpoint.OrganizationID] = enabled
+	s.cimdOrgFlagMu.Unlock()
+	return enabled
+}
+
+// redirectURIMatches reports whether the request's redirect_uri matches an
+// entry registered on the client row. The rule is exact string matching (RFC
+// 9700 §4.1.3) with exactly one exception, applied to CIMD-resolved rows
+// only: when both the registered and requested URIs are RFC 8252 §7.3
+// loopback redirects, the port is ignored. RFC 8252 requires the AS to allow
+// variable loopback ports for native apps — Claude Code binds an OS-assigned
+// ephemeral port per invocation — and RFC 9700 preserves that carve-out. The
+// port is the ONLY component allowed to vary: host, path, and query must
+// match, and neither side may carry userinfo — otherwise an attacker-crafted
+// authorize URL could inject extra query parameters (or browser-sent Basic
+// credentials) into the legitimate client's local callback. DCR rows keep
+// byte-exact matching.
+func redirectURIMatches(client *usersessions_repo.UserSessionClient, requested string) bool {
+	if slices.Contains(client.RedirectUris, requested) {
+		return true
+	}
+	if !client.ClientIDMetadataUri.Valid {
+		return false
+	}
+
+	requestedURL, err := url.Parse(requested)
+	if err != nil || requestedURL.User != nil || !cimd.IsLoopbackRedirectURI(requestedURL) {
+		return false
+	}
+	for _, registered := range client.RedirectUris {
+		registeredURL, err := url.Parse(registered)
+		if err != nil || registeredURL.User != nil || !cimd.IsLoopbackRedirectURI(registeredURL) {
+			continue
+		}
+		if strings.EqualFold(registeredURL.Hostname(), requestedURL.Hostname()) &&
+			registeredURL.Path == requestedURL.Path &&
+			registeredURL.RawQuery == requestedURL.RawQuery {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -153,6 +153,15 @@
         color: var(--text-default);
       }
 
+      .loopback-warning {
+        margin: 0;
+        padding: 0.75rem 1rem;
+        border: solid 1px var(--border-neutral-softest);
+        border-radius: 0.5rem;
+        font-size: 0.8125rem;
+        color: var(--text-default-warning);
+      }
+
       .remotes {
         display: flex;
         flex-direction: column;
@@ -347,11 +356,23 @@
         <dl class="info">
           <dt>Signing in as</dt>
           <dd>{{.SubjectDisplay}}</dd>
+          {{if .ClientIDOrigin}}
+          <dt>Client verified from</dt>
+          <dd>{{.ClientIDOrigin}}</dd>
+          {{end}}
           {{if .RedirectURI}}
           <dt>Will redirect to</dt>
           <dd>{{.RedirectURI}}</dd>
           {{end}}
         </dl>
+
+        {{if .LoopbackRedirectWarning}}
+        <p class="loopback-warning">
+          This client receives its authorization at a local address on your
+          device. Only approve if you just started this request from an app
+          running on this computer.
+        </p>
+        {{end}}
 
         {{if .RemoteSessionCards}}
         <div class="remotes">

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -47,6 +48,7 @@ import (
 	deployments_repo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	externalmcp_repo "github.com/speakeasy-api/gram/server/internal/externalmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -86,20 +88,31 @@ type IdentityResolver interface {
 }
 
 type Service struct {
-	logger                 *slog.Logger
-	tracer                 trace.Tracer
-	metrics                *metrics
-	guardianPolicy         *guardian.Policy
-	db                     *pgxpool.Pool
-	authRepo               *auth_repo.Queries
-	toolsetsRepo           *toolsets_repo.Queries
-	mcpMetadataRepo        *metadata_repo.Queries
-	orgsRepo               *organizations_repo.Queries
-	auth                   *auth.Auth
-	env                    toolconfig.EnvironmentLoader
-	serverURL              *url.URL
-	siteURL                *url.URL
-	posthog                *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
+	logger          *slog.Logger
+	tracer          trace.Tracer
+	metrics         *metrics
+	guardianPolicy  *guardian.Policy
+	db              *pgxpool.Pool
+	authRepo        *auth_repo.Queries
+	toolsetsRepo    *toolsets_repo.Queries
+	mcpMetadataRepo *metadata_repo.Queries
+	orgsRepo        *organizations_repo.Queries
+	auth            *auth.Auth
+	env             toolconfig.EnvironmentLoader
+	serverURL       *url.URL
+	siteURL         *url.URL
+	posthog         *posthog.Posthog // posthog metrics will no-op if the dependency is not provided
+	// features gates flag-controlled behavior on the OAuth surface (inbound
+	// CIMD). Wired from the same posthog client in production; typed as the
+	// interface so tests can inject feature.InMemory.
+	features feature.Provider
+	// cimdOrgFlagLastKnown remembers the last successful per-organization
+	// evaluation of FlagUserSessionCIMD so a flag-provider outage degrades
+	// to the last known state instead of failing closed on the
+	// unauthenticated OAuth surface. Guarded by cimdOrgFlagMu; holds one bool
+	// per organization that touches the surface.
+	cimdOrgFlagMu          sync.RWMutex
+	cimdOrgFlagLastKnown   map[string]bool
 	toolProxy              *gateway.ToolProxy
 	oauthService           OAuthService
 	oauthRepo              *oauth_repo.Queries
@@ -239,6 +252,7 @@ func NewService(
 	chatSessionsManager *chatsessions.Manager,
 	env toolconfig.EnvironmentLoader,
 	posthog *posthog.Posthog,
+	features feature.Provider,
 	serverURL *url.URL,
 	siteURL *url.URL,
 	enc *encryption.Client,
@@ -286,22 +300,25 @@ func NewService(
 	)
 
 	return &Service{
-		logger:          logger,
-		tracer:          tracer,
-		metrics:         newMetrics(meter, logger),
-		guardianPolicy:  guardianPolicy,
-		db:              db,
-		authRepo:        auth_repo.New(db),
-		toolsetsRepo:    toolsets_repo.New(db),
-		mcpMetadataRepo: metadata_repo.New(db),
-		orgsRepo:        organizations_repo.New(db),
-		deploymentsRepo: deployments_repo.New(db),
-		externalmcpRepo: externalmcp_repo.New(db),
-		auth:            auth.New(logger, db, sessions, authzEngine),
-		env:             env,
-		serverURL:       serverURL,
-		siteURL:         siteURL,
-		posthog:         posthog,
+		logger:               logger,
+		tracer:               tracer,
+		metrics:              newMetrics(meter, logger),
+		guardianPolicy:       guardianPolicy,
+		db:                   db,
+		authRepo:             auth_repo.New(db),
+		toolsetsRepo:         toolsets_repo.New(db),
+		mcpMetadataRepo:      metadata_repo.New(db),
+		orgsRepo:             organizations_repo.New(db),
+		deploymentsRepo:      deployments_repo.New(db),
+		externalmcpRepo:      externalmcp_repo.New(db),
+		auth:                 auth.New(logger, db, sessions, authzEngine),
+		env:                  env,
+		serverURL:            serverURL,
+		siteURL:              siteURL,
+		posthog:              posthog,
+		features:             features,
+		cimdOrgFlagMu:        sync.RWMutex{},
+		cimdOrgFlagLastKnown: map[string]bool{},
 		toolProxy: gateway.NewToolProxy(
 			logger,
 			tracerProvider,

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -37,6 +37,7 @@ import (
 	deployments_repo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/keys"
@@ -95,6 +96,9 @@ type testInstance struct {
 	authzEngine         *authz.Engine
 	audit               *audit.Logger
 	tunnelRoutes        route.Store
+	// features is the injectable flag provider wired into the service; tests
+	// enable flag-gated behavior (e.g. inbound CIMD) with SetFlag.
+	features *feature.InMemory
 }
 
 // newTestMCPService wires a permissive identity resolver. Tests asserting
@@ -139,7 +143,22 @@ func newTestMCPServiceWithIdentityResolver(t *testing.T, identityResolver mcp.Id
 	})
 }
 
-func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.IdentityResolver, tunnelPublicConfig mcp.TunnelPublicConfig) (context.Context, *testInstance) {
+// newTestMCPServiceWithGuardianOptions wires the permissive identity
+// resolver plus extra guardian policy options — e.g. guardian.WithTLSRootCAs
+// so CIMD document fetches trust an httptest.NewTLSServer certificate.
+func newTestMCPServiceWithGuardianOptions(t *testing.T, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
+	t.Helper()
+
+	return newTestMCPServiceWithTunnelPublicConfig(t, &mockIdentityResolver{hasAccessOK: true}, mcp.TunnelPublicConfig{
+		SessionTTL:         0,
+		LiveSessionCap:     0,
+		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+		RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+		MaxRequestLifetime: 0,
+	}, guardianOpts...)
+}
+
+func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.IdentityResolver, tunnelPublicConfig mcp.TunnelPublicConfig, guardianOpts ...func(*guardian.Policy)) (context.Context, *testInstance) {
 	t.Helper()
 
 	ctx := t.Context()
@@ -147,7 +166,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
-	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{}, guardianOpts...)
 	require.NoError(t, err)
 
 	conn, err := infra.CloneTestDatabase(t, "mcptest")
@@ -224,7 +243,8 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 		ManagedAssistantInsightsTools: managedLogsTools,
 	})
 	tunnelRoutes := route.NewRouteTable()
-	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, serverURL, siteURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig)
+	features := &feature.InMemory{}
+	svc := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, features, serverURL, siteURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig)
 
 	authnCache := cache.NewTypedObjectCache[mcp.AuthnChallengeState](logger, cacheAdapter, cache.SuffixNone)
 
@@ -242,6 +262,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 		authzEngine:         authzEngine,
 		audit:               auditLogger,
 		tunnelRoutes:        tunnelRoutes,
+		features:            features,
 	}
 }
 

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -1,0 +1,226 @@
+// Package cimd implements the inbound side of OAuth Client ID Metadata
+// Documents (draft-ietf-oauth-client-id-metadata-document-02): resolving a
+// URL-shaped client_id presented to the user-session authorization server by
+// fetching the document it names, parsing it, and validating it against the
+// spec's rules plus Gram's own origin-binding policy.
+//
+// The package is deliberately stateless: no caching, no persistence, no
+// logging. Callers own the upsert of the resolved client and
+// the mapping of returned errors onto their wire format. Spec-defined
+// rejections are returned as *usersessions.OAuthError with a client-safe
+// description; transport-level fetch failures are returned as plain wrapped
+// errors whose text may reference internal details and MUST NOT be echoed to
+// the OAuth client verbatim.
+package cimd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+const (
+	// maxClientIDLength caps the URL-shaped client_id in application code.
+	// The client_id column is unconstrained TEXT feeding a btree unique
+	// index with a ~2704-byte entry limit, so oversized URLs must be
+	// rejected here with a clean OAuth error rather than a Postgres index
+	// failure.
+	maxClientIDLength = 2048
+
+	// maxDocumentBytes is the read cap on the fetched document body. Draft
+	// -02 §8.7 frames the size limit as a read cap, not a Content-Length
+	// check — the header can lie. Hitting the cap is a fetch failure.
+	maxDocumentBytes = 5 * 1024
+
+	// fetchTimeout bounds a single document fetch. The spec is silent on
+	// timeouts; this is our choice, applied per Resolve call on top of the
+	// caller's context.
+	fetchTimeout = 10 * time.Second
+
+	// maxClientNameLength caps the display name an attacker-controlled
+	// document can persist and render on the consent page. The whole-body
+	// cap alone would allow a ~5 KB name, enough to push the consent
+	// screen's origin line — the anti-spoofing trust anchor — out of view.
+	maxClientNameLength = 256
+
+	// maxRedirectURIs / maxRedirectURILength bound the TEXT[] a document
+	// can write into user_session_clients.redirect_uris. Real clients
+	// register a handful of URIs; the caps only exist to stop abuse.
+	maxRedirectURIs      = 32
+	maxRedirectURILength = 2048
+)
+
+// Document is the subset of a Client ID Metadata Document that the
+// user-session AS honours, plus the fields it must detect to reject a
+// document (client_secret and friends). Unknown members are deliberately
+// tolerated (default encoding/json behavior): metadata fields come from the
+// open RFC 7591 IANA registry, -02 §4.3 allows an embedded
+// software_statement, and future fields (e.g. client_id_expires_at) may
+// appear. Rejecting unknown fields is an interop bug, not strictness.
+type Document struct {
+	// ClientID is the document's own client_id member. -02 §4 requires it
+	// to equal the Client Identifier URL the document was fetched from; the
+	// validator enforces that equality.
+	ClientID string `json:"client_id"`
+
+	// ClientName is the human-readable display name shown on the consent
+	// page. Required (MCP mandates it, and the user_session_clients column
+	// is NOT NULL) and attacker-chosen for any accepted document — the
+	// consent page pairs it with the client_id origin as the verifiable
+	// trust anchor.
+	ClientName string `json:"client_name"`
+
+	// ClientSecret is captured as a raw presence marker only: -02 §4.1
+	// forbids a metadata document from containing client_secret (the
+	// document is public by definition), so any appearance — whatever the
+	// value type — invalidates the document.
+	ClientSecret json.RawMessage `json:"client_secret"`
+
+	// ClientSecretExpiresAt is a raw presence marker like ClientSecret;
+	// its appearance invalidates the document for the same reason.
+	ClientSecretExpiresAt json.RawMessage `json:"client_secret_expires_at"`
+
+	// ClientURI is the client's informational homepage URL. Optional and
+	// currently unused by the AS.
+	ClientURI string `json:"client_uri"`
+
+	// GrantTypes is parsed but not enforced: the AS only ever issues
+	// authorization_code (+ refresh_token), and request-time validation
+	// already rejects anything else. Rejecting a document that merely
+	// *declares* additional grant types the client uses elsewhere would be
+	// an interop bug.
+	GrantTypes []string `json:"grant_types"`
+
+	// JWKS is inspected for private key material (-02 §4.1 bans it) and
+	// otherwise ignored (no private_key_jwt support).
+	JWKS json.RawMessage `json:"jwks"`
+
+	// LogoURI is the client's logo URL. Optional and deliberately not
+	// rendered: like ClientName it is attacker-controllable, and an image
+	// is a stronger spoofing primitive than text.
+	LogoURI string `json:"logo_uri"`
+
+	// RedirectURIs is the registered redirect set. Required; each entry
+	// must pass the standard redirect-URI scheme rules plus Gram's
+	// same-origin binding with the loopback exception.
+	RedirectURIs []string `json:"redirect_uris"`
+
+	// ResponseTypes is parsed but not enforced, for the same reason as
+	// GrantTypes — the AS only supports response type "code".
+	ResponseTypes []string `json:"response_types"`
+
+	// TokenEndpointAuthMethod must be "none" — only public clients are
+	// accepted. An absent value is also rejected: the RFC 7591 default is
+	// client_secret_basic, a symmetric method -02 bans for CIMD.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+}
+
+// IsClientIDURL reports whether a presented client_id should be treated as a
+// Client ID Metadata Document URL. Draft -02 §3 requires the https scheme
+// with no normalization anywhere in the protocol, so a case-sensitive prefix
+// check is the correct discriminator: DCR-issued ids never look like this,
+// and anything https-shaped that fails the full §3 syntax check is an
+// invalid CIMD client_id rather than an unknown DCR client.
+func IsClientIDURL(clientID string) bool {
+	return len(clientID) > len("https://") && clientID[:len("https://")] == "https://"
+}
+
+// NewFetchClient builds the production document-fetch client from a
+// guardian policy: the SSRF dialer's post-DNS IP check satisfies -02 §8.6's
+// ban on fetching RFC 6890 special-use addresses and is immune to DNS
+// rebinding. Tests that host documents on httptest servers should pass
+// newFetchClientFrom(server.Client()) — or build the policy with
+// guardian.WithTLSRootCAs — since httptest certificates are self-signed.
+func NewFetchClient(policy *guardian.Policy) *guardian.HTTPClient {
+	return newFetchClientFrom(policy.Client())
+}
+
+// newFetchClientFrom applies the CIMD fetch rules to a copy of the base
+// client: redirects are never followed (-02 §5 MUST NOT; guardian's client
+// would otherwise follow up to 10 hops), so a redirect status surfaces as a
+// non-200 fetch failure. The copy keeps the caller's client untouched in
+// case it is shared.
+func newFetchClientFrom(base *guardian.HTTPClient) *guardian.HTTPClient {
+	client := *base
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &client
+}
+
+// Resolve fetches, parses, and validates the Client ID Metadata Document
+// named by clientID. client should come from NewFetchClient. The returned
+// Document has passed every check this AS imposes: -02 §3 URL syntax, §4
+// triple client_id equality (the fetch never follows redirects, so the
+// fetched URL is the presented URL by construction), required client_name +
+// redirect_uris, public-client-only auth method, secret/private-key bans,
+// and Gram's same-origin redirect-URI binding.
+func Resolve(ctx context.Context, client *guardian.HTTPClient, clientID string) (*Document, error) {
+	clientIDURL, err := validateClientIDURL(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := fetchDocument(ctx, client, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch client metadata document: %w", err)
+	}
+
+	// A malformed body is reported like any other fetch failure (plain
+	// wrapped error, generic wire response) rather than as a distinct OAuth
+	// error: a distinguishable "reachable but not JSON" response would give
+	// unauthenticated callers an oracle for probing external hosts through
+	// Gram.
+	var doc Document
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("parse client metadata document: %w", err)
+	}
+
+	if err := validateDocument(&doc, clientID, clientIDURL); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
+}
+
+// fetchDocument retrieves the metadata document. Only HTTP 200 is accepted
+// (-02 §5 MUST; other statuses — including the unfollowed redirects — are
+// fetch failures and are never cached per §5.2), and the body read is capped
+// at maxDocumentBytes.
+func fetchDocument(ctx context.Context, client *guardian.HTTPClient, clientID string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build document request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request document: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("document endpoint returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxDocumentBytes))
+	if err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			return nil, fmt.Errorf("document exceeds %d byte limit", maxDocumentBytes)
+		}
+		return nil, fmt.Errorf("read document body: %w", err)
+	}
+
+	return body, nil
+}

--- a/server/internal/usersessions/cimd/cimd_test.go
+++ b/server/internal/usersessions/cimd/cimd_test.go
@@ -1,0 +1,181 @@
+package cimd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+)
+
+func TestIsClientIDURL(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsClientIDURL("https://client.example.com/oauth/client.json"))
+	require.False(t, IsClientIDURL("client_5f2c9a"))
+	require.False(t, IsClientIDURL("http://client.example.com/client.json"))
+	require.False(t, IsClientIDURL("HTTPS://client.example.com/client.json"), "no normalization: scheme must be lowercase")
+	require.False(t, IsClientIDURL("https://"))
+}
+
+// newDocServer starts a TLS server whose /client.json responds via handler
+// and returns the server plus a fetch client that trusts its certificate —
+// the same injection pattern production uses with a guardian-built client.
+func newDocServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *http.Client) {
+	t.Helper()
+
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, newFetchClientFrom(srv.Client())
+}
+
+// serveDocumentJSON responds 200 application/json with the document derived
+// from the request URL by fn.
+func serveDocumentJSON(t *testing.T, fn func(clientID string) map[string]any) (*httptest.Server, *http.Client, string) {
+	t.Helper()
+
+	var clientID string
+	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(fn(clientID)); err != nil {
+			t.Errorf("encode document: %v", err)
+		}
+	})
+	clientID = srv.URL + "/client.json"
+	return srv, client, clientID
+}
+
+func validDocumentJSON(clientID string) map[string]any {
+	return map[string]any{
+		"client_id":                  clientID,
+		"client_name":                "CIMD Test Client",
+		"redirect_uris":              []string{"http://127.0.0.1:3000/callback"},
+		"token_endpoint_auth_method": "none",
+	}
+}
+
+func TestResolve_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	_, client, clientID := serveDocumentJSON(t, validDocumentJSON)
+
+	doc, err := Resolve(t.Context(), client, clientID)
+	require.NoError(t, err)
+	require.Equal(t, clientID, doc.ClientID)
+	require.Equal(t, "CIMD Test Client", doc.ClientName)
+	require.Equal(t, []string{"http://127.0.0.1:3000/callback"}, doc.RedirectURIs)
+}
+
+func TestResolve_Non200Rejected(t *testing.T) {
+	t.Parallel()
+
+	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	require.ErrorContains(t, err, "status 404")
+}
+
+func TestResolve_RedirectNotFollowed(t *testing.T) {
+	t.Parallel()
+
+	// -02 §5: the fetch MUST NOT follow redirects. The 302 must surface as
+	// a fetch failure even though its target would serve a valid document.
+	var clientID string
+	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/target.json" {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(validDocumentJSON(clientID)); err != nil {
+				t.Errorf("encode document: %v", err)
+			}
+			return
+		}
+		http.Redirect(w, r, "/target.json", http.StatusFound)
+	})
+	clientID = srv.URL + "/client.json"
+
+	_, err := Resolve(t.Context(), client, clientID)
+	require.ErrorContains(t, err, "status 302")
+}
+
+func TestResolve_OversizedDocumentRejected(t *testing.T) {
+	t.Parallel()
+
+	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"padding":%q`, strings.Repeat("a", maxDocumentBytes+1)); err != nil {
+			t.Errorf("write oversized document: %v", err)
+		}
+	})
+
+	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	require.ErrorContains(t, err, "byte limit")
+}
+
+func TestResolve_InvalidJSONRejected(t *testing.T) {
+	t.Parallel()
+
+	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte("not json")); err != nil {
+			t.Errorf("write document: %v", err)
+		}
+	})
+
+	// Deliberately NOT an OAuthError: a distinguishable "reachable but not
+	// JSON" outcome would let unauthenticated callers probe external hosts
+	// through Gram, so it reports like any other fetch failure.
+	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	require.ErrorContains(t, err, "parse client metadata document")
+	var oauthErr *usersessions.OAuthError
+	require.NotErrorAs(t, err, &oauthErr)
+}
+
+func TestResolve_DocumentClientIDMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	_, client, clientID := serveDocumentJSON(t, func(clientID string) map[string]any {
+		doc := validDocumentJSON(clientID)
+		doc["client_id"] = clientID + "?other"
+		return doc
+	})
+
+	_, err := Resolve(t.Context(), client, clientID)
+	requireOAuthError(t, err, "invalid_client_metadata")
+}
+
+func TestResolve_InvalidClientIDURLNoFetch(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+	})
+
+	_, err := Resolve(t.Context(), client, srv.URL) // no path component
+	requireOAuthError(t, err, "invalid_request")
+	require.Zero(t, requests, "syntactically invalid client_id must never be fetched")
+}
+
+func TestResolve_ProductionPolicyBlocksLoopback(t *testing.T) {
+	t.Parallel()
+
+	// The production guardian policy (default CIDR blocklist) must refuse
+	// to fetch documents from RFC 6890 special-use addresses — httptest
+	// binds 127.0.0.1, so the dial itself is denied (-02 §8.6).
+	srv, _ := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("SSRF-guarded client must not reach a loopback document host")
+	})
+
+	client := NewFetchClient(guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)))
+	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	require.ErrorContains(t, err, "request document")
+}

--- a/server/internal/usersessions/cimd/validate.go
+++ b/server/internal/usersessions/cimd/validate.go
@@ -1,0 +1,183 @@
+package cimd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+)
+
+// validateClientIDURL enforces the -02 §3 Client Identifier URL syntax rules
+// on the presented client_id and returns the parsed URL:
+//
+//   - https scheme (IsClientIDURL gates entry, so a violation here means a
+//     mixed-case or otherwise mangled prefix)
+//   - no userinfo component
+//   - a path component is required (bare https://example.com is invalid)
+//   - no "." or ".." path segments
+//   - no fragment
+//   - a query string is tolerated (clients SHOULD NOT use one)
+//
+// No normalization is applied anywhere — -02 §3 mandates simple string
+// comparison per RFC 3986 §6.2.1, so https://example.com/c and
+// https://example.com:443/c are different client identifiers.
+func validateClientIDURL(clientID string) (*url.URL, error) {
+	if len(clientID) > maxClientIDLength {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: fmt.Sprintf("client_id exceeds the %d byte limit", maxClientIDLength)}
+	}
+	if !strings.HasPrefix(clientID, "https://") {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must use the https scheme"}
+	}
+	// url.Parse tolerates fragments by splitting them off; detect them on
+	// the raw string so an empty "#" is caught too.
+	if strings.Contains(clientID, "#") {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must not contain a fragment"}
+	}
+
+	parsed, err := url.Parse(clientID)
+	if err != nil {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id is not a valid URL"}
+	}
+	if parsed.User != nil {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must not contain a userinfo component"}
+	}
+	if parsed.Host == "" {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must include a host"}
+	}
+	if parsed.Path == "" {
+		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must include a path component"}
+	}
+	for segment := range strings.SplitSeq(parsed.Path, "/") {
+		if segment == "." || segment == ".." {
+			return nil, &usersessions.OAuthError{Code: "invalid_request", Description: `client_id URL must not contain "." or ".." path segments`}
+		}
+	}
+
+	return parsed, nil
+}
+
+// validateDocument applies the -02 §4 document rules plus Gram policy to a
+// parsed document. clientID is both the client_id the OAuth client presented
+// and the URL that was fetched (the fetcher never follows redirects), so the
+// single equality check here completes the §4 triple equality requirement.
+func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) error {
+	if doc.ClientID != clientID {
+		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "document client_id does not match the client identifier URL"}
+	}
+	// MCP requires client_name, and the user_session_clients.client_name
+	// column is NOT NULL — requiring it here avoids fallback logic.
+	if doc.ClientName == "" {
+		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "client_name is required"}
+	}
+	if len(doc.ClientName) > maxClientNameLength {
+		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: fmt.Sprintf("client_name exceeds the %d byte limit", maxClientNameLength)}
+	}
+	// Only public clients are accepted. -02 §8.2's direction of travel is that
+	// capable clients SHOULD authenticate (MCP clients MAY use
+	// private_key_jwt — ChatGPT's documents do); accepting those is
+	// deferred, and when it lands §8.2's RFC 7523 §2.2 enforcement MUST
+	// come with it. An absent value is rejected too: the RFC 7591 default
+	// is client_secret_basic, a symmetric method the spec bans for CIMD.
+	if doc.TokenEndpointAuthMethod != "none" {
+		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: `token_endpoint_auth_method must be "none"`}
+	}
+	// -02 §4.1: a metadata document is public, so it must never carry a
+	// client secret in any form. Presence alone invalidates the document.
+	if doc.ClientSecret != nil || doc.ClientSecretExpiresAt != nil {
+		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "document must not contain client_secret or client_secret_expires_at"}
+	}
+	if err := validateJWKSPublicOnly(doc.JWKS); err != nil {
+		return err
+	}
+
+	if len(doc.RedirectURIs) == 0 {
+		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: "redirect_uris is required"}
+	}
+	if len(doc.RedirectURIs) > maxRedirectURIs {
+		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uris exceeds the limit of %d entries", maxRedirectURIs)}
+	}
+	for _, uri := range doc.RedirectURIs {
+		if len(uri) > maxRedirectURILength {
+			return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uri exceeds the %d byte limit", maxRedirectURILength)}
+		}
+		if err := usersessions.ValidateRedirectURI(uri); err != nil {
+			return fmt.Errorf("validate redirect_uri: %w", err)
+		}
+		if err := validateOriginBinding(clientIDURL, uri); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateOriginBinding enforces Gram's CIMD redirect-URI origin-binding
+// policy: every redirect_uri in the document must share the client_id URL's
+// origin (scheme + host + port, compared without normalization), except
+// loopback redirects, which are always allowed on any port. This is
+// deliberate Gram policy expressly permitted by -02 §8.1, not a spec
+// requirement — under open admission the client_id origin is the only
+// identity anchor, and binding ensures authorization codes are only ever
+// delivered to that origin (or to loopback). All known vendor CIMD documents
+// pass this rule (verified 2026-07); a legitimate cross-origin client would
+// need a per-URL exemption on the admission allowlist (follow-up work).
+func validateOriginBinding(clientIDURL *url.URL, redirectURI string) error {
+	parsed, err := url.Parse(redirectURI)
+	if err != nil {
+		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: "redirect_uri must be an absolute URL"}
+	}
+	if IsLoopbackRedirectURI(parsed) {
+		return nil
+	}
+	if parsed.Scheme != clientIDURL.Scheme || parsed.Host != clientIDURL.Host {
+		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uri %q is not same-origin with the client_id URL", redirectURI)}
+	}
+	return nil
+}
+
+// IsLoopbackRedirectURI reports whether a parsed redirect URI is an RFC 8252
+// §7.3 loopback redirect: http scheme with a host of 127.0.0.1, ::1, or
+// localhost, on any port. Shared with the mcp package's request-time
+// redirect matching, where RFC 8252 requires variable loopback ports to be
+// accepted for native apps.
+func IsLoopbackRedirectURI(u *url.URL) bool {
+	if u.Scheme != "http" {
+		return false
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case "127.0.0.1", "::1", "localhost":
+		return true
+	default:
+		return false
+	}
+}
+
+// validateJWKSPublicOnly rejects a jwks member containing private or
+// symmetric key material (-02 §4.1 — new in -02). A public metadata document
+// carrying a private key would let anyone impersonate the client, so the
+// whole document is invalid. Detection keys on the JWK members that only
+// appear on non-public keys: "d" (RSA / EC / OKP private component) and "k"
+// (symmetric oct key).
+func validateJWKSPublicOnly(raw json.RawMessage) error {
+	if raw == nil {
+		return nil
+	}
+
+	var jwks struct {
+		Keys []map[string]json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(raw, &jwks); err != nil {
+		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "jwks is not a valid JWK Set"}
+	}
+	for _, key := range jwks.Keys {
+		if _, ok := key["d"]; ok {
+			return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "jwks must not contain private key material"}
+		}
+		if _, ok := key["k"]; ok {
+			return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "jwks must not contain symmetric key material"}
+		}
+	}
+	return nil
+}

--- a/server/internal/usersessions/cimd/validate_test.go
+++ b/server/internal/usersessions/cimd/validate_test.go
@@ -1,0 +1,333 @@
+package cimd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+)
+
+// testDocument returns a document that passes every validateDocument check
+// for the given client_id URL: same-origin plus loopback redirect URIs,
+// public auth method, required client_name.
+func testDocument(clientID string) *Document {
+	return &Document{
+		ClientID:                clientID,
+		ClientName:              "Test Client",
+		ClientSecret:            nil,
+		ClientSecretExpiresAt:   nil,
+		ClientURI:               "",
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		JWKS:                    nil,
+		LogoURI:                 "",
+		RedirectURIs:            []string{"https://client.example.com/callback", "http://127.0.0.1:3000/callback"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+	}
+}
+
+const testClientID = "https://client.example.com/oauth/client.json"
+
+func requireOAuthError(t *testing.T, err error, code string) {
+	t.Helper()
+	var oauthErr *usersessions.OAuthError
+	require.ErrorAs(t, err, &oauthErr)
+	require.Equal(t, code, oauthErr.Code)
+}
+
+func TestValidateClientIDURL_Valid(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+	require.Equal(t, "client.example.com", parsed.Host)
+	require.Equal(t, "/oauth/client.json", parsed.Path)
+}
+
+func TestValidateClientIDURL_QueryTolerated(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("https://client.example.com/oauth/client.json?v=2")
+	require.NoError(t, err)
+}
+
+func TestValidateClientIDURL_MissingPathRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("https://client.example.com")
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateClientIDURL_UserinfoRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("https://user@client.example.com/client.json")
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateClientIDURL_FragmentRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("https://client.example.com/client.json#frag")
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateClientIDURL_DotDotSegmentRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("https://client.example.com/oauth/../client.json")
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateClientIDURL_DotSegmentRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("https://client.example.com/./client.json")
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateClientIDURL_NonHTTPSRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := validateClientIDURL("http://client.example.com/client.json")
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateClientIDURL_OversizedRejected(t *testing.T) {
+	t.Parallel()
+
+	long := "https://client.example.com/" + strings.Repeat("a", maxClientIDLength)
+	_, err := validateClientIDURL(long)
+	requireOAuthError(t, err, "invalid_request")
+}
+
+func TestValidateDocument_Valid(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+	require.NoError(t, validateDocument(testDocument(testClientID), testClientID, parsed))
+}
+
+func TestValidateDocument_ClientIDMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.ClientID = "https://client.example.com/oauth/other.json"
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_MissingClientNameRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.ClientName = ""
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_MissingAuthMethodRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	// Absent token_endpoint_auth_method defaults to client_secret_basic per
+	// RFC 7591 — a symmetric method CIMD forbids, so it must be rejected.
+	doc := testDocument(testClientID)
+	doc.TokenEndpointAuthMethod = ""
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_SymmetricAuthMethodRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.TokenEndpointAuthMethod = "client_secret_basic"
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_ClientSecretRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.ClientSecret = json.RawMessage(`"s3cret"`)
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_ClientSecretExpiresAtRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.ClientSecretExpiresAt = json.RawMessage(`0`)
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_JWKSPrivateKeyRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"EC","crv":"P-256","x":"a","y":"b","d":"private"}]}`)
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_JWKSSymmetricKeyRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"oct","k":"c2VjcmV0"}]}`)
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_JWKSPublicKeyAccepted(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"EC","crv":"P-256","x":"a","y":"b"}]}`)
+	require.NoError(t, validateDocument(doc, testClientID, parsed))
+}
+
+func TestValidateDocument_OversizedClientNameRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.ClientName = strings.Repeat("a", maxClientNameLength+1)
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+}
+
+func TestValidateDocument_TooManyRedirectURIsRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = nil
+	for range maxRedirectURIs + 1 {
+		doc.RedirectURIs = append(doc.RedirectURIs, "https://client.example.com/callback")
+	}
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+}
+
+func TestValidateDocument_OversizedRedirectURIRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{"https://client.example.com/" + strings.Repeat("a", maxRedirectURILength)}
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+}
+
+func TestValidateDocument_MissingRedirectURIsRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = nil
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+}
+
+func TestValidateDocument_CrossOriginHostRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{"https://evil.example.com/callback"}
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+}
+
+func TestValidateDocument_CrossOriginPortRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	// No normalization: an explicit :443 is a different origin string than
+	// the client_id URL's implicit port.
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{"https://client.example.com:443/callback"}
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+}
+
+func TestValidateDocument_CustomSchemeRejectedByOriginBinding(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	// Passes the RFC 8252 scheme rules but cannot be same-origin with an
+	// https client_id, so Gram's origin binding rejects it.
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{"com.example.app://callback"}
+	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+}
+
+func TestValidateDocument_LoopbackAnyPortAccepted(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{
+		"http://127.0.0.1:51423/callback",
+		"http://localhost:9999/cb",
+		"http://[::1]:1234/callback",
+	}
+	require.NoError(t, validateDocument(doc, testClientID, parsed))
+}
+
+func TestValidateDocument_UnknownExtensionFieldsAccepted(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+		"client_id": "` + testClientID + `",
+		"client_name": "Test Client",
+		"redirect_uris": ["https://client.example.com/callback"],
+		"token_endpoint_auth_method": "none",
+		"software_statement": "eyJhbGciOiJub25lIn0.e30.",
+		"client_id_expires_at": 4102444800,
+		"x_vendor_extension": {"nested": true}
+	}`
+	var doc Document
+	require.NoError(t, json.Unmarshal([]byte(raw), &doc))
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+	require.NoError(t, validateDocument(&doc, testClientID, parsed))
+}

--- a/server/internal/usersessions/clientregistration.go
+++ b/server/internal/usersessions/clientregistration.go
@@ -76,7 +76,7 @@ func (r *RegistrationRequest) Validate() error {
 		return &OAuthError{Code: "invalid_redirect_uri", Description: "redirect_uris is required"}
 	}
 	for _, u := range r.RedirectURIs {
-		if err := validateRedirectURI(u); err != nil {
+		if err := ValidateRedirectURI(u); err != nil {
 			return err
 		}
 	}
@@ -113,7 +113,7 @@ func (r *RegistrationRequest) Validate() error {
 	return nil
 }
 
-// validateRedirectURI enforces the OAuth 2.1 / RFC 8252 redirect-URI scheme
+// ValidateRedirectURI enforces the OAuth 2.1 / RFC 8252 redirect-URI scheme
 // rules:
 //
 //   - https://... for web + confidential clients.
@@ -126,7 +126,9 @@ func (r *RegistrationRequest) Validate() error {
 // Dangerous schemes (javascript:, data:, vbscript:, file:, blob:, etc.)
 // are rejected unconditionally — they would let a registered redirect_uri
 // turn the AS's 302 Location into an XSS or local-file fetch vector.
-func validateRedirectURI(raw string) error {
+// Exported for reuse by the cimd subpackage, which applies the same scheme
+// rules to redirect_uris found in Client ID Metadata Documents.
+func ValidateRedirectURI(raw string) error {
 	parsed, err := url.Parse(raw)
 	if err != nil || parsed.Scheme == "" {
 		return &OAuthError{Code: "invalid_redirect_uri", Description: "redirect_uri must be an absolute URL"}

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -325,6 +325,56 @@ VALUES (
 )
 RETURNING *;
 
+-- name: UpsertUserSessionClientFromCIMD :one
+-- Lazy upsert for a client resolved from a Client ID Metadata Document at
+-- authorize time. For CIMD rows the document URL IS the client_id, so the
+-- conflict target is the same partial unique index that serves DCR lookups.
+-- On refresh the mutable metadata (client_name, redirect_uris) and the fetch
+-- stamp are replaced wholesale — the document is refetched on every
+-- authorize.
+--
+-- Two deliberate behaviors:
+--   - A soft-deleted row does not conflict (partial index), so revoking a
+--     CIMD client does not stick: the next authorize resolves the document
+--     again and inserts a fresh row. CIMD identity lives at the URL, and
+--     durable blocking is admission control's job, not revocation's.
+--   - The DO UPDATE is guarded so it can never touch a secret-bearing DCR
+--     row that happens to share the client_id: rewriting it would trip the
+--     client_id_metadata_uri CHECK constraints with an opaque 500. The
+--     guard makes such a collision surface as no-rows, which handlers
+--     already map to invalid_client.
+INSERT INTO user_session_clients (
+    project_id,
+    user_session_issuer_id,
+    client_id,
+    client_secret_hash,
+    client_name,
+    redirect_uris,
+    client_secret_expires_at,
+    client_id_metadata_uri,
+    client_id_metadata_fetched_at
+)
+VALUES (
+    (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
+    @user_session_issuer_id,
+    @client_id,
+    NULL,
+    @client_name,
+    @redirect_uris,
+    NULL,
+    @client_id,
+    clock_timestamp()
+)
+ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE
+DO UPDATE SET
+    client_name = EXCLUDED.client_name,
+    redirect_uris = EXCLUDED.redirect_uris,
+    client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
+    client_id_metadata_fetched_at = EXCLUDED.client_id_metadata_fetched_at,
+    updated_at = clock_timestamp()
+WHERE user_session_clients.client_secret_hash IS NULL
+RETURNING *;
+
 -- name: CreateUserSession :one
 -- user_session_client_id binds the session to the DCR client that minted it.
 -- The /token refresh path requires the same client to refresh; see

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -1369,6 +1369,94 @@ func (q *Queries) UpdateUserSessionIssuer(ctx context.Context, arg UpdateUserSes
 	return i, err
 }
 
+const upsertUserSessionClientFromCIMD = `-- name: UpsertUserSessionClientFromCIMD :one
+INSERT INTO user_session_clients (
+    project_id,
+    user_session_issuer_id,
+    client_id,
+    client_secret_hash,
+    client_name,
+    redirect_uris,
+    client_secret_expires_at,
+    client_id_metadata_uri,
+    client_id_metadata_fetched_at
+)
+VALUES (
+    (SELECT project_id FROM user_session_issuers WHERE id = $1),
+    $1,
+    $2,
+    NULL,
+    $3,
+    $4,
+    NULL,
+    $2,
+    clock_timestamp()
+)
+ON CONFLICT (user_session_issuer_id, client_id) WHERE deleted IS FALSE
+DO UPDATE SET
+    client_name = EXCLUDED.client_name,
+    redirect_uris = EXCLUDED.redirect_uris,
+    client_id_metadata_uri = EXCLUDED.client_id_metadata_uri,
+    client_id_metadata_fetched_at = EXCLUDED.client_id_metadata_fetched_at,
+    updated_at = clock_timestamp()
+WHERE user_session_clients.client_secret_hash IS NULL
+RETURNING id, project_id, user_session_issuer_id, client_id, client_secret_hash, client_name, redirect_uris, client_id_issued_at, client_secret_expires_at, client_id_metadata_uri, client_id_metadata_fetched_at, client_id_metadata_cache_expires_at, client_id_metadata_etag, created_at, updated_at, deleted_at, deleted
+`
+
+type UpsertUserSessionClientFromCIMDParams struct {
+	UserSessionIssuerID uuid.UUID
+	ClientID            string
+	ClientName          string
+	RedirectUris        []string
+}
+
+// Lazy upsert for a client resolved from a Client ID Metadata Document at
+// authorize time. For CIMD rows the document URL IS the client_id, so the
+// conflict target is the same partial unique index that serves DCR lookups.
+// On refresh the mutable metadata (client_name, redirect_uris) and the fetch
+// stamp are replaced wholesale — the document is refetched on every
+// authorize.
+//
+// Two deliberate behaviors:
+//   - A soft-deleted row does not conflict (partial index), so revoking a
+//     CIMD client does not stick: the next authorize resolves the document
+//     again and inserts a fresh row. CIMD identity lives at the URL, and
+//     durable blocking is admission control's job, not revocation's.
+//   - The DO UPDATE is guarded so it can never touch a secret-bearing DCR
+//     row that happens to share the client_id: rewriting it would trip the
+//     client_id_metadata_uri CHECK constraints with an opaque 500. The
+//     guard makes such a collision surface as no-rows, which handlers
+//     already map to invalid_client.
+func (q *Queries) UpsertUserSessionClientFromCIMD(ctx context.Context, arg UpsertUserSessionClientFromCIMDParams) (UserSessionClient, error) {
+	row := q.db.QueryRow(ctx, upsertUserSessionClientFromCIMD,
+		arg.UserSessionIssuerID,
+		arg.ClientID,
+		arg.ClientName,
+		arg.RedirectUris,
+	)
+	var i UserSessionClient
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.UserSessionIssuerID,
+		&i.ClientID,
+		&i.ClientSecretHash,
+		&i.ClientName,
+		&i.RedirectUris,
+		&i.ClientIDIssuedAt,
+		&i.ClientSecretExpiresAt,
+		&i.ClientIDMetadataUri,
+		&i.ClientIDMetadataFetchedAt,
+		&i.ClientIDMetadataCacheExpiresAt,
+		&i.ClientIDMetadataEtag,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const userSessionIssuerHasActiveOwner = `-- name: UserSessionIssuerHasActiveOwner :one
 SELECT EXISTS (
     SELECT 1

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -34,6 +34,7 @@ import (
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/environments"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
@@ -99,6 +100,9 @@ type testInstance struct {
 	shadowMCPClient *shadowmcp.Client
 	cacheAdapter    cache.Cache
 	serverURL       *url.URL
+	// features is the injectable flag provider wired into the wrapped mcp
+	// service; tests enable flag-gated behavior with SetFlag.
+	features *feature.InMemory
 }
 
 func newTestService(t *testing.T) (context.Context, *testInstance) {
@@ -155,7 +159,8 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	userSessionSigner := usersessions.NewSigner("test-jwt-secret")
 	remoteChallengeMgr := remotesessions.NewChallengeManager(logger, conn, enc, guardianPolicy, cacheAdapter, serverURL)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, guardianPolicy, authzEngine, posthogClient, telemLogger, billingClient, billingClient, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter))
-	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
+	features := &feature.InMemory{}
+	mcpService := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthogClient, features, serverURL, serverURL, enc, cacheAdapter, guardianPolicy, funcs, oauthService, billingClient, billingClient, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, nil, nil, nil, userSessionSigner, remoteChallengeMgr, remoteProxyManager, route.NewRouteTable(), "", nil, nil, mcp.TunnelPublicConfig{
 		SessionTTL:         0,
 		LiveSessionCap:     0,
 		InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
@@ -177,6 +182,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		shadowMCPClient: shadowMCPClient,
 		cacheAdapter:    cacheAdapter,
 		serverURL:       serverURL,
+		features:        features,
 	}
 }
 

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/oauthtest"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -578,4 +579,49 @@ func TestHandleWellKnownOAuthProtectedResourceMetadata_IssuerGatedRemoteBackend_
 	authServers, ok := metadata["authorization_servers"].([]any)
 	require.True(t, ok)
 	require.Equal(t, []any{expectedResource}, authServers)
+}
+
+// TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOn verifies the
+// /x/mcp well-known variant advertises client_id_metadata_document_supported
+// when the issuer organization's gram-user-session-cimd flag is on — the
+// shared mcp.ServeGetAuthorizationServer emits it for both route families.
+func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOn(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	ti.features.SetFlag(feature.FlagUserSessionCIMD, authCtx.ActiveOrganizationID, true)
+	slug, _, _ := seedIssuerGatedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.Equal(t, true, metadata["client_id_metadata_document_supported"])
+}
+
+// TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOff pins the
+// omit-when-disabled behavior on the /x/mcp variant.
+func TestHandleWellKnownOAuthServerMetadata_IssuerGated_CIMDFlagOff(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug, _, _ := seedIssuerGatedRemoteMCPEndpoint(t, ctx, ti, *authCtx.ProjectID, "https://upstream.invalid/mcp", "public")
+
+	w, err := runWellKnown(t, ctx, ti.service.HandleWellKnownOAuthServerMetadata, "/.well-known/oauth-authorization-server/x/mcp/"+slug, slug)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+	require.NotContains(t, metadata, "client_id_metadata_document_supported")
 }


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-217/feat-inbound-cimd-support-for-gram-session-oauth

When the `gram-user-session-cimd` feature flag is enabled for the issuer's organization, an MCP client presenting a URL-shaped `client_id` to `/mcp/{slug}/authorize` (or `/x/mcp`) completes a full OAuth 2.1 flow with its metadata resolved from a Client ID Metadata Document ([draft-ietf-oauth-client-id-metadata-document-02](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-02)) instead of RFC 7591 Dynamic Client Registration.

New `server/internal/usersessions/cimd` package: SSRF-guarded fetcher (no redirects, HTTP 200 only, 5 KB read cap, 10s timeout), tolerant parser, and validator enforcing the URL syntax rules, triple `client_id` equality, public clients only (`token_endpoint_auth_method` `"none"`), secret and private-key bans, per-field caps, and Gram's same-origin redirect URI binding with an any-port loopback exception.

All client resolution in the mcp handlers funnels through a single resolver seam (`client_resolver.go`) so later layers (document caching, per-origin rate limits, admission control) attach in one place. Disabling the flag fails closed at authorize, including for previously resolved clients; in-flight token and consent legs keep working. Flag evaluation falls back to the last known per-organization state during provider outages. CIMD rows are lazily upserted keyed on the `(user_session_issuer_id, client_id)` partial unique index, and the `DO UPDATE` guard leaves secret-bearing rows untouched.

For CIMD rows only, loopback redirect URIs match with the port ignored per RFC 8252 section 7.3; host, path, and query must still match and userinfo is rejected. Authorization server metadata advertises `client_id_metadata_document_supported` when the flag is on, and the consent page shows the `client_id` origin as the verifiable trust anchor plus a caution for loopback redirects. `guardian` gains a `WithTLSRootCAs` policy option so tests can fetch documents from httptest TLS servers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inbound CIMD support to Gram Session OAuth for MCP, gated by the `gram-user-session-cimd` flag. URL-shaped `client_id` values can now complete OAuth 2.1 without DCR, including loopback redirects on any port. Implements AIS-217.

- New Features
  - Resolve URL `client_id` via `server/internal/usersessions/cimd` with SSRF guards (no redirects, 200-only, 5 KB cap, 10s timeout); enforce URL rules, triple `client_id` equality, `token_endpoint_auth_method: "none"`, secret/private-key bans, and same-origin redirects with a loopback exception.
  - Centralized resolution in `server/internal/mcp/client_resolver.go`; CIMD clients lazily upserted via `UpsertUserSessionClientFromCIMD`. Token/consent legs keep working if the flag later turns off; a dedicated `errCIMDDisabled` now marks kill-switch rejections in logs without changing wire behavior.
  - Loopback redirect matching ignores port; non-loopback must match exactly. Well-known metadata adds `client_id_metadata_document_supported` when enabled; consent shows the `client_id` origin and a loopback warning.
  - New `feature.FlagUserSessionCIMD`; PostHog feature provider wired into the MCP service; flag off rejects URL `client_id` at authorize. `guardian.Policy` adds `WithTLSRootCAs` for trusting `httptest` TLS in tests.

- Bug Fixes
  - Loopback redirect matching compares escaped URI components and rejects fragments so only the port may vary on loopback.
  - Use `errCIMDDisabled` instead of `pgx.ErrNoRows` when the flag is off to avoid conflating with real lookup misses.

<sup>Written for commit b92e4720488d214e35533f5b680d6dbb33229d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

