### PR TITLE
chore(server): build gram CLI flag groups per call (DNO-719)

### DIFF
--- a/server/cmd/gram/flags_assistants.go
+++ b/server/cmd/gram/flags_assistants.go
@@ -18,105 +18,111 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 )
 
-var assistantRuntimeFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "assistant-runtime-provider",
-		Usage:   "Assistant runtime provider. Allowed values: flyio, gke, local.",
-		Value:   assistants.RuntimeProviderFlyIO,
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_PROVIDER"},
-		Action: func(_ *cli.Context, val string) error {
-			switch val {
-			case "", assistants.RuntimeProviderFlyIO, assistants.RuntimeProviderGKE, assistants.RuntimeProviderLocal:
-				return nil
-			default:
-				return fmt.Errorf("invalid assistant runtime provider: %s", val)
-			}
+// Flag groups are built per call rather than kept in package-level slices
+// because urfave/cli writes the resolved value back onto the flag when it is
+// applied to a flag set. Sharing definitions across flag sets means sharing
+// mutable state.
+func assistantRuntimeFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "assistant-runtime-provider",
+			Usage:   "Assistant runtime provider. Allowed values: flyio, gke, local.",
+			Value:   assistants.RuntimeProviderFlyIO,
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_PROVIDER"},
+			Action: func(_ *cli.Context, val string) error {
+				switch val {
+				case "", assistants.RuntimeProviderFlyIO, assistants.RuntimeProviderGKE, assistants.RuntimeProviderLocal:
+					return nil
+				default:
+					return fmt.Errorf("invalid assistant runtime provider: %s", val)
+				}
+			},
 		},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-local-ca-file",
-		Usage:   "PEM CA bundle mounted into local assistant runtime containers and appended to their trust store, so runners trust the local server's TLS certificate. Typically the mkcert root CA.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_LOCAL_CA_FILE"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-gke-namespace",
-		Usage:   "Kubernetes namespace for GKE Agent Sandbox assistant runtimes. Defaults to gram-{environment}.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_NAMESPACE"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-gke-sandbox-template",
-		Usage:   "SandboxTemplate name that GKE assistant runtime claims reference (a SandboxWarmPool on the same template pre-warms pods).",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_SANDBOX_TEMPLATE"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-gke-cluster-endpoint",
-		Usage:   "API endpoint (host or IP) of the assistant runtime cluster. Setting this enables the GKE backend.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_ENDPOINT"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-gke-cluster-ca",
-		Usage:   "Base64-encoded CA certificate of the assistant runtime cluster.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_CA"},
-	},
-	&cli.StringSliceFlag{
-		Name:    "assistant-runtime-gke-runner-cidr",
-		Usage:   "Pod CIDR(s) the assistant runner pods are reachable on. The server dials runners by pod IP, so these are allowlisted past the guardian egress policy (which blocks RFC1918 by default).",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_RUNNER_CIDR"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-server-url",
-		Usage:   "Optional host-reachable server base URL for assistant runtimes. Defaults to --server-url.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_SERVER_URL"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-flyio-api-token",
-		Usage:   "An organization-scoped API token to use when provisioning assistant runtimes on fly.io.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-flyio-org",
-		Usage:   "The default fly.io organization to deploy assistant runtimes to.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_ORG"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-flyio-region",
-		Usage:   "The default fly.io region to deploy assistant runtimes to.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_REGION"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-flyio-app-name-prefix",
-		Usage:   "Prefix for fly.io assistant runtime app names.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_APP_NAME_PREFIX"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-oci-image",
-		Usage:   "The OCI image repository for the assistant runtime image. It must not include a tag.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-otlp-endpoint",
-		Usage:   "OTLP endpoint assistant runtimes export traces to. Trace export is disabled when unset.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_ENDPOINT"},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-otlp-protocol",
-		Usage:   "OTLP transport for assistant runtime traces. Allowed values: grpc, http/protobuf, http/json.",
-		Value:   "grpc",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_PROTOCOL"},
-		Action: func(_ *cli.Context, val string) error {
-			switch val {
-			case "", "grpc", "http/protobuf", "http/json":
-				return nil
-			default:
-				return fmt.Errorf("invalid assistant runtime otlp protocol: %s", val)
-			}
+		&cli.StringFlag{
+			Name:    "assistant-runtime-local-ca-file",
+			Usage:   "PEM CA bundle mounted into local assistant runtime containers and appended to their trust store, so runners trust the local server's TLS certificate. Typically the mkcert root CA.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_LOCAL_CA_FILE"},
 		},
