### PR TITLE
chore: run server tests as four parallel CI shards

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -5,6 +5,8 @@ server:
   - "agents/**"
   - "ci/**"
   - "server/**"
+  - ".mise-tasks/test/ci.sh"
+  - ".mise-tasks/test/server.sh"
 
 client:
   - ".github/**"

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -3,6 +3,7 @@ server:
   - "go.mod"
   - "go.sum"
   - "agents/**"
+  - "ci/**"
   - "server/**"
 
 client:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1095,6 +1095,9 @@ jobs:
       - name: Build tunnel gateway
         run: mise run build:tunnel-gateway --readonly
 
+      - name: Test CI tooling
+        run: mise run test:ci
+
       - name: Lint with golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -1409,9 +1412,16 @@ jobs:
         run: mise run git:porcelain
 
   server-test:
+    name: server-test (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: blacksmith-8vcpu-ubuntu-2404
     needs: changes
     if: needs.changes.outputs.server == 'true'
+    strategy:
+      # Every shard should report, otherwise a single failure hides the state of
+      # the rest of the suite.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       GOMAXPROCS: 8
       # The runner VM is destroyed after the job, and the reaper is the one
@@ -1447,7 +1457,7 @@ jobs:
         run: mise run install:go
 
       - name: Test
-        run: mise run test:server
+        run: mise run test:server --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
   docker-build-client:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.mise-tasks/test/ci.sh
+++ b/.mise-tasks/test/ci.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE dir="{{ config_root }}"
+#MISE description="Test the CI helper commands under ci/"
+
+set -e
+
+go vet ./ci/...
+gotestsum --junitfile junit-report.xml --format-hide-empty-pkg -- ./ci/...

--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -5,6 +5,7 @@
 # Check if flags are provided
 cover=false
 open_html=false
+shard=""
 args=()
 
 for arg in "$@"; do
@@ -15,6 +16,9 @@ for arg in "$@"; do
     --html)
       open_html=true
       shift ;;
+    --shard=*)
+      shard="${arg#--shard=}"
+      shift ;;
     *)
       args+=("$arg") ;;
   esac
@@ -22,6 +26,44 @@ done
 
 if [ ${#args[@]} -eq 0 ]; then
   args=("-tags=inv.debug" "./...")
+fi
+
+# --shard=<index>/<total> runs a deterministic subset of the packages that have
+# tests, so CI can spread the suite over several runners. See ci/cmd/shard for
+# how packages are distributed.
+if [ -n "$shard" ]; then
+  # Package patterns are sharded; every other argument is passed to 'go test'
+  # as-is. Build tags also go to the shard tool so it and 'go test' agree on
+  # which packages and test files exist.
+  flags=()
+  patterns=()
+  tags=()
+  for arg in "${args[@]}"; do
+    case $arg in
+      -tags=*|--tags=*)
+        tags+=("$arg")
+        flags+=("$arg") ;;
+      -*)
+        flags+=("$arg") ;;
+      *)
+        patterns+=("$arg") ;;
+    esac
+  done
+
+  shard_packages=$(go run github.com/speakeasy-api/gram/ci/cmd/shard \
+    -i "$shard" "${tags[@]}" "${patterns[@]}") || exit $?
+
+  packages=()
+  while IFS= read -r line; do
+    [ -n "$line" ] && packages+=("$line")
+  done <<< "$shard_packages"
+
+  if [ ${#packages[@]} -eq 0 ]; then
+    echo "Shard $shard: no packages to test."
+    exit 0
+  fi
+
+  args=("${flags[@]}" "${packages[@]}")
 fi
 
 if [ "$cover" = true ]; then

--- a/.mise-tasks/test/server.sh
+++ b/.mise-tasks/test/server.sh
@@ -32,21 +32,35 @@ fi
 # tests, so CI can spread the suite over several runners. See ci/cmd/shard for
 # how packages are distributed.
 if [ -n "$shard" ]; then
-  # Package patterns are sharded; every other argument is passed to 'go test'
-  # as-is. Build tags also go to the shard tool so it and 'go test' agree on
-  # which packages and test files exist.
+  # Only package patterns are sharded. Everything else reaches 'go test' in the
+  # order it was given, including values that follow a flag — the 'TestFoo' in
+  # '-run TestFoo' is not a package. Build tags also go to the shard tool so it
+  # and 'go test' agree on which packages and test files exist.
   flags=()
   patterns=()
   tags=()
+  tags_next=false
   for arg in "${args[@]}"; do
+    if [ "$tags_next" = true ]; then
+      tags_next=false
+      tags+=("-tags=$arg")
+      flags+=("$arg")
+      continue
+    fi
+
     case $arg in
       -tags=*|--tags=*)
         tags+=("$arg")
         flags+=("$arg") ;;
-      -*)
+      -tags|--tags)
+        tags_next=true
         flags+=("$arg") ;;
