### PR TITLE
feat(oauth): require consent before the proxy releases an auth code

### DIFF
--- a/server/internal/oauth/consent.go
+++ b/server/internal/oauth/consent.go
@@ -1,0 +1,129 @@
+// Consent interstitial for the OAuth proxy.
+//
+// The upstream callback parks the finished authorization in the cache and
+// renders this page instead of handing the authorization code straight back
+// to the MCP client. Consent is asked for on every authorization — no record
+// of prior approvals is kept — so an upstream session that resumes silently
+// (SSO, a live provider cookie) can never complete a dynamically registered
+// client's authorization without a human in the loop.
+
+package oauth
+
+import (
+	_ "embed"
+	"html/template"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+//go:embed consent_template.html
+var consentPageTmplData string
+
+// consentPageData is the field set consent_template.html renders against.
+// It carries display copy plus the opaque ConsentID; every security-relevant
+// value stays in the PendingConsent record behind that ID.
+type consentPageData struct {
+	ConsentID    string
+	ClientName   string
+	MCPSlug      string
+	MCPURL       string
+	RedirectURI  string
+	ProviderSlug string
+	Scopes       []string
+}
+
+// handleConsent finishes an OAuth proxy authorization once the user has acted
+// on the consent screen. Mounted at `POST /oauth/{mcpSlug}/consent`.
+//
+// The pending record is consumed on the first POST regardless of the decision,
+// so a consent screen cannot be replayed to mint a second redirect carrying
+// the same authorization code.
+func (s *Service) handleConsent(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	mcpSlug := chi.URLParam(r, "mcpSlug")
+	if mcpSlug == "" {
+		return oops.E(oops.CodeBadRequest, nil, "an mcp slug must be provided").LogError(ctx, s.logger)
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, requestMaxBodyBytes)
+	if err := r.ParseForm(); err != nil {
+		return oops.E(oops.CodeBadRequest, err, "malformed consent submission").LogError(ctx, s.logger)
+	}
+
+	consentID := r.PostForm.Get("consent_id")
+	if consentID == "" {
+		return oops.E(oops.CodeBadRequest, nil, "consent_id is required").LogError(ctx, s.logger)
+	}
+
+	// Unknown, expired and already-consumed IDs are indistinguishable here,
+	// and all equally unfinishable — the user has to restart the flow.
+	pending, err := s.pendingConsentStorage.Get(ctx, PendingConsentCacheKey(consentID))
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "this authorization request is no longer valid, please try again").LogError(ctx, s.logger)
+	}
+
+	// The parked record is authoritative for the slug; a mismatch means the
+	// form was replayed against a different MCP server's consent route.
+	if pending.MCPSlug != mcpSlug {
+		return oops.E(oops.CodeBadRequest, nil, "consent does not match this mcp server").LogError(ctx, s.logger)
+	}
+
+	// Consume before acting so a resubmitted form cannot mint a second
+	// redirect for the same code.
+	if err := s.pendingConsentStorage.DeleteByKey(ctx, PendingConsentCacheKey(consentID)); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "consume pending consent").LogError(ctx, s.logger)
+	}
+
+	approved := r.PostForm.Get("action") == "approve"
+
+	logger := s.logger.With(
+		attr.SlogOAuthClientID(pending.ClientID),
+		attr.SlogToolsetMCPSlug(pending.MCPSlug),
+	)
+
+	redirectURL := pending.ApproveURL
+	if !approved {
+		redirectURL = pending.DenyURL
+
+		// The grant was already minted during the upstream callback, so a
+		// denial has to actively drop it rather than merely withhold the URL.
+		if err := s.grantManager.RevokeGrant(ctx, pending.ToolsetID, pending.Code); err != nil {
+			logger.ErrorContext(ctx, "failed to revoke grant after consent denial", attr.SlogError(err))
+		}
+	}
+
+	logger.InfoContext(ctx, "oauth proxy consent decision recorded",
+		attr.SlogOAuthStatus(conv.Ternary(approved, "approved", "denied")))
+
+	if pending.UseResultPage {
+		data := gramOAuthResultPageData{
+			RedirectURL:      template.URL(redirectURL), // #nosec G203 // Built server-side from an already-validated redirect_uri
+			ScriptHash:       s.oauthStatusPageScriptHash,
+			ErrorCode:        "",
+			ErrorDescription: "",
+		}
+
+		resultTmpl := s.successPageTmpl
+		if !approved {
+			data.ErrorCode = "access_denied"
+			data.ErrorDescription = "You declined to authorize this application."
+			resultTmpl = s.failurePageTmpl
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := resultTmpl.Execute(w, data); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "render oauth result page").LogError(ctx, logger)
+		}
+
+		return nil
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+	return nil
+}

--- a/server/internal/oauth/consent_template.html
+++ b/server/internal/oauth/consent_template.html
@@ -3,201 +3,242 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Authorization Request</title>
+    <title>Authorize {{.ClientName}}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&display=swap"
+      rel="stylesheet"
+    />
     <style>
+      html,
       body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background-color: #f5f5f5;