-	},
-	&cli.StringFlag{
-		Name:    "assistant-runtime-otlp-headers",
-		Usage:   "Headers for the assistant runtime OTLP exporter as comma-separated key=value pairs.",
-		EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_HEADERS"},
-	},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-gke-namespace",
+			Usage:   "Kubernetes namespace for GKE Agent Sandbox assistant runtimes. Defaults to gram-{environment}.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_NAMESPACE"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-gke-sandbox-template",
+			Usage:   "SandboxTemplate name that GKE assistant runtime claims reference (a SandboxWarmPool on the same template pre-warms pods).",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_SANDBOX_TEMPLATE"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-gke-cluster-endpoint",
+			Usage:   "API endpoint (host or IP) of the assistant runtime cluster. Setting this enables the GKE backend.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_ENDPOINT"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-gke-cluster-ca",
+			Usage:   "Base64-encoded CA certificate of the assistant runtime cluster.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_CLUSTER_CA"},
+		},
+		&cli.StringSliceFlag{
+			Name:    "assistant-runtime-gke-runner-cidr",
+			Usage:   "Pod CIDR(s) the assistant runner pods are reachable on. The server dials runners by pod IP, so these are allowlisted past the guardian egress policy (which blocks RFC1918 by default).",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_GKE_RUNNER_CIDR"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-server-url",
+			Usage:   "Optional host-reachable server base URL for assistant runtimes. Defaults to --server-url.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_SERVER_URL"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-flyio-api-token",
+			Usage:   "An organization-scoped API token to use when provisioning assistant runtimes on fly.io.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_API_TOKEN"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-flyio-org",
+			Usage:   "The default fly.io organization to deploy assistant runtimes to.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_ORG"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-flyio-region",
+			Usage:   "The default fly.io region to deploy assistant runtimes to.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_REGION"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-flyio-app-name-prefix",
+			Usage:   "Prefix for fly.io assistant runtime app names.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_FLYIO_APP_NAME_PREFIX"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-oci-image",
+			Usage:   "The OCI image repository for the assistant runtime image. It must not include a tag.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OCI_IMAGE"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-otlp-endpoint",
+			Usage:   "OTLP endpoint assistant runtimes export traces to. Trace export is disabled when unset.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_ENDPOINT"},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-otlp-protocol",
+			Usage:   "OTLP transport for assistant runtime traces. Allowed values: grpc, http/protobuf, http/json.",
+			Value:   "grpc",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_PROTOCOL"},
+			Action: func(_ *cli.Context, val string) error {
+				switch val {
+				case "", "grpc", "http/protobuf", "http/json":
+					return nil
+				default:
+					return fmt.Errorf("invalid assistant runtime otlp protocol: %s", val)
+				}
+			},
+		},
+		&cli.StringFlag{
+			Name:    "assistant-runtime-otlp-headers",
+			Usage:   "Headers for the assistant runtime OTLP exporter as comma-separated key=value pairs.",
+			EnvVars: []string{"GRAM_ASSISTANT_RUNTIME_OTLP_HEADERS"},
+		},
+	}
 }
 
 func assistantRuntimeConfigFromCLI(c *cli.Context, serverURL *url.URL) (assistants.RuntimeBackendConfig, error) {

--- a/server/cmd/gram/flags_assistants_test.go
+++ b/server/cmd/gram/flags_assistants_test.go
@@ -117,10 +117,10 @@ func newAssistantRuntimeCLIContext(t *testing.T, values map[string]string) *cli.
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
 	require.NoError(t, (&cli.StringFlag{Name: "server-url"}).Apply(set))
 	require.NoError(t, (&cli.StringFlag{Name: "environment"}).Apply(set))
-	for _, item := range functionsFlags {
+	for _, item := range functionsFlags() {
 		require.NoError(t, item.Apply(set))
 	}
-	for _, item := range assistantRuntimeFlags {
+	for _, item := range assistantRuntimeFlags() {
 		require.NoError(t, item.Apply(set))
 	}
 	for key, value := range values {

--- a/server/cmd/gram/flags_clickhouse.go
+++ b/server/cmd/gram/flags_clickhouse.go
@@ -2,41 +2,43 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var clickHouseFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:     "clickhouse-host",
-		Required: false,
-		EnvVars:  []string{"CLICKHOUSE_HOST"},
-		Value:    "localhost",
-	},
-	&cli.StringFlag{
-		Name:     "clickhouse-database",
-		Required: false,
-		EnvVars:  []string{"CLICKHOUSE_DATABASE"},
-		Value:    "default",
-	},
-	&cli.StringFlag{
-		Name:     "clickhouse-username",
-		Required: false,
-		EnvVars:  []string{"CLICKHOUSE_USERNAME"},
-		Value:    "gram",
-	},
-	&cli.StringFlag{
-		Name:     "clickhouse-password",
-		Required: false,
-		EnvVars:  []string{"CLICKHOUSE_PASSWORD"},
-		Value:    "gram",
-	},
-	&cli.StringFlag{
-		Name:     "clickhouse-native-port",
-		Required: false,
-		EnvVars:  []string{"CLICKHOUSE_NATIVE_PORT"},
-		Value:    "9440",
-	},
-	&cli.BoolFlag{
-		Name:     "clickhouse-insecure",
-		Required: false,
-		EnvVars:  []string{"CLICKHOUSE_INSECURE"},
-		Value:    false,
-	},
+func clickHouseFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     "clickhouse-host",
+			Required: false,
+			EnvVars:  []string{"CLICKHOUSE_HOST"},
+			Value:    "localhost",
+		},
+		&cli.StringFlag{
+			Name:     "clickhouse-database",
+			Required: false,
+			EnvVars:  []string{"CLICKHOUSE_DATABASE"},
+			Value:    "default",
+		},
+		&cli.StringFlag{
+			Name:     "clickhouse-username",
+			Required: false,
+			EnvVars:  []string{"CLICKHOUSE_USERNAME"},
+			Value:    "gram",
+		},
+		&cli.StringFlag{
+			Name:     "clickhouse-password",
+			Required: false,
+			EnvVars:  []string{"CLICKHOUSE_PASSWORD"},
+			Value:    "gram",
+		},
+		&cli.StringFlag{
+			Name:     "clickhouse-native-port",
+			Required: false,
+			EnvVars:  []string{"CLICKHOUSE_NATIVE_PORT"},
+			Value:    "9440",
+		},
+		&cli.BoolFlag{
+			Name:     "clickhouse-insecure",
+			Required: false,
+			EnvVars:  []string{"CLICKHOUSE_INSECURE"},
+			Value:    false,
+		},
+	}
 }

