### PR TITLE
perf(assistants): widen project assistant warm window to cut cold-start latency

### DIFF
--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -147,13 +147,16 @@ func (s *ServiceCore) EnableManagedAssistant(
 // the caller can reflect it without a re-read.
 func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) (int, error) {
 	warmTTL := int(managedAssistantWarmTTLSeconds)
+	// Only warm_ttl_seconds is set; the other nargs stay nil so UpdateAssistant's
+	// COALESCE leaves those columns untouched. Built through the conv helpers
+	// (not empty pgtype literals) to satisfy exhaustruct.
 	updated, err := assistantrepo.New(s.db).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
-		Name:           pgtype.Text{},
-		Model:          pgtype.Text{},
-		Instructions:   pgtype.Text{},
+		Name:           conv.PtrToPGText(nil),
+		Model:          conv.PtrToPGText(nil),
+		Instructions:   conv.PtrToPGText(nil),
 		WarmTtlSeconds: conv.PtrToPGInt8(&warmTTL),
-		MaxConcurrency: pgtype.Int8{},
-		Status:         pgtype.Text{},
+		MaxConcurrency: conv.PtrToPGInt8(nil),
+		Status:         conv.PtrToPGText(nil),
 		AssistantID:    assistantID,
 		ProjectID:      projectID,
 	})

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -146,18 +146,19 @@ func (s *ServiceCore) EnableManagedAssistant(
 // in SQL (RaiseAssistantWarmTtlSeconds updates only when the stored value is
 // below the target), so this is a single effective write under concurrent
 // chat-opens, never lowers a deliberately longer window, and leaves updated_at
-// untouched. The row is guaranteed to sit at the default afterwards — whether
-// this call or a racing one did the write — so the caller reflects the target
-// without a re-read.
-func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) error {
-	if _, err := assistantrepo.New(s.db).RaiseAssistantWarmTtlSeconds(ctx, assistantrepo.RaiseAssistantWarmTtlSecondsParams{
+// untouched. Returns the number of rows written: 1 when this call performed the
+// raise, 0 when the row was already at or above the target (already healed, or a
+// deliberately longer window) so no write was needed.
+func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) (int64, error) {
+	rows, err := assistantrepo.New(s.db).RaiseAssistantWarmTtlSeconds(ctx, assistantrepo.RaiseAssistantWarmTtlSecondsParams{
 		WarmTtlSeconds: managedAssistantWarmTTLSeconds,
 		AssistantID:    assistantID,
 		ProjectID:      projectID,
-	}); err != nil {
-		return fmt.Errorf("raise managed assistant warm ttl: %w", err)
+	})
+	if err != nil {
+		return 0, fmt.Errorf("raise managed assistant warm ttl: %w", err)
 	}
-	return nil
+	return rows, nil
 }
 
 // GetManagedAssistant resolves a project's managed assistant and hydrates its
@@ -182,12 +183,25 @@ func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UU
 	// not fail the read: the assistant still works at its stored TTL, so log and
 	// carry on.
 	if record.WarmTTLSeconds < int(managedAssistantWarmTTLSeconds) {
-		if err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); err != nil {
+		switch rows, err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); {
+		case err != nil:
 			s.logger.WarnContext(ctx, "heal managed assistant warm ttl", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
-		} else {
-			// The row now sits at the default (this write or a racing one); reflect
-			// it without a re-read. updated_at is intentionally unchanged.
+		case rows > 0:
+			// This call performed the raise, so the row now holds the target.
 			record.WarmTTLSeconds = int(managedAssistantWarmTTLSeconds)
+		default:
+			// No row written: a concurrent update already lifted warm_ttl to at
+			// least the target (possibly a deliberately longer window). The value
+			// read before the heal is stale, so re-read the authoritative one
+			// rather than assuming the target.
+			if fresh, err := assistantrepo.New(s.db).GetAssistant(ctx, assistantrepo.GetAssistantParams{
+				AssistantID: record.ID,
+				ProjectID:   projectID,
+			}); err != nil {
+				s.logger.WarnContext(ctx, "re-read managed assistant warm ttl after no-op heal", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
+			} else {
+				record.WarmTTLSeconds = conv.SafeInt(fresh.WarmTtlSeconds)
+			}
 		}
 	}
 	if err := s.hydrateAssistantToolSources(ctx, projectID, &record); err != nil {

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -57,9 +57,14 @@ const (
 	// legacyManagedAssistantWarmTTLSeconds is the warm window managed assistants
 	// were provisioned with before managedAssistantWarmTTLSeconds was widened to
 	// 300. The lazy heal targets this exact value — not "anything below the new
-	// default" — so a deliberately chosen custom window (including one shorter
-	// than the default, set via UpdateAssistant) is never overwritten. If the
-	// managed default is bumped again, add the intervening prior default(s) here.
+	// default" — so a custom window set to any *other* value (e.g. a deliberately
+	// shorter 120s, set via UpdateAssistant) is left untouched. The one value it
+	// cannot distinguish is this legacy default itself: a window a user
+	// deliberately set to exactly 60s is indistinguishable from an un-migrated row
+	// and will be raised to 300. Inferring "stale default" from the stored value
+	// accepts that narrow ambiguity rather than paying for durable per-row
+	// "customized" metadata on a platform-managed field. If the managed default is
+	// bumped again, add the intervening prior default(s) here.
 	legacyManagedAssistantWarmTTLSeconds int64 = 60
 )
 
@@ -153,8 +158,11 @@ func (s *ServiceCore) EnableManagedAssistant(
 // warm window: it sets warm_ttl_seconds to the current managed default only when
 // the row currently holds exactly legacyManagedAssistantWarmTTLSeconds. Matching
 // the exact prior default (rather than "anything below the new default") means a
-// deliberately chosen custom window — including one shorter than the default,
-// set via UpdateAssistant — is never overwritten. The predicate lives in SQL, so
+// custom window set to any other value — e.g. a deliberately shorter 120s set via
+// UpdateAssistant — is left untouched; only a window still equal to the legacy
+// default is raised (a value a user deliberately set to exactly that default is
+// indistinguishable from an un-migrated row — see the constant's doc). The
+// predicate lives in SQL, so
 // the heal is a single effective write under concurrent chat-opens (later racers
 // match no row) and updated_at is left untouched (this is an internal backfill,
 // not a user edit). Returns the number of rows written: 1 when this call
@@ -189,8 +197,11 @@ func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UU
 	// write-scoped ensure path fires only when one is missing) — so an assistant
 	// on the legacy default is raised the next time its owner opens the chat, with
 	// no data migration. The guard is the *exact* legacy value, not "below the new
-	// default", so a deliberately chosen custom window (warm_ttl is user-settable
-	// via UpdateAssistant) is left alone. The heal is one-time: once healed the
+	// default", so a custom window (warm_ttl is user-settable via UpdateAssistant)
+	// set to any value other than the legacy default is left alone — the lone
+	// ambiguity being a window deliberately set to exactly the legacy default, which
+	// reads as un-migrated (see legacyManagedAssistantWarmTTLSeconds). The heal is
+	// one-time: once healed the
 	// guard is false and this stays a pure read, so the steady state is read-only.
 	// updated_at is left untouched (see raiseManagedAssistantWarmTTL). A repair
 	// failure must not fail the read: the assistant still works at its stored TTL,

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -38,7 +38,20 @@ const (
 
 	// Schema defaults for the assistants table, applied explicitly so the
 	// managed assistant's intent is visible at the call site.
-	managedAssistantWarmTTLSeconds int64 = 60
+	//
+	// warmTTL is how long the assistant's Fly VM is kept alive after it goes
+	// idle. One VM serves every thread (chat) under an assistant, so the window
+	// is per-VM: it stays up until the assistant's *last* active thread has been
+	// quiet for warmTTL. The managed ("Project") assistant is an interactive
+	// dashboard chat: a user reads a reply, thinks, and follows up — gaps of a
+	// minute or two between turns are the norm. At 60s the VM was torn down
+	// inside that think-time gap, so nearly every follow-up (and every re-opened
+	// or newly opened chat that found the VM idle) paid a full Fly cold boot —
+	// the dominant contributor to the multi-second "first response" latency.
+	// Widen the window to cover ordinary think-time so an active project stays on
+	// a warm VM across back-to-back chats. The cost is a shared-CPU/1GB machine
+	// staying up longer between turns; tune here if that trade shifts.
+	managedAssistantWarmTTLSeconds int64 = 300
 	managedAssistantMaxConcurrency int64 = 10
 )
 
@@ -94,6 +107,8 @@ func (s *ServiceCore) EnableManagedAssistant(
 		if err := s.ensureDashboardTrigger(ctx, s.db, organizationID, projectID, existing.ID, existing.Name); err != nil {
 			return assistantRecord{}, err
 		}
+		// GetManagedAssistant already healed a stale warm window (see there), so
+		// `existing` carries the current value — nothing to repair here.
 		return existing, nil
 	case errors.Is(err, pgx.ErrNoRows):
 		// fall through to create
@@ -126,6 +141,28 @@ func (s *ServiceCore) EnableManagedAssistant(
 	return assistantRecord{}, err
 }
 
+// raiseManagedAssistantWarmTTL rewrites a managed assistant's stored warm_ttl
+// to the current managed default. Callers gate on the row being below the
+// default, so this only ever raises the window. Returns the value now stored so
+// the caller can reflect it without a re-read.
+func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) (int, error) {
+	warmTTL := int(managedAssistantWarmTTLSeconds)
+	updated, err := assistantrepo.New(s.db).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
+		Name:           pgtype.Text{},
+		Model:          pgtype.Text{},
+		Instructions:   pgtype.Text{},
+		WarmTtlSeconds: conv.PtrToPGInt8(&warmTTL),
+		MaxConcurrency: pgtype.Int8{},
+		Status:         pgtype.Text{},
+		AssistantID:    assistantID,
+		ProjectID:      projectID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("raise managed assistant warm ttl: %w", err)
+	}
+	return conv.SafeInt(updated.WarmTtlSeconds), nil
+}
+
 // GetManagedAssistant resolves a project's managed assistant and hydrates its
 // management read model. Returns pgx.ErrNoRows when the feature isn't enabled for the project.
 func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UUID) (assistantRecord, error) {
@@ -134,6 +171,22 @@ func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UU
 		return assistantRecord{}, fmt.Errorf("get managed assistant: %w", err)
 	}
 	record := assistantRecordFromManagedRow(row)
+	// Lazily heal a stale warm window. warmTTL is stored per-row at create time,
+	// so a bump to managedAssistantWarmTTLSeconds only reaches assistants created
+	// before it by rewriting the row. The dashboard reads the managed assistant
+	// through here on every chat open, so an assistant provisioned under the old
+	// 60s default is raised to the current default the next time its owner opens
+	// the chat — no data migration needed. Raise-only (never lower) so a
+	// deliberately longer window is preserved; guarded so it is a one-time write
+	// that no-ops once healed. A repair failure must not fail the read: the
+	// assistant still works at its stored TTL, so log and carry on.
+	if record.WarmTTLSeconds < int(managedAssistantWarmTTLSeconds) {
+		if healed, err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); err != nil {
+			s.logger.WarnContext(ctx, "heal managed assistant warm ttl", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
+		} else {
+			record.WarmTTLSeconds = healed
+		}
+	}
 	if err := s.hydrateAssistantToolSources(ctx, projectID, &record); err != nil {
 		return assistantRecord{}, err
 	}

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -141,29 +141,23 @@ func (s *ServiceCore) EnableManagedAssistant(
 	return assistantRecord{}, err
 }
 
-// raiseManagedAssistantWarmTTL rewrites a managed assistant's stored warm_ttl
-// to the current managed default. Callers gate on the row being below the
-// default, so this only ever raises the window. Returns the value now stored so
-// the caller can reflect it without a re-read.
-func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) (int, error) {
-	warmTTL := int(managedAssistantWarmTTLSeconds)
-	// Only warm_ttl_seconds is set; the other nargs stay nil so UpdateAssistant's
-	// COALESCE leaves those columns untouched. Built through the conv helpers
-	// (not empty pgtype literals) to satisfy exhaustruct.
-	updated, err := assistantrepo.New(s.db).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
-		Name:           conv.PtrToPGText(nil),
-		Model:          conv.PtrToPGText(nil),
-		Instructions:   conv.PtrToPGText(nil),
-		WarmTtlSeconds: conv.PtrToPGInt8(&warmTTL),
-		MaxConcurrency: conv.PtrToPGInt8(nil),
-		Status:         conv.PtrToPGText(nil),
+// raiseManagedAssistantWarmTTL lifts a managed assistant's stored
+// warm_ttl_seconds to the current managed default. The raise-only guard lives
+// in SQL (RaiseAssistantWarmTtlSeconds updates only when the stored value is
+// below the target), so this is a single effective write under concurrent
+// chat-opens, never lowers a deliberately longer window, and leaves updated_at
+// untouched. The row is guaranteed to sit at the default afterwards — whether
+// this call or a racing one did the write — so the caller reflects the target
+// without a re-read.
+func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) error {
+	if _, err := assistantrepo.New(s.db).RaiseAssistantWarmTtlSeconds(ctx, assistantrepo.RaiseAssistantWarmTtlSecondsParams{
+		WarmTtlSeconds: managedAssistantWarmTTLSeconds,
 		AssistantID:    assistantID,
 		ProjectID:      projectID,
-	})
-	if err != nil {
-		return 0, fmt.Errorf("raise managed assistant warm ttl: %w", err)
+	}); err != nil {
+		return fmt.Errorf("raise managed assistant warm ttl: %w", err)
 	}
-	return conv.SafeInt(updated.WarmTtlSeconds), nil
+	return nil
 }
 
 // GetManagedAssistant resolves a project's managed assistant and hydrates its
