### PR TITLE
fix(dashboard): redirect to login on 401 instead of crashing

### DIFF
--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -25,6 +25,7 @@ import {
   useSearchParams,
 } from "react-router";
 import { orgRoutePaths } from "@/routes";
+import { UNAUTHENTICATED_PATHS } from "@/lib/session-expired";
 import { useSlugs } from "./Sdk";
 import {
   useCaptureUserAuthorizationEvent,
@@ -45,17 +46,6 @@ import {
 import type { ProjectEntry } from "@gram/client/models/components/projectentry.js";
 
 const PREFERRED_PROJECT_KEY = "preferredProject";
-
-const UNAUTHENTICATED_PATHS = [
-  "/login",
-  "/register",
-  "/invite",
-  "/book-demo",
-  "/shadow-mcp/request",
-  "/risk-policy-bypass/request",
-  "/blocks",
-  "/shared",
-];
 
 const SLUG_EXEMPT_PATHS = [
   "/switch-org",

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -25,7 +25,7 @@ import {
   useSearchParams,
 } from "react-router";
 import { orgRoutePaths } from "@/routes";
-import { UNAUTHENTICATED_PATHS } from "@/lib/session-expired";
+import { safeRedirectPath, UNAUTHENTICATED_PATHS } from "@/lib/session-expired";
 import { useSlugs } from "./Sdk";
 import {
   useCaptureUserAuthorizationEvent,
@@ -158,8 +158,10 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
     return <Navigate to={newPath + location.search + location.hash} replace />;
   }
 
-  // Handle initial navigation
-  const redirectParam = searchParams.get("redirect");
+  // Handle initial navigation. The param is attacker-controllable, so only
+  // same-origin paths are honored — a protocol-relative value would send the
+  // freshly authenticated user to a foreign origin.
+  const redirectParam = safeRedirectPath(searchParams.get("redirect"));
   if (redirectParam) {
     return <Navigate to={redirectParam} replace />;
   } else if (isSlugExempt) {

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -1,7 +1,9 @@
 import { handleError } from "@/lib/errors";
+import { isUnauthorizedError } from "@/lib/route-errors";
+import { redirectToLoginOnUnauthorized } from "@/lib/session-expired";
 import { Gram } from "@gram/client";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { createContext, useContext } from "react";
 import { useLocation, useParams } from "react-router";
 
@@ -27,13 +29,28 @@ export const useSdkClient = (): Gram => {
 // Preserve QueryClient across HMR to prevent cache loss
 const createQueryClient = () =>
   new QueryClient({
+    // A 401 means the session is dead (expired, revoked, or — in local dev —
+    // overwritten by another worktree's stack, since the cookie is scoped to
+    // `localhost` and cookies ignore ports). Send the user to /login instead
+    // of letting it throw to the error boundary.
+    queryCache: new QueryCache({
+      onError: (error) => {
+        if (isUnauthorizedError(error)) {
+          redirectToLoginOnUnauthorized();
+        }
+      },
+    }),
     defaultOptions: {
       queries: {
         // Suppress 403s so RBAC-restricted queries degrade gracefully
-        // instead of crashing the page. All other errors still throw to
+        // instead of crashing the page, and 401s because the cache handler
+        // above is already navigating away. All other errors still throw to
         // the nearest error boundary.
         throwOnError: (error) =>
-          !(error instanceof GramError && error.statusCode === 403),
+          !(
+            error instanceof GramError &&
+            (error.statusCode === 403 || error.statusCode === 401)
+          ),
         retry: (failureCount, error: Error) => {
           // Don't retry on 4xx errors
           if (error && typeof error === "object") {

--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -47,10 +47,8 @@ const createQueryClient = () =>
         // above is already navigating away. All other errors still throw to
         // the nearest error boundary.
         throwOnError: (error) =>
-          !(
-            error instanceof GramError &&
-            (error.statusCode === 403 || error.statusCode === 401)
-          ),
+          !isUnauthorizedError(error) &&
+          !(error instanceof GramError && error.statusCode === 403),
         retry: (failureCount, error: Error) => {
           // Don't retry on 4xx errors
           if (error && typeof error === "object") {

--- a/client/dashboard/src/lib/route-errors.ts
+++ b/client/dashboard/src/lib/route-errors.ts
@@ -24,6 +24,10 @@ export function isNotFoundError(error: unknown): boolean {
   return getHttpStatusCode(error) === 404;
 }
 
+export function isUnauthorizedError(error: unknown): boolean {
+  return getHttpStatusCode(error) === 401;
+}
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 

--- a/client/dashboard/src/lib/session-expired.test.ts
+++ b/client/dashboard/src/lib/session-expired.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadModule(pathname: string, search = "") {
+  vi.resetModules();
+  const assign = vi.fn();
+  vi.stubGlobal("window", { location: { pathname, search, assign } });
+  const mod = await import("./session-expired");
+  return { assign, ...mod };
+}
+
+describe("redirectToLoginOnUnauthorized", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("redirects to login and preserves the current location", async () => {
+    const { assign, redirectToLoginOnUnauthorized } = await loadModule(
+      "/acme/projects/default/insights",
+      "?range=7d",
+    );
+
+    redirectToLoginOnUnauthorized();
+
+    expect(assign).toHaveBeenCalledWith(
+      `/login?redirect=${encodeURIComponent("/acme/projects/default/insights?range=7d")}`,
+    );
+  });
+
+  it("redirects once even when several queries fail together", async () => {
+    const { assign, redirectToLoginOnUnauthorized } =
+      await loadModule("/acme/toolsets");
+
+    redirectToLoginOnUnauthorized();
+    redirectToLoginOnUnauthorized();
+    redirectToLoginOnUnauthorized();
+
+    expect(assign).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays put on paths that render without a session", async () => {
+    const { assign, redirectToLoginOnUnauthorized } =
+      await loadModule("/login");
+
+    redirectToLoginOnUnauthorized();
+
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/client/dashboard/src/lib/session-expired.test.ts
+++ b/client/dashboard/src/lib/session-expired.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 async function loadModule(pathname: string, search = "") {
   vi.resetModules();
   const assign = vi.fn();
-  vi.stubGlobal("window", { location: { pathname, search, assign } });
+  vi.stubGlobal("window", {
+    location: { origin: "https://app.example", pathname, search, assign },
+  });
   const mod = await import("./session-expired");
   return { assign, ...mod };
 }
@@ -24,6 +26,16 @@ describe("safeRedirectPath", () => {
     expect(safeRedirectPath("/\\evil.example/path")).toBeUndefined();
     expect(safeRedirectPath("https://evil.example")).toBeUndefined();
     expect(safeRedirectPath(null)).toBeUndefined();
+  });
+
+  // The URL parser strips these characters, so a literal prefix check would
+  // pass the value through and the browser would resolve it off-origin.
+  it("rejects paths that smuggle an origin past the leading slash", async () => {
+    const { safeRedirectPath } = await loadModule("/");
+
+    expect(safeRedirectPath("/\n/evil.example/path")).toBeUndefined();
+    expect(safeRedirectPath("/\t/evil.example/path")).toBeUndefined();
+    expect(safeRedirectPath("/\r/evil.example/path")).toBeUndefined();
   });
 });
 

--- a/client/dashboard/src/lib/session-expired.test.ts
+++ b/client/dashboard/src/lib/session-expired.test.ts
@@ -8,6 +8,25 @@ async function loadModule(pathname: string, search = "") {
   return { assign, ...mod };
 }
 
+describe("safeRedirectPath", () => {
+  it("keeps same-origin paths", async () => {
+    const { safeRedirectPath } = await loadModule("/");
+
+    expect(safeRedirectPath("/acme/toolsets?tab=tools")).toBe(
+      "/acme/toolsets?tab=tools",
+    );
+  });
+
+  it("rejects values that resolve to another origin", async () => {
+    const { safeRedirectPath } = await loadModule("/");
+
+    expect(safeRedirectPath("//evil.example/path")).toBeUndefined();
+    expect(safeRedirectPath("/\\evil.example/path")).toBeUndefined();
+    expect(safeRedirectPath("https://evil.example")).toBeUndefined();
+    expect(safeRedirectPath(null)).toBeUndefined();
+  });
+});
+
 describe("redirectToLoginOnUnauthorized", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
@@ -35,6 +54,16 @@ describe("redirectToLoginOnUnauthorized", () => {
     redirectToLoginOnUnauthorized();
 
     expect(assign).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a redirect that would leave the origin", async () => {
+    const { assign, redirectToLoginOnUnauthorized } = await loadModule(
+      "//evil.example/path",
+    );
+
+    redirectToLoginOnUnauthorized();
+
+    expect(assign).toHaveBeenCalledWith("/login");
   });
 
   it("stays put on paths that render without a session", async () => {

--- a/client/dashboard/src/lib/session-expired.ts
+++ b/client/dashboard/src/lib/session-expired.ts
@@ -1,0 +1,37 @@
+/**
+ * Paths that render without a session. A 401 on these is expected (auth.info
+ * always 401s when logged out), so it must not trigger a login redirect.
+ */
+export const UNAUTHENTICATED_PATHS = [
+  "/login",
+  "/register",
+  "/invite",
+  "/book-demo",
+  "/shadow-mcp/request",
+  "/risk-policy-bypass/request",
+  "/blocks",
+  "/shared",
+];
+
+let redirecting = false;
+
+/**
+ * Bounce to /login after a query comes back 401. The session cookie is gone,
+ * expired, or (in local dev, where the cookie is scoped to `localhost` and
+ * ports are ignored) belongs to another worktree's stack. Without this, the
+ * 401 throws to AuthProvider's error boundary and the user gets a dead
+ * "Something went wrong" screen instead of a login page.
+ *
+ * A hard navigation rather than a router navigate: it drops the React Query
+ * cache built up under the dead session and re-runs the auth bootstrap.
+ */
+export function redirectToLoginOnUnauthorized(): void {
+  if (redirecting) return;
+
+  const { pathname, search } = window.location;
+  if (UNAUTHENTICATED_PATHS.some((p) => pathname.startsWith(p))) return;
+
+  redirecting = true;
+  const redirect = encodeURIComponent(pathname + search);
+  window.location.assign(`/login?redirect=${redirect}`);
+}

--- a/client/dashboard/src/lib/session-expired.ts
+++ b/client/dashboard/src/lib/session-expired.ts
@@ -16,16 +16,29 @@ export const UNAUTHENTICATED_PATHS = [
 let redirecting = false;
 
 /**
- * Narrows a value taken from the URL to a same-origin path. `//evil.com` and
- * `/\evil.com` are protocol-relative URLs that the browser (and react-router's
- * `Navigate`) resolve to a foreign origin, so anything but a single leading
- * slash is rejected and the caller falls back to the app root.
+ * Narrows a value taken from the URL to a same-origin path.
+ *
+ * Prefix checks alone are not enough: the URL parser strips ASCII tab and
+ * newline characters, so `/%0A/evil.example` reaches the browser as
+ * `//evil.example` — a protocol-relative URL pointing at a foreign origin.
+ * Resolving against the current origin and comparing the parsed origin catches
+ * those, and returning the parsed components hands the caller the normalized
+ * path rather than the raw input. A leading slash is still required so the
+ * value can only ever be an absolute in-app path.
  */
 export function safeRedirectPath(value: string | null): string | undefined {
-  if (!value) return undefined;
-  if (!value.startsWith("/")) return undefined;
-  if (value.startsWith("//") || value.startsWith("/\\")) return undefined;
-  return value;
+  if (!value || !value.startsWith("/")) return undefined;
+
+  const origin = window.location.origin;
+  let url: URL;
+  try {
+    url = new URL(value, origin);
+  } catch {
+    return undefined;
+  }
+
+  if (url.origin !== origin) return undefined;
+  return `${url.pathname}${url.search}${url.hash}`;
 }
 
 /**

--- a/client/dashboard/src/lib/session-expired.ts
+++ b/client/dashboard/src/lib/session-expired.ts
@@ -16,6 +16,19 @@ export const UNAUTHENTICATED_PATHS = [
 let redirecting = false;
 
 /**
+ * Narrows a value taken from the URL to a same-origin path. `//evil.com` and
+ * `/\evil.com` are protocol-relative URLs that the browser (and react-router's
+ * `Navigate`) resolve to a foreign origin, so anything but a single leading
+ * slash is rejected and the caller falls back to the app root.
+ */
+export function safeRedirectPath(value: string | null): string | undefined {
+  if (!value) return undefined;
+  if (!value.startsWith("/")) return undefined;
+  if (value.startsWith("//") || value.startsWith("/\\")) return undefined;
+  return value;
+}
+
+/**
  * Bounce to /login after a query comes back 401. The session cookie is gone,
  * expired, or (in local dev, where the cookie is scoped to `localhost` and
  * ports are ignored) belongs to another worktree's stack. Without this, the
@@ -32,6 +45,10 @@ export function redirectToLoginOnUnauthorized(): void {
   if (UNAUTHENTICATED_PATHS.some((p) => pathname.startsWith(p))) return;
 
   redirecting = true;
-  const redirect = encodeURIComponent(pathname + search);
-  window.location.assign(`/login?redirect=${redirect}`);
+  const target = safeRedirectPath(pathname + search);
+  if (!target) {
+    window.location.assign("/login");
+    return;
+  }
+  window.location.assign(`/login?redirect=${encodeURIComponent(target)}`);
 }


### PR DESCRIPTION
## Problem

A 401 on any query other than `auth.info` threw straight into `AuthProvider`'s error boundary, so a dead session rendered the full-page "Something went wrong / unauthorized access" screen with no way out except manually navigating to `/login`. Session state was never marked logged-out, so the existing `LoginCheck` redirect never fired.

Two ways to hit it:

- **Production**: the Redis session entry expires (15-day TTL) while the cookie is still present.
- **Local dev**: the `gram_session` cookie is host-only on `localhost` with `Path=/`, and cookies ignore ports. Every worktree stack shares one cookie, but each worktree runs its own compose project with its own Redis. Logging into a second stack overwrites the cookie, and the first stack's tab then presents a token its Redis has never seen — every `/rpc/*` call 401s at once.

## Fix

- `lib/session-expired.ts` (new): `redirectToLoginOnUnauthorized()` does a hard `window.location.assign("/login?redirect=…")`. The hard navigation (rather than a router navigate) drops the React Query cache built up under the dead session and re-runs the auth bootstrap. Guards:
  - fires once, so a page firing 20 parallel queries doesn't stack navigations;
  - skips paths that legitimately render without a session — `auth.info` always 401s when logged out, which would otherwise loop on `/login`.
  - `UNAUTHENTICATED_PATHS` moves here from `AuthProvider` so both consumers share one list.
- `contexts/Sdk.tsx`: `QueryCache.onError` triggers the redirect; `throwOnError` now suppresses 401 alongside the existing 403 case so there's no error-boundary flash while the browser navigates.
- `lib/route-errors.ts`: `isUnauthorizedError()`, reusing the existing `getHttpStatusCode` helper.

Mutations are deliberately untouched — they already surface errors through the toast handler.

## Testing

- `client/dashboard/src/lib/session-expired.test.ts` — redirect target preserves path + query, redirects only once under concurrent failures, no-ops on session-less paths.
- `pnpm -F dashboard type-check`, `lint`, and `test src/lib src/contexts` (82 tests) pass.

## Not included

Local dev still logs you out of stack A when you log into stack B — only the crash is fixed, not the cookie collision. Truly isolating them needs a distinct hostname per worktree (e.g. `GRAM_HOST=gram-<suffix>.localhost` from `mise git:workinit`), since host is the only thing that separates cookie jars. That means cert SAN regeneration, a vite `allowedHosts` entry, and `*.localhost` resolution — which works on macOS/Chrome but not glibc Linux, so it would break the cloud agent pods. Left as a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects the dashboard to the login page on 401 instead of crashing. Validates the `?redirect` target using parsed-origin checks to block off-origin redirects and clears stale cache for a clean recovery.

- **Bug Fixes**
  - `lib/session-expired.ts`: `redirectToLoginOnUnauthorized()` does a hard `window.location.assign("/login?redirect=…")`, fires once, skips unauthenticated paths, and adds `safeRedirectPath()` that parses and compares origin to block protocol-relative and smuggled off-origin redirects; centralizes `UNAUTHENTICATED_PATHS`.
  - `contexts/Sdk.tsx`: uses `@tanstack/react-query` `QueryCache.onError` to redirect on any 401 (including non-`GramError`); `throwOnError` suppresses 401/403 to avoid error-boundary flashes.
  - `lib/route-errors.ts`: added `isUnauthorizedError()`; `contexts/AuthProvider.tsx` now uses `safeRedirectPath()` for the `?redirect` param and imports `UNAUTHENTICATED_PATHS`.
  - Tests cover redirect target preservation, single-fire behavior, unauthenticated paths, and off-origin attempts (protocol-relative and whitespace smuggling).

<sup>Written for commit d8501271d3e82a57e93004b34bb7f49427664f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

