### PR TITLE
fix(dashboard): coverage meter track invisible in dark mode

### DIFF
--- a/.changeset/coverage-meter-track-contrast.md
+++ b/.changeset/coverage-meter-track-contrast.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Fix the agent-coverage meter reading as far more filled than its real percentage in dark mode. The track used `bg-muted`, which collapses to the card color in dark mode, hiding the uncovered remainder so the filled portion looked much larger than its true share. The track now uses a foreground tint that stays visible on both light and dark grounds.

--- a/client/dashboard/src/pages/org/device-integrations/coverage-pipeline.tsx
+++ b/client/dashboard/src/pages/org/device-integrations/coverage-pipeline.tsx
@@ -216,8 +216,12 @@ function CoverageNode({
           covered · {running} of {total} devices
         </Type>
       </Stack>
+      {/* The track needs its own contrast: bg-muted collapses to the card
+          color in dark mode, which hides the uncovered remainder and makes the
+          filled portion read as far more than its true share. foreground/15
+          stays visible on both grounds. */}
       <div
-        className="bg-muted flex h-2 overflow-hidden rounded-full"
+        className="bg-foreground/15 flex h-2 overflow-hidden rounded-full"
         role="img"
         aria-label={`${running} running the agent, ${coverage.agentStale} stale, of ${total} devices`}
       >


### PR DESCRIPTION
The agent-coverage meter's track used `bg-muted`, which resolves to the same color as the card in dark mode (both `rgb(18,18,18)`) — so the uncovered remainder was invisible and the filled portion read as far more than its true share (a 58% bar looked ~80% full). The track now uses `bg-foreground/15`, which stays visible on both light and dark grounds. Verified in dark mode: the track is now distinct from the card and green reads as its true percentage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the coverage meter track in dark mode so the uncovered remainder is visible and the bar reflects the true percentage. Switches the track from `bg-muted` to `bg-foreground/15` to maintain contrast on light and dark backgrounds.

<sup>Written for commit 74faf3af31f5b09020367d1d9af3bf872d2a48d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