--- a/server/cmd/gram/flags_functions.go
+++ b/server/cmd/gram/flags_functions.go
@@ -2,66 +2,68 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var functionsFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:     "functions-provider",
-		Usage:    "Determines what provider to use to deploy and call Gram Functions. Allowed values: local, flyio.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_PROVIDER"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-runner-oci-image",
-		Usage:    "The name of the OCI image for the Gram Functions runner. It must not include a tag.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_RUNNER_OCI_IMAGE"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-runner-version",
-		Usage:    "The version of the Gram Functions runner to use. It must exist in the OCI registry.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_RUNNER_VERSION"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-flyio-api-token",
-		Usage:    "An organization-scoped API token to use when deploying Gram Functions to fly.io.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_FLYIO_API_TOKEN"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-flyio-org",
-		Usage:    "The default fly.io organization to deploy Gram Functions runner apps to.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_FLYIO_ORG"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-flyio-region",
-		Usage:    "The default fly.io region to deploy Gram Functions runner apps to.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_FLYIO_REGION"},
-		Value:    "us",
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-tigris-bucket-uri",
-		Usage:    "The URI of the Tigris bucket to use for storing function artifacts.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_TIGRIS_BUCKET_URI"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-tigris-key",
-		Usage:    "The access key for the Tigris bucket.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_TIGRIS_KEY"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-tigris-secret",
-		Usage:    "The secret key for the Tigris bucket.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_TIGRIS_SECRET"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "functions-local-runner-root",
-		Usage:    "Path to the functions package containing the entrypoints for various runtimes.",
-		EnvVars:  []string{"GRAM_FUNCTIONS_LOCAL_RUNNER_ROOT"},
-		Required: false,
-	},
+func functionsFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     "functions-provider",
+			Usage:    "Determines what provider to use to deploy and call Gram Functions. Allowed values: local, flyio.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_PROVIDER"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-runner-oci-image",
+			Usage:    "The name of the OCI image for the Gram Functions runner. It must not include a tag.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_RUNNER_OCI_IMAGE"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-runner-version",
+			Usage:    "The version of the Gram Functions runner to use. It must exist in the OCI registry.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_RUNNER_VERSION"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-flyio-api-token",
+			Usage:    "An organization-scoped API token to use when deploying Gram Functions to fly.io.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_FLYIO_API_TOKEN"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-flyio-org",
+			Usage:    "The default fly.io organization to deploy Gram Functions runner apps to.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_FLYIO_ORG"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-flyio-region",
+			Usage:    "The default fly.io region to deploy Gram Functions runner apps to.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_FLYIO_REGION"},
+			Value:    "us",
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-tigris-bucket-uri",
+			Usage:    "The URI of the Tigris bucket to use for storing function artifacts.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_TIGRIS_BUCKET_URI"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-tigris-key",
+			Usage:    "The access key for the Tigris bucket.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_TIGRIS_KEY"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-tigris-secret",
+			Usage:    "The secret key for the Tigris bucket.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_TIGRIS_SECRET"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "functions-local-runner-root",
+			Usage:    "Path to the functions package containing the entrypoints for various runtimes.",
+			EnvVars:  []string{"GRAM_FUNCTIONS_LOCAL_RUNNER_ROOT"},
+			Required: false,
+		},
+	}
 }

