### PR TITLE
chore: bound temporal dev server resources in tests

### DIFF
--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -84,6 +84,13 @@ linters:
         linters:
           - exhaustruct
           - gosec
+      # gosec stays on for testenv; exempt only G306 (the Temporal dev server
+      # shim has to carry the exec bit, and it is written 0700 into a 0700
+      # MkdirTemp directory).
+      - path: internal/testenv/temporal\.go
+        linters:
+          - gosec
+        text: G306
       # False positives that scope constants are somehow hardcoded credentials.
       - path: internal/access/scopes\.go
         linters:

--- a/server/internal/testenv/launch.go
+++ b/server/internal/testenv/launch.go
@@ -49,6 +49,7 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 	var clickhousecontainer terminateable
 	var presidioserver *presidiotest.MockServer
 	var temporalserver *testsuite.DevServer
+	var temporalserverCleanup func() error
 	var temporalserverErr error
 	var temporalserverOnce sync.Once
 
@@ -125,7 +126,7 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 			t.Helper()
 
 			temporalserverOnce.Do(func() {
-				temporalserver, temporalserverErr = NewTemporalDevServer(ctx)
+				temporalserver, temporalserverCleanup, temporalserverErr = NewTemporalDevServer(ctx)
 			})
 			require.NoError(t, temporalserverErr, "start temporal dev server")
 
