### PR TITLE
fix: name the exact CNAME record in unhealthy custom domain messaging

### DIFF
--- a/client/dashboard/src/pages/org/OrgDomains.tsx
+++ b/client/dashboard/src/pages/org/OrgDomains.tsx
@@ -87,9 +87,9 @@ type IPRow = { id: number; value: string; error: string | null };
 
 const healthIssueMessages: Record<string, string> = {
   dns_not_found:
-    "We couldn't find DNS records for this domain. Check that the record still exists with your DNS provider.",
+    "We couldn't find DNS records for this domain. Set this record with your DNS provider:",
   dns_target_mismatch:
-    "This domain's DNS does not resolve to the platform's endpoint. If the domain sits behind a proxy or CDN, traffic may still work; otherwise update its DNS record to the value shown when you registered the domain.",
+    "This domain's DNS does not resolve to the expected CNAME target. If the domain sits behind a proxy or CDN, traffic may still work; otherwise set this DNS record:",
   resource_missing:
     "The routing configuration for this domain is missing. Run the check again to confirm the problem persists.",
   certificate_missing:
@@ -109,6 +109,32 @@ function customDomainHealthMessage(issue?: string): string {
     ? (healthIssueMessages[issue] ??
         "The latest health check found a problem with this domain.")
     : "The latest health check found a problem with this domain.";
+}
+
+// DNS-shaped issues end in a colon and expect the exact record the customer
+// must create; the other messages stand alone.
+function CustomDomainHealthMessage({
+  issue,
+  domainName,
+}: {
+  issue?: string;
+  domainName: string;
+}) {
+  const showsExpectedRecord =
+    issue === "dns_not_found" || issue === "dns_target_mismatch";
+  return (
+    <>
+      {customDomainHealthMessage(issue)}
+      {showsExpectedRecord && (
+        <>
+          {" "}
+          <code className="break-all">
+            {domainName} CNAME {getCustomDomainCNAME()}
+          </code>
+        </>
+      )}
+    </>
+  );
 }
 
 // A single failed probe (check_failed) is usually a transient Gram-side issue,
@@ -519,7 +545,10 @@ function OrgDomainsInner() {
                   <Type variant="body" className="text-sm">
                     It failed health checks continuously for over a week, so its
                     routing and TLS certificate were removed.{" "}
-                    {customDomainHealthMessage(domain.healthIssue)}
+                    <CustomDomainHealthMessage
+                      issue={domain.healthIssue}
+                      domainName={domain.domain}
+                    />
                   </Type>
                   {domain.unhealthySince && (
                     <Type variant="body" className="text-sm opacity-80">
@@ -552,7 +581,10 @@ function OrgDomainsInner() {
                     This custom domain may not be working
                   </Type>
                   <Type variant="body" className="text-sm">
-                    {customDomainHealthMessage(domain.healthIssue)}
+                    <CustomDomainHealthMessage
+                      issue={domain.healthIssue}
+                      domainName={domain.domain}
+                    />
                   </Type>
                   {domain.healthCheckedAt && (
                     <Type variant="body" className="text-sm opacity-80">

--- a/server/internal/background/activities/custom_domain_health.go
+++ b/server/internal/background/activities/custom_domain_health.go
@@ -346,7 +346,7 @@ func (c *CustomDomainHealth) NotifyOrgAdmins(ctx context.Context, args NotifyCus
 		tmpl := email.CustomDomainUnhealthy{
 			Email:        user.Email,
 			Domain:       args.Domain,
-			IssueMessage: customdomains.HealthIssueMessage(args.Issue),
+			IssueMessage: customdomains.HealthIssueMessage(args.Issue, c.expectedTarget),
 			DomainLink:   domainLink,
 		}
 		// CheckedAt is stable across retries; hashing satisfies Loops's 100-character key limit.

--- a/server/internal/customdomains/health.go
+++ b/server/internal/customdomains/health.go
@@ -1,6 +1,7 @@
 package customdomains
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/k8s"
@@ -43,12 +44,21 @@ type HealthObservation struct {
 	CertificateExpiresAt *time.Time
 }
 
-func HealthIssueMessage(issue HealthIssue) string {
+// HealthIssueMessage renders the customer-facing description of a health
+// issue. expectedCNAME is the CNAME target customers must point their domain
+// at; product messaging names the exact record instead of the platform.
+func HealthIssueMessage(issue HealthIssue, expectedCNAME string) string {
 	switch issue {
 	case HealthIssueDNSNotFound:
+		if expectedCNAME != "" {
+			return fmt.Sprintf("DNS records for the domain could not be found. Create a CNAME record pointing the domain at %s.", expectedCNAME)
+		}
 		return "DNS records for the domain could not be found."
 	case HealthIssueDNSTargetMismatch:
-		return "The domain's DNS no longer resolves to Gram's endpoint."
+		if expectedCNAME != "" {
+			return fmt.Sprintf("The domain's DNS no longer resolves to the expected target. Point the domain's CNAME record at %s.", expectedCNAME)
+		}
+		return "The domain's DNS no longer resolves to the expected target."
 	case HealthIssueResourceMissing:
 		return "The routing configuration for the domain is missing."
 	case HealthIssueCertificateMissing,

--- a/server/internal/customdomains/health_test.go
+++ b/server/internal/customdomains/health_test.go
@@ -258,9 +258,33 @@ func TestHealthIssueMessageCertificateProblemsAreManagedByGram(t *testing.T) {
 	} {
 		require.Equal(t,
 			"There is a problem with the domain's TLS certificate. We're working to resolve it.",
-			HealthIssueMessage(issue),
+			HealthIssueMessage(issue, "cname.example.com."),
 		)
 	}
+}
+
+func TestHealthIssueMessageNamesExpectedCNAME(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		"The domain's DNS no longer resolves to the expected target. Point the domain's CNAME record at cname.example.com..",
+		HealthIssueMessage(HealthIssueDNSTargetMismatch, "cname.example.com."),
+	)
+	require.Equal(t,
+		"DNS records for the domain could not be found. Create a CNAME record pointing the domain at cname.example.com..",
+		HealthIssueMessage(HealthIssueDNSNotFound, "cname.example.com."),
+	)
+
+	// An unconfigured target must not leak an empty parenthetical or name the
+	// platform.
+	require.Equal(t,
+		"The domain's DNS no longer resolves to the expected target.",
+		HealthIssueMessage(HealthIssueDNSTargetMismatch, ""),
+	)
+	require.Equal(t,
+		"DNS records for the domain could not be found.",
+		HealthIssueMessage(HealthIssueDNSNotFound, ""),
+	)
 }
 
 func TestShouldAutoDisableRequiresAllThresholds(t *testing.T) {


### PR DESCRIPTION
## What

Product messaging update for unhealthy custom domain surfaces: name the exact expected CNAME record instead of referring to "Gram's endpoint" or "the value shown when you registered the domain".

## Changes

**Email (`server/internal/customdomains/health.go`)**

`HealthIssueMessage` now takes the expected CNAME target (already configured via `GRAM_CUSTOM_DOMAIN_CNAME` and plumbed into the health activity):

- `dns_target_mismatch`: "The domain's DNS no longer resolves to the expected target. Point the domain's CNAME record at cname.getgram.ai.."
- `dns_not_found`: "DNS records for the domain could not be found. Create a CNAME record pointing the domain at cname.getgram.ai.."
- With no configured target, both fall back to neutral copy that never names the platform.

**Dashboard (`client/dashboard/src/pages/org/OrgDomains.tsx`)**

The unhealthy and auto-disabled domain alerts now render the exact expected record inline for DNS-shaped issues, using the same `getCustomDomainCNAME()` value shown during registration:

> This domain's DNS does not resolve to the expected CNAME target. If the domain sits behind a proxy or CDN, traffic may still work; otherwise set this DNS record: `yourdomain.com CNAME cname.getgram.ai.`

## Testing

- `go test ./server/internal/customdomains/` (incl. new `TestHealthIssueMessageNamesExpectedCNAME`) and `./server/internal/background/...`
- `mise lint:server`, `pnpm -F dashboard type-check`, `pnpm -F dashboard lint`

## Notes

The Loops template body for the unhealthy-domain email lives in Loops; only the `issue_message` variable comes from this repo. Worth a follow-up check that the Loops-side copy avoids "Gram" too.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the exact expected CNAME in custom-domain health messages so users know the precise DNS record to set. Makes DNS issues clear in both emails and the dashboard.

- **New Features**
  - Email: `HealthIssueMessage` now takes the expected CNAME and includes it for `dns_not_found` and `dns_target_mismatch`, with a neutral fallback when no target is configured.
  - Dashboard: Health alerts render the exact record inline for DNS issues, e.g., "<domain> CNAME <target>".

<sup>Written for commit d92e91d96056ee08eed4e035fdece197dfe22e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