--- a/server/cmd/gram/flags_gcp.go
+++ b/server/cmd/gram/flags_gcp.go
@@ -2,15 +2,17 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var gcpFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "gcp-project-id",
-		Usage:   "Google Cloud project ID",
-		EnvVars: []string{"GRAM_GCP_PROJECT_ID"},
-	},
-	&cli.StringFlag{
-		Name:    "pubsub-emulator-host",
-		Usage:   "Host to use for the PubSub emulator",
-		EnvVars: []string{"PUBSUB_EMULATOR_HOST"},
-	},
+func gcpFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "gcp-project-id",
+			Usage:   "Google Cloud project ID",
+			EnvVars: []string{"GRAM_GCP_PROJECT_ID"},
+		},
+		&cli.StringFlag{
+			Name:    "pubsub-emulator-host",
+			Usage:   "Host to use for the PubSub emulator",
+			EnvVars: []string{"PUBSUB_EMULATOR_HOST"},
+		},
+	}
 }

--- a/server/cmd/gram/flags_plugins.go
+++ b/server/cmd/gram/flags_plugins.go
@@ -2,29 +2,31 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var pluginsFlags = []cli.Flag{
-	&cli.Int64Flag{
-		Name:     "plugins-github-app-id",
-		Usage:    "GitHub App ID for plugin publishing.",
-		EnvVars:  []string{"GRAM_PLUGINS_GITHUB_APP_ID"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "plugins-github-private-key",
-		Usage:    "PEM-encoded private key for the GitHub App.",
-		EnvVars:  []string{"GRAM_PLUGINS_GITHUB_PRIVATE_KEY"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "plugins-github-org",
-		Usage:    "GitHub organization to create plugin repos in.",
-		EnvVars:  []string{"GRAM_PLUGINS_GITHUB_ORG"},
-		Required: false,
-	},
-	&cli.Int64Flag{
-		Name:     "plugins-github-installation-id",
-		Usage:    "GitHub App installation ID on the target org.",
-		EnvVars:  []string{"GRAM_PLUGINS_GITHUB_INSTALLATION_ID"},
-		Required: false,
-	},
+func pluginsFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.Int64Flag{
+			Name:     "plugins-github-app-id",
+			Usage:    "GitHub App ID for plugin publishing.",
+			EnvVars:  []string{"GRAM_PLUGINS_GITHUB_APP_ID"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "plugins-github-private-key",
+			Usage:    "PEM-encoded private key for the GitHub App.",
+			EnvVars:  []string{"GRAM_PLUGINS_GITHUB_PRIVATE_KEY"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "plugins-github-org",
+			Usage:    "GitHub organization to create plugin repos in.",
+			EnvVars:  []string{"GRAM_PLUGINS_GITHUB_ORG"},
+			Required: false,
+		},
+		&cli.Int64Flag{
+			Name:     "plugins-github-installation-id",
+			Usage:    "GitHub App installation ID on the target org.",
+			EnvVars:  []string{"GRAM_PLUGINS_GITHUB_INSTALLATION_ID"},
+			Required: false,
+		},
+	}
 }

--- a/server/cmd/gram/flags_posthog.go
+++ b/server/cmd/gram/flags_posthog.go
@@ -2,30 +2,32 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var posthogFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:     "posthog-endpoint",
-		Usage:    "The endpoint to proxy product metrics to",
-		EnvVars:  []string{"POSTHOG_ENDPOINT"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "posthog-api-key",
-		Usage:    "The posthog public API key",
-		EnvVars:  []string{"POSTHOG_API_KEY"},
-		Required: false,
-	},
-	&cli.StringFlag{
-		Name:     "posthog-personal-api-key",
-		Usage:    "The posthog personal API key for local feature flag evaluation",
-		EnvVars:  []string{"POSTHOG_PERSONAL_API_KEY"},
-		Required: false,
-	},
+func posthogFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     "posthog-endpoint",
+			Usage:    "The endpoint to proxy product metrics to",
+			EnvVars:  []string{"POSTHOG_ENDPOINT"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "posthog-api-key",
+			Usage:    "The posthog public API key",
+			EnvVars:  []string{"POSTHOG_API_KEY"},
+			Required: false,
+		},
+		&cli.StringFlag{
+			Name:     "posthog-personal-api-key",
+			Usage:    "The posthog personal API key for local feature flag evaluation",
+			EnvVars:  []string{"POSTHOG_PERSONAL_API_KEY"},
+			Required: false,
+		},
 
-	&cli.StringFlag{
-		Name:     "local-feature-flags-csv",
-		Usage:    "Path to a CSV file containing local feature flags. Format: distinct_id,flag,enabled (with header row). The path must be under the server working directory.",
-		EnvVars:  []string{"GRAM_LOCAL_FEATURE_FLAGS_CSV"},
-		Required: false,
-	},
+		&cli.StringFlag{
+			Name:     "local-feature-flags-csv",
+			Usage:    "Path to a CSV file containing local feature flags. Format: distinct_id,flag,enabled (with header row). The path must be under the server working directory.",
+			EnvVars:  []string{"GRAM_LOCAL_FEATURE_FLAGS_CSV"},
+			Required: false,
+		},
+	}
 }

--- a/server/cmd/gram/flags_pulsemcp.go
+++ b/server/cmd/gram/flags_pulsemcp.go
@@ -2,17 +2,19 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var pulseMCPFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:     "pulse-registry-tenant",
-		Usage:    "The tenant ID used to communicate with the Pulse MCP registry",
-		EnvVars:  []string{"PULSE_REGISTRY_TENANT"},
-		Required: true,
-	},
-	&cli.StringFlag{
-		Name:     "pulse-registry-api-key",
-		Usage:    "The API key used to communicate with the Pulse MCP registry",
-		EnvVars:  []string{"PULSE_REGISTRY_KEY"},
-		Required: true,
-	},
+func pulseMCPFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:     "pulse-registry-tenant",
+			Usage:    "The tenant ID used to communicate with the Pulse MCP registry",
+			EnvVars:  []string{"PULSE_REGISTRY_TENANT"},
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "pulse-registry-api-key",
+			Usage:    "The API key used to communicate with the Pulse MCP registry",
+			EnvVars:  []string{"PULSE_REGISTRY_KEY"},
+			Required: true,
+		},
+	}
 }

