### PR TITLE
feat: proxy mcp client info and oauth client ID to Gram functions

### DIFF
--- a/.changeset/fifty-places-wonder.md
+++ b/.changeset/fifty-places-wonder.md
@@ -1,0 +1,7 @@
+---
+"@gram-ai/functions": minor
+"function-runners": minor
+"server": minor
+---
+
+Expose MCP Client Metadata to Gram Functions tool calls

--- a/functions/internal/javascript/gram-start.mjs
+++ b/functions/internal/javascript/gram-start.mjs
@@ -96,11 +96,87 @@ class FunctionsError extends Error {
 }
 
 /**
+ * Identity of the MCP client that made a tool call, as reported by the client
+ * itself.
+ *
+ * @typedef {{ name: string, version: string }} MCPClientInfo
+ */
+
+/**
+ * Per-call metadata about the caller, keyed the way MCP keys request `_meta`.
+ *
+ * @typedef {{
+ *   "io.modelcontextprotocol/clientInfo"?: MCPClientInfo,
+ *   "gram.ai/oauth-client-id"?: string,
+ * }} ToolCallMeta
+ */
+
+/**
+ * Coerce an untrusted client identity into an `MCPClientInfo`. Returns
+ * undefined unless a non-empty `name` string is present; `version` defaults to
+ * "" so a client that reports only a name is still usable. Mirrors the
+ * normalization `@gram-ai/functions` applies when a function serves MCP
+ * itself.
+ *
+ * @param {unknown} value
+ * @returns {MCPClientInfo | undefined}
+ */
+function normalizeClientInfo(value) {
+  if (value == null || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = /** @type {Record<string, unknown>} */ (value);
+  const name = record["name"];
+  if (typeof name !== "string" || name === "") {
+    return undefined;
+  }
+
+  const version =
+    typeof record["version"] === "string" ? record["version"] : "";
+
+  return { name, version };
+}
+
+/**
+ * Extract the tool-call options a `_meta` block carries. Anything malformed is
+ * dropped rather than surfaced: losing the caller's identity must never fail
+ * the call.
+ *
+ * @param {unknown} meta
+ * @returns {{ clientInfo?: MCPClientInfo, oauthClientId?: string }}
+ */
+function toolCallOptionsFromMeta(meta) {
+  if (meta == null || typeof meta !== "object") {
+    return {};
+  }
+
+  const record = /** @type {Record<string, unknown>} */ (meta);
+
+  /** @type {{ clientInfo?: MCPClientInfo, oauthClientId?: string }} */
+  const options = {};
+
+  const clientInfo = normalizeClientInfo(
+    record["io.modelcontextprotocol/clientInfo"],
+  );
+  if (clientInfo != null) {
+    options.clientInfo = clientInfo;
+  }
+
+  const oauthClientId = record["gram.ai/oauth-client-id"];
+  if (typeof oauthClientId === "string" && oauthClientId !== "") {
+    options.oauthClientId = oauthClientId;
+  }
+
+  return options;
+}
+
+/**
  * @param {string[]} args
  * @returns {{
  *   type: "tool",
  *   pipePath: string,
- *   request: { name: string, input: unknown }
+ *   request: { name: string, input: unknown, _meta?: ToolCallMeta }
  * } | {
  *   type: "resource",
  *   pipePath: string,
@@ -155,14 +231,17 @@ function parseArgs(args) {
 }
 
 /**
- * @param {(call: {name: string, input: unknown}) => Promise<Response>} func
+ * @param {(call: {name: string, input: unknown}, options?: {clientInfo?: MCPClientInfo, oauthClientId?: string}) => Promise<Response>} func
  * @param {string} name
  * @param {unknown} input
+ * @param {{clientInfo?: MCPClientInfo, oauthClientId?: string}} options
  * @returns {Promise<Response>}
  */
-async function callTool(func, name, input) {
+async function callTool(func, name, input, options) {
   try {
-    const response = await func({ name, input });
+    // Handlers that predate caller identity — and any plain `handleToolCall`
+    // export — simply ignore the second argument.
+    const response = await func({ name, input }, options);
     if (!(response instanceof Response)) {
       throw new FunctionsError(
         ERROR_CODES.INVALID_TOOL_RESULT,
@@ -266,7 +345,7 @@ async function writeHTTPResponse(pipeFile, response) {
 
 /**
  * @param {string} codePath
- * @returns {Promise<{ok: true, value: (call: {name: string, input: unknown}) => Promise<Response>} | {ok: false, error: FunctionsError}>}
+ * @returns {Promise<{ok: true, value: (call: {name: string, input: unknown}, options?: {clientInfo?: MCPClientInfo, oauthClientId?: string}) => Promise<Response>} | {ok: false, error: FunctionsError}>}
  */
 async function importToolCallHandler(codePath) {
   try {
@@ -375,7 +454,7 @@ const USER_CODE_PATH = path.join(process.cwd(), "functions.js");
 /**
  *
  * @param {import("node:fs/promises").FileHandle} pipeFile
- * @param {{name: string, input: unknown}} toolCall
+ * @param {{name: string, input: unknown, _meta?: ToolCallMeta}} toolCall
  * @param {string} codePath
  * @returns
  */
@@ -391,6 +470,7 @@ async function handleToolCall(pipeFile, toolCall, codePath) {
       importResult.value,
       toolCall.name,
       toolCall.input,
+      toolCallOptionsFromMeta(toolCall._meta),
     );
     await writeHTTPResponse(pipeFile, res);
   } catch (e) {
@@ -441,7 +521,9 @@ export async function main(args = process.argv, codePath = USER_CODE_PATH) {
       case "tool":
         await handleToolCall(
           pipeFile,
-          /** @type {{name: string, input: unknown}} */ (request),
+          /** @type {{name: string, input: unknown, _meta?: ToolCallMeta}} */ (
+            request
+          ),
           codePath,
         );
         break;

--- a/functions/internal/javascript/gram-start.mjs
+++ b/functions/internal/javascript/gram-start.mjs
@@ -143,8 +143,12 @@ function normalizeClientInfo(value) {
  * dropped rather than surfaced: losing the caller's identity must never fail
  * the call.
  *
+ * The block is forwarded whole as `meta` as well, so a tool can read keys this
+ * runner does not model. The runner has already re-encoded it from a declared
+ * shape, so only known keys survive to here.
+ *
  * @param {unknown} meta
- * @returns {{ clientInfo?: MCPClientInfo, oauthClientId?: string }}
+ * @returns {{ clientInfo?: MCPClientInfo, oauthClientId?: string, meta?: Record<string, unknown> }}
  */
 function toolCallOptionsFromMeta(meta) {
   if (meta == null || typeof meta !== "object") {
@@ -153,8 +157,8 @@ function toolCallOptionsFromMeta(meta) {
 
   const record = /** @type {Record<string, unknown>} */ (meta);
 
-  /** @type {{ clientInfo?: MCPClientInfo, oauthClientId?: string }} */
-  const options = {};
+  /** @type {{ clientInfo?: MCPClientInfo, oauthClientId?: string, meta?: Record<string, unknown> }} */
+  const options = { meta: record };
 
   const clientInfo = normalizeClientInfo(
     record["io.modelcontextprotocol/clientInfo"],
@@ -231,10 +235,10 @@ function parseArgs(args) {
 }
 
 /**
- * @param {(call: {name: string, input: unknown}, options?: {clientInfo?: MCPClientInfo, oauthClientId?: string}) => Promise<Response>} func
+ * @param {(call: {name: string, input: unknown}, options?: {clientInfo?: MCPClientInfo, oauthClientId?: string, meta?: Record<string, unknown>}) => Promise<Response>} func
  * @param {string} name
  * @param {unknown} input
- * @param {{clientInfo?: MCPClientInfo, oauthClientId?: string}} options
+ * @param {{clientInfo?: MCPClientInfo, oauthClientId?: string, meta?: Record<string, unknown>}} options
  * @returns {Promise<Response>}
  */
 async function callTool(func, name, input, options) {
@@ -345,7 +349,7 @@ async function writeHTTPResponse(pipeFile, response) {
 
 /**
  * @param {string} codePath
- * @returns {Promise<{ok: true, value: (call: {name: string, input: unknown}, options?: {clientInfo?: MCPClientInfo, oauthClientId?: string}) => Promise<Response>} | {ok: false, error: FunctionsError}>}
+ * @returns {Promise<{ok: true, value: (call: {name: string, input: unknown}, options?: {clientInfo?: MCPClientInfo, oauthClientId?: string, meta?: Record<string, unknown>}) => Promise<Response>} | {ok: false, error: FunctionsError}>}
  */
 async function importToolCallHandler(codePath) {
   try {

--- a/functions/internal/javascript/tests/caller-identity.js
+++ b/functions/internal/javascript/tests/caller-identity.js
@@ -1,0 +1,13 @@
+/**
+ * Echoes the caller identity the runner forwards as the second argument, so
+ * tests can assert exactly what reaches user code.
+ *
+ * @param {{name: string, input: unknown}} _call
+ * @param {{clientInfo?: {name: string, version: string}, oauthClientId?: string}} [options]
+ */
+export async function handleToolCall(_call, options) {
+  return new Response(JSON.stringify(options ?? null), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/functions/internal/javascript/tests/gram-start.test.ts
+++ b/functions/internal/javascript/tests/gram-start.test.ts
@@ -455,3 +455,58 @@ test("fails when functions file does not export handleResources", async () => {
   expect(content).toContain(ERROR_CODES.INVALID_RESOURCE_FUNC);
   expect(content).toMatchSnapshot();
 });
+
+/**
+ * Runs the caller-identity fixture and returns the options the entrypoint
+ * handed to user code.
+ */
+async function callerIdentityOptions(meta: unknown) {
+  const pipePath = await fakepipe();
+  const args = JSON.stringify({
+    name: "whoami",
+    input: {},
+    ...(meta === undefined ? {} : { _meta: meta }),
+  });
+
+  await main(
+    ["node", "./gram-start.mjs", pipePath, args, "tool"],
+    join(import.meta.dirname, "caller-identity.js"),
+  );
+
+  const content = await readFile(pipePath, "utf-8");
+  return JSON.parse(content.trim().split("\n").at(-1) ?? "");
+}
+
+test("forwards caller identity from _meta to the tool", async () => {
+  const options = await callerIdentityOptions({
+    "io.modelcontextprotocol/clientInfo": { name: "claude-code", version: "2.1" },
+    "gram.ai/oauth-client-id": "client-abc",
+  });
+
+  expect(options).toEqual({
+    clientInfo: { name: "claude-code", version: "2.1" },
+    oauthClientId: "client-abc",
+  });
+});
+
+test("defaults a missing client version so a name-only client is still usable", async () => {
+  const options = await callerIdentityOptions({
+    "io.modelcontextprotocol/clientInfo": { name: "claude-code" },
+  });
+
+  expect(options).toEqual({ clientInfo: { name: "claude-code", version: "" } });
+});
+
+test("drops malformed and unknown _meta entries", async () => {
+  const options = await callerIdentityOptions({
+    "io.modelcontextprotocol/clientInfo": { version: "2.1" },
+    "gram.ai/oauth-client-id": 42,
+    "example.com/unknown": "ignored",
+  });
+
+  expect(options).toEqual({});
+});
+
+test("omits caller identity when the call carries no _meta", async () => {
+  expect(await callerIdentityOptions(undefined)).toEqual({});
+});

--- a/functions/internal/javascript/tests/gram-start.test.ts
+++ b/functions/internal/javascript/tests/gram-start.test.ts
@@ -486,7 +486,7 @@ test("forwards caller identity from _meta to the tool", async () => {
     "gram.ai/oauth-client-id": "client-abc",
   });
 
-  expect(options).toEqual({
+  expect(options).toMatchObject({
     clientInfo: { name: "claude-code", version: "2.1" },
     oauthClientId: "client-abc",
   });
@@ -497,7 +497,25 @@ test("defaults a missing client version so a name-only client is still usable", 
     "io.modelcontextprotocol/clientInfo": { name: "claude-code" },
   });
 
-  expect(options).toEqual({ clientInfo: { name: "claude-code", version: "" } });
+  expect(options.clientInfo).toEqual({ name: "claude-code", version: "" });
+});
+
+test("forwards the whole _meta block so tools can read unmodelled keys", async () => {
+  const options = await callerIdentityOptions({
+    "io.modelcontextprotocol/clientInfo": {
+      name: "claude-code",
+      version: "2.1",
+    },
+    "example.com/experiment": "b",
+  });
+
+  expect(options.meta).toEqual({
+    "io.modelcontextprotocol/clientInfo": {
+      name: "claude-code",
+      version: "2.1",
+    },
+    "example.com/experiment": "b",
+  });
 });
 
 test("drops malformed and unknown _meta entries", async () => {
@@ -507,7 +525,8 @@ test("drops malformed and unknown _meta entries", async () => {
     "example.com/unknown": "ignored",
   });
 
-  expect(options).toEqual({});
+  expect(options.clientInfo).toBeUndefined();
+  expect(options.oauthClientId).toBeUndefined();
 });
 
 test("omits caller identity when the call carries no _meta", async () => {

--- a/functions/internal/javascript/tests/gram-start.test.ts
+++ b/functions/internal/javascript/tests/gram-start.test.ts
@@ -479,7 +479,10 @@ async function callerIdentityOptions(meta: unknown) {
 
 test("forwards caller identity from _meta to the tool", async () => {
   const options = await callerIdentityOptions({
-    "io.modelcontextprotocol/clientInfo": { name: "claude-code", version: "2.1" },
+    "io.modelcontextprotocol/clientInfo": {
+      name: "claude-code",
+      version: "2.1",
+    },
     "gram.ai/oauth-client-id": "client-abc",
   });
 

--- a/functions/internal/runner/bench_test.go
+++ b/functions/internal/runner/bench_test.go
@@ -86,6 +86,7 @@ func benchToolRequest(tb testing.TB) callRequest {
 		ToolName:    "bench_tool",
 		Input:       json.RawMessage(`{"hello":"world"}`),
 		Environment: nil,
+		Meta:        nil,
 	})
 	if err != nil {
 		tb.Fatalf("marshal request: %v", err)

--- a/functions/internal/runner/handle_tool_call.go
+++ b/functions/internal/runner/handle_tool_call.go
@@ -42,10 +42,35 @@ var allowedHeaders = map[string]struct{}{
 	"x-ratelimit-reset":       {},
 }
 
+// CallToolPayload is the request body Gram POSTs to /tool-call. Mirrored by
+// the server's own encode type in `server/internal/functions/auth.go` — the
+// two live in separate `internal` subtrees and cannot import one another, so
+// they must be changed together.
 type CallToolPayload struct {
 	ToolName    string            `json:"name"`
 	Input       json.RawMessage   `json:"input"`
 	Environment map[string]string `json:"environment,omitempty,omitzero"`
+	Meta        *ToolCallMeta     `json:"_meta,omitempty"`
+}
+
+// ToolCallMeta describes the caller of one tool call, keyed the way MCP keys
+// request `_meta`. Decoding into a declared shape (rather than forwarding the
+// bytes) is what bounds what reaches the entrypoint: the request is re-encoded
+// from this struct, so unknown keys never make it into the subprocess
+// arguments.
+type ToolCallMeta struct {
+	// ClientInfo is what the MCP client reports about itself. Untrusted and
+	// self-reported.
+	ClientInfo *MCPClientInfo `json:"io.modelcontextprotocol/clientInfo,omitempty"`
+	// OAuthClientID is the OAuth client the caller authenticated as.
+	OAuthClientID string `json:"gram.ai/oauth-client-id,omitempty"`
+}
+
+// MCPClientInfo is an MCP `Implementation` value: the name and version a
+// client reports for itself.
+type MCPClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 type callRequest struct {

--- a/functions/internal/runner/handle_tool_call_test.go
+++ b/functions/internal/runner/handle_tool_call_test.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -73,4 +75,61 @@ func TestCallToolPayload_OmitsMetaWhenAbsent(t *testing.T) {
 	encoded, err := json.Marshal(payload)
 	require.NoError(t, err)
 	require.NotContains(t, string(encoded), "_meta")
+}
+
+// echoCallerBundle returns whatever the entrypoint hands it as a second
+// argument, which is how a tool sees its caller.
+const echoCallerBundle = `
+export async function handleToolCall(call, options) {
+  return new Response(JSON.stringify(options ?? null), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+`
+
+// TestCallTool_DeliversCallerIdentityToUserCode runs the whole runner path for
+// real — payload decode, subprocess spawn, the embedded entrypoint, and user
+// code — so the identity is proven to survive every hop rather than only the
+// encoding steps the tests above pin.
+func TestCallTool_DeliversCallerIdentityToUserCode(t *testing.T) {
+	t.Parallel()
+
+	svc := benchService(t, echoCallerBundle)
+	recorder := httptest.NewRecorder()
+
+	err := svc.callTool(t.Context(), svc.logger, CallToolPayload{
+		ToolName:    "whoami",
+		Input:       json.RawMessage(`{}`),
+		Environment: nil,
+		Meta: &ToolCallMeta{
+			ClientInfo:    &MCPClientInfo{Name: "claude-code", Version: "2.1"},
+			OAuthClientID: "client-abc",
+		},
+	}, recorder)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{
+	  "clientInfo": {"name": "claude-code", "version": "2.1"},
+	  "oauthClientId": "client-abc"
+	}`, recorder.Body.String())
+}
+
+func TestCallTool_UnknownCallerReachesUserCodeAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	svc := benchService(t, echoCallerBundle)
+	recorder := httptest.NewRecorder()
+
+	err := svc.callTool(t.Context(), svc.logger, CallToolPayload{
+		ToolName:    "whoami",
+		Input:       json.RawMessage(`{}`),
+		Environment: nil,
+		Meta:        nil,
+	}, recorder)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{}`, recorder.Body.String())
 }

--- a/functions/internal/runner/handle_tool_call_test.go
+++ b/functions/internal/runner/handle_tool_call_test.go
@@ -110,9 +110,15 @@ func TestCallTool_DeliversCallerIdentityToUserCode(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, recorder.Code)
+	// The whole block rides along as `meta` beside the named fields, so a tool
+	// can read keys the runner does not model.
 	require.JSONEq(t, `{
 	  "clientInfo": {"name": "claude-code", "version": "2.1"},
-	  "oauthClientId": "client-abc"
+	  "oauthClientId": "client-abc",
+	  "meta": {
+	    "io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1"},
+	    "gram.ai/oauth-client-id": "client-abc"
+	  }
 	}`, recorder.Body.String())
 }
 

--- a/functions/internal/runner/handle_tool_call_test.go
+++ b/functions/internal/runner/handle_tool_call_test.go
@@ -77,6 +77,41 @@ func TestCallToolPayload_OmitsMetaWhenAbsent(t *testing.T) {
 	require.NotContains(t, string(encoded), "_meta")
 }
 
+// TestCallToolPayload_PartialCallerIdentity covers the shape most production
+// traffic actually has. A public MCP server authenticates nobody, so calls
+// arrive with a reported client and no OAuth client; an authenticated caller
+// that never reported a name is the mirror image. Neither half depends on the
+// other being present, and the absent one leaves no key behind.
+func TestCallToolPayload_PartialCallerIdentity(t *testing.T) {
+	t.Parallel()
+
+	var clientOnly CallToolPayload
+	require.NoError(t, json.Unmarshal([]byte(`{
+	  "name": "whoami",
+	  "input": {},
+	  "_meta": {"io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1"}}
+	}`), &clientOnly))
+	require.Equal(t, &MCPClientInfo{Name: "claude-code", Version: "2.1"}, clientOnly.Meta.ClientInfo)
+	require.Empty(t, clientOnly.Meta.OAuthClientID)
+
+	encoded, err := json.Marshal(clientOnly)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "oauth-client-id")
+
+	var oauthOnly CallToolPayload
+	require.NoError(t, json.Unmarshal([]byte(`{
+	  "name": "whoami",
+	  "input": {},
+	  "_meta": {"gram.ai/oauth-client-id": "client-abc"}
+	}`), &oauthOnly))
+	require.Nil(t, oauthOnly.Meta.ClientInfo)
+	require.Equal(t, "client-abc", oauthOnly.Meta.OAuthClientID)
+
+	encoded, err = json.Marshal(oauthOnly)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "clientInfo")
+}
+
 // echoCallerBundle returns whatever the entrypoint hands it as a second
 // argument, which is how a tool sees its caller.
 const echoCallerBundle = `
@@ -120,6 +155,34 @@ func TestCallTool_DeliversCallerIdentityToUserCode(t *testing.T) {
 	    "gram.ai/oauth-client-id": "client-abc"
 	  }
 	}`, recorder.Body.String())
+}
+
+// TestCallTool_ClientWithoutOAuthReachesUserCode runs the public-MCP shape all
+// the way into user code: an absent OAuth client must arrive as undefined, not
+// as an empty string a tool might mistake for a real id.
+func TestCallTool_ClientWithoutOAuthReachesUserCode(t *testing.T) {
+	t.Parallel()
+
+	svc := benchService(t, echoCallerBundle)
+	recorder := httptest.NewRecorder()
+
+	err := svc.callTool(t.Context(), svc.logger, CallToolPayload{
+		ToolName:    "whoami",
+		Input:       json.RawMessage(`{}`),
+		Environment: nil,
+		Meta: &ToolCallMeta{
+			ClientInfo:    &MCPClientInfo{Name: "claude-code", Version: "2.1"},
+			OAuthClientID: "",
+		},
+	}, recorder)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{
+	  "clientInfo": {"name": "claude-code", "version": "2.1"},
+	  "meta": {"io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1"}}
+	}`, recorder.Body.String())
+	require.NotContains(t, recorder.Body.String(), "oauthClientId")
 }
 
 func TestCallTool_UnknownCallerReachesUserCodeAsEmpty(t *testing.T) {

--- a/functions/internal/runner/handle_tool_call_test.go
+++ b/functions/internal/runner/handle_tool_call_test.go
@@ -1,0 +1,76 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// gramToolCallBody is the request body Gram sends for a tool call carrying
+// caller identity. Kept as a literal so a rename of any JSON tag on either
+// side of the wire fails loudly here rather than silently dropping the
+// caller's identity in production.
+const gramToolCallBody = `{
+  "name": "whoami",
+  "input": {"q": 1},
+  "environment": {"API_KEY": "secret"},
+  "_meta": {
+    "io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1"},
+    "gram.ai/oauth-client-id": "client-abc"
+  }
+}`
+
+func TestCallToolPayload_DecodesCallerIdentity(t *testing.T) {
+	t.Parallel()
+
+	var payload CallToolPayload
+	require.NoError(t, json.Unmarshal([]byte(gramToolCallBody), &payload))
+
+	require.Equal(t, "whoami", payload.ToolName)
+	require.NotNil(t, payload.Meta)
+	require.Equal(t, "client-abc", payload.Meta.OAuthClientID)
+	require.Equal(t, &MCPClientInfo{Name: "claude-code", Version: "2.1"}, payload.Meta.ClientInfo)
+}
+
+// TestCallToolPayload_ReencodeDropsUnknownMeta pins the reason `_meta` is a
+// declared type rather than raw bytes: the entrypoint arguments are re-encoded
+// from this struct, so keys we never declared cannot ride along into the
+// subprocess.
+func TestCallToolPayload_ReencodeDropsUnknownMeta(t *testing.T) {
+	t.Parallel()
+
+	var payload CallToolPayload
+	require.NoError(t, json.Unmarshal([]byte(`{
+	  "name": "whoami",
+	  "input": {},
+	  "_meta": {
+	    "io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1"},
+	    "example.com/smuggled": "payload"
+	  }
+	}`), &payload))
+
+	// Mirrors what callTool sends to the entrypoint: everything but the
+	// environment, re-encoded from the decoded struct.
+	payload.Environment = nil
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(encoded), "smuggled")
+	require.Contains(t, string(encoded), `"io.modelcontextprotocol/clientInfo":{"name":"claude-code","version":"2.1"}`)
+}
+
+// TestCallToolPayload_OmitsMetaWhenAbsent keeps calls with no caller identity
+// byte-identical to what the runner received before `_meta` existed, so older
+// entrypoints see nothing new.
+func TestCallToolPayload_OmitsMetaWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	var payload CallToolPayload
+	require.NoError(t, json.Unmarshal([]byte(`{"name": "whoami", "input": {}}`), &payload))
+	require.Nil(t, payload.Meta)
+
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "_meta")
+}

--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -65,6 +65,7 @@ const (
 	AdminAuthContextKey         contextKey = "adminAuthKey"
 	RPCContextKey               contextKey = "rpcContextKey"
 	pubsubSubscriberContextKey  contextKey = "pubsubSubscriberKey"
+	oauthClientIDContextKey     contextKey = "oauthClientIDKey"
 )
 
 func SetSessionTokenInContext(ctx context.Context, value string) context.Context {
@@ -138,6 +139,26 @@ func SetAssistantPrincipal(ctx context.Context, value AssistantPrincipal) contex
 func GetAssistantPrincipal(ctx context.Context) (AssistantPrincipal, bool) {
 	value, ok := ctx.Value(AssistantPrincipalKey).(AssistantPrincipal)
 	return value, ok
+}
+
+// SetOAuthClientID records the OAuth client the request's bearer token was
+// issued to.
+//
+// It lives outside AuthContext on purpose: an anonymous session on a public
+// MCP server has a real registered OAuth client but deliberately never gets an
+// AuthContext, since stamping the endpoint's organization would misrepresent
+// an unknown caller as a member of it.
+func SetOAuthClientID(ctx context.Context, value string) context.Context {
+	return context.WithValue(ctx, oauthClientIDContextKey, value)
+}
+
+// GetOAuthClientID returns the OAuth client the request authenticated as. The
+// second result is false when the request carried no OAuth client — an
+// unauthenticated caller, a non-OAuth credential, or a token minted before the
+// `client_id` claim existed.
+func GetOAuthClientID(ctx context.Context) (string, bool) {
+	value, ok := ctx.Value(oauthClientIDContextKey).(string)
+	return value, ok && value != ""
 }
 
 func SetAdminSessionTokenInContext(ctx context.Context, value string) context.Context {

--- a/server/internal/functions/auth.go
+++ b/server/internal/functions/auth.go
@@ -40,10 +40,35 @@ func TokenV1(enc *encryption.Client, req TokenRequestV1) (string, error) {
 	return fmt.Sprintf("v01.%s", encBs), nil
 }
 
+// CallToolPayload is the request body Gram POSTs to a function runner's
+// /tool-call endpoint. Mirrored by the runner's own decode type in
+// `functions/internal/runner/handle_tool_call.go` — the two live in separate
+// `internal` subtrees and cannot import one another, so they must be changed
+// together.
 type CallToolPayload struct {
 	ToolName    string            `json:"name"`
 	Input       json.RawMessage   `json:"input"`
 	Environment map[string]string `json:"environment,omitempty,omitzero"`
+	Meta        *ToolCallMeta     `json:"_meta,omitempty"`
+}
+
+// ToolCallMeta carries per-call metadata about the caller, keyed the way MCP
+// keys request `_meta`. Configuration belongs in Environment; this is about
+// who is on the other end of this particular call.
+type ToolCallMeta struct {
+	// ClientInfo is what the MCP client reports about itself. Untrusted and
+	// self-reported — for observability and convenience, never authorization.
+	ClientInfo *MCPClientInfo `json:"io.modelcontextprotocol/clientInfo,omitempty"`
+	// OAuthClientID is the OAuth client the caller authenticated as. Unlike
+	// ClientInfo this one is established by the authorization flow.
+	OAuthClientID string `json:"gram.ai/oauth-client-id,omitempty"`
+}
+
+// MCPClientInfo is an MCP `Implementation` value: the name and version a
+// client reports for itself.
+type MCPClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 type ReadResourcePayload struct {

--- a/server/internal/functions/auth.go
+++ b/server/internal/functions/auth.go
@@ -55,12 +55,15 @@ type CallToolPayload struct {
 // ToolCallMeta carries per-call metadata about the caller, keyed the way MCP
 // keys request `_meta`. Configuration belongs in Environment; this is about
 // who is on the other end of this particular call.
+//
+// Everything here is attribution, not authorization. A function receives it as
+// ordinary request metadata and cannot tell which host attached it, so tools
+// are documented never to gate access on it.
 type ToolCallMeta struct {
-	// ClientInfo is what the MCP client reports about itself. Untrusted and
-	// self-reported — for observability and convenience, never authorization.
+	// ClientInfo is what the MCP client reports about itself.
 	ClientInfo *MCPClientInfo `json:"io.modelcontextprotocol/clientInfo,omitempty"`
-	// OAuthClientID is the OAuth client the caller authenticated as. Unlike
-	// ClientInfo this one is established by the authorization flow.
+	// OAuthClientID is the OAuth client the caller authenticated as, read here
+	// from the verified bearer token.
 	OAuthClientID string `json:"gram.ai/oauth-client-id,omitempty"`
 }
 

--- a/server/internal/functions/calltoolpayload_test.go
+++ b/server/internal/functions/calltoolpayload_test.go
@@ -1,0 +1,55 @@
+package functions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCallToolPayload_CallerIdentityWireShape pins the exact keys Gram sends to
+// a function runner. The runner decodes this body with its own mirrored type in
+// `functions/internal/runner/handle_tool_call.go`, which cannot import this
+// package — an identical literal there is what keeps the two in step, so a tag
+// changed on one side fails a test rather than silently dropping the caller's
+// identity in production.
+func TestCallToolPayload_CallerIdentityWireShape(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(CallToolPayload{
+		ToolName:    "whoami",
+		Input:       json.RawMessage(`{"q":1}`),
+		Environment: map[string]string{"API_KEY": "secret"},
+		Meta: &ToolCallMeta{
+			ClientInfo:    &MCPClientInfo{Name: "claude-code", Version: "2.1"},
+			OAuthClientID: "client-abc",
+		},
+	})
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{
+	  "name": "whoami",
+	  "input": {"q": 1},
+	  "environment": {"API_KEY": "secret"},
+	  "_meta": {
+	    "io.modelcontextprotocol/clientInfo": {"name": "claude-code", "version": "2.1"},
+	    "gram.ai/oauth-client-id": "client-abc"
+	  }
+	}`, string(encoded))
+}
+
+// TestCallToolPayload_OmitsMetaWhenUnknown keeps direct (non-MCP) invocations
+// sending exactly what they sent before caller identity existed.
+func TestCallToolPayload_OmitsMetaWhenUnknown(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := json.Marshal(CallToolPayload{
+		ToolName:    "whoami",
+		Input:       json.RawMessage(`{}`),
+		Environment: nil,
+		Meta:        nil,
+	})
+	require.NoError(t, err)
+
+	require.JSONEq(t, `{"name": "whoami", "input": {}}`, string(encoded))
+}

--- a/server/internal/functions/deploy.go
+++ b/server/internal/functions/deploy.go
@@ -100,6 +100,9 @@ type RunnerToolCallRequest struct {
 
 	ToolURN  urn.Tool
 	ToolName string
+	// Meta describes the caller of this specific tool call. Nil when nothing
+	// is known about them (a direct, non-MCP invocation).
+	Meta *ToolCallMeta
 }
 
 type RunnerResourceReadRequest struct {

--- a/server/internal/functions/deploy_fly.go
+++ b/server/internal/functions/deploy_fly.go
@@ -220,6 +220,7 @@ func (f *FlyRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (ht
 		ToolName:    req.ToolName,
 		Input:       req.Input,
 		Environment: req.Environment,
+		Meta:        req.Meta,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to marshal function tool payload").LogError(ctx, logger)

--- a/server/internal/functions/deploy_local.go
+++ b/server/internal/functions/deploy_local.go
@@ -124,6 +124,7 @@ func (l *LocalRunner) ToolCall(ctx context.Context, req RunnerToolCallRequest) (
 		ToolName:    req.ToolName,
 		Input:       req.Input,
 		Environment: req.Environment,
+		Meta:        req.Meta,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "marshal local function tool payload").LogError(ctx, logger)

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -437,6 +437,7 @@ func (tp *ToolProxy) doFunction(
 		},
 		ToolURN:  descriptor.URN,
 		ToolName: descriptor.Name,
+		Meta:     toolCallMeta(env.MCPClient),
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to create function tool call request").LogError(ctx, logger)
@@ -490,6 +491,28 @@ func (tp *ToolProxy) doFunction(
 		OrganizationID:    descriptor.OrganizationID,
 		OrganizationSlug:  descriptor.OrganizationSlug,
 	})
+}
+
+// toolCallMeta converts a resolved caller identity into the `_meta` block sent
+// to a function runner, or nil when nothing is known about the caller. The
+// values are platform-supplied: no user configuration path can reach them.
+func toolCallMeta(client toolconfig.MCPClientIdentity) *functions.ToolCallMeta {
+	if client.IsZero() {
+		return nil
+	}
+
+	meta := &functions.ToolCallMeta{
+		ClientInfo:    nil,
+		OAuthClientID: client.OAuthClientID,
+	}
+	if client.Name != "" {
+		meta.ClientInfo = &functions.MCPClientInfo{
+			Name:    client.Name,
+			Version: client.Version,
+		}
+	}
+
+	return meta
 }
 
 func (tp *ToolProxy) doHTTP(

--- a/server/internal/gateway/proxy_calleridentity_test.go
+++ b/server/internal/gateway/proxy_calleridentity_test.go
@@ -1,0 +1,130 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/functions"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+// callFunctionToolWithClient runs one function tool call and returns the
+// `_meta` block the proxy handed to the runner.
+func callFunctionToolWithClient(t *testing.T, client toolconfig.MCPClientIdentity) *functions.ToolCallMeta {
+	t.Helper()
+
+	var invocationID uuid.UUID
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Gram-Invoke-ID", invocationID.String())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": "success"}`))
+	}))
+	t.Cleanup(mockServer.Close)
+
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	toolCallPlan := NewFunctionToolCallPlan(newTestToolDescriptor(), &FunctionToolCallPlan{
+		FunctionID:        uuid.New().String(),
+		FunctionsAccessID: uuid.New().String(),
+		Runtime:           "nodejs",
+		InputSchema:       []byte{},
+		Variables:         map[string]*functions.ManifestVariableAttributeV0{},
+		AuthInput:         nil,
+	})
+
+	var captured *functions.ToolCallMeta
+	proxy := NewToolProxy(
+		testenv.NewLogger(t),
+		tracerProvider,
+		testenv.NewMeterProvider(t),
+		ToolCallSourceMCP,
+		testenv.NewEncryptionClient(t),
+		nil,
+		policy,
+		&mockToolCaller{
+			serverURL: mockServer.URL,
+			onCall:    func(invID uuid.UUID) { invocationID = invID },
+			onRequest: func(req functions.RunnerToolCallRequest) { captured = req.Meta },
+		},
+		nil,
+	)
+
+	bodyBytes, err := json.Marshal(ToolCallBody{
+		PathParameters:       nil,
+		QueryParameters:      nil,
+		HeaderParameters:     nil,
+		Body:                 json.RawMessage(`{"test": "data"}`),
+		ResponseFilter:       nil,
+		EnvironmentVariables: nil,
+		GramRequestSummary:   "",
+	})
+	require.NoError(t, err)
+
+	err = proxy.Do(t.Context(), httptest.NewRecorder(), bytes.NewReader(bodyBytes), toolconfig.ToolCallEnv{
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+		GramChatID: "",
+		MCPClient:  client,
+	}, toolCallPlan, tm.HTTPLogAttributes{})
+	require.NoError(t, err)
+
+	return captured
+}
+
+func TestToolProxy_Do_FunctionTool_ForwardsCallerIdentity(t *testing.T) {
+	t.Parallel()
+
+	meta := callFunctionToolWithClient(t, toolconfig.MCPClientIdentity{
+		Name:          "claude-code",
+		Version:       "2.1",
+		OAuthClientID: "client-abc",
+	})
+
+	require.NotNil(t, meta)
+	require.Equal(t, &functions.MCPClientInfo{Name: "claude-code", Version: "2.1"}, meta.ClientInfo)
+	require.Equal(t, "client-abc", meta.OAuthClientID)
+}
+
+// TestToolProxy_Do_FunctionTool_OAuthClientWithoutClientInfo covers a caller
+// that authenticated but never reported an identity: the verified half must
+// still reach the function.
+func TestToolProxy_Do_FunctionTool_OAuthClientWithoutClientInfo(t *testing.T) {
+	t.Parallel()
+
+	meta := callFunctionToolWithClient(t, toolconfig.MCPClientIdentity{
+		Name:          "",
+		Version:       "",
+		OAuthClientID: "client-abc",
+	})
+
+	require.NotNil(t, meta)
+	require.Nil(t, meta.ClientInfo)
+	require.Equal(t, "client-abc", meta.OAuthClientID)
+}
+
+// TestToolProxy_Do_FunctionTool_UnknownCallerSendsNoMeta keeps direct
+// (non-MCP) invocations byte-identical to what they sent before caller
+// identity existed.
+func TestToolProxy_Do_FunctionTool_UnknownCallerSendsNoMeta(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, callFunctionToolWithClient(t, toolconfig.MCPClientIdentity{
+		Name:          "",
+		Version:       "",
+		OAuthClientID: "",
+	}))
+}

--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -1440,11 +1440,17 @@ func TestResourceProxy_ReadResource(t *testing.T) {
 type mockToolCaller struct {
 	serverURL string
 	onCall    func(uuid.UUID)
+	// onRequest receives the whole runner request, for assertions on fields
+	// the mock payload below does not reproduce.
+	onRequest func(functions.RunnerToolCallRequest)
 }
 
 func (m *mockToolCaller) ToolCall(ctx context.Context, req functions.RunnerToolCallRequest) (*http.Request, error) {
 	if m.onCall != nil {
 		m.onCall(req.InvocationID)
+	}
+	if m.onRequest != nil {
+		m.onRequest(req)
 	}
 
 	// Create request payload with environment variables

--- a/server/internal/instances/impl.go
+++ b/server/internal/instances/impl.go
@@ -338,6 +338,8 @@ func (s *Service) ExecuteInstanceTool(w http.ResponseWriter, r *http.Request) er
 		OAuthToken: "", // Instances do not support OAuth tokens for external MCP
 		GramEmail:  "",
 		GramChatID: "",
+		// Direct invocation — there is no MCP client on the other end.
+		MCPClient: toolconfig.MCPClientIdentity{Name: "", Version: "", OAuthClientID: ""},
 	}, plan, attrRecorder)
 	if err != nil {
 		return fmt.Errorf("failed to proxy tool call: %w", err)

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -190,12 +190,14 @@ var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated 
 // whose org lookup failed wraps errIssuerGateOrgLookup, letting the caller
 // label it as an operational failure rather than a bad credential.
 //
-// Anonymous subjects deliberately leave the context untouched (non-nil
-// subject, no AuthContext set). The request belongs to no known principal, so
+// Anonymous subjects deliberately leave the AuthContext unset (non-nil
+// subject, no AuthContext). The request belongs to no known principal, so
 // stamping the endpoint's org as ActiveOrganizationID would misrepresent
 // the caller as a member of that org. Downstream code on the public
 // path reads org/project off the resolved endpoint directly, the same
-// way it does for unauthenticated public-endpoint traffic.
+// way it does for unauthenticated public-endpoint traffic. The OAuth client
+// id is still stamped for them — an anonymous session is anonymous in its
+// principal, not in the client that registered for it.
 //
 // SessionID is populated for non-anonymous subjects so
 // authz.Engine.ShouldEnforce / PrepareContext treat the request as a real
@@ -205,9 +207,14 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	if token == "" {
 		return ctx, nil, nil
 	}
-	subject, jti, err := s.userSessionSigner.ValidateBearer(ctx, token, endpoint.AudienceURN, s.chatSessionsManager)
+	session, err := s.userSessionSigner.ValidateBearer(ctx, token, endpoint.AudienceURN, s.chatSessionsManager)
 	if err != nil {
 		return ctx, nil, fmt.Errorf("validate user-session bearer: %w", err)
+	}
+
+	subject := session.Subject
+	if session.ClientID != "" {
+		ctx = contextvalues.SetOAuthClientID(ctx, session.ClientID)
 	}
 
 	if subject.Kind == urn.SessionSubjectKindAnonymous {
@@ -227,7 +234,7 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 		APIKeyID:              "",
 		APIKeyName:            "",
 		OrgWidePluginHooksKey: false,
-		SessionID:             &jti,
+		SessionID:             &session.JTI,
 		OrganizationSlug:      orgMetadata.Slug,
 		Email:                 nil,
 		AccountType:           orgMetadata.GramAccountType,

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -342,7 +342,13 @@ func (s *Service) mintSessionAndRespond(
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build issuer URL").LogError(ctx, logger)
 	}
-	access, jti, err := s.userSessionSigner.Mint(subject, endpoint.AudienceURN, issuerURL, accessTokenLifetime)
+	access, jti, err := s.userSessionSigner.Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: endpoint.AudienceURN,
+		Issuer:   issuerURL,
+		Lifetime: accessTokenLifetime,
+		ClientID: clientRow.ClientID,
+	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "mint session jwt").LogError(ctx, logger)
 	}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -53,6 +53,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
@@ -124,9 +125,10 @@ type Service struct {
 	platformToolsets       map[string]platformtools.Toolset
 	authnChallengeCache    cache.TypedCacheObject[AuthnChallengeState]
 	userSessionGrantCache  cache.TypedCacheObject[UserSessionGrant]
-	// sessionClientInfoCache holds the MCP client identity captured at
-	// initialize so tools/call on the same session can resolve it.
-	sessionClientInfoCache cache.TypedCacheObject[SessionClientInfo]
+	// sessionClientInfo holds the MCP client identity captured at initialize
+	// so tools/call on the same session can resolve it. Always usable: without
+	// Redis it records nothing and every caller resolves as unknown.
+	sessionClientInfo *sessionclientinfo.Store
 	// userSessionSigner mints the SessionClaims JWT issued at /token.
 	// HS256 with GRAM_JWT_SIGNING_KEY -- same key the chat-session signer
 	// uses, intentionally separate signer code so each path is removable
@@ -344,11 +346,7 @@ func NewService(
 			cacheImpl,
 			cache.SuffixNone,
 		),
-		sessionClientInfoCache: cache.NewTypedObjectCache[SessionClientInfo](
-			logger.With(attr.SlogCacheNamespace("mcp_session_client_info")),
-			cacheImpl,
-			cache.SuffixNone,
-		),
+		sessionClientInfo:  sessionclientinfo.NewStore(redisClient, 0),
 		identityResolver:   identityResolver,
 		userSessionSigner:  userSessionSigner,
 		remoteChallengeMgr: remoteChallengeMgr,
@@ -1142,13 +1140,13 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "ping":
 		return handlePing(ctx, s.logger, req.ID)
 	case "initialize":
-		return handleInitialize(ctx, s.logger, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo, &s.sessionClientInfoCache)
+		return handleInitialize(ctx, s.logger, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo, s.sessionClientInfo)
 	case "notifications/initialized", "notifications/cancelled":
 		return nil, nil
 	case "tools/list":
 		return handleToolsList(ctx, s.logger, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.posthog, &s.toolsetCache, s.vectorToolStore, s.temporal, s.shadowMCPClient, s.platformExtras)
 	case "tools/call":
-		return handleToolsCall(ctx, s.logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger, s.platformExtras, &s.sessionClientInfoCache)
+		return handleToolsCall(ctx, s.logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger, s.platformExtras, s.sessionClientInfo)
 	case "prompts/list":
 		return handlePromptsList(ctx, s.logger, s.db, payload, req, &s.toolsetCache, s.platformExtras)
 	case "prompts/get":
@@ -1429,7 +1427,7 @@ func (s *Service) HandleToolsCall(
 		s.mcpMetadataRepo,
 		s.auditLogger,
 		s.platformExtras,
-		&s.sessionClientInfoCache,
+		s.sessionClientInfo,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("handle tool call: %w", err)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1148,7 +1148,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "tools/list":
 		return handleToolsList(ctx, s.logger, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.posthog, &s.toolsetCache, s.vectorToolStore, s.temporal, s.shadowMCPClient, s.platformExtras)
 	case "tools/call":
-		return handleToolsCall(ctx, s.logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger, s.platformExtras)
+		return handleToolsCall(ctx, s.logger, s.metrics, s.authz, s.guardianPolicy, s.db, s.env, payload, req, s.toolProxy, s.billingTracker, s.billingRepository, &s.toolsetCache, s.telemLogger, s.vectorToolStore, s.temporal, s.mcpMetadataRepo, s.auditLogger, s.platformExtras, &s.sessionClientInfoCache)
 	case "prompts/list":
 		return handlePromptsList(ctx, s.logger, s.db, payload, req, &s.toolsetCache, s.platformExtras)
 	case "prompts/get":
@@ -1429,6 +1429,7 @@ func (s *Service) HandleToolsCall(
 		s.mcpMetadataRepo,
 		s.auditLogger,
 		s.platformExtras,
+		&s.sessionClientInfoCache,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("handle tool call: %w", err)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -124,6 +124,9 @@ type Service struct {
 	platformToolsets       map[string]platformtools.Toolset
 	authnChallengeCache    cache.TypedCacheObject[AuthnChallengeState]
 	userSessionGrantCache  cache.TypedCacheObject[UserSessionGrant]
+	// sessionClientInfoCache holds the MCP client identity captured at
+	// initialize so tools/call on the same session can resolve it.
+	sessionClientInfoCache cache.TypedCacheObject[SessionClientInfo]
 	// userSessionSigner mints the SessionClaims JWT issued at /token.
 	// HS256 with GRAM_JWT_SIGNING_KEY -- same key the chat-session signer
 	// uses, intentionally separate signer code so each path is removable
@@ -338,6 +341,11 @@ func NewService(
 		),
 		userSessionGrantCache: cache.NewTypedObjectCache[UserSessionGrant](
 			logger.With(attr.SlogCacheNamespace("user_session_grant")),
+			cacheImpl,
+			cache.SuffixNone,
+		),
+		sessionClientInfoCache: cache.NewTypedObjectCache[SessionClientInfo](
+			logger.With(attr.SlogCacheNamespace("mcp_session_client_info")),
 			cacheImpl,
 			cache.SuffixNone,
 		),
@@ -1134,7 +1142,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "ping":
 		return handlePing(ctx, s.logger, req.ID)
 	case "initialize":
-		return handleInitialize(ctx, s.logger, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo)
+		return handleInitialize(ctx, s.logger, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo, &s.sessionClientInfoCache)
 	case "notifications/initialized", "notifications/cancelled":
 		return nil, nil
 	case "tools/list":

--- a/server/internal/mcp/remotesession_resolver_test.go
+++ b/server/internal/mcp/remotesession_resolver_test.go
@@ -245,12 +245,12 @@ func mintUserSessionBearerForSubject(
 ) string {
 	t.Helper()
 
-	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(
-		subject,
-		urn.NewToolset(toolset.ID).String(),
-		ti.serverURL.String()+"/mcp/"+toolset.McpSlug.String,
-		time.Hour,
-	)
+	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: urn.NewToolset(toolset.ID).String(),
+		Issuer:   ti.serverURL.String() + "/mcp/" + toolset.McpSlug.String,
+		Lifetime: time.Hour,
+	})
 	require.NoError(t, err)
 	return token
 }

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
@@ -58,7 +59,7 @@ func parseInitializeParams(raw json.RawMessage) (initializeParams, []string, err
 	return params, slices.Sorted(maps.Keys(params.Capabilities)), nil
 }
 
-func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries) (json.RawMessage, error) {
+func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries, clientInfoCache *cache.TypedCacheObject[SessionClientInfo]) (json.RawMessage, error) {
 	params, capabilities, err := parseInitializeParams(req.Params)
 	validParams := err == nil
 	if err != nil {
@@ -66,6 +67,8 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest,
 		// recorded client info for this request.
 		logger.WarnContext(ctx, "failed to parse mcp initialize params", attr.SlogError(err))
 	}
+
+	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, params.ClientInfo.Name, params.ClientInfo.Version)
 
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		if err := productMetrics.CaptureEvent(ctx, "mcp_initialized", payload.sessionID, map[string]any{

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
@@ -59,7 +58,7 @@ func parseInitializeParams(raw json.RawMessage) (initializeParams, []string, err
 	return params, slices.Sorted(maps.Keys(params.Capabilities)), nil
 }
 
-func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries, clientInfoCache *cache.TypedCacheObject[SessionClientInfo]) (json.RawMessage, error) {
+func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries, clientInfoStore sessionClientInfoStore) (json.RawMessage, error) {
 	params, capabilities, err := parseInitializeParams(req.Params)
 	validParams := err == nil
 	if err != nil {
@@ -68,7 +67,7 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest,
 		logger.WarnContext(ctx, "failed to parse mcp initialize params", attr.SlogError(err))
 	}
 
-	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, params.ClientInfo.Name, params.ClientInfo.Version)
+	storeSessionClientInfo(ctx, logger, clientInfoStore, payload, params.ClientInfo.Name, params.ClientInfo.Version)
 
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		if err := productMetrics.CaptureEvent(ctx, "mcp_initialized", payload.sessionID, map[string]any{

--- a/server/internal/mcp/rpc_resources_read.go
+++ b/server/internal/mcp/rpc_resources_read.go
@@ -201,6 +201,10 @@ func handleResourcesRead(
 		OAuthToken: "", // Resources do not support OAuth tokens for external MCP
 		GramEmail:  "",
 		GramChatID: payload.chatID,
+		// Resource reads reach functions through a separate payload that
+		// carries no caller identity, and the functions SDK exposes none on a
+		// resource handler.
+		MCPClient: toolconfig.MCPClientIdentity{Name: "", Version: "", OAuthClientID: ""},
 	}, plan, logAttrs)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute resource call").LogError(ctx, logger)

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -97,7 +97,7 @@ func handleToolsCall(
 	mcpMetadataRepo *mcpmetadata_repo.Queries,
 	auditLogger *audit.Logger,
 	platformExtras []platformtools.ExternalTool,
-	clientInfoCache *cache.TypedCacheObject[SessionClientInfo],
+	clientInfoStore sessionClientInfoStore,
 ) (json.RawMessage, error) {
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -286,7 +286,7 @@ func handleToolsCall(
 		OAuthToken: oauthToken,
 		GramEmail:  gramEmail,
 		GramChatID: payload.chatID,
-		MCPClient:  resolveClientIdentity(ctx, logger, clientInfoCache, payload, clientInfoHint),
+		MCPClient:  resolveClientIdentity(ctx, logger, clientInfoStore, payload, clientInfoHint),
 	}
 
 	err = filterOmittedEnvVars(ctx, toolCallEnv, mcpMetadataRepo, toolsetID)

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -52,6 +52,23 @@ import (
 type toolsCallParams struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments"`
+	Meta      *toolsCallMeta  `json:"_meta,omitempty"`
+}
+
+// toolsCallMeta is the subset of request `_meta` Gram reads. Clients may send
+// any keys they like; unknown ones are dropped on decode.
+type toolsCallMeta struct {
+	// ClientInfo is the per-request caller identity introduced by the draft
+	// stateless MCP work (SEP-2575), where the handshake fields move onto
+	// every request.
+	ClientInfo *mcpClientInfoHint `json:"io.modelcontextprotocol/clientInfo,omitempty"`
+}
+
+// mcpClientInfoHint is an MCP `Implementation` value as reported by a client.
+// Untrusted and self-reported.
+type mcpClientInfoHint struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 const (
@@ -80,6 +97,7 @@ func handleToolsCall(
 	mcpMetadataRepo *mcpmetadata_repo.Queries,
 	auditLogger *audit.Logger,
 	platformExtras []platformtools.ExternalTool,
+	clientInfoCache *cache.TypedCacheObject[SessionClientInfo],
 ) (json.RawMessage, error) {
 	var params toolsCallParams
 	if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -257,12 +275,18 @@ func handleToolsCall(
 		}
 	}
 
+	var clientInfoHint *mcpClientInfoHint
+	if params.Meta != nil {
+		clientInfoHint = params.Meta.ClientInfo
+	}
+
 	toolCallEnv := toolconfig.ToolCallEnv{
 		UserConfig: userConfig,
 		SystemEnv:  systemConfig,
 		OAuthToken: oauthToken,
 		GramEmail:  gramEmail,
 		GramChatID: payload.chatID,
+		MCPClient:  resolveClientIdentity(ctx, logger, clientInfoCache, payload, clientInfoHint),
 	}
 
 	err = filterOmittedEnvVars(ctx, toolCallEnv, mcpMetadataRepo, toolsetID)

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -317,6 +317,8 @@ func (s *Service) callPlatformToolsetTool(
 		OAuthToken: "",
 		GramEmail:  gramEmail,
 		GramChatID: chatIDHeader,
+		// Platform toolsets serve Gram's own tools, never customer functions.
+		MCPClient: toolconfig.MCPClientIdentity{Name: "", Version: "", OAuthClientID: ""},
 	}
 
 	var mcpURL string

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -670,12 +670,12 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_ResolvesG
 	// the issuer URN (remote-backed endpoints bind the audience to the
 	// issuer, not the backend id). Subject is the dev user, an active member
 	// of the org, so PrepareContext can resolve principals.
-	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(
-		urn.NewUserSubject(mockidp.MockUserID),
-		urn.NewUserSessionIssuer(issuerID).String(),
-		ti.serverURL.String()+"/x/mcp/"+endpointSlug,
-		time.Hour,
-	)
+	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+		Subject:  urn.NewUserSubject(mockidp.MockUserID),
+		Audience: urn.NewUserSessionIssuer(issuerID).String(),
+		Issuer:   ti.serverURL.String() + "/x/mcp/" + endpointSlug,
+		Lifetime: time.Hour,
+	})
 	require.NoError(t, err)
 
 	// A plain context (no session auth) so the only credential is the bearer
@@ -734,12 +734,12 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_RequiresC
 	endpointSlug := "endpoint-" + uuid.NewString()
 	createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, upstream.URL, endpointSlug, "private", issuerID)
 
-	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(
-		urn.NewUserSubject(mockidp.MockUserID),
-		urn.NewUserSessionIssuer(issuerID).String(),
-		ti.serverURL.String()+"/x/mcp/"+endpointSlug,
-		time.Hour,
-	)
+	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+		Subject:  urn.NewUserSubject(mockidp.MockUserID),
+		Audience: urn.NewUserSessionIssuer(issuerID).String(),
+		Issuer:   ti.serverURL.String() + "/x/mcp/" + endpointSlug,
+		Lifetime: time.Hour,
+	})
 	require.NoError(t, err)
 
 	_, err = servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), token, nil)

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -2,8 +2,7 @@ package mcp
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
+	"errors"
 	"log/slog"
 	"strings"
 	"time"
@@ -11,105 +10,57 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
-const (
-	// maxClientInfoFieldLength bounds each stored client identity field. The
-	// same cap is applied to the PostHog properties recorded at initialize.
-	maxClientInfoFieldLength = 100
-	// sessionClientInfoTTL is how long a handshake identity outlives its
-	// initialize. Matches the default anonymous tunnel session lifetime.
-	sessionClientInfoTTL = 24 * time.Hour
-)
+// maxClientInfoFieldLength bounds each stored client identity field. The same
+// cap is applied to the PostHog properties recorded at initialize.
+const maxClientInfoFieldLength = 100
 
-// SessionClientInfo is the MCP client identity reported during the initialize
-// handshake, cached so later requests on the same session can resolve it.
-//
-// Under the currently-shipped MCP protocol `clientInfo` is sent only at
-// initialize, and Gram's hosted MCP path is otherwise stateless — without this
-// entry the identity is gone by the time the client calls a tool.
-//
-// The values are untrusted and self-reported. They are for observability and
-// convenience only, never authorization.
-type SessionClientInfo struct {
-	// ProjectID and ToolsetSlug scope the entry. Session ids arrive on a
-	// client-supplied header, so scoping the key keeps one tenant's sessions
-	// from addressing another's.
-	ProjectID   uuid.UUID `json:"-"`
-	ToolsetSlug string    `json:"-"`
-	SessionID   string    `json:"-"`
-
-	Name    string `json:"name"`
-	Version string `json:"version"`
+// sessionClientInfoStore records and resolves the identity a client reported
+// during the initialize handshake. Narrow interface so resolution can be
+// exercised without Redis; the production implementation is
+// sessionclientinfo.Store.
+type sessionClientInfoStore interface {
+	Store(ctx context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, info sessionclientinfo.Info, nowMillis int64) error
+	Load(ctx context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, nowMillis int64) (sessionclientinfo.Info, error)
 }
 
-var _ cache.CacheableObject[SessionClientInfo] = (*SessionClientInfo)(nil)
-
-// SessionClientInfoCacheKey builds the cache key for one session's handshake
-// identity. Exported so readers can look an entry up without materializing a
-// partial SessionClientInfo.
-//
-// The session id is hashed rather than embedded. It arrives on a
-// client-supplied header of unbounded length, and it doubles as the bearer of
-// the session — hashing gives a fixed-length key that neither bloats Redis nor
-// writes the raw value into a keyspace that gets logged and enumerated.
-// Truncating instead would collide every id sharing a prefix, letting one
-// session read another's cached identity.
-func SessionClientInfoCacheKey(projectID uuid.UUID, toolsetSlug, sessionID string) string {
-	digest := sha256.Sum256([]byte(sessionID))
-	return "mcpClientInfo:" + projectID.String() + ":" + toolsetSlug + ":" + hex.EncodeToString(digest[:])
-}
-
-// CacheKey implements cache.CacheableObject.
-func (s SessionClientInfo) CacheKey() string {
-	return SessionClientInfoCacheKey(s.ProjectID, s.ToolsetSlug, s.SessionID)
-}
-
-// AdditionalCacheKeys implements cache.CacheableObject. Single-key entry; no
-// fan-out.
-func (s SessionClientInfo) AdditionalCacheKeys() []string { return []string{} }
-
-// TTL implements cache.CacheableObject.
-func (s SessionClientInfo) TTL() time.Duration { return sessionClientInfoTTL }
-
-// storeSessionClientInfo caches the identity a client reported at initialize.
-// A client that reports no name leaves no entry, and a store failure is logged
-// rather than surfaced: losing the identity must never fail the handshake.
-func storeSessionClientInfo(ctx context.Context, logger *slog.Logger, clientInfoCache *cache.TypedCacheObject[SessionClientInfo], payload *mcpInputs, name, version string) {
+// storeSessionClientInfo records the identity a client reported at initialize.
+// A client that reports no name leaves no record, and a write failure is
+// logged rather than surfaced: losing the identity must never fail the
+// handshake.
+func storeSessionClientInfo(ctx context.Context, logger *slog.Logger, store sessionClientInfoStore, payload *mcpInputs, name, version string) {
 	name = sanitizeClientInfoField(name)
 	if name == "" || payload.sessionID == "" {
 		return
 	}
 
-	err := clientInfoCache.Store(ctx, SessionClientInfo{
-		ProjectID:   payload.projectID,
-		ToolsetSlug: payload.toolset,
-		SessionID:   payload.sessionID,
-		Name:        name,
-		Version:     sanitizeClientInfoField(version),
-	})
+	err := store.Store(ctx, payload.projectID, payload.toolset, payload.sessionID, sessionclientinfo.Info{
+		Name:    name,
+		Version: sanitizeClientInfoField(version),
+	}, time.Now().UnixMilli())
 	if err != nil {
-		logger.WarnContext(ctx, "failed to cache mcp session client info", attr.SlogError(err))
+		logger.WarnContext(ctx, "failed to record mcp session client info", attr.SlogError(err))
 	}
 }
 
 // resolveClientIdentity determines who is calling a tool.
 //
 // The client identity has two possible sources. Under the currently-shipped
-// protocol it comes from the initialize handshake, which is why it was cached.
-// Under the draft stateless model (SEP-2575) the client repeats it on every
-// request in `_meta`, and that per-call hint wins — it is the fresher of the
-// two, and a client sending it may never have handshaked at all. This matches
-// the precedence `@gram-ai/functions` already applies when a function serves
-// MCP itself.
+// protocol it comes from the initialize handshake, which is why it was
+// recorded. Under the draft stateless model (SEP-2575) the client repeats it
+// on every request in `_meta`, and that per-call hint wins — it is the fresher
+// of the two, and a client sending it may never have handshaked at all. This
+// matches the precedence `@gram-ai/functions` already applies when a function
+// serves MCP itself.
 //
 // The OAuth client id comes from the verified bearer token instead, so it is
 // unaffected by whatever the caller reports about itself.
-func resolveClientIdentity(ctx context.Context, logger *slog.Logger, clientInfoCache *cache.TypedCacheObject[SessionClientInfo], payload *mcpInputs, hint *mcpClientInfoHint) toolconfig.MCPClientIdentity {
+func resolveClientIdentity(ctx context.Context, logger *slog.Logger, store sessionClientInfoStore, payload *mcpInputs, hint *mcpClientInfoHint) toolconfig.MCPClientIdentity {
 	identity := toolconfig.MCPClientIdentity{Name: "", Version: "", OAuthClientID: ""}
 	if clientID, ok := contextvalues.GetOAuthClientID(ctx); ok {
 		identity.OAuthClientID = clientID
@@ -127,11 +78,14 @@ func resolveClientIdentity(ctx context.Context, logger *slog.Logger, clientInfoC
 		return identity
 	}
 
-	// A miss is an ordinary outcome — no Redis, an expired entry, a client
-	// that never reported a name — so it stays at debug level.
-	info, err := clientInfoCache.Get(ctx, SessionClientInfoCacheKey(payload.projectID, payload.toolset, payload.sessionID))
-	if err != nil {
-		logger.DebugContext(ctx, "no cached mcp session client info", attr.SlogError(err))
+	info, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, time.Now().UnixMilli())
+	switch {
+	case errors.Is(err, sessionclientinfo.ErrNotFound):
+		// An unknown caller is ordinary: no Redis, an evicted record, or a
+		// client that never reported a name.
+		return identity
+	case err != nil:
+		logger.WarnContext(ctx, "failed to load mcp session client info", attr.SlogError(err))
 		return identity
 	}
 

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"strings"
 	"time"
@@ -19,11 +21,6 @@ const (
 	// maxClientInfoFieldLength bounds each stored client identity field. The
 	// same cap is applied to the PostHog properties recorded at initialize.
 	maxClientInfoFieldLength = 100
-	// maxSessionIDKeyLength bounds how much of a client-supplied
-	// Mcp-Session-Id is used as cache key material, so a misbehaving client
-	// cannot bloat Redis keys. Mirrors
-	// tunnelsessions.MaxBackendSessionIDLength.
-	maxSessionIDKeyLength = 512
 	// sessionClientInfoTTL is how long a handshake identity outlives its
 	// initialize. Matches the default anonymous tunnel session lifetime.
 	sessionClientInfoTTL = 24 * time.Hour
@@ -55,8 +52,16 @@ var _ cache.CacheableObject[SessionClientInfo] = (*SessionClientInfo)(nil)
 // SessionClientInfoCacheKey builds the cache key for one session's handshake
 // identity. Exported so readers can look an entry up without materializing a
 // partial SessionClientInfo.
+//
+// The session id is hashed rather than embedded. It arrives on a
+// client-supplied header of unbounded length, and it doubles as the bearer of
+// the session — hashing gives a fixed-length key that neither bloats Redis nor
+// writes the raw value into a keyspace that gets logged and enumerated.
+// Truncating instead would collide every id sharing a prefix, letting one
+// session read another's cached identity.
 func SessionClientInfoCacheKey(projectID uuid.UUID, toolsetSlug, sessionID string) string {
-	return "mcpClientInfo:" + projectID.String() + ":" + toolsetSlug + ":" + conv.TruncateString(sessionID, maxSessionIDKeyLength)
+	digest := sha256.Sum256([]byte(sessionID))
+	return "mcpClientInfo:" + projectID.String() + ":" + toolsetSlug + ":" + hex.EncodeToString(digest[:])
 }
 
 // CacheKey implements cache.CacheableObject.

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -10,7 +10,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
 const (
@@ -88,6 +90,50 @@ func storeSessionClientInfo(ctx context.Context, logger *slog.Logger, clientInfo
 	if err != nil {
 		logger.WarnContext(ctx, "failed to cache mcp session client info", attr.SlogError(err))
 	}
+}
+
+// resolveClientIdentity determines who is calling a tool.
+//
+// The client identity has two possible sources. Under the currently-shipped
+// protocol it comes from the initialize handshake, which is why it was cached.
+// Under the draft stateless model (SEP-2575) the client repeats it on every
+// request in `_meta`, and that per-call hint wins — it is the fresher of the
+// two, and a client sending it may never have handshaked at all. This matches
+// the precedence `@gram-ai/functions` already applies when a function serves
+// MCP itself.
+//
+// The OAuth client id comes from the verified bearer token instead, so it is
+// unaffected by whatever the caller reports about itself.
+func resolveClientIdentity(ctx context.Context, logger *slog.Logger, clientInfoCache *cache.TypedCacheObject[SessionClientInfo], payload *mcpInputs, hint *mcpClientInfoHint) toolconfig.MCPClientIdentity {
+	identity := toolconfig.MCPClientIdentity{Name: "", Version: "", OAuthClientID: ""}
+	if clientID, ok := contextvalues.GetOAuthClientID(ctx); ok {
+		identity.OAuthClientID = clientID
+	}
+
+	if hint != nil {
+		if name := sanitizeClientInfoField(hint.Name); name != "" {
+			identity.Name = name
+			identity.Version = sanitizeClientInfoField(hint.Version)
+			return identity
+		}
+	}
+
+	if payload.sessionID == "" {
+		return identity
+	}
+
+	// A miss is an ordinary outcome — no Redis, an expired entry, a client
+	// that never reported a name — so it stays at debug level.
+	info, err := clientInfoCache.Get(ctx, SessionClientInfoCacheKey(payload.projectID, payload.toolset, payload.sessionID))
+	if err != nil {
+		logger.DebugContext(ctx, "no cached mcp session client info", attr.SlogError(err))
+		return identity
+	}
+
+	identity.Name = info.Name
+	identity.Version = info.Version
+
+	return identity
 }
 
 // sanitizeClientInfoField bounds one untrusted client identity field. Invalid

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+const (
+	// maxClientInfoFieldLength bounds each stored client identity field. The
+	// same cap is applied to the PostHog properties recorded at initialize.
+	maxClientInfoFieldLength = 100
+	// maxSessionIDKeyLength bounds how much of a client-supplied
+	// Mcp-Session-Id is used as cache key material, so a misbehaving client
+	// cannot bloat Redis keys. Mirrors
+	// tunnelsessions.MaxBackendSessionIDLength.
+	maxSessionIDKeyLength = 512
+	// sessionClientInfoTTL is how long a handshake identity outlives its
+	// initialize. Matches the default anonymous tunnel session lifetime.
+	sessionClientInfoTTL = 24 * time.Hour
+)
+
+// SessionClientInfo is the MCP client identity reported during the initialize
+// handshake, cached so later requests on the same session can resolve it.
+//
+// Under the currently-shipped MCP protocol `clientInfo` is sent only at
+// initialize, and Gram's hosted MCP path is otherwise stateless — without this
+// entry the identity is gone by the time the client calls a tool.
+//
+// The values are untrusted and self-reported. They are for observability and
+// convenience only, never authorization.
+type SessionClientInfo struct {
+	// ProjectID and ToolsetSlug scope the entry. Session ids arrive on a
+	// client-supplied header, so scoping the key keeps one tenant's sessions
+	// from addressing another's.
+	ProjectID   uuid.UUID `json:"-"`
+	ToolsetSlug string    `json:"-"`
+	SessionID   string    `json:"-"`
+
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+var _ cache.CacheableObject[SessionClientInfo] = (*SessionClientInfo)(nil)
+
+// SessionClientInfoCacheKey builds the cache key for one session's handshake
+// identity. Exported so readers can look an entry up without materializing a
+// partial SessionClientInfo.
+func SessionClientInfoCacheKey(projectID uuid.UUID, toolsetSlug, sessionID string) string {
+	return "mcpClientInfo:" + projectID.String() + ":" + toolsetSlug + ":" + conv.TruncateString(sessionID, maxSessionIDKeyLength)
+}
+
+// CacheKey implements cache.CacheableObject.
+func (s SessionClientInfo) CacheKey() string {
+	return SessionClientInfoCacheKey(s.ProjectID, s.ToolsetSlug, s.SessionID)
+}
+
+// AdditionalCacheKeys implements cache.CacheableObject. Single-key entry; no
+// fan-out.
+func (s SessionClientInfo) AdditionalCacheKeys() []string { return []string{} }
+
+// TTL implements cache.CacheableObject.
+func (s SessionClientInfo) TTL() time.Duration { return sessionClientInfoTTL }
+
+// storeSessionClientInfo caches the identity a client reported at initialize.
+// A client that reports no name leaves no entry, and a store failure is logged
+// rather than surfaced: losing the identity must never fail the handshake.
+func storeSessionClientInfo(ctx context.Context, logger *slog.Logger, clientInfoCache *cache.TypedCacheObject[SessionClientInfo], payload *mcpInputs, name, version string) {
+	name = sanitizeClientInfoField(name)
+	if name == "" || payload.sessionID == "" {
+		return
+	}
+
+	err := clientInfoCache.Store(ctx, SessionClientInfo{
+		ProjectID:   payload.projectID,
+		ToolsetSlug: payload.toolset,
+		SessionID:   payload.sessionID,
+		Name:        name,
+		Version:     sanitizeClientInfoField(version),
+	})
+	if err != nil {
+		logger.WarnContext(ctx, "failed to cache mcp session client info", attr.SlogError(err))
+	}
+}
+
+// sanitizeClientInfoField bounds one untrusted client identity field. Invalid
+// UTF-8 and control characters are dropped and the result is capped, so the
+// value stays safe to store and, later, to hand to a function runner.
+func sanitizeClientInfoField(value string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, strings.ToValidUTF8(value, ""))
+
+	return conv.TruncateString(cleaned, maxClientInfoFieldLength)
+}

--- a/server/internal/mcp/sessionclientinfo/setup_test.go
+++ b/server/internal/mcp/sessionclientinfo/setup_test.go
@@ -1,0 +1,28 @@
+package sessionclientinfo
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Redis: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+	}
+
+	infra = res
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("cleanup test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}

--- a/server/internal/mcp/sessionclientinfo/store.go
+++ b/server/internal/mcp/sessionclientinfo/store.go
@@ -1,0 +1,183 @@
+// Package sessionclientinfo holds the Redis-only record of who is on the other
+// end of an MCP session. A client reports its identity once, during the
+// initialize handshake; Gram's hosted MCP path is otherwise stateless, so
+// without this record the identity is gone by the time the client calls a tool.
+//
+// There is deliberately no Postgres row and no expiry. MCP sessions can run for
+// a month or longer, and a TTL long enough to cover that would put no bound on
+// the keyspace at all — while a short one would quietly drop the identity of a
+// session that is merely idle. Instead each MCP server gets a fixed budget of
+// records and the least recently used ones fall out when it is exceeded.
+//
+// That bounds abuse to the server being abused: initialize is unauthenticated
+// on a public MCP server, so anyone can mint records, but they can only churn
+// that one server's budget rather than compete for Redis with the OAuth
+// challenges and session grants sharing it.
+package sessionclientinfo
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// DefaultLiveRecordCap bounds the identities tracked per MCP server. Matches
+// the anonymous session cap the tunneled path uses; at roughly 360 bytes a
+// record that is a few megabytes per server.
+const DefaultLiveRecordCap = 10000
+
+// ErrNotFound is returned when a session has no recorded identity — never
+// handshaked with one, or evicted since. Callers treat it as "caller unknown",
+// which is an ordinary outcome rather than a failure.
+var ErrNotFound = errors.New("session client info not found")
+
+// Info is the identity a client reported for itself at initialize. Untrusted
+// and self-reported: it is carried for attribution, never authorization.
+type Info struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Store reads and writes session identities in Redis.
+type Store struct {
+	redis *redis.Client
+	cap   int
+}
+
+// NewStore builds a store bounded at cap records per MCP server. A cap of zero
+// or less takes DefaultLiveRecordCap.
+//
+// A nil client yields a store that records nothing and finds nothing, so
+// callers never have to test for one — an environment without Redis simply
+// reports every caller as unknown.
+func NewStore(redisClient *redis.Client, recordCap int) *Store {
+	if recordCap <= 0 {
+		recordCap = DefaultLiveRecordCap
+	}
+	return &Store{redis: redisClient, cap: recordCap}
+}
+
+// scope is the key fragment shared by an MCP server's record keys and its live
+// set. Wrapped in a Redis hash tag so both land in the same cluster slot —
+// admitRecord derives one from the other and must be able to touch both.
+//
+// Session ids arrive on a client-supplied header, so scoping by project and
+// toolset stops one tenant's sessions from addressing another's.
+func scope(projectID uuid.UUID, toolsetSlug string) string {
+	return "{" + projectID.String() + ":" + toolsetSlug + "}"
+}
+
+func liveSetKey(projectID uuid.UUID, toolsetSlug string) string {
+	return "mcpClientInfoLive:" + scope(projectID, toolsetSlug)
+}
+
+func recordKeyPrefix(projectID uuid.UUID, toolsetSlug string) string {
+	return "mcpClientInfo:" + scope(projectID, toolsetSlug) + ":"
+}
+
+// member hashes the session id used as key material. The id arrives on an
+// unbounded client-supplied header and doubles as the bearer of the session,
+// so hashing gives a fixed-length key that neither bloats Redis nor writes the
+// raw value into a keyspace that gets logged and enumerated. Truncating
+// instead would collide every id sharing a prefix, letting one session read
+// another's identity.
+func member(sessionID string) string {
+	digest := sha256.Sum256([]byte(sessionID))
+	return hex.EncodeToString(digest[:])
+}
+
+// admitScript writes a record, admits it to the live set, and evicts the
+// excess in one atomic step.
+//
+// Eviction is by least recent use, not by age: the score is refreshed every
+// time a record is read, so a session still in use survives no matter how old
+// it is, and what falls out is genuinely dormant. Evicting oldest-first would
+// drop exactly the long-lived sessions this record exists to serve.
+var admitScript = redis.NewScript(`
+redis.call('SET', KEYS[2], ARGV[3])
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1])
+local excess = redis.call('ZCARD', KEYS[1]) - tonumber(ARGV[4])
+if excess > 0 then
+  local evicted = redis.call('ZRANGE', KEYS[1], 0, excess - 1)
+  for _, victim in ipairs(evicted) do
+    redis.call('DEL', ARGV[5] .. victim)
+  end
+  redis.call('ZREMRANGEBYRANK', KEYS[1], 0, excess - 1)
+end
+return 1
+`)
+
+// loadScript reads a record and, when present, slides its live-set score so
+// the entry counts as recently used. A record that is gone drops its (stale)
+// live-set member too, so the budget accounting converges.
+var loadScript = redis.NewScript(`
+local value = redis.call('GET', KEYS[1])
+if not value then
+  redis.call('ZREM', KEYS[2], ARGV[1])
+  return false
+end
+redis.call('ZADD', KEYS[2], 'XX', ARGV[2], ARGV[1])
+return value
+`)
+
+// Store records the identity a client reported at initialize, evicting the
+// least recently used records of the same MCP server once the budget is full.
+//
+// nowMillis is supplied by the caller so ordering is testable.
+func (s *Store) Store(ctx context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, info Info, nowMillis int64) error {
+	if s.redis == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("marshal session client info: %w", err)
+	}
+
+	key := member(sessionID)
+	err = admitScript.Run(ctx, s.redis,
+		[]string{liveSetKey(projectID, toolsetSlug), recordKeyPrefix(projectID, toolsetSlug) + key},
+		key, nowMillis, string(payload), s.cap, recordKeyPrefix(projectID, toolsetSlug),
+	).Err()
+	if err != nil {
+		return fmt.Errorf("admit session client info: %w", err)
+	}
+
+	return nil
+}
+
+// Load returns the identity recorded for a session and marks it recently used.
+// Returns ErrNotFound when the session has none.
+func (s *Store) Load(ctx context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, nowMillis int64) (Info, error) {
+	if s.redis == nil {
+		return Info{}, ErrNotFound
+	}
+
+	key := member(sessionID)
+	raw, err := loadScript.Run(ctx, s.redis,
+		[]string{recordKeyPrefix(projectID, toolsetSlug) + key, liveSetKey(projectID, toolsetSlug)},
+		key, nowMillis,
+	).Text()
+	switch {
+	case errors.Is(err, redis.Nil):
+		return Info{}, ErrNotFound
+	case err != nil:
+		return Info{}, fmt.Errorf("load session client info: %w", err)
+	}
+
+	var info Info
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return Info{}, fmt.Errorf("unmarshal session client info: %w", err)
+	}
+	if info.Name == "" {
+		return Info{}, ErrNotFound
+	}
+
+	return info, nil
+}

--- a/server/internal/mcp/sessionclientinfo/store_test.go
+++ b/server/internal/mcp/sessionclientinfo/store_test.go
@@ -1,0 +1,132 @@
+package sessionclientinfo
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T, recordCap int) *Store {
+	t.Helper()
+	client, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	return NewStore(client, recordCap)
+}
+
+func TestStoreLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 0)
+	projectID := uuid.New()
+
+	require.NoError(t, store.Store(t.Context(), projectID, "widgets", "session-1", Info{
+		Name:    "claude-code",
+		Version: "2.1",
+	}, 1))
+
+	got, err := store.Load(t.Context(), projectID, "widgets", "session-1", 2)
+	require.NoError(t, err)
+	require.Equal(t, Info{Name: "claude-code", Version: "2.1"}, got)
+}
+
+func TestLoadUnknownSessionIsNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 0)
+
+	_, err := store.Load(t.Context(), uuid.New(), "widgets", "never-seen", 1)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestRecordsAreScopedPerMCPServer covers the tenancy boundary: session ids
+// arrive on a client-supplied header, so a record must not be reachable from
+// another project or toolset.
+func TestRecordsAreScopedPerMCPServer(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 0)
+	projectA, projectB := uuid.New(), uuid.New()
+
+	require.NoError(t, store.Store(t.Context(), projectA, "widgets", "shared", Info{
+		Name:    "claude-code",
+		Version: "2.1",
+	}, 1))
+
+	_, err := store.Load(t.Context(), projectB, "widgets", "shared", 2)
+	require.ErrorIs(t, err, ErrNotFound, "another project must not resolve this session")
+
+	_, err = store.Load(t.Context(), projectA, "gadgets", "shared", 2)
+	require.ErrorIs(t, err, ErrNotFound, "another toolset must not resolve this session")
+}
+
+// TestCapEvictsLeastRecentlyUsed is the property the whole design rests on:
+// initialize is unauthenticated on a public MCP server, so the budget is what
+// bounds the damage, and eviction must spare sessions that are still in use no
+// matter how old they are.
+func TestCapEvictsLeastRecentlyUsed(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 2)
+	projectID := uuid.New()
+	ctx := t.Context()
+
+	require.NoError(t, store.Store(ctx, projectID, "widgets", "old-but-active", Info{Name: "active", Version: ""}, 1))
+	require.NoError(t, store.Store(ctx, projectID, "widgets", "dormant", Info{Name: "dormant", Version: ""}, 2))
+
+	// Using the older record makes it the most recently used, so the dormant
+	// one becomes the eviction candidate.
+	_, err := store.Load(ctx, projectID, "widgets", "old-but-active", 3)
+	require.NoError(t, err)
+
+	require.NoError(t, store.Store(ctx, projectID, "widgets", "newcomer", Info{Name: "newcomer", Version: ""}, 4))
+
+	got, err := store.Load(ctx, projectID, "widgets", "old-but-active", 5)
+	require.NoError(t, err, "a session still in use must survive eviction regardless of age")
+	require.Equal(t, "active", got.Name)
+
+	_, err = store.Load(ctx, projectID, "widgets", "dormant", 5)
+	require.ErrorIs(t, err, ErrNotFound, "the least recently used record is the one that falls out")
+}
+
+func TestCapBoundsRecordsPerMCPServer(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 3)
+	projectID := uuid.New()
+	ctx := t.Context()
+
+	for i := range 25 {
+		require.NoError(t, store.Store(ctx, projectID, "widgets", uuid.NewString(), Info{
+			Name:    "spammer",
+			Version: "",
+		}, int64(i+1)))
+	}
+
+	client, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	live, err := client.ZCard(ctx, liveSetKey(projectID, "widgets")).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 3, live, "the live set stays at the cap")
+
+	records, err := client.Keys(ctx, recordKeyPrefix(projectID, "widgets")+"*").Result()
+	require.NoError(t, err)
+	require.Len(t, records, 3, "evicted records are deleted, not just unlinked from the live set")
+}
+
+// TestStoreWithoutRedisIsInert keeps environments with no cache wired working:
+// every caller simply resolves as unknown rather than erroring.
+func TestStoreWithoutRedisIsInert(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore(nil, 0)
+
+	require.NoError(t, store.Store(t.Context(), uuid.New(), "widgets", "session-1", Info{
+		Name:    "claude-code",
+		Version: "2.1",
+	}, 1))
+
+	_, err := store.Load(t.Context(), uuid.New(), "widgets", "session-1", 2)
+	require.ErrorIs(t, err, ErrNotFound)
+}

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -2,94 +2,49 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
-// mapCache is a minimal in-process cache.Cache for exercising resolution
-// precedence without a Redis round trip. Values round-trip through JSON so the
-// stored shape matches production.
-type mapCache struct {
-	entries map[string][]byte
+// fakeClientInfoStore records identities in memory so resolution precedence can
+// be exercised without Redis. The Redis-backed behaviour (scoping, eviction)
+// has its own tests in the sessionclientinfo package.
+type fakeClientInfoStore struct {
+	records map[string]sessionclientinfo.Info
 }
 
-var _ cache.Cache = (*mapCache)(nil)
+func newFakeClientInfoStore() *fakeClientInfoStore {
+	return &fakeClientInfoStore{records: map[string]sessionclientinfo.Info{}}
+}
 
-func newMapCache() *mapCache { return &mapCache{entries: map[string][]byte{}} }
+func (f *fakeClientInfoStore) key(projectID uuid.UUID, toolsetSlug, sessionID string) string {
+	return projectID.String() + ":" + toolsetSlug + ":" + sessionID
+}
 
-func (c *mapCache) Get(_ context.Context, key string, value any) error {
-	raw, ok := c.entries[key]
+func (f *fakeClientInfoStore) Store(_ context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, info sessionclientinfo.Info, _ int64) error {
+	f.records[f.key(projectID, toolsetSlug, sessionID)] = info
+	return nil
+}
+
+func (f *fakeClientInfoStore) Load(_ context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, _ int64) (sessionclientinfo.Info, error) {
+	info, ok := f.records[f.key(projectID, toolsetSlug, sessionID)]
 	if !ok {
-		return errNoTestCacheEntry
+		return sessionclientinfo.Info{}, sessionclientinfo.ErrNotFound
 	}
-	if err := json.Unmarshal(raw, value); err != nil {
-		return errNoTestCacheEntry
-	}
-	return nil
+	return info, nil
 }
 
-func (c *mapCache) Set(_ context.Context, key string, value any, _ time.Duration) error {
-	raw, err := json.Marshal(value)
-	if err != nil {
-		return err //nolint:wrapcheck // test double
-	}
-	c.entries[key] = raw
-	return nil
-}
-
-func (c *mapCache) GetAndDelete(ctx context.Context, key string, value any) error {
-	if err := c.Get(ctx, key, value); err != nil {
-		return err
-	}
-	delete(c.entries, key)
-	return nil
-}
-
-func (c *mapCache) Add(_ context.Context, key string, _ time.Duration) (bool, error) {
-	if _, ok := c.entries[key]; ok {
-		return false, nil
-	}
-	c.entries[key] = []byte("{}")
-	return true, nil
-}
-
-func (c *mapCache) Update(ctx context.Context, key string, value any) error {
-	return c.Set(ctx, key, value, 0)
-}
-
-func (c *mapCache) Delete(_ context.Context, key string) error {
-	delete(c.entries, key)
-	return nil
-}
-
-func (c *mapCache) Expire(context.Context, string, time.Duration) error { return nil }
-
-func (c *mapCache) ListAppend(context.Context, string, any, time.Duration) error { return nil }
-
-func (c *mapCache) ListRange(context.Context, string, int64, int64, any) error { return nil }
-
-func (c *mapCache) DeleteByPrefix(context.Context, string) error { return nil }
-
-var errNoTestCacheEntry = errors.New("no cache entry for key")
-
-func newClientIdentityFixture(t *testing.T) (*cache.TypedCacheObject[SessionClientInfo], *mcpInputs) {
+func newClientIdentityFixture(t *testing.T) (*fakeClientInfoStore, *mcpInputs) {
 	t.Helper()
 
-	backing := newMapCache()
-	typed := cache.NewTypedObjectCache[SessionClientInfo](testenv.NewLogger(t), backing, cache.SuffixNone)
-
-	return &typed, &mcpInputs{
+	return newFakeClientInfoStore(), &mcpInputs{
 		projectID:             uuid.New(),
 		toolset:               "widgets",
 		environment:           "",
@@ -108,49 +63,16 @@ func newClientIdentityFixture(t *testing.T) (*cache.TypedCacheObject[SessionClie
 	}
 }
 
-// TestSessionClientInfoCacheKey_DistinguishesLongSessionIDs guards the reason
-// the session id is hashed: a prefix-truncated key would map every id sharing
-// that prefix onto one entry, handing one session another's cached identity.
-func TestSessionClientInfoCacheKey_DistinguishesLongSessionIDs(t *testing.T) {
-	t.Parallel()
-
-	projectID := uuid.New()
-	shared := strings.Repeat("s", 4096)
-
-	first := SessionClientInfoCacheKey(projectID, "widgets", shared+"a")
-	second := SessionClientInfoCacheKey(projectID, "widgets", shared+"b")
-
-	require.NotEqual(t, first, second)
-	require.Len(t, second, len(first), "keys are fixed length regardless of session id size")
-	require.NotContains(t, first, shared, "the raw session id must not land in the keyspace")
-}
-
-func TestSessionClientInfoCacheKey_ScopedPerProjectAndToolset(t *testing.T) {
-	t.Parallel()
-
-	sessionID := "session-1"
-	projectA, projectB := uuid.New(), uuid.New()
-
-	require.NotEqual(t,
-		SessionClientInfoCacheKey(projectA, "widgets", sessionID),
-		SessionClientInfoCacheKey(projectB, "widgets", sessionID),
-	)
-	require.NotEqual(t,
-		SessionClientInfoCacheKey(projectA, "widgets", sessionID),
-		SessionClientInfoCacheKey(projectA, "gadgets", sessionID),
-	)
-}
-
 func TestResolveClientIdentity_FallsBackToHandshake(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
-	clientInfoCache, payload := newClientIdentityFixture(t)
+	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, "handshake-client", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3")
 
-	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, nil)
+	identity := resolveClientIdentity(ctx, logger, store, payload, nil)
 	require.Equal(t, toolconfig.MCPClientIdentity{
 		Name:          "handshake-client",
 		Version:       "1.2.3",
@@ -167,11 +89,11 @@ func TestResolveClientIdentity_PerCallHintWins(t *testing.T) {
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
-	clientInfoCache, payload := newClientIdentityFixture(t)
+	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, "handshake-client", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3")
 
-	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, &mcpClientInfoHint{
+	identity := resolveClientIdentity(ctx, logger, store, payload, &mcpClientInfoHint{
 		Name:    "per-call-client",
 		Version: "9.9.9",
 	})
@@ -186,11 +108,11 @@ func TestResolveClientIdentity_NamelessHintFallsBack(t *testing.T) {
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
-	clientInfoCache, payload := newClientIdentityFixture(t)
+	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, "handshake-client", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3")
 
-	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, &mcpClientInfoHint{
+	identity := resolveClientIdentity(ctx, logger, store, payload, &mcpClientInfoHint{
 		Name:    "",
 		Version: "9.9.9",
 	})
@@ -203,14 +125,45 @@ func TestResolveClientIdentity_BoundsPerCallHint(t *testing.T) {
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
-	clientInfoCache, payload := newClientIdentityFixture(t)
+	store, payload := newClientIdentityFixture(t)
 
-	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, &mcpClientInfoHint{
+	identity := resolveClientIdentity(ctx, logger, store, payload, &mcpClientInfoHint{
 		Name:    "ev\x00il\nclient",
 		Version: "1.\t0",
 	})
 	require.Equal(t, "evilclient", identity.Name)
 	require.Equal(t, "1.0", identity.Version)
+}
+
+// TestStoreSessionClientInfo_BoundsRecordedFields pins that the untrusted
+// handshake values are cleaned before they are recorded, not just on the way
+// out.
+func TestStoreSessionClientInfo_BoundsRecordedFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	store, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, store, payload, "ev\x00il\nclient", "1.\t0")
+
+	info, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, 0)
+	require.NoError(t, err)
+	require.Equal(t, "evilclient", info.Name)
+	require.Equal(t, "1.0", info.Version)
+}
+
+func TestStoreSessionClientInfo_NamelessClientRecordsNothing(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	store, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, store, payload, "", "1.2.3")
+
+	_, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, 0)
+	require.ErrorIs(t, err, sessionclientinfo.ErrNotFound)
 }
 
 // TestResolveClientIdentity_OAuthClientIsIndependent pins the split between the
@@ -220,10 +173,10 @@ func TestResolveClientIdentity_OAuthClientIsIndependent(t *testing.T) {
 	t.Parallel()
 
 	logger := testenv.NewLogger(t)
-	clientInfoCache, payload := newClientIdentityFixture(t)
+	store, payload := newClientIdentityFixture(t)
 	ctx := contextvalues.SetOAuthClientID(t.Context(), "oauth-client-1")
 
-	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, nil)
+	identity := resolveClientIdentity(ctx, logger, store, payload, nil)
 	require.Empty(t, identity.Name, "no client reported an identity")
 	require.Equal(t, "oauth-client-1", identity.OAuthClientID)
 }
@@ -233,7 +186,7 @@ func TestResolveClientIdentity_UnknownCallerIsZero(t *testing.T) {
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
-	clientInfoCache, payload := newClientIdentityFixture(t)
+	store, payload := newClientIdentityFixture(t)
 
-	require.True(t, resolveClientIdentity(ctx, logger, clientInfoCache, payload, nil).IsZero())
+	require.True(t, resolveClientIdentity(ctx, logger, store, payload, nil).IsZero())
 }

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,6 +106,39 @@ func newClientIdentityFixture(t *testing.T) (*cache.TypedCacheObject[SessionClie
 		mcpServerID:           nil,
 		tags:                  nil,
 	}
+}
+
+// TestSessionClientInfoCacheKey_DistinguishesLongSessionIDs guards the reason
+// the session id is hashed: a prefix-truncated key would map every id sharing
+// that prefix onto one entry, handing one session another's cached identity.
+func TestSessionClientInfoCacheKey_DistinguishesLongSessionIDs(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	shared := strings.Repeat("s", 4096)
+
+	first := SessionClientInfoCacheKey(projectID, "widgets", shared+"a")
+	second := SessionClientInfoCacheKey(projectID, "widgets", shared+"b")
+
+	require.NotEqual(t, first, second)
+	require.Len(t, second, len(first), "keys are fixed length regardless of session id size")
+	require.NotContains(t, first, shared, "the raw session id must not land in the keyspace")
+}
+
+func TestSessionClientInfoCacheKey_ScopedPerProjectAndToolset(t *testing.T) {
+	t.Parallel()
+
+	sessionID := "session-1"
+	projectA, projectB := uuid.New(), uuid.New()
+
+	require.NotEqual(t,
+		SessionClientInfoCacheKey(projectA, "widgets", sessionID),
+		SessionClientInfoCacheKey(projectB, "widgets", sessionID),
+	)
+	require.NotEqual(t,
+		SessionClientInfoCacheKey(projectA, "widgets", sessionID),
+		SessionClientInfoCacheKey(projectA, "gadgets", sessionID),
+	)
 }
 
 func TestResolveClientIdentity_FallsBackToHandshake(t *testing.T) {

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -1,0 +1,205 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+// mapCache is a minimal in-process cache.Cache for exercising resolution
+// precedence without a Redis round trip. Values round-trip through JSON so the
+// stored shape matches production.
+type mapCache struct {
+	entries map[string][]byte
+}
+
+var _ cache.Cache = (*mapCache)(nil)
+
+func newMapCache() *mapCache { return &mapCache{entries: map[string][]byte{}} }
+
+func (c *mapCache) Get(_ context.Context, key string, value any) error {
+	raw, ok := c.entries[key]
+	if !ok {
+		return errNoTestCacheEntry
+	}
+	if err := json.Unmarshal(raw, value); err != nil {
+		return errNoTestCacheEntry
+	}
+	return nil
+}
+
+func (c *mapCache) Set(_ context.Context, key string, value any, _ time.Duration) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err //nolint:wrapcheck // test double
+	}
+	c.entries[key] = raw
+	return nil
+}
+
+func (c *mapCache) GetAndDelete(ctx context.Context, key string, value any) error {
+	if err := c.Get(ctx, key, value); err != nil {
+		return err
+	}
+	delete(c.entries, key)
+	return nil
+}
+
+func (c *mapCache) Add(_ context.Context, key string, _ time.Duration) (bool, error) {
+	if _, ok := c.entries[key]; ok {
+		return false, nil
+	}
+	c.entries[key] = []byte("{}")
+	return true, nil
+}
+
+func (c *mapCache) Update(ctx context.Context, key string, value any) error {
+	return c.Set(ctx, key, value, 0)
+}
+
+func (c *mapCache) Delete(_ context.Context, key string) error {
+	delete(c.entries, key)
+	return nil
+}
+
+func (c *mapCache) Expire(context.Context, string, time.Duration) error { return nil }
+
+func (c *mapCache) ListAppend(context.Context, string, any, time.Duration) error { return nil }
+
+func (c *mapCache) ListRange(context.Context, string, int64, int64, any) error { return nil }
+
+func (c *mapCache) DeleteByPrefix(context.Context, string) error { return nil }
+
+var errNoTestCacheEntry = errors.New("no cache entry for key")
+
+func newClientIdentityFixture(t *testing.T) (*cache.TypedCacheObject[SessionClientInfo], *mcpInputs) {
+	t.Helper()
+
+	backing := newMapCache()
+	typed := cache.NewTypedObjectCache[SessionClientInfo](testenv.NewLogger(t), backing, cache.SuffixNone)
+
+	return &typed, &mcpInputs{
+		projectID:             uuid.New(),
+		toolset:               "widgets",
+		environment:           "",
+		mcpEnvVariables:       nil,
+		oauthTokenInputs:      nil,
+		authenticated:         false,
+		sessionID:             "session-1",
+		chatID:                "",
+		mode:                  ToolModeStatic,
+		userID:                "",
+		externalUserID:        "",
+		apiKeyID:              "",
+		toolVariationsGroupID: nil,
+		mcpServerID:           nil,
+		tags:                  nil,
+	}
+}
+
+func TestResolveClientIdentity_FallsBackToHandshake(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	clientInfoCache, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, "handshake-client", "1.2.3")
+
+	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, nil)
+	require.Equal(t, toolconfig.MCPClientIdentity{
+		Name:          "handshake-client",
+		Version:       "1.2.3",
+		OAuthClientID: "",
+	}, identity)
+}
+
+// TestResolveClientIdentity_PerCallHintWins covers the draft stateless model
+// (SEP-2575), where a client repeats its identity on every request. That value
+// is fresher than the handshake and belongs to a client that may never have
+// handshaked at all.
+func TestResolveClientIdentity_PerCallHintWins(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	clientInfoCache, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, "handshake-client", "1.2.3")
+
+	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, &mcpClientInfoHint{
+		Name:    "per-call-client",
+		Version: "9.9.9",
+	})
+	require.Equal(t, "per-call-client", identity.Name)
+	require.Equal(t, "9.9.9", identity.Version)
+}
+
+// TestResolveClientIdentity_NamelessHintFallsBack keeps a malformed or empty
+// per-call hint from erasing a good handshake identity.
+func TestResolveClientIdentity_NamelessHintFallsBack(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	clientInfoCache, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, clientInfoCache, payload, "handshake-client", "1.2.3")
+
+	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, &mcpClientInfoHint{
+		Name:    "",
+		Version: "9.9.9",
+	})
+	require.Equal(t, "handshake-client", identity.Name)
+	require.Equal(t, "1.2.3", identity.Version)
+}
+
+func TestResolveClientIdentity_BoundsPerCallHint(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	clientInfoCache, payload := newClientIdentityFixture(t)
+
+	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, &mcpClientInfoHint{
+		Name:    "ev\x00il\nclient",
+		Version: "1.\t0",
+	})
+	require.Equal(t, "evilclient", identity.Name)
+	require.Equal(t, "1.0", identity.Version)
+}
+
+// TestResolveClientIdentity_OAuthClientIsIndependent pins the split between the
+// two identities: the OAuth client comes from the verified bearer token, so it
+// survives whatever the caller reports (or fails to report) about itself.
+func TestResolveClientIdentity_OAuthClientIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	logger := testenv.NewLogger(t)
+	clientInfoCache, payload := newClientIdentityFixture(t)
+	ctx := contextvalues.SetOAuthClientID(t.Context(), "oauth-client-1")
+
+	identity := resolveClientIdentity(ctx, logger, clientInfoCache, payload, nil)
+	require.Empty(t, identity.Name, "no client reported an identity")
+	require.Equal(t, "oauth-client-1", identity.OAuthClientID)
+}
+
+func TestResolveClientIdentity_UnknownCallerIsZero(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	clientInfoCache, payload := newClientIdentityFixture(t)
+
+	require.True(t, resolveClientIdentity(ctx, logger, clientInfoCache, payload, nil).IsZero())
+}

--- a/server/internal/mcp/sessionclientinfo_test.go
+++ b/server/internal/mcp/sessionclientinfo_test.go
@@ -1,0 +1,118 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// makeInitializeBodyWithClientInfo builds an initialize request reporting a
+// specific client identity.
+func makeInitializeBodyWithClientInfo(t *testing.T, name, version string) []byte {
+	t.Helper()
+
+	bs, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": name, "version": version},
+		},
+	})
+	require.NoError(t, err)
+
+	return bs
+}
+
+func TestServePublic_InitializeCachesClientInfo(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "client-info-capture")
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "initialize response: %s", w.Body.String())
+
+	sessionID := w.Header().Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+
+	clientInfoCache := cache.NewTypedObjectCache[mcp.SessionClientInfo](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	info, err := clientInfoCache.Get(ctx, mcp.SessionClientInfoCacheKey(*authCtx.ProjectID, toolset.Slug, sessionID))
+	require.NoError(t, err, "the handshake identity must outlive initialize; tool calls have no other source for it")
+	require.Equal(t, "test-client", info.Name)
+	require.Equal(t, "1.0.0", info.Version)
+}
+
+// TestServePublic_InitializeBoundsCachedClientInfo covers the untrusted nature
+// of clientInfo: the values are self-reported by the caller and end up in a
+// function tool-call payload, so they must be stripped of control characters
+// and capped before they are stored.
+func TestServePublic_InitializeBoundsCachedClientInfo(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "client-info-bounds")
+
+	body := makeInitializeBodyWithClientInfo(t, "ev\x00il\nclient"+strings.Repeat("x", 200), "1.\t0")
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "initialize response: %s", w.Body.String())
+
+	sessionID := w.Header().Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+
+	clientInfoCache := cache.NewTypedObjectCache[mcp.SessionClientInfo](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	info, err := clientInfoCache.Get(ctx, mcp.SessionClientInfoCacheKey(*authCtx.ProjectID, toolset.Slug, sessionID))
+	require.NoError(t, err)
+	require.Equal(t, "evilclient"+strings.Repeat("x", 90), info.Name)
+	require.Len(t, info.Name, 100)
+	require.Equal(t, "1.0", info.Version)
+}
+
+// TestServePublic_InitializeWithoutClientInfoCachesNothing keeps the cache free
+// of nameless entries so readers can treat a miss and an anonymous client the
+// same way.
+func TestServePublic_InitializeWithoutClientInfoCachesNothing(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsets_repo.New(ti.conn), authCtx, "client-info-absent")
+
+	body := makeInitializeBodyWithClientInfo(t, "", "")
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "initialize response: %s", w.Body.String())
+
+	sessionID := w.Header().Get("Mcp-Session-Id")
+	require.NotEmpty(t, sessionID)
+
+	clientInfoCache := cache.NewTypedObjectCache[mcp.SessionClientInfo](ti.logger, ti.cacheAdapter, cache.SuffixNone)
+	_, err = clientInfoCache.Get(ctx, mcp.SessionClientInfoCacheKey(*authCtx.ProjectID, toolset.Slug, sessionID))
+	require.Error(t, err)
+}

