### PR TITLE
chore: add writing-skills skill and recommended external skill set

### DIFF
--- a/.agents/recommended-skills.json
+++ b/.agents/recommended-skills.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "Recommended external agent skills. Installed on opt-in by `mise run skills:recommended` (offered by ./zero); contents land in .agents/skills/<name>/ and are kept out of git via .git/info/exclude. Pin `ref` to a commit SHA.",
+  "skills": {
+    "worktrunk": {
+      "repo": "https://github.com/max-sixty/worktrunk",
+      "ref": "1eded279436736e432a467cb8a0bd5d4496d797a",
+      "path": "plugins/worktrunk/skills/worktrunk"
+    }
+  }
+}

--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: writing-skills
+description: Use when adding, editing, or reviewing an agent skill in this repo (.agents/skills/), when new guidance needs to reach every supported harness (.claude, .codex, .opencode, .cursor), or when deciding whether repeated agent failures should become a skill. Triggers: "add a skill", "write a skill", "SKILL.md", "skills:sync".
+---
+
+# Writing repo skills
+
+Skills are agent-facing reference docs in `.agents/skills/<name>/SKILL.md`, symlinked into each supported harness's dotfolder. Core principle: a skill is only as good as a cold agent's ability to act on it — validate with fresh-context subagents performing the real workflow, not by rereading it yourself.
+
+## Mechanics
+
+1. Baseline per the eval loop below, then author `.agents/skills/<name>/SKILL.md` — kebab-case, verb-first name (`writing-skills`, not `skill-creation`).
+2. Run `mise run skills:sync` — creates the symlinks in `.claude/skills/`, `.codex/skills/`, `.opencode/skills/`, `.cursor/skills/` and prunes stale ones. Never hand-create the links; you will miss a harness.
+3. Add a row to the skills table in `CLAUDE.md`.
+4. Commit the skill and the symlinks together.
+
+## Frontmatter
+
+`name` + `description` only. The description is triggering conditions ONLY — third person, starts "Use when …", packed with the symptoms, synonyms, commands, and error strings an agent would match on. Never summarize the skill's workflow there: agents follow the summary and skip the body.
+
+## Body shape
+
+Succinct reference, not narrative: overview with the core principle → quick-reference table → per-workflow detail → common mistakes. Target well under 1000 words. One excellent example beats many. Make only claims you have verified by running the commands, and record observed failure modes with exact error text — hypothetical caveats age badly, empirical ones survive review.
+
+## Eval loop (required)
+
+Baseline first: watch an agent attempt the task WITHOUT the skill and record the failure verbatim. No baseline failure ⇒ no skill needed.
+
+1. Write the minimal skill addressing those observed failures.
+2. Dispatch a fresh-context subagent with no prior knowledge. It must perform a REAL instance of the workflow using only the skill — consulting fallback docs counts as a documentation failure — and return structured feedback: VERDICT (ship/no-ship), RATING /10, ANSWERS, CONFUSIONS quoting the text at fault, SUGGESTED EDITS.
+3. Fold the feedback in; repeat with a new subagent each round until one returns ship-as-is (9+/10) with no load-bearing confusions.
+
+Vary rounds between do-the-task and adversarial trap questions; live environments surface what desk-checking cannot. Edits after the ship verdict also get a round — one-line additions included.
+
+## External (recommended) skills
+
+Third-party skills are not committed. Declare them in `.agents/recommended-skills.json` — `repo` + `ref` (absolute commit SHA) + `path` (subdirectory to extract) — and let the tooling own the rest: `./zero` asks once and persists `USE_RECOMMENDED_SKILLS` to `mise.local.toml`; when true, `mise run skills:sync` installs/updates the set into `.agents/skills/<name>/` and keeps every installed path out of git via `.git/info/exclude`. To add one: manifest entry, then `mise run skills:recommended` (`--yes` skips the prompt) for the initial install; thereafter `mise run skills:sync` keeps the set updated. To bump: change the SHA, re-run sync.
+
+## Common mistakes
+
+- Hand-symlinking one harness dir and missing the other three — `mise skills:sync` owns the links.
+- Description that summarizes the procedure — agents act on it and never read the body.
+- Caveats invented at the desk instead of failures observed in a run — evaluators refute them.
+- Leaning on plugin or private docs — this repo is public and other harnesses lack them; skills must be self-contained.

--- a/.claude/skills/gram-playwright-cli
+++ b/.claude/skills/gram-playwright-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-playwright-cli

--- a/.claude/skills/writing-skills
+++ b/.claude/skills/writing-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-skills

--- a/.codex/skills/gram-playwright-cli
+++ b/.codex/skills/gram-playwright-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-playwright-cli

--- a/.codex/skills/writing-skills
+++ b/.codex/skills/writing-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-skills

--- a/.cursor/skills/gram-playwright-cli
+++ b/.cursor/skills/gram-playwright-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-playwright-cli

