### PR TITLE
feat: alter update created_at, assistant_id data backfill

### DIFF
--- a/server/cmd/tools/migrations/README.md
+++ b/server/cmd/tools/migrations/README.md
@@ -6,9 +6,10 @@ reusable **Source → Transform → Sink** pipeline.
 Each concrete migration is a set of three small implementations wired together by
 the shared harness. The migrations shipped today:
 
-| Migration                                            | Doc                                                      |
-| ---------------------------------------------------- | -------------------------------------------------------- |
-| Postgres `risk_results` → ClickHouse `risk_findings` | [RISK_RESULTS_MIGRATION.md](./RISK_RESULTS_MIGRATION.md) |
+| Migration                                                                           | Doc                                                                |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Postgres `risk_results` → ClickHouse `risk_findings`                                | [RISK_RESULTS_MIGRATION.md](./RISK_RESULTS_MIGRATION.md)           |
+| `risk_findings` `message_created_at`/`assistant_id` column backfill (via mutations) | [RISKFINDINGS_COLS_MIGRATION.md](./RISKFINDINGS_COLS_MIGRATION.md) |
 
 ## Concepts
 
@@ -77,12 +78,13 @@ without changing the harness. Publish typed keys as their real Go types
 
 ## Usage
 
-Each migration is invoked through the single `migrations` binary. The flags,
+Each migration is invoked through the single `migrations` binary, selected by
+an optional leading subcommand (omitting it runs `riskfindings`). The flags,
 environment variables, and examples are migration-specific — see the linked doc
 for the migration you want to run. The general shape is:
 
 ```
-go run ./server/cmd/tools/migrations [flags]
+go run ./server/cmd/tools/migrations [migration] [flags]
 ```
 
 `-dry-run` defaults to **true** for every migration: a plain run reads and

--- a/server/cmd/tools/migrations/RISKFINDINGS_COLS_MIGRATION.md
+++ b/server/cmd/tools/migrations/RISKFINDINGS_COLS_MIGRATION.md
@@ -1,0 +1,207 @@
+# risk_findings message_created_at / assistant_id column backfill
+
+Backfills two columns onto **existing ClickHouse `risk_findings` rows** from
+Postgres, via ClickHouse **mutations** (`ALTER TABLE ... UPDATE`):
+
+| ClickHouse column    | Type / default                     | Source of truth in Postgres                                                                             |
+| -------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `message_created_at` | `DateTime64(9) DEFAULT created_at` | `chat_messages.created_at` of the scanned message (finding `created_at` when no message resolves)       |
+| `assistant_id`       | `String DEFAULT ''`                | `assistant_threads.assistant_id` of a live (`deleted IS FALSE`) thread whose `chat_id` matches the chat |
+
+Rows written before the columns existed carry the DEFAULTs (`message_created_at`
+= scan time, `assistant_id` = `''`); this migration rewrites them in place with
+the true values. Run it with the migration subcommand:
+
+```
+go run ./server/cmd/tools/migrations riskfindingscols [flags]
+```
+
+For the generic pipeline concepts (Source / Transform / Sink, `Criteria`,
+lifecycle), see [README.md](./README.md).
+
+## Why mutations, not inserts
+
+Re-inserting enriched copies of old rows (and letting the read path dedup)
+**does not work here**. The read path dedups duplicate ids by keeping the copy
+that sorts first under `message_created_at DESC ... inserted_at DESC`. An old
+copy's DEFAULT `message_created_at` equals its `created_at` — the scan time —
+which is always **>= the enriched copy's true event time** (the message
+predates its scan). The unenriched copy would therefore sort first and win,
+making an insert-based backfill a no-op at best. Rewriting the existing row via
+a mutation is the only correct shape.
+
+## Stages
+
+Implemented in the `riskfindingscols` package:
+
+| Stage       | Type                           | What it does                                                                                                                                                                                             |
+| ----------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Source      | `riskfindingscols.Source`      | Keyset-paginates `risk_results` by `id` (UUIDv7, so id order is time order), LEFT JOINing `chat_messages` for the event time and a lateral live-`assistant_threads` lookup for the assistant. Resumable. |
+| Transformer | `riskfindingscols.Transformer` | Near pass-through (kept for harness symmetry); guards a zero message time by falling back to the finding's `created_at`.                                                                                 |
+| Sink        | `riskfindingscols.Sink`        | Batches updates and submits ONE mutation per batch (see below).                                                                                                                                          |
+
+### What the source reads
+
+Only rows that exist in ClickHouse are scanned: `found IS TRUE AND rule_id IS
+NOT NULL` mirrors both the live outbox emission and the riskfindings backfill,
+so "nothing found" sentinels and dead-letter rows are never mutated.
+
+- **`message_created_at`**: `chat_messages.created_at` via
+  `risk_results.chat_message_id`. Content-part-anchored findings (the only rows
+  whose message join can miss — message-anchored rows cascade-delete with their
+  message) fall back to the finding's own `created_at`, which is exactly the
+  ClickHouse column DEFAULT, making the update a no-op for them rather than a
+  wrong value.
+- **`assistant_id`**: mirrors the live `GetAssistantThreadAssistantIDByChatID`
+  lookup — a live (`deleted IS FALSE`) `assistant_threads` row whose `chat_id`
+  matches the scanned message's chat, `ORDER BY id LIMIT 1` for determinism.
+  Soft-deleted threads and chats without threads yield `''`.
+
+### The mutation
+
+Each sink batch becomes one statement:
+
+```sql
+ALTER TABLE risk_findings UPDATE
+    message_created_at = transform(toString(id), ['<id>', ...], [toDateTime64('<ns>', 9), ...], message_created_at),
+    assistant_id       = transform(toString(id), ['<id>', ...], ['<assistant>', ...], assistant_id)
+WHERE id IN ('<id>', ...) AND created_at >= toDateTime64('<min batch created_at - 1h>', 9)
+```
+
+- The `created_at` lower bound exists purely for **partition pruning**
+  (`risk_findings` is `PARTITION BY toYYYYMMDD(created_at)`): without it every
+  mutation would rewrite every partition. ClickHouse `created_at` is the exact
+  value copied from Postgres, so the one-hour slack is pure headroom.
+- Values are inlined as literals, not bound: clickhouse-go's positional binding
+  formats `time.Time` at **second** precision, which would truncate the
+  sub-second event times this migration exists to backfill. Timestamps render
+  as `toDateTime64('<unix-nanos>', 9)` (timezone-independent, the driver's own
+  nanosecond rendering); ids and assistant ids are canonical UUID strings.
+- The default batch size is small (500) because each row contributes its id
+  three times to the statement text, and ClickHouse's default `max_query_size`
+  is 256 KiB.
+
+**Mutations are asynchronous.** `ALTER TABLE ... UPDATE` returns once the
+mutation is queued; ClickHouse rewrites the affected parts in the background.
+The tool fires and continues, logging each batch's id range. A queued mutation
+is durable server-side (it survives restarts), so the resume cursor advances on
+submission. Watch progress with:
+
+```sql
+SELECT mutation_id, command, parts_to_do, is_done, latest_fail_reason
+FROM system.mutations
+WHERE table = 'risk_findings' AND NOT is_done;
+```
+
+**Idempotency.** Re-running a batch rewrites the same rows to the same values,
+so overlap after a resume is harmless — no dedup token or quiescing of the live
+writer is needed (the live writer inserts _new_ ids; this tool only updates
+_existing_ ones).
+
+## Flags
+
+Secrets are **never** flag values — they would leak through `argv` / `ps`:
+
+| Secret (env var)      | Meaning                               |
+| --------------------- | ------------------------------------- |
+| `GRAM_DATABASE_URL`   | Postgres connection string (required) |
+| `CLICKHOUSE_PASSWORD` | ClickHouse password                   |
+
+Non-secret flags:
+
+| Flag              | Env fallback             | Default     | Meaning                                                                             |
+| ----------------- | ------------------------ | ----------- | ----------------------------------------------------------------------------------- |
+| `-ch-host`        | `CLICKHOUSE_HOST`        | `localhost` | ClickHouse host (IPv4, IPv6, or DNS)                                                |
+| `-ch-database`    | `CLICKHOUSE_DATABASE`    | `default`   | ClickHouse database                                                                 |
+| `-ch-username`    | `CLICKHOUSE_USERNAME`    | `gram`      | ClickHouse username                                                                 |
+| `-ch-native-port` | `CLICKHOUSE_NATIVE_PORT` | `9440`      | ClickHouse native protocol port                                                     |
+| `-ch-insecure`    | `CLICKHOUSE_INSECURE`    | `false`     | Skip ClickHouse TLS verification                                                    |
+| `-org`            | —                        | (all)       | Scope to one `organization_id`                                                      |
+| `-project`        | —                        | (all)       | Scope to one `project_id` (uuid)                                                    |
+| `-from`           | —                        | (beginning) | Lower time bound, RFC3339 (`created_at >= from`); applies with or without `-cursor` |
+| `-to`             | —                        | (end)       | Upper time bound, RFC3339 (`created_at < to`)                                       |
+| `-cursor`         | —                        | —           | Resume after this `risk_results` id (exclusive); keyset resume position only        |
+| `-batch-size`     | —                        | `500`       | Rows per source page and per mutation                                               |
+| `-buffer`         | —                        | `500`       | Channel buffer between pipeline stages                                              |
+| `-dry-run`        | —                        | `true`      | When true, read + report but submit nothing (and do not connect to ClickHouse)      |
+
+An interrupted run (Ctrl-C / SIGTERM) exits with a **nonzero** status and logs
+the `-cursor` to resume from, so shell automation never mistakes a partial
+backfill for a completed one. As with the riskfindings migration, **repeat the
+original `-org`/`-project`/`-from`/`-to` filters when resuming** — the cursor
+does not encode query scope.
+
+## Examples
+
+Dry run over everything (counts and batch ranges only, no ClickHouse
+connection):
+
+```bash
+GRAM_DATABASE_URL=postgres://gram:gram@127.0.0.1:5439/gram?sslmode=disable \
+  go run ./server/cmd/tools/migrations riskfindingscols
+```
+
+Apply, scoped to one org and time window:
+
+```bash
+GRAM_DATABASE_URL=... CLICKHOUSE_PASSWORD=... \
+  go run ./server/cmd/tools/migrations riskfindingscols \
+  -ch-host 127.0.0.1 -ch-database gram -ch-username gram \
+  -org org_123 -from 2026-05-01T00:00:00Z -to 2026-07-01T00:00:00Z \
+  -dry-run=false
+```
+
+Resume an interrupted run from the last printed cursor (same scope flags):
+
+```bash
+go run ./server/cmd/tools/migrations riskfindingscols \
+  -org org_123 -from 2026-05-01T00:00:00Z -to 2026-07-01T00:00:00Z \
+  -cursor 019f65f6-ed75-7186-84a5-7ed095aab7b3 -dry-run=false
+```
+
+## Safety and caveats
+
+- **Dry run by default.** Nothing is submitted unless you pass
+  `-dry-run=false`. A dry run reports no resume cursor — nothing was submitted,
+  so there is no checkpoint to resume the real migration from.
+- **The columns must exist first.** The tool assumes `message_created_at` and
+  `assistant_id` are already on `risk_findings` (they ship in a parallel schema
+  change); a mutation referencing a missing column fails server-side.
+- **Async completion.** The final report counts _submitted_ mutations, not
+  applied ones. Validate after `system.mutations` drains (see below).
+- **Scope your runs.** Each batch is one mutation; a full-table run at the
+  default batch size can queue thousands. That is safe but slow to drain —
+  prefer `-org`/`-from`/`-to` scoping, and let `system.mutations` empty out
+  between large runs.
+- **90-day TTL.** Rows older than the table TTL are evicted on merge; the
+  backfill only ever needs to cover the trailing 90 days of findings.
+
+## Validation
+
+After the mutation queue drains (`SELECT count() FROM system.mutations WHERE
+table = 'risk_findings' AND NOT is_done` returns 0):
+
+```sql
+-- Enriched rows: message time strictly before scan time.
+SELECT count() FROM risk_findings WHERE message_created_at < created_at;
+
+-- Remaining defaulted rows in the migrated window (should be only findings
+-- without a resolvable message, e.g. content-part anchored ones).
+SELECT count() FROM risk_findings
+WHERE message_created_at = created_at AND created_at >= '<from>' AND created_at < '<to>';
+
+-- Assistant attribution coverage.
+SELECT countIf(assistant_id != ''), count() FROM risk_findings
+WHERE created_at >= '<from>' AND created_at < '<to>';
+```
+
+Spot-check any id against Postgres:
+
+```sql
+-- Postgres
+SELECT r.id, cm.created_at AS message_created_at, t.assistant_id
+FROM risk_results r
+LEFT JOIN chat_messages cm ON cm.id = r.chat_message_id
+LEFT JOIN assistant_threads t ON t.chat_id = cm.chat_id AND t.deleted IS FALSE
+WHERE r.id = '<id>';
+```