--- a/server/internal/mcp/sessionclientinfo_test.go
+++ b/server/internal/mcp/sessionclientinfo_test.go
@@ -8,11 +8,21 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
+
+// newClientInfoStore reads the same records the server writes, so these tests
+// assert against real Redis rather than the service's own view of it.
+func newClientInfoStore(t *testing.T) *sessionclientinfo.Store {
+	t.Helper()
+
+	client, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	return sessionclientinfo.NewStore(client, 0)
+}
 
 // makeInitializeBodyWithClientInfo builds an initialize request reporting a
 // specific client identity.
@@ -52,8 +62,7 @@ func TestServePublic_InitializeCachesClientInfo(t *testing.T) {
 	sessionID := w.Header().Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
 
-	clientInfoCache := cache.NewTypedObjectCache[mcp.SessionClientInfo](ti.logger, ti.cacheAdapter, cache.SuffixNone)
-	info, err := clientInfoCache.Get(ctx, mcp.SessionClientInfoCacheKey(*authCtx.ProjectID, toolset.Slug, sessionID))
+	info, err := newClientInfoStore(t).Load(ctx, *authCtx.ProjectID, toolset.Slug, sessionID, 0)
 	require.NoError(t, err, "the handshake identity must outlive initialize; tool calls have no other source for it")
 	require.Equal(t, "test-client", info.Name)
 	require.Equal(t, "1.0.0", info.Version)
@@ -82,8 +91,7 @@ func TestServePublic_InitializeBoundsCachedClientInfo(t *testing.T) {
 	sessionID := w.Header().Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
 
-	clientInfoCache := cache.NewTypedObjectCache[mcp.SessionClientInfo](ti.logger, ti.cacheAdapter, cache.SuffixNone)
-	info, err := clientInfoCache.Get(ctx, mcp.SessionClientInfoCacheKey(*authCtx.ProjectID, toolset.Slug, sessionID))
+	info, err := newClientInfoStore(t).Load(ctx, *authCtx.ProjectID, toolset.Slug, sessionID, 0)
 	require.NoError(t, err)
 	require.Equal(t, "evilclient"+strings.Repeat("x", 90), info.Name)
 	require.Len(t, info.Name, 100)
@@ -112,7 +120,6 @@ func TestServePublic_InitializeWithoutClientInfoCachesNothing(t *testing.T) {
 	sessionID := w.Header().Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
 
-	clientInfoCache := cache.NewTypedObjectCache[mcp.SessionClientInfo](ti.logger, ti.cacheAdapter, cache.SuffixNone)
-	_, err = clientInfoCache.Get(ctx, mcp.SessionClientInfoCacheKey(*authCtx.ProjectID, toolset.Slug, sessionID))
-	require.Error(t, err)
+	_, err = newClientInfoStore(t).Load(ctx, *authCtx.ProjectID, toolset.Slug, sessionID, 0)
+	require.ErrorIs(t, err, sessionclientinfo.ErrNotFound)
 }

--- a/server/internal/toolconfig/env.go
+++ b/server/internal/toolconfig/env.go
@@ -132,10 +132,12 @@ func (c *CaseInsensitiveEnv) Keys() []string {
 
 // MCPClientIdentity describes who is on the other end of an MCP tool call.
 //
-// The two identities have very different weight. Name and Version are
-// self-reported by the client and must never be used for authorization —
-// they exist so tools can adapt to a known caller and for observability.
-// OAuthClientID is established by the authorization flow.
+// Name and Version are self-reported by the client. OAuthClientID is read from
+// the caller's verified bearer token, so it is the sounder of the two here —
+// but it is forwarded to tools as plain request metadata, where that
+// provenance no longer travels with it. Both are for attribution and
+// observability; authorization stays on this side of the boundary, where the
+// credential is actually checked.
 //
 // Every field is optional: direct (non-MCP) tool calls populate none of them,
 // and an MCP client may report an identity without authenticating, or the

--- a/server/internal/toolconfig/env.go
+++ b/server/internal/toolconfig/env.go
@@ -130,6 +130,27 @@ func (c *CaseInsensitiveEnv) Keys() []string {
 	return keys
 }
 
+// MCPClientIdentity describes who is on the other end of an MCP tool call.
+//
+// The two identities have very different weight. Name and Version are
+// self-reported by the client and must never be used for authorization —
+// they exist so tools can adapt to a known caller and for observability.
+// OAuthClientID is established by the authorization flow.
+//
+// Every field is optional: direct (non-MCP) tool calls populate none of them,
+// and an MCP client may report an identity without authenticating, or the
+// reverse.
+type MCPClientIdentity struct {
+	Name          string
+	Version       string
+	OAuthClientID string
+}
+
+// IsZero reports whether nothing is known about the caller.
+func (m MCPClientIdentity) IsZero() bool {
+	return m.Name == "" && m.Version == "" && m.OAuthClientID == ""
+}
+
 // ToolCallEnv holds the environment configuration for a tool call.
 // SystemEnv contains base values, UserConfig contains user overrides.
 // OAuthToken is an optional OAuth token for external MCP servers that require authentication.
@@ -140,6 +161,8 @@ type ToolCallEnv struct {
 	GramEmail  string // Authenticated Gram user's email (empty if not applicable)
 	// GramChatID is the authoritative assistant chat UUID when supplied by the caller.
 	GramChatID string
+	// MCPClient identifies the MCP caller, when the tool was called over MCP.
+	MCPClient MCPClientIdentity
 }
 
 // Merged returns a case-insensitive view where UserConfig values override

--- a/server/internal/usersessions/jwt.go
+++ b/server/internal/usersessions/jwt.go
@@ -47,10 +47,26 @@ type SessionClaims struct {
 	// this one is established by the authorization flow rather than
 	// self-reported.
 	//
-	// Empty on tokens minted outside an OAuth client flow, and on tokens
-	// minted before this claim existed — readers must treat it as optional.
+	// Mint paths with no registered client stamp FirstPartyClientID instead.
+	// Empty only on tokens minted before this claim existed, so readers must
+	// still treat it as optional.
 	ClientID string `json:"client_id,omitempty"`
 }
+
+// FirstPartyClientID is the `client_id` stamped on sessions minted for our own
+// surfaces, which have no registered OAuth client because they never run the
+// authorization dance.
+//
+// A deliberate departure from RFC 9068, where `client_id` names a registered
+// client. Leaving it empty is indistinguishable from "unknown", and a reader
+// asking who called cannot tell a first-party session from an old token minted
+// before the claim existed. A URN says it outright.
+//
+// Deliberately not a resolvable URL: an `https://…` value would be read as an
+// OAuth Client ID Metadata Document, which requires the client_id to equal a
+// URL serving that document (see `user_session_clients.client_id_metadata_uri`).
+// This resolves to nothing and should never be looked up.
+const FirstPartyClientID = "client:first-party"
 
 // JWTSigningKeyFlag is the CLI flag (and env var via GRAM_JWT_SIGNING_KEY)
 // that supplies the HMAC secret to NewSigner at server boot. Defining the

--- a/server/internal/usersessions/jwt.go
+++ b/server/internal/usersessions/jwt.go
@@ -7,7 +7,8 @@
 // reads. The two signers are intentionally separate code paths so the
 // chat-session signer can be deleted in isolation.
 //
-// Schema is OIDC-shaped registered claims only (per `schemas/jwt.go`): no
+// Schema is standard claims only: the OIDC registered set plus `client_id`
+// from RFC 9068 §2.2 (JWT Profile for OAuth 2.0 Access Tokens). No
 // Gram-specific extras live on the JWT. Org / project / etc. resolve from the
 // session record in Postgres (`user_sessions`), keyed by the refresh-token
 // hash on token exchange or by JTI on access-token validation.
@@ -36,9 +37,19 @@ type RevocationChecker interface {
 
 // SessionClaims is the unified JWT claim shape for Gram-issued user sessions
 // (and, as the chat-session path retires, all Gram session tokens). Carries
-// only the standard OIDC registered claims.
+// the standard OIDC registered claims plus the OAuth client the token was
+// issued to.
 type SessionClaims struct {
 	jwt.RegisteredClaims
+
+	// ClientID identifies the OAuth client this token was issued to (RFC 9068
+	// §2.2). Unlike the client identity an MCP client reports at initialize,
+	// this one is established by the authorization flow rather than
+	// self-reported.
+	//
+	// Empty on tokens minted outside an OAuth client flow, and on tokens
+	// minted before this claim existed — readers must treat it as optional.
+	ClientID string `json:"client_id,omitempty"`
 }
 
 // JWTSigningKeyFlag is the CLI flag (and env var via GRAM_JWT_SIGNING_KEY)
@@ -58,23 +69,37 @@ func NewSigner(secret string) *Signer {
 	return &Signer{key: []byte(secret)}
 }
 
-// Mint produces an HS256-signed JWT carrying the supplied subject + audience
-// + issuer + lifetime. Returns the signed token plus the JTI so the caller
-// can persist it on the user_sessions row for later revocation.
-func (s *Signer) Mint(subject urn.SessionSubject, audience, issuer string, lifetime time.Duration) (token string, jti string, err error) {
+// MintParams describes one session token to sign. A struct rather than
+// positional arguments so every caller has to state which OAuth client the
+// token belongs to — several mint paths legitimately have none.
+type MintParams struct {
+	Subject  urn.SessionSubject
+	Audience string
+	Issuer   string
+	Lifetime time.Duration
+	// ClientID is the OAuth client the token is issued to, or empty for mint
+	// paths with no client (e.g. API-key exchange).
+	ClientID string
+}
+
+// Mint produces an HS256-signed JWT from the supplied params. Returns the
+// signed token plus the JTI so the caller can persist it on the user_sessions
+// row for later revocation.
+func (s *Signer) Mint(params MintParams) (token string, jti string, err error) {
 	now := time.Now()
 	jti = uuid.NewString()
 
 	claims := SessionClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        jti,
-			Issuer:    issuer,
-			Subject:   subject.String(),
-			Audience:  jwt.ClaimStrings{audience},
+			Issuer:    params.Issuer,
+			Subject:   params.Subject.String(),
+			Audience:  jwt.ClaimStrings{params.Audience},
 			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(lifetime)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(params.Lifetime)),
 			NotBefore: nil,
 		},
+		ClientID: params.ClientID,
 	}
 
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -99,7 +124,7 @@ func (s *Signer) Validate(token, expectedAudience string) (*SessionClaims, error
 		NotBefore: nil,
 		IssuedAt:  nil,
 		ID:        "",
-	}}
+	}, ClientID: ""}
 	parsed, err := jwt.ParseWithClaims(token, &claims, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
@@ -115,21 +140,31 @@ func (s *Signer) Validate(token, expectedAudience string) (*SessionClaims, error
 	return &claims, nil
 }
 
+// ValidatedSession is what a Bearer token resolves to once it has been
+// verified: who is calling, which token it was, and which OAuth client holds
+// it.
+type ValidatedSession struct {
+	Subject urn.SessionSubject
+	JTI     string
+	// ClientID is the OAuth client the token was issued to, empty when the
+	// token carries no `client_id` claim.
+	ClientID string
+}
+
 // ValidateBearer bundles the full /mcp/{slug} Bearer validation path:
 // signature + expiry + audience match (via Validate), revocation cache
 // lookup (via the RevocationChecker), and URN parse of the `sub` claim.
-// Returns the parsed subject and JTI on success.
 //
 // Callers stay free of JWT primitives and revocation plumbing — they only
 // need a Signer + a RevocationChecker (typically *chatsessions.Manager
 // while the unified revocation keyspace is shared with chat sessions).
-func (s *Signer) ValidateBearer(ctx context.Context, token, expectedAudience string, revocation RevocationChecker) (urn.SessionSubject, string, error) {
+func (s *Signer) ValidateBearer(ctx context.Context, token, expectedAudience string, revocation RevocationChecker) (ValidatedSession, error) {
 	claims, err := s.Validate(token, expectedAudience)
 	if err != nil {
-		return urn.SessionSubject{}, "", err
+		return ValidatedSession{}, err
 	}
 	if claims == nil {
-		return urn.SessionSubject{}, "", errors.New("validate token: nil claims")
+		return ValidatedSession{}, errors.New("validate token: nil claims")
 	}
 	// Fail closed on revocation-cache errors: if we can't tell whether a
 	// token is revoked (Redis outage, network blip), refuse the token
@@ -139,16 +174,16 @@ func (s *Signer) ValidateBearer(ctx context.Context, token, expectedAudience str
 	// worst possible failure mode for a security control.
 	revoked, err := revocation.IsTokenRevoked(ctx, claims.ID)
 	if err != nil {
-		return urn.SessionSubject{}, "", fmt.Errorf("check revocation: %w", err)
+		return ValidatedSession{}, fmt.Errorf("check revocation: %w", err)
 	}
 	if revoked {
-		return urn.SessionSubject{}, "", errors.New("token is revoked")
+		return ValidatedSession{}, errors.New("token is revoked")
 	}
 	subject, err := urn.ParseSessionSubject(claims.Subject)
 	if err != nil {
-		return urn.SessionSubject{}, "", fmt.Errorf("parse session subject: %w", err)
+		return ValidatedSession{}, fmt.Errorf("parse session subject: %w", err)
 	}
-	return subject, claims.ID, nil
+	return ValidatedSession{Subject: subject, JTI: claims.ID, ClientID: claims.ClientID}, nil
 }
 
 // ParseUnverifiedJTI extracts the `jti` claim from a token without verifying
@@ -165,7 +200,7 @@ func (s *Signer) ParseUnverifiedJTI(token string) (string, error) {
 		NotBefore: nil,
 		IssuedAt:  nil,
 		ID:        "",
-	}}
+	}, ClientID: ""}
 	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
 		return "", fmt.Errorf("parse unverified token: %w", err)
 	}

