### PR TITLE
feat(dashboard): tooltips for skill source and classification (DNO-728)

### DIFF
--- a/client/dashboard/src/components/filters/FilterControl.tsx
+++ b/client/dashboard/src/components/filters/FilterControl.tsx
@@ -56,6 +56,7 @@ export function FilterControl({
                   label: o.label,
                   value: o.value,
                   icon: o.icon,
+                  description: o.description,
                 }))
           }
           defaultValue={value as string[]}
@@ -91,7 +92,11 @@ export function FilterControl({
           <SelectContent>
             <SelectItem value={SELECT_ALL_VALUE}>{allLabelFor(dim)}</SelectItem>
             {flattenOptions(options).map((o) => (
-              <SelectItem key={o.value} value={o.value}>
+              <SelectItem
+                key={o.value}
+                value={o.value}
+                description={o.description}
+              >
                 {o.label}
               </SelectItem>
             ))}

--- a/client/dashboard/src/components/filters/filter-schema.ts
+++ b/client/dashboard/src/components/filters/filter-schema.ts
@@ -28,6 +28,12 @@ export interface FilterOption {
   label: string;
   value: string;
   icon?: ComponentType<{ className?: string }>;
+  /**
+   * Optional secondary explanation under the option label in select /
+   * multiselect menus. Prefer this for non-obvious values users need to
+   * distinguish (e.g. Manual vs Captured).
+   */
+  description?: string;
 }
 
 /** Multiselect dimensions may supply grouped options (e.g. servers by type). */

--- a/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.test.tsx
@@ -112,3 +112,72 @@ describe("MultiSelect search filtering (AIS-84)", () => {
     expect(screen.getByText("No results found.")).toBeTruthy();
   });
 });
