### PR TITLE
feat: auto-provision the Drata Custom Connection on connect

### DIFF
--- a/.changeset/device-integration-advanced-fields.md
+++ b/.changeset/device-integration-advanced-fields.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Tuck optional device-integration settings behind an "Advanced" disclosure in the connect/configure sheet, so the default view shows only the required fields (e.g. Drata is just Region + API Key + Test — the Custom Connection ID is created automatically). Driven by the descriptor's `required` flag, so it applies to every provider; the section auto-expands when an optional field already holds a value.

--- a/.changeset/drata-auto-provision.md
+++ b/.changeset/drata-auto-provision.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Auto-provision the Drata Custom Connection on connect. When an evidence-sink provider implements the new optional `Provisioner` capability, the connect flow creates its vendor-side object and stores the resulting ids, so the customer no longer hand-crafts it against the vendor API. Drata implements it: it find-or-creates the dedicated Custom Connection with the exact record schema and `required` list (omitting `agentLastSeenAt` so never-seen-agent records are never rejected), keyed on a deterministic name so a re-save reuses the connection instead of duplicating it. A new optional `workspace_id` field defaults to 1, and `connection_id` becomes optional — filled in automatically.

--- a/.changeset/hide-vanta-provider.md
+++ b/.changeset/hide-vanta-provider.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Hide the Vanta evidence-push provider from the MDM integrations UI until a supported path exists — Vanta does not support custom resources for partner-built integrations. Uses the existing `isProviderVisible` frontend gate, so backend registration is untouched and revealing it later is a one-line change.

--- a/client/dashboard/src/pages/org/device-integrations/device-integration-configure-sheet.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/device-integration-configure-sheet.tsx
@@ -1,4 +1,9 @@
 import { RequireScope } from "@/components/require-scope";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -11,17 +16,20 @@ import {
 } from "@/components/ui/sheet";
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Type } from "@/components/ui/type";
+import { cn } from "@/lib/utils";
 import type { DeviceIntegrationProvider } from "@gram/client/models/components/deviceintegrationprovider.js";
 import type { DeviceIntegrationProviderField } from "@gram/client/models/components/deviceintegrationproviderfield.js";
 import { Badge, Button, Stack } from "@speakeasy-api/moonshine";
 import {
   CheckCircle2,
+  ChevronRight,
   Loader2,
   PauseCircle,
   PlugZap,
   Trash2,
   XCircle,
 } from "lucide-react";
+import { useState } from "react";
 import { providerUI } from "./provider-ui";
 import type { DeviceIntegrationConfigForm } from "./use-device-integration-config";
 