--- a/server/internal/usersessions/jwt_test.go
+++ b/server/internal/usersessions/jwt_test.go
@@ -1,0 +1,88 @@
+package usersessions_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+)
+
+// neverRevoked is a RevocationChecker that admits every token, so signer tests
+// exercise claim handling without a Redis round trip.
+type neverRevoked struct{}
+
+func (neverRevoked) IsTokenRevoked(context.Context, string) (bool, error) { return false, nil }
+
+// decodeJWTPayload returns the raw claim set of a signed token, so tests can
+// assert on the wire representation rather than the parsed struct.
+func decodeJWTPayload(t *testing.T, token string) map[string]any {
+	t.Helper()
+
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(raw, &claims))
+
+	return claims
+}
+
+func TestSigner_MintCarriesOAuthClientID(t *testing.T) {
+	t.Parallel()
+
+	signer := usersessions.NewSigner("test-jwt-secret")
+	subject := urn.NewUserSubject("user-1")
+
+	token, jti, err := signer.Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: "aud",
+		Issuer:   "https://example.test/mcp/slug",
+		Lifetime: time.Hour,
+		ClientID: "client-abc",
+	})
+	require.NoError(t, err)
+
+	session, err := signer.ValidateBearer(t.Context(), token, "aud", neverRevoked{})
+	require.NoError(t, err)
+	require.Equal(t, subject, session.Subject)
+	require.Equal(t, jti, session.JTI)
+	require.Equal(t, "client-abc", session.ClientID,
+		"the OAuth client must survive the round trip; it is the only verified caller identity a tool call gets")
+
+	require.Equal(t, "client-abc", decodeJWTPayload(t, token)["client_id"],
+		"the claim name is client_id per RFC 9068 §2.2")
+}
+
+// TestSigner_MintWithoutClientIDOmitsClaim covers the mint paths that have no
+// OAuth client (API-key exchange) and, equally, tokens minted before the claim
+// existed: readers must see an absent claim, not an empty string on the wire.
+func TestSigner_MintWithoutClientIDOmitsClaim(t *testing.T) {
+	t.Parallel()
+
+	signer := usersessions.NewSigner("test-jwt-secret")
+
+	token, _, err := signer.Mint(usersessions.MintParams{
+		Subject:  urn.NewUserSubject("user-1"),
+		Audience: "aud",
+		Issuer:   "https://example.test/mcp/slug",
+		Lifetime: time.Hour,
+		ClientID: "",
+	})
+	require.NoError(t, err)
+
+	require.NotContains(t, decodeJWTPayload(t, token), "client_id")
+
+	session, err := signer.ValidateBearer(t.Context(), token, "aud", neverRevoked{})
+	require.NoError(t, err)
+	require.Empty(t, session.ClientID)
+}

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -120,7 +120,14 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 	}
 
 	subject := urn.NewUserSubject(authCtx.UserID)
