### PR TITLE
feat(mcp): telemetry for CIMD metadata fetch lifecycle

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -134,17 +134,30 @@ const (
 	// chat_analysis:work_units:score telemetry rows the chat analysis
 	// publisher emits once per scored session, and read back by
 	// attribute_metrics_summaries_mv's work-units measures.
-	ChatAnalysisWorkUnitsKey       = attribute.Key("gram.chat_analysis.work_units")
-	ChatAnalysisScoredCostKey      = attribute.Key("gram.chat_analysis.scored_cost")
-	ChatAnalysisScoredTokensKey    = attribute.Key("gram.chat_analysis.scored_tokens")
-	MCPRegistryIDKey               = attribute.Key("gram.mcp_registry.id")
-	MCPRegistryURLKey              = attribute.Key("gram.mcp_registry.url")
-	ExternalMCPIDKey               = attribute.Key("gram.external_mcp.id")
-	ExternalMCPSlugKey             = attribute.Key("gram.external_mcp.slug")
-	ExternalMCPNameKey             = attribute.Key("gram.external_mcp.name")
-	URLKey                         = attribute.Key("url")
-	CacheKeyKey                    = attribute.Key("gram.cache.key")
-	CacheNamespaceKey              = attribute.Key("gram.cache.namespace")
+	ChatAnalysisWorkUnitsKey    = attribute.Key("gram.chat_analysis.work_units")
+	ChatAnalysisScoredCostKey   = attribute.Key("gram.chat_analysis.scored_cost")
+	ChatAnalysisScoredTokensKey = attribute.Key("gram.chat_analysis.scored_tokens")
+	MCPRegistryIDKey            = attribute.Key("gram.mcp_registry.id")
+	MCPRegistryURLKey           = attribute.Key("gram.mcp_registry.url")
+	ExternalMCPIDKey            = attribute.Key("gram.external_mcp.id")
+	ExternalMCPSlugKey          = attribute.Key("gram.external_mcp.slug")
+	ExternalMCPNameKey          = attribute.Key("gram.external_mcp.name")
+	URLKey                      = attribute.Key("url")
+	CacheKeyKey                 = attribute.Key("gram.cache.key")
+	CacheNamespaceKey           = attribute.Key("gram.cache.namespace")
+
+	// CIMDOriginKey is the host of a Client ID Metadata Document URL — the
+	// per-metadata-host dimension on cimd.fetch.* metrics. Attacker-influenced
+	// on the unauthenticated OAuth surface until CIMD admission control
+	// (AIS-371) bounds accepted client_id URLs, so it is deliberately omitted
+	// for client_ids that fail URL-syntax validation before a fetch.
+	CIMDOriginKey = attribute.Key("gram.cimd.origin")
+
+	// CIMDValidationReasonKey is the machine-readable reason a Client ID
+	// Metadata Document (or its client_id URL) failed validation — the
+	// per-reason dimension on cimd.validation.failures.
+	CIMDValidationReasonKey = attribute.Key("gram.cimd.validation_reason")
+
 	ComponentKey                   = attribute.Key("gram.component")
 	DBDeletedRowsCountKey          = attribute.Key("gram.db.deleted_rows_count")
 	DeploymentIDKey                = attribute.Key("gram.deployment.id")
@@ -844,6 +857,17 @@ func SlogCacheKey(v string) slog.Attr      { return slog.String(string(CacheKeyK
 
 func CacheNamespace(v string) attribute.KeyValue { return CacheNamespaceKey.String(v) }
 func SlogCacheNamespace(v string) slog.Attr      { return slog.String(string(CacheNamespaceKey), v) }
+
+func CIMDOrigin(v string) attribute.KeyValue { return CIMDOriginKey.String(v) }
+func SlogCIMDOrigin(v string) slog.Attr      { return slog.String(string(CIMDOriginKey), v) }
+
+func CIMDValidationReason[V ~string](v V) attribute.KeyValue {
+	return CIMDValidationReasonKey.String(string(v))
+}
+
+func SlogCIMDValidationReason[V ~string](v V) slog.Attr {
+	return slog.String(string(CIMDValidationReasonKey), string(v))
+}
 
 func Component(v string) attribute.KeyValue { return ComponentKey.String(v) }
 func SlogComponent(v string) slog.Attr      { return slog.String(string(ComponentKey), v) }

--- a/server/internal/mcp/client_resolver.go
+++ b/server/internal/mcp/client_resolver.go
@@ -82,10 +82,9 @@ func (s *Service) resolveUserSessionClient(ctx context.Context, logger *slog.Log
 			return nil, errCIMDDisabled
 		}
 
-		doc, err := cimd.Resolve(ctx, cimd.NewFetchClient(s.guardianPolicy), clientID)
+		doc, err := s.cimdResolver.Resolve(ctx, clientID)
 		if err != nil {
-			var oauthErr *usersessions.OAuthError
-			if errors.As(err, &oauthErr) {
+			if _, ok := errors.AsType[*usersessions.OAuthError](err); ok {
 				return nil, fmt.Errorf("resolve cimd client: %w", err)
 			}
 			return nil, fmt.Errorf("%w: %w", errCIMDFetchFailed, err)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -77,6 +77,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
 	"github.com/speakeasy-api/gram/tunnel/route"
 )
 
@@ -113,8 +114,11 @@ type Service struct {
 	// to the last known state instead of failing closed on the
 	// unauthenticated OAuth surface. Guarded by cimdOrgFlagMu; holds one bool
 	// per organization that touches the surface.
-	cimdOrgFlagMu          sync.RWMutex
-	cimdOrgFlagLastKnown   map[string]bool
+	cimdOrgFlagMu        sync.RWMutex
+	cimdOrgFlagLastKnown map[string]bool
+	// cimdResolver fetches + validates Client ID Metadata Documents for
+	// URL-shaped client_ids and owns the cimd.* telemetry.
+	cimdResolver           *cimd.Resolver
 	toolProxy              *gateway.ToolProxy
 	oauthService           OAuthService
 	oauthRepo              *oauth_repo.Queries
@@ -325,6 +329,7 @@ func NewService(
 		features:             features,
 		cimdOrgFlagMu:        sync.RWMutex{},
 		cimdOrgFlagLastKnown: map[string]bool{},
+		cimdResolver:         cimd.NewResolver(guardianPolicy, meterProvider, logger),
 		toolProxy: gateway.NewToolProxy(
 			logger,
 			tracerProvider,

--- a/server/internal/usersessions/cimd/cimd.go
+++ b/server/internal/usersessions/cimd/cimd.go
@@ -4,13 +4,17 @@
 // fetching the document it names, parsing it, and validating it against the
 // spec's rules plus Gram's own origin-binding policy.
 //
-// The package is deliberately stateless: no caching, no persistence, no
-// logging. Callers own the upsert of the resolved client and
-// the mapping of returned errors onto their wire format. Spec-defined
-// rejections are returned as *usersessions.OAuthError with a client-safe
-// description; transport-level fetch failures are returned as plain wrapped
-// errors whose text may reference internal details and MUST NOT be echoed to
-// the OAuth client verbatim.
+// The Resolver owns the fetch lifecycle and its telemetry (metrics + logs) but
+// deliberately nothing else: no caching (until AIS-216) and no persistence.
+// Callers own the upsert of the resolved client and the mapping of returned
+// errors onto their wire format. Spec-defined rejections are returned as
+// *usersessions.OAuthError with a client-safe description; transport-level
+// fetch failures are returned as plain wrapped errors whose text may reference
+// internal details and MUST NOT be echoed to the OAuth client verbatim. The
+// same opacity rule applies to the internal result taxonomy: parse failures
+// are distinguished from fetch failures only in metrics and logs, never in the
+// returned error shape, so unauthenticated callers cannot use the wire
+// response as an oracle for probing external hosts through Gram.
 package cimd
 
 import (
@@ -19,9 +23,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
@@ -132,14 +140,35 @@ func IsClientIDURL(clientID string) bool {
 	return len(clientID) > len("https://") && clientID[:len("https://")] == "https://"
 }
 
-// NewFetchClient builds the production document-fetch client from a
-// guardian policy: the SSRF dialer's post-DNS IP check satisfies -02 §8.6's
-// ban on fetching RFC 6890 special-use addresses and is immune to DNS
-// rebinding. Tests that host documents on httptest servers should pass
+// Resolver fetches, parses, and validates Client ID Metadata Documents and
+// records the telemetry for each attempt. It is safe for concurrent use; one
+// instance should live for the process lifetime so instruments are created
+// once.
+type Resolver struct {
+	client  *guardian.HTTPClient
+	logger  *slog.Logger
+	metrics *metrics
+}
+
+// NewResolver builds the production resolver from a guardian policy: the SSRF
+// dialer's post-DNS IP check satisfies -02 §8.6's ban on fetching RFC 6890
+// special-use addresses and is immune to DNS rebinding. Tests that host
+// documents on httptest servers should use newResolver with
 // newFetchClientFrom(server.Client()) — or build the policy with
 // guardian.WithTLSRootCAs — since httptest certificates are self-signed.
-func NewFetchClient(policy *guardian.Policy) *guardian.HTTPClient {
-	return newFetchClientFrom(policy.Client())
+func NewResolver(policy *guardian.Policy, meterProvider metric.MeterProvider, logger *slog.Logger) *Resolver {
+	return newResolver(newFetchClientFrom(policy.Client()), meterProvider, logger)
+}
+
+// newResolver is the injection seam for tests that need a fetch client built
+// from an httptest server instead of a guardian policy.
+func newResolver(client *guardian.HTTPClient, meterProvider metric.MeterProvider, logger *slog.Logger) *Resolver {
+	logger = logger.With(attr.SlogComponent("cimd"))
+	return &Resolver{
+		client:  client,
+		logger:  logger,
+		metrics: newMetrics(meterProvider, logger),
+	}
 }
 
 // newFetchClientFrom applies the CIMD fetch rules to a copy of the base
@@ -156,20 +185,47 @@ func newFetchClientFrom(base *guardian.HTTPClient) *guardian.HTTPClient {
 }
 
 // Resolve fetches, parses, and validates the Client ID Metadata Document
-// named by clientID. client should come from NewFetchClient. The returned
-// Document has passed every check this AS imposes: -02 §3 URL syntax, §4
-// triple client_id equality (the fetch never follows redirects, so the
-// fetched URL is the presented URL by construction), required client_name +
-// redirect_uris, public-client-only auth method, secret/private-key bans,
-// and Gram's same-origin redirect-URI binding.
-func Resolve(ctx context.Context, client *guardian.HTTPClient, clientID string) (*Document, error) {
+// named by clientID. The returned Document has passed every check this AS
+// imposes: -02 §3 URL syntax, §4 triple client_id equality (the fetch never
+// follows redirects, so the fetched URL is the presented URL by
+// construction), required client_name + redirect_uris, public-client-only
+// auth method, secret/private-key bans, and Gram's same-origin redirect-URI
+// binding.
+func (r *Resolver) Resolve(ctx context.Context, clientID string) (*Document, error) {
 	clientIDURL, err := validateClientIDURL(clientID)
 	if err != nil {
+		// Pre-fetch rejection: no origin has been established (the URL did
+		// not parse or failed syntax rules), so the origin attribute and the
+		// duration histogram are both deliberately omitted.
+		r.observe(ctx, resolveObservation{
+			clientID:      clientID,
+			origin:        "",
+			result:        fetchResultValidationError,
+			reason:        validationReasonOf(err),
+			status:        0,
+			duration:      0,
+			fetched:       false,
+			responseBytes: 0,
+			err:           err,
+		})
 		return nil, err
 	}
+	origin := clientIDURL.Host
 
-	body, err := fetchDocument(ctx, client, clientID)
+	start := time.Now()
+	body, status, err := r.fetchDocument(ctx, origin, clientID)
 	if err != nil {
+		r.observe(ctx, resolveObservation{
+			clientID:      clientID,
+			origin:        origin,
+			result:        fetchResultFetchError,
+			reason:        "",
+			status:        status,
+			duration:      time.Since(start),
+			fetched:       true,
+			responseBytes: 0,
+			err:           err,
+		})
 		return nil, fmt.Errorf("fetch client metadata document: %w", err)
 	}
 
@@ -177,50 +233,152 @@ func Resolve(ctx context.Context, client *guardian.HTTPClient, clientID string) 
 	// wrapped error, generic wire response) rather than as a distinct OAuth
 	// error: a distinguishable "reachable but not JSON" response would give
 	// unauthenticated callers an oracle for probing external hosts through
-	// Gram.
+	// Gram. The parse_error result exists only in telemetry.
 	var doc Document
 	if err := json.Unmarshal(body, &doc); err != nil {
+		r.observe(ctx, resolveObservation{
+			clientID:      clientID,
+			origin:        origin,
+			result:        fetchResultParseError,
+			reason:        "",
+			status:        status,
+			duration:      time.Since(start),
+			fetched:       true,
+			responseBytes: len(body),
+			err:           err,
+		})
 		return nil, fmt.Errorf("parse client metadata document: %w", err)
 	}
 
 	if err := validateDocument(&doc, clientID, clientIDURL); err != nil {
+		r.observe(ctx, resolveObservation{
+			clientID:      clientID,
+			origin:        origin,
+			result:        fetchResultValidationError,
+			reason:        validationReasonOf(err),
+			status:        status,
+			duration:      time.Since(start),
+			fetched:       true,
+			responseBytes: len(body),
+			err:           err,
+		})
 		return nil, err
 	}
 
+	r.observe(ctx, resolveObservation{
+		clientID:      clientID,
+		origin:        origin,
+		result:        fetchResultSuccess,
+		reason:        "",
+		status:        status,
+		duration:      time.Since(start),
+		fetched:       true,
+		responseBytes: len(body),
+		err:           nil,
+	})
 	return &doc, nil
+}
+
+// resolveObservation carries everything one Resolve attempt learned to the
+// single metrics + log emission point.
+type resolveObservation struct {
+	clientID string
+	origin   string // empty until the client_id URL has parsed
+	result   fetchResult
+	reason   validationReason // non-empty only for validation_error
+	status   int              // HTTP status, 0 when no response was received
+	duration time.Duration
+	fetched  bool // whether an upstream fetch actually ran
+	// responseBytes is the completed body read length, 0 when no body was
+	// read; log-only (the cimd.fetch.response_size histogram is recorded
+	// inside fetchDocument, where the cap-hit case is also visible).
+	responseBytes int
+	err           error
+}
+
+func (r *Resolver) observe(ctx context.Context, o resolveObservation) {
+	r.metrics.RecordAttempt(ctx, o.origin, o.result)
+	if o.fetched {
+		r.metrics.RecordFetchDuration(ctx, o.origin, o.result, o.duration)
+	}
+	if o.result == fetchResultValidationError {
+		r.metrics.RecordValidationFailure(ctx, o.reason)
+	}
+
+	// The client_id is attacker-chosen on an unauthenticated surface and, on
+	// the client_id_too_long rejection specifically, has not yet been bounded
+	// by the length cap — truncate so a request-sized URL cannot inflate
+	// every warn line.
+	clientID := o.clientID
+	if len(clientID) > maxClientIDLength {
+		clientID = clientID[:maxClientIDLength] + "…(truncated)"
+	}
+	logAttrs := []any{
+		attr.SlogOAuthClientID(clientID),
+		attr.SlogOutcome(string(o.result)),
+	}
+	if o.origin != "" {
+		logAttrs = append(logAttrs, attr.SlogCIMDOrigin(o.origin))
+	}
+	if o.status != 0 {
+		logAttrs = append(logAttrs, attr.SlogHTTPResponseStatusCode(o.status))
+	}
+	if o.fetched {
+		logAttrs = append(logAttrs, attr.SlogHTTPClientRequestDuration(float64(o.duration)/float64(time.Millisecond)))
+	}
+	if o.responseBytes > 0 {
+		logAttrs = append(logAttrs, attr.SlogHTTPResponseBodyBytes(o.responseBytes))
+	}
+	if o.reason != "" {
+		logAttrs = append(logAttrs, attr.SlogCIMDValidationReason(o.reason))
+	}
+	if o.err != nil {
+		logAttrs = append(logAttrs, attr.SlogError(o.err))
+		r.logger.WarnContext(ctx, "cimd document resolution failed", logAttrs...)
+		return
+	}
+	r.logger.InfoContext(ctx, "cimd document resolved", logAttrs...)
 }
 
 // fetchDocument retrieves the metadata document. Only HTTP 200 is accepted
 // (-02 §5 MUST; other statuses — including the unfollowed redirects — are
 // fetch failures and are never cached per §5.2), and the body read is capped
-// at maxDocumentBytes.
-func fetchDocument(ctx context.Context, client *guardian.HTTPClient, clientID string) ([]byte, error) {
+// at maxDocumentBytes. The returned status is 0 when no response was
+// received. Response size is recorded here because the byte count only
+// exists inside the read: the full body length on success, or the cap itself
+// when the read tripped it.
+func (r *Resolver) fetchDocument(ctx context.Context, origin string, clientID string) ([]byte, int, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
+	// A build failure here is practically unreachable — clientID already
+	// passed validateClientIDURL — so the fetch_error result it produces is
+	// accepted despite no request having been sent.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("build document request: %w", err)
+		return nil, 0, fmt.Errorf("build document request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request document: %w", err)
+		return nil, 0, fmt.Errorf("request document: %w", err)
 	}
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("document endpoint returned status %d", resp.StatusCode)
+		return nil, resp.StatusCode, fmt.Errorf("document endpoint returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxDocumentBytes))
 	if err != nil {
 		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
-			return nil, fmt.Errorf("document exceeds %d byte limit", maxDocumentBytes)
+			r.metrics.RecordResponseSize(ctx, origin, maxDocumentBytes)
+			return nil, resp.StatusCode, fmt.Errorf("document exceeds %d byte limit", maxDocumentBytes)
 		}
-		return nil, fmt.Errorf("read document body: %w", err)
+		return nil, resp.StatusCode, fmt.Errorf("read document body: %w", err)
 	}
+	r.metrics.RecordResponseSize(ctx, origin, int64(len(body)))
 
-	return body, nil
+	return body, resp.StatusCode, nil
 }

--- a/server/internal/usersessions/cimd/cimd_test.go
+++ b/server/internal/usersessions/cimd/cimd_test.go
@@ -26,30 +26,31 @@ func TestIsClientIDURL(t *testing.T) {
 }
 
 // newDocServer starts a TLS server whose /client.json responds via handler
-// and returns the server plus a fetch client that trusts its certificate —
-// the same injection pattern production uses with a guardian-built client.
-func newDocServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *http.Client) {
+// and returns the server plus a resolver whose fetch client trusts its
+// certificate — the same injection pattern production uses with a
+// guardian-built client.
+func newDocServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Resolver) {
 	t.Helper()
 
 	srv := httptest.NewTLSServer(handler)
 	t.Cleanup(srv.Close)
-	return srv, newFetchClientFrom(srv.Client())
+	return srv, newResolver(newFetchClientFrom(srv.Client()), testenv.NewMeterProvider(t), testenv.NewLogger(t))
 }
 
 // serveDocumentJSON responds 200 application/json with the document derived
 // from the request URL by fn.
-func serveDocumentJSON(t *testing.T, fn func(clientID string) map[string]any) (*httptest.Server, *http.Client, string) {
+func serveDocumentJSON(t *testing.T, fn func(clientID string) map[string]any) (*httptest.Server, *Resolver, string) {
 	t.Helper()
 
 	var clientID string
-	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(fn(clientID)); err != nil {
 			t.Errorf("encode document: %v", err)
 		}
 	})
 	clientID = srv.URL + "/client.json"
-	return srv, client, clientID
+	return srv, resolver, clientID
 }
 
 func validDocumentJSON(clientID string) map[string]any {
@@ -64,9 +65,9 @@ func validDocumentJSON(clientID string) map[string]any {
 func TestResolve_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	_, client, clientID := serveDocumentJSON(t, validDocumentJSON)
+	_, resolver, clientID := serveDocumentJSON(t, validDocumentJSON)
 
-	doc, err := Resolve(t.Context(), client, clientID)
+	doc, err := resolver.Resolve(t.Context(), clientID)
 	require.NoError(t, err)
 	require.Equal(t, clientID, doc.ClientID)
 	require.Equal(t, "CIMD Test Client", doc.ClientName)
@@ -76,11 +77,11 @@ func TestResolve_HappyPath(t *testing.T) {
 func TestResolve_Non200Rejected(t *testing.T) {
 	t.Parallel()
 
-	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	})
 
-	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
 	require.ErrorContains(t, err, "status 404")
 }
 
@@ -90,7 +91,7 @@ func TestResolve_RedirectNotFollowed(t *testing.T) {
 	// -02 §5: the fetch MUST NOT follow redirects. The 302 must surface as
 	// a fetch failure even though its target would serve a valid document.
 	var clientID string
-	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/target.json" {
 			w.Header().Set("Content-Type", "application/json")
 			if err := json.NewEncoder(w).Encode(validDocumentJSON(clientID)); err != nil {
@@ -102,28 +103,28 @@ func TestResolve_RedirectNotFollowed(t *testing.T) {
 	})
 	clientID = srv.URL + "/client.json"
 
-	_, err := Resolve(t.Context(), client, clientID)
+	_, err := resolver.Resolve(t.Context(), clientID)
 	require.ErrorContains(t, err, "status 302")
 }
 
 func TestResolve_OversizedDocumentRejected(t *testing.T) {
 	t.Parallel()
 
-	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := fmt.Fprintf(w, `{"padding":%q`, strings.Repeat("a", maxDocumentBytes+1)); err != nil {
 			t.Errorf("write oversized document: %v", err)
 		}
 	})
 
-	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
 	require.ErrorContains(t, err, "byte limit")
 }
 
 func TestResolve_InvalidJSONRejected(t *testing.T) {
 	t.Parallel()
 
-	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write([]byte("not json")); err != nil {
 			t.Errorf("write document: %v", err)
@@ -133,7 +134,7 @@ func TestResolve_InvalidJSONRejected(t *testing.T) {
 	// Deliberately NOT an OAuthError: a distinguishable "reachable but not
 	// JSON" outcome would let unauthenticated callers probe external hosts
 	// through Gram, so it reports like any other fetch failure.
-	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
 	require.ErrorContains(t, err, "parse client metadata document")
 	var oauthErr *usersessions.OAuthError
 	require.NotErrorAs(t, err, &oauthErr)
@@ -142,13 +143,13 @@ func TestResolve_InvalidJSONRejected(t *testing.T) {
 func TestResolve_DocumentClientIDMismatchRejected(t *testing.T) {
 	t.Parallel()
 
-	_, client, clientID := serveDocumentJSON(t, func(clientID string) map[string]any {
+	_, resolver, clientID := serveDocumentJSON(t, func(clientID string) map[string]any {
 		doc := validDocumentJSON(clientID)
 		doc["client_id"] = clientID + "?other"
 		return doc
 	})
 
-	_, err := Resolve(t.Context(), client, clientID)
+	_, err := resolver.Resolve(t.Context(), clientID)
 	requireOAuthError(t, err, "invalid_client_metadata")
 }
 
@@ -156,11 +157,11 @@ func TestResolve_InvalidClientIDURLNoFetch(t *testing.T) {
 	t.Parallel()
 
 	requests := 0
-	srv, client := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
+	srv, resolver := newDocServer(t, func(w http.ResponseWriter, r *http.Request) {
 		requests++
 	})
 
-	_, err := Resolve(t.Context(), client, srv.URL) // no path component
+	_, err := resolver.Resolve(t.Context(), srv.URL) // no path component
 	requireOAuthError(t, err, "invalid_request")
 	require.Zero(t, requests, "syntactically invalid client_id must never be fetched")
 }
@@ -175,7 +176,7 @@ func TestResolve_ProductionPolicyBlocksLoopback(t *testing.T) {
 		t.Error("SSRF-guarded client must not reach a loopback document host")
 	})
 
-	client := NewFetchClient(guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)))
-	_, err := Resolve(t.Context(), client, srv.URL+"/client.json")
+	resolver := NewResolver(guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)), testenv.NewMeterProvider(t), testenv.NewLogger(t))
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
 	require.ErrorContains(t, err, "request document")
 }

--- a/server/internal/usersessions/cimd/metrics.go
+++ b/server/internal/usersessions/cimd/metrics.go
@@ -1,0 +1,189 @@
+package cimd
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const (
+	meterFetchAttempts        = "cimd.fetch.attempts"
+	meterFetchDurationSeconds = "cimd.fetch.duration_seconds"
+	meterFetchResponseSize    = "cimd.fetch.response_size"
+	meterCacheHits            = "cimd.cache.hits"
+	meterValidationFailures   = "cimd.validation.failures"
+)
+
+// fetchResult labels the outcome of one Resolve attempt on the cimd.fetch.*
+// metrics. Every Resolve call records exactly one cimd.fetch.attempts point;
+// cimd.fetch.duration_seconds is recorded only for results where an upstream
+// fetch actually ran, so short-circuit results never skew latency percentiles.
+type fetchResult string
+
+const (
+	fetchResultSuccess         fetchResult = "success"
+	fetchResultFetchError      fetchResult = "fetch_error"
+	fetchResultParseError      fetchResult = "parse_error"
+	fetchResultValidationError fetchResult = "validation_error"
+
+	// The remaining results are PROVISIONAL: they label lifecycle stages that
+	// follow-up issues add inside this package — document caching (AIS-216:
+	// cached, conditional_not_modified), per-origin rate limiting (AIS-215:
+	// rate_limited), and admission control (AIS-371: admission_denied). They
+	// are declared now so the label vocabulary is stable for dashboards, but
+	// nothing records them yet and their exact semantics may still shift when
+	// the emitting code lands — do not build monitors on them until then.
+	fetchResultCached                 fetchResult = "cached"
+	fetchResultConditionalNotModified fetchResult = "conditional_not_modified"
+	fetchResultRateLimited            fetchResult = "rate_limited"
+	fetchResultAdmissionDenied        fetchResult = "admission_denied"
+)
+
+// validationReason is the machine-readable label recorded on
+// cimd.validation.failures for each rejection site in validate.go.
+type validationReason string
+
+const (
+	reasonClientIDTooLong        validationReason = "client_id_too_long"
+	reasonClientIDScheme         validationReason = "client_id_scheme"
+	reasonClientIDFragment       validationReason = "client_id_fragment"
+	reasonClientIDUnparseable    validationReason = "client_id_unparseable"
+	reasonClientIDUserinfo       validationReason = "client_id_userinfo"
+	reasonClientIDMissingHost    validationReason = "client_id_missing_host"
+	reasonClientIDMissingPath    validationReason = "client_id_missing_path"
+	reasonClientIDDotSegments    validationReason = "client_id_dot_segments"
+	reasonClientIDMismatch       validationReason = "client_id_mismatch"
+	reasonMissingClientName      validationReason = "missing_client_name"
+	reasonClientNameTooLong      validationReason = "client_name_too_long"
+	reasonInvalidAuthMethod      validationReason = "invalid_auth_method"
+	reasonContainsSecret         validationReason = "contains_secret"
+	reasonJWKSInvalid            validationReason = "jwks_invalid"
+	reasonJWKSPrivateKey         validationReason = "jwks_private_key"
+	reasonJWKSSymmetricKey       validationReason = "jwks_symmetric_key"
+	reasonMissingRedirectURIs    validationReason = "missing_redirect_uris"
+	reasonTooManyRedirectURIs    validationReason = "too_many_redirect_uris"
+	reasonRedirectURITooLong     validationReason = "redirect_uri_too_long"
+	reasonRedirectURIInvalid     validationReason = "redirect_uri_invalid"
+	reasonRedirectOriginMismatch validationReason = "redirect_origin_mismatch"
+)
+
+type metrics struct {
+	fetchAttempts      metric.Int64Counter
+	fetchDuration      metric.Float64Histogram
+	fetchResponseSize  metric.Int64Histogram
+	cacheHits          metric.Int64Counter
+	validationFailures metric.Int64Counter
+}
+
+func newMetrics(meterProvider metric.MeterProvider, logger *slog.Logger) *metrics {
+	ctx := context.Background()
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/usersessions/cimd")
+
+	fetchAttempts, err := meter.Int64Counter(
+		meterFetchAttempts,
+		metric.WithDescription("Count of CIMD metadata document resolve attempts by origin and result"),
+		metric.WithUnit("{attempt}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFetchAttempts), attr.SlogError(err))
+	}
+
+	fetchDuration, err := meter.Float64Histogram(
+		meterFetchDurationSeconds,
+		metric.WithDescription("Duration of CIMD metadata document resolution in seconds, recorded only when an upstream fetch ran"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFetchDurationSeconds), attr.SlogError(err))
+	}
+
+	fetchResponseSize, err := meter.Int64Histogram(
+		meterFetchResponseSize,
+		metric.WithDescription("Bytes of CIMD metadata document body read before the size cap, or the cap itself when hit"),
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(256, 512, 1024, 2048, 4096, maxDocumentBytes),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterFetchResponseSize), attr.SlogError(err))
+	}
+
+	cacheHits, err := meter.Int64Counter(
+		meterCacheHits,
+		metric.WithDescription("Count of CIMD metadata document cache hits by origin"),
+		metric.WithUnit("{hit}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterCacheHits), attr.SlogError(err))
+	}
+
+	validationFailures, err := meter.Int64Counter(
+		meterValidationFailures,
+		metric.WithDescription("Count of CIMD metadata document validation failures by reason"),
+		metric.WithUnit("{failure}"),
+	)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to create metric", attr.SlogMetricName(meterValidationFailures), attr.SlogError(err))
+	}
+
+	return &metrics{
+		fetchAttempts:      fetchAttempts,
+		fetchDuration:      fetchDuration,
+		fetchResponseSize:  fetchResponseSize,
+		cacheHits:          cacheHits,
+		validationFailures: validationFailures,
+	}
+}
+
+// RecordAttempt counts one Resolve attempt. origin may be empty (pre-parse
+// URL-syntax rejections have no established origin); the attribute is omitted
+// then rather than recorded as "".
+func (m *metrics) RecordAttempt(ctx context.Context, origin string, result fetchResult) {
+	if m == nil || m.fetchAttempts == nil {
+		return
+	}
+	m.fetchAttempts.Add(ctx, 1, metric.WithAttributes(fetchAttributes(origin, result)...))
+}
+
+func (m *metrics) RecordFetchDuration(ctx context.Context, origin string, result fetchResult, duration time.Duration) {
+	if m == nil || m.fetchDuration == nil {
+		return
+	}
+	m.fetchDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(fetchAttributes(origin, result)...))
+}
+
+func (m *metrics) RecordResponseSize(ctx context.Context, origin string, bytes int64) {
+	if m == nil || m.fetchResponseSize == nil {
+		return
+	}
+	m.fetchResponseSize.Record(ctx, bytes, metric.WithAttributes(attr.CIMDOrigin(origin)))
+}
+
+// RecordCacheHit is reserved for the document cache added by AIS-216; nothing
+// calls it in the fetch-every-time lifecycle shipped by AIS-217.
+func (m *metrics) RecordCacheHit(ctx context.Context, origin string) {
+	if m == nil || m.cacheHits == nil {
+		return
+	}
+	m.cacheHits.Add(ctx, 1, metric.WithAttributes(attr.CIMDOrigin(origin)))
+}
+
+func (m *metrics) RecordValidationFailure(ctx context.Context, reason validationReason) {
+	if m == nil || m.validationFailures == nil || reason == "" {
+		return
+	}
+	m.validationFailures.Add(ctx, 1, metric.WithAttributes(attr.CIMDValidationReason(reason)))
+}
+
+func fetchAttributes(origin string, result fetchResult) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{attr.Outcome(result)}
+	if origin != "" {
+		attrs = append(attrs, attr.CIMDOrigin(origin))
+	}
+	return attrs
+}

--- a/server/internal/usersessions/cimd/metrics_test.go
+++ b/server/internal/usersessions/cimd/metrics_test.go
@@ -1,0 +1,313 @@
+package cimd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// newObservedResolver builds a doc server plus a resolver whose metrics are
+// readable through the returned ManualReader.
+func newObservedResolver(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Resolver, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	resolver := newResolver(newFetchClientFrom(srv.Client()), meterProvider, testenv.NewLogger(t))
+	return srv, resolver, reader
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	return rm
+}
+
+func findMetric(rm metricdata.ResourceMetrics, name string) (metricdata.Metrics, bool) {
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m, true
+			}
+		}
+	}
+	return metricdata.Metrics{}, false
+}
+
+func counterPoints(t *testing.T, rm metricdata.ResourceMetrics, name string) []metricdata.DataPoint[int64] {
+	t.Helper()
+
+	m, ok := findMetric(rm, name)
+	require.True(t, ok, "missing metric %q", name)
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "metric %q is not an int64 sum", name)
+	return sum.DataPoints
+}
+
+func requireAttr(t *testing.T, set attribute.Set, key attribute.Key, want string) {
+	t.Helper()
+
+	value, ok := set.Value(key)
+	require.True(t, ok, "missing attribute %q", key)
+	require.Equal(t, want, value.AsString())
+}
+
+func requireNoAttr(t *testing.T, set attribute.Set, key attribute.Key) {
+	t.Helper()
+
+	_, ok := set.Value(key)
+	require.False(t, ok, "unexpected attribute %q", key)
+}
+
+func TestResolverMetrics_Success(t *testing.T) {
+	t.Parallel()
+
+	var clientID string
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(validDocumentJSON(clientID)); err != nil {
+			t.Errorf("encode document: %v", err)
+		}
+	})
+	clientID = srv.URL + "/client.json"
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	origin := srvURL.Host
+
+	_, err = resolver.Resolve(t.Context(), clientID)
+	require.NoError(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	require.Equal(t, int64(1), attempts[0].Value)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultSuccess))
+	requireAttr(t, attempts[0].Attributes, attr.CIMDOriginKey, origin)
+
+	durationMetric, ok := findMetric(rm, meterFetchDurationSeconds)
+	require.True(t, ok)
+	durationHistogram, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, durationHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), durationHistogram.DataPoints[0].Count)
+	requireAttr(t, durationHistogram.DataPoints[0].Attributes, attr.OutcomeKey, string(fetchResultSuccess))
+	requireAttr(t, durationHistogram.DataPoints[0].Attributes, attr.CIMDOriginKey, origin)
+
+	sizeMetric, ok := findMetric(rm, meterFetchResponseSize)
+	require.True(t, ok)
+	sizeHistogram, ok := sizeMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, sizeHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), sizeHistogram.DataPoints[0].Count)
+	require.Positive(t, sizeHistogram.DataPoints[0].Sum)
+	requireAttr(t, sizeHistogram.DataPoints[0].Attributes, attr.CIMDOriginKey, origin)
+}
+
+func TestResolverMetrics_FetchError(t *testing.T) {
+	t.Parallel()
+
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	require.Error(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultFetchError))
+
+	durationMetric, ok := findMetric(rm, meterFetchDurationSeconds)
+	require.True(t, ok)
+	durationHistogram, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, durationHistogram.DataPoints, 1)
+	requireAttr(t, durationHistogram.DataPoints[0].Attributes, attr.OutcomeKey, string(fetchResultFetchError))
+
+	// The 404 fails the fetch before the body read, so no size is recorded.
+	_, ok = findMetric(rm, meterFetchResponseSize)
+	require.False(t, ok)
+}
+
+func TestResolverMetrics_ParseError(t *testing.T) {
+	t.Parallel()
+
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte("not json")); err != nil {
+			t.Errorf("write document: %v", err)
+		}
+	})
+
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	require.Error(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultParseError))
+
+	// The body was fully read before parsing failed, so its size is recorded.
+	sizeMetric, ok := findMetric(rm, meterFetchResponseSize)
+	require.True(t, ok)
+	sizeHistogram, ok := sizeMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, sizeHistogram.DataPoints, 1)
+	require.Equal(t, int64(len("not json")), sizeHistogram.DataPoints[0].Sum)
+}
+
+func TestResolverMetrics_OversizedDocumentRecordsCap(t *testing.T) {
+	t.Parallel()
+
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"padding":%q`, strings.Repeat("a", maxDocumentBytes+1)); err != nil {
+			t.Errorf("write oversized document: %v", err)
+		}
+	})
+
+	_, err := resolver.Resolve(t.Context(), srv.URL+"/client.json")
+	require.Error(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultFetchError))
+
+	sizeMetric, ok := findMetric(rm, meterFetchResponseSize)
+	require.True(t, ok)
+	sizeHistogram, ok := sizeMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, sizeHistogram.DataPoints, 1)
+	require.Equal(t, int64(maxDocumentBytes), sizeHistogram.DataPoints[0].Sum, "cap hits record the cap itself")
+}
+
+func TestResolverMetrics_ValidationErrorWithReason(t *testing.T) {
+	t.Parallel()
+
+	var clientID string
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		doc := validDocumentJSON(clientID)
+		doc["client_id"] = clientID + "?other"
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(doc); err != nil {
+			t.Errorf("encode document: %v", err)
+		}
+	})
+	clientID = srv.URL + "/client.json"
+
+	_, err := resolver.Resolve(t.Context(), clientID)
+	require.Error(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultValidationError))
+
+	failures := counterPoints(t, rm, meterValidationFailures)
+	require.Len(t, failures, 1)
+	require.Equal(t, int64(1), failures[0].Value)
+	requireAttr(t, failures[0].Attributes, attr.CIMDValidationReasonKey, string(reasonClientIDMismatch))
+}
+
+// TestResolverMetrics_URLSyntaxFailure pins the pre-fetch shape: the attempt
+// counts as a validation error with its reason, but no origin attribute is
+// recorded (the attacker-controlled URL never parsed) and no duration point
+// exists (nothing was fetched).
+func TestResolverMetrics_URLSyntaxFailure(t *testing.T) {
+	t.Parallel()
+
+	srv, resolver, reader := newObservedResolver(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("syntactically invalid client_id must never be fetched")
+	})
+
+	_, err := resolver.Resolve(t.Context(), srv.URL) // no path component
+	require.Error(t, err)
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, 1)
+	requireAttr(t, attempts[0].Attributes, attr.OutcomeKey, string(fetchResultValidationError))
+	requireNoAttr(t, attempts[0].Attributes, attr.CIMDOriginKey)
+
+	_, ok := findMetric(rm, meterFetchDurationSeconds)
+	require.False(t, ok)
+
+	failures := counterPoints(t, rm, meterValidationFailures)
+	require.Len(t, failures, 1)
+	requireAttr(t, failures[0].Attributes, attr.CIMDValidationReasonKey, string(reasonClientIDMissingPath))
+}
+
+// TestMetrics_NamesPinned pins the wire spellings of the metric names so a
+// const rename cannot silently break dashboards built on them.
+func TestMetrics_NamesPinned(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cimd.fetch.attempts", meterFetchAttempts)
+	require.Equal(t, "cimd.fetch.duration_seconds", meterFetchDurationSeconds)
+	require.Equal(t, "cimd.fetch.response_size", meterFetchResponseSize)
+	require.Equal(t, "cimd.cache.hits", meterCacheHits)
+	require.Equal(t, "cimd.validation.failures", meterValidationFailures)
+}
+
+// TestMetrics_ReservedResultLabels pins the provisional label spellings that
+// follow-up issues will emit — cached / conditional_not_modified (AIS-216),
+// rate_limited (AIS-215), admission_denied (AIS-371) — plus the reserved
+// cimd.cache.hits instrument, so dashboards built on this vocabulary stay
+// valid when the emitting code lands.
+func TestMetrics_ReservedResultLabels(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := newMetrics(meterProvider, testenv.NewLogger(t))
+
+	reserved := []struct {
+		result fetchResult
+		want   string
+	}{
+		{result: fetchResultCached, want: "cached"},
+		{result: fetchResultConditionalNotModified, want: "conditional_not_modified"},
+		{result: fetchResultRateLimited, want: "rate_limited"},
+		{result: fetchResultAdmissionDenied, want: "admission_denied"},
+	}
+	for _, r := range reserved {
+		require.Equal(t, r.want, string(r.result))
+		m.RecordAttempt(ctx, "client.example.com", r.result)
+	}
+	m.RecordCacheHit(ctx, "client.example.com")
+
+	rm := collectMetrics(t, reader)
+
+	attempts := counterPoints(t, rm, meterFetchAttempts)
+	require.Len(t, attempts, len(reserved))
+
+	hits := counterPoints(t, rm, meterCacheHits)
+	require.Len(t, hits, 1)
+	require.Equal(t, int64(1), hits[0].Value)
+	requireAttr(t, hits[0].Attributes, attr.CIMDOriginKey, "client.example.com")
+}

--- a/server/internal/usersessions/cimd/validate.go
+++ b/server/internal/usersessions/cimd/validate.go
@@ -2,12 +2,40 @@ package cimd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 )
+
+// validationError pairs a validation rejection with the machine-readable
+// reason label recorded on cimd.validation.failures. Unwrap keeps the
+// *usersessions.OAuthError (or wrapped equivalent) reachable via errors.As,
+// so callers' wire-format mapping is unaffected by the annotation.
+type validationError struct {
+	reason validationReason
+	err    error
+}
+
+func (e *validationError) Error() string { return e.err.Error() }
+func (e *validationError) Unwrap() error { return e.err }
+
+// oauthValidationError builds the standard rejection shape: a client-safe
+// OAuth error annotated with its metric reason.
+func oauthValidationError(reason validationReason, code string, description string) error {
+	return &validationError{reason: reason, err: &usersessions.OAuthError{Code: code, Description: description}}
+}
+
+// validationReasonOf extracts the reason label from a validation rejection,
+// or "" when the error did not come from a validate function.
+func validationReasonOf(err error) validationReason {
+	if ve, ok := errors.AsType[*validationError](err); ok {
+		return ve.reason
+	}
+	return ""
+}
 
 // validateClientIDURL enforces the -02 §3 Client Identifier URL syntax rules
 // on the presented client_id and returns the parsed URL:
@@ -25,33 +53,33 @@ import (
 // https://example.com:443/c are different client identifiers.
 func validateClientIDURL(clientID string) (*url.URL, error) {
 	if len(clientID) > maxClientIDLength {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: fmt.Sprintf("client_id exceeds the %d byte limit", maxClientIDLength)}
+		return nil, oauthValidationError(reasonClientIDTooLong, "invalid_request", fmt.Sprintf("client_id exceeds the %d byte limit", maxClientIDLength))
 	}
 	if !strings.HasPrefix(clientID, "https://") {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must use the https scheme"}
+		return nil, oauthValidationError(reasonClientIDScheme, "invalid_request", "client_id URL must use the https scheme")
 	}
 	// url.Parse tolerates fragments by splitting them off; detect them on
 	// the raw string so an empty "#" is caught too.
 	if strings.Contains(clientID, "#") {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must not contain a fragment"}
+		return nil, oauthValidationError(reasonClientIDFragment, "invalid_request", "client_id URL must not contain a fragment")
 	}
 
 	parsed, err := url.Parse(clientID)
 	if err != nil {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id is not a valid URL"}
+		return nil, oauthValidationError(reasonClientIDUnparseable, "invalid_request", "client_id is not a valid URL")
 	}
 	if parsed.User != nil {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must not contain a userinfo component"}
+		return nil, oauthValidationError(reasonClientIDUserinfo, "invalid_request", "client_id URL must not contain a userinfo component")
 	}
 	if parsed.Host == "" {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must include a host"}
+		return nil, oauthValidationError(reasonClientIDMissingHost, "invalid_request", "client_id URL must include a host")
 	}
 	if parsed.Path == "" {
-		return nil, &usersessions.OAuthError{Code: "invalid_request", Description: "client_id URL must include a path component"}
+		return nil, oauthValidationError(reasonClientIDMissingPath, "invalid_request", "client_id URL must include a path component")
 	}
 	for segment := range strings.SplitSeq(parsed.Path, "/") {
 		if segment == "." || segment == ".." {
-			return nil, &usersessions.OAuthError{Code: "invalid_request", Description: `client_id URL must not contain "." or ".." path segments`}
+			return nil, oauthValidationError(reasonClientIDDotSegments, "invalid_request", `client_id URL must not contain "." or ".." path segments`)
 		}
 	}
 
@@ -64,15 +92,15 @@ func validateClientIDURL(clientID string) (*url.URL, error) {
 // single equality check here completes the §4 triple equality requirement.
 func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) error {
 	if doc.ClientID != clientID {
-		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "document client_id does not match the client identifier URL"}
+		return oauthValidationError(reasonClientIDMismatch, "invalid_client_metadata", "document client_id does not match the client identifier URL")
 	}
 	// MCP requires client_name, and the user_session_clients.client_name
 	// column is NOT NULL — requiring it here avoids fallback logic.
 	if doc.ClientName == "" {
-		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "client_name is required"}
+		return oauthValidationError(reasonMissingClientName, "invalid_client_metadata", "client_name is required")
 	}
 	if len(doc.ClientName) > maxClientNameLength {
-		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: fmt.Sprintf("client_name exceeds the %d byte limit", maxClientNameLength)}
+		return oauthValidationError(reasonClientNameTooLong, "invalid_client_metadata", fmt.Sprintf("client_name exceeds the %d byte limit", maxClientNameLength))
 	}
 	// Only public clients are accepted. -02 §8.2's direction of travel is that
 	// capable clients SHOULD authenticate (MCP clients MAY use
@@ -81,29 +109,32 @@ func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) erro
 	// come with it. An absent value is rejected too: the RFC 7591 default
 	// is client_secret_basic, a symmetric method the spec bans for CIMD.
 	if doc.TokenEndpointAuthMethod != "none" {
-		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: `token_endpoint_auth_method must be "none"`}
+		return oauthValidationError(reasonInvalidAuthMethod, "invalid_client_metadata", `token_endpoint_auth_method must be "none"`)
 	}
 	// -02 §4.1: a metadata document is public, so it must never carry a
 	// client secret in any form. Presence alone invalidates the document.
 	if doc.ClientSecret != nil || doc.ClientSecretExpiresAt != nil {
-		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "document must not contain client_secret or client_secret_expires_at"}
+		return oauthValidationError(reasonContainsSecret, "invalid_client_metadata", "document must not contain client_secret or client_secret_expires_at")
 	}
 	if err := validateJWKSPublicOnly(doc.JWKS); err != nil {
 		return err
 	}
 
 	if len(doc.RedirectURIs) == 0 {
-		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: "redirect_uris is required"}
+		return oauthValidationError(reasonMissingRedirectURIs, "invalid_redirect_uri", "redirect_uris is required")
 	}
 	if len(doc.RedirectURIs) > maxRedirectURIs {
-		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uris exceeds the limit of %d entries", maxRedirectURIs)}
+		return oauthValidationError(reasonTooManyRedirectURIs, "invalid_redirect_uri", fmt.Sprintf("redirect_uris exceeds the limit of %d entries", maxRedirectURIs))
 	}
 	for _, uri := range doc.RedirectURIs {
 		if len(uri) > maxRedirectURILength {
-			return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uri exceeds the %d byte limit", maxRedirectURILength)}
+			return oauthValidationError(reasonRedirectURITooLong, "invalid_redirect_uri", fmt.Sprintf("redirect_uri exceeds the %d byte limit", maxRedirectURILength))
 		}
+		// ValidateRedirectURI returns *usersessions.OAuthError values of its
+		// own, so the wrap preserves the client-safe wire mapping while the
+		// annotation adds the shared metric reason.
 		if err := usersessions.ValidateRedirectURI(uri); err != nil {
-			return fmt.Errorf("validate redirect_uri: %w", err)
+			return &validationError{reason: reasonRedirectURIInvalid, err: fmt.Errorf("validate redirect_uri: %w", err)}
 		}
 		if err := validateOriginBinding(clientIDURL, uri); err != nil {
 			return err
@@ -126,13 +157,13 @@ func validateDocument(doc *Document, clientID string, clientIDURL *url.URL) erro
 func validateOriginBinding(clientIDURL *url.URL, redirectURI string) error {
 	parsed, err := url.Parse(redirectURI)
 	if err != nil {
-		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: "redirect_uri must be an absolute URL"}
+		return oauthValidationError(reasonRedirectURIInvalid, "invalid_redirect_uri", "redirect_uri must be an absolute URL")
 	}
 	if IsLoopbackRedirectURI(parsed) {
 		return nil
 	}
 	if parsed.Scheme != clientIDURL.Scheme || parsed.Host != clientIDURL.Host {
-		return &usersessions.OAuthError{Code: "invalid_redirect_uri", Description: fmt.Sprintf("redirect_uri %q is not same-origin with the client_id URL", redirectURI)}
+		return oauthValidationError(reasonRedirectOriginMismatch, "invalid_redirect_uri", fmt.Sprintf("redirect_uri %q is not same-origin with the client_id URL", redirectURI))
 	}
 	return nil
 }
@@ -169,14 +200,14 @@ func validateJWKSPublicOnly(raw json.RawMessage) error {
 		Keys []map[string]json.RawMessage `json:"keys"`
 	}
 	if err := json.Unmarshal(raw, &jwks); err != nil {
-		return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "jwks is not a valid JWK Set"}
+		return oauthValidationError(reasonJWKSInvalid, "invalid_client_metadata", "jwks is not a valid JWK Set")
 	}
 	for _, key := range jwks.Keys {
 		if _, ok := key["d"]; ok {
-			return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "jwks must not contain private key material"}
+			return oauthValidationError(reasonJWKSPrivateKey, "invalid_client_metadata", "jwks must not contain private key material")
 		}
 		if _, ok := key["k"]; ok {
-			return &usersessions.OAuthError{Code: "invalid_client_metadata", Description: "jwks must not contain symmetric key material"}
+			return oauthValidationError(reasonJWKSSymmetricKey, "invalid_client_metadata", "jwks must not contain symmetric key material")
 		}
 	}
 	return nil

--- a/server/internal/usersessions/cimd/validate_test.go
+++ b/server/internal/usersessions/cimd/validate_test.go
@@ -38,6 +38,15 @@ func requireOAuthError(t *testing.T, err error, code string) {
 	require.Equal(t, code, oauthErr.Code)
 }
 
+// requireValidationError asserts both halves of a validation rejection: the
+// client-facing OAuth error code reachable through errors.As, and the metric
+// reason label extracted by validationReasonOf.
+func requireValidationError(t *testing.T, err error, code string, reason validationReason) {
+	t.Helper()
+	requireOAuthError(t, err, code)
+	require.Equal(t, reason, validationReasonOf(err))
+}
+
 func TestValidateClientIDURL_Valid(t *testing.T) {
 	t.Parallel()
 
@@ -58,42 +67,42 @@ func TestValidateClientIDURL_MissingPathRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := validateClientIDURL("https://client.example.com")
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDMissingPath)
 }
 
 func TestValidateClientIDURL_UserinfoRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := validateClientIDURL("https://user@client.example.com/client.json")
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDUserinfo)
 }
 
 func TestValidateClientIDURL_FragmentRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := validateClientIDURL("https://client.example.com/client.json#frag")
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDFragment)
 }
 
 func TestValidateClientIDURL_DotDotSegmentRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := validateClientIDURL("https://client.example.com/oauth/../client.json")
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDDotSegments)
 }
 
 func TestValidateClientIDURL_DotSegmentRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := validateClientIDURL("https://client.example.com/./client.json")
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDDotSegments)
 }
 
 func TestValidateClientIDURL_NonHTTPSRejected(t *testing.T) {
 	t.Parallel()
 
 	_, err := validateClientIDURL("http://client.example.com/client.json")
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDScheme)
 }
 
 func TestValidateClientIDURL_OversizedRejected(t *testing.T) {
@@ -101,7 +110,7 @@ func TestValidateClientIDURL_OversizedRejected(t *testing.T) {
 
 	long := "https://client.example.com/" + strings.Repeat("a", maxClientIDLength)
 	_, err := validateClientIDURL(long)
-	requireOAuthError(t, err, "invalid_request")
+	requireValidationError(t, err, "invalid_request", reasonClientIDTooLong)
 }
 
 func TestValidateDocument_Valid(t *testing.T) {
@@ -120,7 +129,7 @@ func TestValidateDocument_ClientIDMismatchRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientID = "https://client.example.com/oauth/other.json"
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonClientIDMismatch)
 }
 
 func TestValidateDocument_MissingClientNameRejected(t *testing.T) {
@@ -131,7 +140,7 @@ func TestValidateDocument_MissingClientNameRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientName = ""
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonMissingClientName)
 }
 
 func TestValidateDocument_MissingAuthMethodRejected(t *testing.T) {
@@ -144,7 +153,7 @@ func TestValidateDocument_MissingAuthMethodRejected(t *testing.T) {
 	// RFC 7591 — a symmetric method CIMD forbids, so it must be rejected.
 	doc := testDocument(testClientID)
 	doc.TokenEndpointAuthMethod = ""
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonInvalidAuthMethod)
 }
 
 func TestValidateDocument_SymmetricAuthMethodRejected(t *testing.T) {
@@ -155,7 +164,7 @@ func TestValidateDocument_SymmetricAuthMethodRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.TokenEndpointAuthMethod = "client_secret_basic"
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonInvalidAuthMethod)
 }
 
 func TestValidateDocument_ClientSecretRejected(t *testing.T) {
@@ -166,7 +175,7 @@ func TestValidateDocument_ClientSecretRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientSecret = json.RawMessage(`"s3cret"`)
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonContainsSecret)
 }
 
 func TestValidateDocument_ClientSecretExpiresAtRejected(t *testing.T) {
@@ -177,7 +186,18 @@ func TestValidateDocument_ClientSecretExpiresAtRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientSecretExpiresAt = json.RawMessage(`0`)
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonContainsSecret)
+}
+
+func TestValidateDocument_JWKSNotAJWKSetRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	doc := testDocument(testClientID)
+	doc.JWKS = json.RawMessage(`[]`)
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonJWKSInvalid)
 }
 
 func TestValidateDocument_JWKSPrivateKeyRejected(t *testing.T) {
@@ -188,7 +208,7 @@ func TestValidateDocument_JWKSPrivateKeyRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"EC","crv":"P-256","x":"a","y":"b","d":"private"}]}`)
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonJWKSPrivateKey)
 }
 
 func TestValidateDocument_JWKSSymmetricKeyRejected(t *testing.T) {
@@ -199,7 +219,7 @@ func TestValidateDocument_JWKSSymmetricKeyRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.JWKS = json.RawMessage(`{"keys":[{"kty":"oct","k":"c2VjcmV0"}]}`)
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonJWKSSymmetricKey)
 }
 
 func TestValidateDocument_JWKSPublicKeyAccepted(t *testing.T) {
@@ -221,7 +241,7 @@ func TestValidateDocument_OversizedClientNameRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.ClientName = strings.Repeat("a", maxClientNameLength+1)
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_client_metadata", reasonClientNameTooLong)
 }
 
 func TestValidateDocument_TooManyRedirectURIsRejected(t *testing.T) {
@@ -235,7 +255,7 @@ func TestValidateDocument_TooManyRedirectURIsRejected(t *testing.T) {
 	for range maxRedirectURIs + 1 {
 		doc.RedirectURIs = append(doc.RedirectURIs, "https://client.example.com/callback")
 	}
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonTooManyRedirectURIs)
 }
 
 func TestValidateDocument_OversizedRedirectURIRejected(t *testing.T) {
@@ -246,7 +266,7 @@ func TestValidateDocument_OversizedRedirectURIRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"https://client.example.com/" + strings.Repeat("a", maxRedirectURILength)}
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectURITooLong)
 }
 
 func TestValidateDocument_MissingRedirectURIsRejected(t *testing.T) {
@@ -257,7 +277,25 @@ func TestValidateDocument_MissingRedirectURIsRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = nil
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonMissingRedirectURIs)
+}
+
+// TestValidateDocument_NonLoopbackHTTPRedirectURIRejected exercises the
+// usersessions.ValidateRedirectURI rejection path — the one site whose
+// wrapping shape differs (a fmt.Errorf layer between the validationError and
+// the OAuthError), so both the reason extraction and the errors.As traversal
+// through the extra layer are pinned here.
+func TestValidateDocument_NonLoopbackHTTPRedirectURIRejected(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := validateClientIDURL(testClientID)
+	require.NoError(t, err)
+
+	// An http redirect on a non-loopback host fails ValidateRedirectURI's
+	// RFC 8252 §7.3 rule before origin binding is consulted.
+	doc := testDocument(testClientID)
+	doc.RedirectURIs = []string{"http://client.example.com/callback"}
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectURIInvalid)
 }
 
 func TestValidateDocument_CrossOriginHostRejected(t *testing.T) {
@@ -268,7 +306,7 @@ func TestValidateDocument_CrossOriginHostRejected(t *testing.T) {
 
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"https://evil.example.com/callback"}
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectOriginMismatch)
 }
 
 func TestValidateDocument_CrossOriginPortRejected(t *testing.T) {
@@ -281,7 +319,7 @@ func TestValidateDocument_CrossOriginPortRejected(t *testing.T) {
 	// the client_id URL's implicit port.
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"https://client.example.com:443/callback"}
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectOriginMismatch)
 }
 
 func TestValidateDocument_CustomSchemeRejectedByOriginBinding(t *testing.T) {
@@ -294,7 +332,7 @@ func TestValidateDocument_CustomSchemeRejectedByOriginBinding(t *testing.T) {
 	// https client_id, so Gram's origin binding rejects it.
 	doc := testDocument(testClientID)
 	doc.RedirectURIs = []string{"com.example.app://callback"}
-	requireOAuthError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri")
+	requireValidationError(t, validateDocument(doc, testClientID, parsed), "invalid_redirect_uri", reasonRedirectOriginMismatch)
 }
 
 func TestValidateDocument_LoopbackAnyPortAccepted(t *testing.T) {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-214/feat-telemetry-for-cimd-metadata-fetch-lifecycle

Refactor the `cimd` package from stateless free functions to a `Resolver` struct that owns the document fetch lifecycle and its telemetry. The `mcp` service constructs one `Resolver` at init and calls it from `resolveUserSessionClient`.

New metrics on the `usersessions/cimd` meter: `cimd.fetch.attempts` (counter, outcome and origin attributes), `cimd.fetch.duration_seconds` (histogram, recorded only when an upstream fetch ran), `cimd.fetch.response_size` (bytes read before the 5KB cap, or the cap itself when hit), `cimd.validation.failures` (per-reason counter), and a reserved `cimd.cache.hits` counter for the AIS-216 cache. Provisional outcome labels (`cached`, `conditional_not_modified`, `rate_limited`, `admission_denied`) are declared and pinned in tests for the AIS-216, AIS-215, and AIS-371 follow-ups but not yet emitted.

Validation rejections in `validate.go` are annotated with machine-readable reasons via an internal wrapper whose `Unwrap` preserves the client-facing `OAuthError`, so wire behavior is unchanged. The origin attribute (`client_id` URL host) is omitted on pre-parse URL syntax failures because the value is attacker-controlled until admission control lands. Each resolve attempt emits one structured log line (info on success, warn with the error chain on failure), with the logged `client_id` truncated at the length cap. The `parse_error` vs `fetch_error` distinction exists only in telemetry, never in the returned error shape, preserving the anti-SSRF-oracle design.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OTel/Prometheus telemetry to the CIMD metadata fetch lifecycle and refactors `cimd` into a stateful `Resolver` used by `mcp` to improve observability and safety. Supports Linear AIS-214 to roll out the `gram-user-session-cimd` flag with confidence.

- **New Features**
  - Metrics: `cimd.fetch.attempts` (outcome, origin), `cimd.fetch.duration_seconds` (only when a fetch ran), `cimd.fetch.response_size` (bytes read; records the 5KB cap on hit), `cimd.validation.failures` (per reason), plus reserved `cimd.cache.hits`. Provisional outcomes declared: `cached`, `conditional_not_modified`, `rate_limited`, `admission_denied` (not emitted yet).
  - Structured logs per resolve attempt (info on success, warn on failure); truncates logged `client_id`. Omits `gram.cimd.origin` on pre-parse URL failures. Parse vs fetch errors differ only in telemetry.
  - New attributes in `attr`: `gram.cimd.origin` and `gram.cimd.validation_reason`.

- **Refactors**
  - Replaced stateless functions with a `Resolver` that owns fetch, validation, metrics, and logs.
  - `mcp.Service` constructs one `Resolver` at init and calls it from `resolveUserSessionClient`.

<sup>Written for commit ca608cb5d9300a76afbb5edc182c37818123d707. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

