### PR TITLE
fix(domains): reconcile ingress on challenge token update

### DIFF
--- a/.changeset/challenge-token-ingress-reconcile.md
+++ b/.changeset/challenge-token-ingress-reconcile.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Saving an OpenAI app-submission verification token now reconciles the custom domain's ingress. Domains provisioned before the challenge feature shipped were missing the `/.well-known/openai-apps-challenge` route, so the token endpoint returned a 404 until an unrelated setting change rebuilt the ingress; setting or clearing the token now triggers that rebuild directly.

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -268,7 +268,9 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit custom domain update").LogError(ctx, s.logger)
 	}
-	if payload.IPAllowlist != nil {
+	// Token changes also reconcile: domains provisioned before the challenge
+	// route existed need their ingress rebuilt to gain the well-known path.
+	if payload.IPAllowlist != nil || payload.OpenaiAppsChallengeToken != nil {
 		if err := s.reconcileCustomDomain(ctx, domain.ID); err != nil {
 			return nil, err
 		}

--- a/server/internal/customdomains/impl.go
+++ b/server/internal/customdomains/impl.go
@@ -268,8 +268,6 @@ func (s *Service) UpdateDomain(ctx context.Context, payload *gen.UpdateDomainPay
 	if err := dbtx.Commit(ctx); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "commit custom domain update").LogError(ctx, s.logger)
 	}
-	// Token changes also reconcile: domains provisioned before the challenge
-	// route existed need their ingress rebuilt to gain the well-known path.
 	if payload.IPAllowlist != nil || payload.OpenaiAppsChallengeToken != nil {
 		if err := s.reconcileCustomDomain(ctx, domain.ID); err != nil {
 			return nil, err

--- a/server/internal/customdomains/updatedomain_test.go
+++ b/server/internal/customdomains/updatedomain_test.go
@@ -123,7 +123,7 @@ func TestUpdateDomain_OpenAIAppsChallengeTokenSetReplaceClearAndAudit(t *testing
 	require.NoError(t, err)
 	require.Equal(t, first, requireValue(t, res.OpenaiAppsChallengeToken))
 	require.Equal(t, []string{"10.0.0.0/8"}, res.IPAllowlist)
-	require.Zero(t, ti.temporal.reconcileCalls)
+	require.Equal(t, 1, ti.temporal.reconcileCalls)
 	requireLatestChallengeTokenAuditTransition(t, ctx, ti, nil, &first)
 
 	second := "challenge-token-second"
@@ -134,6 +134,7 @@ func TestUpdateDomain_OpenAIAppsChallengeTokenSetReplaceClearAndAudit(t *testing
 	})
 	require.NoError(t, err)
 	require.Equal(t, second, requireValue(t, res.OpenaiAppsChallengeToken))
+	require.Equal(t, 2, ti.temporal.reconcileCalls)
 	requireLatestChallengeTokenAuditTransition(t, ctx, ti, &first, &second)
 
 	clearToken := ""
@@ -144,6 +145,7 @@ func TestUpdateDomain_OpenAIAppsChallengeTokenSetReplaceClearAndAudit(t *testing
 	})
 	require.NoError(t, err)
 	require.Nil(t, res.OpenaiAppsChallengeToken)
+	require.Equal(t, 3, ti.temporal.reconcileCalls)
 	requireLatestChallengeTokenAuditTransition(t, ctx, ti, &second, nil)
 
 	row, err := ti.repo.GetCustomDomainByOrganization(ctx, authCtx.ActiveOrganizationID)


### PR DESCRIPTION
## Summary

Setting or clearing `openai_apps_challenge_token` via `UpdateDomain` persisted the token but never triggered the custom-domain reconcile workflow. Custom domains provisioned before #4601 have ingresses without the `/.well-known/openai-apps-challenge` path, so the challenge endpoint 404s at nginx even though the server route exists (observed live on chat.speakeasy.com).

This widens the post-commit reconcile gate to also fire on token updates, rebuilding the ingress with the well-known path. Reconcile is idempotent, so it is a no-op for already-current ingresses.

## Changes

- `server/internal/customdomains/impl.go`: reconcile when `OpenaiAppsChallengeToken` is set in the payload, not just `IPAllowlist`.
- `server/internal/customdomains/updatedomain_test.go`: token set/replace/clear now each assert a reconcile call (previously asserted zero).

## Testing

- `go test ./internal/customdomains/ -count=1` — full package passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Triggers ingress reconciliation when the OpenAI Apps challenge token changes so older custom domains gain the `/.well-known/openai-apps-challenge` path. Prevents nginx 404s by rebuilding ingress as needed.

- **Bug Fixes**
  - Reconcile in `UpdateDomain` when `OpenaiAppsChallengeToken` is set, replaced, or cleared (not just `IPAllowlist`).
  - Updated tests to assert reconcile on token changes; added changeset entry; reconciliation remains idempotent.

<sup>Written for commit e7864e6c6f67bb6e1a01915357cf54786c6e4d1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