--- a/server/cmd/gram/flags_redis.go
+++ b/server/cmd/gram/flags_redis.go
@@ -2,21 +2,23 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var redisFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "redis-cache-addr",
-		Usage:   "Address of the redis cache server",
-		EnvVars: []string{"GRAM_REDIS_CACHE_ADDR"},
-	},
-	&cli.StringFlag{
-		Name:    "redis-cache-password",
-		Usage:   "Password for the redis cache server",
-		EnvVars: []string{"GRAM_REDIS_CACHE_PASSWORD"},
-	},
-	&cli.BoolFlag{
-		Name:    "redis-enable-tracing",
-		Usage:   "Enable tracing for the redis cache server",
-		Value:   false,
-		EnvVars: []string{"GRAM_REDIS_ENABLE_TRACING"},
-	},
+func redisFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "redis-cache-addr",
+			Usage:   "Address of the redis cache server",
+			EnvVars: []string{"GRAM_REDIS_CACHE_ADDR"},
+		},
+		&cli.StringFlag{
+			Name:    "redis-cache-password",
+			Usage:   "Password for the redis cache server",
+			EnvVars: []string{"GRAM_REDIS_CACHE_PASSWORD"},
+		},
+		&cli.BoolFlag{
+			Name:    "redis-enable-tracing",
+			Usage:   "Enable tracing for the redis cache server",
+			Value:   false,
+			EnvVars: []string{"GRAM_REDIS_ENABLE_TRACING"},
+		},
+	}
 }