-      *)
+      # Relative paths, anything ending in "..." and import paths such as
+      # example.com/mod/pkg. A bare word like "TestFoo" is a flag value.
+      ./*|../*|/*|.|*...|*.*/*)
         patterns+=("$arg") ;;
+      *)
+        flags+=("$arg") ;;
     esac
   done
 

--- a/ci/cmd/shard/main.go
+++ b/ci/cmd/shard/main.go
@@ -239,6 +239,18 @@ func assign(pkgs []pkg, index int, total int) []pkg {
 		)
 	})
 
+	// Weights are always positive, so an empty shard is lighter than any shard
+	// holding a package: with more shards than packages, the shards past the
+	// last package are always empty. Only tracking the ones that can win keeps
+	// a spec like -i 1/1000000000 from allocating its way to an OOM.
+	if total > len(ordered) {
+		if index > len(ordered) {
+			return nil
+		}
+
+		total = len(ordered)
+	}
+
 	loads := make([]int64, total)
 	var selected []pkg
 

--- a/ci/cmd/shard/main.go
+++ b/ci/cmd/shard/main.go
@@ -1,0 +1,265 @@
+// Command shard splits the Go test packages under one or more directories into
+// deterministic, roughly balanced shards so CI can spread a suite over several
+// runners.
+//
+// Usage:
+//
+//	go run ./ci/cmd/shard -i 1/4 ./server
+//
+// It prints the import paths of the packages assigned to the requested shard,
+// one per line. Packages without test files are never printed: they are already
+// compiled by the build and lint jobs, so testing them buys nothing.
+//
+// Packages are weighted by the size of their test sources — a stand-in for how
+// long they take to run — and packed largest first into whichever shard is
+// lightest so far. The assignment is a pure function of the package list, so
+// every shard reaches the same answer without sharing state or recorded
+// timings.
+package main
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const usage = `Usage: shard -i <index>/<total> [flags] [packages...]
+
+Prints the test packages assigned to one shard, one import path per line.
+Directory arguments are expanded to match the tree below them, so "./server"
+lists everything under the server directory. Defaults to "./..." when no
+packages are given.
+
+Flags:
+`
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "shard: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// pkg holds the fields of `go list -json` output that shard cares about.
+type pkg struct {
+	ImportPath   string
+	Dir          string
+	TestGoFiles  []string
+	XTestGoFiles []string
+
+	// weight approximates how long the package takes to test.
+	weight int64
+}
+
+func run(argv []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("shard", flag.ContinueOnError)
+	// Errors are reported by the caller so they are not printed twice.
+	fs.SetOutput(io.Discard)
+
+	spec := fs.String("i", "", "shard to print, as <index>/<total> (1-indexed), e.g. 1/4")
+	tags := fs.String("tags", "", "comma-separated build tags to pass to 'go list'")
+
+	if err := fs.Parse(argv); err != nil {
+		fs.SetOutput(stderr)
+		fmt.Fprint(stderr, usage)
+		fs.PrintDefaults()
+
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+
+		return err
+	}
+
+	index, total, err := parseShard(*spec)
+	if err != nil {
+		return err
+	}
+
+	patterns := fs.Args()
+	if len(patterns) == 0 {
+		patterns = []string{"./..."}
+	}
+	for i, p := range patterns {
+		patterns[i] = expandPattern(p)
+	}
+
+	pkgs, err := listTestPackages(*tags, patterns, stderr)
+	if err != nil {
+		return err
+	}
+
+	selected := assign(pkgs, index, total)
+
+	var selectedWeight, totalWeight int64
+	for _, p := range pkgs {
+		totalWeight += p.weight
+	}
+	for _, p := range selected {
+		selectedWeight += p.weight
+	}
+
+	fmt.Fprintf(stderr, "shard %d/%d: %d of %d test packages, %dKB of %dKB test sources\n",
+		index, total, len(selected), len(pkgs), selectedWeight/1000, totalWeight/1000)
+
+	for _, p := range selected {
+		if _, err := fmt.Fprintln(stdout, p.ImportPath); err != nil {
+			return fmt.Errorf("write package list: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// parseShard reads an "<index>/<total>" shard spec, where index is 1-indexed.
+func parseShard(spec string) (index int, total int, err error) {
+	if spec == "" {
+		return 0, 0, errors.New("missing -i: expected a shard like -i 1/4")
+	}
+
+	rawIndex, rawTotal, ok := strings.Cut(spec, "/")
+	if !ok {
+		return 0, 0, fmt.Errorf("shard %q is not in <index>/<total> form, e.g. 1/4", spec)
+	}
+
+	index, err = strconv.Atoi(rawIndex)
+	if err != nil {
+		return 0, 0, fmt.Errorf("shard index %q is not a number", rawIndex)
+	}
+
+	total, err = strconv.Atoi(rawTotal)
+	if err != nil {
+		return 0, 0, fmt.Errorf("shard total %q is not a number", rawTotal)
+	}
+
+	if total < 1 {
+		return 0, 0, fmt.Errorf("shard total %d must be at least 1", total)
+	}
+
+	if index < 1 || index > total {
+		return 0, 0, fmt.Errorf("shard index %d must be between 1 and %d", index, total)
+	}
+
+	return index, total, nil
+}
+
+// expandPattern turns a directory argument such as "./server" into the package
+// pattern "./server/...", so callers can name a tree rather than spell out a
+// pattern. Arguments that already end in "..." are left alone.
+func expandPattern(pattern string) string {
+	if strings.HasSuffix(pattern, "...") {
+		return pattern
+	}
+
+	return strings.TrimSuffix(pattern, "/") + "/..."
+}
+
+// listTestPackages returns the packages matching patterns that have test files,
+// each weighted by the size of its test sources.
+func listTestPackages(tags string, patterns []string, stderr io.Writer) ([]pkg, error) {
+	args := []string{"list", "-json=ImportPath,Dir,TestGoFiles,XTestGoFiles"}
+	if tags != "" {
+		args = append(args, "-tags="+tags)
+	}
+	args = append(args, patterns...)
+
+	cmd := exec.Command("go", args...)
+	cmd.Stderr = stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list: %w", err)
+	}
+
+	var pkgs []pkg
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for {
+		var p pkg
+		if err := dec.Decode(&p); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("decode go list output: %w", err)
+		}
+
+		if len(p.TestGoFiles)+len(p.XTestGoFiles) == 0 {
+			continue
+		}
+
+		p.weight, err = weigh(p)
+		if err != nil {
+			return nil, err
+		}
+
+		pkgs = append(pkgs, p)
+	}
+
+	return pkgs, nil
+}
+
+// weigh sums the size of a package's test sources. Each file also contributes a
+// byte of its own so that packages of empty test files still differ in weight.
+func weigh(p pkg) (int64, error) {
+	var weight int64
+
+	for _, name := range slices.Concat(p.TestGoFiles, p.XTestGoFiles) {
+		path := filepath.Join(p.Dir, name)
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return 0, fmt.Errorf("stat test file %s: %w", path, err)
+		}
+
+		weight += info.Size() + 1
+	}
+
+	return weight, nil
+}
+
+// assign packs pkgs into total shards, heaviest package first into the shard
+// carrying the least weight so far, and returns the packages that landed in
+// shard index (1-indexed), sorted by import path.
+func assign(pkgs []pkg, index int, total int) []pkg {
+	ordered := slices.Clone(pkgs)
+	slices.SortFunc(ordered, func(a, b pkg) int {
+		// Ties break on import path so the order never depends on how the
+		// packages happened to arrive.
+		return cmp.Or(
+			cmp.Compare(b.weight, a.weight),
+			cmp.Compare(a.ImportPath, b.ImportPath),
+		)
+	})
+
+	loads := make([]int64, total)
+	var selected []pkg
+
+	for _, p := range ordered {
+		lightest := 0
+		for i := 1; i < total; i++ {
+			if loads[i] < loads[lightest] {
+				lightest = i
+			}
+		}
+
+		loads[lightest] += p.weight
+
+		if lightest == index-1 {
+			selected = append(selected, p)
+		}
+	}
+
+	slices.SortFunc(selected, func(a, b pkg) int {
+		return cmp.Compare(a.ImportPath, b.ImportPath)
+	})
+
+	return selected
+}

--- a/ci/cmd/shard/main_test.go
+++ b/ci/cmd/shard/main_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseShard(t *testing.T) {
+	t.Parallel()
+
+	index, total, err := parseShard("1/4")
+	require.NoError(t, err)
+	require.Equal(t, 1, index)
+	require.Equal(t, 4, total)
+
+	index, total, err = parseShard("4/4")
+	require.NoError(t, err)
+	require.Equal(t, 4, index)
+	require.Equal(t, 4, total)
+}
+
+func TestParseShard_Invalid(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		spec    string
+		wantErr string
+	}{
+		{spec: "", wantErr: "missing -i"},
+		{spec: "1", wantErr: "not in <index>/<total> form"},
+		{spec: "one/4", wantErr: `shard index "one" is not a number`},
+		{spec: "1/four", wantErr: `shard total "four" is not a number`},
+		{spec: "1/0", wantErr: "shard total 0 must be at least 1"},
+		{spec: "0/4", wantErr: "shard index 0 must be between 1 and 4"},
+		{spec: "5/4", wantErr: "shard index 5 must be between 1 and 4"},
+		{spec: "-1/4", wantErr: "shard index -1 must be between 1 and 4"},
+	}
+
+	for _, c := range cases {
+		_, _, err := parseShard(c.spec)
+		require.ErrorContains(t, err, c.wantErr, "spec %q", c.spec)
+	}
+}
+
+func TestExpandPattern(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "./server/...", expandPattern("./server"))
+	require.Equal(t, "./server/...", expandPattern("./server/"))
+	require.Equal(t, "./...", expandPattern("."))
+	require.Equal(t, "./server/...", expandPattern("./server/..."))
+	require.Equal(t, "./internal/oops/...", expandPattern("./internal/oops/..."))
+}
+
+func TestAssign_CoversEveryPackageExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const total = 4
+	pkgs := testPackages(97)
+
+	var got []string
+	for index := 1; index <= total; index++ {
+		for _, p := range assign(pkgs, index, total) {
+			got = append(got, p.ImportPath)
+		}
+	}
+
+	var want []string
+	for _, p := range pkgs {
+		want = append(want, p.ImportPath)
+	}
+
+	slices.Sort(got)
+	slices.Sort(want)
+	require.Equal(t, want, got, "shards must partition the package list")
+}
+
+func TestAssign_SingleShardTakesEverything(t *testing.T) {
+	t.Parallel()
+
+	pkgs := testPackages(10)
+	require.Len(t, assign(pkgs, 1, 1), len(pkgs))
+}
+
+func TestAssign_MoreShardsThanPackages(t *testing.T) {
+	t.Parallel()
+
+	pkgs := testPackages(2)
+
+	require.Len(t, assign(pkgs, 1, 4), 1)
+	require.Len(t, assign(pkgs, 2, 4), 1)
+	require.Empty(t, assign(pkgs, 3, 4))
+	require.Empty(t, assign(pkgs, 4, 4))
+}
+
+func TestAssign_BalancesWeight(t *testing.T) {
+	t.Parallel()
+
+	const total = 4
+	pkgs := testPackages(97)
+
+	var heaviest, lightest int64
+	for index := 1; index <= total; index++ {
+		var load int64
+		for _, p := range assign(pkgs, index, total) {
+			load += p.weight
+		}
+
+		if index == 1 || load > heaviest {
+			heaviest = load
+		}
+		if index == 1 || load < lightest {
+			lightest = load
+		}
+	}
+
+	// Packing largest first keeps shards within one package's weight of each
+	// other; the widest gap here is a fraction of that.
+	require.Less(t, heaviest-lightest, int64(1000), "shard loads drifted too far apart")
+}
+
+func TestAssign_IgnoresInputOrder(t *testing.T) {
+	t.Parallel()
+
+	pkgs := testPackages(50)
+	reversed := slices.Clone(pkgs)
+	slices.Reverse(reversed)
+
+	for index := 1; index <= 3; index++ {
+		require.Equal(t, assign(pkgs, index, 3), assign(reversed, index, 3),
+			"assignment must not depend on the order go list returned packages in")
+	}
+}
+
+// testPackages builds n packages whose weights vary over a wide range so that
+// balancing has something to do.
+func testPackages(n int) []pkg {
+	pkgs := make([]pkg, 0, n)
+	for i := range n {
+		pkgs = append(pkgs, pkg{
+			ImportPath:   fmt.Sprintf("example.com/mod/pkg%02d", i),
+			Dir:          fmt.Sprintf("/mod/pkg%02d", i),
+			TestGoFiles:  []string{"main_test.go"},
+			XTestGoFiles: nil,
+			weight:       int64(1 + (i*7919)%5000),
+		})
+	}
+
+	return pkgs
+}

