### PR TITLE
feat: expose authenticated hook ingestion (DNO-703)

### DIFF
--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -44,6 +44,29 @@ func isExplicitSkillActivation(payload *gen.IngestPayload) bool {
 	return strings.TrimSpace(payload.Event.Type) == eventTypeSkillActivated
 }
 
+// IngestAuthenticated bypasses transport authentication for trusted in-process
+// callers that have already authenticated the supplied organization and project.
+func (s *Service) IngestAuthenticated(ctx context.Context, authCtx *contextvalues.AuthContext, payload *gen.IngestPayload) (*gen.IngestHookResult, error) {
+	if payload == nil {
+		return nil, oops.E(oops.CodeInvalid, nil, "ingest payload is required")
+	}
+	if authCtx == nil || strings.TrimSpace(authCtx.ActiveOrganizationID) == "" {
+		return nil, oops.E(oops.CodeInvalid, nil, "authenticated organization is required")
+	}
+	if authCtx.ProjectID == nil || *authCtx.ProjectID == uuid.Nil {
+		return nil, oops.E(oops.CodeInvalid, nil, "authenticated project is required")
+	}
+
+	authCopy := *authCtx
+	projectID := *authCtx.ProjectID
+	authCopy.ProjectID = &projectID
+	payloadCopy := *payload
+	payloadCopy.ApikeyToken = nil
+	payloadCopy.ProjectSlugInput = nil
+
+	return s.Ingest(contextvalues.SetAuthContext(ctx, &authCopy), &payloadCopy)
+}
+
 // Ingest is the feature-first hook endpoint; this path only accepts the
 // canonical Gram contract. Auth is optional so hook senders stay non-blocking
 // for machines that never signed in: a keyless request is acknowledged without

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -213,6 +213,51 @@ func TestIngest_RejectedCredentialsUnauthorized(t *testing.T) {
 	require.Contains(t, strings.ToLower(err.Error()), "unauthorized")
 }
 
+func TestIngestAuthenticated_UsesSuppliedIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := "authenticated-ingest-" + uuid.NewString()
+	idempotencyKey := "authenticated-ingest-" + uuid.NewString()
+	prompt := "authenticated ingestion prompt " + uuid.NewString()
+	untrustedAPIKey := "must-not-override-authenticated-context"
+	untrustedProjectSlug := "must-not-override-authenticated-project"
+	payload := canonicalIngestPayload("litellm", "prompt.submitted", sessionID)
+	payload.ApikeyToken = &untrustedAPIKey
+	payload.ProjectSlugInput = &untrustedProjectSlug
+	payload.IdempotencyKey = &idempotencyKey
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &prompt},
+	}
+	ti.service.riskScanner = &stubResultScanner{result: &risk.ScanResult{
+		Action:      "block",
+		PolicyID:    uuid.NewString(),
+		PolicyName:  "authenticated boundary policy",
+		Description: "blocked by deterministic test scanner",
+	}}
+
+	result, err := ti.service.IngestAuthenticated(t.Context(), authCtx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision)
+
+	messages, err := chatRepo.New(ti.conn).ListChatMessages(t.Context(), chatRepo.ListChatMessagesParams{
+		ChatID:    sessionIDToUUID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.True(t, messages[0].ProjectID.Valid)
+	require.Equal(t, *authCtx.ProjectID, messages[0].ProjectID.UUID)
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, prompt, messages[0].Content)
+}
+
 // A shared plugins-* key carries no usable identity of its own, but the
 // session may already be attributed through the OTEL/device-bridge metadata
 // cache. User-scoped shadow-MCP policies must see that cached identity during


### PR DESCRIPTION
## Summary
- expose a trusted in-process entry point for canonical hook ingestion
- preserve existing enforcement, idempotency, telemetry, and conversation persistence behavior
- strip transport credentials before applying the caller-supplied organization and project identity
- cover direct enforcement and chat persistence without an HTTP hop

Linear: DNO-703

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a trusted in-process entry point for canonical hook ingestion using a pre-authenticated org/project context. This enables `LiteLLM` to reuse enforcement and chat capture without an HTTP hop (DNO-703).

- **New Features**
  - Added `Service.IngestAuthenticated(...)` for trusted in-process callers with supplied identity.
  - Strips payload transport credentials (`ApikeyToken`, `ProjectSlugInput`) and applies `authCtx`.
  - Mirrors canonical HTTP ingestion behavior (enforcement, idempotency, telemetry, conversation capture) without a network hop.
  - Added a test that ingests with the supplied identity and verifies a deny verdict and persisted user message.

<sup>Written for commit 9bba22cd214139a64300a4e190aef63f0ca88886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

