### PR TITLE
preview: consent tool filtering stack (do not merge)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1544,6 +1544,10 @@ CREATE TABLE IF NOT EXISTS user_sessions (
   refresh_token_hash TEXT NOT NULL,
   refresh_expires_at timestamptz NOT NULL,
   expires_at timestamptz NOT NULL,
+  -- Tool selection the subject chose on the consent screen, carried across
+  -- refresh-grant slides. NULL means all tools. Shape and mode values are
+  -- validated in application code.
+  tool_selection JSONB,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -1566,6 +1570,12 @@ WHERE deleted IS FALSE;
 
 CREATE INDEX IF NOT EXISTS user_sessions_subject_idx
 ON user_sessions (subject_urn, user_session_issuer_id)
+WHERE deleted IS FALSE;
+
+-- Serve-path tool-selection lookup: sessions are addressed by issuer + jti on
+-- every runtime request.
+CREATE INDEX IF NOT EXISTS user_sessions_user_session_issuer_id_jti_idx
+ON user_sessions (user_session_issuer_id, jti)
 WHERE deleted IS FALSE;
 
 -- Remote Session Issuers are references to external authorization servers

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2497,6 +2497,7 @@ type UserSession struct {
 	RefreshTokenHash    string
 	RefreshExpiresAt    pgtype.Timestamptz
 	ExpiresAt           pgtype.Timestamptz
+	ToolSelection       []byte
 	CreatedAt           pgtype.Timestamptz
 	UpdatedAt           pgtype.Timestamptz
 	DeletedAt           pgtype.Timestamptz

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -35,6 +35,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
@@ -157,8 +158,12 @@ type UserSessionGrant struct {
 	// length choice. Token minting clamps it to the issuer maximum. Zero means
 	// "no explicit choice" and the mint uses that maximum. Keep the JSON key
 	// stable so grants survive rolling deploys.
-	DesiredSessionDurationHours int       `json:"session_duration_hours,omitempty"`
-	CreatedAt                   time.Time `json:"created_at"`
+	DesiredSessionDurationHours int `json:"session_duration_hours,omitempty"`
+	// ToolSelection is the subject's consent-screen tool policy, already
+	// validated against the endpoint's live tool inventory and resource-bound.
+	// Nil means all tools.
+	ToolSelection *toolfilter.SessionSelection `json:"tool_selection,omitempty"`
+	CreatedAt     time.Time                    `json:"created_at"`
 }
 
 var _ cache.CacheableObject[UserSessionGrant] = (*UserSessionGrant)(nil)
@@ -208,13 +213,28 @@ var errIssuerGateOrgLookup = errors.New("describe organization for issuer-gated 
 // authz.Engine.ShouldEnforce / PrepareContext treat the request as a real
 // authenticated session. AccountType is retained as session metadata but does
 // not control RBAC enforcement.
-func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, error) {
+func (s *Service) validateUserSessionToken(ctx context.Context, token string, endpoint *ResolvedMcpEndpoint) (context.Context, *urn.SessionSubject, *toolfilter.SessionSelection, error) {
 	if token == "" {
-		return ctx, nil, nil
+		return ctx, nil, nil, nil
 	}
 	session, err := s.userSessionSigner.ValidateBearer(ctx, token, endpoint.AudienceURN, s.chatSessionsManager)
 	if err != nil {
-		return ctx, nil, fmt.Errorf("validate user-session bearer: %w", err)
+		return ctx, nil, nil, fmt.Errorf("validate user-session bearer: %w", err)
+	}
+
+	// The consent-screen tool selection loads for every subject kind —
+	// including anonymous, which early-returns below before AuthContext is
+	// stamped. Load failures fail closed: a policy-store outage must never
+	// widen a restrictive session to all tools.
+	toolSelection, err := s.loadSessionToolSelection(ctx, endpoint, session.JTI)
+	if err != nil {
+		return ctx, nil, nil, fmt.Errorf("resolve session tool selection: %w", err)
+	}
+	if toolSelection != nil && toolSelection.Resource != endpointToolSelectionResource(endpoint) {
+		// Issuer-scoped tokens are portable across endpoints sharing the
+		// issuer; a selection consented on endpoint A must not authorize
+		// same-named tools on endpoint B. Reject into reauth.
+		return ctx, nil, nil, errToolSelectionResourceMismatch
 	}
 
 	subject := session.Subject
@@ -223,12 +243,12 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 	}
 
 	if subject.Kind == urn.SessionSubjectKindAnonymous {
-		return ctx, &subject, nil
+		return ctx, &subject, toolSelection, nil
 	}
 
 	orgMetadata, err := mv.DescribeOrganization(ctx, s.logger, s.orgsRepo, s.billingRepository, endpoint.OrganizationID)
 	if err != nil {
-		return ctx, nil, fmt.Errorf("%w: %w", errIssuerGateOrgLookup, err)
+		return ctx, nil, nil, fmt.Errorf("%w: %w", errIssuerGateOrgLookup, err)
 	}
 	projectID := endpoint.ProjectID
 	authCtx := &contextvalues.AuthContext{
@@ -258,7 +278,7 @@ func (s *Service) validateUserSessionToken(ctx context.Context, token string, en
 		// Unreachable: anonymous subjects return ctx untouched above. Listed
 		// for exhaustiveness so the linter doesn't flag the switch.
 	}
-	return contextvalues.SetAuthContext(ctx, authCtx), &subject, nil
+	return contextvalues.SetAuthContext(ctx, authCtx), &subject, toolSelection, nil
 }
 
 // AuthenticateChallengeHeader builds the WWW-Authenticate value (RFC 9728
@@ -328,13 +348,13 @@ func (s *Service) ApplyIssuerGate(
 	w http.ResponseWriter,
 	authToken, baseURL string,
 	endpoint *ResolvedMcpEndpoint,
-) (context.Context, map[uuid.UUID]string, error) {
+) (context.Context, map[uuid.UUID]string, *toolfilter.SessionSelection, error) {
 	protectedResourceURL, err := endpoint.ProtectedResourceURL(baseURL)
 	if err != nil {
-		return ctx, nil, oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
+		return ctx, nil, nil, oops.E(oops.CodeUnexpected, err, "build protected-resource URL").LogError(ctx, s.logger)
 	}
 
-	newCtx, subject, valErr := s.validateUserSessionToken(ctx, authToken, endpoint)
+	newCtx, subject, toolSelection, valErr := s.validateUserSessionToken(ctx, authToken, endpoint)
 	if subject == nil {
 		// Accept an assistant-runtime JWT, but only when the assistant
 		// belongs to the endpoint's project — otherwise a token minted
@@ -358,13 +378,16 @@ func (s *Service) ApplyIssuerGate(
 			if errors.Is(valErr, errIssuerGateOrgLookup) {
 				failureReason = "org_lookup_failed"
 			}
+			if errors.Is(valErr, errToolSelectionResourceMismatch) {
+				failureReason = "tool_selection_resource_mismatch"
+			}
 			endpoint.LogWith(s.logger).WarnContext(ctx, "mcp issuer gate rejected bearer token",
 				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
 				attr.SlogOAuthFailureReason(failureReason),
 				attr.SlogError(valErr),
 			)
 		}
-		return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
+		return ctx, nil, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "expired or invalid access token")
 	}
 
 	// Resolve the upstream remote_sessions for this subject before
@@ -392,13 +415,13 @@ func (s *Service) ApplyIssuerGate(
 				attr.SlogUserSessionIssuerID(endpoint.UserSessionIssuerID.String()),
 				attr.SlogOAuthFailureReason("invalid_remote_session"),
 			)
-			return ctx, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
+			return ctx, nil, nil, WriteAuthenticateChallenge(w, protectedResourceURL, "")
 		case rerr != nil:
-			return ctx, nil, oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)
+			return ctx, nil, nil, oops.E(oops.CodeUnexpected, rerr, "resolve remote session").LogError(newCtx, s.logger)
 		}
 		upstreamTokens = tokens
 	}
-	return newCtx, upstreamTokens, nil
+	return newCtx, upstreamTokens, toolSelection, nil
 }
 
 var errToolsetEndpointMismatch = errors.New("authn challenge endpoint does not match toolset")

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -121,6 +121,10 @@ type consentTemplateData struct {
 	// (connected or expired), so a change can be persisted immediately rather
 	// than only riding the next connect.
 	AutoRefreshHasSessions bool
+	// ToolsSection is the "Tool access" picker: annotation checkboxes plus a
+	// name-snapshot tool list, rendered only for toolset-backed endpoints on
+	// client-grant (non-first-party) pages.
+	ToolsSection consentToolsSection
 }
 
 // sessionDurationOption is one <option> of the consent page's session length
@@ -249,6 +253,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	clientName := "Gram"
 	clientIDOrigin := ""
 	loopbackRedirectWarning := false
+	var clientRowID uuid.UUID
 	if !challengeState.FirstParty {
 		client, err := s.resolveUserSessionClient(ctx, logger, endpoint, challengeState.ClientID, lookupClientOnly)
 		if err != nil {
@@ -257,6 +262,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 			}
 			return oops.E(oops.CodeUnexpected, err, "lookup user session client").LogError(ctx, logger)
 		}
+		clientRowID = client.ID
 		clientName = client.ClientName
 		if client.ClientIDMetadataUri.Valid {
 			if u, err := url.Parse(client.ClientIDMetadataUri.String); err == nil {
@@ -314,6 +320,22 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		}
 	}
 
+	// Tool picker: only client-grant pages on toolset-backed endpoints. A
+	// resolution failure fails the render — hiding the picker while leaving
+	// approval enabled would let a transient lookup error mint an all-tools
+	// session on an endpoint whose reauth was meant to narrow it.
+	toolsSection := consentToolsSection{Supported: false, FilteringEnabled: false, AnnotationOptions: nil, Tools: nil, Scopes: nil, UnannotatedCount: 0, ProxyExcludedCount: 0}
+	if !challengeState.FirstParty {
+		pickerToolset, terr := s.describeConsentToolset(ctx, endpoint)
+		if terr != nil {
+			return oops.E(oops.CodeUnexpected, terr, "resolve toolset for consent tool picker").LogError(ctx, logger)
+		}
+		if pickerToolset != nil {
+			prefill := s.consentToolSelectionPrefill(ctx, endpoint, *challengeState.Subject, clientRowID)
+			toolsSection = buildConsentToolsSection(pickerToolset, prefill)
+		}
+	}
+
 	data := consentTemplateData{
 		ClientName:              clientName,
 		MCPSlug:                 endpoint.Slug,
@@ -333,6 +355,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		AutoRefreshSupported:    autoRefreshSupported,
 		AutoRefreshOn:           autoRefreshOn,
 		AutoRefreshHasSessions:  autoRefreshHasSessions,
+		ToolsSection:            toolsSection,
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -347,8 +370,10 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	ctx := r.Context()
 
 	// Cap form body to defend against memory exhaustion (gosec G120). The
-	// consent form has a few short fields; 16 KiB is generous.
-	r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
+	// tool picker can post consentToolNameLimit names of up to
+	// consentToolNameMaxRunes runes; 128 KiB fits that worst case with room
+	// for the fixed fields while staying bounded.
+	r.Body = http.MaxBytesReader(w, r.Body, 128<<10)
 	if err := r.ParseForm(); err != nil {
 		return oops.E(oops.CodeBadRequest, err, "failed to parse form").LogError(ctx, s.logger)
 	}
@@ -446,6 +471,11 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		return oops.E(oops.CodeUnexpected, err, "record consent").LogError(ctx, logger)
 	}
 
+	toolSelection, err := s.chosenToolSelection(ctx, endpoint, r.PostForm)
+	if err != nil {
+		return oops.E(oops.CodeBadRequest, err, "invalid tool selection").LogError(ctx, logger)
+	}
+
 	code, err := generateOpaqueToken()
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
@@ -463,6 +493,7 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		CodeChallengeMethod:         challengeState.CodeChallengeMethod,
 		Subject:                     subject,
 		DesiredSessionDurationHours: desiredSessionDurationHours(r.PostForm.Get("session_duration_hours")),
