### PR TITLE
fix: shorten Shadow MCP detector description (AGE-3092)

### DIFF
--- a/.changeset/shadow-mcp-tool-calls-desc.md
+++ b/.changeset/shadow-mcp-tool-calls-desc.md
@@ -3,4 +3,4 @@
 "server": patch
 ---
 
-Shorten Shadow MCP detector copy to omit the list of supported agent harnesses (Cursor, Claude Code, Codex, …).
+Stop enumerating supported coding agents (Cursor, Claude Code, Codex, …) in Shadow MCP detector copy and other user-facing product strings. Prefer generic wording so new agents like opencode do not require list updates.

--- a/.changeset/shadow-mcp-tool-calls-desc.md
+++ b/.changeset/shadow-mcp-tool-calls-desc.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Shorten the Shadow MCP detector description to "Tool calls..." so supported agent harnesses are not listed in the copy.

--- a/.changeset/shadow-mcp-tool-calls-desc.md
+++ b/.changeset/shadow-mcp-tool-calls-desc.md
@@ -3,4 +3,4 @@
 "server": patch
 ---
 
-Shorten the Shadow MCP detector description to "Tool calls..." so supported agent harnesses are not listed in the copy.
+Shorten Shadow MCP detector copy to omit the list of supported agent harnesses (Cursor, Claude Code, Codex, …).

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -24054,7 +24054,7 @@ paths:
         name: UpdateInviteRole
   /rpc/organizations.verifyOnboardingHooksSetup:
     get:
-      description: Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+      description: Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
       operationId: verifyOnboardingHooksSetup
       parameters:
         - allowEmptyValue: true