@@ -115,14 +123,22 @@ export function DeviceIntegrationConfigureSheet({
 
         <Stack gap={4} className="px-4">
           <SetupSteps steps={providerUI(provider).setupSteps} />
-          {provider.fields.map((field) => (
-            <FieldInput
-              key={field.key}
-              provider={provider.id}
-              field={field}
-              form={form}
-            />
-          ))}
+          {provider.fields
+            .filter((field) => field.required)
+            .map((field) => (
+              <FieldInput
+                key={field.key}
+                provider={provider.id}
+                field={field}
+                form={form}
+              />
+            ))}
+
+          <AdvancedFields
+            provider={provider.id}
+            fields={provider.fields.filter((field) => !field.required)}
+            form={form}
+          />
 
           {form.isConfigured ? (
             <TestConnectionRow form={form} />
@@ -206,6 +222,62 @@ function FieldInput({
         disabled={form.isLoading || form.isMutating}
       />
     </Stack>
+  );
+}
+
+// Optional settings live behind an "Advanced" disclosure so the default view is
+// just the required fields (e.g. Region + API Key for Drata — the connection id
+// is created automatically, so most customers never touch it). Rendered from
+// the descriptor's `required` flag, so every provider's optional fields tuck
+// away with zero per-provider frontend work. The section auto-expands when an
+// optional field already holds a value, so editing a config that uses one never
+// hides it.
+function AdvancedFields({
+  provider,
+  fields,
+  form,
+}: {
+  provider: string;
+  fields: DeviceIntegrationProviderField[];
+  form: DeviceIntegrationConfigForm;
+}) {
+  const hasValue = fields.some(
+    (field) => (form.settings[field.key] ?? "") !== "",
+  );
+  // null = follow the data (open iff a value exists); a boolean is the user's
+  // explicit choice, which then wins. Derived during render — no effect, so no
+  // stale-collapsed flash when the config loads.
+  const [override, setOverride] = useState<boolean | null>(null);
+  const open = override ?? hasValue;
+
+  if (fields.length === 0) return null;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOverride}>
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs font-medium"
+        >
+          <ChevronRight
+            className={cn("size-3.5 transition-transform", open && "rotate-90")}
+          />
+          Advanced
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <Stack gap={4} className="pt-4">
+          {fields.map((field) => (
+            <FieldInput
+              key={field.key}
+              provider={provider}
+              field={field}
+              form={form}
+            />
+          ))}
+        </Stack>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 

--- a/client/dashboard/src/pages/org/device-integrations/provider-role.ts
+++ b/client/dashboard/src/pages/org/device-integrations/provider-role.ts
@@ -26,7 +26,12 @@ export function isSink(provider: DeviceIntegrationProvider): boolean {
 // breakdown, and direct-URL access — until they are fully supported. This is a
 // deliberately temporary frontend gate: drop the id here to reveal it, no
 // backend change needed.
-const HIDDEN_PROVIDER_IDS = new Set(["intune"]);
+//   - intune: inventory source not yet fully supported.
+//   - vanta: evidence push is blocked on Vanta — custom resources aren't
+//     supported for partner-built integrations, and they'd require each
+//     customer to hand-author the compliance test. Hidden until Vanta offers a
+//     supported path (e.g. a partner-writable device resource type).
+const HIDDEN_PROVIDER_IDS = new Set(["intune", "vanta"]);
 
 export function isProviderVisible(
   provider: DeviceIntegrationProvider,

--- a/server/internal/deviceintegrations/impl.go
+++ b/server/internal/deviceintegrations/impl.go
@@ -45,6 +45,11 @@ const (
 	// remotemcp's URL verification).
 	testConnectionTimeout = 10 * time.Second
 
+	// provisionTimeout bounds the synchronous connect-time provisioning call
+	// (creating a vendor-side connection/resource). Larger than the probe: it
+	// may list then create, but still short enough to fail a broken save fast.
+	provisionTimeout = 20 * time.Second
+
 	// activeWindow is the freshness window for the coverage buckets: an
 	// assigned user counts as agent-active when their heartbeat is within
 	// it. The agent polls every 60s, so an hour is generous — anything
@@ -282,6 +287,15 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 		return nil, err
 	}
 
+	// Give the provider a chance to create its vendor-side object (e.g. a Drata
+	// Custom Connection) and fold the resulting ids into settings. Runs before
+	// the transaction — it's an external round-trip — and persists as part of
+	// the same save below.
+	settings, err = s.provisionIfSupported(ctx, desc, creds, settings)
+	if err != nil {
+		return nil, err
+	}
+
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
@@ -438,6 +452,40 @@ func (s *Service) probeProvider(ctx context.Context, desc providers.Descriptor, 
 	default:
 		return oops.E(oops.CodeUnexpected, nil, "provider %s has no testable capability", desc.ID)
 	}
+}
+
+// provisionIfSupported lets a provider that implements providers.Provisioner
+// create its vendor-side object (e.g. a Drata Custom Connection) during
+// connect, returning settings to persist. It runs OUTSIDE the config
+// transaction — provisioning is an external side effect that must not hold the
+// row lock across a vendor round-trip — so the caller persists what it returns.
+// A no-op passthrough for providers that don't provision. A provisioning
+// failure surfaces as an actionable bad-request so the customer fixes the
+// credentials/workspace instead of saving a config that can never sync.
+func (s *Service) provisionIfSupported(ctx context.Context, desc providers.Descriptor, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
+	deps := providers.Deps{Client: boundedProviderClient(s.guardian)}
+	var prov providers.Provisioner
+	switch {
+	case desc.NewEvidenceSink != nil:
+		if p, ok := desc.NewEvidenceSink(deps).(providers.Provisioner); ok {
+			prov = p
+		}
+	case desc.NewInventorySource != nil:
+		if p, ok := desc.NewInventorySource(deps).(providers.Provisioner); ok {
+			prov = p
+		}
+	}
+	if prov == nil {
+		return settings, nil
+	}
+
+	provCtx, cancel := context.WithTimeout(ctx, provisionTimeout)
+	defer cancel()
+	out, err := prov.Provision(provCtx, creds, settings)
+	if err != nil {
+		return nil, oops.E(oops.CodeBadRequest, err, "provision %s connection", desc.ID)
+	}
+	return out, nil
 }
 
 func (s *Service) ListSchedules(ctx context.Context, payload *gen.ListSchedulesPayload) (*gen.ListDeviceIntegrationSchedulesResult, error) {

--- a/server/internal/deviceintegrations/impl.go
+++ b/server/internal/deviceintegrations/impl.go
@@ -46,9 +46,12 @@ const (
 	testConnectionTimeout = 10 * time.Second
 
 	// provisionTimeout bounds the synchronous connect-time provisioning call
-	// (creating a vendor-side connection/resource). Larger than the probe: it
-	// may list then create, but still short enough to fail a broken save fast.
-	provisionTimeout = 20 * time.Second
+	// (creating a vendor-side connection/resource). It runs inside the config
+	// upsert while the per-config advisory lock is held, so it is deliberately
+	// tight: a hung vendor must not pin that lock (and the Postgres transaction)
+	// for long. It still allows the list-then-create round trips that a
+	// find-or-create provisioner makes.
+	provisionTimeout = 10 * time.Second
 
 	// activeWindow is the freshness window for the coverage buckets: an
 	// assigned user counts as agent-active when their heartbeat is within

--- a/server/internal/deviceintegrations/impl.go
+++ b/server/internal/deviceintegrations/impl.go
@@ -302,7 +302,7 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 	// update provisions correctly, and concurrent first-time connects can't
 	// double-create. Nil for providers with nothing to provision.
 	provision := func(ctx context.Context, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
-		return s.provisionIfSupported(ctx, desc, creds, settings)
+		return s.provisionIfSupported(ctx, authCtx.ActiveOrganizationID, desc, creds, settings)
 	}
 
 	result, err := s.store.upsertWithTx(ctx, dbtx, desc, authCtx.ActiveOrganizationID, creds, settings, payload.Enabled, provision)
@@ -467,7 +467,7 @@ func (s *Service) probeProvider(ctx context.Context, desc providers.Descriptor, 
 // lock. A no-op passthrough for providers that don't provision. A provisioning
 // failure surfaces as an actionable bad-request so the customer fixes the
 // credentials/workspace instead of saving a config that can never sync.
-func (s *Service) provisionIfSupported(ctx context.Context, desc providers.Descriptor, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
+func (s *Service) provisionIfSupported(ctx context.Context, orgID string, desc providers.Descriptor, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
 	deps := providers.Deps{Client: boundedProviderClient(s.guardian)}
 	var prov providers.Provisioner
 	switch {
@@ -486,7 +486,7 @@ func (s *Service) provisionIfSupported(ctx context.Context, desc providers.Descr
 
 	provCtx, cancel := context.WithTimeout(ctx, provisionTimeout)
 	defer cancel()
-	out, err := prov.Provision(provCtx, creds, settings)
+	out, err := prov.Provision(provCtx, orgID, creds, settings)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "provision %s connection", desc.ID)
 	}

--- a/server/internal/deviceintegrations/impl.go
+++ b/server/internal/deviceintegrations/impl.go
@@ -287,22 +287,22 @@ func (s *Service) UpsertConfig(ctx context.Context, payload *gen.UpsertConfigPay
 		return nil, err
 	}
 
-	// Give the provider a chance to create its vendor-side object (e.g. a Drata
-	// Custom Connection) and fold the resulting ids into settings. Runs before
-	// the transaction — it's an external round-trip — and persists as part of
-	// the same save below.
-	settings, err = s.provisionIfSupported(ctx, desc, creds, settings)
-	if err != nil {
-		return nil, err
-	}
-
 	dbtx, err := s.db.Begin(ctx)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to begin transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
-	result, err := s.store.upsertWithTx(ctx, dbtx, desc, authCtx.ActiveOrganizationID, creds, settings, payload.Enabled)
+	// Provisioning (creating the provider's vendor-side object, e.g. a Drata
+	// Custom Connection) is handed to the store so it runs on the merged
+	// effective config and inside the (org, provider) advisory lock — a partial
+	// update provisions correctly, and concurrent first-time connects can't
+	// double-create. Nil for providers with nothing to provision.
+	provision := func(ctx context.Context, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
+		return s.provisionIfSupported(ctx, desc, creds, settings)
+	}
+
+	result, err := s.store.upsertWithTx(ctx, dbtx, desc, authCtx.ActiveOrganizationID, creds, settings, payload.Enabled, provision)
 	if err != nil {
 		return nil, err
 	}
@@ -456,10 +456,12 @@ func (s *Service) probeProvider(ctx context.Context, desc providers.Descriptor, 
 
 // provisionIfSupported lets a provider that implements providers.Provisioner
 // create its vendor-side object (e.g. a Drata Custom Connection) during
-// connect, returning settings to persist. It runs OUTSIDE the config
-// transaction — provisioning is an external side effect that must not hold the
-// row lock across a vendor round-trip — so the caller persists what it returns.
-// A no-op passthrough for providers that don't provision. A provisioning
+// connect, returning settings to persist. It is invoked by the store's upsert
+// on the merged effective config and under the (org, provider) advisory lock,
+// so a partial update provisions correctly and concurrent first-time connects
+// cannot double-create; the provider itself no-ops when nothing needs
+// provisioning, so the common re-save makes no vendor call while holding the
+// lock. A no-op passthrough for providers that don't provision. A provisioning
 // failure surfaces as an actionable bad-request so the customer fixes the
 // credentials/workspace instead of saving a config that can never sync.
 func (s *Service) provisionIfSupported(ctx context.Context, desc providers.Descriptor, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -515,18 +515,17 @@ func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credent
 				return string(c.ID), nil
 			}
 		}
-		next := ""
-		if list.Pagination.Cursor != nil {
-			next = *list.Pagination.Cursor
-		}
-		if next == "" {
-			// True end of the list, no match: the connection does not exist and
-			// the caller creates it.
+		if list.Pagination.Cursor == nil {
+			// A genuine null cursor is Drata's only end-of-list signal: no match
+			// through the true end means the connection does not exist and the
+			// caller creates it. A present-but-empty cursor is NOT this signal —
+			// it falls through to the can't-advance error below.
 			return "", nil
 		}
-		if next == cursor {
-			// A cursor that won't advance can't prove the connection is absent;
-			// fail rather than fall through and risk a duplicate.
+		next := *list.Pagination.Cursor
+		if next == "" || next == cursor {
+			// A cursor that is empty or unchanged can't advance the scan and
+			// isn't proof of absence; fail rather than risk a duplicate.
 			return "", fmt.Errorf("connection list cursor did not advance")
 		}
 		cursor = next

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -114,10 +114,14 @@ const (
 	// displayNameKey names the record field Drata shows as each row's label.
 	displayNameKey = "hostname"
 
-	// connectionListLimit bounds the find-existing lookup. A customer's
-	// dedicated Gram connection is created once; a page this size comfortably
-	// covers finding it without paginating.
+	// connectionListLimit is the page size for the find-existing lookup.
 	connectionListLimit = 200
+
+	// maxConnectionListPages bounds how far find-existing pages before giving
+	// up (and creating a fresh connection). 50 × the page size is far more
+	// connections than any tenant realistically has; the bound only exists so a
+	// cursor that never clears cannot loop forever.
+	maxConnectionListPages = 50
 )
 
 // defaultRegions allowlists the customer-selectable Drata regions. Deriving
@@ -450,28 +454,52 @@ func parseWorkspaceID(settings providers.Settings) (int, error) {
 
 // findConnectionByName returns the id of an existing custom connection whose
 // display name matches, or "" when none exists. Reusing a prior Gram-created
-// connection is what keeps provisioning idempotent across re-saves.
+// connection is what keeps provisioning idempotent across re-saves — so the
+// lookup follows the pagination cursor: a customer with more connections than
+// one page could carry the Gram one onto a later page, and missing it there
+// would create a duplicate on every save.
 func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credentials, base, name string) (string, error) {
-	body, err := s.doJSON(ctx, creds, http.MethodGet, base+"/public/v2/custom-connections?limit="+strconv.Itoa(connectionListLimit), nil)
-	if err != nil {
-		return "", err
-	}
-	var list struct {
-		Data []struct {
-			ID flexID `json:"id"`
-			// Drata echoes the create-time "name" back as "clientAlias"; match
-			// either so the lookup is robust to which the list endpoint returns.
-			ClientAlias string `json:"clientAlias"`
-			Name        string `json:"name"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &list); err != nil {
-		return "", fmt.Errorf("decode connection list: %w", err)
-	}
-	for _, c := range list.Data {
-		if c.ClientAlias == name || c.Name == name {
-			return string(c.ID), nil
+	cursor := ""
+	for range maxConnectionListPages {
+		requestURL := base + "/public/v2/custom-connections?limit=" + strconv.Itoa(connectionListLimit)
+		if cursor != "" {
+			requestURL += "&cursor=" + url.QueryEscape(cursor)
 		}
+		body, err := s.doJSON(ctx, creds, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return "", err
+		}
+		var list struct {
+			Data []struct {
+				ID flexID `json:"id"`
+				// Drata echoes the create-time "name" back as "clientAlias";
+				// match either so the lookup is robust to which the list
+				// endpoint returns.
+				ClientAlias string `json:"clientAlias"`
+				Name        string `json:"name"`
+			} `json:"data"`
+			Pagination struct {
+				Cursor *string `json:"cursor"`
+			} `json:"pagination"`
+		}
+		if err := json.Unmarshal(body, &list); err != nil {
+			return "", fmt.Errorf("decode connection list: %w", err)
+		}
+		for _, c := range list.Data {
+			if c.ClientAlias == name || c.Name == name {
+				return string(c.ID), nil
+			}
+		}
+		next := ""
+		if list.Pagination.Cursor != nil {
+			next = *list.Pagination.Cursor
+		}
+		// Stop on the last page, or if the cursor fails to advance (a defensive
+		// guard against a mispaged response looping forever).
+		if next == "" || next == cursor {
+			return "", nil
+		}
+		cursor = next
 	}
 	return "", nil
 }

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -122,10 +122,11 @@ const (
 	// connectionListLimit is the page size for the find-existing lookup.
 	connectionListLimit = 200
 
-	// maxConnectionListPages bounds how far find-existing pages before giving
-	// up (and creating a fresh connection). 50 × the page size is far more
-	// connections than any tenant realistically has; the bound only exists so a
-	// cursor that never clears cannot loop forever.
+	// maxConnectionListPages bounds how far find-existing pages before it fails
+	// the provision (reaching the cap is treated as unproven-absence, not
+	// not-found, so it never silently creates a duplicate). 50 × the page size
+	// is far more connections than any tenant realistically has; the bound only
+	// exists so a cursor that never clears cannot loop forever.
 	maxConnectionListPages = 50
 )
 
@@ -470,11 +471,18 @@ func parseWorkspaceID(settings providers.Settings) (int, error) {
 }
 
 // findConnectionByName returns the id of an existing custom connection whose
-// display name matches, or "" when none exists. Reusing a prior Gram-created
-// connection is what keeps provisioning idempotent across re-saves — so the
-// lookup follows the pagination cursor: a customer with more connections than
-// one page could carry the Gram one onto a later page, and missing it there
-// would create a duplicate on every save.
+// display name matches, or "" when the scan reaches the genuine last page
+// without one. Reusing a prior Gram-created connection is what keeps
+// provisioning idempotent across re-saves — so the lookup follows the
+// pagination cursor: a customer with more connections than one page could carry
+// the Gram one onto a later page, and missing it there would create a duplicate
+// on every save.
+//
+// Only a null cursor (the true end of the list) counts as "not found"; a scan
+// that hits the page cap or a cursor that won't advance leaves the connection's
+// existence unproven, so it returns an error rather than "" — reporting "not
+// found" there would create a duplicate on every connect, the exact bug the
+// pagination is here to prevent.
 func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credentials, base, name string) (string, error) {
 	cursor := ""
 	for range maxConnectionListPages {
@@ -511,14 +519,21 @@ func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credent
 		if list.Pagination.Cursor != nil {
 			next = *list.Pagination.Cursor
 		}
-		// Stop on the last page, or if the cursor fails to advance (a defensive
-		// guard against a mispaged response looping forever).
-		if next == "" || next == cursor {
+		if next == "" {
+			// True end of the list, no match: the connection does not exist and
+			// the caller creates it.
 			return "", nil
+		}
+		if next == cursor {
+			// A cursor that won't advance can't prove the connection is absent;
+			// fail rather than fall through and risk a duplicate.
+			return "", fmt.Errorf("connection list cursor did not advance")
 		}
 		cursor = next
 	}
-	return "", nil
+	// Ran out of pages before reaching the end: a match could still be beyond
+	// the cap, so this is unproven-absence, not not-found. Fail loudly.
+	return "", fmt.Errorf("connection list exceeded %d pages", maxConnectionListPages)
 }
 
 // createConnection creates the dedicated Custom Connection with the exact

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -478,11 +478,12 @@ func parseWorkspaceID(settings providers.Settings) (int, error) {
 // the Gram one onto a later page, and missing it there would create a duplicate
 // on every save.
 //
-// Only a null cursor (the true end of the list) counts as "not found"; a scan
-// that hits the page cap or a cursor that won't advance leaves the connection's
-// existence unproven, so it returns an error rather than "" — reporting "not
-// found" there would create a duplicate on every connect, the exact bug the
-// pagination is here to prevent.
+// Only an explicit null cursor (the true end of the list) counts as "not
+// found"; a scan that hits the page cap, a cursor that won't advance, or a
+// response that omits the cursor altogether leaves the connection's existence
+// unproven, so it returns an error rather than "" — reporting "not found" there
+// would create a duplicate on every connect, the exact bug the pagination is
+// here to prevent.
 func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credentials, base, name string) (string, error) {
 	cursor := ""
 	for range maxConnectionListPages {
@@ -503,8 +504,11 @@ func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credent
 				ClientAlias string `json:"clientAlias"`
 				Name        string `json:"name"`
 			} `json:"data"`
+			// RawMessage, not *string, so field presence survives decoding: an
+			// omitted cursor and an explicit null both decode a *string to nil,
+			// but only the explicit null is Drata's end-of-list signal.
 			Pagination struct {
-				Cursor *string `json:"cursor"`
+				Cursor json.RawMessage `json:"cursor"`
 			} `json:"pagination"`
 		}
 		if err := json.Unmarshal(body, &list); err != nil {
@@ -515,14 +519,23 @@ func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credent
 				return string(c.ID), nil
 			}
 		}
-		if list.Pagination.Cursor == nil {
-			// A genuine null cursor is Drata's only end-of-list signal: no match
+		raw := bytes.TrimSpace(list.Pagination.Cursor)
+		if len(raw) == 0 {
+			// The cursor field is absent entirely (missing, or no pagination
+			// object): an incomplete response, not a proof of the end. Fail
+			// rather than mistake it for end-of-list and create a duplicate.
+			return "", fmt.Errorf("connection list response missing pagination cursor")
+		}
+		if string(raw) == "null" {
+			// An explicit null is Drata's only end-of-list signal: no match
 			// through the true end means the connection does not exist and the
-			// caller creates it. A present-but-empty cursor is NOT this signal —
-			// it falls through to the can't-advance error below.
+			// caller creates it.
 			return "", nil
 		}
-		next := *list.Pagination.Cursor
+		var next string
+		if err := json.Unmarshal(raw, &next); err != nil {
+			return "", fmt.Errorf("decode pagination cursor: %w", err)
+		}
 		if next == "" || next == cursor {
 			// A cursor that is empty or unchanged can't advance the scan and
 			// isn't proof of absence; fail rather than risk a duplicate.

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -60,6 +60,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -96,8 +97,27 @@ const (
 	sessionStatusInProgress = "IN_PROGRESS"
 
 	fieldRegion       = "region"
+	fieldWorkspaceID  = "workspace_id"
 	fieldConnectionID = "connection_id"
 	fieldAPIKey       = "api_key"
+
+	// provisionConnectionName is the deterministic name of the connection Gram
+	// creates and reuses on the customer's behalf. Find-or-create keys on it,
+	// so a re-save reuses the same connection instead of spawning duplicates.
+	provisionConnectionName = "Speakeasy Device Agent Coverage"
+
+	// defaultWorkspaceID is the workspace a connection is created in when the
+	// customer leaves the field blank. Drata requires workspaceIds on create,
+	// and single-workspace accounts — the common case — are workspace 1.
+	defaultWorkspaceID = 1
+
+	// displayNameKey names the record field Drata shows as each row's label.
+	displayNameKey = "hostname"
+
+	// connectionListLimit bounds the find-existing lookup. A customer's
+	// dedicated Gram connection is created once; a page this size comfortably
+	// covers finding it without paginating.
+	connectionListLimit = 200
 )
 
 // defaultRegions allowlists the customer-selectable Drata regions. Deriving
@@ -118,7 +138,10 @@ func init() {
 		Capabilities: []providers.Capability{providers.CapabilityEvidenceSink},
 		Fields: []providers.CredentialField{
 			{Key: fieldRegion, Label: "Region (us, eu, or apac)", Kind: providers.FieldKindText, Secret: false, Required: true},
-			{Key: fieldConnectionID, Label: "Custom Connection ID", Kind: providers.FieldKindText, Secret: false, Required: true},
+			{Key: fieldWorkspaceID, Label: "Workspace ID (usually 1)", Kind: providers.FieldKindText, Secret: false, Required: false},
+			// Optional: Gram creates and fills this in on connect. A customer
+			// may still supply an existing connection to reuse instead.
+			{Key: fieldConnectionID, Label: "Custom Connection ID (optional — created automatically)", Kind: providers.FieldKindText, Secret: false, Required: false},
 			{Key: fieldAPIKey, Label: "API Key", Kind: providers.FieldKindText, Secret: true, Required: true},
 		},
 		Schedules: []providers.ScheduleSpec{
@@ -140,7 +163,11 @@ type sink struct {
 	regions map[string]string
 }
 
-var _ providers.EvidenceSink = (*sink)(nil)
+var (
+	_ providers.EvidenceSink = (*sink)(nil)
+	// The sink also provisions its own Custom Connection during connect.
+	_ providers.Provisioner = (*sink)(nil)
+)
 
 // target is the resolved, validated push destination: the base URL and the
 // connection's path root, derived exactly once per operation so the
@@ -150,15 +177,26 @@ type target struct {
 	connPath string
 }
 
-// resolveTarget validates the configured region and connection id.
-func (s *sink) resolveTarget(settings providers.Settings) (target, error) {
+// regionBaseURL resolves the configured region to its API base URL. Split out
+// from resolveTarget because provisioning needs the base before a connection
+// id exists.
+func (s *sink) regionBaseURL(settings providers.Settings) (string, error) {
 	region := strings.ToLower(strings.TrimSpace(settings[fieldRegion]))
 	if region == "" {
-		return target{}, fmt.Errorf("region is not configured")
+		return "", fmt.Errorf("region is not configured")
 	}
 	base, ok := s.regions[region]
 	if !ok {
-		return target{}, fmt.Errorf("region must be one of us, eu, or apac")
+		return "", fmt.Errorf("region must be one of us, eu, or apac")
+	}
+	return base, nil
+}
+
+// resolveTarget validates the configured region and connection id.
+func (s *sink) resolveTarget(settings providers.Settings) (target, error) {
+	base, err := s.regionBaseURL(settings)
+	if err != nil {
+		return target{}, err
 	}
 	id := strings.TrimSpace(settings[fieldConnectionID])
 	if id == "" {
@@ -356,6 +394,137 @@ func (s *sink) cancelStrandedSessions(ctx context.Context, creds providers.Crede
 		}
 	}
 	return nil
+}
+
+// Provision creates (or reuses) the dedicated Custom Connection this config
+// pushes into, so the customer never has to hand-craft it against the Drata
+// API — the setup that is otherwise a raw curl with an exact record schema and
+// the easily-missed `required` list. Idempotent: a no-op when a connection id
+// is already configured, and a fresh provision first looks for an existing
+// Gram-created connection by name before creating one, so a re-save never
+// spawns a duplicate.
+func (s *sink) Provision(ctx context.Context, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
+	if strings.TrimSpace(settings[fieldConnectionID]) != "" {
+		return settings, nil
+	}
+	base, err := s.regionBaseURL(settings)
+	if err != nil {
+		return nil, fmt.Errorf("drata provisioning: %w", err)
+	}
+	workspaceID, err := parseWorkspaceID(settings)
+	if err != nil {
+		return nil, fmt.Errorf("drata provisioning: %w", err)
+	}
+
+	connID, err := s.findConnectionByName(ctx, creds, base, provisionConnectionName)
+	if err != nil {
+		return nil, fmt.Errorf("drata provisioning: find existing connection: %w", err)
+	}
+	if connID == "" {
+		connID, err = s.createConnection(ctx, creds, base, workspaceID)
+		if err != nil {
+			return nil, fmt.Errorf("drata provisioning: create connection: %w", err)
+		}
+	}
+
+	out := make(providers.Settings, len(settings)+1)
+	maps.Copy(out, settings)
+	out[fieldConnectionID] = connID
+	return out, nil
+}
+
+// parseWorkspaceID reads the customer-supplied workspace, defaulting to the
+// single-workspace common case when blank. Drata requires workspaceIds on
+// create; a bad value fails loudly here rather than as an opaque 400.
+func parseWorkspaceID(settings providers.Settings) (int, error) {
+	raw := strings.TrimSpace(settings[fieldWorkspaceID])
+	if raw == "" {
+		return defaultWorkspaceID, nil
+	}
+	id, err := strconv.Atoi(raw)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("workspace_id must be a positive integer")
+	}
+	return id, nil
+}
+
+// findConnectionByName returns the id of an existing custom connection whose
+// display name matches, or "" when none exists. Reusing a prior Gram-created
+// connection is what keeps provisioning idempotent across re-saves.
+func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credentials, base, name string) (string, error) {
+	body, err := s.doJSON(ctx, creds, http.MethodGet, base+"/public/v2/custom-connections?limit="+strconv.Itoa(connectionListLimit), nil)
+	if err != nil {
+		return "", err
+	}
+	var list struct {
+		Data []struct {
+			ID flexID `json:"id"`
+			// Drata echoes the create-time "name" back as "clientAlias"; match
+			// either so the lookup is robust to which the list endpoint returns.
+			ClientAlias string `json:"clientAlias"`
+			Name        string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return "", fmt.Errorf("decode connection list: %w", err)
+	}
+	for _, c := range list.Data {
+		if c.ClientAlias == name || c.Name == name {
+			return string(c.ID), nil
+		}
+	}
+	return "", nil
+}
+
+// createConnection creates the dedicated Custom Connection with the exact
+// record schema the push path expects.
+func (s *sink) createConnection(ctx context.Context, creds providers.Credentials, base string, workspaceID int) (string, error) {
+	payload := map[string]any{
+		"name":           provisionConnectionName,
+		"providerTypes":  []string{"CUSTOM"},
+		"workspaceIds":   []int{workspaceID},
+		"displayNameKey": displayNameKey,
+		"schema":         connectionRecordSchema(),
+	}
+	body, err := s.doJSON(ctx, creds, http.MethodPost, base+"/public/v2/custom-connections", payload)
+	if err != nil {
+		return "", err
+	}
+	var created struct {
+		ID flexID `json:"id"`
+	}
+	if err := json.Unmarshal(body, &created); err != nil {
+		return "", fmt.Errorf("decode created connection: %w", err)
+	}
+	if string(created.ID) == "" {
+		return "", fmt.Errorf("created connection carried no id")
+	}
+	return string(created.ID), nil
+}
+
+// connectionRecordSchema is the JTD the pushed records must match. The
+// `required` list deliberately OMITS agentLastSeenAt: Drata marks every
+// property required when the list is absent, which would reject the
+// never-seen-agent records the sink emits without that field — the single
+// most error-prone step of manual setup, encoded correctly here once.
+func connectionRecordSchema() map[string]any {
+	str := map[string]string{"type": "string"}
+	return map[string]any{
+		"type": "object",
+		"required": []string{
+			"id", "serialNumber", "hostname",
+			"assignedUserEmail", "agentActive", "agentAttestation",
+		},
+		"properties": map[string]any{
+			"id":                str,
+			"serialNumber":      str,
+			"hostname":          str,
+			"assignedUserEmail": str,
+			"agentActive":       map[string]string{"type": "boolean"},
+			"agentAttestation":  str,
+			"agentLastSeenAt":   str,
+		},
+	}
 }
 
 // TestConnection proves the stored credentials with the same read the push

--- a/server/internal/deviceintegrations/providers/drata/drata.go
+++ b/server/internal/deviceintegrations/providers/drata/drata.go
@@ -57,6 +57,8 @@ package drata
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -101,9 +103,12 @@ const (
 	fieldConnectionID = "connection_id"
 	fieldAPIKey       = "api_key"
 
-	// provisionConnectionName is the deterministic name of the connection Gram
-	// creates and reuses on the customer's behalf. Find-or-create keys on it,
-	// so a re-save reuses the same connection instead of spawning duplicates.
+	// provisionConnectionName is the display-name stem of the connection Gram
+	// creates and reuses on the customer's behalf. The effective name appends a
+	// per-Gram-org suffix (see connectionNameForOrg): find-or-create keys on the
+	// full name, so a re-save reuses the same connection, and two Gram orgs that
+	// happen to share one Drata tenant each own a distinct connection instead of
+	// racing to create — or later clobbering — a single shared one.
 	provisionConnectionName = "Speakeasy Device Agent Coverage"
 
 	// defaultWorkspaceID is the workspace a connection is created in when the
@@ -407,7 +412,7 @@ func (s *sink) cancelStrandedSessions(ctx context.Context, creds providers.Crede
 // is already configured, and a fresh provision first looks for an existing
 // Gram-created connection by name before creating one, so a re-save never
 // spawns a duplicate.
-func (s *sink) Provision(ctx context.Context, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
+func (s *sink) Provision(ctx context.Context, orgID string, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
 	if strings.TrimSpace(settings[fieldConnectionID]) != "" {
 		return settings, nil
 	}
@@ -420,12 +425,13 @@ func (s *sink) Provision(ctx context.Context, creds providers.Credentials, setti
 		return nil, fmt.Errorf("drata provisioning: %w", err)
 	}
 
-	connID, err := s.findConnectionByName(ctx, creds, base, provisionConnectionName)
+	name := connectionNameForOrg(orgID)
+	connID, err := s.findConnectionByName(ctx, creds, base, name)
 	if err != nil {
 		return nil, fmt.Errorf("drata provisioning: find existing connection: %w", err)
 	}
 	if connID == "" {
-		connID, err = s.createConnection(ctx, creds, base, workspaceID)
+		connID, err = s.createConnection(ctx, creds, base, name, workspaceID)
 		if err != nil {
 			return nil, fmt.Errorf("drata provisioning: create connection: %w", err)
 		}
@@ -435,6 +441,17 @@ func (s *sink) Provision(ctx context.Context, creds providers.Credentials, setti
 	maps.Copy(out, settings)
 	out[fieldConnectionID] = connID
 	return out, nil
+}
+
+// connectionNameForOrg is the deterministic connection name for one Gram org.
+// Encoding the org into the find-or-create key is what makes provisioning
+// correct when two Gram orgs share a single Drata tenant: each owns a distinct
+// connection, so they neither race to create a duplicate nor later resolve to —
+// and overwrite — each other's evidence. A short hash keeps the customer-facing
+// name tidy while staying stable and collision-resistant across orgs.
+func connectionNameForOrg(orgID string) string {
+	sum := sha256.Sum256([]byte(orgID))
+	return fmt.Sprintf("%s (%s)", provisionConnectionName, hex.EncodeToString(sum[:4]))
 }
 
 // parseWorkspaceID reads the customer-supplied workspace, defaulting to the
@@ -506,9 +523,9 @@ func (s *sink) findConnectionByName(ctx context.Context, creds providers.Credent
 
 // createConnection creates the dedicated Custom Connection with the exact
 // record schema the push path expects.
-func (s *sink) createConnection(ctx context.Context, creds providers.Credentials, base string, workspaceID int) (string, error) {
+func (s *sink) createConnection(ctx context.Context, creds providers.Credentials, base, name string, workspaceID int) (string, error) {
 	payload := map[string]any{
-		"name":           provisionConnectionName,
+		"name":           name,
 		"providerTypes":  []string{"CUSTOM"},
 		"workspaceIds":   []int{workspaceID},
 		"displayNameKey": displayNameKey,

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -111,14 +112,35 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 		}
 		switch r.Method {
 		case http.MethodGet:
+			// Paginate by the requested limit so find-existing's cursor-following
+			// is exercised: a connection past the first page must still be found.
+			limit := 200
+			if raw := r.URL.Query().Get("limit"); raw != "" {
+				if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+					limit = parsed
+				}
+			}
+			offset := 0
+			if raw := r.URL.Query().Get("cursor"); raw != "" {
+				parsed, err := strconv.Atoi(raw)
+				assert.NoError(f.t, err, "cursor is the opaque token the fake handed back")
+				offset = parsed
+			}
 			f.mu.Lock()
-			items := []byte("[]")
-			if f.existingConnections != nil {
-				items, _ = json.Marshal(f.existingConnections)
+			all := f.existingConnections
+			end := min(offset+limit, len(all))
+			page := []map[string]any{}
+			if offset < len(all) {
+				page = all[offset:end]
 			}
 			f.mu.Unlock()
+			items, _ := json.Marshal(page)
+			cursor := "null"
+			if end < len(all) {
+				cursor = strconv.Quote(strconv.Itoa(end))
+			}
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprintf(w, `{"data": %s}`, items)
+			_, _ = fmt.Fprintf(w, `{"data": %s, "pagination": {"cursor": %s}}`, items, cursor)
 		case http.MethodPost:
 			var body map[string]any
 			assert.NoError(f.t, json.NewDecoder(r.Body).Decode(&body))
@@ -798,6 +820,31 @@ func TestProvisionReusesExistingConnection(t *testing.T) {
 	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
 	require.NoError(t, err)
 	require.Equal(t, "777", out[fieldConnectionID], "reuses the existing Gram connection by name")
+	require.Empty(t, fake.createdConnections, "a matching connection must never be duplicated")
+}
+
+func TestProvisionFindsConnectionOnLaterPage(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrata(t)
+	// A tenant with more connections than one page fits, with the Gram
+	// connection last: a single-page lookup would miss it and duplicate on
+	// every save. The lookup must follow the cursor to find it.
+	for i := range connectionListLimit + 5 {
+		fake.existingConnections = append(fake.existingConnections, map[string]any{
+			"id":          1000 + i,
+			"clientAlias": fmt.Sprintf("Other Connection %d", i),
+		})
+	}
+	fake.existingConnections = append(fake.existingConnections, map[string]any{
+		"id":          9999,
+		"clientAlias": provisionConnectionName,
+	})
+	s := fake.newSink(t)
+
+	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.NoError(t, err)
+	require.Equal(t, "9999", out[fieldConnectionID], "cursor-following finds the connection past the first page")
 	require.Empty(t, fake.createdConnections, "a matching connection must never be duplicated")
 }
 

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -20,6 +20,7 @@ import (
 const (
 	testConnectionID = "8711"
 	testResourceID   = "42"
+	testOrgID        = "org_test"
 )
 
 // fakeDrata is an httptest stand-in for the Custom Connections API: the
@@ -783,13 +784,14 @@ func TestProvisionCreatesConnection(t *testing.T) {
 	fake := newFakeDrata(t)
 	s := fake.newSink(t)
 
-	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
+	out, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
 	require.NoError(t, err)
 	require.NotEmpty(t, out[fieldConnectionID], "provision fills in the created connection id")
 
 	require.Len(t, fake.createdConnections, 1)
 	body := fake.createdConnections[0]
-	require.Equal(t, provisionConnectionName, body["name"])
+	require.Equal(t, connectionNameForOrg(testOrgID), body["name"], "the connection is named per Gram org")
+	require.Contains(t, body["name"], provisionConnectionName, "the org-scoped name keeps the readable stem")
 	require.Equal(t, []any{"CUSTOM"}, body["providerTypes"])
 	require.Equal(t, displayNameKey, body["displayNameKey"])
 	require.Equal(t, []any{float64(defaultWorkspaceID)}, body["workspaceIds"], "blank workspace defaults to 1")
@@ -813,14 +815,38 @@ func TestProvisionReusesExistingConnection(t *testing.T) {
 	fake := newFakeDrata(t)
 	fake.existingConnections = []map[string]any{
 		{"id": 42, "clientAlias": "Some Other Connection"},
-		{"id": 777, "clientAlias": provisionConnectionName},
+		// The bare-stemmed name from before org-scoping was added must NOT
+		// match — only this org's fully-scoped connection is reused.
+		{"id": 43, "clientAlias": provisionConnectionName},
+		{"id": 777, "clientAlias": connectionNameForOrg(testOrgID)},
 	}
 	s := fake.newSink(t)
 
-	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
+	out, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
 	require.NoError(t, err)
-	require.Equal(t, "777", out[fieldConnectionID], "reuses the existing Gram connection by name")
+	require.Equal(t, "777", out[fieldConnectionID], "reuses this org's existing Gram connection by name")
 	require.Empty(t, fake.createdConnections, "a matching connection must never be duplicated")
+}
+
+func TestProvisionSeparatesConnectionsPerOrg(t *testing.T) {
+	t.Parallel()
+
+	// Two Gram orgs sharing one Drata tenant: the second must not resolve to
+	// (and clobber) the first's connection — it provisions its own.
+	fake := newFakeDrata(t)
+	s := fake.newSink(t)
+
+	firstOrg := "org_first"
+	secondOrg := "org_second"
+	require.NotEqual(t, connectionNameForOrg(firstOrg), connectionNameForOrg(secondOrg))
+
+	first, err := s.Provision(t.Context(), firstOrg, fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.NoError(t, err)
+	second, err := s.Provision(t.Context(), secondOrg, fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.NoError(t, err)
+
+	require.NotEqual(t, first[fieldConnectionID], second[fieldConnectionID], "each org owns a distinct connection")
+	require.Len(t, fake.createdConnections, 2, "the shared tenant gets one connection per Gram org")
 }
 
 func TestProvisionFindsConnectionOnLaterPage(t *testing.T) {
@@ -838,11 +864,11 @@ func TestProvisionFindsConnectionOnLaterPage(t *testing.T) {
 	}
 	fake.existingConnections = append(fake.existingConnections, map[string]any{
 		"id":          9999,
-		"clientAlias": provisionConnectionName,
+		"clientAlias": connectionNameForOrg(testOrgID),
 	})
 	s := fake.newSink(t)
 
-	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
+	out, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
 	require.NoError(t, err)
 	require.Equal(t, "9999", out[fieldConnectionID], "cursor-following finds the connection past the first page")
 	require.Empty(t, fake.createdConnections, "a matching connection must never be duplicated")
@@ -855,7 +881,7 @@ func TestProvisionNoOpWhenConfigured(t *testing.T) {
 	s := fake.newSink(t)
 
 	in := providers.Settings{fieldRegion: "us", fieldConnectionID: "existing-123"}
-	out, err := s.Provision(t.Context(), fake.creds(), in)
+	out, err := s.Provision(t.Context(), testOrgID, fake.creds(), in)
 	require.NoError(t, err)
 	require.Equal(t, "existing-123", out[fieldConnectionID])
 	require.Empty(t, fake.createdConnections, "a configured connection is never re-provisioned")
@@ -868,7 +894,7 @@ func TestProvisionWorkspaceID(t *testing.T) {
 		t.Parallel()
 		fake := newFakeDrata(t)
 		s := fake.newSink(t)
-		_, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us", fieldWorkspaceID: "3"})
+		_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us", fieldWorkspaceID: "3"})
 		require.NoError(t, err)
 		require.Equal(t, []any{float64(3)}, fake.createdConnections[0]["workspaceIds"])
 	})
@@ -877,7 +903,7 @@ func TestProvisionWorkspaceID(t *testing.T) {
 		t.Parallel()
 		fake := newFakeDrata(t)
 		s := fake.newSink(t)
-		_, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us", fieldWorkspaceID: "not-a-number"})
+		_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us", fieldWorkspaceID: "not-a-number"})
 		require.ErrorContains(t, err, "workspace_id")
 		require.Empty(t, fake.createdConnections)
 	})

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -72,6 +72,9 @@ type fakeDrata struct {
 	// connectionsCursorFrozen makes the list endpoint return the same non-null
 	// cursor every time, driving the non-advancing-cursor guard.
 	connectionsCursorFrozen bool
+	// connectionsCursorEmpty makes the list endpoint return a present-but-empty
+	// cursor — distinct from a null cursor, so it must NOT count as end-of-list.
+	connectionsCursorEmpty bool
 	// createdConnections records the bodies POSTed to the collection endpoint,
 	// so provisioning tests can assert the schema and workspace sent.
 	createdConnections []map[string]any
@@ -101,6 +104,7 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 		existingConnections:     nil,
 		connectionsPageForever:  false,
 		connectionsCursorFrozen: false,
+		connectionsCursorEmpty:  false,
 		createdConnections:      nil,
 		nextConnID:              900,
 		server:                  nil,
@@ -133,6 +137,11 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 			if f.connectionsCursorFrozen {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = fmt.Fprint(w, `{"data": [], "pagination": {"cursor": "frozen"}}`)
+				return
+			}
+			if f.connectionsCursorEmpty {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"data": [], "pagination": {"cursor": ""}}`)
 				return
 			}
 			// Paginate by the requested limit so find-existing's cursor-following
@@ -922,6 +931,20 @@ func TestProvisionFailsWhenCursorStuck(t *testing.T) {
 	_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
 	require.ErrorContains(t, err, "did not advance")
 	require.Empty(t, fake.createdConnections, "a stuck cursor must not create a connection")
+}
+
+func TestProvisionFailsWhenCursorEmptyNotNull(t *testing.T) {
+	t.Parallel()
+
+	// A present-but-empty cursor is not Drata's null end-of-list signal, so it
+	// must not be mistaken for "no more pages" and permit a duplicate create.
+	fake := newFakeDrata(t)
+	fake.connectionsCursorEmpty = true
+	s := fake.newSink(t)
+
+	_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.ErrorContains(t, err, "did not advance")
+	require.Empty(t, fake.createdConnections, "an empty non-null cursor must not create a connection")
 }
 
 func TestProvisionNoOpWhenConfigured(t *testing.T) {

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -75,6 +75,10 @@ type fakeDrata struct {
 	// connectionsCursorEmpty makes the list endpoint return a present-but-empty
 	// cursor — distinct from a null cursor, so it must NOT count as end-of-list.
 	connectionsCursorEmpty bool
+	// connectionsCursorMissing makes the list endpoint omit the pagination
+	// cursor entirely — an incomplete response that must not be mistaken for a
+	// null end-of-list cursor.
+	connectionsCursorMissing bool
 	// createdConnections records the bodies POSTed to the collection endpoint,
 	// so provisioning tests can assert the schema and workspace sent.
 	createdConnections []map[string]any
@@ -87,27 +91,28 @@ type fakeDrata struct {
 func newFakeDrata(t *testing.T) *fakeDrata {
 	t.Helper()
 	f := &fakeDrata{
-		t:                       t,
-		apiKey:                  "test-api-key",
-		resourceIDs:             []string{testResourceID},
-		mu:                      sync.Mutex{},
-		sessions:                map[string][]map[string]any{},
-		sessionStatus:           map[string]string{},
-		ignoreStatusFilter:      false,
-		failComplete:            false,
-		rejectRecordID:          "",
-		records:                 nil,
-		uploadRequests:          0,
-		completed:               nil,
-		canceled:                nil,
-		deletedRecords:          nil,
-		existingConnections:     nil,
-		connectionsPageForever:  false,
-		connectionsCursorFrozen: false,
-		connectionsCursorEmpty:  false,
-		createdConnections:      nil,
-		nextConnID:              900,
-		server:                  nil,
+		t:                        t,
+		apiKey:                   "test-api-key",
+		resourceIDs:              []string{testResourceID},
+		mu:                       sync.Mutex{},
+		sessions:                 map[string][]map[string]any{},
+		sessionStatus:            map[string]string{},
+		ignoreStatusFilter:       false,
+		failComplete:             false,
+		rejectRecordID:           "",
+		records:                  nil,
+		uploadRequests:           0,
+		completed:                nil,
+		canceled:                 nil,
+		deletedRecords:           nil,
+		existingConnections:      nil,
+		connectionsPageForever:   false,
+		connectionsCursorFrozen:  false,
+		connectionsCursorEmpty:   false,
+		connectionsCursorMissing: false,
+		createdConnections:       nil,
+		nextConnID:               900,
+		server:                   nil,
 	}
 
 	connBase := "/public/v2/custom-connections/" + testConnectionID
@@ -142,6 +147,12 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 			if f.connectionsCursorEmpty {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = fmt.Fprint(w, `{"data": [], "pagination": {"cursor": ""}}`)
+				return
+			}
+			if f.connectionsCursorMissing {
+				// No pagination cursor at all — an incomplete response.
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"data": []}`)
 				return
 			}
 			// Paginate by the requested limit so find-existing's cursor-following
@@ -945,6 +956,20 @@ func TestProvisionFailsWhenCursorEmptyNotNull(t *testing.T) {
 	_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
 	require.ErrorContains(t, err, "did not advance")
 	require.Empty(t, fake.createdConnections, "an empty non-null cursor must not create a connection")
+}
+
+func TestProvisionFailsWhenCursorMissing(t *testing.T) {
+	t.Parallel()
+
+	// A response that omits the cursor is incomplete, not end-of-list: it must
+	// not be mistaken for a null cursor and permit a duplicate create.
+	fake := newFakeDrata(t)
+	fake.connectionsCursorMissing = true
+	s := fake.newSink(t)
+
+	_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.ErrorContains(t, err, "missing pagination cursor")
+	require.Empty(t, fake.createdConnections, "a missing cursor must not create a connection")
 }
 
 func TestProvisionNoOpWhenConfigured(t *testing.T) {

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -66,6 +66,12 @@ type fakeDrata struct {
 	// existingConnections is the collection the list endpoint returns, as
 	// {id, clientAlias} maps — pre-seed to exercise find-existing.
 	existingConnections []map[string]any
+	// connectionsPageForever makes the list endpoint hand back an advancing,
+	// never-null cursor with no match, driving the page-cap guard.
+	connectionsPageForever bool
+	// connectionsCursorFrozen makes the list endpoint return the same non-null
+	// cursor every time, driving the non-advancing-cursor guard.
+	connectionsCursorFrozen bool
 	// createdConnections records the bodies POSTed to the collection endpoint,
 	// so provisioning tests can assert the schema and workspace sent.
 	createdConnections []map[string]any
@@ -78,24 +84,26 @@ type fakeDrata struct {
 func newFakeDrata(t *testing.T) *fakeDrata {
 	t.Helper()
 	f := &fakeDrata{
-		t:                   t,
-		apiKey:              "test-api-key",
-		resourceIDs:         []string{testResourceID},
-		mu:                  sync.Mutex{},
-		sessions:            map[string][]map[string]any{},
-		sessionStatus:       map[string]string{},
-		ignoreStatusFilter:  false,
-		failComplete:        false,
-		rejectRecordID:      "",
-		records:             nil,
-		uploadRequests:      0,
-		completed:           nil,
-		canceled:            nil,
-		deletedRecords:      nil,
-		existingConnections: nil,
-		createdConnections:  nil,
-		nextConnID:          900,
-		server:              nil,
+		t:                       t,
+		apiKey:                  "test-api-key",
+		resourceIDs:             []string{testResourceID},
+		mu:                      sync.Mutex{},
+		sessions:                map[string][]map[string]any{},
+		sessionStatus:           map[string]string{},
+		ignoreStatusFilter:      false,
+		failComplete:            false,
+		rejectRecordID:          "",
+		records:                 nil,
+		uploadRequests:          0,
+		completed:               nil,
+		canceled:                nil,
+		deletedRecords:          nil,
+		existingConnections:     nil,
+		connectionsPageForever:  false,
+		connectionsCursorFrozen: false,
+		createdConnections:      nil,
+		nextConnID:              900,
+		server:                  nil,
 	}
 
 	connBase := "/public/v2/custom-connections/" + testConnectionID
@@ -113,6 +121,20 @@ func newFakeDrata(t *testing.T) *fakeDrata {
 		}
 		switch r.Method {
 		case http.MethodGet:
+			if f.connectionsPageForever {
+				offset := 0
+				if raw := r.URL.Query().Get("cursor"); raw != "" {
+					offset, _ = strconv.Atoi(raw)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprintf(w, `{"data": [], "pagination": {"cursor": %q}}`, strconv.Itoa(offset+1))
+				return
+			}
+			if f.connectionsCursorFrozen {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"data": [], "pagination": {"cursor": "frozen"}}`)
+				return
+			}
 			// Paginate by the requested limit so find-existing's cursor-following
 			// is exercised: a connection past the first page must still be found.
 			limit := 200
@@ -872,6 +894,34 @@ func TestProvisionFindsConnectionOnLaterPage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "9999", out[fieldConnectionID], "cursor-following finds the connection past the first page")
 	require.Empty(t, fake.createdConnections, "a matching connection must never be duplicated")
+}
+
+func TestProvisionFailsWhenScanExceedsPageCap(t *testing.T) {
+	t.Parallel()
+
+	// The list never ends and never matches: reaching the page cap must fail
+	// the provision, not fall through to create a duplicate on every connect.
+	fake := newFakeDrata(t)
+	fake.connectionsPageForever = true
+	s := fake.newSink(t)
+
+	_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.ErrorContains(t, err, "exceeded")
+	require.Empty(t, fake.createdConnections, "hitting the cap must not create a connection")
+}
+
+func TestProvisionFailsWhenCursorStuck(t *testing.T) {
+	t.Parallel()
+
+	// A cursor that never advances can't prove absence: fail rather than
+	// duplicate.
+	fake := newFakeDrata(t)
+	fake.connectionsCursorFrozen = true
+	s := fake.newSink(t)
+
+	_, err := s.Provision(t.Context(), testOrgID, fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.ErrorContains(t, err, "did not advance")
+	require.Empty(t, fake.createdConnections, "a stuck cursor must not create a connection")
 }
 
 func TestProvisionNoOpWhenConfigured(t *testing.T) {

--- a/server/internal/deviceintegrations/providers/drata/drata_test.go
+++ b/server/internal/deviceintegrations/providers/drata/drata_test.go
@@ -61,34 +61,80 @@ type fakeDrata struct {
 	// empty-fleet clear path.
 	deletedRecords []string
 
+	// existingConnections is the collection the list endpoint returns, as
+	// {id, clientAlias} maps — pre-seed to exercise find-existing.
+	existingConnections []map[string]any
+	// createdConnections records the bodies POSTed to the collection endpoint,
+	// so provisioning tests can assert the schema and workspace sent.
+	createdConnections []map[string]any
+	// nextConnID is the id assigned to the next created connection.
+	nextConnID int
+
 	server *httptest.Server
 }
 
 func newFakeDrata(t *testing.T) *fakeDrata {
 	t.Helper()
 	f := &fakeDrata{
-		t:                  t,
-		apiKey:             "test-api-key",
-		resourceIDs:        []string{testResourceID},
-		mu:                 sync.Mutex{},
-		sessions:           map[string][]map[string]any{},
-		sessionStatus:      map[string]string{},
-		ignoreStatusFilter: false,
-		failComplete:       false,
-		rejectRecordID:     "",
-		records:            nil,
-		uploadRequests:     0,
-		completed:          nil,
-		canceled:           nil,
-		deletedRecords:     nil,
-		server:             nil,
+		t:                   t,
+		apiKey:              "test-api-key",
+		resourceIDs:         []string{testResourceID},
+		mu:                  sync.Mutex{},
+		sessions:            map[string][]map[string]any{},
+		sessionStatus:       map[string]string{},
+		ignoreStatusFilter:  false,
+		failComplete:        false,
+		rejectRecordID:      "",
+		records:             nil,
+		uploadRequests:      0,
+		completed:           nil,
+		canceled:            nil,
+		deletedRecords:      nil,
+		existingConnections: nil,
+		createdConnections:  nil,
+		nextConnID:          900,
+		server:              nil,
 	}
 
 	connBase := "/public/v2/custom-connections/" + testConnectionID
+	collection := "/public/v2/custom-connections"
 	sessionsList := connBase + "/resources/" + testResourceID + "/sessions"
 	sessionsBase := sessionsList + "/"
 
 	mux := http.NewServeMux()
+	// Collection endpoint (exact path, so it never shadows the per-connection
+	// routes below): GET lists connections for find-existing; POST creates one
+	// for provisioning.
+	mux.HandleFunc(collection, func(w http.ResponseWriter, r *http.Request) {
+		if !f.authorized(w, r) {
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			f.mu.Lock()
+			items := []byte("[]")
+			if f.existingConnections != nil {
+				items, _ = json.Marshal(f.existingConnections)
+			}
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"data": %s}`, items)
+		case http.MethodPost:
+			var body map[string]any
+			assert.NoError(f.t, json.NewDecoder(r.Body).Decode(&body))
+			f.mu.Lock()
+			f.createdConnections = append(f.createdConnections, body)
+			f.nextConnID++
+			id := f.nextConnID
+			name, _ := body["name"].(string)
+			f.existingConnections = append(f.existingConnections, map[string]any{"id": id, "clientAlias": name})
+			f.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"id": %d, "clientAlias": %q}`, id, name)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
 	// Registered without the trailing slash so the list read does not fall
 	// into ServeMux's subtree redirect onto the upload handler.
 	mux.HandleFunc(sessionsList, func(w http.ResponseWriter, r *http.Request) {
@@ -707,4 +753,85 @@ func TestPushCoverageEmitsAttestationPerRecord(t *testing.T) {
 		require.NotContains(t, r, "assignedUserAgentActive")
 		require.NotContains(t, r, "assignedUserAgentLastSeenAt")
 	}
+}
+
+func TestProvisionCreatesConnection(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrata(t)
+	s := fake.newSink(t)
+
+	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.NoError(t, err)
+	require.NotEmpty(t, out[fieldConnectionID], "provision fills in the created connection id")
+
+	require.Len(t, fake.createdConnections, 1)
+	body := fake.createdConnections[0]
+	require.Equal(t, provisionConnectionName, body["name"])
+	require.Equal(t, []any{"CUSTOM"}, body["providerTypes"])
+	require.Equal(t, displayNameKey, body["displayNameKey"])
+	require.Equal(t, []any{float64(defaultWorkspaceID)}, body["workspaceIds"], "blank workspace defaults to 1")
+
+	schema, ok := body["schema"].(map[string]any)
+	require.True(t, ok, "create carries the record schema")
+	required, ok := schema["required"].([]any)
+	require.True(t, ok)
+	// The whole point of provisioning: encode the required list correctly so a
+	// never-seen-agent record (no agentLastSeenAt) is never rejected at sync.
+	require.NotContains(t, required, "agentLastSeenAt")
+	require.Contains(t, required, "agentActive")
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, props, "agentLastSeenAt", "the property still exists — just not required")
+}
+
+func TestProvisionReusesExistingConnection(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrata(t)
+	fake.existingConnections = []map[string]any{
+		{"id": 42, "clientAlias": "Some Other Connection"},
+		{"id": 777, "clientAlias": provisionConnectionName},
+	}
+	s := fake.newSink(t)
+
+	out, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us"})
+	require.NoError(t, err)
+	require.Equal(t, "777", out[fieldConnectionID], "reuses the existing Gram connection by name")
+	require.Empty(t, fake.createdConnections, "a matching connection must never be duplicated")
+}
+
+func TestProvisionNoOpWhenConfigured(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeDrata(t)
+	s := fake.newSink(t)
+
+	in := providers.Settings{fieldRegion: "us", fieldConnectionID: "existing-123"}
+	out, err := s.Provision(t.Context(), fake.creds(), in)
+	require.NoError(t, err)
+	require.Equal(t, "existing-123", out[fieldConnectionID])
+	require.Empty(t, fake.createdConnections, "a configured connection is never re-provisioned")
+}
+
+func TestProvisionWorkspaceID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("explicit workspace is used", func(t *testing.T) {
+		t.Parallel()
+		fake := newFakeDrata(t)
+		s := fake.newSink(t)
+		_, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us", fieldWorkspaceID: "3"})
+		require.NoError(t, err)
+		require.Equal(t, []any{float64(3)}, fake.createdConnections[0]["workspaceIds"])
+	})
+
+	t.Run("invalid workspace fails loudly and creates nothing", func(t *testing.T) {
+		t.Parallel()
+		fake := newFakeDrata(t)
+		s := fake.newSink(t)
+		_, err := s.Provision(t.Context(), fake.creds(), providers.Settings{fieldRegion: "us", fieldWorkspaceID: "not-a-number"})
+		require.ErrorContains(t, err, "workspace_id")
+		require.Empty(t, fake.createdConnections)
+	})
 }

--- a/server/internal/deviceintegrations/providers/providers.go
+++ b/server/internal/deviceintegrations/providers/providers.go
@@ -212,17 +212,21 @@ type EvidenceSink interface {
 // perform one-time vendor-side setup during connect — creating the object it
 // will read from or push to (e.g. a Drata Custom Connection) so the customer
 // does not have to hand-craft it against the vendor API. The framework calls
-// Provision from the connect flow before the config is persisted and stores
-// the returned Settings, so a provider can hand back the id of whatever it
-// created (a connection id, a resource id) for later syncs to use.
+// Provision during the config upsert, after credentials and settings are
+// merged with any stored values, and stores the returned Settings — so a
+// provider can hand back the id of whatever it created (a connection id, a
+// resource id) for later syncs to use.
 //
 // Two hard requirements:
 //   - Idempotent (find-or-create): a re-save must reuse the existing vendor
 //     object, never create a duplicate. Return the settings unchanged when
 //     nothing needs provisioning.
-//   - Side-effect-only on the vendor: Provision runs OUTSIDE the config
-//     transaction, so it must not assume any Gram-side state beyond the creds
-//     and settings it is handed.
+//   - Self-contained on the vendor: Provision must work from only the creds and
+//     settings it is handed. It runs inside the config-upsert transaction (under
+//     the same advisory lock that serializes upserts), so it must not read
+//     Gram-side state that the not-yet-committed transaction would not see, and
+//     it must not block on slow vendor I/O longer than the upsert can hold that
+//     lock — see provisionTimeout in impl.go.
 type Provisioner interface {
 	Provision(ctx context.Context, creds Credentials, settings Settings) (Settings, error)
 }

--- a/server/internal/deviceintegrations/providers/providers.go
+++ b/server/internal/deviceintegrations/providers/providers.go
@@ -208,6 +208,25 @@ type EvidenceSink interface {
 	PushCoverage(ctx context.Context, creds Credentials, settings Settings, snapshot CoverageSnapshot) error
 }
 
+// Provisioner is an OPTIONAL capability a source or sink may also implement to
+// perform one-time vendor-side setup during connect — creating the object it
+// will read from or push to (e.g. a Drata Custom Connection) so the customer
+// does not have to hand-craft it against the vendor API. The framework calls
+// Provision from the connect flow before the config is persisted and stores
+// the returned Settings, so a provider can hand back the id of whatever it
+// created (a connection id, a resource id) for later syncs to use.
+//
+// Two hard requirements:
+//   - Idempotent (find-or-create): a re-save must reuse the existing vendor
+//     object, never create a duplicate. Return the settings unchanged when
+//     nothing needs provisioning.
+//   - Side-effect-only on the vendor: Provision runs OUTSIDE the config
+//     transaction, so it must not assume any Gram-side state beyond the creds
+//     and settings it is handed.
+type Provisioner interface {
+	Provision(ctx context.Context, creds Credentials, settings Settings) (Settings, error)
+}
+
 // Descriptor declares one vendor to the framework.
 type Descriptor struct {
 	// ID is the provider discriminator stored on device_integration_configs

--- a/server/internal/deviceintegrations/providers/providers.go
+++ b/server/internal/deviceintegrations/providers/providers.go
@@ -215,20 +215,25 @@ type EvidenceSink interface {
 // Provision during the config upsert, after credentials and settings are
 // merged with any stored values, and stores the returned Settings — so a
 // provider can hand back the id of whatever it created (a connection id, a
-// resource id) for later syncs to use.
+// resource id) for later syncs to use. orgID is the Gram organization the
+// config belongs to; encode it into the vendor object's identity so two Gram
+// orgs that share one vendor account each own a distinct object.
 //
 // Two hard requirements:
 //   - Idempotent (find-or-create): a re-save must reuse the existing vendor
 //     object, never create a duplicate. Return the settings unchanged when
-//     nothing needs provisioning.
-//   - Self-contained on the vendor: Provision must work from only the creds and
-//     settings it is handed. It runs inside the config-upsert transaction (under
-//     the same advisory lock that serializes upserts), so it must not read
-//     Gram-side state that the not-yet-committed transaction would not see, and
-//     it must not block on slow vendor I/O longer than the upsert can hold that
-//     lock — see provisionTimeout in impl.go.
+//     nothing needs provisioning. The org-scoped identity above is also what
+//     keeps this correct across orgs: the Gram-side advisory lock only
+//     serializes one (org, provider), so nothing stops two different orgs
+//     sharing a vendor account from provisioning concurrently.
+//   - Self-contained on the vendor: Provision must work from only the orgID,
+//     creds, and settings it is handed. It runs inside the config-upsert
+//     transaction (under the same advisory lock that serializes upserts), so it
+//     must not read Gram-side state that the not-yet-committed transaction would
+//     not see, and it must not block on slow vendor I/O longer than the upsert
+//     can hold that lock — see provisionTimeout in impl.go.
 type Provisioner interface {
-	Provision(ctx context.Context, creds Credentials, settings Settings) (Settings, error)
+	Provision(ctx context.Context, orgID string, creds Credentials, settings Settings) (Settings, error)
 }
 
 // Descriptor declares one vendor to the framework.

--- a/server/internal/deviceintegrations/setup_test.go
+++ b/server/internal/deviceintegrations/setup_test.go
@@ -192,7 +192,7 @@ func upsertProviderTx(t *testing.T, ctx context.Context, conn *pgxpool.Pool, sto
 	var result UpsertResult
 	err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
 		var err error
-		result, err = store.upsertWithTx(ctx, tx, desc, orgID, creds, settings, enabled)
+		result, err = store.upsertWithTx(ctx, tx, desc, orgID, creds, settings, enabled, nil)
 		return err
 	})
 	if err != nil {

--- a/server/internal/deviceintegrations/store.go
+++ b/server/internal/deviceintegrations/store.go
@@ -255,7 +255,16 @@ type UpsertResult struct {
 // rotating a secret must not orphan the synced fleet inventory. Saving is
 // also the user's "try again" signal: machine-initiated auto-pauses are
 // lifted, while user-initiated schedule disables are deliberately untouched.
-func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, desc providers.Descriptor, orgID string, creds providers.Credentials, settings providers.Settings, enabled bool) (UpsertResult, error) {
+// ProvisionFunc creates the provider's vendor-side object (e.g. a Drata Custom
+// Connection) and returns settings to persist. It is invoked inside the upsert
+// — after the effective credentials/settings are merged from stored state, and
+// while the (org, provider) advisory lock is held — so it sees a complete
+// config even on a partial update, and concurrent first-time connects cannot
+// race to create duplicate vendor objects. Nil when the caller has nothing to
+// provision.
+type ProvisionFunc func(context.Context, providers.Credentials, providers.Settings) (providers.Settings, error)
+
+func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, desc providers.Descriptor, orgID string, creds providers.Credentials, settings providers.Settings, enabled bool, provision ProvisionFunc) (UpsertResult, error) {
 	q := repo.New(dbtx)
 
 	// Serialize concurrent upserts: the advisory lock covers the absent-row
@@ -335,6 +344,30 @@ func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, desc providers
 	// declares secret fields; a secretless provider is legitimate.
 	if !exists && !credentialsSupplied && len(desc.SecretFields()) > 0 {
 		return UpsertResult{}, oops.E(oops.CodeInvalid, nil, "credentials are required to connect %s", desc.ID)
+	}
+
+	// Provision the vendor-side object now — on the merged effective config, so
+	// a partial update (a stored key/connection id the client omitted) still
+	// provisions correctly, and under the advisory lock, so two first-time
+	// connects can't both create a duplicate. Runs only when there's something
+	// to provision (nil callback, or the provider no-ops when already set).
+	if provision != nil {
+		// The settings merge above already made stored settings effective. The
+		// credentials merge only ran when the client supplied secrets, so on a
+		// settings-only update decrypt the stored credentials for provisioning
+		// too — without them a save that still needs a connection would fail
+		// with the secret sitting right there in the row.
+		provisionCreds := creds
+		if len(provisionCreds) == 0 && exists {
+			if stored, decErr := s.decryptCredentials(existingRow.CredentialsEncrypted); decErr == nil {
+				provisionCreds = stored
+			}
+		}
+		provisioned, err := provision(ctx, provisionCreds, settings)
+		if err != nil {
+			return UpsertResult{}, err
+		}
+		settings = provisioned
 	}
 
 	settingsDoc, err := json.Marshal(settings)

--- a/server/internal/deviceintegrations/store_test.go
+++ b/server/internal/deviceintegrations/store_test.go
@@ -1,6 +1,8 @@
 package deviceintegrations
 
 import (
+	"context"
+	"maps"
 	"testing"
 	"time"
 
@@ -327,4 +329,42 @@ func TestCredentialRotationMergesSavedSecrets(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "original-id", creds["client_id"], "blank supplied secret keeps the stored value")
 	require.Equal(t, "rotated-again!", creds["client_secret"])
+}
+
+// TestProvisionRunsOnMergedConfig covers the P1: provisioning must see the
+// fully-merged effective config, not the sparse client payload, so a partial
+// update (a stored secret/setting the client omitted) still provisions.
+func TestProvisionRunsOnMergedConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+	mustUpsert(t, ctx, conn, store, orgID, validCreds(), validSettings(), true)
+
+	desc, ok := providers.Lookup(testProviderID)
+	require.True(t, ok)
+
+	var seenCreds providers.Credentials
+	var seenSettings providers.Settings
+	provision := func(_ context.Context, creds providers.Credentials, settings providers.Settings) (providers.Settings, error) {
+		seenCreds = maps.Clone(creds)
+		seenSettings = maps.Clone(settings)
+		out := maps.Clone(settings)
+		out["note"] = "provisioned"
+		return out, nil
+	}
+
+	// Partial update: settings-only, no credentials — the client relies on the
+	// stored api_key surviving the merge.
+	err := pgx.BeginFunc(ctx, conn, func(tx pgx.Tx) error {
+		_, err := store.upsertWithTx(ctx, tx, desc, orgID, nil, providers.Settings{"instance_url": "https://example.test"}, true, provision)
+		return err
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "secret-token", seenCreds["api_key"], "provision runs on the merged credentials, not the sparse payload")
+	require.Equal(t, "https://example.test", seenSettings["instance_url"])
+
+	cfg, err := store.LoadConfig(ctx, orgID, testProviderID)
+	require.NoError(t, err)
+	require.Equal(t, "provisioned", cfg.Settings["note"], "settings the provision step returns are persisted")
 }


### PR DESCRIPTION
Closes DNO-698.

## Problem

Setting up the Drata evidence sink required the customer to:
1. Find their workspace id (the scoped key can't list workspaces — 403).
2. Run a raw `curl` to `POST /custom-connections` with the exact record schema.
3. Get the `required` list exactly right — omit it and Drata marks *every* property required, so never-seen-agent records (which omit `agentLastSeenAt`) are rejected **at first sync, not at setup**.
4. Copy the connection id back into Gram.

Steps 2–4 are error-prone and step 3 is a delayed landmine.

## What

Gram now provisions the connection itself — Drata's public API supports connection creation (unlike Vanta), so the same key that pushes data can create the connection.

- **New optional `Provisioner` capability** (`providers.go`): a source/sink may implement it to create its vendor-side object during connect and return settings to persist. Additive — only Drata implements it.
- **Drata `Provision`**: find-or-create the dedicated Custom Connection by a deterministic name, with the correct schema and `required` list (omitting `agentLastSeenAt`) baked in. Idempotent — no-op when a connection id is set; reuse-by-name otherwise; create only when neither, so a re-save never duplicates.
- **Connect-flow wiring** (`impl.go`): `UpsertConfig` calls provisioning **before** the transaction (external round-trip) and persists the result; a failure surfaces as an actionable bad-request (which doubles as an early check for the "Custom Connections" entitlement).
- `connection_id` becomes optional (filled automatically); a `workspace_id` field defaults to 1.

The setup drops from ~6 steps to ~4: make a key → enter region + workspace + key → Gram provisions → enable. The customer *cannot* get the schema wrong because Gram owns it.

## Testing

- Unit tests: create / reuse-by-name / no-op-when-configured / workspace parsing.
- **Real Drata, end-to-end** (via a throwaway build-tagged harness, since removed): provisioning created the connection, a re-run reused it (idempotency), and the resulting schema marks every property required **except** `agentLastSeenAt`.

The provider view's `fields` array is schema-driven, so the dashboard form renders the new/optional fields with no frontend change.

Docs updated separately in the marketing-site repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-provisions the Drata Custom Connection during connect to remove manual curl/schema steps and prevent first-sync failures; connections are scoped per Gram org to avoid collisions. The dashboard now shows only required fields and tucks optional settings under an “Advanced” section for a simpler setup (DNO-698).

- **New Features**
  - Added optional `Provisioner` capability for providers; invoked during upsert on the merged config under the advisory lock.
  - Drata sink implements it: find-or-create by a deterministic per-org name, apply the exact schema, and omit `agentLastSeenAt` from `required` (idempotent).
  - `connection_id` is now optional and filled automatically; added `workspace_id` (defaults to 1).
  - Connect flow returns clear errors if provisioning fails, doubling as an entitlement check.
  - Hide the `vanta` evidence-push provider in the dashboard via `isProviderVisible` until a supported path exists.
  - Collapse optional provider fields under an “Advanced” disclosure that auto-expands when a value exists; driven by the descriptor’s `required` flag so Drata shows just Region + API Key by default.

- **Bug Fixes**
  - Provisioning runs inside the store upsert with merged credentials/settings, preventing duplicate creation and allowing settings-only updates to use stored secrets.
  - Find-existing follows pagination and reuses the connection even on later pages; bounded by a 10s timeout while holding the lock.
  - Only a null Drata pagination cursor ends the scan; empty, non-advancing, or missing cursors now error, preventing silent duplicate creation.

<sup>Written for commit 462d415420a6f2d11f96eef2b00ddcf5866fc68c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

