### PR TITLE
feat(oauth): retire the proxy for issuer-gated mcp servers

### DIFF
--- a/.changeset/ais-391-retire-proxy-for-issuer-gated.md
+++ b/.changeset/ais-391-retire-proxy-for-issuer-gated.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Toolsets with a user_session_issuer no longer accept the OAuth proxy endpoints. Previously attaching an issuer only stopped new proxy authorizations while clients holding proxy refresh tokens kept exchanging them indefinitely, outside the issuer consent, session duration, revocation and RBAC. The proxy token endpoint now answers 400 invalid_grant so clients discard those tokens and re-authorize against the issuer; authorize and register return 404, and discovery already points migrated servers at the issuer endpoints.

--- a/server/internal/oauth/impl.go
+++ b/server/internal/oauth/impl.go
@@ -51,6 +51,12 @@ var (
 	errToolsetNotFound      = errors.New("toolset not found")
 	errCustomDomainNotFound = errors.New("custom domain not found")
 	errOAuthUnavailable     = errors.New("oauth unavailable for private mcp server")
+	// errProxyRetired marks a toolset that has moved to a user_session_issuer.
+	// Attaching an issuer previously only stopped NEW authorizations: the proxy
+	// endpoints kept serving, so clients holding proxy refresh tokens went on
+	// exchanging them indefinitely, outside the issuer's consent, session
+	// duration and revocation. Migrated toolsets now refuse the proxy outright.
+	errProxyRetired = errors.New("oauth proxy retired for issuer-gated mcp server")
 )
 
 //go:embed hosted_oauth_success_page.html.tmpl
@@ -226,6 +232,13 @@ func (s *Service) loadToolsetFromCurrentURLContext(ctx context.Context, mcpSlug 
 		return nil, "", errOAuthUnavailable
 	}
 
+	// Discovery already advertises the issuer's endpoints for these toolsets
+	// (see mcp.serveAuthorizationServerMetadata), so a client turned away here
+	// re-discovers and completes on the issuer-gated path.
+	if toolset.UserSessionIssuerID.Valid {
+		return nil, "", errProxyRetired
+	}
+
 	return &toolset, mcpURL, nil
 }
 
@@ -273,7 +286,7 @@ func (s *Service) handleAuthorize(w http.ResponseWriter, r *http.Request) error 
 	// Load toolset from MCP slug
 	toolset, fullMCPURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
 	switch {
-	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
+	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable), errors.Is(err, errProxyRetired):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load authorization details for mcp server").LogError(ctx, s.logger)
@@ -480,6 +493,23 @@ func (s *Service) handleToken(w http.ResponseWriter, r *http.Request) error {
 
 	toolset, fullMCPURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
 	switch {
+	case errors.Is(err, errProxyRetired):
+		// RFC 6749 §5.2: invalid_grant is the signal a client acts on by
+		// discarding its tokens and re-running authorization. A 404 here would
+		// read as "server gone" and strand the client on a dead refresh token
+		// instead of moving it onto the issuer-gated path.
+		s.logger.InfoContext(ctx, "refused proxy token exchange for issuer-gated mcp server",
+			attr.SlogToolsetMCPSlug(mcpSlug))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "This MCP server has moved to a new authorization server. Re-authorize to continue.",
+		}); err != nil {
+			s.logger.ErrorContext(ctx, "failed to encode invalid_grant response", attr.SlogError(err))
+		}
+		return nil
 	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