+		ToolSelection:               toolSelection,
 		CreatedAt:                   time.Now(),
 	}
 	if err := s.userSessionGrantCache.Store(ctx, grant); err != nil {

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -259,3 +259,70 @@ func TestConsentScriptClosesOnlyMarkedPages(t *testing.T) {
 	require.Contains(t, script, "}, 3000);")
 	require.Contains(t, script, `guardActionButtons("button[data-refresh-link]", "Refreshing…")`)
 }
+
+func TestConsentTemplateToolAccessSection(t *testing.T) {
+	t.Parallel()
+
+	var page bytes.Buffer
+	err := consentTemplate.Execute(&page, consentTemplateData{
+		ClientName:     "Demo",
+		MCPSlug:        "example",
+		MCPRouteBase:   "mcp",
+		State:          "state",
+		CSRFToken:      "csrf",
+		SubjectDisplay: "user@example.com",
+		RedirectURI:    "http://127.0.0.1/cb",
+		ScriptURL:      "/mcp/consent-page-test.js",
+		ConsentEnabled: true,
+		FirstParty:     false,
+		ToolsSection: consentToolsSection{
+			Supported:        true,
+			FilteringEnabled: true,
+			AnnotationOptions: []consentAnnotationOption{
+				{Value: "read_only", Label: "Read-only", Count: 3, Checked: true},
+				{Value: "destructive", Label: "Destructive", Count: 1, Checked: false},
+			},
+			Tools: []consentToolEntry{
+				{Name: "get_thing", Annotations: []string{"read_only"}, AnnotationsJoined: "read_only", Checked: false},
+				{Name: "delete_thing", Annotations: []string{"destructive"}, AnnotationsJoined: "destructive", Checked: true},
+			},
+			Scopes:             []consentToolScope{{Tag: "billing", Count: 2, NamesJoined: "get_thing,delete_thing"}},
+			UnannotatedCount:   4,
+			ProxyExcludedCount: 2,
+		},
+	})
+	require.NoError(t, err)
+
+	html := page.String()
+	require.Contains(t, html, "Tool access")
+	require.Contains(t, html, `name="tool_filtering"`)
+	require.Contains(t, html, `value="read_only"`)
+	require.Contains(t, html, `name="tool_annotations"`)
+	require.Contains(t, html, `name="tools"`)
+	require.Contains(t, html, `value="get_thing"`)
+	require.Contains(t, html, `data-scope-tools="get_thing,delete_thing"`)
+	require.Contains(t, html, "external MCP tools are")
+	require.Contains(t, html, "carry no annotations")
+	// FilteringEnabled preselects "Limit tools" and reveals the panel.
+	require.NotContains(t, html, `data-tools-panel
+            hidden`)
+}
+
+func TestConsentTemplateToolAccessHiddenWhenUnsupported(t *testing.T) {
+	t.Parallel()
+
+	var page bytes.Buffer
+	err := consentTemplate.Execute(&page, consentTemplateData{
+		ClientName:     "Demo",
+		MCPSlug:        "example",
+		MCPRouteBase:   "mcp",
+		State:          "state",
+		CSRFToken:      "csrf",
+		SubjectDisplay: "user@example.com",
+		ScriptURL:      "/mcp/consent-page-test.js",
+		ConsentEnabled: true,
+		FirstParty:     false,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, page.String(), "Tool access")
+}

--- a/server/internal/mcp/authnchallenge_consent_tools.go
+++ b/server/internal/mcp/authnchallenge_consent_tools.go
@@ -1,0 +1,345 @@
+// Consent-screen tool picker: builds the view model for the "Tool access"
+// section and parses the approve form's selection into a resource-bound
+// session policy. Only toolset-backed endpoints offer the picker; proxy
+// (external MCP) tools are listed nowhere because restrictive selections
+// exclude them wholesale in v1.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
+	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/mv"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// consentToolNameLimit caps how many explicit tool names one selection may
+// carry; combined with the per-name length cap it keeps a legitimate form
+// well under the 64 KiB body limit.
+const (
+	consentToolNameLimit    = 256
+	consentToolNameMaxRunes = 200
+)
+
+// consentAnnotationLabels maps the fixed annotation vocabulary to its
+// user-facing labels, in display order (toolfilter.KnownAnnotations).
+var consentAnnotationLabels = map[string]string{
+	toolfilter.AnnotationReadOnly:    "Read-only",
+	toolfilter.AnnotationDestructive: "Destructive",
+	toolfilter.AnnotationIdempotent:  "Idempotent",
+	toolfilter.AnnotationOpenWorld:   "Open world",
+}
+
+// consentAnnotationOption is one annotation checkbox.
+type consentAnnotationOption struct {
+	Value   string
+	Label   string
+	Count   int
+	Checked bool
+}
+
+// consentToolEntry is one tool checkbox row.
+type consentToolEntry struct {
+	Name string
+	// Annotations are the raw hints that are explicitly true, as vocabulary
+	// values — rendered as badges and mirrored into a data attribute so the
+	// script can mark rows covered by a selected annotation.
+	Annotations       []string
+	AnnotationsJoined string
+	Checked           bool
+}
+
+// consentToolScope is a tag-scope convenience chip: clicking it checks its
+// member tools. Selection stays name-based (snapshot), so the chip is pure
+// UI sugar.
+type consentToolScope struct {
+	Tag         string
+	Count       int
+	NamesJoined string
+}
+
+// consentToolsSection is the template view model for the tool picker.
+type consentToolsSection struct {
+	Supported bool
+	// FilteringEnabled preselects "Limit tools" when a live session for the
+	// same subject/client/resource already carries a restrictive policy.
+	FilteringEnabled   bool
+	AnnotationOptions  []consentAnnotationOption
+	Tools              []consentToolEntry
+	Scopes             []consentToolScope
+	UnannotatedCount   int
+	ProxyExcludedCount int
+}
+
+// describeConsentToolset resolves the endpoint's toolset and effective
+// variation group exactly the way the runtime does, so the picker shows the
+// same inventory tools/list will serve.
+func (s *Service) describeConsentToolset(ctx context.Context, endpoint *ResolvedMcpEndpoint) (*types.Toolset, error) {
+	if !endpoint.ToolsetID.Valid {
+		return nil, nil
+	}
+
+	toolsetRow, err := toolsets_repo.New(s.db).GetToolsetByIDAndProject(ctx, toolsets_repo.GetToolsetByIDAndProjectParams{
+		ID:        endpoint.ToolsetID.UUID,
+		ProjectID: endpoint.ProjectID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load toolset for consent picker: %w", err)
+	}
+
+	var serverGroupID *uuid.UUID
+	if endpoint.McpServerID.Valid {
+		serverRow, serr := mcpservers_repo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpservers_repo.GetMCPServerByIDAndProjectIDParams{
+			ID:        endpoint.McpServerID.UUID,
+			ProjectID: endpoint.ProjectID,
+		})
+		if serr != nil {
+			// Falling back to the toolset's group here would render (and
+			// validate against) a different inventory than the runtime
+			// resolves — fail instead.
+			return nil, fmt.Errorf("load mcp server for consent picker: %w", serr)
+		}
+		if serverRow.ToolVariationsGroupID.Valid {
+			id := serverRow.ToolVariationsGroupID.UUID
+			serverGroupID = &id
+		}
+	}
+	var toolsetGroupID *uuid.UUID
+	if toolsetRow.ToolVariationsGroupID.Valid {
+		id := toolsetRow.ToolVariationsGroupID.UUID
+		toolsetGroupID = &id
+	}
+	groupID := toolfilter.ResolveGroupID(serverGroupID, toolsetGroupID)
+
+	toolset, err := mv.DescribeToolset(ctx, s.logger, s.db, mv.ProjectID(endpoint.ProjectID), mv.ToolsetSlug(conv.ToLower(toolsetRow.Slug)), &s.toolsetCache, groupID, s.platformExtras...)
+	if err != nil {
+		return nil, err
+	}
+	return toolset, nil
+}
+
+// buildConsentToolsSection materializes the picker view model. prefill is
+// the stored selection from the subject's newest live session (nil when
+// none or not applicable); it must already be resource-checked.
+func buildConsentToolsSection(toolset *types.Toolset, prefill *toolfilter.SessionSelection) consentToolsSection {
+	section := consentToolsSection{
+		Supported:          toolset != nil,
+		FilteringEnabled:   prefill != nil,
+		AnnotationOptions:  nil,
+		Tools:              nil,
+		Scopes:             nil,
+		UnannotatedCount:   0,
+		ProxyExcludedCount: 0,
+	}
+	if toolset == nil {
+		return section
+	}
+
+	prefillAnnotations := map[string]bool{}
+	prefillNames := map[string]bool{}
+	if prefill != nil {
+		for _, a := range prefill.Annotations {
+			prefillAnnotations[a] = true
+		}
+		for _, name := range prefill.Tools {
+			prefillNames[name] = true
+		}
+	}
+
+	counts := map[string]int{}
+	scopeNames := map[string][]string{}
+	for _, tool := range toolset.Tools {
+		if tool == nil {
+			continue
+		}
+		if conv.IsProxyTool(tool) {
+			section.ProxyExcludedCount++
+			continue
+		}
+		base, err := conv.ToBaseTool(tool)
+		if err != nil {
+			continue
+		}
+
+		annotations := trueAnnotationValues(base.Annotations)
+		if len(annotations) == 0 {
+			section.UnannotatedCount++
+		}
+		for _, a := range annotations {
+			counts[a]++
+		}
+		for _, tag := range toolfilter.EffectiveToolTags(tool) {
+			scopeNames[tag] = append(scopeNames[tag], base.Name)
+		}
+
+		section.Tools = append(section.Tools, consentToolEntry{
+			Name:              base.Name,
+			Annotations:       annotations,
+			AnnotationsJoined: strings.Join(annotations, " "),
+			Checked:           prefillNames[base.Name],
+		})
+	}
+	slices.SortFunc(section.Tools, func(a, b consentToolEntry) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	for _, value := range toolfilter.KnownAnnotations {
+		section.AnnotationOptions = append(section.AnnotationOptions, consentAnnotationOption{
+			Value:   value,
+			Label:   consentAnnotationLabels[value],
+			Count:   counts[value],
+			Checked: prefillAnnotations[value],
+		})
+	}
+
+	for _, tag := range slices.Sorted(maps.Keys(scopeNames)) {
+		names := scopeNames[tag]
+		slices.Sort(names)
+		section.Scopes = append(section.Scopes, consentToolScope{
+			Tag:         tag,
+			Count:       len(names),
+			NamesJoined: strings.Join(names, ","),
+		})
+	}
+
+	return section
+}
+
+// trueAnnotationValues lists the vocabulary values whose raw hint is
+// explicitly true — the same axis the runtime matcher applies.
+func trueAnnotationValues(annotations *types.ToolAnnotations) []string {
+	if annotations == nil {
+		return nil
+	}
+	var values []string
+	hintTrue := func(hint *bool) bool { return hint != nil && *hint }
+	if hintTrue(annotations.ReadOnlyHint) {
+		values = append(values, toolfilter.AnnotationReadOnly)
+	}
+	if hintTrue(annotations.DestructiveHint) {
+		values = append(values, toolfilter.AnnotationDestructive)
+	}
+	if hintTrue(annotations.IdempotentHint) {
+		values = append(values, toolfilter.AnnotationIdempotent)
+	}
+	if hintTrue(annotations.OpenWorldHint) {
+		values = append(values, toolfilter.AnnotationOpenWorld)
+	}
+	return values
+}
+
+// consentToolSelectionPrefill loads the stored selection from the subject's
+// newest live session for the same issuer + client, returning nil unless it
+// is restrictive AND bound to this endpoint's resource. Anonymous subjects
+// never prefill: each authorization mints a fresh random subject, and
+// matching by issuer/client alone would leak another user's preference.
+func (s *Service) consentToolSelectionPrefill(ctx context.Context, endpoint *ResolvedMcpEndpoint, subject urn.SessionSubject, clientRowID uuid.UUID) *toolfilter.SessionSelection {
+	if subject.Kind == urn.SessionSubjectKindAnonymous {
+		return nil
+	}
+	resource := endpointToolSelectionResource(endpoint)
+	if resource == "" {
+		return nil
+	}
+	raw, err := usersessions_repo.New(s.db).GetLatestLiveUserSessionToolSelection(ctx, usersessions_repo.GetLatestLiveUserSessionToolSelectionParams{
+		ProjectID:           endpoint.ProjectID,
+		UserSessionIssuerID: endpoint.UserSessionIssuerID,
+		UserSessionClientID: uuid.NullUUID{UUID: clientRowID, Valid: true},
+		SubjectUrn:          subject,
+		Resource:            resource,
+	})
+	if err != nil {
+		return nil
+	}
+	sel, _, err := toolfilter.ParseSessionSelection(raw)
+	if err != nil {
+		s.logger.WarnContext(ctx, "ignore malformed stored tool selection for consent prefill", attr.SlogError(err))
+		return nil
+	}
+	if sel == nil || sel.Resource != resource {
+		return nil
+	}
+	return sel
+}
+
+// chosenToolSelection parses the approve form's tool picker into a
+// resource-bound policy. Non-toolset endpoints never carry a policy. A
+// missing tool_filtering field reads as "off": forms rendered before the
+// picker deployed (the challenge TTL spans a rolling deploy) omit it, and
+// omission grants nothing the default "All tools" radio wouldn't — only an
+// unknown value marks a crafted form and fails the approve. Unknown
+// submitted names are intersected away against the live inventory (a
+// crafted form can only narrow), but an inventory resolution failure is an
+// error: degrading to name-less would widen the selection.
+func (s *Service) chosenToolSelection(ctx context.Context, endpoint *ResolvedMcpEndpoint, form url.Values) (*toolfilter.SessionSelection, error) {
+	resource := endpointToolSelectionResource(endpoint)
+	if !endpoint.ToolsetID.Valid || resource == "" {
+		return nil, nil
+	}
+	switch form.Get("tool_filtering") {
+	case "", "off":
+		return nil, nil
+	case "on":
+		// fall through
+	default:
+		return nil, fmt.Errorf("tool_filtering must be \"on\" or \"off\"")
+	}
+
+	var annotations []string
+	for _, a := range form["tool_annotations"] {
+		if slices.Contains(toolfilter.KnownAnnotations, a) && !slices.Contains(annotations, a) {
+			annotations = append(annotations, a)
+		}
+	}
+
+	var names []string
+	submitted := form["tools"]
+	if len(submitted) > 0 {
+		toolset, err := s.describeConsentToolset(ctx, endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("resolve toolset for consent selection: %w", err)
+		}
+		live := map[string]bool{}
+		if toolset != nil {
+			for _, tool := range toolset.Tools {
+				if tool == nil || conv.IsProxyTool(tool) {
+					continue
+				}
+				if base, berr := conv.ToBaseTool(tool); berr == nil {
+					live[base.Name] = true
+				}
+			}
+		}
+		seen := map[string]bool{}
+		for _, name := range submitted {
+			if len(names) >= consentToolNameLimit {
+				break
+			}
+			if len([]rune(name)) > consentToolNameMaxRunes || seen[name] || !live[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+
+	return &toolfilter.SessionSelection{
+		Annotations: annotations,
+		Tools:       names,
+		Resource:    resource,
+	}, nil
+}

--- a/server/internal/mcp/authnchallenge_token.go
+++ b/server/internal/mcp/authnchallenge_token.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/sessiontokens"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -242,7 +243,16 @@ func (s *Service) handleTokenAuthorizationCodeGrant(
 		d := time.Duration(grant.DesiredSessionDurationHours) * time.Hour
 		desiredSessionDuration = &d
 	}
-	if err := s.mintSessionAndRespond(ctx, w, endpoint, clientRow, grant.Subject, desiredSessionDuration, nil, baseURL, logger); err != nil {
+	var toolSelection []byte
+	if grant.ToolSelection != nil {
+		encoded, merr := json.Marshal(grant.ToolSelection)
+		if merr != nil {
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageToken)
+			return oops.E(oops.CodeUnexpected, merr, "encode tool selection").LogError(ctx, logger)
+		}
+		toolSelection = encoded
+	}
+	if err := s.mintSessionAndRespond(ctx, w, endpoint, clientRow, grant.Subject, desiredSessionDuration, nil, toolSelection, baseURL, logger); err != nil {
 		// Almost all errors here occur before the 200 is written — issuer
 		// lookup, session_duration validation, signing, or persisting the
 		// user_sessions row — so no token reached the client and failed is
@@ -328,7 +338,16 @@ func (s *Service) handleTokenRefreshTokenGrant(
 	// that deadline forward verbatim; it never opens a fresh authorization
 	// window merely because the client exchanged its refresh token.
 	authorizationExpiresAt := oldSession.RefreshExpiresAt.Time
-	return s.mintSessionAndRespond(ctx, w, endpoint, clientRow, oldSession.SubjectUrn, nil, &authorizationExpiresAt, baseURL, logger)
+	// The tool selection rides refresh slides verbatim; only a fresh
+	// authorization-code grant (which re-runs consent) replaces it. Validate
+	// before minting: the serve path rejects a malformed policy anyway, so
+	// refusing here returns invalid_grant (forcing reauth) instead of
+	// minting tokens that immediately 401.
+	if _, _, perr := toolfilter.ParseSessionSelection(oldSession.ToolSelection); perr != nil {
+		logOAuthClientCredentialEvent(ctx, logger, r, "oauth refresh_token request rejected", clientRow.ClientID, presentedAuthMethod, "refresh_token", "tool_selection_malformed")
+		return writeTokenError(ctx, w, logger, http.StatusBadRequest, "invalid_grant", "session tool selection is malformed; reauthorize")
+	}
+	return s.mintSessionAndRespond(ctx, w, endpoint, clientRow, oldSession.SubjectUrn, nil, &authorizationExpiresAt, oldSession.ToolSelection, baseURL, logger)
 }
 
 // accessTokenLifetime is the wall-clock validity of a minted access-token
@@ -358,6 +377,10 @@ const accessTokenLifetime = 1 * time.Hour
 // "no explicit choice", falling back to the issuer's session_duration.
 // authorizationExpiresAt is used only for rotation and is carried from the
 // prior row. Exactly one is normally non-nil.
+//
+// toolSelection is the consent-screen tool policy JSON persisted verbatim on
+// the new row (nil = all tools). The auth-code grant encodes it from the
+// consent choice; the refresh grant carries the old row's value.
 func (s *Service) mintSessionAndRespond(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -366,6 +389,7 @@ func (s *Service) mintSessionAndRespond(
 	subject urn.SessionSubject,
 	desiredSessionDuration *time.Duration,
 	authorizationExpiresAt *time.Time,
+	toolSelection []byte,
 	baseURL string,
 	logger *slog.Logger,
 ) error {
@@ -443,6 +467,7 @@ func (s *Service) mintSessionAndRespond(
 		RefreshTokenHash:    sha256Hex(refreshTokenRaw),
 		ExpiresAt:           pgtype.Timestamptz{Time: accessExpiresAt, InfinityModifier: 0, Valid: true},
 		RefreshExpiresAt:    pgtype.Timestamptz{Time: *authorizationExpiresAt, InfinityModifier: 0, Valid: true},
+		ToolSelection:       toolSelection,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, logger)
 	}

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -78,6 +78,84 @@
   guardActionButtons("button[data-connect-link]", "Connecting…");
   guardActionButtons("button[data-refresh-link]", "Refreshing…");
 
+  // Tool access: the "Limit tools" radio reveals the picker panel; a scope
+  // chip bulk-checks its member tools (selection stays name-based); and tool
+  // rows covered by a checked annotation are marked "included" so an
+  // unchecked name checkbox is never read as an exclusion.
+  var toolPanel = document.querySelector("[data-tools-panel]");
+  if (toolPanel) {
+    var radios = document.querySelectorAll("input[data-tool-filtering]");
+    Array.prototype.forEach.call(radios, function (radio) {
+      radio.addEventListener("change", function () {
+        var limiting = false;
+        Array.prototype.forEach.call(radios, function (r) {
+          if (r.checked && r.value === "on") {
+            limiting = true;
+          }
+        });
+        if (limiting) {
+          toolPanel.removeAttribute("hidden");
+        } else {
+          toolPanel.setAttribute("hidden", "");
+        }
+      });
+    });
+
+    var refreshAnnotationMarks = function () {
+      var selected = {};
+      var boxes = document.querySelectorAll("input[data-annotation-checkbox]");
+      Array.prototype.forEach.call(boxes, function (box) {
+        if (box.checked) {
+          selected[box.value] = true;
+        }
+      });
+      var rows = document.querySelectorAll("[data-tool-row]");
+      Array.prototype.forEach.call(rows, function (row) {
+        var covered = false;
+        var annotations = (row.getAttribute("data-annotations") || "").split(
+          " ",
+        );
+        Array.prototype.forEach.call(annotations, function (annotation) {
+          if (annotation && selected[annotation]) {
+            covered = true;
+          }
+        });
+        if (covered) {
+          row.setAttribute("data-via-annotation", "");
+        } else {
+          row.removeAttribute("data-via-annotation");
+        }
+      });
+    };
+    var annotationBoxes = document.querySelectorAll(
+      "input[data-annotation-checkbox]",
+    );
+    Array.prototype.forEach.call(annotationBoxes, function (box) {
+      box.addEventListener("change", refreshAnnotationMarks);
+    });
+    refreshAnnotationMarks();
+
+    var chips = document.querySelectorAll("button[data-scope-tools]");
+    Array.prototype.forEach.call(chips, function (chip) {
+      chip.addEventListener("click", function () {
+        var names = {};
+        (chip.getAttribute("data-scope-tools") || "")
+          .split(",")
+          .forEach(function (name) {
+            if (name) {
+              names[name] = true;
+            }
+          });
+        var toolBoxes = document.querySelectorAll("input[data-tool-checkbox]");
+        Array.prototype.forEach.call(toolBoxes, function (box) {
+          if (names[box.value]) {
+            box.checked = true;
+          }
+        });
+      });
+    });
+  }
+
   // Auto refresh: the page-level combobox drives every provider at once. A
   // change syncs each card's hidden auto_refresh input (so a subsequent
   // Connect carries the choice) and, when a stored session exists to update,

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -369,6 +369,150 @@
         opacity: 0.65;
       }
 
+      .tools {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .tools h3 {
+        margin: 0;
+        color: var(--fill-neutral-default);
+        font-size: 0.875rem;
+        font-weight: 400;
+      }
+
+      .tools-modes {
+        display: flex;
+        gap: 1rem;
+        font-size: 0.8125rem;
+      }
+
+      .tools-modes label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        cursor: pointer;
+      }
+
+      .tools-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        border: solid 1px var(--border-neutral-softest);
+        border-radius: 0.5rem;
+        padding: 0.875rem 1rem;
+        background: var(--fill-neutral-default-inverse);
+      }
+
+      .tools-annotations {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+        font-size: 0.8125rem;
+      }
+
+      .tools-annotations label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        cursor: pointer;
+      }
+
+      .tools-annotations .count {
+        color: var(--text-default);
+        font-size: 0.6875rem;
+        font-family: var(--font-diatype-mono);
+      }
+
+      .tools-scopes {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.375rem;
+      }
+
+      .scope-chip {
+        font: inherit;
+        font-size: 0.6875rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        padding: 0.25rem 0.625rem;
+        border: solid 1px var(--border-neutral-softest);
+        border-radius: 999px;
+        background: var(--bg-surface-primary-default);
+        color: var(--text-default);
+        cursor: pointer;
+      }
+
+      .scope-chip:hover {
+        color: var(--fill-neutral-highlight);
+        border-color: var(--color-neutral-700);
+      }
+
+      .tools-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        max-height: 16rem;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        font-size: 0.8125rem;
+      }
+
+      .tools-list label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        padding: 0.125rem 0;
+      }
+
+      .tools-list .tool-name {
+        font-family: var(--font-diatype-mono);
+        word-break: break-all;
+      }
+
+      .tools-list .badge {
+        font-size: 0.625rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        padding: 0.0625rem 0.375rem;
+        border: solid 1px var(--border-neutral-softest);
+        border-radius: 999px;
+        color: var(--text-default);
+        white-space: nowrap;
+      }
+
+      .tools-list li[data-via-annotation] .tool-name {
+        color: var(--text-default-success);
+      }
+
+      .tools-list li[data-via-annotation]::after {
+        content: "included";
+        font-size: 0.625rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        color: var(--text-default-success);
+        margin-left: auto;
+      }
+
+      .tools-list li {
+        display: flex;
+        align-items: center;
+      }
+
+      .tools-list li label {
+        flex: 1;
+      }
+
+      .tools-note {
+        margin: 0;
+        font-size: 0.75rem;
+        color: var(--text-default);
+      }
+
       .actions {
         display: flex;
         gap: 0.75rem;
@@ -655,7 +799,108 @@
           </form>
           {{end}}
         </div>
-        {{end}} {{if .AutoClose}}
+        {{end}}
+
+        {{if and .ToolsSection.Supported (not .FirstParty)}}
+        <div class="tools">
+          <h3>Tool access</h3>
+          <div class="tools-modes">
+            <label>
+              <input
+                type="radio"
+                name="tool_filtering"
+                value="off"
+                form="consent-approve-form"
+                {{if not .ToolsSection.FilteringEnabled}}checked{{end}}
+                data-tool-filtering
+              />
+              All tools
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="tool_filtering"
+                value="on"
+                form="consent-approve-form"
+                {{if .ToolsSection.FilteringEnabled}}checked{{end}}
+                data-tool-filtering
+              />
+              Limit tools
+            </label>
+          </div>
+          <div
+            class="tools-panel"
+            data-tools-panel
+            {{if not .ToolsSection.FilteringEnabled}}hidden{{end}}
+          >
+            <div
+              class="tools-annotations"
+              title="Declared behavior hints from tool authors — not verified safety properties."
+            >
+              {{range .ToolsSection.AnnotationOptions}}
+              <label>
+                <input
+                  type="checkbox"
+                  name="tool_annotations"
+                  value="{{.Value}}"
+                  form="consent-approve-form"
+                  {{if .Checked}}checked{{end}}
+                  data-annotation-checkbox
+                />
+                {{.Label}} <span class="count">{{.Count}}</span>
+              </label>
+              {{end}}
+            </div>
+            {{if .ToolsSection.Scopes}}
+            <div class="tools-scopes">
+              {{range .ToolsSection.Scopes}}
+              <button
+                type="button"
+                class="scope-chip"
+                data-scope-tools="{{.NamesJoined}}"
+              >
+                {{.Tag}} ({{.Count}})
+              </button>
+              {{end}}
+            </div>
+            {{end}}
+            <ul class="tools-list">
+              {{range .ToolsSection.Tools}}
+              <li data-tool-row data-annotations="{{.AnnotationsJoined}}">
+                <label>
+                  <input
+                    type="checkbox"
+                    name="tools"
+                    value="{{.Name}}"
+                    form="consent-approve-form"
+                    {{if .Checked}}checked{{end}}
+                    data-tool-checkbox
+                  />
+                  <span class="tool-name">{{.Name}}</span>
+                  {{range .Annotations}}
+                  <span class="badge">{{.}}</span>
+                  {{end}}
+                </label>
+              </li>
+              {{end}}
+            </ul>
+            {{if .ToolsSection.ProxyExcludedCount}}
+            <p class="tools-note">
+              {{.ToolsSection.ProxyExcludedCount}} external MCP tools are
+              unavailable while limiting tools.
+            </p>
+            {{end}}
+            {{if .ToolsSection.UnannotatedCount}}
+            <p class="tools-note">
+              {{.ToolsSection.UnannotatedCount}} tools carry no annotations and
+              are only included when selected individually.
+            </p>
+            {{end}}
+          </div>
+        </div>
+        {{end}}
+
+        {{if .AutoClose}}
         <p class="info">
           Connection complete. This tab will close automatically.
         </p>

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -58,6 +58,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
@@ -150,6 +151,7 @@ type Service struct {
 	platformToolsets       map[string]platformtools.Toolset
 	authnChallengeCache    cache.TypedCacheObject[AuthnChallengeState]
 	userSessionGrantCache  cache.TypedCacheObject[UserSessionGrant]
+	toolSelectionCache     cache.TypedCacheObject[sessionToolSelectionEntry]
 	// sessionClientInfo holds the MCP client identity captured at initialize
 	// so tools/call on the same session can resolve it. Always usable: without
 	// Redis it records nothing and every caller resolves as unknown.
@@ -258,6 +260,10 @@ type mcpInputs struct {
 	// tools/call expose only tools whose variation row carries one of these
 	// tags. Empty means no filtering.
 	tags []string
+	// toolSelection is the consent-screen tool policy loaded from the
+	// session row by the issuer gate. Nil means all tools; non-nil is always
+	// restrictive and intersects with the live toolset, ?tags=, and RBAC.
+	toolSelection *toolfilter.SessionSelection
 }
 
 func NewService(
@@ -374,6 +380,11 @@ func NewService(
 		),
 		userSessionGrantCache: cache.NewTypedObjectCache[UserSessionGrant](
 			logger.With(attr.SlogCacheNamespace("user_session_grant")),
+			cacheImpl,
+			cache.SuffixNone,
+		),
+		toolSelectionCache: cache.NewTypedObjectCache[sessionToolSelectionEntry](
+			logger.With(attr.SlogCacheNamespace("session_tool_selection")),
 			cacheImpl,
 			cache.SuffixNone,
 		),
@@ -686,7 +697,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	// Legacy toolset-by-slug path has no mcp_server, so there is no
 	// server-level variation group override (ServeToolsetResolved falls back to
 	// the toolset's own column) and no fronting mcp_servers id to record.
-	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, nil, nil, nil)
+	return s.ServeToolsetResolved(w, r, toolset, mcpSlug, "mcp", false, nil, nil, nil, nil)
 }
 
 // ServeToolsetResolved serves an MCP runtime request after the slug has
@@ -725,7 +736,11 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 // off the row.
 //
 // The caller is responsible for closing r.Body.
-func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]string, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID) error {
+// callerToolSelection is the consent-screen tool policy resolved by a
+// caller-side issuer gate (today: /x/mcp's pre-dispatch ApplyIssuerGate run).
+// Nil when the caller ran no gate or the session carries no policy; the
+// in-toolset gate below populates it for /mcp callers.
+func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, skipIssuerGate bool, extraUpstreamTokens map[uuid.UUID]string, callerToolSelection *toolfilter.SessionSelection, mcpServerVariationsGroupID *uuid.UUID, mcpServerID *uuid.UUID) error {
 	ctx := r.Context()
 	var err error
 
@@ -820,11 +835,12 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		// all need to match the caller's surface, not the toolset's
 		// canonical /mcp surface.
 		endpoint := newResolvedMcpEndpointFromToolset(toolset, mcpRouteBase)
-		newCtx, gateTokens, err := s.ApplyIssuerGate(ctx, w, authToken, baseURL, endpoint)
+		newCtx, gateTokens, gateToolSelection, err := s.ApplyIssuerGate(ctx, w, authToken, baseURL, endpoint)
 		if err != nil {
 			return err
 		}
 		ctx = newCtx
+		callerToolSelection = gateToolSelection
 		tokenInputs, err = appendRemoteSessionTokenInputs(tokenInputs, gateTokens)
 		if err != nil {
 			return oops.E(oops.CodeUnexpected, err, "resolve upstream tokens for issuer-gated toolset").LogError(ctx, s.logger)
@@ -1004,6 +1020,7 @@ func (s *Service) ServeToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		toolVariationsGroupID: toolVariationsGroupID,
 		mcpServerID:           mcpServerID,
 		tags:                  tags,
+		toolSelection:         callerToolSelection,
 	}
 
 	// Record the resolved variation group and requested tag filter for

--- a/server/internal/mcp/remotesession_resolver_test.go
+++ b/server/internal/mcp/remotesession_resolver_test.go
@@ -246,12 +246,33 @@ func mintUserSessionBearerForSubject(
 ) string {
 	t.Helper()
 
-	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+	token, jti, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
 		Subject:  subject,
 		Audience: urn.NewToolset(toolset.ID).String(),
 		Issuer:   ti.serverURL.String() + "/mcp/" + toolset.McpSlug.String,
 		Lifetime: time.Hour,
 	})
 	require.NoError(t, err)
+	persistTestUserSession(t, ti, toolset.UserSessionIssuerID.UUID, subject, jti)
 	return token
+}
+
+// persistTestUserSession backs a test-minted JWT with its user_sessions row:
+// the serve path loads the consent tool selection by jti and fails closed
+// when the row is missing, so a bare JWT no longer authenticates.
+func persistTestUserSession(t *testing.T, ti *testInstance, issuerID uuid.UUID, subject urn.SessionSubject, jti string) {
+	t.Helper()
+
+	now := time.Now()
+	_, err := usersessions_repo.New(ti.conn).CreateUserSession(context.Background(), usersessions_repo.CreateUserSessionParams{
+		UserSessionIssuerID: issuerID,
+		UserSessionClientID: uuid.NullUUID{},
+		SubjectUrn:          subject,
+		Jti:                 jti,
+		RefreshTokenHash:    "test-bearer-" + uuid.NewString(),
+		RefreshExpiresAt:    pgtype.Timestamptz{Time: now.Add(24 * time.Hour), Valid: true},
+		ExpiresAt:           pgtype.Timestamptz{Time: now.Add(time.Hour), Valid: true},
+		ToolSelection:       nil,
+	})
+	require.NoError(t, err)
 }

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -124,6 +124,15 @@ func handleToolsCall(
 		recordToolFilterSpan(ctx, len(toolset.Tools), before-len(toolset.Tools))
 	}
 
