### PR TITLE
chore: cap local temporal memory and upgrade to server 1.31.2

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -33,14 +33,25 @@ services:
     command: redis-server --port 35299 --requirepass xi9XILbY
 
   gram-temporal:
-    image: temporalio/server:1.27.2
+    # The CLI image, not temporalio/server: as of 1.31 the server image no
+    # longer bundles the `temporal` binary that `server start-dev` needs.
+    # CLI 1.8.1 embeds Server 1.31.2 and UI 2.50.1.
+    image: temporalio/temporal:1.8.1
     restart: unless-stopped
     ports:
       - "${TEMPORAL_PORT}:7233"
       - "${TEMPORAL_WEB_PORT}:8233"
+    environment:
+      # The dev server is a single Go process, so its footprint is governed by
+      # the Go runtime rather than by cgroup limits. GOMEMLIMIT is a soft heap
+      # ceiling the GC actively works to stay under, which is what caps memory
+      # in sandboxes where `deploy.resources.limits` cannot be applied.
+      GOMEMLIMIT: 256MiB
+      # Per-P allocator caches and GC workers scale with core count; the dev
+      # server never needs the whole host.
+      GOMAXPROCS: 4
     entrypoint: ["temporal"]
-    command:
-      [
+    command: [
         "server",
         "start-dev",
         "--ip",
@@ -51,6 +62,27 @@ services:
         "default",
         "--db-filename",
         "/home/temporal/dev.db",
+        # Temporal's history cache is count-bounded by default (128k mutable
+        # state entries host-wide), which puts no ceiling on bytes. Switch it to
+        # a size-based limit so the live heap stays bounded and GOMEMLIMIT does
+        # not turn into GC thrash. 1.31 dropped the shard-level cache, so
+        # hostLevelCacheMaxSizeBytes is the only size knob left.
+        "--dynamic-config-value",
+        "history.cacheSizeBasedLimit=true",
+        "--dynamic-config-value",
+        "history.hostLevelCacheMaxSizeBytes=67108864",
+        "--dynamic-config-value",
+        "history.eventsCacheMaxSizeBytes=2097152",
+        "--dynamic-config-value",
+        'history.cacheTTL="5m"',
+        "--dynamic-config-value",
+        'history.eventsCacheTTL="5m"',
+        # A single local worker does not need the default 4 task queue
+        # partitions, each of which carries its own manager and buffers.
+        "--dynamic-config-value",
+        "matching.numTaskqueueReadPartitions=1",
+        "--dynamic-config-value",
+        "matching.numTaskqueueWritePartitions=1",
       ]
     volumes:
       - temporal_data:/home/temporal


### PR DESCRIPTION
## What

Bound the local Temporal dev server's memory from the inside, and move it to Server 1.31.2.

## Why

`deploy.resources.limits` is not an option for everyone — cloud sandboxes that already run inside a container cannot apply cgroup limits to a nested one. The dev server is a single Go process, so the equivalent knob is the Go runtime itself.

## Changes

All in `compose.yml`, on the `gram-temporal` service:

- **`GOMEMLIMIT=256MiB`** — a soft heap ceiling the GC actively works to stay under. This is the cap that replaces the cgroup limit we cannot set.
- **`GOMAXPROCS=4`** — per-P allocator caches and GC workers scale with core count; a local dev server does not need the whole host.
- **Size-based history cache** (`history.cacheSizeBasedLimit=true`, `hostLevelCacheMaxSizeBytes=64MiB`) — Temporal's cache is count-bounded by default (128k mutable state entries host-wide), which puts no ceiling on bytes. Without a byte bound the live heap can outgrow `GOMEMLIMIT`, and a soft limit the GC cannot reach turns into continuous GC instead of a cap.
- **Events cache bounded to 2 MiB**, both cache TTLs dropped to 5m.
- **Task queue read/write partitions set to 1** — a single local worker does not need the default 4, each of which carries its own manager and buffers.
- **Image switched** from `temporalio/server:1.27.2` to `temporalio/temporal:1.8.1`.

The values are hard-coded; edit `GOMEMLIMIT` in `compose.yml` to go tighter locally. Note it is a soft limit — set below the genuine live heap it trades CPU for memory rather than failing allocations.

## Why the image changed

As of 1.31 `temporalio/server` no longer bundles the `temporal` binary (the image dropped from 369 MB to 132 MB), so `server start-dev` cannot run from it. The dev server now comes from the CLI image: `temporalio/temporal:1.8.1` = CLI 1.8.1 / Server 1.31.2 / UI 2.50.1. It is 577 MB on disk, up from 369 MB.

1.31 also removed the shard-level history cache, so `history.cacheMaxSize`, `cacheInitialSize`, `cacheMaxSizeBytes`, and `enableHostHistoryCache` no longer exist; `hostLevelCacheMaxSizeBytes` is the remaining size knob.

Upside beyond memory: 1.31 is the server floor for standalone activities (`activity.enableStandalone`), which previously could not be exercised locally.

## ⚠️ Upgrading requires wiping the local Temporal volume

**This is a breaking change for existing checkouts.** 1.31 will happily open a `dev.db` created by 1.27 — health checks pass and `temporal workflow list` works — but the sqlite schema is never migrated, so the tables 1.31's matching service needs are absent. Every worker poll then fails with:

```
GetTaskQueue operation failed. Failed to check if task queue main of type Workflow existed.
Error: SQL logic error: no such table: task_queues_v2 (1)
```

Nothing surfaces in the Temporal server logs — the error is returned to the client — so it shows up as workflows silently never starting. Seeding fails with `Timed out after 60000ms: evolve deployment`.

After pulling this change, run once:

```sh
docker compose down gram-temporal
docker volume rm <compose-project>_temporal_data
docker compose up -d gram-temporal
```

Local workflow history is discarded; nothing else is affected. A fresh volume gets the 1.31 schema (`task_queues_v2`, `tasks_v2`) and the worker polls cleanly.

## Verification

`./zero --agent` brings up all 12 daemons, the worker polls cleanly against 1.31.2, and seeding completes — including the deployment-evolve workflow. SDK in `go.mod` is `go.temporal.io/sdk v1.46.0`.
## <!-- This is an auto-generated description by cubic. -->

## Summary by cubic

Caps memory for the local Temporal dev server and upgrades it to Server 1.31.2 by running from the `temporalio/temporal:1.8.1` CLI image with tighter runtime/cache settings. This keeps memory predictable in container-in-container sandboxes and preserves existing volumes.

- **Refactors**
  - Add Go runtime limits: GOMEMLIMIT=512MiB, GOMAXPROCS=4.
  - Use size-based history caches (host 64 MiB, events 2 MiB, TTLs 5m) and set task queue read/write partitions to 1.

- **Dependencies**
  - Switch from `temporalio/server:1.27.2` to `temporalio/temporal:1.8.1` (CLI 1.8.1 / Server 1.31.2 / UI 2.50.1) since the server image no longer includes the `temporal` binary needed by start-dev.

<sup>Written for commit 1bfbe34a479d0fa0005963678fe9bf80c4f35c31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