--- a/server/cmd/gram/flags_risk.go
+++ b/server/cmd/gram/flags_risk.go
@@ -2,16 +2,18 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var riskFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "risk-fingerprint-pepper-keyring",
-		Usage:   "JSON payload containing the pepper keyring for fingerprinting risk findings",
-		EnvVars: []string{"GRAM_RISK_FINGERPRINT_PEPPER_KEYRING"},
-	},
-	&cli.BoolFlag{
-		Name:    "disable-clickhouse-risk-writes",
-		Usage:   "Disable the ClickHouse risk_findings subscriber (kill switch for the shadow write path)",
-		EnvVars: []string{"GRAM_DISABLE_CLICKHOUSE_RISK_WRITES"},
-		Value:   false,
-	},
+func riskFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "risk-fingerprint-pepper-keyring",
+			Usage:   "JSON payload containing the pepper keyring for fingerprinting risk findings",
+			EnvVars: []string{"GRAM_RISK_FINGERPRINT_PEPPER_KEYRING"},
+		},
+		&cli.BoolFlag{
+			Name:    "disable-clickhouse-risk-writes",
+			Usage:   "Disable the ClickHouse risk_findings subscriber (kill switch for the shadow write path)",
+			EnvVars: []string{"GRAM_DISABLE_CLICKHOUSE_RISK_WRITES"},
+			Value:   false,
+		},
+	}
 }

--- a/server/cmd/gram/flags_svix.go
+++ b/server/cmd/gram/flags_svix.go
@@ -2,10 +2,12 @@ package gram
 
 import "github.com/urfave/cli/v2"
 
-var svixFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "svix-api-key",
-		Usage:   "API key for Svix used to send webhook events",
-		EnvVars: []string{"GRAM_SVIX_API_KEY"},
-	},
+func svixFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "svix-api-key",
+			Usage:   "API key for Svix used to send webhook events",
+			EnvVars: []string{"GRAM_SVIX_API_KEY"},
+		},
+	}
 }

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -443,15 +443,15 @@ func newStartCommand() *cli.Command {
 		},
 	}
 
-	flags = append(flags, redisFlags...)
-	flags = append(flags, clickHouseFlags...)
-	flags = append(flags, functionsFlags...)
-	flags = append(flags, pluginsFlags...)
-	flags = append(flags, assistantRuntimeFlags...)
-	flags = append(flags, pulseMCPFlags...)
-	flags = append(flags, posthogFlags...)
-	flags = append(flags, svixFlags...)
-	flags = append(flags, gcpFlags...)
+	flags = append(flags, redisFlags()...)
+	flags = append(flags, clickHouseFlags()...)
+	flags = append(flags, functionsFlags()...)
+	flags = append(flags, pluginsFlags()...)
+	flags = append(flags, assistantRuntimeFlags()...)
+	flags = append(flags, pulseMCPFlags()...)
+	flags = append(flags, posthogFlags()...)
+	flags = append(flags, svixFlags()...)
+	flags = append(flags, gcpFlags()...)
 
 	return &cli.Command{
 		Name:  "start",

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -193,10 +193,10 @@ func newStreamsCommand() *cli.Command {
 		},
 	}
 
