### PR TITLE
test(opencode): guard observability shim against agenthooks drift

### DIFF
--- a/.changeset/opencode-shim-drift-test.md
+++ b/.changeset/opencode-shim-drift-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+test(opencode): golden test guarding the observability shim's forwarding body against agenthooks drift

--- a/server/internal/plugins/generate_opencode_shim_test.go
+++ b/server/internal/plugins/generate_opencode_shim_test.go
@@ -21,6 +21,8 @@ import (
 // forwarding logic, gram's hand-maintained copy must be re-synced — this test
 // fails when it isn't.
 func TestOpenCodeShimBodyMatchesAgentHooks(t *testing.T) {
+	t.Parallel()
+
 	fsys, err := install.Render(
 		install.Manifest{Command: []string{"speakeasy-hooks"}},
 		install.Target{Provider: agenthooks.ProviderOpenCode, Scope: install.ScopeProject, Dir: "."},

--- a/server/internal/plugins/generate_opencode_shim_test.go
+++ b/server/internal/plugins/generate_opencode_shim_test.go
@@ -1,0 +1,46 @@
+package plugins
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/speakeasy-api/agenthooks"
+	"github.com/speakeasy-api/agenthooks/install"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenCodeShimBodyMatchesAgentHooks guards against silent drift between
+// gram's opencodeObservabilityShim and agenthooks' canonical OpenCode shim.
+//
+// The two files intentionally differ in their invocation layer: agenthooks
+// bakes a static COMMAND (a direct binary path), while gram wraps it in a
+// per-OS hooks/bootstrap.{sh,ps1} pinned-binary launcher. But the NDJSON
+// serve protocol and the hook-forwarding body below the COMMAND are a copy of
+// agenthooks' render_opencode.go. If agenthooks changes the protocol or the
+// forwarding logic, gram's hand-maintained copy must be re-synced — this test
+// fails when it isn't.
+func TestOpenCodeShimBodyMatchesAgentHooks(t *testing.T) {
+	fsys, err := install.Render(
+		install.Manifest{Command: []string{"speakeasy-hooks"}},
+		install.Target{Provider: agenthooks.ProviderOpenCode, Scope: install.ScopeProject, Dir: "."},
+	)
+	require.NoError(t, err)
+	b, err := fs.ReadFile(fsys, ".opencode/plugin/agenthooks.ts")
+	require.NoError(t, err)
+
+	// The shared region is everything from the seq counter (right after the
+	// spawn call, where the two invocation preambles rejoin) up to the
+	// differing `export default <name>` trailer.
+	body := func(shim string) string {
+		start := strings.Index(shim, "let seq = 0")
+		end := strings.Index(shim, "export default")
+		require.GreaterOrEqual(t, start, 0, "shim missing `let seq = 0` anchor")
+		require.Greater(t, end, start, "shim missing `export default` anchor")
+		return shim[start:end]
+	}
+
+	require.Equal(t, body(string(b)), body(opencodeObservabilityShim),
+		"opencodeObservabilityShim has drifted from agenthooks install.Render for OpenCode; "+
+			"re-sync the forwarding body from agenthooks/install/render_opencode.go")
+}


### PR DESCRIPTION
## What

Adds a golden test in `server/internal/plugins` that guards gram's hand-maintained `opencodeObservabilityShim` against silent drift from agenthooks' canonical OpenCode shim.

## Why

gram's `opencodeObservabilityShim` and agenthooks' `install/render_opencode.go` deliberately differ in their **invocation layer** — agenthooks bakes a static `COMMAND` (direct binary path), gram wraps it in a per-OS `hooks/bootstrap.{sh,ps1}` pinned-binary launcher. But the NDJSON serve protocol and hook-forwarding **body** below the command is a copy of agenthooks. Nothing asserted that copy stayed in sync, so an upstream change to the protocol or forwarding logic would drift unnoticed.

## How

Render agenthooks' canonical shim via the public `install.Render`, then compare the shared body region (`let seq = 0` .. `export default`) against gram's constant. The differing invocation preamble and export name are excluded by the anchors. Fails CI with a re-sync message when they diverge.

Test-only; empty changeset (no version bump).