@@ -540,7 +570,7 @@ func (s *Service) handleClientRegistration(w http.ResponseWriter, r *http.Reques
 
 	_, fullMcpURL, err := s.loadToolsetFromCurrentURLContext(ctx, mcpSlug)
 	switch {
-	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable):
+	case errors.Is(err, errToolsetNotFound), errors.Is(err, errOAuthUnavailable), errors.Is(err, errProxyRetired):
 		return oops.E(oops.CodeNotFound, err, "mcp server not found")
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load client registration details for mcp server").LogError(ctx, s.logger)

--- a/server/internal/oauth/proxyretired_test.go
+++ b/server/internal/oauth/proxyretired_test.go
@@ -1,0 +1,173 @@
+package oauth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oauth"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// retiredProxyEnv is a proxy-backed toolset plus a mux serving the oauth
+// endpoints against the same database.
+type retiredProxyEnv struct {
+	mux     goahttp.Muxer
+	mcpSlug string
+	// attachIssuer links a user_session_issuer to the toolset, which is what
+	// retires the proxy for it.
+	attachIssuer func(t *testing.T)
+}
+
+func newRetiredProxyEnv(t *testing.T) (context.Context, *retiredProxyEnv) {
+	t.Helper()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+
+	conn, err := infra.CloneTestDatabase(t, "proxyretired")
+	require.NoError(t, err)
+
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	enc := testenv.NewEncryptionClient(t)
+	sessionManager := testenv.NewTestManager(t, logger, tracerProvider, conn, redisClient,
+		cache.Suffix("gram-local"), billing.NewStubClient(logger, tracerProvider))
+
+	ctx := authztest.InitAuthContext(t, t.Context(), conn, sessionManager)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok, "auth context must be initialized")
+
+	proxy := oauthtest.CreateProxyToolset(t, ctx, conn, authCtx, oauthtest.ProxyToolsetOpts{
+		Slug:         "retired-proxy",
+		IsPublic:     true,
+		ProviderType: "gram",
+	})
+
+	env := oauthtest.NewOAuthServiceEnvWithDB(t, conn, cache.NewRedisCacheAdapter(redisClient), enc)
+	mux := goahttp.NewMuxer()
+	oauth.Attach(mux, env.Service)
+
+	return ctx, &retiredProxyEnv{
+		mux:     mux,
+		mcpSlug: proxy.Toolset.McpSlug.String,
+		attachIssuer: func(t *testing.T) {
+			t.Helper()
+
+			issuer, err := usersessions_repo.New(conn).CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
+				ProjectID:          *authCtx.ProjectID,
+				Slug:               "issuer-" + uuid.New().String()[:8],
+				AuthnChallengeMode: "interactive",
+				SessionDuration:    pgtype.Interval{Microseconds: int64(time.Hour / time.Microsecond), Days: 0, Months: 0, Valid: true},
+			})
+			require.NoError(t, err)
+
+			_, err = toolsets_repo.New(conn).UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+				UserSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+				Slug:                proxy.Toolset.Slug,
+				ProjectID:           proxy.Toolset.ProjectID,
+			})
+			require.NoError(t, err)
+		},
+	}
+}
+
+func (e *retiredProxyEnv) postToken(t *testing.T, ctx context.Context) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "a-stale-proxy-refresh-token")
+	form.Set("client_id", "some-client")
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost,
+		"/oauth/"+e.mcpSlug+"/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rec := httptest.NewRecorder()
+	e.mux.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// A client holding a proxy refresh token for a migrated server must be told
+// invalid_grant, which is the signal it acts on by discarding the token and
+// re-running authorization against the issuer.
+func TestTokenEndpointRefusesIssuerGatedToolsetWithInvalidGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+	env.attachIssuer(t)
+
+	rec := env.postToken(t, ctx)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	body := rec.Body.String()
+	require.Contains(t, body, `"error":"invalid_grant"`)
+	require.Contains(t, body, "Re-authorize to continue")
+}
+
+// Without an issuer the proxy still serves; the request fails on its own
+// merits (a bogus refresh token) rather than on the retirement gate.
+func TestTokenEndpointStillServesToolsetWithoutIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+
+	rec := env.postToken(t, ctx)
+
+	require.NotContains(t, rec.Body.String(), "moved to a new authorization server",
+		"a toolset with no issuer must not be treated as retired")
+}
+
+func TestAuthorizeEndpointRefusesIssuerGatedToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+	env.attachIssuer(t)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet,
+		"/oauth/"+env.mcpSlug+"/authorize?response_type=code&client_id=c&redirect_uri=http://localhost/cb", nil)
+	rec := httptest.NewRecorder()
+	env.mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"a retired proxy must not start a new authorization")
+}
+
+func TestRegisterEndpointRefusesIssuerGatedToolset(t *testing.T) {
+	t.Parallel()
+
+	ctx, env := newRetiredProxyEnv(t)
+	env.attachIssuer(t)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost,
+		"/oauth/"+env.mcpSlug+"/register",
+		strings.NewReader(`{"client_name":"new client","redirect_uris":["http://localhost/cb"]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	env.mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"a retired proxy must not accept new client registrations")
+}

--- a/server/internal/oauthtest/serviceenv.go
+++ b/server/internal/oauthtest/serviceenv.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/cache"
@@ -29,6 +30,15 @@ type OAuthServiceEnv struct {
 func NewOAuthServiceEnv(t *testing.T, cacheAdapter cache.Cache, enc *encryption.Client) *OAuthServiceEnv {
 	t.Helper()
 
+	return NewOAuthServiceEnvWithDB(t, nil, cacheAdapter, enc)
+}
+
+// NewOAuthServiceEnvWithDB is NewOAuthServiceEnv backed by a live database,
+// for tests exercising handlers that resolve a toolset before doing anything
+// else — the issuer gate on the proxy endpoints.
+func NewOAuthServiceEnvWithDB(t *testing.T, db *pgxpool.Pool, cacheAdapter cache.Cache, enc *encryption.Client) *OAuthServiceEnv {
+	t.Helper()
+
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
@@ -36,7 +46,7 @@ func NewOAuthServiceEnv(t *testing.T, cacheAdapter cache.Cache, enc *encryption.
 	serverURL, err := url.Parse("http://0.0.0.0")
 	require.NoError(t, err)
 
-	svc := oauth.NewService(logger, tracerProvider, meterProvider, nil, serverURL, cacheAdapter, enc, nil, nil, nil, nil)
+	svc := oauth.NewService(logger, tracerProvider, meterProvider, db, serverURL, cacheAdapter, enc, nil, nil, nil, nil)
 
 	return &OAuthServiceEnv{
 		TokenIssuer: NewTokenIssuer(t, cacheAdapter, enc),


### PR DESCRIPTION
Attaching a `user_session_issuer` to a toolset only ever stopped **new** proxy
authorizations. The `/oauth/{slug}/*` endpoints kept serving, because the
`oauth` package gates purely on `oauth_proxy_server_id` and never reads
`user_session_issuer_id`. Clients holding proxy refresh tokens went on
exchanging them indefinitely — outside the issuer's consent, session duration,
revocation and RBAC.

So a "migrated" server wasn't migrated so much as fitted with a second, weaker
door. This is also what blocks deleting the proxy: the old grants never die on
their own.

Production bears this out. On one migrated toolset, `register`/`authorize`
traffic stopped days before the issuer was attached, while `token` kept
returning `200` and the daily volume _rose_ afterwards — pure refresh traffic
on grants minted under the old regime.

## Change

Toolsets with a `user_session_issuer` now refuse the proxy outright.

| endpoint                  | response            | rationale                                                                                         |
| ------------------------- | ------------------- | ------------------------------------------------------------------------------------------------- |
| `/oauth/{slug}/token`     | `400 invalid_grant` | RFC 6749 §5.2 — the signal a client acts on by discarding its tokens and re-running authorization |
| `/oauth/{slug}/authorize` | `404`               | client re-discovers and lands on the issuer                                                       |
| `/oauth/{slug}/register`  | `404`               | same                                                                                              |

The token endpoint deliberately does **not** reuse the loader's `404`. A `404`
reads as "server gone" and would strand a client on a dead refresh token
instead of moving it onto the issuer-gated path.

Authorize and register can stay `404` because
`serveAuthorizationServerMetadata` already branches on `UserSessionIssuerID` —
discovery advertises the issuer's endpoints for these toolsets, so a client
turned away re-discovers and completes there.

`loadToolsetForProjectAndMCPSlug` (used by `/oauth/callback`) is intentionally
left ungated: authorize is closed, so no new callbacks originate, and leaving
it open lets flows already in flight when the issuer was attached finish their
10-minute window rather than stranding mid-dance.

## Expected impact

Clients on migrated servers get one re-authorization prompt, then complete
through the issuer. This is the intent, not a side effect — severing those
grants _is_ the migration. Toolsets quiet in the logs may still hold dormant
refresh tokens and surface a prompt when they next reconnect.

## Tests

Four new tests against a live database — the `invalid_grant` shape on a gated
toolset, `404` on authorize and register, and a negative test proving a
toolset without an issuer still reaches the normal exchange path.

Adds `oauthtest.NewOAuthServiceEnvWithDB`, since the existing env constructs
the service with a nil DB and these handlers resolve a toolset first.
`NewOAuthServiceEnv` now delegates to it.

Context: AIS-391.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the OAuth proxy for MCP servers that have a `user_session_issuer`, forcing clients to re-authorize with the issuer and cutting off old proxy refresh grants. Addresses Linear AIS-391 by closing the insecure proxy path once an issuer is attached.

- **Bug Fixes**
  - Gate proxy handlers on `user_session_issuer`; discovery already points to the issuer.
  - `/oauth/{slug}/token`: 400 invalid_grant (JSON) to trigger re-auth.
  - `/oauth/{slug}/authorize` and `/oauth/{slug}/register`: 404.

- **Migration**
  - No config changes. Clients get a one-time re-auth prompt and then use the issuer.

<sup>Written for commit 5f74343504c753476cb2b2b2264b5d3bb88b9ac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

