### PR TITLE
fix(dashboard): stop catalog detail cards stretching to column height

### DIFF
--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -29,7 +29,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useMemo, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 import { Outlet, useParams } from "react-router";
 
 // Map of server specifiers to their website URLs
@@ -228,7 +228,7 @@ export default function CatalogDetail(): JSX.Element {
         />
       </Page.Header>
       <Page.Body>
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+        <div className="grid grid-cols-1 items-start gap-8 lg:grid-cols-3">
           {/* Left Column - Server Details */}
           <div className="space-y-6 lg:col-span-2">
             {/* Header */}
@@ -336,138 +336,92 @@ export default function CatalogDetail(): JSX.Element {
           </div>
 
           {/* Right Column - Info */}
-          <div className="space-y-4">
-            {/* Usage Stats */}
-            {(weeklyUsage || visitorsTotal || totalUsage) && (
-              <Card>
-                <Card.Header>
-                  <Card.Title>Usage</Card.Title>
-                </Card.Header>
-                <Card.Content>
-                  <div className="space-y-3">
-                    {weeklyUsage !== undefined && weeklyUsage > 0 && (
-                      <div className="flex justify-between gap-4">
-                        <Text small muted>
-                          This Week
-                        </Text>
-                        <Text className="font-medium">
-                          {weeklyUsage.toLocaleString()}
-                        </Text>
-                      </div>
-                    )}
-                    {visitorsTotal !== undefined && visitorsTotal > 0 && (
-                      <div className="flex justify-between gap-4">
-                        <Text small muted>
-                          Monthly
-                        </Text>
-                        <Text className="font-medium">
-                          {visitorsTotal.toLocaleString()}
-                        </Text>
-                      </div>
-                    )}
-                    {totalUsage !== undefined && totalUsage > 0 && (
-                      <div className="flex justify-between gap-4">
-                        <Text small muted>
-                          All Time
-                        </Text>
-                        <Text className="font-medium">
-                          {totalUsage.toLocaleString()}
-                        </Text>
-                      </div>
-                    )}
-                  </div>
-                </Card.Content>
-              </Card>
-            )}
-
-            {/* Version & Release Info */}
+          <div>
             <Card>
-              <Card.Header>
-                <Card.Title>Version & Release</Card.Title>
-              </Card.Header>
               <Card.Content>
-                <div className="space-y-3">
-                  <div className="flex justify-between gap-4">
-                    <Text small muted>
-                      Version
-                    </Text>
-                    <Text className="font-mono">{server.version}</Text>
-                  </div>
-                  {versionMeta?.status && (
-                    <div className="flex justify-between gap-4">
-                      <Text small muted>
-                        Status
-                      </Text>
-                      <Text className="capitalize">{versionMeta.status}</Text>
-                    </div>
+                <div className="divide-y">
+                  {(weeklyUsage || visitorsTotal || totalUsage) && (
+                    <DetailGroup label="Usage">
+                      {weeklyUsage !== undefined && weeklyUsage > 0 && (
+                        <DetailRow label="This Week">
+                          <Text className="font-medium">
+                            {weeklyUsage.toLocaleString()}
+                          </Text>
+                        </DetailRow>
+                      )}
+                      {visitorsTotal !== undefined && visitorsTotal > 0 && (
+                        <DetailRow label="Monthly">
+                          <Text className="font-medium">
+                            {visitorsTotal.toLocaleString()}
+                          </Text>
+                        </DetailRow>
+                      )}
+                      {totalUsage !== undefined && totalUsage > 0 && (
+                        <DetailRow label="All Time">
+                          <Text className="font-medium">
+                            {totalUsage.toLocaleString()}
+                          </Text>
+                        </DetailRow>
+                      )}
+                    </DetailGroup>
                   )}
-                  {versionMeta?.publishedAt && (
-                    <div className="flex justify-between gap-4">
-                      <Text small muted>
-                        Published
-                      </Text>
-                      <Text>
-                        {new Date(versionMeta.publishedAt).toLocaleDateString()}
-                      </Text>
-                    </div>
-                  )}
-                  {versionMeta?.updatedAt && (
-                    <div className="flex justify-between gap-4">
-                      <Text small muted>
-                        Last Updated
-                      </Text>
-                      <Text>
-                        {new Date(versionMeta.updatedAt).toLocaleDateString()}
-                      </Text>
-                    </div>
-                  )}
-                  {versionMeta?.source && (
-                    <div className="flex justify-between gap-4">
-                      <Text small muted>
-                        Source
-                      </Text>
-                      <a
-                        href={
-                          versionMeta.source.startsWith("http")
-                            ? versionMeta.source
-                            : `https://${versionMeta.source}`
-                        }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary flex items-center gap-1 hover:underline"
-                      >
-                        <Text className="max-w-[150px] truncate text-right">
-                          {versionMeta.source}
-                        </Text>
-                        <ExternalLink className="h-3 w-3 shrink-0" />
-                      </a>
-                    </div>
-                  )}
-                </div>
-              </Card.Content>
-            </Card>
 
-            {/* Registry Info */}
-            <Card>
-              <Card.Header>
-                <Card.Title>Registry</Card.Title>
-              </Card.Header>
-              <Card.Content>
-                <div className="space-y-3">
-                  <div className="flex justify-between gap-4">
-                    <Text small muted>
-                      Registry
-                    </Text>
-                    <Text className="text-right">{server.registryId}</Text>
-                  </div>
-                  <div className="flex items-center justify-between gap-4">
-                    <Text small muted>
-                      Specifier
-                    </Text>
-                    <Text className="text-right font-mono text-xs break-all">
-                      {server.registrySpecifier}
-                    </Text>
-                  </div>
+                  <DetailGroup label="Version & Release">
+                    <DetailRow label="Version">
+                      <Text className="font-mono">{server.version}</Text>
+                    </DetailRow>
+                    {versionMeta?.status && (
+                      <DetailRow label="Status">
+                        <Text className="capitalize">{versionMeta.status}</Text>
+                      </DetailRow>
+                    )}
+                    {versionMeta?.publishedAt && (
+                      <DetailRow label="Published">
+                        <Text>
+                          {new Date(
+                            versionMeta.publishedAt,
+                          ).toLocaleDateString()}
+                        </Text>
+                      </DetailRow>
+                    )}
+                    {versionMeta?.updatedAt && (
+                      <DetailRow label="Last Updated">
+                        <Text>
+                          {new Date(versionMeta.updatedAt).toLocaleDateString()}
+                        </Text>
+                      </DetailRow>
+                    )}
+                    {versionMeta?.source && (
+                      <DetailRow label="Source">
+                        <a
+                          href={
+                            versionMeta.source.startsWith("http")
+                              ? versionMeta.source
+                              : `https://${versionMeta.source}`
+                          }
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary flex items-center gap-1 hover:underline"
+                        >
+                          <Text className="max-w-[150px] truncate text-right">
+                            {versionMeta.source}
+                          </Text>
+                          <ExternalLink className="h-3 w-3 shrink-0" />
+                        </a>
+                      </DetailRow>
+                    )}
+                  </DetailGroup>
+
+                  <DetailGroup label="Registry">
+                    <DetailRow label="Registry">
+                      <Text className="text-right">{server.registryId}</Text>
+                    </DetailRow>
+                    <DetailRow label="Specifier">
+                      <Text className="text-right font-mono text-xs break-all">
+                        {server.registrySpecifier}
+                      </Text>
+                    </DetailRow>
+                  </DetailGroup>
                 </div>
               </Card.Content>
             </Card>
@@ -483,6 +437,38 @@ export default function CatalogDetail(): JSX.Element {
         />
       </Page.Body>
     </Page>
+  );
+}
+
+function DetailGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-3 py-4 first:pt-0 last:pb-0">
+      <Card.Title>{label}</Card.Title>
+      {children}
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <Text small muted>
+        {label}
+      </Text>
+      {children}
+    </div>
   );
 }
 

--- a/client/dashboard/src/pages/skills/ApproveAllSkillSuggestions.tsx
+++ b/client/dashboard/src/pages/skills/ApproveAllSkillSuggestions.tsx
@@ -97,7 +97,7 @@ export function ApproveAllSkillSuggestions({
         reason="You need write access to approve suggested edits."
       >
         <Button
-          size="lg"
+          className="h-10"
           disabled={!fullyLoaded}
           tooltip={
             fullyLoaded


### PR DESCRIPTION
Follow-up to #4743. Two visual regressions from the design-system internalisation, plus one layout tidy-up on the catalog detail page.

## Cards stretched to column height

The internalised `Card` carries `h-full` on its wrapper; the moonshine one didn't. `h-full` is a no-op while the parent's height is auto, which is why most pages are unaffected — but the catalog detail page lays its columns out in a grid, and a grid item's default `align-items: stretch` gives each column the row's height. That made the height definite, so `h-full` resolved against it and the About and Usage cards grew to fill the whole column.

Fixed locally with `items-start` on that grid rather than removing `h-full` from `Card`, since other pages rely on it for equal-height card grids.

The same regression is likely on other asymmetric grids (`RiskOverviewCategoryDetail`, `RiskOverviewUserDetail`, `ExternalMCPDetails`, `InsightsEmployeeDetail`) — not touched here. The wider fix would be dropping `h-full` from `Card` and opting into it where equal-height grids need it.

## Oversized "Approve all" on the skills page

`Toolbar` sizes every control to a shared 40px (`CONTROL_HEIGHT`), and `Toolbar.Refresh` hits it with the default `md` variant plus `h-10`. The Approve-all button used `size="lg"`, which lands at the same height but drags `px-6`, `text-lg` and `size-5` icons with it — a visibly different scale, and enough extra width to tip the toolbar row into wrapping onto two lines. Now sized like its neighbours.

## Right column merged into one card

Usage, Version & Release, and Registry were three stacked cards; they're now one card with `divide-y` groups. Two small local helpers (`DetailGroup`, `DetailRow`) replace the label/value row that repeated ten times. Section headings reuse `Card.Title`, so the typography is unchanged.

## Verification

- `pnpm -F dashboard type-check` clean
- `SkillsList.page.test.tsx` — 16 tests pass
- Catalog detail checked in the local dashboard: cards hug their content, right column renders as one grouped card
- Skills toolbar not verifiable locally (the local seed has no skills, so the page renders its empty state and the toolbar never mounts)

## Not addressed

The Registry group shows `registryId` as a raw UUID that wraps onto two lines next to the human-readable specifier. Pre-existing — it looked the same as its own card — so left alone.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stretched cards on the catalog detail page by aligning the grid items to content height. Also streamlines the right column into one grouped card and sizes the skills “Approve all” button to prevent toolbar wrapping.

- **Bug Fixes**
  - Catalog detail: grid uses `items-start` so `Card` no longer fills the column height.
  - Skills toolbar: “Approve all” now uses `h-10` to match the 40px control height and avoid wrapping.

- **Refactors**
  - Merged “Usage”, “Version & Release”, and “Registry” into one `Card` with divided groups.
  - Added local `DetailGroup` and `DetailRow` helpers to dedupe label/value rows.

<sup>Written for commit 5e1640e3b4a15a5f0d7fffdf6765cc55f21f6bdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

