### PR TITLE
fix(costs): move breakdown axis and search next to the table

### DIFF
--- a/client/dashboard/src/pages/costs/BreakdownBar.tsx
+++ b/client/dashboard/src/pages/costs/BreakdownBar.tsx
@@ -12,18 +12,17 @@ import {
   SelectValue,
 } from "@/components/ui/Select";
 import { cn } from "@/lib/utils";
-import type { ReactNode } from "react";
 
-// The costs page's single control strip: the search box, the axes to re-cut
-// the page by (the track), the table actions (CSV export), and the page-scope
-// controls (dataset + date range). It sits at the top of the page because the
-// breakdown axis re-cuts every visualization below it — the chart and the
-// table — and the dataset/range scope every number on the page.
+// The breakdown section's control strip: the axes to re-cut the chart and
+// table by (the track), and the free-text search that narrows the table's
+// rows. It sits directly above the chart/table — not in the page-scope bar
+// under the headline stats — so the controls that reshape this section read
+// as belonging to it.
 //
 // The axis track replaced a bare "Breakdown by <select>": users didn't find
 // the dropdown, and the word "breakdown" reads as jargon until you've watched
 // it re-cut the same spend. So the axes are promoted to visible segments, and
-// the section title below states the current cut ("Cost by Model") rather than
+// the section title above states the current cut ("Cost by Model") rather than
 // naming the mechanism — pairing a lit segment with a title that echoes it
 // teaches the idea on the first click.
 