--- a/ci/cmd/shard/main_test.go
+++ b/ci/cmd/shard/main_test.go
@@ -96,6 +96,16 @@ func TestAssign_MoreShardsThanPackages(t *testing.T) {
 	require.Empty(t, assign(pkgs, 4, 4))
 }
 
+func TestAssign_ShardCountFarBeyondPackageCount(t *testing.T) {
+	t.Parallel()
+
+	pkgs := testPackages(3)
+
+	// Tracking a load per requested shard would allocate 8GB here.
+	require.Len(t, assign(pkgs, 1, 1_000_000_000), 1)
+	require.Empty(t, assign(pkgs, 4, 1_000_000_000))
+}
+
 func TestAssign_BalancesWeight(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Splits `server-test` into a 4-way matrix so the server suite runs on four runners instead of one.

- `ci/cmd/shard` — new command that prints the test packages belonging to one shard
- `mise run test:server --shard=1/4` — task flag that runs only that shard's packages
- `server-test` — `strategy.matrix.shard: [1, 2, 3, 4]`, `fail-fast: false` so one failing shard doesn't hide the others

## Result

| | `main` ([run](https://github.com/speakeasy-api/gram/actions/runs/30666318142/job/91274185072)) | this branch ([run](https://github.com/speakeasy-api/gram/actions/runs/30667566561/job/91278090122)) |
| --- | --- | --- |
| `Test` step | 5m39s | 2m20s (slowest shard; others 1m52s–2m12s) |
| whole job | 6m28s | 3m01s (slowest shard) |

Roughly 2.4x on the test step, ~3.5 minutes off every pull request that touches the server.

Part of that is the split itself, and part is that the packages no longer contend for one machine. Much of this suite spins up test containers, so a single runner has every package's Postgres, ClickHouse, Redis and friends competing for the same CPUs and memory at once. Four runners each hold a quarter of that footprint, which is why the shards come in faster than a straight quarter of the original would predict.

## How the split works

`go run ./ci/cmd/shard -i 1/4 ./server` lists the packages that have tests, weights each by the size of its test sources (a stand-in for runtime), and packs them heaviest-first into whichever shard is lightest so far. Ties break on import path, so the assignment is a pure function of the package list: every shard derives the same partition independently, no coordinator and no recorded timings needed.

Packages without test files are dropped — `server-build-lint` already compiles and lints the whole tree.

Today that splits 177 test packages as 44/44/45/44, with test-source weight balanced to within 0.4%.

## Notes for reviewers

- All four shards share one Go cache key, so three will log a benign "cache already exists" on save. Per-shard keys would quadruple cache storage, which seemed the worse trade.
- Each shard keeps the 8vcpu runner, so this trades ~4x runner-minutes for wall-clock time.
- `ci/**` was added to the `server` paths filter, and `mise run test:ci` (unit tests for the packing logic) runs once in `server-build-lint` rather than in every shard.
- Unsharded `mise run test:server` is unchanged.