--- a/.cursor/skills/writing-skills
+++ b/.cursor/skills/writing-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-skills

--- a/.mise-tasks/skills/recommended.sh
+++ b/.mise-tasks/skills/recommended.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+#MISE description="Install/update the recommended external agent skills from .agents/recommended-skills.json (SHA-pinned, gitignored)"
+#MISE dir="{{ config_root }}"
+
+#USAGE flag "-y --yes" help="Install without prompting (does not persist the USE_RECOMMENDED_SKILLS choice)"
+
+set -euo pipefail
+
+MANIFEST=".agents/recommended-skills.json"
+SKILLS_DIR=".agents/skills"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "No $MANIFEST found"
+  exit 1
+fi
+
+names=$(jq -r '.skills | keys[]' "$MANIFEST")
+if [ -z "$names" ]; then
+  echo "No recommended skills declared in $MANIFEST"
+  exit 0
+fi
+
+if [ "${usage_yes:-false}" != "true" ]; then
+  echo "Recommended agent skills (SHA-pinned, kept out of git; see $MANIFEST):"
+  for name in $names; do
+    echo "  - $name ($(jq -r ".skills[\"$name\"].repo" "$MANIFEST"))"
+  done
+  if command -v gum &> /dev/null; then
+    gum confirm "Install them?" || exit 0
+  else
+    echo -n "Install them? [y/N] "
+    read -r answer
+    [ "$(echo "$answer" | tr '[:upper:]' '[:lower:]')" = "y" ] || exit 0
+  fi
+  # A manual, consented run also persists the choice so skills:sync keeps
+  # the set up to date from now on.
+  mise set --file mise.local.toml USE_RECOMMENDED_SKILLS=true
+fi
+
+# Keep installed skills and their harness symlinks out of git status without
+# touching the committed .gitignore. info/exclude lives in the common git dir,
+# so it covers every worktree of this clone.
+exclude_file="$(git rev-parse --git-common-dir)/info/exclude"
+mkdir -p "$(dirname "$exclude_file")"
+touch "$exclude_file"
+add_exclude() {
+  grep -qxF "$1" "$exclude_file" || echo "$1" >> "$exclude_file"
+}
+
+for name in $names; do
+  repo=$(jq -r ".skills[\"$name\"].repo" "$MANIFEST")
+  ref=$(jq -r ".skills[\"$name\"].ref" "$MANIFEST")
+  path=$(jq -r ".skills[\"$name\"].path" "$MANIFEST")
+  dest="$SKILLS_DIR/$name"
+  marker="$dest/.recommended-ref"
+
+  for p in ".agents/skills/$name/" ".claude/skills/$name" ".codex/skills/$name" ".opencode/skills/$name" ".cursor/skills/$name"; do
+    add_exclude "$p"
+  done
+
+  if [ -f "$marker" ] && [ "$(cat "$marker")" = "$ref" ]; then
+    echo "✅ $name already at ${ref:0:12}"
+    continue
+  fi
+
+  echo "⏳ Fetching $name from $repo@${ref:0:12}"
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  git -C "$tmp" init -q
+  git -C "$tmp" remote add origin "$repo"
+  # GitHub permits shallow fetches of arbitrary commit SHAs.
+  git -C "$tmp" fetch -q --depth 1 origin "$ref"
+  git -C "$tmp" checkout -q FETCH_HEAD -- "$path"
+
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  rsync -a "$tmp/$path/" "$dest/"
+  echo "$ref" > "$marker"
+  rm -rf "$tmp"
+  trap - EXIT
+  echo "✅ Installed $name -> $dest"
+done

--- a/.mise-tasks/skills/sync.sh
+++ b/.mise-tasks/skills/sync.sh
@@ -5,6 +5,12 @@
 
 set -euo pipefail
 
