### PR TITLE
feat(dashboard): hide Intune provider and refine agent-input copy

### DIFF
--- a/.changeset/hide-intune-provider.md
+++ b/.changeset/hide-intune-provider.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Hide Microsoft Intune from the MDM integrations UI until it is fully supported — a central `isProviderVisible` filter removes hidden providers from the list, the pipeline source count, the fleet-source breakdown, and direct-URL access, while leaving backend registration untouched. Also pluralize the pipeline agent-input label to "Active agents" and label its source as "reported by device agent".

--- a/client/dashboard/src/pages/org/device-integrations/DeviceIntegrations.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/DeviceIntegrations.tsx
@@ -7,7 +7,7 @@ import { Stack } from "@speakeasy-api/moonshine";
 import React from "react";
 import { CoveragePipeline } from "./coverage-pipeline";
 import { DeviceIntegrationConnectionRow } from "./device-integration-connection-row";
-import { isSink } from "./provider-role";
+import { isProviderVisible, isSink } from "./provider-role";
 
 // MDM Integrations catalog, rendered as a tab of the Device Agent page. The
 // page is a one-directional pipeline: inventory sources pull the managed
@@ -23,7 +23,7 @@ export function MdmIntegrationsTab(): React.JSX.Element {
     // The provider registry only changes on deploy.
     { staleTime: 300_000 },
   );
-  const providers = data?.providers ?? [];
+  const providers = (data?.providers ?? []).filter(isProviderVisible);
   const sources = providers.filter((provider) => !isSink(provider));
   const sinks = providers.filter(isSink);
 

--- a/client/dashboard/src/pages/org/device-integrations/MdmIntegrationDetail.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/MdmIntegrationDetail.tsx
@@ -17,7 +17,12 @@ import { PlugZap } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link, Navigate, useParams } from "react-router";
 import { CoverageSummaryTiles, ManagedDeviceTable } from "./coverage-widgets";
-import { isSink, providerRole, ROLE_COPY } from "./provider-role";
+import {
+  isProviderVisible,
+  isSink,
+  providerRole,
+  ROLE_COPY,
+} from "./provider-role";
 import {
   ConnectionStatusBadge,
   DeviceIntegrationConfigureSheet,
@@ -56,7 +61,11 @@ export default function MdmIntegrationDetail(): JSX.Element | null {
 
   const provider = data?.providers.find((p) => p.id === providerID);
   if (isLoading) return null;
-  if (!provider) return <Navigate to=".." replace />;
+  // Hidden providers 404 to the list even by direct URL, so a not-yet-supported
+  // integration can't be reached out of band.
+  if (!provider || !isProviderVisible(provider)) {
+    return <Navigate to=".." replace />;
+  }
 
   return (
     <Page>
@@ -397,7 +406,10 @@ function FleetSourceBreakdown() {
     staleTime: 300_000,
   });
   const sources = useMemo(
-    () => (data?.providers ?? []).filter((provider) => !isSink(provider)),
+    () =>
+      (data?.providers ?? []).filter(
+        (provider) => !isSink(provider) && isProviderVisible(provider),
+      ),
     [data],
   );
   const coverageQueries = useQueries({

--- a/client/dashboard/src/pages/org/device-integrations/coverage-pipeline.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/coverage-pipeline.tsx
@@ -70,7 +70,7 @@ export function CoveragePipeline({
   // reports device attestation for every active device; otherwise fall back
   // to the weaker match wording (and default weak while coverage loads).
   const deviceAttested = coverage?.attestation === "device";
-  const agentLabel = deviceAttested ? "Running the agent" : "Active agent";
+  const agentLabel = deviceAttested ? "Running the agent" : "Active agents";
   const agentHint = deviceAttested
     ? "with a live device-agent heartbeat"
     : "assigned user has a live agent";
@@ -90,7 +90,7 @@ export function CoveragePipeline({
             label={agentLabel}
             value={running}
             hint={agentHint}
-            foot="reported by the agent"
+            foot="reported by device agent"
           />
         </div>
 

--- a/client/dashboard/src/pages/org/device-integrations/provider-role.ts
+++ b/client/dashboard/src/pages/org/device-integrations/provider-role.ts
@@ -21,6 +21,19 @@ export function isSink(provider: DeviceIntegrationProvider): boolean {
   return providerRole(provider) === "sink";
 }
 
+// Providers that are registered on the backend but not ready for general use.
+// Hidden from the UI entirely — the list, the pipeline counts, the source
+// breakdown, and direct-URL access — until they are fully supported. This is a
+// deliberately temporary frontend gate: drop the id here to reveal it, no
+// backend change needed.
+const HIDDEN_PROVIDER_IDS = new Set(["intune"]);
+
+export function isProviderVisible(
+  provider: DeviceIntegrationProvider,
+): boolean {
+  return !HIDDEN_PROVIDER_IDS.has(provider.id);
+}
+
 // Role-specific verbs, kept in one place so "synced" never leaks onto a sink
 // or "pushed" onto a source.
 export const ROLE_COPY: Record<


### PR DESCRIPTION
Follow-up to #4753 — this commit missed that PR's squash-merge by ~90 seconds, so it needs its own PR to main.

## What

- **Hide Microsoft Intune** from the MDM integrations UI until it's fully supported. A central `isProviderVisible` filter removes hidden providers from the list, the pipeline source count, the "Fleet sourced from" breakdown, and direct-URL access (the detail route redirects to the list). Backend registration is untouched, so revealing it later is a one-line change (drop `"intune"` from `HIDDEN_PROVIDER_IDS`) — no feature flag, no backend churn.
- **Copy:** pluralize the pipeline agent-input label to "Active agents" and change its footer to "reported by device agent".

Verified live: Intune gone from the list (Jamf + Iru remain), source count reads "of 2 sources connected", `/mdm-integrations/intune` redirects away, agent node reads "Active agents … reported by device agent". Type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Microsoft Intune from the MDM integrations UI until it’s supported, and refine the agent tile copy for clarity.

- **New Features**
  - Hide `intune` across the UI via a central `isProviderVisible` filter. It’s removed from the list, source counts, and fleet-source breakdown; direct URLs redirect to the list. Backend registration is unchanged; unhide by removing `intune` from `HIDDEN_PROVIDER_IDS`.
  - Copy: change agent tile to "Active agents" and footer to "reported by device agent".

<sup>Written for commit 991b6301cac0f3ed79777187ce4ae27247f68623. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

