### PR TITLE
fix(dashboard): Cost page tab underline spans full width (DNO-701)

### DIFF
--- a/client/dashboard/src/pages/costs/Costs.tsx
+++ b/client/dashboard/src/pages/costs/Costs.tsx
@@ -95,8 +95,10 @@ function TabbedCostsPage({
             onValueChange={(value) => setActiveTab(value as CostsTab)}
             className="min-h-0 flex-1 gap-0"
           >
-            <div className="mx-auto w-full max-w-7xl px-8 pt-6">
-              <div className="border-b">
+            {/* Full-bleed border so the hairline matches the full-width
+                explorer header below; tabs stay aligned to the content column. */}
+            <div className="border-border w-full border-b pt-6">
+              <div className="mx-auto w-full max-w-7xl px-8">
                 <PageTabsList>
                   <PageTabsTrigger value="costs">Costs</PageTabsTrigger>
                   <PageTabsTrigger


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [DNO-701](https://linear.app/speakeasy/issue/DNO-701): the Costs/Budgets tab hairline above the gradient header was cut off instead of spanning the full page width.

The tab strip’s `border-b` lived inside the `max-w-7xl` content column, while `EntityProfile`’s header wash is full-bleed. On wide viewports the separator stopped short of the header edges.

## Change

- Move `border-b` to a full-width wrapper
- Keep `PageTabsList` / triggers aligned to the `max-w-7xl` content column (`px-8`)

Same pattern as other page tabs that need a full-bleed rule with inset triggers (e.g. Access / Device Agent use `-mx` bleed; here the page body is already `fullWidth` + `noPadding`, so a full-width border wrapper is enough).

## Verification

Verified locally at 1920×1080 with `gram-budgets` / new costs enabled (dev telemetry enables all flags):

- Tab border element matches `<main>` width end-to-end (`borderMatchesMain: true`)
- Pixel sample across the hairline is continuous gray (`#dbdbdb`) both left of and under the content column (old layout would leave gaps outside `max-w-7xl`)

![Costs tab border full width](https://cursor.com/artifacts/c/art-20028671-febd-4c5d-8ed5-e6630e6f2e8d)

## Test plan

- [x] With budgets tab visible, open Costs → gray hairline under Costs/Budgets runs edge-to-edge above the gradient header
- [x] Tab labels still align with the content column / explorer header content
- [ ] Switch Costs ↔ Budgets; active underline still sits correctly on the hairline
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-701](https://linear.app/speakeasy/issue/DNO-701/bug-cost-page-tab-underline-is-cut-off-above-header)

<div><a href="https://cursor.com/agents/bc-94edff3a-5152-4afd-b1b0-2644eeb63cb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94edff3a-5152-4afd-b1b0-2644eeb63cb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-701: The Costs/Budgets tab separator now spans the full page width above the gradient header. Moved the `border-b` to a full-width wrapper; tabs remain aligned to the `max-w-7xl` content column.

<sup>Written for commit 310db36e2f67d758a2e75dbb685b9ece63ce3b86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

