### PR TITLE
fix(usersessions): invalidate outstanding access tokens on client revoke

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -315,6 +315,7 @@ const (
 	AuditSubjectKey                   = attribute.Key("gram.audit.subject")
 	AuditSubjectIDKey                 = attribute.Key("gram.audit.subject_id")
 	UserSessionIssuerIDKey            = attribute.Key("gram.user_session_issuer.id")
+	UserSessionClientIDKey            = attribute.Key("gram.user_session_client.id")
 	UserSessionClientMigratedCountKey = attribute.Key("gram.user_session_client.migrated_count")
 	RiskPolicyCountKey                = attribute.Key("gram.risk.policy_count")
 	RiskPolicyIDKey                   = attribute.Key("gram.risk.policy_id")
@@ -1385,6 +1386,11 @@ func SlogAuditSubjectID(v string) slog.Attr      { return slog.String(string(Aud
 func UserSessionIssuerID(v string) attribute.KeyValue { return UserSessionIssuerIDKey.String(v) }
 func SlogUserSessionIssuerID(v string) slog.Attr {
 	return slog.String(string(UserSessionIssuerIDKey), v)
+}
+
+func UserSessionClientID(v string) attribute.KeyValue { return UserSessionClientIDKey.String(v) }
+func SlogUserSessionClientID(v string) slog.Attr {
+	return slog.String(string(UserSessionClientIDKey), v)
 }
 
 func UserSessionClientMigratedCount(v int64) attribute.KeyValue {

--- a/server/internal/usersessions/clienthandlers.go
+++ b/server/internal/usersessions/clienthandlers.go
@@ -3,6 +3,8 @@ package usersessions
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -20,6 +22,21 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
+
+// revocationPushBudget caps the post-commit jti push in
+// RevokeUserSessionClient. A healthy Redis answers in well under a
+// millisecond, so this covers thousands of sessions; a Redis that is down
+// costs on the order of seconds per attempt (1s DialTimeout plus go-redis
+// retries, with no short-circuit), so the budget stops the handler from
+// blocking for minutes on a client that owns many sessions.
+const revocationPushBudget = 5 * time.Second
+
+// maxReportedRevocationFailures caps how many failed jtis are named in the
+// error a failed revocation push produces. The counts in the user-facing
+// message carry the full picture; this only bounds the diagnostic detail so a
+// client owning thousands of sessions can't produce a single enormous log
+// record and span attribute.
+const maxReportedRevocationFailures = 20
 
 // Lists DCR-registered clients; keyset paginated by id (descending).
 // client_secret_hash is stripped from the view.
@@ -139,8 +156,32 @@ func (s *Service) RevokeUserSessionClient(ctx context.Context, payload *gen.Revo
 		return oops.E(oops.CodeUnexpected, err, "revoke user session client").LogError(ctx, logger)
 	}
 
-	if _, err := txRepo.SoftDeleteUserSessionsByClientID(ctx, uuid.NullUUID{UUID: revoked.ID, Valid: true}); err != nil {
+	logger = logger.With(attr.SlogUserSessionClientID(revoked.ID.String()))
+
+	revokedSessions, err := txRepo.SoftDeleteUserSessionsByClientID(ctx, uuid.NullUUID{UUID: revoked.ID, Valid: true})
+	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "delete child user sessions").LogError(ctx, logger)
+	}
+
+	// One audit entry per cascaded session, not one covering the batch, so
+	// each session's life cycle stays reconstructable and auditlogs.list can
+	// filter to a single session id. Emitted before the parent client-revoke
+	// event; all of them commit with the cascade. Note this costs two round
+	// trips per session (audit row plus outbox append) while the transaction
+	// holds row locks on every session it just soft-deleted.
+	for _, session := range revokedSessions {
+		if err := s.audit.LogUserSessionRevoke(ctx, dbtx, audit.LogUserSessionRevokeEvent{
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			ProjectID:        *authCtx.ProjectID,
+			Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID),
+			ActorDisplayName: authCtx.Email,
+			ActorSlug:        nil,
+			UserSessionURN:   urn.NewUserSession(session.ID),
+			Principal:        session.SubjectUrn,
+			Jti:              session.Jti,
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "log cascaded user session revocation").LogError(ctx, logger)
+		}
 	}
 
 	if err := s.audit.LogUserSessionClientRevoke(ctx, dbtx, audit.LogUserSessionClientRevokeEvent{
@@ -158,6 +199,66 @@ func (s *Service) RevokeUserSessionClient(ctx context.Context, payload *gen.Revo
 
 	if err := dbtx.Commit(ctx); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, logger)
+	}
+
+	// Push every cascaded jti into the revocation cache after the DB commit so
+	// a cached jti always corresponds to a soft-deleted row. Without this the
+	// client's already-issued access tokens keep validating until they expire
+	// on their own clock (up to an hour), because the Bearer path checks only
+	// signature, expiry, audience, and this cache — never the row's liveness.
+	//
+	// Bounded: a Redis that is refusing connections costs on the order of a
+	// second per attempt, and a blackholed one costs several (1s DialTimeout
+	// plus go-redis retries, with no short-circuit). One client row can own a
+	// session per user, since a CIMD client_id is shared across every user of
+	// that client, so an unbounded loop could block the handler for minutes.
+	// pushCtx is passed into each call, so the deadline bounds the loop as a
+	// whole rather than each attempt.
+	//
+	// Detached from the request's cancellation: the rows are already committed
+	// as deleted, so a caller that disconnects between the commit and the push
+	// would otherwise leave every one of those access tokens live until expiry.
+	pushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), revocationPushBudget)
+	defer cancel()
+
+	pushed := 0
+	failedJTIs := make([]string, 0, len(revokedSessions))
+	var firstErr error
+	for _, session := range revokedSessions {
+		if pushCtx.Err() != nil {
+			break
+		}
+		if err := s.chatSessions.RevokeToken(pushCtx, session.Jti); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			failedJTIs = append(failedJTIs, session.Jti)
+			continue
+		}
+		pushed++
+	}
+
+	// Surfaced rather than logged and swallowed: the client and its sessions
+	// are already gone from the database, so reporting success here would tell
+	// an operator that a security control took effect while some access tokens
+	// are still live. Marked Permanent because retrying cannot help — the
+	// client row is soft-deleted, so a second revoke returns not-found.
+	if pushed < len(revokedSessions) {
+		cause := firstErr
+		if cause == nil {
+			cause = pushCtx.Err()
+		}
+		// Capped: with one session per user, an outage would otherwise put
+		// thousands of near-identical jtis into a single log record and span.
+		reported := failedJTIs
+		if len(reported) > maxReportedRevocationFailures {
+			reported = reported[:maxReportedRevocationFailures]
+		}
+		return oops.E(
+			oops.CodeUnexpected,
+			oops.Permanent(fmt.Errorf("push revoked jtis (failed, capped at %d: %v): %w", maxReportedRevocationFailures, reported, cause)),
+			"revoke access tokens for client (%d of %d sessions invalidated)", pushed, len(revokedSessions),
+		).LogError(ctx, logger)
 	}
 
 	return nil

--- a/server/internal/usersessions/impl.go
+++ b/server/internal/usersessions/impl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
-	"github.com/speakeasy-api/gram/server/internal/auth/chatsessions"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
@@ -43,7 +42,7 @@ type Service struct {
 	db           *pgxpool.Pool
 	auth         *auth.Auth
 	authz        *authz.Engine
-	chatSessions *chatsessions.Manager
+	chatSessions TokenRevoker
 	audit        *audit.Logger
 	// signer mints the user-session JWT returned by mintUserSession. Same
 	// signer the /mcp/{slug}/token handler uses, so the resulting JWTs
@@ -73,11 +72,13 @@ var (
 
 // NewService constructs a Service ready to be Attached against each of the
 // four user_session* Goa services. chatSessionsManager is used by the
-// userSessions revoke handler to push revoked jtis into the revocation cache.
+// userSessions and userSessionClients revoke handlers to push revoked jtis
+// into the revocation cache; it is held as a TokenRevoker so tests can
+// substitute a failing revoker.
 // signer + serverURL drive mintUserSession; pass an empty serverURL to
 // disable that handler (it will 503 on call — used in tests that don't
 // need the surface).
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionManager *sessions.Manager, chatSessionsManager *chatsessions.Manager, authzEngine *authz.Engine, auditLogger *audit.Logger, signer *Signer, serverURL string, remoteSessions *remotesessions.Service) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionManager *sessions.Manager, chatSessionsManager TokenRevoker, authzEngine *authz.Engine, auditLogger *audit.Logger, signer *Signer, serverURL string, remoteSessions *remotesessions.Service) *Service {
 	logger = logger.With(attr.SlogComponent("usersessions"))
 
 	return &Service{

--- a/server/internal/usersessions/jwt.go
+++ b/server/internal/usersessions/jwt.go
@@ -35,6 +35,16 @@ type RevocationChecker interface {
 	IsTokenRevoked(ctx context.Context, jti string) (bool, error)
 }
 
+// TokenRevoker pushes a JTI into the revocation cache the RevocationChecker
+// reads. Declared as an interface rather than taking *chatsessions.Manager
+// directly so revoke handlers can be tested against a failing revoker without
+// standing up an unreachable Redis, which costs seconds per call (1s
+// DialTimeout plus go-redis retries) and so taxes every run of these tests
+// once per seeded session.
+type TokenRevoker interface {
+	RevokeToken(ctx context.Context, jti string) error
+}
+
 // SessionClaims is the unified JWT claim shape for Gram-issued user sessions
 // (and, as the chat-session path retires, all Gram session tokens). Carries
 // the standard OIDC registered claims plus the OAuth client the token was

--- a/server/internal/usersessions/revokeusersessionclient_test.go
+++ b/server/internal/usersessions/revokeusersessionclient_test.go
@@ -1,6 +1,7 @@
 package usersessions_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -13,6 +14,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
 func TestRevokeUserSessionClient(t *testing.T) {
@@ -56,6 +59,160 @@ func TestRevokeUserSessionClient(t *testing.T) {
 		ProjectSlugInput: nil,
 	})
 	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// Revoking a client must invalidate every access token already issued
+// through it. Without the post-commit revocation-cache push those tokens keep
+// validating until they expire on their own clock (up to an hour), because
+// the Bearer path never rechecks the session row's liveness.
+func TestRevokeUserSessionClient_CascadedSessionsRevoked(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+
+	issuer, err := ti.service.CreateUserSessionIssuer(ctx, &issuersgen.CreateUserSessionIssuerPayload{
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+		Slug:                 "revoke-client-cascade",
+		AuthnChallengeMode:   "chain",
+		SessionDurationHours: 24,
+	})
+	require.NoError(t, err)
+
+	client, err := seedUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), "cascade-target")
+	require.NoError(t, err)
+
+	sessions := make([]repo.UserSession, 0, 3)
+	for i := range 3 {
+		session, err := seedUserSessionForClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), client.ID, urn.NewUserSubject(fmt.Sprintf("cascade-user-%d", i)))
+		require.NoError(t, err)
+		sessions = append(sessions, session)
+	}
+
+	// A session on the same issuer but bound to a different client must be
+	// left alone: revoking one client cannot invalidate another's tokens.
+	otherClient, err := seedUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), "cascade-bystander")
+	require.NoError(t, err)
+	bystander, err := seedUserSessionForClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), otherClient.ID, urn.NewUserSubject("cascade-bystander-user"))
+	require.NoError(t, err)
+
+	for _, session := range sessions {
+		require.False(t, jtiRevoked(t, ctx, ti.redis, session.Jti))
+	}
+
+	beforeSessionRevokes, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionUserSessionRevoke)
+	require.NoError(t, err)
+
+	err = ti.service.RevokeUserSessionClient(ctx, &gen.RevokeUserSessionClientPayload{
+		ID:               client.ID.String(),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+
+	for _, session := range sessions {
+		require.True(t, jtiRevoked(t, ctx, ti.redis, session.Jti), "client revoke must push every cascaded session jti into the revocation cache")
+	}
+	require.False(t, jtiRevoked(t, ctx, ti.redis, bystander.Jti), "another client's session must not be revoked")
+
+	// One audit entry per cascaded session, not one covering the batch.
+	afterSessionRevokes, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionUserSessionRevoke)
+	require.NoError(t, err)
+	require.Equal(t, beforeSessionRevokes+int64(len(sessions)), afterSessionRevokes)
+}
+
+// A revocation-cache failure must not be reported as success: the client and
+// its sessions are already committed as deleted, so a silent success would
+// claim a security control took effect while access tokens are still live.
+func TestRevokeUserSessionClient_RevocationCacheFailure(t *testing.T) {
+	t.Parallel()
+
+	revoker := &failingTokenRevoker{}
+	ctx, ti := newTestServiceWithRevoker(t, revoker)
+
+	issuer, err := ti.service.CreateUserSessionIssuer(ctx, &issuersgen.CreateUserSessionIssuerPayload{
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+		Slug:                 "revoke-client-cache-fail",
+		AuthnChallengeMode:   "chain",
+		SessionDurationHours: 24,
+	})
+	require.NoError(t, err)
+
+	client, err := seedUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), "cache-fail-target")
+	require.NoError(t, err)
+
+	for i := range 2 {
+		_, err := seedUserSessionForClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), client.ID, urn.NewUserSubject(fmt.Sprintf("cache-fail-user-%d", i)))
+		require.NoError(t, err)
+	}
+
+	err = ti.service.RevokeUserSessionClient(ctx, &gen.RevokeUserSessionClientPayload{
+		ID:               client.ID.String(),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+
+	// Every jti is attempted rather than bailing on the first failure, so a
+	// partial outage still shrinks the blast radius as far as it can.
+	require.Equal(t, 2, revoker.Calls())
+
+	// The database side committed regardless — the failure is in the cache
+	// push, which happens after commit.
+	_, err = ti.service.GetUserSessionClient(ctx, &gen.GetUserSessionClientPayload{
+		ID:               client.ID.String(),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// One jti failing must not stop the rest: a partial push still shrinks the
+// blast radius, and the reported counts must reflect what actually landed.
+func TestRevokeUserSessionClient_PartialRevocationFailure(t *testing.T) {
+	t.Parallel()
+
+	revoker := &partialTokenRevoker{}
+	ctx, ti := newTestServiceWithRevoker(t, revoker)
+
+	issuer, err := ti.service.CreateUserSessionIssuer(ctx, &issuersgen.CreateUserSessionIssuerPayload{
+		SessionToken:         nil,
+		ApikeyToken:          nil,
+		ProjectSlugInput:     nil,
+		Slug:                 "revoke-client-partial-fail",
+		AuthnChallengeMode:   "chain",
+		SessionDurationHours: 24,
+	})
+	require.NoError(t, err)
+
+	client, err := seedUserSessionClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), "partial-fail-target")
+	require.NoError(t, err)
+
+	jtis := make([]string, 0, 3)
+	for i := range 3 {
+		session, err := seedUserSessionForClient(t, ctx, ti.conn, uuid.MustParse(issuer.ID), client.ID, urn.NewUserSubject(fmt.Sprintf("partial-fail-user-%d", i)))
+		require.NoError(t, err)
+		jtis = append(jtis, session.Jti)
+	}
+	revoker.failOn(jtis[1])
+
+	err = ti.service.RevokeUserSessionClient(ctx, &gen.RevokeUserSessionClientPayload{
+		ID:               client.ID.String(),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	requireOopsCode(t, err, oops.CodeUnexpected)
+	require.ErrorContains(t, err, "2 of 3 sessions invalidated")
+
+	// The failure must not short-circuit the two that would have succeeded.
+	require.ElementsMatch(t, jtis, revoker.Calls())
 }
 
 func TestRevokeUserSessionClient_NotFound(t *testing.T) {

--- a/server/internal/usersessions/setup_test.go
+++ b/server/internal/usersessions/setup_test.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,6 +70,17 @@ type testInstance struct {
 func newTestService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 
+	return newTestServiceWithRevoker(t, nil)
+}
+
+// newTestServiceWithRevoker builds the service with a substitute
+// TokenRevoker so revoke tests can exercise the revocation-cache failure path
+// without an unreachable Redis, which would cost ~1.7s per seeded session
+// (1s DialTimeout plus go-redis retries). Pass nil for the real
+// chatsessions.Manager over the test Redis.
+func newTestServiceWithRevoker(t *testing.T, revoker usersessions.TokenRevoker) (context.Context, *testInstance) {
+	t.Helper()
+
 	ctx := t.Context()
 
 	logger := testenv.NewLogger(t)
@@ -110,12 +123,17 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		cache.NewRedisCacheAdapter(redisClient),
 	)
 
+	var tokenRevoker usersessions.TokenRevoker = chatSessionsManager
+	if revoker != nil {
+		tokenRevoker = revoker
+	}
+
 	svc := usersessions.NewService(
 		logger,
 		tracerProvider,
 		conn,
 		sessionManager,
-		chatSessionsManager,
+		tokenRevoker,
 		authzEngine,
 		audit.NewLogger(),
 		usersessions.NewSigner("test-jwt-secret"),
@@ -130,6 +148,62 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 		chatSessionsManager: chatSessionsManager,
 		redis:               redisClient,
 	}
+}
+
+// failingTokenRevoker is a usersessions.TokenRevoker whose every push fails,
+// and which records how many pushes were attempted. TokenRevoker is our own
+// interface rather than a vendor type, so a hand-rolled stub is preferred to
+// testify/mock here.
+type failingTokenRevoker struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *failingTokenRevoker) RevokeToken(_ context.Context, jti string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return fmt.Errorf("revocation cache unavailable for jti %s", jti)
+}
+
+func (f *failingTokenRevoker) Calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// partialTokenRevoker fails only for the jtis registered with failOn and
+// records every jti it was asked to revoke, so tests can pin the mixed
+// success/failure accounting the handler reports.
+type partialTokenRevoker struct {
+	mu     sync.Mutex
+	failed map[string]bool
+	calls  []string
+}
+
+func (p *partialTokenRevoker) failOn(jti string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.failed == nil {
+		p.failed = map[string]bool{}
+	}
+	p.failed[jti] = true
+}
+
+func (p *partialTokenRevoker) RevokeToken(_ context.Context, jti string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, jti)
+	if p.failed[jti] {
+		return fmt.Errorf("revocation cache rejected jti %s", jti)
+	}
+	return nil
+}
+
+func (p *partialTokenRevoker) Calls() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.calls)
 }
 
 // jtiRevoked reports whether the chat_session_revoked:{jti}: key exists in