-	access, jti, err := s.signer.Mint(subject, target.audience, target.issuerURL, mintAccessTokenLifetime)
+	access, jti, err := s.signer.Mint(MintParams{
+		Subject:  subject,
+		Audience: target.audience,
+		Issuer:   target.issuerURL,
+		Lifetime: mintAccessTokenLifetime,
+		// No DCR-registered client — this mint bypasses the OAuth dance.
+		ClientID: "",
+	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "mint session jwt").LogError(ctx, s.logger)
 	}

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -125,8 +125,9 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 		Audience: target.audience,
 		Issuer:   target.issuerURL,
 		Lifetime: mintAccessTokenLifetime,
-		// No DCR-registered client — this mint bypasses the OAuth dance.
-		ClientID: "",
+		// No DCR-registered client — this mint bypasses the OAuth dance, so the
+		// session is attributed to our own surface rather than left unlabelled.
+		ClientID: FirstPartyClientID,
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "mint session jwt").LogError(ctx, s.logger)

--- a/server/internal/usersessions/minthandler_test.go
+++ b/server/internal/usersessions/minthandler_test.go
@@ -85,6 +85,13 @@ func TestMintUserSessionAllowsMCPConnect(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, row.UserSessionClientID.Valid)
 	require.True(t, strings.HasPrefix(row.RefreshTokenHash, "dashboard-mint:"))
