### PR TITLE
fix: decode Drata session listings with numeric ids

### DIFF
--- a/.changeset/drata-session-list-decode.md
+++ b/.changeset/drata-session-list-decode.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix the Drata evidence push failing to decode the session listing: the production API returns numeric session ids inside a data/pagination envelope, which the stranded-session sweep decoded as strings and then misreported via a bare-array fallback. The sweep now tolerates numeric or string ids, treats a null/absent data field as an empty sweep, and reports the envelope's real decode error.

--- a/.changeset/drata-session-list-decode.md
+++ b/.changeset/drata-session-list-decode.md
@@ -2,4 +2,4 @@
 "server": patch
 ---
 
-Fix the Drata evidence push failing to decode the session listing: the production API returns numeric session ids inside a data/pagination envelope, which the stranded-session sweep decoded as strings and then misreported via a bare-array fallback. The sweep now tolerates numeric or string ids, treats a null/absent data field as an empty sweep, and reports the envelope's real decode error.
+Fix three Drata evidence-push defects found running against the live API. The stranded-session sweep failed to decode the session listing (Drata returns numeric session ids inside a data/pagination envelope; the sweep decoded them as strings and misreported the failure via a bare-array fallback) — session ids now tolerate numbers or strings, a null/absent data field counts as an empty sweep, and the envelope's real decode error surfaces. An empty fleet now clears evidence by deleting records directly, because Drata refuses to complete a session with no records. Per-record schema-validation rejections hidden inside 2xx upload responses now fail the push instead of silently publishing a partial fleet.

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -218,15 +218,32 @@ func (s *sink) doJSON(ctx context.Context, creds providers.Credentials, method, 
 // flexID tolerates Drata serializing ids as JSON numbers or strings. The
 // reference documents resource ids as numbers, and session listings have been
 // observed carrying numeric "id" fields in production — but a string-typed id
-// must not permanently brick the integration either way.
+// must not permanently brick the integration either way. Only strings,
+// numbers, and null decode; any other JSON value fails the surrounding
+// decode loudly, because these ids become URL path segments (resource and
+// session-cancel requests) and a mangled composite value must not turn into
+// a bogus API call.
 type flexID string
 
 func (r *flexID) UnmarshalJSON(data []byte) error {
-	trimmed := strings.Trim(strings.TrimSpace(string(data)), `"`)
-	if trimmed == "null" {
-		trimmed = ""
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		*r = ""
+		return nil
 	}
-	*r = flexID(trimmed)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return fmt.Errorf("decode id: %w", err)
+		}
+		*r = flexID(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(trimmed, &n); err != nil {
+		return fmt.Errorf("decode id: %w", err)
+	}
+	*r = flexID(n)
 	return nil
 }
 

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -433,13 +433,31 @@ func checkUploadResults(body []byte) error {
 	return nil
 }
 
-// deleteAllRecords clears the resource's live records one by one. It exists
-// because sessions cannot express an empty fleet (completion of an empty
-// session is refused), so this is the only truthful path when every device
-// has departed. Each pass re-lists the first page and deletes what it finds,
-// so cursor semantics never matter: the loop drains the list or reports the
-// first failure.
-func (s *sink) deleteAllRecords(ctx context.Context, creds providers.Credentials, resourcePath string) error {
+// clearEvidenceRecords deletes every live record on the resource, one by one.
+//
+// DESTRUCTIVE — read before calling. This removes the connection's entire
+// evidence dataset. It is safe only because of three invariants, and a new
+// call site must re-justify all of them:
+//
+//  1. It expresses a truthful state, not a cleanup: it is called only when a
+//     completed inventory sync reported zero managed devices, so "no
+//     evidence" IS the correct evidence. Mark-missing is completion-gated
+//     upstream, so a failed or partial MDM sync can never produce the empty
+//     snapshot that reaches here.
+//  2. It only ever touches data this integration owns: resolveResourceID
+//     refuses any connection carrying more than one resource, so the
+//     resource being cleared holds nothing but records earlier pushes wrote.
+//  3. It is the N=0 case of the deletion every ordinary push already
+//     performs — completing a session deletes all records not in it — and
+//     exists only because the production API refuses to complete an empty
+//     session (422 "Cannot complete a session with no data records"), making
+//     this the one snapshot size sessions cannot express. A later non-empty
+//     push fully restores the dataset, so the operation is self-correcting.
+//
+// Each pass re-lists the first page and deletes what it finds, so cursor
+// semantics never matter: the loop drains the list or reports the first
+// failure.
+func (s *sink) clearEvidenceRecords(ctx context.Context, creds providers.Credentials, resourcePath string) error {
 	deleted := make(map[string]bool)
 	for {
 		body, err := s.doJSON(ctx, creds, http.MethodGet, resourcePath+"/records", nil)
@@ -521,8 +539,9 @@ func (s *sink) PushCoverage(ctx context.Context, creds providers.Credentials, se
 		// the completing action with 422 "Cannot complete a session with no
 		// data records". Stale evidence still has to clear — a departed
 		// fleet must not keep attesting — so the truthful empty state is
-		// reached by deleting the live records directly.
-		if err := s.deleteAllRecords(ctx, creds, resourcePath); err != nil {
+		// reached by deleting the live records directly. See the invariants
+		// on clearEvidenceRecords before touching this path.
+		if err := s.clearEvidenceRecords(ctx, creds, resourcePath); err != nil {
 			return fmt.Errorf("clear evidence for empty fleet: %w", err)
 		}
 		return nil

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -34,10 +34,12 @@
 //
 // Endpoints used (all under the region's public API base URL):
 //
-//	GET  /public/v2/custom-connections/{id}?expand[]=customResources — connection test + resource discovery
-//	GET  /public/v2/custom-connections/{id}/resources/{rid}/sessions?status=IN_PROGRESS — stranded-session sweep
-//	POST /public/v2/custom-connections/{id}/resources/{rid}/sessions/{sid} — batched record upload
-//	POST /public/v2/custom-connections/{id}/resources/{rid}/sessions/{sid}/actions — cancel a strand, then complete the session
+//	GET    /public/v2/custom-connections/{id}?expand[]=customResources — connection test + resource discovery
+//	GET    /public/v2/custom-connections/{id}/resources/{rid}/sessions?status=IN_PROGRESS — stranded-session sweep
+//	POST   /public/v2/custom-connections/{id}/resources/{rid}/sessions/{sid} — batched record upload
+//	POST   /public/v2/custom-connections/{id}/resources/{rid}/sessions/{sid}/actions — cancel a strand, then complete the session
+//	GET    /public/v2/custom-connections/{id}/resources/{rid}/records — enumerate live records (empty-fleet clear)
+//	DELETE /public/v2/custom-connections/{id}/resources/{rid}/records/{recordId} — delete one record (empty-fleet clear)
 //
 // Sessions give true snapshot-replace semantics: completing a session makes
 // it the authoritative dataset and Drata deletes every record not in it, so
@@ -392,6 +394,88 @@ func buildRecords(snapshot providers.CoverageSnapshot) []coverageRecord {
 	return records
 }
 
+// checkUploadResults surfaces per-record rejections hidden inside a 2xx
+// upload response. The observed shape is a bare array of per-record results;
+// a rejected record carries an "error" object (with the schema-validation
+// message) while its top-level "statusCode" still reads 201, so the error
+// field is the only reliable discriminator. Unknown response shapes pass:
+// the 2xx already says the request itself succeeded, and failing on a shape
+// change would break pushes that worked.
+func checkUploadResults(body []byte) error {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil
+	}
+	var results []struct {
+		ID    string `json:"id"`
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(trimmed, &results); err != nil {
+		return nil
+	}
+	for _, r := range results {
+		if r.Error == nil {
+			continue
+		}
+		// Rejected results have been observed carrying the record only under
+		// "data", so fall back there for the id naming the failure.
+		id := r.ID
+		if id == "" {
+			id = r.Data.ID
+		}
+		return fmt.Errorf("record %q rejected: %s", id, r.Error.Message)
+	}
+	return nil
+}
+
+// deleteAllRecords clears the resource's live records one by one. It exists
+// because sessions cannot express an empty fleet (completion of an empty
+// session is refused), so this is the only truthful path when every device
+// has departed. Each pass re-lists the first page and deletes what it finds,
+// so cursor semantics never matter: the loop drains the list or reports the
+// first failure.
+func (s *sink) deleteAllRecords(ctx context.Context, creds providers.Credentials, resourcePath string) error {
+	deleted := make(map[string]bool)
+	for {
+		body, err := s.doJSON(ctx, creds, http.MethodGet, resourcePath+"/records", nil)
+		if err != nil {
+			return err
+		}
+		var page struct {
+			Data []struct {
+				ID flexID `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &page); err != nil {
+			return fmt.Errorf("decode record list: %w", err)
+		}
+		if len(page.Data) == 0 {
+			return nil
+		}
+		for _, rec := range page.Data {
+			id := string(rec.ID)
+			if id == "" {
+				return fmt.Errorf("record listed with no id")
+			}
+			// A re-listed id whose delete already returned success means
+			// deletes are not taking effect; erroring out beats spinning
+			// on the listing forever.
+			if deleted[id] {
+				return fmt.Errorf("record %q reappeared after deletion", id)
+			}
+			if _, err := s.doJSON(ctx, creds, http.MethodDelete, resourcePath+"/records/"+url.PathEscape(id), nil); err != nil {
+				return fmt.Errorf("delete stale record: %w", err)
+			}
+			deleted[id] = true
+		}
+	}
+}
+
 // PushCoverage replaces the connection's evidence with the snapshot: batched
 // uploads into a fresh session, then a completing action that makes the
 // session authoritative (Drata deletes everything not in it).
@@ -433,15 +517,26 @@ func (s *sink) PushCoverage(ctx context.Context, creds providers.Credentials, se
 	// completion publishes each id once.
 	records := buildRecords(snapshot)
 	if len(records) == 0 {
-		// An empty fleet still pushes: sessions are created implicitly by
-		// their first upload, so one empty batch makes the session exist,
-		// and completing it clears stale evidence — the truthful state.
-		if _, err := s.doJSON(ctx, creds, http.MethodPost, sessionPath, map[string]any{"data": []coverageRecord{}}); err != nil {
-			return fmt.Errorf("upload evidence batch: %w", err)
+		// Sessions cannot express an empty fleet: the production API refuses
+		// the completing action with 422 "Cannot complete a session with no
+		// data records". Stale evidence still has to clear — a departed
+		// fleet must not keep attesting — so the truthful empty state is
+		// reached by deleting the live records directly.
+		if err := s.deleteAllRecords(ctx, creds, resourcePath); err != nil {
+			return fmt.Errorf("clear evidence for empty fleet: %w", err)
 		}
+		return nil
 	}
 	for batch := range slices.Chunk(records, recordBatchSize) {
-		if _, err := s.doJSON(ctx, creds, http.MethodPost, sessionPath, map[string]any{"data": batch}); err != nil {
+		body, err := s.doJSON(ctx, creds, http.MethodPost, sessionPath, map[string]any{"data": batch})
+		if err != nil {
+			return fmt.Errorf("upload evidence batch: %w", err)
+		}
+		// A 2xx upload can still reject records: the response carries a
+		// per-record result whose "error" field reports schema-validation
+		// failures. Ignoring those would complete a session missing part of
+		// the fleet — or, for a wholly rejected batch, publish an empty one.
+		if err := checkUploadResults(body); err != nil {
 			return fmt.Errorf("upload evidence batch: %w", err)
 		}
 	}

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -213,17 +213,18 @@ func (s *sink) doJSON(ctx context.Context, creds providers.Credentials, method, 
 	return respBody, nil
 }
 
-// resourceID tolerates Drata serializing resource ids as JSON numbers or
-// strings — the reference documents numbers, but a string-typed id must not
-// permanently brick the integration.
-type resourceID string
+// flexID tolerates Drata serializing ids as JSON numbers or strings. The
+// reference documents resource ids as numbers, and session listings have been
+// observed carrying numeric "id" fields in production — but a string-typed id
+// must not permanently brick the integration either way.
+type flexID string
 
-func (r *resourceID) UnmarshalJSON(data []byte) error {
+func (r *flexID) UnmarshalJSON(data []byte) error {
 	trimmed := strings.Trim(strings.TrimSpace(string(data)), `"`)
 	if trimmed == "null" {
 		trimmed = ""
 	}
-	*r = resourceID(trimmed)
+	*r = flexID(trimmed)
 	return nil
 }
 
@@ -242,7 +243,7 @@ func (s *sink) resolveResourceID(ctx context.Context, creds providers.Credential
 
 	var connection struct {
 		CustomResources []struct {
-			ID resourceID `json:"id"`
+			ID flexID `json:"id"`
 		} `json:"customResources"`
 	}
 	if err := json.Unmarshal(body, &connection); err != nil {
@@ -261,14 +262,16 @@ func (s *sink) resolveResourceID(ctx context.Context, creds providers.Credential
 	return id, nil
 }
 
-// sessionRef is one entry of the session list. Drata documents neither the
-// envelope nor the item shape for this endpoint, so both are decoded
-// permissively: the id is read from "sessionId" (the field the documented
-// action response carries) or "id", and the status is required rather than
-// assumed.
+// sessionRef is one entry of the session list. Drata does not document this
+// endpoint's shapes; the production API has been observed returning a
+// {"data": [...], "pagination": {...}} envelope whose items carry a numeric
+// "id" alongside the caller-chosen string "sessionId" — hence flexID — so
+// both fields are decoded and the id is read from "sessionId" (the field the
+// documented action response carries) or "id". The status is required rather
+// than assumed.
 type sessionRef struct {
 	SessionID string `json:"sessionId"`
-	ID        string `json:"id"`
+	ID        flexID `json:"id"`
 	Status    string `json:"status"`
 }
 
@@ -276,7 +279,7 @@ func (r sessionRef) identifier() string {
 	if r.SessionID != "" {
 		return r.SessionID
 	}
-	return r.ID
+	return string(r.ID)
 }
 
 // cancelStrandedSessions cancels every IN_PROGRESS session on the resource,
@@ -293,21 +296,35 @@ func (s *sink) cancelStrandedSessions(ctx context.Context, creds providers.Crede
 		return err
 	}
 
-	var envelope struct {
-		Data []sessionRef `json:"data"`
-	}
+	// The observed response is a {"data": [...]} envelope; a bare array is
+	// tolerated in case the shape changes. The branch is picked by looking at
+	// the payload, not by trying one decode and falling back on error — a
+	// fallback would swallow the envelope's real decode error (e.g. an
+	// unexpected field type) and report a useless "cannot unmarshal object
+	// into []sessionRef" instead.
 	var sessions []sessionRef
-	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Data != nil {
+	if trimmed := bytes.TrimSpace(body); len(trimmed) > 0 && trimmed[0] == '[' {
+		if err := json.Unmarshal(trimmed, &sessions); err != nil {
+			return fmt.Errorf("decode session list: %w", err)
+		}
+	} else {
+		var envelope struct {
+			Data []sessionRef `json:"data"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			return fmt.Errorf("decode session list: %w", err)
+		}
+		// A null or absent "data" is an empty sweep, not an error.
 		sessions = envelope.Data
-	} else if err := json.Unmarshal(body, &sessions); err != nil {
-		return fmt.Errorf("decode session list: %w", err)
 	}
 
 	for _, sess := range sessions {
-		// The status filter is re-checked here rather than trusted. An API
-		// that ignored an unknown query param would hand back ACTIVE
-		// sessions too, and cancelling one of those would destroy the live
-		// evidence this integration exists to publish.
+		// The status filter is re-checked here rather than trusted, and that
+		// is load-bearing: the production API has been observed ignoring the
+		// status query param entirely (returning CANCELED sessions). An API
+		// handing back ACTIVE sessions the same way would otherwise get them
+		// cancelled — destroying the live evidence this integration exists
+		// to publish.
 		if sess.Status != sessionStatusInProgress {
 			continue
 		}

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -587,6 +587,30 @@ func TestStrandedSweepDecodesSessionListShapes(t *testing.T) {
 	}
 }
 
+// TestFlexIDAcceptsOnlyScalarIDs pins the decode boundary: ids become URL
+// path segments (resource and session-cancel requests), so a non-scalar id
+// must fail the decode loudly rather than serialize into a bogus API call.
+func TestFlexIDAcceptsOnlyScalarIDs(t *testing.T) {
+	t.Parallel()
+
+	var ref sessionRef
+	require.Error(t, json.Unmarshal([]byte(`{"id": {"nested": 1}}`), &ref))
+	require.Error(t, json.Unmarshal([]byte(`{"id": true}`), &ref))
+	require.Error(t, json.Unmarshal([]byte(`{"id": ["7"]}`), &ref))
+
+	var quoted sessionRef
+	require.NoError(t, json.Unmarshal([]byte(`{"id": "a\"b"}`), &quoted))
+	require.Equal(t, `a"b`, string(quoted.ID), "string escapes decode as JSON, not by quote-trimming")
+
+	var numeric sessionRef
+	require.NoError(t, json.Unmarshal([]byte(`{"id": 42}`), &numeric))
+	require.Equal(t, "42", string(numeric.ID))
+
+	var null sessionRef
+	require.NoError(t, json.Unmarshal([]byte(`{"id": null}`), &null))
+	require.Empty(t, string(null.ID))
+}
+
 func TestPushRecoversAfterPartialFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -46,6 +46,10 @@ type fakeDrata struct {
 	// failComplete rejects the completing action, stranding the session
 	// mid-push the way a crashed or timed-out run does.
 	failComplete bool
+	// rejectRecordID makes the upload endpoint reject that record the way
+	// the real API rejects a schema-validation failure: the response stays
+	// 2xx and the rejection rides in the per-record result's "error" field.
+	rejectRecordID string
 	// records is the authoritative dataset: replaced wholesale when a
 	// session completes, exactly like the real API.
 	records []map[string]any
@@ -53,6 +57,9 @@ type fakeDrata struct {
 	uploadRequests int
 	completed      []string
 	canceled       []string
+	// deletedRecords logs ids removed via the record-delete endpoint, the
+	// empty-fleet clear path.
+	deletedRecords []string
 
 	server *httptest.Server
 }
@@ -68,10 +75,12 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 		sessionStatus:      map[string]string{},
 		ignoreStatusFilter: false,
 		failComplete:       false,
+		rejectRecordID:     "",
 		records:            nil,
 		uploadRequests:     0,
 		completed:          nil,
 		canceled:           nil,
+		deletedRecords:     nil,
 		server:             nil,
 	}
 
@@ -158,6 +167,14 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			if len(uploaded) == 0 {
+				// Mirrors production: completing a session with no records is
+				// refused with 422 "Cannot complete a session with no data
+				// records" — which is why the empty-fleet path must delete
+				// records instead of pushing an empty session.
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				return
+			}
 			// Completion makes the session the authoritative dataset.
 			f.records = uploaded
 			f.sessionStatus[sessionID] = "ACTIVE"
@@ -187,15 +204,72 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 				return
 			}
 		}
+		// Per-record results mirror the real response: overall 2xx with a
+		// bare array whose rejected entries carry an "error" object (their
+		// statusCode still reads 201) and the record only under "data".
+		// Rejected records are not staged into the session.
+		results := make([]string, 0, len(payload.Data))
+		accepted := make([]map[string]any, 0, len(payload.Data))
+		for _, rec := range payload.Data {
+			id, _ := rec["id"].(string)
+			if f.rejectRecordID != "" && id == f.rejectRecordID {
+				results = append(results, fmt.Sprintf(`{"statusCode": 201, "error": {"message": "Schema validation failed for data", "code": 28022}, "data": {"id": %q}}`, id))
+				continue
+			}
+			results = append(results, fmt.Sprintf(`{"id": %q, "statusCode": 201, "data": {"id": %q}}`, id, id))
+			accepted = append(accepted, rec)
+		}
 		// Assignment (not just append) so an empty first upload still
 		// creates the session, mirroring implicit session creation.
-		f.sessions[rest] = append(f.sessions[rest], payload.Data...)
+		f.sessions[rest] = append(f.sessions[rest], accepted...)
 		if _, seen := f.sessionStatus[rest]; !seen {
 			f.sessionStatus[rest] = "IN_PROGRESS"
 		}
 		f.uploadRequests++
 		f.mu.Unlock()
-		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, "[%s]", strings.Join(results, ","))
+	})
+
+	recordsBase := connBase + "/resources/" + testResourceID + "/records"
+	mux.HandleFunc(recordsBase, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(f.t, http.MethodGet, r.Method)
+		if !f.authorized(w, r) {
+			return
+		}
+		f.mu.Lock()
+		items := make([]string, 0, len(f.records))
+		for _, rec := range f.records {
+			items = append(items, fmt.Sprintf(`{"id": %q, "data": {"id": %q}}`, rec["id"], rec["id"]))
+		}
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"data": [%s], "pagination": {"cursor": null}}`, strings.Join(items, ","))
+	})
+	mux.HandleFunc(recordsBase+"/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(f.t, http.MethodDelete, r.Method)
+		if !f.authorized(w, r) {
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, recordsBase+"/")
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		kept := make([]map[string]any, 0, len(f.records))
+		found := false
+		for _, rec := range f.records {
+			if !found && rec["id"] == id {
+				found = true
+				continue
+			}
+			kept = append(kept, rec)
+		}
+		if !found {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		f.records = kept
+		f.deletedRecords = append(f.deletedRecords, id)
+		w.WriteHeader(http.StatusNoContent)
 	})
 
 	f.server = httptest.NewTLSServer(mux)
@@ -309,6 +383,28 @@ func TestPushCoverageEmptyFleetClearsEvidence(t *testing.T) {
 	empty.GeneratedAt = empty.GeneratedAt.Add(time.Hour)
 	require.NoError(t, s.PushCoverage(t.Context(), fake.creds(), fake.settings(), empty))
 	require.Empty(t, fake.records, "an empty fleet replaces stale evidence with the truthful empty set")
+	require.Len(t, fake.deletedRecords, 4, "the empty fleet clears via record deletion — the API refuses to complete an empty session")
+	require.Len(t, fake.completed, 1, "only the initial non-empty push completes a session")
+}
+
+// TestPushSurfacesPerRecordRejection pins the trap where an upload's 2xx
+// response hides schema-validation rejections in per-record results: a push
+// that ignored them would complete a session missing part of the fleet and
+// publish it as the authoritative dataset.
+func TestPushSurfacesPerRecordRejection(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrata(t)
+	s := fake.newSink(t)
+
+	fake.mu.Lock()
+	fake.rejectRecordID = "dev-0002"
+	fake.mu.Unlock()
+
+	err := s.PushCoverage(t.Context(), fake.creds(), fake.settings(), snapshotOf(3))
+	require.ErrorContains(t, err, "dev-0002")
+	require.ErrorContains(t, err, "Schema validation failed")
+	require.Empty(t, fake.completed, "a partially rejected upload must not publish the session")
 }
 
 func TestTestConnection(t *testing.T) {

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -89,15 +89,19 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 		}
 		wanted := r.URL.Query().Get("status")
 		f.mu.Lock()
+		// Items mirror the shape observed from the production API: a numeric
+		// "id" alongside the caller-chosen "sessionId", extra timestamp
+		// fields, and a pagination envelope. The provider once decoded "id"
+		// as a string and the mismatch broke every push.
 		listed := make([]string, 0, len(f.sessionStatus))
 		for id, status := range f.sessionStatus {
 			if f.ignoreStatusFilter || wanted == "" || status == wanted {
-				listed = append(listed, fmt.Sprintf(`{"sessionId": %q, "status": %q}`, id, status))
+				listed = append(listed, fmt.Sprintf(`{"id": %d, "sessionId": %q, "status": %q, "activatedAt": null}`, len(listed)+1, id, status))
 			}
 		}
 		f.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"data": [%s]}`, strings.Join(listed, ","))
+		_, _ = fmt.Fprintf(w, `{"data": [%s], "pagination": {"cursor": null}}`, strings.Join(listed, ","))
 	})
 	mux.HandleFunc(connBase, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(f.t, http.MethodGet, r.Method)
@@ -420,6 +424,71 @@ func TestPushCancelsStrandedSession(t *testing.T) {
 	require.Len(t, fake.completed, 1)
 	require.NotContains(t, fake.completed, "gram-stranded")
 	require.Len(t, fake.records, 2, "the live dataset is the new snapshot alone")
+}
+
+// TestStrandedSweepDecodesSessionListShapes pins the sweep's decode against
+// the response shapes the endpoint is undocumented enough to serve. The
+// production API returns numeric session "id"s inside a data/pagination
+// envelope — decoding "id" as a string once broke every push — and an empty
+// sweep may surface as data: null or a missing data key rather than [].
+func TestStrandedSweepDecodesSessionListShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		// wantCancel is the session identifier the sweep must cancel, or ""
+		// when the listing holds nothing cancellable.
+		wantCancel string
+	}{
+		{name: "envelope with null data", body: `{"data": null, "pagination": {"cursor": null}}`, wantCancel: ""},
+		{name: "envelope without data key", body: `{"pagination": {"cursor": null}}`, wantCancel: ""},
+		{name: "bare empty array", body: `[]`, wantCancel: ""},
+		{name: "bare array with a strand", body: `[{"sessionId": "gram-old", "status": "IN_PROGRESS"}]`, wantCancel: "gram-old"},
+		{
+			name:       "production envelope shape",
+			body:       `{"data": [{"id": 2, "sessionId": "gram-old", "status": "IN_PROGRESS", "createdAt": "2026-07-30T16:55:20.756Z", "activatedAt": null}], "pagination": {"cursor": null}}`,
+			wantCancel: "gram-old",
+		},
+		{
+			// No sessionId at all: the identifier must fall back to the
+			// numeric id, stringified, because it names the cancel URL.
+			name:       "numeric id only",
+			body:       `{"data": [{"id": 7, "status": "IN_PROGRESS"}]}`,
+			wantCancel: "7",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var canceled []string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/resource/sessions", func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "IN_PROGRESS", r.URL.Query().Get("status"))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, tc.body)
+			})
+			mux.HandleFunc("/resource/sessions/", func(w http.ResponseWriter, r *http.Request) {
+				id, ok := strings.CutSuffix(strings.TrimPrefix(r.URL.Path, "/resource/sessions/"), "/actions")
+				assert.True(t, ok, "only action posts are expected here")
+				canceled = append(canceled, id)
+				w.WriteHeader(http.StatusCreated)
+			})
+			server := httptest.NewTLSServer(mux)
+			t.Cleanup(server.Close)
+
+			s := &sink{client: server.Client(), regions: map[string]string{"us": server.URL}}
+			require.NoError(t, s.cancelStrandedSessions(t.Context(), providers.Credentials{fieldAPIKey: "k"}, server.URL+"/resource"))
+
+			if tc.wantCancel == "" {
+				require.Empty(t, canceled)
+			} else {
+				require.Equal(t, []string{tc.wantCancel}, canceled)
+			}
+		})
+	}
 }
 
 func TestPushRecoversAfterPartialFailure(t *testing.T) {


### PR DESCRIPTION
## What

Live Drata evidence pushes fail with `push coverage: clear stranded drata session: decode session list: json: cannot unmarshal object into Go value of type []drata.sessionRef`.

The stranded-session sweep declared `sessionRef.ID` as a string, but Drata's (undocumented) session-list endpoint returns **numeric** ids:

```json
{"data":[{"id":2,"sessionId":"gram-...","status":"CANCELED",...}],"pagination":{"cursor":null}}
```

The envelope decode failed on the number→string mismatch, and the bare-array fallback then masked the real error with the misleading one above. Every push hit this, because the sweep runs first.

## Fix

- Session ids now use the same tolerant number-or-string decoding (`flexID`) that resource ids already had — the identical trap, anticipated once but not extended.
- The decode branch (envelope vs bare array) is picked by payload shape instead of try-and-fall-back, so a decode failure reports the envelope's real error; a `null`/absent `data` field counts as an empty sweep.
- The test fake now serves the observed production shape (numeric `id`, extra fields, pagination envelope), plus a table test pinning all tolerated shapes — including the numeric-id-only fallback that names the cancel URL.

Also verified live: the endpoint **ignores** the `?status=IN_PROGRESS` filter (it returned a `CANCELED` session), so the sweep's in-loop status re-check is load-bearing; the comment now records that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Drata evidence pushes by decoding session listings with numeric IDs, clearing empty fleets by deleting records, and failing pushes when uploads reject records. Also tightens ID decoding to accept only scalar JSON values to avoid bogus API calls.

- **Bug Fixes**
  - Decode session lists with numeric or string IDs via `flexID`; choose envelope vs array by payload shape; treat null/missing `data` as empty and surface real decode errors.
  - Restrict `flexID` to scalar JSON IDs (string/number/null); reject object/array/bool values and decode string escapes correctly to prevent malformed path segments.
  - Clear empty fleets by listing and deleting `/records` via `clearEvidenceRecords` (sessions cannot complete with no records).
  - Parse per-record upload results; if any record has an `error`, fail the push with the schema message instead of publishing a partial dataset.

<sup>Written for commit 13508448f52c9097981bea7cad8b6da4635811ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