+	// The consent-screen tool selection narrows the same slice before any
+	// resolution, so a deselected tool surfaces as method-not-found exactly
+	// like a ?tags=-filtered one.
+	if payload.toolSelection != nil {
+		before := len(toolset.Tools)
+		toolset.Tools = toolfilter.FilterToolsBySelection(toolset.Tools, payload.toolSelection)
+		recordToolFilterSpan(ctx, len(toolset.Tools), before-len(toolset.Tools))
+	}
+
 	if payload.mode != ToolModeStatic {
 		switch params.Name {
 		case searchToolsToolName:

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -77,6 +77,15 @@ func handleToolsList(
 		recordToolFilterSpan(ctx, len(toolset.Tools), before-len(toolset.Tools))
 	}
 
+	// The consent-screen tool selection narrows the same slice the ?tags=
+	// filter does, so static mode, dynamic-mode search/describe, and the
+	// call-side lookup all agree on the session's visible tools.
+	if payload.toolSelection != nil {
+		before := len(toolset.Tools)
+		toolset.Tools = toolfilter.FilterToolsBySelection(toolset.Tools, payload.toolSelection)
+		recordToolFilterSpan(ctx, len(toolset.Tools), before-len(toolset.Tools))
+	}
+
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		if err := productMetrics.CaptureEvent(ctx, "mcp_server_count", payload.sessionID, map[string]any{
 			"project_id":           payload.projectID.String(),

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	"github.com/speakeasy-api/gram/server/internal/mcpendpoints"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
@@ -128,19 +129,21 @@ func (s *Service) serveResolvedMCPEndpoint(
 	// remote-backed proxying forwards the upstream remote-session token
 	// via AuthorizationOverride.
 	var upstreamTokens map[uuid.UUID]string
+	var sessionToolSelection *toolfilter.SessionSelection
 	var wwwAuthenticate string
 	if issuerGated {
 		resolvedEndpoint, err := s.BuildResolvedMcpEndpointForServer(ctx, logger, mcpEndpoint, mcpServer, mcpRouteBase)
 		if err != nil {
 			return err
 		}
-		newCtx, tokens, err := s.ApplyIssuerGate(ctx, w, httpheaders.AuthorizationBearerToken(r), s.BaseURLForRequest(r), resolvedEndpoint)
+		newCtx, tokens, toolSelection, err := s.ApplyIssuerGate(ctx, w, httpheaders.AuthorizationBearerToken(r), s.BaseURLForRequest(r), resolvedEndpoint)
 		if err != nil {
 			return fmt.Errorf("apply issuer gate: %w", err)
 		}
 		ctx = newCtx
 		r = r.WithContext(ctx)
 		upstreamTokens = tokens
+		sessionToolSelection = toolSelection
 
 		// Issuer-gated clients authenticate with this server's AS, so an
 		// upstream 401/403 relayed by the proxy must challenge them with
@@ -154,16 +157,21 @@ func (s *Service) serveResolvedMCPEndpoint(
 	}
 
 	switch {
-	case mcpServer.RemoteMcpServerID.Valid:
-		upstreamToken, err := singleUpstreamToken(upstreamTokens)
-		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "resolve upstream token for remote MCP backend").LogError(ctx, logger)
+	case mcpServer.RemoteMcpServerID.Valid, mcpServer.TunneledMcpServerID.Valid:
+		// The consent picker is never offered for remote/tunneled backends,
+		// and the gate rejects any restrictive selection bound to another
+		// endpoint, so reaching here with a policy means a code path started
+		// offering the picker without adding proxy-side enforcement. Refuse
+		// rather than silently serving every upstream tool.
+		if sessionToolSelection != nil {
+			return oops.E(oops.CodeUnexpected, nil, "session tool selection is not enforceable on proxied MCP backends").LogError(ctx, logger)
 		}
-		return s.serveRemoteBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken, wwwAuthenticate)
-	case mcpServer.TunneledMcpServerID.Valid:
 		upstreamToken, err := singleUpstreamToken(upstreamTokens)
 		if err != nil {
-			return oops.E(oops.CodeUnexpected, err, "resolve upstream token for tunneled MCP backend").LogError(ctx, logger)
+			return oops.E(oops.CodeUnexpected, err, "resolve upstream token for proxied MCP backend").LogError(ctx, logger)
+		}
+		if mcpServer.RemoteMcpServerID.Valid {
+			return s.serveRemoteBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken, wwwAuthenticate)
 		}
 		return s.serveTunneledBackend(w, r, logger, mcpEndpoint, mcpServer, upstreamToken, wwwAuthenticate)
 	case mcpServer.ToolsetID.Valid:
@@ -193,7 +201,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			mcpServerVariationsGroupID = &id
 		}
 
-		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamTokens, mcpServerVariationsGroupID, &mcpServer.ID); err != nil {
+		if err := s.ServeToolsetResolved(w, r, &toolset, slug, mcpRouteBase, issuerGated, upstreamTokens, sessionToolSelection, mcpServerVariationsGroupID, &mcpServer.ID); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -674,13 +674,14 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_ResolvesG
 	// the issuer URN (remote-backed endpoints bind the audience to the
 	// issuer, not the backend id). Subject is the dev user, an active member
 	// of the org, so PrepareContext can resolve principals.
-	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+	token, jti, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
 		Subject:  urn.NewUserSubject(mockidp.MockUserID),
 		Audience: urn.NewUserSessionIssuer(issuerID).String(),
 		Issuer:   ti.serverURL.String() + "/x/mcp/" + endpointSlug,
 		Lifetime: time.Hour,
 	})
 	require.NoError(t, err)
+	persistTestUserSession(t, ti, issuerID, urn.NewUserSubject(mockidp.MockUserID), jti)
 
 	// A plain context (no session auth) so the only credential is the bearer
 	// JWT, exactly as a real Remote MCP client would present it.
@@ -738,13 +739,14 @@ func TestServePublic_McpEndpoint_IssuerGatedPrivateRemote_RBACEnforced_RequiresC
 	endpointSlug := "endpoint-" + uuid.NewString()
 	mcpServer, _ := createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, upstream.URL, endpointSlug, "private", issuerID)
 