--- a/server/cmd/tools/migrations/main.go
+++ b/server/cmd/tools/migrations/main.go
@@ -1,10 +1,15 @@
 // Command migrations back-fills historical data into ClickHouse using a generic
-// Source -> Transform -> Sink pipeline (see the pipeline package). The only wired
-// migration today moves Postgres risk_results rows into the ClickHouse
-// risk_findings event log.
+// Source -> Transform -> Sink pipeline (see the pipeline package). Two
+// migrations are wired, selected by an optional leading subcommand:
 //
-// It is an offline operator tool, run by hand against production reached through
-// Cloud SQL Auth Proxy and a ClickHouse tunnel:
+//   - riskfindings (default): moves Postgres risk_results rows into the
+//     ClickHouse risk_findings event log (see RISK_RESULTS_MIGRATION.md).
+//   - riskfindingscols: backfills the message_created_at and assistant_id
+//     columns onto existing risk_findings rows via ClickHouse mutations (see
+//     RISKFINDINGS_COLS_MIGRATION.md).
+//
+// It is an offline operator tool, run by hand against production reached
+// through Cloud SQL Auth Proxy and a ClickHouse tunnel:
 //
 // Secrets come from the environment only (never flags, which leak through argv):
 //
@@ -49,15 +54,22 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk"
 )
 
