### PR TITLE
feat: capture LiteLLM responses (DNO-705)

### DIFF
--- a/.changeset/dno-705-litellm-response-capture.md
+++ b/.changeset/dno-705-litellm-response-capture.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Capture LiteLLM model responses with consistent per-call session and user attribution for asynchronous risk analysis.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -77,6 +77,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/k8s"
 	"github.com/speakeasy-api/gram/server/internal/keys"
 	"github.com/speakeasy-api/gram/server/internal/litellm"
+	"github.com/speakeasy-api/gram/server/internal/litellm/callcache"
 	"github.com/speakeasy-api/gram/server/internal/marketplace"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcpclient"
@@ -1132,7 +1133,7 @@ func newStartCommand() *cli.Command {
 				c.String("jwt-signing-key"),
 			)
 			hooks.Attach(mux, hooksService)
-			litellm.Attach(mux, litellm.NewService(logger, tracerProvider, db, sessionManager, authzEngine, hooksService))
+			litellm.Attach(mux, litellm.NewService(logger, tracerProvider, db, sessionManager, authzEngine, hooksService, callcache.New(cache.NewRedisCacheAdapter(redisClient))))
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))
 			deviceintegrations.Attach(mux, deviceintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, guardianPolicy, &background.DeviceIntegrationSyncTrigger{TemporalEnv: temporalEnv, Logger: logger}, featureFlags))
 			modelkeys.Attach(mux, modelkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, openRouter, productFeatures, auditLogger))

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -767,6 +767,14 @@ func SlogSpanID(v string) slog.Attr      { return slog.String(string(SpanIDKey),
 func TraceID(v string) attribute.KeyValue { return TraceIDKey.String(v) }
 func SlogTraceID(v string) slog.Attr      { return slog.String(string(TraceIDKey), v) }
 
+func SlogLiteLLMCallID(v string) slog.Attr {
+	return slog.String(string(LiteLLMCallIDKey), v)
+}
+
+func SlogLiteLLMTraceID(v string) slog.Attr {
+	return slog.String(string(LiteLLMTraceIDKey), v)
+}
+
 func DataDogGitCommitSHA(v string) attribute.KeyValue { return DataDogGitCommitSHAKey.String(v) }
 func SlogDataDogGitCommitSHA(v string) slog.Attr {
 	return slog.String(string(DataDogGitCommitSHAKey), v)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -37,6 +37,20 @@ type AuthenticatedIngestOptions struct {
 	AllowWarnAcknowledgement     bool
 	AllowSessionIdentityFallback bool
 	SourceAttributes             map[attr.Key]any
+	OutputToolCalls              []any
+}
+
+// ResolvedActor is the exact actor selected by canonical hook attribution.
+type ResolvedActor struct {
+	UserID string
+	Email  string
+}
+
+// AuthenticatedIngestResult includes the public hook result and trusted
+// attribution details needed by in-process adapters.
+type AuthenticatedIngestResult struct {
+	Result *gen.IngestHookResult
+	Actor  ResolvedActor
 }
 
 func defaultAuthenticatedIngestOptions() AuthenticatedIngestOptions {
@@ -44,6 +58,7 @@ func defaultAuthenticatedIngestOptions() AuthenticatedIngestOptions {
 		AllowWarnAcknowledgement:     true,
 		AllowSessionIdentityFallback: true,
 		SourceAttributes:             nil,
+		OutputToolCalls:              nil,
 	}
 }
 
@@ -78,6 +93,16 @@ func (s *Service) IngestAuthenticated(ctx context.Context, authCtx *contextvalue
 // IngestAuthenticatedWithOptions bypasses transport authentication and applies
 // behavior selected by a trusted in-process caller.
 func (s *Service) IngestAuthenticatedWithOptions(ctx context.Context, authCtx *contextvalues.AuthContext, payload *gen.IngestPayload, options AuthenticatedIngestOptions) (*gen.IngestHookResult, error) {
+	result, err := s.IngestAuthenticatedDetailed(ctx, authCtx, payload, options)
+	if err != nil {
+		return nil, err
+	}
+	return result.Result, nil
+}
+
+// IngestAuthenticatedDetailed bypasses transport authentication and returns
+// the canonical actor resolved during ingestion to trusted in-process callers.
+func (s *Service) IngestAuthenticatedDetailed(ctx context.Context, authCtx *contextvalues.AuthContext, payload *gen.IngestPayload, options AuthenticatedIngestOptions) (*AuthenticatedIngestResult, error) {
 	if payload == nil {
 		return nil, oops.E(oops.CodeInvalid, nil, "ingest payload is required")
 	}
@@ -95,10 +120,11 @@ func (s *Service) IngestAuthenticatedWithOptions(ctx context.Context, authCtx *c
 	payloadCopy.ApikeyToken = nil
 	payloadCopy.ProjectSlugInput = nil
 	options.SourceAttributes = maps.Clone(options.SourceAttributes)
+	options.OutputToolCalls = append([]any(nil), options.OutputToolCalls...)
 
 	ctx = contextvalues.SetAuthContext(ctx, &authCopy)
 	ctx = context.WithValue(ctx, authenticatedIngestOptionsKey{}, options)
-	return s.Ingest(ctx, &payloadCopy)
+	return s.ingest(ctx, &payloadCopy)
 }
 
 // Ingest is the feature-first hook endpoint; this path only accepts the
@@ -113,6 +139,14 @@ func (s *Service) IngestAuthenticatedWithOptions(ctx context.Context, authCtx *c
 // falling back to the token owner for personal keys and senders without a
 // device agent.
 func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *gen.IngestHookResult, err error) {
+	detailed, err := s.ingest(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+	return detailed.Result, nil
+}
+
+func (s *Service) ingest(ctx context.Context, payload *gen.IngestPayload) (res *AuthenticatedIngestResult, err error) {
 	start := time.Now()
 	source := ""
 	eventType := ""
@@ -124,8 +158,8 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 			outcome = hookMetricOutcomeFailure
 		}
 		decision := hookMetricDecisionNone
-		if res != nil {
-			decision = res.Decision
+		if res != nil && res.Result != nil {
+			decision = res.Result.Decision
 		}
 		s.metrics.RecordHookEventDuration(ctx, source, eventType, outcome, decision, orgSlug, *riskScanned, time.Since(start))
 	}()
@@ -151,7 +185,10 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 			attr.SlogHookSource(source),
 			attr.SlogHookEvent(eventType),
 		)
-		return canonicalAllowResult(), nil
+		return &AuthenticatedIngestResult{
+			Result: canonicalAllowResult(),
+			Actor:  ResolvedActor{UserID: "", Email: ""},
+		}, nil
 	}
 	orgSlug = authCtx.OrganizationSlug
 	actor := s.resolveCanonicalActor(ctx, payload, authCtx)
@@ -215,9 +252,15 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 	// duplicate).
 	s.captureMCPAttribution(context.WithoutCancel(ctx), payload, authCtx)
 	if blockReason != "" {
-		return s.withOrgSettings(ctx, authCtx.ActiveOrganizationID, canonicalDenyResult(userReason), skillCapture), nil
+		return &AuthenticatedIngestResult{
+			Result: s.withOrgSettings(ctx, authCtx.ActiveOrganizationID, canonicalDenyResult(userReason), skillCapture),
+			Actor:  ResolvedActor(actor),
+		}, nil
 	}
-	return s.withOrgSettings(ctx, authCtx.ActiveOrganizationID, canonicalAllowResult(), skillCapture), nil
+	return &AuthenticatedIngestResult{
+		Result: s.withOrgSettings(ctx, authCtx.ActiveOrganizationID, canonicalAllowResult(), skillCapture),
+		Actor:  ResolvedActor(actor),
+	}, nil
 }
 
 type skillCaptureSignal struct {
@@ -1134,10 +1177,19 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		titleContent = content
 	case "assistant.responded":
 		content := canonicalMessageText(payload)
-		if strings.TrimSpace(content) == "" {
+		outputToolCalls := authenticatedIngestOptions(ctx).OutputToolCalls
+		if strings.TrimSpace(content) == "" && len(outputToolCalls) == 0 {
 			return nil
 		}
 		msg = baseMsg("assistant", content)
+		if len(outputToolCalls) > 0 {
+			toolCallsJSON, err := json.Marshal(outputToolCalls)
+			if err != nil {
+				return fmt.Errorf("marshal output tool calls: %w", err)
+			}
+			msg.FinishReason = conv.ToPGText("tool_calls")
+			msg.ToolCalls = toolCallsJSON
+		}
 		titleContent = content
 	case "tool.requested":
 		// Permission prompts (codex PermissionRequest) also normalize to

--- a/server/internal/litellm/callcache/callcache.go
+++ b/server/internal/litellm/callcache/callcache.go
@@ -1,0 +1,63 @@
+package callcache
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	redisCache "github.com/go-redis/cache/v9"
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/cache"
+)
+
+const ttl = 24 * time.Hour
+
+type Record struct {
+	ProjectID uuid.UUID
+	CallID    string
+	TraceID   string
+	SessionID string
+	UserID    string
+	Email     string
+}
+
+type Cache struct {
+	cache cache.Cache
+}
+
+func New(cacheImpl cache.Cache) *Cache {
+	return &Cache{cache: cacheImpl}
+}
+
+func (c *Cache) Store(ctx context.Context, record Record) error {
+	if err := c.cache.Set(ctx, key(record.ProjectID, record.CallID), record, ttl); err != nil {
+		return fmt.Errorf("store LiteLLM call: %w", err)
+	}
+	return nil
+}
+
+func (c *Cache) Get(ctx context.Context, projectID uuid.UUID, callID string) (Record, error) {
+	var record Record
+	if err := c.cache.Get(ctx, key(projectID, callID), &record); err != nil {
+		return Record{
+			ProjectID: uuid.Nil,
+			CallID:    "",
+			TraceID:   "",
+			SessionID: "",
+			UserID:    "",
+			Email:     "",
+		}, fmt.Errorf("get LiteLLM call: %w", err)
+	}
+	return record, nil
+}
+
+func IsMiss(err error) bool {
+	return errors.Is(err, redisCache.ErrCacheMiss)
+}
+
+func key(projectID uuid.UUID, callID string) string {
+	return "litellm:call:" + projectID.String() + ":" + fmt.Sprintf("%x", sha256.Sum256([]byte(callID)))
+}

--- a/server/internal/litellm/callcache/callcache_test.go
+++ b/server/internal/litellm/callcache/callcache_test.go
@@ -1,0 +1,18 @@
+package callcache
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyScopesCallByAuthenticatedProject(t *testing.T) {
+	t.Parallel()
+	projectA := uuid.New()
+	projectB := uuid.New()
+
+	require.NotEqual(t, key(projectA, "shared-call"), key(projectB, "shared-call"))
+	require.NotEqual(t, key(projectA, "first-call"), key(projectA, "second-call"))
+	require.Contains(t, key(projectA, "shared-call"), projectA.String())
+}

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
@@ -22,14 +23,18 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/litellm/callcache"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
-const genericBlockedReason = "Request blocked by policy."
+const (
+	genericBlockedReason = "Request blocked by policy."
+	callCacheTimeout     = time.Second
+)
 
 type HookIngester interface {
-	IngestAuthenticatedWithOptions(context.Context, *contextvalues.AuthContext, *hooksgen.IngestPayload, hooks.AuthenticatedIngestOptions) (*hooksgen.IngestHookResult, error)
+	IngestAuthenticatedDetailed(context.Context, *contextvalues.AuthContext, *hooksgen.IngestPayload, hooks.AuthenticatedIngestOptions) (*hooks.AuthenticatedIngestResult, error)
 }
 
 type authorizer interface {
@@ -41,17 +46,19 @@ type Service struct {
 	logger *slog.Logger
 	auth   authorizer
 	hooks  HookIngester
+	calls  *callcache.Cache
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionsManager *sessions.Manager, authzEngine *authz.Engine, hookIngester HookIngester) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionsManager *sessions.Manager, authzEngine *authz.Engine, hookIngester HookIngester, calls *callcache.Cache) *Service {
 	return &Service{
 		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/litellm"),
 		logger: logger.With(attr.SlogComponent("litellm")),
 		auth:   auth.New(logger, db, sessionsManager, authzEngine),
 		hooks:  hookIngester,
+		calls:  calls,
 	}
 }
 
@@ -80,13 +87,21 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (*gen.
 	if payload == nil || payload.RequestData == nil {
 		return nil, oops.E(oops.CodeBadRequest, nil, "request_data is required")
 	}
-	if payload.InputType != "request" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "only request input_type is supported")
-	}
 	callID := strings.TrimSpace(conv.PtrValOr(payload.LitellmCallID, ""))
 	if callID == "" {
 		return nil, oops.E(oops.CodeBadRequest, nil, "litellm_call_id is required")
 	}
+	switch payload.InputType {
+	case "request":
+		return s.ingestRequest(ctx, payload, callID)
+	case "response":
+		return s.ingestResponse(ctx, payload, callID)
+	default:
+		return nil, oops.E(oops.CodeBadRequest, nil, "input_type must be request or response")
+	}
+}
+
+func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload, callID string) (*gen.LitellmIngestResult, error) {
 	prompt := latestUserPrompt(payload.StructuredMessages)
 	if prompt == "" {
 		prompt = lastText(payload.Texts)
@@ -99,11 +114,7 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (*gen.
 	if !ok || authCtx == nil {
 		return nil, oops.E(oops.CodeUnauthorized, nil, "unauthorized")
 	}
-	authCopy := *authCtx
-	authCopy.UserID = ""
-	authCopy.Email = nil
-	authCopy.ExternalUserID = ""
-	authCopy.OrgWidePluginHooksKey = false
+	authCopy := strippedAuthContext(authCtx)
 
 	traceID := strings.TrimSpace(conv.PtrValOr(payload.LitellmTraceID, ""))
 	sessionID := sessionHeader(payload.RequestHeaders)
@@ -152,16 +163,17 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (*gen.
 		},
 		Raw: nil,
 	}
-	result, err := s.hooks.IngestAuthenticatedWithOptions(ctx, &authCopy, hookPayload, hooks.AuthenticatedIngestOptions{
+	result, err := s.hooks.IngestAuthenticatedDetailed(ctx, &authCopy, hookPayload, hooks.AuthenticatedIngestOptions{
 		AllowWarnAcknowledgement:     false,
 		AllowSessionIdentityFallback: false,
 		SourceAttributes:             sourceAttributes(payload),
+		OutputToolCalls:              nil,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("ingest LiteLLM hook: %w", err)
 	}
-	if result.Decision == "deny" {
-		reason := strings.TrimSpace(conv.PtrValOr(result.Message, ""))
+	if result.Result.Decision == "deny" {
+		reason := strings.TrimSpace(conv.PtrValOr(result.Result.Message, ""))
 		if reason == "" {
 			reason = genericBlockedReason
 		}
@@ -174,7 +186,121 @@ func (s *Service) Ingest(ctx context.Context, payload *gen.IngestPayload) (*gen.
 			StreamHoldbackChars: nil,
 		}, nil
 	}
+	cacheCtx, cancel := context.WithTimeout(ctx, callCacheTimeout)
+	err = s.calls.Store(cacheCtx, callcache.Record{
+		ProjectID: *authCtx.ProjectID,
+		CallID:    callID,
+		TraceID:   traceID,
+		SessionID: sessionID,
+		UserID:    result.Actor.UserID,
+		Email:     result.Actor.Email,
+	})
+	cancel()
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to cache LiteLLM call",
+			attr.SlogError(err),
+			attr.SlogProjectID(authCtx.ProjectID.String()),
+			attr.SlogGenAIConversationID(sessionID),
+			attr.SlogLiteLLMCallID(callID),
+			attr.SlogLiteLLMTraceID(traceID),
+		)
+	}
 	return noneResult(), nil
+}
+
+func (s *Service) ingestResponse(ctx context.Context, payload *gen.IngestPayload, callID string) (*gen.LitellmIngestResult, error) {
+	text := joinedTexts(payload.Texts)
+	if text == "" && len(payload.ToolCalls) == 0 {
+		return noneResult(), nil
+	}
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return nil, oops.E(oops.CodeUnauthorized, nil, "unauthorized")
+	}
+	authCopy := strippedAuthContext(authCtx)
+	traceID := strings.TrimSpace(conv.PtrValOr(payload.LitellmTraceID, ""))
+	sessionID := sessionHeader(payload.RequestHeaders)
+	if sessionID == "" {
+		sessionID = conv.Default(traceID, callID)
+	}
+	email := conv.NormalizeEmail(conv.PtrValOr(payload.RequestData.UserAPIKeyUserEmail, ""))
+
+	cacheCtx, cancel := context.WithTimeout(ctx, callCacheTimeout)
+	cached, err := s.calls.Get(cacheCtx, *authCtx.ProjectID, callID)
+	cancel()
+	if err == nil {
+		sessionID = cached.SessionID
+		authCopy.UserID = cached.UserID
+		authCopy.Email = conv.PtrEmpty(cached.Email)
+		email = cached.Email
+	} else if !callcache.IsMiss(err) {
+		s.logger.WarnContext(ctx, "failed to read cached LiteLLM call",
+			attr.SlogError(err),
+			attr.SlogProjectID(authCtx.ProjectID.String()),
+			attr.SlogLiteLLMCallID(callID),
+		)
+	}
+
+	model := strings.TrimSpace(conv.PtrValOr(payload.Model, ""))
+	version := strings.TrimSpace(conv.PtrValOr(payload.LitellmVersion, ""))
+	idempotencyKey := "litellm:" + callID + ":response"
+	role := "assistant"
+	hookPayload := &hooksgen.IngestPayload{
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Replayed:         nil,
+		SchemaVersion:    "hook.ingest.v1",
+		IdempotencyKey:   &idempotencyKey,
+		Source: &hooksgen.HookIngestSource{
+			Adapter:        "litellm",
+			AdapterVersion: conv.PtrEmpty(version),
+			RawEventName:   nil,
+			Hostname:       nil,
+			UserEmail:      conv.PtrEmpty(email),
+		},
+		Session: &hooksgen.HookIngestSession{
+			ID:     &sessionID,
+			TurnID: &callID,
+			Cwd:    nil,
+			Model:  conv.PtrEmpty(model),
+		},
+		Event: &hooksgen.HookIngestEvent{
+			Type:       "assistant.responded",
+			OccurredAt: nil,
+		},
+		Data: &hooksgen.HookIngestData{
+			Prompt:            nil,
+			ToolCall:          nil,
+			Mcp:               nil,
+			McpInventory:      nil,
+			Usage:             nil,
+			Message:           &hooksgen.HookMessageData{Text: &text, Role: &role, DurationMs: nil},
+			Skill:             nil,
+			Notification:      nil,
+			McpAttribution:    nil,
+			PromptAttachments: nil,
+		},
+		Raw: nil,
+	}
+	_, err = s.hooks.IngestAuthenticatedDetailed(ctx, &authCopy, hookPayload, hooks.AuthenticatedIngestOptions{
+		AllowWarnAcknowledgement:     false,
+		AllowSessionIdentityFallback: false,
+		SourceAttributes:             sourceAttributes(payload),
+		OutputToolCalls:              payload.ToolCalls,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ingest LiteLLM hook: %w", err)
+	}
+	return noneResult(), nil
+}
+
+func strippedAuthContext(authCtx *contextvalues.AuthContext) contextvalues.AuthContext {
+	authCopy := *authCtx
+	authCopy.UserID = ""
+	authCopy.Email = nil
+	authCopy.ExternalUserID = ""
+	authCopy.OrgWidePluginHooksKey = false
+	return authCopy
 }
 
 func noneResult() *gen.LitellmIngestResult {
@@ -230,6 +356,16 @@ func lastText(texts []string) string {
 		return ""
 	}
 	return strings.TrimSpace(texts[len(texts)-1])
+}
+
+func joinedTexts(texts []string) string {
+	joined := make([]string, 0, len(texts))
+	for _, text := range texts {
+		if text = strings.TrimSpace(text); text != "" {
+			joined = append(joined, text)
+		}
+	}
+	return strings.Join(joined, "\n")
 }
 
 func sessionHeader(headers map[string]string) string {

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -163,7 +163,7 @@ func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload,
 		},
 		Raw: nil,
 	}
-	result, err := s.hooks.IngestAuthenticatedDetailed(ctx, &authCopy, hookPayload, hooks.AuthenticatedIngestOptions{
+	outcome, err := s.hooks.IngestAuthenticatedDetailed(ctx, &authCopy, hookPayload, hooks.AuthenticatedIngestOptions{
 		AllowWarnAcknowledgement:     false,
 		AllowSessionIdentityFallback: false,
 		SourceAttributes:             sourceAttributes(payload),
@@ -172,8 +172,8 @@ func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload,
 	if err != nil {
 		return nil, fmt.Errorf("ingest LiteLLM hook: %w", err)
 	}
-	if result.Result.Decision == "deny" {
-		reason := strings.TrimSpace(conv.PtrValOr(result.Result.Message, ""))
+	if outcome.Result.Decision == "deny" {
+		reason := strings.TrimSpace(conv.PtrValOr(outcome.Result.Message, ""))
 		if reason == "" {
 			reason = genericBlockedReason
 		}
@@ -192,8 +192,8 @@ func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload,
 		CallID:    callID,
 		TraceID:   traceID,
 		SessionID: sessionID,
-		UserID:    result.Actor.UserID,
-		Email:     result.Actor.Email,
+		UserID:    outcome.Actor.UserID,
+		Email:     outcome.Actor.Email,
 	})
 	cancel()
 	if err != nil {

--- a/server/internal/litellm/ingest_test.go
+++ b/server/internal/litellm/ingest_test.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	redisCache "github.com/go-redis/cache/v9"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	goahttp "goa.design/goa/v3/http"
@@ -18,8 +21,10 @@ import (
 	hooksgen "github.com/speakeasy-api/gram/server/gen/hooks"
 	gen "github.com/speakeasy-api/gram/server/gen/litellm"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/litellm/callcache"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -30,14 +35,52 @@ type capturedHookCall struct {
 }
 
 type captureIngester struct {
-	result *hooksgen.IngestHookResult
+	result *hooks.AuthenticatedIngestResult
 	err    error
 	calls  []capturedHookCall
 }
 
-func (c *captureIngester) IngestAuthenticatedWithOptions(_ context.Context, authCtx *contextvalues.AuthContext, payload *hooksgen.IngestPayload, options hooks.AuthenticatedIngestOptions) (*hooksgen.IngestHookResult, error) {
+func (c *captureIngester) IngestAuthenticatedDetailed(_ context.Context, authCtx *contextvalues.AuthContext, payload *hooksgen.IngestPayload, options hooks.AuthenticatedIngestOptions) (*hooks.AuthenticatedIngestResult, error) {
 	c.calls = append(c.calls, capturedHookCall{auth: authCtx, payload: payload, options: options})
 	return c.result, c.err
+}
+
+type memoryCache struct {
+	cache.Cache
+	entries map[string][]byte
+	ttls    []time.Duration
+}
+
+func newMemoryCache() *memoryCache {
+	return &memoryCache{Cache: cache.NoopCache, entries: map[string][]byte{}, ttls: nil}
+}
+
+func (c *memoryCache) Get(_ context.Context, key string, value any) error {
+	raw, ok := c.entries[key]
+	if !ok {
+		return redisCache.ErrCacheMiss
+	}
+	if err := json.Unmarshal(raw, value); err != nil {
+		return fmt.Errorf("unmarshal cache value: %w", err)
+	}
+	return nil
+}
+
+func (c *memoryCache) Set(_ context.Context, key string, value any, ttl time.Duration) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal cache value: %w", err)
+	}
+	c.entries[key] = raw
+	c.ttls = append(c.ttls, ttl)
+	return nil
+}
+
+func allowResult(actor hooks.ResolvedActor) *hooks.AuthenticatedIngestResult {
+	return &hooks.AuthenticatedIngestResult{
+		Result: &hooksgen.IngestHookResult{Decision: "allow", Reason: nil, Message: nil, Effects: nil},
+		Actor:  actor,
+	}
 }
 
 type fixedAuthorizer struct {
@@ -107,13 +150,14 @@ func unitService(t *testing.T, ingester HookIngester, authCtx *contextvalues.Aut
 		logger: testenv.NewLogger(t),
 		auth:   fixedAuthorizer{authCtx: authCtx},
 		hooks:  ingester,
+		calls:  callcache.New(newMemoryCache()),
 	}
 }
 
 func TestIngestTranslatesLatestStructuredUserMessage(t *testing.T) {
 	t.Parallel()
 	authCtx := testAuthContext()
-	ingester := &captureIngester{result: &hooksgen.IngestHookResult{Decision: "allow", Reason: nil, Message: nil, Effects: nil}, err: nil, calls: nil}
+	ingester := &captureIngester{result: allowResult(hooks.ResolvedActor{UserID: "resolved-user", Email: "member@example.test"}), err: nil, calls: nil}
 	service := unitService(t, ingester, authCtx)
 	payload := testPayload()
 	payload.StructuredMessages = []*gen.LiteLLMStructuredMessage{
@@ -163,6 +207,7 @@ func TestIngestTranslatesLatestStructuredUserMessage(t *testing.T) {
 	require.Equal(t, authCtx.APIKeyID, call.auth.APIKeyID)
 	require.False(t, call.options.AllowWarnAcknowledgement)
 	require.False(t, call.options.AllowSessionIdentityFallback)
+	require.Nil(t, call.options.OutputToolCalls)
 	require.Equal(t, "call-1", call.options.SourceAttributes[attr.LiteLLMCallIDKey])
 	require.Equal(t, "trace-1", call.options.SourceAttributes[attr.LiteLLMTraceIDKey])
 	require.Equal(t, "virtual-key-user", call.options.SourceAttributes[attr.LiteLLMUserIDKey])
@@ -171,12 +216,22 @@ func TestIngestTranslatesLatestStructuredUserMessage(t *testing.T) {
 	require.Equal(t, "caller-controlled-end-user", call.options.SourceAttributes[attr.LiteLLMEndUserIDKey])
 	require.Equal(t, "external-org", call.options.SourceAttributes[attr.LiteLLMOrganizationIDKey])
 	require.Equal(t, "integration-key-owner", authCtx.UserID)
+	cached, err := service.calls.Get(t.Context(), *authCtx.ProjectID, "call-1")
+	require.NoError(t, err)
+	require.Equal(t, callcache.Record{
+		ProjectID: *authCtx.ProjectID,
+		CallID:    "call-1",
+		TraceID:   "trace-1",
+		SessionID: "session-from-header",
+		UserID:    "resolved-user",
+		Email:     "member@example.test",
+	}, cached)
 }
 
 func TestIngestUsesTextsAndSessionFallbacks(t *testing.T) {
 	t.Parallel()
 	authCtx := testAuthContext()
-	ingester := &captureIngester{result: &hooksgen.IngestHookResult{Decision: "allow", Reason: nil, Message: nil, Effects: nil}, err: nil, calls: nil}
+	ingester := &captureIngester{result: allowResult(hooks.ResolvedActor{UserID: "", Email: ""}), err: nil, calls: nil}
 	service := unitService(t, ingester, authCtx)
 
 	headerPayload := testPayload()
@@ -211,15 +266,81 @@ func TestIngestUsesTextsAndSessionFallbacks(t *testing.T) {
 	require.Equal(t, "call-3", *ingester.calls[2].payload.Session.ID)
 }
 
+func TestIngestResponseUsesCachedActorAndSession(t *testing.T) {
+	t.Parallel()
+	authCtx := testAuthContext()
+	ingester := &captureIngester{result: allowResult(hooks.ResolvedActor{UserID: "cached-user", Email: "cached@example.test"}), err: nil, calls: nil}
+	service := unitService(t, ingester, authCtx)
+	require.NoError(t, service.calls.Store(t.Context(), callcache.Record{
+		ProjectID: *authCtx.ProjectID,
+		CallID:    "call-1",
+		TraceID:   "request-trace",
+		SessionID: "request-session",
+		UserID:    "cached-user",
+		Email:     "cached@example.test",
+	}))
+
+	payload := testPayload()
+	payload.InputType = "response"
+	payload.Texts = []string{" first segment ", "", "  second segment  "}
+	payload.StructuredMessages = []*gen.LiteLLMStructuredMessage{{Role: "user", Content: "request history must be ignored"}}
+	payload.ToolCalls = []any{map[string]any{"id": "tool-1", "type": "function"}}
+	payload.RequestHeaders = map[string]string{"x-gram-session-id": "conflicting-response-session"}
+	payload.LitellmTraceID = new("conflicting-response-trace")
+	payload.RequestData.UserAPIKeyUserEmail = new("conflicting@example.test")
+
+	result, err := service.Ingest(contextvalues.SetAuthContext(t.Context(), authCtx), payload)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	require.Len(t, ingester.calls, 1)
+	call := ingester.calls[0]
+	require.Equal(t, "assistant.responded", call.payload.Event.Type)
+	require.Equal(t, "first segment\nsecond segment", *call.payload.Data.Message.Text)
+	require.Equal(t, "assistant", *call.payload.Data.Message.Role)
+	require.Equal(t, "request-session", *call.payload.Session.ID)
+	require.Equal(t, "call-1", *call.payload.Session.TurnID)
+	require.Equal(t, "litellm:call-1:response", *call.payload.IdempotencyKey)
+	require.Equal(t, "cached-user", call.auth.UserID)
+	require.Equal(t, "cached@example.test", *call.auth.Email)
+	require.False(t, call.auth.OrgWidePluginHooksKey)
+	require.Equal(t, "cached@example.test", *call.payload.Source.UserEmail)
+	require.Equal(t, payload.ToolCalls, call.options.OutputToolCalls)
+}
+
+func TestIngestResponseCacheMissUsesTrustedEmailWithoutKeyOwner(t *testing.T) {
+	t.Parallel()
+	authCtx := testAuthContext()
+	ingester := &captureIngester{result: allowResult(hooks.ResolvedActor{UserID: "", Email: "member@example.test"}), err: nil, calls: nil}
+	service := unitService(t, ingester, authCtx)
+	payload := testPayload()
+	payload.InputType = "response"
+	payload.Texts = []string{"response"}
+	payload.LitellmCallID = new("response-miss")
+	payload.LitellmTraceID = new("response-trace")
+	payload.RequestData.UserAPIKeyUserEmail = new(" Member@Example.Test ")
+
+	result, err := service.Ingest(contextvalues.SetAuthContext(t.Context(), authCtx), payload)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	require.Len(t, ingester.calls, 1)
+	call := ingester.calls[0]
+	require.Empty(t, call.auth.UserID)
+	require.Nil(t, call.auth.Email)
+	require.Empty(t, call.auth.ExternalUserID)
+	require.False(t, call.auth.OrgWidePluginHooksKey)
+	require.Equal(t, "member@example.test", *call.payload.Source.UserEmail)
+	require.Equal(t, "response-trace", *call.payload.Session.ID)
+}
+
 func TestIngestValidatesAndSkipsEmptyPrompt(t *testing.T) {
 	t.Parallel()
 	authCtx := testAuthContext()
-	ingester := &captureIngester{result: &hooksgen.IngestHookResult{Decision: "allow", Reason: nil, Message: nil, Effects: nil}, err: nil, calls: nil}
+	ingester := &captureIngester{result: allowResult(hooks.ResolvedActor{UserID: "", Email: ""}), err: nil, calls: nil}
 	service := unitService(t, ingester, authCtx)
 
-	responsePayload := testPayload()
-	responsePayload.InputType = "response"
-	result, err := service.Ingest(contextvalues.SetAuthContext(t.Context(), authCtx), responsePayload)
+	invalidPayload := testPayload()
+	invalidPayload.InputType = "invalid"
+	result, err := service.Ingest(contextvalues.SetAuthContext(t.Context(), authCtx), invalidPayload)
 	require.Error(t, err)
 	require.Nil(t, result)
 
@@ -244,13 +365,16 @@ func TestIngestMapsDenyAndErrors(t *testing.T) {
 	payload := testPayload()
 	payload.Texts = []string{"prompt"}
 
-	deny := &captureIngester{result: &hooksgen.IngestHookResult{Decision: "deny", Reason: nil, Message: &message, Effects: nil}, err: nil, calls: nil}
+	deny := &captureIngester{result: &hooks.AuthenticatedIngestResult{
+		Result: &hooksgen.IngestHookResult{Decision: "deny", Reason: nil, Message: &message, Effects: nil},
+		Actor:  hooks.ResolvedActor{UserID: "", Email: ""},
+	}, err: nil, calls: nil}
 	result, err := unitService(t, deny, authCtx).Ingest(contextvalues.SetAuthContext(t.Context(), authCtx), payload)
 	require.NoError(t, err)
 	require.Equal(t, gen.LiteLLMGuardrailAction("BLOCKED"), result.Action)
 	require.Equal(t, message, *result.BlockedReason)
 
-	deny.result.Message = nil
+	deny.result.Result.Message = nil
 	result, err = unitService(t, deny, authCtx).Ingest(contextvalues.SetAuthContext(t.Context(), authCtx), payload)
 	require.NoError(t, err)
 	require.Equal(t, genericBlockedReason, *result.BlockedReason)
@@ -265,7 +389,7 @@ func TestIngestMapsDenyAndErrors(t *testing.T) {
 func TestHTTPRouteRequiresKeyAndExplicitProject(t *testing.T) {
 	t.Parallel()
 	authCtx := testAuthContext()
-	ingester := &captureIngester{result: &hooksgen.IngestHookResult{Decision: "allow", Reason: nil, Message: nil, Effects: nil}, err: nil, calls: nil}
+	ingester := &captureIngester{result: allowResult(hooks.ResolvedActor{UserID: "", Email: ""}), err: nil, calls: nil}
 	service := unitService(t, ingester, authCtx)
 	mux := goahttp.NewMuxer()
 	Attach(mux, service)

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -2,6 +2,7 @@ package litellm
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -10,16 +11,29 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/testsuite"
 
+	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	hooksgen "github.com/speakeasy-api/gram/server/gen/hooks"
 	gen "github.com/speakeasy-api/gram/server/gen/litellm"
+	riskanalysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/message"
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
+	riskcelenv "github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
@@ -28,6 +42,12 @@ type recordingScanner struct {
 	seenUserIDs        []string
 	acknowledgementHit bool
 	challenges         int
+}
+
+type noMCPProvenance struct{}
+
+func (noMCPProvenance) LookupMCPProvenanceByToolCallID(_ context.Context, _ uuid.UUID, _ []string, _ time.Time) (map[string]telemetryrepo.MCPProvenance, error) {
+	return map[string]telemetryrepo.MCPProvenance{}, nil
 }
 
 func requireChatMessages(t *testing.T, ctx context.Context, conn *pgxpool.Pool, params chatrepo.ListChatMessagesParams, count int) []chatrepo.ChatMessage {
@@ -106,6 +126,293 @@ func TestRealHooksPersistsMixedCaseMemberAndDedupesRetry(t *testing.T) {
 	require.Equal(t, "litellm", messages[0].Source.String)
 	require.Equal(t, userID, messages[0].UserID.String)
 	require.Equal(t, conv.NormalizeEmail(storedEmail), messages[0].ExternalUserID.String)
+}
+
+func TestRealHooksCapturesResponseWithCachedActorAndDedupesRetry(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	userID := "user_" + uuid.NewString()
+	storedEmail := "Member." + uuid.NewString() + "@Example.Test"
+	_, err := usersrepo.New(ti.conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       storedEmail,
+		DisplayName: "Response Member",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	_, err = organizationsrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, organizationsrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+
+	callID := "response-" + uuid.NewString()
+	sessionID := "session-" + uuid.NewString()
+	request := testPayload()
+	request.LitellmCallID = &callID
+	request.Texts = []string{"safe prompt"}
+	request.RequestHeaders = map[string]string{"x-gram-session-id": sessionID}
+	request.RequestData.UserAPIKeyUserEmail = &storedEmail
+	result, err := ti.service.Ingest(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+
+	toolCalls := []any{map[string]any{
+		"id":   "call_1",
+		"type": "function",
+		"function": map[string]any{
+			"name":      "lookup",
+			"arguments": `{"query":"test"}`,
+		},
+	}}
+	response := testPayload()
+	response.InputType = "response"
+	response.LitellmCallID = &callID
+	response.Texts = []string{" first response segment ", " ", "second response segment"}
+	response.ToolCalls = toolCalls
+	response.StructuredMessages = []*gen.LiteLLMStructuredMessage{{Role: "user", Content: "request history"}}
+	response.RequestHeaders = map[string]string{"x-gram-session-id": "conflicting-session"}
+	response.RequestData.UserAPIKeyUserEmail = new("conflicting@example.test")
+	result, err = ti.service.Ingest(ctx, response)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	result, err = ti.service.Ingest(ctx, response)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	}, 2)
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, "safe prompt", messages[0].Content)
+	require.Equal(t, "assistant", messages[1].Role)
+	require.Equal(t, "first response segment\nsecond response segment", messages[1].Content)
+	require.Equal(t, userID, messages[0].UserID.String)
+	require.Equal(t, userID, messages[1].UserID.String)
+	require.Equal(t, conv.NormalizeEmail(storedEmail), messages[0].ExternalUserID.String)
+	require.Equal(t, conv.NormalizeEmail(storedEmail), messages[1].ExternalUserID.String)
+	expectedToolCalls, err := json.Marshal(toolCalls)
+	require.NoError(t, err)
+	require.JSONEq(t, string(expectedToolCalls), string(messages[1].ToolCalls))
+	require.Empty(t, messages[1].ToolCallID.String)
+	require.Empty(t, messages[1].ToolUrn.Kind)
+	require.Empty(t, messages[1].ToolUrn.Source)
+	require.Empty(t, messages[1].ToolUrn.Name)
+	require.False(t, messages[1].ToolOutcome.Valid)
+	for _, msg := range messages {
+		require.NotEqual(t, "tool", msg.Role)
+	}
+	require.Eventually(t, func() bool {
+		return ti.observer.count(*authCtx.ProjectID) >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestRealHooksPersistsToolCallOnlyResponse(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	callID := "tool-only-" + uuid.NewString()
+
+	request := testPayload()
+	request.LitellmCallID = &callID
+	request.Texts = []string{"prompt"}
+	_, err := ti.service.Ingest(ctx, request)
+	require.NoError(t, err)
+
+	response := testPayload()
+	response.InputType = "response"
+	response.LitellmCallID = &callID
+	response.Texts = []string{"", "  "}
+	response.ToolCalls = []any{map[string]any{"id": "call_only", "type": "function"}}
+	_, err = ti.service.Ingest(ctx, response)
+	require.NoError(t, err)
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(callID),
+		ProjectID: *authCtx.ProjectID,
+	}, 2)
+	require.Equal(t, "assistant", messages[1].Role)
+	require.Empty(t, messages[1].Content)
+	require.NotEmpty(t, messages[1].ToolCalls)
+}
+
+func TestRealHooksResponseCacheMissDoesNotUseIntegrationKeyOwner(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	callID := "response-miss-" + uuid.NewString()
+	reportedEmail := "Missing." + uuid.NewString() + "@Example.Test"
+
+	response := testPayload()
+	response.InputType = "response"
+	response.LitellmCallID = &callID
+	response.Texts = []string{"uncached response"}
+	response.RequestData.UserAPIKeyUserEmail = &reportedEmail
+	result, err := ti.service.Ingest(ctx, response)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(callID),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "assistant", messages[0].Role)
+	require.False(t, messages[0].UserID.Valid)
+	require.NotEqual(t, authCtx.UserID, messages[0].UserID.String)
+	require.Equal(t, conv.NormalizeEmail(reportedEmail), messages[0].ExternalUserID.String)
+}
+
+func TestRealHooksPureTextResponseProducesAssistantPolicyFinding(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	analyzerConfig, err := riskanalysis.WithDetectionScopes(nil, []riskanalysis.DetectionScopeConfig{{
+		Category:     string(categories.CategorySecrets),
+		ScopeInclude: `kind == "assistant_message"`,
+		ScopeExempt:  "",
+	}})
+	require.NoError(t, err)
+	policyID, err := uuid.NewV7()
+	require.NoError(t, err)
+	policy, err := riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:                   policyID,
+		ProjectID:            *authCtx.ProjectID,
+		OrganizationID:       authCtx.ActiveOrganizationID,
+		Name:                 "assistant response secrets",
+		PolicyType:           nil,
+		Sources:              []string{riskanalysis.SourceGitleaks},
+		PresidioEntities:     nil,
+		AnalyzerConfig:       analyzerConfig,
+		PromptInjectionRules: nil,
+		DisabledRules:        nil,
+		CustomRuleIds:        nil,
+		MessageTypes:         []string{message.Assistant},
+		ScopeInclude:         pgtype.Text{},
+		ScopeExempt:          pgtype.Text{},
+		Enabled:              true,
+		Action:               "flag",
+		AudienceType:         "everyone",
+		ShadowMcpDisposition: pgtype.Text{},
+		AutoName:             false,
+		UserMessage:          pgtype.Text{},
+		Prompt:               pgtype.Text{},
+		ModelConfig:          nil,
+		Score:                pgtype.Float8{},
+	})
+	require.NoError(t, err)
+
+	callID := "assistant-policy-" + uuid.NewString()
+	response := testPayload()
+	response.InputType = "response"
+	response.LitellmCallID = &callID
+	response.Texts = []string{"AccessKeyId ASIAZ2XY3WNBQR5TUVWX SecretAccessKey wJalrXUtnFEMIbKp7MDoRZfiCYqTvHgNsQ8xLcWd"}
+	response.ToolCalls = nil
+	result, err := ti.service.Ingest(ctx, response)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	require.Eventually(t, func() bool {
+		return ti.observer.count(*authCtx.ProjectID) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(callID),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "assistant", messages[0].Role)
+	require.Nil(t, messages[0].ToolCalls)
+
+	fetch := riskanalysis.NewFetchUnanalyzed(testenv.NewLogger(t), testenv.NewTracerProvider(t), ti.conn)
+	fetched, err := fetch.Do(ctx, riskanalysis.FetchUnanalyzedArgs{
+		ProjectID:    *authCtx.ProjectID,
+		IDLowerBound: uuid.Nil,
+		BatchLimit:   100,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{messages[0].ID}, fetched.MessageIDs)
+	require.Len(t, fetched.Policies, 1)
+	require.Equal(t, []string{message.Assistant}, fetched.Policies[0].MessageTypes)
+
+	customRules, err := customruleanalyzer.NewScanner(ti.conn)
+	require.NoError(t, err)
+	celEngine, err := riskcelenv.New()
+	require.NoError(t, err)
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagRiskRecommendedScopes, authCtx.ActiveOrganizationID, true)
+	shadowMCPClient := shadowmcp.NewClient(testenv.NewLogger(t), ti.conn, cache.NoopCache, nil)
+	analyze, err := riskanalysis.NewAnalyzeBatch(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		nil,
+		&riskanalysis.StubPIIScanner{},
+		nil,
+		shadowMCPClient,
+		noMCPProvenance{},
+		nil,
+		flags,
+		gcp.NewNoopPublisher[*riskv1.PresidioAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.GitleaksAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.PromptInjectionAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.PromptPolicyAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.CustomRulesAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.Finding](),
+		customRules,
+		celEngine,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(analyze.Do)
+	activityResult, err := env.ExecuteActivity(analyze.Do, riskanalysis.AnalyzeBatchArgs{
+		ProjectID:              *authCtx.ProjectID,
+		OrganizationID:         authCtx.ActiveOrganizationID,
+		RiskPolicyID:           policy.ID,
+		PolicyVersion:          policy.Version,
+		MessageIDs:             fetched.MessageIDs,
+		ContentPartIDs:         nil,
+		Sources:                policy.Sources,
+		MessageTypes:           policy.MessageTypes,
+		PresidioEntities:       nil,
+		PresidioScoreThreshold: 0,
+		CustomRuleIds:          nil,
+		ApprovedEmailDomains:   nil,
+		BuiltinPresetsEnabled:  false,
+		DetectionScopes:        nil,
+	})
+	require.NoError(t, err)
+	var analyzed riskanalysis.AnalyzeBatchResult
+	require.NoError(t, activityResult.Get(&analyzed))
+	require.Equal(t, 1, analyzed.Processed)
+	require.Positive(t, analyzed.Findings)
+
+	findings, err := riskrepo.New(ti.conn).ListRiskResultsByProjectAndPolicy(ctx, riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID:              *authCtx.ProjectID,
+		RiskPolicyID:           policy.ID,
+		CursorMessageCreatedAt: pgtype.Timestamptz{},
+		CursorID:               uuid.NullUUID{},
+		PageLimit:              10,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+	require.Equal(t, riskanalysis.SourceGitleaks, findings[0].Source)
+	require.True(t, findings[0].Found)
+	require.Equal(t, messages[0].ID, findings[0].ChatMessageID.UUID)
 }
 
 func TestRealHooksBlocksAndCapturesPolicyMessage(t *testing.T) {

--- a/server/internal/litellm/setup_test.go
+++ b/server/internal/litellm/setup_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -18,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/chat"
 	"github.com/speakeasy-api/gram/server/internal/hooks"
+	"github.com/speakeasy-api/gram/server/internal/litellm/callcache"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
@@ -49,9 +51,33 @@ func TestMain(m *testing.M) {
 }
 
 type realTestInstance struct {
-	service *Service
-	hooks   *hooks.Service
-	conn    *pgxpool.Pool
+	service  *Service
+	hooks    *hooks.Service
+	conn     *pgxpool.Pool
+	observer *recordingMessageObserver
+}
+
+type recordingMessageObserver struct {
+	mu       sync.Mutex
+	projects []uuid.UUID
+}
+
+func (r *recordingMessageObserver) OnMessagesStored(_ context.Context, projectID uuid.UUID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.projects = append(r.projects, projectID)
+}
+
+func (r *recordingMessageObserver) count(projectID uuid.UUID) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, observed := range r.projects {
+		if observed == projectID {
+			count++
+		}
+	}
+	return count
 }
 
 func newRealTestService(t *testing.T, scanner risk.RiskScanner) (context.Context, *realTestInstance) {
@@ -74,6 +100,8 @@ func newRealTestService(t *testing.T, scanner risk.RiskScanner) (context.Context
 	assetStorage := assetstest.NewTestBlobStore(t)
 	chatWriter, shutdownWriter := chat.NewChatMessageWriter(logger, conn, assetStorage)
 	t.Cleanup(func() { require.NoError(t, shutdownWriter(t.Context())) })
+	observer := &recordingMessageObserver{mu: sync.Mutex{}, projects: nil}
+	chatWriter.AddObserver(observer)
 	serverURL, err := url.Parse("https://localhost:8080")
 	require.NoError(t, err)
 	siteURL, err := url.Parse("https://app.example.test")
@@ -106,10 +134,11 @@ func newRealTestService(t *testing.T, scanner risk.RiskScanner) (context.Context
 		siteURL,
 		"test-jwt-secret",
 	)
-	service := NewService(logger, tracerProvider, conn, sessionManager, authzEngine, hookService)
+	service := NewService(logger, tracerProvider, conn, sessionManager, authzEngine, hookService, callcache.New(cacheAdapter))
 	return ctx, &realTestInstance{
-		service: service,
-		hooks:   hookService,
-		conn:    conn,
+		service:  service,
+		hooks:    hookService,
+		conn:     conn,
+		observer: observer,
 	}
 }


### PR DESCRIPTION
Depends on #4812.

## Summary
- capture LiteLLM post-call responses through canonical hook ingestion
- preserve authoritative pre-call actor and session attribution in a project-scoped call cache
- retain model-output tool calls as metadata without creating execution records
- reuse the existing chat observer and asynchronous risk-analysis pipeline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture LiteLLM post-call responses and store them as assistant messages through the canonical `hooks` pipeline. Adds a per-call Redis-backed `callcache` so request and response share the same actor/session; responses feed async risk analysis and request-time enforcement stays the same. Implements DNO-705.

- New Features
  - Support `input_type=response`: persist assistant messages and return `NONE`.
  - Project-scoped per-call attribution cache (`callcache`) written pre-call and read post-call; on miss, attribute from trusted response metadata (never the integration-key owner).
  - Response idempotency via `litellm:<call_id>:response` to dedupe retries.
  - Persist model-output tool calls as assistant metadata (`finish_reason=tool_calls`); join segmented texts; capture tool-call-only responses.
  - `hooks` now returns the resolved actor (`AuthenticatedIngestResult`) and accepts `OutputToolCalls`; request/response land on the same session/turn.
  - Wire Redis-backed `callcache` into `litellm`; add logging attrs `attr.SlogLiteLLMCallID` and `attr.SlogLiteLLMTraceID`.

<sup>Written for commit 76a32ecdcb28496b2acdc70044c1cc8c153aae47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

