### PR TITLE
feat: scope billing usage card to the selected time range

### DIFF
--- a/.changeset/billing-period-scoped-usage-card.md
+++ b/.changeset/billing-period-scoped-usage-card.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The billing page's usage card now follows the selected time range instead of always showing the full billing cycle. A custom range (typed, calendar-picked, or bar-click drill-down) shows the range's billed tokens, a time-attributed overage figure (tokens recorded after the cycle's cumulative usage crossed the allowance, crossing day prorated), and the per-unit average over the range window; the allowance figure, percentage, and meter remain cycle-only concepts and hide on partial ranges. The details table's Overage column uses the same attribution for ranges instead of showing an em dash, so the card and table always agree.

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -3829,9 +3829,13 @@ async function seedObservabilityData(init: {
   // when the seed runs. The billed TUM population is much narrower than the
   // raw telemetry inserted here (registry exclusions, cache reads dropped,
   // stored-evidence gating): an unboosted seed bills ~350k tokens/day, the
-  // divisor below. Capped so an early-cycle run doesn't inflate sessions to
-  // absurdity. Run-date dependent, which is fine: the full-project delete
-  // preamble in chSQL resets every re-run.
+  // divisor below. The cap only guards against pathological division — it
+  // sits above the worst-case single-elapsed-day boost (~286x) so the
+  // overage renders whether the cycle is a day old or nearly sealed. Sole
+  // gap: on the cycle's first day the history (which ends yesterday) has no
+  // rows inside the cycle yet, so overage appears from day two. Run-date
+  // dependent, which is fine: the full-project delete preamble in chSQL
+  // resets every re-run.
   const nowUtc = new Date(now);
   const currentCycleStartMs = Date.UTC(
     nowUtc.getUTCFullYear(),
@@ -3843,7 +3847,7 @@ async function seedObservabilityData(init: {
     Math.floor((todayUtcStart - currentCycleStartMs) / msPerDay),
   );
   const currentCycleBoost = Math.min(
-    60,
+    300,
     Math.max(1, 100_000_000 / (elapsedCycleDays * 350_000)),
   );
   const chBackfillInserts: string[] = [];

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -3915,9 +3915,14 @@ async function seedObservabilityData(init: {
 
       // Cache-heavy token mix (agent sessions replay large cached prompts);
       // ~15% are light API-style calls with little cache traffic. Sessions
-      // in the active billing cycle carry the overage boost.
+      // in the active billing cycle carry the overage boost, divided by the
+      // day's weekend session damping so every in-cycle day contributes
+      // roughly the same volume — otherwise an early-month seed whose only
+      // elapsed days are a weekend would miss the overage target.
       const cycleBoost =
-        dayStartMs >= currentCycleStartMs ? currentCycleBoost : 1;
+        dayStartMs >= currentCycleStartMs
+          ? currentCycleBoost / weekendFactor
+          : 1;
       const cacheDiv = r() < 0.15 ? 10 : 1;
       const inputTokens = Math.round(
         (800 + Math.floor(r() * 7_000)) * anonBoost * cycleBoost,

--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -3821,6 +3821,31 @@ async function seedObservabilityData(init: {
   const todayUtcStart = Math.floor(now / msPerDay) * msPerDay;
   const rawTtlBoundaryMs = todayUtcStart - RAW_TTL_SAFETY_DAYS * msPerDay;
   const rawTtlBoundaryNano = BigInt(rawTtlBoundaryMs) * BigInt(1_000_000);
+
+  // Days inside the ACTIVE billing cycle (anchor day 1 → the current UTC
+  // month) run heavier so the cycle lands clearly past the 50M contracted
+  // allowance and the billing page renders a real overage segment. The boost
+  // targets ~100M BILLED tokens for the cycle's elapsed days regardless of
+  // when the seed runs. The billed TUM population is much narrower than the
+  // raw telemetry inserted here (registry exclusions, cache reads dropped,
+  // stored-evidence gating): an unboosted seed bills ~350k tokens/day, the
+  // divisor below. Capped so an early-cycle run doesn't inflate sessions to
+  // absurdity. Run-date dependent, which is fine: the full-project delete
+  // preamble in chSQL resets every re-run.
+  const nowUtc = new Date(now);
+  const currentCycleStartMs = Date.UTC(
+    nowUtc.getUTCFullYear(),
+    nowUtc.getUTCMonth(),
+    1,
+  );
+  const elapsedCycleDays = Math.max(
+    1,
+    Math.floor((todayUtcStart - currentCycleStartMs) / msPerDay),
+  );
+  const currentCycleBoost = Math.min(
+    60,
+    Math.max(1, 100_000_000 / (elapsedCycleDays * 350_000)),
+  );
   const chBackfillInserts: string[] = [];
   // Risky history sessions also get a Postgres chat + one message so
   // seedRiskFindings can attach findings (risk_results FKs to chat_messages).
@@ -3885,14 +3910,23 @@ async function seedObservabilityData(init: {
           : null;
 
       // Cache-heavy token mix (agent sessions replay large cached prompts);
-      // ~15% are light API-style calls with little cache traffic.
+      // ~15% are light API-style calls with little cache traffic. Sessions
+      // in the active billing cycle carry the overage boost.
+      const cycleBoost =
+        dayStartMs >= currentCycleStartMs ? currentCycleBoost : 1;
       const cacheDiv = r() < 0.15 ? 10 : 1;
-      const inputTokens = (800 + Math.floor(r() * 7_000)) * anonBoost;
-      const outputTokens = (300 + Math.floor(r() * 3_500)) * anonBoost;
-      const cacheReadTokens =
-        Math.floor((8_000 + r() * 80_000) / cacheDiv) * anonBoost;
-      const cacheCreationTokens =
-        Math.floor((1_500 + r() * 18_000) / cacheDiv) * anonBoost;
+      const inputTokens = Math.round(
+        (800 + Math.floor(r() * 7_000)) * anonBoost * cycleBoost,
+      );
+      const outputTokens = Math.round(
+        (300 + Math.floor(r() * 3_500)) * anonBoost * cycleBoost,
+      );
+      const cacheReadTokens = Math.round(
+        Math.floor((8_000 + r() * 80_000) / cacheDiv) * anonBoost * cycleBoost,
+      );
+      const cacheCreationTokens = Math.round(
+        Math.floor((1_500 + r() * 18_000) / cacheDiv) * anonBoost * cycleBoost,
+      );
       const totalTokens =
         inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
       const cost = computeUsageCost(

--- a/client/dashboard/src/components/billing/billing-cycles.ts
+++ b/client/dashboard/src/components/billing/billing-cycles.ts
@@ -97,6 +97,43 @@ export type BilledDays = {
   covered: { start: number; end: number }[];
 };
 
+// Billed tokens per UTC day across every known cycle. The daily series is
+// advisory — a finalized cycle serves its sealed snapshot total while the
+// days recompute live and can drift (late telemetry) or expire (aggregate
+// TTL) — so each cycle's days are scaled to sum to its billed total, the
+// number on the usage card; cumulative rounding keeps the series integral
+// without losing the exact sum.
+//
+// `covered` records the cycle windows the billed data fully describes —
+// including zero-token cycles, where every day is a known zero (a sealed
+// zero total beats whatever late telemetry recomputed). A cycle with a
+// nonzero total but no daily shape (the synthesized active-cycle fallback)
+// stays uncovered, and consumers fall back to analytics totals there.
+export function billedDaysFromCycles(cycles: BillingCycle[]): BilledDays {
+  const byDate = new Map<string, number>();
+  const covered: { start: number; end: number }[] = [];
+  for (const c of cycles) {
+    const daysSum = c.days.reduce((sum, d) => sum + d.tokens, 0);
+    if (daysSum === 0) {
+      if (c.tokens === 0) {
+        covered.push({ start: c.start.getTime(), end: c.end.getTime() });
+      }
+      continue;
+    }
+    covered.push({ start: c.start.getTime(), end: c.end.getTime() });
+    const scale = c.tokens / daysSum;
+    let acc = 0;
+    let prevRounded = 0;
+    for (const d of c.days) {
+      acc += d.tokens * scale;
+      const rounded = Math.round(acc);
+      byDate.set(d.date, rounded - prevRounded);
+      prevRounded = rounded;
+    }
+  }
+  return { byDate, covered };
+}
+
 // The UTC calendar day of a daily bucket, as "YYYY-MM-DD" — the key the
 // billed per-day series (BillingCycle.days) aligns on. Bucket timestamps are
 // unix-nano strings that exceed Number precision; divide as BigInt first.
@@ -142,6 +179,85 @@ export function periodDisplayRange(period: BillingPeriod): {
     ),
     to: new Date(last.getUTCFullYear(), last.getUTCMonth(), last.getUTCDate()),
   };
+}
+
+// Title for a custom-range usage card: the picker's parse label when the
+// range came from one, else the local display dates ("Jul 5 – Jul 18"),
+// matching the range picker's own format.
+const rangeDayFormat = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+});
+
+export function formatPeriodLabel(period: BillingPeriod): string {
+  if (period.label) return period.label;
+  const { from, to } = periodDisplayRange(period);
+  const fromLabel = rangeDayFormat.format(from);
+  const toLabel = rangeDayFormat.format(to);
+  return fromLabel === toLabel ? fromLabel : `${fromLabel} – ${toLabel}`;
+}
+
+// Whether the billed daily series fully answers a period: its bounds sit on
+// UTC day boundaries and every day falls inside a covered cycle window.
+// Cycles are contiguous, so a sorted sweep over the windows suffices.
+export function periodCoveredByBilled(
+  period: { start: Date; end: Date },
+  covered: { start: number; end: number }[],
+): boolean {
+  if (!isUTCMidnight(period.start) || !isUTCMidnight(period.end)) return false;
+  const sorted = [...covered].sort((a, b) => a.start - b.start);
+  const end = period.end.getTime();
+  let cursor = period.start.getTime();
+  for (const w of sorted) {
+    if (cursor >= end) break;
+    if (w.end <= cursor) continue;
+    if (w.start > cursor) return false;
+    cursor = w.end;
+  }
+  return cursor >= end;
+}
+
+// Sum of a per-UTC-day series over a period. Keys are "YYYY-MM-DD", which
+// parse back to the day's start instant.
+export function sumDaysInPeriod(
+  byDate: Map<string, number>,
+  period: { start: Date; end: Date },
+): number {
+  const start = period.start.getTime();
+  const end = period.end.getTime();
+  let sum = 0;
+  for (const [date, tokens] of byDate) {
+    const ms = Date.parse(date);
+    if (ms >= start && ms < end) sum += tokens;
+  }
+  return sum;
+}
+
+// Per-day billed overage tokens under a contracted allowance: within each
+// cycle carrying a daily series, a crossing-point walk over the normalized
+// billed days (BilledDays.byDate), recorded as the day-over-day increase of
+// the cumulative excess — which prorates the crossing day and telescopes to
+// exactly the cycle's billed overage. Cycles without a daily series
+// contribute nothing; their windows are only covered when sealed at zero,
+// where overage is zero anyway.
+export function overageDaysFromBilled(
+  cycles: BillingCycle[],
+  billed: BilledDays,
+  limit: number,
+): Map<string, number> {
+  const overage = new Map<string, number>();
+  for (const cycle of cycles) {
+    const dates = cycle.days.map((d) => d.date).sort();
+    let cumulative = 0;
+    let prevExcess = 0;
+    for (const date of dates) {
+      cumulative += billed.byDate.get(date) ?? 0;
+      const excess = Math.max(0, cumulative - limit);
+      overage.set(date, excess - prevExcess);
+      prevExcess = excess;
+    }
+  }
+  return overage;
 }
 
 // React Query staleTime for data scoped to a period: closed windows are

--- a/client/dashboard/src/components/billing/billing-cycles.ts
+++ b/client/dashboard/src/components/billing/billing-cycles.ts
@@ -115,7 +115,10 @@ export function billedDaysFromCycles(cycles: BillingCycle[]): BilledDays {
   for (const c of cycles) {
     const daysSum = c.days.reduce((sum, d) => sum + d.tokens, 0);
     if (daysSum === 0) {
-      if (c.tokens === 0) {
+      // A zero-token cycle is fully known ONLY once sealed: the active
+      // cycle reads zero before its first snapshot lands, and marking it
+      // covered would report billed zeros over real live traffic.
+      if (c.tokens === 0 && !c.current) {
         covered.push({ start: c.start.getTime(), end: c.end.getTime() });
       }
       continue;
@@ -200,7 +203,7 @@ export function formatPeriodLabel(period: BillingPeriod): string {
 // Whether the billed daily series fully answers a period: its bounds sit on
 // UTC day boundaries and every day falls inside a covered cycle window.
 // Cycles are contiguous, so a sorted sweep over the windows suffices.
-export function periodCoveredByBilled(
+function periodCoveredByBilled(
   period: { start: Date; end: Date },
   covered: { start: number; end: number }[],
 ): boolean {
@@ -219,7 +222,7 @@ export function periodCoveredByBilled(
 
 // Sum of a per-UTC-day series over a period. Keys are "YYYY-MM-DD", which
 // parse back to the day's start instant.
-export function sumDaysInPeriod(
+function sumDaysInPeriod(
   byDate: Map<string, number>,
   period: { start: Date; end: Date },
 ): number {
@@ -258,6 +261,49 @@ export function overageDaysFromBilled(
     }
   }
   return overage;
+}
+
+// The billed answers for one period, resolved once so the usage card, the
+// chart headline, and the details table all read the same numbers — their
+// agreement is structural, not three recomputations that must be kept in
+// lockstep.
+export type PeriodFigures = {
+  // Whether the billed daily series fully answers the period's window.
+  covered: boolean;
+  // Billed tokens in the period; null when the billed data can't answer it
+  // (consumers fall back to the analytics totals).
+  tokens: number | null;
+  // Billed overage tokens in the period; null when not attributable (no
+  // contracted allowance, or an uncovered window).
+  overage: number | null;
+};
+
+export function resolvePeriodFigures(
+  period: BillingPeriod,
+  billedDays: BilledDays,
+  overageDays: Map<string, number> | null,
+  limit: number | null,
+): PeriodFigures {
+  const cycle = period.cycle;
+  const covered = periodCoveredByBilled(period, billedDays.covered);
+  if (cycle) {
+    return {
+      covered,
+      tokens: cycle.tokens,
+      overage: limit != null ? Math.max(0, cycle.tokens - limit) : null,
+    };
+  }
+  if (!covered) {
+    return { covered, tokens: null, overage: null };
+  }
+  return {
+    covered,
+    tokens: sumDaysInPeriod(billedDays.byDate, period),
+    overage:
+      overageDays != null
+        ? Math.round(sumDaysInPeriod(overageDays, period))
+        : null,
+  };
 }
 
 // React Query staleTime for data scoped to a period: closed windows are

--- a/client/dashboard/src/components/billing/token-usage-panel.tsx
+++ b/client/dashboard/src/components/billing/token-usage-panel.tsx
@@ -90,6 +90,7 @@ export function TokenUsagePanel({
   stackBy,
   breakdownPicker,
   loading,
+  failed,
   onSelectRange,
 }: {
   // Gap-filled daily buckets from the billing details response — the axis
@@ -107,6 +108,9 @@ export function TokenUsagePanel({
   // the head of the control row.
   breakdownPicker: ReactNode;
   loading: boolean;
+  // Whether the details request failed with nothing to show — renders a
+  // distinct failure message so an outage can't read as an empty period.
+  failed: boolean;
   // Called when a bar is clicked with the bucket's time range — the caller
   // narrows the page's period to it (drill-down). Bars aren't clickable
   // without it.
@@ -130,7 +134,11 @@ export function TokenUsagePanel({
       headerControls={breakdownPicker}
       formatValue={formatTokens}
       formatAxisValue={formatTokensAxis}
-      emptyMessage="No token usage in this range."
+      emptyMessage={
+        failed
+          ? "Couldn't load usage for this range. Try again shortly."
+          : "No token usage in this range."
+      }
       loading={loading}
       onSelectRange={onSelectRange}
     />

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -2,36 +2,75 @@ import { Page } from "@/components/page-layout";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
+import { type TokensUnderManagement } from "@gram/client/models/components/tokensundermanagement.js";
 import {
   invalidateAllGetTokensUnderManagement,
   useGetTokensUnderManagement,
 } from "@gram/client/react-query/getTokensUnderManagement.js";
 import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 // Platform-admin form for the org's contracted tokens-under-management
 // terms: monthly allowance, alert email, and the billing cycle anchor day.
+// The form only mounts once the current terms have loaded — its fields seed
+// from them at mount, so saving-before-load (which would overwrite terms
+// with empty defaults) is unrepresentable, and background refetches can't
+// clobber in-progress edits.
 export const TumAdminSection = (): JSX.Element => {
+  const { data: tum, isError } = useGetTokensUnderManagement();
+
+  let body: JSX.Element;
+  if (tum) {
+    body = <ContractForm initial={tum} />;
+  } else if (isError) {
+    body = (
+      <Text muted small>
+        Couldn't load the current contract terms. Reload the page to try again.
+      </Text>
+    );
+  } else {
+    body = (
+      <div className="max-w-md space-y-4">
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-9 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <Page.Section>
+      <Page.Section.Title>
+        TUM Contract (PLATFORM ADMIN VIEW ONLY)
+      </Page.Section.Title>
+      <Page.Section.Description>
+        Set this organization's contracted tokens under management terms.
+        Customers never see this section or the alert email.
+      </Page.Section.Description>
+      <Page.Section.Body>{body}</Page.Section.Body>
+    </Page.Section>
+  );
+};
+
+function ContractForm({
+  initial,
+}: {
+  // The loaded contract terms the fields seed from at mount.
+  initial: TokensUnderManagement;
+}): JSX.Element {
   const queryClient = useQueryClient();
-  const { data: tum } = useGetTokensUnderManagement();
 
-  const [tokenLimit, setTokenLimit] = useState("");
-  const [alertEmail, setAlertEmail] = useState("");
-  const [anchorDay, setAnchorDay] = useState("1");
-  const [prefilled, setPrefilled] = useState(false);
-
-  // Prefill the form once the current contract terms load. Once only — a
-  // background refetch must not clobber in-progress edits.
-  useEffect(() => {
-    if (!tum || prefilled) return;
-    setTokenLimit(tum.monthlyTokenLimit?.toString() ?? "");
-    setAlertEmail(tum.alertEmail ?? "");
-    setAnchorDay(tum.billingCycleAnchorDay.toString());
-    setPrefilled(true);
-  }, [tum, prefilled]);
+  const [tokenLimit, setTokenLimit] = useState(
+    () => initial.monthlyTokenLimit?.toString() ?? "",
+  );
+  const [alertEmail, setAlertEmail] = useState(() => initial.alertEmail ?? "");
+  const [anchorDay, setAnchorDay] = useState(() =>
+    initial.billingCycleAnchorDay.toString(),
+  );
 
   const mutation = useSetBillingMetadataMutation({
     onSuccess: () => {
@@ -63,79 +102,59 @@ export const TumAdminSection = (): JSX.Element => {
   };
 
   return (
-    <Page.Section>
-      <Page.Section.Title>
-        TUM Contract (PLATFORM ADMIN VIEW ONLY)
-      </Page.Section.Title>
-      <Page.Section.Description>
-        Set this organization's contracted tokens under management terms.
-        Customers never see this section or the alert email.
-      </Page.Section.Description>
-      <Page.Section.Body>
-        <Stack gap={4} className="max-w-md">
-          <Stack gap={2}>
-            <Label htmlFor="tum-monthly-limit">
-              Allowed TUM per month (tokens)
-            </Label>
-            <Input
-              id="tum-monthly-limit"
-              type="number"
-              min={0}
-              placeholder="Leave empty for no contracted limit"
-              value={tokenLimit}
-              onChange={setTokenLimit}
-            />
-          </Stack>
-          <Stack gap={2}>
-            <Label htmlFor="tum-alert-email">Alert email</Label>
-            <Input
-              id="tum-alert-email"
-              type="email"
-              placeholder="billing-alerts@customer.com"
-              value={alertEmail}
-              onChange={setAlertEmail}
-            />
-          </Stack>
-          <Stack gap={2}>
-            <Label htmlFor="tum-anchor-day">
-              Billing cycle anchor day (1–31)
-            </Label>
-            <Input
-              id="tum-anchor-day"
-              type="number"
-              min={1}
-              max={31}
-              value={anchorDay}
-              onChange={setAnchorDay}
-            />
-          </Stack>
-          <Stack direction="horizontal" align="center" gap={3}>
-            <Button
-              onClick={handleSave}
-              // Gated on the prefill: saving before the current terms load
-              // would overwrite them with empty defaults.
-              disabled={
-                !prefilled ||
-                mutation.isPending ||
-                limitInvalid ||
-                anchorDayInvalid
-              }
-            >
-              {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
-            </Button>
-            {mutation.isSuccess && !mutation.isPending && (
-              <Text muted small>
-                Saved.
-              </Text>
-            )}
-            {mutation.isError && (
-              <Text small className="text-destructive">
-                Failed to save contract terms.
-              </Text>
-            )}
-          </Stack>
-        </Stack>
-      </Page.Section.Body>
-    </Page.Section>
+    <Stack gap={4} className="max-w-md">
+      <Stack gap={2}>
+        <Label htmlFor="tum-monthly-limit">
+          Allowed TUM per month (tokens)
+        </Label>
+        <Input
+          id="tum-monthly-limit"
+          type="number"
+          min={0}
+          placeholder="Leave empty for no contracted limit"
+          value={tokenLimit}
+          onChange={setTokenLimit}
+        />
+      </Stack>
+      <Stack gap={2}>
+        <Label htmlFor="tum-alert-email">Alert email</Label>
+        <Input
+          id="tum-alert-email"
+          type="email"
+          placeholder="billing-alerts@customer.com"
+          value={alertEmail}
+          onChange={setAlertEmail}
+        />
+      </Stack>
+      <Stack gap={2}>
+        <Label htmlFor="tum-anchor-day">Billing cycle anchor day (1–31)</Label>
+        <Input
+          id="tum-anchor-day"
+          type="number"
+          min={1}
+          max={31}
+          value={anchorDay}
+          onChange={setAnchorDay}
+        />
+      </Stack>
+      <Stack direction="horizontal" align="center" gap={3}>
+        <Button
+          onClick={handleSave}
+          disabled={mutation.isPending || limitInvalid || anchorDayInvalid}
+        >
+          {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
+        </Button>
+        {mutation.isSuccess && !mutation.isPending && (
+          <Text muted small>
+            Saved.
+          </Text>
+        )}
+        {mutation.isError && (
+          <Text small className="text-destructive">
+            Failed to save contract terms.
+          </Text>
+        )}
+      </Stack>
+    </Stack>
   );
-};
+}

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -112,7 +112,14 @@ export const TumAdminSection = (): JSX.Element => {
           <Stack direction="horizontal" align="center" gap={3}>
             <Button
               onClick={handleSave}
-              disabled={mutation.isPending || limitInvalid || anchorDayInvalid}
+              // Gated on the prefill: saving before the current terms load
+              // would overwrite them with empty defaults.
+              disabled={
+                !prefilled ||
+                mutation.isPending ||
+                limitInvalid ||
+                anchorDayInvalid
+              }
             >
               {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
             </Button>

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -21,14 +21,17 @@ export const TumAdminSection = (): JSX.Element => {
   const [tokenLimit, setTokenLimit] = useState("");
   const [alertEmail, setAlertEmail] = useState("");
   const [anchorDay, setAnchorDay] = useState("1");
+  const [prefilled, setPrefilled] = useState(false);
 
-  // Prefill the form once the current contract terms load.
+  // Prefill the form once the current contract terms load. Once only — a
+  // background refetch must not clobber in-progress edits.
   useEffect(() => {
-    if (!tum) return;
+    if (!tum || prefilled) return;
     setTokenLimit(tum.monthlyTokenLimit?.toString() ?? "");
     setAlertEmail(tum.alertEmail ?? "");
     setAnchorDay(tum.billingCycleAnchorDay.toString());
-  }, [tum]);
+    setPrefilled(true);
+  }, [tum, prefilled]);
 
   const mutation = useSetBillingMetadataMutation({
     onSuccess: () => {
@@ -38,9 +41,10 @@ export const TumAdminSection = (): JSX.Element => {
 
   const parsedLimit = tokenLimit.trim() === "" ? undefined : Number(tokenLimit);
   const parsedAnchorDay = Number(anchorDay);
+  // The limit is a token count: the API schema only accepts integers.
   const limitInvalid =
     parsedLimit !== undefined &&
-    (!Number.isFinite(parsedLimit) || parsedLimit < 0);
+    (!Number.isInteger(parsedLimit) || parsedLimit < 0);
   const anchorDayInvalid =
     !Number.isInteger(parsedAnchorDay) ||
     parsedAnchorDay < 1 ||

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -1,0 +1,130 @@
+import { Page } from "@/components/page-layout";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import { Stack } from "@/components/ui/Stack";
+import { Text } from "@/components/ui/Text";
+import {
+  invalidateAllGetTokensUnderManagement,
+  useGetTokensUnderManagement,
+} from "@gram/client/react-query/getTokensUnderManagement.js";
+import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+// Platform-admin form for the org's contracted tokens-under-management
+// terms: monthly allowance, alert email, and the billing cycle anchor day.
+export const TumAdminSection = (): JSX.Element => {
+  const queryClient = useQueryClient();
+  const { data: tum } = useGetTokensUnderManagement();
+
+  const [tokenLimit, setTokenLimit] = useState("");
+  const [alertEmail, setAlertEmail] = useState("");
+  const [anchorDay, setAnchorDay] = useState("1");
+
+  // Prefill the form once the current contract terms load.
+  useEffect(() => {
+    if (!tum) return;
+    setTokenLimit(tum.monthlyTokenLimit?.toString() ?? "");
+    setAlertEmail(tum.alertEmail ?? "");
+    setAnchorDay(tum.billingCycleAnchorDay.toString());
+  }, [tum]);
+
+  const mutation = useSetBillingMetadataMutation({
+    onSuccess: () => {
+      void invalidateAllGetTokensUnderManagement(queryClient);
+    },
+  });
+
+  const parsedLimit = tokenLimit.trim() === "" ? undefined : Number(tokenLimit);
+  const parsedAnchorDay = Number(anchorDay);
+  const limitInvalid =
+    parsedLimit !== undefined &&
+    (!Number.isFinite(parsedLimit) || parsedLimit < 0);
+  const anchorDayInvalid =
+    !Number.isInteger(parsedAnchorDay) ||
+    parsedAnchorDay < 1 ||
+    parsedAnchorDay > 31;
+
+  const handleSave = () => {
+    mutation.mutate({
+      request: {
+        setBillingMetadataRequestBody: {
+          monthlyTokenLimit: parsedLimit,
+          alertEmail: alertEmail.trim() === "" ? undefined : alertEmail.trim(),
+          billingCycleAnchorDay: parsedAnchorDay,
+        },
+      },
+    });
+  };
+
+  return (
+    <Page.Section>
+      <Page.Section.Title>
+        TUM Contract (PLATFORM ADMIN VIEW ONLY)
+      </Page.Section.Title>
+      <Page.Section.Description>
+        Set this organization's contracted tokens under management terms.
+        Customers never see this section or the alert email.
+      </Page.Section.Description>
+      <Page.Section.Body>
+        <Stack gap={4} className="max-w-md">
+          <Stack gap={2}>
+            <Label htmlFor="tum-monthly-limit">
+              Allowed TUM per month (tokens)
+            </Label>
+            <Input
+              id="tum-monthly-limit"
+              type="number"
+              min={0}
+              placeholder="Leave empty for no contracted limit"
+              value={tokenLimit}
+              onChange={setTokenLimit}
+            />
+          </Stack>
+          <Stack gap={2}>
+            <Label htmlFor="tum-alert-email">Alert email</Label>
+            <Input
+              id="tum-alert-email"
+              type="email"
+              placeholder="billing-alerts@customer.com"
+              value={alertEmail}
+              onChange={setAlertEmail}
+            />
+          </Stack>
+          <Stack gap={2}>
+            <Label htmlFor="tum-anchor-day">
+              Billing cycle anchor day (1–31)
+            </Label>
+            <Input
+              id="tum-anchor-day"
+              type="number"
+              min={1}
+              max={31}
+              value={anchorDay}
+              onChange={setAnchorDay}
+            />
+          </Stack>
+          <Stack direction="horizontal" align="center" gap={3}>
+            <Button
+              onClick={handleSave}
+              disabled={mutation.isPending || limitInvalid || anchorDayInvalid}
+            >
+              {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
+            </Button>
+            {mutation.isSuccess && !mutation.isPending && (
+              <Text muted small>
+                Saved.
+              </Text>
+            )}
+            {mutation.isError && (
+              <Text small className="text-destructive">
+                Failed to save contract terms.
+              </Text>
+            )}
+          </Stack>
+        </Stack>
+      </Page.Section.Body>
+    </Page.Section>
+  );
+};

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -13,9 +13,8 @@ import {
   type BilledDays,
   type BillingCycle,
   type BillingPeriod,
+  type PeriodFigures,
   bucketDateKey,
-  periodCoveredByBilled,
-  sumDaysInPeriod,
 } from "./billing-cycles";
 import {
   breakdownLabel,
@@ -284,6 +283,29 @@ function DetailGroupSection({
   );
 }
 
+// Rescale raw overage weights so the "Total tokens" row's weighted sum lands
+// exactly on the billed overage target. When the analytics carry no tokens
+// where the weights are nonzero there is nothing to attribute over: a zero
+// target yields a clean all-zero column, a positive one is unattributable
+// (null — the "—" column) rather than silently rendering as zero overage.
+function pinWeights(
+  weights: number[],
+  points: { totalTokens: number }[],
+  billedScale: number,
+  target: number,
+): number[] | null {
+  const billedTarget = Math.max(0, Math.round(target));
+  const weightedTotal = points.reduce(
+    (sum, p, i) => sum + p.totalTokens * billedScale * weights[i]!,
+    0,
+  );
+  if (weightedTotal === 0) {
+    return billedTarget > 0 ? null : weights.map(() => 0);
+  }
+  const scale = billedTarget / weightedTotal;
+  return weights.map((w) => w * scale);
+}
+
 // What the Total column carries: billed-normalized tokens whenever the
 // billed data covers the view (full cycles and ranges within them), raw
 // analytics otherwise.
@@ -306,7 +328,7 @@ function overageTooltipFor(
   if (attributed) {
     return "The range's billed overage (tokens recorded after the cycle's cumulative usage crossed the included allowance), attributed to each metric by its tokens in that window. The crossing day is prorated.";
   }
-  return "Overage can't be attributed here — no contracted allowance is set, or the range cannot be fully represented by the billed daily data.";
+  return "Overage can't be attributed here — no contracted allowance is set, the range cannot be fully represented by the billed daily data, or there are no analytics tokens in the overage window to attribute it over.";
 }
 
 /**
@@ -320,19 +342,21 @@ export function TumDetailsTable({
   limit,
   billedDays,
   overageDays,
+  figures,
 }: {
   period: BillingPeriod;
   // Project id → name, for labeling the Project section's UUID values.
   projectNames: Map<string, string>;
   // Contracted monthly allowance; drives the per-metric overage share.
   limit: number | null;
-  // The billed per-day series and the cycle windows it fully describes —
-  // custom-range overage attribution only applies inside them.
+  // The billed per-day series the per-day overage fractions divide by.
   billedDays: BilledDays;
-  // Per-day billed overage across covered cycles (the usage card reads the
-  // same map, keeping the two surfaces in exact agreement); null when the
-  // org has no contracted allowance.
+  // Per-day billed overage across covered cycles; null when the org has no
+  // contracted allowance.
   overageDays: Map<string, number> | null;
+  // The shared resolved figures — the same tokens/overage the usage card
+  // displays, which the Total row pins to exactly.
+  figures: PeriodFigures;
 }): JSX.Element {
   const client = useGramContext();
   const organization = useOrganization();
@@ -358,11 +382,7 @@ export function TumDetailsTable({
   // to custom ranges the billed daily series fully covers; both switch off
   // when the range escapes the billed data.
   const billedCycle = period.cycle;
-  const rangeCovered = useMemo(
-    () =>
-      billedCycle == null && periodCoveredByBilled(period, billedDays.covered),
-    [billedCycle, period, billedDays],
-  );
+  const rangeCovered = billedCycle == null && figures.covered;
 
   // The table presents BILLED tokens: the analytics aggregate supplies the
   // distribution across metrics (it has the dimensions; billing's per-session
@@ -385,15 +405,14 @@ export function TumDetailsTable({
       }
       return billedCycle.tokens / analyticsTotal;
     }
-    if (!rangeCovered) return 1;
-    // Covered custom range: normalize to the billed range total, the number
-    // on the usage card. A zero billed total stays unscaled — unlike a
-    // sealed cycle there is no per-range seal, and a transiently stale TUM
-    // response must not blank live traffic.
-    const billedTotal = sumDaysInPeriod(billedDays.byDate, period);
-    if (billedTotal === 0) return 1;
-    return billedTotal / analyticsTotal;
-  }, [data, billedCycle, rangeCovered, billedDays, period]);
+    if (!rangeCovered || figures.tokens == null) return 1;
+    // Covered custom range: normalize to the billed range total — the
+    // card's number. Covered windows with zero billed tokens are sealed
+    // zeros (an active cycle's empty window is never covered), so a zero
+    // total scales to zero exactly like a sealed zero-token cycle.
+    if (figures.tokens === 0) return 0;
+    return figures.tokens / analyticsTotal;
+  }, [data, billedCycle, rangeCovered, figures.tokens]);
 
   const groups = useMemo<DetailGroup[]>(() => {
     const points = data?.points ?? [];
@@ -437,96 +456,60 @@ export function TumDetailsTable({
   // Time-based overage attribution: tokens count as overage from the moment
   // the organization's cumulative usage crossed the included allowance. Days
   // before the crossing weigh 0, days after weigh 1, and the crossing day is
-  // prorated by how far into its tokens the allowance ran out (the data is
-  // daily, so metrics are assumed to share the within-day distribution). The
-  // crossing point is walked on the cycle's BILLED daily series.
+  // prorated (the data is daily, so metrics are assumed to share the
+  // within-day distribution). Full cycles and covered ranges both read the
+  // per-day fractions from the shared overageDays/billedDays walks — the
+  // same maps behind the usage card's Overage figure — and pin the "Total
+  // tokens" row to the card's number exactly (the rows are billed-scaled
+  // analytics, which track the billed series closely but not to the token).
   //
-  // Custom ranges attribute from the covered cycles' per-day billed overage
-  // (the same map behind the usage card's Overage figure). Null when overage
-  // does not apply: no contracted allowance, or a range that escapes the
-  // billed daily data.
+  // Null when overage does not apply or can't be attributed: no contracted
+  // allowance, a range that escapes the billed daily data, or no analytics
+  // tokens in the overage window to spread it over (the "—" column).
   const overageWeights = useMemo<number[] | null>(() => {
     const cycle = billedCycle;
     if (limit == null) return null;
     const points = data?.points ?? [];
 
-    if (cycle == null) {
-      if (overageDays == null || !rangeCovered) return null;
-      // Per-day overage fraction of the billed series, applied to each
-      // metric's tokens that day.
-      const weights = points.map((p) => {
-        const key = bucketDateKey(p.bucketTimeUnixNano);
-        const dayBilled = billedDays.byDate.get(key) ?? 0;
-        if (dayBilled <= 0) return 0;
-        return (overageDays.get(key) ?? 0) / dayBilled;
-      });
-      // The rows are billed-scaled analytics, which track the billed series
-      // closely but not to the token — pin the "Total tokens" row's overage
-      // to the usage card's range figure exactly.
-      const rangeOverage = Math.round(sumDaysInPeriod(overageDays, period));
-      const weightedTotal = points.reduce(
-        (sum, p, i) => sum + p.totalTokens * billedScale * weights[i]!,
-        0,
-      );
-      if (weightedTotal === 0) return weights.map(() => 0);
-      const rangeScale = rangeOverage / weightedTotal;
-      return weights.map((w) => w * rangeScale);
+    // Synthesized active cycle without a daily series: there is no billed
+    // per-day shape, so walk the crossing on the billed-scaled analytics
+    // series directly.
+    if (cycle != null && cycle.days.length === 0) {
+      const billed = points.map((p) => p.totalTokens * billedScale);
+      const weights = billed.map(() => 0);
+      let cumulative = 0;
+      for (let i = 0; i < billed.length; i++) {
+        const before = cumulative;
+        cumulative += billed[i]!;
+        if (cumulative <= limit) continue;
+        weights[i] =
+          before >= limit ? 1 : (cumulative - limit) / (billed[i]! || 1);
+      }
+      return pinWeights(weights, points, billedScale, cycle.tokens - limit);
     }
 
-    // The daily series the crossing is walked on. Normally the cycle's
-    // billed days; when the TUM response didn't carry them (the synthesized
-    // active-cycle fallback has none), an all-zero walk would silently zero
-    // the whole column — fall back to the billed-scaled analytics series.
-    let billed: number[];
-    if (cycle.days.length > 0) {
-      // The daily series is advisory: it recomputes live under the CURRENT
-      // billing scope, while a sealed cycle's total is the invoiced record
-      // and can describe a larger (or drifted) population. Walking the raw
-      // days against the allowance would then never reach the crossing the
-      // card reports — scale the series to the cycle's billed total first,
-      // the same normalization the chart's billed series applies.
-      const daysSum = cycle.days.reduce((sum, d) => sum + d.tokens, 0);
-      const daysScale = daysSum > 0 ? cycle.tokens / daysSum : 0;
-      const billedByDate = new Map(
-        cycle.days.map((d) => [d.date, d.tokens * daysScale]),
-      );
-      billed = points.map(
-        (p) => billedByDate.get(bucketDateKey(p.bucketTimeUnixNano)) ?? 0,
-      );
-    } else {
-      billed = points.map((p) => p.totalTokens * billedScale);
-    }
-
-    const weights = billed.map(() => 0);
-    let cumulative = 0;
-    for (let i = 0; i < billed.length; i++) {
-      const before = cumulative;
-      cumulative += billed[i]!;
-      if (cumulative <= limit) continue;
-      weights[i] =
-        before >= limit ? 1 : (cumulative - limit) / (billed[i]! || 1);
-    }
-    // The rows are billed-scaled analytics, which track the billed series
-    // within a fraction of a percent but not to the token — pin the "Total
-    // tokens" row's overage to the usage card's number exactly.
-    const billedOverage = Math.max(0, cycle.tokens - limit);
-    const totals = points.map((p) => p.totalTokens * billedScale);
-    const weightedTotal = totals.reduce(
-      (sum, t, i) => sum + t * weights[i]!,
-      0,
-    );
-    if (weightedTotal === 0) return weights.map(() => 0);
-    const scale = billedOverage / weightedTotal;
-    return weights.map((w) => w * scale);
+    if (overageDays == null) return null;
+    if (cycle == null && !rangeCovered) return null;
+    // Per-day overage fraction of the billed series, applied to each
+    // metric's tokens that day.
+    const weights = points.map((p) => {
+      const key = bucketDateKey(p.bucketTimeUnixNano);
+      const dayBilled = billedDays.byDate.get(key) ?? 0;
+      if (dayBilled <= 0) return 0;
+      return (overageDays.get(key) ?? 0) / dayBilled;
+    });
+    const target =
+      cycle != null ? cycle.tokens - limit : (figures.overage ?? 0);
+    return pinWeights(weights, points, billedScale, target);
   }, [
     data,
     limit,
     billedCycle,
     billedScale,
-    period,
     billedDays,
     overageDays,
     rangeCovered,
+    figures.overage,
   ]);
 
   const loading = isFetching && !data;

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -284,6 +284,16 @@ function DetailGroupSection({
   );
 }
 
+// What the Total column carries: billed-normalized tokens whenever the
+// billed data covers the view (full cycles and ranges within them), raw
+// analytics otherwise.
+function totalTooltipFor(billedNormalized: boolean): string {
+  if (billedNormalized) {
+    return "Billed tokens under management, attributed across metrics by the analytics distribution.";
+  }
+  return "Tokens for the selected range, from the analytics aggregates. This range extends beyond the billed daily data, so billed normalization does not apply.";
+}
+
 // What the Overage column means in the current view: full-cycle attribution,
 // range attribution, or not attributable at all (the "—" column).
 function overageTooltipFor(
@@ -344,31 +354,46 @@ export function TumDetailsTable({
     });
   };
 
-  // Billed normalization and overage attribution are organization-cycle
-  // concepts (the TUM contract has no sub-cycle split), so both switch off
-  // when a custom range narrows the data.
+  // Billed normalization and overage attribution apply to full cycles and
+  // to custom ranges the billed daily series fully covers; both switch off
+  // when the range escapes the billed data.
   const billedCycle = period.cycle;
+  const rangeCovered = useMemo(
+    () =>
+      billedCycle == null && periodCoveredByBilled(period, billedDays.covered),
+    [billedCycle, period, billedDays],
+  );
 
   // The table presents BILLED tokens: the analytics aggregate supplies the
   // distribution across metrics (it has the dimensions; billing's per-session
   // qualification can't be expressed there), and one uniform scale converts
-  // it into billed units so the Total row equals the cycle's billed tokens —
-  // the usage card's number — exactly. The two aggregates track within a
-  // fraction of a percent, so the correction is invisible per metric.
+  // it into billed units so the Total row equals the billed tokens for the
+  // period — the usage card's number — exactly. The two aggregates track
+  // within a fraction of a percent, so the correction is invisible per
+  // metric.
   const billedScale = useMemo(() => {
-    if (!billedCycle) return 1;
     const analyticsTotal = data?.totals?.totalTokens ?? 0;
     if (analyticsTotal === 0) return 1;
-    // A CLOSED zero-token cycle is a known zero: scale everything to 0 so
-    // the Total row matches the card even when live analytics recomputed
-    // nonzero tokens after the seal. The active cycle is exempt — its card
-    // total is a live number that can trail the details query by a refetch,
-    // and a transient zero must not blank real traffic.
-    if (billedCycle.tokens === 0) {
-      return billedCycle.current ? 1 : 0;
+    if (billedCycle) {
+      // A CLOSED zero-token cycle is a known zero: scale everything to 0 so
+      // the Total row matches the card even when live analytics recomputed
+      // nonzero tokens after the seal. The active cycle is exempt — its card
+      // total is a live number that can trail the details query by a refetch,
+      // and a transient zero must not blank real traffic.
+      if (billedCycle.tokens === 0) {
+        return billedCycle.current ? 1 : 0;
+      }
+      return billedCycle.tokens / analyticsTotal;
     }
-    return billedCycle.tokens / analyticsTotal;
-  }, [data, billedCycle]);
+    if (!rangeCovered) return 1;
+    // Covered custom range: normalize to the billed range total, the number
+    // on the usage card. A zero billed total stays unscaled — unlike a
+    // sealed cycle there is no per-range seal, and a transiently stale TUM
+    // response must not blank live traffic.
+    const billedTotal = sumDaysInPeriod(billedDays.byDate, period);
+    if (billedTotal === 0) return 1;
+    return billedTotal / analyticsTotal;
+  }, [data, billedCycle, rangeCovered, billedDays, period]);
 
   const groups = useMemo<DetailGroup[]>(() => {
     const points = data?.points ?? [];
@@ -426,8 +451,7 @@ export function TumDetailsTable({
     const points = data?.points ?? [];
 
     if (cycle == null) {
-      if (overageDays == null) return null;
-      if (!periodCoveredByBilled(period, billedDays.covered)) return null;
+      if (overageDays == null || !rangeCovered) return null;
       // Per-day overage fraction of the billed series, applied to each
       // metric's tokens that day.
       const weights = points.map((p) => {
@@ -436,12 +460,12 @@ export function TumDetailsTable({
         if (dayBilled <= 0) return 0;
         return (overageDays.get(key) ?? 0) / dayBilled;
       });
-      // The rows are analytics tokens, which track the billed series closely
-      // but not to the token — pin the "Total tokens" row's overage to the
-      // usage card's range figure exactly.
+      // The rows are billed-scaled analytics, which track the billed series
+      // closely but not to the token — pin the "Total tokens" row's overage
+      // to the usage card's range figure exactly.
       const rangeOverage = Math.round(sumDaysInPeriod(overageDays, period));
       const weightedTotal = points.reduce(
-        (sum, p, i) => sum + p.totalTokens * weights[i]!,
+        (sum, p, i) => sum + p.totalTokens * billedScale * weights[i]!,
         0,
       );
       if (weightedTotal === 0) return weights.map(() => 0);
@@ -494,14 +518,21 @@ export function TumDetailsTable({
     if (weightedTotal === 0) return weights.map(() => 0);
     const scale = billedOverage / weightedTotal;
     return weights.map((w) => w * scale);
-  }, [data, limit, billedCycle, billedScale, period, billedDays, overageDays]);
+  }, [
+    data,
+    limit,
+    billedCycle,
+    billedScale,
+    period,
+    billedDays,
+    overageDays,
+    rangeCovered,
+  ]);
 
   const loading = isFetching && !data;
   const failed = !loading && !data && isError;
 
-  const totalTooltip = billedCycle
-    ? "Billed tokens under management, attributed across metrics by the analytics distribution."
-    : "Tokens for the selected range, from the analytics aggregates. Billed normalization applies to full billing cycles only.";
+  const totalTooltip = totalTooltipFor(billedCycle != null || rangeCovered);
   const overageTooltip = overageTooltipFor(
     billedCycle,
     overageWeights !== null,

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -9,7 +9,14 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { cn } from "@/lib/utils";
 import { CHART_COLORS, OTHER_COLOR } from "@/components/stacked-time-series";
-import { type BillingPeriod, bucketDateKey } from "./billing-cycles";
+import {
+  type BilledDays,
+  type BillingCycle,
+  type BillingPeriod,
+  bucketDateKey,
+  periodCoveredByBilled,
+  sumDaysInPeriod,
+} from "./billing-cycles";
 import {
   breakdownLabel,
   breakdownValueLabel,
@@ -277,6 +284,21 @@ function DetailGroupSection({
   );
 }
 
+// What the Overage column means in the current view: full-cycle attribution,
+// range attribution, or not attributable at all (the "—" column).
+function overageTooltipFor(
+  billedCycle: BillingCycle | null,
+  attributed: boolean,
+): string {
+  if (billedCycle) {
+    return "The billed overage (tokens beyond the included allowance), attributed to each metric by its tokens recorded after the allowance ran out. The crossing day is prorated.";
+  }
+  if (attributed) {
+    return "The range's billed overage (tokens recorded after the cycle's cumulative usage crossed the included allowance), attributed to each metric by its tokens in that window. The crossing day is prorated.";
+  }
+  return "Overage can't be attributed here — no contracted allowance is set, or the range extends beyond the billed daily data.";
+}
+
 /**
  * Per-metric usage details for the selected period, rendered under the token
  * usage chart. Everything comes from a single telemetry.queryTumDetails
@@ -286,12 +308,21 @@ export function TumDetailsTable({
   period,
   projectNames,
   limit,
+  billedDays,
+  overageDays,
 }: {
   period: BillingPeriod;
   // Project id → name, for labeling the Project section's UUID values.
   projectNames: Map<string, string>;
   // Contracted monthly allowance; drives the per-metric overage share.
   limit: number | null;
+  // The billed per-day series and the cycle windows it fully describes —
+  // custom-range overage attribution only applies inside them.
+  billedDays: BilledDays;
+  // Per-day billed overage across covered cycles (the usage card reads the
+  // same map, keeping the two surfaces in exact agreement); null when the
+  // org has no contracted allowance.
+  overageDays: Map<string, number> | null;
 }): JSX.Element {
   const client = useGramContext();
   const organization = useOrganization();
@@ -385,12 +416,38 @@ export function TumDetailsTable({
   // daily, so metrics are assumed to share the within-day distribution). The
   // crossing point is walked on the cycle's BILLED daily series.
   //
-  // Null when overage does not apply: no contracted allowance, or a custom
-  // range (the allowance is an org-cycle number).
+  // Custom ranges attribute from the covered cycles' per-day billed overage
+  // (the same map behind the usage card's Overage figure). Null when overage
+  // does not apply: no contracted allowance, or a range that escapes the
+  // billed daily data.
   const overageWeights = useMemo<number[] | null>(() => {
     const cycle = billedCycle;
-    if (limit == null || cycle == null) return null;
+    if (limit == null) return null;
     const points = data?.points ?? [];
+
+    if (cycle == null) {
+      if (overageDays == null) return null;
+      if (!periodCoveredByBilled(period, billedDays.covered)) return null;
+      // Per-day overage fraction of the billed series, applied to each
+      // metric's tokens that day.
+      const weights = points.map((p) => {
+        const key = bucketDateKey(p.bucketTimeUnixNano);
+        const dayBilled = billedDays.byDate.get(key) ?? 0;
+        if (dayBilled <= 0) return 0;
+        return (overageDays.get(key) ?? 0) / dayBilled;
+      });
+      // The rows are analytics tokens, which track the billed series closely
+      // but not to the token — pin the "Total tokens" row's overage to the
+      // usage card's range figure exactly.
+      const rangeOverage = Math.round(sumDaysInPeriod(overageDays, period));
+      const weightedTotal = points.reduce(
+        (sum, p, i) => sum + p.totalTokens * weights[i]!,
+        0,
+      );
+      if (weightedTotal === 0) return weights.map(() => 0);
+      const rangeScale = rangeOverage / weightedTotal;
+      return weights.map((w) => w * rangeScale);
+    }
 
     // The daily series the crossing is walked on. Normally the cycle's
     // billed days; when the TUM response didn't carry them (the synthesized
@@ -437,7 +494,7 @@ export function TumDetailsTable({
     if (weightedTotal === 0) return weights.map(() => 0);
     const scale = billedOverage / weightedTotal;
     return weights.map((w) => w * scale);
-  }, [data, limit, billedCycle, billedScale]);
+  }, [data, limit, billedCycle, billedScale, period, billedDays, overageDays]);
 
   const loading = isFetching && !data;
   const failed = !loading && !data && isError;
@@ -445,9 +502,10 @@ export function TumDetailsTable({
   const totalTooltip = billedCycle
     ? "Billed tokens under management, attributed across metrics by the analytics distribution."
     : "Tokens for the selected range, from the analytics aggregates. Billed normalization applies to full billing cycles only.";
-  const overageTooltip = billedCycle
-    ? "The billed overage (tokens beyond the included allowance), attributed to each metric by its tokens recorded after the allowance ran out. The crossing day is prorated."
-    : "The token allowance is an organization-per-cycle number; select a full billing cycle to see the overage.";
+  const overageTooltip = overageTooltipFor(
+    billedCycle,
+    overageWeights !== null,
+  );
 
   return (
     <div className="border-border overflow-hidden rounded-lg border">

--- a/client/dashboard/src/components/billing/tum-details-table.tsx
+++ b/client/dashboard/src/components/billing/tum-details-table.tsx
@@ -291,7 +291,7 @@ function totalTooltipFor(billedNormalized: boolean): string {
   if (billedNormalized) {
     return "Billed tokens under management, attributed across metrics by the analytics distribution.";
   }
-  return "Tokens for the selected range, from the analytics aggregates. This range extends beyond the billed daily data, so billed normalization does not apply.";
+  return "Tokens for the selected range, from the analytics aggregates. Billed normalization does not apply because this range cannot be fully represented by the billed daily data.";
 }
 
 // What the Overage column means in the current view: full-cycle attribution,
@@ -306,7 +306,7 @@ function overageTooltipFor(
   if (attributed) {
     return "The range's billed overage (tokens recorded after the cycle's cumulative usage crossed the included allowance), attributed to each metric by its tokens in that window. The crossing day is prorated.";
   }
-  return "Overage can't be attributed here — no contracted allowance is set, or the range extends beyond the billed daily data.";
+  return "Overage can't be attributed here — no contracted allowance is set, or the range cannot be fully represented by the billed daily data.";
 }
 
 /**

--- a/client/dashboard/src/components/billing/tum-section.tsx
+++ b/client/dashboard/src/components/billing/tum-section.tsx
@@ -14,6 +14,7 @@ import {
   cyclesFromTum,
   overageDaysFromBilled,
   periodDisplayRange,
+  resolvePeriodFigures,
 } from "./billing-cycles";
 import { TumDefinitionTooltip } from "./tum-definition";
 import { TumDetailsTable } from "./tum-details-table";
@@ -69,6 +70,17 @@ export const TumUsageSection = (): JSX.Element => {
     [cycles, billedDays, monthlyLimit],
   );
 
+  // The billed answers for the effective period, resolved once and handed to
+  // the card, the chart headline, and the details table — their agreement is
+  // structural, not three parallel recomputations.
+  const figures = useMemo(
+    () =>
+      period == null
+        ? null
+        : resolvePeriodFigures(period, billedDays, overageDays, monthlyLimit),
+    [period, billedDays, overageDays, monthlyLimit],
+  );
+
   return (
     <Page.Section>
       <Page.Section.Title>Billing</Page.Section.Title>
@@ -78,7 +90,7 @@ export const TumUsageSection = (): JSX.Element => {
         excluded, as is inference the platform runs itself.
       </Page.Section.Description>
       <Page.Section.Body>
-        {tum && period ? (
+        {tum && period && figures ? (
           <Stack gap={3} className="mb-6">
             <Stack direction="horizontal" align="center" gap={1}>
               <Text variant="body" className="font-medium">
@@ -118,8 +130,7 @@ export const TumUsageSection = (): JSX.Element => {
             <PeriodUsageCard
               period={period}
               cycles={cycles}
-              billedDays={billedDays}
-              overageDays={overageDays}
+              figures={figures}
               limit={monthlyLimit}
             />
             <div className="mt-8">
@@ -128,6 +139,7 @@ export const TumUsageSection = (): JSX.Element => {
                 period={period}
                 projectNames={projectNames}
                 billedDays={billedDays}
+                figures={figures}
                 onSelectRange={selectBarRange}
               />
             </div>
@@ -139,6 +151,7 @@ export const TumUsageSection = (): JSX.Element => {
                 limit={monthlyLimit}
                 billedDays={billedDays}
                 overageDays={overageDays}
+                figures={figures}
               />
             </div>
           </Stack>

--- a/client/dashboard/src/components/billing/tum-section.tsx
+++ b/client/dashboard/src/components/billing/tum-section.tsx
@@ -1,173 +1,31 @@
 import { Page } from "@/components/page-layout";
-import { Input } from "@/components/ui/Input";
-import { Label } from "@/components/ui/Label";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { Stack } from "@/components/ui/Stack";
 import { Text } from "@/components/ui/Text";
 import { useOrganization } from "@/contexts/Auth";
-import { Dimension } from "@gram/client/models/components/queryfilter.js";
-import { useGramContext } from "@gram/client/react-query/_context.js";
-import {
-  invalidateAllGetTokensUnderManagement,
-  useGetTokensUnderManagement,
-} from "@gram/client/react-query/getTokensUnderManagement.js";
+import { useGetTokensUnderManagement } from "@gram/client/react-query/getTokensUnderManagement.js";
 import { useListProjects } from "@gram/client/react-query/listProjects.js";
-import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
-import { Button } from "@/components/ui/Button";
-import { Stack } from "@/components/ui/Stack";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { RotateCcw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { TimeRangePicker } from "@/components/DashboardTimeRangePicker";
 import { BillingCyclePicker } from "./billing-cycle-picker";
 import {
-  type BilledDays,
-  type BillingPeriod,
-  bucketDateKey,
-  cycleKey,
+  billedDaysFromCycles,
   cyclesFromTum,
-  formatCycleName,
+  overageDaysFromBilled,
   periodDisplayRange,
-  periodFromCycle,
 } from "./billing-cycles";
-import {
-  BREAKDOWN_TOTAL,
-  breakdownValueLabel,
-  isServerRollupRow,
-  stackModeFor,
-} from "./breakdown-options";
-import { BreakdownPicker } from "./breakdown-picker";
-import { type GroupSeries, TokenUsagePanel } from "./token-usage-panel";
 import { TumDefinitionTooltip } from "./tum-definition";
 import { TumDetailsTable } from "./tum-details-table";
-import { tumDetailsQuery } from "./tum-queries";
-import { TumUsageCard } from "./tum-usage-card";
+import { TumTokenBreakdown } from "./tum-token-breakdown";
+import { PeriodUsageCard } from "./tum-usage-card";
+import { useBillingPeriod } from "./use-billing-period";
 
-// Org-wide token breakdown for one billing cycle: stacked daily tokens by a
-// selectable dimension or by token type — one unified picker drives both.
-// Everything renders from the billing details request shared with the
-// details table (the server scopes it to the observed agent traffic, cache
-// reads excluded), except the headline total, which prefers the billed
-// per-day series the usage endpoint returns — the exact numbers on the
-// usage card. No data-availability pruning of the dimension list:
-// dimensions without data simply chart as "(unset)".
-function TumTokenBreakdown({
-  period,
-  projectNames,
-  billedDays,
-  onSelectRange,
-}: {
-  period: BillingPeriod;
-  // Project id → name, for labeling the Project breakdown's UUID values.
-  projectNames: Map<string, string>;
-  // The billed per-day series and the cycle windows it fully describes.
-  billedDays: BilledDays;
-  // Bar-click drill-down: narrows the page's period to the clicked bucket.
-  onSelectRange: (start: Date, end: Date) => void;
-}): JSX.Element {
-  const client = useGramContext();
-  const organization = useOrganization();
-  // The picker's selection, plus the last-picked dimension so switching to
-  // token type and back doesn't lose the grouping. Opens on the total view —
-  // the billed series that matches the usage card exactly.
-  const [breakdown, setBreakdown] = useState<string>(BREAKDOWN_TOTAL);
-  const [dimension, setDimension] = useState<string>(Dimension.DivisionName);
-  const stackBy = stackModeFor(breakdown);
-
-  const scope = { client, orgId: organization.id, period };
-  // Shared with the details table (same key — one request).
-  const { data, isFetching } = useQuery(tumDetailsQuery(scope));
-
-  const points = useMemo(() => data?.points ?? [], [data]);
-
-  // The selected dimension's rows. "" rows are real observed traffic that
-  // lacks the attribute — charted as "(unset)", same as the details table.
-  // The server's top-N remainder row is flagged as the rollup so the chart
-  // pins it to the neutral color by identity, not by label.
-  const groups = useMemo<GroupSeries[]>(() => {
-    const rows = data?.breakdowns.find((b) => b.key === dimension)?.rows ?? [];
-    return rows.map((r, i) => ({
-      label: breakdownValueLabel(dimension, r.value, projectNames),
-      series: r.series,
-      rollup: isServerRollupRow(rows, i) || undefined,
-    }));
-  }, [data, dimension, projectNames]);
-
-  // The billed series aligned to the points grid, used only when the billed
-  // data COVERS every charted day — coverage, not positivity: a sealed
-  // zero-token cycle is fully known (all zeros beat late-recomputed
-  // telemetry), while a day outside every covered cycle window (e.g. a
-  // synthesized active cycle without history) makes the whole view fall
-  // back to the details totals rather than charting misleading zeros.
-  const billedSeries = useMemo(() => {
-    if (points.length === 0) return null;
-    const series: number[] = [];
-    for (const p of points) {
-      const key = bucketDateKey(p.bucketTimeUnixNano);
-      // Bucket dates are UTC midnights, so the key parses back to the
-      // bucket's exact start instant.
-      const ms = Date.parse(key);
-      const coveredDay = billedDays.covered.some(
-        (r) => ms >= r.start && ms < r.end,
-      );
-      if (!coveredDay) return null;
-      series.push(billedDays.byDate.get(key) ?? 0);
-    }
-    return series;
-  }, [points, billedDays]);
-
-  const breakdownPicker = (
-    <BreakdownPicker
-      value={breakdown}
-      onChange={(value) => {
-        setBreakdown(value);
-        // Only actual dimensions pick a breakdown; the special modes
-        // (total / token type) keep the last-picked dimension.
-        if (stackModeFor(value) === "group") {
-          setDimension(value);
-        }
-      }}
-    />
-  );
-
-  return (
-    <TokenUsagePanel
-      points={points}
-      groups={groups}
-      billedSeries={billedSeries}
-      stackBy={stackBy}
-      breakdownPicker={breakdownPicker}
-      loading={isFetching && !data}
-      onSelectRange={onSelectRange}
-    />
-  );
-}
-
-// The range picker's calendar hands back local midnights for both ends. The
-// page's data is bucketed by UTC day (matching the billing-cycle boundaries),
-// so a picked day means that UTC calendar day — otherwise a one-day pick
-// spans two UTC buckets and the chart grows a phantom extra day. The last day
-// is inclusive. Natural-language parses carry real times and pass through
-// untouched.
-function customRangeFromPicker(
-  from: Date,
-  to: Date,
-): { start: Date; end: Date } {
-  const isLocalMidnight = (d: Date) =>
-    d.getHours() === 0 &&
-    d.getMinutes() === 0 &&
-    d.getSeconds() === 0 &&
-    d.getMilliseconds() === 0;
-  if (!isLocalMidnight(from) || !isLocalMidnight(to)) {
-    return { start: from, end: to };
-  }
-  return {
-    start: new Date(
-      Date.UTC(from.getFullYear(), from.getMonth(), from.getDate()),
-    ),
-    end: new Date(Date.UTC(to.getFullYear(), to.getMonth(), to.getDate() + 1)),
-  };
-}
-
+// The tokens-under-management billing section: period controls (cycle picker,
+// range picker, reset), the usage card, the token breakdown chart, and the
+// per-metric details table — all scoped to one effective period resolved by
+// useBillingPeriod, and all reading the billed daily series derived here so
+// every surface reports the same numbers.
 export const TumUsageSection = (): JSX.Element => {
   const { data: tum } = useGetTokensUnderManagement();
   const organization = useOrganization();
@@ -185,125 +43,30 @@ export const TumUsageSection = (): JSX.Element => {
     [projectsData],
   );
 
-  // The selected billing cycle scopes the usage bar and the breakdown chart.
-  // Derived (not synced) so the current cycle is the default once TUM loads.
   const cycles = useMemo(() => (tum ? cyclesFromTum(tum) : []), [tum]);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const selectedCycle =
-    cycles.find((c) => cycleKey(c) === selectedKey) ??
-    cycles.find((c) => c.current) ??
-    cycles[0] ??
-    null;
-
-  // A custom range (typed into the range picker or drilled into via a chart
-  // bar click) overrides the cycle selection for the chart and details table.
-  const [customRange, setCustomRange] = useState<{
-    start: Date;
-    end: Date;
-    label?: string;
-  } | null>(null);
-
-  // Bumped by the Reset button; remounting the breakdown clears its internal
-  // view state too (breakdown pick, granularity, cumulative, hidden series).
-  const [viewNonce, setViewNonce] = useState(0);
-  const handleReset = (): void => {
-    setSelectedKey(null);
-    setCustomRange(null);
-    setViewNonce((n) => n + 1);
-  };
+  const {
+    period,
+    selectedCycle,
+    customRange,
+    viewNonce,
+    selectCycle,
+    setPickedRange,
+    clearCustomRange,
+    selectBarRange,
+    reset,
+  } = useBillingPeriod(cycles);
 
   const monthlyLimit = tum?.monthlyTokenLimit ?? null;
 
-  // Billed tokens per UTC day across every known cycle, for the chart's
-  // headline total. The daily series is advisory — a finalized cycle serves
-  // its sealed snapshot total while the days recompute live and can drift
-  // (late telemetry) or expire (aggregate TTL) — so each cycle's days are
-  // scaled to sum to its billed total, the number on the usage card. Same
-  // normalization as the details table; cumulative rounding keeps the series
-  // integral without losing the exact sum.
-  //
-  // `covered` records the cycle windows the billed data fully describes —
-  // including zero-token cycles, where every day is a known zero (a sealed
-  // zero total beats whatever late telemetry recomputed). A cycle with a
-  // nonzero total but no daily shape (the synthesized active-cycle fallback)
-  // stays uncovered, and the chart falls back to the details totals there.
-  const billedDays = useMemo<BilledDays>(() => {
-    const byDate = new Map<string, number>();
-    const covered: { start: number; end: number }[] = [];
-    for (const c of cycles) {
-      const daysSum = c.days.reduce((sum, d) => sum + d.tokens, 0);
-      if (daysSum === 0) {
-        if (c.tokens === 0) {
-          covered.push({ start: c.start.getTime(), end: c.end.getTime() });
-        }
-        continue;
-      }
-      covered.push({ start: c.start.getTime(), end: c.end.getTime() });
-      const scale = c.tokens / daysSum;
-      let acc = 0;
-      let prevRounded = 0;
-      for (const d of c.days) {
-        acc += d.tokens * scale;
-        const rounded = Math.round(acc);
-        byDate.set(d.date, rounded - prevRounded);
-        prevRounded = rounded;
-      }
-    }
-    return { byDate, covered };
-  }, [cycles]);
-
-  // The effective period. A custom range that happens to match a cycle's
-  // exact boundaries IS that cycle (billed normalization applies).
-  const period: BillingPeriod | null = useMemo(() => {
-    if (customRange) {
-      const exact =
-        cycles.find(
-          (c) =>
-            c.start.getTime() === customRange.start.getTime() &&
-            c.end.getTime() === customRange.end.getTime(),
-        ) ?? null;
-      return {
-        start: customRange.start,
-        end: customRange.end,
-        cycle: exact,
-        label: customRange.label,
-      };
-    }
-    return selectedCycle ? periodFromCycle(selectedCycle) : null;
-  }, [customRange, cycles, selectedCycle]);
-
-  // The usage card keeps showing the billing position of the cycle the
-  // period sits inside — bar-click drill-downs never leave the viewed cycle.
-  // A typed range spanning cycles has no single billing position; hide it.
-  const cardCycle = useMemo(() => {
-    if (!period) return null;
-    return (
-      period.cycle ??
-      cycles.find(
-        (c) =>
-          c.start.getTime() <= period.start.getTime() &&
-          period.end.getTime() <= c.end.getTime(),
-      ) ??
-      null
-    );
-  }, [period, cycles]);
-
-  // Bar-click drill-down, clamped to the current period (week/month buckets
-  // can overhang the period's edges). Stable identity — it feeds the chart
-  // panel's chartOptions memo.
-  const handleBarSelect = useCallback(
-    (start: Date, end: Date): void => {
-      if (!period) return;
-      const s = Math.max(start.getTime(), period.start.getTime());
-      const e = Math.min(end.getTime(), period.end.getTime());
-      if (e <= s) return;
-      setCustomRange({
-        start: new Date(s),
-        end: new Date(e),
-        label: undefined,
-      });
-    },
-    [period],
+  // The billed per-day series every surface (card, chart headline, details
+  // table) reads, and the per-day overage attribution derived from it.
+  const billedDays = useMemo(() => billedDaysFromCycles(cycles), [cycles]);
+  const overageDays = useMemo(
+    () =>
+      monthlyLimit == null
+        ? null
+        : overageDaysFromBilled(cycles, billedDays, monthlyLimit),
+    [cycles, billedDays, monthlyLimit],
   );
 
   return (
@@ -326,10 +89,7 @@ export const TumUsageSection = (): JSX.Element => {
                 <BillingCyclePicker
                   cycles={cycles}
                   selected={customRange ? null : selectedCycle}
-                  onSelect={(c) => {
-                    setCustomRange(null);
-                    setSelectedKey(cycleKey(c));
-                  }}
+                  onSelect={selectCycle}
                 />
                 {/* Always shows the effective window; typing a range (natural
                     language or calendar) narrows the section to it, clearing
@@ -341,18 +101,13 @@ export const TumUsageSection = (): JSX.Element => {
                     customRange ? (customRange.label ?? "Custom") : "Cycle"
                   }
                   availablePresets={[]}
-                  onCustomRangeChange={(from, to, label) =>
-                    setCustomRange({
-                      ...customRangeFromPicker(from, to),
-                      label,
-                    })
-                  }
-                  onClearCustomRange={() => setCustomRange(null)}
+                  onCustomRangeChange={setPickedRange}
+                  onClearCustomRange={clearCustomRange}
                   className="bg-background py-1.5 text-sm"
                 />
                 <button
                   type="button"
-                  onClick={handleReset}
+                  onClick={reset}
                   className="border-border hover:bg-muted text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md border px-2.5 py-2 text-sm transition-colors"
                 >
                   <RotateCcw className="size-3.5" />
@@ -360,27 +115,20 @@ export const TumUsageSection = (): JSX.Element => {
                 </button>
               </div>
             </Stack>
-            {cardCycle && (
-              <TumUsageCard
-                cycle={cardCycle}
-                limit={monthlyLimit}
-                // On a custom range the card still shows the WHOLE containing
-                // cycle's billing position — larger than the range's totals
-                // below, so say which cycle these figures are for.
-                label={
-                  customRange
-                    ? `${formatCycleName(cardCycle)} — full-cycle totals`
-                    : formatCycleName(cardCycle)
-                }
-              />
-            )}
+            <PeriodUsageCard
+              period={period}
+              cycles={cycles}
+              billedDays={billedDays}
+              overageDays={overageDays}
+              limit={monthlyLimit}
+            />
             <div className="mt-8">
               <TumTokenBreakdown
                 key={viewNonce}
                 period={period}
                 projectNames={projectNames}
                 billedDays={billedDays}
-                onSelectRange={handleBarSelect}
+                onSelectRange={selectBarRange}
               />
             </div>
             <div className="mt-4">
@@ -389,6 +137,8 @@ export const TumUsageSection = (): JSX.Element => {
                 period={period}
                 projectNames={projectNames}
                 limit={monthlyLimit}
+                billedDays={billedDays}
+                overageDays={overageDays}
               />
             </div>
           </Stack>
@@ -399,121 +149,6 @@ export const TumUsageSection = (): JSX.Element => {
             <Skeleton className="h-40 w-full" />
           </div>
         )}
-      </Page.Section.Body>
-    </Page.Section>
-  );
-};
-
-export const TumAdminSection = (): JSX.Element => {
-  const queryClient = useQueryClient();
-  const { data: tum } = useGetTokensUnderManagement();
-
-  const [tokenLimit, setTokenLimit] = useState("");
-  const [alertEmail, setAlertEmail] = useState("");
-  const [anchorDay, setAnchorDay] = useState("1");
-
-  // Prefill the form once the current contract terms load.
-  useEffect(() => {
-    if (!tum) return;
-    setTokenLimit(tum.monthlyTokenLimit?.toString() ?? "");
-    setAlertEmail(tum.alertEmail ?? "");
-    setAnchorDay(tum.billingCycleAnchorDay.toString());
-  }, [tum]);
-
-  const mutation = useSetBillingMetadataMutation({
-    onSuccess: () => {
-      void invalidateAllGetTokensUnderManagement(queryClient);
-    },
-  });
-
-  const parsedLimit = tokenLimit.trim() === "" ? undefined : Number(tokenLimit);
-  const parsedAnchorDay = Number(anchorDay);
-  const limitInvalid =
-    parsedLimit !== undefined &&
-    (!Number.isFinite(parsedLimit) || parsedLimit < 0);
-  const anchorDayInvalid =
-    !Number.isInteger(parsedAnchorDay) ||
-    parsedAnchorDay < 1 ||
-    parsedAnchorDay > 31;
-
-  const handleSave = () => {
-    mutation.mutate({
-      request: {
-        setBillingMetadataRequestBody: {
-          monthlyTokenLimit: parsedLimit,
-          alertEmail: alertEmail.trim() === "" ? undefined : alertEmail.trim(),
-          billingCycleAnchorDay: parsedAnchorDay,
-        },
-      },
-    });
-  };
-
-  return (
-    <Page.Section>
-      <Page.Section.Title>
-        TUM Contract (PLATFORM ADMIN VIEW ONLY)
-      </Page.Section.Title>
-      <Page.Section.Description>
-        Set this organization's contracted tokens under management terms.
-        Customers never see this section or the alert email.
-      </Page.Section.Description>
-      <Page.Section.Body>
-        <Stack gap={4} className="max-w-md">
-          <Stack gap={2}>
-            <Label htmlFor="tum-monthly-limit">
-              Allowed TUM per month (tokens)
-            </Label>
-            <Input
-              id="tum-monthly-limit"
-              type="number"
-              min={0}
-              placeholder="Leave empty for no contracted limit"
-              value={tokenLimit}
-              onChange={setTokenLimit}
-            />
-          </Stack>
-          <Stack gap={2}>
-            <Label htmlFor="tum-alert-email">Alert email</Label>
-            <Input
-              id="tum-alert-email"
-              type="email"
-              placeholder="billing-alerts@customer.com"
-              value={alertEmail}
-              onChange={setAlertEmail}
-            />
-          </Stack>
-          <Stack gap={2}>
-            <Label htmlFor="tum-anchor-day">
-              Billing cycle anchor day (1–31)
-            </Label>
-            <Input
-              id="tum-anchor-day"
-              type="number"
-              min={1}
-              max={31}
-              value={anchorDay}
-              onChange={setAnchorDay}
-            />
-          </Stack>
-          <Stack direction="horizontal" align="center" gap={3}>
-            <Button
-              onClick={handleSave}
-              disabled={mutation.isPending || limitInvalid || anchorDayInvalid}
-            >
-              {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
-            </Button>
-            {mutation.isSuccess && !mutation.isPending && (
-              <Text muted small>
-                Saved.
-              </Text>
-            )}
-            {mutation.isError && (
-              <Text small className="text-destructive">
-                Failed to save contract terms.
-              </Text>
-            )}
-          </Stack>
-        </Stack>
       </Page.Section.Body>
     </Page.Section>
   );

--- a/client/dashboard/src/components/billing/tum-token-breakdown.tsx
+++ b/client/dashboard/src/components/billing/tum-token-breakdown.tsx
@@ -7,6 +7,7 @@ import {
   type BilledDays,
   type BillingPeriod,
   bucketDateKey,
+  periodCoveredByBilled,
 } from "./billing-cycles";
 import {
   BREAKDOWN_TOTAL,
@@ -69,27 +70,20 @@ export function TumTokenBreakdown({
   }, [data, dimension, projectNames]);
 
   // The billed series aligned to the points grid, used only when the billed
-  // data COVERS every charted day — coverage, not positivity: a sealed
+  // data COVERS the whole period — coverage, not positivity: a sealed
   // zero-token cycle is fully known (all zeros beat late-recomputed
   // telemetry), while a day outside every covered cycle window (e.g. a
-  // synthesized active cycle without history) makes the whole view fall
-  // back to the details totals rather than charting misleading zeros.
+  // synthesized active cycle without history) or a non-day-aligned range
+  // (whose partial first/last day a full billed-day value would overstate)
+  // makes the whole view fall back to the details totals rather than
+  // charting misleading numbers.
   const billedSeries = useMemo(() => {
     if (points.length === 0) return null;
-    const series: number[] = [];
-    for (const p of points) {
-      const key = bucketDateKey(p.bucketTimeUnixNano);
-      // Bucket dates are UTC midnights, so the key parses back to the
-      // bucket's exact start instant.
-      const ms = Date.parse(key);
-      const coveredDay = billedDays.covered.some(
-        (r) => ms >= r.start && ms < r.end,
-      );
-      if (!coveredDay) return null;
-      series.push(billedDays.byDate.get(key) ?? 0);
-    }
-    return series;
-  }, [points, billedDays]);
+    if (!periodCoveredByBilled(period, billedDays.covered)) return null;
+    return points.map(
+      (p) => billedDays.byDate.get(bucketDateKey(p.bucketTimeUnixNano)) ?? 0,
+    );
+  }, [points, billedDays, period]);
 
   const breakdownPicker = (
     <BreakdownPicker

--- a/client/dashboard/src/components/billing/tum-token-breakdown.tsx
+++ b/client/dashboard/src/components/billing/tum-token-breakdown.tsx
@@ -1,0 +1,119 @@
+import { useOrganization } from "@/contexts/Auth";
+import { Dimension } from "@gram/client/models/components/queryfilter.js";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import {
+  type BilledDays,
+  type BillingPeriod,
+  bucketDateKey,
+} from "./billing-cycles";
+import {
+  BREAKDOWN_TOTAL,
+  breakdownValueLabel,
+  isServerRollupRow,
+  stackModeFor,
+} from "./breakdown-options";
+import { BreakdownPicker } from "./breakdown-picker";
+import { type GroupSeries, TokenUsagePanel } from "./token-usage-panel";
+import { tumDetailsQuery } from "./tum-queries";
+
+// Org-wide token breakdown for one billing period: stacked daily tokens by a
+// selectable dimension or by token type — one unified picker drives both.
+// Everything renders from the billing details request shared with the
+// details table (the server scopes it to the observed agent traffic, cache
+// reads excluded), except the headline total, which prefers the billed
+// per-day series the usage endpoint returns — the exact numbers on the
+// usage card. No data-availability pruning of the dimension list:
+// dimensions without data simply chart as "(unset)".
+export function TumTokenBreakdown({
+  period,
+  projectNames,
+  billedDays,
+  onSelectRange,
+}: {
+  period: BillingPeriod;
+  // Project id → name, for labeling the Project breakdown's UUID values.
+  projectNames: Map<string, string>;
+  // The billed per-day series and the cycle windows it fully describes.
+  billedDays: BilledDays;
+  // Bar-click drill-down: narrows the page's period to the clicked bucket.
+  onSelectRange: (start: Date, end: Date) => void;
+}): JSX.Element {
+  const client = useGramContext();
+  const organization = useOrganization();
+  // The picker's selection, plus the last-picked dimension so switching to
+  // token type and back doesn't lose the grouping. Opens on the total view —
+  // the billed series that matches the usage card exactly.
+  const [breakdown, setBreakdown] = useState<string>(BREAKDOWN_TOTAL);
+  const [dimension, setDimension] = useState<string>(Dimension.DivisionName);
+  const stackBy = stackModeFor(breakdown);
+
+  const scope = { client, orgId: organization.id, period };
+  // Shared with the details table (same key — one request).
+  const { data, isFetching } = useQuery(tumDetailsQuery(scope));
+
+  const points = useMemo(() => data?.points ?? [], [data]);
+
+  // The selected dimension's rows. "" rows are real observed traffic that
+  // lacks the attribute — charted as "(unset)", same as the details table.
+  // The server's top-N remainder row is flagged as the rollup so the chart
+  // pins it to the neutral color by identity, not by label.
+  const groups = useMemo<GroupSeries[]>(() => {
+    const rows = data?.breakdowns.find((b) => b.key === dimension)?.rows ?? [];
+    return rows.map((r, i) => ({
+      label: breakdownValueLabel(dimension, r.value, projectNames),
+      series: r.series,
+      rollup: isServerRollupRow(rows, i) || undefined,
+    }));
+  }, [data, dimension, projectNames]);
+
+  // The billed series aligned to the points grid, used only when the billed
+  // data COVERS every charted day — coverage, not positivity: a sealed
+  // zero-token cycle is fully known (all zeros beat late-recomputed
+  // telemetry), while a day outside every covered cycle window (e.g. a
+  // synthesized active cycle without history) makes the whole view fall
+  // back to the details totals rather than charting misleading zeros.
+  const billedSeries = useMemo(() => {
+    if (points.length === 0) return null;
+    const series: number[] = [];
+    for (const p of points) {
+      const key = bucketDateKey(p.bucketTimeUnixNano);
+      // Bucket dates are UTC midnights, so the key parses back to the
+      // bucket's exact start instant.
+      const ms = Date.parse(key);
+      const coveredDay = billedDays.covered.some(
+        (r) => ms >= r.start && ms < r.end,
+      );
+      if (!coveredDay) return null;
+      series.push(billedDays.byDate.get(key) ?? 0);
+    }
+    return series;
+  }, [points, billedDays]);
+
+  const breakdownPicker = (
+    <BreakdownPicker
+      value={breakdown}
+      onChange={(value) => {
+        setBreakdown(value);
+        // Only actual dimensions pick a breakdown; the special modes
+        // (total / token type) keep the last-picked dimension.
+        if (stackModeFor(value) === "group") {
+          setDimension(value);
+        }
+      }}
+    />
+  );
+
+  return (
+    <TokenUsagePanel
+      points={points}
+      groups={groups}
+      billedSeries={billedSeries}
+      stackBy={stackBy}
+      breakdownPicker={breakdownPicker}
+      loading={isFetching && !data}
+      onSelectRange={onSelectRange}
+    />
+  );
+}

--- a/client/dashboard/src/components/billing/tum-token-breakdown.tsx
+++ b/client/dashboard/src/components/billing/tum-token-breakdown.tsx
@@ -52,7 +52,7 @@ export function TumTokenBreakdown({
 
   const scope = { client, orgId: organization.id, period };
   // Shared with the details table (same key — one request).
-  const { data, isFetching } = useQuery(tumDetailsQuery(scope));
+  const { data, isFetching, isError } = useQuery(tumDetailsQuery(scope));
 
   const points = useMemo(() => data?.points ?? [], [data]);
 
@@ -107,6 +107,7 @@ export function TumTokenBreakdown({
       stackBy={stackBy}
       breakdownPicker={breakdownPicker}
       loading={isFetching && !data}
+      failed={!isFetching && !data && isError}
       onSelectRange={onSelectRange}
     />
   );

--- a/client/dashboard/src/components/billing/tum-token-breakdown.tsx
+++ b/client/dashboard/src/components/billing/tum-token-breakdown.tsx
@@ -6,8 +6,8 @@ import { useMemo, useState } from "react";
 import {
   type BilledDays,
   type BillingPeriod,
+  type PeriodFigures,
   bucketDateKey,
-  periodCoveredByBilled,
 } from "./billing-cycles";
 import {
   BREAKDOWN_TOTAL,
@@ -31,13 +31,17 @@ export function TumTokenBreakdown({
   period,
   projectNames,
   billedDays,
+  figures,
   onSelectRange,
 }: {
   period: BillingPeriod;
   // Project id → name, for labeling the Project breakdown's UUID values.
   projectNames: Map<string, string>;
-  // The billed per-day series and the cycle windows it fully describes.
+  // The billed per-day series the headline stack plots.
   billedDays: BilledDays;
+  // The shared resolved figures — the coverage gate the card and details
+  // table also read.
+  figures: PeriodFigures;
   // Bar-click drill-down: narrows the page's period to the clicked bucket.
   onSelectRange: (start: Date, end: Date) => void;
 }): JSX.Element {
@@ -79,11 +83,11 @@ export function TumTokenBreakdown({
   // charting misleading numbers.
   const billedSeries = useMemo(() => {
     if (points.length === 0) return null;
-    if (!periodCoveredByBilled(period, billedDays.covered)) return null;
+    if (!figures.covered) return null;
     return points.map(
       (p) => billedDays.byDate.get(bucketDateKey(p.bucketTimeUnixNano)) ?? 0,
     );
-  }, [points, billedDays, period]);
+  }, [points, billedDays, figures.covered]);
 
   const breakdownPicker = (
     <BreakdownPicker

--- a/client/dashboard/src/components/billing/tum-usage-card.tsx
+++ b/client/dashboard/src/components/billing/tum-usage-card.tsx
@@ -180,7 +180,7 @@ function overageHintFor(
 ): string | undefined {
   if (fullCycle) return undefined;
   if (overage == null) {
-    return "Overage can't be attributed for this range — it extends beyond the billed daily data.";
+    return "Overage can't be attributed for this range — it cannot be fully represented by the billed daily data.";
   }
   return "Tokens in this range recorded after the organization's cumulative cycle usage crossed the included allowance. The crossing day is prorated.";
 }

--- a/client/dashboard/src/components/billing/tum-usage-card.tsx
+++ b/client/dashboard/src/components/billing/tum-usage-card.tsx
@@ -1,9 +1,22 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Info } from "lucide-react";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { ToggleButton } from "@/components/ui/ToggleButton";
-import { type BillingCycle } from "./billing-cycles";
+import { useOrganization } from "@/contexts/Auth";
+import { useGramContext } from "@gram/client/react-query/_context.js";
+import { useQuery } from "@tanstack/react-query";
+import {
+  type BilledDays,
+  type BillingCycle,
+  type BillingPeriod,
+  formatCycleName,
+  formatPeriodLabel,
+  periodCoveredByBilled,
+  sumDaysInPeriod,
+} from "./billing-cycles";
+import { tumDetailsQuery } from "./tum-queries";
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -16,24 +29,33 @@ const AVERAGE_UNITS: { unit: AverageUnit; ms: number }[] = [
   { unit: "week", ms: 7 * 24 * HOUR_MS },
 ];
 
-// The window the cycle's averages describe: the full cycle once it closes,
-// the elapsed portion while it's active (a whole-cycle denominator would
-// dilute the rate with days that haven't happened yet). Clamped to at least
-// an hour so a just-opened cycle doesn't extrapolate absurd rates.
-function averagingWindowMs(cycle: BillingCycle, now: number): number {
-  const end = cycle.current
-    ? Math.min(now, cycle.end.getTime())
-    : cycle.end.getTime();
-  return Math.max(end - cycle.start.getTime(), HOUR_MS);
+// The window the period's averages describe: the full window once it has
+// passed, the elapsed portion while it is still underway (a whole-window
+// denominator would dilute the rate with time that hasn't happened yet).
+// Clamped to at least an hour so a just-opened window doesn't extrapolate
+// absurd rates.
+function averagingWindowMs(period: BillingPeriod, now: number): number {
+  const end = Math.min(now, period.end.getTime());
+  return Math.max(end - period.start.getTime(), HOUR_MS);
 }
 
-// One average-rate figure with a unit switcher: the cycle's tokens expressed
+// One average-rate figure with a unit switcher: the period's tokens expressed
 // per hour / day / week, defaulting to per day.
-function AverageStat({ cycle }: { cycle: BillingCycle }): JSX.Element {
+function AverageStat({
+  period,
+  tokens,
+}: {
+  period: BillingPeriod;
+  // Billed tokens within the period; null while the total is still loading.
+  tokens: number | null;
+}): JSX.Element {
   const [unit, setUnit] = useState<AverageUnit>("day");
-  const windowMs = averagingWindowMs(cycle, Date.now());
+  const now = Date.now();
+  const windowMs = averagingWindowMs(period, now);
   const unitMs = AVERAGE_UNITS.find((u) => u.unit === unit)?.ms ?? HOUR_MS;
-  const average = Math.round((cycle.tokens * unitMs) / windowMs);
+  const average =
+    tokens != null ? Math.round((tokens * unitMs) / windowMs) : null;
+  const stillRunning = period.end.getTime() > now;
   return (
     <div className="flex flex-col gap-0.5">
       {/* Pinned to the text-xs line height so the pill's chrome overflows
@@ -56,9 +78,9 @@ function AverageStat({ cycle }: { cycle: BillingCycle }): JSX.Element {
         </span>
         <SimpleTooltip
           tooltip={
-            cycle.current
-              ? "Averaged over the elapsed portion of the active cycle."
-              : "Averaged over the full cycle."
+            stillRunning
+              ? "Averaged over the elapsed portion of the selected period."
+              : "Averaged over the full selected period."
           }
         >
           {/* A real button so the explanation is reachable by keyboard
@@ -72,96 +94,247 @@ function AverageStat({ cycle }: { cycle: BillingCycle }): JSX.Element {
           </button>
         </SimpleTooltip>
       </span>
-      <span className="text-xl font-semibold tabular-nums">
-        {average.toLocaleString()}
-      </span>
+      {average != null ? (
+        <span className="text-xl font-semibold tabular-nums">
+          {average.toLocaleString()}
+        </span>
+      ) : (
+        <Skeleton className="h-7 w-24" />
+      )}
     </div>
   );
 }
 
 // One headline figure in the TUM usage card. The tone ties the number to its
-// meter segment: green for the included allowance, amber for overage.
+// meter segment: green for the included allowance, amber for overage. A null
+// value renders a loading skeleton.
 function Stat({
   label,
   value,
   tone,
+  hint,
 }: {
   label: string;
-  value: string;
+  value: string | null;
   tone?: "success" | "warning";
+  // Optional explanation surfaced as an info tooltip beside the label.
+  hint?: string;
 }): JSX.Element {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-muted-foreground text-xs">{label}</span>
-      <span
-        className={cn(
-          "text-xl font-semibold tabular-nums",
-          // The success text tokens wash out here: near-white in dark mode,
-          // muted olive in light. Pin the palette steps that read as green in
-          // each mode.
-          tone === "success" &&
-            "text-[var(--color-feedback-green-600)] dark:text-[var(--color-feedback-green-400)]",
-          tone === "warning" && "text-warning",
+      <span className="text-muted-foreground flex h-4 items-center gap-1 text-xs">
+        {label}
+        {hint && (
+          <SimpleTooltip tooltip={hint}>
+            <button
+              type="button"
+              aria-label={`About ${label}`}
+              className="inline-flex shrink-0 cursor-help"
+            >
+              <Info aria-hidden className="size-3" />
+            </button>
+          </SimpleTooltip>
         )}
-      >
-        {value}
       </span>
+      {value != null ? (
+        <span
+          className={cn(
+            "text-xl font-semibold tabular-nums",
+            // The success text tokens wash out here: near-white in dark mode,
+            // muted olive in light. Pin the palette steps that read as green in
+            // each mode.
+            tone === "success" &&
+              "text-[var(--color-feedback-green-600)] dark:text-[var(--color-feedback-green-400)]",
+            tone === "warning" && "text-warning",
+          )}
+        >
+          {value}
+        </span>
+      ) : (
+        <Skeleton className="h-7 w-28" />
+      )}
     </div>
   );
 }
 
+// The meter spans max(usage, allowance): under the cap it reads as a
+// fill-toward-the-limit bar; over it, the amber overage segment grows.
+function meterShares(
+  tokens: number,
+  limit: number,
+): { included: number; overage: number } {
+  const over = Math.max(0, tokens - limit);
+  const scale = Math.max(tokens, limit);
+  if (scale <= 0) return { included: 0, overage: 0 };
+  return {
+    included: (Math.min(tokens, limit) / scale) * 100,
+    overage: (over / scale) * 100,
+  };
+}
+
+// Why the Overage figure reads the way it does on a custom range. Full
+// cycles carry the plain billed number and need no hint.
+function overageHintFor(
+  fullCycle: BillingCycle | null,
+  overage: number | null,
+): string | undefined {
+  if (fullCycle) return undefined;
+  if (overage == null) {
+    return "Overage can't be attributed for this range — it extends beyond the billed daily data.";
+  }
+  return "Tokens in this range recorded after the organization's cumulative cycle usage crossed the included allowance. The crossing day is prorated.";
+}
+
 /**
- * The billed tokens-under-management position for one billing cycle: headline
- * figures (used / included / extra) with a slim two-segment meter underneath.
- * The numbers live up here as first-class stats rather than as labels crammed
- * around the meter, so nothing clips or collides at extreme overage ratios.
+ * Resolves the usage card's figures for the effective period. Full cycles
+ * render their billed position directly; custom ranges sum the billed daily
+ * series when it covers every day of the range (falling back to the shared
+ * details query's analytics total when it doesn't) and attribute overage by
+ * the covered cycles' allowance-crossing days — the same numbers the details
+ * table's Overage column pins to.
  */
-export function TumUsageCard({
-  cycle,
+export function PeriodUsageCard({
+  period,
+  cycles,
+  billedDays,
+  overageDays,
   limit,
-  label,
 }: {
-  // The billing cycle whose position the card shows — billed tokens plus the
-  // time window its per-unit averages are computed over.
-  cycle: BillingCycle;
+  period: BillingPeriod;
+  cycles: BillingCycle[];
+  billedDays: BilledDays;
+  // Per-day billed overage across covered cycles; null when no allowance.
+  overageDays: Map<string, number> | null;
+  limit: number | null;
+}): JSX.Element {
+  const client = useGramContext();
+  const organization = useOrganization();
+  const fullCycle = period.cycle;
+  const covered = periodCoveredByBilled(period, billedDays.covered);
+  // Fallback total for ranges the billed daily series can't answer — the
+  // same request (identical query key) the chart and details table share.
+  const { data: details } = useQuery(
+    tumDetailsQuery({ client, orgId: organization.id, period }),
+  );
+
+  // The cycle the period sits inside, for the title's context suffix.
+  const containingCycle = useMemo(
+    () =>
+      fullCycle ??
+      cycles.find(
+        (c) =>
+          c.start.getTime() <= period.start.getTime() &&
+          period.end.getTime() <= c.end.getTime(),
+      ) ??
+      null,
+    [fullCycle, cycles, period],
+  );
+
+  let tokens: number | null;
+  if (fullCycle) {
+    tokens = fullCycle.tokens;
+  } else if (covered) {
+    tokens = sumDaysInPeriod(billedDays.byDate, period);
+  } else {
+    tokens = details?.totals?.totalTokens ?? null;
+  }
+
+  let overage: number | null = null;
+  if (limit != null && fullCycle) {
+    overage = Math.max(0, fullCycle.tokens - limit);
+  } else if (covered && overageDays != null) {
+    overage = Math.round(sumDaysInPeriod(overageDays, period));
+  }
+
+  return (
+    <TumUsageCard
+      period={period}
+      containingCycle={containingCycle}
+      tokens={tokens}
+      overage={overage}
+      limit={limit}
+    />
+  );
+}
+
+/**
+ * The billed tokens-under-management position for the selected period.
+ * A full billing cycle renders its complete billing position: headline
+ * figures (used / included / overage) with a slim two-segment meter
+ * underneath. A custom range renders range-scoped figures only — the
+ * allowance, percentage, and meter are cycle-level concepts and hide rather
+ * than compare days of traffic against a monthly number.
+ */
+function TumUsageCard({
+  period,
+  containingCycle,
+  tokens,
+  overage,
+  limit,
+}: {
+  // The effective page period the card describes.
+  period: BillingPeriod;
+  // The cycle the period sits inside — the title's context suffix on custom
+  // ranges. Null when the range spans cycle boundaries.
+  containingCycle: BillingCycle | null;
+  // Billed tokens within the period; null while a fallback total loads.
+  tokens: number | null;
+  // Billed overage tokens within the period; null when it can't be
+  // attributed (no allowance, or the range escapes the billed daily data).
+  overage: number | null;
   // Contracted monthly allowance; null when the org has no contracted cap.
   limit: number | null;
-  // Which billing cycle these figures describe. Essential when the page is
-  // scoped to a custom range: the card's whole-cycle totals exceed the
-  // range's totals, and the label is what keeps that from reading as a bug.
-  label: string;
 }): JSX.Element {
-  const tokens = cycle.tokens;
-  const overage = limit != null ? Math.max(0, tokens - limit) : 0;
-  // The meter spans max(usage, allowance): under the cap it reads as a
-  // fill-toward-the-limit bar; over it, the amber overage segment grows.
-  const scale = limit != null ? Math.max(tokens, limit) : 0;
-  const includedShare =
-    scale > 0 ? (Math.min(tokens, limit ?? 0) / scale) * 100 : 0;
-  const overageShare = scale > 0 ? (overage / scale) * 100 : 0;
+  const fullCycle = period.cycle;
+
+  const rangeTitle = (
+    <>
+      {formatPeriodLabel(period)}
+      {containingCycle && (
+        <span className="font-normal">
+          {" "}
+          · {formatCycleName(containingCycle)}
+        </span>
+      )}
+    </>
+  );
+
+  const overageValue = overage != null ? overage.toLocaleString() : "—";
+  const meter =
+    fullCycle != null && limit != null
+      ? meterShares(fullCycle.tokens, limit)
+      : null;
   const usedPercent =
-    limit != null && limit > 0 ? (tokens / limit) * 100 : null;
+    fullCycle != null && limit != null && limit > 0
+      ? (fullCycle.tokens / limit) * 100
+      : null;
 
   return (
     <div className="border-border rounded-lg border p-4">
       <div className="text-muted-foreground mb-3 text-sm font-medium">
-        {label}
+        {fullCycle ? formatCycleName(fullCycle) : rangeTitle}
       </div>
       <div className="flex flex-wrap items-start gap-x-10 gap-y-3">
-        <Stat label="Tokens Managed" value={tokens.toLocaleString()} />
         <Stat
-          label="Included allowance"
-          value={limit != null ? limit.toLocaleString() : "No limit"}
-          tone={limit != null ? "success" : undefined}
+          label="Tokens Managed"
+          value={tokens != null ? tokens.toLocaleString() : null}
         />
+        {fullCycle != null && (
+          <Stat
+            label="Included allowance"
+            value={limit != null ? limit.toLocaleString() : "No limit"}
+            tone={limit != null ? "success" : undefined}
+          />
+        )}
         {limit != null && (
           <Stat
             label="Overage"
-            value={overage.toLocaleString()}
-            tone={overage > 0 ? "warning" : undefined}
+            value={overageValue}
+            tone={overage != null && overage > 0 ? "warning" : undefined}
+            hint={overageHintFor(fullCycle, overage)}
           />
         )}
-        <AverageStat cycle={cycle} />
+        <AverageStat period={period} tokens={tokens} />
         {usedPercent != null && (
           <span
             className={cn(
@@ -174,16 +347,16 @@ export function TumUsageCard({
         )}
       </div>
 
-      {limit != null && (
+      {meter != null && (
         <div className="bg-muted mt-4 flex h-2 w-full gap-0.5 overflow-hidden rounded-full">
           <div
             className="bg-success-default h-full rounded-full transition-all duration-300"
-            style={{ width: `${includedShare}%` }}
+            style={{ width: `${meter.included}%` }}
           />
-          {overage > 0 && (
+          {meter.overage > 0 && (
             <div
               className="bg-warning-default h-full rounded-full transition-all duration-300"
-              style={{ width: `${overageShare}%` }}
+              style={{ width: `${meter.overage}%` }}
             />
           )}
         </div>

--- a/client/dashboard/src/components/billing/tum-usage-card.tsx
+++ b/client/dashboard/src/components/billing/tum-usage-card.tsx
@@ -8,17 +8,37 @@ import { useOrganization } from "@/contexts/Auth";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useQuery } from "@tanstack/react-query";
 import {
-  type BilledDays,
   type BillingCycle,
   type BillingPeriod,
+  type PeriodFigures,
   formatCycleName,
   formatPeriodLabel,
-  periodCoveredByBilled,
-  sumDaysInPeriod,
 } from "./billing-cycles";
 import { tumDetailsQuery } from "./tum-queries";
 
 const HOUR_MS = 60 * 60 * 1000;
+
+// Keyboard-reachable info tooltip beside a stat label: a real button so the
+// explanation is reachable by keyboard focus, not just pointer hover.
+function InfoHint({
+  label,
+  tooltip,
+}: {
+  label: string;
+  tooltip: string;
+}): JSX.Element {
+  return (
+    <SimpleTooltip tooltip={tooltip}>
+      <button
+        type="button"
+        aria-label={label}
+        className="inline-flex shrink-0 cursor-help"
+      >
+        <Info aria-hidden className="size-3" />
+      </button>
+    </SimpleTooltip>
+  );
+}
 
 // The selectable units for the average-rate stat.
 type AverageUnit = "hour" | "day" | "week";
@@ -32,11 +52,22 @@ const AVERAGE_UNITS: { unit: AverageUnit; ms: number }[] = [
 // The window the period's averages describe: the full window once it has
 // passed, the elapsed portion while it is still underway (a whole-window
 // denominator would dilute the rate with time that hasn't happened yet).
-// Clamped to at least an hour so a just-opened window doesn't extrapolate
-// absurd rates.
-function averagingWindowMs(period: BillingPeriod, now: number): number {
-  const end = Math.min(now, period.end.getTime());
-  return Math.max(end - period.start.getTime(), HOUR_MS);
+// Which cycle is active is the server's call — a sealed cycle always
+// averages over its full window, so a skewed browser clock can't shrink a
+// complete cycle's denominator. Clamped to at least an hour so a just-opened
+// window doesn't extrapolate absurd rates.
+function averagingWindow(
+  period: BillingPeriod,
+  now: number,
+): { ms: number; partial: boolean } {
+  const clampToNow = period.cycle ? period.cycle.current : true;
+  const end = clampToNow
+    ? Math.min(now, period.end.getTime())
+    : period.end.getTime();
+  return {
+    ms: Math.max(end - period.start.getTime(), HOUR_MS),
+    partial: clampToNow && period.end.getTime() > now,
+  };
 }
 
 // One average-rate figure with a unit switcher: the period's tokens expressed
@@ -44,18 +75,34 @@ function averagingWindowMs(period: BillingPeriod, now: number): number {
 function AverageStat({
   period,
   tokens,
+  failed,
 }: {
   period: BillingPeriod;
-  // Billed tokens within the period; null while the total is still loading.
+  // Billed tokens within the period; null while the total is still loading
+  // or when the fallback request failed.
   tokens: number | null;
+  // Whether the total is null because the fallback request failed.
+  failed: boolean;
 }): JSX.Element {
   const [unit, setUnit] = useState<AverageUnit>("day");
-  const now = Date.now();
-  const windowMs = averagingWindowMs(period, now);
+  const avgWindow = averagingWindow(period, Date.now());
   const unitMs = AVERAGE_UNITS.find((u) => u.unit === unit)?.ms ?? HOUR_MS;
   const average =
-    tokens != null ? Math.round((tokens * unitMs) / windowMs) : null;
-  const stillRunning = period.end.getTime() > now;
+    tokens != null ? Math.round((tokens * unitMs) / avgWindow.ms) : null;
+
+  let value: JSX.Element;
+  if (average != null) {
+    value = (
+      <span className="text-xl font-semibold tabular-nums">
+        {average.toLocaleString()}
+      </span>
+    );
+  } else if (failed) {
+    value = <span className="text-xl font-semibold tabular-nums">—</span>;
+  } else {
+    value = <Skeleton className="h-7 w-24" />;
+  }
+
   return (
     <div className="flex flex-col gap-0.5">
       {/* Pinned to the text-xs line height so the pill's chrome overflows
@@ -76,31 +123,16 @@ function AverageStat({
             </ToggleButton>
           ))}
         </span>
-        <SimpleTooltip
+        <InfoHint
+          label="How the average is calculated"
           tooltip={
-            stillRunning
+            avgWindow.partial
               ? "Averaged over the elapsed portion of the selected period."
               : "Averaged over the full selected period."
           }
-        >
-          {/* A real button so the explanation is reachable by keyboard
-              focus, not just pointer hover. */}
-          <button
-            type="button"
-            aria-label="How the average is calculated"
-            className="inline-flex shrink-0 cursor-help"
-          >
-            <Info aria-hidden className="size-3" />
-          </button>
-        </SimpleTooltip>
+        />
       </span>
-      {average != null ? (
-        <span className="text-xl font-semibold tabular-nums">
-          {average.toLocaleString()}
-        </span>
-      ) : (
-        <Skeleton className="h-7 w-24" />
-      )}
+      {value}
     </div>
   );
 }
@@ -124,17 +156,7 @@ function Stat({
     <div className="flex flex-col gap-0.5">
       <span className="text-muted-foreground flex h-4 items-center gap-1 text-xs">
         {label}
-        {hint && (
-          <SimpleTooltip tooltip={hint}>
-            <button
-              type="button"
-              aria-label={`About ${label}`}
-              className="inline-flex shrink-0 cursor-help"
-            >
-              <Info aria-hidden className="size-3" />
-            </button>
-          </SimpleTooltip>
-        )}
+        {hint && <InfoHint label={`About ${label}`} tooltip={hint} />}
       </span>
       {value != null ? (
         <span
@@ -186,34 +208,29 @@ function overageHintFor(
 }
 
 /**
- * Resolves the usage card's figures for the effective period. Full cycles
- * render their billed position directly; custom ranges sum the billed daily
- * series when it covers every day of the range (falling back to the shared
- * details query's analytics total when it doesn't) and attribute overage by
- * the covered cycles' allowance-crossing days — the same numbers the details
- * table's Overage column pins to.
+ * Resolves the usage card's numbers for the effective period from the shared
+ * PeriodFigures (the same object the chart headline and details table read),
+ * falling back to the analytics total from the shared details query for
+ * ranges the billed daily series can't answer.
  */
 export function PeriodUsageCard({
   period,
   cycles,
-  billedDays,
-  overageDays,
+  figures,
   limit,
 }: {
   period: BillingPeriod;
   cycles: BillingCycle[];
-  billedDays: BilledDays;
-  // Per-day billed overage across covered cycles; null when no allowance.
-  overageDays: Map<string, number> | null;
+  // The billed answers for the period, resolved once in the section.
+  figures: PeriodFigures;
   limit: number | null;
 }): JSX.Element {
   const client = useGramContext();
   const organization = useOrganization();
   const fullCycle = period.cycle;
-  const covered = periodCoveredByBilled(period, billedDays.covered);
   // Fallback total for ranges the billed daily series can't answer — the
   // same request (identical query key) the chart and details table share.
-  const { data: details } = useQuery(
+  const { data: details, isError } = useQuery(
     tumDetailsQuery({ client, orgId: organization.id, period }),
   );
 
@@ -230,29 +247,19 @@ export function PeriodUsageCard({
     [fullCycle, cycles, period],
   );
 
-  let tokens: number | null;
-  if (fullCycle) {
-    tokens = fullCycle.tokens;
-  } else if (covered) {
-    tokens = sumDaysInPeriod(billedDays.byDate, period);
-  } else {
-    tokens = details?.totals?.totalTokens ?? null;
-  }
-
-  let overage: number | null = null;
-  if (limit != null && fullCycle) {
-    overage = Math.max(0, fullCycle.tokens - limit);
-  } else if (covered && overageDays != null) {
-    overage = Math.round(sumDaysInPeriod(overageDays, period));
-  }
+  const tokens = figures.tokens ?? details?.totals?.totalTokens ?? null;
+  // Only the fallback path depends on the details request; when it failed
+  // with nothing cached, say so instead of skeleting forever.
+  const failed = figures.tokens == null && !details && isError;
 
   return (
     <TumUsageCard
       period={period}
       containingCycle={containingCycle}
       tokens={tokens}
-      overage={overage}
+      overage={figures.overage}
       limit={limit}
+      failed={failed}
     />
   );
 }
@@ -271,6 +278,7 @@ function TumUsageCard({
   tokens,
   overage,
   limit,
+  failed,
 }: {
   // The effective page period the card describes.
   period: BillingPeriod;
@@ -284,6 +292,9 @@ function TumUsageCard({
   overage: number | null;
   // Contracted monthly allowance; null when the org has no contracted cap.
   limit: number | null;
+  // Whether the tokens total is unavailable because its request failed —
+  // rendered as an explicit dash, never as an endless loading skeleton.
+  failed: boolean;
 }): JSX.Element {
   const fullCycle = period.cycle;
 
@@ -298,6 +309,18 @@ function TumUsageCard({
       )}
     </>
   );
+
+  let tokensValue: string | null;
+  if (tokens != null) {
+    tokensValue = tokens.toLocaleString();
+  } else if (failed) {
+    tokensValue = "—";
+  } else {
+    tokensValue = null;
+  }
+  const tokensHint = failed
+    ? "Couldn't load usage for this range. Try again shortly."
+    : undefined;
 
   const overageValue = overage != null ? overage.toLocaleString() : "—";
   const meter =
@@ -315,10 +338,7 @@ function TumUsageCard({
         {fullCycle ? formatCycleName(fullCycle) : rangeTitle}
       </div>
       <div className="flex flex-wrap items-start gap-x-10 gap-y-3">
-        <Stat
-          label="Tokens Managed"
-          value={tokens != null ? tokens.toLocaleString() : null}
-        />
+        <Stat label="Tokens Managed" value={tokensValue} hint={tokensHint} />
         {fullCycle != null && (
           <Stat
             label="Included allowance"
@@ -334,7 +354,7 @@ function TumUsageCard({
             hint={overageHintFor(fullCycle, overage)}
           />
         )}
-        <AverageStat period={period} tokens={tokens} />
+        <AverageStat period={period} tokens={tokens} failed={failed} />
         {usedPercent != null && (
           <span
             className={cn(

--- a/client/dashboard/src/components/billing/use-billing-period.ts
+++ b/client/dashboard/src/components/billing/use-billing-period.ts
@@ -1,0 +1,144 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  type BillingCycle,
+  type BillingPeriod,
+  cycleKey,
+  periodFromCycle,
+} from "./billing-cycles";
+
+// A custom time range overriding the cycle selection, with the range
+// picker's parse label when it came from one (e.g. "Last 7 days").
+export type CustomRange = { start: Date; end: Date; label?: string };
+
+// The range picker's calendar hands back local midnights for both ends. The
+// page's data is bucketed by UTC day (matching the billing-cycle boundaries),
+// so a picked day means that UTC calendar day — otherwise a one-day pick
+// spans two UTC buckets and the chart grows a phantom extra day. The last day
+// is inclusive. Natural-language parses carry real times and pass through
+// untouched.
+function customRangeFromPicker(
+  from: Date,
+  to: Date,
+): { start: Date; end: Date } {
+  const isLocalMidnight = (d: Date) =>
+    d.getHours() === 0 &&
+    d.getMinutes() === 0 &&
+    d.getSeconds() === 0 &&
+    d.getMilliseconds() === 0;
+  if (!isLocalMidnight(from) || !isLocalMidnight(to)) {
+    return { start: from, end: to };
+  }
+  return {
+    start: new Date(
+      Date.UTC(from.getFullYear(), from.getMonth(), from.getDate()),
+    ),
+    end: new Date(Date.UTC(to.getFullYear(), to.getMonth(), to.getDate() + 1)),
+  };
+}
+
+/**
+ * Selection state behind the billing page's effective time period: a billing
+ * cycle from the cycle picker (defaulting to the active cycle once TUM
+ * loads), overridden by a custom range typed into the range picker or
+ * drilled into via a chart bar click. A custom range that happens to match a
+ * cycle's exact boundaries IS that cycle (billed normalization applies).
+ */
+export function useBillingPeriod(cycles: BillingCycle[]): {
+  // The effective period; null until the cycles are known.
+  period: BillingPeriod | null;
+  // The picked (or defaulted) cycle, regardless of any range override.
+  selectedCycle: BillingCycle | null;
+  // The active range override, if any.
+  customRange: CustomRange | null;
+  // Remount key for view state; bumped by reset().
+  viewNonce: number;
+  // Scope the page to a cycle, clearing any range override.
+  selectCycle: (cycle: BillingCycle) => void;
+  // Scope the page to a range picked in the range picker (calendar or
+  // natural-language parse).
+  setPickedRange: (from: Date, to: Date, label?: string) => void;
+  // Drop the range override, returning to the selected cycle.
+  clearCustomRange: () => void;
+  // Bar-click drill-down: narrow to the clicked bucket, clamped to the
+  // current period (week/month buckets can overhang the period's edges).
+  selectBarRange: (start: Date, end: Date) => void;
+  // Back to the default cycle with all view state remounted.
+  reset: () => void;
+} {
+  // Derived (not synced) so the current cycle is the default once TUM loads.
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const selectedCycle =
+    cycles.find((c) => cycleKey(c) === selectedKey) ??
+    cycles.find((c) => c.current) ??
+    cycles[0] ??
+    null;
+
+  const [customRange, setCustomRange] = useState<CustomRange | null>(null);
+  const [viewNonce, setViewNonce] = useState(0);
+
+  // The effective period. A custom range that happens to match a cycle's
+  // exact boundaries IS that cycle (billed normalization applies).
+  const period: BillingPeriod | null = useMemo(() => {
+    if (customRange) {
+      const exact =
+        cycles.find(
+          (c) =>
+            c.start.getTime() === customRange.start.getTime() &&
+            c.end.getTime() === customRange.end.getTime(),
+        ) ?? null;
+      return {
+        start: customRange.start,
+        end: customRange.end,
+        cycle: exact,
+        label: customRange.label,
+      };
+    }
+    return selectedCycle ? periodFromCycle(selectedCycle) : null;
+  }, [customRange, cycles, selectedCycle]);
+
+  const selectCycle = useCallback((cycle: BillingCycle): void => {
+    setCustomRange(null);
+    setSelectedKey(cycleKey(cycle));
+  }, []);
+
+  const setPickedRange = useCallback(
+    (from: Date, to: Date, label?: string): void => {
+      setCustomRange({ ...customRangeFromPicker(from, to), label });
+    },
+    [],
+  );
+
+  const clearCustomRange = useCallback((): void => {
+    setCustomRange(null);
+  }, []);
+
+  // Stable identity — it feeds the chart panel's chartOptions memo.
+  const selectBarRange = useCallback(
+    (start: Date, end: Date): void => {
+      if (!period) return;
+      const s = Math.max(start.getTime(), period.start.getTime());
+      const e = Math.min(end.getTime(), period.end.getTime());
+      if (e <= s) return;
+      setCustomRange({ start: new Date(s), end: new Date(e) });
+    },
+    [period],
+  );
+
+  const reset = useCallback((): void => {
+    setSelectedKey(null);
+    setCustomRange(null);
+    setViewNonce((n) => n + 1);
+  }, []);
+
+  return {
+    period,
+    selectedCycle,
+    customRange,
+    viewNonce,
+    selectCycle,
+    setPickedRange,
+    clearCustomRange,
+    selectBarRange,
+    reset,
+  };
+}

--- a/client/dashboard/src/components/billing/use-billing-period.ts
+++ b/client/dashboard/src/components/billing/use-billing-period.ts
@@ -10,22 +10,24 @@ import {
 // picker's parse label when it came from one (e.g. "Last 7 days").
 export type CustomRange = { start: Date; end: Date; label?: string };
 
-// The range picker's calendar hands back local midnights for both ends. The
-// page's data is bucketed by UTC day (matching the billing-cycle boundaries),
-// so a picked day means that UTC calendar day — otherwise a one-day pick
-// spans two UTC buckets and the chart grows a phantom extra day. The last day
-// is inclusive. Natural-language parses carry real times and pass through
-// untouched.
+// The range picker's calendar hands back the start of the local day for both
+// ends. The page's data is bucketed by UTC day (matching the billing-cycle
+// boundaries), so a picked day means that UTC calendar day — otherwise a
+// one-day pick spans two UTC buckets and the chart grows a phantom extra
+// day. The last day is inclusive. Natural-language parses carry real times
+// and pass through untouched.
 function customRangeFromPicker(
   from: Date,
   to: Date,
 ): { start: Date; end: Date } {
-  const isLocalMidnight = (d: Date) =>
-    d.getHours() === 0 &&
-    d.getMinutes() === 0 &&
-    d.getSeconds() === 0 &&
-    d.getMilliseconds() === 0;
-  if (!isLocalMidnight(from) || !isLocalMidnight(to)) {
+  // "Start of the local day", not "local midnight": on a DST spring-forward
+  // day that skips midnight (e.g. 00:00 → 01:00 in Chile or Cuba), the
+  // calendar pick lands at 01:00 and a midnight check would silently drop
+  // the UTC-day mapping for that pick.
+  const isStartOfLocalDay = (d: Date) =>
+    d.getTime() ===
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  if (!isStartOfLocalDay(from) || !isStartOfLocalDay(to)) {
     return { start: from, end: to };
   }
   return {

--- a/client/dashboard/src/components/billing/use-billing-period.ts
+++ b/client/dashboard/src/components/billing/use-billing-period.ts
@@ -103,7 +103,11 @@ export function useBillingPeriod(cycles: BillingCycle[]): {
 
   const setPickedRange = useCallback(
     (from: Date, to: Date, label?: string): void => {
-      setCustomRange({ ...customRangeFromPicker(from, to), label });
+      const range = customRangeFromPicker(from, to);
+      // A natural-language parse can hand back an inverted window; keep the
+      // prior selection rather than scoping the page to an empty range.
+      if (range.end.getTime() <= range.start.getTime()) return;
+      setCustomRange({ ...range, label });
     },
     [],
   );

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -23,10 +23,8 @@ import { Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { RequireScope } from "@/components/require-scope";
 import { TopUpCTA, UsageProgress } from "@/components/billing/usage-controls";
-import {
-  TumAdminSection,
-  TumUsageSection,
-} from "@/components/billing/tum-section";
+import { TumAdminSection } from "@/components/billing/tum-admin-section";
+import { TumUsageSection } from "@/components/billing/tum-section";
 
 export default function Billing(): JSX.Element {
   return (


### PR DESCRIPTION
## What

The billing page's usage card previously always showed the full billing cycle's position, even when the page was scoped to a custom date range (typed, calendar-picked, or bar-click drill-down). It now follows the selected range:

- **Full cycle** (picker selection, or a range matching a cycle's exact boundaries): unchanged — allowance, overage, % of allowance, and the two-segment meter.
- **Custom range**: the title becomes the range (`Jul 10 – Jul 20 · July Billing Cycle`, or the picker's parse label like "Last 7 days"; the cycle suffix drops when the range spans cycles). Tokens Managed is the range's billed total, Overage is time-attributed — tokens recorded after the cycle's cumulative billed usage crossed the allowance, crossing day prorated — with an info tooltip. The per-unit average uses the range window. Allowance, percentage, and meter hide: they're cycle-level concepts and comparing days of traffic against a monthly number would mislead.
- Ranges the billed daily series can't answer (outside known cycles, non-day-aligned) fall back to the analytics total and show `—` for overage with an explanatory tooltip.

The details table's Overage column adopts the same attribution for custom ranges (it previously showed `—`), and its Total row pins to the usage card's figure exactly, so the two surfaces always agree to the token.

## Code organization

The TUM billing module is split by responsibility so this is easier to extend:

- `billing-cycles.ts` — pure domain logic: cycle/period types, billed-daily-series normalization (`billedDaysFromCycles`), the allowance-crossing overage walk (`overageDaysFromBilled`, shared by card and table), coverage checks, label formatting.
- `use-billing-period.ts` — new hook owning all period-selection state (cycle pick, range override, bar drill-down, reset).
- `tum-token-breakdown.tsx` / `tum-admin-section.tsx` — extracted from the section file.
- `tum-usage-card.tsx` — the card view plus its data-resolving `PeriodUsageCard` wrapper.
- `tum-section.tsx` — thin composition only (~160 lines, was ~520).

## Seed

`seed.mts` now boosts days inside the active billing cycle so the current cycle lands clearly past the seeded 50M allowance (~190% of allowance), making the overage rendering visible in local dev regardless of when the seed runs.

## Testing

- Verified in the local dashboard end-to-end: full cycle → calendar-picked range → card re-scopes (title, tokens, attributed overage, hidden meter) → details table Total row matches the card exactly → Reset returns to the full cycle.
- `pnpm -F dashboard type-check`, `lint`, and `lint:format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the billing usage card and details table to the selected time range so tokens and overage reflect the view; full-cycle behavior is unchanged. All surfaces (card, chart headline, table) now resolve shared billed figures and overage consistently, with clear fallbacks and failure states.

- New Features
  - Range-aware card: titles show the range label/dates with a cycle suffix; Tokens Managed uses billed totals in-range; Overage is time-attributed with a prorated crossing day; allowance, % used, and meter hide on partial ranges. Average rate uses the selected window, shows skeletons while loading, and displays "—" with an explanation if the fallback total fails.
  - Coverage and fallbacks: billed normalization and overage attribution apply to full cycles and day-aligned ranges fully covered by billed data; otherwise the UI falls back to analytics totals and shows "—" for overage with a tooltip. The breakdown chart now renders a distinct failure message when details fail.
  - Details table: reads the same resolved figures, pins its Total to the card, attributes overage via per‑day billed fractions, and shows "—" when overage is not attributable (no allowance, uncovered range, or no tokens in-window). Tooltips clarify billed-normalized vs analytics totals and overage meaning.

- Refactors
  - Centralized period logic and figures: added `PeriodUsageCard`, `use-billing-period.ts` (DST-safe range parsing, drill‑down, reset), and new helpers in `billing-cycles.ts` (`billedDaysFromCycles`, `overageDaysFromBilled`, `resolvePeriodFigures`, `formatPeriodLabel`). Extracted `tum-token-breakdown.tsx` and `tum-admin-section.tsx`; `tum-section.tsx` simplified.
  - Chart/table share the same details query; `TokenUsagePanel` accepts `failed` to distinguish outages from empty ranges. Seed script boosts active-cycle usage with a weekend-aware multiplier to reliably surface overage in local dev.

<sup>Written for commit f7a85a51870f785b0fb3f1e435e3753432243a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

