### PR TITLE
feat: add OAuth flow visualization to identity provider and client detail pages

### DIFF
--- a/client/dashboard/src/pages/remote-identity-providers/OAuthFlowDiagram.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/OAuthFlowDiagram.tsx
@@ -1,0 +1,390 @@
+import { cn } from "@/lib/utils";
+import { Badge, Icon, type IconName } from "@speakeasy-api/moonshine";
+import {
+  Background,
+  BaseEdge,
+  Handle,
+  MarkerType,
+  Position,
+  ReactFlow,
+  getBezierPath,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useMemo } from "react";
+
+// Flow tier definitions
+type FlowTier = "issuer" | "client" | "server" | "session";
+
+const FLOW_TIER_LABELS: Record<FlowTier, string> = {
+  issuer: "Identity Provider",
+  client: "OAuth Client",
+  server: "MCP Server",
+  session: "User Session",
+};
+
+const FLOW_TIER_ICONS: Record<FlowTier, IconName> = {
+  issuer: "fingerprint",
+  client: "key",
+  server: "server",
+  session: "users",
+};
+
+const FLOW_TIER_TONES: Record<FlowTier, string> = {
+  issuer: "bg-blue-500/10 text-blue-600 ring-blue-500/20 dark:text-blue-400",
+  client:
+    "bg-purple-500/10 text-purple-600 ring-purple-500/20 dark:text-purple-400",
+  server:
+    "bg-amber-500/10 text-amber-600 ring-amber-500/20 dark:text-amber-400",
+  session:
+    "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-400",
+};
+
+const FLOW_EDGE_COLOR = "var(--color-muted-foreground)";
+const FLOW_EDGE_MARKER = {
+  type: MarkerType.ArrowClosed,
+  width: 9,
+  height: 9,
+  color: FLOW_EDGE_COLOR,
+};
+
+// Node data types
+export type FlowNodeData = {
+  tier: FlowTier;
+  label: string;
+  count?: number;
+  isHighlighted?: boolean;
+  subtitle?: string;
+};
+
+type FlowGraphNode = Node<FlowNodeData>;
+type FlowGraphEdge = Edge<{ animated?: boolean }>;
+
+// Node component
+function FlowNodeCard({ data }: NodeProps<FlowGraphNode>) {
+  const icon = FLOW_TIER_ICONS[data.tier];
+  const tone = FLOW_TIER_TONES[data.tier];
+
+  return (
+    <div
+      className={cn(
+        "bg-card/95 border-border rounded-lg border shadow-sm backdrop-blur",
+        "min-w-40 max-w-48 p-3",
+        data.isHighlighted && "ring-primary/50 ring-2",
+      )}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="border-background! bg-muted-foreground!"
+      />
+      <div className="mb-2 flex items-center gap-2">
+        <div
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md ring-1 ring-inset",
+            tone,
+          )}
+        >
+          <Icon name={icon} className="h-4 w-4" />
+        </div>
+        <div className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+          {FLOW_TIER_LABELS[data.tier]}
+        </div>
+      </div>
+      <div className="truncate text-sm font-semibold" title={data.label}>
+        {data.label}
+      </div>
+      {data.subtitle && (
+        <div
+          className="text-muted-foreground mt-0.5 truncate text-xs"
+          title={data.subtitle}
+        >
+          {data.subtitle}
+        </div>
+      )}
+      {data.count !== undefined && (
+        <div className="mt-2">
+          <Badge variant="neutral" background size="sm">
+            <Badge.Text>
+              {data.count} {data.count === 1 ? "active" : "active"}
+            </Badge.Text>
+          </Badge>
+        </div>
+      )}
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="border-background! bg-muted-foreground!"
+      />
+    </div>
+  );
+}
+
+// Edge component with animation
+function FlowEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}: EdgeProps<FlowGraphEdge>) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <BaseEdge
+      id={id}
+      path={edgePath}
+      className="oauth-flow-edge"
+      style={{
+        stroke: FLOW_EDGE_COLOR,
+        strokeWidth: 1.5,
+        strokeDasharray: data?.animated ? "5 6" : undefined,
+        animation: data?.animated
+          ? "oauth-flow-edge-dash 900ms linear infinite"
+          : undefined,
+      }}
+      markerEnd={`url(#${MarkerType.ArrowClosed})`}
+    />
+  );
+}
+
+const FLOW_NODE_TYPES = { flowNode: FlowNodeCard };
+const FLOW_EDGE_TYPES = { flowEdge: FlowEdge };
+
+// Animation styles
+function FlowEdgeAnimationStyles() {
+  return (
+    <style>{`
+      @keyframes oauth-flow-edge-dash {
+        to {
+          stroke-dashoffset: -11;
+        }
+      }
+
+      .oauth-flow-graph .react-flow__node {
+        pointer-events: auto !important;
+      }
+
+      .oauth-flow-graph .react-flow__handle {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .oauth-flow-edge {
+          animation: none !important;
+        }
+      }
+    `}</style>
+  );
+}
+
+// Layout helpers
+const NODE_WIDTH = 180;
+const NODE_GAP_X = 80;
+
+function layoutNodes(nodes: FlowNodeData[]): FlowGraphNode[] {
+  return nodes.map((data, index) => ({
+    id: `node-${data.tier}`,
+    type: "flowNode",
+    position: { x: index * (NODE_WIDTH + NODE_GAP_X), y: 0 },
+    data,
+  }));
+}
+
+function layoutEdges(nodes: FlowNodeData[]): FlowGraphEdge[] {
+  const edges: FlowGraphEdge[] = [];
+  for (let i = 0; i < nodes.length - 1; i++) {
+    const currentNode = nodes[i];
+    const nextNode = nodes[i + 1];
+    if (currentNode && nextNode) {
+      edges.push({
+        id: `edge-${currentNode.tier}-${nextNode.tier}`,
+        source: `node-${currentNode.tier}`,
+        target: `node-${nextNode.tier}`,
+        type: "flowEdge",
+        data: { animated: true },
+        markerEnd: FLOW_EDGE_MARKER,
+      });
+    }
+  }
+  return edges;
+}
+
+// Props for different flow types
+export type IssuerFlowData = {
+  issuerName: string;
+  issuerUrl: string;
+  clientCount: number;
+  mcpServerCount?: number;
+  sessionCount?: number;
+};
+
+export type ClientFlowData = {
+  issuerName: string;
+  issuerUrl: string;
+  clientName: string;
+  clientId: string;
+  mcpServerCount: number;
+  sessionCount: number;
+};
+
+type OAuthFlowDiagramProps =
+  | {
+      variant: "issuer";
+      data: IssuerFlowData;
+    }
+  | {
+      variant: "client";
+      data: ClientFlowData;
+    };
+
+export function OAuthFlowDiagram({
+  variant,
+  data,
+}: OAuthFlowDiagramProps): JSX.Element {
+  const { nodes, edges } = useMemo(() => {
+    if (variant === "issuer") {
+      const issuerData = data as IssuerFlowData;
+      const nodeData: FlowNodeData[] = [
+        {
+          tier: "issuer",
+          label: issuerData.issuerName,
+          subtitle: issuerData.issuerUrl,
+          isHighlighted: true,
+        },
+        {
+          tier: "client",
+          label:
+            issuerData.clientCount === 1
+              ? "1 OAuth Client"
+              : `${issuerData.clientCount} OAuth Clients`,
+          count:
+            issuerData.clientCount > 0 ? issuerData.clientCount : undefined,
+        },
+        {
+          tier: "server",
+          label:
+            issuerData.mcpServerCount === undefined
+              ? "MCP Servers"
+              : issuerData.mcpServerCount === 1
+                ? "1 MCP Server"
+                : `${issuerData.mcpServerCount} MCP Servers`,
+          count:
+            issuerData.mcpServerCount !== undefined &&
+            issuerData.mcpServerCount > 0
+              ? issuerData.mcpServerCount
+              : undefined,
+        },
+        {
+          tier: "session",
+          label:
+            issuerData.sessionCount === undefined
+              ? "User Sessions"
+              : issuerData.sessionCount === 1
+                ? "1 Session"
+                : `${issuerData.sessionCount} Sessions`,
+          count:
+            issuerData.sessionCount !== undefined && issuerData.sessionCount > 0
+              ? issuerData.sessionCount
+              : undefined,
+        },
+      ];
+      return { nodes: layoutNodes(nodeData), edges: layoutEdges(nodeData) };
+    }
+
+    // Client variant
+    const clientData = data as ClientFlowData;
+    const nodeData: FlowNodeData[] = [
+      {
+        tier: "issuer",
+        label: clientData.issuerName,
+        subtitle: clientData.issuerUrl,
+      },
+      {
+        tier: "client",
+        label: clientData.clientName,
+        subtitle: clientData.clientId,
+        isHighlighted: true,
+      },
+      {
+        tier: "server",
+        label:
+          clientData.mcpServerCount === 1
+            ? "1 MCP Server"
+            : `${clientData.mcpServerCount} MCP Servers`,
+        count:
+          clientData.mcpServerCount > 0 ? clientData.mcpServerCount : undefined,
+      },
+      {
+        tier: "session",
+        label:
+          clientData.sessionCount === 1
+            ? "1 Active Session"
+            : `${clientData.sessionCount} Active Sessions`,
+        count:
+          clientData.sessionCount > 0 ? clientData.sessionCount : undefined,
+      },
+    ];
+    return { nodes: layoutNodes(nodeData), edges: layoutEdges(nodeData) };
+  }, [variant, data]);
+
+  return (
+    <div className="bg-muted/20 h-[140px] overflow-hidden rounded-lg border">
+      <FlowEdgeAnimationStyles />
+      <ReactFlow<FlowGraphNode, FlowGraphEdge>
+        className="oauth-flow-graph"
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={FLOW_NODE_TYPES}
+        edgeTypes={FLOW_EDGE_TYPES}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        minZoom={0.5}
+        maxZoom={1.2}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        panOnScroll={false}
+        panOnDrag={false}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background gap={24} size={1} />
+        <svg>
+          <defs>
+            <marker
+              id={MarkerType.ArrowClosed}
+              viewBox="0 0 10 10"
+              refX="8"
+              refY="5"
+              markerWidth="9"
+              markerHeight="9"
+              orient="auto-start-reverse"
+            >
+              <path
+                d="M 0 0 L 10 5 L 0 10 z"
+                fill={FLOW_EDGE_COLOR}
+                strokeWidth="0"
+              />
+            </marker>
+          </defs>
+        </svg>
+      </ReactFlow>
+    </div>
+  );
+}

