### PR TITLE
feat: assistant tools for risk exclusions and false positives

### DIFF
--- a/.changeset/assistant-risk-write-tools.md
+++ b/.changeset/assistant-risk-write-tools.md
@@ -1,0 +1,12 @@
+---
+"server": patch
+---
+
+Let the project's managed assistant act on risk findings, not just read them.
+Adds `platform_list_risk_exclusions` and `platform_create_risk_exclusion` for
+suppressing a whole class of findings, plus
+`platform_mark_risk_false_positive` and
+`platform_unmark_risk_false_positive` for dismissing (and restoring)
+specific findings. The writes go through the same risk service methods the
+dashboard uses, so they stay gated on org admin and audited against the
+invoking user.

--- a/.changeset/assistant-risk-write-tools.md
+++ b/.changeset/assistant-risk-write-tools.md
@@ -10,3 +10,9 @@ suppressing a whole class of findings, plus
 specific findings. The writes go through the same risk service methods the
 dashboard uses, so they stay gated on org admin and audited against the
 invoking user.
+
+Also keeps the assistant's context from ballooning while it triages: the
+agent-facing findings listing now defaults to 25 results and caps at 50
+(a 200-row page was tens of thousands of tokens that stayed in context for the
+rest of the turn), and the new `platform_get_risk_rule_breakdown` answers
+"which rules fire most" in one small call instead of many large pages.

--- a/.changeset/assistant-risk-write-tools.md
+++ b/.changeset/assistant-risk-write-tools.md
@@ -9,7 +9,9 @@ suppressing a whole class of findings, plus
 `platform_unmark_risk_false_positive` for dismissing (and restoring)
 specific findings. The writes go through the same risk service methods the
 dashboard uses, so they stay gated on org admin and audited against the
-invoking user.
+invoking user. Exact and regex match values are fingerprinted before they reach
+the model, so `platform_create_risk_exclusion` reuses an equivalent existing
+exclusion rather than duplicating one the model had no way to recognise.
 
 Also keeps the assistant's context from ballooning while it triages: the
 agent-facing findings listing now defaults to 25 results and caps at 50

--- a/server/internal/platformtools/core/schema.go
+++ b/server/internal/platformtools/core/schema.go
@@ -77,6 +77,15 @@ func WithPropertyNumberRange(propertyName string, minValue float64, maxValue flo
 	})
 }
 
+func WithPropertyItemsRange(propertyName string, minItems int, maxItems int) InputSchemaOption {
+	return WithPropertyMutator(propertyName, func(prop *jsonschema.Schema) {
+		minimum := minItems
+		maximum := maxItems
+		prop.MinItems = &minimum
+		prop.MaxItems = &maximum
+	})
+}
+
 func PermissiveObjectSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Type:                 "object",

--- a/server/internal/platformtools/risk/shared.go
+++ b/server/internal/platformtools/risk/shared.go
@@ -16,4 +16,22 @@ type RiskService interface {
 	ListRiskResultsForAgent(ctx context.Context, payload *risk.ListRiskResultsForAgentPayload) (*risk.ListRiskResultsForAgentResult, error)
 	ListRiskResultsByChat(ctx context.Context, payload *risk.ListRiskResultsByChatPayload) (*risk.ListRiskResultsByChatResult, error)
 	GetRiskPolicyStatus(ctx context.Context, payload *risk.GetRiskPolicyStatusPayload) (*types.RiskPolicyStatus, error)
+	ListRiskExclusions(ctx context.Context, payload *risk.ListRiskExclusionsPayload) (*risk.ListRiskExclusionsResult, error)
+	CreateRiskExclusion(ctx context.Context, payload *risk.CreateRiskExclusionPayload) (*types.RiskExclusion, error)
+	MarkRiskResultsFalsePositive(ctx context.Context, payload *risk.MarkRiskResultsFalsePositivePayload) error
+	UnmarkRiskResultsFalsePositive(ctx context.Context, payload *risk.UnmarkRiskResultsFalsePositivePayload) error
+}
+
+// writeAnnotations describes a tool that mutates project state. Kept separate
+// from core.ReadOnlyAnnotations so MCP clients can prompt before the call.
+func writeAnnotations(destructive, idempotent bool) *types.ToolAnnotations {
+	readOnly := false
+	openWorld := false
+	return &types.ToolAnnotations{
+		Title:           nil,
+		ReadOnlyHint:    &readOnly,
+		DestructiveHint: &destructive,
+		IdempotentHint:  &idempotent,
+		OpenWorldHint:   &openWorld,
+	}
 }

