### PR TITLE
chore: slim project-home assistant into a compact card

### DIFF
--- a/client/dashboard/src/lib/chat-gradient.ts
+++ b/client/dashboard/src/lib/chat-gradient.ts
@@ -13,6 +13,25 @@ export const CHAT_LANDING_GRADIENT = [
   "radial-gradient(36% 46% at 26% 54%, #9BC3FF 0%, rgba(155,195,255,0) 72%)",
 ].join(",");
 
+/**
+ * Faint mesh laid over the project home assistant card. Three mid-tone brand
+ * hues, widely spaced and soft-light blended, so it tints whichever surface it
+ * sits on — barely-there warmth on the left, cool on the right — rather than
+ * painting a colour of its own.
+ */
+export const HOME_ASSISTANT_GRADIENT = [
+  "radial-gradient(70% 120% at 6% 10%, #C2603A 0%, rgba(194,96,58,0) 70%)",
+  "radial-gradient(80% 130% at 96% 40%, #2E7D93 0%, rgba(46,125,147,0) 72%)",
+  "radial-gradient(60% 110% at 55% 105%, #4E7A4A 0%, rgba(78,122,74,0) 72%)",
+].join(",");
+
+/**
+ * Film grain laid over the mesh — an inline SVG turbulence tile, so no network
+ * request and no image asset. Blended and heavily faded; purely texture.
+ */
+export const GRAIN_TEXTURE_URL =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E\")";
+
 /** Blob geometry shared by the landing backdrop and the launch overlay. */
 export const CHAT_LANDING_GRADIENT_CLASS =
   "h-[560px] w-[920px] max-w-[140vw] opacity-60 blur-[72px] dark:opacity-40";

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -161,11 +161,16 @@ function useCyclingPlaceholder(): { text: string; visible: boolean } {
  * the `/chat` landing and embedded on the project home page. Submitting opens
  * a fresh conversation on the shared runtime and navigates to the full-page
  * chat; the server mints the chat id on the first send.
+ *
+ * `compact` drops the pinned/recents history so the widget can sit inside the
+ * project home page without competing with the dashboard below it.
  */
 export function ChatLanding({
   autoFocusInput = false,
+  compact = false,
 }: {
   autoFocusInput?: boolean;
+  compact?: boolean;
 }): ReactElement {
   const { user } = useSession();
   const navigate = useNavigate();
@@ -248,7 +253,12 @@ export function ChatLanding({
     <div className="flex w-full flex-col gap-6">
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-          <h1 className="text-foreground text-3xl font-semibold tracking-tight">
+          <h1
+            className={cn(
+              "text-foreground font-semibold tracking-tight",
+              compact ? "text-xl" : "text-3xl",
+            )}
+          >
             {greeting}
           </h1>
           <ReleaseStageBadge stage="beta" />
@@ -307,9 +317,24 @@ export function ChatLanding({
         </form>
       </div>
 
-      <ChatHomePinned />
-      <ChatHomeRecents />
-      <ChatHomeSuggestions />
+      {compact ? (
+        // Side-by-side columns so the card stays short: starters on the left,
+        // a peek at recent threads on the right.
+        <div className="flex flex-col gap-6 md:flex-row md:gap-8">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <ChatHomeSuggestions compact />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <ChatHomeCompactRecents />
+          </div>
+        </div>
+      ) : (
+        <>
+          <ChatHomePinned />
+          <ChatHomeRecents />
+          <ChatHomeSuggestions />
+        </>
+      )}
     </div>
   );
 }
@@ -363,8 +388,10 @@ function SlashCommandMenu({
             onMouseEnter={() => onHover(index)}
             onClick={() => onSelect(command)}
             className={cn(
-              "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left",
-              active ? "bg-muted" : "hover:bg-muted/60",
+              // `bg-accent`, not `bg-muted` — on the home page the menu sits
+              // inside a muted card, where a muted highlight is invisible.
+              "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors",
+              active ? "bg-accent" : "hover:bg-accent/60",
             )}
           >
             <Icon className="text-muted-foreground size-4 shrink-0" />
@@ -548,6 +575,56 @@ function ChatHomeRecents(): ReactElement {
         )}
       </div>
       <RecentsBody chats={chats} loading={loading} showAll={showAll} />
+    </section>
+  );
+}
+
+// Recent threads shown by the compact (project home) variant. Deliberately a
+// peek, not a list — "View more" hands off to the full `/chat` landing.
+const COMPACT_RECENTS_COUNT = 3;
+
+function ChatHomeCompactRecents(): ReactElement {
+  const routes = useRoutes();
+  // Pinned chats take the slots first; recents fill whatever is left.
+  const { chats: pinnedChats, loading: pinnedLoading } =
+    useProjectAssistantChats(Pinned.True);
+  const { chats: recentChats, loading: recentLoading } =
+    useProjectAssistantChats(Pinned.False);
+  const loading = pinnedLoading || recentLoading;
+  const chats = [
+    ...pinnedChats.map((chat) => ({ chat, pinned: true })),
+    ...recentChats.map((chat) => ({ chat, pinned: false })),
+  ];
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between px-3">
+        <h2 className="text-muted-foreground text-sm font-medium">
+          Recent Chats
+        </h2>
+        {chats.length > COMPACT_RECENTS_COUNT && (
+          <Link
+            to={routes.chat.href()}
+            className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+          >
+            View more
+          </Link>
+        )}
+      </div>
+      {loading ? (
+        <p className="text-muted-foreground px-3 text-sm">
+          Loading conversations…
+        </p>
+      ) : chats.length === 0 ? (
+        <p className="text-muted-foreground px-3 text-sm">
+          Your recent conversations will appear here.
+        </p>
+      ) : (
+        <div className="flex flex-col">
+          {chats.slice(0, COMPACT_RECENTS_COUNT).map(({ chat, pinned }) => (
+            <RecentRow key={chat.id} chat={chat} pinned={pinned} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }
@@ -747,15 +824,31 @@ function PinButton({
  * which flies it to the centre of the screen and then morphs it into the user
  * bubble of the conversation it just started.
  */
-function ChatHomeSuggestions(): ReactElement {
+// Chips shown by the compact (project home) variant — two rows in the
+// half-width column it sits in.
+const COMPACT_SUGGESTION_COUNT = 4;
+
+function ChatHomeSuggestions({
+  compact = false,
+}: {
+  compact?: boolean;
+}): ReactElement {
   const launchChat = useChatLaunch();
+  // The full landing indents chips to line up with the recents rows; the
+  // compact card has no rows, so chips align flush with the composer.
+  const inset = compact ? "" : "px-3";
+  // Compact shows a trimmed set so the chips stay within two rows at the
+  // widths the project home page renders at.
+  const suggestions = compact
+    ? CHAT_LANDING_SUGGESTIONS.slice(0, COMPACT_SUGGESTION_COUNT)
+    : CHAT_LANDING_SUGGESTIONS;
   return (
     <section className="flex flex-col gap-3">
-      <h2 className="text-muted-foreground px-3 text-sm font-medium">
+      <h2 className={cn("text-muted-foreground text-sm font-medium", inset)}>
         Suggestions
       </h2>
-      <div className="flex flex-wrap gap-x-2 gap-y-2.5 px-3">
-        {CHAT_LANDING_SUGGESTIONS.map((suggestion) => {
+      <div className={cn("flex flex-wrap gap-x-2 gap-y-2.5", inset)}>
+        {suggestions.map((suggestion) => {
           const SuggestionIcon =
             INSIGHTS_SUGGESTION_ICONS[suggestion.icon ?? "sparkles"];
           return (

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -2,6 +2,10 @@ import { useHideInsightsDock } from "@/components/insights-context";
 import { Page } from "@/components/page-layout";
 import { ProjectDashboard } from "@/components/project/ProjectDashboard";
 import { RequireScope } from "@/components/require-scope";
+import {
+  GRAIN_TEXTURE_URL,
+  HOME_ASSISTANT_GRADIENT,
+} from "@/lib/chat-gradient";
 import { ChatLanding } from "@/pages/chat/Chat";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useRoutes } from "@/routes";
@@ -30,9 +34,31 @@ export default function Home(): JSX.Element {
       <Page.Body>
         <RequireScope scope="project:read" level="page">
           {/* Full content width so the widget lines up with the dashboard
-              below (the /chat page centers it; the home page does not). */}
+              below (the /chat page centers it; the home page does not). The
+              compact variant drops pinned/recents — history lives on /chat. */}
           <div className="w-full pt-2 pb-6">
-            <ChatLanding />
+            {/* A surface one step off the page background, tinted by a faint
+                mesh and a whisper of grain — present, but low contrast. */}
+            {/* No `overflow-hidden` here — it would clip the composer's slash
+                menu. The decorative layers round themselves instead. */}
+            {/* `z-10` lifts the card's stacking context above the dashboard
+                below, so the slash menu overlays it instead of the other way
+                round. */}
+            <div className="bg-muted border-border relative isolate z-10 rounded-xl border p-6">
+              <div
+                aria-hidden="true"
+                // Blend follows the surface: multiply tints a light card,
+                // screen lifts a dark one.
+                className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-xl opacity-20 mix-blend-multiply blur-3xl dark:opacity-25 dark:mix-blend-screen"
+                style={{ background: HOME_ASSISTANT_GRADIENT }}
+              />
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 -z-10 rounded-xl opacity-[0.07] mix-blend-overlay"
+                style={{ backgroundImage: GRAIN_TEXTURE_URL }}
+              />
+              <ChatLanding compact />
+            </div>
           </div>
           <ProjectDashboard />
         </RequireScope>


### PR DESCRIPTION
The project home page embedded the full `/chat` landing widget — greeting, composer, pinned list, full recents list, and every suggestion chip. It was too busy above the Project Overview dashboard.

## What changed

**Compact variant of `ChatLanding`** (`compact` prop), used only on project home:

- Composer + a two-column row below it: suggestions on the left, a peek at recent chats on the right.
- Suggestions trimmed to 4 chips (two rows at the width the column renders at).
- Recent chats show 3 rows — pinned first, then most recent — with **View more** linking to `/chat` for the full history.
- Greeting drops from `text-3xl` to `text-xl`.

The `/chat` landing is unchanged: it keeps the full pinned + recents lists and all suggestions.

**Card styling** — the widget now sits in a `bg-muted` card, tinted by a faint mesh gradient (`HOME_ASSISTANT_GRADIENT`) and a grain tile, both new exports in `lib/chat-gradient.ts`. The mesh multiplies on the light surface and screens on the dark one, so the tint is present in both themes without lifting contrast.

**Two layout fixes** the card surfaced:

- The card deliberately has no `overflow-hidden` (it would clip the composer's slash menu); the decorative layers round themselves instead.
- `z-10` on the card lifts its stacking context above the dashboard, so the slash menu no longer renders behind the time-range filter.

**Slash menu highlight** now uses `bg-accent` instead of `bg-muted` — inside a muted card, a muted highlight was invisible, so hovered rows had no visible state.

## Screenshot

<img width="3078" height="3336" alt="CleanShot 2026-07-31 at 15 13 25@2x" src="https://github.com/user-attachments/assets/addf0d5e-1307-4ca1-8e1f-9b4e0626f551" />


## Verification

- `pnpm -F dashboard type-check` clean.
- Checked in the dev dashboard in both themes: card tint, two-column layout, pinned-first recents, slash menu overlay + hover.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slimmed the project-home assistant into a compact card to reduce clutter and keep focus on the dashboard. Adds a compact `ChatLanding` variant and a subtle card style; the full `/chat` landing remains unchanged.

- New Features
  - Added `compact` prop to `ChatLanding` for project home.
  - Compact layout: composer + two columns (4 suggestion chips; 3 recent chats, pinned first, with “View more” to `/chat`).
  - Smaller greeting in compact mode.
  - Card wrapper with soft tint and grain via `HOME_ASSISTANT_GRADIENT` and `GRAIN_TEXTURE_URL`.

- Bug Fixes
  - Removed container `overflow-hidden` so the slash menu isn’t clipped.
  - Raised card stacking (`z-10`) so the slash menu overlays dashboard filters.
  - Slash menu hover now uses `bg-accent` for visibility inside the muted card.

<sup>Written for commit c688605608272d839ffb32eaa23f78f0672e4b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