-	token, _, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
+	token, jti, err := usersessions.NewSigner("test-jwt-secret").Mint(usersessions.MintParams{
 		Subject:  urn.NewUserSubject(mockidp.MockUserID),
 		Audience: urn.NewUserSessionIssuer(issuerID).String(),
 		Issuer:   ti.serverURL.String() + "/x/mcp/" + endpointSlug,
 		Lifetime: time.Hour,
 	})
 	require.NoError(t, err)
+	persistTestUserSession(t, ti, issuerID, urn.NewUserSubject(mockidp.MockUserID), jti)
 
 	_, err = servePublicHTTP(t, context.Background(), ti, endpointSlug, makeInitializeBody(), token, nil)
 	require.Error(t, err)

--- a/server/internal/mcp/toolfilter/selection.go
+++ b/server/internal/mcp/toolfilter/selection.go
@@ -1,0 +1,145 @@
+package toolfilter
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+// Annotation names a raw MCP tool hint the consent screen can filter on.
+// These are declared behavior hints supplied by tool authors, not verified
+// safety properties.
+const (
+	AnnotationReadOnly    = "read_only"
+	AnnotationDestructive = "destructive"
+	AnnotationIdempotent  = "idempotent"
+	AnnotationOpenWorld   = "open_world"
+)
+
+// KnownAnnotations is the fixed vocabulary consent forms may submit, in
+// display order.
+var KnownAnnotations = []string{
+	AnnotationReadOnly,
+	AnnotationDestructive,
+	AnnotationIdempotent,
+	AnnotationOpenWorld,
+}
+
+// SessionSelection is the consent-screen tool policy persisted on
+// user_sessions.tool_selection. A nil selection (NULL column) means every
+// tool — the only all-tools representation. Any non-nil selection is
+// restrictive: a tool passes iff one of its RAW hints is explicitly true for
+// a selected annotation, OR its name is listed. Both axes empty means zero
+// tools.
+type SessionSelection struct {
+	// Annotations are live grants against the fixed vocabulary above: a tool
+	// that later acquires a selected hint joins the session.
+	Annotations []string `json:"annotations,omitempty"`
+	// Tools are snapshot grants by tool name. Consent-time group picks are
+	// pre-expanded into names so later group-membership changes cannot widen
+	// a live session.
+	Tools []string `json:"tools,omitempty"`
+	// Resource pins the selection to the endpoint whose tool inventory the
+	// user consented on: "mcp_server:<uuid>" or "toolset:<uuid>". Session
+	// tokens are portable across endpoints sharing an issuer, so a selection
+	// served against a different resource is rejected, never reinterpreted.
+	Resource string `json:"resource"`
+}
+
+// ParseSessionSelection decodes a stored tool_selection document. A stored
+// policy with no resource is malformed — callers fail closed on error.
+// Unknown stored annotation values are dropped (not an error) and reported
+// in dropped so callers can log them: during a mixed-version deploy that
+// fails narrower rather than wider.
+func ParseSessionSelection(raw []byte) (sel *SessionSelection, dropped []string, err error) {
+	if len(raw) == 0 {
+		return nil, nil, nil
+	}
+	var decoded SessionSelection
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, nil, fmt.Errorf("decode tool selection: %w", err)
+	}
+	if decoded.Resource == "" {
+		return nil, nil, fmt.Errorf("tool selection missing resource binding")
+	}
+	known := decoded.Annotations[:0]
+	for _, a := range decoded.Annotations {
+		if slices.Contains(KnownAnnotations, a) {
+			known = append(known, a)
+		} else {
+			dropped = append(dropped, a)
+		}
+	}
+	decoded.Annotations = known
+	return &decoded, dropped, nil
+}
+
+// MatchesAnnotations reports whether any selected annotation's raw hint is
+// explicitly true on the tool. Nil and false hints are identical (fail
+// closed). Deliberately NOT the priority-collapsed disposition used by RBAC:
+// a tool carrying readOnlyHint and idempotentHint matches either selection.
+func (s *SessionSelection) MatchesAnnotations(annotations *types.ToolAnnotations) bool {
+	if s == nil || annotations == nil {
+		return false
+	}
+	hintTrue := func(hint *bool) bool { return hint != nil && *hint }
+	for _, a := range s.Annotations {
+		switch a {
+		case AnnotationReadOnly:
+			if hintTrue(annotations.ReadOnlyHint) {
+				return true
+			}
+		case AnnotationDestructive:
+			if hintTrue(annotations.DestructiveHint) {
+				return true
+			}
+		case AnnotationIdempotent:
+			if hintTrue(annotations.IdempotentHint) {
+				return true
+			}
+		case AnnotationOpenWorld:
+			if hintTrue(annotations.OpenWorldHint) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FilterToolsBySelection intersects tools with a session selection. A nil
+// selection returns the slice untouched. Proxy/external-MCP placeholders are
+// dropped from every restrictive selection: their callable names exist only
+// after upstream unfolding and their hints cannot be verified call-side, so
+// they fail closed.
+func FilterToolsBySelection(tools []*types.Tool, sel *SessionSelection) []*types.Tool {
+	if sel == nil {
+		return tools
+	}
+
+	names := make(map[string]struct{}, len(sel.Tools))
+	for _, name := range sel.Tools {
+		names[name] = struct{}{}
+	}
+
+	filtered := make([]*types.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if tool == nil || conv.IsProxyTool(tool) {
+			continue
+		}
+		base, err := conv.ToBaseTool(tool)
+		if err != nil {
+			continue
+		}
+		if _, ok := names[base.Name]; ok {
+			filtered = append(filtered, tool)
+			continue
+		}
+		if sel.MatchesAnnotations(base.Annotations) {
+			filtered = append(filtered, tool)
+		}
+	}
+	return filtered
+}

--- a/server/internal/mcp/toolfilter/selection_test.go
+++ b/server/internal/mcp/toolfilter/selection_test.go
@@ -1,0 +1,140 @@
+package toolfilter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+func httpToolWithAnnotations(name string, annotations *types.ToolAnnotations) *types.Tool {
+	return &types.Tool{
+		HTTPToolDefinition: &types.HTTPToolDefinition{Name: name, Annotations: annotations},
+	}
+}
+
+func proxyTool(name string) *types.Tool {
+	proxy := "proxy"
+	return &types.Tool{
+		ExternalMcpToolDefinition: &types.ExternalMCPToolDefinition{Name: name, Type: &proxy},
+	}
+}
+
+func TestParseSessionSelection_NullMeansAll(t *testing.T) {
+	t.Parallel()
+
+	sel, dropped, err := ParseSessionSelection(nil)
+	require.NoError(t, err)
+	require.Nil(t, sel)
+	require.Empty(t, dropped)
+}
+
+func TestParseSessionSelection_MissingResourceFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseSessionSelection([]byte(`{"annotations":["read_only"]}`))
+	require.Error(t, err)
+}
+
+func TestParseSessionSelection_MalformedFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseSessionSelection([]byte(`{`))
+	require.Error(t, err)
+}
+
+func TestParseSessionSelection_UnknownStoredAnnotationsDropped(t *testing.T) {
+	t.Parallel()
+
+	sel, dropped, err := ParseSessionSelection([]byte(`{"annotations":["read_only","sneaky_future_value"],"resource":"toolset:x"}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{AnnotationReadOnly}, sel.Annotations)
+	require.Equal(t, []string{"sneaky_future_value"}, dropped)
+}
+
+func TestMatchesAnnotations_RawHintsNotDisposition(t *testing.T) {
+	t.Parallel()
+
+	// readOnlyHint outranks idempotentHint in the RBAC disposition collapse;
+	// the selection matcher must still see the idempotent hint.
+	annotations := &types.ToolAnnotations{
+		Title:           nil,
+		ReadOnlyHint:    new(true),
+		DestructiveHint: nil,
+		IdempotentHint:  new(true),
+		OpenWorldHint:   nil,
+	}
+	require.Equal(t, "read_only", conv.DispositionFromAnnotations(annotations))
+
+	sel := &SessionSelection{Annotations: []string{AnnotationIdempotent}, Tools: nil, Resource: "toolset:x"}
+	require.True(t, sel.MatchesAnnotations(annotations))
+}
+
+func TestMatchesAnnotations_NilAndFalseFailClosed(t *testing.T) {
+	t.Parallel()
+
+	sel := &SessionSelection{Annotations: []string{AnnotationReadOnly}, Tools: nil, Resource: "toolset:x"}
+	require.False(t, sel.MatchesAnnotations(nil))
+	require.False(t, sel.MatchesAnnotations(&types.ToolAnnotations{
+		Title:           nil,
+		ReadOnlyHint:    new(false),
+		DestructiveHint: nil,
+		IdempotentHint:  nil,
+		OpenWorldHint:   nil,
+	}))
+}
+
+func TestFilterToolsBySelection_NilSelectionPassthrough(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{httpToolWithAnnotations("a", nil), proxyTool("p")}
+	require.Equal(t, tools, FilterToolsBySelection(tools, nil))
+}
+
+func TestFilterToolsBySelection_UnionOfAnnotationsAndNames(t *testing.T) {
+	t.Parallel()
+
+	readOnly := httpToolWithAnnotations("reader", &types.ToolAnnotations{
+		Title:           nil,
+		ReadOnlyHint:    new(true),
+		DestructiveHint: nil,
+		IdempotentHint:  nil,
+		OpenWorldHint:   nil,
+	})
+	writer := httpToolWithAnnotations("writer", nil)
+	other := httpToolWithAnnotations("other", nil)
+
+	sel := &SessionSelection{
+		Annotations: []string{AnnotationReadOnly},
+		Tools:       []string{"writer"},
+		Resource:    "toolset:x",
+	}
+	filtered := FilterToolsBySelection([]*types.Tool{readOnly, writer, other}, sel)
+	require.Len(t, filtered, 2)
+	require.Equal(t, "reader", filtered[0].HTTPToolDefinition.Name)
+	require.Equal(t, "writer", filtered[1].HTTPToolDefinition.Name)
+}
+
+func TestFilterToolsBySelection_EmptyAxesMeanZeroTools(t *testing.T) {
+	t.Parallel()
+
+	tools := []*types.Tool{httpToolWithAnnotations("a", nil)}
+	sel := &SessionSelection{Annotations: nil, Tools: nil, Resource: "toolset:x"}
+	require.Empty(t, FilterToolsBySelection(tools, sel))
+}
+
+func TestFilterToolsBySelection_ProxyToolsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	// A proxy placeholder is dropped from every restrictive selection even
+	// when its name is explicitly listed: its callable names exist only
+	// after upstream unfolding and its hints cannot be verified call-side.
+	sel := &SessionSelection{
+		Annotations: []string{AnnotationReadOnly},
+		Tools:       []string{"p"},
+		Resource:    "toolset:x",
+	}
+	require.Empty(t, FilterToolsBySelection([]*types.Tool{proxyTool("p")}, sel))
+}

--- a/server/internal/mcp/toolselection.go
+++ b/server/internal/mcp/toolselection.go
@@ -1,0 +1,116 @@
+// Serve-path loading of the consent-screen tool selection. The session JWT
+// stays standard-claims-only, so the policy lives on the user_sessions row
+// and is pulled per request through a short-TTL Redis cache keyed by
+// (issuer, jti). Failures reject the request (fail closed) — a policy store
+// outage must never widen a restrictive session to all tools.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// sessionToolSelectionTTL bounds staleness of the cached policy. The jti in
+// the key rotates on every refresh-token slide, so a rotated session never
+// reads a predecessor's entry; the TTL only bounds how long a same-jti
+// revision (there are none today — rows are written once) could lag.
+const sessionToolSelectionTTL = 5 * time.Minute
+
+// errToolSelectionResourceMismatch marks a restrictive selection presented
+// against an endpoint other than the one it was consented on. Session tokens
+// are issuer-scoped and portable across endpoints sharing the issuer, so the
+// caller must 401 into reauth rather than reinterpret the policy.
+var errToolSelectionResourceMismatch = errors.New("session tool selection is bound to a different endpoint")
+
+// sessionToolSelectionEntry is the cached (issuer, jti) -> raw policy row.
+type sessionToolSelectionEntry struct {
+	IssuerID string `json:"issuer_id"`
+	JTI      string `json:"jti"`
+	// Selection is the raw tool_selection document; empty means NULL (all
+	// tools). Kept raw so the cache round-trip cannot normalize away a parse
+	// failure — parsing (and its fail-closed error) happens on every read.
+	Selection []byte `json:"selection,omitempty"`
+}
+
+func sessionToolSelectionCacheKey(issuerID, jti string) string {
+	return "sessionToolSelection:" + issuerID + ":" + jti
+}
+
+// CacheKey implements cache.CacheableObject.
+func (e sessionToolSelectionEntry) CacheKey() string {
+	return sessionToolSelectionCacheKey(e.IssuerID, e.JTI)
+}
+
+// AdditionalCacheKeys implements cache.CacheableObject.
+func (e sessionToolSelectionEntry) AdditionalCacheKeys() []string { return []string{} }
+
+// TTL implements cache.CacheableObject.
+func (e sessionToolSelectionEntry) TTL() time.Duration { return sessionToolSelectionTTL }
+
+// endpointToolSelectionResource is the server-authored identity a consent
+// selection binds to: the fronting mcp_server when there is one, else the
+// toolset. Empty when the endpoint has neither (remote/tunneled backends do
+// not offer the picker).
+func endpointToolSelectionResource(endpoint *ResolvedMcpEndpoint) string {
+	switch {
+	case endpoint.McpServerID.Valid:
+		return "mcp_server:" + endpoint.McpServerID.UUID.String()
+	case endpoint.ToolsetID.Valid:
+		return "toolset:" + endpoint.ToolsetID.UUID.String()
+	default:
+		return ""
+	}
+}
+
+// loadSessionToolSelection resolves the tool policy for a validated session
+// jti. Returns nil for an all-tools session. Any error means the request
+// must be rejected: missing row (a live jti always has one — refresh
+// rotation revokes the old jti before soft-deleting its row), database
+// failure, or a malformed stored policy.
+func (s *Service) loadSessionToolSelection(ctx context.Context, endpoint *ResolvedMcpEndpoint, jti string) (*toolfilter.SessionSelection, error) {
+	issuerID := endpoint.UserSessionIssuerID.String()
+
+	var raw []byte
+	if cached, err := s.toolSelectionCache.Get(ctx, sessionToolSelectionCacheKey(issuerID, jti)); err == nil {
+		raw = cached.Selection
+	} else {
+		row, derr := usersessions_repo.New(s.db).GetUserSessionToolSelectionByJTI(ctx, usersessions_repo.GetUserSessionToolSelectionByJTIParams{
+			UserSessionIssuerID: endpoint.UserSessionIssuerID,
+			Jti:                 jti,
+		})
+		if derr != nil {
+			if errors.Is(derr, pgx.ErrNoRows) {
+				return nil, fmt.Errorf("user session row not found for jti")
+			}
+			return nil, fmt.Errorf("load session tool selection: %w", derr)
+		}
+		raw = row.ToolSelection
+		if cerr := s.toolSelectionCache.Store(ctx, sessionToolSelectionEntry{
+			IssuerID:  issuerID,
+			JTI:       jti,
+			Selection: raw,
+		}); cerr != nil {
+			s.logger.WarnContext(ctx, "cache session tool selection", attr.SlogError(cerr))
+		}
+	}
+
+	sel, dropped, err := toolfilter.ParseSessionSelection(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse stored tool selection: %w", err)
+	}
+	if len(dropped) > 0 {
+		s.logger.WarnContext(ctx, "dropped unknown stored tool selection annotations",
+			attr.SlogValueAny(dropped),
+		)
+	}
+	return sel, nil
+}

--- a/server/internal/mcp/toolselection_integration_test.go
+++ b/server/internal/mcp/toolselection_integration_test.go
@@ -1,0 +1,285 @@
+package mcp_test
+
+// Integration coverage for the consent-screen tool selection on the serve
+// path: the policy loads for anonymous subjects, narrows tools/list and
+// tools/call identically, fails closed on resource mismatch / malformed
+// policies / missing session rows, and NULL still means all tools.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	deployments_repo "github.com/speakeasy-api/gram/server/internal/deployments/repo"
+	tools_repo "github.com/speakeasy-api/gram/server/internal/tools/repo"
+	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usersessions"
+	usersessions_repo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
+)
+
+// seedSelectionToolset builds a PUBLIC issuer-gated toolset with three HTTP
+// tools: reader (readOnlyHint true), writer and eraser (unannotated). Public
+// keeps RBAC out of the way and exercises the anonymous-subject path — the
+// one that early-returns before AuthContext is stamped.
+func seedSelectionToolset(t *testing.T, ctx context.Context, ti *testInstance) (toolsets_repo.Toolset, usersessions_repo.UserSessionIssuer) {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "selection-"+uuid.NewString()[:8])
+
+	deploymentID, err := deployments_repo.New(ti.conn).InsertDeployment(ctx, deployments_repo.InsertDeploymentParams{
+		ProjectID:      toolset.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         "test-user",
+		IdempotencyKey: uuid.New().String(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, deployments_repo.New(ti.conn).CreateDeploymentStatus(ctx, deployments_repo.CreateDeploymentStatusParams{
+		DeploymentID: deploymentID,
+		Status:       "completed",
+	}))
+
+	toolURNs := make([]urn.Tool, 0, 3)
+	for _, tool := range []struct {
+		name     string
+		readOnly pgtype.Bool
+	}{
+		{name: "reader", readOnly: pgtype.Bool{Bool: true, Valid: true}},
+		{name: "writer", readOnly: pgtype.Bool{}},
+		{name: "eraser", readOnly: pgtype.Bool{}},
+	} {
+		toolURN := urn.NewTool(urn.ToolKindHTTP, tool.name, uuid.New().String()[:8])
+		toolURNs = append(toolURNs, toolURN)
+		require.NoError(t, tools_repo.New(ti.conn).CreateHTTPToolDefinition(ctx, tools_repo.CreateHTTPToolDefinitionParams{
+			ProjectID:       toolset.ProjectID,
+			DeploymentID:    deploymentID,
+			ToolUrn:         toolURN,
+			Name:            tool.name,
+			UntruncatedName: pgtype.Text{},
+			Summary:         tool.name + " summary",
+			Description:     tool.name + " description",
+			Tags:            []string{},
+			HttpMethod:      "GET",
+			Path:            "/test",
+			SchemaVersion:   "3.0.0",
+			Schema:          []byte(`{}`),
+			ServerEnvVar:    "TEST_SERVER_URL",
+			Security:        []byte(`[]`),
+			HeaderSettings:  []byte(`{}`),
+			QuerySettings:   []byte(`{}`),
+			PathSettings:    []byte(`{}`),
+			ReadOnlyHint:    tool.readOnly,
+			DestructiveHint: pgtype.Bool{},
+			IdempotentHint:  pgtype.Bool{},
+			OpenWorldHint:   pgtype.Bool{},
+		}))
+	}
+	_, err = toolsetsRepo.CreateToolsetVersion(ctx, toolsets_repo.CreateToolsetVersionParams{
+		ToolsetID:     toolset.ID,
+		Version:       1,
+		ToolUrns:      toolURNs,
+		ResourceUrns:  []urn.Resource{},
+		PredecessorID: uuid.NullUUID{},
+	})
+	require.NoError(t, err)
+
+	issuer, err := usersessions_repo.New(ti.conn).CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
+		ProjectID:          toolset.ProjectID,
+		Slug:               toolset.Slug + "-issuer",
+		AuthnChallengeMode: "interactive",
+		SessionDuration:    pgtype.Interval{Microseconds: int64(24 * time.Hour / time.Microsecond), Valid: true},
+	})
+	require.NoError(t, err)
+	toolset, err = toolsetsRepo.UpdateToolsetUserSessionIssuer(ctx, toolsets_repo.UpdateToolsetUserSessionIssuerParams{
+		UserSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+		Slug:                toolset.Slug,
+		ProjectID:           toolset.ProjectID,
+	})
+	require.NoError(t, err)
+
+	return toolset, issuer
+}
+
+// mintSelectionSession signs a session JWT with the test signer and persists
+// its user_sessions row carrying the given raw tool_selection (nil = NULL).
+func mintSelectionSession(t *testing.T, ctx context.Context, ti *testInstance, toolset toolsets_repo.Toolset, issuer usersessions_repo.UserSessionIssuer, selection []byte) string {
+	t.Helper()
+
+	signer := usersessions.NewSigner("test-jwt-secret")
+	subject := urn.NewAnonymousSubject(uuid.NewString())
+	access, jti, err := signer.Mint(usersessions.MintParams{
+		Subject:  subject,
+		Audience: urn.NewToolset(toolset.ID).String(),
+		Issuer:   "https://test.example",
+		Lifetime: time.Hour,
+		ClientID: "test-client",
+	})
+	require.NoError(t, err)
+
+	now := time.Now()
+	_, err = usersessions_repo.New(ti.conn).CreateUserSession(ctx, usersessions_repo.CreateUserSessionParams{
+		UserSessionIssuerID: issuer.ID,
+		UserSessionClientID: uuid.NullUUID{},
+		SubjectUrn:          subject,
+		Jti:                 jti,
+		RefreshTokenHash:    "test-selection-" + uuid.NewString(),
+		RefreshExpiresAt:    pgtype.Timestamptz{Time: now.Add(24 * time.Hour), Valid: true},
+		ExpiresAt:           pgtype.Timestamptz{Time: now.Add(time.Hour), Valid: true},
+		ToolSelection:       selection,
+	})
+	require.NoError(t, err)
+	return access
+}
+
+func TestToolSelection_NullSelectionServesAllTools(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, nil)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.ElementsMatch(t, []string{"reader", "writer", "eraser"}, names)
+}
+
+func TestToolSelection_NameSnapshotNarrowsListAndCall(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	selection := fmt.Appendf(nil, `{"tools":["writer"],"resource":"toolset:%s"}`, toolset.ID)
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, selection)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.Equal(t, []string{"writer"}, names)
+
+	// tools/call parity: a deselected tool is method-not-found; the selected
+	// one resolves past the filter (its execution then fails on the missing
+	// upstream env, which is fine — it must NOT be "tool not found").
+	w, err = servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsCallBody("reader"), access, nil)
+	if err != nil {
+		require.Contains(t, err.Error(), "not found")
+	} else {
+		require.Contains(t, w.Body.String(), "not found")
+	}
+
+	w, err = servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsCallBody("writer"), access, nil)
+	combined := w.Body.String()
+	if err != nil {
+		combined += err.Error()
+	}
+	require.NotContains(t, combined, "tool not found")
+}
+
+func TestToolSelection_AnnotationAxisMatchesRawHints(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	selection := fmt.Appendf(nil, `{"annotations":["read_only"],"resource":"toolset:%s"}`, toolset.ID)
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, selection)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.Equal(t, []string{"reader"}, names)
+}
+
+func TestToolSelection_UnionOfAnnotationsAndNames(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	selection := fmt.Appendf(nil, `{"annotations":["read_only"],"tools":["eraser"],"resource":"toolset:%s"}`, toolset.ID)
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, selection)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	names := toolNames(parseToolsListResponse(t, w.Body.Bytes()))
+	require.ElementsMatch(t, []string{"reader", "eraser"}, names)
+}
+
+func TestToolSelection_EmptyPolicyMeansZeroTools(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	selection := fmt.Appendf(nil, `{"resource":"toolset:%s"}`, toolset.ID)
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, selection)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Empty(t, toolNames(parseToolsListResponse(t, w.Body.Bytes())))
+}
+
+func TestToolSelection_ResourceMismatchRejects(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	// Bound to a different endpoint sharing the issuer: must 401 into
+	// reauth, never be reinterpreted against this endpoint's inventory.
+	selection := fmt.Appendf(nil, `{"tools":["writer"],"resource":"toolset:%s"}`, uuid.NewString())
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, selection)
+
+	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired or invalid access token")
+}
+
+func TestToolSelection_MalformedStoredPolicyRejects(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, issuer := seedSelectionToolset(t, ctx, ti)
+	// Missing resource binding — fail closed, never "all tools".
+	access := mintSelectionSession(t, ctx, ti, toolset, issuer, []byte(`{"annotations":["read_only"]}`))
+
+	_, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expired or invalid access token")
+}
+
+func TestToolSelection_MissingSessionRowRejects(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset, _ := seedSelectionToolset(t, ctx, ti)
+
+	// Valid signature, but no user_sessions row for the jti: the policy
+	// lookup fails closed rather than serving all tools.
+	signer := usersessions.NewSigner("test-jwt-secret")
+	access, _, err := signer.Mint(usersessions.MintParams{
+		Subject:  urn.NewAnonymousSubject(uuid.NewString()),
+		Audience: urn.NewToolset(toolset.ID).String(),
+		Issuer:   "https://test.example",
+		Lifetime: time.Hour,
+		ClientID: "test-client",
+	})
+	require.NoError(t, err)
+
+	_, serveErr := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), access, nil)
+	require.Error(t, serveErr)
+	require.Contains(t, serveErr.Error(), "expired or invalid access token")
+}

--- a/server/internal/mcp/types.go
+++ b/server/internal/mcp/types.go
@@ -101,5 +101,6 @@ func (m *McpInputs) toInternal() *mcpInputs {
 		toolVariationsGroupID: nil,
 		mcpServerID:           nil,
 		tags:                  nil,
+		toolSelection:         nil,
 	}
 }

--- a/server/internal/usersessions/minthandler.go
+++ b/server/internal/usersessions/minthandler.go
@@ -149,6 +149,7 @@ func (s *Service) MintUserSession(ctx context.Context, payload *gen.MintUserSess
 		RefreshTokenHash: fmt.Sprintf("%s:%s", dashboardMintRefreshTokenHashPrefix, jti),
 		ExpiresAt:        pgtype.Timestamptz{Time: now.Add(mintAccessTokenLifetime), InfinityModifier: 0, Valid: true},
 		RefreshExpiresAt: pgtype.Timestamptz{Time: now.Add(refreshLifetime), InfinityModifier: 0, Valid: true},
+		ToolSelection:    nil,
 	}); err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "persist user session").LogError(ctx, s.logger)
 	}

--- a/server/internal/usersessions/queries.sql
+++ b/server/internal/usersessions/queries.sql
@@ -366,6 +366,36 @@ WHERE user_session_issuer_id = @user_session_issuer_id
   AND deleted IS FALSE
 RETURNING *;
 
+-- name: GetUserSessionToolSelectionByJTI :one
+-- Serve-path lookup for the consent-screen tool selection, keyed the same way
+-- runtime requests are addressed (issuer + jti). Deliberately narrow: request
+-- handling must not haul refresh-token material around. Project scoping is
+-- intentionally NOT applied here -- the OAuth surface is public and the
+-- issuer_id is the authoritative scope.
+SELECT tool_selection, expires_at
+FROM user_sessions
+WHERE user_session_issuer_id = @user_session_issuer_id
+  AND jti = @jti
+  AND deleted IS FALSE;
+
+-- name: GetLatestLiveUserSessionToolSelection :one
+-- Reauth prefill: the identified subject's newest live restrictive policy
+-- for the same issuer + client + endpoint resource. Filtering by resource in
+-- SQL keeps a newer session on a sibling endpoint from shadowing this
+-- endpoint's policy. Anonymous subjects never prefill (each authorization
+-- mints a fresh random subject).
+SELECT tool_selection
+FROM user_sessions
+WHERE project_id = @project_id
+  AND user_session_issuer_id = @user_session_issuer_id
+  AND user_session_client_id = @user_session_client_id
+  AND subject_urn = @subject_urn
+  AND tool_selection ->> 'resource' = @resource::text
+  AND deleted IS FALSE
+  AND refresh_expires_at > clock_timestamp()
+ORDER BY created_at DESC, id DESC
+LIMIT 1;
+
 -- name: GetUserSessionByJTI :one
 -- Looks up the session row by jti, scoped to the issuer. Used by the OAuth
 -- /revoke endpoint to verify a presented access token belongs to the
@@ -476,7 +506,8 @@ INSERT INTO user_sessions (
     jti,
     refresh_token_hash,
     refresh_expires_at,
-    expires_at
+    expires_at,
+    tool_selection
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = @user_session_issuer_id),
@@ -486,7 +517,8 @@ VALUES (
     @jti,
     @refresh_token_hash,
     @refresh_expires_at,
-    @expires_at
+    @expires_at,
+    @tool_selection
 )
 RETURNING *;
 

--- a/server/internal/usersessions/repo/models.go
+++ b/server/internal/usersessions/repo/models.go
@@ -20,6 +20,7 @@ type UserSession struct {
 	RefreshTokenHash    string
 	RefreshExpiresAt    pgtype.Timestamptz
 	ExpiresAt           pgtype.Timestamptz
+	ToolSelection       []byte
 	CreatedAt           pgtype.Timestamptz
 	UpdatedAt           pgtype.Timestamptz
 	DeletedAt           pgtype.Timestamptz

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -34,7 +34,7 @@ VALUES (
     $6,
     $7
 )
-RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateUserSessionParams struct {
@@ -71,6 +71,7 @@ func (q *Queries) CreateUserSession(ctx context.Context, arg CreateUserSessionPa
 		&i.RefreshTokenHash,
 		&i.RefreshExpiresAt,
 		&i.ExpiresAt,
+		&i.ToolSelection,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -402,7 +403,7 @@ func (q *Queries) DeleteUserSessionIssuerCimdClient(ctx context.Context, arg Del
 }
 
 const getUserSessionByID = `-- name: GetUserSessionByID :one
-SELECT s.id, s.project_id, s.user_session_issuer_id, s.user_session_client_id, s.subject_urn, s.jti, s.refresh_token_hash, s.refresh_expires_at, s.expires_at, s.created_at, s.updated_at, s.deleted_at, s.deleted
+SELECT s.id, s.project_id, s.user_session_issuer_id, s.user_session_client_id, s.subject_urn, s.jti, s.refresh_token_hash, s.refresh_expires_at, s.expires_at, s.tool_selection, s.created_at, s.updated_at, s.deleted_at, s.deleted
 FROM user_sessions AS s
 JOIN user_session_issuers AS iss ON iss.id = s.user_session_issuer_id
 WHERE s.id = $1 AND iss.project_id = $2 AND s.deleted IS FALSE
@@ -428,6 +429,7 @@ func (q *Queries) GetUserSessionByID(ctx context.Context, arg GetUserSessionByID
 		&i.RefreshTokenHash,
 		&i.RefreshExpiresAt,
 		&i.ExpiresAt,
+		&i.ToolSelection,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -437,7 +439,7 @@ func (q *Queries) GetUserSessionByID(ctx context.Context, arg GetUserSessionByID
 }
 
 const getUserSessionByJTI = `-- name: GetUserSessionByJTI :one
-SELECT id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 FROM user_sessions
 WHERE user_session_issuer_id = $1
   AND jti = $2
@@ -466,6 +468,7 @@ func (q *Queries) GetUserSessionByJTI(ctx context.Context, arg GetUserSessionByJ
 		&i.RefreshTokenHash,
 		&i.RefreshExpiresAt,
 		&i.ExpiresAt,
+		&i.ToolSelection,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -475,7 +478,7 @@ func (q *Queries) GetUserSessionByJTI(ctx context.Context, arg GetUserSessionByJ
 }
 
 const getUserSessionByRefreshTokenHash = `-- name: GetUserSessionByRefreshTokenHash :one
-SELECT id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 FROM user_sessions
 WHERE user_session_issuer_id = $1
   AND refresh_token_hash = $2
@@ -505,6 +508,7 @@ func (q *Queries) GetUserSessionByRefreshTokenHash(ctx context.Context, arg GetU
 		&i.RefreshTokenHash,
 		&i.RefreshExpiresAt,
 		&i.ExpiresAt,
+		&i.ToolSelection,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -1252,7 +1256,7 @@ WHERE s.id = $1
   AND iss.id = s.user_session_issuer_id
   AND iss.project_id = $2
   AND s.deleted IS FALSE
-RETURNING s.id, s.project_id, s.user_session_issuer_id, s.user_session_client_id, s.subject_urn, s.jti, s.refresh_token_hash, s.refresh_expires_at, s.expires_at, s.created_at, s.updated_at, s.deleted_at, s.deleted
+RETURNING s.id, s.project_id, s.user_session_issuer_id, s.user_session_client_id, s.subject_urn, s.jti, s.refresh_token_hash, s.refresh_expires_at, s.expires_at, s.tool_selection, s.created_at, s.updated_at, s.deleted_at, s.deleted
 `
 
 type RevokeUserSessionParams struct {
@@ -1276,6 +1280,7 @@ func (q *Queries) RevokeUserSession(ctx context.Context, arg RevokeUserSessionPa
 		&i.RefreshTokenHash,
 		&i.RefreshExpiresAt,
 		&i.ExpiresAt,
+		&i.ToolSelection,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -1290,7 +1295,7 @@ SET deleted_at = clock_timestamp()
 WHERE user_session_issuer_id = $1
   AND refresh_token_hash = $2
   AND deleted IS FALSE
-RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 `
 
 type RevokeUserSessionByRefreshTokenHashParams struct {
@@ -1316,6 +1321,7 @@ func (q *Queries) RevokeUserSessionByRefreshTokenHash(ctx context.Context, arg R
 		&i.RefreshTokenHash,
 		&i.RefreshExpiresAt,
 		&i.ExpiresAt,
+		&i.ToolSelection,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -1464,7 +1470,7 @@ const softDeleteUserSessionsByClientID = `-- name: SoftDeleteUserSessionsByClien
 UPDATE user_sessions
 SET deleted_at = clock_timestamp()
 WHERE user_session_client_id = $1 AND deleted IS FALSE
-RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 `
 
 // Cascading soft-delete of user_sessions issued through a client being revoked.
@@ -1488,6 +1494,7 @@ func (q *Queries) SoftDeleteUserSessionsByClientID(ctx context.Context, userSess
 			&i.RefreshTokenHash,
 			&i.RefreshExpiresAt,
 			&i.ExpiresAt,
+			&i.ToolSelection,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -1507,7 +1514,7 @@ const softDeleteUserSessionsByIssuerID = `-- name: SoftDeleteUserSessionsByIssue
 UPDATE user_sessions
 SET deleted_at = clock_timestamp()
 WHERE user_session_issuer_id = $1 AND deleted IS FALSE
-RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 `
 
 // Cascading soft-delete of user_sessions for an issuer being soft-deleted.
@@ -1531,6 +1538,7 @@ func (q *Queries) SoftDeleteUserSessionsByIssuerID(ctx context.Context, userSess
 			&i.RefreshTokenHash,
 			&i.RefreshExpiresAt,
 			&i.ExpiresAt,
+			&i.ToolSelection,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,

--- a/server/internal/usersessions/repo/queries.sql.go
+++ b/server/internal/usersessions/repo/queries.sql.go
@@ -22,7 +22,8 @@ INSERT INTO user_sessions (
     jti,
     refresh_token_hash,
     refresh_expires_at,
-    expires_at
+    expires_at,
+    tool_selection
 )
 VALUES (
     (SELECT project_id FROM user_session_issuers WHERE id = $1),
@@ -32,7 +33,8 @@ VALUES (
     $4,
     $5,
     $6,
-    $7
+    $7,
+    $8
 )
 RETURNING id, project_id, user_session_issuer_id, user_session_client_id, subject_urn, jti, refresh_token_hash, refresh_expires_at, expires_at, tool_selection, created_at, updated_at, deleted_at, deleted
 `
@@ -45,6 +47,7 @@ type CreateUserSessionParams struct {
 	RefreshTokenHash    string
 	RefreshExpiresAt    pgtype.Timestamptz
 	ExpiresAt           pgtype.Timestamptz
+	ToolSelection       []byte
 }
 
 // user_session_client_id binds the session to the DCR client that minted it.
@@ -59,6 +62,7 @@ func (q *Queries) CreateUserSession(ctx context.Context, arg CreateUserSessionPa
 		arg.RefreshTokenHash,
 		arg.RefreshExpiresAt,
 		arg.ExpiresAt,
+		arg.ToolSelection,
 	)
 	var i UserSession
 	err := row.Scan(
@@ -402,6 +406,46 @@ func (q *Queries) DeleteUserSessionIssuerCimdClient(ctx context.Context, arg Del
 	return i, err
 }
 
+const getLatestLiveUserSessionToolSelection = `-- name: GetLatestLiveUserSessionToolSelection :one
+SELECT tool_selection
+FROM user_sessions
+WHERE project_id = $1
+  AND user_session_issuer_id = $2
+  AND user_session_client_id = $3
+  AND subject_urn = $4
+  AND tool_selection ->> 'resource' = $5::text
+  AND deleted IS FALSE
+  AND refresh_expires_at > clock_timestamp()
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestLiveUserSessionToolSelectionParams struct {
+	ProjectID           uuid.UUID
+	UserSessionIssuerID uuid.UUID
+	UserSessionClientID uuid.NullUUID
+	SubjectUrn          urn.SessionSubject
+	Resource            string
+}
+
+// Reauth prefill: the identified subject's newest live restrictive policy
+// for the same issuer + client + endpoint resource. Filtering by resource in
+// SQL keeps a newer session on a sibling endpoint from shadowing this
+// endpoint's policy. Anonymous subjects never prefill (each authorization
+// mints a fresh random subject).
+func (q *Queries) GetLatestLiveUserSessionToolSelection(ctx context.Context, arg GetLatestLiveUserSessionToolSelectionParams) ([]byte, error) {
+	row := q.db.QueryRow(ctx, getLatestLiveUserSessionToolSelection,
+		arg.ProjectID,
+		arg.UserSessionIssuerID,
+		arg.UserSessionClientID,
+		arg.SubjectUrn,
+		arg.Resource,
+	)
+	var tool_selection []byte
+	err := row.Scan(&tool_selection)
+	return tool_selection, err
+}
+
 const getUserSessionByID = `-- name: GetUserSessionByID :one
 SELECT s.id, s.project_id, s.user_session_issuer_id, s.user_session_client_id, s.subject_urn, s.jti, s.refresh_token_hash, s.refresh_expires_at, s.expires_at, s.tool_selection, s.created_at, s.updated_at, s.deleted_at, s.deleted
 FROM user_sessions AS s
@@ -730,6 +774,36 @@ func (q *Queries) GetUserSessionIssuerCimdClientByID(ctx context.Context, arg Ge
 		&i.DeletedAt,
 		&i.Deleted,
 	)
+	return i, err
+}
+
+const getUserSessionToolSelectionByJTI = `-- name: GetUserSessionToolSelectionByJTI :one
+SELECT tool_selection, expires_at
+FROM user_sessions
+WHERE user_session_issuer_id = $1
+  AND jti = $2
+  AND deleted IS FALSE
+`
+
+type GetUserSessionToolSelectionByJTIParams struct {
+	UserSessionIssuerID uuid.UUID
+	Jti                 string
+}
+
+type GetUserSessionToolSelectionByJTIRow struct {
+	ToolSelection []byte
+	ExpiresAt     pgtype.Timestamptz
+}
+
+// Serve-path lookup for the consent-screen tool selection, keyed the same way
+// runtime requests are addressed (issuer + jti). Deliberately narrow: request
+// handling must not haul refresh-token material around. Project scoping is
+// intentionally NOT applied here -- the OAuth surface is public and the
+// issuer_id is the authoritative scope.
+func (q *Queries) GetUserSessionToolSelectionByJTI(ctx context.Context, arg GetUserSessionToolSelectionByJTIParams) (GetUserSessionToolSelectionByJTIRow, error) {
+	row := q.db.QueryRow(ctx, getUserSessionToolSelectionByJTI, arg.UserSessionIssuerID, arg.Jti)
+	var i GetUserSessionToolSelectionByJTIRow
+	err := row.Scan(&i.ToolSelection, &i.ExpiresAt)
 	return i, err
 }
 

--- a/server/migrations/20260807145206_user-sessions-tool-selection.sql
+++ b/server/migrations/20260807145206_user-sessions-tool-selection.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "user_sessions" table
+ALTER TABLE "user_sessions" ADD COLUMN "tool_selection" jsonb NULL;
+-- Create index "user_sessions_user_session_issuer_id_jti_idx" to table: "user_sessions"
+CREATE INDEX CONCURRENTLY "user_sessions_user_session_issuer_id_jti_idx" ON "user_sessions" ("user_session_issuer_id", "jti") WHERE (deleted IS FALSE);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:E05/fgXe/Gl67ilPpWYLVe5//KBvu5e3Pj32Z28JX9k=
+h1:6rvlAjDwnZeOj1hXpdbIuTzk7TlmRt9ji9g8ABQKKvs=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -322,3 +322,4 @@ h1:E05/fgXe/Gl67ilPpWYLVe5//KBvu5e3Pj32Z28JX9k=
 20260806224308_trials-table-tier.sql h1:77p16W+Y+06uZULh/GZxFuIvSLmaMsSPp6uGlfmjfUI=
 20260807090620_risk-results-fk-cascade-indexes.sql h1:kViSEj0zhDuK1yw9ti+36gkApVeRf/E0TbK4b53C27c=
 20260807103825_remote-session-refresh-support.sql h1:TDffGSjAKJYFJ7ZtmkmUkwnt31NO69kJBpOOBPMrQEw=
+20260807145206_user-sessions-tool-selection.sql h1:FSS0hbOCA2OI19SytsOaLIreH3jpvRaF+q1AVelSBBA=


### PR DESCRIPTION
Draft PR that exists only to spawn a preview environment for the stacked tool-filtering work — the real PRs are #4704 → #4705 → #4806 → #4807, and preview environments only deploy for main-based PRs. Contains the whole stack; do not review or merge here. Will be closed once preview validation is done.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds consent-screen tool filtering for issuer‑gated MCP endpoints, page‑level Keep alive and session length controls (now supports months), and a tri‑state auto‑refresh capability on remote session clients. Also ships a jittered hourly refresh sweep with concurrency‑safe token handling and new API/UI fields for session length and auto‑refresh.

- **New Features**
  - Consent tool picker for issuer‑gated sessions; persists `user_sessions.tool_selection` (NULL = all tools) and enforces it in `tools/list` and `tools/call`. Policy loads per request via issuer+jti cache, is resource‑bound, fails closed, and excludes proxy/external MCP tools; proxied (remote/tunneled) backends reject restrictive selections. Selection rides refresh slides after validation (malformed = `invalid_grant` reauth), and a JWT without a backing `user_sessions` row is rejected.
  - Page‑level Keep alive and Session length picker; length stored on `user_sessions.session_duration` (hours/days/weeks/months). Remote session clients gain `capability_to_auto_refresh` (`enabled_default_on` | `enabled_default_off` | `disabled`) with tri‑state controls in the dashboard and SDK/OpenAPI updates. Non‑consuming consent actions added for connect, disconnect, and auto‑refresh toggle.
  - Jittered hourly pre‑emptive refresh via Temporal with per‑org fan‑out; uses a concurrency‑safe `RefreshService`, replays RFC 8707 resource, respects client capability + per‑session opt‑in, requires a live Gram user session, and classifies `invalid_grant` cleanly.

- **Migration**
  - Run DB migrations: adds `remote_sessions.resource`, `remote_sessions.auto_refresh`, `remote_session_clients.capability_to_auto_refresh`, `user_sessions.session_duration`, `user_sessions.tool_selection`, and a partial index on (`user_session_issuer_id`, `jti`) for serve‑path lookups.
  - Ensure the Temporal worker is running; the hourly refresh schedule is (re)registered with jitter and does not overlap.
  - No breaking changes: existing clients default to `enabled_default_on`; existing sessions remain unconstrained (all tools) until a selection is made.

<sup>Written for commit 4abf09459637d2593e717b8b1d940c0b531cc829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