-	flags = append(flags, gcpFlags...)
-	flags = append(flags, posthogFlags...)
-	flags = append(flags, riskFlags...)
-	flags = append(flags, clickHouseFlags...)
+	flags = append(flags, gcpFlags()...)
+	flags = append(flags, posthogFlags()...)
+	flags = append(flags, riskFlags()...)
+	flags = append(flags, clickHouseFlags()...)
 
 	return &cli.Command{
 		Name:  "streams",

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -317,15 +317,15 @@ func newWorkerCommand() *cli.Command {
 		},
 	}
 
-	flags = append(flags, redisFlags...)
-	flags = append(flags, clickHouseFlags...)
-	flags = append(flags, functionsFlags...)
-	flags = append(flags, pulseMCPFlags...)
-	flags = append(flags, assistantRuntimeFlags...)
-	flags = append(flags, svixFlags...)
-	flags = append(flags, pluginsFlags...)
-	flags = append(flags, posthogFlags...)
-	flags = append(flags, gcpFlags...)
+	flags = append(flags, redisFlags()...)
+	flags = append(flags, clickHouseFlags()...)
+	flags = append(flags, functionsFlags()...)
+	flags = append(flags, pulseMCPFlags()...)
+	flags = append(flags, assistantRuntimeFlags()...)
+	flags = append(flags, svixFlags()...)
+	flags = append(flags, pluginsFlags()...)
+	flags = append(flags, posthogFlags()...)
+	flags = append(flags, gcpFlags()...)
 
 	return &cli.Command{
 		Name:  "worker",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DNO-719.

## Problem

`server/cmd/gram` failed under `-race`. The shared flag groups (`assistantRuntimeFlags`, `functionsFlags`, and their siblings) were package-level `[]cli.Flag` slices. `urfave/cli` writes the resolved value back onto the flag struct when it is applied to a flag set (`flag_string.go` sets `f.Value`/`f.HasBeenSet`), so the seven parallel `TestAssistantRuntimeConfigFromCLI*` tests all mutated the same `StringFlag` values through `newAssistantRuntimeCLIContext`. One tripped race marks every subsequent test in the binary as failed, which is why the whole package went red and why full-suite runs produced a different set of failures each time.

## Change

Each flag group in `server/cmd/gram` is now a constructor (`func assistantRuntimeFlags() []cli.Flag`) instead of a package-level slice, so every flag set — one per command, one per test — gets its own flag values. The `start`, `worker`, `streams`, and `admin` commands also stop sharing flag state with each other as a side effect.

The nine other `flags_*.go` files are converted alongside the two the test applies, so the package has one rule rather than a mix of vars and constructors, and so the next test that needs a flag group does not reintroduce the race. Those diffs are the composite literal moving inside a `return`; no flag definition changed.

## Verification

- `mise exec -- go test -race -count=1 ./cmd/gram/` on `origin/main`: 56 `WARNING: DATA RACE` blocks, all 7 tests failed. On this branch: 0 warnings, all 7 pass. Also clean at `-count=50`.
- `gram start|worker|streams|admin --help` output is byte-identical before and after, confirming flag registration is unchanged.
- `mise exec -- go build ./...`, `go vet ./cmd/gram/`, and `mise lint:server` are clean.

No changeset: this is an internal test/dev-ergonomics fix with no user-facing behavior change (`chore(...)` title also skips the changeset check).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-719](https://linear.app/speakeasy/issue/DNO-719/data-race-in-cmdgram-flags-assistants-testgo-parallel-tests-share-a)

<div><a href="https://cursor.com/agents/bc-53b2d3f9-d5eb-412a-975f-806f37557932?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53b2d3f9-d5eb-412a-975f-806f37557932&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build flag groups per call in `server/cmd/gram` to remove shared state and fix the CLI flag data race in parallel tests. Addresses DNO-719 with no user-facing changes.

- **Bug Fixes**
  - Replaced package-level `[]cli.Flag` slices with per-call constructors (e.g., `assistantRuntimeFlags()`, `functionsFlags()`) to prevent `urfave/cli` from mutating shared state.
  - Stopped `start`, `worker`, `streams`, and `admin` from sharing flag state; `--help` output and flag definitions are unchanged.

<sup>Written for commit be1063b40d47e1598bd36cf1e06fe2746512ede9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