@@ -171,11 +172,18 @@ func Launch(ctx context.Context, opts LaunchOptions) (*Environment, func() error
 		if presidioserver != nil {
 			presidioserver.Close()
 		}
-		if temporalserver != nil {
+		if temporalserver != nil || temporalserverCleanup != nil {
 			eg.Go(func() error {
-				temporalserver.Client().Close()
-				if err := temporalserver.Stop(); err != nil {
-					log.Printf("terminate temporal dev server: %v", err)
+				if temporalserver != nil {
+					temporalserver.Client().Close()
+					if err := temporalserver.Stop(); err != nil {
+						log.Printf("terminate temporal dev server: %v", err)
+					}
+				}
+				if temporalserverCleanup != nil {
+					if err := temporalserverCleanup(); err != nil {
+						log.Printf("clean up temporal dev server: %v", err)
+					}
 				}
 				return nil
 			})

--- a/server/internal/testenv/temporal.go
+++ b/server/internal/testenv/temporal.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,11 +20,86 @@ import (
 	servertemporal "github.com/speakeasy-api/gram/server/internal/temporal"
 )
 
+// A single dev server is shared by every test in a package, and each test
+// registers its own namespace and task queues against it. Left at its
+// defaults the server sizes itself for a production host and its footprint
+// grows with the number of namespaces, so it is bounded here from two sides:
+// the Go runtime knobs below and the dynamic config in devServerArgs.
+const (
+	// GOMEMLIMIT is a soft heap ceiling the GC actively works to stay under.
+	// It is the only real cap available, since the dev server is a plain
+	// subprocess with no cgroup of its own. It must stay above the live set:
+	// a limit below it does not bound memory, it just makes the GC run
+	// continuously trying to reach a target it cannot hit. 512MiB measured as
+	// too tight for a full package run and cost ~70% more dev server CPU.
+	devServerMemLimit = "1GiB"
+	// Per-P allocator caches and GC workers scale with core count. The dev
+	// server is infrastructure for the test, not the thing under test, and
+	// should not claim the whole host alongside a `-race` test binary.
+	devServerMaxProcs = "2"
+)
+
+// devServerArgs bounds the dev server's caches by size rather than by entry
+// count, which is what the defaults do.
+var devServerArgs = []string{
+	// The history cache is count-bounded by default (128k mutable state
+	// entries host-wide), which puts no ceiling on bytes. Switching it to a
+	// size-based limit is what makes GOMEMLIMIT reachable instead of a source
+	// of continuous GC. Server 1.31 dropped the shard-level cache, so
+	// hostLevelCacheMaxSizeBytes is the remaining size knob.
+	//
+	// These are sized for a whole package's worth of concurrent namespaces,
+	// not for one workflow: too small and every workflow task misses the cache
+	// and rebuilds mutable state from the event history, which costs more CPU
+	// than the memory it saves.
+	"--dynamic-config-value", "history.cacheSizeBasedLimit=true",
+	"--dynamic-config-value", "history.hostLevelCacheMaxSizeBytes=134217728",
+	"--dynamic-config-value", "history.eventsCacheMaxSizeBytes=8388608",
+	"--dynamic-config-value", `history.cacheTTL="1m"`,
+	"--dynamic-config-value", `history.eventsCacheTTL="1m"`,
+	// Every test registers a namespace and stands up workers on four task
+	// queues, and each partition carries its own manager and buffers. A test
+	// worker has no use for the default four partitions per queue, so this
+	// cuts the per-test matching overhead fourfold.
+	"--dynamic-config-value", "matching.numTaskqueueReadPartitions=1",
+	"--dynamic-config-value", "matching.numTaskqueueWritePartitions=1",
+}
+
 func nextRandom() string {
 	return uuid.NewString()
 }
 
-func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, error) {
+// newTemporalShim writes a shell shim that runs the temporal binary with the
+// Go runtime limits above applied. The SDK launches the dev server as a child
+// process and never sets cmd.Env, so the child inherits the test process's
+// environment verbatim; a shim is the only way to give the child variables the
+// test process itself must not have. `exec` replaces the shell, so the dev
+// server keeps the PID that DevServer.Stop signals.
+func newTemporalShim(dir string) (string, error) {
+	exe, err := exec.LookPath("temporal")
+	if err != nil {
+		return "", fmt.Errorf("locate temporal binary: %w", err)
+	}
+
+	script := fmt.Sprintf(
+		"#!/bin/sh\nexport GOMEMLIMIT=%s\nexport GOMAXPROCS=%s\nexec '%s' \"$@\"\n",
+		devServerMemLimit,
+		devServerMaxProcs,
+		strings.ReplaceAll(exe, "'", `'\''`),
+	)
+
+	// Owner-only: the exec bit is the point of the file, and nothing outside
+	// this test process ever runs it. The containing directory is MkdirTemp's
+	// 0700 as well.
+	path := filepath.Join(dir, "temporal-shim")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		return "", fmt.Errorf("write temporal shim: %w", err)
+	}
+
+	return path, nil
+}
+
+func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, func() error, error) {
 	var stdout io.Writer
 	var stderr io.Writer
 	if !isTestingVerbose() {
@@ -28,20 +107,36 @@ func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, error) {
 		stderr = io.Discard
 	}
 
+	shimDir, err := os.MkdirTemp("", "gram-temporal-*")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create temporal shim dir: %w", err)
+	}
+	cleanup := func() error {
+		if err := os.RemoveAll(shimDir); err != nil {
+			return fmt.Errorf("remove temporal shim dir: %w", err)
+		}
+		return nil
+	}
+
+	shim, err := newTemporalShim(shimDir)
+	if err != nil {
+		return nil, cleanup, err
+	}
+
 	var devserver *testsuite.DevServer
-	var err error
 	logger := NewLogger(nil)
 
 	for range 5 {
 		devserver, err = testsuite.StartDevServer(ctx, testsuite.DevServerOptions{
 			LogLevel:     "error",
-			ExistingPath: "temporal",
+			ExistingPath: shim,
 			ClientOptions: &client.Options{
 				Namespace: "default",
 				Logger:    logger,
 			},
-			Stdout: stdout,
-			Stderr: stderr,
+			ExtraArgs: devServerArgs,
+			Stdout:    stdout,
+			Stderr:    stderr,
 		})
 		if err == nil {
 			break
@@ -49,10 +144,10 @@ func NewTemporalDevServer(ctx context.Context) (*testsuite.DevServer, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("start temporal dev server: %w", err)
+		return nil, cleanup, fmt.Errorf("start temporal dev server: %w", err)
 	}
 
-	return devserver, nil
+	return devserver, cleanup, nil
 }
 
 func NewTemporalEnvironment(t *testing.T, devserver *testsuite.DevServer) (*servertemporal.Environment, error) {


### PR DESCRIPTION
## What

Bounds the Temporal dev server that `testenv` starts for tests, applying the same idea as #4774 (which capped the local dev server in `compose.yml`) to the test suite.

## Why

One dev server is shared by every test in a package, and each test registers its own namespace and stands up workers on four task queues. Left at its defaults it sizes itself for a production host, so its footprint grows with the number of namespaces — and because packages run concurrently, several are alive at once.

## Changes

All in `server/internal/testenv/`:

- **`GOMEMLIMIT=1GiB`, `GOMAXPROCS=2`** on the dev server process.
- **Size-based history cache** (`history.cacheSizeBasedLimit=true`, 128 MiB host cache, 8 MiB events cache, 1m TTLs) rather than the count-bounded default, which puts no ceiling on bytes.
- **`matching.numTaskqueueRead/WritePartitions=1`** — the largest structural win. At the default of 4 partitions, a package registering ~130 namespaces across 4 task queues creates on the order of 2000 partition managers, each with its own buffers.

### Why a shell shim

`testsuite.StartDevServer` launches the binary as a child process and never sets `cmd.Env`, so the child inherits the test process's environment verbatim. Setting `GOMEMLIMIT` on the test process itself would leak to every other subprocess a test spawns, so `NewTemporalDevServer` writes a two-line `/bin/sh` shim that exports the vars and `exec`s the real binary. `exec` preserves the PID that `DevServer.Stop` signals. It returns a cleanup func for the shim's temp dir, wired through `launch.go`.

### Why the cache sizes are larger than #4774's

Those values are sized for a single local workflow. Applied to a package run with ~130 concurrent namespaces they are too small: every workflow task misses the cache and rebuilds mutable state from the event history. Measured with `GOMEMLIMIT=512MiB` and a 32 MiB host cache, memory fell further (951 MiB peak) but dev-server CPU rose from 61s to 103s and wall time went up 22% — a soft limit below the live set makes the GC run continuously instead of capping anything. `GOMAXPROCS=4` was also tried: identical wall time to 2, but 176s CPU vs 103s.

## Verification

### `./internal/deployments` in isolation (`-race -count=1`)

| Temporal dev server | before   | after    |      |
| ------------------- | -------- | -------- | ---- |
| Peak RSS            | 1835 MiB | 1051 MiB | −43% |
| Mean RSS            | 1153 MiB | 738 MiB  | −36% |
| CPU                 | 60.8 s   | 54.9 s   | −10% |
| Peak threads        | 16       | 9        |      |
| Package wall time   | 57.29 s  | 57.13 s  | flat |

### Full server suite (`-race -tags=inv.debug -count=1 -p 4 ./...`)

Test binaries pre-built via `-exec=/bin/true` so no compilation sits inside the measured window. Dev-server figures are aggregated across concurrently running packages.

| Temporal dev servers         | before   | after    |                          |
| ---------------------------- | -------- | -------- | ------------------------ |
| Distinct servers started     | 7        | 7        |                          |
| Peak concurrent              | 2        | 3        | after ran _more_ at once |
| Peak aggregate RSS           | 2454 MiB | 1618 MiB | −34%                     |
| Mean RSS while ≥1 running    | 1695 MiB | 872 MiB  | −49%                     |
| Total CPU                    | 2349 s   | 1199 s   | −49%                     |
| Max system MemAvailable drop | 7490 MiB | 5597 MiB | −25%                     |
| Suite wall clock             | 1269 s   | 1170 s   | −8%                      |

The peak figure understates the change: the tuned run held a lower peak while running one more dev server concurrently. No OOM kills and no swap growth in either run.

## Suite state (unchanged by this PR)

Neither run of the full suite is green, before or after. Two pre-existing problems surfaced, filed separately:

- **DNO-719** — `cmd/gram/flags_assistants_test.go` has a real data race (parallel tests `Apply()` a package-global `urfave/cli` `StringFlag`). Fails on `main` too.
- **DNO-720** — `internal/deployments` hits the default 10m `go test` timeout under full-suite load, in both runs (57s in isolation).

The tuned run additionally showed `background` (race detector), `mcpendpoints` and `toolsets` (testcontainers dropping out — `No such container`, `connection refused`) failing. All three pass in isolation with this change applied, and `background` never calls `testenv.Launch`, so none are attributable to this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the Temporal dev server used in tests to reduce resource usage across the suite (−34–49% RSS, −49% CPU in full run). Applies Go runtime limits and size-based cache/partition settings without slowing tests.

- **Refactors**
  - Runs `temporal` via a shell shim that exports `GOMEMLIMIT=1GiB` and `GOMAXPROCS=2`; returns a cleanup func and calls it on shutdown.
  - Sends dynamic config via `ExtraArgs`: size-based history cache (host 128 MiB, events 8 MiB, 1m TTLs) and `matching.numTaskqueueReadPartitions=1` / `matching.numTaskqueueWritePartitions=1`.
  - Launches the dev server through the shim (`ExistingPath`), retries start up to 5 times, quiets stdout/stderr unless `-v`, and stops the client/server safely.
  - Updates `.golangci.yaml` to exempt gosec `G306` for the executable shim file.

<sup>Written for commit 23f34fc058ba77cfba88a69d5993e93a7ec7c38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