+// clickhouseConfig carries the non-secret ClickHouse connection settings
+// shared by every migration subcommand; the password comes from the
+// environment.
+type clickhouseConfig struct {
+	host       string
+	database   string
+	username   string
+	password   string
+	nativePort string
+	insecure   bool
+}
+
 type config struct {
 	dbURL         string
 	pepperKeyring string
-	chHost        string
-	chDatabase    string
-	chUsername    string
-	chPassword    string
-	chNativePort  string
-	chInsecure    bool
+	ch            clickhouseConfig
 	orgID         string
 	projectID     uuid.NullUUID
 	policyID      uuid.NullUUID
@@ -75,7 +87,29 @@ func main() {
 }
 
 func run() int {
-	cfg, err := parseFlags()
+	// The subcommand is the optional first non-flag argument; a bare flag list
+	// keeps the original riskfindings behavior.
+	args := os.Args[1:]
+	migration := "riskfindings"
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		migration = args[0]
+		args = args[1:]
+	}
+
+	switch migration {
+	case "riskfindings":
+		return runRiskFindings(args)
+	case "riskfindingscols":
+		return runRiskFindingsCols(args)
+	default:
+		// The unrecognized name is deliberately not echoed (log injection).
+		log.Printf("unknown migration subcommand (available: riskfindings, riskfindingscols)")
+		return 2
+	}
+}
+
+func runRiskFindings(args []string) int {
+	cfg, err := parseFlags(args)
 	if err != nil {
 		log.Printf("invalid arguments: %v", err)
 		return 2
@@ -103,7 +137,7 @@ func run() int {
 
 	var chConn clickhouse.Conn
 	if !cfg.dryRun {
-		chConn, err = openClickhouse(ctx, cfg)
+		chConn, err = openClickhouse(ctx, cfg.ch)
 		if err != nil {
 			log.Printf("connect clickhouse: %v", err)
 			return 1
@@ -172,17 +206,17 @@ func (c config) criteria() pipeline.Criteria {
 	return crit
 }
 
-func openClickhouse(ctx context.Context, cfg config) (clickhouse.Conn, error) {
+func openClickhouse(ctx context.Context, cfg clickhouseConfig) (clickhouse.Conn, error) {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Protocol: clickhouse.Native,
-		Addr:     []string{net.JoinHostPort(cfg.chHost, cfg.chNativePort)},
+		Addr:     []string{net.JoinHostPort(cfg.host, cfg.nativePort)},
 		Auth: clickhouse.Auth{
-			Database: cfg.chDatabase,
-			Username: cfg.chUsername,
-			Password: cfg.chPassword,
+			Database: cfg.database,
+			Username: cfg.username,
+			Password: cfg.password,
 		},
 		TLS: &tls.Config{
-			InsecureSkipVerify: cfg.chInsecure, // #nosec G402 -- operator-supplied flag for local/tunnelled use
+			InsecureSkipVerify: cfg.insecure, // #nosec G402 -- operator-supplied flag for local/tunnelled use
 			MinVersion:         tls.VersionTLS12,
 		},
 	})
@@ -195,29 +229,49 @@ func openClickhouse(ctx context.Context, cfg config) (clickhouse.Conn, error) {
 	return conn, nil
 }
 
-func parseFlags() (config, error) {
+// registerClickhouseFlags declares the shared non-secret ClickHouse flags on
+// fs; the returned struct is populated (password included, from the
+// environment) once fs.Parse has run.
+func registerClickhouseFlags(fs *flag.FlagSet) *clickhouseConfig {
+	cfg := &clickhouseConfig{
+		host:       "",
+		database:   "",
+		username:   "",
+		password:   "",
+		nativePort: "",
+		insecure:   false,
+	}
+	fs.StringVar(&cfg.host, "ch-host", envOr("CLICKHOUSE_HOST", "localhost"), "ClickHouse host")
+	fs.StringVar(&cfg.database, "ch-database", envOr("CLICKHOUSE_DATABASE", "default"), "ClickHouse database")
+	fs.StringVar(&cfg.username, "ch-username", envOr("CLICKHOUSE_USERNAME", "gram"), "ClickHouse username")
+	fs.StringVar(&cfg.nativePort, "ch-native-port", envOr("CLICKHOUSE_NATIVE_PORT", "9440"), "ClickHouse native protocol port")
+	fs.BoolVar(&cfg.insecure, "ch-insecure", os.Getenv("CLICKHOUSE_INSECURE") == "true", "skip ClickHouse TLS verification")
+	return cfg
+}
+
+func parseFlags(args []string) (config, error) {
+	fs := flag.NewFlagSet("riskfindings", flag.ContinueOnError)
+
 	// Secrets (Postgres URL, ClickHouse password, fingerprint pepper) are read
 	// from the environment (or a file, for the pepper) only — never as flag
 	// values — so they do not leak through argv / ps.
 	var (
-		pepperKeyringFile = flag.String("pepper-keyring-file", "", "path to a file holding the JSON pepper keyring (alternative to $GRAM_RISK_FINGERPRINT_PEPPER_KEYRING)")
-		chHost            = flag.String("ch-host", envOr("CLICKHOUSE_HOST", "localhost"), "ClickHouse host")
-		chDatabase        = flag.String("ch-database", envOr("CLICKHOUSE_DATABASE", "default"), "ClickHouse database")
-		chUsername        = flag.String("ch-username", envOr("CLICKHOUSE_USERNAME", "gram"), "ClickHouse username")
-		chNativePort      = flag.String("ch-native-port", envOr("CLICKHOUSE_NATIVE_PORT", "9440"), "ClickHouse native protocol port")
-		chInsecure        = flag.Bool("ch-insecure", os.Getenv("CLICKHOUSE_INSECURE") == "true", "skip ClickHouse TLS verification")
-		orgID             = flag.String("org", "", "organization_id to scope the migration (optional; all orgs if empty)")
-		projectID         = flag.String("project", "", "project_id (uuid) to scope (optional)")
-		policyID          = flag.String("policy", "", "risk_policy_id (uuid) to scope (optional)")
-		fromStr           = flag.String("from", "", "lower time bound, RFC3339 (optional; from the beginning if empty)")
-		toStr             = flag.String("to", "", "upper time bound, RFC3339 (optional; to the end if empty)")
-		cursorStr         = flag.String("cursor", "", "resume after this risk_results id (exclusive); keyset resume position only — still pass the original -from/-to/-org/-project/-policy")
-		batchSize         = flag.Int("batch-size", riskfindings.DefaultBatchSize, "rows per source page and sink batch")
-		bufferSize        = flag.Int("buffer", riskfindings.DefaultBatchSize, "channel buffer between pipeline stages")
-		dryRun            = flag.Bool("dry-run", true, "when true (default) read and transform but do not write; pass -dry-run=false to insert")
-		liftPartGuard     = flag.Bool("lift-partition-guard", true, "set max_partitions_per_insert_block=0 on inserts; pass -lift-partition-guard=false when the ClickHouse settings profile constrains that setting (code 452)")
+		pepperKeyringFile = fs.String("pepper-keyring-file", "", "path to a file holding the JSON pepper keyring (alternative to $GRAM_RISK_FINGERPRINT_PEPPER_KEYRING)")
+		chCfg             = registerClickhouseFlags(fs)
+		orgID             = fs.String("org", "", "organization_id to scope the migration (optional; all orgs if empty)")
+		projectID         = fs.String("project", "", "project_id (uuid) to scope (optional)")
+		policyID          = fs.String("policy", "", "risk_policy_id (uuid) to scope (optional)")
+		fromStr           = fs.String("from", "", "lower time bound, RFC3339 (optional; from the beginning if empty)")
+		toStr             = fs.String("to", "", "upper time bound, RFC3339 (optional; to the end if empty)")
+		cursorStr         = fs.String("cursor", "", "resume after this risk_results id (exclusive); keyset resume position only — still pass the original -from/-to/-org/-project/-policy")
+		batchSize         = fs.Int("batch-size", riskfindings.DefaultBatchSize, "rows per source page and sink batch")
+		bufferSize        = fs.Int("buffer", riskfindings.DefaultBatchSize, "channel buffer between pipeline stages")
+		dryRun            = fs.Bool("dry-run", true, "when true (default) read and transform but do not write; pass -dry-run=false to insert")
+		liftPartGuard     = fs.Bool("lift-partition-guard", true, "set max_partitions_per_insert_block=0 on inserts; pass -lift-partition-guard=false when the ClickHouse settings profile constrains that setting (code 452)")
 	)
-	flag.Parse()
+	if err := fs.Parse(args); err != nil {
+		return config{}, fmt.Errorf("parse flags: %w", err)
+	}
 
 	pepperKeyring := os.Getenv("GRAM_RISK_FINGERPRINT_PEPPER_KEYRING")
 	if *pepperKeyringFile != "" {
@@ -228,15 +282,12 @@ func parseFlags() (config, error) {
 		pepperKeyring = strings.TrimSpace(string(b))
 	}
 
+	chCfg.password = os.Getenv("CLICKHOUSE_PASSWORD")
+
 	cfg := config{
 		dbURL:         os.Getenv("GRAM_DATABASE_URL"),
 		pepperKeyring: pepperKeyring,
-		chHost:        *chHost,
-		chDatabase:    *chDatabase,
-		chUsername:    *chUsername,
-		chPassword:    os.Getenv("CLICKHOUSE_PASSWORD"),
-		chNativePort:  *chNativePort,
-		chInsecure:    *chInsecure,
+		ch:            *chCfg,
 		orgID:         *orgID,
 		projectID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		policyID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},

--- a/server/cmd/tools/migrations/riskfindingscols/setup_test.go
+++ b/server/cmd/tools/migrations/riskfindingscols/setup_test.go
@@ -1,0 +1,301 @@
+package riskfindingscols
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/pipeline"
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{
+		Postgres:   true,
+		Redis:      false,
+		ClickHouse: true,
+		Temporal:   false,
+		Presidio:   false,
+	})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+	}
+
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("cleanup test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+// tenant is a seeded org/project/policy triple in a per-test Postgres clone,
+// plus helpers to hang chats, messages, assistants, and risk results off it.
+type tenant struct {
+	pool      *pgxpool.Pool
+	orgID     string
+	projectID uuid.UUID
+	policyID  uuid.UUID
+}
+
+func seedTenant(t *testing.T) *tenant {
+	t.Helper()
+	ctx := t.Context()
+
+	pool, err := infra.CloneTestDatabase(t, "riskfindingscols")
+	require.NoError(t, err)
+
+	orgID := "org_" + uuid.NewString()
+	now := time.Now().UTC()
+	require.NoError(t, testrepo.New(pool).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID:                 orgID,
+		Name:               "backfill test org",
+		Slug:               "backfill-" + uuid.NewString()[:8],
+		GramAccountType:    "free",
+		Whitelisted:        true,
+		FreeTrialStartedAt: pgtype.Timestamptz{Time: now, Valid: true},
+		FreeTrialEndsAt:    pgtype.Timestamptz{Time: now.AddDate(0, 0, 14), Valid: true},
+	}))
+
+	project, err := projectsrepo.New(pool).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "backfill",
+		Slug:           "backfill",
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	policy, err := riskrepo.New(pool).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:             uuid.Must(uuid.NewV7()),
+		ProjectID:      project.ID,
+		OrganizationID: orgID,
+		Name:           "backfill policy",
+		PolicyType:     "standard",
+		Sources:        []string{"presidio"},
+		CustomRuleIds:  []string{},
+		MessageTypes:   []string{},
+		Enabled:        true,
+		Action:         "flag",
+		AudienceType:   "everyone",
+		AutoName:       true,
+	})
+	require.NoError(t, err)
+
+	return &tenant{
+		pool:      pool,
+		orgID:     orgID,
+		projectID: project.ID,
+		policyID:  policy.ID,
+	}
+}
+
+func (tn *tenant) newChat(t *testing.T) uuid.UUID {
+	t.Helper()
+	chatID, err := chatrepo.New(tn.pool).UpsertChat(t.Context(), chatrepo.UpsertChatParams{
+		ID:             uuid.Must(uuid.NewV7()),
+		ProjectID:      tn.projectID,
+		OrganizationID: tn.orgID,
+	})
+	require.NoError(t, err)
+	return chatID
+}
+
+// newMessage seeds a chat message stamped with createdAt — the event time the
+// migration backfills into message_created_at.
+func (tn *tenant) newMessage(t *testing.T, chatID uuid.UUID, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+	repo := testrepo.New(tn.pool)
+	msgID, err := repo.InsertChatMessage(ctx, testrepo.InsertChatMessageParams{
+		ChatID:    chatID,
+		ProjectID: uuid.NullUUID{UUID: tn.projectID, Valid: true},
+		Role:      "user",
+		Content:   "hello alice@example.com",
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.UpdateChatMessageCreatedAt(ctx, testrepo.UpdateChatMessageCreatedAtParams{
+		CreatedAt: pgtype.Timestamptz{Time: createdAt, Valid: true},
+		ID:        msgID,
+	}))
+	return msgID
+}
+
+// linkAssistant creates an assistant and a live assistant_threads row backing
+// chatID, returning both ids so a test can soft-delete the thread.
+func (tn *tenant) linkAssistant(t *testing.T, chatID uuid.UUID) (assistantID, threadID uuid.UUID) {
+	t.Helper()
+	ctx := t.Context()
+	repo := assistantsrepo.New(tn.pool)
+
+	assistant, err := repo.CreateAssistant(ctx, assistantsrepo.CreateAssistantParams{
+		ProjectID:      tn.projectID,
+		OrganizationID: tn.orgID,
+		Name:           "backfill assistant " + uuid.NewString()[:8],
+		Model:          "test-model",
+		Instructions:   "noop",
+		WarmTtlSeconds: 300,
+		MaxConcurrency: 1,
+		Status:         "active",
+	})
+	require.NoError(t, err)
+
+	threadID, err = repo.UpsertAssistantThread(ctx, assistantsrepo.UpsertAssistantThreadParams{
+		AssistantID:   assistant.ID,
+		ProjectID:     tn.projectID,
+		CorrelationID: uuid.NewString(),
+		ChatID:        chatID,
+		SourceKind:    "test",
+		SourceRefJson: []byte("{}"),
+	})
+	require.NoError(t, err)
+
+	return assistant.ID, threadID
+}
+
+func (tn *tenant) softDeleteThread(t *testing.T, threadID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, assistantsrepo.New(tn.pool).SoftDeleteAssistantThread(t.Context(), assistantsrepo.SoftDeleteAssistantThreadParams{
+		ID:        threadID,
+		ProjectID: tn.projectID,
+	}))
+}
+
+// newFinding seeds a true-positive risk_results row anchored to messageID with
+// the given created_at (the scan time) and returns its id.
+func (tn *tenant) newFinding(t *testing.T, messageID uuid.UUID, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+
+	id := uuid.Must(uuid.NewV7())
+	n, err := riskrepo.New(tn.pool).InsertRiskResults(ctx, []riskrepo.InsertRiskResultsParams{{
+		ID:                id,
+		ProjectID:         tn.projectID,
+		OrganizationID:    tn.orgID,
+		RiskPolicyID:      tn.policyID,
+		RiskPolicyVersion: 1,
+		ChatMessageID:     uuid.NullUUID{UUID: messageID, Valid: true},
+		Source:            "presidio",
+		Found:             true,
+		RuleID:            conv.ToPGText("pii.email_address"),
+		Description:       conv.ToPGText("an email"),
+		Match:             conv.ToPGText("alice@example.com"),
+		Tags:              []string{"pii"},
+	}})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+
+	require.NoError(t, testrepo.New(tn.pool).UpdateRiskResultCreatedAt(ctx, testrepo.UpdateRiskResultCreatedAtParams{
+		CreatedAt: pgtype.Timestamptz{Time: createdAt, Valid: true},
+		ID:        id,
+	}))
+	return id
+}
+
+// newNonFinding seeds a risk_results row the source must skip: found=false
+// when foundValue is false, or found=true with a NULL rule_id otherwise.
+func (tn *tenant) newNonFinding(t *testing.T, messageID uuid.UUID, foundValue bool) uuid.UUID {
+	t.Helper()
+
+	id := uuid.Must(uuid.NewV7())
+	params := riskrepo.InsertRiskResultsParams{
+		ID:                id,
+		ProjectID:         tn.projectID,
+		OrganizationID:    tn.orgID,
+		RiskPolicyID:      tn.policyID,
+		RiskPolicyVersion: 1,
+		ChatMessageID:     uuid.NullUUID{UUID: messageID, Valid: true},
+		Source:            "none",
+		Found:             foundValue,
+		Tags:              []string{},
+	}
+	if !foundValue {
+		params.RuleID = conv.ToPGText("pii.email_address")
+	}
+	n, err := riskrepo.New(tn.pool).InsertRiskResults(t.Context(), []riskrepo.InsertRiskResultsParams{params})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+	return id
+}
+
+// newContentPartFinding seeds a risk_results row anchored to a chat content
+// part instead of a message (chat_message_id IS NULL), so the source's
+// chat_messages join misses and message_created_at must fall back to the
+// finding's own created_at.
+func (tn *tenant) newContentPartFinding(t *testing.T, chatID uuid.UUID, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+	repo := testrepo.New(tn.pool)
+
+	partID, err := repo.InsertChatContentPartFixture(ctx, testrepo.InsertChatContentPartFixtureParams{
+		ChatID:          chatID,
+		ProjectID:       uuid.NullUUID{UUID: tn.projectID, Valid: true},
+		Kind:            "prompt_attachment",
+		ContentAssetUrl: "asset://test",
+	})
+	require.NoError(t, err)
+
+	id := uuid.Must(uuid.NewV7())
+	require.NoError(t, repo.InsertContentPartRiskResultFixture(ctx, testrepo.InsertContentPartRiskResultFixtureParams{
+		ID:                id,
+		ProjectID:         tn.projectID,
+		OrganizationID:    tn.orgID,
+		RiskPolicyID:      tn.policyID,
+		RiskPolicyVersion: 1,
+		ChatContentPartID: uuid.NullUUID{UUID: partID, Valid: true},
+		Source:            "presidio",
+		RuleID:            conv.ToPGText("pii.email_address"),
+		Description:       conv.ToPGText("an email"),
+		Match:             conv.ToPGText("alice@example.com"),
+		Tags:              []string{"pii"},
+	}))
+	require.NoError(t, repo.UpdateRiskResultCreatedAt(ctx, testrepo.UpdateRiskResultCreatedAtParams{
+		CreatedAt: pgtype.Timestamptz{Time: createdAt, Valid: true},
+		ID:        id,
+	}))
+	return id
+}
+
+// readAll drains the source into a slice using the given criteria.
+func readAll(t *testing.T, source *Source, criteria pipeline.Criteria) []SourceRow {
+	t.Helper()
+
+	out := make(chan SourceRow, 1024)
+	done := make(chan error, 1)
+	go func() { done <- source.Read(t.Context(), criteria, out) }()
+
+	var rows []SourceRow
+	for {
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+			// Drain anything buffered before the source returned.
+			for {
+				select {
+				case r := <-out:
+					rows = append(rows, r)
+				default:
+					return rows
+				}
+			}
+		case r := <-out:
+			rows = append(rows, r)
+		}
+	}
+}

--- a/server/cmd/tools/migrations/riskfindingscols/sink.go
+++ b/server/cmd/tools/migrations/riskfindingscols/sink.go
@@ -1,0 +1,194 @@
+package riskfindingscols
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
+)
+
+// createdAtSlack widens the mutation's created_at lower bound below the
+// batch's minimum finding created_at. The ClickHouse created_at is the exact
+// value copied from Postgres, so in principle no slack is needed; an hour of
+// headroom guards against any precision or clock quirks while still letting
+// ClickHouse prune all but the batch's own daily partitions.
+const createdAtSlack = time.Hour
+
+// Sink batches UpdateRow values and applies each batch as ONE ClickHouse
+// mutation:
+//
+//	ALTER TABLE risk_findings UPDATE
+//	    message_created_at = transform(toString(id), [ids...], [values...], message_created_at),
+//	    assistant_id       = transform(toString(id), [ids...], [values...], assistant_id)
+//	WHERE id IN (ids...) AND created_at >= <min batch created_at - slack>
+//
+// Mutations — not inserts — are required here: the read path dedups duplicate
+// ids by keeping the copy sorting first under message_created_at DESC ...
+// inserted_at DESC, and an old copy's DEFAULT message_created_at (created_at,
+// i.e. scan time) is >= the enriched copy's event time, so a re-inserted
+// enriched copy would lose to the original. The created_at bound exists purely
+// for partition pruning (the table is partitioned daily on created_at).
+//
+// Mutations are asynchronous server-side: Exec returns once the mutation is
+// queued, and ClickHouse rewrites the affected parts in the background. The
+// sink fires and continues, logging each batch's id range; completion can be
+// observed via system.mutations.
+type Sink struct {
+	conn      clickhouse.Conn
+	in        chan UpdateRow
+	batchSize int
+	dryRun    bool
+
+	mutated       int64
+	batches       int64
+	lastCommitted uuid.UUID
+}
+
+// NewSink builds a ClickHouse mutation sink. conn may be nil when dryRun is
+// true, in which case batches are counted and logged but no mutation is
+// issued. bufferSize sizes the input channel; batchSize bounds each mutation.
+func NewSink(conn clickhouse.Conn, bufferSize, batchSize int, dryRun bool) *Sink {
+	if bufferSize < 0 {
+		bufferSize = 0
+	}
+	if batchSize <= 0 {
+		batchSize = DefaultBatchSize
+	}
+	return &Sink{
+		conn:          conn,
+		in:            make(chan UpdateRow, bufferSize),
+		batchSize:     batchSize,
+		dryRun:        dryRun,
+		mutated:       0,
+		batches:       0,
+		lastCommitted: uuid.Nil,
+	}
+}
+
+// Input implements pipeline.Sink.
+func (s *Sink) Input() chan<- UpdateRow { return s.in }
+
+// Mutated returns the number of rows targeted by submitted mutations (or, in
+// dry-run, that would be).
+func (s *Sink) Mutated() int64 { return s.mutated }
+
+// Batches returns the number of mutations submitted (or, in dry-run, that
+// would be).
+func (s *Sink) Batches() int64 { return s.batches }
+
+// LastCommitted returns the id of the last row in the last successfully
+// submitted mutation. Because records flow through the pipeline in id order,
+// everything up to and including this id has been handed to ClickHouse, so it
+// is the safe cursor to resume a later run from (unlike the source's read
+// position, which runs ahead). "Submitted" — not "applied": mutations complete
+// asynchronously, but a queued mutation survives restarts server-side, so
+// resuming past it never loses work. It stays uuid.Nil in dry-run, where no
+// mutation is submitted and there is therefore no durable checkpoint.
+func (s *Sink) LastCommitted() uuid.UUID { return s.lastCommitted }
+
+// Run implements pipeline.Sink. It drains the input channel, flushing whenever
+// a batch fills, and flushes the final partial batch when the channel closes.
+func (s *Sink) Run(ctx context.Context) error {
+	buf := make([]UpdateRow, 0, s.batchSize)
+
+	flush := func() error {
+		if len(buf) == 0 {
+			return nil
+		}
+		if err := s.flush(ctx, buf); err != nil {
+			return err
+		}
+		s.mutated += int64(len(buf))
+		s.batches++
+		// Only a real submission advances the durable resume cursor. In
+		// dry-run the flush is a no-op, so exposing a cursor would let an
+		// operator resume the real migration from a checkpoint that was never
+		// written.
+		if !s.dryRun && s.conn != nil {
+			s.lastCommitted = buf[len(buf)-1].ID
+		}
+		log.Printf("sink: %s batch=%d rows total=%d ids=[%s..%s]",
+			mutationVerb(s.dryRun), len(buf), s.mutated, buf[0].ID, buf[len(buf)-1].ID)
+		buf = buf[:0]
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("sink interrupted: %w", ctx.Err())
+		case row, ok := <-s.in:
+			if !ok {
+				return flush()
+			}
+			buf = append(buf, row)
+			if len(buf) >= s.batchSize {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func mutationVerb(dryRun bool) string {
+	if dryRun {
+		return "would mutate"
+	}
+	return "submitted mutation"
+}
+
+// flush submits one batch as a single mutation. Re-running a batch is
+// idempotent by construction: the mutation rewrites each targeted row to the
+// same values, so overlap after a resume is harmless.
+func (s *Sink) flush(ctx context.Context, rows []UpdateRow) error {
+	if s.dryRun || s.conn == nil {
+		return nil
+	}
+
+	stmt := mutationStatement(rows)
+	if err := s.conn.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("submit mutation for batch [%s..%s]: %w", rows[0].ID, rows[len(rows)-1].ID, err)
+	}
+	return nil
+}
+
+var chStringEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+
+// mutationStatement renders the single ALTER TABLE ... UPDATE covering rows.
+// Values are inlined as literals rather than bound: clickhouse-go's positional
+// binding formats time.Time at second precision only, which would truncate the
+// sub-second event times this migration exists to backfill. Timestamps are
+// rendered the same way the driver renders nanosecond-scale values —
+// toDateTime64('<unix-nanos>', 9) — which is timezone-independent, and the id
+// and assistant values are canonical UUID strings (escaped anyway, out of
+// caution).
+func mutationStatement(rows []UpdateRow) string {
+	ids := make([]string, len(rows))
+	messageTimes := make([]string, len(rows))
+	assistants := make([]string, len(rows))
+	minCreatedAt := rows[0].CreatedAt
+	for i := range rows {
+		ids[i] = "'" + chStringEscaper.Replace(rows[i].ID.String()) + "'"
+		messageTimes[i] = fmt.Sprintf("toDateTime64('%d', 9)", rows[i].MessageCreatedAt.UnixNano())
+		assistants[i] = "'" + chStringEscaper.Replace(rows[i].AssistantID) + "'"
+		if rows[i].CreatedAt.Before(minCreatedAt) {
+			minCreatedAt = rows[i].CreatedAt
+		}
+	}
+
+	idList := strings.Join(ids, ", ")
+	return fmt.Sprintf(
+		"ALTER TABLE risk_findings UPDATE"+
+			" message_created_at = transform(toString(id), [%s], [%s], message_created_at),"+
+			" assistant_id = transform(toString(id), [%s], [%s], assistant_id)"+
+			" WHERE id IN (%s) AND created_at >= toDateTime64('%d', 9)",
+		idList, strings.Join(messageTimes, ", "),
+		idList, strings.Join(assistants, ", "),
+		idList, minCreatedAt.Add(-createdAtSlack).UnixNano(),
+	)
+}

--- a/server/cmd/tools/migrations/riskfindingscols/sink.go
+++ b/server/cmd/tools/migrations/riskfindingscols/sink.go
@@ -2,6 +2,7 @@ package riskfindingscols
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -11,11 +12,11 @@ import (
 	"github.com/google/uuid"
 )
 
-// createdAtSlack widens the mutation's created_at lower bound below the
-// batch's minimum finding created_at. The ClickHouse created_at is the exact
-// value copied from Postgres, so in principle no slack is needed; an hour of
-// headroom guards against any precision or clock quirks while still letting
-// ClickHouse prune all but the batch's own daily partitions.
+// createdAtSlack widens the mutation's created_at bounds beyond the batch's
+// minimum and maximum finding created_at. The ClickHouse created_at is the
+// exact value copied from Postgres, so in principle no slack is needed; an
+// hour of headroom guards against any precision or clock quirks while still
+// letting ClickHouse prune all but the batch's own daily partitions.
 const createdAtSlack = time.Hour
 
 // Sink batches UpdateRow values and applies each batch as ONE ClickHouse
@@ -24,7 +25,9 @@ const createdAtSlack = time.Hour
 //	ALTER TABLE risk_findings UPDATE
 //	    message_created_at = transform(toString(id), [ids...], [values...], message_created_at),
 //	    assistant_id       = transform(toString(id), [ids...], [values...], assistant_id)
-//	WHERE id IN (ids...) AND created_at >= <min batch created_at - slack>
+//	WHERE id IN (ids...)
+//	  AND created_at >= <min batch created_at - slack>
+//	  AND created_at <= <max batch created_at + slack>
 //
 // Mutations — not inserts — are required here: the read path dedups duplicate
 // ids by keeping the copy sorting first under message_created_at DESC ...
@@ -146,8 +149,13 @@ func mutationVerb(dryRun bool) string {
 // idempotent by construction: the mutation rewrites each targeted row to the
 // same values, so overlap after a resume is harmless.
 func (s *Sink) flush(ctx context.Context, rows []UpdateRow) error {
-	if s.dryRun || s.conn == nil {
+	if s.dryRun {
 		return nil
+	}
+	// A nil connection is only legal in dry-run mode; treating it as a no-op
+	// here would count and log submitted mutations while writing nothing.
+	if s.conn == nil {
+		return errors.New("nil clickhouse connection with dry-run disabled")
 	}
 
 	stmt := mutationStatement(rows)
@@ -172,6 +180,7 @@ func mutationStatement(rows []UpdateRow) string {
 	messageTimes := make([]string, len(rows))
 	assistants := make([]string, len(rows))
 	minCreatedAt := rows[0].CreatedAt
+	maxCreatedAt := rows[0].CreatedAt
 	for i := range rows {
 		ids[i] = "'" + chStringEscaper.Replace(rows[i].ID.String()) + "'"
 		messageTimes[i] = fmt.Sprintf("toDateTime64('%d', 9)", rows[i].MessageCreatedAt.UnixNano())
@@ -179,16 +188,23 @@ func mutationStatement(rows []UpdateRow) string {
 		if rows[i].CreatedAt.Before(minCreatedAt) {
 			minCreatedAt = rows[i].CreatedAt
 		}
+		if rows[i].CreatedAt.After(maxCreatedAt) {
+			maxCreatedAt = rows[i].CreatedAt
+		}
 	}
 
+	// created_at is bounded on both sides of the batch (with slack) so each
+	// mutation prunes to the batch's own daily partitions. A lower bound alone
+	// would leave every later partition scanned by every batch, queuing
+	// repeated full-tail mutations over a long backfill.
 	idList := strings.Join(ids, ", ")
 	return fmt.Sprintf(
 		"ALTER TABLE risk_findings UPDATE"+
 			" message_created_at = transform(toString(id), [%s], [%s], message_created_at),"+
 			" assistant_id = transform(toString(id), [%s], [%s], assistant_id)"+
-			" WHERE id IN (%s) AND created_at >= toDateTime64('%d', 9)",
+			" WHERE id IN (%s) AND created_at >= toDateTime64('%d', 9) AND created_at <= toDateTime64('%d', 9)",
 		idList, strings.Join(messageTimes, ", "),
 		idList, strings.Join(assistants, ", "),
-		idList, minCreatedAt.Add(-createdAtSlack).UnixNano(),
+		idList, minCreatedAt.Add(-createdAtSlack).UnixNano(), maxCreatedAt.Add(createdAtSlack).UnixNano(),
 	)
 }

--- a/server/cmd/tools/migrations/riskfindingscols/sink_test.go
+++ b/server/cmd/tools/migrations/riskfindingscols/sink_test.go
@@ -1,0 +1,230 @@
+package riskfindingscols
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/pipeline"
+)
+
+// TestSinkDryRunCountsButExposesNoCursor exercises the sink lifecycle without a
+// real ClickHouse connection: dry-run drains and counts every row across
+// batches but must NOT expose a commit cursor, since nothing was submitted.
+func TestSinkDryRunCountsButExposesNoCursor(t *testing.T) {
+	t.Parallel()
+
+	const batchSize = 2
+	sink := NewSink(nil, 4, batchSize, true)
+
+	done := make(chan error, 1)
+	go func() { done <- sink.Run(t.Context()) }()
+
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
+	in := sink.Input()
+	now := time.Now().UTC()
+	for _, id := range ids {
+		in <- UpdateRow{ID: id, CreatedAt: now, MessageCreatedAt: now, AssistantID: ""}
+	}
+	close(in)
+
+	require.NoError(t, <-done)
+	require.Equal(t, int64(len(ids)), sink.Mutated())
+	require.Equal(t, int64(3), sink.Batches(), "5 rows at batch size 2 are 3 mutations")
+	require.Equal(t, uuid.Nil, sink.LastCommitted())
+}
+
+// TestSinkEmptyCommitsNothing checks that a sink that never receives a row does
+// not advance the commit cursor.
+func TestSinkEmptyCommitsNothing(t *testing.T) {
+	t.Parallel()
+
+	sink := NewSink(nil, 1, 2, true)
+
+	done := make(chan error, 1)
+	go func() { done <- sink.Run(t.Context()) }()
+	close(sink.Input())
+
+	require.NoError(t, <-done)
+	require.Equal(t, int64(0), sink.Mutated())
+	require.Equal(t, int64(0), sink.Batches())
+	require.Equal(t, uuid.Nil, sink.LastCommitted())
+}
+
+// TestMutationStatementRendersAlignedArraysAndBound pins the exact mutation a
+// batch produces: both transform() maps and the IN list share the same id
+// order, timestamps render at nanosecond scale (positional binding would
+// truncate to seconds, which is why the statement is built by hand), and the
+// created_at bound is the batch minimum minus the slack.
+func TestMutationStatementRendersAlignedArraysAndBound(t *testing.T) {
+	t.Parallel()
+
+	id1 := uuid.Must(uuid.NewV7())
+	id2 := uuid.Must(uuid.NewV7())
+	created1 := time.Date(2026, 7, 20, 10, 0, 0, 123456789, time.UTC)
+	created2 := created1.Add(-2 * time.Hour) // the batch minimum, out of order on purpose
+	message1 := created1.Add(-30 * time.Minute)
+	message2 := created2.Add(-45 * time.Minute)
+	assistantID := uuid.NewString()
+
+	got := mutationStatement([]UpdateRow{
+		{ID: id1, CreatedAt: created1, MessageCreatedAt: message1, AssistantID: assistantID},
+		{ID: id2, CreatedAt: created2, MessageCreatedAt: message2, AssistantID: ""},
+	})
+
+	want := fmt.Sprintf(
+		"ALTER TABLE risk_findings UPDATE"+
+			" message_created_at = transform(toString(id), ['%[1]s', '%[2]s'], [toDateTime64('%[3]d', 9), toDateTime64('%[4]d', 9)], message_created_at),"+
+			" assistant_id = transform(toString(id), ['%[1]s', '%[2]s'], ['%[5]s', ''], assistant_id)"+
+			" WHERE id IN ('%[1]s', '%[2]s') AND created_at >= toDateTime64('%[6]d', 9)",
+		id1, id2, message1.UnixNano(), message2.UnixNano(), assistantID,
+		created2.Add(-createdAtSlack).UnixNano(),
+	)
+	require.Equal(t, want, got)
+}
+
+// TestMutationStatementEscapesStrings guards the literal escaping: a value
+// containing quotes or backslashes must not break out of its string literal.
+func TestMutationStatementEscapesStrings(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	got := mutationStatement([]UpdateRow{
+		{ID: uuid.Must(uuid.NewV7()), CreatedAt: now, MessageCreatedAt: now, AssistantID: `o'brien\`},
+	})
+	require.Contains(t, got, `'o\'brien\\'`)
+}
+
+// TestPipelineMutatesClickHouseRows drives the full source -> transform ->
+// sink pipeline against real Postgres and ClickHouse: pre-inserted
+// risk_findings rows carrying the column DEFAULTs are enriched in place by the
+// mutation, while a row outside the -to window stays untouched.
+func TestPipelineMutatesClickHouseRows(t *testing.T) {
+	t.Parallel()
+
+	tn := seedTenant(t)
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	ensureBackfillColumns(t, conn)
+
+	// Recent relative dates: risk_findings has a 90-day created_at TTL, so
+	// hardcoded old dates would expire at insert.
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-48 * time.Hour)
+	scanAt := base.Add(2 * time.Hour)
+
+	// A: live assistant thread, message an event time behind the scan time.
+	chatA := tn.newChat(t)
+	assistantID, _ := tn.linkAssistant(t, chatA)
+	messageTimeA := base
+	findingA := tn.newFinding(t, tn.newMessage(t, chatA, messageTimeA), scanAt)
+
+	// B: no assistant.
+	chatB := tn.newChat(t)
+	messageTimeB := base.Add(time.Minute)
+	findingB := tn.newFinding(t, tn.newMessage(t, chatB, messageTimeB), scanAt)
+
+	// C: enrichable in Postgres (live thread via chat A), but outside the -to
+	// window — its ClickHouse row must keep its DEFAULT values, proving the
+	// bound holds end to end.
+	outsideAt := scanAt.Add(time.Hour)
+	findingC := tn.newFinding(t, tn.newMessage(t, chatA, base.Add(2*time.Minute)), outsideAt)
+
+	insertFindings(t, conn, tn, []chFinding{
+		{id: findingA, createdAt: scanAt},
+		{id: findingB, createdAt: scanAt},
+		{id: findingC, createdAt: outsideAt},
+	})
+
+	source := NewSource(tn.pool)
+	sink := NewSink(conn, 16, 2, false)
+	require.NoError(t, pipeline.Run[SourceRow, UpdateRow](t.Context(), source, NewTransformer(), sink, pipeline.Criteria{
+		CriteriaOrgID: tn.orgID,
+		CriteriaTo:    outsideAt, // exclusive: keeps C out
+	}, 16))
+
+	require.EqualValues(t, 2, source.Scanned())
+	require.EqualValues(t, 2, sink.Mutated())
+	require.EqualValues(t, 1, sink.Batches())
+	require.NotEqual(t, uuid.Nil, sink.LastCommitted())
+
+	// The mutation is asynchronous server-side: poll until the enriched values
+	// are visible.
+	type enriched struct {
+		messageCreatedAt time.Time
+		assistantID      string
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rows, err := conn.Query(t.Context(), `
+			SELECT id, message_created_at, assistant_id
+			FROM risk_findings
+			WHERE organization_id = ?
+		`, tn.orgID)
+		if !assert.NoError(c, err) {
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		got := map[uuid.UUID]enriched{}
+		for rows.Next() {
+			var (
+				id  uuid.UUID
+				row enriched
+			)
+			if !assert.NoError(c, rows.Scan(&id, &row.messageCreatedAt, &row.assistantID)) {
+				return
+			}
+			got[id] = row
+		}
+		if !assert.Len(c, got, 3) {
+			return
+		}
+
+		a := got[findingA]
+		assert.True(c, messageTimeA.Equal(a.messageCreatedAt), "A backfills the message event time, got %s", a.messageCreatedAt)
+		assert.Equal(c, assistantID.String(), a.assistantID)
+
+		b := got[findingB]
+		assert.True(c, messageTimeB.Equal(b.messageCreatedAt), "B backfills the message event time, got %s", b.messageCreatedAt)
+		assert.Empty(c, b.assistantID)
+
+		cRow := got[findingC]
+		assert.True(c, outsideAt.Equal(cRow.messageCreatedAt), "C stays at its DEFAULT (created_at), got %s", cRow.messageCreatedAt)
+		assert.Empty(c, cRow.assistantID)
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// ensureBackfillColumns adds the two backfill target columns to the test
+// container's risk_findings table. They land in server/clickhouse/schema.sql
+// through a parallel workstream; ADD COLUMN IF NOT EXISTS keeps this a no-op
+// once that ships.
+func ensureBackfillColumns(t *testing.T, conn clickhouse.Conn) {
+	t.Helper()
+	ctx := t.Context()
+	require.NoError(t, conn.Exec(ctx, "ALTER TABLE risk_findings ADD COLUMN IF NOT EXISTS message_created_at DateTime64(9) DEFAULT created_at"))
+	require.NoError(t, conn.Exec(ctx, "ALTER TABLE risk_findings ADD COLUMN IF NOT EXISTS assistant_id String DEFAULT ''"))
+}
+
+type chFinding struct {
+	id        uuid.UUID
+	createdAt time.Time
+}
+
+// insertFindings seeds pre-migration risk_findings rows: only identity and
+// required columns are set, so message_created_at and assistant_id carry their
+// column DEFAULTs exactly like rows inserted before the columns existed.
+func insertFindings(t *testing.T, conn clickhouse.Conn, tn *tenant, rows []chFinding) {
+	t.Helper()
+	ctx := t.Context()
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO risk_findings (id, created_at, organization_id, project_id, rule_id, source, tags)")
+	require.NoError(t, err)
+	for _, row := range rows {
+		require.NoError(t, batch.Append(row.id, row.createdAt, tn.orgID, tn.projectID.String(), "pii.email_address", "presidio", []string{"pii"}))
+	}
+	require.NoError(t, batch.Send())
+}

--- a/server/cmd/tools/migrations/riskfindingscols/sink_test.go
+++ b/server/cmd/tools/migrations/riskfindingscols/sink_test.go
@@ -60,7 +60,8 @@ func TestSinkEmptyCommitsNothing(t *testing.T) {
 // batch produces: both transform() maps and the IN list share the same id
 // order, timestamps render at nanosecond scale (positional binding would
 // truncate to seconds, which is why the statement is built by hand), and the
-// created_at bound is the batch minimum minus the slack.
+// created_at bounds are the batch minimum minus the slack and the batch
+// maximum plus the slack.
 func TestMutationStatementRendersAlignedArraysAndBound(t *testing.T) {
 	t.Parallel()
 
@@ -81,9 +82,10 @@ func TestMutationStatementRendersAlignedArraysAndBound(t *testing.T) {
 		"ALTER TABLE risk_findings UPDATE"+
 			" message_created_at = transform(toString(id), ['%[1]s', '%[2]s'], [toDateTime64('%[3]d', 9), toDateTime64('%[4]d', 9)], message_created_at),"+
 			" assistant_id = transform(toString(id), ['%[1]s', '%[2]s'], ['%[5]s', ''], assistant_id)"+
-			" WHERE id IN ('%[1]s', '%[2]s') AND created_at >= toDateTime64('%[6]d', 9)",
+			" WHERE id IN ('%[1]s', '%[2]s') AND created_at >= toDateTime64('%[6]d', 9) AND created_at <= toDateTime64('%[7]d', 9)",
 		id1, id2, message1.UnixNano(), message2.UnixNano(), assistantID,
 		created2.Add(-createdAtSlack).UnixNano(),
+		created1.Add(createdAtSlack).UnixNano(),
 	)
 	require.Equal(t, want, got)
 }

--- a/server/cmd/tools/migrations/riskfindingscols/source.go
+++ b/server/cmd/tools/migrations/riskfindingscols/source.go
@@ -1,0 +1,214 @@
+// Package riskfindingscols implements the Postgres source, transform, and
+// ClickHouse sink that backfill the message_created_at and assistant_id
+// columns onto EXISTING ClickHouse risk_findings rows. Unlike the sibling
+// riskfindings package (which inserts whole rows), this migration issues
+// ALTER TABLE ... UPDATE mutations keyed by finding id: re-inserting enriched
+// copies would be wrong because the read path dedups duplicate ids by keeping
+// the copy that sorts first under message_created_at DESC ... inserted_at
+// DESC, and an old copy's DEFAULT message_created_at (= created_at, the scan
+// time) is >= the enriched copy's true event time, so the unenriched copy
+// would win.
+package riskfindingscols
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/pipeline"
+)
+
+// DefaultBatchSize is the number of rows fetched per source page and mutated
+// per sink batch when the caller does not override it. It is deliberately much
+// smaller than the riskfindings insert batch: every row contributes its id
+// three times (two transform() maps plus the IN list) to a single ALTER
+// statement, so large batches would push the query text past ClickHouse's
+// default 256 KiB max_query_size.
+const DefaultBatchSize = 500
+
+// Criteria keys understood by the Postgres source. All are optional; an unset
+// time window scans the whole table.
+const (
+	CriteriaOrgID     = "org_id"     // string; filters organization_id
+	CriteriaProjectID = "project_id" // uuid.UUID; filters project_id
+	CriteriaFrom      = "from"       // time.Time; created_at >= from (applies with or without a cursor)
+	CriteriaTo        = "to"         // time.Time; created_at < to
+	CriteriaCursor    = "cursor"     // uuid.UUID; resume after this id (exclusive)
+	CriteriaBatchSize = "batch_size" // int; rows per page
+)
+
+// SourceRow is the per-finding enrichment tuple read from Postgres: the
+// finding id (which is also the ClickHouse row id), the finding's created_at
+// (used by the sink to bound the mutation for partition pruning), the event
+// time of the scanned chat message, and the assistant linked to the finding's
+// chat (empty when none).
+type SourceRow struct {
+	ID        uuid.UUID
+	CreatedAt time.Time
+
+	// MessageCreatedAt is chat_messages.created_at for the scanned message.
+	// When the finding is not anchored to a chat message (content-part
+	// anchored rows), it falls back to the finding's created_at — the same
+	// value the ClickHouse column DEFAULT computes, making the update a
+	// no-op for those rows rather than a wrong value.
+	MessageCreatedAt time.Time
+
+	// AssistantID is assistant_threads.assistant_id for a live (deleted IS
+	// FALSE) thread whose chat_id matches the scanned message's chat. Empty
+	// when the finding has no message, the chat backs no thread, or the
+	// thread is soft-deleted.
+	AssistantID string
+}
+
+// selectPage walks risk_results in id order (uuidv7). The id is used ONLY as a
+// keyset pagination/resume key (id > cursor); it is deliberately NOT used to
+// prune the time window (a row's uuidv7 id and its created_at are minted at
+// slightly different instants, so the id timestamp is not a sound bound for a
+// created_at filter). Time bounds are enforced exactly by the created_at
+// predicates ($3/$4).
+//
+// Optional filters use the "$n IS NULL OR col = $n" idiom so a single prepared
+// statement serves every filter combination.
+//
+// found IS TRUE AND rule_id IS NOT NULL mirrors both the live outbox emission
+// and the riskfindings backfill source: only those rows exist in ClickHouse,
+// so mutating any other id would be wasted work.
+//
+// The chat_messages LEFT JOIN misses only for content-part-anchored findings
+// (message-anchored rows cannot dangle: the FK cascades the risk_results row
+// away with its message); COALESCE then falls back to the finding's own
+// created_at, matching the ClickHouse column DEFAULT. The assistant lookup
+// mirrors the live GetAssistantThreadAssistantIDByChatID query
+// (chat/queries.sql): a live (deleted IS FALSE) assistant_threads row whose
+// chat_id matches the scanned message's chat, with ORDER BY id LIMIT 1 making
+// the pick deterministic should a chat ever back multiple threads.
+const selectPage = `
+SELECT r.id,
+       r.created_at,
+       COALESCE(cm.created_at, r.created_at) AS message_created_at,
+       COALESCE(at.assistant_id::text, '') AS assistant_id
+FROM risk_results r
+LEFT JOIN chat_messages cm
+  ON cm.id = r.chat_message_id
+LEFT JOIN LATERAL (
+    SELECT t.assistant_id
+    FROM assistant_threads t
+    WHERE t.chat_id = cm.chat_id
+      AND t.deleted IS FALSE
+    ORDER BY t.id
+    LIMIT 1
+) at ON TRUE
+WHERE ($1::text IS NULL OR r.organization_id = $1)
+  AND ($2::uuid IS NULL OR r.project_id = $2)
+  AND ($3::timestamptz IS NULL OR r.created_at >= $3)
+  AND ($4::timestamptz IS NULL OR r.created_at < $4)
+  AND r.id > $5
+  AND r.found IS TRUE
+  AND r.rule_id IS NOT NULL
+ORDER BY r.id
+LIMIT $6
+`
+
+// Source reads enrichment tuples from Postgres page by page and publishes them
+// to the pipeline. It tracks the last processed id so an interrupted run can
+// resume.
+type Source struct {
+	pool *pgxpool.Pool
+
+	scanned int64
+}
+
+// NewSource builds a Postgres source over pool.
+func NewSource(pool *pgxpool.Pool) *Source {
+	return &Source{
+		pool:    pool,
+		scanned: 0,
+	}
+}
+
+// Scanned returns the number of rows read so far.
+func (s *Source) Scanned() int64 { return s.scanned }
+
+// Read implements pipeline.Source. It paginates risk_results by keyset over
+// id, publishing each enrichment tuple to out, and returns when the window is
+// exhausted.
+func (s *Source) Read(ctx context.Context, criteria pipeline.Criteria, out chan<- SourceRow) error {
+	org, _ := criteria[CriteriaOrgID].(string)
+	batchSize, _ := criteria[CriteriaBatchSize].(int)
+	if batchSize <= 0 {
+		batchSize = DefaultBatchSize
+	}
+
+	// Keyset lower bound / resume point. The cursor only sets the id resume
+	// position (id > cursor); it does NOT relax the time window. -from/-to
+	// still apply so a resumed scoped run stays inside its window.
+	cursor := uuid.Nil
+	if c, ok := criteria[CriteriaCursor].(uuid.UUID); ok {
+		cursor = c
+	}
+
+	// nil interface values become SQL NULL, disabling the optional filters.
+	var fromArg, toArg any
+	if from, ok := criteria[CriteriaFrom].(time.Time); ok {
+		fromArg = from
+	}
+	if to, ok := criteria[CriteriaTo].(time.Time); ok {
+		toArg = to
+	}
+	var orgArg, projectArg any
+	if org != "" {
+		orgArg = org
+	}
+	if projectID, ok := criteria[CriteriaProjectID].(uuid.UUID); ok {
+		projectArg = projectID
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("read interrupted at %s: %w", cursor, err)
+		}
+
+		rows, err := s.pool.Query(ctx, selectPage, orgArg, projectArg, fromArg, toArg, cursor, batchSize)
+		if err != nil {
+			return fmt.Errorf("query page after %s: %w", cursor, err)
+		}
+
+		n := 0
+		for rows.Next() {
+			var r SourceRow
+			if err := rows.Scan(&r.ID, &r.CreatedAt, &r.MessageCreatedAt, &r.AssistantID); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan row after %s: %w", cursor, err)
+			}
+			cursor = r.ID
+			n++
+
+			select {
+			case out <- r:
+			case <-ctx.Done():
+				rows.Close()
+				return fmt.Errorf("publish interrupted at %s: %w", cursor, ctx.Err())
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterate page after %s: %w", cursor, err)
+		}
+		rows.Close()
+
+		s.scanned += int64(n)
+		// This is the read position, not a safe resume point: rows up to here
+		// may still be in flight downstream. The resume cursor is the sink's
+		// committed id (see Sink.LastCommitted), printed in the final report.
+		log.Printf("source: read page=%d total=%d read_through=%s", n, s.scanned, cursor)
+
+		// A short page means we reached the end of the window.
+		if n < batchSize {
+			return nil
+		}
+	}
+}

--- a/server/cmd/tools/migrations/riskfindingscols/source_test.go
+++ b/server/cmd/tools/migrations/riskfindingscols/source_test.go
@@ -1,0 +1,192 @@
+package riskfindingscols
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/pipeline"
+)
+
+func TestSourcePaginatesInIdOrderAndResumes(t *testing.T) {
+	t.Parallel()
+
+	tn := seedTenant(t)
+	chatID := tn.newChat(t)
+
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-24 * time.Hour)
+	ids := make([]uuid.UUID, 0, 5)
+	for i := range 5 {
+		msgID := tn.newMessage(t, chatID, base.Add(time.Duration(i)*time.Minute))
+		ids = append(ids, tn.newFinding(t, msgID, base.Add(time.Duration(i)*time.Minute+30*time.Second)))
+	}
+	// UUIDv7 ids minted in the same millisecond are not guaranteed monotonic;
+	// the source contract is id order, so compare against the sorted set.
+	slices.SortFunc(ids, func(a, b uuid.UUID) int { return slices.Compare(a[:], b[:]) })
+
+	// A page size smaller than the row count forces multiple keyset pages.
+	source := NewSource(tn.pool)
+	rows := readAll(t, source, pipeline.Criteria{
+		CriteriaOrgID:     tn.orgID,
+		CriteriaBatchSize: 2,
+	})
+
+	require.Len(t, rows, 5)
+	require.EqualValues(t, 5, source.Scanned())
+	for i, row := range rows {
+		require.Equal(t, ids[i], row.ID, "rows must stream in id order")
+	}
+
+	// Resuming after the third id re-reads exactly the tail, honoring the
+	// exclusive cursor.
+	resumed := readAll(t, NewSource(tn.pool), pipeline.Criteria{
+		CriteriaOrgID:     tn.orgID,
+		CriteriaBatchSize: 2,
+		CriteriaCursor:    ids[2],
+	})
+	require.Len(t, resumed, 2)
+	require.Equal(t, ids[3], resumed[0].ID)
+	require.Equal(t, ids[4], resumed[1].ID)
+}
+
+func TestSourceHonorsTenantAndTimeBounds(t *testing.T) {
+	t.Parallel()
+
+	tn := seedTenant(t)
+	chatID := tn.newChat(t)
+
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-24 * time.Hour)
+	early := tn.newFinding(t, tn.newMessage(t, chatID, base), base)
+	middle := tn.newFinding(t, tn.newMessage(t, chatID, base.Add(time.Hour)), base.Add(time.Hour))
+	late := tn.newFinding(t, tn.newMessage(t, chatID, base.Add(2*time.Hour)), base.Add(2*time.Hour))
+
+	source := NewSource(tn.pool)
+
+	// A different org matches nothing.
+	require.Empty(t, readAll(t, source, pipeline.Criteria{CriteriaOrgID: "org_other"}))
+
+	// A different project matches nothing.
+	require.Empty(t, readAll(t, source, pipeline.Criteria{
+		CriteriaOrgID:     tn.orgID,
+		CriteriaProjectID: uuid.New(),
+	}))
+
+	// The matching project returns everything.
+	require.Len(t, readAll(t, source, pipeline.Criteria{
+		CriteriaOrgID:     tn.orgID,
+		CriteriaProjectID: tn.projectID,
+	}), 3)
+
+	// [from, to) brackets exactly the middle finding: from is inclusive, to is
+	// exclusive.
+	windowed := readAll(t, source, pipeline.Criteria{
+		CriteriaOrgID: tn.orgID,
+		CriteriaFrom:  base.Add(time.Hour),
+		CriteriaTo:    base.Add(2 * time.Hour),
+	})
+	require.Len(t, windowed, 1)
+	require.Equal(t, middle, windowed[0].ID)
+
+	// The bounds by themselves keep the edges out.
+	fromOnly := readAll(t, source, pipeline.Criteria{
+		CriteriaOrgID: tn.orgID,
+		CriteriaFrom:  base.Add(2 * time.Hour),
+	})
+	require.Len(t, fromOnly, 1)
+	require.Equal(t, late, fromOnly[0].ID)
+
+	toOnly := readAll(t, source, pipeline.Criteria{
+		CriteriaOrgID: tn.orgID,
+		CriteriaTo:    base.Add(time.Hour),
+	})
+	require.Len(t, toOnly, 1)
+	require.Equal(t, early, toOnly[0].ID)
+}
+
+func TestSourceResolvesAssistantAndMessageTime(t *testing.T) {
+	t.Parallel()
+
+	tn := seedTenant(t)
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-24 * time.Hour)
+
+	// Chat A backs a live assistant thread.
+	chatA := tn.newChat(t)
+	assistantID, _ := tn.linkAssistant(t, chatA)
+	msgTimeA := base
+	findingA := tn.newFinding(t, tn.newMessage(t, chatA, msgTimeA), base.Add(time.Hour))
+
+	// Chat B's thread is soft-deleted: no assistant attribution.
+	chatB := tn.newChat(t)
+	_, threadB := tn.linkAssistant(t, chatB)
+	tn.softDeleteThread(t, threadB)
+	msgTimeB := base.Add(time.Minute)
+	findingB := tn.newFinding(t, tn.newMessage(t, chatB, msgTimeB), base.Add(time.Hour))
+
+	// Chat C never had a thread.
+	chatC := tn.newChat(t)
+	msgTimeC := base.Add(2 * time.Minute)
+	findingC := tn.newFinding(t, tn.newMessage(t, chatC, msgTimeC), base.Add(time.Hour))
+
+	rows := readAll(t, NewSource(tn.pool), pipeline.Criteria{CriteriaOrgID: tn.orgID})
+	require.Len(t, rows, 3)
+
+	byID := make(map[uuid.UUID]SourceRow, len(rows))
+	for _, row := range rows {
+		byID[row.ID] = row
+	}
+
+	a := byID[findingA]
+	require.Equal(t, assistantID.String(), a.AssistantID)
+	require.True(t, msgTimeA.Equal(a.MessageCreatedAt), "message_created_at must be the chat message event time")
+	require.True(t, base.Add(time.Hour).Equal(a.CreatedAt))
+
+	b := byID[findingB]
+	require.Empty(t, b.AssistantID, "a soft-deleted thread must not attribute an assistant")
+	require.True(t, msgTimeB.Equal(b.MessageCreatedAt))
+
+	c := byID[findingC]
+	require.Empty(t, c.AssistantID)
+	require.True(t, msgTimeC.Equal(c.MessageCreatedAt))
+}
+
+func TestSourceFallsBackForContentPartFinding(t *testing.T) {
+	t.Parallel()
+
+	tn := seedTenant(t)
+	chatID := tn.newChat(t)
+	// Even with a live thread on the chat, a content-part-anchored finding has
+	// no chat message to join through, so both enrichments fall back: the
+	// assistant lookup keys off the missing message's chat and yields '', and
+	// message_created_at collapses to the finding's own created_at (the same
+	// value the ClickHouse column DEFAULT computes).
+	tn.linkAssistant(t, chatID)
+
+	createdAt := time.Now().UTC().Truncate(time.Microsecond).Add(-24 * time.Hour)
+	findingID := tn.newContentPartFinding(t, chatID, createdAt)
+
+	rows := readAll(t, NewSource(tn.pool), pipeline.Criteria{CriteriaOrgID: tn.orgID})
+	require.Len(t, rows, 1)
+	require.Equal(t, findingID, rows[0].ID)
+	require.True(t, createdAt.Equal(rows[0].MessageCreatedAt), "content-part findings fall back to the finding created_at")
+	require.Empty(t, rows[0].AssistantID)
+}
+
+func TestSourceSkipsNonFindings(t *testing.T) {
+	t.Parallel()
+
+	tn := seedTenant(t)
+	chatID := tn.newChat(t)
+
+	base := time.Now().UTC().Truncate(time.Microsecond).Add(-24 * time.Hour)
+	msgID := tn.newMessage(t, chatID, base)
+	finding := tn.newFinding(t, msgID, base.Add(time.Minute))
+	tn.newNonFinding(t, msgID, false) // found=false sentinel
+	tn.newNonFinding(t, msgID, true)  // found=true but rule_id IS NULL
+
+	rows := readAll(t, NewSource(tn.pool), pipeline.Criteria{CriteriaOrgID: tn.orgID})
+	require.Len(t, rows, 1, "only clean true positives exist in ClickHouse, so only they are worth mutating")
+	require.Equal(t, finding, rows[0].ID)
+}

--- a/server/cmd/tools/migrations/riskfindingscols/transform.go
+++ b/server/cmd/tools/migrations/riskfindingscols/transform.go
@@ -1,0 +1,47 @@
+package riskfindingscols
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UpdateRow is one per-finding column update ready for the ClickHouse mutation
+// sink: the target row id, the finding's created_at (bounds the mutation for
+// partition pruning), and the two new column values.
+type UpdateRow struct {
+	ID               uuid.UUID
+	CreatedAt        time.Time
+	MessageCreatedAt time.Time
+	AssistantID      string
+}
+
+// Transformer maps a SourceRow to an UpdateRow. The mapping is a near
+// pass-through — the source query already resolves both values — and the stage
+// exists for harness symmetry with the riskfindings migration. Its one piece
+// of logic is a defensive guard mirroring the source's SQL COALESCE: a zero
+// MessageCreatedAt falls back to the finding's created_at, the same value the
+// ClickHouse column DEFAULT computes, so a malformed input can never write a
+// zero timestamp into ClickHouse.
+type Transformer struct{}
+
+// NewTransformer builds the pass-through transformer.
+func NewTransformer() *Transformer {
+	return &Transformer{}
+}
+
+// Transform implements pipeline.Transformer.
+func (t *Transformer) Transform(_ context.Context, in SourceRow) ([]UpdateRow, error) {
+	messageCreatedAt := in.MessageCreatedAt
+	if messageCreatedAt.IsZero() {
+		messageCreatedAt = in.CreatedAt
+	}
+
+	return []UpdateRow{{
+		ID:               in.ID,
+		CreatedAt:        in.CreatedAt,
+		MessageCreatedAt: messageCreatedAt,
+		AssistantID:      in.AssistantID,
+	}}, nil
+}

--- a/server/cmd/tools/migrations/riskfindingscols/transform_test.go
+++ b/server/cmd/tools/migrations/riskfindingscols/transform_test.go
@@ -1,0 +1,53 @@
+package riskfindingscols
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	tf := NewTransformer()
+	createdAt := time.Now().UTC()
+	messageCreatedAt := createdAt.Add(-time.Hour)
+	in := SourceRow{
+		ID:               uuid.Must(uuid.NewV7()),
+		CreatedAt:        createdAt,
+		MessageCreatedAt: messageCreatedAt,
+		AssistantID:      uuid.NewString(),
+	}
+
+	out, err := tf.Transform(t.Context(), in)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, in.ID, out[0].ID)
+	require.True(t, createdAt.Equal(out[0].CreatedAt))
+	require.True(t, messageCreatedAt.Equal(out[0].MessageCreatedAt))
+	require.Equal(t, in.AssistantID, out[0].AssistantID)
+}
+
+func TestTransformZeroMessageTimeFallsBackToCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	// A zero MessageCreatedAt must never reach ClickHouse: it falls back to
+	// the finding's created_at, matching both the source's SQL COALESCE and
+	// the ClickHouse column DEFAULT.
+	tf := NewTransformer()
+	createdAt := time.Now().UTC()
+	in := SourceRow{
+		ID:               uuid.Must(uuid.NewV7()),
+		CreatedAt:        createdAt,
+		MessageCreatedAt: time.Time{},
+		AssistantID:      "",
+	}
+
+	out, err := tf.Transform(t.Context(), in)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.True(t, createdAt.Equal(out[0].MessageCreatedAt))
+	require.Empty(t, out[0].AssistantID)
+}

--- a/server/cmd/tools/migrations/riskfindingscols_cmd.go
+++ b/server/cmd/tools/migrations/riskfindingscols_cmd.go
@@ -145,6 +145,12 @@ func parseColsFlags(args []string) (colsConfig, error) {
 	if err := fs.Parse(args); err != nil {
 		return colsConfig{}, fmt.Errorf("parse flags: %w", err)
 	}
+	// A leftover positional token is almost always a mistyped flag (e.g. a
+	// scope value detached from its -org/-project). Silently ignoring it would
+	// run the migration at its default all-org scope.
+	if fs.NArg() > 0 {
+		return colsConfig{}, fmt.Errorf("unexpected positional arguments: %q", fs.Args())
+	}
 
 	chCfg.password = os.Getenv("CLICKHOUSE_PASSWORD")
 

--- a/server/cmd/tools/migrations/riskfindingscols_cmd.go
+++ b/server/cmd/tools/migrations/riskfindingscols_cmd.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/pipeline"
+	"github.com/speakeasy-api/gram/server/cmd/tools/migrations/riskfindingscols"
+)
+
+// colsConfig configures the riskfindingscols migration: backfilling the
+// message_created_at and assistant_id columns onto existing ClickHouse
+// risk_findings rows via mutations. See RISKFINDINGS_COLS_MIGRATION.md.
+type colsConfig struct {
+	dbURL      string
+	ch         clickhouseConfig
+	orgID      string
+	projectID  uuid.NullUUID
+	from       *time.Time
+	to         *time.Time
+	cursor     uuid.NullUUID
+	batchSize  int
+	bufferSize int
+	dryRun     bool
+}
+
+func runRiskFindingsCols(args []string) int {
+	cfg, err := parseColsFlags(args)
+	if err != nil {
+		log.Printf("invalid arguments: %v", err)
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, cfg.dbURL)
+	if err != nil {
+		log.Printf("connect postgres: %v", err)
+		return 1
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		log.Printf("ping postgres: %v", err)
+		return 1
+	}
+
+	var chConn clickhouse.Conn
+	if !cfg.dryRun {
+		chConn, err = openClickhouse(ctx, cfg.ch)
+		if err != nil {
+			log.Printf("connect clickhouse: %v", err)
+			return 1
+		}
+		defer func() {
+			if cerr := chConn.Close(); cerr != nil {
+				log.Printf("close clickhouse: %v", cerr)
+			}
+		}()
+	}
+
+	source := riskfindingscols.NewSource(pool)
+	transformer := riskfindingscols.NewTransformer()
+	sink := riskfindingscols.NewSink(chConn, cfg.bufferSize, cfg.batchSize, cfg.dryRun)
+
+	runErr := pipeline.Run[riskfindingscols.SourceRow, riskfindingscols.UpdateRow](
+		ctx, source, transformer, sink, cfg.criteria(), cfg.bufferSize,
+	)
+
+	// Resume from the sink's committed id, not the source read position: rows
+	// the source read but the sink had not yet flushed on interruption were
+	// never handed to ClickHouse, and resuming from the read position would
+	// skip them.
+	printColsReport(cfg, source.Scanned(), sink.Mutated(), sink.Batches(), sink.LastCommitted())
+
+	if runErr != nil {
+		// Both interruption and hard failure leave an incomplete backfill: exit
+		// nonzero and, whenever anything was durably submitted, point the
+		// operator at the cursor to resume from so shell automation never
+		// treats a partial run as done.
+		resumeHint := ""
+		if committed := sink.LastCommitted(); committed != uuid.Nil {
+			resumeHint = fmt.Sprintf("; resume with -cursor %s (repeat the same -from/-to/-org/-project)", committed)
+		}
+		if errors.Is(runErr, context.Canceled) {
+			log.Printf("migration interrupted before completion%s", resumeHint)
+			return 130
+		}
+		log.Printf("migration failed: %v%s", runErr, resumeHint)
+		return 1
+	}
+	return 0
+}
+
+func (c colsConfig) criteria() pipeline.Criteria {
+	crit := pipeline.Criteria{
+		riskfindingscols.CriteriaBatchSize: c.batchSize,
+	}
+	if c.orgID != "" {
+		crit[riskfindingscols.CriteriaOrgID] = c.orgID
+	}
+	if c.projectID.Valid {
+		crit[riskfindingscols.CriteriaProjectID] = c.projectID.UUID
+	}
+	if c.from != nil {
+		crit[riskfindingscols.CriteriaFrom] = *c.from
+	}
+	if c.to != nil {
+		crit[riskfindingscols.CriteriaTo] = *c.to
+	}
+	if c.cursor.Valid {
+		crit[riskfindingscols.CriteriaCursor] = c.cursor.UUID
+	}
+	return crit
+}
+
+func parseColsFlags(args []string) (colsConfig, error) {
+	fs := flag.NewFlagSet("riskfindingscols", flag.ContinueOnError)
+
+	// Secrets (Postgres URL, ClickHouse password) are read from the
+	// environment only — never as flag values — so they do not leak through
+	// argv / ps.
+	var (
+		chCfg      = registerClickhouseFlags(fs)
+		orgID      = fs.String("org", "", "organization_id to scope the migration (optional; all orgs if empty)")
+		projectID  = fs.String("project", "", "project_id (uuid) to scope (optional)")
+		fromStr    = fs.String("from", "", "lower time bound, RFC3339 (optional; from the beginning if empty)")
+		toStr      = fs.String("to", "", "upper time bound, RFC3339 (optional; to the end if empty)")
+		cursorStr  = fs.String("cursor", "", "resume after this risk_results id (exclusive); keyset resume position only — still pass the original -from/-to/-org/-project")
+		batchSize  = fs.Int("batch-size", riskfindingscols.DefaultBatchSize, "rows per source page and per mutation batch")
+		bufferSize = fs.Int("buffer", riskfindingscols.DefaultBatchSize, "channel buffer between pipeline stages")
+		dryRun     = fs.Bool("dry-run", true, "when true (default) read and transform but do not write; pass -dry-run=false to submit mutations")
+	)
+	if err := fs.Parse(args); err != nil {
+		return colsConfig{}, fmt.Errorf("parse flags: %w", err)
+	}
+
+	chCfg.password = os.Getenv("CLICKHOUSE_PASSWORD")
+
+	cfg := colsConfig{
+		dbURL:      os.Getenv("GRAM_DATABASE_URL"),
+		ch:         *chCfg,
+		orgID:      *orgID,
+		projectID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		from:       nil,
+		to:         nil,
+		cursor:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		batchSize:  *batchSize,
+		bufferSize: *bufferSize,
+		dryRun:     *dryRun,
+	}
+
+	if cfg.dbURL == "" {
+		return cfg, errors.New("missing $GRAM_DATABASE_URL")
+	}
+	if cfg.batchSize <= 0 {
+		return cfg, errors.New("-batch-size must be positive")
+	}
+
+	if *projectID != "" {
+		pid, err := uuid.Parse(*projectID)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid -project: %w", err)
+		}
+		cfg.projectID = uuid.NullUUID{UUID: pid, Valid: true}
+	}
+	if *fromStr != "" {
+		from, err := time.Parse(time.RFC3339, *fromStr)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid -from: %w", err)
+		}
+		cfg.from = &from
+	}
+	if *toStr != "" {
+		to, err := time.Parse(time.RFC3339, *toStr)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid -to: %w", err)
+		}
+		cfg.to = &to
+	}
+	if cfg.from != nil && cfg.to != nil && !cfg.from.Before(*cfg.to) {
+		return cfg, errors.New("-from must be before -to")
+	}
+	if *cursorStr != "" {
+		cur, err := uuid.Parse(*cursorStr)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid -cursor: %w", err)
+		}
+		cfg.cursor = uuid.NullUUID{UUID: cur, Valid: true}
+	}
+
+	return cfg, nil
+}
+
+func printColsReport(cfg colsConfig, scanned, mutated, batches int64, lastCursor uuid.UUID) {
+	mode := "DRY RUN (no writes)"
+	if !cfg.dryRun {
+		mode = "APPLIED"
+	}
+	fmt.Println()
+	fmt.Println("risk_findings columns migration summary")
+	fmt.Printf("  mode:          %s\n", mode)
+	if cfg.orgID != "" {
+		fmt.Printf("  org:           %s\n", cfg.orgID)
+	} else {
+		fmt.Printf("  org:           (all)\n")
+	}
+	fmt.Printf("  scanned:       %d\n", scanned)
+	fmt.Printf("  rows targeted: %d\n", mutated)
+	fmt.Printf("  mutations:     %d\n", batches)
+	// The resume cursor is meaningful only for an applied run: in dry-run
+	// nothing is submitted, so there is no durable checkpoint to resume from.
+	if cfg.dryRun {
+		fmt.Printf("  last cursor:   (dry run — no durable checkpoint)\n")
+	} else {
+		fmt.Printf("  last cursor:   %s\n", lastCursor)
+	}
+	if cfg.dryRun && scanned > 0 {
+		fmt.Println()
+		fmt.Println("re-run with -dry-run=false to submit ClickHouse mutations.")
+	}
+}

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -230,3 +230,23 @@ WHERE s.device_integration_schedule_id = sch.id
 UPDATE device_integration_configs
 SET credentials_encrypted = 'not-a-valid-ciphertext'
 WHERE id = @id;
+
+-- name: InsertChatContentPartFixture :one
+-- Test-only fixture: seeds a minimal chat content part so tests can anchor a
+-- risk_results row to it.
+INSERT INTO chat_content_parts (chat_id, project_id, kind, content_asset_url)
+VALUES (@chat_id, @project_id, @kind, @content_asset_url)
+RETURNING id;
+
+-- name: InsertContentPartRiskResultFixture :exec
+-- Test-only fixture: seeds a risk_results row anchored to a chat content part
+-- (chat_message_id IS NULL), a shape the production InsertRiskResults copyfrom
+-- cannot produce, so backfill tooling can exercise the fallback path its
+-- chat_messages join takes when a finding has no chat message.
+INSERT INTO risk_results (
+  id, project_id, organization_id, risk_policy_id, risk_policy_version,
+  chat_content_part_id, source, found, rule_id, description, match, tags
+) VALUES (
+  @id, @project_id, @organization_id, @risk_policy_id, @risk_policy_version,
+  @chat_content_part_id, @source, TRUE, @rule_id, @description, @match, @tags
+);

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -328,6 +328,33 @@ func (q *Queries) GetOutboxRelayState(ctx context.Context, outboxID int64) (GetO
 	return i, err
 }
 
+const insertChatContentPartFixture = `-- name: InsertChatContentPartFixture :one
+INSERT INTO chat_content_parts (chat_id, project_id, kind, content_asset_url)
+VALUES ($1, $2, $3, $4)
+RETURNING id
+`
+
+type InsertChatContentPartFixtureParams struct {
+	ChatID          uuid.UUID
+	ProjectID       uuid.NullUUID
+	Kind            string
+	ContentAssetUrl string
+}
+
+// Test-only fixture: seeds a minimal chat content part so tests can anchor a
+// risk_results row to it.
+func (q *Queries) InsertChatContentPartFixture(ctx context.Context, arg InsertChatContentPartFixtureParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, insertChatContentPartFixture,
+		arg.ChatID,
+		arg.ProjectID,
+		arg.Kind,
+		arg.ContentAssetUrl,
+	)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const insertChatMessage = `-- name: InsertChatMessage :one
 INSERT INTO chat_messages (chat_id, project_id, role, content)
 VALUES ($1, $2, $3, $4)
@@ -351,6 +378,51 @@ func (q *Queries) InsertChatMessage(ctx context.Context, arg InsertChatMessagePa
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err
+}
+
+const insertContentPartRiskResultFixture = `-- name: InsertContentPartRiskResultFixture :exec
+INSERT INTO risk_results (
+  id, project_id, organization_id, risk_policy_id, risk_policy_version,
+  chat_content_part_id, source, found, rule_id, description, match, tags
+) VALUES (
+  $1, $2, $3, $4, $5,
+  $6, $7, TRUE, $8, $9, $10, $11
+)
+`
+
+type InsertContentPartRiskResultFixtureParams struct {
+	ID                uuid.UUID
+	ProjectID         uuid.UUID
+	OrganizationID    string
+	RiskPolicyID      uuid.UUID
+	RiskPolicyVersion int64
+	ChatContentPartID uuid.NullUUID
+	Source            string
+	RuleID            pgtype.Text
+	Description       pgtype.Text
+	Match             pgtype.Text
+	Tags              []string
+}
+
+// Test-only fixture: seeds a risk_results row anchored to a chat content part
+// (chat_message_id IS NULL), a shape the production InsertRiskResults copyfrom
+// cannot produce, so backfill tooling can exercise the fallback path its
+// chat_messages join takes when a finding has no chat message.
+func (q *Queries) InsertContentPartRiskResultFixture(ctx context.Context, arg InsertContentPartRiskResultFixtureParams) error {
+	_, err := q.db.Exec(ctx, insertContentPartRiskResultFixture,
+		arg.ID,
+		arg.ProjectID,
+		arg.OrganizationID,
+		arg.RiskPolicyID,
+		arg.RiskPolicyVersion,
+		arg.ChatContentPartID,
+		arg.Source,
+		arg.RuleID,
+		arg.Description,
+		arg.Match,
+		arg.Tags,
+	)
+	return err
 }
 
 const insertDeviceAgentDeviceSyncFixture = `-- name: InsertDeviceAgentDeviceSyncFixture :exec


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Backfills `message_created_at` and `assistant_id` on existing ClickHouse `risk_findings` rows via `ALTER TABLE ... UPDATE` mutations, giving historical findings accurate event time and assistant attribution. Adds a new `riskfindingscols` migration subcommand and updates the `migrations` CLI to support subcommands, with stricter mutation bounds and safer CLI validation.

- **New Features**
  - New `riskfindingscols` pipeline (Source → Transform → Sink) that reads Postgres, resolves message time and assistant, and batches one ClickHouse mutation per batch.
  - Hardened safety: dry-run by default, idempotent mutations, double-bounded `created_at` pruning per batch, error on nil ClickHouse connection when not dry-run, strict CLI flag parsing (rejects stray args), and a printed resume cursor (last committed id).
  - `migrations` binary now accepts subcommands: `riskfindings` (default) and `riskfindingscols`. README updated for subcommand usage.
  - Added `RISKFINDINGS_COLS_MIGRATION.md` with usage, flags, examples, and validation.
  - Tests cover source/transform/sink and an end-to-end path against test Postgres/ClickHouse (with new fixtures).

- **Migration**
  - Ensure ClickHouse has `message_created_at` and `assistant_id`.
  - Run: `go run ./server/cmd/tools/migrations riskfindingscols` (dry-run), then re-run with `-dry-run=false` to apply.
  - Scope with `-org`, `-project`, `-from`, and `-to`. Resume with the printed `-cursor` and the same scope flags.

<sup>Written for commit 450eb94d53ba194ca8fe54e9e36381734694e05c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