-        margin: 0;
-        padding: 20px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        min-height: 100vh;
+        --font-diatype:
+          "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          Helvetica, Arial, sans-serif;
+        --font-diatype-mono:
+          "Geist Mono", SFMono-Regular, Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+
+        --color-base-white: hsl(0 0% 100%);
+        --color-base-black: hsl(0 0% 0%);
+
+        --color-neutral-50: hsl(0, 0%, 99%);
+        --color-neutral-100: hsl(0, 0%, 98%);
+        --color-neutral-200: hsl(0, 0%, 92%);
+        --color-neutral-500: hsl(0, 0%, 55%);
+        --color-neutral-700: hsl(0, 0%, 33%);
+        --color-neutral-800: hsl(0, 0%, 20%);
+
+        --text-default: var(--color-neutral-700);
+        --text-muted: var(--color-neutral-500);
+        --text-default-inverse: var(--color-neutral-100);
+
+        --fill-neutral-highlight: var(--color-base-black);
+        --fill-neutral-default: var(--color-neutral-800);
+
+        --bg-surface-primary-default: var(--color-base-white);
+        --bg-surface-secondary-default: var(--color-neutral-100);
+
+        --border-neutral-softest: var(--color-neutral-200);
+
+        font-family: var(--font-diatype);
+        color: var(--text-default);
+        background: var(--bg-surface-secondary-default);
       }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .main {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+
       .auth-consent-container {
-        background: white;
-        border-radius: 8px;
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-        padding: 30px;
-        max-width: 400px;
+        background: var(--bg-surface-primary-default);
+        border: 1px solid var(--border-neutral-softest);
+        border-radius: 12px;
+        padding: 32px;
+        max-width: 440px;
         width: 100%;
       }
-      .header {
-        text-align: center;
-        margin-bottom: 30px;
-      }
+
       .header h1 {
-        color: #333;
-        margin: 0 0 10px 0;
-        font-size: 24px;
+        margin: 0 0 8px 0;
+        font-size: 20px;
+        font-weight: 600;
+        color: var(--fill-neutral-highlight);
       }
+
       .header p {
-        color: #666;
         margin: 0;
-        font-size: 16px;
-      }
-      .client-info {
-        background: #f8f9fa;
-        border-radius: 6px;
-        padding: 20px;
-        margin-bottom: 30px;
-      }
-      .client-info h3 {
-        margin: 0 0 10px 0;
-        color: #333;
-        font-size: 16px;
-      }
-      .client-info p {
-        margin: 5px 0;
-        color: #666;
         font-size: 14px;
+        line-height: 1.5;
       }
+
+      .header strong {
+        color: var(--fill-neutral-highlight);
+        font-weight: 600;
+      }
+
+      dl.info {
+        margin: 24px 0 0 0;
+        padding: 16px;
+        background: var(--bg-surface-secondary-default);
+        border-radius: 8px;
+        font-size: 13px;
+      }
+
+      dl.info dt {
+        color: var(--text-muted);
+        margin-bottom: 2px;
+      }
+
+      dl.info dd {
+        margin: 0 0 12px 0;
+        font-family: var(--font-diatype-mono);
+        color: var(--fill-neutral-default);
+        word-break: break-all;
+      }
+
+      dl.info dd:last-child {
+        margin-bottom: 0;
+      }
+
       .permissions {
-        margin-bottom: 30px;
+        margin-top: 24px;
       }
-      .permissions h3 {
-        margin: 0 0 15px 0;
-        color: #333;
-        font-size: 16px;
+
+      .permissions h2 {
+        margin: 0 0 8px 0;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-muted);
       }
+
       .permissions ul {
         list-style: none;
         padding: 0;
         margin: 0;
+        font-family: var(--font-diatype-mono);
+        font-size: 13px;
       }
+
       .permissions li {
-        padding: 8px 0;
-        color: #666;
-        font-size: 14px;
+        padding: 4px 0;
+        color: var(--fill-neutral-default);
+        word-break: break-all;
       }
-      .permissions li:before {
-        content: "✓";
-        color: #28a745;
-        font-weight: bold;
-        margin-right: 10px;
-      }
+
       .actions {
         display: flex;
-        gap: 10px;
-        justify-content: center;
+        gap: 12px;
+        margin-top: 28px;
       }
-      .btn {
+
+      .actions form {
         flex: 1;
-        padding: 12px 20px;
-        border: none;
-        border-radius: 6px;
-        font-size: 16px;
-        font-weight: 600;
-        cursor: pointer;
-        text-decoration: none;
-        text-align: center;
-        display: inline-block;
-        transition: background-color 0.2s;
-        min-width: 120px;
+      }
+
+      .btn {
         width: 100%;
+        padding: 10px 16px;
+        border: 1px solid transparent;
+        border-radius: 8px;
+        font-family: inherit;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
       }
+
       .btn-primary {
-        background-color: #007bff;
-        color: white;
+        background: var(--fill-neutral-highlight);
+        color: var(--text-default-inverse);
       }
+
       .btn-primary:hover {
-        background-color: #0056b3;
+        background: var(--fill-neutral-default);
       }
+
       .btn-secondary {
-        background-color: #6c757d;
-        color: white;
+        background: var(--bg-surface-primary-default);
+        border-color: var(--border-neutral-softest);
+        color: var(--text-default);
       }
+
       .btn-secondary:hover {
-        background-color: #545b62;
+        background: var(--bg-surface-secondary-default);
       }
     </style>
   </head>
   <body>
-    <div class="auth-consent-container">
-      <div class="header">
-        <h1>Authorization Request</h1>
-        {{if .ClientName}}
-        <p>
-          <strong>{{.ClientName}}</strong> is requesting access to your account
-        </p>
-        {{else}}
-        <p>An application is requesting access to your account</p>
-        {{end}}
-        <p style="font-size: 14px; color: #888; margin-top: 10px">
-          You may close this window when authentication is complete
-        </p>
-      </div>
+    <main class="main">
+      <div class="auth-consent-container">
+        <div class="header">
+          <h1>Authorize {{.ClientName}}</h1>
+          <p>
+            <strong>{{.ClientName}}</strong> is requesting access to the MCP
+            server <strong>{{.MCPSlug}}</strong> on your behalf.
+          </p>
+        </div>
 
-      <div class="client-info">
-        <h3>Application Details</h3>
-        {{if .ClientName}}
-        <p><strong>Application Name:</strong> {{.ClientName}}</p>
-        {{end}}
-        <p><strong>MCP Server:</strong></p>
-        <p>{{.MCPURL}}</p>
-      </div>
-
-      {{if .Scope}}
-      <div class="permissions">
-        <h3>Requested Permissions</h3>
-        <ul>
-          {{range .Scopes}}
-          <li>{{.}}</li>
+        <dl class="info">
+          <dt>MCP server</dt>
+          <dd>{{.MCPURL}}</dd>
+          {{if .ProviderSlug}}
+          <dt>Signed in with</dt>
+          <dd>{{.ProviderSlug}}</dd>
           {{end}}
-        </ul>
-      </div>
-      {{end}}
+          <dt>Will redirect to</dt>
+          <dd>{{.RedirectURI}}</dd>
+        </dl>
 
-      <div class="actions">
-        <form
-          method="POST"
-          action="/oauth/{{.MCPSlug}}/complete"
-          style="flex: 1"
-        >
-          <input type="hidden" name="client_id" value="{{.ClientID}}" />
-          <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
-          <input type="hidden" name="scope" value="{{.Scope}}" />
-          <input type="hidden" name="state" value="{{.State}}" />
-          <input
-            type="hidden"
-            name="code_challenge"
-            value="{{.CodeChallenge}}"
-          />
-          <input
-            type="hidden"
-            name="code_challenge_method"
-            value="{{.CodeChallengeMethod}}"
-          />
-          <input type="hidden" name="response_type" value="{{.ResponseType}}" />
-          <button
-            type="submit"
-            name="action"
-            value="approve"
-            class="btn btn-primary"
-          >
-            Authorize
-          </button>
-        </form>
-        <form
-          method="POST"
-          action="/oauth/{{.MCPSlug}}/complete"
-          style="flex: 1"
-        >
-          <input type="hidden" name="client_id" value="{{.ClientID}}" />
-          <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}" />
-          <input type="hidden" name="state" value="{{.State}}" />
-          <button
-            type="submit"
-            name="action"
-            value="deny"
-            class="btn btn-secondary"
-          >
-            Cancel
-          </button>
-        </form>
+        {{if .Scopes}}
+        <div class="permissions">
+          <h2>Requested scopes</h2>
+          <ul>
+            {{range .Scopes}}
+            <li>{{.}}</li>
+            {{end}}
+          </ul>
+        </div>
+        {{end}}
+
+        <div class="actions">
+          <form method="POST" action="/oauth/{{.MCPSlug}}/consent">
+            <input type="hidden" name="consent_id" value="{{.ConsentID}}" />
+            <button
+              type="submit"
+              name="action"
+              value="approve"
+              class="btn btn-primary"
+            >
+              Authorize
+            </button>
+          </form>
+          <form method="POST" action="/oauth/{{.MCPSlug}}/consent">
+            <input type="hidden" name="consent_id" value="{{.ConsentID}}" />
+            <button
+              type="submit"
+              name="action"
+              value="deny"
+              class="btn btn-secondary"
+            >
+              Cancel
+            </button>
+          </form>
+        </div>
       </div>
-    </div>
+    </main>
   </body>
 </html>

--- a/server/internal/oauth/consent_template_internal_test.go
+++ b/server/internal/oauth/consent_template_internal_test.go
@@ -1,0 +1,92 @@
+package oauth
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func renderConsentPage(t *testing.T, data consentPageData) string {
+	t.Helper()
+
+	tmpl, err := template.New("oauth_consent").Parse(consentPageTmplData)
+	require.NoError(t, err)
+
+	var page bytes.Buffer
+	require.NoError(t, tmpl.Execute(&page, data))
+
+	return page.String()
+}
+
+func TestConsentTemplateRendersBothDecisions(t *testing.T) {
+	t.Parallel()
+
+	page := renderConsentPage(t, consentPageData{
+		ConsentID:    "consent-abc",
+		ClientName:   "Test Client",
+		MCPSlug:      "my-server",
+		MCPURL:       "https://app.example.com/mcp/my-server",
+		RedirectURI:  "http://localhost:8080/callback",
+		ProviderSlug: "okta",
+		Scopes:       []string{"read:things", "write:things"},
+	})
+
+	require.Contains(t, page, `action="/oauth/my-server/consent"`, "forms must post back to the slug's consent route")
+	require.Contains(t, page, `value="consent-abc"`, "both forms must carry the consent id")
+	require.Contains(t, page, `value="approve"`)
+	require.Contains(t, page, `value="deny"`, "cancel must always be offered")
+	require.Equal(t, 2, strings.Count(page, `name="consent_id"`), "approve and deny each need the consent id")
+
+	require.Contains(t, page, "Test Client")
+	require.Contains(t, page, "https://app.example.com/mcp/my-server")
+	require.Contains(t, page, "http://localhost:8080/callback")
+	require.Contains(t, page, "okta")
+	require.Contains(t, page, "read:things")
+	require.Contains(t, page, "write:things")
+}
+
+// The whole point of parking the authorization server-side is that the code
+// never reaches the browser until the user approves. The template has no
+// field to leak it, and this pins that shape against future edits.
+func TestConsentTemplateHasNoFieldCarryingTheAuthorizationCode(t *testing.T) {
+	t.Parallel()
+
+	require.NotContains(t, consentPageTmplData, "ApproveURL")
+	require.NotContains(t, consentPageTmplData, "DenyURL")
+	require.NotContains(t, consentPageTmplData, ".Code")
+}
+
+func TestConsentTemplateEscapesClientName(t *testing.T) {
+	t.Parallel()
+
+	page := renderConsentPage(t, consentPageData{
+		ConsentID:   "consent-abc",
+		ClientName:  `<script>alert(1)</script>`,
+		MCPSlug:     "my-server",
+		MCPURL:      "https://app.example.com/mcp/my-server",
+		RedirectURI: "http://localhost:8080/callback",
+	})
+
+	// Client names come from unauthenticated dynamic client registration, so
+	// they are fully attacker-controlled.
+	require.NotContains(t, page, "<script>alert(1)</script>")
+	require.Contains(t, page, "&lt;script&gt;")
+}
+
+func TestConsentTemplateOmitsOptionalSections(t *testing.T) {
+	t.Parallel()
+
+	page := renderConsentPage(t, consentPageData{
+		ConsentID:   "consent-abc",
+		ClientName:  "Test Client",
+		MCPSlug:     "my-server",
+		MCPURL:      "https://app.example.com/mcp/my-server",
+		RedirectURI: "http://localhost:8080/callback",
+	})
+
+	require.NotContains(t, page, "Requested scopes", "no scopes means no scope block")
+	require.NotContains(t, page, "Signed in with", "no provider slug means no provider row")
+}

--- a/server/internal/oauth/consent_test.go
+++ b/server/internal/oauth/consent_test.go
@@ -1,0 +1,219 @@
+package oauth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/oauth"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+const (
+	consentSlug       = "consent-server"
+	consentApproveURL = "http://localhost:8080/callback?code=the-auth-code&state=client-state"
+	consentDenyURL    = "http://localhost:8080/callback?error=access_denied&state=client-state"
+)
+
+// seedPendingConsent parks a PendingConsent in the same cache the service
+// reads from, standing in for the upstream callback that normally creates it.
+func seedPendingConsent(t *testing.T, env *oauthtest.OAuthServiceEnv, toolsetID uuid.UUID, useResultPage bool) string {
+	t.Helper()
+
+	consentID := uuid.NewString()
+	storage := cache.NewTypedObjectCache[oauth.PendingConsent](testenv.NewLogger(t), env.Cache, cache.SuffixNone)
+
+	require.NoError(t, storage.Store(t.Context(), oauth.PendingConsent{
+		ID:            consentID,
+		ToolsetID:     toolsetID,
+		Code:          "the-auth-code",
+		ApproveURL:    consentApproveURL,
+		DenyURL:       consentDenyURL,
+		ClientID:      "test-client",
+		MCPSlug:       consentSlug,
+		UseResultPage: useResultPage,
+	}))
+
+	return consentID
+}
+
+func postConsent(t *testing.T, env *oauthtest.OAuthServiceEnv, slug, consentID, action string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	mux := goahttp.NewMuxer()
+	oauth.Attach(mux, env.Service)
+
+	form := url.Values{}
+	form.Set("consent_id", consentID)
+	form.Set("action", action)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,
+		"/oauth/"+slug+"/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestHandleConsentApproveRedirectsToClient(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	consentID := seedPendingConsent(t, env, uuid.New(), false)
+
+	rec := postConsent(t, env, consentSlug, consentID, "approve")
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	require.Equal(t, consentApproveURL, rec.Header().Get("Location"),
+		"approval hands the client the authorization code")
+}
+
+func TestHandleConsentDenyRedirectsWithAccessDenied(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	consentID := seedPendingConsent(t, env, uuid.New(), false)
+
+	rec := postConsent(t, env, consentSlug, consentID, "deny")
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	require.Equal(t, consentDenyURL, rec.Header().Get("Location"),
+		"denial returns access_denied instead of a code")
+}
+
+// Anything other than an explicit approve is a denial — a form replayed
+// without the action field must not be treated as consent.
+func TestHandleConsentMissingActionIsDenial(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	consentID := seedPendingConsent(t, env, uuid.New(), false)
+
+	rec := postConsent(t, env, consentSlug, consentID, "")
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	require.Equal(t, consentDenyURL, rec.Header().Get("Location"))
+}
+
+func TestHandleConsentDenyRevokesGrant(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	env := newOAuthServiceTestEnv(t)
+	toolsetID := uuid.New()
+
+	grantStorage := cache.NewTypedObjectCache[oauth.Grant](testenv.NewLogger(t), env.Cache, cache.SuffixNone)
+	require.NoError(t, grantStorage.Store(ctx, oauth.Grant{
+		ToolsetID: toolsetID,
+		Code:      "the-auth-code",
+		ClientID:  "test-client",
+		ExpiresAt: time.Now().Add(10 * time.Minute),
+	}))
+
+	consentID := seedPendingConsent(t, env, toolsetID, false)
+
+	rec := postConsent(t, env, consentSlug, consentID, "deny")
+	require.Equal(t, http.StatusFound, rec.Code)
+
+	_, err := grantStorage.Get(ctx, oauth.GrantCacheKey(toolsetID, "the-auth-code"))
+	require.Error(t, err, "a denied authorization must leave no redeemable code behind")
+}
+
+func TestHandleConsentApproveKeepsGrantRedeemable(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	env := newOAuthServiceTestEnv(t)
+	toolsetID := uuid.New()
+
+	grantStorage := cache.NewTypedObjectCache[oauth.Grant](testenv.NewLogger(t), env.Cache, cache.SuffixNone)
+	require.NoError(t, grantStorage.Store(ctx, oauth.Grant{
+		ToolsetID: toolsetID,
+		Code:      "the-auth-code",
+		ClientID:  "test-client",
+		ExpiresAt: time.Now().Add(10 * time.Minute),
+	}))
+
+	consentID := seedPendingConsent(t, env, toolsetID, false)
+
+	rec := postConsent(t, env, consentSlug, consentID, "approve")
+	require.Equal(t, http.StatusFound, rec.Code)
+
+	grant, err := grantStorage.Get(ctx, oauth.GrantCacheKey(toolsetID, "the-auth-code"))
+	require.NoError(t, err, "approval leaves the grant for the token endpoint to consume")
+	require.Equal(t, "test-client", grant.ClientID)
+}
+
+func TestHandleConsentIsSingleUse(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	consentID := seedPendingConsent(t, env, uuid.New(), false)
+
+	first := postConsent(t, env, consentSlug, consentID, "approve")
+	require.Equal(t, http.StatusFound, first.Code)
+
+	second := postConsent(t, env, consentSlug, consentID, "approve")
+	require.NotEqual(t, http.StatusFound, second.Code,
+		"a replayed consent form must not mint a second redirect for the same code")
+}
+
+func TestHandleConsentRejectsSlugMismatch(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	consentID := seedPendingConsent(t, env, uuid.New(), false)
+
+	rec := postConsent(t, env, "some-other-server", consentID, "approve")
+
+	require.NotEqual(t, http.StatusFound, rec.Code)
+	require.Empty(t, rec.Header().Get("Location"))
+}
+
+func TestHandleConsentRejectsUnknownConsentID(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	rec := postConsent(t, env, consentSlug, uuid.NewString(), "approve")
+
+	require.NotEqual(t, http.StatusFound, rec.Code)
+	require.Empty(t, rec.Header().Get("Location"))
+}
+
+func TestHandleConsentRejectsMissingConsentID(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	rec := postConsent(t, env, consentSlug, "", "approve")
+
+	require.NotEqual(t, http.StatusFound, rec.Code)
+	require.Empty(t, rec.Header().Get("Location"))
+}
+
+// Gram-managed providers finish in a hosted status page that reports back to
+// the opener rather than a bare 302, on both decisions.
+func TestHandleConsentRendersResultPageForGramProvider(t *testing.T) {
+	t.Parallel()
+	env := newOAuthServiceTestEnv(t)
+
+	approveID := seedPendingConsent(t, env, uuid.New(), true)
+	approved := postConsent(t, env, consentSlug, approveID, "approve")
+	require.Equal(t, http.StatusOK, approved.Code)
+	require.Contains(t, approved.Header().Get("Content-Type"), "text/html")
+	// The page HTML-escapes the URL it redirects to, so match the code alone.
+	require.Contains(t, approved.Body.String(), "code=the-auth-code")
+
+	denyID := seedPendingConsent(t, env, uuid.New(), true)
+	denied := postConsent(t, env, consentSlug, denyID, "deny")
+	require.Equal(t, http.StatusOK, denied.Code)
+	require.Contains(t, denied.Body.String(), "access_denied")
+}

