### PR TITLE
feat: normalize LiteLLM spans into canonical model-usage telemetry

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -955,7 +955,8 @@ func newStartCommand() *cli.Command {
 				otelForwarder.Shutdown(ctx)
 				return nil
 			})
-			litellmTraceProcessor = litellm.NewTraceProcessor(logger, meterProvider, telemLogger)
+			litellmCalls := callcache.New(cache.NewRedisCacheAdapter(redisClient))
+			litellmTraceProcessor = litellm.NewTraceProcessor(logger, meterProvider, telemLogger, litellmCalls)
 			litellmTraceProcessor.Start(ctx)
 
 			svixClient, shutdown, err := newSvixClient(c, logger, guardianPolicy)
@@ -1153,7 +1154,7 @@ func newStartCommand() *cli.Command {
 				c.String("jwt-signing-key"),
 			)
 			hooks.Attach(mux, hooksService)
-			litellm.Attach(mux, litellm.NewService(logger, tracerProvider, db, sessionManager, authzEngine, hooksService, callcache.New(cache.NewRedisCacheAdapter(redisClient)), litellmTraceProcessor))
+			litellm.Attach(mux, litellm.NewService(logger, tracerProvider, db, sessionManager, authzEngine, hooksService, litellmCalls, litellmTraceProcessor))
 			aiintegrations.Attach(mux, aiintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, &background.TemporalAIUsagePoller{TemporalEnv: temporalEnv}))
 			deviceintegrations.Attach(mux, deviceintegrations.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, encryptionClient, guardianPolicy, &background.DeviceIntegrationSyncTrigger{TemporalEnv: temporalEnv, Logger: logger}, featureFlags))
 			modelkeys.Attach(mux, modelkeys.NewService(logger, tracerProvider, db, sessionManager, authzEngine, encryptionClient, openRouter, productFeatures, auditLogger))

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -427,8 +427,12 @@ const (
 	LiteLLMTeamAliasKey      = attribute.Key("gram.litellm.team_alias")
 	LiteLLMEndUserIDKey      = attribute.Key("gram.litellm.end_user_id")
 	LiteLLMOrganizationIDKey = attribute.Key("gram.litellm.org_id")
-	LiteLLMIsStreamingKey    = attribute.Key("litellm.is_streaming")
-	LiteLLMResponseCostKey   = attribute.Key("litellm.response.cost")
+	LiteLLMAPIKeyHashKey     = attribute.Key("gram.litellm.api_key_hash")
+	LiteLLMAPIKeyAliasKey    = attribute.Key("gram.litellm.api_key_alias")
+	LiteLLMInputCostKey      = attribute.Key("litellm.cost.input")
+	LiteLLMOutputCostKey     = attribute.Key("litellm.cost.output")
+	LiteLLMCacheReadCostKey  = attribute.Key("litellm.cost.cache_read")
+	LiteLLMCacheWriteCostKey = attribute.Key("litellm.cost.cache_creation")
 	// MCPMatchKey carries the server-level identifier the matcher resolved
 	// for a hook-time MCP tool call — an HTTP/SSE URL, a stdio command, or
 	// (as fallback) the `mcp__<server>__` prefix from the tool name. Set on
@@ -499,7 +503,6 @@ const (
 	GenAIUsagePromptTokensKey             = attribute.Key("gen_ai.usage.prompt_tokens")
 	GenAIUsageCompletionTokensKey         = attribute.Key("gen_ai.usage.completion_tokens")
 	GenAIRequestIsStreamingKey            = attribute.Key("gen_ai.request.is_streaming")
-	GenAIRequestStreamingKey              = attribute.Key("gen_ai.request.streaming")
 
 	CursorUsageEventHashKey = attribute.Key("cursor.event_hash")
 	CursorChargedCentsKey   = attribute.Key("cursor.charged_cents")

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -3,6 +3,8 @@ package litellm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 	"go.temporal.io/sdk/testsuite"
 	goahttp "goa.design/goa/v3/http"
 
@@ -128,6 +131,78 @@ func TestRealHooksPersistsMixedCaseMemberAndDedupesRetry(t *testing.T) {
 	require.Equal(t, "litellm", messages[0].Source.String)
 	require.Equal(t, userID, messages[0].UserID.String)
 	require.Equal(t, conv.NormalizeEmail(storedEmail), messages[0].ExternalUserID.String)
+}
+
+func TestOTLPTraceUsesGuardrailCallAttribution(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	userID := "user_" + uuid.NewString()
+	storedEmail := "Trace." + uuid.NewString() + "@Example.Test"
+	_, err := usersrepo.New(ti.conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       storedEmail,
+		DisplayName: "Trace Member",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	_, err = organizationsrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, organizationsrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+
+	callID := "trace-call-" + uuid.NewString()
+	traceID := "trace-session-" + uuid.NewString()
+	payload := testPayload()
+	payload.LitellmCallID = &callID
+	payload.LitellmTraceID = &traceID
+	payload.Texts = []string{"joined prompt"}
+	payload.RequestData.UserAPIKeyUserEmail = new(storedEmail)
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(traceID),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+
+	ti.service.auth = fixedAuthorizer{authCtx: authCtx}
+	start := time.Now().UTC()
+	body := fmt.Appendf(nil, `{"resourceSpans":[{"scopeSpans":[{"spans":[{"traceId":"0123456789abcdef0123456789abcdef","spanId":"0123456789abcdef","name":"chat model","kind":3,"startTimeUnixNano":"%d","endTimeUnixNano":"%d","attributes":[{"key":"gen_ai.operation.name","value":{"stringValue":"chat"}},{"key":"gen_ai.request.model","value":{"stringValue":"model-group"}},{"key":"litellm.provider.model","value":{"stringValue":"openai/gpt-4o"}},{"key":"litellm.call_id","value":{"stringValue":"%s"}},{"key":"litellm.trace_id","value":{"stringValue":"otel-trace"}},{"key":"litellm.metadata.user_api_key_user_email","value":{"stringValue":"otel@example.test"}},{"key":"gen_ai.usage.input_tokens","value":{"intValue":"11"}},{"key":"gen_ai.usage.output_tokens","value":{"intValue":"7"}},{"key":"litellm.cost.total","value":{"doubleValue":0.125}}]}]}]}]}`, start.UnixNano(), start.Add(125*time.Millisecond).UnixNano(), callID)
+	response := serveTraceRequest(t, mountedTraceMux(ti.service), body, "application/json", "", "fixture-key", "fixture-project")
+	require.Equal(t, http.StatusAccepted, response.Code)
+	require.NoError(t, ti.service.traces.Shutdown(t.Context()))
+
+	query := telemetryrepo.New(ti.chConn)
+	var logs []telemetryrepo.TelemetryLog
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+		var queryErr error
+		logs, queryErr = query.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     start.Add(-time.Second).UnixNano(),
+			TimeEnd:       start.Add(time.Second).UnixNano(),
+			GramURNs:      []string{litellmOTLPResourceURN},
+			SortOrder:     "asc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		assert.NoError(collect, queryErr)
+		assert.Len(collect, logs, 1)
+	}, 10*time.Second, 50*time.Millisecond)
+
+	require.Equal(t, messages[0].UserID.String, gjson.Get(logs[0].Attributes, "user.id").String())
+	require.Equal(t, conv.NormalizeEmail(storedEmail), gjson.Get(logs[0].Attributes, "user.email").String())
+	require.Equal(t, callID, gjson.Get(logs[0].Attributes, "gram.litellm.call_id").String())
+	require.Equal(t, traceID, gjson.Get(logs[0].Attributes, "gram.litellm.trace_id").String())
+	require.Equal(t, traceID, gjson.Get(logs[0].Attributes, "gen_ai.conversation.id").String())
+	require.EqualValues(t, 18, gjson.Get(logs[0].Attributes, "gen_ai.usage.total_tokens").Int())
+	require.Equal(t, "urn:telemetry:provider_otel:span:chat", gjson.Get(logs[0].Attributes, "gram.event.urn").String())
 }
 
 func TestRealHooksCapturesResponseWithCachedActorAndDedupesRetry(t *testing.T) {

--- a/server/internal/litellm/otlp.go
+++ b/server/internal/litellm/otlp.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -44,7 +45,6 @@ const (
 	otlpAttributeBool
 	otlpAttributeInteger
 	otlpAttributeNumber
-	otlpAttributeStringArray
 )
 
 type otlpAttributeSpec struct {
@@ -53,49 +53,65 @@ type otlpAttributeSpec struct {
 }
 
 var spanAttributeAllowlist = map[string]otlpAttributeSpec{
-	"gen_ai.operation.name":                    {target: attr.GenAIOperationNameKey, kind: otlpAttributeString},
-	"gen_ai.provider.name":                     {target: attr.GenAIProviderNameKey, kind: otlpAttributeString},
-	"gen_ai.system":                            {target: attr.GenAISystemKey, kind: otlpAttributeString},
-	"gen_ai.request.model":                     {target: attr.GenAIRequestModelKey, kind: otlpAttributeString},
-	"gen_ai.response.model":                    {target: attr.GenAIResponseModelKey, kind: otlpAttributeString},
-	"gen_ai.response.id":                       {target: attr.GenAIResponseIDKey, kind: otlpAttributeString},
-	"gen_ai.response.finish_reasons":           {target: attr.GenAIResponseFinishReasonsKey, kind: otlpAttributeStringArray},
-	"gen_ai.conversation.id":                   {target: attr.GenAIConversationIDKey, kind: otlpAttributeString},
-	"gen_ai.usage.input_tokens":                {target: attr.GenAIUsageInputTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.output_tokens":               {target: attr.GenAIUsageOutputTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.total_tokens":                {target: attr.GenAIUsageTotalTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.prompt_tokens":               {target: attr.GenAIUsagePromptTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.completion_tokens":           {target: attr.GenAIUsageCompletionTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.cache_read.input_tokens":     {target: attr.GenAIUsageCacheReadInputTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.cache_creation.input_tokens": {target: attr.GenAIUsageCacheCreationInputTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.reasoning_tokens":            {target: attr.GenAIUsageReasoningTokensKey, kind: otlpAttributeInteger},
-	"gen_ai.usage.cost":                        {target: attr.GenAIUsageCostKey, kind: otlpAttributeNumber},
-	"gen_ai.request.is_streaming":              {target: attr.GenAIRequestIsStreamingKey, kind: otlpAttributeBool},
-	"gen_ai.request.streaming":                 {target: attr.GenAIRequestStreamingKey, kind: otlpAttributeBool},
-	"litellm.is_streaming":                     {target: attr.LiteLLMIsStreamingKey, kind: otlpAttributeBool},
-	"litellm.response.cost":                    {target: attr.LiteLLMResponseCostKey, kind: otlpAttributeNumber},
-	"litellm.call_id":                          {target: attr.LiteLLMCallIDKey, kind: otlpAttributeString},
-	"litellm_call_id":                          {target: attr.LiteLLMCallIDKey, kind: otlpAttributeString},
-	"litellm.trace_id":                         {target: attr.LiteLLMTraceIDKey, kind: otlpAttributeString},
-	"litellm_trace_id":                         {target: attr.LiteLLMTraceIDKey, kind: otlpAttributeString},
-	"litellm.user_id":                          {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
-	"user_api_key_user_id":                     {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
-	"metadata.user_api_key_user_id":            {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
-	"litellm.user_email":                       {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
-	"user_api_key_user_email":                  {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
-	"metadata.user_api_key_user_email":         {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
-	"litellm.team_id":                          {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
-	"user_api_key_team_id":                     {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
-	"metadata.user_api_key_team_id":            {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
-	"litellm.team_alias":                       {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
-	"user_api_key_team_alias":                  {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
-	"metadata.user_api_key_team_alias":         {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
-	"litellm.org_id":                           {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
-	"litellm.organization_id":                  {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
-	"user_api_key_org_id":                      {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
-	"metadata.user_api_key_org_id":             {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
-	"user_api_key_end_user_id":                 {target: attr.LiteLLMEndUserIDKey, kind: otlpAttributeString},
-	"metadata.user_api_key_end_user_id":        {target: attr.LiteLLMEndUserIDKey, kind: otlpAttributeString},
+	"gen_ai.operation.name":                     {target: attr.GenAIOperationNameKey, kind: otlpAttributeString},
+	"gen_ai.provider.name":                      {target: attr.GenAIProviderNameKey, kind: otlpAttributeString},
+	"gen_ai.system":                             {target: attr.GenAISystemKey, kind: otlpAttributeString},
+	"gen_ai.request.model":                      {target: attr.GenAIRequestModelKey, kind: otlpAttributeString},
+	"gen_ai.response.model":                     {target: attr.GenAIResponseModelKey, kind: otlpAttributeString},
+	"gen_ai.response.id":                        {target: attr.GenAIResponseIDKey, kind: otlpAttributeString},
+	"gen_ai.conversation.id":                    {target: attr.GenAIConversationIDKey, kind: otlpAttributeString},
+	"gen_ai.usage.input_tokens":                 {target: attr.GenAIUsageInputTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.output_tokens":                {target: attr.GenAIUsageOutputTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.total_tokens":                 {target: attr.GenAIUsageTotalTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.prompt_tokens":                {target: attr.GenAIUsagePromptTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.completion_tokens":            {target: attr.GenAIUsageCompletionTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.cache_read.input_tokens":      {target: attr.GenAIUsageCacheReadInputTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.cache_creation.input_tokens":  {target: attr.GenAIUsageCacheCreationInputTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.reasoning_tokens":             {target: attr.GenAIUsageReasoningTokensKey, kind: otlpAttributeInteger},
+	"gen_ai.usage.cost":                         {target: attr.GenAIUsageCostKey, kind: otlpAttributeNumber},
+	"gen_ai.request.is_streaming":               {target: attr.GenAIRequestIsStreamingKey, kind: otlpAttributeBool},
+	"gen_ai.request.streaming":                  {target: attr.GenAIRequestIsStreamingKey, kind: otlpAttributeBool},
+	"litellm.is_streaming":                      {target: attr.GenAIRequestIsStreamingKey, kind: otlpAttributeBool},
+	"litellm.request.streaming":                 {target: attr.GenAIRequestIsStreamingKey, kind: otlpAttributeBool},
+	"llm.is_streaming":                          {target: attr.GenAIRequestIsStreamingKey, kind: otlpAttributeBool},
+	"litellm.response.cost":                     {target: attr.GenAIUsageCostKey, kind: otlpAttributeNumber},
+	"litellm.cost.total":                        {target: attr.GenAIUsageCostKey, kind: otlpAttributeNumber},
+	"litellm.cost.input":                        {target: attr.LiteLLMInputCostKey, kind: otlpAttributeNumber},
+	"litellm.cost.output":                       {target: attr.LiteLLMOutputCostKey, kind: otlpAttributeNumber},
+	"litellm.cost.cache_read":                   {target: attr.LiteLLMCacheReadCostKey, kind: otlpAttributeNumber},
+	"litellm.cost.cache_creation":               {target: attr.LiteLLMCacheWriteCostKey, kind: otlpAttributeNumber},
+	"litellm.provider.model":                    {target: attr.GenAIResponseModelKey, kind: otlpAttributeString},
+	"litellm.call_id":                           {target: attr.LiteLLMCallIDKey, kind: otlpAttributeString},
+	"litellm_call_id":                           {target: attr.LiteLLMCallIDKey, kind: otlpAttributeString},
+	"litellm.trace_id":                          {target: attr.LiteLLMTraceIDKey, kind: otlpAttributeString},
+	"litellm_trace_id":                          {target: attr.LiteLLMTraceIDKey, kind: otlpAttributeString},
+	"litellm.user_id":                           {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
+	"user_api_key_user_id":                      {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
+	"metadata.user_api_key_user_id":             {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
+	"litellm.user_email":                        {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
+	"user_api_key_user_email":                   {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
+	"metadata.user_api_key_user_email":          {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
+	"litellm.team_id":                           {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
+	"user_api_key_team_id":                      {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
+	"metadata.user_api_key_team_id":             {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
+	"litellm.team_alias":                        {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
+	"user_api_key_team_alias":                   {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
+	"metadata.user_api_key_team_alias":          {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
+	"litellm.org_id":                            {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
+	"litellm.organization_id":                   {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
+	"user_api_key_org_id":                       {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
+	"metadata.user_api_key_org_id":              {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
+	"user_api_key_end_user_id":                  {target: attr.LiteLLMEndUserIDKey, kind: otlpAttributeString},
+	"metadata.user_api_key_end_user_id":         {target: attr.LiteLLMEndUserIDKey, kind: otlpAttributeString},
+	"litellm.team.id":                           {target: attr.LiteLLMTeamIDKey, kind: otlpAttributeString},
+	"litellm.team.alias":                        {target: attr.LiteLLMTeamAliasKey, kind: otlpAttributeString},
+	"litellm.api_key.hash":                      {target: attr.LiteLLMAPIKeyHashKey, kind: otlpAttributeString},
+	"litellm.end_user.id":                       {target: attr.LiteLLMEndUserIDKey, kind: otlpAttributeString},
+	"litellm.metadata.user_api_key_user_id":     {target: attr.LiteLLMUserIDKey, kind: otlpAttributeString},
+	"litellm.metadata.user_api_key_user_email":  {target: attr.LiteLLMUserEmailKey, kind: otlpAttributeString},
+	"litellm.metadata.user_api_key_org_id":      {target: attr.LiteLLMOrganizationIDKey, kind: otlpAttributeString},
+	"litellm.metadata.user_api_key_alias":       {target: attr.LiteLLMAPIKeyAliasKey, kind: otlpAttributeString},
+	"litellm.metadata.user_api_key_end_user_id": {target: attr.LiteLLMEndUserIDKey, kind: otlpAttributeString},
 }
 
 var resourceAttributeAllowlist = map[string]otlpAttributeSpec{
@@ -1150,9 +1166,22 @@ func (s *Service) traceLogParams(ctx context.Context, request *otlpExportRequest
 					}
 				}
 
-				operation, _ := spanAttributes[attr.GenAIOperationNameKey].(string)
-				operation = lowCardinalityGenAIOperation(operation)
-				eventURN := urn.NewTelemetryEvent(urn.TelemetryEventOriginProviderOTEL, urn.TelemetryEventKindSpan, operation).String()
+				deriveLiteLLMTotalTokens(spanAttributes)
+				operation := liteLLMModelOperation(spanAttributes, int32(span.Kind))
+				userInfo := telemetry.UserInfoByID("")
+				if operation != "unknown" {
+					callID, _ := spanAttributes[attr.LiteLLMCallIDKey].(string)
+					traceID, _ := spanAttributes[attr.LiteLLMTraceIDKey].(string)
+					if conversationID := conv.Default(traceID, callID); conversationID != "" {
+						spanAttributes[attr.GenAIConversationIDKey] = conversationID
+					}
+					if email, _ := spanAttributes[attr.LiteLLMUserEmailKey].(string); email != "" {
+						userInfo = telemetry.UserInfoByEmail(email)
+					}
+				} else {
+					stripLiteLLMUsageAttributes(spanAttributes)
+				}
+				eventURN := liteLLMEventURN(operation)
 				spanAttributes[attr.EventURNKey] = eventURN
 
 				params = append(params, telemetry.WithOTELMetadata(telemetry.LogParams{
@@ -1166,7 +1195,7 @@ func (s *Service) traceLogParams(ctx context.Context, request *otlpExportRequest
 						FunctionID:     nil,
 						OrganizationID: organizationID,
 					},
-					UserInfo:   telemetry.UserInfoByID(""),
+					UserInfo:   userInfo,
 					Attributes: spanAttributes,
 				}, observed, resourceAttributes))
 			}
@@ -1241,17 +1270,6 @@ func validOTLPAttributeValue(value any, kind otlpAttributeValueKind) bool {
 		default:
 			return false
 		}
-	case otlpAttributeStringArray:
-		values, ok := value.([]any)
-		if !ok {
-			return false
-		}
-		for _, item := range values {
-			if _, ok := item.(string); !ok {
-				return false
-			}
-		}
-		return true
 	default:
 		return false
 	}
@@ -1284,6 +1302,71 @@ func lowCardinalityGenAIOperation(operation string) string {
 		return operation
 	default:
 		return "unknown"
+	}
+}
+
+func liteLLMModelOperation(attributes map[attr.Key]any, kind int32) string {
+	operation, _ := attributes[attr.GenAIOperationNameKey].(string)
+	operation = lowCardinalityGenAIOperation(operation)
+	if operation == "unknown" || tracev1.Span_SpanKind(kind) != tracev1.Span_SPAN_KIND_CLIENT {
+		return "unknown"
+	}
+	for _, key := range []attr.Key{
+		attr.GenAIRequestModelKey,
+		attr.GenAIResponseModelKey,
+		attr.LiteLLMCallIDKey,
+		attr.GenAIUsageInputTokensKey,
+		attr.GenAIUsageOutputTokensKey,
+		attr.GenAIUsageTotalTokensKey,
+		attr.GenAIUsageCostKey,
+	} {
+		if _, ok := attributes[key]; ok {
+			return operation
+		}
+	}
+	return "unknown"
+}
+
+func liteLLMEventURN(operation string) string {
+	return urn.NewTelemetryEvent(urn.TelemetryEventOriginProviderOTEL, urn.TelemetryEventKindSpan, operation).String()
+}
+
+func deriveLiteLLMTotalTokens(attributes map[attr.Key]any) {
+	if _, exists := attributes[attr.GenAIUsageTotalTokensKey]; exists {
+		return
+	}
+	input, hasInput := attributes[attr.GenAIUsageInputTokensKey].(int64)
+	output, hasOutput := attributes[attr.GenAIUsageOutputTokensKey].(int64)
+	if (!hasInput && !hasOutput) || input > math.MaxInt64-output {
+		return
+	}
+	attributes[attr.GenAIUsageTotalTokensKey] = input + output
+}
+
+func stripLiteLLMUsageAttributes(attributes map[attr.Key]any) {
+	for _, key := range []attr.Key{
+		attr.GenAIProviderNameKey,
+		attr.GenAISystemKey,
+		attr.GenAIRequestModelKey,
+		attr.GenAIResponseModelKey,
+		attr.GenAIResponseIDKey,
+		attr.GenAIConversationIDKey,
+		attr.GenAIUsageInputTokensKey,
+		attr.GenAIUsageOutputTokensKey,
+		attr.GenAIUsageTotalTokensKey,
+		attr.GenAIUsagePromptTokensKey,
+		attr.GenAIUsageCompletionTokensKey,
+		attr.GenAIUsageCacheReadInputTokensKey,
+		attr.GenAIUsageCacheCreationInputTokensKey,
+		attr.GenAIUsageReasoningTokensKey,
+		attr.GenAIUsageCostKey,
+		attr.GenAIRequestIsStreamingKey,
+		attr.LiteLLMInputCostKey,
+		attr.LiteLLMOutputCostKey,
+		attr.LiteLLMCacheReadCostKey,
+		attr.LiteLLMCacheWriteCostKey,
+	} {
+		delete(attributes, key)
 	}
 }
 

--- a/server/internal/litellm/setup_test.go
+++ b/server/internal/litellm/setup_test.go
@@ -156,14 +156,15 @@ func newRealTestServiceWithScannerFactory(t *testing.T, scannerFactory func(*pgx
 		siteURL,
 		"test-jwt-secret",
 	)
-	traceProcessor := NewTraceProcessor(logger, meterProvider, telemetryLogger)
+	calls := callcache.New(cacheAdapter)
+	traceProcessor := NewTraceProcessor(logger, meterProvider, telemetryLogger, calls)
 	traceProcessor.Start(ctx)
 	t.Cleanup(func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		require.NoError(t, traceProcessor.Shutdown(shutdownCtx))
 	})
-	service := NewService(logger, tracerProvider, conn, sessionManager, authzEngine, hookService, callcache.New(cacheAdapter), traceProcessor)
+	service := NewService(logger, tracerProvider, conn, sessionManager, authzEngine, hookService, calls, traceProcessor)
 	return ctx, &realTestInstance{
 		service:   service,
 		hooks:     hookService,

--- a/server/internal/litellm/trace_processor.go
+++ b/server/internal/litellm/trace_processor.go
@@ -94,7 +94,9 @@ func enrichTraceAttribution(ctx context.Context, logger *slog.Logger, calls *cal
 		if !attribution.found {
 			continue
 		}
-		spans[index].UserInfo = telemetry.UserInfoByIDAndEmail(attribution.record.UserID, attribution.record.Email)
+		if attribution.record.UserID != "" || attribution.record.Email != "" {
+			spans[index].UserInfo = telemetry.UserInfoByIDAndEmail(attribution.record.UserID, attribution.record.Email)
+		}
 		if attribution.record.SessionID != "" {
 			spans[index].Attributes[attr.GenAIConversationIDKey] = attribution.record.SessionID
 		}

--- a/server/internal/litellm/trace_processor.go
+++ b/server/internal/litellm/trace_processor.go
@@ -7,9 +7,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/litellm/callcache"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 )
 
@@ -43,8 +45,63 @@ type TraceProcessor struct {
 	invalidIdentifiers metric.Int64Counter
 }
 
-func NewTraceProcessor(logger *slog.Logger, meterProvider metric.MeterProvider, telemetryLogger *telemetry.Logger) *TraceProcessor {
-	return newTraceProcessor(logger, meterProvider, telemetryLogger.LogBulkBounded, traceProcessorWorkers, traceProcessorQueueSize)
+func NewTraceProcessor(logger *slog.Logger, meterProvider metric.MeterProvider, telemetryLogger *telemetry.Logger, calls *callcache.Cache) *TraceProcessor {
+	logBulk := func(ctx context.Context, spans []telemetry.LogParams) error {
+		cacheCtx, cancel := context.WithTimeout(ctx, callCacheTimeout)
+		enrichTraceAttribution(cacheCtx, logger, calls, spans)
+		cancel()
+		return telemetryLogger.LogBulkBounded(ctx, spans)
+	}
+	return newTraceProcessor(logger, meterProvider, logBulk, traceProcessorWorkers, traceProcessorQueueSize)
+}
+
+type traceAttribution struct {
+	record callcache.Record
+	found  bool
+}
+
+func enrichTraceAttribution(ctx context.Context, logger *slog.Logger, calls *callcache.Cache, spans []telemetry.LogParams) {
+	cache := make(map[string]traceAttribution)
+	for index := range spans {
+		if spans[index].Attributes[attr.EventURNKey] == liteLLMEventURN("unknown") {
+			continue
+		}
+		callID, _ := spans[index].Attributes[attr.LiteLLMCallIDKey].(string)
+		if callID == "" {
+			continue
+		}
+		cacheKey := spans[index].ToolInfo.ProjectID + ":" + callID
+		attribution, ok := cache[cacheKey]
+		if !ok {
+			if ctx.Err() != nil {
+				return
+			}
+			projectID, err := uuid.Parse(spans[index].ToolInfo.ProjectID)
+			if err != nil {
+				continue
+			}
+			record, err := calls.Get(ctx, projectID, callID)
+			attribution = traceAttribution{record: record, found: err == nil}
+			cache[cacheKey] = attribution
+			if err != nil && !callcache.IsMiss(err) {
+				logger.WarnContext(ctx, "read cached LiteLLM trace attribution",
+					attr.SlogError(err),
+					attr.SlogProjectID(spans[index].ToolInfo.ProjectID),
+					attr.SlogLiteLLMCallID(callID),
+				)
+			}
+		}
+		if !attribution.found {
+			continue
+		}
+		spans[index].UserInfo = telemetry.UserInfoByIDAndEmail(attribution.record.UserID, attribution.record.Email)
+		if attribution.record.SessionID != "" {
+			spans[index].Attributes[attr.GenAIConversationIDKey] = attribution.record.SessionID
+		}
+		if attribution.record.TraceID != "" {
+			spans[index].Attributes[attr.LiteLLMTraceIDKey] = attribution.record.TraceID
+		}
+	}
 }
 
 func newTraceProcessor(logger *slog.Logger, meterProvider metric.MeterProvider, logBulk func(context.Context, []telemetry.LogParams) error, workers, queueSize int) *TraceProcessor {

--- a/server/internal/litellm/traces_test.go
+++ b/server/internal/litellm/traces_test.go
@@ -1399,6 +1399,38 @@ func TestEnrichTraceAttributionUsesPreCallCache(t *testing.T) {
 	require.NotContains(t, spans[1].Attributes, attr.LiteLLMTraceIDKey)
 }
 
+func TestEnrichTraceAttributionPreservesOTLPActorWhenCachedActorIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	calls := callcache.New(newMemoryCache())
+	require.NoError(t, calls.Store(t.Context(), callcache.Record{
+		ProjectID: projectID,
+		CallID:    "call-id",
+		TraceID:   "cached-trace",
+		SessionID: "cached-session",
+		UserID:    "",
+		Email:     "",
+	}))
+	spans := []telemetry.LogParams{{
+		Timestamp: time.Time{},
+		ToolInfo: telemetry.ToolInfo{
+			ID: "", URN: litellmOTLPResourceURN, Name: "litellm", ProjectID: projectID.String(), DeploymentID: "", FunctionID: nil, OrganizationID: "org-id",
+		},
+		UserInfo: telemetry.UserInfoByEmail("otel@example.test"),
+		Attributes: map[attr.Key]any{
+			attr.LiteLLMCallIDKey: "call-id",
+			attr.EventURNKey:      liteLLMEventURN("chat"),
+		},
+	}}
+
+	enrichTraceAttribution(t.Context(), testenv.NewLogger(t), calls, spans)
+	require.Empty(t, spans[0].UserInfo.UserID())
+	require.Equal(t, "otel@example.test", spans[0].UserInfo.Email())
+	require.Equal(t, "cached-session", spans[0].Attributes[attr.GenAIConversationIDKey])
+	require.Equal(t, "cached-trace", spans[0].Attributes[attr.LiteLLMTraceIDKey])
+}
+
 func TestOTLPResourceAttributeBudgetDropsOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/litellm/traces_test.go
+++ b/server/internal/litellm/traces_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -29,6 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/litellm/callcache"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
@@ -1004,10 +1006,24 @@ func TestTracePersistenceKeepsOnlyAllowlistedAttributes(t *testing.T) {
 	}
 	require.True(t, invalidFound)
 
-	require.Equal(t, "0123456789abcdef0123456789abcdef", gjson.Get(logs[0].Attributes, "trace.id").String())
-	require.Equal(t, "fixture-logical-trace", gjson.Get(logs[0].Attributes, "gram.litellm.trace_id").String())
-	require.Equal(t, "openai", gjson.Get(logs[0].Attributes, "gen_ai.provider.name").String())
-	require.EqualValues(t, 11, gjson.Get(logs[0].Attributes, "gen_ai.usage.input_tokens").Int())
+	for _, log := range logs[:2] {
+		require.Equal(t, "0123456789abcdef0123456789abcdef", gjson.Get(log.Attributes, "trace.id").String())
+		require.Equal(t, "fixture-logical-trace", gjson.Get(log.Attributes, "gram.litellm.trace_id").String())
+		require.Equal(t, "fixture-call-id", gjson.Get(log.Attributes, "gram.litellm.call_id").String())
+		require.Equal(t, "fixture-logical-trace", gjson.Get(log.Attributes, "gen_ai.conversation.id").String())
+		require.Equal(t, "openai", gjson.Get(log.Attributes, "gen_ai.provider.name").String())
+		require.Equal(t, "fixture-model", gjson.Get(log.Attributes, "gen_ai.request.model").String())
+		require.Equal(t, "fixture-model-v2", gjson.Get(log.Attributes, "gen_ai.response.model").String())
+		require.Equal(t, "fixture-response-id", gjson.Get(log.Attributes, "gen_ai.response.id").String())
+		require.EqualValues(t, 11, gjson.Get(log.Attributes, "gen_ai.usage.input_tokens").Int())
+		require.EqualValues(t, 7, gjson.Get(log.Attributes, "gen_ai.usage.output_tokens").Int())
+		require.EqualValues(t, 18, gjson.Get(log.Attributes, "gen_ai.usage.total_tokens").Int())
+		require.InDelta(t, 0.00125, gjson.Get(log.Attributes, "gen_ai.usage.cost").Float(), 0.0000001)
+		require.InDelta(t, 125, gjson.Get(log.Attributes, "otel.span.duration_ms").Float(), 0.000001)
+		require.True(t, gjson.Get(log.Attributes, "gen_ai.request.is_streaming").Bool())
+		require.Equal(t, "urn:telemetry:provider_otel:span:chat", gjson.Get(log.Attributes, "gram.event.urn").String())
+		require.False(t, gjson.Get(log.Attributes, "gen_ai.response.finish_reasons").Exists())
+	}
 }
 
 func TestOTLPAttributeLimitsAndRecursiveValues(t *testing.T) {
@@ -1033,7 +1049,7 @@ func TestOTLPAttributeLimitsAndRecursiveValues(t *testing.T) {
 		Key:   "gen_ai.response.finish_reasons",
 		Value: otlpAnyValue{ArrayValue: &otlpArrayValue{Values: []otlpAnyValue{{StringValue: &finish}}}},
 	}}, spanAttributeAllowlist)
-	require.Equal(t, []any{"stop"}, recursive["gen_ai.response.finish_reasons"])
+	require.Empty(t, recursive)
 
 	nonFinite, err := decodeOTLPJSON([]byte(`{"resourceSpans":[{"scopeSpans":[{"spans":[{"attributes":[{"key":"gen_ai.usage.cost","value":{"doubleValue":"NaN"}}]}]}]}]}`))
 	require.NoError(t, err)
@@ -1143,19 +1159,16 @@ func TestOTLPAttributeTypeAllowlistAcceptsSafeValues(t *testing.T) {
 
 	service, processor := newTraceTestService(t, fixedAuthorizer{authCtx: testAuthContext()}, testenv.NewMeterProvider(t), func(context.Context, []telemetry.LogParams) error { return nil })
 	model := "safe-model"
-	finishReason := "stop"
 	streaming := true
 	tokens := jsonInt64(42)
 	cost := jsonFloat64(0.125)
 	result := service.sanitizeOTLPAttributes(t.Context(), []otlpKeyValue{
 		{Key: "gen_ai.request.model", Value: otlpAnyValue{StringValue: &model}},
-		{Key: "gen_ai.response.finish_reasons", Value: otlpAnyValue{ArrayValue: &otlpArrayValue{Values: []otlpAnyValue{{StringValue: &finishReason}}}}},
 		{Key: "gen_ai.request.is_streaming", Value: otlpAnyValue{BoolValue: &streaming}},
 		{Key: "gen_ai.usage.input_tokens", Value: otlpAnyValue{IntValue: &tokens}},
 		{Key: "gen_ai.usage.cost", Value: otlpAnyValue{DoubleValue: &cost}},
 	}, spanAttributeAllowlist)
 	require.Equal(t, "safe-model", result[attr.GenAIRequestModelKey])
-	require.Equal(t, []any{"stop"}, result[attr.GenAIResponseFinishReasonsKey])
 	require.Equal(t, true, result[attr.GenAIRequestIsStreamingKey])
 	require.Equal(t, int64(42), result[attr.GenAIUsageInputTokensKey])
 	require.InDelta(t, 0.125, result[attr.GenAIUsageCostKey], 1e-12)
@@ -1186,8 +1199,204 @@ func TestOTLPAttributeTypeAllowlistRejectsNegativeUsageAndAcceptsZero(t *testing
 	}, spanAttributeAllowlist)
 	require.Equal(t, int64(0), zero[attr.GenAIUsageInputTokensKey])
 	require.InDelta(t, 0, zero[attr.GenAIUsageCostKey], 0)
-	require.Equal(t, int64(0), zero[attr.LiteLLMResponseCostKey])
 	require.NoError(t, processor.Shutdown(t.Context()))
+}
+
+func TestOTLPV2AttributesNormalizeToCanonicalUsage(t *testing.T) {
+	t.Parallel()
+
+	service, processor := newTraceTestService(t, fixedAuthorizer{authCtx: testAuthContext()}, testenv.NewMeterProvider(t), func(context.Context, []telemetry.LogParams) error { return nil })
+	stringsByKey := map[string]string{
+		"litellm.provider.model":                    "openai/gpt-4o",
+		"litellm.team.id":                           "team-id",
+		"litellm.team.alias":                        "engineering",
+		"litellm.api_key.hash":                      "key-hash",
+		"litellm.end_user.id":                       "metadata-end-user",
+		"litellm.metadata.user_api_key_user_id":     "user-id",
+		"litellm.metadata.user_api_key_user_email":  "member@example.test",
+		"litellm.metadata.user_api_key_org_id":      "provider-org",
+		"litellm.metadata.user_api_key_alias":       "key-alias",
+		"litellm.metadata.user_api_key_end_user_id": "metadata-end-user",
+	}
+	values := make([]otlpKeyValue, 0, len(stringsByKey)+6)
+	for key, value := range stringsByKey {
+		current := value
+		values = append(values, otlpKeyValue{Key: key, Value: otlpAnyValue{StringValue: &current}})
+	}
+	streaming := true
+	totalCost := jsonFloat64(0.12)
+	inputCost := jsonFloat64(0.07)
+	outputCost := jsonFloat64(0.05)
+	cacheReadCost := jsonFloat64(0.01)
+	cacheWriteCost := jsonFloat64(0.02)
+	values = append(values,
+		otlpKeyValue{Key: "litellm.request.streaming", Value: otlpAnyValue{BoolValue: &streaming}},
+		otlpKeyValue{Key: "litellm.cost.total", Value: otlpAnyValue{DoubleValue: &totalCost}},
+		otlpKeyValue{Key: "litellm.cost.input", Value: otlpAnyValue{DoubleValue: &inputCost}},
+		otlpKeyValue{Key: "litellm.cost.output", Value: otlpAnyValue{DoubleValue: &outputCost}},
+		otlpKeyValue{Key: "litellm.cost.cache_read", Value: otlpAnyValue{DoubleValue: &cacheReadCost}},
+		otlpKeyValue{Key: "litellm.cost.cache_creation", Value: otlpAnyValue{DoubleValue: &cacheWriteCost}},
+	)
+
+	result := service.sanitizeOTLPAttributes(t.Context(), values, spanAttributeAllowlist)
+	require.Equal(t, "openai/gpt-4o", result[attr.GenAIResponseModelKey])
+	require.Equal(t, true, result[attr.GenAIRequestIsStreamingKey])
+	require.InDelta(t, 0.12, result[attr.GenAIUsageCostKey], 1e-12)
+	require.InDelta(t, 0.07, result[attr.LiteLLMInputCostKey], 1e-12)
+	require.InDelta(t, 0.05, result[attr.LiteLLMOutputCostKey], 1e-12)
+	require.InDelta(t, 0.01, result[attr.LiteLLMCacheReadCostKey], 1e-12)
+	require.InDelta(t, 0.02, result[attr.LiteLLMCacheWriteCostKey], 1e-12)
+	require.Equal(t, "team-id", result[attr.LiteLLMTeamIDKey])
+	require.Equal(t, "engineering", result[attr.LiteLLMTeamAliasKey])
+	require.Equal(t, "key-hash", result[attr.LiteLLMAPIKeyHashKey])
+	require.Equal(t, "metadata-end-user", result[attr.LiteLLMEndUserIDKey])
+	require.Equal(t, "user-id", result[attr.LiteLLMUserIDKey])
+	require.Equal(t, "member@example.test", result[attr.LiteLLMUserEmailKey])
+	require.Equal(t, "provider-org", result[attr.LiteLLMOrganizationIDKey])
+	require.Equal(t, "key-alias", result[attr.LiteLLMAPIKeyAliasKey])
+	require.NoError(t, processor.Shutdown(t.Context()))
+}
+
+func TestLiteLLMModelOperationExcludesNonModelSpans(t *testing.T) {
+	t.Parallel()
+
+	attributes := map[attr.Key]any{
+		attr.GenAIOperationNameKey: "chat",
+		attr.GenAIRequestModelKey:  "model",
+	}
+	require.Equal(t, "chat", liteLLMModelOperation(attributes, int32(tracev1.Span_SPAN_KIND_CLIENT)))
+	require.Equal(t, "unknown", liteLLMModelOperation(attributes, int32(tracev1.Span_SPAN_KIND_INTERNAL)))
+	require.Equal(t, "unknown", liteLLMModelOperation(map[attr.Key]any{attr.GenAIOperationNameKey: "chat"}, int32(tracev1.Span_SPAN_KIND_CLIENT)))
+	require.Equal(t, "unknown", liteLLMModelOperation(map[attr.Key]any{attr.GenAIOperationNameKey: "execute_guardrail"}, int32(tracev1.Span_SPAN_KIND_INTERNAL)))
+}
+
+func TestTraceLogParamsKeepsGuardrailSpanOperationalOnly(t *testing.T) {
+	t.Parallel()
+
+	service, processor := newTraceTestService(t, fixedAuthorizer{authCtx: testAuthContext()}, testenv.NewMeterProvider(t), func(context.Context, []telemetry.LogParams) error { return nil })
+	operation := "execute_guardrail"
+	model := "must-not-be-usage"
+	cost := jsonFloat64(1.25)
+	callID := "guardrail-call"
+	request := &otlpExportRequest{ResourceSpans: []otlpResourceSpans{{
+		Resource: nil,
+		ScopeSpans: []otlpScopeSpans{{
+			Scope: nil,
+			Spans: []otlpSpan{{
+				TraceID: "", SpanID: "", ParentSpanID: "", Name: "execute_guardrail policy", Kind: jsonInt32(tracev1.Span_SPAN_KIND_INTERNAL),
+				StartTimeUnixNano: 1000000, EndTimeUnixNano: 2000000,
+				Attributes: []otlpKeyValue{
+					{Key: "gen_ai.operation.name", Value: otlpAnyValue{StringValue: &operation}},
+					{Key: "gen_ai.request.model", Value: otlpAnyValue{StringValue: &model}},
+					{Key: "litellm.cost.total", Value: otlpAnyValue{DoubleValue: &cost}},
+					{Key: "litellm.call_id", Value: otlpAnyValue{StringValue: &callID}},
+				},
+				DroppedAttributesCount: 0, Status: nil,
+			}},
+		}},
+	}}}
+	params := service.traceLogParams(t.Context(), request, "org-id", uuid.NewString())
+	require.Len(t, params, 1)
+	require.Equal(t, "urn:telemetry:provider_otel:span:unknown", params[0].Attributes[attr.EventURNKey])
+	require.Equal(t, "execute_guardrail", params[0].Attributes[attr.GenAIOperationNameKey])
+	require.Equal(t, "execute_guardrail policy", params[0].Attributes[attr.OTelSpanNameKey])
+	require.Equal(t, "internal", params[0].Attributes[attr.OTelSpanKindKey])
+	require.InDelta(t, 1, params[0].Attributes[attr.OTelSpanDurationMSKey], 0.000001)
+	require.Equal(t, "guardrail-call", params[0].Attributes[attr.LiteLLMCallIDKey])
+	require.NotContains(t, params[0].Attributes, attr.GenAIRequestModelKey)
+	require.NotContains(t, params[0].Attributes, attr.GenAIUsageCostKey)
+	require.NoError(t, processor.Shutdown(t.Context()))
+}
+
+func TestTraceLogParamsUsesOTLPFallbackWithoutCachedCall(t *testing.T) {
+	t.Parallel()
+
+	service, processor := newTraceTestService(t, fixedAuthorizer{authCtx: testAuthContext()}, testenv.NewMeterProvider(t), func(context.Context, []telemetry.LogParams) error { return nil })
+	operation := "embeddings"
+	model := "embedding-model"
+	callID := "fallback-call"
+	traceID := "fallback-trace"
+	email := "fallback@example.test"
+	inputTokens := jsonInt64(11)
+	outputTokens := jsonInt64(7)
+	request := &otlpExportRequest{ResourceSpans: []otlpResourceSpans{{
+		Resource: nil,
+		ScopeSpans: []otlpScopeSpans{{
+			Scope: nil,
+			Spans: []otlpSpan{{
+				TraceID: "", SpanID: "", ParentSpanID: "", Name: "embeddings model", Kind: jsonInt32(tracev1.Span_SPAN_KIND_CLIENT),
+				StartTimeUnixNano: 0, EndTimeUnixNano: 0,
+				Attributes: []otlpKeyValue{
+					{Key: "gen_ai.operation.name", Value: otlpAnyValue{StringValue: &operation}},
+					{Key: "gen_ai.request.model", Value: otlpAnyValue{StringValue: &model}},
+					{Key: "litellm.call_id", Value: otlpAnyValue{StringValue: &callID}},
+					{Key: "litellm.trace_id", Value: otlpAnyValue{StringValue: &traceID}},
+					{Key: "litellm.metadata.user_api_key_user_email", Value: otlpAnyValue{StringValue: &email}},
+					{Key: "gen_ai.usage.input_tokens", Value: otlpAnyValue{IntValue: &inputTokens}},
+					{Key: "gen_ai.usage.output_tokens", Value: otlpAnyValue{IntValue: &outputTokens}},
+				},
+				DroppedAttributesCount: 0, Status: nil,
+			}},
+		}},
+	}}}
+	projectID := uuid.NewString()
+	params := service.traceLogParams(t.Context(), request, "org-id", projectID)
+	require.Len(t, params, 1)
+	require.Equal(t, projectID, params[0].ToolInfo.ProjectID)
+	require.Equal(t, "org-id", params[0].ToolInfo.OrganizationID)
+	require.Equal(t, "fallback@example.test", params[0].UserInfo.Email())
+	require.Empty(t, params[0].UserInfo.UserID())
+	require.Equal(t, "fallback-trace", params[0].Attributes[attr.GenAIConversationIDKey])
+	require.EqualValues(t, 18, params[0].Attributes[attr.GenAIUsageTotalTokensKey])
+	require.Equal(t, "urn:telemetry:provider_otel:span:embeddings", params[0].Attributes[attr.EventURNKey])
+	require.NoError(t, processor.Shutdown(t.Context()))
+}
+
+func TestEnrichTraceAttributionUsesPreCallCache(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	calls := callcache.New(newMemoryCache())
+	require.NoError(t, calls.Store(t.Context(), callcache.Record{
+		ProjectID: projectID,
+		CallID:    "call-id",
+		TraceID:   "cached-trace",
+		SessionID: "cached-session",
+		UserID:    "cached-user",
+		Email:     "cached@example.test",
+	}))
+	spans := []telemetry.LogParams{{
+		Timestamp: time.Time{},
+		ToolInfo: telemetry.ToolInfo{
+			ID: "", URN: litellmOTLPResourceURN, Name: "litellm", ProjectID: projectID.String(), DeploymentID: "", FunctionID: nil, OrganizationID: "org-id",
+		},
+		UserInfo: telemetry.UserInfoByEmail("otel@example.test"),
+		Attributes: map[attr.Key]any{
+			attr.LiteLLMCallIDKey:       "call-id",
+			attr.LiteLLMTraceIDKey:      "otel-trace",
+			attr.GenAIConversationIDKey: "otel-session",
+			attr.EventURNKey:            liteLLMEventURN("chat"),
+		},
+	}, {
+		Timestamp: time.Time{},
+		ToolInfo: telemetry.ToolInfo{
+			ID: "", URN: litellmOTLPResourceURN, Name: "litellm", ProjectID: projectID.String(), DeploymentID: "", FunctionID: nil, OrganizationID: "org-id",
+		},
+		UserInfo: telemetry.UserInfoByID(""),
+		Attributes: map[attr.Key]any{
+			attr.LiteLLMCallIDKey: "call-id",
+			attr.EventURNKey:      liteLLMEventURN("unknown"),
+		},
+	}}
+
+	enrichTraceAttribution(t.Context(), testenv.NewLogger(t), calls, spans)
+	require.Equal(t, "cached-user", spans[0].UserInfo.UserID())
+	require.Equal(t, "cached@example.test", spans[0].UserInfo.Email())
+	require.Equal(t, "cached-session", spans[0].Attributes[attr.GenAIConversationIDKey])
+	require.Equal(t, "cached-trace", spans[0].Attributes[attr.LiteLLMTraceIDKey])
+	require.Empty(t, spans[1].UserInfo.UserID())
+	require.NotContains(t, spans[1].Attributes, attr.GenAIConversationIDKey)
+	require.NotContains(t, spans[1].Attributes, attr.LiteLLMTraceIDKey)
 }
 
 func TestOTLPResourceAttributeBudgetDropsOverflow(t *testing.T) {


### PR DESCRIPTION
## Summary

- normalize pinned LiteLLM V2 client model spans into canonical model, token, cost, duration, streaming, and correlation attributes
- enrich model rows from the authoritative pre-call cache with bounded best-effort fallback to OTel identity
- retain infrastructure and guardrail spans as operational telemetry while excluding model-usage and session attribution

Stacked on #4819.

Linear: DNO-709

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes LiteLLM v2 CLIENT spans into canonical per-call model-usage telemetry and enriches them with pre-call attribution, keeping non-model/guardrail spans operational only. Matches Linear DNO-709 and uses OTLP email fallback when needed.

- **New Features**
  - Normalize chat/embeddings/completions CLIENT spans to per-call usage: model, tokens (derive total when missing), cost (total and per-part: input/output/cache read/write), duration, streaming, call/response IDs, and conversation ID from `trace_id` or `call_id`.
  - Attribution and mapping: read user/session/trace from pre-call `callcache` with OTLP actor/email fallback; map `litellm.provider.model`→`gen_ai.response.model`; map `litellm.response.cost`/`litellm.cost.total`→`gen_ai.usage.cost`; expose `litellm.cost.{input,output,cache_read,cache_creation}`; unify streaming to `gen_ai.request.is_streaming` from `gen_ai.request.streaming`, `litellm.is_streaming`, `litellm.request.streaming`, and `llm.is_streaming`; include team id/alias, API key hash/alias, and end-user id. Emit usage only for model CLIENT spans with stable event URNs; strip usage fields from infra/guardrail spans; drop unsupported array attributes (e.g., finish reasons). Share a single `callcache` between the service and trace processor.

- **Bug Fixes**
  - Preserve OTLP actor/email when the cached identity is empty.

<sup>Written for commit 31dcd19448119eab07cc56006e218bb6bcba49fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