@@ -211,15 +285,33 @@ func seedUserSession(t *testing.T, ctx context.Context, conn *pgxpool.Pool, issu
 	return seedUserSessionWithExpiry(t, ctx, conn, issuerID, principalURN, now.Add(24*time.Hour), now.Add(time.Hour))
 }
 
+// seedUserSessionForClient inserts a user_sessions row bound to a
+// user_session_clients row, so the client-revoke cascade has something to
+// sweep up. Sessions seeded through seedUserSession carry no client id and
+// are deliberately invisible to SoftDeleteUserSessionsByClientID.
+func seedUserSessionForClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, issuerID, clientID uuid.UUID, principalURN urn.SessionSubject) (repo.UserSession, error) {
+	t.Helper()
+
+	now := time.Now()
+	return seedUserSessionFull(t, ctx, conn, issuerID, uuid.NullUUID{UUID: clientID, Valid: true}, principalURN, now.Add(24*time.Hour), now.Add(time.Hour))
+}
+
 // seedUserSessionWithExpiry inserts a user_sessions row with explicit access-
 // token (expires_at) and refresh-token (refresh_expires_at) expiry times so
 // tests can exercise the status filter's reliance on refresh_expires_at.
 func seedUserSessionWithExpiry(t *testing.T, ctx context.Context, conn *pgxpool.Pool, issuerID uuid.UUID, principalURN urn.SessionSubject, expiresAt, refreshExpiresAt time.Time) (repo.UserSession, error) {
 	t.Helper()
 
+	return seedUserSessionFull(t, ctx, conn, issuerID, uuid.NullUUID{UUID: uuid.Nil, Valid: false}, principalURN, expiresAt, refreshExpiresAt)
+}
+
+func seedUserSessionFull(t *testing.T, ctx context.Context, conn *pgxpool.Pool, issuerID uuid.UUID, clientID uuid.NullUUID, principalURN urn.SessionSubject, expiresAt, refreshExpiresAt time.Time) (repo.UserSession, error) {
+	t.Helper()
+
 	r := repo.New(conn)
 	row, err := r.CreateUserSession(ctx, repo.CreateUserSessionParams{
 		UserSessionIssuerID: issuerID,
+		UserSessionClientID: clientID,
 		SubjectUrn:          principalURN,
 		Jti:                 "jti-" + uuid.NewString(),
 		RefreshTokenHash:    "hash-" + uuid.NewString(),


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-406/fix-client-revoke-does-not-invalidate-outstanding-access-tokens

`RevokeUserSessionClient` soft-deleted the client and cascaded a soft-delete to every `user_session` issued through it, but never pushed the revoked sessions' `jti`s into the revocation cache. The Bearer path checks only signature, expiry, audience, and that cache, never the session row's liveness, so every access token already issued to a revoked client kept working until it expired on its own clock, up to an hour.

The cascade query already returns the affected rows. Push each `jti` after the transaction commits, attempting all of them so a partial outage still shrinks the blast radius, and surface a failure as a permanent `Unexpected` rather than reporting success for a security control that did not take effect. The push runs under a 5s budget and is detached from request cancellation: a Redis that is down costs seconds per attempt with no short-circuit, and a caller disconnecting after the commit would otherwise strand every token.

Also emits one audit event per cascaded session, matching the convention that bulk mutations produce one entry per affected row, and narrows the service's revoker dependency to a `TokenRevoker` interface so the failure path is testable without an unreachable Redis.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AIS-406 by invalidating outstanding access tokens when a user session client is revoked. After the DB cascade, each revoked session `jti` is pushed to the revocation cache so Bearer tokens stop working immediately.

- Bug Fixes
  - Push cascaded session `jti`s to the revocation cache after commit; 5s budget and detached from request to avoid long blocks or lost pushes.
  - Attempt all `jti`s and return an `Unexpected` error on partial failure with counts (includes a capped sample of failed `jti`s).
  - Emit one audit event per revoked session.

- Refactors
  - Replace the concrete revoker with a `TokenRevoker` interface for testability; add tests for cascade revoke, partial failures, and cache outages.
  - Add `gram.user_session_client.id` log/trace attribute.

<sup>Written for commit da07293156d59abcc50e60a49a5be774ed321415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

