### PR TITLE
chore: stop pitchfork daemons in the infra:stop mise task

### DIFF
--- a/.mise-tasks/infra/stop.sh
+++ b/.mise-tasks/infra/stop.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-#MISE description="Stop all docker compose services"
+#MISE description="Stop this worktree's pitchfork daemons and docker compose services"
 
 set -e
+
+# Stop this worktree's daemons before the containers they depend on go away.
+# Otherwise the server, worker and friends keep running against a database that
+# no longer exists and fill their logs with connection errors. Best-effort, as
+# in nuke: a supervisor that is not running is not an error here, and neither is
+# a daemon that has already exited.
+if pitchfork supervisor status &> /dev/null; then
+    pitchfork stop --all-local || true
+fi
 
 docker compose --profile "*" down --remove-orphans


### PR DESCRIPTION
## Summary

`mise run infra:stop` removed the worktree's containers but left its pitchfork daemons running, so `server`, `worker` and friends kept talking to a Postgres that no longer existed and filled their logs with connection errors. `nuke` already stops daemons before tearing down compose; this brings `infra:stop` in line.

## Details

- Runs `pitchfork stop --all-local` before `docker compose down`, guarded on `pitchfork supervisor status` exactly as `nuke.sh` does. The guard is load bearing under `set -e`: an unguarded call would abort the task before the compose teardown whenever the supervisor is not running, silently making `infra:stop` stop doing the one thing it already did.
- `--all-local` is scoped to the current worktree. Daemons are namespaced by worktree (`<worktree>/<daemon>` in `pitchfork list`), so this cannot reach into another worktree's stack.
- Deliberately does **not** call `pitchfork clean`, which `nuke` also runs. Pruning the daemon list is global across worktrees, which is out of scope for a reversible stop.
- The `#MISE description` is updated to match the widened behavior.

## Verification

Ran `mise run infra:stop` in a worktree with no daemons and no compose project up: exits 0, prints `pitchfork WARN No daemons to stop`, and every other worktree's running daemons and compose project were left untouched. `mise tasks` shows the new description.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop this worktree’s `pitchfork` daemons before tearing down containers in `mise run infra:stop` to prevent server/worker from spamming errors against a missing Postgres. Aligns behavior with `nuke` while keeping the task reversible.

- **Bug Fixes**
  - Run `pitchfork stop --all-local` before `docker compose down`, only if `pitchfork supervisor status` succeeds.
  - Scope is this worktree; other worktrees’ daemons and compose projects are not touched.
  - Do not run `pitchfork clean`; updated the task description to reflect the new behavior.

<sup>Written for commit 9b2b1caa8b7d0b76e1819342a572909bc2d96c79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

