### PR TITLE
chore: confirm before rotating device agent token

### DIFF
--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -1,6 +1,7 @@
 import { CodeBlock } from "@/components/code";
 import { Page } from "@/components/page-layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Dialog } from "@/components/ui/dialog";
 import { Link as ExternalLink } from "@/components/ui/link";
 import {
   Sheet,
@@ -503,6 +504,7 @@ function GenerateInlineButton({
 function FleetIdentity() {
   const { name: orgName, slug: orgSlug } = useOrganization();
   const apiKeysHref = useOrgRoutes().apiKeys.href();
+  const [rotateConfirmOpen, setRotateConfirmOpen] = useState(false);
 
   // org_slug / org_name are org-level constants, safe to prefill. email is
   // per-user: this fleet-wide file must not pin one identity, so the example
@@ -541,6 +543,20 @@ function FleetIdentity() {
     generatedToken ?? ORG_TOKEN_SENTINEL,
   );
 
+  const handleGenerateOrRotate = () => {
+    if (hasExistingAgentKey) {
+      setRotateConfirmOpen(true);
+      return;
+    }
+
+    generate();
+  };
+
+  const confirmRotation = () => {
+    setRotateConfirmOpen(false);
+    generate();
+  };
+
   // Host the inline action only while no token exists. CodeBlock matches the
   // sentinel as a substring of whatever token shiki emits (it ends up quoted as
   // a JSON value), so we key by the bare sentinel; copyText keeps a
@@ -551,7 +567,7 @@ function FleetIdentity() {
         [ORG_TOKEN_SENTINEL]: {
           node: (
             <GenerateInlineButton
-              onClick={generate}
+              onClick={handleGenerateOrRotate}
               pending={isPending}
               disabled={!canGenerate}
               existing={hasExistingAgentKey}
@@ -593,21 +609,6 @@ function FleetIdentity() {
 
       <div>
         <SubHeading>Example managed.json</SubHeading>
-        {hasExistingAgentKey && !generatedToken && (
-          <Alert variant="destructive" className="mb-3">
-            <Icon name="triangle-alert" className="h-4 w-4" />
-            <AlertTitle>
-              Rotating this token will break your current MDM integration
-            </AlertTitle>
-            <AlertDescription>
-              Clicking <strong>Rotate token</strong> expires the token currently
-              deployed in your MDM settings. You must replace it with the new{" "}
-              <code>org_token</code> and propagate the updated configuration to
-              every managed device. Until then, policy syncing to end-user
-              devices will not work.
-            </AlertDescription>
-          </Alert>
-        )}
         <CodeBlock language="json" slots={slots}>
           {exampleManagedJson}
         </CodeBlock>
@@ -677,6 +678,40 @@ function FleetIdentity() {
           check that it's readable by the logged-in user, and validate the JSON.
         </Type>
       </div>
+
+      <Dialog open={rotateConfirmOpen} onOpenChange={setRotateConfirmOpen}>
+        <Dialog.Content>
+          <Dialog.Header>
+            <Dialog.Title>Rotate device agent token?</Dialog.Title>
+            <Dialog.Description>
+              This expires the token currently deployed in your MDM settings.
+            </Dialog.Description>
+          </Dialog.Header>
+          <Alert variant="destructive">
+            <Icon name="triangle-alert" className="h-4 w-4" />
+            <AlertTitle>
+              Your current MDM integration will stop working
+            </AlertTitle>
+            <AlertDescription>
+              You must replace the existing <code>org_token</code> with the new
+              token and propagate the updated configuration to every managed
+              device. Until then, policy syncing to end-user devices will not
+              work.
+            </AlertDescription>
+          </Alert>
+          <Dialog.Footer>
+            <Button
+              variant="tertiary"
+              onClick={() => setRotateConfirmOpen(false)}
+            >
+              <Button.Text>Cancel</Button.Text>
+            </Button>
+            <Button variant="destructive-primary" onClick={confirmRotation}>
+              <Button.Text>Rotate token</Button.Text>
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
     </div>
   );
 }

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -593,6 +593,21 @@ function FleetIdentity() {
 
       <div>
         <SubHeading>Example managed.json</SubHeading>
+        {hasExistingAgentKey && !generatedToken && (
+          <Alert variant="destructive" className="mb-3">
+            <Icon name="triangle-alert" className="h-4 w-4" />
+            <AlertTitle>
+              Rotating this token will break your current MDM integration
+            </AlertTitle>
+            <AlertDescription>
+              Clicking <strong>Rotate token</strong> expires the token currently
+              deployed in your MDM settings. You must replace it with the new{" "}
+              <code>org_token</code> and propagate the updated configuration to
+              every managed device. Until then, policy syncing to end-user
+              devices will not work.
+            </AlertDescription>
+          </Alert>
+        )}
         <CodeBlock language="json" slots={slots}>
           {exampleManagedJson}
         </CodeBlock>
@@ -603,8 +618,10 @@ function FleetIdentity() {
           platform's equivalent) so one profile serves the whole fleet, or omit{" "}
           <code>email</code> and have each user run{" "}
           <code>speakeasy enroll</code>. Click{" "}
-          <strong className="text-foreground">Generate token</strong> in the
-          example to mint the <code>org_token</code>.
+          <strong className="text-foreground">
+            {hasExistingAgentKey ? "Rotate token" : "Generate token"}
+          </strong>{" "}
+          in the example to mint the <code>org_token</code>.
         </Type>
 
         <div className="mt-4 flex flex-col gap-3">


### PR DESCRIPTION
## What changed

- show a prominent destructive warning when the device-agent onboarding flow detects an existing agent token
- explain that rotation expires the token deployed through MDM and requires propagating the replacement to every managed device
- clarify that policy syncing will not work until the updated configuration reaches end-user devices
- keep the explanatory action label in sync between generate and rotate states

<img width="1024" height="584" alt="device-agent-rotate-token-warning" src="https://github.com/user-attachments/assets/d5029cf3-95d4-44f9-b2b1-39afdd04ad6a" />

## Why

Rotating the device-agent token revokes the previous agent token. The existing hover text did not make the resulting MDM outage or required rollout sufficiently clear before the action.

## Validation

- `pnpm -F dashboard lint:format`
- `pnpm -F dashboard lint:oxlint`
- `pnpm -F dashboard type-check`
- verified the rotate state in the local dashboard with Playwright

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a clear destructive warning before rotating a device-agent token so admins understand rotation revokes the MDM-deployed token and requires rollout to all devices. The action label now switches to “Rotate token” when an existing token is detected.

- **New Features**
  - Show a destructive warning in the onboarding flow when an existing agent token is present, noting MDM impact and that policy syncing pauses until the new `org_token` reaches devices.
  - Sync the example’s action label to show “Generate token” or “Rotate token” based on state.

<sup>Written for commit 73caffbf7301fa35e2fbaa7e854bf439fcadbc59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

