### PR TITLE
fix(costs): reset scroll on cost table drill navigation (DNO-699)

### DIFF
--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -198,6 +198,18 @@ function HeaderStat({
   return <div className="flex flex-col">{inner}</div>;
 }
 
+// Walk up from `el` to the nearest ancestor that actually scrolls vertically.
+// The app shell scrolls an inner container (Page.Body / TabsContent), not the
+// window — callers that need the scrollport (sticky pinning, scroll-to-top)
+// must find that ancestor rather than assuming `window`.
+function findVerticalScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let root: HTMLElement | null = el?.parentElement ?? null;
+  while (root && !/auto|scroll/.test(getComputedStyle(root).overflowY)) {
+    root = root.parentElement;
+  }
+  return root;
+}
+
 // ── EntityProfile ───────────────────────────────────────────────────────────
 
 export type EntityProfileProps = {
@@ -362,10 +374,7 @@ export function EntityProfile({
   useEffect(() => {
     const sentinel = pinSentinelRef.current;
     if (!sentinel) return;
-    let root: HTMLElement | null = sentinel.parentElement;
-    while (root && !/auto|scroll/.test(getComputedStyle(root).overflowY)) {
-      root = root.parentElement;
-    }
+    const root = findVerticalScrollParent(sentinel);
     const observer = new IntersectionObserver(
       ([entry]) => setPinned(entry ? !entry.isIntersecting : false),
       { root, threshold: 0 },
@@ -373,6 +382,17 @@ export function EntityProfile({
     observer.observe(sentinel);
     return () => observer.disconnect();
   }, []);
+
+  // Drill navigation keeps the EntityProfile mounted and only swaps props, so
+  // the browser never resets scroll on its own. Jump back to the top of the
+  // scrollport whenever the drill path changes — otherwise a mid-table click
+  // lands the new profile still scrolled down, and it looks like nothing moved.
+  const pathKey = path.map((c) => `${c.dim}:${c.value}`).join("/");
+  useEffect(() => {
+    const root = findVerticalScrollParent(pinSentinelRef.current);
+    if (root) root.scrollTop = 0;
+    else window.scrollTo(0, 0);
+  }, [pathKey]);
 
   // The efficiency lens quotes the slice's work units where the cost lenses
   // quote spend — the caption's grammar fits either ("… — 1,204.5 work units

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -16,7 +16,13 @@ import { Text } from "@/components/ui/Text";
 import { cn } from "@/lib/utils";
 import { Dimension } from "@gram/client/models/components/queryfilter.js";
 import { type QueryRow } from "@gram/client/models/components/queryrow.js";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { ChevronLeft, Download, Home, Info, RotateCcw } from "lucide-react";
 import { CostMeasureLabel } from "@/components/estimated-cost";
 import { BreakdownBar } from "./BreakdownBar";
@@ -387,8 +393,9 @@ export function EntityProfile({
   // the browser never resets scroll on its own. Jump back to the top of the
   // scrollport whenever the drill path changes — otherwise a mid-table click
   // lands the new profile still scrolled down, and it looks like nothing moved.
+  // useLayoutEffect so the reset lands before paint (no flash of mid-page).
   const pathKey = path.map((c) => `${c.dim}:${c.value}`).join("/");
-  useEffect(() => {
+  useLayoutEffect(() => {
     const root = findVerticalScrollParent(pinSentinelRef.current);
     if (root) root.scrollTop = 0;
     else window.scrollTo(0, 0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [DNO-699](https://linear.app/speakeasy/issue/DNO-699/bug-cost-table-navigation-does-not-reset-scroll-position): clicking a row in the cost breakdown table drilled into a new entity profile but left the page scrolled mid-table, making the navigation hard to notice.

`EntityProfile` stays mounted across drills (props swap only), so the browser never resets scroll on its own. On drill-path change we now scroll the page scrollport (the app shell's inner `overflow-y-auto` container) back to the top via `useLayoutEffect` (before paint, so no flash of the old offset).

Also extracts a shared `findVerticalScrollParent` helper used by both sticky control-bar pinning and the new scroll reset.

## Test plan

- [ ] Open Costs, scroll down to the breakdown table
- [ ] Click a drillable row
- [ ] Confirm the new entity profile starts at the top of the page (hero/header visible)
- [ ] Navigate back / home and confirm scroll still resets
- [ ] Re-pivot breakdown axis without drilling — scroll position can stay (path unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-699](https://linear.app/speakeasy/issue/DNO-699/bug-cost-table-navigation-does-not-reset-scroll-position)

<div><a href="https://cursor.com/agents/bc-fc8f0d37-b2c4-43d2-a3d5-e0b7bf745922?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc8f0d37-b2c4-43d2-a3d5-e0b7bf745922&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the page scroll to top when drilling into a cost table row so the new entity profile starts at the top. Fixes DNO-699 and prevents flicker by resetting before paint.

- **Bug Fixes**
  - Scroll to top on drill path change by targeting the app shell’s vertical scroll parent (not `window`), using `useLayoutEffect` to run before paint.
  - Added a shared `findVerticalScrollParent` helper reused by sticky control-bar pinning and the scroll reset.

<sup>Written for commit 11d1f25a78a076d0fe120cf85312b96db9700227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