@@ -174,20 +168,26 @@ func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UU
 		return assistantRecord{}, fmt.Errorf("get managed assistant: %w", err)
 	}
 	record := assistantRecordFromManagedRow(row)
-	// Lazily heal a stale warm window. warmTTL is stored per-row at create time,
-	// so a bump to managedAssistantWarmTTLSeconds only reaches assistants created
-	// before it by rewriting the row. The dashboard reads the managed assistant
-	// through here on every chat open, so an assistant provisioned under the old
-	// 60s default is raised to the current default the next time its owner opens
-	// the chat — no data migration needed. Raise-only (never lower) so a
-	// deliberately longer window is preserved; guarded so it is a one-time write
-	// that no-ops once healed. A repair failure must not fail the read: the
-	// assistant still works at its stored TTL, so log and carry on.
+	// Lazily heal a stale warm window. warm_ttl_seconds is stored per-row at
+	// create time, so a bump to managedAssistantWarmTTLSeconds only reaches
+	// assistants created before it by rewriting the row. The dashboard resolves
+	// the managed assistant through here on every chat open — the only path that
+	// reliably runs for an already-provisioned assistant (the write-scoped ensure
+	// path fires only when one is missing) — so an assistant on the old 60s
+	// default is raised the next time its owner opens the chat, with no data
+	// migration. The write is one-time: once healed the guard below is false and
+	// this stays a pure read, so the steady state is read-only. The SQL is
+	// raise-only and leaves updated_at untouched (see raiseManagedAssistantWarmTTL),
+	// so a heal never disturbs the row's change timestamp. A repair failure must
+	// not fail the read: the assistant still works at its stored TTL, so log and
+	// carry on.
 	if record.WarmTTLSeconds < int(managedAssistantWarmTTLSeconds) {
-		if healed, err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); err != nil {
+		if err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); err != nil {
 			s.logger.WarnContext(ctx, "heal managed assistant warm ttl", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
 		} else {
-			record.WarmTTLSeconds = healed
+			// The row now sits at the default (this write or a racing one); reflect
+			// it without a re-read. updated_at is intentionally unchanged.
+			record.WarmTTLSeconds = int(managedAssistantWarmTTLSeconds)
 		}
 	}
 	if err := s.hydrateAssistantToolSources(ctx, projectID, &record); err != nil {

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -53,6 +53,14 @@ const (
 	// staying up longer between turns; tune here if that trade shifts.
 	managedAssistantWarmTTLSeconds int64 = 300
 	managedAssistantMaxConcurrency int64 = 10
+
+	// legacyManagedAssistantWarmTTLSeconds is the warm window managed assistants
+	// were provisioned with before managedAssistantWarmTTLSeconds was widened to
+	// 300. The lazy heal targets this exact value — not "anything below the new
+	// default" — so a deliberately chosen custom window (including one shorter
+	// than the default, set via UpdateAssistant) is never overwritten. If the
+	// managed default is bumped again, add the intervening prior default(s) here.
+	legacyManagedAssistantWarmTTLSeconds int64 = 60
 )
 
 // ErrManagedAssistantNameTaken is returned by EnableManagedAssistant when a
@@ -141,19 +149,23 @@ func (s *ServiceCore) EnableManagedAssistant(
 	return assistantRecord{}, err
 }
 
-// raiseManagedAssistantWarmTTL lifts a managed assistant's stored
-// warm_ttl_seconds to the current managed default. The raise-only guard lives
-// in SQL (RaiseAssistantWarmTtlSeconds updates only when the stored value is
-// below the target), so this is a single effective write under concurrent
-// chat-opens, never lowers a deliberately longer window, and leaves updated_at
-// untouched. Returns the number of rows written: 1 when this call performed the
-// raise, 0 when the row was already at or above the target (already healed, or a
-// deliberately longer window) so no write was needed.
+// raiseManagedAssistantWarmTTL heals a managed assistant still on the legacy
+// warm window: it sets warm_ttl_seconds to the current managed default only when
+// the row currently holds exactly legacyManagedAssistantWarmTTLSeconds. Matching
+// the exact prior default (rather than "anything below the new default") means a
+// deliberately chosen custom window — including one shorter than the default,
+// set via UpdateAssistant — is never overwritten. The predicate lives in SQL, so
+// the heal is a single effective write under concurrent chat-opens (later racers
+// match no row) and updated_at is left untouched (this is an internal backfill,
+// not a user edit). Returns the number of rows written: 1 when this call
+// performed the heal, 0 when the row no longer holds the legacy value (already
+// healed, or a custom window).
 func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) (int64, error) {
 	rows, err := assistantrepo.New(s.db).RaiseAssistantWarmTtlSeconds(ctx, assistantrepo.RaiseAssistantWarmTtlSecondsParams{
-		WarmTtlSeconds: managedAssistantWarmTTLSeconds,
-		AssistantID:    assistantID,
-		ProjectID:      projectID,
+		WarmTtlSeconds:     managedAssistantWarmTTLSeconds,
+		AssistantID:        assistantID,
+		ProjectID:          projectID,
+		FromWarmTtlSeconds: legacyManagedAssistantWarmTTLSeconds,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("raise managed assistant warm ttl: %w", err)
@@ -169,31 +181,32 @@ func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UU
 		return assistantRecord{}, fmt.Errorf("get managed assistant: %w", err)
 	}
 	record := assistantRecordFromManagedRow(row)
-	// Lazily heal a stale warm window. warm_ttl_seconds is stored per-row at
-	// create time, so a bump to managedAssistantWarmTTLSeconds only reaches
-	// assistants created before it by rewriting the row. The dashboard resolves
-	// the managed assistant through here on every chat open — the only path that
-	// reliably runs for an already-provisioned assistant (the write-scoped ensure
-	// path fires only when one is missing) — so an assistant on the old 60s
-	// default is raised the next time its owner opens the chat, with no data
-	// migration. The write is one-time: once healed the guard below is false and
-	// this stays a pure read, so the steady state is read-only. The SQL is
-	// raise-only and leaves updated_at untouched (see raiseManagedAssistantWarmTTL),
-	// so a heal never disturbs the row's change timestamp. A repair failure must
-	// not fail the read: the assistant still works at its stored TTL, so log and
-	// carry on.
-	if record.WarmTTLSeconds < int(managedAssistantWarmTTLSeconds) {
+	// Lazily heal an assistant still on the legacy warm window. warm_ttl_seconds
+	// is stored per-row at create time, so widening managedAssistantWarmTTLSeconds
+	// only reaches assistants created before it by rewriting the row. The
+	// dashboard resolves the managed assistant through here on every chat open —
+	// the only path that reliably runs for an already-provisioned assistant (the
+	// write-scoped ensure path fires only when one is missing) — so an assistant
+	// on the legacy default is raised the next time its owner opens the chat, with
+	// no data migration. The guard is the *exact* legacy value, not "below the new
+	// default", so a deliberately chosen custom window (warm_ttl is user-settable
+	// via UpdateAssistant) is left alone. The heal is one-time: once healed the
+	// guard is false and this stays a pure read, so the steady state is read-only.
+	// updated_at is left untouched (see raiseManagedAssistantWarmTTL). A repair
+	// failure must not fail the read: the assistant still works at its stored TTL,
+	// so log and carry on.
+	if record.WarmTTLSeconds == int(legacyManagedAssistantWarmTTLSeconds) {
 		switch rows, err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); {
 		case err != nil:
 			s.logger.WarnContext(ctx, "heal managed assistant warm ttl", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
 		case rows > 0:
-			// This call performed the raise, so the row now holds the target.
+			// This call performed the heal, so the row now holds the default.
 			record.WarmTTLSeconds = int(managedAssistantWarmTTLSeconds)
 		default:
-			// No row written: a concurrent update already lifted warm_ttl to at
-			// least the target (possibly a deliberately longer window). The value
-			// read before the heal is stale, so re-read the authoritative one
-			// rather than assuming the target.
+			// No row written: a concurrent update changed warm_ttl away from the
+			// legacy value between the read and the heal. The value read before the
+			// heal is stale, so re-read the authoritative one rather than assuming
+			// the default.
 			if fresh, err := assistantrepo.New(s.db).GetAssistant(ctx, assistantrepo.GetAssistantParams{
 				AssistantID: record.ID,
 				ProjectID:   projectID,

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -236,6 +236,44 @@ func TestGetManagedAssistantPreservesLongerWarmTTL(t *testing.T) {
 	require.Equal(t, longer, stored.WarmTtlSeconds, "raise-only heal must leave a longer window untouched")
 }
 
+// TestGetManagedAssistantPreservesCustomShorterWarmTTL guards the heal's
+// exact-match guard: a deliberately chosen window below the default but not equal
+// to the legacy default must never be clobbered up to the default. Warm TTL is
+// user-settable via UpdateAssistant, so healing "anything below the default"
+// would silently overwrite such a choice on every chat open.
+func TestGetManagedAssistantPreservesCustomShorterWarmTTL(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_custom_warm_ttl")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-custom-warm-ttl")
+
+	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	// A custom window that is below the default yet not the legacy default.
+	custom := int64(120)
+	require.Less(t, custom, managedAssistantWarmTTLSeconds)
+	require.NotEqual(t, legacyManagedAssistantWarmTTLSeconds, custom, "test premise: custom value must differ from the legacy default")
+	_, err = assistantrepo.New(conn).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
+		WarmTtlSeconds: pgtype.Int8{Int64: custom, Valid: true},
+		AssistantID:    enabled.ID,
+		ProjectID:      projectID,
+	})
+	require.NoError(t, err)
+
+	got, err := core.GetManagedAssistant(ctx, projectID)
+	require.NoError(t, err)
+	require.Equal(t, int(custom), got.WarmTTLSeconds, "resolve must not overwrite a deliberately chosen sub-default window")
+
+	stored, err := assistantrepo.New(conn).GetAssistant(ctx, assistantrepo.GetAssistantParams{AssistantID: enabled.ID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, custom, stored.WarmTtlSeconds, "the heal must leave a custom window untouched")
+}
+
 // TestEnableManagedAssistantFailsWhenNameTaken: a user assistant already
 // holding the managed name blocks enablement with an actionable error instead
 // of silently masking it as "no managed assistant".

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -163,6 +164,76 @@ func TestGetManagedAssistantNoRows(t *testing.T) {
 
 	_, err = core.GetManagedAssistant(ctx, projectID)
 	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+// TestGetManagedAssistantHealsStaleWarmTTL verifies the lazy warm-window heal:
+// an assistant left on an older, shorter warm_ttl is raised to the current
+// managed default the next time it is resolved (the path the dashboard hits on
+// every chat open), and the new value is persisted — not merely reflected in the
+// response.
+func TestGetManagedAssistantHealsStaleWarmTTL(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_heal_warm_ttl")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-heal-warm-ttl")
+
+	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	// Simulate an assistant provisioned under the old, shorter default.
+	stale := int64(60)
+	require.Less(t, stale, managedAssistantWarmTTLSeconds, "test premise: stale value must be below the current default")
+	_, err = assistantrepo.New(conn).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
+		WarmTtlSeconds: pgtype.Int8{Int64: stale, Valid: true},
+		AssistantID:    enabled.ID,
+		ProjectID:      projectID,
+	})
+	require.NoError(t, err)
+
+	got, err := core.GetManagedAssistant(ctx, projectID)
+	require.NoError(t, err)
+	require.Equal(t, int(managedAssistantWarmTTLSeconds), got.WarmTTLSeconds, "resolve must heal a stale warm window to the managed default")
+
+	stored, err := assistantrepo.New(conn).GetAssistant(ctx, assistantrepo.GetAssistantParams{AssistantID: enabled.ID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, managedAssistantWarmTTLSeconds, stored.WarmTtlSeconds, "heal must persist the raised warm window")
+}
+
+// TestGetManagedAssistantPreservesLongerWarmTTL verifies the heal is raise-only:
+// a deliberately longer warm window is never lowered to the managed default, and
+// the resolve reports the true stored value rather than assuming the default.
+func TestGetManagedAssistantPreservesLongerWarmTTL(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_preserve_warm_ttl")
+	require.NoError(t, err)
+	ctx := t.Context()
+
+	core := newProvisioningCore(t, conn)
+	projectID := newProvisioningProject(t, conn, "managed-preserve-warm-ttl")
+
+	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
+	require.NoError(t, err)
+
+	longer := managedAssistantWarmTTLSeconds * 2
+	_, err = assistantrepo.New(conn).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
+		WarmTtlSeconds: pgtype.Int8{Int64: longer, Valid: true},
+		AssistantID:    enabled.ID,
+		ProjectID:      projectID,
+	})
+	require.NoError(t, err)
+
+	got, err := core.GetManagedAssistant(ctx, projectID)
+	require.NoError(t, err)
+	require.Equal(t, int(longer), got.WarmTTLSeconds, "resolve must not lower a longer warm window")
+
+	stored, err := assistantrepo.New(conn).GetAssistant(ctx, assistantrepo.GetAssistantParams{AssistantID: enabled.ID, ProjectID: projectID})
+	require.NoError(t, err)
+	require.Equal(t, longer, stored.WarmTtlSeconds, "raise-only heal must leave a longer window untouched")
 }
 
 // TestEnableManagedAssistantFailsWhenNameTaken: a user assistant already

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -493,6 +493,24 @@ WHERE id = @assistant_id
   AND deleted IS FALSE
 RETURNING id, project_id, organization_id, created_by_user_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status, created_at, updated_at, deleted_at;
 
+-- name: RaiseAssistantWarmTtlSeconds :execrows
+-- Atomically raise an assistant's warm_ttl_seconds to @warm_ttl_seconds, but
+-- only when the stored value is strictly below it. The `warm_ttl_seconds <`
+-- guard lives in the WHERE, not in application memory, so the heal is a single
+-- effective write even when concurrent chat-opens race to repair the same stale
+-- row: the first update lifts the value and every later one matches no row. It
+-- is genuinely raise-only — a deliberately longer window can never be lowered,
+-- because a stored value already at or above the target fails the guard.
+-- updated_at is deliberately left untouched: this is an internal, system-driven
+-- backfill of an infra field, not a user edit, so it must not disturb the row's
+-- change timestamp (and a GET that heals then returns the row stays consistent).
+UPDATE assistants
+SET warm_ttl_seconds = @warm_ttl_seconds
+WHERE id = @assistant_id
+  AND project_id = @project_id
+  AND deleted IS FALSE
+  AND warm_ttl_seconds < @warm_ttl_seconds;
+
 -- name: DeleteAssistant :exec
 UPDATE assistants
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -494,22 +494,12 @@ WHERE id = @assistant_id
 RETURNING id, project_id, organization_id, created_by_user_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status, created_at, updated_at, deleted_at;
 
 -- name: RaiseAssistantWarmTtlSeconds :execrows
--- Atomically raise an assistant's warm_ttl_seconds to @warm_ttl_seconds, but
--- only when the stored value is strictly below it. The `warm_ttl_seconds <`
--- guard lives in the WHERE, not in application memory, so the heal is a single
--- effective write even when concurrent chat-opens race to repair the same stale
--- row: the first update lifts the value and every later one matches no row. It
--- is genuinely raise-only — a deliberately longer window can never be lowered,
--- because a stored value already at or above the target fails the guard.
--- updated_at is deliberately left untouched: this is an internal, system-driven
--- backfill of an infra field, not a user edit, so it must not disturb the row's
--- change timestamp (and a GET that heals then returns the row stays consistent).
 UPDATE assistants
 SET warm_ttl_seconds = @warm_ttl_seconds
 WHERE id = @assistant_id
   AND project_id = @project_id
   AND deleted IS FALSE
-  AND warm_ttl_seconds < @warm_ttl_seconds;
+  AND warm_ttl_seconds = @from_warm_ttl_seconds;
 
 -- name: DeleteAssistant :exec
 UPDATE assistants

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2576,7 +2576,12 @@ type RaiseAssistantWarmTtlSecondsParams struct {
 }
 
 func (q *Queries) RaiseAssistantWarmTtlSeconds(ctx context.Context, arg RaiseAssistantWarmTtlSecondsParams) (int64, error) {
-	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds, arg.WarmTtlSeconds, arg.AssistantID, arg.ProjectID, arg.FromWarmTtlSeconds)
+	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds,
+		arg.WarmTtlSeconds,
+		arg.AssistantID,
+		arg.ProjectID,
+		arg.FromWarmTtlSeconds,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2559,6 +2559,29 @@ func (q *Queries) MarkAssistantRuntimeReaped(ctx context.Context, arg MarkAssist
 	return err
 }
 
+const raiseAssistantWarmTtlSeconds = `-- name: RaiseAssistantWarmTtlSeconds :execrows
+UPDATE assistants
+SET warm_ttl_seconds = $1
+WHERE id = $2
+  AND project_id = $3
+  AND deleted IS FALSE
+  AND warm_ttl_seconds < $1
+`
+
+type RaiseAssistantWarmTtlSecondsParams struct {
+	WarmTtlSeconds int64
+	AssistantID    uuid.UUID
+	ProjectID      uuid.UUID
+}
+
+func (q *Queries) RaiseAssistantWarmTtlSeconds(ctx context.Context, arg RaiseAssistantWarmTtlSecondsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds, arg.WarmTtlSeconds, arg.AssistantID, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const reapStuckAssistantRuntimes = `-- name: ReapStuckAssistantRuntimes :many
 UPDATE assistant_runtimes
 SET

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2565,27 +2565,18 @@ SET warm_ttl_seconds = $1
 WHERE id = $2
   AND project_id = $3
   AND deleted IS FALSE
-  AND warm_ttl_seconds < $1
+  AND warm_ttl_seconds = $4
 `
 
 type RaiseAssistantWarmTtlSecondsParams struct {
-	WarmTtlSeconds int64
-	AssistantID    uuid.UUID
-	ProjectID      uuid.UUID
+	WarmTtlSeconds     int64
+	AssistantID        uuid.UUID
+	ProjectID          uuid.UUID
+	FromWarmTtlSeconds int64
 }
 
-// Atomically raise an assistant's warm_ttl_seconds to @warm_ttl_seconds, but
-// only when the stored value is strictly below it. The `warm_ttl_seconds <`
-// guard lives in the WHERE, not in application memory, so the heal is a single
-// effective write even when concurrent chat-opens race to repair the same stale
-// row: the first update lifts the value and every later one matches no row. It
-// is genuinely raise-only — a deliberately longer window can never be lowered,
-// because a stored value already at or above the target fails the guard.
-// updated_at is deliberately left untouched: this is an internal, system-driven
-// backfill of an infra field, not a user edit, so it must not disturb the row's
-// change timestamp (and a GET that heals then returns the row stays consistent).
 func (q *Queries) RaiseAssistantWarmTtlSeconds(ctx context.Context, arg RaiseAssistantWarmTtlSecondsParams) (int64, error) {
-	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds, arg.WarmTtlSeconds, arg.AssistantID, arg.ProjectID)
+	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds, arg.WarmTtlSeconds, arg.AssistantID, arg.ProjectID, arg.FromWarmTtlSeconds)
 	if err != nil {
 		return 0, err
 	}

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2574,6 +2574,16 @@ type RaiseAssistantWarmTtlSecondsParams struct {
 	ProjectID      uuid.UUID
 }
 
+// Atomically raise an assistant's warm_ttl_seconds to @warm_ttl_seconds, but
+// only when the stored value is strictly below it. The `warm_ttl_seconds <`
+// guard lives in the WHERE, not in application memory, so the heal is a single
+// effective write even when concurrent chat-opens race to repair the same stale
+// row: the first update lifts the value and every later one matches no row. It
+// is genuinely raise-only — a deliberately longer window can never be lowered,
+// because a stored value already at or above the target fails the guard.
+// updated_at is deliberately left untouched: this is an internal, system-driven
+// backfill of an infra field, not a user edit, so it must not disturb the row's
+// change timestamp (and a GET that heals then returns the row stays consistent).
 func (q *Queries) RaiseAssistantWarmTtlSeconds(ctx context.Context, arg RaiseAssistantWarmTtlSecondsParams) (int64, error) {
 	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds, arg.WarmTtlSeconds, arg.AssistantID, arg.ProjectID)
 	if err != nil {

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -31,6 +31,13 @@ const (
 	defaultFlyRuntimeHealthTimeout  = 45 * time.Second
 	defaultFlyRuntimeRequestTimeout = 2 * time.Minute
 
+	// flyRuntimeHealthPollInterval is the gap between /healthz probes while
+	// waiting for a freshly started runner to come up. The runner becomes ready
+	// at an arbitrary point within an interval, so the interval is the worst-case
+	// slack added to a cold boot after the process is already serving. Kept short
+	// so that slack stays small; the probes are cheap and only run during a boot.
+	flyRuntimeHealthPollInterval = 250 * time.Millisecond
+
 	// flyRuntimeReapCallTimeout caps a single Fly API call during reap so
 	// one wedged row cannot consume the parent activity's deadline.
 	flyRuntimeReapCallTimeout = 30 * time.Second
@@ -1128,7 +1135,7 @@ func (f *FlyRuntimeBackend) waitForRuntimeHealth(ctx context.Context, target fly
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("wait for runtime health: %w", ctx.Err())
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(flyRuntimeHealthPollInterval):
 		}
 	}
 }


### PR DESCRIPTION
The managed ("Project") assistant runs on a **per-assistant** Fly VM that the server boots on demand — one VM serves every thread (chat) under the assistant, up to its max concurrency. The warm window — how long that VM is kept alive after its **last** active thread goes idle — was 60s. In an interactive dashboard chat, think-time gaps between turns routinely exceed a minute, so the VM was torn down mid-conversation and the next chat to find it idle (a follow-up, or a fresh chat) paid a full Fly cold boot: machine launch + runner readiness + first-turn bootstrap. That cold boot is the dominant contributor to the multi-second "first response" latency.

Raise the managed-assistant warm TTL from 60s to 300s so an active project stays on a warm VM across back-to-back chats. The cost is a shared-CPU/1GB machine staying up longer between turns.

The warm TTL is stored per assistant row at create time, so bumping the constant alone would only reach newly provisioned assistants. `GetManagedAssistant` now lazily heals a stale warm window (exact-legacy-match on the prior 60s default, raise-only, `updated_at` untouched, failure-tolerant): the dashboard reads the managed assistant through it on every chat open, so an assistant provisioned under the old default is raised on the owner's next open — no data migration. A window deliberately set to any other value is left alone; the one value it can't distinguish from an un-migrated row is an explicit 60s.

Also name the Fly runner `/healthz` poll interval and tighten it 500ms → 250ms to shave worst-case slack off the cold boots that remain.

---
## Summary by cubic
Raise the Project Assistant warm TTL from 60s to 300s so dashboard chats keep a warm Fly VM between turns, reducing first-response cold-starts. Also cut the runner /healthz boot poll interval to 250ms to trim worst-case cold boots.

- **Performance**
  - Auto-heal existing assistants on read with an atomic, raise-only SQL update guarded to the exact 60s legacy value; leaves updated_at unchanged, preserves custom windows (an exact 60s choice is indistinguishable and will be raised), and re-reads on no-op to return the stored window. Tests cover healing a stale window and preserving both longer and custom-short windows.
  - Tighten Fly runner /healthz polling from 500ms to 250ms during boot only.
  - Tradeoff: the per-assistant shared-CPU/1GB VM can idle up to 5 minutes between turns.

<sup>Written for commit 9ee883a46f3e838de33efacb2235904283fc7139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4820?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)