### PR TITLE
feat: LiteLLM as a truthful source in analytics aggregates and dashboards

### DIFF
--- a/.mise-tasks/seed.mts
+++ b/.mise-tasks/seed.mts
@@ -4693,6 +4693,15 @@ function chatSessionBackfillSQL(
             is_claude_otel_row
             AND (toString(attributes.event.name) = 'tool_result' OR body = 'claude_code.tool_result')
         ) AS is_claude_tool_result,
+        (gram_urn = 'codex:otel:logs') AS is_codex_otel_row,
+        (
+            is_codex_otel_row
+            AND toString(attributes.event.name) = 'codex.sse_event'
+            AND toString(attributes.event.kind) = 'response.completed'
+            AND (toString(attributes.input_token_count) != '' OR toString(attributes.output_token_count) != '')
+        ) AS is_codex_api_request,
+        least(greatest(toInt64OrZero(toString(attributes.cached_token_count)), 0), greatest(toInt64OrZero(toString(attributes.input_token_count)), 0)) AS codex_cache_read_tokens,
+        (greatest(toInt64OrZero(toString(attributes.input_token_count)), 0) - codex_cache_read_tokens) AS codex_input_tokens,
         (startsWith(gram_urn, 'codex:usage') OR startsWith(gram_urn, 'cursor:usage') OR startsWith(gram_urn, 'claude_chat:usage') OR startsWith(gram_urn, 'claude_chat:cost') OR startsWith(gram_urn, 'chatgpt:usage')) AS is_agent_usage_row,
         (
             hook_source = 'opencode'
@@ -4700,13 +4709,21 @@ function chatSessionBackfillSQL(
             AND (toString(attributes.gen_ai.usage.input_tokens) != '' OR toString(attributes.gen_ai.usage.output_tokens) != '' OR toString(attributes.gen_ai.usage.cost) != '')
         ) AS is_opencode_usage_row,
         (
+            gram_urn = 'litellm:otel:traces'
+            AND event_urn IN (
+                'urn:telemetry:provider_otel:span:chat',
+                'urn:telemetry:provider_otel:span:embeddings',
+                'urn:telemetry:provider_otel:span:text_completion'
+            )
+        ) AS is_litellm_usage_row,
+        (
             hook_source IN ('codex', 'cursor', 'opencode')
             AND toString(attributes.gram.tool.name) != ''
             AND toString(attributes.gram.tool.name) NOT IN ('claude-code', 'codex', 'cursor')
             AND toString(attributes.gram.hook.event) IN ('PostToolUse', 'PostToolUseFailure')
         ) AS is_agent_tool_call,
         (is_claude_tool_result OR is_agent_tool_call) AS is_counted_tool_call,
-        (is_claude_api_request OR is_agent_usage_row OR is_opencode_usage_row) AS is_usage_row,
+        (is_claude_api_request OR is_codex_api_request OR is_agent_usage_row OR is_opencode_usage_row OR is_litellm_usage_row) AS is_usage_row,
         (
             (is_claude_tool_result AND toString(attributes.success) = 'false')
             OR (is_agent_tool_call AND (toString(attributes.gram.hook.event) = 'PostToolUseFailure' OR toInt32OrZero(toString(attributes.http.response.status_code)) >= 400))
@@ -4716,10 +4733,18 @@ function chatSessionBackfillSQL(
             toString(attributes.gen_ai.tool.call.id) != '', toString(attributes.gen_ai.tool.call.id),
             toString(id)
         ) AS tool_call_dedup_id,
-        multiIf(is_claude_api_request, toString(attributes.prompt.id), is_opencode_usage_row, toString(id), toString(attributes.gen_ai.response.id)) AS session_message_id,
+        multiIf(
+            is_claude_api_request, toString(attributes.prompt.id),
+            is_litellm_usage_row AND toString(attributes.gram.litellm.call_id) != '', toString(attributes.gram.litellm.call_id),
+            is_litellm_usage_row AND toString(attributes.gen_ai.response.id) != '', toString(attributes.gen_ai.response.id),
+            is_codex_api_request OR is_opencode_usage_row OR is_litellm_usage_row, toString(id),
+            toString(attributes.gen_ai.response.id)
+        ) AS session_message_id,
         multiIf(
             is_claude_api_request AND toString(attributes.model) != '', toString(attributes.model),
             is_claude_api_request AND toString(attributes.gen_ai.request.model) != '', toString(attributes.gen_ai.request.model),
+            is_litellm_usage_row AND toString(attributes.gen_ai.response.model) != '', toString(attributes.gen_ai.response.model),
+            is_litellm_usage_row, toString(attributes.gen_ai.request.model),
             toString(attributes.gen_ai.response.model)
         ) AS effective_model
     SELECT
@@ -4734,10 +4759,10 @@ function chatSessionBackfillSQL(
         uniqExactIfState(session_message_id, session_message_id != '') AS message_count,
         uniqExactIfState(tool_call_dedup_id, is_counted_tool_call) AS tool_call_count,
         countIf(is_failed_tool_call) AS failed_tool_call_count,
-        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.input_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))), is_usage_row) AS total_input_tokens,
-        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.output_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))), is_usage_row) AS total_output_tokens,
-        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.input_tokens)) + toInt64OrZero(toString(attributes.output_tokens)) + toInt64OrZero(toString(attributes.cache_creation_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens))), is_usage_row) AS total_tokens,
-        sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.cache_read_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens))), is_usage_row) AS cache_read_input_tokens,
+        sumIf(multiIf(is_claude_api_request, toInt64OrZero(toString(attributes.input_tokens)), is_codex_api_request, codex_input_tokens, toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens))), is_usage_row) AS total_input_tokens,
+        sumIf(multiIf(is_claude_api_request, toInt64OrZero(toString(attributes.output_tokens)), is_codex_api_request, toInt64OrZero(toString(attributes.output_token_count)), toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens))), is_usage_row) AS total_output_tokens,
+        sumIf(multiIf(is_claude_api_request, toInt64OrZero(toString(attributes.input_tokens)) + toInt64OrZero(toString(attributes.output_tokens)) + toInt64OrZero(toString(attributes.cache_creation_tokens)), is_codex_api_request, codex_input_tokens + toInt64OrZero(toString(attributes.output_token_count)), toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.output_tokens)) + toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens))), is_usage_row) AS total_tokens,
+        sumIf(multiIf(is_claude_api_request, toInt64OrZero(toString(attributes.cache_read_tokens)), is_codex_api_request, codex_cache_read_tokens, toInt64OrZero(toString(attributes.gen_ai.usage.cache_read.input_tokens))), is_usage_row) AS cache_read_input_tokens,
         sumIf(if(is_claude_api_request, toInt64OrZero(toString(attributes.cache_creation_tokens)), toInt64OrZero(toString(attributes.gen_ai.usage.cache_creation.input_tokens))), is_usage_row) AS cache_creation_input_tokens,
         sumIf(if(is_claude_api_request, multiIf(toString(attributes.cost_usd) != '', toFloat64OrZero(toString(attributes.cost_usd)), toString(attributes.cost_usd_micros) != '', toFloat64OrZero(toString(attributes.cost_usd_micros)) / 1000000, 0), toFloat64OrZero(toString(attributes.gen_ai.usage.cost))), is_usage_row) AS total_cost,
         groupUniqArray(toString(attributes.user.attributes.department_name)) AS department_names,