+
+	// No registered OAuth client backs this mint, so the claim names our own
+	// surface rather than going out empty — empty would be indistinguishable
+	// from a token minted before the claim existed.
+	require.Equal(t, usersessions.FirstPartyClientID, claims.ClientID)
+	require.NotContains(t, claims.ClientID, "://",
+		"a URL-shaped client id would be read as an OAuth Client ID Metadata Document")
 }
 
 func TestMintUserSessionRequiresExactlyOneTarget(t *testing.T) {

--- a/ts-framework/functions/src/framework.test.ts
+++ b/ts-framework/functions/src/framework.test.ts
@@ -945,3 +945,51 @@ test("extend() merges resources from another Gram instance", () => {
     },
   ]);
 });
+
+// The Gram-hosted path reaches handleToolCall directly from the function
+// runner's entrypoint, not through fromGram, so caller identity has to survive
+// this call signature.
+describe("caller identity on ToolContext", () => {
+  const echoCaller = new Gram().tool({
+    name: "whoami",
+    description: "Echoes the caller identity",
+    inputSchema: {},
+    async execute(ctx) {
+      return ctx.json({
+        clientInfo: ctx.clientInfo ?? null,
+        oauthClientId: ctx.oauthClientId ?? null,
+        meta: ctx.meta ?? null,
+      });
+    },
+  });
+
+  test("exposes the identity the caller was invoked with", async () => {
+    const response = await echoCaller.handleToolCall(
+      { name: "whoami", input: {} },
+      {
+        clientInfo: { name: "claude-code", version: "2.1" },
+        oauthClientId: "client-abc",
+        meta: { "example.com/experiment": "b" },
+      },
+    );
+
+    expect(await response.json()).toEqual({
+      clientInfo: { name: "claude-code", version: "2.1" },
+      oauthClientId: "client-abc",
+      meta: { "example.com/experiment": "b" },
+    });
+  });
+
+  test("leaves every field undefined for a direct invocation", async () => {
+    const response = await echoCaller.handleToolCall({
+      name: "whoami",
+      input: {},
+    });
+
+    expect(await response.json()).toEqual({
+      clientInfo: null,
+      oauthClientId: null,
+      meta: null,
+    });
+  });
+});

