### PR TITLE
mig(risk): index risk_results for false-positive lookups

### DIFF
--- a/.changeset/risk-false-positives-missing-index.md
+++ b/.changeset/risk-false-positives-missing-index.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add a partial index on `risk_results (project_id, false_positive_at DESC, id DESC) WHERE false_positive_at IS NOT NULL` so the Policy Center False Positives tab (`risk.listDismissedResults`) no longer forces a sequential scan on projects with a large `risk_results` table. Every existing index on that table only serves the `false_positive_at IS NULL` case, leaving the dismissed-results count and list queries with nothing to scan but the whole table.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4485,6 +4485,17 @@ CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx
 ON risk_results (excluded_exclusion_id)
 WHERE excluded_exclusion_id IS NOT NULL;
 
+-- Serves the False Positives tab (ListFalsePositiveRiskResults,
+-- CountFalsePositiveRiskResults): every other partial index on this table
+-- filters on false_positive_at IS NULL, so a project with a large
+-- risk_results table forced a sequential scan for the IS NOT NULL case. The
+-- (false_positive_at DESC, id DESC) trailing order matches the keyset
+-- pagination cursor exactly, letting the list query walk the index directly
+-- instead of sorting, and lets the count query run as an index-only scan.
+CREATE INDEX IF NOT EXISTS risk_results_project_false_positive_idx
+ON risk_results (project_id, false_positive_at DESC, id DESC)
+WHERE false_positive_at IS NOT NULL;
+
 -- risk_policy_eval_reviews is the durable "regression set" for a prompt-based
 -- risk policy: a reviewer's ground-truth verdict on whether a given chat session
 -- should be flagged by the policy. The policy-eval workbench replays the

--- a/server/migrations/20260731163856_risk-results-false-positive-idx.sql
+++ b/server/migrations/20260731163856_risk-results-false-positive-idx.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "risk_results_project_false_positive_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_project_false_positive_idx" ON "risk_results" ("project_id", "false_positive_at" DESC, "id" DESC) WHERE (false_positive_at IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:nl0qDGaUHyRAQ0KEMJNOwJq9p3jf6m37JpIoOliWEsE=
+h1:z9IR/Icvk1jMdw3Vd3mLm/G9aIG/OiBXgAQzNQny8l4=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -309,3 +309,4 @@ h1:nl0qDGaUHyRAQ0KEMJNOwJq9p3jf6m37JpIoOliWEsE=
 20260728201450_cimd_inbound_storage.sql h1:al8Z9FQ75jt6vp7WIIhJ8+uyTDmf51PA3zb4Anggt1w=
 20260729235455_dno643-device-agent-device-syncs.sql h1:2xYuc2B1oopRAdvkZ57ys+5kncKCyM1Zw78D/M8bCXM=
 20260730125106_custom-domain-root-mcp-and-challenge.sql h1:RBOpyM/n3XVpvcfMBEhhY2FojQ9DYg4UwVuFtqTYzno=
+20260731163856_risk-results-false-positive-idx.sql h1:vy4SbxsWJDKNPeSMsORnDEg+gwpNZAClOltwPmQqYtA=


### PR DESCRIPTION
## Why
`risk.listDismissedResults` (the False Positives tab under Risk Policies) is very slow in production for projects with a large `risk_results` table. Every existing index on `risk_results` filters on `false_positive_at IS NULL` (the open-findings case), so the count and list queries backing this tab, which filter on `false_positive_at IS NOT NULL`, had no matching index and fell back to a sequential scan of the whole table.

## What changed
- `server/database/schema.sql`: added a partial index `risk_results_project_false_positive_idx` on `(project_id, false_positive_at DESC, id DESC) WHERE false_positive_at IS NOT NULL`. This matches `CountFalsePositiveRiskResults`'s WHERE clause and `ListFalsePositiveRiskResults`'s WHERE + ORDER BY (keyset pagination cursor) exactly, in `server/internal/risk/queries.sql`.
- `server/migrations/20260731163856_risk-results-false-positive-idx.sql`: generated via `mise db:diff`, `CREATE INDEX CONCURRENTLY` per the repo's Atlas `concurrent_index` policy.
- `.changeset/risk-false-positives-missing-index.md`: server patch changeset.

### Before
Both queries ran a sequential (or parallel sequential) scan over the entire `risk_results` table, filtering `false_positive_at IS NOT NULL` in a table-wide `Filter`, then sorting the list results in memory.

Verified locally against a synthetic 1M-row `risk_results` table (50k matching rows for one project): count query 50ms via parallel seq scan, list query 41ms via seq scan + sort.

### After
`EXPLAIN ANALYZE` against the same table with the new index:
- Count query: `Index Only Scan` on the new index, 0 heap fetches, ~10.6ms.
- List query: `Index Scan` on the new index matching the ORDER BY exactly (no sort step), ~0.2ms.

Ran `mise run test:server ./internal/risk/...` (444 tests pass) and `mise lint:server` (clean) after applying the migration locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the False Positives tab in Risk Policies by indexing dismissed results in `risk_results`. Removes full table scans; count runs index-only and list walks the index in order.

- **Performance**
  - Added partial index `risk_results_project_false_positive_idx` on `(project_id, false_positive_at DESC, id DESC) WHERE false_positive_at IS NOT NULL`.
  - Matches `CountFalsePositiveRiskResults` and `ListFalsePositiveRiskResults` WHERE and ORDER BY (keyset), eliminating sorts and scans.
  - Shipped via migration using `CREATE INDEX CONCURRENTLY`.

<sup>Written for commit 9d3c7b6cc899b8a4ff4dd3601c4d05bdc965ece9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