--- a/server/internal/oauth/grant_manager.go
+++ b/server/internal/oauth/grant_manager.go
@@ -323,6 +323,16 @@ func (gm *GrantManager) getGrant(ctx context.Context, toolsetId uuid.UUID, code 
 	return &grant, nil
 }
 
+// RevokeGrant drops a grant without redeeming it, so an authorization the
+// user declined on the consent screen leaves no code behind that the MCP
+// client could still exchange.
+func (gm *GrantManager) RevokeGrant(ctx context.Context, toolsetID uuid.UUID, code string) error {
+	if err := gm.grantStorage.DeleteByKey(ctx, GrantCacheKey(toolsetID, code)); err != nil {
+		return fmt.Errorf("revoke grant: %w", err)
+	}
+	return nil
+}
+
 func (gm *GrantManager) deleteGrant(ctx context.Context, grant Grant) error {
 	if err := gm.grantStorage.Delete(ctx, grant); err != nil {
 		return fmt.Errorf("failed to delete grant: %w", err)

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -51,6 +51,12 @@ var (
 	errToolsetNotFound      = errors.New("toolset not found")
 	errCustomDomainNotFound = errors.New("custom domain not found")
 	errOAuthUnavailable     = errors.New("oauth unavailable for private mcp server")
+	// errProxyRetired marks a toolset that has moved to a user_session_issuer.
+	// Attaching an issuer previously only stopped NEW authorizations: the proxy
+	// endpoints kept serving, so clients holding proxy refresh tokens went on
+	// exchanging them indefinitely, outside the issuer's consent, session
+	// duration and revocation. Migrated toolsets now refuse the proxy outright.
+	errProxyRetired = errors.New("oauth proxy retired for issuer-gated mcp server")
 )
 
 //go:embed hosted_oauth_success_page.html.tmpl
@@ -237,6 +243,13 @@ func (s *Service) loadToolsetFromCurrentURLContext(ctx context.Context, mcpSlug 
 		return nil, "", errOAuthUnavailable
 	}
 
+	// Discovery already advertises the issuer's endpoints for these toolsets
+	// (see mcp.serveAuthorizationServerMetadata), so a client turned away here
+	// re-discovers and completes on the issuer-gated path.
+	if toolset.UserSessionIssuerID.Valid {
+		return nil, "", errProxyRetired
+	}
+
 	return &toolset, mcpURL, nil
 }
 
@@ -284,7 +297,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	// Load toolset from MCP slug
 	toolset, fullMCPURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
 	switch {
-	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
+	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable), errors.Is(err, errProxyRetired):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load authorization details for mcp server").LogError(ctx, s.logger)
@@ -491,6 +504,23 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 
 	toolset, fullMCPURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
 	switch {
+	case errors.Is(err, errProxyRetired):
+		// RFC 6749 §5.2: invalid_grant is the signal a client acts on by
+		// discarding its tokens and re-running authorization. A 404 here would
+		// read as "server gone" and strand the client on a dead refresh token
+		// instead of moving it onto the issuer-gated path.
+		s.logger.InfoContext(ctx, "refused proxy token exchange for issuer-gated mcp server",
+			attr.SlogToolsetMCPSlug(mcpSlug))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "This MCP server has moved to a new authorization server. Re-authorize to continue.",
+		}); err != nil {
+			s.logger.ErrorContext(ctx, "failed to encode invalid_grant response", attr.SlogError(err))
+		}
+		return nil
 	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