@@ -4759,7 +4784,7 @@ function chatSessionBackfillSQL(
     WHERE gram_project_id = '${projectId}'
       AND (${timePredicate})
       AND chat_id != ''
-      AND (is_claude_api_request OR is_claude_tool_result OR is_agent_usage_row OR is_opencode_usage_row OR is_agent_tool_call)
+      AND (is_claude_api_request OR is_claude_tool_result OR is_codex_api_request OR is_agent_usage_row OR is_opencode_usage_row OR is_litellm_usage_row OR is_agent_tool_call)
     GROUP BY gram_project_id, time_bucket, chat_id;
   `;
 }

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -65057,7 +65057,7 @@ components:
             - desc
         source:
           type: string
-          description: Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+          description: Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
           default: logs
           enum:
             - logs

--- a/client/dashboard/src/lib/formatPlatform.test.ts
+++ b/client/dashboard/src/lib/formatPlatform.test.ts
@@ -24,6 +24,7 @@ describe("formatPlatform", () => {
     expect(formatPlatform("ChatGPT")).toBe("ChatGPT");
     expect(formatPlatform("chatgpt-work")).toBe("ChatGPT Work");
     expect(formatPlatform("opencode")).toBe("opencode");
+    expect(formatPlatform("litellm")).toBe("LiteLLM");
     expect(formatPlatform("aws-bedrock")).toBe("AWS Bedrock");
   });
 

--- a/client/dashboard/src/lib/formatPlatform.ts
+++ b/client/dashboard/src/lib/formatPlatform.ts
@@ -24,6 +24,7 @@ const PRODUCT_SURFACE_LABELS: Record<string, string> = {
   chatgpt: "ChatGPT",
   "chatgpt-work": "ChatGPT Work",
   opencode: "opencode",
+  litellm: "LiteLLM",
   copilot: "Copilot",
   "github-copilot": "Copilot",
   gemini: "Gemini",

--- a/client/dashboard/src/sdk/src/models/components/searchuserspayload.ts
+++ b/client/dashboard/src/sdk/src/models/components/searchuserspayload.ts
@@ -50,14 +50,14 @@ export const SearchUsersPayloadSort = {
 export type SearchUsersPayloadSort = ClosedEnum<typeof SearchUsersPayloadSort>;
 
 /**
- * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+ * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
  */
 export const Source = {
   Logs: "logs",
   AgentMetrics: "agent_metrics",
 } as const;
 /**
- * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+ * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
  */
 export type Source = ClosedEnum<typeof Source>;
 
@@ -104,7 +104,7 @@ export type SearchUsersPayload = {
    */
   sort?: SearchUsersPayloadSort | undefined;
   /**
-   * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+   * Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
    */
   source?: Source | undefined;
   /**

--- a/server/design/telemetry/design.go
+++ b/server/design/telemetry/design.go
@@ -1212,7 +1212,7 @@ var SearchUsersPayload = Type("SearchUsersPayload", func() {
 		Enum("full", "basic")
 		Default("full")
 	})
-	Attribute("source", String, "Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.", func() {
+	Attribute("source", String, "Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.", func() {
 		Enum("logs", "agent_metrics")
 		Default("logs")
 	})

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -65328,7 +65328,7 @@ components:
                         - desc
                 source:
                     type: string
-                    description: Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
+                    description: Where per-user summaries are read from (internal employee grouping only). 'logs' (default) scans raw telemetry_logs and computes the metrics selected by 'metrics'. 'agent_metrics' reads the pre-aggregated attribute_metrics_summaries view — canonical observed agent usage (Claude Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far cheaper but returns only identity, last activity (hourly), and input/output/total token sums; users without an email in the window are surfaced separately from raw logs with activity but no token counts.
                     default: logs
                     enum:
                         - logs

--- a/server/gen/http/telemetry/client/types.go
+++ b/server/gen/http/telemetry/client/types.go
@@ -86,10 +86,10 @@ type SearchUsersRequestBody struct {
 	// 'logs' (default) scans raw telemetry_logs and computes the metrics selected
 	// by 'metrics'. 'agent_metrics' reads the pre-aggregated
 	// attribute_metrics_summaries view — canonical observed agent usage (Claude
-	// Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but
-	// returns only identity, last activity (hourly), and input/output/total token
-	// sums; users without an email in the window are surfaced separately from raw
-	// logs with activity but no token counts.
+	// Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far
+	// cheaper but returns only identity, last activity (hourly), and
+	// input/output/total token sums; users without an email in the window are
+	// surfaced separately from raw logs with activity but no token counts.
 	Source string `form:"source" json:"source" xml:"source"`
 }
 

--- a/server/gen/http/telemetry/server/types.go
+++ b/server/gen/http/telemetry/server/types.go
@@ -86,10 +86,10 @@ type SearchUsersRequestBody struct {
 	// 'logs' (default) scans raw telemetry_logs and computes the metrics selected
 	// by 'metrics'. 'agent_metrics' reads the pre-aggregated
 	// attribute_metrics_summaries view — canonical observed agent usage (Claude
-	// Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but
-	// returns only identity, last activity (hourly), and input/output/total token
-	// sums; users without an email in the window are surfaced separately from raw
-	// logs with activity but no token counts.
+	// Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far
+	// cheaper but returns only identity, last activity (hourly), and
+	// input/output/total token sums; users without an email in the window are
+	// surfaced separately from raw logs with activity but no token counts.
 	Source *string `form:"source,omitempty" json:"source,omitempty" xml:"source,omitempty"`
 }
 

--- a/server/gen/telemetry/service.go
+++ b/server/gen/telemetry/service.go
@@ -1479,10 +1479,10 @@ type SearchUsersPayload struct {
 	// 'logs' (default) scans raw telemetry_logs and computes the metrics selected
 	// by 'metrics'. 'agent_metrics' reads the pre-aggregated
 	// attribute_metrics_summaries view — canonical observed agent usage (Claude
-	// Code, Codex, Cursor, Claude Chat), keyed by email — which is far cheaper but
-	// returns only identity, last activity (hourly), and input/output/total token
-	// sums; users without an email in the window are surfaced separately from raw
-	// logs with activity but no token counts.
+	// Code, Codex, Cursor, Claude Chat, LiteLLM), keyed by email — which is far
+	// cheaper but returns only identity, last activity (hourly), and
+	// input/output/total token sums; users without an email in the window are
+	// surfaced separately from raw logs with activity but no token counts.
 	Source string
 }
 

--- a/server/internal/telemetry/list_sessions_summary_test.go
+++ b/server/internal/telemetry/list_sessions_summary_test.go
@@ -48,6 +48,7 @@ func TestListSessions_SummaryPathMatchesRawPath(t *testing.T) {
 	claudeChatID := uuid.NewString()
 	agentChatID := uuid.NewString()
 	failedChatID := uuid.NewString()
+	liteLLMChatID := uuid.NewString()
 
 	// A Claude session: two turns (different models) plus a successful tool
 	// call.
@@ -89,6 +90,12 @@ func TestListSessions_SummaryPathMatchesRawPath(t *testing.T) {
 		statusCode: 200,
 		toolURN:    "mcp__petstore__listPets",
 	})
+	insertLiteLLMSpan(t, ctx, liteLLMSpanParams{
+		projectID: projectID, timestamp: now.Add(-4 * time.Minute), chatID: liteLLMChatID, callID: uuid.NewString(),
+		gramURN: "litellm:otel:traces", eventURN: "urn:telemetry:provider_otel:span:text_completion",
+		requestModel: "completion-group", responseModel: "", email: "lee@example.com",
+		inputTokens: 40, outputTokens: 10, cost: 0.5,
+	})
 	// A Cursor usage session.
 	insertListSessionCompletionLog(t, ctx, listSessionLogParams{
 		projectID:    projectID,
@@ -126,7 +133,7 @@ func TestListSessions_SummaryPathMatchesRawPath(t *testing.T) {
 		SortBy: "total_cost",
 		Limit:  10,
 	}, func(res *gen.ListSessionsResult) bool {
-		return len(res.Sessions) == 3
+		return len(res.Sessions) == 4
 	})
 
 	summaryRes := waitForListSessions(t, ctx, ti, &gen.ListSessionsPayload{
@@ -135,7 +142,7 @@ func TestListSessions_SummaryPathMatchesRawPath(t *testing.T) {
 		SortBy: "total_cost",
 		Limit:  10,
 	}, func(res *gen.ListSessionsResult) bool {
-		return len(res.Sessions) == 3
+		return len(res.Sessions) == 4
 	})
 
 	require.Equal(t, rawRes.Sessions, summaryRes.Sessions,
@@ -159,6 +166,20 @@ func TestListSessions_SummaryPathMatchesRawPath(t *testing.T) {
 	failed := byChat[failedChatID]
 	require.NotNil(t, failed)
 	require.Equal(t, "error", failed.Status)
+
+	liteLLM := byChat[liteLLMChatID]
+	require.NotNil(t, liteLLM)
+	require.NotNil(t, liteLLM.UserEmail)
+	require.Equal(t, "lee@example.com", *liteLLM.UserEmail)
+	require.NotNil(t, liteLLM.HookSource)
+	require.Equal(t, "litellm", *liteLLM.HookSource)
+	require.Equal(t, int64(1), liteLLM.MessageCount)
+	require.Equal(t, int64(40), liteLLM.TotalInputTokens)
+	require.Equal(t, int64(10), liteLLM.TotalOutputTokens)
+	require.Equal(t, int64(50), liteLLM.TotalTokens)
+	require.InDelta(t, 0.5, liteLLM.TotalCost, 1e-9)
+	require.NotNil(t, liteLLM.Model)
+	require.Equal(t, "completion-group", *liteLLM.Model)
 }
 
 // TestListSessions_SummaryPathFilters covers the filter translation onto the

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -135,6 +135,57 @@ func insertAttributeClaudeAPIRequestLog(t *testing.T, ctx context.Context, proje
 	require.NoError(t, err)
 }
 
+type liteLLMSpanParams struct {
+	projectID     string
+	timestamp     time.Time
+	chatID        string
+	callID        string
+	gramURN       string
+	eventURN      string
+	requestModel  string
+	responseModel string
+	email         string
+	inputTokens   int
+	outputTokens  int
+	cost          float64
+}
+
+func insertLiteLLMSpan(t *testing.T, ctx context.Context, p liteLLMSpanParams) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+	attributes := map[string]any{
+		"gen_ai.conversation.id":     p.chatID,
+		"gen_ai.request.model":       p.requestModel,
+		"gen_ai.usage.input_tokens":  p.inputTokens,
+		"gen_ai.usage.output_tokens": p.outputTokens,
+		"gen_ai.usage.total_tokens":  p.inputTokens + p.outputTokens,
+		"gen_ai.usage.cost":          p.cost,
+		"gram.event.urn":             p.eventURN,
+		"gram.hook.source":           "litellm",
+		"gram.litellm.call_id":       p.callID,
+		"gram.resource.urn":          p.gramURN,
+		"user.email":                 p.email,
+	}
+	if p.responseModel != "" {
+		attributes["gen_ai.response.model"] = p.responseModel
+	}
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), p.timestamp.UnixNano(), p.timestamp.UnixNano(), "INFO", "LiteLLM model span",
+		nil, nil, string(attrsJSON), "{}", p.projectID, p.gramURN, "litellm")
+	require.NoError(t, err)
+}
+
 // insertAttributeGramCompletionLog inserts a gram-server LLM completion row
 // tagged with the given usage source (e.g. "playground", "assistants").
 func insertAttributeGramCompletionLog(t *testing.T, ctx context.Context, projectID string, timestamp time.Time, chatID string, cost float64, totalTokens int, model, hookSource, email, department string, roles []string) {
@@ -1005,6 +1056,60 @@ func TestQuery_ExcludesAssistantChatCompletions(t *testing.T) {
 	require.Len(t, result.Table, 1)
 	require.Equal(t, "claude-code", result.Table[0].GroupValue)
 	require.InDelta(t, 0.25, result.Table[0].Measures.TotalCost, 1e-9)
+}
+
+func TestQuery_IncludesOnlyCanonicalLiteLLMModelSpans(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+	ctx = authztest.WithExactGrants(t, ctx, authz.Grant{
+		Scope:    authz.ScopeOrgRead,
+		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
+	})
+
+	now := time.Now().UTC()
+	base := liteLLMSpanParams{
+		projectID: projectID, timestamp: now.Add(-10 * time.Minute), chatID: uuid.NewString(), callID: uuid.NewString(),
+		gramURN: "litellm:otel:traces", eventURN: "urn:telemetry:provider_otel:span:chat",
+		requestModel: "model-group", responseModel: "openai/gpt-4o", email: "litellm@example.test",
+		inputTokens: 11, outputTokens: 7, cost: 0.125,
+	}
+	insertLiteLLMSpan(t, ctx, base)
+	operational := base
+	operational.eventURN = "urn:telemetry:provider_otel:span:unknown"
+	insertLiteLLMSpan(t, ctx, operational)
+	metric := base
+	metric.eventURN = "urn:telemetry:provider_otel:metric:usage"
+	insertLiteLLMSpan(t, ctx, metric)
+	spoofed := base
+	spoofed.gramURN = "other:otel:traces"
+	insertLiteLLMSpan(t, ctx, spoofed)
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	to := now.Add(1 * time.Hour).Format(time.RFC3339)
+	var result *gen.QueryResult
+	require.Eventually(t, func() bool {
+		res, err := ti.service.Query(ctx, &gen.QueryPayload{
+			From: from, To: to, GroupBy: conv.PtrEmpty("hook_source"),
+			Filters: []*gen.QueryFilter{{Dimension: "hook_source", Values: []string{"litellm"}}},
+			TopN:    10, SortBy: "total_cost",
+		})
+		if err != nil || res == nil || len(res.Table) != 1 {
+			return false
+		}
+		result = res
+		return res.Table[0].Measures.TotalTokens == 18
+	}, 10*time.Second, 200*time.Millisecond)
+
+	require.Equal(t, "litellm", result.Table[0].GroupValue)
+	require.EqualValues(t, 11, result.Table[0].Measures.TotalInputTokens)
+	require.EqualValues(t, 7, result.Table[0].Measures.TotalOutputTokens)
+	require.EqualValues(t, 18, result.Table[0].Measures.TotalTokens)
+	require.InDelta(t, 0.125, result.Table[0].Measures.TotalCost, 1e-9)
 }
 
 func TestQuery_AttributesClaudeAPIRequestByMCPAndSkill(t *testing.T) {

--- a/server/internal/telemetry/query_test.go
+++ b/server/internal/telemetry/query_test.go
@@ -1070,7 +1070,7 @@ func TestQuery_IncludesOnlyCanonicalLiteLLMModelSpans(t *testing.T) {
 		Selector: authz.NewSelector(authz.ScopeOrgRead, authCtx.ActiveOrganizationID),
 	})
 
-	now := time.Now().UTC()
+	now := time.Date(2026, time.July, 14, 1, 0, 0, 0, time.UTC)
 	base := liteLLMSpanParams{
 		projectID: projectID, timestamp: now.Add(-10 * time.Minute), chatID: uuid.NewString(), callID: uuid.NewString(),
 		gramURN: "litellm:otel:traces", eventURN: "urn:telemetry:provider_otel:span:chat",
@@ -1087,6 +1087,7 @@ func TestQuery_IncludesOnlyCanonicalLiteLLMModelSpans(t *testing.T) {
 	spoofed := base
 	spoofed.gramURN = "other:otel:traces"
 	insertLiteLLMSpan(t, ctx, spoofed)
+	insertAttributeClaudeAPIRequestLog(t, ctx, projectID, base.timestamp, uuid.NewString(), 0.25, 20, 5, 0, 0, "opus", "claude@example.test", "Engineering", nil, "main", "", "", "", "")
 	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	from := now.Add(-1 * time.Hour).Format(time.RFC3339)
@@ -1095,21 +1096,32 @@ func TestQuery_IncludesOnlyCanonicalLiteLLMModelSpans(t *testing.T) {
 	require.Eventually(t, func() bool {
 		res, err := ti.service.Query(ctx, &gen.QueryPayload{
 			From: from, To: to, GroupBy: conv.PtrEmpty("hook_source"),
-			Filters: []*gen.QueryFilter{{Dimension: "hook_source", Values: []string{"litellm"}}},
-			TopN:    10, SortBy: "total_cost",
+			TopN: 10, SortBy: "total_cost",
 		})
-		if err != nil || res == nil || len(res.Table) != 1 {
+		if err != nil || res == nil || len(res.Table) != 2 {
 			return false
 		}
 		result = res
-		return res.Table[0].Measures.TotalTokens == 18
+		return res.Table[0].GroupValue == "claude-code" && res.Table[1].GroupValue == "litellm"
 	}, 10*time.Second, 200*time.Millisecond)
 
-	require.Equal(t, "litellm", result.Table[0].GroupValue)
-	require.EqualValues(t, 11, result.Table[0].Measures.TotalInputTokens)
-	require.EqualValues(t, 7, result.Table[0].Measures.TotalOutputTokens)
-	require.EqualValues(t, 18, result.Table[0].Measures.TotalTokens)
-	require.InDelta(t, 0.125, result.Table[0].Measures.TotalCost, 1e-9)
+	require.EqualValues(t, 20, result.Table[0].Measures.TotalInputTokens)
+	require.EqualValues(t, 5, result.Table[0].Measures.TotalOutputTokens)
+	require.EqualValues(t, 25, result.Table[0].Measures.TotalTokens)
+	require.InDelta(t, 0.25, result.Table[0].Measures.TotalCost, 1e-9)
+	require.EqualValues(t, 11, result.Table[1].Measures.TotalInputTokens)
+	require.EqualValues(t, 7, result.Table[1].Measures.TotalOutputTokens)
+	require.EqualValues(t, 18, result.Table[1].Measures.TotalTokens)
+	require.InDelta(t, 0.125, result.Table[1].Measures.TotalCost, 1e-9)
+
+	filtered, err := ti.service.Query(ctx, &gen.QueryPayload{
+		From: from, To: to, GroupBy: conv.PtrEmpty("hook_source"),
+		Filters: []*gen.QueryFilter{{Dimension: "hook_source", Values: []string{"litellm"}}},
+		TopN:    10, SortBy: "total_cost",
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered.Table, 1)
+	require.Equal(t, "litellm", filtered.Table[0].GroupValue)
 }
 
 func TestQuery_AttributesClaudeAPIRequestByMCPAndSkill(t *testing.T) {

--- a/server/internal/telemetry/repo/employee_agent_usage.go
+++ b/server/internal/telemetry/repo/employee_agent_usage.go
@@ -20,7 +20,7 @@ type SearchEmployeeAgentUsageParams struct {
 // accept:
 //
 //   - Scope is canonical observed agent usage only — Claude Code, Codex, Cursor,
-//     and Claude Chat — matching the costs/billing pages. Gram-hosted chat
+//     Claude Chat, and LiteLLM — matching the costs/billing pages. Gram-hosted chat
 //     completions and duplicate usage-metric rows are excluded.
 //   - Users are keyed by email. Identities that never carry an email in the
 //     window are absent here; surface them via ListEmaillessIdentities.

--- a/server/internal/telemetry/repo/sessions.go
+++ b/server/internal/telemetry/repo/sessions.go
@@ -76,6 +76,13 @@ const (
 		"toString(attributes.gram.hook.event) = 'AfterAgentResponse' AND " +
 		"(toString(attributes.gen_ai.usage.input_tokens) != '' OR toString(attributes.gen_ai.usage.output_tokens) != '' OR toString(attributes.gen_ai.usage.cost) != '')" +
 		")"
+	// sessionLiteLLMUsageRowPredicate matches only normalized LiteLLM client
+	// model spans. Resource provenance plus the closed event-URN set excludes
+	// guardrail, infrastructure, and metric rows from usage aggregates.
+	sessionLiteLLMUsageRowPredicate = "(" +
+		"gram_urn = 'litellm:otel:traces' AND " +
+		"event_urn IN ('urn:telemetry:provider_otel:span:chat', 'urn:telemetry:provider_otel:span:embeddings', 'urn:telemetry:provider_otel:span:text_completion')" +
+		")"
 	// sessionAgentToolCallPredicate matches Codex/Cursor/opencode completed
 	// tool-call hook rows (they have no OTEL stream). The hook.event guard excludes
 	// the PreToolUse companion row; provider names are not tool calls.
@@ -107,11 +114,11 @@ const (
 	// usage rows, and opencode assistant.responded rows. This is the sumIf guard
 	// for every token/cost measure, keeping session totals aligned with the
 	// aggregate.
-	sessionUsageMeasureFilter = "(" + sessionClaudeAPIRequestPredicate + " OR " + sessionCodexAPIRequestPredicate + " OR " + sessionAgentUsageRowPredicate + " OR " + sessionOpencodeUsageRowPredicate + ")"
+	sessionUsageMeasureFilter = "(" + sessionClaudeAPIRequestPredicate + " OR " + sessionCodexAPIRequestPredicate + " OR " + sessionAgentUsageRowPredicate + " OR " + sessionOpencodeUsageRowPredicate + " OR " + sessionLiteLLMUsageRowPredicate + ")"
 	// sessionSourceRowPredicate admits every row class the session list derives
 	// from, matching the aggregate MV's WHERE clause so the two views cover the
 	// same sessions.
-	sessionSourceRowPredicate = "(" + sessionClaudeAPIRequestPredicate + " OR " + sessionClaudeToolResultPredicate + " OR " + sessionCodexAPIRequestPredicate + " OR " + sessionAgentUsageRowPredicate + " OR " + sessionOpencodeUsageRowPredicate + " OR " + sessionAgentToolCallPredicate + ")"
+	sessionSourceRowPredicate = "(" + sessionClaudeAPIRequestPredicate + " OR " + sessionClaudeToolResultPredicate + " OR " + sessionCodexAPIRequestPredicate + " OR " + sessionAgentUsageRowPredicate + " OR " + sessionOpencodeUsageRowPredicate + " OR " + sessionLiteLLMUsageRowPredicate + " OR " + sessionAgentToolCallPredicate + ")"
 
 	// Token/cost measures are source-aware: Claude api_request rows carry usage
 	// on flat attributes (input_tokens, cost_usd, …), Codex response.completed
@@ -158,17 +165,21 @@ const (
 	sessionModelExpr = "multiIf(" +
 		sessionClaudeAPIRequestPredicate + " AND toString(attributes.model) != '', toString(attributes.model), " +
 		sessionClaudeAPIRequestPredicate + " AND toString(attributes.gen_ai.request.model) != '', toString(attributes.gen_ai.request.model), " +
+		sessionLiteLLMUsageRowPredicate + " AND toString(attributes.gen_ai.response.model) != '', toString(attributes.gen_ai.response.model), " +
+		sessionLiteLLMUsageRowPredicate + ", toString(attributes.gen_ai.request.model), " +
 		"toString(attributes.gen_ai.response.model))"
 
 	// sessionMessageIDExpr identifies a distinct message/turn per row: Claude
 	// api_request rows are one turn each (unique prompt.id); Codex
 	// response.completed and opencode assistant.responded rows are one turn each
 	// but carry no stable turn id, so they fall back to the row id (count-per-row,
-	// same degradation as the tool-call dedup); generic rows key off
-	// gen_ai.response.id. Counted distinct for message_count.
+	// same degradation as the tool-call dedup). LiteLLM uses call ID, response ID,
+	// then row ID. Generic rows key off gen_ai.response.id.
 	sessionMessageIDExpr = "multiIf(" + sessionClaudeAPIRequestPredicate + ", " +
 		"toString(attributes.prompt.id), " +
-		"(" + sessionCodexAPIRequestPredicate + " OR " + sessionOpencodeUsageRowPredicate + "), toString(id), " +
+		sessionLiteLLMUsageRowPredicate + " AND toString(attributes.gram.litellm.call_id) != '', toString(attributes.gram.litellm.call_id), " +
+		sessionLiteLLMUsageRowPredicate + " AND toString(attributes.gen_ai.response.id) != '', toString(attributes.gen_ai.response.id), " +
+		"(" + sessionCodexAPIRequestPredicate + " OR " + sessionOpencodeUsageRowPredicate + " OR " + sessionLiteLLMUsageRowPredicate + "), toString(id), " +
 		"toString(attributes.gen_ai.response.id))"
 	sessionMessageCountExpr = "uniqExactIf(" + sessionMessageIDExpr + ", " + sessionMessageIDExpr + " != '')"
 )

--- a/server/internal/telemetry/repo/sessions_schema_sync_test.go
+++ b/server/internal/telemetry/repo/sessions_schema_sync_test.go
@@ -26,6 +26,10 @@ var sessionSharedPredicateFragments = []string{
 	"(toString(attributes.event.name) = 'tool_result' OR body = 'claude_code.tool_result')",
 	// Agent usage-row URN prefixes.
 	"(startsWith(gram_urn, 'codex:usage') OR startsWith(gram_urn, 'cursor:usage') OR startsWith(gram_urn, 'claude_chat:usage') OR startsWith(gram_urn, 'claude_chat:cost') OR startsWith(gram_urn, 'chatgpt:usage'))",
+	// Codex OTEL usage rows.
+	"toString(attributes.event.name) = 'codex.sse_event' AND toString(attributes.event.kind) = 'response.completed'",
+	// LiteLLM normalized model spans.
+	"gram_urn = 'litellm:otel:traces' AND event_urn IN ('urn:telemetry:provider_otel:span:chat', 'urn:telemetry:provider_otel:span:embeddings', 'urn:telemetry:provider_otel:span:text_completion')",
 	// Agent completed tool-call hook rows.
 	"hook_source IN ('codex', 'cursor', 'opencode') AND toString(attributes.gram.tool.name) != '' AND toString(attributes.gram.tool.name) NOT IN ('claude-code', 'codex', 'cursor') AND toString(attributes.gram.hook.event) IN ('PostToolUse', 'PostToolUseFailure')",
 	// Tool-call dedup identity.
@@ -66,7 +70,9 @@ func TestSessionPredicates_SchemaMVStaysInSync(t *testing.T) {
 	goConstants := normalizeSQL(strings.Join([]string{
 		sessionClaudeAPIRequestPredicate,
 		sessionClaudeToolResultPredicate,
+		sessionCodexAPIRequestPredicate,
 		sessionAgentUsageRowPredicate,
+		sessionLiteLLMUsageRowPredicate,
 		sessionAgentToolCallPredicate,
 		sessionFailedToolCallPredicate,
 		sessionCountedToolCallPredicate,

--- a/server/internal/telemetry/search_users_test.go
+++ b/server/internal/telemetry/search_users_test.go
@@ -1330,6 +1330,37 @@ func TestSearchUsers_AgentMetricsSource(t *testing.T) {
 	assert.NotEqual(t, "0", emaillessUser.LastSeenUnixNano, "email-less identity should carry last activity")
 }
 
+func TestSearchUsers_AgentMetricsSourceIncludesLiteLLMUser(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	now := time.Now().UTC()
+	email := "litellm-user-" + uuid.NewString() + "@example.test"
+	insertLiteLLMSpan(t, ctx, liteLLMSpanParams{
+		projectID: authCtx.ProjectID.String(), timestamp: now.Add(-10 * time.Minute), chatID: uuid.NewString(), callID: uuid.NewString(),
+		gramURN: "litellm:otel:traces", eventURN: "urn:telemetry:provider_otel:span:embeddings",
+		requestModel: "embedding-group", responseModel: "openai/text-embedding-3-small", email: email,
+		inputTokens: 13, outputTokens: 0, cost: 0.0003,
+	})
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	res, err := ti.service.SearchUsers(ctx, &gen.SearchUsersPayload{
+		Filter: &gen.SearchUsersFilter{
+			From: now.Add(-1 * time.Hour).Format(time.RFC3339),
+			To:   now.Add(1 * time.Hour).Format(time.RFC3339),
+		},
+		UserType: "internal", Limit: 100, Sort: "desc", Source: "agent_metrics",
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 1)
+	require.Equal(t, email, res.Users[0].UserID)
+	require.Equal(t, email, res.Users[0].UserEmail)
+	require.EqualValues(t, 13, res.Users[0].TotalInputTokens)
+	require.EqualValues(t, 13, res.Users[0].TotalTokens)
+}
+
 // TestSearchUsers_AgentMetricsSourceRejectsUnsupportedFilters pins that the
 // agent-metrics source fails loud rather than silently returning project-wide
 // data when given a filter it cannot honor (the view is keyed by email + time


### PR DESCRIPTION
## Summary

- admit only provenance-anchored LiteLLM model spans into cost, token, enrollment, and session summaries
- keep raw session, materialized-view, migration, and seed predicates synchronized while excluding operational spans and opt-in metrics
- expose the existing dynamic source value with canonical LiteLLM branding and generated API documentation

## Migration note

The view change is forward-only because the parent LiteLLM ingestion stack is not deployed, so no production LiteLLM rows exist to backfill.

Stacked on #4824.

Linear: DNO-710

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `litellm` as a first-class analytics source across aggregates, sessions (raw and summary), employee `agent_metrics`, and dashboards, per Linear DNO-710. Only canonical LiteLLM model spans (chat, embeddings, text_completion) are counted; Codex SSE token/cache math is corrected.

- **New Features**
  - Classify and admit `litellm` usage: closed predicates for canonical spans; synced Go/view/seed predicates; message ID fallback (call_id → response_id → row id) and model mapping (response → request).
  - Query/UI/SDK: group/filter by `hook_source=litellm`; dashboards label “LiteLLM”; `agent_metrics` and employee enrollment include LiteLLM; OpenAPI/SDK docs updated.
  - Tests: canonical span isolation, raw↔summary parity, schema-predicate sync, `agent_metrics` user search, and session totals (tokens/cost).

- **Migration**
  - Forward-only view changes; no backfill until the `litellm` ingestion stack is deployed.

<sup>Written for commit d1c50cb6f890b5f1f1af1fe5f079606534f26ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

