### PR TITLE
feat: set explicit test parallelism from CPU count in `mise test:server`

### DIFF
--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -28,6 +28,30 @@ if [ "$cover" = true ]; then
   args=("-coverprofile=cover.out" "-covermode=atomic" "${args[@]}")
 fi
 
+# Explicit package/test parallelism from CPU count (bash 3.2+ / macOS-safe).
+# Callers can still override by passing -p / -parallel themselves.
+cpus=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+case "$cpus" in
+  ''|*[!0-9]*) cpus=1 ;;
+  0) cpus=1 ;;
+esac
+
+has_p=false
+has_parallel=false
+for arg in "${args[@]}"; do
+  case "$arg" in
+    -p|-p=*) has_p=true ;;
+    -parallel|-parallel=*) has_parallel=true ;;
+  esac
+done
+
+if [ "$has_p" = false ]; then
+  args=("-p" "$cpus" "${args[@]}")
+fi
+if [ "$has_parallel" = false ]; then
+  args=("-parallel" "$cpus" "${args[@]}")
+fi
+
 gotestsum --junitfile junit-report.xml --format-hide-empty-pkg -- "${args[@]}"
 test_exit_code=$?
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves [AIS-407](https://linear.app/speakeasy/issue/AIS-407/feat-set-explicit-test-parallelism-from-cpu-count-in-mise-testserver).

`mise test:server` now sets explicit `go test` package and test parallelism from the host CPU count:

- `-p <cpus>` — packages tested in parallel
- `-parallel <cpus>` — `t.Parallel` tests within a package

CPU count is resolved with `getconf _NPROCESSORS_ONLN` (Linux/macOS), falling back to `sysctl -n hw.ncpu`, then `1`. Callers that already pass `-p` / `-parallel` keep those values.

## Test plan

- [x] Smoke-tested `mise run test:server -- ./internal/conv/...`
- [x] Confirmed via `bash -x` that gotestsum receives `-parallel N -p N`
- [x] Confirmed caller-supplied `-p` / `-parallel` are not overridden
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-407](https://linear.app/speakeasy/issue/AIS-407/feat-set-explicit-test-parallelism-from-cpu-count-in-mise-testserver)

<div><a href="https://cursor.com/agents/bc-102f4e58-963d-471c-83c3-593a84627d4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-102f4e58-963d-471c-83c3-593a84627d4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set explicit `go test` parallelism in `mise test:server` from the host CPU count to make concurrency predictable and faster, while preserving caller-supplied `-p` and `-parallel` (resolves AIS-407).

- **New Features**
  - Derives CPU count via `getconf _NPROCESSORS_ONLN`, fallback `sysctl -n hw.ncpu`, default `1`.
  - Adds `-p <cpus>` and `-parallel <cpus>` to `gotestsum`/`go test` when not already provided.
  - Clamps non-numeric or zero CPU values to `1`.

<sup>Written for commit 3c857d174e4d4586750921e6b6b0a937bbbbe406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

