### PR TITLE
feat: add optional local LiteLLM proxy

### DIFF
--- a/.mise-tasks/start/litellm.sh
+++ b/.mise-tasks/start/litellm.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+#MISE description="Start a local LiteLLM proxy"
+#MISE dir="{{ config_root }}"
+
+set -euo pipefail
+
+if [[ -z "${OPENROUTER_DEV_KEY:-}" || "${OPENROUTER_DEV_KEY}" == "unset" ]]; then
+  echo "OPENROUTER_DEV_KEY is not set. Run 'mise run zero:openrouter' first." >&2
+  exit 1
+fi
+
+cleanup() {
+  docker compose --profile litellm stop litellm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+docker compose --profile litellm up --menu=false litellm

--- a/compose.yml
+++ b/compose.yml
@@ -87,6 +87,27 @@ services:
     depends_on:
       - otel-collector
 
+  litellm:
+    profiles: [litellm]
+    image: ghcr.io/berriai/litellm:v1.94.0@sha256:65d84a2282137b4dc73bbe184650a7c807177c533e4223b3bfbc87963fe3fabe
+    restart: unless-stopped
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    environment:
+      OPENROUTER_API_KEY: ${OPENROUTER_DEV_KEY}
+    volumes:
+      - ./local/litellm/config.yaml:/app/config.yaml:ro
+    ports:
+      - "${LITELLM_PORT}:4000"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'python3 -c "import urllib.request; urllib.request.urlopen(''http://localhost:4000/health/liveliness'')"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
   clickhouse:
     build:
       context: ./local/clickhouse

--- a/local/litellm/config.yaml
+++ b/local/litellm/config.yaml
@@ -1,0 +1,5 @@
+model_list:
+  - model_name: openrouter
+    litellm_params:
+      model: openrouter/openai/gpt-4o-mini
+      api_key: os.environ/OPENROUTER_API_KEY

--- a/mise.toml
+++ b/mise.toml
@@ -202,6 +202,7 @@ GRAM_ENABLE_OTEL_METRICS = 1
 ################################
 JAEGER_WEB_PORT = "16686"
 PROMETHEUS_PORT = "9099"
+LITELLM_PORT = "4000"
 GRAM_LOG_PRETTY = { default = "1" }
 ## Default Gram API URL baked into the dashboard's inlined Elements code and
 ## used by the CLI to point to the correct Gram API server

--- a/mise.toml
+++ b/mise.toml
@@ -202,7 +202,7 @@ GRAM_ENABLE_OTEL_METRICS = 1
 ################################
 JAEGER_WEB_PORT = "16686"
 PROMETHEUS_PORT = "9099"
-LITELLM_PORT = "4000"
+LITELLM_PORT = "4001"
 GRAM_LOG_PRETTY = { default = "1" }
 ## Default Gram API URL baked into the dashboard's inlined Elements code and
 ## used by the CLI to point to the correct Gram API server


### PR DESCRIPTION
## Summary

- add a digest-pinned LiteLLM Compose profile with a local OpenRouter model config
- expose the proxy through `mise run start:litellm` using the existing development key
- keep LiteLLM out of normal infrastructure and Pitchfork startup

Linear: DNO-692

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional local `litellm` proxy with a pinned image and OpenRouter model, isolated from the default stack. Supports Linear DNO-692 by enabling a reproducible local setup where LiteLLM routes inference while Gram handles risk and observability.

- New Features
  - `docker compose` profile `litellm` with digest-pinned `ghcr.io/berriai/litellm:v1.94.0` and healthcheck.
  - Local config for `openrouter/openai/gpt-4o-mini` with `OPENROUTER_API_KEY` passthrough.
  - `.mise-tasks/start/litellm.sh` to run the proxy; adds `LITELLM_PORT` (default 4001 to avoid OIDC emulator clash).
  - Not included in the default stack startup.

- Migration
  - Set `OPENROUTER_DEV_KEY` with `mise run zero:openrouter`.
  - Start the proxy with `mise run start:litellm` (listens on `localhost:${LITELLM_PORT}`).

<sup>Written for commit 11b69b0aa88b3f0612f574be3fd8e74e37c3be1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