--- a/server/internal/platformtools/risk/shared.go
+++ b/server/internal/platformtools/risk/shared.go
@@ -16,6 +16,7 @@ type RiskService interface {
 	ListRiskResultsForAgent(ctx context.Context, payload *risk.ListRiskResultsForAgentPayload) (*risk.ListRiskResultsForAgentResult, error)
 	ListRiskResultsByChat(ctx context.Context, payload *risk.ListRiskResultsByChatPayload) (*risk.ListRiskResultsByChatResult, error)
 	GetRiskPolicyStatus(ctx context.Context, payload *risk.GetRiskPolicyStatusPayload) (*types.RiskPolicyStatus, error)
+	GetRiskRuleBreakdown(ctx context.Context, payload *risk.GetRiskRuleBreakdownPayload) (*risk.RiskRuleBreakdownResult, error)
 	ListRiskExclusions(ctx context.Context, payload *risk.ListRiskExclusionsPayload) (*risk.ListRiskExclusionsResult, error)
 	CreateRiskExclusion(ctx context.Context, payload *risk.CreateRiskExclusionPayload) (*types.RiskExclusion, error)
 	MarkRiskResultsFalsePositive(ctx context.Context, payload *risk.MarkRiskResultsFalsePositivePayload) error

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion.go
@@ -50,10 +50,10 @@ func (s *CreateRiskExclusion) Descriptor() core.ToolDescriptor {
 }
 
 // findEquivalent returns an existing exclusion identical to the one described by
-// input, or nil if there is none. Enabled is deliberately not compared: a
-// disabled exclusion is the same rule, and re-creating it would leave two rows
-// disagreeing about whether it applies.
-func (s *CreateRiskExclusion) findEquivalent(ctx context.Context, input createRiskExclusionInput, ruleIDFilter, sourceFilter string) (*types.RiskExclusion, error) {
+// input, or nil if there is none. Enabled is part of the comparison: reusing a
+// disabled row for an enable request would report success while leaving the
+// findings flagged, which is the opposite of what the caller asked for.
+func (s *CreateRiskExclusion) findEquivalent(ctx context.Context, input createRiskExclusionInput, policyID *string, ruleIDFilter, sourceFilter string, enabled bool) (*types.RiskExclusion, error) {
 	// Listed unfiltered: a nil risk_policy_id means "global", not "any policy",
 	// so the policy binding has to be compared here rather than pushed down.
 	listed, err := s.risk.ListRiskExclusions(ctx, &risk.ListRiskExclusionsPayload{
@@ -73,7 +73,10 @@ func (s *CreateRiskExclusion) findEquivalent(ctx context.Context, input createRi
 		if exclusion.RuleIDFilter != ruleIDFilter || exclusion.SourceFilter != sourceFilter {
 			continue
 		}
-		if !samePolicyBinding(exclusion.RiskPolicyID, input.RiskPolicyID) {
+		if exclusion.Enabled != enabled {
+			continue
+		}
+		if !samePolicyBinding(exclusion.RiskPolicyID, policyID) {
 			continue
 		}
 		return exclusion, nil
@@ -126,13 +129,20 @@ func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv
 	if input.SourceFilter != nil {
 		sourceFilter = *input.SourceFilter
 	}
+	// The service reads an empty risk_policy_id as global, same as an omitted
+	// one, so they are collapsed here too — otherwise the two spellings look
+	// like distinct scopes to the equivalence check below.
+	policyID := input.RiskPolicyID
+	if policyID != nil && *policyID == "" {
+		policyID = nil
+	}
 
 	// platform_list_risk_exclusions fingerprints exact/regex match values, so the
 	// model cannot tell from that listing whether the exclusion it is about to
 	// create already exists. Dedupe here instead: this call has the raw proposed
 	// value and the raw existing ones, so the comparison happens without either
 	// pattern reaching the model.
-	existing, err := s.findEquivalent(ctx, input, ruleIDFilter, sourceFilter)
+	existing, err := s.findEquivalent(ctx, input, policyID, ruleIDFilter, sourceFilter, enabled)
 	if err != nil {
 		return err
 	}
@@ -144,7 +154,7 @@ func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv
 		ApikeyToken:      nil,
 		SessionToken:     nil,
 		ProjectSlugInput: nil,
-		RiskPolicyID:     input.RiskPolicyID,
+		RiskPolicyID:     policyID,
 		MatchType:        input.MatchType,
 		MatchValue:       input.MatchValue,
 		RuleIDFilter:     ruleIDFilter,

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
@@ -35,7 +36,7 @@ func (s *CreateRiskExclusion) Descriptor() core.ToolDescriptor {
 		SourceSlug:  "risk",
 		HandlerName: "create_risk_exclusion",
 		Name:        "platform_create_risk_exclusion",
-		Description: "Create a risk exclusion so matching findings stop being flagged, now and in future scans. Use this for a whole class of findings; use platform_mark_risk_false_positive to dismiss specific findings without changing future detection.",
+		Description: "Create a risk exclusion so matching findings stop being flagged, now and in future scans. Use this for a whole class of findings; use platform_mark_risk_false_positive to dismiss specific findings without changing future detection. If an equivalent exclusion already exists it is returned unchanged rather than duplicated.",
 		InputSchema: core.BuildInputSchema[createRiskExclusionInput](
 			core.WithPropertyFormat("risk_policy_id", "uuid"),
 			core.WithPropertyEnum("match_type", "exact", "regex", "rule_id", "source", "entity_type"),
@@ -46,6 +47,46 @@ func (s *CreateRiskExclusion) Descriptor() core.ToolDescriptor {
 		OwnerKind:   nil,
 		OwnerID:     nil,
 	}
+}
+
+// findEquivalent returns an existing exclusion identical to the one described by
+// input, or nil if there is none. Enabled is deliberately not compared: a
+// disabled exclusion is the same rule, and re-creating it would leave two rows
+// disagreeing about whether it applies.
+func (s *CreateRiskExclusion) findEquivalent(ctx context.Context, input createRiskExclusionInput, ruleIDFilter, sourceFilter string) (*types.RiskExclusion, error) {
+	// Listed unfiltered: a nil risk_policy_id means "global", not "any policy",
+	// so the policy binding has to be compared here rather than pushed down.
+	listed, err := s.risk.ListRiskExclusions(ctx, &risk.ListRiskExclusionsPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		RiskPolicyID:     nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list risk exclusions: %w", err)
+	}
+
+	for _, exclusion := range listed.Exclusions {
+		if exclusion.MatchType != input.MatchType || exclusion.MatchValue != input.MatchValue {
+			continue
+		}
+		if exclusion.RuleIDFilter != ruleIDFilter || exclusion.SourceFilter != sourceFilter {
+			continue
+		}
+		if !samePolicyBinding(exclusion.RiskPolicyID, input.RiskPolicyID) {
+			continue
+		}
+		return exclusion, nil
+	}
+
+	return nil, nil
+}
+
+func samePolicyBinding(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
 }
 
 func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
@@ -84,6 +125,19 @@ func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv
 	sourceFilter := ""
 	if input.SourceFilter != nil {
 		sourceFilter = *input.SourceFilter
+	}
+
+	// platform_list_risk_exclusions fingerprints exact/regex match values, so the
+	// model cannot tell from that listing whether the exclusion it is about to
+	// create already exists. Dedupe here instead: this call has the raw proposed
+	// value and the raw existing ones, so the comparison happens without either
+	// pattern reaching the model.
+	existing, err := s.findEquivalent(ctx, input, ruleIDFilter, sourceFilter)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return core.EncodeResult(wr, toExclusionView(existing))
 	}
 
 	result, err := s.risk.CreateRiskExclusion(ctx, &risk.CreateRiskExclusionPayload{

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion.go
@@ -101,5 +101,7 @@ func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv
 		return fmt.Errorf("create risk exclusion: %w", err)
 	}
 
-	return core.EncodeResult(wr, result)
+	// Same view as the listing so the two tools agree on shape. The model
+	// supplied this match_value itself, so nothing new is hidden from it.
+	return core.EncodeResult(wr, toExclusionView(result))
 }

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion.go
@@ -1,0 +1,105 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type CreateRiskExclusion struct {
+	risk RiskService
+}
+
+type createRiskExclusionInput struct {
+	RiskPolicyID *string `json:"risk_policy_id,omitempty" jsonschema:"Bind the exclusion to a single policy. Omit for a global exclusion that applies to every policy in the project."`
+	MatchType    string  `json:"match_type" jsonschema:"How match_value is interpreted: exact (finding text), regex (RE2 pattern over finding text), rule_id, source, or entity_type (presidio entity, matched as rule_id 'pii.<entity>')."`
+	MatchValue   string  `json:"match_value" jsonschema:"The value matched against findings, interpreted per match_type."`
+	RuleIDFilter *string `json:"rule_id_filter,omitempty" jsonschema:"Narrow an exact/regex/source exclusion to findings with this rule_id. Omit to apply to any rule."`
+	SourceFilter *string `json:"source_filter,omitempty" jsonschema:"Narrow an exact/regex/rule_id exclusion to findings from this source. Omit to apply to any source."`
+	Enabled      *bool   `json:"enabled,omitempty" jsonschema:"Whether the exclusion is active. Defaults to true."`
+}
+
+func NewCreateRiskExclusionTool(riskSvc RiskService) *CreateRiskExclusion {
+	return &CreateRiskExclusion{risk: riskSvc}
+}
+
+func (s *CreateRiskExclusion) Descriptor() core.ToolDescriptor {
+	destructive := false
+	idempotent := false
+
+	return core.ToolDescriptor{
+		SourceSlug:  "risk",
+		HandlerName: "create_risk_exclusion",
+		Name:        "platform_create_risk_exclusion",
+		Description: "Create a risk exclusion so matching findings stop being flagged, now and in future scans. Use this for a whole class of findings; use platform_mark_risk_false_positive to dismiss specific findings without changing future detection.",
+		InputSchema: core.BuildInputSchema[createRiskExclusionInput](
+			core.WithPropertyFormat("risk_policy_id", "uuid"),
+			core.WithPropertyEnum("match_type", "exact", "regex", "rule_id", "source", "entity_type"),
+		),
+		Variables:   nil,
+		Annotations: writeAnnotations(destructive, idempotent),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *CreateRiskExclusion) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if s.risk == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := createRiskExclusionInput{
+		RiskPolicyID: nil,
+		MatchType:    "",
+		MatchValue:   "",
+		RuleIDFilter: nil,
+		SourceFilter: nil,
+		Enabled:      nil,
+	}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.MatchType == "" {
+		return fmt.Errorf("match_type is required")
+	}
+	if input.MatchValue == "" {
+		return fmt.Errorf("match_value is required")
+	}
+
+	// The Goa defaults for these fields are applied by the HTTP decoder, which
+	// this in-process call bypasses, so they are applied here instead.
+	enabled := true
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+	ruleIDFilter := ""
+	if input.RuleIDFilter != nil {
+		ruleIDFilter = *input.RuleIDFilter
+	}
+	sourceFilter := ""
+	if input.SourceFilter != nil {
+		sourceFilter = *input.SourceFilter
+	}
+
+	result, err := s.risk.CreateRiskExclusion(ctx, &risk.CreateRiskExclusionPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		RiskPolicyID:     input.RiskPolicyID,
+		MatchType:        input.MatchType,
+		MatchValue:       input.MatchValue,
+		RuleIDFilter:     ruleIDFilter,
+		SourceFilter:     sourceFilter,
+		Enabled:          enabled,
+	})
+	if err != nil {
+		return fmt.Errorf("create risk exclusion: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion_test.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion_test.go
@@ -82,18 +82,42 @@ func callCreate(t *testing.T, svc RiskService, payload string) exclusionView {
 func TestCreateRiskExclusionReusesEquivalent(t *testing.T) {
 	t.Parallel()
 
-	svc := &fakeRiskService{exclusions: []*types.RiskExclusion{existingExclusion()}, created: nil, agentLimit: nil}
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "global via omitted policy id", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks"}`},
+		// The service reads "" as global, so the tool must not treat it as a
+		// separate scope and create a second row.
+		{name: "global via empty policy id", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks","risk_policy_id":""}`},
+	}
 
-	view := callCreate(t, svc, `{
-		"match_type": "exact",
-		"match_value": "AKIAIOSFODNN7EXAMPLE",
-		"rule_id_filter": "secret.aws_access_key",
-		"source_filter": "gitleaks"
-	}`)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.Empty(t, svc.created, "an equivalent exclusion already exists")
-	require.Equal(t, "0192bd2a-0000-7000-8000-000000000000", view.ID)
-	require.NotContains(t, view.MatchValue, "AKIAIOSFODNN7EXAMPLE")
+			svc := &fakeRiskService{exclusions: []*types.RiskExclusion{existingExclusion()}, created: nil, agentLimit: nil}
+
+			view := callCreate(t, svc, tt.payload)
+
+			require.Empty(t, svc.created, "an equivalent exclusion already exists")
+			require.Equal(t, "0192bd2a-0000-7000-8000-000000000000", view.ID)
+			require.NotContains(t, view.MatchValue, "AKIAIOSFODNN7EXAMPLE")
+		})
+	}
+}
+
+// An empty risk_policy_id means global to the service, so it must reach it as
+// nil rather than as a distinct scope the equivalence check cannot match.
+func TestCreateRiskExclusionNormalizesEmptyPolicyID(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeRiskService{exclusions: nil, created: nil, agentLimit: nil}
+
+	callCreate(t, svc, `{"match_type":"exact","match_value":"secret","risk_policy_id":""}`)
+
+	require.Len(t, svc.created, 1)
+	require.Nil(t, svc.created[0].RiskPolicyID)
 }
 
 func TestCreateRiskExclusionCreatesWhenNotEquivalent(t *testing.T) {
@@ -108,13 +132,21 @@ func TestCreateRiskExclusionCreatesWhenNotEquivalent(t *testing.T) {
 		{name: "different rule filter", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","source_filter":"gitleaks"}`},
 		{name: "different source filter", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key"}`},
 		{name: "policy bound rather than global", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks","risk_policy_id":"0192bd2a-0000-7000-8000-000000000002"}`},
+		// A disabled row does not suppress anything, so reusing it for an enable
+		// request would report success while the findings stay flagged.
+		{name: "enabling a disabled exclusion", payload: `{"match_type":"exact","match_value":"disabled-draft","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks"}`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			svc := &fakeRiskService{exclusions: []*types.RiskExclusion{existingExclusion()}, created: nil, agentLimit: nil}
+			disabled := existingExclusion()
+			disabled.ID = "0192bd2a-0000-7000-8000-000000000003"
+			disabled.MatchValue = "disabled-draft"
+			disabled.Enabled = false
+
+			svc := &fakeRiskService{exclusions: []*types.RiskExclusion{existingExclusion(), disabled}, created: nil, agentLimit: nil}
 			callCreate(t, svc, tt.payload)
 
 			require.Len(t, svc.created, 1)

--- a/server/internal/platformtools/risk/tool_create_risk_exclusion_test.go
+++ b/server/internal/platformtools/risk/tool_create_risk_exclusion_test.go
@@ -1,0 +1,155 @@
+package risk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+// fakeRiskService only implements the methods a test exercises; the embedded
+// interface makes the rest panic rather than silently returning zero values.
+type fakeRiskService struct {
+	RiskService
+
+	exclusions []*types.RiskExclusion
+	created    []*risk.CreateRiskExclusionPayload
+	agentLimit *int
+}
+
+func (f *fakeRiskService) ListRiskExclusions(ctx context.Context, payload *risk.ListRiskExclusionsPayload) (*risk.ListRiskExclusionsResult, error) {
+	return &risk.ListRiskExclusionsResult{Exclusions: f.exclusions}, nil
+}
+
+func (f *fakeRiskService) CreateRiskExclusion(ctx context.Context, payload *risk.CreateRiskExclusionPayload) (*types.RiskExclusion, error) {
+	f.created = append(f.created, payload)
+	return &types.RiskExclusion{
+		ID:           "0192bd2a-0000-7000-8000-00000000000f",
+		ProjectID:    "0192bd2a-0000-7000-8000-000000000001",
+		RiskPolicyID: payload.RiskPolicyID,
+		MatchType:    payload.MatchType,
+		MatchValue:   payload.MatchValue,
+		RuleIDFilter: payload.RuleIDFilter,
+		SourceFilter: payload.SourceFilter,
+		Enabled:      payload.Enabled,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+		UpdatedAt:    "2026-01-01T00:00:00Z",
+	}, nil
+}
+
+func (f *fakeRiskService) ListRiskResultsForAgent(ctx context.Context, payload *risk.ListRiskResultsForAgentPayload) (*risk.ListRiskResultsForAgentResult, error) {
+	f.agentLimit = payload.Limit
+	return &risk.ListRiskResultsForAgentResult{Results: nil, TotalCount: 0, NextCursor: nil}, nil
+}
+
+func existingExclusion() *types.RiskExclusion {
+	return &types.RiskExclusion{
+		ID:           "0192bd2a-0000-7000-8000-000000000000",
+		ProjectID:    "0192bd2a-0000-7000-8000-000000000001",
+		RiskPolicyID: nil,
+		MatchType:    "exact",
+		MatchValue:   "AKIAIOSFODNN7EXAMPLE",
+		RuleIDFilter: "secret.aws_access_key",
+		SourceFilter: "gitleaks",
+		Enabled:      true,
+		CreatedAt:    "2026-01-01T00:00:00Z",
+		UpdatedAt:    "2026-01-01T00:00:00Z",
+	}
+}
+
+func callCreate(t *testing.T, svc RiskService, payload string) exclusionView {
+	t.Helper()
+
+	var out bytes.Buffer
+	err := NewCreateRiskExclusionTool(svc).Call(t.Context(), toolconfig.ToolCallEnv{}, strings.NewReader(payload), &out)
+	require.NoError(t, err)
+
+	var view exclusionView
+	require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+
+	return view
+}
+
+// The listing fingerprints exact/regex match values, so the model cannot dedupe
+// on its own — an equivalent exclusion must be reused server-side instead.
+func TestCreateRiskExclusionReusesEquivalent(t *testing.T) {
+	t.Parallel()
+
+	svc := &fakeRiskService{exclusions: []*types.RiskExclusion{existingExclusion()}, created: nil, agentLimit: nil}
+
+	view := callCreate(t, svc, `{
+		"match_type": "exact",
+		"match_value": "AKIAIOSFODNN7EXAMPLE",
+		"rule_id_filter": "secret.aws_access_key",
+		"source_filter": "gitleaks"
+	}`)
+
+	require.Empty(t, svc.created, "an equivalent exclusion already exists")
+	require.Equal(t, "0192bd2a-0000-7000-8000-000000000000", view.ID)
+	require.NotContains(t, view.MatchValue, "AKIAIOSFODNN7EXAMPLE")
+}
+
+func TestCreateRiskExclusionCreatesWhenNotEquivalent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "different match value", payload: `{"match_type":"exact","match_value":"other","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks"}`},
+		{name: "different match type", payload: `{"match_type":"regex","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks"}`},
+		{name: "different rule filter", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","source_filter":"gitleaks"}`},
+		{name: "different source filter", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key"}`},
+		{name: "policy bound rather than global", payload: `{"match_type":"exact","match_value":"AKIAIOSFODNN7EXAMPLE","rule_id_filter":"secret.aws_access_key","source_filter":"gitleaks","risk_policy_id":"0192bd2a-0000-7000-8000-000000000002"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &fakeRiskService{exclusions: []*types.RiskExclusion{existingExclusion()}, created: nil, agentLimit: nil}
+			callCreate(t, svc, tt.payload)
+
+			require.Len(t, svc.created, 1)
+		})
+	}
+}
+
+// DecodeInput is a plain unmarshal, so the schema's range on limit is advisory:
+// the handler has to enforce the token budget itself.
+func TestListRiskResultsForAgentClampsLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		payload string
+		want    int
+	}{
+		{payload: `{}`, want: agentResultsDefaultLimit},
+		{payload: `{"limit":10}`, want: 10},
+		{payload: `{"limit":5000}`, want: agentResultsMaxLimit},
+		{payload: `{"limit":0}`, want: 1},
+		{payload: `{"limit":-3}`, want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.payload, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &fakeRiskService{exclusions: nil, created: nil, agentLimit: nil}
+
+			var out bytes.Buffer
+			err := NewListRiskResultsForAgentTool(svc).Call(t.Context(), toolconfig.ToolCallEnv{}, strings.NewReader(tt.payload), &out)
+			require.NoError(t, err)
+
+			require.NotNil(t, svc.agentLimit)
+			require.Equal(t, tt.want, *svc.agentLimit)
+		})
+	}
+}

--- a/server/internal/platformtools/risk/tool_get_risk_rule_breakdown.go
+++ b/server/internal/platformtools/risk/tool_get_risk_rule_breakdown.go
@@ -1,0 +1,84 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type GetRiskRuleBreakdown struct {
+	risk RiskService
+}
+
+type getRiskRuleBreakdownInput struct {
+	Category string  `json:"category" jsonschema:"Category key to break down by rule_id."`
+	From     *string `json:"from,omitempty" jsonschema:"Inclusive start of the window as an ISO 8601 timestamp. Defaults to the same 7-day window as the risk overview."`
+	To       *string `json:"to,omitempty" jsonschema:"Exclusive end of the window as an ISO 8601 timestamp. Defaults to now."`
+}
+
+func NewGetRiskRuleBreakdownTool(riskSvc RiskService) *GetRiskRuleBreakdown {
+	return &GetRiskRuleBreakdown{risk: riskSvc}
+}
+
+// categoryKeys enumerates the category registry into the input schema so the
+// model picks a real key instead of guessing one and getting an empty result.
+func categoryKeys() []any {
+	defs := categories.All()
+	keys := make([]any, 0, len(defs))
+	for _, def := range defs {
+		keys = append(keys, string(def.Category))
+	}
+	return keys
+}
+
+func (s *GetRiskRuleBreakdown) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "risk",
+		HandlerName: "get_risk_rule_breakdown",
+		Name:        "platform_get_risk_rule_breakdown",
+		Description: "Get per-rule_id finding counts for one category over a time window. Prefer this over paginating platform_list_risk_results_for_agent when the question is about volume or which rules fire most — it answers in one small call instead of many large pages.",
+		InputSchema: core.BuildInputSchema[getRiskRuleBreakdownInput](
+			core.WithPropertyEnum("category", categoryKeys()...),
+			core.WithPropertyFormat("from", "date-time"),
+			core.WithPropertyFormat("to", "date-time"),
+		),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *GetRiskRuleBreakdown) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if s.risk == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := getRiskRuleBreakdownInput{Category: "", From: nil, To: nil}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.Category == "" {
+		return fmt.Errorf("category is required")
+	}
+
+	result, err := s.risk.GetRiskRuleBreakdown(ctx, &risk.GetRiskRuleBreakdownPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Category:         input.Category,
+		From:             input.From,
+		To:               input.To,
+	})
+	if err != nil {
+		return fmt.Errorf("get risk rule breakdown: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}

--- a/server/internal/platformtools/risk/tool_get_risk_rule_breakdown_test.go
+++ b/server/internal/platformtools/risk/tool_get_risk_rule_breakdown_test.go
@@ -1,0 +1,20 @@
+package risk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The model can only pick a valid category if the registry keys are enumerated
+// into the schema — a guessed key returns an empty breakdown, which reads as
+// "no findings" rather than as an error.
+func TestGetRiskRuleBreakdownSchemaEnumeratesCategories(t *testing.T) {
+	t.Parallel()
+
+	schema := string(NewGetRiskRuleBreakdownTool(nil).Descriptor().InputSchema)
+
+	for _, key := range []string{"secrets", "pii", "prompt_injection", "shadow_mcp"} {
+		require.Contains(t, schema, `"`+key+`"`, "category %q missing from input schema", key)
+	}
+}

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions.go
@@ -2,13 +2,67 @@ package risk
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 
 	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
+
+// exclusionView is the model-facing shape of an exclusion. For the free-text
+// match types, match_value is the literal string the author wanted suppressed —
+// often the very secret or email that triggered the finding — so it is
+// fingerprinted here for the same reason the risk service redacts it in audit
+// snapshots, and the same reason listRiskResultsForAgent exists at all. The
+// remaining match types and both filters are rule/source identifiers, not
+// captured content, so they stay readable: without them the model cannot tell
+// what an exclusion covers.
+type exclusionView struct {
+	ID           string  `json:"id"`
+	RiskPolicyID *string `json:"risk_policy_id,omitempty"`
+	MatchType    string  `json:"match_type"`
+	MatchValue   string  `json:"match_value"`
+	RuleIDFilter string  `json:"rule_id_filter"`
+	SourceFilter string  `json:"source_filter"`
+	Enabled      bool    `json:"enabled"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
+}
+
+type listRiskExclusionsResult struct {
+	Exclusions []exclusionView `json:"exclusions"`
+}
+
+// redactMatchValue mirrors the risk service's audit-snapshot fingerprint so the
+// same exclusion reads identically in both places.
+func redactMatchValue(matchType, matchValue string) string {
+	if matchType != "exact" && matchType != "regex" {
+		return matchValue
+	}
+	if matchValue == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(matchValue))
+	return "redacted:sha256:" + hex.EncodeToString(sum[:])[:12]
+}
+
+func toExclusionView(exclusion *types.RiskExclusion) exclusionView {
+	return exclusionView{
+		ID:           exclusion.ID,
+		RiskPolicyID: exclusion.RiskPolicyID,
+		MatchType:    exclusion.MatchType,
+		MatchValue:   redactMatchValue(exclusion.MatchType, exclusion.MatchValue),
+		RuleIDFilter: exclusion.RuleIDFilter,
+		SourceFilter: exclusion.SourceFilter,
+		Enabled:      exclusion.Enabled,
+		CreatedAt:    exclusion.CreatedAt,
+		UpdatedAt:    exclusion.UpdatedAt,
+	}
+}
 
 type ListRiskExclusions struct {
 	risk RiskService
@@ -27,7 +81,7 @@ func (s *ListRiskExclusions) Descriptor() core.ToolDescriptor {
 		SourceSlug:  "risk",
 		HandlerName: "list_risk_exclusions",
 		Name:        "platform_list_risk_exclusions",
-		Description: "List the risk exclusions configured for the current project. Call this before creating an exclusion to check whether an equivalent one already exists.",
+		Description: "List the risk exclusions configured for the current project. Call this before creating an exclusion to check whether an equivalent one already exists. For exact and regex exclusions the match_value is a stable sha256 fingerprint rather than the literal pattern, so suppressed secret content never enters the model context.",
 		InputSchema: core.BuildInputSchema[listRiskExclusionsInput](
 			core.WithPropertyFormat("risk_policy_id", "uuid"),
 		),
@@ -59,5 +113,10 @@ func (s *ListRiskExclusions) Call(ctx context.Context, _ toolconfig.ToolCallEnv,
 		return fmt.Errorf("list risk exclusions: %w", err)
 	}
 
-	return core.EncodeResult(wr, result)
+	views := make([]exclusionView, 0, len(result.Exclusions))
+	for _, exclusion := range result.Exclusions {
+		views = append(views, toExclusionView(exclusion))
+	}
+
+	return core.EncodeResult(wr, listRiskExclusionsResult{Exclusions: views})
 }

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions.go
@@ -1,0 +1,63 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListRiskExclusions struct {
+	risk RiskService
+}
+
+type listRiskExclusionsInput struct {
+	RiskPolicyID *string `json:"risk_policy_id,omitempty" jsonschema:"Only return exclusions bound to this policy ID. Omit to return every exclusion in the project (global plus policy-bound)."`
+}
+
+func NewListRiskExclusionsTool(riskSvc RiskService) *ListRiskExclusions {
+	return &ListRiskExclusions{risk: riskSvc}
+}
+
+func (s *ListRiskExclusions) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  "risk",
+		HandlerName: "list_risk_exclusions",
+		Name:        "platform_list_risk_exclusions",
+		Description: "List the risk exclusions configured for the current project. Call this before creating an exclusion to check whether an equivalent one already exists.",
+		InputSchema: core.BuildInputSchema[listRiskExclusionsInput](
+			core.WithPropertyFormat("risk_policy_id", "uuid"),
+		),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *ListRiskExclusions) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if s.risk == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := listRiskExclusionsInput{RiskPolicyID: nil}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+
+	result, err := s.risk.ListRiskExclusions(ctx, &risk.ListRiskExclusionsPayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		RiskPolicyID:     input.RiskPolicyID,
+	})
+	if err != nil {
+		return fmt.Errorf("list risk exclusions: %w", err)
+	}
+
+	return core.EncodeResult(wr, result)
+}

--- a/server/internal/platformtools/risk/tool_list_risk_exclusions_test.go
+++ b/server/internal/platformtools/risk/tool_list_risk_exclusions_test.go
@@ -1,0 +1,72 @@
+package risk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+// An exact or regex exclusion's match_value is the literal string someone chose
+// to suppress — frequently the secret that triggered the finding. It must never
+// reach the model verbatim, while the identifier-shaped match types stay
+// readable so the model can still tell what an exclusion covers.
+func TestExclusionViewRedactsOnlyFreeTextMatchValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		matchType string
+		redacted  bool
+	}{
+		{matchType: "exact", redacted: true},
+		{matchType: "regex", redacted: true},
+		{matchType: "rule_id", redacted: false},
+		{matchType: "source", redacted: false},
+		{matchType: "entity_type", redacted: false},
+	}
+
+	const secret = "AKIAIOSFODNN7EXAMPLE"
+
+	for _, tt := range tests {
+		t.Run(tt.matchType, func(t *testing.T) {
+			t.Parallel()
+
+			view := toExclusionView(&types.RiskExclusion{
+				ID:           "0192bd2a-0000-7000-8000-000000000000",
+				ProjectID:    "0192bd2a-0000-7000-8000-000000000001",
+				RiskPolicyID: nil,
+				MatchType:    tt.matchType,
+				MatchValue:   secret,
+				RuleIDFilter: "secret.aws_access_key",
+				SourceFilter: "gitleaks",
+				Enabled:      true,
+				CreatedAt:    "2026-01-01T00:00:00Z",
+				UpdatedAt:    "2026-01-01T00:00:00Z",
+			})
+
+			if tt.redacted {
+				require.NotContains(t, view.MatchValue, secret)
+				require.Contains(t, view.MatchValue, "redacted:sha256:")
+			} else {
+				require.Equal(t, secret, view.MatchValue)
+			}
+
+			// Filters are rule/source identifiers, not captured content.
+			require.Equal(t, "secret.aws_access_key", view.RuleIDFilter)
+			require.Equal(t, "gitleaks", view.SourceFilter)
+		})
+	}
+}
+
+func TestFalsePositiveSchemasCapBatchSize(t *testing.T) {
+	t.Parallel()
+
+	for _, schema := range []string{
+		string(NewMarkRiskResultsFalsePositiveTool(nil).Descriptor().InputSchema),
+		string(NewUnmarkRiskResultsFalsePositiveTool(nil).Descriptor().InputSchema),
+	} {
+		require.Contains(t, schema, `"maxItems":500`)
+		require.Contains(t, schema, `"minItems":1`)
+	}
+}

--- a/server/internal/platformtools/risk/tool_list_risk_results_for_agent.go
+++ b/server/internal/platformtools/risk/tool_list_risk_results_for_agent.go
@@ -10,6 +10,15 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
+// A page of findings costs roughly 200 tokens per row and stays in the
+// transcript for the rest of the turn, so the agent gets a much tighter budget
+// than the dashboard's 200. Anything wider than this is a question for
+// platform_get_risk_rule_breakdown, not a bigger page.
+const (
+	agentResultsDefaultLimit = 25
+	agentResultsMaxLimit     = 50
+)
+
 type ListRiskResultsForAgent struct {
 	risk RiskService
 }
@@ -26,7 +35,7 @@ type listRiskResultsForAgentInput struct {
 	From         *string `json:"from,omitempty" jsonschema:"Filter to messages created at or after this ISO 8601 timestamp."`
 	To           *string `json:"to,omitempty" jsonschema:"Filter to messages created strictly before this ISO 8601 timestamp."`
 	Cursor       *string `json:"cursor,omitempty" jsonschema:"Cursor for pagination."`
-	Limit        *int    `json:"limit,omitempty" jsonschema:"Maximum results per page."`
+	Limit        *int    `json:"limit,omitempty" jsonschema:"Maximum results per page. Defaults to 25. Keep this small: a full page of findings is tens of thousands of tokens and stays in context for the rest of the turn. To characterize a large finding set, use platform_get_risk_rule_breakdown instead of paginating."`
 }
 
 func NewListRiskResultsForAgentTool(riskSvc RiskService) *ListRiskResultsForAgent {
@@ -45,7 +54,7 @@ func (s *ListRiskResultsForAgent) Descriptor() core.ToolDescriptor {
 			core.WithPropertyFormat("assistant_id", "uuid"),
 			core.WithPropertyFormat("from", "date-time"),
 			core.WithPropertyFormat("to", "date-time"),
-			core.WithPropertyNumberRange("limit", 1, 200),
+			core.WithPropertyNumberRange("limit", 1, agentResultsMaxLimit),
 		),
 		Variables:   nil,
 		Annotations: core.ReadOnlyAnnotations(),
@@ -78,6 +87,14 @@ func (s *ListRiskResultsForAgent) Call(ctx context.Context, _ toolconfig.ToolCal
 		return err
 	}
 
+	// The service defaults an omitted limit to its own (larger) page size, so
+	// the agent's default is applied here rather than left unset.
+	limit := input.Limit
+	if limit == nil {
+		defaultLimit := agentResultsDefaultLimit
+		limit = &defaultLimit
+	}
+
 	result, err := s.risk.ListRiskResultsForAgent(ctx, &risk.ListRiskResultsForAgentPayload{
 		ApikeyToken:      nil,
 		SessionToken:     nil,
@@ -93,7 +110,7 @@ func (s *ListRiskResultsForAgent) Call(ctx context.Context, _ toolconfig.ToolCal
 		From:             input.From,
 		To:               input.To,
 		Cursor:           input.Cursor,
-		Limit:            input.Limit,
+		Limit:            limit,
 	})
 	if err != nil {
 		return fmt.Errorf("list risk results for agent: %w", err)

--- a/server/internal/platformtools/risk/tool_list_risk_results_for_agent.go
+++ b/server/internal/platformtools/risk/tool_list_risk_results_for_agent.go
@@ -88,12 +88,14 @@ func (s *ListRiskResultsForAgent) Call(ctx context.Context, _ toolconfig.ToolCal
 	}
 
 	// The service defaults an omitted limit to its own (larger) page size, so
-	// the agent's default is applied here rather than left unset.
-	limit := input.Limit
-	if limit == nil {
-		defaultLimit := agentResultsDefaultLimit
-		limit = &defaultLimit
+	// the agent's default is applied here rather than left unset. The schema
+	// range is advisory — DecodeInput is a plain unmarshal — so the bound is
+	// enforced here too.
+	limitValue := agentResultsDefaultLimit
+	if input.Limit != nil {
+		limitValue = min(max(*input.Limit, 1), agentResultsMaxLimit)
 	}
+	limit := &limitValue
 
 	result, err := s.risk.ListRiskResultsForAgent(ctx, &risk.ListRiskResultsForAgentPayload{
 		ApikeyToken:      nil,

--- a/server/internal/platformtools/risk/tool_mark_risk_results_false_positive.go
+++ b/server/internal/platformtools/risk/tool_mark_risk_results_false_positive.go
@@ -10,11 +10,17 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
-// falsePositiveResult is what the mark/unmark tools echo back: the service
-// methods return only an error, so the model needs an explicit acknowledgement
-// of what was acted on.
+// maxFalsePositiveBatch mirrors the risk service's own bulk cap so an oversized
+// batch is rejected by the input schema rather than after a round trip.
+const maxFalsePositiveBatch = 500
+
+// falsePositiveResult acknowledges what was submitted, not what changed. The
+// service methods return only an error — the rows they actually updated are
+// discarded before the Goa boundary — so ids that don't exist or belong to
+// another project are silently skipped and cannot be reported here. The field
+// name says "requested" so the model doesn't state more than it knows.
 type falsePositiveResult struct {
-	ResultIDs []string `json:"result_ids"`
+	RequestedResultIDs []string `json:"requested_result_ids"`
 }
 
 type MarkRiskResultsFalsePositive struct {
@@ -22,7 +28,7 @@ type MarkRiskResultsFalsePositive struct {
 }
 
 type markRiskResultsFalsePositiveInput struct {
-	ResultIDs []string `json:"result_ids" jsonschema:"IDs of the risk results to dismiss, as returned by platform_list_risk_results_for_agent. Max 500."`
+	ResultIDs []string `json:"result_ids" jsonschema:"IDs of the risk results to dismiss, as returned by platform_list_risk_results_for_agent. Max 500 per call. IDs that don't exist or belong to another project are skipped without error."`
 	Reason    *string  `json:"reason,omitempty" jsonschema:"Optional free-text reason for the dismissal."`
 }
 
@@ -39,7 +45,9 @@ func (s *MarkRiskResultsFalsePositive) Descriptor() core.ToolDescriptor {
 		HandlerName: "mark_risk_results_false_positive",
 		Name:        "platform_mark_risk_false_positive",
 		Description: "Mark specific risk findings as manually-reviewed false positives, moving them to the Dismissed tab. This only suppresses the findings picked, not future findings that match the same rule — use platform_create_risk_exclusion for that. Reversible with platform_unmark_risk_false_positive.",
-		InputSchema: core.BuildInputSchema[markRiskResultsFalsePositiveInput](),
+		InputSchema: core.BuildInputSchema[markRiskResultsFalsePositiveInput](
+			core.WithPropertyItemsRange("result_ids", 1, maxFalsePositiveBatch),
+		),
 		Variables:   nil,
 		Annotations: writeAnnotations(destructive, idempotent),
 		Managed:     true,
@@ -71,5 +79,5 @@ func (s *MarkRiskResultsFalsePositive) Call(ctx context.Context, _ toolconfig.To
 		return fmt.Errorf("mark risk results false positive: %w", err)
 	}
 
-	return core.EncodeResult(wr, falsePositiveResult{ResultIDs: input.ResultIDs})
+	return core.EncodeResult(wr, falsePositiveResult{RequestedResultIDs: input.ResultIDs})
 }

--- a/server/internal/platformtools/risk/tool_mark_risk_results_false_positive.go
+++ b/server/internal/platformtools/risk/tool_mark_risk_results_false_positive.go
@@ -1,0 +1,75 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+// falsePositiveResult is what the mark/unmark tools echo back: the service
+// methods return only an error, so the model needs an explicit acknowledgement
+// of what was acted on.
+type falsePositiveResult struct {
+	ResultIDs []string `json:"result_ids"`
+}
+
+type MarkRiskResultsFalsePositive struct {
+	risk RiskService
+}
+
+type markRiskResultsFalsePositiveInput struct {
+	ResultIDs []string `json:"result_ids" jsonschema:"IDs of the risk results to dismiss, as returned by platform_list_risk_results_for_agent. Max 500."`
+	Reason    *string  `json:"reason,omitempty" jsonschema:"Optional free-text reason for the dismissal."`
+}
+
+func NewMarkRiskResultsFalsePositiveTool(riskSvc RiskService) *MarkRiskResultsFalsePositive {
+	return &MarkRiskResultsFalsePositive{risk: riskSvc}
+}
+
+func (s *MarkRiskResultsFalsePositive) Descriptor() core.ToolDescriptor {
+	destructive := false
+	idempotent := true
+
+	return core.ToolDescriptor{
+		SourceSlug:  "risk",
+		HandlerName: "mark_risk_results_false_positive",
+		Name:        "platform_mark_risk_false_positive",
+		Description: "Mark specific risk findings as manually-reviewed false positives, moving them to the Dismissed tab. This only suppresses the findings picked, not future findings that match the same rule — use platform_create_risk_exclusion for that. Reversible with platform_unmark_risk_false_positive.",
+		InputSchema: core.BuildInputSchema[markRiskResultsFalsePositiveInput](),
+		Variables:   nil,
+		Annotations: writeAnnotations(destructive, idempotent),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *MarkRiskResultsFalsePositive) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if s.risk == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := markRiskResultsFalsePositiveInput{ResultIDs: nil, Reason: nil}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if len(input.ResultIDs) == 0 {
+		return fmt.Errorf("result_ids is required")
+	}
+
+	if err := s.risk.MarkRiskResultsFalsePositive(ctx, &risk.MarkRiskResultsFalsePositivePayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ResultIds:        input.ResultIDs,
+		Reason:           input.Reason,
+	}); err != nil {
+		return fmt.Errorf("mark risk results false positive: %w", err)
+	}
+
+	return core.EncodeResult(wr, falsePositiveResult{ResultIDs: input.ResultIDs})
+}

--- a/server/internal/platformtools/risk/tool_unmark_risk_results_false_positive.go
+++ b/server/internal/platformtools/risk/tool_unmark_risk_results_false_positive.go
@@ -15,7 +15,7 @@ type UnmarkRiskResultsFalsePositive struct {
 }
 
 type unmarkRiskResultsFalsePositiveInput struct {
-	ResultIDs []string `json:"result_ids" jsonschema:"IDs of the dismissed risk results to restore. Max 500."`
+	ResultIDs []string `json:"result_ids" jsonschema:"IDs of the dismissed risk results to restore. Max 500 per call. IDs that don't exist or belong to another project are skipped without error."`
 }
 
 func NewUnmarkRiskResultsFalsePositiveTool(riskSvc RiskService) *UnmarkRiskResultsFalsePositive {
@@ -31,7 +31,9 @@ func (s *UnmarkRiskResultsFalsePositive) Descriptor() core.ToolDescriptor {
 		HandlerName: "unmark_risk_results_false_positive",
 		Name:        "platform_unmark_risk_false_positive",
 		Description: "Undo a false-positive dismissal, returning the findings to the active results list.",
-		InputSchema: core.BuildInputSchema[unmarkRiskResultsFalsePositiveInput](),
+		InputSchema: core.BuildInputSchema[unmarkRiskResultsFalsePositiveInput](
+			core.WithPropertyItemsRange("result_ids", 1, maxFalsePositiveBatch),
+		),
 		Variables:   nil,
 		Annotations: writeAnnotations(destructive, idempotent),
 		Managed:     true,
@@ -62,5 +64,5 @@ func (s *UnmarkRiskResultsFalsePositive) Call(ctx context.Context, _ toolconfig.
 		return fmt.Errorf("unmark risk results false positive: %w", err)
 	}
 
-	return core.EncodeResult(wr, falsePositiveResult(input))
+	return core.EncodeResult(wr, falsePositiveResult{RequestedResultIDs: input.ResultIDs})
 }

--- a/server/internal/platformtools/risk/tool_unmark_risk_results_false_positive.go
+++ b/server/internal/platformtools/risk/tool_unmark_risk_results_false_positive.go
@@ -1,0 +1,66 @@
+package risk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/gen/risk"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type UnmarkRiskResultsFalsePositive struct {
+	risk RiskService
+}
+
+type unmarkRiskResultsFalsePositiveInput struct {
+	ResultIDs []string `json:"result_ids" jsonschema:"IDs of the dismissed risk results to restore. Max 500."`
+}
+
+func NewUnmarkRiskResultsFalsePositiveTool(riskSvc RiskService) *UnmarkRiskResultsFalsePositive {
+	return &UnmarkRiskResultsFalsePositive{risk: riskSvc}
+}
+
+func (s *UnmarkRiskResultsFalsePositive) Descriptor() core.ToolDescriptor {
+	destructive := false
+	idempotent := true
+
+	return core.ToolDescriptor{
+		SourceSlug:  "risk",
+		HandlerName: "unmark_risk_results_false_positive",
+		Name:        "platform_unmark_risk_false_positive",
+		Description: "Undo a false-positive dismissal, returning the findings to the active results list.",
+		InputSchema: core.BuildInputSchema[unmarkRiskResultsFalsePositiveInput](),
+		Variables:   nil,
+		Annotations: writeAnnotations(destructive, idempotent),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (s *UnmarkRiskResultsFalsePositive) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if s.risk == nil {
+		return fmt.Errorf("risk service not configured")
+	}
+
+	input := unmarkRiskResultsFalsePositiveInput{ResultIDs: nil}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if len(input.ResultIDs) == 0 {
+		return fmt.Errorf("result_ids is required")
+	}
+
+	if err := s.risk.UnmarkRiskResultsFalsePositive(ctx, &risk.UnmarkRiskResultsFalsePositivePayload{
+		ApikeyToken:      nil,
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		ResultIds:        input.ResultIDs,
+	}); err != nil {
+		return fmt.Errorf("unmark risk results false positive: %w", err)
+	}
+
+	return core.EncodeResult(wr, falsePositiveResult(input))
+}

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -173,13 +173,19 @@ func ManagedAssistantUsersTools(orgSvc platformusers.OrganizationsService) []pla
 
 // ManagedAssistantRiskTools returns risk/policy tools for the project's
 // managed assistant. listRiskResultsForAgent redacts matches so raw secret
-// content never reaches the model context.
+// content never reaches the model context. The exclusion and false-positive
+// tools mutate project state; the risk service gates them on org admin and
+// audits the invoking user as the actor.
 func ManagedAssistantRiskTools(riskSvc platformrisk.RiskService) []platformtools.ExternalTool {
 	return []platformtools.ExternalTool{
 		{Executor: platformrisk.NewListRiskPoliciesTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewListRiskResultsForAgentTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewListRiskResultsByChatTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewGetRiskPolicyStatusTool(riskSvc), RequiredFeature: ""},
+		{Executor: platformrisk.NewListRiskExclusionsTool(riskSvc), RequiredFeature: ""},
+		{Executor: platformrisk.NewCreateRiskExclusionTool(riskSvc), RequiredFeature: ""},
+		{Executor: platformrisk.NewMarkRiskResultsFalsePositiveTool(riskSvc), RequiredFeature: ""},
+		{Executor: platformrisk.NewUnmarkRiskResultsFalsePositiveTool(riskSvc), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -182,6 +182,7 @@ func ManagedAssistantRiskTools(riskSvc platformrisk.RiskService) []platformtools
 		{Executor: platformrisk.NewListRiskResultsForAgentTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewListRiskResultsByChatTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewGetRiskPolicyStatusTool(riskSvc), RequiredFeature: ""},
+		{Executor: platformrisk.NewGetRiskRuleBreakdownTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewListRiskExclusionsTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewCreateRiskExclusionTool(riskSvc), RequiredFeature: ""},
 		{Executor: platformrisk.NewMarkRiskResultsFalsePositiveTool(riskSvc), RequiredFeature: ""},

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -89,6 +89,7 @@ func TestManagedAssistantRiskToolsExposesCatalog(t *testing.T) {
 		"platform_list_risk_results_for_agent",
 		"platform_list_risk_results_by_chat",
 		"platform_get_risk_policy_status",
+		"platform_get_risk_rule_breakdown",
 		"platform_list_risk_exclusions",
 		"platform_create_risk_exclusion",
 		"platform_mark_risk_false_positive",

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -89,7 +89,31 @@ func TestManagedAssistantRiskToolsExposesCatalog(t *testing.T) {
 		"platform_list_risk_results_for_agent",
 		"platform_list_risk_results_by_chat",
 		"platform_get_risk_policy_status",
+		"platform_list_risk_exclusions",
+		"platform_create_risk_exclusion",
+		"platform_mark_risk_false_positive",
+		"platform_unmark_risk_false_positive",
 	}, got)
+}
+
+// Providers reject tool names longer than 64 characters, and the assistant
+// runtime prefixes every platform tool with `mcp__<server-slug>_` (25 chars
+// for the managed assistant). A name over this budget doesn't degrade — the
+// whole turn fails with a schema error before the model sees anything.
+func TestManagedAssistantToolNamesFitProviderLimit(t *testing.T) {
+	t.Parallel()
+
+	const maxNameLen = 40
+
+	tools := ManagedAssistantRiskTools(nil)
+	tools = append(tools, ManagedAssistantLogsTools(nil)...)
+	tools = append(tools, ManagedAssistantChatsTools(nil)...)
+	tools = append(tools, ManagedAssistantUsersTools(nil)...)
+	tools = append(tools, ManagedAssistantDeploymentsTools(nil)...)
+
+	for _, name := range toolNames(tools) {
+		require.LessOrEqual(t, len(name), maxNameLen, "tool name %q is too long once prefixed", name)
+	}
 }
 
 func TestManagedAssistantDeploymentsToolsExposesCatalog(t *testing.T) {


### PR DESCRIPTION
The managed assistant could read risk findings but not act on them — every remediation ended with "here's what I found, now go do it in the dashboard". This adds the write half for the two workflows that matter: excluding a class of findings, and dismissing specific ones.

## Tools

| Tool                                  | Service method                   | Annotations                            |
| ------------------------------------- | -------------------------------- | -------------------------------------- |
| `platform_list_risk_exclusions`       | `ListRiskExclusions`             | read-only                              |
| `platform_create_risk_exclusion`      | `CreateRiskExclusion`            | write, non-destructive, non-idempotent |
| `platform_mark_risk_false_positive`   | `MarkRiskResultsFalsePositive`   | write, non-destructive, idempotent     |
| `platform_unmark_risk_false_positive` | `UnmarkRiskResultsFalsePositive` | write, idempotent                      |

List-exclusions is included so the model can check for an equivalent rule before creating a duplicate; unmark is the undo path for a wrong dismissal. The descriptions cross-reference each other, since the two concepts have deliberately different blast radii: an exclusion is a pattern rule that also suppresses future scans, while a false positive dismisses only the rows picked.

## Notes for reviewers

- **Security posture is inherited, not re-implemented.** All four call the same risk service methods the dashboard uses, so they stay gated on `authz.ScopeOrgAdmin` and audit the invoking user as the actor. A non-admin's assistant gets a 403; the audit log names the human, not the assistant.
- **Goa defaults are re-applied by hand** in `platform_create_risk_exclusion`. Platform tools call the service in-process, bypassing the HTTP decoder that applies `Default()` — without this, every model-created exclusion would land disabled with empty filters.
- **Tool names are length-constrained.** The runtime prefixes each platform tool with `mcp__<server-slug>_` (25 chars for the managed assistant) and providers cap the result at 64, leaving ~39. Over that budget the provider rejects the entire catalog and the turn dies before the model emits a token — it reads as a hang, not an error. Caught during manual testing; `TestManagedAssistantToolNamesFitProviderLimit` now asserts the budget across every managed-assistant bundle so the next long name fails in CI instead.

## Testing

- `go test ./internal/platformtools/...` — 189 pass, including the updated catalog test and the new name-length guard.
- Manual: loaded the tool catalog in a local assistant turn, which is how the name-length failure was found. End-to-end exclusion and dismissal flows against seeded findings have not been run yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the managed project assistant act on risk findings. Adds tools for exclusions, false positives, and rule breakdown; caps agent listings, redacts exclusion patterns with server-side dedupe, and enforces page/batch limits to keep context small and safe.

- New Features
  - Added `platform_list_risk_exclusions`, `platform_create_risk_exclusion`, `platform_mark_risk_false_positive`, `platform_unmark_risk_false_positive`, and `platform_get_risk_rule_breakdown`.
  - Calls use the same risk service as the dashboard; gated on org admin and audited to the invoking user.
  - Capped `platform_list_risk_results_for_agent` to 25 by default (50 max) and enforce the bound in the handler to reduce token load; use `platform_get_risk_rule_breakdown` for “which rules fire most” instead of paging large result sets.

- Bug Fixes
  - Re-applied Goa defaults in `platform_create_risk_exclusion` to prevent disabled/empty exclusions.
  - Tightened exclusion dedupe: normalize empty `risk_policy_id` to global so both spellings match, and include `enabled` in equivalence to avoid reusing disabled exclusions.
  - Enforced provider tool-name length budget with `TestManagedAssistantToolNamesFitProviderLimit`.
  - Redacted `match_value` for exact/regex exclusions to a stable sha256 fingerprint in tool outputs; reuse an equivalent existing exclusion to avoid duplicates.
  - Capped false-positive batch size via the input schema to 500 (min 1) for `platform_mark_risk_false_positive` and `platform_unmark_risk_false_positive`.

<sup>Written for commit 07f2fb6181714012a0cd71c8298a03a753fb3c83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