+# Opted-in via ./zero (persisted in mise.local.toml): install/update the
+# SHA-pinned external skill set before linking, so sync keeps it current.
+if [ "${USE_RECOMMENDED_SKILLS:-false}" = "true" ] && [ -f ".agents/recommended-skills.json" ]; then
+  mise run skills:recommended --yes
+fi
+
 SOURCE_DIR=".agents/skills"
 TARGETS=(
   ".claude/skills"
@@ -43,6 +49,10 @@ for target in "${TARGETS[@]}"; do
         continue
       fi
       rm "$link_path"
+    elif [ -e "$link_path" ]; then
+      # Real directory (harness-specific skill, e.g. .claude/skills/datadog-insights)
+      # shadows the shared name; linking into it would nest a stray symlink inside.
+      continue
     fi
 
     ln -s "$rel_target" "$link_path"

--- a/.opencode/skills/gram-playwright-cli
+++ b/.opencode/skills/gram-playwright-cli
@@ -1,0 +1,1 @@
+../../.agents/skills/gram-playwright-cli

--- a/.opencode/skills/writing-skills
+++ b/.opencode/skills/writing-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,8 @@ Activate a skill when your task falls within its scope.
 | `mise-tasks`                      | Creating or editing mise task scripts in `.mise-tasks/`                         |
 | `jaeger`                          | Testing backend endpoints locally and inspecting traces via Jaeger API          |
 | `pitchfork`                       | Starting/stopping/restarting local dev services or querying their logs          |
+| `worktrunk`                       | `wt` worktrees: create/boot/remove stacks, hooks, config (via `./zero` opt-in)  |
+| `writing-skills`                  | Adding or editing an agent skill in `.agents/skills/` and validating it         |
 | `datadog`                         | Investigating errors, performance, incidents, or telemetry via Datadog          |
 | `datadog-insights`                | Running the full Gram production health digest and posting it to Slack          |
 | `spec`                            | Interviewing user in-depth to produce a detailed spec before building           |

--- a/zero
+++ b/zero
@@ -150,6 +150,26 @@ mise run zero:tls
 echo -e "\n⏳ Updating VS Code and Cursor editor settings"
 mise run install:vscode
 
+echo -e "\n⏳ Syncing agent skills"
+# One-time choice, persisted to mise.local.toml; skills:sync installs and
+# keeps the SHA-pinned external set current whenever it is true.
+if ! grep -q 'USE_RECOMMENDED_SKILLS' mise.local.toml 2>/dev/null; then
+    if $agent_mode || $auto_yes; then
+        mise set --file mise.local.toml USE_RECOMMENDED_SKILLS=true
+    else
+        echo "Install recommended agent skills? Third-party, pinned to commit SHAs,"
+        echo "kept out of git (see .agents/recommended-skills.json)."
+        echo -n "[y/N] "
+        read -r answer
+        if [ "$(echo "$answer" | tr '[:upper:]' '[:lower:]')" = "y" ]; then
+            mise set --file mise.local.toml USE_RECOMMENDED_SKILLS=true
+        else
+            mise set --file mise.local.toml USE_RECOMMENDED_SKILLS=false
+        fi
+    fi
+fi
+mise run skills:sync
+
 echo -e "\n⏳ Setting up hooks"
 if $agent_mode; then
     mise run zero:hk --yes


### PR DESCRIPTION
## What

1. **`writing-skills` skill** — how to author repo skills: mechanics (`.agents/skills/<name>/SKILL.md` → `mise run skills:sync` → CLAUDE.md row), frontmatter/description rules, and the required eval loop (baseline failure first, then fresh-context subagent rounds performing the real workflow from the skill alone, until a ship-as-is verdict).
2. **Recommended external skill set** — third-party skills declared in `.agents/recommended-skills.json` (`repo` + absolute commit `ref` + `path` subdirectory) and never committed: `./zero` asks once and persists `USE_RECOMMENDED_SKILLS` into `mise.local.toml`; when true, `mise run skills:sync` installs/updates the set and keeps every installed path out of git via `.git/info/exclude`. First entry: the upstream [worktrunk skill](https://github.com/max-sixty/worktrunk/tree/main/plugins/worktrunk/skills/worktrunk) (MIT/Apache-2.0), which ships its own `reference/` docs and covers the `wt` worktree flow end to end — so no vendored copy of it lives here.
3. `skills:sync` fix — no longer drops a stray nested symlink when a harness-specific skill directory shadows a shared name (e.g. `.claude/skills/feature-flag/feature-flag`).

## Why

Skills were being added by hand (this PR's first draft hand-created one harness symlink and missed the other three), and there was no path for excellent third-party skills short of vendoring them. The worktrunk skill is the motivating case: agents without guidance defaulted to raw `git worktree add` — bare worktrees, leaked compose stacks on teardown.

## Validation

- Subagent eval round on `writing-skills` from a cold context: 9/10 ship-as-is; it also ran the installer live and confirmed the promised git-invisibility.
- Fresh-clone behavioral tests, all passing: flag unset ⇒ sync links repo skills only (no fetch); flag true ⇒ SHA-pinned fetch of the manifest `path` subtree including `reference/` docs; `git status` stays empty post-install; corrupted/stale ref marker ⇒ re-fetch; `USE_RECOMMENDED_SKILLS=false` in `mise.local.toml` ⇒ no fetch.
- Installer is idempotent (SHA marker) and shellcheck-clean; CI (hk formatting, PR title lint) green.

## Notes for reviewers

- `./zero --agent` (and `-y`) opts in automatically; the manifest is committed and SHA-pinned, so what gets fetched is PR-reviewed. Interactive `./zero` asks once and persists either answer.
- Worktree checkouts inherit the choice: `mise.local.toml` is copied by `git:workinit`, and `.git/info/exclude` lives in the common git dir.