--- a/client/dashboard/src/components/billing/tum-definition.tsx
+++ b/client/dashboard/src/components/billing/tum-definition.tsx
@@ -18,8 +18,8 @@ export function TumDefinitionHint(): JSX.Element {
     <div className="flex max-w-xs flex-col gap-1.5">
       <p>
         The volume of agent traffic the platform observes from your users'
-        sessions each billing cycle — Claude Code, Cowork, Cursor, Codex, and
-        the rest — measured in tokens.
+        sessions each billing cycle — across supported coding agents —
+        measured in tokens.
       </p>
       <p>
         <span className="font-medium">Counted:</span> input tokens, output

--- a/client/dashboard/src/components/billing/tum-definition.tsx
+++ b/client/dashboard/src/components/billing/tum-definition.tsx
@@ -18,8 +18,8 @@ export function TumDefinitionHint(): JSX.Element {
     <div className="flex max-w-xs flex-col gap-1.5">
       <p>
         The volume of agent traffic the platform observes from your users'
-        sessions each billing cycle — across supported coding agents —
-        measured in tokens.
+        sessions each billing cycle — across supported coding agents — measured
+        in tokens.
       </p>
       <p>
         <span className="font-medium">Counted:</span> input tokens, output

--- a/client/dashboard/src/components/project/ProjectDashboard.tsx
+++ b/client/dashboard/src/components/project/ProjectDashboard.tsx
@@ -710,7 +710,7 @@ export function ProjectDashboard(): JSX.Element {
 
                     <DashboardCard
                       title="Most Used Agents"
-                      tooltip="Agents (e.g. Claude, Cursor, Codex) ranked by token volume in the selected period, identified from client metadata sent with each call."
+                      tooltip="Coding agents ranked by token volume in the selected period, identified from client metadata sent with each call."
                       action={
                         <CardActions>
                           <ExploreWithAIButton

--- a/client/dashboard/src/lib/insights-suggestions.ts
+++ b/client/dashboard/src/lib/insights-suggestions.ts
@@ -633,7 +633,7 @@ export const INSIGHTS_SUGGESTIONS = {
       label: "Compare clients",
       icon: "bot",
       prompt:
-        "Compare usage across different AI coding clients (Claude Code, Cursor, Codex, etc). Which is most popular?",
+        "Compare usage across different AI coding clients. Which is most popular?",
     },
   ],
 

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -1288,7 +1288,7 @@ function NextSteps({
               </div>
               <div className="flex-1">
                 <Text className="text-sm font-medium no-underline">
-                  Connect via Claude, Cursor, Codex
+                  Connect via coding agents
                 </Text>
               </div>
               <ArrowRight className="text-muted-foreground h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100" />

--- a/client/dashboard/src/pages/org/OrgLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgLogs.tsx
@@ -239,9 +239,8 @@ function OrgLogsInner() {
                 variant="body"
                 className="text-muted-foreground ml-6 text-sm"
               >
-                Capture user prompts and assistant responses from agents like
-                Cursor, Claude Code, Codex, and more. Sessions appear in the
-                Agent Sessions tab.
+                Capture user prompts and assistant responses from supported
+                coding agents. Sessions appear in the Agent Sessions tab.
               </Text>
             </Stack>
             {featuresData && (

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -725,8 +725,8 @@ export default function PluginDetail(): JSX.Element | null {
               <div className="mb-3 flex items-center justify-between gap-4">
                 <Text small muted className="max-w-md">
                   Controls delivery to devices running the Speakeasy agent.
-                  Marketplace installs (Claude, Cursor, Codex) receive every
-                  published plugin regardless.
+                  Marketplace installs receive every published plugin
+                  regardless.
                 </Text>
                 <Button
                   variant="secondary"

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -279,7 +279,7 @@ export default function Plugins(): JSX.Element {
   const createCard = (
     <CreateResourceCard
       title="New Plugin"
-      description="Bundle MCP servers and hooks for distribution to Claude Code, Cursor, and Codex."
+      description="Bundle MCP servers and hooks for distribution to supported coding agents."
       onClick={() => setIsCreateDialogOpen(true)}
     />
   );
@@ -294,8 +294,8 @@ export default function Plugins(): JSX.Element {
           <Page.Section.Title>Plugins</Page.Section.Title>
           <Page.Section.Description className={hasPlugins ? "w-3/4" : ""}>
             Create distributable plugin bundles that package MCP servers and
-            skills together. Assign plugins to roles and publish them to Claude
-            Code, Cursor, and Codex marketplaces via GitHub.
+            skills together. Assign plugins to roles and publish them to
+            supported agent marketplaces via GitHub.
           </Page.Section.Description>
           <Page.Section.Body>
             <Stack direction="vertical" gap={8}>
@@ -458,8 +458,9 @@ export default function Plugins(): JSX.Element {
               <Dialog.Title>Marketplace settings</Dialog.Title>
               <Dialog.Description>
                 The marketplace name is the identifier your team types after the
-                plugin slug ({"<plugin>@<marketplace>"}) when installing from
-                Claude Code or Codex. Applies to all plugins in this project.
+                plugin slug ({"<plugin>@<marketplace>"}) when installing from a
+                supported agent marketplace. Applies to all plugins in this
+                project.
               </Dialog.Description>
             </Dialog.Header>
             <form
@@ -575,9 +576,8 @@ function ObservabilityPluginCard({
       </div>
 
       <Text small muted className="mb-3 line-clamp-3">
-        Forwards tool events from your team&apos;s Claude Code, Cursor and Codex
-        installs to your project dashboard. Ships first in your marketplace,
-        marked Required.
+        Forwards tool events from your team&apos;s coding agent installs to your
+        project dashboard. Ships first in your marketplace, marked Required.
       </Text>
 
       <div className="mt-auto flex items-center justify-between gap-2 pt-2">

--- a/client/dashboard/src/pages/plugins/PublishDialog.tsx
+++ b/client/dashboard/src/pages/plugins/PublishDialog.tsx
@@ -265,8 +265,8 @@ export const PublishDialog = memo(function PublishDialog({
               </Dialog.Description>
               <Dialog.Description>
                 At least one user in your organization will need to be given
-                access to connect the generated repository with Claude, Cursor,
-                or Codex.
+                access to connect the generated repository with their coding
+                agents.
               </Dialog.Description>
             </>
           )}

--- a/client/dashboard/src/pages/security/detection-rules-data.ts
+++ b/client/dashboard/src/pages/security/detection-rules-data.ts
@@ -62,7 +62,7 @@ const CATEGORY_RULE_DESCRIPTION: Record<RuleCategory, string> = {
   off_policy:
     "Classifier-backed detector for requests that fall outside the organization's acceptable-use policy.",
   shadow_mcp:
-    "Detects MCP tool calls in Cursor, Claude Code, and Codex that didn't originate from a Speakeasy-issued MCP server. Requires Speakeasy hooks on the agent.",
+    "Detects MCP tool calls that didn't originate from a Speakeasy-issued MCP server. Requires Speakeasy hooks on the agent.",
   destructive_tool:
     "Flags tool calls whose Speakeasy tool definition is annotated as destructive. Requires Speakeasy hooks and Speakeasy-issued tool metadata.",
   cli_destructive:

--- a/client/dashboard/src/pages/security/policy-data.ts
+++ b/client/dashboard/src/pages/security/policy-data.ts
@@ -93,7 +93,7 @@ export const RULE_CATEGORY_META: Record<
   shadow_mcp: {
     label: "Shadow MCP",
     description:
-      "Tool calls in Cursor, Claude Code, and Codex that don't come from a Speakeasy-issued MCP server. Requires Speakeasy hooks to be installed on the agent.",
+      "Tool calls that don't come from a Speakeasy-issued MCP server. Requires Speakeasy hooks to be installed on the agent.",
     icon: "shield-off",
   },
   destructive_tool: {

--- a/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/confirm-traffic-step.tsx
@@ -165,7 +165,7 @@ export function ConfirmTrafficStep({
             </div>
           </div>
           <p className="text-muted-foreground text-sm">
-            Listening for Claude Code, Cursor, and Codex hooks…
+            Listening for agent hooks…
           </p>
         </div>
       </StepContainer>
@@ -180,7 +180,7 @@ export function ConfirmTrafficStep({
         </div>
       }
       title="Confirm traffic"
-      description="We're listening for events from your agent platforms. Trigger any action in Claude Code, Cursor, or Codex on a managed machine to confirm the instrumentation works."
+      description="We're listening for events from your agent platforms. Trigger any action in a managed coding agent to confirm the instrumentation works."
       onContinue={onComplete}
       continueLabel="Continue"
       showBack

--- a/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/create-marketplace-step.tsx
@@ -76,7 +76,7 @@ export function CreateMarketplaceStep({
         </div>
       }
       title="Create plugin marketplace"
-      description="Speakeasy publishes a private GitHub repo that acts as your team's plugin marketplace for Claude Code, Cursor, and Codex. It ships with our core observability plugin, required for us to collect usage metrics and enforce authorization, and is also where any plugins you build in Speakeasy later get published — so this only needs to be set up once per project."
+      description="Speakeasy publishes a private GitHub repo that acts as your team's plugin marketplace for supported coding agents. It ships with our core observability plugin, required for us to collect usage metrics and enforce authorization, and is also where any plugins you build in Speakeasy later get published — so this only needs to be set up once per project."
       onContinue={primaryAction}
       continueLabel={primaryLabel}
       isLoading={publishMutation.isPending || isLoading}
@@ -108,7 +108,7 @@ export function CreateMarketplaceStep({
                   Clicking the button below opens a dialog where you can
                   optionally add GitHub usernames who get read access to the
                   repo. At least one user needs access so they can connect the
-                  marketplace to Claude, Cursor, or Codex on their machine.
+                  marketplace to their coding agents.
                 </p>
               </div>
             </div>

--- a/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/distribute-servers-step.tsx
@@ -616,8 +616,8 @@ export function DistributeServersStep({
                     <p className="text-muted-foreground text-xs leading-relaxed">
                       Push the marketplace to every developer through Claude
                       Code Managed Settings — no per-user install command
-                      required. The full guide also covers Claude Cowork,
-                      Cursor, and Codex.
+                      required. The full guide also covers the other supported
+                      platforms.
                     </p>
                     <InstallInstructionsButton
                       repoOwner={publishStatus.repoOwner}

--- a/client/dashboard/src/sdk/src/funcs/organizationsVerifyOnboardingHooksSetup.ts
+++ b/client/dashboard/src/sdk/src/funcs/organizationsVerifyOnboardingHooksSetup.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * verifyOnboardingHooksSetup organizations
  *
  * @remarks
- * Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+ * Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
  */
 export function organizationsVerifyOnboardingHooksSetup(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/react-query/verifyOnboardingHooksSetup.ts
+++ b/client/dashboard/src/sdk/src/react-query/verifyOnboardingHooksSetup.ts
@@ -59,7 +59,7 @@ export type VerifyOnboardingHooksSetupQueryError =
  * verifyOnboardingHooksSetup organizations
  *
  * @remarks
- * Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+ * Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
  */
 export function useVerifyOnboardingHooksSetup(
   request?: VerifyOnboardingHooksSetupRequest | undefined,
@@ -88,7 +88,7 @@ export function useVerifyOnboardingHooksSetup(
  * verifyOnboardingHooksSetup organizations
  *
  * @remarks
- * Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+ * Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
  */
 export function useVerifyOnboardingHooksSetupSuspense(
   request?: VerifyOnboardingHooksSetupRequest | undefined,

--- a/client/dashboard/src/sdk/src/sdk/organizations.ts
+++ b/client/dashboard/src/sdk/src/sdk/organizations.ts
@@ -336,7 +336,7 @@ export class Organizations extends ClientSDK {
    * verifyOnboardingHooksSetup organizations
    *
    * @remarks
-   * Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+   * Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
    */
   async verifyOnboardingHooksSetup(
     request?: VerifyOnboardingHooksSetupRequest | undefined,

--- a/docs/plugins/local-development.md
+++ b/docs/plugins/local-development.md
@@ -85,7 +85,7 @@ You can fully exercise plugin creation, editing, and per-platform ZIP downloads 
 2. Create a plugin (name required, slug auto-generated)
 3. Add MCP servers (toolsets with MCP enabled)
 4. Configure assignments
-5. Use **Download** on the plugin detail page to get a ZIP for Claude, Cursor, or Codex
+5. Use **Download** on the plugin detail page to get a ZIP for each supported coding agent
 
 The **Publish to GitHub** button will be hidden/disabled when the server has no GitHub config.
 

--- a/docs/plugins/overview.md
+++ b/docs/plugins/overview.md
@@ -4,7 +4,7 @@ cwd: ../..
 
 # Plugins
 
-Plugins are distributable bundles of MCP servers (and observability hooks) that org admins create in Gram and publish to AI coding platforms. Once published, team members install the plugin through Claude Code, Cursor, or Codex's native plugin marketplace instead of configuring MCP servers manually.
+Plugins are distributable bundles of MCP servers (and observability hooks) that org admins create in Gram and publish to AI coding platforms. Once published, team members install the plugin through each platform's native plugin marketplace instead of configuring MCP servers manually.
 
 ## What a plugin is
 

--- a/docs/runbooks/oauth-debugging.md
+++ b/docs/runbooks/oauth-debugging.md
@@ -39,5 +39,5 @@ ngrok http --url=gram-yourname.ngrok.app https://localhost:8080
 
 ## Test the OAuth Flow
 
-Add a Gram MCP server that uses OAuth to your desired app (Claude Code, Cursor,
-or any other MCP client) and test the authentication flow.
+Add a Gram MCP server that uses OAuth to your desired app (any MCP client)
+and test the authentication flow.

--- a/docs/runbooks/oauth-debugging.md
+++ b/docs/runbooks/oauth-debugging.md
@@ -39,5 +39,5 @@ ngrok http --url=gram-yourname.ngrok.app https://localhost:8080
 
 ## Test the OAuth Flow
 
-Add a Gram MCP server that uses OAuth to your desired app (any MCP client)
+Add a Gram MCP server that uses OAuth to your desired app
 and test the authentication flow.

--- a/server/design/organizations/design.go
+++ b/server/design/organizations/design.go
@@ -236,7 +236,7 @@ var _ = Service("organizations", func() {
 	})
 
 	Method("verifyOnboardingHooksSetup", func() {
-		Description("Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.")
+		Description("Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.")
 
 		Payload(func() {
 			Attribute("since_unix_nano", String, "Only return events with time_unix_nano greater than this value. Pass the previous response's latest_unix_nano to poll for new events. Stringified to preserve int64 precision.")

--- a/server/design/organizations/design.go
+++ b/server/design/organizations/design.go
@@ -236,7 +236,7 @@ var _ = Service("organizations", func() {
 	})
 
 	Method("verifyOnboardingHooksSetup", func() {
-		Description("Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.")
+		Description("Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.")
 
 		Payload(func() {
 			Attribute("since_unix_nano", String, "Only return events with time_unix_nano greater than this value. Pass the previous response's latest_unix_nano to poll for new events. Stringified to preserve int64 precision.")

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -12337,7 +12337,7 @@ func organizationsUsage() {
 	fmt.Fprintln(os.Stderr, `    disable-webhooks: Disable  webhooks for the active organization.`)
 	fmt.Fprintln(os.Stderr, `    create-portal-session: Create a webhook portal session.`)
 	fmt.Fprintln(os.Stderr, `    get-onboarding-status: Get the onboarding status for the active organization by checking WorkOS SSO connections and directory sync state.`)
-	fmt.Fprintln(os.Stderr, `    verify-onboarding-hooks-setup: Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
+	fmt.Fprintln(os.Stderr, `    verify-onboarding-hooks-setup: Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
 	fmt.Fprintln(os.Stderr, `    send-enterprise-admin-onboarding-email: Send the enterprise admin onboarding email to one or more recipients. The email links each recipient to the wizard for the active organization. Used by the Platform Admin onboarding tools.`)
 	fmt.Fprintln(os.Stderr, `    generate-work-os-admin-portal-link: Generate a WorkOS Admin Portal link for the given intent (e.g. dsync, sso).`)
 	fmt.Fprintln(os.Stderr)
@@ -12559,7 +12559,7 @@ func organizationsVerifyOnboardingHooksSetupUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
+	fmt.Fprintln(os.Stderr, `Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -since-unix-nano STRING: `)

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -12337,7 +12337,7 @@ func organizationsUsage() {
 	fmt.Fprintln(os.Stderr, `    disable-webhooks: Disable  webhooks for the active organization.`)
 	fmt.Fprintln(os.Stderr, `    create-portal-session: Create a webhook portal session.`)
 	fmt.Fprintln(os.Stderr, `    get-onboarding-status: Get the onboarding status for the active organization by checking WorkOS SSO connections and directory sync state.`)
-	fmt.Fprintln(os.Stderr, `    verify-onboarding-hooks-setup: Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
+	fmt.Fprintln(os.Stderr, `    verify-onboarding-hooks-setup: Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
 	fmt.Fprintln(os.Stderr, `    send-enterprise-admin-onboarding-email: Send the enterprise admin onboarding email to one or more recipients. The email links each recipient to the wizard for the active organization. Used by the Platform Admin onboarding tools.`)
 	fmt.Fprintln(os.Stderr, `    generate-work-os-admin-portal-link: Generate a WorkOS Admin Portal link for the given intent (e.g. dsync, sso).`)
 	fmt.Fprintln(os.Stderr)
@@ -12559,7 +12559,7 @@ func organizationsVerifyOnboardingHooksSetupUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
+	fmt.Fprintln(os.Stderr, `Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -since-unix-nano STRING: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -24573,7 +24573,7 @@ paths:
                 name: UpdateInviteRole
     /rpc/organizations.verifyOnboardingHooksSetup:
         get:
-            description: Return recent hook events for the active organization so the onboarding wizard can confirm that Claude Code, Cursor, or Codex instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+            description: Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
             operationId: verifyOnboardingHooksSetup
             parameters:
                 - allowEmptyValue: true

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -24573,7 +24573,7 @@ paths:
                 name: UpdateInviteRole
     /rpc/organizations.verifyOnboardingHooksSetup:
         get:
-            description: Return recent hook events for the active organization so the onboarding wizard can confirm that coding-agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
+            description: Return recent hook events for the active organization so the onboarding wizard can confirm that coding agent instrumentation is delivering events to Gram. Polled from the confirm-traffic step.
             operationId: verifyOnboardingHooksSetup
             parameters:
                 - allowEmptyValue: true

--- a/server/gen/organizations/service.go
+++ b/server/gen/organizations/service.go
@@ -43,8 +43,8 @@ type Service interface {
 	// connections and directory sync state.
 	GetOnboardingStatus(context.Context, *GetOnboardingStatusPayload) (res *OnboardingStatusResult, err error)
 	// Return recent hook events for the active organization so the onboarding
-	// wizard can confirm that Claude Code, Cursor, or Codex instrumentation is
-	// delivering events to Gram. Polled from the confirm-traffic step.
+	// wizard can confirm that coding-agent instrumentation is delivering events to
+	// Gram. Polled from the confirm-traffic step.
 	VerifyOnboardingHooksSetup(context.Context, *VerifyOnboardingHooksSetupPayload) (res *VerifyOnboardingHooksSetupResult, err error)
 	// Send the enterprise admin onboarding email to one or more recipients. The
 	// email links each recipient to the wizard for the active organization. Used

--- a/server/gen/organizations/service.go
+++ b/server/gen/organizations/service.go
@@ -43,7 +43,7 @@ type Service interface {
 	// connections and directory sync state.
 	GetOnboardingStatus(context.Context, *GetOnboardingStatusPayload) (res *OnboardingStatusResult, err error)
 	// Return recent hook events for the active organization so the onboarding
-	// wizard can confirm that coding-agent instrumentation is delivering events to
+	// wizard can confirm that coding agent instrumentation is delivering events to
 	// Gram. Polled from the confirm-traffic step.
 	VerifyOnboardingHooksSetup(context.Context, *VerifyOnboardingHooksSetupPayload) (res *VerifyOnboardingHooksSetupResult, err error)
 	// Send the enterprise admin onboarding email to one or more recipients. The

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -745,7 +745,7 @@ func generateReadme(plugins []PluginInfo, cfg GenerateConfig) []byte {
 
 	b.WriteString("# " + cfg.OrgName + " Plugins\n\n")
 	b.WriteString("This repository contains plugin packages managed by [Speakeasy](https://getgram.ai). ")
-	b.WriteString("Each plugin bundles MCP servers for distribution via supported coding-agent marketplaces.\n\n")
+	b.WriteString("Each plugin bundles MCP servers for distribution via supported coding agent marketplaces.\n\n")
 	b.WriteString("## How this repo works\n\n")
 	b.WriteString("- **Read-only access.** Collaborators are granted pull permission only. You can clone and inspect the repository, but you cannot push to it.\n")
 	b.WriteString("- **Auto-managed by Speakeasy.** Each publish from the Speakeasy dashboard overwrites this repository's contents. Any manual edits, new branches, or local commits will be discarded on the next publish — make changes in Speakeasy instead.\n\n")

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -745,7 +745,7 @@ func generateReadme(plugins []PluginInfo, cfg GenerateConfig) []byte {
 
 	b.WriteString("# " + cfg.OrgName + " Plugins\n\n")
 	b.WriteString("This repository contains plugin packages managed by [Speakeasy](https://getgram.ai). ")
-	b.WriteString("Each plugin bundles MCP servers for distribution via Claude Code, Cursor, and Codex marketplaces.\n\n")
+	b.WriteString("Each plugin bundles MCP servers for distribution via supported coding-agent marketplaces.\n\n")
 	b.WriteString("## How this repo works\n\n")
 	b.WriteString("- **Read-only access.** Collaborators are granted pull permission only. You can clone and inspect the repository, but you cannot push to it.\n")
 	b.WriteString("- **Auto-managed by Speakeasy.** Each publish from the Speakeasy dashboard overwrites this repository's contents. Any manual edits, new branches, or local commits will be discarded on the next publish — make changes in Speakeasy instead.\n\n")

--- a/server/internal/risk/categories/categories.go
+++ b/server/internal/risk/categories/categories.go
@@ -75,7 +75,7 @@ var Definitions = []Definition{
 	{
 		Category:    CategoryShadowMCP,
 		Label:       "Shadow MCP",
-		Description: "Tool calls in Cursor and Claude Code that don't come from a Speakeasy-issued MCP server. Requires Speakeasy hooks to be installed on the agent.",
+		Description: "Tool calls that don't come from a Speakeasy-issued MCP server. Requires Speakeasy hooks to be installed on the agent.",
 		Icon:        "shield-off",
 		Source:      "shadow_mcp",
 	},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stop enumerating supported coding agents (Cursor, Claude Code, Codex, …) in product copy so adding agents like opencode does not require list updates.

## Changes

**Shadow MCP detector (AGE-3092)**
- `RULE_CATEGORY_META.shadow_mcp` → `Tool calls that don't come from a Speakeasy-issued MCP server…`
- Matching category description in `server/internal/risk/categories`
- Synthetic rule description in `detection-rules-data.ts`

**Broader UI / docs**
- Onboarding (marketplace, confirm traffic, distribute)
- Plugins list/detail/publish copy + generated marketplace README
- Org logs, billing TUM tooltip, project dashboard, catalog connect CTA, insights suggestion
- Plugin docs / oauth runbook
- `organizations.verifyOnboardingHooksSetup` Goa description + regenerated gen output

Left alone: platform-specific install steps that name a real product feature (e.g. Claude Code Managed Settings), code comments, changelogs, and generated SDK docs.

Fixes AGE-3092.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3092](https://linear.app/speakeasy/issue/AGE-3092/fix-change-the-tool-calls-in-cursor-claude-code-and-codex-to-just-tool)

<div><a href="https://cursor.com/agents/bc-e39f7d19-85ce-489a-9857-c84bd56ab878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e39f7d19-85ce-489a-9857-c84bd56ab878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