--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -162,9 +162,9 @@ export interface MCPClientInfo {
 }
 
 /**
- * What is known about the caller of a single tool call. Every field is
- * optional: a caller may report an identity without authenticating, or the
- * reverse, and a direct (non-MCP) invocation has neither.
+ * What a tool call reports about its caller. Every field is optional and every
+ * field is attribution only — none of it is verified at the point a tool reads
+ * it, so none of it may be used for authorization.
  */
 export interface ToolCaller {
   clientInfo?: MCPClientInfo;
@@ -192,10 +192,15 @@ class ToolContext<Env> {
    */
   readonly clientInfo?: MCPClientInfo;
   /**
-   * The OAuth client the caller authenticated as, when the call arrived over
-   * an authenticated MCP connection. Unlike `clientInfo` this is established
-   * by the authorization flow rather than self-reported, so it is the
-   * identity to reach for when the answer has to be trustworthy.
+   * The OAuth client id attributed to the caller, when one accompanied the
+   * call.
+   *
+   * For attribution only — logging, metrics, telling one integration's traffic
+   * from another's. Never use it for authorization. It reaches a tool as
+   * ordinary request metadata, and a tool has no way to tell a value a trusted
+   * host attached from one a caller supplied itself, so an allowlist keyed on
+   * it can be defeated by simply claiming the right id. Authorization belongs
+   * to whatever verifies credentials in front of the tool.
    */
   readonly oauthClientId?: string;
   /**

--- a/ts-framework/functions/src/framework.ts
+++ b/ts-framework/functions/src/framework.ts
@@ -161,6 +161,17 @@ export interface MCPClientInfo {
   version: string;
 }
 
+/**
+ * What is known about the caller of a single tool call. Every field is
+ * optional: a caller may report an identity without authenticating, or the
+ * reverse, and a direct (non-MCP) invocation has neither.
+ */
+export interface ToolCaller {
+  clientInfo?: MCPClientInfo;
+  oauthClientId?: string;
+  meta?: Record<string, unknown>;
+}
+
 class ToolContext<Env> {
   /**
    * The parsed environment variables available to the tool.
@@ -180,10 +191,24 @@ class ToolContext<Env> {
    * observability and convenience, never for authorization.
    */
   readonly clientInfo?: MCPClientInfo;
-  constructor(signal: AbortSignal, env: Env, clientInfo?: MCPClientInfo) {
+  /**
+   * The OAuth client the caller authenticated as, when the call arrived over
+   * an authenticated MCP connection. Unlike `clientInfo` this is established
+   * by the authorization flow rather than self-reported, so it is the
+   * identity to reach for when the answer has to be trustworthy.
+   */
+  readonly oauthClientId?: string;
+  /**
+   * The raw `_meta` block that accompanied the call, for keys this SDK does
+   * not model yet. Prefer the named fields above where they exist.
+   */
+  readonly meta?: Record<string, unknown>;
+  constructor(signal: AbortSignal, env: Env, caller?: ToolCaller) {
     this.signal = signal;
     this.env = env;
-    this.clientInfo = clientInfo;
+    this.clientInfo = caller?.clientInfo;
+    this.oauthClientId = caller?.oauthClientId;
+    this.meta = caller?.meta;
   }
 
   /**
@@ -496,7 +521,7 @@ export class Gram<
       name: TName;
       input: InferInput<TTools[TName]>;
     },
-    options?: { signal?: AbortSignal; clientInfo?: MCPClientInfo },
+    options?: { signal?: AbortSignal } & ToolCaller,
   ): Promise<InferResult<TTools[TName]>> {
     const tool = this.#tools.get(request.name);
     if (!tool) {
@@ -508,7 +533,7 @@ export class Gram<
     const ctx = new ToolContext(
       options?.signal || new AbortController().signal,
       envSchema.parse(tool.inputEnv ?? process.env),
-      options?.clientInfo,
+      options,
     );
 
     const schema = zm.object(tool.inputSchema);

--- a/ts-framework/functions/src/mcp.test.ts
+++ b/ts-framework/functions/src/mcp.test.ts
@@ -346,4 +346,57 @@ describe("fromGram", () => {
       });
     });
   });
+
+  describe("oauthClientId on ToolContext", () => {
+    // A tool that echoes the verified caller identity and the raw _meta block.
+    const echoCaller = new Gram().tool({
+      name: "whoami",
+      description: "Echoes the verified caller identity",
+      inputSchema: {},
+      async execute(ctx) {
+        return ctx.json({
+          oauthClientId: ctx.oauthClientId ?? null,
+          meta: ctx.meta ?? null,
+        });
+      },
+    });
+
+    function parseCaller(result: Awaited<ReturnType<Client["callTool"]>>) {
+      const content = result.content as Array<{ type: string; text: string }>;
+      return JSON.parse(content[0]!.text);
+    }
+
+    test("populates ctx.oauthClientId from _meta", async () => {
+      const client = await setup(echoCaller);
+      const result = await client.callTool({
+        name: "whoami",
+        arguments: {},
+        _meta: { "gram.ai/oauth-client-id": "client-abc" },
+      });
+
+      expect(parseCaller(result).oauthClientId).toBe("client-abc");
+    });
+
+    test("leaves ctx.oauthClientId undefined for an unauthenticated call", async () => {
+      const client = await setup(echoCaller);
+      const result = await client.callTool({ name: "whoami", arguments: {} });
+
+      expect(parseCaller(result).oauthClientId).toBeNull();
+    });
+
+    // ctx.meta is the escape hatch for keys this SDK does not model yet, so a
+    // tool can read them without waiting for an SDK release.
+    test("exposes the raw _meta block", async () => {
+      const client = await setup(echoCaller);
+      const result = await client.callTool({
+        name: "whoami",
+        arguments: {},
+        _meta: { "example.com/experiment": "b" },
+      });
+
+      expect(parseCaller(result).meta).toMatchObject({
+        "example.com/experiment": "b",
+      });
+    });
+  });
 });

--- a/ts-framework/functions/src/mcp.ts
+++ b/ts-framework/functions/src/mcp.ts
@@ -336,11 +336,21 @@ export function fromGram(
           req.params._meta?.["io.modelcontextprotocol/clientInfo"],
         ) ?? normalizeClientInfo(server.getClientVersion());
 
+      // The OAuth client, in contrast, is established by the authorization
+      // flow. Gram stamps it on `_meta` when it fronts this server.
+      const rawOAuthClientId = req.params._meta?.["gram.ai/oauth-client-id"];
+      const oauthClientId =
+        typeof rawOAuthClientId === "string" && rawOAuthClientId !== ""
+          ? rawOAuthClientId
+          : undefined;
+
       let resp: Response;
       try {
         resp = (await g.handleToolCall({ name, input: args } as any, {
           signal: extra.signal,
           clientInfo,
+          oauthClientId,
+          meta: req.params._meta,
         })) as Response;
       } catch (err) {
         // `ctx.fail()` and input validation failures reject with a `Response`

--- a/ts-framework/functions/src/mcp.ts
+++ b/ts-framework/functions/src/mcp.ts
@@ -336,8 +336,10 @@ export function fromGram(
           req.params._meta?.["io.modelcontextprotocol/clientInfo"],
         ) ?? normalizeClientInfo(server.getClientVersion());
 
-      // The OAuth client, in contrast, is established by the authorization
-      // flow. Gram stamps it on `_meta` when it fronts this server.
+      // The OAuth client id rides the same untrusted `_meta` block. Nothing
+      // here verifies it — this server is reachable directly, so the value is
+      // whatever the caller sent. It is carried for attribution only, and
+      // `ctx.oauthClientId` documents that it must never gate access.
       const rawOAuthClientId = req.params._meta?.["gram.ai/oauth-client-id"];
       const oauthClientId =
         typeof rawOAuthClientId === "string" && rawOAuthClientId !== ""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Proxies the MCP caller identity and OAuth client ID to Gram Functions so tools can see who invoked them. Identity comes from per-call `_meta` (preferred) or an initialize-cached value; OAuth `client_id` is read from session JWTs (`client:first-party` for dashboard). Linked to Linear AIS-340.

- **New Features**
  - Add `_meta` to function tool-call payloads with `io.modelcontextprotocol/clientInfo` and `gram.ai/oauth-client-id`; forward the raw block as `options.meta`. The runner passes the caller as the second arg to `handleToolCall`; `@gram-ai/functions` exposes `ctx.clientInfo`, `ctx.oauthClientId`, and `ctx.meta`; `fromGram` populates them. Attribution only, never authorization.
  - Resolve caller from per-call `_meta`, else from initialize-cached identity. Cache is sanitized and LRU-bounded per project + toolset + session; per-call data wins. Non‑MCP paths (instances, resource reads, platform toolsets) send no identity.
  - Stamp OAuth `client_id` onto session tokens and request context; dashboard mints use `client:first-party`.

- **Bug Fixes**
  - Forward `ctx.meta` on the Gram-hosted path; decode/re-encode `_meta` so unknown keys are dropped before reaching user code; omit `oauthClientId` when unauthenticated (undefined, not empty). Tests cover partial identity.
  - Bound the initialize client-info cache with an LRU per MCP server to prevent unbounded Redis growth; hash session IDs in cache keys to avoid collisions and keep raw IDs out of keyspace.

<sup>Written for commit 556bdb7eccbe8f542397ae4ae924df493313868e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

