### PR TITLE
chore: add LiteLLM real proxy e2e (DNO-707)

### DIFF
--- a/.github/workflows/litellm-e2e.yml
+++ b/.github/workflows/litellm-e2e.yml
@@ -21,6 +21,20 @@ jobs:
           cache: true
           env: false
 
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: Cache Go
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ env.GH_CACHE_GO_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_GO_KEY }}
+            ${{ env.GH_CACHE_GO_KEY_PARTIAL }}
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+
       - name: Install Go dependencies
         run: mise run install:go
 

--- a/.github/workflows/litellm-e2e.yml
+++ b/.github/workflows/litellm-e2e.yml
@@ -1,0 +1,28 @@
+name: LiteLLM real proxy E2E
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  litellm-e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Install Go dependencies
+        run: mise run install:go
+
+      - name: Test
+        run: mise run test:litellm-e2e

--- a/.github/workflows/litellm-e2e.yml
+++ b/.github/workflows/litellm-e2e.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   litellm-e2e:
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.mise-tasks/test/litellm-e2e.sh
+++ b/.mise-tasks/test/litellm-e2e.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+#MISE description="Run the pinned LiteLLM real-proxy end-to-end suite"
+#MISE dir="{{ config_root }}/server"
+
+set -euo pipefail
+
+gotestsum --format-hide-empty-pkg -- -tags=inv.debug,litellm_e2e ./internal/litellm -run '^TestLiteLLMProxyE2E$' -count=1 -timeout=20m

--- a/server/internal/litellm/fixtures/litellm-v1.94.0/README.md
+++ b/server/internal/litellm/fixtures/litellm-v1.94.0/README.md
@@ -43,6 +43,29 @@ guardrails:
 
 Every JSONL line is the callback body as received by the local recorder after the documented normalization. There are no synthetic default-stream callback files in this corpus; unsupported repeated callbacks are documented above rather than presented as recorded support.
 
+## Real proxy end-to-end test
+
+Docker must be running. Run the first-class local suite from the repository root:
+
+```sh
+mise run test:litellm-e2e
+```
+
+The suite starts the exact image in `manifest.json` and uses a synthetic local inference provider with real Gram auth, hooks, risk enforcement, capture, Redis idempotency, Postgres persistence, and durable risk analysis. It does not use external provider credentials. It verifies:
+
+The test clones the canonical stanza with `default_on: false` only so each normal and outage posture can be selected independently; customer configuration keeps the documented `default_on: true`.
+
+- Safe non-streaming requests return the fixture completion and capture exactly one user and one assistant message in the explicit session.
+- A synthetic-secret policy violation returns the configured block message before a provider call, captures one blocked user message, and produces a durable gitleaks finding tied to that message.
+- Safe streaming returns valid SSE and captures the user and assistant messages; a blocked stream is rejected before the provider and captures only the user message.
+- A 503 guardrail outage fails closed before provider execution and captures nothing.
+- The explicit `unreachable_fallback: fail_open` variant completes through the provider and captures nothing during the outage.
+- A callback that persists the request and then exceeds the global timeout fails before provider execution; resending with the same `x-litellm-call-id` completes once and leaves exactly one user and one assistant message.
+
+LiteLLM 1.94.0 does not retry a guardrail timeout. Deduplication applies when a client or gateway resends with the same call ID; an ordinary retry with a new call ID is a distinct call. Output blocking is not qualified by this suite. Streaming uses the required `streaming_end_of_stream_only: true`; DNO-738 tracks repeated default streaming callbacks.
+
+This is not part of normal pull-request CI because the large third-party image introduces registry, network, and startup failure modes unrelated to most changes. The manual workflow runs the same mise task. To qualify a new LiteLLM version, update the fixture manifest through the sanctioned contract-fixture regeneration workflow, regenerate the fixture corpus, and require this suite to pass before documenting the version as supported.
+
 ## Regeneration
 
 Docker must be running. From the repository root:

--- a/server/internal/litellm/litellm_proxy_e2e_test.go
+++ b/server/internal/litellm/litellm_proxy_e2e_test.go
@@ -407,7 +407,7 @@ func newProxyHarness(t *testing.T) *proxyHarness {
 		testcontainers.WithEnv(map[string]string{
 			"GRAM_LITELLM_INGEST_KEY": apiKey,
 			"GRAM_PROJECT_SLUG":       *authCtx.ProjectSlug,
-			"REQUEST_TIMEOUT":         "3",
+			"REQUEST_TIMEOUT":         fmt.Sprintf("%d", proxyRequestTimeout/time.Second),
 		}),
 		testcontainers.WithCmd("--config", "/app/e2e-config.yaml", "--port", "4000"),
 		testcontainers.WithWaitStrategy(wait.ForHTTP("/health/liveliness").WithPort("4000/tcp").WithStartupTimeout(3*time.Minute)),

--- a/server/internal/litellm/litellm_proxy_e2e_test.go
+++ b/server/internal/litellm/litellm_proxy_e2e_test.go
@@ -1,0 +1,781 @@
+//go:build litellm_e2e
+
+package litellm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.temporal.io/sdk/testsuite"
+	goahttp "goa.design/goa/v3/http"
+	"gopkg.in/yaml.v3"
+
+	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/auth"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	riskanalysis "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
+	"github.com/speakeasy-api/gram/server/internal/message"
+	"github.com/speakeasy-api/gram/server/internal/risk"
+	riskcelenv "github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	fixtureAnswer       = "fixture answer"
+	proxyMasterKey      = "fixture-master-key"
+	policyBlockedReason = "Synthetic secrets are not permitted."
+	syntheticSecret     = "ghp_R2D2C3POLuk3Skywalker1234567890ab"
+	proxyRequestTimeout = 3 * time.Second
+)
+
+type proxyManifest struct {
+	Image string `json:"image"`
+}
+
+type proxyGuardrail struct {
+	Name   string         `yaml:"guardrail_name"`
+	Params map[string]any `yaml:"litellm_params"`
+}
+
+type canonicalGuardrails struct {
+	Guardrails []proxyGuardrail `yaml:"guardrails"`
+}
+
+type proxyConfig struct {
+	Models          []proxyModel     `yaml:"model_list"`
+	GeneralSettings map[string]any   `yaml:"general_settings"`
+	Guardrails      []proxyGuardrail `yaml:"guardrails"`
+}
+
+type proxyModel struct {
+	Name   string         `yaml:"model_name"`
+	Params map[string]any `yaml:"litellm_params"`
+}
+
+type providerCallKey struct {
+	Scenario string
+	Session  string
+	CallID   string
+}
+
+type fixtureProvider struct {
+	mu    sync.Mutex
+	calls map[providerCallKey]int
+}
+
+func (p *fixtureProvider) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var request struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil || len(request.Messages) == 0 {
+		http.Error(w, "invalid fixture request", http.StatusBadRequest)
+		return
+	}
+	fields := strings.Fields(request.Messages[len(request.Messages)-1].Content)
+	if len(fields) < 3 {
+		http.Error(w, "missing fixture call key", http.StatusBadRequest)
+		return
+	}
+	key := providerCallKey{
+		Scenario: strings.TrimPrefix(fields[0], "scenario="),
+		Session:  strings.TrimPrefix(fields[1], "session="),
+		CallID:   strings.TrimPrefix(fields[2], "call="),
+	}
+	p.mu.Lock()
+	p.calls[key]++
+	p.mu.Unlock()
+
+	if request.Stream {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		chunks := []string{"fixture ", "answer"}
+		for index, text := range chunks {
+			finishReason := any(nil)
+			if index == len(chunks)-1 {
+				finishReason = "stop"
+			}
+			chunk, marshalErr := json.Marshal(map[string]any{
+				"id": "chatcmpl-fixture-stream", "object": "chat.completion.chunk", "created": 1,
+				"model": "fixture-openai", "choices": []any{map[string]any{
+					"index": 0, "delta": map[string]any{"content": text}, "finish_reason": finishReason,
+				}},
+			})
+			if marshalErr != nil {
+				return
+			}
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id": "chatcmpl-fixture", "object": "chat.completion", "created": 1, "model": "fixture-openai",
+		"choices": []any{map[string]any{
+			"index": 0, "message": map[string]any{"role": "assistant", "content": fixtureAnswer}, "finish_reason": "stop",
+		}},
+		"usage": map[string]any{"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+	})
+}
+
+func (p *fixtureProvider) count(key providerCallKey) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls[key]
+}
+
+type timeoutRelay struct {
+	gramURL       string
+	apiKey        string
+	projectSlug   string
+	timeoutCallID string
+	release       chan struct{}
+	releaseOnce   sync.Once
+	mu            sync.Mutex
+	preCalls      int
+	waiting       bool
+}
+
+func (r *timeoutRelay) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	var callback struct {
+		InputType string `json:"input_type"`
+		CallID    string `json:"litellm_call_id"`
+	}
+	if err := json.Unmarshal(body, &callback); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	forward, err := http.NewRequestWithContext(req.Context(), http.MethodPost, r.gramURL+req.URL.Path, bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	forward.Header.Set("Content-Type", "application/json")
+	forward.Header.Set("Gram-Key", r.apiKey)
+	forward.Header.Set("Gram-Project", r.projectSlug)
+	response, err := http.DefaultClient.Do(forward)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	responseBody, readErr := io.ReadAll(response.Body)
+	closeErr := response.Body.Close()
+	if readErr != nil || closeErr != nil {
+		http.Error(w, "read Gram response", http.StatusBadGateway)
+		return
+	}
+
+	if callback.InputType == "request" && callback.CallID == r.timeoutCallID {
+		r.mu.Lock()
+		r.preCalls++
+		first := r.preCalls == 1
+		r.mu.Unlock()
+		if first {
+			r.mu.Lock()
+			r.waiting = true
+			r.mu.Unlock()
+			timer := time.NewTimer(proxyRequestTimeout + 500*time.Millisecond)
+			select {
+			case <-r.release:
+			case <-timer.C:
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			http.Error(w, "synthetic delayed guardrail response", http.StatusServiceUnavailable)
+			r.mu.Lock()
+			r.waiting = false
+			r.mu.Unlock()
+			return
+		}
+	}
+	for name, values := range response.Header {
+		w.Header()[name] = values
+	}
+	w.WriteHeader(response.StatusCode)
+	_, _ = w.Write(responseBody)
+}
+
+func (r *timeoutRelay) isWaiting() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.waiting
+}
+
+func (r *timeoutRelay) releaseFirst() {
+	r.releaseOnce.Do(func() { close(r.release) })
+}
+
+type proxyHarness struct {
+	t          *testing.T
+	conn       *pgxpool.Pool
+	projectID  uuid.UUID
+	orgID      string
+	policy     riskrepo.RiskPolicy
+	proxyURL   string
+	provider   *fixtureProvider
+	relay      *timeoutRelay
+	httpClient *http.Client
+}
+
+type proxyResponse struct {
+	Status int
+	Header http.Header
+	Body   []byte
+}
+
+func TestLiteLLMProxyE2E(t *testing.T) { //nolint:paralleltest // Scenarios intentionally share one proxy container.
+	test := newProxyHarness(t)
+	test.safeNonStreaming()
+	test.blockedNonStreaming()
+	test.safeStreaming()
+	test.blockedStreaming()
+	test.failClosed()
+	test.failOpen()
+	test.timeoutAndResend()
+}
+
+func newProxyHarness(t *testing.T) *proxyHarness {
+	t.Helper()
+	ctx, instance := newRealTestServiceWithScannerFactory(t, func(conn *pgxpool.Pool) risk.RiskScanner {
+		customRules, err := customruleanalyzer.NewScanner(conn)
+		require.NoError(t, err)
+		celEngine, err := riskcelenv.New()
+		require.NoError(t, err)
+		scanner, err := risk.NewScanner(
+			testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn,
+			customRules, nil, nil, nil, &feature.InMemory{}, celEngine,
+		)
+		require.NoError(t, err)
+		return scanner
+	})
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	require.NotNil(t, authCtx.ProjectSlug)
+
+	policyID := uuid.New()
+	policy, err := riskrepo.New(instance.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:                   policyID,
+		ProjectID:            *authCtx.ProjectID,
+		OrganizationID:       authCtx.ActiveOrganizationID,
+		Name:                 "synthetic secret block",
+		PolicyType:           nil,
+		Sources:              []string{riskanalysis.SourceGitleaks},
+		PresidioEntities:     nil,
+		AnalyzerConfig:       nil,
+		PromptInjectionRules: nil,
+		DisabledRules:        nil,
+		CustomRuleIds:        nil,
+		MessageTypes:         []string{message.User},
+		ScopeInclude:         pgtype.Text{},
+		ScopeExempt:          pgtype.Text{},
+		Enabled:              true,
+		Action:               "block",
+		AudienceType:         "everyone",
+		ShadowMcpDisposition: pgtype.Text{},
+		AutoName:             false,
+		UserMessage:          pgtype.Text{String: policyBlockedReason, Valid: true},
+		Prompt:               pgtype.Text{},
+		ModelConfig:          nil,
+		Score:                pgtype.Float8{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, authz.ReplaceGrantsForResource(ctx, instance.conn, authz.ResourceGrant{
+		Resource: authz.Resource{
+			OrganizationID: authCtx.ActiveOrganizationID,
+			Scope:          authz.ScopeRiskPolicyEvaluate,
+			ResourceID:     policyID.String(),
+		},
+		Effect:     authz.PolicyEffectAllow,
+		Principals: []urn.Principal{authz.AllUsersPrincipal()},
+		Selector:   nil,
+	}))
+
+	apiKey := createProxyAPIKey(t, ctx, instance.conn, authCtx)
+	mux := goahttp.NewMuxer()
+	Attach(mux, instance.service)
+	gramServer := httptest.NewServer(mux)
+	t.Cleanup(gramServer.Close)
+
+	provider := &fixtureProvider{mu: sync.Mutex{}, calls: make(map[providerCallKey]int)}
+	providerServer := httptest.NewServer(provider)
+	t.Cleanup(providerServer.Close)
+	// Keep the resend on a fresh Docker Desktop host-port connection after the
+	// intentional guardrail read timeout, while using the same fixture provider.
+	timeoutProviderServer := httptest.NewServer(provider)
+	t.Cleanup(timeoutProviderServer.Close)
+	failureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "synthetic guardrail outage", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(failureServer.Close)
+
+	timeoutCallID := "e2e-timeout-call"
+	relay := &timeoutRelay{
+		gramURL:       gramServer.URL + "/rpc/litellm.ingest",
+		apiKey:        apiKey,
+		projectSlug:   *authCtx.ProjectSlug,
+		timeoutCallID: timeoutCallID,
+		release:       make(chan struct{}),
+		releaseOnce:   sync.Once{},
+		mu:            sync.Mutex{},
+		preCalls:      0,
+		waiting:       false,
+	}
+	relayServer := httptest.NewServer(relay)
+	t.Cleanup(func() {
+		relay.releaseFirst()
+		relayServer.Close()
+	})
+
+	config := buildProxyConfig(t,
+		containerURL(t, providerServer.URL)+"/v1",
+		containerURL(t, timeoutProviderServer.URL)+"/v1",
+		containerURL(t, gramServer.URL)+"/rpc/litellm.ingest",
+		containerURL(t, failureServer.URL),
+		containerURL(t, relayServer.URL),
+	)
+	manifestBytes := testenv.ReadFixture(t, contractFixtureDir+"manifest.json")
+	var manifest proxyManifest
+	require.NoError(t, json.Unmarshal(manifestBytes, &manifest))
+	require.NotEmpty(t, manifest.Image)
+
+	configBytes, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	hostPorts := []int{
+		serverPort(t, gramServer.URL), serverPort(t, providerServer.URL), serverPort(t, timeoutProviderServer.URL),
+		serverPort(t, failureServer.URL), serverPort(t, relayServer.URL),
+	}
+	container, err := testcontainers.Run(t.Context(), manifest.Image,
+		testcontainers.WithLogger(testenv.NewTestcontainersLogger()),
+		testcontainers.WithExposedPorts("4000/tcp"),
+		testcontainers.WithHostPortAccess(hostPorts...),
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			Reader: bytes.NewReader(configBytes), ContainerFilePath: "/app/e2e-config.yaml", FileMode: 0o644,
+		}),
+		testcontainers.WithEnv(map[string]string{
+			"GRAM_LITELLM_INGEST_KEY": apiKey,
+			"GRAM_PROJECT_SLUG":       *authCtx.ProjectSlug,
+			"REQUEST_TIMEOUT":         "3",
+		}),
+		testcontainers.WithCmd("--config", "/app/e2e-config.yaml", "--port", "4000"),
+		testcontainers.WithWaitStrategy(wait.ForHTTP("/health/liveliness").WithPort("4000/tcp").WithStartupTimeout(3*time.Minute)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if t.Failed() {
+			logs, logsErr := container.Logs(context.Background())
+			if logsErr == nil {
+				logBody, readErr := io.ReadAll(logs)
+				if readErr == nil {
+					t.Logf("LiteLLM logs:\n%s", logBody)
+				}
+				_ = logs.Close()
+			}
+		}
+		require.NoError(t, container.Terminate(context.Background()))
+	})
+	proxyURL, err := container.Endpoint(t.Context(), "http")
+	require.NoError(t, err)
+
+	return &proxyHarness{
+		t: t, conn: instance.conn, projectID: *authCtx.ProjectID, orgID: authCtx.ActiveOrganizationID,
+		policy: policy, proxyURL: proxyURL, provider: provider, relay: relay, httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func createProxyAPIKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, authCtx *contextvalues.AuthContext) string {
+	t.Helper()
+	raw := make([]byte, 24)
+	_, err := rand.Read(raw)
+	require.NoError(t, err)
+	key := "gram_test_" + hex.EncodeToString(raw)
+	hash, err := auth.GetAPIKeyHash(key)
+	require.NoError(t, err)
+	_, err = keysrepo.New(conn).CreateAPIKey(ctx, keysrepo.CreateAPIKeyParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		ProjectID:       uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		CreatedByUserID: authCtx.UserID,
+		Name:            "litellm-e2e-hooks-key",
+		KeyPrefix:       key[:10],
+		KeyHash:         hash,
+		Scopes:          []string{auth.APIKeyScopeHooks.String()},
+	})
+	require.NoError(t, err)
+	return key
+}
+
+func buildProxyConfig(t *testing.T, providerURL, timeoutProviderURL, gramURL, failureURL, relayURL string) proxyConfig {
+	t.Helper()
+	readme := string(testenv.ReadFixture(t, contractFixtureDir+"README.md"))
+	marker := "The canonical guardrail stanza is:"
+	start := strings.Index(readme, marker)
+	require.NotEqual(t, -1, start)
+	fenceStart := strings.Index(readme[start:], "```yaml\n")
+	require.NotEqual(t, -1, fenceStart)
+	fenceStart += start + len("```yaml\n")
+	fenceEnd := strings.Index(readme[fenceStart:], "\n```")
+	require.NotEqual(t, -1, fenceEnd)
+
+	var canonical canonicalGuardrails
+	require.NoError(t, yaml.Unmarshal([]byte(readme[fenceStart:fenceStart+fenceEnd]), &canonical))
+	require.Len(t, canonical.Guardrails, 1)
+	guardrail := canonical.Guardrails[0]
+	require.Equal(t, "gram", guardrail.Name)
+	require.Equal(t, "generic_guardrail_api", guardrail.Params["guardrail"])
+	require.Equal(t, true, guardrail.Params["default_on"])
+	require.Equal(t, true, guardrail.Params["streaming_end_of_stream_only"])
+	require.NotEmpty(t, guardrail.Params["api_base"])
+	require.ElementsMatch(t, []any{"pre_call", "post_call"}, guardrail.Params["mode"])
+	require.Equal(t, []any{"x-gram-session-id"}, guardrail.Params["extra_headers"])
+	headers, ok := guardrail.Params["headers"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "os.environ/GRAM_LITELLM_INGEST_KEY", headers["Gram-Key"])
+	require.Equal(t, "os.environ/GRAM_PROJECT_SLUG", headers["Gram-Project"])
+
+	clone := func(name, apiBase string, failureBehavior bool) proxyGuardrail {
+		params := maps.Clone(guardrail.Params)
+		params["api_base"] = apiBase
+		params["default_on"] = false
+		if failureBehavior {
+			params["fail_on_error"] = true
+		}
+		return proxyGuardrail{Name: name, Params: params}
+	}
+	normal := clone("gram-e2e", gramURL, false)
+	failClosed := clone("gram-e2e-fail-closed", failureURL, true)
+	failOpen := clone("gram-e2e-fail-open", failureURL, true)
+	failOpen.Params["unreachable_fallback"] = "fail_open"
+	timeout := clone("gram-e2e-timeout", relayURL, true)
+
+	return proxyConfig{
+		Models: []proxyModel{
+			{
+				Name: "fixture-openai",
+				Params: map[string]any{
+					"model": "openai/fixture-openai", "api_base": providerURL, "api_key": "fixture-provider-key", "num_retries": 0,
+				},
+			},
+			{
+				Name: "fixture-timeout",
+				Params: map[string]any{
+					"model": "openai/fixture-timeout", "api_base": timeoutProviderURL, "api_key": "fixture-provider-key", "num_retries": 0,
+				},
+			},
+		},
+		GeneralSettings: map[string]any{"master_key": proxyMasterKey},
+		Guardrails:      []proxyGuardrail{normal, failClosed, failOpen, timeout},
+	}
+}
+
+func containerURL(t *testing.T, rawURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return "http://host.testcontainers.internal:" + parsed.Port()
+}
+
+func serverPort(t *testing.T, rawURL string) int {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	_, port, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	var value int
+	_, err = fmt.Sscanf(port, "%d", &value)
+	require.NoError(t, err)
+	return value
+}
+
+func (h *proxyHarness) request(scenario, sessionID, callID, guardrail, text string, stream bool) proxyResponse {
+	h.t.Helper()
+	prompt := fmt.Sprintf("scenario=%s session=%s call=%s %s", scenario, sessionID, callID, text)
+	model := "fixture-openai"
+	if scenario == "timeout" {
+		model = "fixture-timeout"
+	}
+	body, err := json.Marshal(map[string]any{
+		"model": model, "messages": []any{map[string]any{"role": "user", "content": prompt}},
+		"guardrails": []string{guardrail}, "stream": stream,
+	})
+	require.NoError(h.t, err)
+	req, err := http.NewRequestWithContext(h.t.Context(), http.MethodPost, h.proxyURL+"/v1/chat/completions", bytes.NewReader(body))
+	require.NoError(h.t, err)
+	req.Header.Set("Authorization", "Bearer "+proxyMasterKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-gram-session-id", sessionID)
+	req.Header.Set("x-litellm-call-id", callID)
+	response, err := h.httpClient.Do(req)
+	require.NoError(h.t, err)
+	responseBody, err := io.ReadAll(response.Body)
+	require.NoError(h.t, err)
+	require.NoError(h.t, response.Body.Close())
+	return proxyResponse{Status: response.StatusCode, Header: response.Header.Clone(), Body: responseBody}
+}
+
+func (h *proxyHarness) key(scenario, sessionID, callID string) providerCallKey {
+	return providerCallKey{Scenario: scenario, Session: sessionID, CallID: callID}
+}
+
+func (h *proxyHarness) prompt(scenario, sessionID, callID, text string) string {
+	return fmt.Sprintf("scenario=%s session=%s call=%s %s", scenario, sessionID, callID, text)
+}
+
+func (h *proxyHarness) messages(sessionID string, count int) []chatrepo.ChatMessage {
+	h.t.Helper()
+	return requireChatMessages(h.t, h.t.Context(), h.conn, chatrepo.ListChatMessagesParams{
+		ChatID: chat.SessionIDToChatID(sessionID), ProjectID: h.projectID,
+	}, count)
+}
+
+func (h *proxyHarness) noMessages(sessionID string) {
+	h.t.Helper()
+	messages, err := chatrepo.New(h.conn).ListChatMessages(h.t.Context(), chatrepo.ListChatMessagesParams{
+		ChatID: chat.SessionIDToChatID(sessionID), ProjectID: h.projectID,
+	})
+	require.NoError(h.t, err)
+	require.Empty(h.t, messages)
+}
+
+func (h *proxyHarness) requireConversation(messages []chatrepo.ChatMessage, prompt string) {
+	h.t.Helper()
+	require.Equal(h.t, []string{"user", "assistant"}, []string{messages[0].Role, messages[1].Role})
+	require.Equal(h.t, prompt, messages[0].Content)
+	require.Equal(h.t, fixtureAnswer, messages[1].Content)
+	for _, stored := range messages {
+		require.Equal(h.t, "litellm", stored.Source.String)
+	}
+}
+
+func (h *proxyHarness) requireCompletion(body []byte) {
+	h.t.Helper()
+	var completion struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	require.NoError(h.t, json.Unmarshal(body, &completion))
+	require.Len(h.t, completion.Choices, 1)
+	require.Equal(h.t, fixtureAnswer, completion.Choices[0].Message.Content)
+}
+
+func (h *proxyHarness) requireBlocked(body []byte) {
+	h.t.Helper()
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(h.t, json.Unmarshal(body, &response))
+	require.Equal(h.t, policyBlockedReason, response.Error.Message)
+}
+
+func (h *proxyHarness) requireSSE(body []byte) {
+	h.t.Helper()
+	var answer strings.Builder
+	done := false
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			done = true
+			continue
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		require.NoError(h.t, json.Unmarshal([]byte(data), &chunk))
+		require.Len(h.t, chunk.Choices, 1)
+		answer.WriteString(chunk.Choices[0].Delta.Content)
+	}
+	require.NoError(h.t, scanner.Err())
+	require.True(h.t, done)
+	require.Equal(h.t, fixtureAnswer, answer.String())
+}
+
+func (h *proxyHarness) safeNonStreaming() {
+	scenario, sessionID, callID := "safe", "e2e-safe-session", "e2e-safe-call"
+	response := h.request(scenario, sessionID, callID, "gram-e2e", "safe prompt", false)
+	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
+	h.requireCompletion(response.Body)
+	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
+	h.requireConversation(h.messages(sessionID, 2), h.prompt(scenario, sessionID, callID, "safe prompt"))
+}
+
+func (h *proxyHarness) blockedNonStreaming() {
+	scenario, sessionID, callID := "blocked", "e2e-blocked-session", "e2e-blocked-call"
+	response := h.request(scenario, sessionID, callID, "gram-e2e", "token="+syntheticSecret, false)
+	require.Equal(h.t, http.StatusBadRequest, response.Status, string(response.Body))
+	h.requireBlocked(response.Body)
+	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
+	messages := h.messages(sessionID, 1)
+	require.Equal(h.t, "user", messages[0].Role)
+	require.Equal(h.t, h.prompt(scenario, sessionID, callID, "token="+syntheticSecret), messages[0].Content)
+	require.Equal(h.t, "litellm", messages[0].Source.String)
+	h.materializeFinding(messages[0].ID)
+}
+
+func (h *proxyHarness) safeStreaming() {
+	scenario, sessionID, callID := "stream-safe", "e2e-stream-safe-session", "e2e-stream-safe-call"
+	response := h.request(scenario, sessionID, callID, "gram-e2e", "safe streaming prompt", true)
+	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
+	require.Contains(h.t, response.Header.Get("Content-Type"), "text/event-stream")
+	h.requireSSE(response.Body)
+	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
+	h.requireConversation(h.messages(sessionID, 2), h.prompt(scenario, sessionID, callID, "safe streaming prompt"))
+}
+
+func (h *proxyHarness) blockedStreaming() {
+	scenario, sessionID, callID := "stream-blocked", "e2e-stream-blocked-session", "e2e-stream-blocked-call"
+	response := h.request(scenario, sessionID, callID, "gram-e2e", "token="+syntheticSecret, true)
+	require.Equal(h.t, http.StatusBadRequest, response.Status, string(response.Body))
+	h.requireBlocked(response.Body)
+	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
+	messages := h.messages(sessionID, 1)
+	require.Equal(h.t, "user", messages[0].Role)
+	require.Equal(h.t, h.prompt(scenario, sessionID, callID, "token="+syntheticSecret), messages[0].Content)
+	require.Equal(h.t, "litellm", messages[0].Source.String)
+}
+
+func (h *proxyHarness) failClosed() {
+	scenario, sessionID, callID := "fail-closed", "e2e-fail-closed-session", "e2e-fail-closed-call"
+	response := h.request(scenario, sessionID, callID, "gram-e2e-fail-closed", "outage prompt", false)
+	require.NotContains(h.t, []int{http.StatusOK, http.StatusCreated, http.StatusNoContent}, response.Status, string(response.Body))
+	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
+	h.noMessages(sessionID)
+}
+
+func (h *proxyHarness) failOpen() {
+	scenario, sessionID, callID := "fail-open", "e2e-fail-open-session", "e2e-fail-open-call"
+	response := h.request(scenario, sessionID, callID, "gram-e2e-fail-open", "outage prompt", false)
+	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
+	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
+	h.noMessages(sessionID)
+}
+
+func (h *proxyHarness) timeoutAndResend() {
+	// LiteLLM 1.94.0 does not retry a timed-out guardrail callback. A gateway may
+	// safely resend with the same call ID; an ordinary retry with a new call ID is distinct.
+	scenario, sessionID, callID := "timeout", "e2e-timeout-session", "e2e-timeout-call"
+	first := h.request(scenario, sessionID, callID, "gram-e2e-timeout", "timeout prompt", false)
+	require.NotEqual(h.t, http.StatusOK, first.Status, string(first.Body))
+	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
+	require.Equal(h.t, "user", h.messages(sessionID, 1)[0].Role)
+	h.relay.releaseFirst()
+	require.EventuallyWithT(h.t, func(collect *assert.CollectT) {
+		assert.False(collect, h.relay.isWaiting())
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Never(h.t, func() bool {
+		return h.provider.count(h.key(scenario, sessionID, callID)) > 0
+	}, 3*time.Second, 10*time.Millisecond)
+	second := h.request(scenario, sessionID, callID, "gram-e2e-timeout", "timeout prompt", false)
+	require.Equal(h.t, http.StatusOK, second.Status, string(second.Body))
+	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
+	h.requireConversation(h.messages(sessionID, 2), h.prompt(scenario, sessionID, callID, "timeout prompt"))
+}
+
+func (h *proxyHarness) materializeFinding(messageID uuid.UUID) {
+	h.t.Helper()
+	customRules, err := customruleanalyzer.NewScanner(h.conn)
+	require.NoError(h.t, err)
+	celEngine, err := riskcelenv.New()
+	require.NoError(h.t, err)
+	flags := &feature.InMemory{}
+	shadowMCPClient := shadowmcp.NewClient(testenv.NewLogger(h.t), h.conn, cache.NoopCache, nil)
+	analyze, err := riskanalysis.NewAnalyzeBatch(
+		testenv.NewLogger(h.t), testenv.NewTracerProvider(h.t), testenv.NewMeterProvider(h.t), h.conn,
+		nil, &riskanalysis.StubPIIScanner{}, nil, shadowMCPClient, noMCPProvenance{}, nil, flags,
+		gcp.NewNoopPublisher[*riskv1.PresidioAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.GitleaksAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.PromptInjectionAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.PromptPolicyAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.CustomRulesAnalysis](),
+		gcp.NewNoopPublisher[*riskv1.Finding](),
+		customRules, celEngine, nil, nil,
+	)
+	require.NoError(h.t, err)
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(analyze.Do)
+	activityResult, err := env.ExecuteActivity(analyze.Do, riskanalysis.AnalyzeBatchArgs{
+		ProjectID: h.projectID, OrganizationID: h.orgID, RiskPolicyID: h.policy.ID, PolicyVersion: h.policy.Version,
+		MessageIDs: []uuid.UUID{messageID}, ContentPartIDs: nil, Sources: h.policy.Sources, MessageTypes: h.policy.MessageTypes,
+		PresidioEntities: nil, PresidioScoreThreshold: 0, CustomRuleIds: nil, ApprovedEmailDomains: nil,
+		BuiltinPresetsEnabled: false, DetectionScopes: nil,
+	})
+	require.NoError(h.t, err)
+	var analyzed riskanalysis.AnalyzeBatchResult
+	require.NoError(h.t, activityResult.Get(&analyzed))
+	require.Equal(h.t, 1, analyzed.Processed)
+	require.Positive(h.t, analyzed.Findings)
+	findings, err := riskrepo.New(h.conn).ListRiskResultsByProjectAndPolicy(h.t.Context(), riskrepo.ListRiskResultsByProjectAndPolicyParams{
+		ProjectID: h.projectID, RiskPolicyID: h.policy.ID, CursorMessageCreatedAt: pgtype.Timestamptz{},
+		CursorID: uuid.NullUUID{}, PageLimit: 10,
+	})
+	require.NoError(h.t, err)
+	require.NotEmpty(h.t, findings)
+	require.Equal(h.t, riskanalysis.SourceGitleaks, findings[0].Source)
+	require.True(h.t, findings[0].Found)
+	require.Equal(h.t, messageID, findings[0].ChatMessageID.UUID)
+}

--- a/server/internal/litellm/litellm_proxy_e2e_test.go
+++ b/server/internal/litellm/litellm_proxy_e2e_test.go
@@ -540,7 +540,7 @@ func serverPort(t *testing.T, rawURL string) int {
 
 func (h *proxyHarness) request(scenario, sessionID, callID, guardrail, text string, stream bool) proxyResponse {
 	h.t.Helper()
-	prompt := fmt.Sprintf("scenario=%s session=%s call=%s %s", scenario, sessionID, callID, text)
+	prompt := h.prompt(scenario, sessionID, callID, text)
 	model := "fixture-openai"
 	if scenario == "timeout" {
 		model = "fixture-timeout"

--- a/server/internal/litellm/setup_test.go
+++ b/server/internal/litellm/setup_test.go
@@ -82,12 +82,18 @@ func (r *recordingMessageObserver) count(projectID uuid.UUID) int {
 
 func newRealTestService(t *testing.T, scanner risk.RiskScanner) (context.Context, *realTestInstance) {
 	t.Helper()
+	return newRealTestServiceWithScannerFactory(t, func(*pgxpool.Pool) risk.RiskScanner { return scanner })
+}
+
+func newRealTestServiceWithScannerFactory(t *testing.T, scannerFactory func(*pgxpool.Pool) risk.RiskScanner) (context.Context, *realTestInstance) {
+	t.Helper()
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
 	meterProvider := testenv.NewMeterProvider(t)
 	conn, err := testInfra.CloneTestDatabase(t, "testdb")
 	require.NoError(t, err)
+	scanner := scannerFactory(conn)
 	redisClient, err := testInfra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 	billingClient := billing.NewStubClient(logger, tracerProvider)


### PR DESCRIPTION
Depends on #4816.

## Summary
- exercise the exact pinned LiteLLM proxy against real Gram auth, policy enforcement, capture, Redis idempotency, and durable risk analysis
- cover safe, blocked, streaming, fail-closed, explicit fail-open, and preserved-call-ID timeout resend scenarios with a synthetic provider
- reuse and validate the canonical customer guardrail stanza from the recorded fixture documentation
- provide `mise run test:litellm-e2e` plus a manual qualification workflow for supported LiteLLM version bumps

LiteLLM 1.94.0 does not retry guardrail timeouts itself. The resend scenario preserves `x-litellm-call-id`; ordinary retries with new call IDs remain distinct calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-proxy end-to-end suite against the pinned `LiteLLM` image to qualify version bumps. It verifies Gram auth, policy enforcement, capture, Redis idempotency, durable risk analysis, and resend dedup using the same `x-litellm-call-id` (DNO-707), and provides a local `mise` task plus a manual GitHub Actions workflow.

- **New Features**
  - Adds `TestLiteLLMProxyE2E` covering safe, blocked, streaming, fail-closed, fail-open, and timeout-resend; the timeout path uses a relay and a dedicated `fixture-timeout` model to delay the guardrail callback.
  - Reads the canonical guardrail stanza from fixtures, clones variants (`normal`, `fail-closed`, `fail-open`, `timeout`) with `default_on: false`, uses `streaming_end_of_stream_only: true`, starts the exact image from the fixture manifest, provides `mise run test:litellm-e2e`, a manual `LiteLLM real proxy E2E` workflow, and documents run/qualification steps in the fixture README.

- **Bug Fixes**
  - Allows cold setup by constructing scanners with the test DB, waits on `/health/liveliness`, exposes host ports for callbacks, and prints container logs on failure.
  - Stabilizes the timeout test by splitting provider ports, keeping a fresh connection after the read timeout, and asserting exactly one provider call after resend with the same `x-litellm-call-id`.

<sup>Written for commit cce5f98a569b6015b77b18923649184207528a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