@@ -551,7 +581,7 @@ func (s *Service) handleClientRegistration(w http.ResponseWriter, r *http.Reques
 
 	_, fullMcpURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
 	switch {
-	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
+	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable), errors.Is(err, errProxyRetired):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load client registration details for mcp server").LogError(ctx, s.logger)

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -95,9 +95,11 @@ type Service struct {
 	gramProvider              *providers.GramProvider
 	customProvider            *providers.CustomProvider
 	upstreamPKCEStorage       cache.TypedCacheObject[UpstreamPKCEVerifier]
+	pendingConsentStorage     cache.TypedCacheObject[PendingConsent]
 	guardianPolicy            *guardian.Policy
 	successPageTmpl           *template.Template
 	failurePageTmpl           *template.Template
+	consentPageTmpl           *template.Template
 	oauthStatusPageScriptHash string
 	oauthStatusPageScriptData []byte
 }
@@ -119,6 +121,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 	// Parse templates once during initialization
 	successPageTmpl := template.Must(template.New("oauth_success").Parse(oauthSuccessPageTmplData))
 	failurePageTmpl := template.Must(template.New("oauth_failure").Parse(oauthFailurePageTmplData))
+	consentPageTmpl := template.Must(template.New("oauth_consent").Parse(consentPageTmplData))
 
 	// Calculate content hash for success script (for cache busting)
 	hash := sha256.Sum256(oauthSuccessScriptData)
@@ -145,14 +148,16 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, meterP
 		identity:           identityResolver,
 
 		// OAuth providers
-		gramProvider:        gramProvider,
-		customProvider:      customProvider,
-		upstreamPKCEStorage: cache.NewTypedObjectCache[UpstreamPKCEVerifier](logger.With(attr.SlogCacheNamespace("upstream_pkce")), cacheImpl, cache.SuffixNone),
-		guardianPolicy:      guardianPolicy,
+		gramProvider:          gramProvider,
+		customProvider:        customProvider,
+		upstreamPKCEStorage:   cache.NewTypedObjectCache[UpstreamPKCEVerifier](logger.With(attr.SlogCacheNamespace("upstream_pkce")), cacheImpl, cache.SuffixNone),
+		pendingConsentStorage: cache.NewTypedObjectCache[PendingConsent](logger.With(attr.SlogCacheNamespace("oauth_pending_consent")), cacheImpl, cache.SuffixNone),
+		guardianPolicy:        guardianPolicy,
 
 		// HTML templates
 		successPageTmpl: successPageTmpl,
 		failurePageTmpl: failurePageTmpl,
+		consentPageTmpl: consentPageTmpl,
 
 		// Success page script with hash for cache busting
 		oauthStatusPageScriptHash: scriptHash,
@@ -179,6 +184,12 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	// OAuth 2.1 Token Endpoint
 	o11y.AttachHandler(mux, "POST", "/oauth/{mcpSlug}/token", func(w http.ResponseWriter, r *http.Request) {
 		oops.ErrHandle(service.logger, service.handleToken).ServeHTTP(w, r)
+	})
+
+	// Consent decision. POST-only: the consent page itself is rendered
+	// inline by the authorization callback, not fetched from here.
+	o11y.AttachHandler(mux, "POST", "/oauth/{mcpSlug}/consent", func(w http.ResponseWriter, r *http.Request) {
+		oops.ErrHandle(service.logger, service.handleConsent).ServeHTTP(w, r)
 	})
 
 	// OAuth Proxy DCR helper — performs Dynamic Client Registration against an
@@ -758,26 +769,52 @@ func (s *Service) handleAuthorizationCallback(w http.ResponseWriter, r *http.Req
 	s.logger.InfoContext(ctx, "authorization grant created after external provider callback",
 		attr.SlogOAuthClientID(authReq.ClientID))
 
-	// Build authorization response and redirect back to client
+	// Build both terminal responses up front and park them server-side. The
+	// authorization code stays out of the front-channel until the user acts
+	// on the consent screen, so an upstream session that resumed without
+	// prompting still cannot complete the client's authorization on its own.
 	responseURL, err := s.grantManager.BuildAuthorizationResponse(ctx, grant, authReq.RedirectURI)
 	if err != nil {
 		return oops.E(oops.CodeBadRequest, err, "failed to build authorization response").LogError(ctx, s.logger)
 	}
 
-	if provider.ProviderType == string(OAuthProxyProviderTypeGram) {
-		data := gramOAuthResultPageData{
-			RedirectURL:      template.URL(responseURL), // #nosec G203 // This has been checked and escaped
-			ScriptHash:       s.oauthStatusPageScriptHash,
-			ErrorDescription: "",
-			ErrorCode:        "",
-		}
+	denyURL, err := s.grantManager.BuildErrorResponse(ctx, authReq.RedirectURI, "access_denied", "The user denied the authorization request.", authReq.State)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build consent denial response").LogError(ctx, s.logger)
+	}
 
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		if err := s.successPageTmpl.Execute(w, data); err != nil {
-			return oops.E(oops.CodeUnexpected, err, "failed to render oauth success page").LogError(ctx, s.logger)
-		}
-	} else {
-		http.Redirect(w, r, responseURL, http.StatusFound)
+	consentID := uuid.NewString()
+	if err := s.pendingConsentStorage.Store(ctx, PendingConsent{
+		ID:            consentID,
+		ToolsetID:     toolset.ID,
+		Code:          grant.Code,
+		ApproveURL:    responseURL,
+		DenyURL:       denyURL,
+		ClientID:      authReq.ClientID,
+		MCPSlug:       mcpSlug,
+		UseResultPage: provider.ProviderType == string(OAuthProxyProviderTypeGram),
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "store pending consent").LogError(ctx, s.logger)
+	}
+
+	// Client name is display-only; an unregistered-but-valid client falls
+	// back to its ID rather than failing the flow this late.
+	clientName := authReq.ClientID
+	if client, err := s.clientRegistration.GetClient(ctx, fullMCPURL, authReq.ClientID); err == nil && client.ClientName != "" {
+		clientName = client.ClientName
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.consentPageTmpl.Execute(w, consentPageData{
+		ConsentID:    consentID,
+		ClientName:   clientName,
+		MCPSlug:      mcpSlug,
+		MCPURL:       fullMCPURL,
+		RedirectURI:  authReq.RedirectURI,
+		ProviderSlug: provider.Slug,
+		Scopes:       strings.Fields(authReq.Scope),
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "render oauth consent page").LogError(ctx, s.logger)
 	}
 
 	return nil

--- a/server/internal/oauth/proxyretired_test.go
+++ b/server/internal/oauth/proxyretired_test.go
@@ -1,0 +1,173 @@
+package oauth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oauth"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// retiredProxyEnv is a proxy-backed toolset plus a mux serving the oauth
+// endpoints against the same database.
+type retiredProxyEnv struct {
+	mux     goahttp.Muxer
+	mcpSlug string
+	// attachIssuer links a user_session_issuer to the toolset, which is what
+	// retires the proxy for it.
+	attachIssuer func(t *testing.T)
+}
+
+func newRetiredProxyEnv(t *testing.T) (context.Context, *retiredProxyEnv) {
+	t.Helper()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+
+	conn, err := infra.CloneTestDatabase(t, "proxyretired")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	enc := testenv.NewEncryptionClient(t)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient,
+		cache.Suffix("gram-local"), billing.NewStubClient(logger, tracerProvider))
+
+	ctx := authztest.InitAuthContext(t, t.Context(), conn, sessionManager)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok, "auth context must be initialized")
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "retired-proxy",
+		IsPublic:     true,
+		ProviderType: "gram",
+	})
+
+	env := oauthtest.NewOAuthServiceEnvWithDB(t, conn, cache.NewRedisCacheAdapter(redisClient), enc)
+	mux := goahttp.NewMuxer()
+	oauth.Attach(mux, env.Service)
+
+	return ctx, &retiredProxyEnv{
+		mux:     mux,
+		mcpSlug: proxy.Toolset.McpSlug.String,
+		attachIssuer: func(t *testing.T) {
+			t.Helper()
+
+			issuer, err := usersessions_repo.New(conn).CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
+				ProjectID:          *authCtx.ProjectID,
+				Slug:               "issuer-" + uuid.New().String()[:8],
+				AuthnChallengeMode: "interactive",
+				SessionDuration:    pgtype.Interval{Microseconds: int64(time.Hour / time.Microsecond), Days: 0, Months: 0, Valid: true},
+			})
+			require.NoError(t, err)
+
+			_, err = toolsets_repo.New(conn).UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+				UserSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+				Slug:                proxy.Toolset.Slug,
+				ProjectID:           proxy.Toolset.ProjectID,
+			})
+			require.NoError(t, err)
+		},
+	}
+}
+
+func (e *retiredProxyEnv) postToken(t *testing.T, ctx context.Context) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "a-stale-proxy-refresh-token")
+	form.Set("client_id", "some-client")
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost,
+		"/oauth/"+e.mcpSlug+"/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rec := httptest.NewRecorder()
+	e.mux.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// A client holding a proxy refresh token for a migrated server must be told
+// invalid_grant, which is the signal it acts on by discarding the token and
+// re-running authorization against the issuer.
+func TestTokenEndpointRefusesIssuerGatedToolsetWithInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+	env.attachIssuer(t)
+
+	rec := env.postToken(t, ctx)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	body := rec.Body.String()
+	require.Contains(t, body, `"error":"invalid_grant"`)
+	require.Contains(t, body, "Re-authorize to continue")
+}
+
+// Without an issuer the proxy still serves; the request fails on its own
+// merits (a bogus refresh token) rather than on the retirement gate.
+func TestTokenEndpointStillServesToolsetWithoutIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+
+	rec := env.postToken(t, ctx)
+
+	require.NotContains(t, rec.Body.String(), "moved to a new authorization server",
+		"a toolset with no issuer must not be treated as retired")
+}
+
+func TestAuthorizeEndpointRefusesIssuerGatedToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+	env.attachIssuer(t)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet,
+		"/oauth/"+env.mcpSlug+"/authorize?response_type=code&client_id=c&redirect_uri=http://localhost/cb", nil)
+	rec := httptest.NewRecorder()
+	env.mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"a retired proxy must not start a new authorization")
+}
+
+func TestRegisterEndpointRefusesIssuerGatedToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+	env.attachIssuer(t)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost,
+		"/oauth/"+env.mcpSlug+"/register",
+		strings.NewReader(`{"client_name":"new client","redirect_uris":["http://localhost/cb"]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	env.mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"a retired proxy must not accept new client registrations")
+}

--- a/server/internal/oauth/storage.go
+++ b/server/internal/oauth/storage.go
@@ -143,3 +143,47 @@ func (v UpstreamPKCEVerifier) AdditionalCacheKeys() []string {
 func (v UpstreamPKCEVerifier) TTL() time.Duration {
 	return 10 * time.Minute
 }
+
+var _ cache.CacheableObject[PendingConsent] = (*PendingConsent)(nil)
+
+// PendingConsent parks a finished authorization server-side while the user
+// decides on the consent screen. The upstream callback mints the grant as
+// usual but does not hand the code to the MCP client, so both terminal URLs
+// are built up front and exactly one of them is ever served.
+//
+// Only the opaque ID traverses the front-channel. The MCP client cannot
+// influence either URL, which is what keeps the POST-back from becoming an
+// open redirect.
+type PendingConsent struct {
+	ID        string    `json:"id"`
+	ToolsetID uuid.UUID `json:"toolset_id"`
+	// Code is the authorization code embedded in ApproveURL, retained so a
+	// denial can revoke the grant it points at.
+	Code       string `json:"code"`
+	ApproveURL string `json:"approve_url"`
+	DenyURL    string `json:"deny_url"`
+	ClientID   string `json:"client_id"`
+	MCPSlug    string `json:"mcp_slug"`
+	// UseResultPage mirrors the callback's provider split: Gram-managed
+	// providers finish in a hosted status page that reports back and closes
+	// the popup, custom providers finish in a bare 302.
+	UseResultPage bool `json:"use_result_page"`
+}
+
+func PendingConsentCacheKey(id string) string {
+	return "oauthPendingConsent:" + id
+}
+
+func (p PendingConsent) CacheKey() string {
+	return PendingConsentCacheKey(p.ID)
+}
+
+func (p PendingConsent) AdditionalCacheKeys() []string {
+	return []string{}
+}
+
+func (p PendingConsent) TTL() time.Duration {
+	// Matches the grant expiration in GrantManager: once the code behind
+	// ApproveURL is dead there is nothing left to consent to.
+	return 10 * time.Minute
+}

--- a/server/internal/oauthtest/serviceenv.go
+++ b/server/internal/oauthtest/serviceenv.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -29,6 +30,15 @@ type OAuthServiceEnv struct {
 func NewOAuthServiceEnv(t *testing.T, cacheAdapter cache.Cache, enc *encryption.Client) *OAuthServiceEnv {
 	t.Helper()
 
+	return NewOAuthServiceEnvWithDB(t, nil, cacheAdapter, enc)
+}
+
+// NewOAuthServiceEnvWithDB is NewOAuthServiceEnv backed by a live database,
+// for tests exercising handlers that resolve a toolset before doing anything
+// else — the issuer gate on the proxy endpoints.
+func NewOAuthServiceEnvWithDB(t *testing.T, db *pgxpool.Pool, cacheAdapter cache.Cache, enc *encryption.Client) *OAuthServiceEnv {
+	t.Helper()
+
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
@@ -36,7 +46,7 @@ func NewOAuthServiceEnv(t *testing.T, cacheAdapter cache.Cache, enc *encryption.
 	serverURL, err := url.Parse("http://0.0.0.0")
 	require.NoError(t, err)
 
-	svc := oauth.NewService(logger, tracerProvider, meterProvider, nil, serverURL, cacheAdapter, enc, nil, nil, nil, nil)
+	svc := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cacheAdapter, enc, nil, nil, nil, nil)
 
 	return &OAuthServiceEnv{
 		TokenIssuer: NewTokenIssuer(t, cacheAdapter, enc),


### PR DESCRIPTION
The OAuth proxy accepts dynamically registered clients, so any client that completes registration could previously drive a full authorization on its own: if the user's upstream session resumed without prompting (SSO, a live provider cookie), the callback exchanged the code, minted a grant and 302'd straight back to the client's redirect_uri with no human in the loop.

The authorization callback now parks the finished authorization in the cache and renders a consent screen instead. Both terminal URLs are built server side up front and only the opaque consent id reaches the browser, so the POST back cannot be turned into an open redirect. Approval serves the authorization response, denial serves access_denied and revokes the grant so no redeemable code is left behind. The pending record is consumed on the first POST either way, so a resubmitted form cannot mint a second redirect.

Consent is asked for on every authorization. Prior approvals are not recorded yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit user consent before the OAuth proxy releases an authorization code and retire the proxy for issuer‑gated MCP servers. This mitigates Linear AIS-391 by stopping silent authorizations and ensures migrated servers honor the issuer’s consent, session, and revocation.

- **New Features**
  - Park finished authorizations server-side and render a consent screen instead of immediate redirect.
  - Use an opaque consent_id; approve/deny URLs are built server-side to avoid open redirects.
  - POST-only consent endpoint at /oauth/{mcpSlug}/consent; single-use and slug-locked to stop replays and cross-server misuse.
  - Approve returns the authorization response; deny returns access_denied and revokes the grant so no redeemable code remains.
  - Always prompt for consent; shows client name, MCP server, redirect URI, and scopes. Gram-managed providers use the hosted result page; custom providers 302 after consent.
  - Retire the proxy when a user_session_issuer is attached: token returns 400 invalid_grant to trigger re-authorization; authorize/register return 404. Discovery already advertises issuer endpoints, so clients re-discover and continue on the issuer path.

- **Migration**
  - No config changes. Users will now see a consent prompt for each OAuth authorization via the proxy.
  - For issuer-gated servers, existing proxy refresh tokens will receive invalid_grant and must re-authorize via the issuer. Existing popup flows continue with one extra interstitial before receiving the code.

<sup>Written for commit a916918e880ce60f278cb090c9d070c146551a73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

