### PR TITLE
DRAFT chore(db): rename toolsets MCP publishing columns to deprecated_*

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1696,13 +1696,14 @@ CREATE TABLE IF NOT EXISTS toolsets (
   slug TEXT NOT NULL CHECK (slug <> '' AND CHAR_LENGTH(slug) <= 60),
   description TEXT CHECK (description <> '' AND CHAR_LENGTH(description) <= 250),
   default_environment_slug TEXT CHECK (default_environment_slug <> '' AND CHAR_LENGTH(default_environment_slug) <= 60),
-  mcp_slug TEXT CHECK (
-    mcp_slug IS NULL OR (mcp_slug <> '' AND CHAR_LENGTH(mcp_slug) <= 60)
-  ),
-  mcp_is_public BOOLEAN NOT NULL DEFAULT FALSE,
-  mcp_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  -- Deprecated MCP publishing columns: publishing state lives on
+  -- mcp_servers/mcp_endpoints. Kept renamed (not dropped) so the pre-swap
+  -- values remain recoverable; a later contract migration drops them.
+  deprecated_mcp_slug TEXT,
+  deprecated_mcp_is_public BOOLEAN NOT NULL DEFAULT FALSE,
+  deprecated_mcp_enabled BOOLEAN NOT NULL DEFAULT FALSE,
   tool_selection_mode TEXT NOT NULL DEFAULT 'static',
-  custom_domain_id uuid,
+  deprecated_custom_domain_id uuid,
 
   -- OAuth configuration - mutually exclusive
   external_oauth_server_id uuid,
@@ -1724,7 +1725,7 @@ CREATE TABLE IF NOT EXISTS toolsets (
 
   CONSTRAINT toolsets_pkey PRIMARY KEY (id),
   CONSTRAINT toolsets_project_id_fkey FOREIGN key (project_id) REFERENCES projects (id) ON DELETE SET NULL,
-  CONSTRAINT toolsets_custom_domain_id_fkey FOREIGN key (custom_domain_id) REFERENCES custom_domains (id) ON DELETE SET NULL,
+  CONSTRAINT toolsets_custom_domain_id_fkey FOREIGN key (deprecated_custom_domain_id) REFERENCES custom_domains (id) ON DELETE SET NULL,
   CONSTRAINT toolsets_external_oauth_server_id_fkey FOREIGN KEY (external_oauth_server_id) REFERENCES external_oauth_server_metadata (id) ON DELETE SET NULL,
   CONSTRAINT toolsets_oauth_proxy_server_id_fkey FOREIGN KEY (oauth_proxy_server_id) REFERENCES oauth_proxy_servers (id) ON DELETE SET NULL,
   CONSTRAINT toolsets_user_session_issuer_id_fkey FOREIGN KEY (user_session_issuer_id) REFERENCES user_session_issuers (id) ON DELETE SET NULL,
@@ -1735,14 +1736,6 @@ CREATE TABLE IF NOT EXISTS toolsets (
 CREATE UNIQUE INDEX IF NOT EXISTS toolsets_project_id_slug_key
 ON toolsets (project_id, slug)
 WHERE deleted IS FALSE;
-
-CREATE UNIQUE INDEX IF NOT EXISTS toolsets_mcp_slug_custom_domain_id_key
-ON toolsets (mcp_slug, custom_domain_id)
-WHERE mcp_slug IS NOT NULL AND custom_domain_id IS NOT NULL AND deleted IS FALSE;
-
-CREATE UNIQUE INDEX IF NOT EXISTS toolsets_mcp_slug_null_custom_domain_id_key
-ON toolsets (mcp_slug)
-WHERE mcp_slug IS NOT NULL AND custom_domain_id IS NULL AND deleted IS FALSE;
 
 CREATE TABLE IF NOT EXISTS toolset_versions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2121,26 +2121,26 @@ type ToolVariationsGroup struct {
 }
 
 type Toolset struct {
-	ID                     uuid.UUID
-	OrganizationID         string
-	ProjectID              uuid.UUID
-	Name                   string
-	Slug                   string
-	Description            pgtype.Text
-	DefaultEnvironmentSlug pgtype.Text
-	McpSlug                pgtype.Text
-	McpIsPublic            bool
-	McpEnabled             bool
-	ToolSelectionMode      string
-	CustomDomainID         uuid.NullUUID
-	ExternalOauthServerID  uuid.NullUUID
-	OauthProxyServerID     uuid.NullUUID
-	UserSessionIssuerID    uuid.NullUUID
-	ToolVariationsGroupID  uuid.NullUUID
-	CreatedAt              pgtype.Timestamptz
-	UpdatedAt              pgtype.Timestamptz
-	DeletedAt              pgtype.Timestamptz
-	Deleted                bool
+	ID                       uuid.UUID
+	OrganizationID           string
+	ProjectID                uuid.UUID
+	Name                     string
+	Slug                     string
+	Description              pgtype.Text
+	DefaultEnvironmentSlug   pgtype.Text
+	DeprecatedMcpSlug        pgtype.Text
+	DeprecatedMcpIsPublic    bool
+	DeprecatedMcpEnabled     bool
+	ToolSelectionMode        string
+	DeprecatedCustomDomainID uuid.NullUUID
+	ExternalOauthServerID    uuid.NullUUID
+	OauthProxyServerID       uuid.NullUUID
+	UserSessionIssuerID      uuid.NullUUID
+	ToolVariationsGroupID    uuid.NullUUID
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
 }
 
 type ToolsetEmbedding struct {

--- a/server/internal/toolsets/repo/models.go
+++ b/server/internal/toolsets/repo/models.go
@@ -31,26 +31,26 @@ type HttpSecurity struct {
 }
 
 type Toolset struct {
-	ID                     uuid.UUID
-	OrganizationID         string
-	ProjectID              uuid.UUID
-	Name                   string
-	Slug                   string
-	Description            pgtype.Text
-	DefaultEnvironmentSlug pgtype.Text
-	McpSlug                pgtype.Text
-	McpIsPublic            bool
-	McpEnabled             bool
-	ToolSelectionMode      string
-	CustomDomainID         uuid.NullUUID
-	ExternalOauthServerID  uuid.NullUUID
-	OauthProxyServerID     uuid.NullUUID
-	UserSessionIssuerID    uuid.NullUUID
-	ToolVariationsGroupID  uuid.NullUUID
-	CreatedAt              pgtype.Timestamptz
-	UpdatedAt              pgtype.Timestamptz
-	DeletedAt              pgtype.Timestamptz
-	Deleted                bool
+	ID                       uuid.UUID
+	OrganizationID           string
+	ProjectID                uuid.UUID
+	Name                     string
+	Slug                     string
+	Description              pgtype.Text
+	DefaultEnvironmentSlug   pgtype.Text
+	DeprecatedMcpSlug        pgtype.Text
+	DeprecatedMcpIsPublic    bool
+	DeprecatedMcpEnabled     bool
+	ToolSelectionMode        string
+	DeprecatedCustomDomainID uuid.NullUUID
+	ExternalOauthServerID    uuid.NullUUID
+	OauthProxyServerID       uuid.NullUUID
+	UserSessionIssuerID      uuid.NullUUID
+	ToolVariationsGroupID    uuid.NullUUID
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
 }
 
 type ToolsetVersion struct {

--- a/server/internal/toolsets/repo/queries.sql.go
+++ b/server/internal/toolsets/repo/queries.sql.go
@@ -28,7 +28,7 @@ SET
   , oauth_proxy_server_id = NULL
   , updated_at = clock_timestamp()
 WHERE slug = $1 AND project_id = $2
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type ClearToolsetOAuthServersParams struct {
@@ -47,11 +47,11 @@ func (q *Queries) ClearToolsetOAuthServers(ctx context.Context, arg ClearToolset
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -96,7 +96,7 @@ INSERT INTO toolsets (
   , $5
   , $6
 )
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateToolsetParams struct {
@@ -126,11 +126,11 @@ func (q *Queries) CreateToolset(ctx context.Context, arg CreateToolsetParams) (T
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -598,7 +598,7 @@ func (q *Queries) GetPromptTemplatesForToolsets(ctx context.Context, arg GetProm
 }
 
 const getToolset = `-- name: GetToolset :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE slug = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -619,11 +619,11 @@ func (q *Queries) GetToolset(ctx context.Context, arg GetToolsetParams) (Toolset
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -637,7 +637,7 @@ func (q *Queries) GetToolset(ctx context.Context, arg GetToolsetParams) (Toolset
 }
 
 const getToolsetByIDAndOrganization = `-- name: GetToolsetByIDAndOrganization :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE id = $1 AND organization_id = $2 AND deleted IS FALSE
 `
@@ -658,11 +658,11 @@ func (q *Queries) GetToolsetByIDAndOrganization(ctx context.Context, arg GetTool
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -676,7 +676,7 @@ func (q *Queries) GetToolsetByIDAndOrganization(ctx context.Context, arg GetTool
 }
 
 const getToolsetByIDAndProject = `-- name: GetToolsetByIDAndProject :one
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE id = $1 AND project_id = $2 AND deleted IS FALSE
 `
@@ -697,11 +697,11 @@ func (q *Queries) GetToolsetByIDAndProject(ctx context.Context, arg GetToolsetBy
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -840,7 +840,7 @@ func (q *Queries) GetToolsetPromptTemplateNames(ctx context.Context, arg GetTool
 
 const getToolsetsByToolURN = `-- name: GetToolsetsByToolURN :many
 SELECT
-    t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted,
+    t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.deprecated_mcp_slug, t.deprecated_mcp_is_public, t.deprecated_mcp_enabled, t.tool_selection_mode, t.deprecated_custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted,
     tv.version as latest_version
 FROM toolsets t
 JOIN toolset_versions tv ON t.id = tv.toolset_id
@@ -862,27 +862,27 @@ type GetToolsetsByToolURNParams struct {
 }
 
 type GetToolsetsByToolURNRow struct {
-	ID                     uuid.UUID
-	OrganizationID         string
-	ProjectID              uuid.UUID
-	Name                   string
-	Slug                   string
-	Description            pgtype.Text
-	DefaultEnvironmentSlug pgtype.Text
-	McpSlug                pgtype.Text
-	McpIsPublic            bool
-	McpEnabled             bool
-	ToolSelectionMode      string
-	CustomDomainID         uuid.NullUUID
-	ExternalOauthServerID  uuid.NullUUID
-	OauthProxyServerID     uuid.NullUUID
-	UserSessionIssuerID    uuid.NullUUID
-	ToolVariationsGroupID  uuid.NullUUID
-	CreatedAt              pgtype.Timestamptz
-	UpdatedAt              pgtype.Timestamptz
-	DeletedAt              pgtype.Timestamptz
-	Deleted                bool
-	LatestVersion          int64
+	ID                       uuid.UUID
+	OrganizationID           string
+	ProjectID                uuid.UUID
+	Name                     string
+	Slug                     string
+	Description              pgtype.Text
+	DefaultEnvironmentSlug   pgtype.Text
+	DeprecatedMcpSlug        pgtype.Text
+	DeprecatedMcpIsPublic    bool
+	DeprecatedMcpEnabled     bool
+	ToolSelectionMode        string
+	DeprecatedCustomDomainID uuid.NullUUID
+	ExternalOauthServerID    uuid.NullUUID
+	OauthProxyServerID       uuid.NullUUID
+	UserSessionIssuerID      uuid.NullUUID
+	ToolVariationsGroupID    uuid.NullUUID
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
+	LatestVersion            int64
 }
 
 func (q *Queries) GetToolsetsByToolURN(ctx context.Context, arg GetToolsetsByToolURNParams) ([]GetToolsetsByToolURNRow, error) {
@@ -902,11 +902,11 @@ func (q *Queries) GetToolsetsByToolURN(ctx context.Context, arg GetToolsetsByToo
 			&i.Slug,
 			&i.Description,
 			&i.DefaultEnvironmentSlug,
-			&i.McpSlug,
-			&i.McpIsPublic,
-			&i.McpEnabled,
+			&i.DeprecatedMcpSlug,
+			&i.DeprecatedMcpIsPublic,
+			&i.DeprecatedMcpEnabled,
 			&i.ToolSelectionMode,
-			&i.CustomDomainID,
+			&i.DeprecatedCustomDomainID,
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
@@ -928,7 +928,7 @@ func (q *Queries) GetToolsetsByToolURN(ctx context.Context, arg GetToolsetsByToo
 }
 
 const listToolsetsByOrganization = `-- name: ListToolsetsByOrganization :many
-SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.mcp_slug, t.mcp_is_public, t.mcp_enabled, t.tool_selection_mode, t.custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
+SELECT t.id, t.organization_id, t.project_id, t.name, t.slug, t.description, t.default_environment_slug, t.deprecated_mcp_slug, t.deprecated_mcp_is_public, t.deprecated_mcp_enabled, t.tool_selection_mode, t.deprecated_custom_domain_id, t.external_oauth_server_id, t.oauth_proxy_server_id, t.user_session_issuer_id, t.tool_variations_group_id, t.created_at, t.updated_at, t.deleted_at, t.deleted
 FROM toolsets t
 JOIN projects p ON t.project_id = p.id
 WHERE p.organization_id = $1
@@ -954,11 +954,11 @@ func (q *Queries) ListToolsetsByOrganization(ctx context.Context, organizationID
 			&i.Slug,
 			&i.Description,
 			&i.DefaultEnvironmentSlug,
-			&i.McpSlug,
-			&i.McpIsPublic,
-			&i.McpEnabled,
+			&i.DeprecatedMcpSlug,
+			&i.DeprecatedMcpIsPublic,
+			&i.DeprecatedMcpEnabled,
 			&i.ToolSelectionMode,
-			&i.CustomDomainID,
+			&i.DeprecatedCustomDomainID,
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
@@ -979,7 +979,7 @@ func (q *Queries) ListToolsetsByOrganization(ctx context.Context, organizationID
 }
 
 const listToolsetsByProject = `-- name: ListToolsetsByProject :many
-SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 FROM toolsets
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -1003,11 +1003,11 @@ func (q *Queries) ListToolsetsByProject(ctx context.Context, projectID uuid.UUID
 			&i.Slug,
 			&i.Description,
 			&i.DefaultEnvironmentSlug,
-			&i.McpSlug,
-			&i.McpIsPublic,
-			&i.McpEnabled,
+			&i.DeprecatedMcpSlug,
+			&i.DeprecatedMcpIsPublic,
+			&i.DeprecatedMcpEnabled,
 			&i.ToolSelectionMode,
-			&i.CustomDomainID,
+			&i.DeprecatedCustomDomainID,
 			&i.ExternalOauthServerID,
 			&i.OauthProxyServerID,
 			&i.UserSessionIssuerID,
@@ -1113,7 +1113,7 @@ SET
   , tool_selection_mode = COALESCE($4, tool_selection_mode)
   , updated_at = clock_timestamp()
 WHERE slug = $5 AND project_id = $6
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetParams struct {
@@ -1143,11 +1143,11 @@ func (q *Queries) UpdateToolset(ctx context.Context, arg UpdateToolsetParams) (T
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -1166,7 +1166,7 @@ SET
     external_oauth_server_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetExternalOAuthServerParams struct {
@@ -1186,11 +1186,11 @@ func (q *Queries) UpdateToolsetExternalOAuthServer(ctx context.Context, arg Upda
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -1209,7 +1209,7 @@ SET
     oauth_proxy_server_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetOAuthProxyServerParams struct {
@@ -1229,11 +1229,11 @@ func (q *Queries) UpdateToolsetOAuthProxyServer(ctx context.Context, arg UpdateT
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -1252,7 +1252,7 @@ SET
     tool_variations_group_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetToolVariationsGroupParams struct {
@@ -1272,11 +1272,11 @@ func (q *Queries) UpdateToolsetToolVariationsGroup(ctx context.Context, arg Upda
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,
@@ -1295,7 +1295,7 @@ SET
     user_session_issuer_id = $1
   , updated_at = clock_timestamp()
 WHERE slug = $2 AND project_id = $3
-RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, mcp_slug, mcp_is_public, mcp_enabled, tool_selection_mode, custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, name, slug, description, default_environment_slug, deprecated_mcp_slug, deprecated_mcp_is_public, deprecated_mcp_enabled, tool_selection_mode, deprecated_custom_domain_id, external_oauth_server_id, oauth_proxy_server_id, user_session_issuer_id, tool_variations_group_id, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateToolsetUserSessionIssuerParams struct {
@@ -1315,11 +1315,11 @@ func (q *Queries) UpdateToolsetUserSessionIssuer(ctx context.Context, arg Update
 		&i.Slug,
 		&i.Description,
 		&i.DefaultEnvironmentSlug,
-		&i.McpSlug,
-		&i.McpIsPublic,
-		&i.McpEnabled,
+		&i.DeprecatedMcpSlug,
+		&i.DeprecatedMcpIsPublic,
+		&i.DeprecatedMcpEnabled,
 		&i.ToolSelectionMode,
-		&i.CustomDomainID,
+		&i.DeprecatedCustomDomainID,
 		&i.ExternalOauthServerID,
 		&i.OauthProxyServerID,
 		&i.UserSessionIssuerID,

--- a/server/migrations/20260731213340_toolsets-deprecate-mcp-publishing-columns.sql
+++ b/server/migrations/20260731213340_toolsets-deprecate-mcp-publishing-columns.sql
@@ -1,0 +1,12 @@
+-- Modify "toolsets" table
+-- Hand-adjusted from Atlas's generated DROP COLUMN/ADD COLUMN pair into
+-- RENAME COLUMN statements so the pre-swap publishing values remain
+-- recoverable until the final drop migration. The end state is identical to
+-- the generated form, so later `mise run db:diff` runs see no drift.
+ALTER TABLE "toolsets" DROP CONSTRAINT "toolsets_mcp_slug_check";
+DROP INDEX "toolsets_mcp_slug_custom_domain_id_key";
+DROP INDEX "toolsets_mcp_slug_null_custom_domain_id_key";
+ALTER TABLE "toolsets" RENAME COLUMN "mcp_slug" TO "deprecated_mcp_slug";
+ALTER TABLE "toolsets" RENAME COLUMN "mcp_is_public" TO "deprecated_mcp_is_public";
+ALTER TABLE "toolsets" RENAME COLUMN "mcp_enabled" TO "deprecated_mcp_enabled";
+ALTER TABLE "toolsets" RENAME COLUMN "custom_domain_id" TO "deprecated_custom_domain_id";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:s95L9NRsqvRnIU/iXmvE9TX5brVSoSNPRMTt72UydnE=
+h1:C8uSslkQ0T7DTvekIe3/kDqmuZeq6xehe5rjS08Zl10=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -310,3 +310,4 @@ h1:s95L9NRsqvRnIU/iXmvE9TX5brVSoSNPRMTt72UydnE=
 20260729235455_dno643-device-agent-device-syncs.sql h1:2xYuc2B1oopRAdvkZ57ys+5kncKCyM1Zw78D/M8bCXM=
 20260730125106_custom-domain-root-mcp-and-challenge.sql h1:RBOpyM/n3XVpvcfMBEhhY2FojQ9DYg4UwVuFtqTYzno=
 20260730222817_business-memories.sql h1:yk1Da+musAggroaqFiaKhRYD9cn09Y1i2V9DCrHu03M=
+20260731213340_toolsets-deprecate-mcp-publishing-columns.sql h1:ZjsieQ5AyHozSEY6rTwuVNbaFbGlslXoGGp+r8uj95U=


### PR DESCRIPTION
**Stack** (bottom → top): #4799 expand · #4800 read cutover · #4801 UI contract · #4802 write freeze · #4803 column contract · #4798 schema contract

---

Migration-only PR. Renames the four columns to `deprecated_*` and drops the two `mcp_slug` unique indexes plus the slug CHECK. **Reviewer note**: Atlas generated a DROP COLUMN/ADD COLUMN pair; the migration was hand-adjusted into RENAME COLUMN statements so the pre-swap values stay recoverable until the final drop migration. End state is identical — `mise run db:diff` verifies drift-free — and `atlas.sum` was rehashed via `mise run db:hash`. A follow-up migration drops the columns once the rename has soaked.