@@ -60,8 +59,6 @@ export function BreakdownBar({
   searchValue,
   onSearchChange,
   searchPlaceholder,
-  actions,
-  scopeControls,
 }: {
   axisValue: string;
   axisOptions: AxisOption[];
@@ -71,12 +68,6 @@ export function BreakdownBar({
   searchValue: string;
   onSearchChange: (value: string) => void;
   searchPlaceholder: string;
-  // Controls that belong to the table below (e.g. CSV export), anchored to
-  // the right of the bar's top row.
-  actions?: ReactNode;
-  // Page-scope controls (dataset selector + date-range picker), leading the
-  // bar's top row.
-  scopeControls?: ReactNode;
 }): JSX.Element {
   const { segments, overflow } = partitionAxes(axisOptions, axisValue);
 
@@ -106,42 +97,31 @@ export function BreakdownBar({
   );
 
   return (
-    // A deliberate two-row control bar on the shared Page.Toolbar shell. The
-    // data options read as one left-stacked block: dataset + range lead the
-    // top row with the breakdown axis track directly beneath them; table
-    // actions (export/reset) anchor top-right and the row search anchors
-    // bottom-right. Every row spans the full bar at every width, so nothing
-    // clips and nothing rags.
+    // Axis track on the left, row search on the right — one Page.Toolbar row
+    // that spans the breakdown section. A lone axis is no choice at all (at a
+    // session leaf "Sessions" is the only option), and a track you can't move
+    // reads as a broken toggle; the section title already names the cut, so
+    // the track is omitted in that case and search keeps the full row.
     <Page.Toolbar>
-      <Page.Toolbar.Row>
-        <Page.Toolbar.Leading>{scopeControls}</Page.Toolbar.Leading>
-        <Page.Toolbar.Actions>{actions}</Page.Toolbar.Actions>
-      </Page.Toolbar.Row>
-      <Page.Toolbar.Row>
+      {axisOptions.length > 1 && (
         <Page.Toolbar.Leading>
-          {/* A lone axis is no choice at all — at a session leaf (Agent,
-              Model) "Sessions" is the only option, and a track you can't move
-              reads as a broken toggle. The section title already names the
-              cut. */}
-          {axisOptions.length > 1 && (
-            <SegmentedControl
-              value={axisValue}
-              onChange={onAxisChange}
-              options={segments}
-              trailing={more}
-            />
-          )}
-        </Page.Toolbar.Leading>
-        {/* Wrapped in Actions so the search anchors right — the left column
-            below the dataset/range belongs to the axis track. */}
-        <Page.Toolbar.Actions>
-          <Page.Toolbar.Search
-            value={searchValue}
-            onChange={onSearchChange}
-            placeholder={searchPlaceholder}
+          <SegmentedControl
+            value={axisValue}
+            onChange={onAxisChange}
+            options={segments}
+            trailing={more}
           />
-        </Page.Toolbar.Actions>
-      </Page.Toolbar.Row>
+        </Page.Toolbar.Leading>
+      )}
+      {/* Wrapped in Actions so the search anchors right — the left column
+          belongs to the axis track. */}
+      <Page.Toolbar.Actions>
+        <Page.Toolbar.Search
+          value={searchValue}
+          onChange={onSearchChange}
+          placeholder={searchPlaceholder}
+        />
+      </Page.Toolbar.Actions>
     </Page.Toolbar>
   );
 }

--- a/client/dashboard/src/pages/costs/EntityProfile.tsx
+++ b/client/dashboard/src/pages/costs/EntityProfile.tsx
@@ -1,4 +1,5 @@
 import { formatCost } from "@/lib/money";
+import { Page } from "@/components/page-layout";
 import { Badge } from "@/components/ui/Badge";
 import {
   Select,
@@ -277,8 +278,9 @@ export type EntityProfileProps = {
   // The summary widgets row (trend chart, mix, KPIs), rendered above the table.
   widgets: ReactNode;
   // The stacked cost-over-time chart, rendered inside the breakdown section
-  // between the section heading and the table — it stacks by the same axis
-  // the top control bar selects, so it reads as part of the breakdown.
+  // between the axis/search controls and the table — it stacks by the same
+  // axis the section's control bar selects, so it reads as part of the
+  // breakdown.
   chart?: ReactNode;
   isLoading: boolean;
   isError: boolean;
@@ -609,12 +611,13 @@ export function EntityProfile({
         </div>
       </div>
 
-      {/* The unified control bar sits under the headline numbers: search, the
-          axis track, table actions, and the page-scope dataset + range
-          controls. The axis re-cuts every visualization below it, and the
-          dataset/range scope every number on the page — so once scrolled past,
-          the bar pins to the top of the scrollport (the sentinel above drives
-          the pinned styling: a full-width blur band with a hairline). */}
+      {/* Page-scope controls sit under the headline numbers: dataset + range
+          shape every number on the page, and export/reset act on the current
+          view. Once scrolled past, the bar pins to the top of the scrollport
+          (the sentinel above drives the pinned styling: a full-width blur
+          band with a hairline). The breakdown axis track and row search live
+          with the chart/table below — not here — so they stay next to the
+          content they reshape. */}
       <div ref={pinSentinelRef} aria-hidden="true" className="h-px w-full" />
       <div
         className={cn(
@@ -624,14 +627,12 @@ export function EntityProfile({
         )}
       >
         <div className="mx-auto w-full max-w-7xl px-8 py-2">
-          <BreakdownBar
-            axisValue={axisValue}
-            axisOptions={axisOptions}
-            onAxisChange={onAxisChange}
-            searchValue={searchValue}
-            onSearchChange={onSearchChange}
-            searchPlaceholder={searchPlaceholder}
-            actions={
+          <Page.Toolbar>
+            <Page.Toolbar.Leading>
+              {datasetControl}
+              {rangePicker}
+            </Page.Toolbar.Leading>
+            <Page.Toolbar.Actions>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
@@ -651,14 +652,8 @@ export function EntityProfile({
                   Reset
                 </button>
               </div>
-            }
-            scopeControls={
-              <>
-                {datasetControl}
-                {rangePicker}
-              </>
-            }
-          />
+            </Page.Toolbar.Actions>
+          </Page.Toolbar>
         </div>
       </div>
 
@@ -667,8 +662,9 @@ export function EntityProfile({
         {/* The breakdown is its own section under the summary widgets, so it
             opens on a rule rather than floating off the last widget. The
             heading states the current cut ("Cost by Model") — echoing the lit
-            segment in the top control bar — with the caption saying what the
-            cut is doing in the user's own numbers. */}
+            segment in the control bar below — with the caption saying what
+            the cut is doing in the user's own numbers. Axis track + search
+            sit here, immediately above the chart/table they affect. */}
         <div className="border-border flex flex-col gap-3 border-t pt-6">
           <div className="flex flex-col gap-0.5">
             <h2 className="flex items-center gap-1.5 text-sm font-semibold">
@@ -694,6 +690,14 @@ export function EntityProfile({
             </h2>
             <p className="text-muted-foreground text-xs">{caption}</p>
           </div>
+          <BreakdownBar
+            axisValue={axisValue}
+            axisOptions={axisOptions}
+            onAxisChange={onAxisChange}
+            searchValue={searchValue}
+            onSearchChange={onSearchChange}
+            searchPlaceholder={searchPlaceholder}
+          />
           {chart}
           {tableOverride ?? dimensionTable}
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [DNO-700](https://linear.app/speakeasy/issue/DNO-700): the breakdown type control and search bar felt too far from the table they affect.

### Changes

- **Sticky bar** under the headline stats now only holds page-scope controls: dataset selector, date range, Export CSV, and Reset.
- **Breakdown axis track + search** move into the breakdown section, directly above the chart/table (after the section title/caption and below the summary widgets).

This keeps page-wide scope controls sticky while associating the re-cut/search controls with the content they reshape.

### Layout (verified locally)

```
Headline stats
├─ Sticky: Dataset | Date range · Export CSV | Reset
├─ Summary widgets
└─ Breakdown section
   ├─ Title + caption ("Cost by Division")
   ├─ Axis track + Search   ← moved here
   ├─ Cost Over Time chart
   └─ Table
```

![Costs page after move](https://cursor.com/artifacts/c/art-0777bd1b-64af-451d-b3bc-cc1cfcd41355)

## Test plan

- [x] Open Costs page — dataset/range/export/reset remain in sticky bar under stats
- [x] Axis track + search sit in breakdown section above chart/table (below widgets)
- [x] Sticky pin on scroll still only shows scope controls (no axis/search)
- [ ] Switching axis still re-cuts widgets, chart, and table
- [ ] Search still filters table rows only

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-700](https://linear.app/speakeasy/issue/DNO-700/feedback-move-breakdown-type-and-search-closer-to-the-table)

<div><a href="https://cursor.com/agents/bc-b458fe68-cd6e-4bce-a824-0e7707f45da2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b458fe68-cd6e-4bce-a824-0e7707f45da2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the breakdown axis and table search into the breakdown section above the chart/table, and keeps only page-scope controls in the sticky toolbar. Addresses Linear DNO-700 to make these controls feel connected to the content.

- **Refactors**
  - Sticky bar now shows dataset selector, date range, Export CSV, and Reset only.
  - Breakdown controls (axis track + row search) now sit above the chart/table in the breakdown section.
  - Simplified BreakdownBar API by removing actions and scopeControls; single toolbar row with optional axis and right-aligned search.

<sup>Written for commit 81f8e9991f7518f83371d06b431e334224ceabab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

