### PR TITLE
fix: stop unattributed challenges starving the challenges page

### DIFF
--- a/.changeset/tidy-pugs-shave.md
+++ b/.changeset/tidy-pugs-shave.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Exclude unattributed authz challenges from the challenge buckets endpoint so the Challenges page pagination and totals match what is rendered

--- a/server/internal/access/list_challenge_buckets_test.go
+++ b/server/internal/access/list_challenge_buckets_test.go
@@ -327,6 +327,96 @@ func TestListChallengeBuckets_IsolatesByOrganization(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
+// TestListChallengeBuckets_ExcludesUnattributedBuckets covers the rows written
+// by batch Filter/FindMatched calls: they carry no scope and no resource, so
+// there is nothing to render and nothing to grant against. They must not reach
+// the caller, and must not be counted in the total.
+func TestListChallengeBuckets_ExcludesUnattributedBuckets(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newChallengeTestService(t)
+	orgID := challengeAuthContext(t, ctx).ActiveOrganizationID
+
+	insertCHChallenge(t, ti, orgID, uuid.NewString(), "deny", "user:u1", "org:admin")
+	insertCHChallengeUnattributed(t, ti, orgID, uuid.NewString(), "allow", "user:u2")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        20,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		if !assert.Len(c, result.Buckets, 1) {
+			return
+		}
+		assert.Equal(c, "org:admin", result.Buckets[0].Scope)
+		assert.Equal(c, 1, result.Total)
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+// TestListChallengeBuckets_UnattributedBucketsDoNotStarvePage reproduces the
+// reported bug: unattributed rows are written on the hottest paths (project and
+// toolset listing, MCP tools/list) so they are always the most recent buckets.
+// When they are paginated as if they were displayable they fill the whole page
+// and the caller is handed nothing to show, even though displayable buckets
+// exist behind them.
+func TestListChallengeBuckets_UnattributedBucketsDoNotStarvePage(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newChallengeTestService(t)
+	orgID := challengeAuthContext(t, ctx).ActiveOrganizationID
+
+	// Older: the buckets a user actually wants to see.
+	insertCHChallenge(t, ti, orgID, uuid.NewString(), "deny", "user:u1", "org:admin")
+	insertCHChallenge(t, ti, orgID, uuid.NewString(), "allow", "user:u1", "org:read")
+
+	// Newer: one unattributed bucket per principal, enough to fill a page.
+	for i := range 3 {
+		insertCHChallengeUnattributed(t, ti, orgID, uuid.NewString(), "allow", fmt.Sprintf("api_key:k%d", i))
+	}
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := ti.service.ListChallengeBuckets(ctx, &gen.ListChallengeBucketsPayload{
+			Outcome:      nil,
+			PrincipalUrn: nil,
+			Scope:        nil,
+			ProjectID:    nil,
+			Resolved:     nil,
+			Limit:        3,
+			Offset:       0,
+			ApikeyToken:  nil,
+			SessionToken: nil,
+		})
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, result) {
+			return
+		}
+		if !assert.Len(c, result.Buckets, 2) {
+			return
+		}
+		for _, b := range result.Buckets {
+			assert.NotEmpty(c, b.Scope)
+			assert.NotNil(c, b.ResourceKind)
+			assert.NotNil(c, b.ResourceID)
+		}
+		assert.Equal(c, 2, result.Total)
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
 func TestListChallengeBuckets_AllChallengeIdsReturned(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/access/list_challenges_test.go
+++ b/server/internal/access/list_challenges_test.go
@@ -461,6 +461,7 @@ func challengeAuthContext(t *testing.T, ctx context.Context) *contextvalues.Auth
 }
 
 // insertCHChallenge inserts a minimal challenge row into ClickHouse for testing.
+// The row carries a fully specified resource, as challenges logged by Require do.
 func insertCHChallenge(t *testing.T, ti *testInstance, orgID, challengeID, outcome, principalURN, scope string) {
 	t.Helper()
 	insertCHChallengeWithUser(t, ti, orgID, challengeID, outcome, principalURN, scope, nil, nil)
@@ -468,6 +469,23 @@ func insertCHChallenge(t *testing.T, ti *testInstance, orgID, challengeID, outco
 
 // insertCHChallengeWithUser inserts a challenge row with optional user enrichment fields.
 func insertCHChallengeWithUser(t *testing.T, ti *testInstance, orgID, challengeID, outcome, principalURN, scope string, userID, userEmail *string) {
+	t.Helper()
+	insertCHChallengeRow(t, ti, orgID, challengeID, outcome, principalURN, scope, "org", orgID, userID, userEmail)
+}
+
+// insertCHChallengeUnattributed inserts a challenge row with no scope and no
+// resource, as batch Filter and FindMatched calls log it: those record a single
+// row for the whole batch with a nil focus check, so the dimensions that
+// identify what was checked are never written.
+func insertCHChallengeUnattributed(t *testing.T, ti *testInstance, orgID, challengeID, outcome, principalURN string) {
+	t.Helper()
+	insertCHChallengeRow(t, ti, orgID, challengeID, outcome, principalURN, "", "", "", nil, nil)
+}
+
+// insertCHChallengeRow inserts a challenge row into ClickHouse for testing. An
+// empty scope/resourceKind/resourceID models the rows written by batch Filter
+// and FindMatched calls, which log without a focus check.
+func insertCHChallengeRow(t *testing.T, ti *testInstance, orgID, challengeID, outcome, principalURN, scope, resourceKind, resourceID string, userID, userEmail *string) {
 	t.Helper()
 
 	err := ti.chConn.Exec(t.Context(), `
@@ -490,7 +508,7 @@ func insertCHChallengeWithUser(t *testing.T, ti *testInstance, orgID, challengeI
 			?, ?,
 			array(),
 			'require', ?, 'no_grants',
-			?, '', '', '',
+			?, ?, ?, '',
 			array(),
 			array(), array(), array(), array(),
 			array(), array(), array(), array(),
@@ -500,7 +518,7 @@ func insertCHChallengeWithUser(t *testing.T, ti *testInstance, orgID, challengeI
 		principalURN,
 		userID, userEmail,
 		outcome,
-		scope,
+		scope, resourceKind, resourceID,
 	)
 	require.NoError(t, err)
 }

--- a/server/internal/authz/repo/queries.go
+++ b/server/internal/authz/repo/queries.go
@@ -176,6 +176,20 @@ func challengeWhere(sb squirrel.SelectBuilder, f ChallengeListFilters) squirrel.
 	return sb
 }
 
+// challengeAttributed keeps only rows that name what was checked.
+//
+// Batch Filter and FindMatched calls log a single row for the whole batch with
+// a nil focus check, so scope, resource_kind and resource_id are all written
+// empty. Those rows carry nothing to display and nothing to grant against, and
+// they are produced on the hottest paths (project and toolset listing, MCP
+// tools/list), which makes them the most recent buckets in almost every
+// organization. Dropping them here rather than in the caller keeps LIMIT/OFFSET
+// and the bucket total consistent with what is actually returned — filtering
+// after pagination lets them fill a page and starve it of real buckets.
+func challengeAttributed(sb squirrel.SelectBuilder) squirrel.SelectBuilder {
+	return sb.Where("scope != '' AND resource_kind != '' AND resource_id != ''")
+}
+
 // challengePagination applies LIMIT/OFFSET to a squirrel SelectBuilder when not skipped.
 func challengePagination(sb squirrel.SelectBuilder, f ChallengeListFilters) squirrel.SelectBuilder {
 	if !f.SkipPagination {
@@ -406,6 +420,7 @@ func (q *Queries) ListChallengeBuckets(ctx context.Context, f ChallengeListFilte
 		GroupBy(challengeBucketGroupBy).
 		OrderBy("max(timestamp) DESC")
 	sb = challengeWhere(sb, f)
+	sb = challengeAttributed(sb)
 	sb = challengePagination(sb, f)
 
 	query, args, err := sb.ToSql()
@@ -460,6 +475,7 @@ func (q *Queries) CountChallengeBuckets(ctx context.Context, f ChallengeListFilt
 		From("authz_challenges").
 		GroupBy(challengeBucketGroupBy)
 	inner = challengeWhere(inner, f)
+	inner = challengeAttributed(inner)
 
 	innerQuery, args, err := inner.ToSql()
 	if err != nil {


### PR DESCRIPTION
## Problem

On `/access/challenges`, every pill except **Denied** rendered an empty table — while the pill's own count showed a non-zero number.

## Root cause

Batch `Filter`/`FindMatched` calls log one challenge row for the whole batch with `Focus: nil` (`server/internal/authz/engine.go:478`, `:584`). With a nil focus, `challengeLogger` never computes a focus selector, so the row is written with `scope=''`, `resource_kind=''`, `resource_id=''`.

The dashboard drops exactly those rows — `isDisplayableBucket` requires all three to be non-empty — but the server paginated them as if they were displayable. Because they are produced on the hottest paths (`projects.Filter` on every dashboard load, `toolsets.Filter`, MCP `tools/list`), they are the most recent buckets in any active org, so they sort to the top and fill the first page. The client then discards the entire page and renders "No challenges found".

The **Denied** pill was unaffected only because these rows are almost always `outcome=allow`, so `outcome=deny` filtered them out.

## Fix

Exclude unattributed rows in both `ListChallengeBuckets` and `CountChallengeBuckets` (shared `challengeAttributed` helper, so list and count cannot drift). Filtering must happen where pagination happens — otherwise `LIMIT`/`OFFSET` and `total` describe a different set than what is returned.

No real challenge is hidden: `validateInput` rejects an empty `ResourceID`, and `Check.selector()` always backfills a non-empty resource kind, so every check that reaches a decision logs all three fields. The only rows newly excluded are the ones the client already discarded.

## Tests

Two new tests, both confirmed failing before the fix:

- `TestListChallengeBuckets_ExcludesUnattributedBuckets` — returned 2 buckets instead of 1.
- `TestListChallengeBuckets_UnattributedBucketsDoNotStarvePage` — returned 3 unattributed buckets instead of the 2 real ones, reproducing the reported empty page.

The existing test helper inserted `resource_kind=''`/`resource_id=''` for every row, so no server test had ever exercised displayability; it now inserts a real resource, with `insertCHChallengeUnattributed` for the batch-log shape.

`mise run test:server ./internal/access/ ./internal/authz/...` — 443 pass. `mise lint:server` and `mise build:server` clean.

## Follow-up (not in this PR)

Batch `Filter`/`FindMatched` challenges remain unattributable in the raw log — the scope is uniform across a batch and could be recorded, but `resource_id` varies, so giving those rows a focus changes what the dimensions mean. Worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dpm1YAsUH3UjjJBbYj2Mh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty tables on `/access/challenges` by filtering out unattributed challenge buckets at the query level so pagination and totals match what the UI can render. Previously, batch `Filter`/`FindMatched` logs produced buckets with empty scope/resource fields that rose to the top and starved the page.

- **Bug Fixes**
  - Drop buckets with empty `scope`, `resource_kind`, and `resource_id` in both list and count queries to keep LIMIT/OFFSET and totals consistent.
  - Add tests for exclusion and the starvation case; update helpers to insert real resources and add an unattributed-row helper.
  - No real challenges are hidden; only rows the client already ignored are filtered.

<sup>Written for commit 4a1865827783ea128da01d49e1a61b9e9b4c4a53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

