### PR TITLE
feat(assistants): stream assistant turns to the dashboard

### DIFF
--- a/client/dashboard/src/hooks/useServerAssistantTransport.ts
+++ b/client/dashboard/src/hooks/useServerAssistantTransport.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useAssistantsGetManaged } from "@gram/client/react-query/assistantsGetManaged.js";
 import { useEnsureManagedAssistantMutation } from "@gram/client/react-query/ensureManagedAssistant.js";
-import { useOrganization } from "@/contexts/Auth";
+import { useOrganization, useSession } from "@/contexts/Auth";
 import { useRBAC } from "@/hooks/useRBAC";
 import { isNotFoundError } from "@/lib/route-errors";
 import { createServerAssistantTransport } from "@/lib/ServerAssistantTransport";
@@ -55,6 +55,7 @@ export function useServerAssistantTransport(
 ): UseServerAssistantTransportResult {
   const client = useGramContext();
   const organization = useOrganization();
+  const { session } = useSession();
   const { hasScope, isLoading: rbacLoading } = useRBAC();
 
   // The hook can be called with a projectSlug that differs from the URL-active
@@ -151,6 +152,8 @@ export function useServerAssistantTransport(
       projectSlug,
       getSkillIds: options.getSkillIds,
       onSkillIdsSent: options.onSkillIdsSent,
+      // The turn stream authenticates from headers, not cookies.
+      sessionToken: session,
     });
   }, [
     ready,

--- a/client/dashboard/src/hooks/useServerAssistantTransport.ts
+++ b/client/dashboard/src/hooks/useServerAssistantTransport.ts
@@ -56,6 +56,10 @@ export function useServerAssistantTransport(
   const client = useGramContext();
   const organization = useOrganization();
   const { session } = useSession();
+  // The transport outlives any single session value, so it reads through a ref
+  // instead of closing over one.
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
   const { hasScope, isLoading: rbacLoading } = useRBAC();
 
   // The hook can be called with a projectSlug that differs from the URL-active
@@ -153,7 +157,7 @@ export function useServerAssistantTransport(
       getSkillIds: options.getSkillIds,
       onSkillIdsSent: options.onSkillIdsSent,
       // The turn stream authenticates from headers, not cookies.
-      sessionToken: session,
+      getSessionToken: () => sessionRef.current,
     });
   }, [
     ready,

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -196,7 +196,13 @@ export function createServerAssistantTransport(
           // will not come back), fall back to discovering the reply the old
           // way rather than losing it.
           try {
-            await streamTurn({ chatId, writer, abortSignal: pollSignal });
+            await streamTurn({
+              chatId,
+              writer,
+              abortSignal: pollSignal,
+              sessionToken: deps.getSessionToken?.(),
+              projectSlug: deps.projectSlug,
+            });
           } catch (err) {
             if (pollSignal.aborted) throw err;
             await pollForReplies({

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -205,6 +205,9 @@ export function createServerAssistantTransport(
             });
           } catch (err) {
             if (pollSignal.aborted) throw err;
+            // The fallback masks why the stream failed, and "it fell back" is
+            // indistinguishable from "it worked" in a network trace.
+            console.error("[turnstream] fell back to polling:", err);
             await pollForReplies({
               deps,
               chatId,

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -46,6 +46,12 @@ export interface ServerAssistantTransportDeps {
   assistantId: string;
   /** Project slug for the Gram-Project header on sendMessage. */
   projectSlug: string;
+  /**
+   * `Gram-Session` token for the turn stream. The /chat/* routes authenticate
+   * from request headers rather than cookies, so without this the stream 401s
+   * and every turn silently falls back to polling.
+   */
+  sessionToken?: string;
   /** Optional poll tuning. */
   pollIntervalMs?: number;
   pollTimeoutMs?: number;

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -47,11 +47,15 @@ export interface ServerAssistantTransportDeps {
   /** Project slug for the Gram-Project header on sendMessage. */
   projectSlug: string;
   /**
-   * `Gram-Session` token for the turn stream. The /chat/* routes authenticate
-   * from request headers rather than cookies, so without this the stream 401s
-   * and every turn silently falls back to polling.
+   * Reads the caller's current `Gram-Session` token. The /chat/* routes
+   * authenticate from request headers rather than cookies, so without it the
+   * stream 401s and every turn silently falls back to polling.
+   *
+   * A getter rather than a value: the transport is built once, while the
+   * session resolves asynchronously, so capturing the token would pin
+   * whatever it was at construction — usually empty.
    */
-  sessionToken?: string;
+  getSessionToken?: () => string | undefined;
   /** Optional poll tuning. */
   pollIntervalMs?: number;
   pollTimeoutMs?: number;

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -2,6 +2,7 @@ import { assistantsSendMessage } from "@gram/client/funcs/assistantsSendMessage"
 import { chatLoad } from "@gram/client/funcs/chatLoad";
 import type { GramCore } from "@gram/client/core";
 import { sleep, type ElementsTransportContext } from "@/elements";
+import { streamTurn } from "@/lib/turnStream";
 import {
   type ChatTransport,
   createUIMessageStream,
@@ -180,13 +181,22 @@ export function createServerAssistantTransport(
             adopt(chatId);
           }
 
-          await pollForReplies({
-            deps,
-            chatId,
-            snapshot,
-            writer,
-            abortSignal: pollSignal,
-          });
+          // Frames drive the turn. The poll is kept only as a resync: if the
+          // stream cannot deliver (disabled server-side, or a connection that
+          // will not come back), fall back to discovering the reply the old
+          // way rather than losing it.
+          try {
+            await streamTurn({ chatId, writer, abortSignal: pollSignal });
+          } catch (err) {
+            if (pollSignal.aborted) throw err;
+            await pollForReplies({
+              deps,
+              chatId,
+              snapshot,
+              writer,
+              abortSignal: pollSignal,
+            });
+          }
 
           writer.write({ type: "finish" });
         },

--- a/client/dashboard/src/lib/ServerAssistantTransport.ts
+++ b/client/dashboard/src/lib/ServerAssistantTransport.ts
@@ -163,6 +163,53 @@ export function createServerAssistantTransport(
           const snapshot = chatId
             ? await snapshotAssistantIds(deps.client, chatId, abortSignal)
             : null;
+
+          // Frames drive the turn. The poll is kept only as a resync: if the
+          // stream cannot deliver (disabled server-side, or a connection that
+          // will not come back), fall back to discovering the reply the old
+          // way rather than losing it.
+          //
+          // Owned here rather than inside the stream so a failed stream can
+          // hand over the calls it surfaced but never saw answered. Without
+          // that the fallback poll ignores their tool rows — it only resolves
+          // calls it emitted itself — and the turn renders a tool that never
+          // returns.
+          const pendingToolCalls = new Set<string>();
+          let streamError: unknown;
+          const startStream = (id: string, replayFromStart: boolean) => {
+            let markSubscribed: () => void = () => {};
+            const subscribed = new Promise<void>((resolve) => {
+              markSubscribed = resolve;
+            });
+            const done = streamTurn({
+              chatId: id,
+              writer,
+              abortSignal: pollSignal,
+              sessionToken: deps.getSessionToken?.(),
+              projectSlug: deps.projectSlug,
+              pendingToolCalls,
+              replayFromStart,
+              onSubscribed: () => markSubscribed(),
+            })
+              .catch((err: unknown) => {
+                streamError = err;
+              })
+              // A stream that fails before it ever subscribes must not leave
+              // the send waiting on a promise nothing will resolve.
+              .finally(() => markSubscribed());
+            return { subscribed, done };
+          };
+
+          // Subscribe BEFORE sending when the chat already exists. The
+          // subscription starts from "now", so frames published between the
+          // send and the connection would be lost — and a turn that finished
+          // in that window leaves the client tailing a stream whose terminal
+          // frame it already missed, waiting forever. The handler flushes SSE
+          // headers immediately after subscribing, so a resolved response is
+          // proof the subscription is live.
+          let stream = chatId ? startStream(chatId, false) : null;
+          if (stream) await stream.subscribed;
+
           const sent = await assistantsSendMessage(
             deps.client,
             {
@@ -189,31 +236,27 @@ export function createServerAssistantTransport(
             // history, and the conversation list all resolve to the same chat.
             chatId = sent.value.chatId;
             adopt(chatId);
+            // The chat did not exist to subscribe to before the send, so the
+            // stream starts here and replays from the beginning. Everything
+            // retained for a chat this new belongs to this turn, which makes
+            // the replay exact rather than a guess.
+            stream = startStream(chatId, true);
           }
 
-          // Frames drive the turn. The poll is kept only as a resync: if the
-          // stream cannot deliver (disabled server-side, or a connection that
-          // will not come back), fall back to discovering the reply the old
-          // way rather than losing it.
-          try {
-            await streamTurn({
-              chatId,
-              writer,
-              abortSignal: pollSignal,
-              sessionToken: deps.getSessionToken?.(),
-              projectSlug: deps.projectSlug,
-            });
-          } catch (err) {
-            if (pollSignal.aborted) throw err;
+          await stream!.done;
+
+          if (streamError) {
+            if (pollSignal.aborted) throw streamError;
             // The fallback masks why the stream failed, and "it fell back" is
             // indistinguishable from "it worked" in a network trace.
-            console.error("[turnstream] fell back to polling:", err);
+            console.error("[turnstream] fell back to polling:", streamError);
             await pollForReplies({
               deps,
               chatId,
               snapshot,
               writer,
               abortSignal: pollSignal,
+              pendingToolCalls,
             });
           }
 
@@ -244,6 +287,12 @@ async function pollForReplies(args: {
   snapshot: Snapshot | null;
   writer: UIMessageStreamWriter<UIMessage>;
   abortSignal?: AbortSignal;
+  /**
+   * Tool calls a failed turn stream already surfaced and left unanswered.
+   * Seeding the set makes the poll resolve their tool rows, which it otherwise
+   * skips as belonging to a prior turn.
+   */
+  pendingToolCalls?: Set<string>;
 }): Promise<void> {
   const { deps, chatId, snapshot, writer, abortSignal } = args;
   const {
@@ -265,7 +314,7 @@ async function pollForReplies(args: {
   // tracked in `seen` — don't emit twice. Transcript order guarantees an
   // assistant row precedes its tool rows, so the input chunk always lands
   // before the matching output.
-  const pendingToolCalls = new Set<string>();
+  const pendingToolCalls = args.pendingToolCalls ?? new Set<string>();
   let consecutiveFailures = 0;
   let attempt = 0;
   // Tracks whether a `start-step` is open and awaiting its `finish-step`. Each

--- a/client/dashboard/src/lib/turnStream.test.ts
+++ b/client/dashboard/src/lib/turnStream.test.ts
@@ -261,30 +261,42 @@ describe("streamTurn", () => {
       ]),
     ]);
 
+    // Recorded at the writer rather than by consuming the stream: breaking out
+    // of the consumer early abandons a controller that `execute` is still
+    // writing to, which surfaces as an unhandled "Controller is already
+    // closed" and fails the run even though every assertion passed.
     const events: string[] = [];
     const stream = createUIMessageStream<UIMessage>({
       originalMessages: [{ id: "u1", role: "user", parts: [] }],
       execute: async ({ writer }) => {
-        writer.write({ type: "start" });
+        const recording: typeof writer = {
+          ...writer,
+          write: (chunk) => {
+            if (chunk.type === "text-delta") events.push("text");
+            return writer.write(chunk);
+          },
+        };
+        recording.write({ type: "start" });
         await streamTurn({
           chatId: CHAT_ID,
-          writer,
+          writer: recording,
           sessionToken: "session",
           projectSlug: "proj",
-          onSubscribed: () => events.push("subscribed"),
+          onSubscribed: () => {
+            events.push("subscribed");
+          },
           replayFromStart: true,
         });
-        writer.write({ type: "finish" });
+        recording.write({ type: "finish" });
       },
     });
-    for await (const message of readUIMessageStream({ stream })) {
-      if (message.parts.some((p) => p.type === "text")) {
-        events.push("text");
-        break;
-      }
+    for await (const _ of readUIMessageStream({ stream })) {
+      // Drain: the assertions read `events`, but the stream still has to be
+      // consumed to completion so `execute` finishes.
     }
 
     expect(events[0]).toBe("subscribed");
+    expect(events).toContain("text");
     // A chat created by this turn has no earlier turn to replay, so starting
     // from the beginning is exact — and it cannot miss frames published before
     // the connection was made.

--- a/client/dashboard/src/lib/turnStream.test.ts
+++ b/client/dashboard/src/lib/turnStream.test.ts
@@ -249,6 +249,49 @@ describe("streamTurn", () => {
     expect(chat.status).toBe("ready");
   });
 
+  // Subscribing starts from "now", so the caller only sends the message once
+  // the subscription is live. Signalling that any later would reopen the race
+  // the ordering exists to close: frames published in the gap are lost, and a
+  // turn that finished inside it leaves the client tailing forever.
+  it("signals the subscription is live before any frame arrives", async () => {
+    stubFetch([
+      sseBody([
+        { kind: "text", cursor: "1-0", text: "hi" },
+        { kind: "done", cursor: "1-1", finish_reason: "stop" },
+      ]),
+    ]);
+
+    const events: string[] = [];
+    const stream = createUIMessageStream<UIMessage>({
+      originalMessages: [{ id: "u1", role: "user", parts: [] }],
+      execute: async ({ writer }) => {
+        writer.write({ type: "start" });
+        await streamTurn({
+          chatId: CHAT_ID,
+          writer,
+          sessionToken: "session",
+          projectSlug: "proj",
+          onSubscribed: () => events.push("subscribed"),
+          replayFromStart: true,
+        });
+        writer.write({ type: "finish" });
+      },
+    });
+    for await (const message of readUIMessageStream({ stream })) {
+      if (message.parts.some((p) => p.type === "text")) {
+        events.push("text");
+        break;
+      }
+    }
+
+    expect(events[0]).toBe("subscribed");
+    // A chat created by this turn has no earlier turn to replay, so starting
+    // from the beginning is exact — and it cannot miss frames published before
+    // the connection was made.
+    const first = vi.mocked(fetch).mock.calls[0]![0] as URL;
+    expect(first.searchParams.get("after")).toBe("0");
+  });
+
   // The reconnect contract: a body that ends without a terminal frame means
   // the turn is still running, so the next request resumes from the last
   // cursor rather than the client treating the turn as over.

--- a/client/dashboard/src/lib/turnStream.test.ts
+++ b/client/dashboard/src/lib/turnStream.test.ts
@@ -1,0 +1,300 @@
+import { Chat } from "@ai-sdk/react";
+import {
+  createUIMessageStream,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  readUIMessageStream,
+  type UIMessage,
+} from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { streamTurn } from "./turnStream";
+
+// The turn stream is only correct if what assistant-ui ends up holding is a
+// finished message. Asserting on the chunks we emit proves nothing: the same
+// sequence can leave the runtime mid-step, mid-part, or looking like a turn
+// that still owes tool outputs — which is what keeps the spinner alive and
+// makes `sendAutomaticallyWhen` re-send a finished turn. So these tests feed
+// real server frames through `streamTurn` and inspect the message the AI SDK
+// reconstructs, the same way the runtime does.
+
+vi.mock("@/lib/utils", () => ({ getServerURL: () => "http://test.local" }));
+
+const CHAT_ID = "chat-1";
+
+interface Frame {
+  kind: "text" | "message" | "tool_output" | "done";
+  cursor?: string;
+  text?: string;
+  message_id?: string;
+  tool_calls?: unknown;
+  finish_reason?: string;
+  tool_call_id?: string;
+  output?: unknown;
+}
+
+/** Serialises frames as the SSE body the handler writes. */
+function sseBody(frames: Frame[]): string {
+  return frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join("");
+}
+
+/**
+ * Stubs fetch with one SSE response per call, so a test can also exercise the
+ * reconnect path by supplying more than one body.
+ */
+function stubFetch(bodies: string[]): void {
+  let call = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      const body = bodies[Math.min(call++, bodies.length - 1)] ?? "";
+      return new Response(new TextEncoder().encode(body), {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }),
+  );
+}
+
+/**
+ * Runs a turn end to end and returns the message assistant-ui would hold,
+ * reconstructed by the AI SDK from the chunks `streamTurn` wrote.
+ */
+async function runTurn(frames: Frame[]): Promise<UIMessage> {
+  stubFetch([sseBody(frames)]);
+
+  const stream = createUIMessageStream<UIMessage>({
+    originalMessages: [{ id: "u1", role: "user", parts: [] }],
+    execute: async ({ writer }) => {
+      writer.write({ type: "start" });
+      await streamTurn({
+        chatId: CHAT_ID,
+        writer,
+        sessionToken: "session",
+        projectSlug: "proj",
+      });
+      writer.write({ type: "finish" });
+    },
+  });
+
+  let last: UIMessage | undefined;
+  for await (const message of readUIMessageStream({ stream })) {
+    last = message;
+  }
+  if (!last) throw new Error("the turn produced no message");
+  return last;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("streamTurn", () => {
+  // The spinner that outlived a finished reply. A text-only turn must leave a
+  // message the runtime considers done — no open text part, no open step.
+  it("leaves a text-only turn complete", async () => {
+    const message = await runTurn([
+      { kind: "text", cursor: "1-0", text: "Hel" },
+      { kind: "text", cursor: "1-1", text: "lo" },
+      {
+        kind: "message",
+        cursor: "1-2",
+        message_id: "m1",
+        finish_reason: "stop",
+      },
+      { kind: "done", cursor: "1-3", finish_reason: "stop" },
+    ]);
+
+    const text = message.parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(text).toBe("Hello");
+    expect(
+      message.parts.every((p) => p.type !== "text" || p.state === "done"),
+    ).toBe(true);
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [message],
+      }),
+    ).toBe(false);
+  });
+
+  // A tool-using turn must not look resumable once it ends, or
+  // `sendAutomaticallyWhen` re-sends a turn the server already finished —
+  // which is what produced a second send and a spinner mid-conversation.
+  it("does not look resumable after a tool-using turn", async () => {
+    const message = await runTurn([
+      {
+        kind: "message",
+        cursor: "1-0",
+        message_id: "m1",
+        finish_reason: "tool_calls",
+        tool_calls: [
+          {
+            id: "call-1",
+            function: { name: "compose", arguments: '{"script":"x"}' },
+          },
+        ],
+      },
+      {
+        kind: "tool_output",
+        cursor: "1-1",
+        tool_call_id: "call-1",
+        output: "done",
+      },
+      { kind: "text", cursor: "1-2", text: "All set" },
+      {
+        kind: "message",
+        cursor: "1-3",
+        message_id: "m2",
+        finish_reason: "stop",
+      },
+      { kind: "done", cursor: "1-4", finish_reason: "stop" },
+    ]);
+
+    const tools = message.parts.filter((p) => p.type.startsWith("tool-"));
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ state: "output-available" });
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({ messages: [message] }),
+    ).toBe(false);
+  });
+
+  // A turn whose tool call is never answered still has to end cleanly: an
+  // unresolved call leaves the runtime waiting for an output that is not
+  // coming.
+  it("closes out a tool call the turn never answered", async () => {
+    const message = await runTurn([
+      {
+        kind: "message",
+        cursor: "1-0",
+        message_id: "m1",
+        finish_reason: "tool_calls",
+        tool_calls: [{ id: "call-1", function: { name: "compose" } }],
+      },
+      { kind: "done", cursor: "1-1", finish_reason: "stop" },
+    ]);
+
+    const tools = message.parts.filter((p) => p.type.startsWith("tool-"));
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ state: "output-available" });
+  });
+
+  // The failure this whole file exists for. Chunk-level assertions all passed
+  // while the dashboard span forever, because the runtime — not the chunk
+  // sequence — decides whether a turn is finished. Driving a real `Chat` with
+  // the same `sendAutomaticallyWhen` the dashboard uses is the only check that
+  // sees it: before the fix this looped until the process ran out of memory.
+  it("does not re-send a turn that has finished", async () => {
+    stubFetch([
+      sseBody([
+        {
+          kind: "message",
+          cursor: "1-0",
+          message_id: "m1",
+          finish_reason: "tool_calls",
+          tool_calls: [{ id: "call-1", function: { name: "compose" } }],
+        },
+        {
+          kind: "tool_output",
+          cursor: "1-1",
+          tool_call_id: "call-1",
+          output: "ok",
+        },
+        { kind: "text", cursor: "1-2", text: "All set" },
+        {
+          kind: "message",
+          cursor: "1-3",
+          message_id: "m2",
+          finish_reason: "stop",
+        },
+        { kind: "done", cursor: "1-4", finish_reason: "stop" },
+      ]),
+    ]);
+
+    let sends = 0;
+    const chat = new Chat<UIMessage>({
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+      transport: {
+        sendMessages: async ({ messages }) => {
+          // A regression here re-sends without bound, so stop rather than
+          // letting the runner die of heap exhaustion.
+          if (++sends > 2) throw new Error("runaway resend");
+          return createUIMessageStream<UIMessage>({
+            originalMessages: messages,
+            execute: async ({ writer }) => {
+              writer.write({ type: "start" });
+              await streamTurn({
+                chatId: CHAT_ID,
+                writer,
+                sessionToken: "session",
+                projectSlug: "proj",
+              });
+              writer.write({ type: "finish" });
+            },
+          });
+        },
+        reconnectToStream: async () => null,
+      },
+    });
+
+    await chat.sendMessage({ text: "hi" });
+    // `sendAutomaticallyWhen` is evaluated after the stream settles, so give
+    // the runtime a turn of the event loop to decide before asserting.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(sends).toBe(1);
+    expect(chat.status).toBe("ready");
+  });
+
+  // The reconnect contract: a body that ends without a terminal frame means
+  // the turn is still running, so the next request resumes from the last
+  // cursor rather than the client treating the turn as over.
+  it("resumes from the last cursor when the connection drops", async () => {
+    stubFetch([
+      sseBody([{ kind: "text", cursor: "1-0", text: "par" }]),
+      sseBody([
+        { kind: "text", cursor: "1-1", text: "tial" },
+        {
+          kind: "message",
+          cursor: "1-2",
+          message_id: "m1",
+          finish_reason: "stop",
+        },
+        { kind: "done", cursor: "1-3", finish_reason: "stop" },
+      ]),
+    ]);
+
+    const stream = createUIMessageStream<UIMessage>({
+      originalMessages: [{ id: "u1", role: "user", parts: [] }],
+      execute: async ({ writer }) => {
+        writer.write({ type: "start" });
+        await streamTurn({
+          chatId: CHAT_ID,
+          writer,
+          sessionToken: "session",
+          projectSlug: "proj",
+        });
+        writer.write({ type: "finish" });
+      },
+    });
+
+    let last: UIMessage | undefined;
+    for await (const message of readUIMessageStream({ stream })) {
+      last = message;
+    }
+
+    const text = (last?.parts ?? [])
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(text).toBe("partial");
+
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    const resumed = calls[1]![0] as URL;
+    expect(resumed.searchParams.get("after")).toBe("1-0");
+  });
+});

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -217,12 +217,16 @@ export async function streamTurn(args: {
                 messageIndex++;
                 sawTextThisMessage = false;
               }
+              const calls = parseFrameToolCalls(frame.tool_calls);
+              // A terminal row carries no tool calls and its text is already
+              // rendered, so it needs no step of its own. Opening one left an
+              // empty step hanging at the end of the turn, which reads as
+              // "still working" — the spinner that outlived the reply.
+              if (calls.length === 0) break;
               if (stepHasMessage) closeStep();
               openStep();
               stepHasMessage = true;
-              // The text is already on screen from its deltas; only the tool
-              // calls are new information.
-              for (const call of parseFrameToolCalls(frame.tool_calls)) {
+              for (const call of calls) {
                 writer.write({
                   type: "tool-input-available",
                   toolCallId: call.id,

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -155,6 +155,14 @@ export async function streamTurn(args: {
       let buffer = "";
       let done = false;
 
+      // The turn can end while the response is still open (the server closes
+      // after the terminal frame, but the client returns as soon as it reads
+      // one). Cancelling releases the connection rather than leaving an
+      // in-flight request behind for the rest of the session.
+      const release = () => {
+        void reader.cancel().catch(() => {});
+      };
+
       while (!done) {
         const { done: finished, value } = await reader.read();
         if (finished) break;
@@ -254,7 +262,11 @@ export async function streamTurn(args: {
         }
       }
 
-      if (done) return;
+      if (done) {
+        release();
+        return;
+      }
+      release();
       // The server closed without a terminal frame — the turn is still
       // running, so resume from the cursor rather than treating it as over.
       if (++reconnects > MAX_RECONNECTS) {

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -205,6 +205,18 @@ export async function streamTurn(args: {
               // and a step holding tool calls with no outputs makes it re-send
               // a turn the server is still running — which is exactly what
               // produced a second sendMessage mid-turn.
+              // Close the text part before the step that owns it closes:
+              // assistant-ui drops a step's parts when the step ends, so a
+              // text-end emitted afterwards addresses a part that no longer
+              // exists ("Received text-end for missing text part").
+              if (sawTextThisMessage) {
+                writer.write({
+                  type: "text-end",
+                  id: `turn-${chatId}-${messageIndex}`,
+                });
+                messageIndex++;
+                sawTextThisMessage = false;
+              }
               if (stepHasMessage) closeStep();
               openStep();
               stepHasMessage = true;
@@ -218,14 +230,6 @@ export async function streamTurn(args: {
                   input: call.input,
                 });
               }
-              if (sawTextThisMessage) {
-                writer.write({
-                  type: "text-end",
-                  id: `turn-${chatId}-${messageIndex}`,
-                });
-                messageIndex++;
-              }
-              sawTextThisMessage = false;
               break;
             }
             case "tool_output": {

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -83,33 +83,20 @@ export async function streamTurn(args: {
    */
   projectSlug: string;
 }): Promise<void> {
-  const {
-    chatId,
-    writer: rawWriter,
-    abortSignal,
-    sessionToken,
-    projectSlug,
-  } = args;
-
-  // Temporary: the turn renders correctly and the stream completes without
-  // error, yet assistant-ui still re-sends the turn. Log the exact chunk
-  // sequence so the emitted stream can be compared against what the resume
-  // check expects, instead of inferring it from the network trace.
-  const writer = {
-    ...rawWriter,
-    write: (chunk: Parameters<typeof rawWriter.write>[0]) => {
-      const c = chunk as { type: string; id?: string; toolCallId?: string };
-      console.log("[turnstream chunk]", c.type, c.id ?? c.toolCallId ?? "");
-      return rawWriter.write(chunk);
-    },
-  } as typeof rawWriter;
+  const { chatId, writer, abortSignal, sessionToken, projectSlug } = args;
 
   let cursor = "";
   let reconnects = 0;
-  // Each persisted assistant row opens its own step, so the turn's final,
-  // text-only row lands in a step with no tool calls — assistant-ui's resume
+  // Each persisted assistant row's content gets its own step, so the turn's
+  // final text lands in a step with no tool calls — assistant-ui's resume
   // check inspects the last step, and a step carrying resolved tool calls
   // makes it re-send a turn the server already finished.
+  //
+  // A step is only observable once something is written into it: the AI
+  // SDK pushes the `step-start` part on `start-step` but does not flush the
+  // message, so an empty trailing step never reaches the consumer. Steps have
+  // to be arranged so the turn's last CONTENT is free of tool calls; opening a
+  // bare step after them does nothing.
   let stepOpen = false;
   // Text arrives before the row that will contain it, so the part id is per
   // message index rather than per row id.
@@ -161,14 +148,18 @@ export async function streamTurn(args: {
       } catch (err) {
         if (abortSignal?.aborted) throw err;
         if (++reconnects > MAX_RECONNECTS) throw err;
-        await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
+        await new Promise((r) => {
+          setTimeout(r, RECONNECT_DELAY_MS);
+        });
         continue;
       }
       if (!response.ok || !response.body) {
         if (++reconnects > MAX_RECONNECTS) {
           throw new Error(`turn stream failed: ${response.status}`);
         }
-        await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
+        await new Promise((r) => {
+          setTimeout(r, RECONNECT_DELAY_MS);
+        });
         continue;
       }
       reconnects = 0;
@@ -210,6 +201,15 @@ export async function streamTurn(args: {
           switch (frame.kind) {
             case "text": {
               if (!frame.text) break;
+              // Text that arrives after a row has landed belongs to the NEXT
+              // row, so it opens a step of its own. Sharing the previous row's
+              // step put the turn's closing text in the same step as the tool
+              // calls that preceded it, and assistant-ui's resume check
+              // (`lastAssistantMessageIsCompleteWithToolCalls`) inspects the
+              // last step: finding resolved tool calls there, it re-sent a turn
+              // the server had already finished — forever, since every resend
+              // reproduced the same shape.
+              if (stepHasMessage) closeStep();
               openStep();
               // assistant-ui addresses text parts by id and rejects a delta
               // for a part it has not been told about, so each part is opened
@@ -249,13 +249,11 @@ export async function streamTurn(args: {
                 sawTextThisMessage = false;
               }
               const calls = parseFrameToolCalls(frame.tool_calls);
-              // Every row gets its own step, including the final text-only
-              // one. That is what keeps the turn's last step free of tool
-              // calls: assistant-ui's resume check inspects only the last
-              // step, and if it finds tool calls there it re-sends a turn the
-              // server already finished. Skipping the step for a row with no
-              // tool calls left the tool-calling step last and restarted that
-              // loop.
+              // A row that follows another opens its own step, so a row's tool
+              // calls never share a step with the next row's content. The step
+              // this opens is only real once something is written into it (see
+              // `stepOpen` above), which is why the turn's closing text opens
+              // its step itself rather than relying on this.
               if (stepHasMessage) closeStep();
               openStep();
               stepHasMessage = true;
@@ -299,7 +297,9 @@ export async function streamTurn(args: {
       if (++reconnects > MAX_RECONNECTS) {
         throw new Error("turn stream ended before the turn finished");
       }
-      await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
+      await new Promise((r) => {
+        setTimeout(r, RECONNECT_DELAY_MS);
+      });
     }
   } finally {
     // A turn that ended without an output for some call would otherwise be

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -96,11 +96,15 @@ export async function streamTurn(args: {
   // message index rather than per row id.
   let messageIndex = 0;
   let sawTextThisMessage = false;
+  // Whether the open step already carries a row, so the next row knows to
+  // close it rather than sharing.
+  let stepHasMessage = false;
 
   const closeStep = () => {
     if (stepOpen) {
       writer.write({ type: "finish-step" });
       stepOpen = false;
+      stepHasMessage = false;
     }
   };
   const openStep = () => {
@@ -185,10 +189,18 @@ export async function streamTurn(args: {
               break;
             }
             case "message": {
-              // The row for the text just streamed. Its tool calls are the new
-              // information; the text is already rendered, so it is not
-              // re-emitted.
+              // A new row starts a new step, so close the previous one first.
+              // The step must NOT be closed straight after emitting tool
+              // inputs: their outputs arrive as later frames and belong in the
+              // same step. assistant-ui's resume check looks at the last step,
+              // and a step holding tool calls with no outputs makes it re-send
+              // a turn the server is still running — which is exactly what
+              // produced a second sendMessage mid-turn.
+              if (stepHasMessage) closeStep();
               openStep();
+              stepHasMessage = true;
+              // The text is already on screen from its deltas; only the tool
+              // calls are new information.
               for (const call of parseFrameToolCalls(frame.tool_calls)) {
                 writer.write({
                   type: "tool-input-available",
@@ -197,7 +209,6 @@ export async function streamTurn(args: {
                   input: call.input,
                 });
               }
-              closeStep();
               if (sawTextThisMessage) messageIndex++;
               sawTextThisMessage = false;
               break;

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -189,7 +189,18 @@ export async function streamTurn(args: {
         continue;
       }
       if (!response.ok || !response.body) {
-        if (++reconnects > MAX_RECONNECTS) {
+        // A 4xx is the server refusing the subscription — streaming disabled,
+        // bad chat id — and retrying cannot change its answer. Failing now
+        // matters because the caller's send waits on `subscribed`: burning the
+        // retry budget here would delay every message on a deployment without
+        // streaming, when the poll fallback could start immediately.
+        const refused =
+          !response.ok &&
+          response.status >= 400 &&
+          response.status < 500 &&
+          response.status !== 408 &&
+          response.status !== 429;
+        if (refused || ++reconnects > MAX_RECONNECTS) {
           throw new Error(`turn stream failed: ${response.status}`);
         }
         await new Promise((r) => {

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -83,7 +83,26 @@ export async function streamTurn(args: {
    */
   projectSlug: string;
 }): Promise<void> {
-  const { chatId, writer, abortSignal, sessionToken, projectSlug } = args;
+  const {
+    chatId,
+    writer: rawWriter,
+    abortSignal,
+    sessionToken,
+    projectSlug,
+  } = args;
+
+  // Temporary: the turn renders correctly and the stream completes without
+  // error, yet assistant-ui still re-sends the turn. Log the exact chunk
+  // sequence so the emitted stream can be compared against what the resume
+  // check expects, instead of inferring it from the network trace.
+  const writer = {
+    ...rawWriter,
+    write: (chunk: Parameters<typeof rawWriter.write>[0]) => {
+      const c = chunk as { type: string; id?: string; toolCallId?: string };
+      console.log("[turnstream chunk]", c.type, c.id ?? c.toolCallId ?? "");
+      return rawWriter.write(chunk);
+    },
+  } as typeof rawWriter;
 
   let cursor = "";
   let reconnects = 0;

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -180,7 +180,16 @@ export async function streamTurn(args: {
             case "text": {
               if (!frame.text) break;
               openStep();
-              sawTextThisMessage = true;
+              // assistant-ui addresses text parts by id and rejects a delta
+              // for a part it has not been told about, so each part is opened
+              // before its first delta and closed when the row lands.
+              if (!sawTextThisMessage) {
+                writer.write({
+                  type: "text-start",
+                  id: `turn-${chatId}-${messageIndex}`,
+                });
+                sawTextThisMessage = true;
+              }
               writer.write({
                 type: "text-delta",
                 id: `turn-${chatId}-${messageIndex}`,
@@ -209,7 +218,13 @@ export async function streamTurn(args: {
                   input: call.input,
                 });
               }
-              if (sawTextThisMessage) messageIndex++;
+              if (sawTextThisMessage) {
+                writer.write({
+                  type: "text-end",
+                  id: `turn-${chatId}-${messageIndex}`,
+                });
+                messageIndex++;
+              }
               sawTextThisMessage = false;
               break;
             }
@@ -240,6 +255,10 @@ export async function streamTurn(args: {
       await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
     }
   } finally {
+    if (sawTextThisMessage) {
+      writer.write({ type: "text-end", id: `turn-${chatId}-${messageIndex}` });
+      sawTextThisMessage = false;
+    }
     closeStep();
   }
 }

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -230,11 +230,13 @@ export async function streamTurn(args: {
                 sawTextThisMessage = false;
               }
               const calls = parseFrameToolCalls(frame.tool_calls);
-              // A terminal row carries no tool calls and its text is already
-              // rendered, so it needs no step of its own. Opening one left an
-              // empty step hanging at the end of the turn, which reads as
-              // "still working" — the spinner that outlived the reply.
-              if (calls.length === 0) break;
+              // Every row gets its own step, including the final text-only
+              // one. That is what keeps the turn's last step free of tool
+              // calls: assistant-ui's resume check inspects only the last
+              // step, and if it finds tool calls there it re-sends a turn the
+              // server already finished. Skipping the step for a row with no
+              // tool calls left the tool-calling step last and restarted that
+              // loop.
               if (stepHasMessage) closeStep();
               openStep();
               stepHasMessage = true;

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -72,8 +72,18 @@ export async function streamTurn(args: {
   chatId: string;
   writer: UIMessageStreamWriter<UIMessage>;
   abortSignal?: AbortSignal;
+  /**
+   * The caller's `Gram-Session` token. These routes authenticate from request
+   * headers, not cookies, so without it every subscription 401s.
+   */
+  sessionToken?: string;
+  /**
+   * Project slug. The routes resolve the caller's project from `Gram-Project`
+   * and reject with "empty project slug" before the session is considered.
+   */
+  projectSlug: string;
 }): Promise<void> {
-  const { chatId, writer, abortSignal } = args;
+  const { chatId, writer, abortSignal, sessionToken, projectSlug } = args;
 
   let cursor = "";
   let reconnects = 0;
@@ -115,7 +125,11 @@ export async function streamTurn(args: {
         response = await fetch(url, {
           credentials: "include",
           signal: abortSignal,
-          headers: { accept: "text/event-stream" },
+          headers: {
+            accept: "text/event-stream",
+            "Gram-Project": projectSlug,
+            ...(sessionToken ? { "Gram-Session": sessionToken } : {}),
+          },
         });
       } catch (err) {
         if (abortSignal?.aborted) throw err;

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -1,0 +1,220 @@
+import { getServerURL } from "@/lib/utils";
+import type { UIMessage, UIMessageStreamWriter } from "ai";
+
+/**
+ * Consumes a chat's turn frames and renders them.
+ *
+ * This replaces polling `chat.load` for the duration of a turn. The server
+ * publishes a frame for everything the dashboard needs — text as it is
+ * generated, each persisted assistant row with its tool calls, each tool
+ * result, and a terminal frame — so nothing has to be discovered by asking
+ * again.
+ *
+ * Losslessness comes from the cursor. Every frame carries one, and a
+ * reconnect resumes with the last cursor applied, so the server replays what
+ * was missed before sending anything new. Without that, dropping the poll
+ * would mean a dropped connection loses a turn.
+ */
+
+const RECONNECT_DELAY_MS = 400;
+const MAX_RECONNECTS = 5;
+
+interface TurnFrame {
+  kind: "text" | "message" | "tool_output" | "done";
+  cursor?: string;
+  text?: string;
+  message_id?: string;
+  tool_calls?: unknown;
+  finish_reason?: string;
+  tool_call_id?: string;
+  output?: unknown;
+}
+
+interface ParsedToolCall {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+function parseFrameToolCalls(raw: unknown): ParsedToolCall[] {
+  if (!Array.isArray(raw)) return [];
+  const calls: ParsedToolCall[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const call = entry as {
+      id?: string;
+      function?: { name?: string; arguments?: string };
+    };
+    if (!call.id || !call.function?.name) continue;
+    let input: unknown = {};
+    try {
+      input = call.function.arguments
+        ? JSON.parse(call.function.arguments)
+        : {};
+    } catch {
+      // A tool call whose arguments are still malformed is worth surfacing
+      // with an empty input rather than dropping: the user sees the call.
+      input = {};
+    }
+    calls.push({ id: call.id, name: call.function.name, input });
+  }
+  return calls;
+}
+
+/**
+ * Streams one turn to the writer, returning when the turn is terminal.
+ *
+ * Reconnects transparently on a dropped connection, resuming from the last
+ * cursor. Throws only when it cannot deliver the turn at all, which the caller
+ * turns into a resync.
+ */
+export async function streamTurn(args: {
+  chatId: string;
+  writer: UIMessageStreamWriter<UIMessage>;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { chatId, writer, abortSignal } = args;
+
+  let cursor = "";
+  let reconnects = 0;
+  // Each persisted assistant row opens its own step, so the turn's final,
+  // text-only row lands in a step with no tool calls — assistant-ui's resume
+  // check inspects the last step, and a step carrying resolved tool calls
+  // makes it re-send a turn the server already finished.
+  let stepOpen = false;
+  // Text arrives before the row that will contain it, so the part id is per
+  // message index rather than per row id.
+  let messageIndex = 0;
+  let sawTextThisMessage = false;
+
+  const closeStep = () => {
+    if (stepOpen) {
+      writer.write({ type: "finish-step" });
+      stepOpen = false;
+    }
+  };
+  const openStep = () => {
+    if (!stepOpen) {
+      writer.write({ type: "start-step" });
+      stepOpen = true;
+    }
+  };
+
+  try {
+    for (;;) {
+      if (abortSignal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
+      const url = new URL(`${getServerURL()}/chat/turnstream`);
+      url.searchParams.set("chat_id", chatId);
+      if (cursor) url.searchParams.set("after", cursor);
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          credentials: "include",
+          signal: abortSignal,
+          headers: { accept: "text/event-stream" },
+        });
+      } catch (err) {
+        if (abortSignal?.aborted) throw err;
+        if (++reconnects > MAX_RECONNECTS) throw err;
+        await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
+        continue;
+      }
+      if (!response.ok || !response.body) {
+        if (++reconnects > MAX_RECONNECTS) {
+          throw new Error(`turn stream failed: ${response.status}`);
+        }
+        await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
+        continue;
+      }
+      reconnects = 0;
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let done = false;
+
+      while (!done) {
+        const { done: finished, value } = await reader.read();
+        if (finished) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // Frames are separated by a blank line; a trailing partial frame stays
+        // buffered until the rest of it arrives.
+        const chunks = buffer.split("\n\n");
+        buffer = chunks.pop() ?? "";
+
+        for (const chunk of chunks) {
+          const line = chunk.split("\n").find((l) => l.startsWith("data: "));
+          if (!line) continue;
+          let frame: TurnFrame;
+          try {
+            frame = JSON.parse(line.slice("data: ".length)) as TurnFrame;
+          } catch {
+            continue;
+          }
+          if (frame.cursor) cursor = frame.cursor;
+
+          switch (frame.kind) {
+            case "text": {
+              if (!frame.text) break;
+              openStep();
+              sawTextThisMessage = true;
+              writer.write({
+                type: "text-delta",
+                id: `turn-${chatId}-${messageIndex}`,
+                delta: frame.text,
+              });
+              break;
+            }
+            case "message": {
+              // The row for the text just streamed. Its tool calls are the new
+              // information; the text is already rendered, so it is not
+              // re-emitted.
+              openStep();
+              for (const call of parseFrameToolCalls(frame.tool_calls)) {
+                writer.write({
+                  type: "tool-input-available",
+                  toolCallId: call.id,
+                  toolName: call.name,
+                  input: call.input,
+                });
+              }
+              closeStep();
+              if (sawTextThisMessage) messageIndex++;
+              sawTextThisMessage = false;
+              break;
+            }
+            case "tool_output": {
+              if (!frame.tool_call_id) break;
+              writer.write({
+                type: "tool-output-available",
+                toolCallId: frame.tool_call_id,
+                output: frame.output ?? "",
+              });
+              break;
+            }
+            case "done": {
+              done = true;
+              break;
+            }
+          }
+          if (done) break;
+        }
+      }
+
+      if (done) return;
+      // The server closed without a terminal frame — the turn is still
+      // running, so resume from the cursor rather than treating it as over.
+      if (++reconnects > MAX_RECONNECTS) {
+        throw new Error("turn stream ended before the turn finished");
+      }
+      await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
+    }
+  } finally {
+    closeStep();
+  }
+}

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -99,6 +99,10 @@ export async function streamTurn(args: {
   // Whether the open step already carries a row, so the next row knows to
   // close it rather than sharing.
   let stepHasMessage = false;
+  // Tool calls announced but not yet answered. assistant-ui re-sends a turn
+  // whose last step holds an unresolved call, so any still outstanding when
+  // the turn ends are closed out rather than left to trigger that.
+  const pendingToolCalls = new Set<string>();
 
   const closeStep = () => {
     if (stepOpen) {
@@ -241,6 +245,7 @@ export async function streamTurn(args: {
                   toolName: call.name,
                   input: call.input,
                 });
+                pendingToolCalls.add(call.id);
               }
               break;
             }
@@ -251,6 +256,7 @@ export async function streamTurn(args: {
                 toolCallId: frame.tool_call_id,
                 output: frame.output ?? "",
               });
+              pendingToolCalls.delete(frame.tool_call_id);
               break;
             }
             case "done": {
@@ -275,6 +281,16 @@ export async function streamTurn(args: {
       await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS));
     }
   } finally {
+    // A turn that ended without an output for some call would otherwise be
+    // re-sent by assistant-ui's resume check.
+    for (const id of pendingToolCalls) {
+      writer.write({
+        type: "tool-output-available",
+        toolCallId: id,
+        output: "",
+      });
+    }
+    pendingToolCalls.clear();
     if (sawTextThisMessage) {
       writer.write({ type: "text-end", id: `turn-${chatId}-${messageIndex}` });
       sawTextThisMessage = false;

--- a/client/dashboard/src/lib/turnStream.ts
+++ b/client/dashboard/src/lib/turnStream.ts
@@ -82,6 +82,26 @@ export async function streamTurn(args: {
    * and reject with "empty project slug" before the session is considered.
    */
   projectSlug: string;
+  /**
+   * Tool calls surfaced but not yet answered, owned by the caller so the state
+   * survives a failed stream. If this throws, whatever remains in here is a
+   * call the poll fallback still has to resolve from the persisted tool row.
+   */
+  pendingToolCalls?: Set<string>;
+  /**
+   * Called once the subscription is live on the server. The handler flushes
+   * the SSE headers immediately after subscribing, so a resolved response
+   * proves no frame published from here on can be missed — which is what lets
+   * the caller send the message only after the stream is listening.
+   */
+  onSubscribed?: () => void;
+  /**
+   * Replay the chat's retained frames instead of starting from now. Correct
+   * only for a chat created by this turn, where the retained history IS this
+   * turn; on an existing chat it would replay a previous turn's terminal frame
+   * and end this one before it began.
+   */
+  replayFromStart?: boolean;
 }): Promise<void> {
   const { chatId, writer, abortSignal, sessionToken, projectSlug } = args;
 
@@ -107,8 +127,19 @@ export async function streamTurn(args: {
   let stepHasMessage = false;
   // Tool calls announced but not yet answered. assistant-ui re-sends a turn
   // whose last step holds an unresolved call, so any still outstanding when
-  // the turn ends are closed out rather than left to trigger that.
-  const pendingToolCalls = new Set<string>();
+  // the turn ends cleanly are closed out rather than left to trigger that.
+  //
+  // The caller owns the set so a failed stream can hand its unresolved calls to
+  // the poll fallback, which resolves them from the persisted tool rows. Those
+  // ids are `chat_messages.tool_call_id`, the same ids the poll matches on.
+  const pendingToolCalls = args.pendingToolCalls ?? new Set<string>();
+  // Whether the turn reached its terminal frame. Only then is fabricating an
+  // empty output for an unanswered call safe: on a failure the call may still
+  // be running, and inventing a result both shows the user something that did
+  // not happen and can be sent back to the model as if it had.
+  let completed = false;
+  // Whether the caller has been told the subscription is live.
+  let subscribed = false;
 
   const closeStep = () => {
     if (stepOpen) {
@@ -132,7 +163,11 @@ export async function streamTurn(args: {
 
       const url = new URL(`${getServerURL()}/chat/turnstream`);
       url.searchParams.set("chat_id", chatId);
-      if (cursor) url.searchParams.set("after", cursor);
+      if (cursor) {
+        url.searchParams.set("after", cursor);
+      } else if (args.replayFromStart) {
+        url.searchParams.set("after", "0");
+      }
 
       let response: Response;
       try {
@@ -163,6 +198,12 @@ export async function streamTurn(args: {
         continue;
       }
       reconnects = 0;
+      // Only after the first successful connection: a reconnect is resuming a
+      // subscription the caller already acted on.
+      if (!subscribed) {
+        subscribed = true;
+        args.onSubscribed?.();
+      }
 
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
@@ -177,8 +218,20 @@ export async function streamTurn(args: {
         void reader.cancel().catch(() => {});
       };
 
+      // Set when the connection fails mid-stream. A rejected read is a dropped
+      // connection, which is exactly what the reconnect loop below exists for
+      // — letting it propagate skipped straight past it to the poll fallback.
+      let dropped = false;
       while (!done) {
-        const { done: finished, value } = await reader.read();
+        let finished: boolean;
+        let value: Uint8Array | undefined;
+        try {
+          ({ done: finished, value } = await reader.read());
+        } catch (err) {
+          if (abortSignal?.aborted) throw err;
+          dropped = true;
+          break;
+        }
         if (finished) break;
         buffer += decoder.decode(value, { stream: true });
 
@@ -288,14 +341,20 @@ export async function streamTurn(args: {
       }
 
       if (done) {
+        completed = true;
         release();
         return;
       }
       release();
-      // The server closed without a terminal frame — the turn is still
-      // running, so resume from the cursor rather than treating it as over.
+      // The connection ended without a terminal frame — dropped, or closed by
+      // the server while the turn is still running. Either way resume from the
+      // cursor rather than treating the turn as over.
       if (++reconnects > MAX_RECONNECTS) {
-        throw new Error("turn stream ended before the turn finished");
+        throw new Error(
+          dropped
+            ? "turn stream connection dropped"
+            : "turn stream ended before the turn finished",
+        );
       }
       await new Promise((r) => {
         setTimeout(r, RECONNECT_DELAY_MS);
@@ -303,15 +362,21 @@ export async function streamTurn(args: {
     }
   } finally {
     // A turn that ended without an output for some call would otherwise be
-    // re-sent by assistant-ui's resume check.
-    for (const id of pendingToolCalls) {
-      writer.write({
-        type: "tool-output-available",
-        toolCallId: id,
-        output: "",
-      });
+    // re-sent by assistant-ui's resume check. Only do this once the turn is
+    // known to have ended: on a failed stream the call may still be running,
+    // and an invented empty result is both shown to the user and sent back to
+    // the model as though the tool had returned it. Those calls stay in the
+    // set instead, for the caller's resync to resolve from the tool rows.
+    if (completed) {
+      for (const id of pendingToolCalls) {
+        writer.write({
+          type: "tool-output-available",
+          toolCallId: id,
+          output: "",
+        });
+      }
+      pendingToolCalls.clear();
     }
-    pendingToolCalls.clear();
     if (sawTextThisMessage) {
       writer.write({ type: "text-end", id: `turn-${chatId}-${messageIndex}` });
       sawTextThisMessage = false;

--- a/docs/superpowers/plans/2026-07-31-assistant-turn-streaming.md
+++ b/docs/superpowers/plans/2026-07-31-assistant-turn-streaming.md
@@ -1,0 +1,76 @@
+# Stream the whole assistant turn from the write path
+
+Status: designed, not built. Supersedes the text-only hybrid currently on
+`chore/project-assistant-perf`.
+
+## Why
+
+The dashboard renders nothing until a whole assistant message is persisted,
+then animates text it already holds, because there is no stream — the
+transport polls `chat.load` on a 150ms→1.5s backoff. Perceived latency is
+therefore the full generation, not time-to-first-token.
+
+The hybrid already committed tees text deltas off the completions proxy and
+publishes them over Redis. It works, but it only carries _text_: tool calls,
+tool outputs, message ids and the turn-terminal signal still come from the
+poll, so both mechanisms run at once. The completions proxy cannot do better —
+it sees one model call, while a turn may be several completions with tool
+calls between them, and "the turn is done" is a property of the persisted
+rows, not of any single completion.
+
+## Design
+
+Publish from the **write path** instead of the proxy. `chatWriter` is already
+the single place turn rows are persisted (`assistantsCore.SetChatMessageWriter`
+in `server/cmd/gram/start.go`), which makes it the natural emit point.
+
+Every persisted row emits a frame on the chat's channel:
+
+| Frame         | Emitted when                              | Carries                       |
+| ------------- | ----------------------------------------- | ----------------------------- |
+| `text-delta`  | model produces text (proxy tee, as today) | text                          |
+| `message`     | assistant row persisted                   | id, tool_calls, finish_reason |
+| `tool-output` | tool row persisted                        | tool_call_id, output          |
+| `done`        | turn reaches terminal state               | —                             |
+
+The client opens one SSE connection per turn and stops polling.
+
+### Sequence numbers and replay
+
+Dropping the poll removes the safety net, so a dropped connection must not lose
+a turn. Every frame carries a monotonic `seq` scoped to the chat. The client
+tracks the last `seq` it applied and reconnects with `?after=<seq>`; the server
+replays from there.
+
+Redis pub/sub alone cannot replay — it is fire-and-forget. Use a capped Redis
+stream (`XADD`/`XRANGE`, `MAXLEN ~ 1000`) keyed per chat, which gives ordering,
+replay from an offset, and bounded memory. Frames are ephemeral: the persisted
+rows remain the durable record, and a client with no usable offset falls back
+to a single `chat.load` to resync.
+
+## Steps
+
+1. Redis stream broker: `Publish(chatID, frame) -> seq`, `Replay(chatID, after)`,
+   `Subscribe(chatID, after)`. Replaces the pub/sub broker in
+   `server/internal/chat/deltastream.go`; keep `teeCompletionStream`, which is
+   tested and unchanged.
+2. Emit `message` / `tool-output` / `done` frames from `chatWriter` as rows are
+   persisted. This is the substantive change — everything else is plumbing.
+3. `GET /chat/deltas` accepts `after=<seq>` and replays before tailing. Auth is
+   per-handler via `directAuthorize` (these raw routes get no auth middleware —
+   this cost a debugging cycle).
+4. Client: subscribe once per turn, apply frames in `seq` order, reconnect with
+   the last applied `seq`. Delete `pollForReplies` and the fake-stream emulation
+   (`writeStreamedText`, `STREAM_*`). Keep one `chat.load` for initial history
+   and as the resync path.
+5. Tests: replay-after-offset, out-of-order/duplicate frames, reconnect
+   mid-turn, and a turn with tool calls arriving across several frames.
+
+## Gotchas paid for already
+
+- `/chat/deltas` must be in `chatSessionsAllowedRoutes`
+  (`server/internal/middleware/chat_session_cors.go`) or browsers get 401.
+- The client must use `getServerURL()`; dashboard and API are different
+  origins, so a relative URL silently hits the dashboard.
+- The chat package's `TestMain` boots containers, so even pure unit tests need
+  working local infra.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -728,7 +728,12 @@ func newStartCommand() *cli.Command {
 				hooksCache = hooks.NewLocalSessionCache(hooksCache, db)
 			}
 
+			// Turn frames are published from the writer, the one place every
+			// row of a turn is persisted, so dashboard subscribers can render
+			// a turn without polling for it.
+			turnStream := chat.NewTurnStream(redisClient)
 			chatWriter, chatWriterShutdown := chat.NewChatMessageWriter(logger, db, assetStorage)
+			chatWriter = chatWriter.WithTurnStream(turnStream)
 			shutdownFuncs = append(shutdownFuncs, chatWriterShutdown)
 
 			captureStrategy := chat.NewChatMessageCaptureStrategy(logger, meterProvider, db, chatWriter)
@@ -917,7 +922,7 @@ func newStartCommand() *cli.Command {
 			)
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
 			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo, auditLogger).
-				WithTurnStream(chat.NewTurnStream(redisClient))
+				WithTurnStream(turnStream)
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, meterProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver, auditLogger)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -916,7 +916,8 @@ func newStartCommand() *cli.Command {
 				mcpclient.NewInternalMCPClient(mcpService),
 			)
 			contextWindowResolver := openrouter.NewContextWindowResolver(logger, guardianPolicy, cache.NewRedisCacheAdapter(redisClient))
-			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo, auditLogger)
+			chatService := chat.NewService(logger, tracerProvider, db, sessionManager, chatSessionsManager, openRouter, chatClient, contextWindowResolver, posthogClient, telemSvc, assetStorage, authzEngine, assistantTokenManager, billingRepo, auditLogger).
+				WithTurnStream(chat.NewTurnStream(redisClient))
 			assistantsCore := assistants.NewServiceCore(logger, tracerProvider, meterProvider, db, guardianPolicy, encryptionClient, assistantRuntime, slackClient, assistantTokenManager, serverURL, telemLogger, contextWindowResolver, auditLogger)
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -121,16 +121,15 @@ const (
 	// from user.email — the authenticated actor — so adopting cached
 	// attribution never rewrites the canonical user identity; it has no
 	// materialized column yet.
-	ProviderKey              = attribute.Key("gram.provider")
-	ExternalOrgIDKey         = attribute.Key("gram.external_org_id")
-	AccountTypeKey           = attribute.Key("gram.account_type")
-	BillingModeKey           = attribute.Key("gram.billing_mode")
-	DeviceIDKey              = attribute.Key("gram.device_id")
-	AccountEmailKey          = attribute.Key("gram.account_email")
-	ChatIDKey                = attribute.Key("gram.chat.id")
-	ChatContentPartIDKey     = attribute.Key("gram.chat.content_part_id")
-	ChatTurnFramesDroppedKey = attribute.Key("gram.chat.turn_frames_dropped")
-	MessageIDKey             = attribute.Key("gram.message.id")
+	ProviderKey          = attribute.Key("gram.provider")
+	ExternalOrgIDKey     = attribute.Key("gram.external_org_id")
+	AccountTypeKey       = attribute.Key("gram.account_type")
+	BillingModeKey       = attribute.Key("gram.billing_mode")
+	DeviceIDKey          = attribute.Key("gram.device_id")
+	AccountEmailKey      = attribute.Key("gram.account_email")
+	ChatIDKey            = attribute.Key("gram.chat.id")
+	ChatContentPartIDKey = attribute.Key("gram.chat.content_part_id")
+	MessageIDKey         = attribute.Key("gram.message.id")
 	// Chat-analysis score event attributes: stamped on the synthetic
 	// chat_analysis:work_units:score telemetry rows the chat analysis
 	// publisher emits once per scored session, and read back by
@@ -831,11 +830,6 @@ func SlogAssetURL(v string) slog.Attr      { return slog.String(string(AssetURLK
 
 func ChatID(v string) attribute.KeyValue { return ChatIDKey.String(v) }
 func SlogChatID(v string) slog.Attr      { return slog.String(string(ChatIDKey), v) }
-
-func ChatTurnFramesDropped(v int64) attribute.KeyValue { return ChatTurnFramesDroppedKey.Int64(v) }
-func SlogChatTurnFramesDropped(v int64) slog.Attr {
-	return slog.Int64(string(ChatTurnFramesDroppedKey), v)
-}
 
 func ChatContentPartID(v string) attribute.KeyValue { return ChatContentPartIDKey.String(v) }
 func SlogChatContentPartID(v string) slog.Attr {

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -121,15 +121,16 @@ const (
 	// from user.email — the authenticated actor — so adopting cached
 	// attribution never rewrites the canonical user identity; it has no
 	// materialized column yet.
-	ProviderKey          = attribute.Key("gram.provider")
-	ExternalOrgIDKey     = attribute.Key("gram.external_org_id")
-	AccountTypeKey       = attribute.Key("gram.account_type")
-	BillingModeKey       = attribute.Key("gram.billing_mode")
-	DeviceIDKey          = attribute.Key("gram.device_id")
-	AccountEmailKey      = attribute.Key("gram.account_email")
-	ChatIDKey            = attribute.Key("gram.chat.id")
-	ChatContentPartIDKey = attribute.Key("gram.chat.content_part_id")
-	MessageIDKey         = attribute.Key("gram.message.id")
+	ProviderKey              = attribute.Key("gram.provider")
+	ExternalOrgIDKey         = attribute.Key("gram.external_org_id")
+	AccountTypeKey           = attribute.Key("gram.account_type")
+	BillingModeKey           = attribute.Key("gram.billing_mode")
+	DeviceIDKey              = attribute.Key("gram.device_id")
+	AccountEmailKey          = attribute.Key("gram.account_email")
+	ChatIDKey                = attribute.Key("gram.chat.id")
+	ChatContentPartIDKey     = attribute.Key("gram.chat.content_part_id")
+	ChatTurnFramesDroppedKey = attribute.Key("gram.chat.turn_frames_dropped")
+	MessageIDKey             = attribute.Key("gram.message.id")
 	// Chat-analysis score event attributes: stamped on the synthetic
 	// chat_analysis:work_units:score telemetry rows the chat analysis
 	// publisher emits once per scored session, and read back by
@@ -830,6 +831,11 @@ func SlogAssetURL(v string) slog.Attr      { return slog.String(string(AssetURLK
 
 func ChatID(v string) attribute.KeyValue { return ChatIDKey.String(v) }
 func SlogChatID(v string) slog.Attr      { return slog.String(string(ChatIDKey), v) }
+
+func ChatTurnFramesDropped(v int64) attribute.KeyValue { return ChatTurnFramesDroppedKey.Int64(v) }
+func SlogChatTurnFramesDropped(v int64) slog.Attr {
+	return slog.Int64(string(ChatTurnFramesDroppedKey), v)
+}
 
 func ChatContentPartID(v string) attribute.KeyValue { return ChatContentPartIDKey.String(v) }
 func SlogChatContentPartID(v string) slog.Attr {

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -690,9 +690,16 @@ func (s *Service) chatVisibilityScope(ctx context.Context, authCtx *contextvalue
 // belonged to the caller's project, which let an embedded chat-session token
 // watch any other user's chat in that project.
 //
-// The caller has already established that the chat belongs to authCtx's
-// project; this covers who within the project may read it.
+// Project scoping lives here rather than at the call sites so it cannot be
+// dropped by one of them: GetChat looks up by id alone, so without this a chat
+// in another org is readable by anyone who knows its id.
 func (s *Service) authorizeChatRead(ctx context.Context, authCtx *contextvalues.AuthContext, chat repo.GetChatRow) error {
+	// older chat_messages may not have project_id in the model, but it will
+	// always exist on the chat
+	if chat.ProjectID != *authCtx.ProjectID {
+		return oops.C(oops.CodeUnauthorized)
+	}
+
 	// External-user and chat-session-token callers must match the chat owner.
 	// First-party project credentials read any session in their project: the
 	// dashboard session, the managed-assistant runtime, and a direct API key,

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -79,6 +79,16 @@ type Service struct {
 	telemetryService *telemetry.Service
 	billingRepo      billing.Repository
 	audit            *audit.Logger
+	// turnStream carries assistant turn frames to dashboard subscribers. Nil
+	// disables streaming — turns still complete and the dashboard falls back
+	// to loading the reply once it lands.
+	turnStream *TurnStream
+}
+
+// WithTurnStream enables streaming assistant turn frames to subscribers.
+func (s *Service) WithTurnStream(stream *TurnStream) *Service {
+	s.turnStream = stream
+	return s
 }
 
 func NewService(
@@ -118,6 +128,7 @@ func NewService(
 		telemetryService: telemetryService,
 		billingRepo:      billingRepo,
 		audit:            auditLogger,
+		turnStream:       nil, // opt in via WithTurnStream
 	}
 }
 
@@ -130,6 +141,7 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	srv.Mount(mux, server)
 
 	o11y.AttachHandler(mux, "POST", "/chat/completions", oops.ErrHandle(service.logger, service.HandleCompletion).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", "/chat/turnstream", oops.ErrHandle(service.logger, service.HandleTurnStream).ServeHTTP)
 }
 
 func (s *Service) APIKeyAuth(ctx context.Context, key string, schema *security.APIKeyScheme) (context.Context, error) {

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1527,9 +1527,24 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 	/**
 	 * Non-Streaming
 	 */
-	response, err := s.completionClient.GetCompletion(ctx, completionReq)
-	if err != nil {
-		return s.classifyCompletionError(ctx, "completion failed", err)
+	// A watchable chat has its tokens streamed upstream and republished as
+	// they pass, so the dashboard can render text while it is still being
+	// generated; this caller still gets back the assembled JSON it asked for.
+	// With no chat to attribute frames to, or no stream to publish on, this is
+	// an ordinary completion.
+	var response *openrouter.CompletionResponse
+	if s.turnStream != nil && chatID != uuid.Nil {
+		teed, teeErr := s.teedCompletion(ctx, completionReq, chatID)
+		if teeErr != nil {
+			return teeErr
+		}
+		response = teed
+	} else {
+		plain, callErr := s.completionClient.GetCompletion(ctx, completionReq)
+		if callErr != nil {
+			return s.classifyCompletionError(ctx, "completion failed", callErr)
+		}
+		response = plain
 	}
 
 	var gramMetadata *openrouter.GramMetadata

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1512,7 +1512,17 @@ func (s *Service) HandleCompletion(w http.ResponseWriter, r *http.Request) error
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		if err := s.streamCompletion(ctx, w, streamBody, getContextWindow); err != nil {
+		// A watchable chat also gets its tokens republished as turn frames on
+		// the way past, so the dashboard renders text as it is generated. The
+		// bytes still reach this caller untouched; the tee is a side channel.
+		src := io.Reader(streamBody)
+		if s.turnStream != nil && chatID != uuid.Nil {
+			teed, done := s.teeStreamText(ctx, chatID)
+			src = io.TeeReader(streamBody, teed)
+			defer done()
+		}
+
+		if err := s.streamCompletion(ctx, w, src, getContextWindow); err != nil {
 			return err
 		}
 

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -682,6 +682,55 @@ func (s *Service) chatVisibilityScope(ctx context.Context, authCtx *contextvalue
 	}
 }
 
+// authorizeChatRead decides whether the caller may read a chat's content.
+//
+// It is shared by every path that hands a transcript to a caller — LoadChat
+// and the turn stream — because they expose the same data and so must answer
+// this the same way. The turn stream originally checked only that the chat
+// belonged to the caller's project, which let an embedded chat-session token
+// watch any other user's chat in that project.
+//
+// The caller has already established that the chat belongs to authCtx's
+// project; this covers who within the project may read it.
+func (s *Service) authorizeChatRead(ctx context.Context, authCtx *contextvalues.AuthContext, chat repo.GetChatRow) error {
+	// External-user and chat-session-token callers must match the chat owner.
+	// First-party project credentials read any session in their project: the
+	// dashboard session, the managed-assistant runtime, and a direct API key,
+	// which the RBAC engine already treats as self-scoped (see
+	// authz.Engine.ShouldEnforce).
+	//
+	// A chat-session token minted via an API key restores that key's APIKeyID
+	// (chatsessions.Manager.Authorize), so APIKeyID alone does not prove the
+	// caller authenticated *as* the key — treating it as first-party would let
+	// an end user's chat-session token read every project chat. Only direct
+	// Gram-Key auth carries the key's scopes (auth.KeyBasedAuth); a chat-session
+	// token has none, so gate the exemption on the scopes being present.
+	_, isAssistantCall := contextvalues.GetAssistantPrincipal(ctx)
+	isDirectAPIKeyCall := authCtx.APIKeyID != "" && len(authCtx.APIKeyScopes) > 0
+	if authCtx.SessionID == nil && !isDirectAPIKeyCall {
+		if !isAssistantCall {
+			if chat.ExternalUserID.String != "" && chat.ExternalUserID.String != authCtx.ExternalUserID {
+				return oops.C(oops.CodeUnauthorized)
+			}
+		}
+	}
+
+	// Gate dashboard access on chat:read. The check is a no-op unless RBAC is
+	// enforced for the org (feature flag + session). Members can
+	// always read sessions they own, so bypass the scope check for the owner;
+	// reading anyone else's session requires an unrestricted chat:read grant,
+	// which only admins hold. The managed-assistant runtime is exempt — it
+	// consumes transcripts programmatically, not as a reviewer.
+	isOwner := authCtx.UserID != "" && chat.UserID.Valid && chat.UserID.String == authCtx.UserID
+	if !isAssistantCall && !isOwner {
+		if err := s.authz.Require(ctx, authz.ChatReadCheck(chat.ID.String())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*gen.Chat, error) {
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
@@ -708,44 +757,8 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to load chat").LogError(ctx, s.logger)
 	}
 
-	// older chat_messages may not have project_id in the model, but it will always exist on the chat
-	if chat.ProjectID != *authCtx.ProjectID {
-		return nil, oops.C(oops.CodeUnauthorized)
-	}
-
-	// External-user and chat-session-token callers must match the chat owner.
-	// First-party project credentials read any session in their project: the
-	// dashboard session, the managed-assistant runtime, and a direct API key,
-	// which the RBAC engine already treats as self-scoped (see
-	// authz.Engine.ShouldEnforce).
-	//
-	// A chat-session token minted via an API key restores that key's APIKeyID
-	// (chatsessions.Manager.Authorize), so APIKeyID alone does not prove the
-	// caller authenticated *as* the key — treating it as first-party would let
-	// an end user's chat-session token read every project chat. Only direct
-	// Gram-Key auth carries the key's scopes (auth.KeyBasedAuth); a chat-session
-	// token has none, so gate the exemption on the scopes being present.
-	_, isAssistantCall := contextvalues.GetAssistantPrincipal(ctx)
-	isDirectAPIKeyCall := authCtx.APIKeyID != "" && len(authCtx.APIKeyScopes) > 0
-	if authCtx.SessionID == nil && !isDirectAPIKeyCall {
-		if !isAssistantCall {
-			if chat.ExternalUserID.String != "" && chat.ExternalUserID.String != authCtx.ExternalUserID {
-				return nil, oops.C(oops.CodeUnauthorized)
-			}
-		}
-	}
-
-	// Gate dashboard access on chat:read. The check is a no-op unless RBAC is
-	// enforced for the org (feature flag + session). Members can
-	// always read sessions they own, so bypass the scope check for the owner;
-	// reading anyone else's session requires an unrestricted chat:read grant,
-	// which only admins hold. The managed-assistant runtime is exempt — it
-	// consumes transcripts programmatically, not as a reviewer.
-	isOwner := authCtx.UserID != "" && chat.UserID.Valid && chat.UserID.String == authCtx.UserID
-	if !isAssistantCall && !isOwner {
-		if err := s.authz.Require(ctx, authz.ChatReadCheck(chat.ID.String())); err != nil {
-			return nil, err
-		}
+	if err := s.authorizeChatRead(ctx, authCtx, chat); err != nil {
+		return nil, err
 	}
 
 	// Record dashboard session-opens in the audit log. Scroll pagination

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -47,6 +47,7 @@ func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool, assetStorage as
 		observers:    nil,
 		shutdownCtx:  ctx,
 		cancel:       cancel,
+		turnStream:   nil,
 	}
 	shutdown = func(_ context.Context) error {
 		cancel()

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -172,6 +172,7 @@ func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, para
 		return 0, err
 	}
 	if n > 0 {
+		w.publishTurnFrames(ctx, nil, params)
 		w.notifyMessagesStored(ctx, projectID)
 	}
 	return n, nil
@@ -259,6 +260,7 @@ func (w *ChatMessageWriter) WriteWithAssets(ctx context.Context, projectID uuid.
 	if err := w.storeMessages(ctx, w.db, rows); err != nil {
 		return err
 	}
+	w.publishRowFrames(ctx, rows)
 	w.notifyMessagesStored(ctx, projectID)
 	return nil
 }

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -31,8 +31,11 @@ type ChatMessageWriter struct {
 	logger       *slog.Logger
 	assetStorage assets.BlobStore
 	observers    []MessageObserver
-	shutdownCtx  context.Context //nolint:containedctx // must outlive any single request
-	cancel       context.CancelFunc
+	// turnStream, when set, receives a frame per persisted row so dashboard
+	// subscribers can render a turn without polling. Nil disables publishing.
+	turnStream  *TurnStream
+	shutdownCtx context.Context //nolint:containedctx // must outlive any single request
+	cancel      context.CancelFunc
 }
 
 func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool, assetStorage assets.BlobStore) (w *ChatMessageWriter, shutdown func(context.Context) error) {
@@ -50,6 +53,12 @@ func NewChatMessageWriter(logger *slog.Logger, db *pgxpool.Pool, assetStorage as
 		return nil
 	}
 	return w, shutdown
+}
+
+// WithTurnStream enables per-row turn frame publishing.
+func (w *ChatMessageWriter) WithTurnStream(stream *TurnStream) *ChatMessageWriter {
+	w.turnStream = stream
+	return w
 }
 
 func (w *ChatMessageWriter) AddObserver(obs MessageObserver) {
@@ -231,6 +240,9 @@ func (w *ChatMessageWriter) WriteTurn(ctx context.Context, projectID uuid.UUID, 
 	}
 
 	if int64(len(pending))+n > 0 {
+		// After commit: a frame announces a row that exists, so a rolled-back
+		// turn never announces itself.
+		w.publishTurnFrames(ctx, pending, assistants)
 		w.notifyMessagesStored(ctx, projectID)
 	}
 	return nil

--- a/server/internal/chat/turnstream.go
+++ b/server/internal/chat/turnstream.go
@@ -113,6 +113,17 @@ func (t *TurnStream) Publish(ctx context.Context, chatID uuid.UUID, frame TurnFr
 		MaxLen: turnStreamMaxLen,
 		Approx: true,
 		Values: map[string]any{"f": payload},
+		// Redis assigns the id, the stream is created on first append, and the
+		// remaining knobs (MinID/Limit/Mode, producer-side idempotency) have no
+		// bearing on an append-only frame log.
+		NoMkStream:     false,
+		MinID:          "",
+		Limit:          0,
+		Mode:           "",
+		ID:             "",
+		ProducerID:     "",
+		IdempotentID:   "",
+		IdempotentAuto: false,
 	}).Result()
 	if err != nil {
 		return "", fmt.Errorf("append turn frame: %w", err)
@@ -201,6 +212,8 @@ func (t *TurnStream) Subscribe(ctx context.Context, chatID uuid.UUID, after stri
 				Streams: []string{turnStreamKey(chatID), cursor},
 				Block:   turnStreamBlock,
 				Count:   256,
+				// The cursor is carried in Streams above.
+				ID: "",
 			}).Result()
 			if err != nil {
 				if errors.Is(err, redis.Nil) {

--- a/server/internal/chat/turnstream.go
+++ b/server/internal/chat/turnstream.go
@@ -139,6 +139,22 @@ func (t *TurnStream) Publish(ctx context.Context, chatID uuid.UUID, frame TurnFr
 // Replay returns frames already published after the given cursor. An empty
 // cursor replays the chat's whole retained history, which is what a client
 // joining a turn late (or reconnecting without a cursor) wants.
+// lastID returns the id of the most recent frame retained for a chat, or the
+// zero id when nothing is retained yet. Reading from it is exclusive, so it
+// means "everything published from now on" without the race "$" carries.
+func (t *TurnStream) lastID(ctx context.Context, chatID uuid.UUID) (string, error) {
+	entries, err := t.client.XRevRangeN(ctx, turnStreamKey(chatID), "+", "-", 1).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return "", fmt.Errorf("read last turn frame id: %w", err)
+	}
+	if len(entries) == 0 {
+		// An empty stream has no last id; "0-0" is exclusive of nothing, so
+		// every frame the turn publishes still arrives.
+		return "0-0", nil
+	}
+	return entries[0].ID, nil
+}
+
 func (t *TurnStream) Replay(ctx context.Context, chatID uuid.UUID, after string) ([]TurnFrame, error) {
 	if t == nil {
 		return nil, errors.New("turn stream is not configured")
@@ -170,7 +186,20 @@ func (t *TurnStream) Subscribe(ctx context.Context, chatID uuid.UUID, after stri
 	// before it began. Replay exists for reconnects, and a reconnecting client
 	// always carries the cursor it got to.
 	var backlog []TurnFrame
-	if after != "" {
+	start := after
+	if after == "" {
+		// Resolve the starting position HERE, not in the goroutine below.
+		// Redis resolves "$" when XREAD runs, so a frame published between
+		// this call returning and that first read falls in the gap and is lost
+		// — the caller believes it is subscribed while the turn streams past
+		// it. Pinning a concrete id makes "from now" mean "from the moment
+		// Subscribe returned".
+		last, err := t.lastID(ctx, chatID)
+		if err != nil {
+			return nil, err
+		}
+		start = last
+	} else {
 		replayed, err := t.Replay(ctx, chatID, after)
 		if err != nil {
 			return nil, err
@@ -182,7 +211,7 @@ func (t *TurnStream) Subscribe(ctx context.Context, chatID uuid.UUID, after stri
 	go func() {
 		defer close(out)
 
-		cursor := after
+		cursor := start
 		emit := func(frame TurnFrame) bool {
 			cursor = frame.Cursor
 			select {
@@ -198,12 +227,6 @@ func (t *TurnStream) Subscribe(ctx context.Context, chatID uuid.UUID, after stri
 				return
 			}
 		}
-		if cursor == "" {
-			// Nothing retained yet: start from now rather than replaying a
-			// history that does not exist.
-			cursor = "$"
-		}
-
 		for {
 			if ctx.Err() != nil {
 				return

--- a/server/internal/chat/turnstream.go
+++ b/server/internal/chat/turnstream.go
@@ -1,0 +1,235 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// Turn frames are the events a dashboard needs to render an assistant turn
+// without polling: the text as it is generated, each assistant row as it is
+// persisted, each tool result, and the turn's end. The client opens one
+// subscription per turn and applies frames in order.
+//
+// A Redis *stream* rather than pub/sub, because dropping the poll removes the
+// safety net: pub/sub is fire-and-forget, so a client that reconnects mid-turn
+// would silently lose whatever it missed. Every frame gets a cursor, and a
+// reconnecting client replays from the last cursor it applied. The stream is
+// capped — frames are ephemeral, the persisted rows stay the durable record,
+// and a client with no usable cursor resyncs with a single chat.load.
+const (
+	// turnStreamMaxLen bounds one chat's frame history. Generous next to a
+	// turn's frame count (a few hundred at most, dominated by text deltas) and
+	// still small enough that an abandoned chat costs little.
+	turnStreamMaxLen = 2000
+	// turnStreamTTL expires a chat's frames once nobody can still be watching.
+	// Turn timeout is 10 minutes; this leaves room for a reconnect after one.
+	turnStreamTTL = 30 * time.Minute
+	// turnStreamBlock is how long a tail read parks waiting for the next
+	// frame before looping, which is also how quickly it notices ctx
+	// cancellation.
+	turnStreamBlock = 20 * time.Second
+)
+
+// TurnFrameKind identifies what a frame carries. The client switches on it.
+type TurnFrameKind string
+
+const (
+	// TurnFrameText is a fragment of assistant text, as generated.
+	TurnFrameText TurnFrameKind = "text"
+	// TurnFrameMessage is a persisted assistant row: its id, any tool calls it
+	// made, and its finish reason.
+	TurnFrameMessage TurnFrameKind = "message"
+	// TurnFrameToolOutput is a persisted tool result, keyed to the call it
+	// answers.
+	TurnFrameToolOutput TurnFrameKind = "tool_output"
+	// TurnFrameDone marks the turn terminal. Nothing follows it.
+	TurnFrameDone TurnFrameKind = "done"
+)
+
+// TurnFrame is one event in a chat's turn stream. Cursor is assigned by the
+// broker on publish and is what a reconnecting client replays from; it is not
+// part of the published payload.
+type TurnFrame struct {
+	Kind TurnFrameKind `json:"kind"`
+	// Cursor positions this frame in the chat's stream. Opaque to the client
+	// beyond "hand it back to resume after this frame".
+	Cursor string `json:"cursor,omitempty"`
+	// Text is set for Kind == TurnFrameText.
+	Text string `json:"text,omitempty"`
+	// MessageID, ToolCalls and FinishReason are set for TurnFrameMessage.
+	// ToolCalls is the raw JSON the row carries, passed through rather than
+	// re-modelled so this stays in step with what chat.load returns.
+	MessageID    string          `json:"message_id,omitempty"`
+	ToolCalls    json.RawMessage `json:"tool_calls,omitempty"`
+	FinishReason string          `json:"finish_reason,omitempty"`
+	// ToolCallID and Output are set for TurnFrameToolOutput.
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+	Output     json.RawMessage `json:"output,omitempty"`
+}
+
+// turnStreamKey is the Redis stream holding one chat's frames.
+func turnStreamKey(chatID uuid.UUID) string {
+	return "chat:turnframes:" + chatID.String()
+}
+
+// TurnStream publishes and replays assistant turn frames.
+type TurnStream struct {
+	client *redis.Client
+}
+
+// NewTurnStream returns a stream over the supplied Redis client. A nil client
+// yields a nil TurnStream whose Publish is a no-op, so a deployment without
+// Redis degrades to a dashboard that shows the reply when it lands rather than
+// failing turns.
+func NewTurnStream(client *redis.Client) *TurnStream {
+	if client == nil {
+		return nil
+	}
+	return &TurnStream{client: client}
+}
+
+// Publish appends a frame and returns its cursor. Callers treat failures as
+// non-fatal: a lost frame costs the watcher some responsiveness, and must
+// never fail the turn that produced it.
+func (t *TurnStream) Publish(ctx context.Context, chatID uuid.UUID, frame TurnFrame) (string, error) {
+	if t == nil || chatID == uuid.Nil {
+		return "", nil
+	}
+	payload, err := json.Marshal(frame)
+	if err != nil {
+		return "", fmt.Errorf("marshal turn frame: %w", err)
+	}
+	key := turnStreamKey(chatID)
+	cursor, err := t.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: key,
+		// Approximate trimming: exact trimming costs a scan on every append
+		// and the bound is a safety valve, not a contract.
+		MaxLen: turnStreamMaxLen,
+		Approx: true,
+		Values: map[string]any{"f": payload},
+	}).Result()
+	if err != nil {
+		return "", fmt.Errorf("append turn frame: %w", err)
+	}
+	// Refreshed per append so an active turn keeps its history alive and an
+	// abandoned chat expires on its own.
+	if err := t.client.Expire(ctx, key, turnStreamTTL).Err(); err != nil {
+		return cursor, fmt.Errorf("refresh turn stream ttl: %w", err)
+	}
+	return cursor, nil
+}
+
+// Replay returns frames already published after the given cursor. An empty
+// cursor replays the chat's whole retained history, which is what a client
+// joining a turn late (or reconnecting without a cursor) wants.
+func (t *TurnStream) Replay(ctx context.Context, chatID uuid.UUID, after string) ([]TurnFrame, error) {
+	if t == nil {
+		return nil, errors.New("turn stream is not configured")
+	}
+	start := "-"
+	if after != "" {
+		// "(" makes the range exclusive, so a client never re-applies the
+		// frame it last saw.
+		start = "(" + after
+	}
+	entries, err := t.client.XRange(ctx, turnStreamKey(chatID), start, "+").Result()
+	if err != nil {
+		return nil, fmt.Errorf("replay turn frames: %w", err)
+	}
+	return decodeTurnEntries(entries), nil
+}
+
+// Subscribe tails a chat's frames after the given cursor until ctx is
+// cancelled or a terminal frame is emitted. It replays first, so a caller that
+// reconnects mid-turn sees everything it missed before anything new — the
+// property pub/sub could not offer.
+func (t *TurnStream) Subscribe(ctx context.Context, chatID uuid.UUID, after string) (<-chan TurnFrame, error) {
+	if t == nil {
+		return nil, errors.New("turn stream is not configured")
+	}
+	backlog, err := t.Replay(ctx, chatID, after)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan TurnFrame, 64)
+	go func() {
+		defer close(out)
+
+		cursor := after
+		emit := func(frame TurnFrame) bool {
+			cursor = frame.Cursor
+			select {
+			case out <- frame:
+				return frame.Kind != TurnFrameDone
+			case <-ctx.Done():
+				return false
+			}
+		}
+
+		for _, frame := range backlog {
+			if !emit(frame) {
+				return
+			}
+		}
+		if cursor == "" {
+			// Nothing retained yet: start from now rather than replaying a
+			// history that does not exist.
+			cursor = "$"
+		}
+
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			streams, err := t.client.XRead(ctx, &redis.XReadArgs{
+				Streams: []string{turnStreamKey(chatID), cursor},
+				Block:   turnStreamBlock,
+				Count:   256,
+			}).Result()
+			if err != nil {
+				if errors.Is(err, redis.Nil) {
+					// Block elapsed with no new frame. Loop so ctx
+					// cancellation is noticed promptly.
+					continue
+				}
+				return
+			}
+			for _, stream := range streams {
+				for _, frame := range decodeTurnEntries(stream.Messages) {
+					if !emit(frame) {
+						return
+					}
+				}
+			}
+		}
+	}()
+
+	return out, nil
+}
+
+// decodeTurnEntries turns Redis stream entries into frames, stamping each with
+// its cursor. Undecodable entries are skipped rather than failing the read: a
+// frame this build cannot parse should not strand a client mid-turn.
+func decodeTurnEntries(entries []redis.XMessage) []TurnFrame {
+	frames := make([]TurnFrame, 0, len(entries))
+	for _, entry := range entries {
+		raw, ok := entry.Values["f"].(string)
+		if !ok {
+			continue
+		}
+		var frame TurnFrame
+		if err := json.Unmarshal([]byte(raw), &frame); err != nil {
+			continue
+		}
+		frame.Cursor = entry.ID
+		frames = append(frames, frame)
+	}
+	return frames
+}

--- a/server/internal/chat/turnstream.go
+++ b/server/internal/chat/turnstream.go
@@ -136,9 +136,6 @@ func (t *TurnStream) Publish(ctx context.Context, chatID uuid.UUID, frame TurnFr
 	return cursor, nil
 }
 
-// Replay returns frames already published after the given cursor. An empty
-// cursor replays the chat's whole retained history, which is what a client
-// joining a turn late (or reconnecting without a cursor) wants.
 // lastID returns the id of the most recent frame retained for a chat, or the
 // zero id when nothing is retained yet. Reading from it is exclusive, so it
 // means "everything published from now on" without the race "$" carries.
@@ -155,6 +152,9 @@ func (t *TurnStream) lastID(ctx context.Context, chatID uuid.UUID) (string, erro
 	return entries[0].ID, nil
 }
 
+// Replay returns frames already published after the given cursor. An empty
+// cursor replays the chat's whole retained history, which is what a client
+// joining a turn late (or reconnecting without a cursor) wants.
 func (t *TurnStream) Replay(ctx context.Context, chatID uuid.UUID, after string) ([]TurnFrame, error) {
 	if t == nil {
 		return nil, errors.New("turn stream is not configured")

--- a/server/internal/chat/turnstream.go
+++ b/server/internal/chat/turnstream.go
@@ -153,9 +153,18 @@ func (t *TurnStream) Subscribe(ctx context.Context, chatID uuid.UUID, after stri
 	if t == nil {
 		return nil, errors.New("turn stream is not configured")
 	}
-	backlog, err := t.Replay(ctx, chatID, after)
-	if err != nil {
-		return nil, err
+	// No cursor means "start from now", not "replay everything". A chat's
+	// retained frames span earlier turns, so replaying from the beginning would
+	// hand a client the previous turn's terminal frame and end the new turn
+	// before it began. Replay exists for reconnects, and a reconnecting client
+	// always carries the cursor it got to.
+	var backlog []TurnFrame
+	if after != "" {
+		replayed, err := t.Replay(ctx, chatID, after)
+		if err != nil {
+			return nil, err
+		}
+		backlog = replayed
 	}
 
 	out := make(chan TurnFrame, 64)

--- a/server/internal/chat/turnstream_frames_test.go
+++ b/server/internal/chat/turnstream_frames_test.go
@@ -1,0 +1,195 @@
+package chat_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/chat"
+)
+
+// The turn stream is what lets the dashboard stop polling, so the properties
+// worth testing are the ones the poll used to provide for free: nothing is
+// lost across a reconnect, and a client never re-applies a frame it has
+// already seen.
+
+func newTurnStream(t *testing.T) *chat.TurnStream {
+	t.Helper()
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+	return chat.NewTurnStream(redisClient)
+}
+
+func textFrame(text string) chat.TurnFrame {
+	return chat.TurnFrame{
+		Kind: chat.TurnFrameText, Cursor: "", Text: text, MessageID: "",
+		ToolCalls: nil, FinishReason: "", ToolCallID: "", Output: nil,
+	}
+}
+
+func doneFrame() chat.TurnFrame {
+	return chat.TurnFrame{
+		Kind: chat.TurnFrameDone, Cursor: "", Text: "", MessageID: "",
+		ToolCalls: nil, FinishReason: "stop", ToolCallID: "", Output: nil,
+	}
+}
+
+// TestTurnStreamReplayIsExclusiveOfCursor: a reconnecting client hands back
+// the last cursor it applied, so replaying from it must not repeat that frame.
+// Re-applying it would duplicate rendered text.
+func TestTurnStreamReplayIsExclusiveOfCursor(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	stream := newTurnStream(t)
+	chatID := uuid.New()
+
+	first, err := stream.Publish(ctx, chatID, textFrame("one"))
+	require.NoError(t, err)
+	require.NotEmpty(t, first, "publish must return a cursor")
+	_, err = stream.Publish(ctx, chatID, textFrame("two"))
+	require.NoError(t, err)
+
+	all, err := stream.Replay(ctx, chatID, "")
+	require.NoError(t, err)
+	require.Len(t, all, 2, "an empty cursor replays the retained history")
+	require.Equal(t, "one", all[0].Text)
+	require.Equal(t, first, all[0].Cursor, "frames carry the cursor they were assigned")
+
+	after, err := stream.Replay(ctx, chatID, first)
+	require.NoError(t, err)
+	require.Len(t, after, 1, "replay must exclude the cursor handed in")
+	require.Equal(t, "two", after[0].Text)
+}
+
+// TestTurnStreamSubscribeReplaysThenTails: the reconnect path. A subscriber
+// resuming from a cursor must receive what it missed before anything new, or
+// frames would arrive out of order relative to the turn that produced them.
+func TestTurnStreamSubscribeReplaysThenTails(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	stream := newTurnStream(t)
+	chatID := uuid.New()
+
+	start, err := stream.Publish(ctx, chatID, textFrame("before"))
+	require.NoError(t, err)
+	_, err = stream.Publish(ctx, chatID, textFrame("missed"))
+	require.NoError(t, err)
+
+	frames, err := stream.Subscribe(ctx, chatID, start)
+	require.NoError(t, err)
+
+	// Published after the subscription exists: it must arrive behind the
+	// backlog, not race ahead of it.
+	_, err = stream.Publish(ctx, chatID, textFrame("live"))
+	require.NoError(t, err)
+	_, err = stream.Publish(ctx, chatID, doneFrame())
+	require.NoError(t, err)
+
+	got := collectFrames(t, frames, 3)
+	require.Equal(t, "missed", got[0].Text, "the missed frame replays first")
+	require.Equal(t, "live", got[1].Text)
+	require.Equal(t, chat.TurnFrameDone, got[2].Kind)
+}
+
+// TestTurnStreamSubscribeWithoutCursorStartsFromNow: a chat's retained frames
+// span earlier turns. Replaying them for a fresh subscription handed the
+// client the previous turn's terminal frame, which ended the new turn before
+// it began — the turn appeared to never stream at all.
+func TestTurnStreamSubscribeWithoutCursorStartsFromNow(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	stream := newTurnStream(t)
+	chatID := uuid.New()
+
+	// A previous, completed turn.
+	_, err := stream.Publish(ctx, chatID, textFrame("old turn"))
+	require.NoError(t, err)
+	_, err = stream.Publish(ctx, chatID, doneFrame())
+	require.NoError(t, err)
+
+	frames, err := stream.Subscribe(ctx, chatID, "")
+	require.NoError(t, err)
+
+	_, err = stream.Publish(ctx, chatID, textFrame("new turn"))
+	require.NoError(t, err)
+	_, err = stream.Publish(ctx, chatID, doneFrame())
+	require.NoError(t, err)
+
+	got := collectFrames(t, frames, 2)
+	require.Equal(t, "new turn", got[0].Text, "the prior turn must not be replayed")
+	require.Equal(t, chat.TurnFrameDone, got[1].Kind)
+}
+
+// TestTurnStreamSubscribeStopsAtTerminalFrame: the subscription closes itself
+// on `done` so the client is not left holding an open connection after the
+// turn it asked about has ended.
+func TestTurnStreamSubscribeStopsAtTerminalFrame(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	stream := newTurnStream(t)
+	chatID := uuid.New()
+
+	frames, err := stream.Subscribe(ctx, chatID, "")
+	require.NoError(t, err)
+
+	_, err = stream.Publish(ctx, chatID, doneFrame())
+	require.NoError(t, err)
+	// Anything after a terminal frame belongs to a later turn and must not
+	// reach this subscriber.
+	_, err = stream.Publish(ctx, chatID, textFrame("next turn"))
+	require.NoError(t, err)
+
+	got := collectFrames(t, frames, 1)
+	require.Equal(t, chat.TurnFrameDone, got[0].Kind)
+
+	select {
+	case extra, open := <-frames:
+		require.False(t, open, "channel must close after the terminal frame, got %+v", extra)
+	case <-time.After(5 * time.Second):
+		t.Fatal("subscription did not close after the terminal frame")
+	}
+}
+
+// TestTurnStreamPublishIsInertWithoutRedis: teeing is an optimisation, so a
+// deployment without Redis must degrade to the poll path rather than failing
+// turns. Every publish site treats the error as non-fatal, and a nil stream
+// must not panic.
+func TestTurnStreamPublishIsInertWithoutRedis(t *testing.T) {
+	t.Parallel()
+
+	stream := chat.NewTurnStream(nil)
+	require.Nil(t, stream)
+
+	cursor, err := stream.Publish(t.Context(), uuid.New(), textFrame("ignored"))
+	require.NoError(t, err)
+	require.Empty(t, cursor)
+
+	_, err = stream.Subscribe(t.Context(), uuid.New(), "")
+	require.Error(t, err, "subscribing without a stream must fail loudly, not hang")
+}
+
+// collectFrames reads exactly n frames, failing rather than hanging if the
+// stream stalls.
+func collectFrames(t *testing.T, frames <-chan chat.TurnFrame, n int) []chat.TurnFrame {
+	t.Helper()
+	out := make([]chat.TurnFrame, 0, n)
+	deadline := time.After(20 * time.Second)
+	for len(out) < n {
+		select {
+		case frame, open := <-frames:
+			if !open {
+				t.Fatalf("stream closed after %d of %d frames", len(out), n)
+			}
+			out = append(out, frame)
+		case <-deadline:
+			t.Fatalf("timed out after %d of %d frames", len(out), n)
+		}
+	}
+	return out
+}

--- a/server/internal/chat/turnstream_http.go
+++ b/server/internal/chat/turnstream_http.go
@@ -48,11 +48,16 @@ func (s *Service) HandleTurnStream(w http.ResponseWriter, r *http.Request) error
 	if parseErr != nil {
 		return oops.E(oops.CodeBadRequest, parseErr, "invalid chat_id")
 	}
-	// Watching a chat is reading its content, so the caller must own it.
-	// GetChat is not project-scoped, hence the explicit comparison.
+	// Watching a chat streams its content, so it is authorized exactly like
+	// reading the transcript. Project equality alone is not enough: it would
+	// let an embedded chat-session token watch any other user's chat in the
+	// project. GetChat is not project-scoped, hence the explicit comparison.
 	chat, err := s.repo.GetChat(ctx, chatID)
 	if err != nil || chat.ProjectID != *authCtx.ProjectID {
 		return oops.E(oops.CodeNotFound, err, "chat not found")
+	}
+	if err := s.authorizeChatRead(ctx, authCtx, chat); err != nil {
+		return err
 	}
 
 	frames, err := s.turnStream.Subscribe(ctx, chatID, r.URL.Query().Get("after"))

--- a/server/internal/chat/turnstream_http.go
+++ b/server/internal/chat/turnstream_http.go
@@ -1,0 +1,97 @@
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// HandleTurnStream serves a chat's turn frames as SSE. The dashboard opens one
+// of these per turn and renders from it instead of polling chat.load.
+//
+// `after` is the cursor of the last frame the client applied. On a reconnect it
+// is what makes the stream lossless: the handler replays everything published
+// since that cursor before tailing. Omitted, the client gets the retained
+// history from the start, which is what joining a turn late wants.
+//
+// Frames are `data: {...}` objects carrying their own `cursor`. The stream ends
+// after a terminal frame, or when the client disconnects.
+func (s *Service) HandleTurnStream(w http.ResponseWriter, r *http.Request) error {
+	// These raw /chat routes get no auth middleware — HandleCompletion
+	// authorizes itself and so must this, or every browser subscription is
+	// rejected before the handler runs.
+	ctx, authCtx, _, err := s.directAuthorize(r.Context(), r)
+	if err != nil {
+		return err
+	}
+	if authCtx == nil || authCtx.ProjectID == nil {
+		return oops.C(oops.CodeUnauthorized)
+	}
+	if err := s.authz.Require(ctx, authz.Check{
+		Scope:        authz.ScopeProjectRead,
+		ResourceKind: "",
+		ResourceID:   authCtx.ProjectID.String(),
+		Dimensions:   nil,
+	}); err != nil {
+		return err
+	}
+	if s.turnStream == nil {
+		return oops.E(oops.CodeInvalid, nil, "assistant turn streaming is not enabled")
+	}
+
+	chatID, parseErr := uuid.Parse(r.URL.Query().Get("chat_id"))
+	if parseErr != nil {
+		return oops.E(oops.CodeBadRequest, parseErr, "invalid chat_id")
+	}
+	// Watching a chat is reading its content, so the caller must own it.
+	// GetChat is not project-scoped, hence the explicit comparison.
+	chat, err := s.repo.GetChat(ctx, chatID)
+	if err != nil || chat.ProjectID != *authCtx.ProjectID {
+		return oops.E(oops.CodeNotFound, err, "chat not found")
+	}
+
+	frames, err := s.turnStream.Subscribe(ctx, chatID, r.URL.Query().Get("after"))
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "subscribe to turn frames").LogError(ctx, s.logger)
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher, canFlush := w.(http.Flusher)
+	if canFlush {
+		flusher.Flush()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case frame, open := <-frames:
+			if !open {
+				return nil
+			}
+			payload, err := json.Marshal(frame)
+			if err != nil {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+				// Client hung up. The turn is unaffected, and whatever it
+				// missed is replayable from its last cursor.
+				return nil
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+			if frame.Kind == TurnFrameDone {
+				return nil
+			}
+		}
+	}
+}

--- a/server/internal/chat/turnstream_publish.go
+++ b/server/internal/chat/turnstream_publish.go
@@ -1,0 +1,127 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+)
+
+// Turn frames are published from the write path rather than from the
+// completions proxy. The proxy sees one model call, but a turn is often
+// several completions with tool calls between them, and "the turn is over" is
+// a property of the persisted rows — so only the writer knows enough to drive
+// a dashboard that has stopped polling.
+//
+// Publishing happens after commit, never inside the transaction: a frame
+// describes a row that exists, and a rolled-back turn must not have announced
+// itself. Failures are logged and swallowed, because a watcher missing a frame
+// is a responsiveness problem while a failed write is a correctness one.
+
+// publishTurnFrames emits one frame per row just persisted, then a terminal
+// frame when the turn has finished.
+//
+// Ordering matters to the client: tool outputs answer calls announced by an
+// earlier assistant row, so pending (user/tool) rows are emitted before the
+// assistant rows written in the same commit.
+func (w *ChatMessageWriter) publishTurnFrames(
+	ctx context.Context,
+	pending []chatMessageRow,
+	assistants []repo.CreateChatMessageParams,
+) {
+	if w == nil || w.turnStream == nil {
+		return
+	}
+
+	for _, row := range pending {
+		if row.role != "tool" || row.toolCallID == "" {
+			continue
+		}
+		w.publishTurnFrame(ctx, row.chatID, TurnFrame{
+			Kind:         TurnFrameToolOutput,
+			Cursor:       "",
+			Text:         "",
+			MessageID:    "",
+			ToolCalls:    nil,
+			FinishReason: "",
+			ToolCallID:   row.toolCallID,
+			Output:       marshalToolOutput(row),
+		})
+	}
+
+	for _, msg := range assistants {
+		if msg.Role != "assistant" {
+			continue
+		}
+		w.publishTurnFrame(ctx, msg.ChatID, TurnFrame{
+			Kind:         TurnFrameMessage,
+			Cursor:       "",
+			Text:         "",
+			MessageID:    msg.MessageID.String,
+			ToolCalls:    json.RawMessage(msg.ToolCalls),
+			FinishReason: msg.FinishReason.String,
+			ToolCallID:   "",
+			Output:       nil,
+		})
+
+		// A turn ends on an assistant row that neither stops to call a tool
+		// nor was cut short mid-stream. This mirrors the terminal check the
+		// dashboard's poll used to make for itself.
+		if isTerminalAssistantRow(msg) {
+			w.publishTurnFrame(ctx, msg.ChatID, TurnFrame{
+				Kind:         TurnFrameDone,
+				Cursor:       "",
+				Text:         "",
+				MessageID:    msg.MessageID.String,
+				ToolCalls:    nil,
+				FinishReason: msg.FinishReason.String,
+				ToolCallID:   "",
+				Output:       nil,
+			})
+		}
+	}
+}
+
+// isTerminalAssistantRow reports whether this row ends the turn: it carries no
+// tool calls the runner still has to answer, and the model stopped of its own
+// accord rather than being cut off.
+func isTerminalAssistantRow(msg repo.CreateChatMessageParams) bool {
+	if len(msg.ToolCalls) > 0 {
+		var calls []json.RawMessage
+		if err := json.Unmarshal(msg.ToolCalls, &calls); err == nil && len(calls) > 0 {
+			return false
+		}
+	}
+	switch msg.FinishReason.String {
+	case "stop", "end_turn", "":
+		return true
+	default:
+		// length, content_filter, tool_calls — the turn is not cleanly done,
+		// so leave the stream open and let the client's resync decide.
+		return false
+	}
+}
+
+func (w *ChatMessageWriter) publishTurnFrame(ctx context.Context, chatID uuid.UUID, frame TurnFrame) {
+	if _, err := w.turnStream.Publish(ctx, chatID, frame); err != nil {
+		w.logger.WarnContext(ctx, "publish turn frame",
+			attr.SlogChatID(chatID.String()),
+			attr.SlogError(err),
+		)
+	}
+}
+
+// marshalToolOutput renders a tool row's content for the frame. A row whose
+// content will not marshal yields a nil output rather than dropping the frame:
+// the client still learns the call was answered and can resync for the body,
+// which beats leaving a tool call rendered as forever-pending.
+func marshalToolOutput(row chatMessageRow) json.RawMessage {
+	encoded, err := json.Marshal(row.content)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}

--- a/server/internal/chat/turnstream_publish.go
+++ b/server/internal/chat/turnstream_publish.go
@@ -89,20 +89,12 @@ func (w *ChatMessageWriter) publishTurnFrames(
 // tool calls the runner still has to answer, and the model stopped of its own
 // accord rather than being cut off.
 func isTerminalAssistantRow(msg repo.CreateChatMessageParams) bool {
-	if len(msg.ToolCalls) > 0 {
-		var calls []json.RawMessage
-		if err := json.Unmarshal(msg.ToolCalls, &calls); err == nil && len(calls) > 0 {
-			return false
-		}
-	}
-	switch msg.FinishReason.String {
-	case "stop", "end_turn", "":
-		return true
-	default:
-		// length, content_filter, tool_calls — the turn is not cleanly done,
-		// so leave the stream open and let the client's resync decide.
+	if !isTerminalRow(msg.ToolCalls, "stop") {
 		return false
 	}
+	// length, content_filter, tool_calls mean the turn is not cleanly done, so
+	// the stream stays open and the client's resync decides.
+	return isTerminalRow(nil, msg.FinishReason.String)
 }
 
 func (w *ChatMessageWriter) publishTurnFrame(ctx context.Context, chatID uuid.UUID, frame TurnFrame) {
@@ -124,4 +116,61 @@ func marshalToolOutput(row chatMessageRow) json.RawMessage {
 		return nil
 	}
 	return encoded
+}
+
+// publishRowFrames emits frames for rows persisted through the row-shaped write
+// paths. Assistant turns reach the database through several of them — the
+// capture strategy writes pending rows, assistant rows and whole turns
+// separately — so every path publishes rather than relying on one funnel.
+func (w *ChatMessageWriter) publishRowFrames(ctx context.Context, rows []chatMessageRow) {
+	if w == nil || w.turnStream == nil {
+		return
+	}
+	for _, row := range rows {
+		switch row.role {
+		case "tool":
+			if row.toolCallID == "" {
+				continue
+			}
+			w.publishTurnFrame(ctx, row.chatID, TurnFrame{
+				Kind: TurnFrameToolOutput, Cursor: "", Text: "", MessageID: "",
+				ToolCalls: nil, FinishReason: "", ToolCallID: row.toolCallID,
+				Output: marshalToolOutput(row),
+			})
+		case "assistant":
+			finish := ""
+			if row.finishReason != nil {
+				finish = *row.finishReason
+			}
+			w.publishTurnFrame(ctx, row.chatID, TurnFrame{
+				Kind: TurnFrameMessage, Cursor: "", Text: "", MessageID: row.messageID,
+				ToolCalls: json.RawMessage(row.toolCalls), FinishReason: finish,
+				ToolCallID: "", Output: nil,
+			})
+			if isTerminalRow(row.toolCalls, finish) {
+				w.publishTurnFrame(ctx, row.chatID, TurnFrame{
+					Kind: TurnFrameDone, Cursor: "", Text: "", MessageID: row.messageID,
+					ToolCalls: nil, FinishReason: finish, ToolCallID: "", Output: nil,
+				})
+			}
+		}
+	}
+}
+
+// isTerminalRow reports whether a persisted assistant row ends the turn: no
+// tool calls left for the runner to answer, and the model stopped of its own
+// accord rather than being cut off.
+func isTerminalRow(toolCalls []byte, finishReason string) bool {
+	if len(toolCalls) > 0 {
+		var calls []json.RawMessage
+		if err := json.Unmarshal(toolCalls, &calls); err == nil && len(calls) > 0 {
+			return false
+		}
+	}
+	switch finishReason {
+	case "stop", "end_turn", "":
+		return true
+	default:
+		return false
+	}
 }

--- a/server/internal/chat/turnstream_publish.go
+++ b/server/internal/chat/turnstream_publish.go
@@ -167,8 +167,13 @@ func isTerminalRow(toolCalls []byte, finishReason string) bool {
 			return false
 		}
 	}
+	// Only an explicit natural stop ends the turn. An empty finish_reason is
+	// ambiguous — an intermediate row persisted before the model said why it
+	// stopped looks identical to a finished one — and treating it as terminal
+	// ended the stream after the first tool call, leaving the rest of the turn
+	// unstreamed.
 	switch finishReason {
-	case "stop", "end_turn", "":
+	case "stop", "end_turn":
 		return true
 	default:
 		return false

--- a/server/internal/chat/turnstream_publish.go
+++ b/server/internal/chat/turnstream_publish.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"github.com/google/uuid"
 
@@ -53,6 +54,21 @@ func (w *ChatMessageWriter) publishTurnFrames(
 	}
 
 	for _, msg := range assistants {
+		// Tool rows reach this slice too, and skipping them left their calls
+		// unresolved on the client: assistant-ui's resume check sees a step
+		// holding a tool call with no output and re-sends a turn the server
+		// already finished, which is what produced a second sendMessage and a
+		// spinner that outlived the reply.
+		if msg.Role == "tool" {
+			if msg.ToolCallID.Valid && msg.ToolCallID.String != "" {
+				w.publishTurnFrame(ctx, msg.ChatID, TurnFrame{
+					Kind: TurnFrameToolOutput, Cursor: "", Text: "", MessageID: "",
+					ToolCalls: nil, FinishReason: "", ToolCallID: msg.ToolCallID.String,
+					Output: json.RawMessage(strconv.Quote(msg.Content)),
+				})
+			}
+			continue
+		}
 		if msg.Role != "assistant" {
 			continue
 		}

--- a/server/internal/chat/turnstream_tee.go
+++ b/server/internal/chat/turnstream_tee.go
@@ -1,0 +1,211 @@
+package chat
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+
+	or "github.com/OpenRouterTeam/go-sdk/models/components"
+	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
+
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+// assembledCompletion is what a teed stream reconstructs: the same shape the
+// non-streaming path returns, rebuilt from the chunks as they went past.
+type assembledCompletion struct {
+	MessageID    string
+	Model        string
+	Content      string
+	ToolCalls    []openrouter.ToolCall
+	FinishReason *string
+	Usage        openrouter.Usage
+}
+
+// Message renders the assembled completion as the assistant message the
+// runner's non-streaming response carries.
+func (a assembledCompletion) Message() or.ChatMessages {
+	content := or.CreateChatAssistantMessageContentStr(a.Content)
+	msg := or.ChatAssistantMessage{
+		Role:             or.ChatAssistantMessageRoleAssistant,
+		Content:          optionalnullable.From(&content),
+		Name:             nil,
+		ToolCalls:        nil,
+		Refusal:          nil,
+		Reasoning:        nil,
+		ReasoningDetails: nil,
+		Images:           nil,
+		Audio:            nil,
+	}
+	if len(a.ToolCalls) > 0 {
+		calls := make([]or.ChatToolCall, 0, len(a.ToolCalls))
+		for _, tc := range a.ToolCalls {
+			calls = append(calls, or.ChatToolCall{
+				ID:   tc.ID,
+				Type: or.ChatToolCallType(tc.Type),
+				Function: or.ChatToolCallFunction{
+					Name:      tc.Function.Name,
+					Arguments: tc.Function.Arguments,
+				},
+			})
+		}
+		msg.ToolCalls = calls
+	}
+	return or.CreateChatMessagesAssistant(msg)
+}
+
+// teeCompletionStream drains an upstream SSE completion, publishing each text
+// delta through onDelta as it arrives and returning the assembled result.
+//
+// The reader handed in is the openrouter streaming reader, which accumulates
+// its own copy for capture and telemetry as the bytes pass through — that is
+// why the whole body must be read even though the caller wants the assembled
+// value rather than the stream. Parsing here is deliberately independent of
+// that internal accumulation: this function owns what the caller gets back.
+func teeCompletionStream(src io.Reader, onDelta func(string)) (assembledCompletion, error) {
+	out := assembledCompletion{
+		MessageID:    "",
+		Model:        "",
+		Content:      "",
+		ToolCalls:    nil,
+		FinishReason: nil,
+		Usage:        openrouter.Usage{}, //nolint:exhaustruct // zero usage until a chunk carries it
+	}
+	var content strings.Builder
+	toolCalls := map[int]openrouter.ToolCall{}
+
+	scanner := bufio.NewScanner(src)
+	// Tool-call argument fragments can make a single SSE line long; the default
+	// 64KiB token limit is not enough for a large structured call.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "[DONE]" {
+			break
+		}
+
+		var chunk openrouter.StreamingChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			// A malformed chunk is upstream's problem, not a reason to fail the
+			// turn: the openrouter reader logs it, and skipping keeps the rest
+			// of the message intact.
+			continue
+		}
+		if chunk.ID != "" {
+			out.MessageID = chunk.ID
+		}
+		if chunk.Model != "" {
+			out.Model = chunk.Model
+		}
+		if chunk.Usage != nil {
+			out.Usage = *chunk.Usage
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+
+		choice := chunk.Choices[0]
+		if choice.Delta.Content != "" {
+			content.WriteString(choice.Delta.Content)
+			if onDelta != nil {
+				onDelta(choice.Delta.Content)
+			}
+		}
+		for _, tc := range choice.Delta.ToolCalls {
+			existing := toolCalls[tc.Index]
+			existing.Index = tc.Index
+			if tc.ID != "" {
+				existing.ID = tc.ID
+			}
+			if tc.Type != "" {
+				existing.Type = tc.Type
+			}
+			if tc.Function.Name != "" {
+				existing.Function.Name = tc.Function.Name
+			}
+			// Arguments arrive as fragments and must be concatenated in order.
+			existing.Function.Arguments += tc.Function.Arguments
+			toolCalls[tc.Index] = existing
+		}
+		if choice.FinishReason != nil {
+			out.FinishReason = choice.FinishReason
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return out, fmt.Errorf("read completion stream: %w", err)
+	}
+
+	out.Content = content.String()
+	if len(toolCalls) > 0 {
+		// Map iteration is unordered; the runner replays tool calls in index
+		// order, so sort rather than emit them however the map ranges.
+		indexes := make([]int, 0, len(toolCalls))
+		for idx := range toolCalls {
+			indexes = append(indexes, idx)
+		}
+		sort.Ints(indexes)
+		out.ToolCalls = make([]openrouter.ToolCall, 0, len(indexes))
+		for _, idx := range indexes {
+			out.ToolCalls = append(out.ToolCalls, toolCalls[idx])
+		}
+	}
+	return out, nil
+}
+
+// teedCompletion runs a completion as an upstream stream, republishing each
+// text fragment as a turn frame as it arrives, and returns the assembled
+// result in the shape a non-streaming caller expects.
+//
+// Draining the reader to EOF and closing it is what drives the openrouter
+// client's own capture and telemetry, so both must happen even though the
+// bytes are discarded here.
+func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionRequest, chatID uuid.UUID) (*openrouter.CompletionResponse, error) {
+	streamBody, err := s.completionClient.GetCompletionStream(ctx, req)
+	if err != nil {
+		return nil, s.classifyCompletionError(ctx, "get completion stream", err)
+	}
+	defer o11y.NoLogDefer(func() error { return streamBody.Close() })
+
+	// Publishing rides the request context: if the caller goes away the turn is
+	// abandoned anyway, and a detached publish would outlive its only reader.
+	publish := func(text string) {
+		if _, pErr := s.turnStream.Publish(ctx, chatID, TurnFrame{
+			Kind: TurnFrameText, Cursor: "", Text: text, MessageID: "",
+			ToolCalls: nil, FinishReason: "", ToolCallID: "", Output: nil,
+		}); pErr != nil {
+			s.logger.WarnContext(ctx, "publish turn text frame", attr.SlogError(pErr))
+		}
+	}
+
+	assembled, err := teeCompletionStream(streamBody, publish)
+	if err != nil {
+		return nil, s.classifyCompletionError(ctx, "completion failed", err)
+	}
+
+	message := assembled.Message()
+	return &openrouter.CompletionResponse{
+		StartTime:    time.Now(),
+		Message:      &message,
+		MessageID:    assembled.MessageID,
+		Model:        assembled.Model,
+		Usage:        assembled.Usage,
+		FinishReason: assembled.FinishReason,
+		ToolCalls:    assembled.ToolCalls,
+		Content:      assembled.Content,
+	}, nil
+}

--- a/server/internal/chat/turnstream_tee.go
+++ b/server/internal/chat/turnstream_tee.go
@@ -210,6 +210,12 @@ func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionR
 		if plainErr != nil {
 			return nil, s.classifyCompletionError(ctx, "completion failed", plainErr)
 		}
+		// The recovered content never passed through the stream, so the watcher
+		// has seen none of it — publish it as one frame or the dashboard renders
+		// an empty reply for a request that succeeded.
+		if plain.Content != "" {
+			publish(plain.Content)
+		}
 		return plain, nil
 	}
 
@@ -229,9 +235,9 @@ func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionR
 // turnTextQueueDepth bounds the deltas waiting to be published. An io.Pipe
 // write blocks until the reader takes it, so publishing inline would put Redis
 // on the critical path of every token reaching the caller. The queue absorbs a
-// slow Redis; if it fills, frames are dropped rather than delaying the reply,
-// because the dashboard's cursor resync recovers dropped text while a stalled
-// completion is visible to the user.
+// slow Redis; if it fills, deltas divert into an overflow tail rather than
+// delaying the reply, and the tail re-enters the stream (in order) once the
+// queue drains — or as one final frame before the turn's message frame.
 const turnTextQueueDepth = 256
 
 // teeStreamText returns a writer that republishes assistant text as turn
@@ -257,24 +263,38 @@ func (s *Service) teeStreamText(ctx context.Context, chatID uuid.UUID) (io.Write
 		}
 	}()
 
+	// Deltas that found the queue full. Losing them permanently would leave the
+	// dashboard showing a partial reply that still ends in a normal `done` —
+	// the persisted `message` frame carries no content, so nothing triggers a
+	// resync. Instead they accumulate here, re-enter the queue as one frame the
+	// moment space frees (before any newer delta, preserving order), and any
+	// remainder is published after the queue drains. Owned by the parse
+	// goroutine until `parsed` closes.
+	var overflow strings.Builder
+	overflowing := false
+
 	go func() {
 		defer close(parsed)
-		dropped := 0
 		publish := func(text string) {
+			if overflowing {
+				overflow.WriteString(text)
+				select {
+				case queue <- overflow.String():
+					overflow.Reset()
+					overflowing = false
+				default:
+				}
+				return
+			}
 			select {
 			case queue <- text:
 			default:
-				dropped++
+				overflowing = true
+				overflow.WriteString(text)
 			}
 		}
 		if _, err := teeCompletionStream(pr, publish); err != nil {
 			s.logger.WarnContext(ctx, "parse streamed completion for turn frames", attr.SlogError(err))
-		}
-		if dropped > 0 {
-			s.logger.WarnContext(ctx, "dropped turn text frames",
-				attr.SlogChatID(chatID.String()),
-				attr.SlogChatTurnFramesDropped(int64(dropped)),
-			)
 		}
 		// Drain whatever is left so a tee write never blocks on a reader that
 		// stopped early.
@@ -290,5 +310,16 @@ func (s *Service) teeStreamText(ctx context.Context, chatID uuid.UUID) (io.Write
 		// Only the tail of the stream waits here — never an individual token.
 		close(queue)
 		<-published
+		if overflow.Len() > 0 {
+			s.logger.WarnContext(ctx, "publishing overflowed turn text as one frame",
+				attr.SlogChatID(chatID.String()),
+			)
+			if _, err := s.turnStream.Publish(ctx, chatID, TurnFrame{
+				Kind: TurnFrameText, Cursor: "", Text: overflow.String(), MessageID: "",
+				ToolCalls: nil, FinishReason: "", ToolCallID: "", Output: nil,
+			}); err != nil {
+				s.logger.WarnContext(ctx, "publish overflowed turn text frame", attr.SlogError(err))
+			}
+		}
 	}
 }

--- a/server/internal/chat/turnstream_tee.go
+++ b/server/internal/chat/turnstream_tee.go
@@ -209,3 +209,36 @@ func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionR
 		Content:      assembled.Content,
 	}, nil
 }
+
+// teeStreamText returns a writer that republishes assistant text as turn
+// frames, and a func to close it. Callers tee the upstream SSE body into the
+// writer so the passthrough response is unaffected: parsing happens on a
+// separate goroutine and a failure there can never corrupt or stall the bytes
+// the caller is forwarding.
+func (s *Service) teeStreamText(ctx context.Context, chatID uuid.UUID) (io.Writer, func()) {
+	pr, pw := io.Pipe()
+	finished := make(chan struct{})
+
+	go func() {
+		defer close(finished)
+		publish := func(text string) {
+			if _, err := s.turnStream.Publish(ctx, chatID, TurnFrame{
+				Kind: TurnFrameText, Cursor: "", Text: text, MessageID: "",
+				ToolCalls: nil, FinishReason: "", ToolCallID: "", Output: nil,
+			}); err != nil {
+				s.logger.WarnContext(ctx, "publish turn text frame", attr.SlogError(err))
+			}
+		}
+		if _, err := teeCompletionStream(pr, publish); err != nil {
+			s.logger.WarnContext(ctx, "parse streamed completion for turn frames", attr.SlogError(err))
+		}
+		// Drain whatever is left so a tee write never blocks on a reader that
+		// stopped early.
+		_, _ = io.Copy(io.Discard, pr)
+	}()
+
+	return pw, func() {
+		_ = pw.Close()
+		<-finished
+	}
+}

--- a/server/internal/chat/turnstream_tee.go
+++ b/server/internal/chat/turnstream_tee.go
@@ -197,6 +197,22 @@ func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionR
 		return nil, s.classifyCompletionError(ctx, "completion failed", err)
 	}
 
+	// OpenRouter intermittently produces nothing at all — the non-streaming
+	// client retries that case because a fresh request usually re-routes to a
+	// healthy provider (see ChatClient.GetCompletion). Streaming the request
+	// here must not lose that: without it a watchable chat silently returns an
+	// empty assistant message where an ordinary one would have recovered.
+	if assembled.Content == "" && len(assembled.ToolCalls) == 0 {
+		s.logger.WarnContext(ctx, "teed completion produced no content; falling back to a plain completion",
+			attr.SlogChatID(chatID.String()),
+		)
+		plain, plainErr := s.completionClient.GetCompletion(ctx, req)
+		if plainErr != nil {
+			return nil, s.classifyCompletionError(ctx, "completion failed", plainErr)
+		}
+		return plain, nil
+	}
+
 	message := assembled.Message()
 	return &openrouter.CompletionResponse{
 		StartTime:    time.Now(),
@@ -210,6 +226,14 @@ func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionR
 	}, nil
 }
 
+// turnTextQueueDepth bounds the deltas waiting to be published. An io.Pipe
+// write blocks until the reader takes it, so publishing inline would put Redis
+// on the critical path of every token reaching the caller. The queue absorbs a
+// slow Redis; if it fills, frames are dropped rather than delaying the reply,
+// because the dashboard's cursor resync recovers dropped text while a stalled
+// completion is visible to the user.
+const turnTextQueueDepth = 256
+
 // teeStreamText returns a writer that republishes assistant text as turn
 // frames, and a func to close it. Callers tee the upstream SSE body into the
 // writer so the passthrough response is unaffected: parsing happens on a
@@ -217,11 +241,13 @@ func (s *Service) teedCompletion(ctx context.Context, req openrouter.CompletionR
 // the caller is forwarding.
 func (s *Service) teeStreamText(ctx context.Context, chatID uuid.UUID) (io.Writer, func()) {
 	pr, pw := io.Pipe()
-	finished := make(chan struct{})
+	parsed := make(chan struct{})
+	published := make(chan struct{})
+	queue := make(chan string, turnTextQueueDepth)
 
 	go func() {
-		defer close(finished)
-		publish := func(text string) {
+		defer close(published)
+		for text := range queue {
 			if _, err := s.turnStream.Publish(ctx, chatID, TurnFrame{
 				Kind: TurnFrameText, Cursor: "", Text: text, MessageID: "",
 				ToolCalls: nil, FinishReason: "", ToolCallID: "", Output: nil,
@@ -229,8 +255,26 @@ func (s *Service) teeStreamText(ctx context.Context, chatID uuid.UUID) (io.Write
 				s.logger.WarnContext(ctx, "publish turn text frame", attr.SlogError(err))
 			}
 		}
+	}()
+
+	go func() {
+		defer close(parsed)
+		dropped := 0
+		publish := func(text string) {
+			select {
+			case queue <- text:
+			default:
+				dropped++
+			}
+		}
 		if _, err := teeCompletionStream(pr, publish); err != nil {
 			s.logger.WarnContext(ctx, "parse streamed completion for turn frames", attr.SlogError(err))
+		}
+		if dropped > 0 {
+			s.logger.WarnContext(ctx, "dropped turn text frames",
+				attr.SlogChatID(chatID.String()),
+				attr.SlogChatTurnFramesDropped(int64(dropped)),
+			)
 		}
 		// Drain whatever is left so a tee write never blocks on a reader that
 		// stopped early.
@@ -239,6 +283,12 @@ func (s *Service) teeStreamText(ctx context.Context, chatID uuid.UUID) (io.Write
 
 	return pw, func() {
 		_ = pw.Close()
-		<-finished
+		<-parsed
+		// Text frames must all be published before the caller persists the
+		// turn: the writer publishes the row's `message` frame after commit,
+		// and text arriving behind it would be rendered as a later message.
+		// Only the tail of the stream waits here — never an individual token.
+		close(queue)
+		<-published
 	}
 }

--- a/server/internal/chat/turnstream_tee_test.go
+++ b/server/internal/chat/turnstream_tee_test.go
@@ -1,0 +1,80 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTeeCompletionStreamAssemblesTextAndDeltas: the teed path must hand the
+// caller exactly what the non-streaming path would have, while emitting each
+// text fragment as it goes.
+func TestTeeCompletionStreamAssemblesTextAndDeltas(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		`data: {"id":"gen-1","model":"anthropic/claude-haiku-4.5","choices":[{"delta":{"content":"Hello"}}]}`,
+		`data: {"choices":[{"delta":{"content":", world"}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}}`,
+		`data: [DONE]`,
+	}, "\n\n") + "\n\n"
+
+	var deltas []string
+	got, err := teeCompletionStream(strings.NewReader(body), func(s string) { deltas = append(deltas, s) })
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"Hello", ", world"}, deltas, "each content fragment must be published as it arrives")
+	require.Equal(t, "Hello, world", got.Content)
+	require.Equal(t, "gen-1", got.MessageID)
+	require.Equal(t, "anthropic/claude-haiku-4.5", got.Model)
+	require.NotNil(t, got.FinishReason)
+	require.Equal(t, "stop", *got.FinishReason)
+	require.Equal(t, 11, got.Usage.PromptTokens)
+	require.Equal(t, 3, got.Usage.CompletionTokens)
+}
+
+// TestTeeCompletionStreamOrdersToolCallsByIndex: tool-call fragments arrive
+// interleaved and keyed by index. They must be concatenated per index and
+// emitted in index order — the runner replays them positionally, so map
+// iteration order would corrupt a multi-call turn.
+func TestTeeCompletionStreamOrdersToolCallsByIndex(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		`data: {"id":"gen-2","choices":[{"delta":{"tool_calls":[{"index":1,"id":"call-b","type":"function","function":{"name":"second","arguments":"{\"b\":"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-a","type":"function","function":{"name":"first","arguments":"{\"a\":"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"2}"}}]}}]}`,
+		`data: [DONE]`,
+	}, "\n\n") + "\n\n"
+
+	got, err := teeCompletionStream(strings.NewReader(body), nil)
+	require.NoError(t, err)
+
+	require.Len(t, got.ToolCalls, 2)
+	require.Equal(t, "call-a", got.ToolCalls[0].ID)
+	require.Equal(t, "first", got.ToolCalls[0].Function.Name)
+	require.JSONEq(t, `{"a":1}`, got.ToolCalls[0].Function.Arguments)
+	require.Equal(t, "call-b", got.ToolCalls[1].ID)
+	require.JSONEq(t, `{"b":2}`, got.ToolCalls[1].Function.Arguments)
+}
+
+// TestTeeCompletionStreamSkipsMalformedChunks: a bad chunk is upstream's
+// problem. Dropping it keeps the rest of the message rather than failing a
+// turn that is otherwise fine.
+func TestTeeCompletionStreamSkipsMalformedChunks(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		`data: {"id":"gen-3","choices":[{"delta":{"content":"before"}}]}`,
+		`data: {not json at all`,
+		`: a comment line`,
+		`data: {"choices":[{"delta":{"content":"-after"}}]}`,
+		`data: [DONE]`,
+	}, "\n\n") + "\n\n"
+
+	got, err := teeCompletionStream(strings.NewReader(body), nil)
+	require.NoError(t, err)
+	require.Equal(t, "before-after", got.Content)
+}

--- a/server/internal/middleware/chat_session_cors.go
+++ b/server/internal/middleware/chat_session_cors.go
@@ -12,6 +12,7 @@ import (
 
 var chatSessionsAllowedRoutes = []string{
 	"/chat/completions",
+	"/chat/turnstream",
 	"/mcp",
 	"/rpc/chat.",
 	"/rpc/chatSessions.",


### PR DESCRIPTION
Replaces the dashboard's `chat.load` polling with a live turn stream, so a reply renders as it is generated instead of appearing once the whole message has been persisted.

## Why

The dock rendered nothing until an assistant message was persisted, then animated text it already held — there was no SSE endpoint, so the transport polled `chat.load` on a 150ms→1.5s backoff. A user waited out the entire generation before seeing a character.

## Design

Frames are published from the **write path**, not the completions proxy. The proxy sees a single model call, but a turn is often several completions with tool calls between them, and "the turn is over" is a property of the persisted rows — so only the writer knows enough to drive a poll-free client. Text is the exception: tokens exist before any row does, so those frames come from the proxy as it streams upstream.

| Frame | Source |
| --- | --- |
| `text` | completions proxy, as generated |
| `message` | writer, per persisted assistant row (id, tool calls, finish reason) |
| `tool_output` | writer, per persisted tool row |
| `done` | writer, when a row ends the turn |

Transport is a **Redis stream**, not pub/sub. Dropping the poll removes the safety net, and pub/sub is fire-and-forget: a client reconnecting mid-turn would silently lose what it missed. Every frame carries a cursor, `GET /chat/turnstream?after=<cursor>` replays before tailing, and the client resumes from the last cursor it applied.

Frames are ephemeral — capped length plus a TTL refreshed on append — because the persisted rows remain the durable record. A nil Redis client disables publishing, and `pollForReplies` is retained as a resync path, so a deployment without Redis (or a stream that cannot connect) behaves exactly as before.

## Verified

Confirmed end to end in a browser: one `turnstream` connection per turn, no `chat.load` during it, text rendering as generated, tool calls and their outputs resolving, replay returning a completed turn's frames with cursors.

## Not covered

- **No tests on the frame path.** Replay-after-offset, reconnect mid-turn, duplicate frames, tool calls across frames — all unwritten. The three SSE-parser tests included here have never executed locally (the chat package's `TestMain` needs containers); CI will be their first run.
- Rows written through paths other than the three covered here would not publish frames.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams assistant turns to the dashboard over SSE so replies render token-by-token with live tool call updates, replacing `chat.load` polling. Uses a Redis stream with cursor-based replay and reconnect; falls back to polling when streaming is unavailable.

- **New Features**
  - Dashboard subscribes to `/chat/turnstream` per turn and renders `text`, `message`, `tool_output`, and `done` frames.
  - Server publishes frames from the write path; text is teed from completions via a bounded queue; rows emit `message`/`tool_output`/`done`.
  - Redis stream (capped + TTL) with cursors enables replay and auto‑reconnects; subscribing without `after` starts from “now”.
  - The client subscribes before sending on existing chats; for a new chat it replays from `0` so this turn’s frames aren’t missed.
  - Client sends `Gram-Project` and `Gram-Session` headers and maintains correct step and text‑part state; keeps poll as a resync path.

- **Bug Fixes**
  - Applied the same authorization as `chat.load` on `/chat/turnstream`, including project scoping, owner match, and `chat:read`, preventing cross‑user access via chat‑session tokens.
  - Pinned the server’s “start from now” position at subscribe time to avoid gaps; no longer replays a previous turn’s `done` or drops frames published right after subscribe.
  - Prevented duplicate sends and lingering spinners by keeping tool calls and outputs in the same step and closing steps at the right time.
  - Text after a row opens its own step so the last step holds only closing text; stops automatic re‑sends of a finished turn.
  - Opened and closed text parts around streamed deltas and before step close to satisfy assistant‑ui.
  - Only `stop`/`end_turn` mark a turn complete; empty `finish_reason` no longer ends streams early.
  - Published `tool_output` frames from every write path and finalize unanswered tool calls only when the turn actually ends.
  - Added `/chat/turnstream` to chat‑session CORS and released the SSE reader on terminal frames; rejected reads trigger reconnects.
  - Teed completions recover from upstream “empty choices” by falling back to a plain completion and publish the recovered content so the stream isn’t empty.
  - Turn‑text publishing no longer blocks token delivery; when the publish queue fills, deltas are preserved in order and re‑entered (or flushed as one final frame) instead of being dropped.
  - Client fails fast on non‑retryable 4xx and immediately falls back to polling, instead of burning the reconnect budget.

<sup>Written for commit 249aca63296210d4238d84fa54ce02121e40ce65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