+
+describe("MultiSelect option descriptions", () => {
+  it("renders secondary descriptions under option labels", () => {
+    render(
+      <MultiSelect
+        options={[
+          {
+            value: "manual",
+            label: "Manual",
+            description: "Added in Speakeasy by someone on your team.",
+          },
+          {
+            value: "captured",
+            label: "Captured",
+            description:
+              "Automatically recorded when an agent in your organization used the skill.",
+          },
+        ]}
+        onValueChange={() => undefined}
+        placeholder="Filter by source"
+        hideSelectAll
+        singleLine
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Filter by source"));
+
+    expect(
+      screen.getByText("Added in Speakeasy by someone on your team."),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Automatically recorded when an agent in your organization used the skill.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("matches options by description text while searching", () => {
+    render(
+      <MultiSelect
+        options={[
+          {
+            value: "manual",
+            label: "Manual",
+            description: "Added in Speakeasy by someone on your team.",
+          },
+          {
+            value: "captured",
+            label: "Captured",
+            description:
+              "Automatically recorded when an agent in your organization used the skill.",
+          },
+        ]}
+        onValueChange={() => undefined}
+        placeholder="Filter by source"
+        hideSelectAll
+        singleLine
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Filter by source"));
+    const input = screen.getByPlaceholderText("Search options...");
+    type(input, "automatically recorded");
+
+    const labels = visibleOptionLabels();
+    expect(labels.some((label) => label.includes("Captured"))).toBe(true);
+    expect(labels.some((label) => label.includes("Manual"))).toBe(false);
+  });
+});

--- a/client/dashboard/src/components/ui/MultiSelect/index.tsx
+++ b/client/dashboard/src/components/ui/MultiSelect/index.tsx
@@ -82,6 +82,11 @@ interface MultiSelectOption {
   value: string;
   /** Optional icon component to display alongside the option. */
   icon?: React.ComponentType<{ className?: string }>;
+  /**
+   * Optional secondary explanation shown under the label. Use for non-obvious
+   * values (e.g. Manual vs Captured) so the meaning is visible while choosing.
+   */
+  description?: string;
   /** Whether this option is disabled */
   disabled?: boolean;
   /** Custom styling for the option */
@@ -311,6 +316,61 @@ export interface MultiSelectRef {
    * Focus the component
    */
   focus: () => void;
+}
+
+function MultiSelectOptionItem({
+  option,
+  isSelected,
+  onToggle,
+}: {
+  option: MultiSelectOption;
+  isSelected: boolean;
+  onToggle: () => void;
+}): React.JSX.Element {
+  return (
+    <CommandItem
+      onSelect={onToggle}
+      role="option"
+      aria-selected={isSelected}
+      aria-disabled={option.disabled}
+      aria-label={`${option.label}${
+        isSelected ? ", selected" : ", not selected"
+      }${option.disabled ? ", disabled" : ""}${
+        option.description ? `. ${option.description}` : ""
+      }`}
+      className={cn(
+        "cursor-pointer",
+        option.disabled && "cursor-not-allowed opacity-50",
+      )}
+      disabled={option.disabled}
+    >
+      <div
+        className={cn(
+          "border-primary mr-2 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border",
+          isSelected
+            ? "bg-primary text-primary-foreground"
+            : "opacity-50 [&_svg]:invisible",
+        )}
+        aria-hidden="true"
+      >
+        <CheckIcon className="h-4 w-4 text-current" />
+      </div>
+      {option.icon && (
+        <option.icon
+          className="text-muted-foreground mr-2 h-4 w-4 shrink-0"
+          aria-hidden="true"
+        />
+      )}
+      <div className="flex min-w-0 flex-col">
+        <span>{option.label}</span>
+        {option.description && (
+          <span className="text-muted-foreground text-xs leading-tight">
+            {option.description}
+          </span>
+        )}
+      </div>
+    </CommandItem>
+  );
 }
 
 export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
@@ -610,6 +670,18 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
       [getAllOptions, creatable],
     );
 
+    const optionMatchesSearch = React.useCallback(
+      (option: MultiSelectOption, needle: string) => {
+        const q = needle.toLowerCase();
+        return (
+          option.label.toLowerCase().includes(q) ||
+          option.value.toLowerCase().includes(q) ||
+          (option.description?.toLowerCase().includes(q) ?? false)
+        );
+      },
+      [],
+    );
+
     const filteredOptions = React.useMemo(() => {
       if (!searchable || !searchValue) return options;
       if (options.length === 0) return [];
@@ -617,22 +689,22 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
         return options
           .map((group) => ({
             ...group,
-            options: group.options.filter(
-              (option) =>
-                option.label
-                  .toLowerCase()
-                  .includes(searchValue.toLowerCase()) ||
-                option.value.toLowerCase().includes(searchValue.toLowerCase()),
+            options: group.options.filter((option) =>
+              optionMatchesSearch(option, searchValue),
             ),
           }))
           .filter((group) => group.options.length > 0);
       }
-      return options.filter(
-        (option) =>
-          option.label.toLowerCase().includes(searchValue.toLowerCase()) ||
-          option.value.toLowerCase().includes(searchValue.toLowerCase()),
+      return options.filter((option) =>
+        optionMatchesSearch(option, searchValue),
       );
-    }, [options, searchValue, searchable, isGroupedOptions]);
+    }, [
+      options,
+      searchValue,
+      searchable,
+      isGroupedOptions,
+      optionMatchesSearch,
+    ]);
 
     // We filter `options` into `filteredOptions` ourselves, so cmdk's built-in
     // filtering is disabled (see <Command shouldFilter={false}> below). Leaving
@@ -1191,91 +1263,26 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
                 {isGroupedOptions(filteredOptions) ? (
                   filteredOptions.map((group) => (
                     <CommandGroup key={group.heading} heading={group.heading}>
-                      {group.options.map((option) => {
-                        const isSelected = selectedValues.includes(
-                          option.value,
-                        );
-                        return (
-                          <CommandItem
-                            key={option.value}
-                            onSelect={() => toggleOption(option.value)}
-                            role="option"
-                            aria-selected={isSelected}
-                            aria-disabled={option.disabled}
-                            aria-label={`${option.label}${
-                              isSelected ? ", selected" : ", not selected"
-                            }${option.disabled ? ", disabled" : ""}`}
-                            className={cn(
-                              "cursor-pointer",
-                              option.disabled &&
-                                "cursor-not-allowed opacity-50",
-                            )}
-                            disabled={option.disabled}
-                          >
-                            <div
-                              className={cn(
-                                "border-primary mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
-                                isSelected
-                                  ? "bg-primary text-primary-foreground"
-                                  : "opacity-50 [&_svg]:invisible",
-                              )}
-                              aria-hidden="true"
-                            >
-                              <CheckIcon className="h-4 w-4 text-current" />
-                            </div>
-                            {option.icon && (
-                              <option.icon
-                                className="text-muted-foreground mr-2 h-4 w-4"
-                                aria-hidden="true"
-                              />
-                            )}
-                            <span>{option.label}</span>
-                          </CommandItem>
-                        );
-                      })}
+                      {group.options.map((option) => (
+                        <MultiSelectOptionItem
+                          key={option.value}
+                          option={option}
+                          isSelected={selectedValues.includes(option.value)}
+                          onToggle={() => toggleOption(option.value)}
+                        />
+                      ))}
                     </CommandGroup>
                   ))
                 ) : (
                   <CommandGroup>
-                    {filteredOptions.map((option) => {
-                      const isSelected = selectedValues.includes(option.value);
-                      return (
-                        <CommandItem
-                          key={option.value}
-                          onSelect={() => toggleOption(option.value)}
-                          role="option"
-                          aria-selected={isSelected}
-                          aria-disabled={option.disabled}
-                          aria-label={`${option.label}${
-                            isSelected ? ", selected" : ", not selected"
-                          }${option.disabled ? ", disabled" : ""}`}
-                          className={cn(
-                            "cursor-pointer",
-                            option.disabled && "cursor-not-allowed opacity-50",
-                          )}
-                          disabled={option.disabled}
-                        >
-                          <div
-                            className={cn(
-                              "border-primary mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
-                              isSelected
-                                ? "bg-primary text-primary-foreground"
-                                : "opacity-50 [&_svg]:invisible",
-                            )}
-                            aria-hidden="true"
-                          >
-                            <CheckIcon className="h-4 w-4 text-current" />
-                          </div>
-                          {option.icon && (
-                            <option.icon
-                              className="text-muted-foreground mr-2 h-4 w-4"
-                              aria-hidden="true"
-                            />
-                          )}
-                          <span>{option.label}</span>
-                        </CommandItem>
-                      );
-                    })}
+                    {filteredOptions.map((option) => (
+                      <MultiSelectOptionItem
+                        key={option.value}
+                        option={option}
+                        isSelected={selectedValues.includes(option.value)}
+                        onToggle={() => toggleOption(option.value)}
+                      />
+                    ))}
                   </CommandGroup>
                 )}
                 <CommandSeparator />

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -22,6 +22,7 @@ import {
 import { Badge } from "@/components/ui/Badge";
 import { Icon } from "@/components/ui/Icon";
 import { type Column, Table } from "@/components/ui/Table";
+import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { useRoutes } from "@/routes";
 import { useQueryState } from "nuqs";
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
@@ -51,9 +52,28 @@ const SKILL_FILTERS = defineFilters([
 ]);
 
 const FILTER_OPTIONS = {
-  sourceKind: SKILL_SOURCE_OPTIONS,
-  classification: SKILL_CLASSIFICATION_OPTIONS,
+  sourceKind: [...SKILL_SOURCE_OPTIONS],
+  classification: [...SKILL_CLASSIFICATION_OPTIONS],
 };
+
+function ColumnHeaderTooltip({
+  label,
+  tooltip,
+}: {
+  label: string;
+  tooltip: string;
+}): JSX.Element {
+  return (
+    <SimpleTooltip tooltip={tooltip}>
+      <span
+        tabIndex={0}
+        className="cursor-help underline decoration-dotted underline-offset-2"
+      >
+        {label}
+      </span>
+    </SimpleTooltip>
+  );
+}
 
 const RESULT_PAGE_SIZE = 50;
 const METRIC_SORT_BATCH_SIZE = 200;
@@ -258,13 +278,23 @@ export default function SkillsList(): JSX.Element {
     },
     {
       key: "source",
-      header: "Source",
+      header: (
+        <ColumnHeaderTooltip
+          label="Source"
+          tooltip="How the skill entered the registry: added manually, or captured from agent use."
+        />
+      ),
       width: "120px",
       render: (skill) => <SkillSourceBadge value={skill.sourceKind} />,
     },
     {
       key: "classification",
-      header: "Classification",
+      header: (
+        <ColumnHeaderTooltip
+          label="Classification"
+          tooltip="Custom skills belong to your organization; built-in skills come from plugins or platform defaults."
+        />
+      ),
       width: "130px",
       render: (skill) => (
         <SkillClassificationBadge value={skill.classification} />
@@ -289,7 +319,12 @@ export default function SkillsList(): JSX.Element {
     },
     {
       key: "efficacy",
-      header: "Efficacy",
+      header: (
+        <ColumnHeaderTooltip
+          label="Efficacy"
+          tooltip="Average usefulness score from sampled sessions that used this skill."
+        />
+      ),
       width: "110px",
       render: (skill) => {
         const efficacy = metricsBySkill.get(skill.id)?.efficacy;
@@ -310,7 +345,12 @@ export default function SkillsList(): JSX.Element {
     },
     {
       key: "estimatedSavings",
-      header: "Estimated savings",
+      header: (
+        <ColumnHeaderTooltip
+          label="Estimated savings"
+          tooltip="Estimated time saved across scored sessions that used this skill."
+        />
+      ),
       width: "150px",
       render: (skill) => {
         const efficacy = metricsBySkill.get(skill.id)?.efficacy;

--- a/client/dashboard/src/pages/skills/skill-badge-options.ts
+++ b/client/dashboard/src/pages/skills/skill-badge-options.ts
@@ -1,9 +1,39 @@
 export const SKILL_SOURCE_OPTIONS = [
-  { value: "manual", label: "Manual" },
-  { value: "captured", label: "Captured" },
-];
+  {
+    value: "manual",
+    label: "Manual",
+    description: "Added in Speakeasy by someone on your team.",
+  },
+  {
+    value: "captured",
+    label: "Captured",
+    description:
+      "Automatically recorded when an agent in your organization used the skill.",
+  },
+] as const;
 
 export const SKILL_CLASSIFICATION_OPTIONS = [
-  { value: "custom", label: "Custom" },
-  { value: "built_in", label: "Built-in" },
-];
+  {
+    value: "custom",
+    label: "Custom",
+    description: "Created or curated for your organization.",
+  },
+  {
+    value: "built_in",
+    label: "Built-in",
+    description: "Provided by a distributed plugin or platform default.",
+  },
+] as const;
+
+export type SkillBadgeOption = {
+  value: string;
+  label: string;
+  description?: string;
+};
+
+export function skillBadgeOption(
+  options: readonly SkillBadgeOption[],
+  value: string,
+): SkillBadgeOption | undefined {
+  return options.find((option) => option.value === value);
+}

--- a/client/dashboard/src/pages/skills/skill-badges.tsx
+++ b/client/dashboard/src/pages/skills/skill-badges.tsx
@@ -2,12 +2,12 @@ import { Badge } from "@/components/ui/Badge";
 import {
   SKILL_CLASSIFICATION_OPTIONS,
   SKILL_SOURCE_OPTIONS,
+  skillBadgeOption,
+  type SkillBadgeOption,
 } from "./skill-badge-options";
 
-function labelFor(value: string): string {
-  const known = [...SKILL_SOURCE_OPTIONS, ...SKILL_CLASSIFICATION_OPTIONS].find(
-    (option) => option.value === value,
-  );
+function labelFor(value: string, options: readonly SkillBadgeOption[]): string {
+  const known = skillBadgeOption(options, value);
   if (known) return known.label;
   return value
     .replaceAll("_", " ")
@@ -15,9 +15,13 @@ function labelFor(value: string): string {
 }
 
 export function SkillSourceBadge({ value }: { value: string }): JSX.Element {
+  const option = skillBadgeOption(SKILL_SOURCE_OPTIONS, value);
   return (
-    <Badge variant={value === "captured" ? "information" : "neutral"}>
-      <Badge.Text>{labelFor(value)}</Badge.Text>
+    <Badge
+      variant={value === "captured" ? "information" : "neutral"}
+      tooltip={option?.description}
+    >
+      <Badge.Text>{labelFor(value, SKILL_SOURCE_OPTIONS)}</Badge.Text>
     </Badge>
   );
 }
@@ -27,9 +31,10 @@ export function SkillClassificationBadge({
 }: {
   value: string;
 }): JSX.Element {
+  const option = skillBadgeOption(SKILL_CLASSIFICATION_OPTIONS, value);
   return (
-    <Badge variant="neutral">
-      <Badge.Text>{labelFor(value)}</Badge.Text>
+    <Badge variant="neutral" tooltip={option?.description}>
+      <Badge.Text>{labelFor(value, SKILL_CLASSIFICATION_OPTIONS)}</Badge.Text>
     </Badge>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Explains non-obvious Skills list filter values and columns so users can tell Manual vs Captured (and Custom vs Built-in) apart without leaving the page.

## Changes

- MultiSelect / filter options support an optional `description` shown under the label (same pattern as `SelectItem`)
- Source filter: Manual / Captured descriptions
- Classification filter: Custom / Built-in descriptions
- Source and Classification badges in the table show the same copy as hover tooltips
- Column header tooltips for Source, Classification, Efficacy, and Estimated savings

## Test plan

- [ ] Open Skills → Source filter → confirm Manual and Captured show explanatory text under each option
- [ ] Classification filter shows Custom / Built-in descriptions
- [ ] Hover Source / Classification badges in the table for tooltips
- [ ] Hover Source, Classification, Efficacy, Estimated savings column headers for tooltips
- [ ] `pnpm -F dashboard test` covers MultiSelect description rendering and search-by-description

Fixes DNO-728

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-728](https://linear.app/speakeasy/issue/DNO-728/feat-add-tooltip-for-non-trivial-cols-filters)

<div><a href="https://cursor.com/agents/bc-8b653409-01fa-4c17-bd02-b7f5138a4d19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b653409-01fa-4c17-bd02-b7f5138a4d19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-filter descriptions and tooltips to clarify skill Source and Classification, addressing DNO-728. Also updates `MultiSelect` to show and search option descriptions, improving clarity while filtering.

- **New Features**
  - `MultiSelect` supports option descriptions under labels; search matches descriptions.
  - Source and Classification filters include explanations for Manual/Captured and Custom/Built‑in.
  - Tooltips added to Source and Classification badges, and to Source, Classification, Efficacy, and Estimated savings column headers.
  - Tests added for description rendering and search-by-description.

<sup>Written for commit 71de8ab0c4d31cf3a7076b562e613af96ea2399d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