--- a/client/dashboard/src/pages/remote-identity-providers/RemoteSessionClientDetail.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/RemoteSessionClientDetail.tsx
@@ -129,7 +129,7 @@ export default function RemoteSessionClientDetail(): JSX.Element {
 
             <div className="mx-auto w-full max-w-[1270px] px-8 py-8">
               <TabsContent value="overview" className="mt-0">
-                {client && <OverviewTab client={client} />}
+                {client && <OverviewTab client={client} issuer={issuer} />}
               </TabsContent>
               <TabsContent value="mcp-servers" className="mt-0">
                 <McpServersTab clientId={clientId} />

--- a/client/dashboard/src/pages/remote-identity-providers/tabs/client/OverviewTab.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/tabs/client/OverviewTab.tsx
@@ -1,39 +1,79 @@
 import type { RemoteSessionClient } from "@gram/client/models/components/remotesessionclient.js";
+import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
+import { useOrganizationRemoteSessionClientMcpServers } from "@gram/client/react-query/organizationRemoteSessionClientMcpServers.js";
+import { useOrganizationRemoteSessionClientSessions } from "@gram/client/react-query/organizationRemoteSessionClientSessions.js";
+import { useMemo } from "react";
+import { remoteSessionClientDisplayName } from "../../clientDisplay";
 import { InfoField, InfoSection, InfoText } from "../../detailFields";
+import { issuerDisplayName } from "../../issuerDisplay";
+import { OAuthFlowDiagram, type ClientFlowData } from "../../OAuthFlowDiagram";
 import { formatTimestamp } from "./formatTimestamp";
 
 export function OverviewTab({
   client,
+  issuer,
 }: {
   client: RemoteSessionClient;
+  issuer: RemoteSessionIssuer | undefined;
 }): JSX.Element {
+  // Fetch MCP servers and sessions for flow counts
+  const { data: mcpServersData } = useOrganizationRemoteSessionClientMcpServers(
+    { clientId: client.id },
+  );
+  const { data: sessionsData } = useOrganizationRemoteSessionClientSessions({
+    clientId: client.id,
+  });
+
+  const flowData: ClientFlowData | null = useMemo(() => {
+    if (!issuer) return null;
+    return {
+      issuerName: issuerDisplayName(issuer),
+      issuerUrl: issuer.issuer,
+      clientName: remoteSessionClientDisplayName(client),
+      clientId: client.clientId,
+      mcpServerCount: mcpServersData?.items?.length ?? 0,
+      sessionCount: sessionsData?.result.items?.length ?? 0,
+    };
+  }, [issuer, client, mcpServersData, sessionsData]);
+
   const scope =
     client.scope && client.scope.length > 0 ? client.scope.join(", ") : "—";
 
   return (
-    <div className="grid max-w-3xl items-start gap-8 sm:grid-cols-2">
-      <InfoSection title="Essentials">
-        <InfoField label="Client ID">
-          <InfoText mono>{client.clientId}</InfoText>
-        </InfoField>
-        <InfoField label="Client Issued At">
-          <InfoText>{formatTimestamp(client.clientIdIssuedAt)}</InfoText>
-        </InfoField>
-      </InfoSection>
+    <div className="max-w-3xl space-y-8">
+      {flowData && (
+        <section>
+          <h3 className="text-muted-foreground mb-3 text-xs font-medium tracking-wide uppercase">
+            OAuth Flow
+          </h3>
+          <OAuthFlowDiagram variant="client" data={flowData} />
+        </section>
+      )}
 
-      <InfoSection title="Details">
-        <InfoField label="Audience">
-          <InfoText mono>{client.audience || "—"}</InfoText>
-        </InfoField>
-        <InfoField label="Scope">
-          <InfoText mono>{scope}</InfoText>
-        </InfoField>
-        <InfoField label="Token Endpoint Authentication Method">
-          <InfoText mono>
-            {client.tokenEndpointAuthMethod ?? "client_secret_basic"}
-          </InfoText>
-        </InfoField>
-      </InfoSection>
+      <div className="grid items-start gap-8 sm:grid-cols-2">
+        <InfoSection title="Essentials">
+          <InfoField label="Client ID">
+            <InfoText mono>{client.clientId}</InfoText>
+          </InfoField>
+          <InfoField label="Client Issued At">
+            <InfoText>{formatTimestamp(client.clientIdIssuedAt)}</InfoText>
+          </InfoField>
+        </InfoSection>
+
+        <InfoSection title="Details">
+          <InfoField label="Audience">
+            <InfoText mono>{client.audience || "—"}</InfoText>
+          </InfoField>
+          <InfoField label="Scope">
+            <InfoText mono>{scope}</InfoText>
+          </InfoField>
+          <InfoField label="Token Endpoint Authentication Method">
+            <InfoText mono>
+              {client.tokenEndpointAuthMethod ?? "client_secret_basic"}
+            </InfoText>
+          </InfoField>
+        </InfoSection>
+      </div>
     </div>
   );
 }

--- a/client/dashboard/src/pages/remote-identity-providers/tabs/issuer/OverviewTab.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/tabs/issuer/OverviewTab.tsx
@@ -2,10 +2,13 @@ import { useOrganization } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
 import { useListProjects } from "@gram/client/react-query/listProjects.js";
-import type { ReactNode } from "react";
+import { useOrganizationRemoteSessionClients } from "@gram/client/react-query/organizationRemoteSessionClients.js";
+import { useMemo, type ReactNode } from "react";
 import { Link } from "react-router";
 import { InfoField, InfoSection, InfoText } from "../../detailFields";
 import { isAbsoluteHttpUrl } from "../../issuerDocumentationLinks";
+import { issuerDisplayName } from "../../issuerDisplay";
+import { OAuthFlowDiagram, type IssuerFlowData } from "../../OAuthFlowDiagram";
 
 // ProjectValue renders the owning project for an issuer: "—" for an
 // organizational issuer (no project_id), otherwise the project's slug linked to
@@ -74,6 +77,34 @@ export function OverviewTab({
 }: {
   issuer: RemoteSessionIssuer;
 }): JSX.Element {
+  // Fetch clients to aggregate counts for the flow diagram
+  const { data: clientsData } = useOrganizationRemoteSessionClients({
+    issuerId: issuer.id,
+  });
+
+  // Aggregate counts across all clients
+  const flowCounts = useMemo(() => {
+    const clients = clientsData?.result.items ?? [];
+    const clientCount = clients.length;
+    const mcpServerCount = clients.reduce(
+      (sum, c) => sum + c.mcpServerCount,
+      0,
+    );
+    const sessionCount = clients.reduce(
+      (sum, c) => sum + c.activeSessionCount,
+      0,
+    );
+    return { clientCount, mcpServerCount, sessionCount };
+  }, [clientsData]);
+
+  const flowData: IssuerFlowData = {
+    issuerName: issuerDisplayName(issuer),
+    issuerUrl: issuer.issuer,
+    clientCount: flowCounts.clientCount,
+    mcpServerCount: flowCounts.mcpServerCount,
+    sessionCount: flowCounts.sessionCount,
+  };
+
   const endpoint = (value: string | undefined): ReactNode => (
     <InfoText mono>{value || "—"}</InfoText>
   );
@@ -88,6 +119,12 @@ export function OverviewTab({
 
   return (
     <div className="max-w-3xl space-y-8">
+      <section>
+        <h3 className="text-muted-foreground mb-3 text-xs font-medium tracking-wide uppercase">
+          OAuth Flow
+        </h3>
+        <OAuthFlowDiagram variant="issuer" data={flowData} />
+      </section>
       <div className="grid items-start gap-8 sm:grid-cols-2">
         <InfoSection title="Essentials">
           <InfoField label="Name">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds a visual flow diagram to the Remote Identity Providers and OAuth Client detail pages, making the OAuth authentication chain from identity provider to user session visually clear.

## Changes

### New Component: `OAuthFlowDiagram.tsx`

A reusable React Flow-based component that visualizes the OAuth authentication chain:

```
Identity Provider → OAuth Client → MCP Server → User Session
```

**Features:**
- Built with `@xyflow/react` following the existing pattern from `InsightsEmployeeDetail.tsx`
- Animated dashed edges flowing left-to-right
- Color-coded nodes for each tier:
  - **Blue** - Identity Provider
  - **Purple** - OAuth Client
  - **Amber** - MCP Server
  - **Emerald** - User Session
- Highlighted node indicates the current detail page context
- Shows active counts for each tier when data is available
- Respects `prefers-reduced-motion` for accessibility

### Integration

**Issuer Detail Page (Overview Tab):**
- Shows the issuer highlighted with aggregated counts across all clients
- Fetches client data to display total MCP servers and sessions

**Client Detail Page (Overview Tab):**
- Shows the specific client highlighted with its MCP servers and sessions
- Parent page passes issuer data for the flow context

## Screenshots

The flow diagram appears at the top of the Overview tab on both detail pages, providing immediate visual context for how the OAuth components relate to each other.

## Testing

- ✅ TypeScript compiles without errors
- ✅ ESLint/formatting passes
- ✅ Manual verification via `computerUse` subagent confirmed the pages load correctly

## Related Issue

Closes AIS-399
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-399](https://linear.app/speakeasy/issue/AIS-399/feat-improve-ux-for-identity-provider-and-session-pages)

<div><a href="https://cursor.com/agents/bc-1e98cc3e-5f7c-4def-8963-ecf09015cc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e98cc3e-5f7c-4def-8963-ecf09015cc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OAuth flow diagram to the Identity Provider and OAuth Client Overview tabs to visualize provider → client → MCP server → session at a glance. Fulfills the UX improvement in AIS-399.

- **New Features**
  - Reusable `OAuthFlowDiagram.tsx` built on `@xyflow/react`; color-coded nodes, animated edges; respects `prefers-reduced-motion`.
  - Issuer Overview highlights the issuer and aggregates client, MCP server, and session counts.
  - Client Overview highlights the client with issuer context and shows MCP server and active session counts.

<sup>Written for commit 07c8e63c9bd915f20a2108469ea936f2284dc814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

