### PR TITLE
feat(dashboard): estimate contract value in the TUM admin view

### DIFF
--- a/.changeset/tum-contract-price-estimator.md
+++ b/.changeset/tum-contract-price-estimator.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Add a contract value estimator to the TUM Contract section of the billing page (platform admin only). It approximates what an enterprise account is worth under either commercial model — a committed platform fee with tiered overage, or uncommitted pay-as-you-go — off the org's observed tokens under management, and flags accounts whose overage has grown large enough relative to their base contract to warrant an expansion conversation.

--- a/client/dashboard/src/components/billing/contract-price-estimator.tsx
+++ b/client/dashboard/src/components/billing/contract-price-estimator.tsx
@@ -31,20 +31,48 @@ import {
 // at what rate, for how much. Showing the bands rather than one lump sum is
 // the point — it's what an account team reads off when a customer asks why
 // the number is what it is.
-function TierTable({ lines }: { lines: TierLine[] }): JSX.Element {
+function TierTable({
+  caption,
+  lines,
+}: {
+  // Names what the bands are measuring. A real <caption> rather than a
+  // heading above the table, so it reaches assistive tech as the table's
+  // label instead of as unrelated preceding text.
+  caption: string;
+  lines: TierLine[];
+}): JSX.Element {
   if (lines.length === 0) {
     return (
-      <Text muted small>
-        No volume in any tier.
-      </Text>
+      <>
+        <div className="text-muted-foreground mb-1 text-xs">{caption}</div>
+        <Text muted small>
+          No volume in any tier.
+        </Text>
+      </>
     );
   }
   return (
     <table className="w-full text-sm tabular-nums">
+      <caption className="text-muted-foreground mb-1 text-left text-xs">
+        {caption}
+      </caption>
+      {/* The columns are only distinguishable by position and formatting,
+          which a screen reader can't convey — so the headers exist for it
+          and are hidden from the compact visual layout. */}
+      <thead className="sr-only">
+        <tr>
+          <th scope="col">Tier</th>
+          <th scope="col">Volume</th>
+          <th scope="col">Rate</th>
+          <th scope="col">Cost</th>
+        </tr>
+      </thead>
       <tbody>
         {lines.map((line) => (
           <tr key={line.label} className="text-muted-foreground">
-            <td className="py-0.5 pr-2">{line.label}</td>
+            <th scope="row" className="py-0.5 pr-2 text-left font-normal">
+              {line.label}
+            </th>
             <td className="py-0.5 pr-2 text-right">
               {formatTokensCompact(line.tokens)}
             </td>
@@ -161,26 +189,25 @@ export function ContractPriceEstimator({
   const [customVolume, setCustomVolume] = useState("");
   const [feeOverride, setFeeOverride] = useState("");
 
-  // Recomputed per render against a single `now`, so every basis in the
-  // picker is measured from the same instant.
-  const options = useMemo(
-    () => volumeBasisOptions(cycles, Date.now()),
-    [cycles],
-  );
+  // Deliberately not memoized on `cycles`. Whether the projection is even
+  // offered depends on how much of the cycle has elapsed, so a `now` captured
+  // once and cached behind a `cycles` dependency would freeze that answer for
+  // as long as the tab stays open. This is a handful of array passes over at
+  // most a year of cycles — cheaper than the staleness it would buy.
+  const options = volumeBasisOptions(cycles, Date.now());
 
   // Land on the steadiest reading the account can actually support, rather
-  // than pinning a basis that may have no data: a three-cycle mean smooths
+  // than pinning a basis that may have no data: a multi-cycle mean smooths
   // the spikes that make a single month misleading, and the projection is a
   // last resort because it's the noisiest of the three. Derived, not stored,
   // so an account that gains history stops defaulting to a weaker basis.
-  const defaultBasis = useMemo<VolumeBasis>(() => {
-    for (const candidate of ["avg3", "last", "projected"] as const) {
-      if (options.find((o) => o.value === candidate)?.tokens != null) {
-        return candidate;
-      }
+  let defaultBasis: VolumeBasis = "custom";
+  for (const candidate of ["avg3", "last", "projected"] as const) {
+    if (options.find((o) => o.value === candidate)?.tokens != null) {
+      defaultBasis = candidate;
+      break;
     }
-    return "custom";
-  }, [options]);
+  }
   const basis = basisOverride ?? defaultBasis;
 
   const parsedCustom = Number(customVolume);
@@ -368,10 +395,10 @@ export function ContractPriceEstimator({
                       {formatUSD(platformFeeAnnual)}
                     </span>
                   </div>
-                  <div className="text-muted-foreground mb-1 text-xs">
-                    Monthly overage
-                  </div>
-                  <TierTable lines={committed.lines} />
+                  <TierTable
+                    caption="Monthly overage"
+                    lines={committed.lines}
+                  />
                   <ModelTotals
                     monthly={committed.monthly}
                     annual={committed.annual}
@@ -393,10 +420,10 @@ export function ContractPriceEstimator({
             >
               {payg && (
                 <>
-                  <div className="text-muted-foreground mb-1 text-xs">
-                    Monthly volume tiers
-                  </div>
-                  <TierTable lines={payg.lines} />
+                  <TierTable
+                    caption="Monthly volume tiers"
+                    lines={payg.lines}
+                  />
                   <ModelTotals
                     monthly={payg.monthly}
                     annual={payg.annual}

--- a/client/dashboard/src/components/billing/contract-price-estimator.tsx
+++ b/client/dashboard/src/components/billing/contract-price-estimator.tsx
@@ -1,0 +1,436 @@
+import { Input } from "@/components/ui/Input";
+import { Label } from "@/components/ui/Label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
+import { Stack } from "@/components/ui/Stack";
+import { Text } from "@/components/ui/Text";
+import { SimpleTooltip } from "@/components/ui/Tooltip";
+import { cn } from "@/lib/utils";
+import { useMemo, useState } from "react";
+import { type BillingCycle } from "./billing-cycles";
+import {
+  BASELINE_RATE_PER_MILLION,
+  derivedAnnualPlatformFee,
+  effectiveRatePerMillion,
+  formatTokensCompact,
+  formatUSD,
+  overageLines,
+  paygLines,
+  sumLines,
+  type TierLine,
+  type VolumeBasis,
+  volumeBasisOptions,
+} from "./contract-pricing";
+
+// The per-band table both model cards share: what volume landed in each tier,
+// at what rate, for how much. Showing the bands rather than one lump sum is
+// the point — it's what an account team reads off when a customer asks why
+// the number is what it is.
+function TierTable({ lines }: { lines: TierLine[] }): JSX.Element {
+  if (lines.length === 0) {
+    return (
+      <Text muted small>
+        No volume in any tier.
+      </Text>
+    );
+  }
+  return (
+    <table className="w-full text-sm tabular-nums">
+      <tbody>
+        {lines.map((line) => (
+          <tr key={line.label} className="text-muted-foreground">
+            <td className="py-0.5 pr-2">{line.label}</td>
+            <td className="py-0.5 pr-2 text-right">
+              {formatTokensCompact(line.tokens)}
+            </td>
+            <td className="py-0.5 pr-2 text-right">
+              ${line.ratePerMillion.toFixed(2)}/M
+            </td>
+            <td className="text-foreground py-0.5 text-right font-medium">
+              {formatUSD(line.cost)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// One model's bottom line. The annual figure is the headline because that's
+// the unit contracts are written and renewed in; the monthly sits under it
+// for reconciling against a single invoice.
+function ModelTotals({
+  monthly,
+  annual,
+  rate,
+}: {
+  monthly: number;
+  annual: number;
+  rate: number | null;
+}): JSX.Element {
+  return (
+    <div className="border-border mt-3 border-t pt-3">
+      <div className="flex items-baseline justify-between">
+        <span className="text-muted-foreground text-xs">Annual</span>
+        <span className="text-xl font-semibold tabular-nums">
+          {formatUSD(annual)}
+        </span>
+      </div>
+      <div className="text-muted-foreground mt-1 flex items-baseline justify-between text-xs tabular-nums">
+        <span>{formatUSD(monthly)}/mo</span>
+        {rate != null && <span>${rate.toFixed(3)}/M blended</span>}
+      </div>
+    </div>
+  );
+}
+
+function ModelCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <div className="border-border rounded-lg border p-4">
+      <div className="mb-3">
+        <div className="text-sm font-medium">{title}</div>
+        <div className="text-muted-foreground text-xs">{subtitle}</div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// How hard the account team should be looking at this contract. Steady
+// accounts run overage at a fraction of their base; once overage rivals the
+// base contract the customer is better off upsizing the baseline than paying
+// the premium, and that conversation is better had by us than by their
+// finance team.
+function overageSignal(share: number): {
+  tone: "muted" | "warning" | "destructive";
+  message: string;
+} {
+  const pct = Math.round(share * 100);
+  if (share >= 1) {
+    return {
+      tone: "destructive",
+      message: `Overage is ${pct}% of the base contract — size up the baseline at renewal.`,
+    };
+  }
+  if (share >= 0.5) {
+    return {
+      tone: "warning",
+      message: `Overage is ${pct}% of the base contract — worth an expansion conversation.`,
+    };
+  }
+  return {
+    tone: "muted",
+    message: `Overage is ${pct}% of the base contract — the account is well-sized.`,
+  };
+}
+
+/**
+ * Approximates what an account is worth under each of the two commercial
+ * shapes — a committed platform fee with tiered overage, and uncommitted
+ * pay-as-you-go — off the org's observed tokens under management.
+ *
+ * Estimate only: nothing here is billed from and nothing is persisted. The
+ * platform fee in particular is a negotiated number, so it's an override the
+ * admin types, defaulted from the baseline at the model's effective rate.
+ */
+export function ContractPriceEstimator({
+  baselineTokens,
+  cycles,
+}: {
+  // The contracted monthly baseline. Read live off the contract-terms form
+  // above, so an admin sizing a new limit sees the price move as they type.
+  // Null when the org has no contracted limit — the committed model has no
+  // tier boundaries without one.
+  baselineTokens: number | null;
+  cycles: BillingCycle[];
+}): JSX.Element {
+  const [basisOverride, setBasisOverride] = useState<VolumeBasis | null>(null);
+  const [customVolume, setCustomVolume] = useState("");
+  const [feeOverride, setFeeOverride] = useState("");
+
+  // Recomputed per render against a single `now`, so every basis in the
+  // picker is measured from the same instant.
+  const options = useMemo(
+    () => volumeBasisOptions(cycles, Date.now()),
+    [cycles],
+  );
+
+  // Land on the steadiest reading the account can actually support, rather
+  // than pinning a basis that may have no data: a three-cycle mean smooths
+  // the spikes that make a single month misleading, and the projection is a
+  // last resort because it's the noisiest of the three. Derived, not stored,
+  // so an account that gains history stops defaulting to a weaker basis.
+  const defaultBasis = useMemo<VolumeBasis>(() => {
+    for (const candidate of ["avg3", "last", "projected"] as const) {
+      if (options.find((o) => o.value === candidate)?.tokens != null) {
+        return candidate;
+      }
+    }
+    return "custom";
+  }, [options]);
+  const basis = basisOverride ?? defaultBasis;
+
+  const parsedCustom = Number(customVolume);
+  const customTokens =
+    customVolume.trim() !== "" &&
+    Number.isFinite(parsedCustom) &&
+    parsedCustom >= 0
+      ? parsedCustom
+      : null;
+
+  const selected = options.find((o) => o.value === basis);
+  const monthlyTokens =
+    (basis === "custom" ? customTokens : (selected?.tokens ?? null)) ?? null;
+
+  const parsedFee = Number(feeOverride);
+  const derivedFee =
+    baselineTokens != null ? derivedAnnualPlatformFee(baselineTokens) : 0;
+  const platformFeeAnnual =
+    feeOverride.trim() !== "" && Number.isFinite(parsedFee) && parsedFee >= 0
+      ? parsedFee
+      : derivedFee;
+
+  const committed = useMemo(() => {
+    if (
+      monthlyTokens == null ||
+      baselineTokens == null ||
+      baselineTokens <= 0
+    ) {
+      return null;
+    }
+    const lines = overageLines(monthlyTokens, baselineTokens);
+    const overageMonthly = sumLines(lines);
+    const annual = platformFeeAnnual + overageMonthly * 12;
+    return {
+      lines,
+      overageMonthly,
+      annual,
+      monthly: annual / 12,
+      rate: effectiveRatePerMillion(annual, monthlyTokens),
+      // Zero-fee contracts would divide by zero; treat them as unsignalled
+      // rather than as infinite overage.
+      share:
+        platformFeeAnnual > 0
+          ? (overageMonthly * 12) / platformFeeAnnual
+          : null,
+    };
+  }, [monthlyTokens, baselineTokens, platformFeeAnnual]);
+
+  const payg = useMemo(() => {
+    if (monthlyTokens == null) return null;
+    const lines = paygLines(monthlyTokens);
+    const monthly = sumLines(lines);
+    const annual = monthly * 12;
+    return {
+      lines,
+      monthly,
+      annual,
+      rate: effectiveRatePerMillion(annual, monthlyTokens),
+    };
+  }, [monthlyTokens]);
+
+  const signal =
+    committed?.share != null ? overageSignal(committed.share) : null;
+  const delta = committed && payg ? payg.annual - committed.annual : null;
+
+  return (
+    <Stack gap={4}>
+      <Stack gap={1}>
+        <Text variant="body" className="font-medium">
+          Estimated contract value
+        </Text>
+        <Text muted small>
+          Approximates this account under both commercial models off its
+          observed TUM. Estimate only — nothing here is billed from or saved.
+        </Text>
+      </Stack>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <Stack gap={2}>
+          <Label htmlFor="contract-volume-basis">Monthly volume basis</Label>
+          <Select
+            value={basis}
+            onValueChange={(value) => setBasisOverride(value as VolumeBasis)}
+          >
+            <SelectTrigger id="contract-volume-basis" className="w-60">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  // History-derived bases the account can't support yet stay
+                  // visible but unselectable, so the gap is legible.
+                  disabled={option.value !== "custom" && option.tokens == null}
+                >
+                  {option.label}
+                  {option.value !== "custom" && option.tokens != null
+                    ? ` — ${formatTokensCompact(option.tokens)}`
+                    : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Stack>
+
+        {basis === "custom" && (
+          <Stack gap={2}>
+            <Label htmlFor="contract-custom-volume">
+              Monthly volume (tokens)
+            </Label>
+            <Input
+              id="contract-custom-volume"
+              type="number"
+              min={0}
+              placeholder="e.g. 30000000000"
+              value={customVolume}
+              onChange={setCustomVolume}
+            />
+          </Stack>
+        )}
+
+        <Stack gap={2}>
+          <Label htmlFor="contract-platform-fee">Annual platform fee ($)</Label>
+          <Input
+            id="contract-platform-fee"
+            type="number"
+            min={0}
+            placeholder={
+              baselineTokens != null && baselineTokens > 0
+                ? Math.round(derivedFee).toString()
+                : "Set a baseline first"
+            }
+            value={feeOverride}
+            onChange={setFeeOverride}
+          />
+        </Stack>
+
+        <SimpleTooltip
+          tooltip={`Defaults to the baseline priced at the model's committed effective rate: baseline × 12 months × $${BASELINE_RATE_PER_MILLION.toFixed(2)}/M. Override it with the actual negotiated fee.`}
+        >
+          <span className="text-muted-foreground pb-2.5 text-xs">
+            How is the fee defaulted?
+          </span>
+        </SimpleTooltip>
+      </div>
+
+      {/* What the selected basis actually measures. Load-bearing for the
+          projection, whose availability rule is otherwise invisible. */}
+      {selected && (
+        <Text muted small>
+          {selected.hint}
+        </Text>
+      )}
+
+      {monthlyTokens == null ? (
+        <Text muted small>
+          {basis === "custom"
+            ? "Enter a monthly volume to estimate."
+            : "This basis has nothing to measure yet — pick another, or enter a custom volume."}
+        </Text>
+      ) : (
+        <>
+          <Text muted small>
+            Estimating at {formatTokensCompact(monthlyTokens)} tokens/month (
+            {formatTokensCompact(monthlyTokens * 12)}/year).
+          </Text>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <ModelCard
+              title="Platform + Overage"
+              subtitle={
+                baselineTokens != null && baselineTokens > 0
+                  ? `Committed baseline ${formatTokensCompact(baselineTokens)}/mo`
+                  : "Requires a contracted baseline"
+              }
+            >
+              {committed ? (
+                <>
+                  <div className="mb-2 flex items-baseline justify-between text-sm tabular-nums">
+                    <span className="text-muted-foreground">
+                      Platform fee (annual)
+                    </span>
+                    <span className="font-medium">
+                      {formatUSD(platformFeeAnnual)}
+                    </span>
+                  </div>
+                  <div className="text-muted-foreground mb-1 text-xs">
+                    Monthly overage
+                  </div>
+                  <TierTable lines={committed.lines} />
+                  <ModelTotals
+                    monthly={committed.monthly}
+                    annual={committed.annual}
+                    rate={committed.rate}
+                  />
+                </>
+              ) : (
+                <Text muted small>
+                  Set an allowed TUM per month above — the overage tiers are
+                  multiples of the baseline, so there's nothing to price without
+                  one.
+                </Text>
+              )}
+            </ModelCard>
+
+            <ModelCard
+              title="Pay As You Go"
+              subtitle="No commitment — every token billed by volume tier"
+            >
+              {payg && (
+                <>
+                  <div className="text-muted-foreground mb-1 text-xs">
+                    Monthly volume tiers
+                  </div>
+                  <TierTable lines={payg.lines} />
+                  <ModelTotals
+                    monthly={payg.monthly}
+                    annual={payg.annual}
+                    rate={payg.rate}
+                  />
+                </>
+              )}
+            </ModelCard>
+          </div>
+
+          {signal && (
+            <div
+              className={cn(
+                "text-sm",
+                signal.tone === "destructive" && "text-destructive",
+                signal.tone === "warning" && "text-warning",
+                signal.tone === "muted" && "text-muted-foreground",
+              )}
+            >
+              {signal.message}
+            </div>
+          )}
+
+          {delta != null && (
+            <Text muted small>
+              {delta > 0
+                ? `Pay-as-you-go costs ${formatUSD(delta)}/yr more than the committed contract at this volume — the number to point at in a "should we commit?" conversation.`
+                : delta < 0
+                  ? `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here, which the model isn't meant to allow — check the platform fee against the baseline.`
+                  : "Both models price identically at this volume."}
+            </Text>
+          )}
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/client/dashboard/src/components/billing/contract-pricing.test.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+
+import { type BillingCycle } from "./billing-cycles";
+import {
+  derivedAnnualPlatformFee,
+  effectiveRatePerMillion,
+  formatTokensCompact,
+  overageLines,
+  paygLines,
+  sumLines,
+  type VolumeBasisOption,
+  volumeBasisOptions,
+} from "./contract-pricing";
+
+const B = 1e9;
+
+function cycle(partial: Partial<BillingCycle>): BillingCycle {
+  return {
+    start: new Date("2026-01-01T00:00:00Z"),
+    end: new Date("2026-02-01T00:00:00Z"),
+    tokens: 0,
+    current: false,
+    days: [],
+    ...partial,
+  };
+}
+
+function byBasis(
+  options: VolumeBasisOption[],
+  value: string,
+): VolumeBasisOption | undefined {
+  return options.find((o) => o.value === value);
+}
+
+describe("pay-as-you-go pricing", () => {
+  // The pricing doc's own worked example. If this drifts, the estimator and
+  // whatever sales quotes have stopped agreeing.
+  it("prices a sustained 80B/month customer at $22,850/month", () => {
+    const lines = paygLines(80 * B);
+    expect(lines.map((l) => [l.tokens, l.cost])).toEqual([
+      [10 * B, 3500],
+      [20 * B, 6000],
+      [45 * B, 12150],
+      [5 * B, 1200],
+    ]);
+    expect(sumLines(lines)).toBeCloseTo(22850, 6);
+  });
+
+  it("prices a 5B/month customer wholly inside tier 1", () => {
+    const lines = paygLines(5 * B);
+    expect(lines).toHaveLength(1);
+    expect(sumLines(lines)).toBeCloseTo(1750, 6);
+  });
+
+  it("charges from the first token — no free baseline", () => {
+    expect(sumLines(paygLines(1e6))).toBeCloseTo(0.35, 6);
+  });
+
+  it("produces no lines at zero volume", () => {
+    expect(paygLines(0)).toEqual([]);
+  });
+
+  it("stops at the band the volume lands in", () => {
+    // Exactly at a boundary the next band contributes nothing, so it must not
+    // appear as a zero-token line.
+    expect(paygLines(10 * B)).toHaveLength(1);
+  });
+});
+
+describe("committed-contract overage pricing", () => {
+  it("charges the first-tier rate between 1x and 2x baseline", () => {
+    const lines = overageLines(15 * B, 10 * B);
+    expect(lines).toEqual([
+      {
+        label: "1×–2× baseline",
+        tokens: 5 * B,
+        ratePerMillion: 0.26,
+        cost: 1300,
+      },
+    ]);
+  });
+
+  it("graduates across bands as usage climbs past multiples of baseline", () => {
+    const lines = overageLines(50 * B, 10 * B);
+    expect(lines.map((l) => [l.tokens, l.cost])).toEqual([
+      [10 * B, 2600], // 1x–2x  @ $0.26
+      [20 * B, 4600], // 2x–4x  @ $0.23
+      [10 * B, 2100], // 4x–8x  @ $0.21, capped at 5x
+    ]);
+    expect(sumLines(lines)).toBeCloseTo(9300, 6);
+  });
+
+  it("steps rates down monotonically, never below the $0.19 floor", () => {
+    const rates = overageLines(100 * B, 1 * B).map((l) => l.ratePerMillion);
+    expect(rates).toEqual([0.26, 0.23, 0.21, 0.19]);
+    for (const rate of rates) expect(rate).toBeGreaterThanOrEqual(0.19);
+  });
+
+  it("prices unplanned usage at a premium over the committed rate", () => {
+    // Tier 1 is where nearly all overage lands, and it must stay above the
+    // baseline rate — otherwise under-committing becomes the cheaper play.
+    const [first] = overageLines(15 * B, 10 * B);
+    expect(first?.ratePerMillion ?? 0).toBeGreaterThan(0.21);
+  });
+
+  it("charges nothing while usage sits under the baseline", () => {
+    expect(overageLines(8 * B, 10 * B)).toEqual([]);
+  });
+
+  it("has nothing to price without a baseline", () => {
+    // Every band is a multiple of the baseline, so a zero baseline leaves them
+    // all zero-width — the caller must read this as "not applicable".
+    expect(overageLines(50 * B, 0)).toEqual([]);
+  });
+});
+
+describe("derived platform fee", () => {
+  it("reproduces the doc's ~$189k contract for a 75B baseline", () => {
+    expect(derivedAnnualPlatformFee(75 * B)).toBeCloseTo(189_000, 6);
+  });
+
+  it("keeps a committed contract cheaper than PAYG at the same volume", () => {
+    // The whole point of the tier design: at equal volume, committing wins.
+    const volume = 80 * B;
+    const committed =
+      derivedAnnualPlatformFee(75 * B) +
+      sumLines(overageLines(volume, 75 * B)) * 12;
+    expect(committed).toBeLessThan(sumLines(paygLines(volume)) * 12);
+  });
+});
+
+describe("effectiveRatePerMillion", () => {
+  it("blends an annual bill back to a $/M rate", () => {
+    // $0.30/M across 12 months of 1B tokens.
+    expect(effectiveRatePerMillion(3600, 1 * B)).toBeCloseTo(0.3, 6);
+  });
+
+  it("is undefined at zero volume rather than infinite", () => {
+    expect(effectiveRatePerMillion(1000, 0)).toBeNull();
+  });
+});
+
+describe("volumeBasisOptions", () => {
+  const now = Date.UTC(2026, 0, 16); // Halfway through a 31-day January cycle.
+
+  it("projects the active cycle to a full cycle at its current rate", () => {
+    const options = volumeBasisOptions(
+      [cycle({ tokens: 5 * B, current: true })],
+      now,
+    );
+    const projected = byBasis(options, "projected")?.tokens ?? 0;
+    // 15 of 31 days elapsed, so the projection roughly doubles the total.
+    expect(projected).toBeGreaterThan(10 * B);
+    expect(projected).toBeLessThan(11 * B);
+  });
+
+  it("withholds the projection until a quarter of the cycle has elapsed", () => {
+    // Day 2 of a 31-day cycle: extrapolating here multiplies a quiet weekend
+    // into a headline contract number, so the basis reports unavailable.
+    const start = Date.UTC(2026, 0, 1);
+    const options = volumeBasisOptions(
+      [
+        cycle({
+          tokens: 1 * B,
+          current: true,
+          start: new Date(start),
+          end: new Date(Date.UTC(2026, 1, 1)),
+        }),
+      ],
+      Date.UTC(2026, 0, 3),
+    );
+    expect(byBasis(options, "projected")?.tokens).toBeNull();
+  });
+
+  it("averages and peaks over closed cycles only", () => {
+    const cycles = [
+      cycle({ tokens: 100 * B, current: true }),
+      cycle({ tokens: 10 * B }),
+      cycle({ tokens: 20 * B }),
+      cycle({ tokens: 30 * B }),
+      // Older than the trailing-3 window: peaks but never averages.
+      cycle({ tokens: 90 * B }),
+    ];
+    const options = volumeBasisOptions(cycles, now);
+    expect(byBasis(options, "last")?.tokens).toBe(10 * B);
+    expect(byBasis(options, "avg3")?.tokens).toBe(20 * B);
+    expect(byBasis(options, "peak")?.tokens).toBe(90 * B);
+  });
+
+  it("reports history-derived bases as unavailable on a brand-new account", () => {
+    const options = volumeBasisOptions(
+      [cycle({ tokens: 0, current: true })],
+      now,
+    );
+    expect(byBasis(options, "last")?.tokens).toBeNull();
+    expect(byBasis(options, "avg3")?.tokens).toBeNull();
+    expect(byBasis(options, "peak")?.tokens).toBeNull();
+  });
+});
+
+describe("formatTokensCompact", () => {
+  it("renders contract-scale volumes in the units the model is written in", () => {
+    expect(formatTokensCompact(80 * B)).toBe("80B");
+    expect(formatTokensCompact(1.5e6)).toBe("1.5M");
+    expect(formatTokensCompact(500)).toBe("500");
+  });
+});

--- a/client/dashboard/src/components/billing/contract-pricing.test.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.test.ts
@@ -187,6 +187,40 @@ describe("volumeBasisOptions", () => {
     expect(byBasis(options, "peak")?.tokens).toBe(90 * B);
   });
 
+  it("withholds the average until there are two cycles to average", () => {
+    // One closed cycle is not a mean — it is exactly "last full cycle", and
+    // labelling it as an average would imply smoothing that isn't happening.
+    const options = volumeBasisOptions(
+      [cycle({ tokens: 5 * B, current: true }), cycle({ tokens: 10 * B })],
+      now,
+    );
+    expect(byBasis(options, "avg3")?.tokens).toBeNull();
+    expect(byBasis(options, "last")?.tokens).toBe(10 * B);
+  });
+
+  it("labels the average with the number of cycles actually in it", () => {
+    const twoCycles = volumeBasisOptions(
+      [
+        cycle({ tokens: 5 * B, current: true }),
+        cycle({ tokens: 10 * B }),
+        cycle({ tokens: 20 * B }),
+      ],
+      now,
+    );
+    expect(byBasis(twoCycles, "avg3")?.label).toBe("Avg. last 2 cycles");
+    expect(byBasis(twoCycles, "avg3")?.tokens).toBe(15 * B);
+
+    const threeCycles = volumeBasisOptions(
+      [
+        cycle({ tokens: 10 * B }),
+        cycle({ tokens: 20 * B }),
+        cycle({ tokens: 30 * B }),
+      ],
+      now,
+    );
+    expect(byBasis(threeCycles, "avg3")?.label).toBe("Avg. last 3 cycles");
+  });
+
   it("reports history-derived bases as unavailable on a brand-new account", () => {
     const options = volumeBasisOptions(
       [cycle({ tokens: 0, current: true })],

--- a/client/dashboard/src/components/billing/contract-pricing.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.ts
@@ -182,6 +182,9 @@ function projectedCurrent(cycles: BillingCycle[], now: number): number | null {
   return Math.round((current.tokens * fullMs) / elapsedMs);
 }
 
+// Fewest closed cycles that make the trailing mean a mean at all.
+const MIN_AVERAGE_CYCLES = 2;
+
 // Cycles, most recent first, that have closed — the only ones whose totals
 // are final enough to average or take a peak from.
 function completedCycles(cycles: BillingCycle[]): BillingCycle[] {
@@ -194,10 +197,16 @@ export function volumeBasisOptions(
 ): VolumeBasisOption[] {
   const completed = completedCycles(cycles);
   const recent = completed.slice(0, 3);
-  const avg3 =
-    recent.length > 0
+  // A single closed cycle is not an average — that reading is exactly "last
+  // full cycle", and offering it under an "Avg." label would imply a
+  // smoothing that isn't happening. Two is the smallest honest mean.
+  const avgTokens =
+    recent.length >= MIN_AVERAGE_CYCLES
       ? Math.round(recent.reduce((s, c) => s + c.tokens, 0) / recent.length)
       : null;
+  // The label states how many cycles actually went into the mean, so a
+  // two-cycle average never reads as a three-cycle one.
+  const avgCount = recent.length >= MIN_AVERAGE_CYCLES ? recent.length : 3;
   const peak =
     completed.length > 0 ? Math.max(...completed.map((c) => c.tokens)) : null;
 
@@ -216,9 +225,12 @@ export function volumeBasisOptions(
     },
     {
       value: "avg3",
-      label: "Avg. last 3 cycles",
-      tokens: avg3,
-      hint: `Mean of the ${recent.length} most recent closed cycles.`,
+      label: `Avg. last ${avgCount} cycles`,
+      tokens: avgTokens,
+      hint:
+        avgTokens != null
+          ? `Mean of the ${recent.length} most recent closed cycles.`
+          : `Needs at least ${MIN_AVERAGE_CYCLES} closed cycles to average — with one, use "Last full cycle".`,
     },
     {
       value: "peak",

--- a/client/dashboard/src/components/billing/contract-pricing.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.ts
@@ -1,0 +1,270 @@
+import { type BillingCycle } from "./billing-cycles";
+
+// Contract pricing math for the platform-admin TUM estimator. Encodes the
+// 7/30 pricing model so an admin can approximate what an account's contract
+// is worth under either commercial shape — a committed platform fee with
+// tiered overage, or uncommitted pay-as-you-go.
+//
+// Nothing here is billed from. These are sales-side approximations off
+// observed TUM, kept in a pure module so the numbers are unit-testable and
+// the component file stays component-only (react-refresh).
+
+const TOKENS_PER_MILLION = 1_000_000;
+
+// The effective rate a committed baseline works out to: annual platform fee
+// divided by committed annual token volume. Used to DERIVE a default platform
+// fee from a baseline when the real negotiated fee isn't to hand — the admin
+// can always overwrite the fee, which is the number that actually matters.
+export const BASELINE_RATE_PER_MILLION = 0.21;
+
+// Overage bands, keyed on MULTIPLES of the monthly baseline — so the band
+// boundaries scale with the contract rather than sitting at absolute volumes.
+// Rates step down as volume grows, the intent being that no band undercuts
+// the committed baseline rate: if one did, under-committing would become the
+// cheaper play and the commit model would invert.
+//
+// Note the 8×+ band at $0.19 does sit under the $0.21 baseline rate, so that
+// property does not strictly hold at the very top of the ladder. The rates
+// here match the pricing model's table (which the PAYG section cross-
+// references as "our lowest contract overage tier ($0.19/M)"); an account
+// running 8× its baseline is a renegotiation conversation long before the
+// inversion matters in practice.
+const OVERAGE_TIERS: {
+  label: string;
+  upToMultiple: number;
+  ratePerMillion: number;
+}[] = [
+  { label: "1×–2× baseline", upToMultiple: 2, ratePerMillion: 0.26 },
+  { label: "2×–4× baseline", upToMultiple: 4, ratePerMillion: 0.23 },
+  { label: "4×–8× baseline", upToMultiple: 8, ratePerMillion: 0.21 },
+  { label: "8×+ baseline", upToMultiple: Infinity, ratePerMillion: 0.19 },
+];
+
+// Pay-as-you-go bands, keyed on absolute monthly volume. The floor rate
+// ($0.24) deliberately sits above both the committed baseline rate and the
+// lowest contract overage rate, so PAYG is never the cheaper option at
+// equivalent volume — it prices flexibility, not discount.
+const PAYG_TIERS: {
+  label: string;
+  upToTokens: number;
+  ratePerMillion: number;
+}[] = [
+  { label: "0–10B", upToTokens: 10e9, ratePerMillion: 0.35 },
+  { label: "10B–30B", upToTokens: 30e9, ratePerMillion: 0.3 },
+  { label: "30B–75B", upToTokens: 75e9, ratePerMillion: 0.27 },
+  { label: "75B+", upToTokens: Infinity, ratePerMillion: 0.24 },
+];
+
+// One band's contribution to a monthly bill.
+export type TierLine = {
+  label: string;
+  tokens: number;
+  ratePerMillion: number;
+  cost: number;
+};
+
+// Walks graduated bands: each band charges only the volume that falls inside
+// it, so the bill is the sum of the slices — the same arithmetic the pricing
+// doc's worked examples use. Bands with no volume are dropped so the UI shows
+// only lines that actually cost something.
+function graduatedLines(
+  tokens: number,
+  bands: { label: string; upper: number; ratePerMillion: number }[],
+  from: number,
+): TierLine[] {
+  const lines: TierLine[] = [];
+  let lower = from;
+  for (const band of bands) {
+    const inBand = Math.min(tokens, band.upper) - lower;
+    if (inBand > 0) {
+      lines.push({
+        label: band.label,
+        tokens: inBand,
+        ratePerMillion: band.ratePerMillion,
+        cost: (inBand / TOKENS_PER_MILLION) * band.ratePerMillion,
+      });
+    }
+    if (tokens <= band.upper) break;
+    lower = band.upper;
+  }
+  return lines;
+}
+
+export function sumLines(lines: TierLine[]): number {
+  return lines.reduce((total, line) => total + line.cost, 0);
+}
+
+// The overage bill for one month at `monthlyTokens` against a contracted
+// `baselineTokens`. A baseline of zero (or none) leaves every multiple-band
+// zero-width, so the model has nothing to price — callers must treat an empty
+// result from a missing baseline as "not applicable", not as "$0 of overage".
+export function overageLines(
+  monthlyTokens: number,
+  baselineTokens: number,
+): TierLine[] {
+  if (baselineTokens <= 0) return [];
+  return graduatedLines(
+    monthlyTokens,
+    OVERAGE_TIERS.map((t) => ({
+      label: t.label,
+      upper: baselineTokens * t.upToMultiple,
+      ratePerMillion: t.ratePerMillion,
+    })),
+    baselineTokens,
+  );
+}
+
+// The full pay-as-you-go bill for one month — every token is charged, from
+// the first one, with no baseline to subtract.
+export function paygLines(monthlyTokens: number): TierLine[] {
+  return graduatedLines(
+    monthlyTokens,
+    PAYG_TIERS.map((t) => ({
+      label: t.label,
+      upper: t.upToTokens,
+      ratePerMillion: t.ratePerMillion,
+    })),
+    0,
+  );
+}
+
+// The platform fee a baseline implies at the model's effective committed
+// rate. A starting point for the estimate, not a quote: real contracts are
+// negotiated, which is why the admin can override the fee.
+export function derivedAnnualPlatformFee(baselineTokens: number): number {
+  return (baselineTokens * 12 * BASELINE_RATE_PER_MILLION) / TOKENS_PER_MILLION;
+}
+
+// The blended $/M an annual bill works out to at a given monthly volume —
+// the single number that makes the two models directly comparable.
+export function effectiveRatePerMillion(
+  annualCost: number,
+  monthlyTokens: number,
+): number | null {
+  const annualTokens = monthlyTokens * 12;
+  if (annualTokens <= 0) return null;
+  return annualCost / (annualTokens / TOKENS_PER_MILLION);
+}
+
+// Which observed volume the estimate runs on. Contract conversations happen
+// against different readings of the same account — what it's doing right now,
+// what it did last month, its recent typical, and its worst month — so the
+// estimator exposes all four rather than picking one.
+export type VolumeBasis = "projected" | "last" | "avg3" | "peak" | "custom";
+
+export type VolumeBasisOption = {
+  value: VolumeBasis;
+  label: string;
+  // Null when the account's history can't support the basis yet (e.g. no
+  // completed cycle). The picker disables those rather than hiding them, so
+  // the absence is visible instead of looking like the option never existed.
+  tokens: number | null;
+  hint: string;
+};
+
+// How much of a cycle must have elapsed before extrapolating it is worth
+// anything. Early in a cycle the multiplier is enormous — on day 2 of a
+// 31-day cycle a projection amplifies one quiet weekend fifteen-fold — and
+// the result reads as a headline contract number rather than as the noise it
+// is. Under this threshold the basis reports as unavailable instead.
+const MIN_PROJECTION_ELAPSED_SHARE = 0.25;
+
+// The active cycle's usage extrapolated to a full cycle at its current rate,
+// or null while the cycle is too young for that to mean anything.
+function projectedCurrent(cycles: BillingCycle[], now: number): number | null {
+  const current = cycles.find((c) => c.current);
+  if (!current) return null;
+  const fullMs = current.end.getTime() - current.start.getTime();
+  if (fullMs <= 0) return current.tokens;
+  const elapsedMs =
+    Math.min(now, current.end.getTime()) - current.start.getTime();
+  if (elapsedMs < fullMs * MIN_PROJECTION_ELAPSED_SHARE) return null;
+  return Math.round((current.tokens * fullMs) / elapsedMs);
+}
+
+// Cycles, most recent first, that have closed — the only ones whose totals
+// are final enough to average or take a peak from.
+function completedCycles(cycles: BillingCycle[]): BillingCycle[] {
+  return cycles.filter((c) => !c.current);
+}
+
+export function volumeBasisOptions(
+  cycles: BillingCycle[],
+  now: number,
+): VolumeBasisOption[] {
+  const completed = completedCycles(cycles);
+  const recent = completed.slice(0, 3);
+  const avg3 =
+    recent.length > 0
+      ? Math.round(recent.reduce((s, c) => s + c.tokens, 0) / recent.length)
+      : null;
+  const peak =
+    completed.length > 0 ? Math.max(...completed.map((c) => c.tokens)) : null;
+
+  return [
+    {
+      value: "projected",
+      label: "Current cycle (projected)",
+      tokens: projectedCurrent(cycles, now),
+      hint: `The active cycle's usage so far, extrapolated to a full cycle. Withheld until ${Math.round(MIN_PROJECTION_ELAPSED_SHARE * 100)}% of the cycle has elapsed — before that the extrapolation is mostly noise.`,
+    },
+    {
+      value: "last",
+      label: "Last full cycle",
+      tokens: completed[0]?.tokens ?? null,
+      hint: "The most recently closed billing cycle's billed total.",
+    },
+    {
+      value: "avg3",
+      label: "Avg. last 3 cycles",
+      tokens: avg3,
+      hint: `Mean of the ${recent.length} most recent closed cycles.`,
+    },
+    {
+      value: "peak",
+      label: "Peak cycle",
+      tokens: peak,
+      hint: "The heaviest closed cycle on record — the worst-case month.",
+    },
+    {
+      value: "custom",
+      label: "Custom volume",
+      // Supplied by the caller's own input, not derived from history.
+      tokens: null,
+      hint: "A hypothetical monthly volume, for sizing a new contract.",
+    },
+  ];
+}
+
+const usdWhole = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+const usdCents = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+// Whole dollars once a figure is big enough that cents are noise; cents below
+// that, so small line items don't all collapse to "$0".
+export function formatUSD(value: number): string {
+  return Math.abs(value) >= 1000
+    ? usdWhole.format(value)
+    : usdCents.format(value);
+}
+
+// Token counts at contract scale are billions — the raw digits are unreadable
+// in a table of prices, so compact them to the unit the pricing model itself
+// is written in.
+export function formatTokensCompact(tokens: number): string {
+  if (tokens >= 1e9) {
+    return `${(tokens / 1e9).toLocaleString("en-US", { maximumFractionDigits: 2 })}B`;
+  }
+  if (tokens >= 1e6) {
+    return `${(tokens / 1e6).toLocaleString("en-US", { maximumFractionDigits: 1 })}M`;
+  }
+  return tokens.toLocaleString("en-US");
+}

--- a/client/dashboard/src/components/billing/tum-admin-section.test.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TokensUnderManagement } from "@gram/client/models/components/tokensundermanagement.js";
+
+const mocks = vi.hoisted(() => ({
+  useGetTokensUnderManagement: vi.fn(),
+  useSetBillingMetadataMutation: vi.fn(),
+}));
+
+vi.mock("@gram/client/react-query/getTokensUnderManagement.js", () => ({
+  useGetTokensUnderManagement: mocks.useGetTokensUnderManagement,
+  invalidateAllGetTokensUnderManagement: vi.fn(),
+}));
+
+vi.mock("@gram/client/react-query/setBillingMetadata.js", () => ({
+  useSetBillingMetadataMutation: mocks.useSetBillingMetadataMutation,
+}));
+
+// Page chrome isn't what's under test; render it as plain boxes so a failure
+// here can only mean the boundary.
+vi.mock("@/components/page-layout", () => {
+  const Section = ({ children }: { children: ReactNode }) => <>{children}</>;
+  Section.Title = ({ children }: { children: ReactNode }) => (
+    <h2>{children}</h2>
+  );
+  Section.Description = ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  );
+  Section.Body = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return { Page: { Section } };
+});
+
+// Stand in for a chunk that fails to load — the stale-tab-after-deploy case,
+// where the hashed asset the page asks for no longer exists. A rejecting
+// module factory makes the dynamic import inside React.lazy reject, which is
+// exactly what Suspense does NOT catch.
+vi.mock("./contract-price-estimator", () => {
+  throw new Error("Failed to fetch dynamically imported module");
+});
+
+const tum = {
+  periodStart: new Date("2026-07-01T00:00:00Z"),
+  periodEnd: new Date("2026-08-01T00:00:00Z"),
+  tokens: 5_000_000_000,
+  monthlyTokenLimit: 30_000_000_000,
+  alertEmail: "billing@example.test",
+  billingCycleAnchorDay: 1,
+  history: [],
+} as unknown as TokensUnderManagement;
+
+function renderSection() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  // Imported lazily so the module-level vi.mock calls above are in place.
+  return import("./tum-admin-section").then(({ TumAdminSection }) =>
+    render(
+      <QueryClientProvider client={client}>
+        <TumAdminSection />
+      </QueryClientProvider>,
+    ),
+  );
+}
+
+describe("TumAdminSection", () => {
+  beforeEach(() => {
+    mocks.useGetTokensUnderManagement.mockReturnValue({
+      data: tum,
+      isError: false,
+    });
+    mocks.useSetBillingMetadataMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    });
+    // React logs the caught error; keep the run readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the contract form usable when the estimator chunk fails to load", async () => {
+    await renderSection();
+
+    // The estimator's failure is contained and explained...
+    await waitFor(() => {
+      expect(screen.getByText(/contract estimate couldn't load/i)).toBeTruthy();
+    });
+
+    // ...and the form beside it — the thing an admin actually came to change
+    // — is still mounted and holding its saved values.
+    const limit = screen.getByLabelText(
+      /allowed tum per month/i,
+    ) as HTMLInputElement;
+    expect(limit.value).toBe("30000000000");
+    expect(screen.getByText(/save contract terms/i)).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -12,7 +12,9 @@ import {
 } from "@gram/client/react-query/getTokensUnderManagement.js";
 import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { cyclesFromTum } from "./billing-cycles";
+import { ContractPriceEstimator } from "./contract-price-estimator";
 
 // Platform-admin form for the org's contracted tokens-under-management
 // terms: monthly allowance, alert email, and the billing cycle anchor day.
@@ -89,6 +91,16 @@ function ContractForm({
     parsedAnchorDay < 1 ||
     parsedAnchorDay > 31;
 
+  const cycles = useMemo(() => cyclesFromTum(initial), [initial]);
+
+  // The estimator prices whatever baseline the admin is currently proposing,
+  // so a limit typed into the field above moves the contract value before
+  // it's saved — that's the sizing workflow. A half-typed invalid entry falls
+  // back to the saved terms instead of blanking the estimate out mid-keystroke.
+  const estimatorBaseline = limitInvalid
+    ? (initial.monthlyTokenLimit ?? null)
+    : (parsedLimit ?? null);
+
   const handleSave = () => {
     mutation.mutate({
       request: {
@@ -102,59 +114,70 @@ function ContractForm({
   };
 
   return (
-    <Stack gap={4} className="max-w-md">
-      <Stack gap={2}>
-        <Label htmlFor="tum-monthly-limit">
-          Allowed TUM per month (tokens)
-        </Label>
-        <Input
-          id="tum-monthly-limit"
-          type="number"
-          min={0}
-          placeholder="Leave empty for no contracted limit"
-          value={tokenLimit}
-          onChange={setTokenLimit}
+    <Stack gap={8}>
+      <Stack gap={4} className="max-w-md">
+        <Stack gap={2}>
+          <Label htmlFor="tum-monthly-limit">
+            Allowed TUM per month (tokens)
+          </Label>
+          <Input
+            id="tum-monthly-limit"
+            type="number"
+            min={0}
+            placeholder="Leave empty for no contracted limit"
+            value={tokenLimit}
+            onChange={setTokenLimit}
+          />
+        </Stack>
+        <Stack gap={2}>
+          <Label htmlFor="tum-alert-email">Alert email</Label>
+          <Input
+            id="tum-alert-email"
+            type="email"
+            placeholder="billing-alerts@customer.com"
+            value={alertEmail}
+            onChange={setAlertEmail}
+          />
+        </Stack>
+        <Stack gap={2}>
+          <Label htmlFor="tum-anchor-day">
+            Billing cycle anchor day (1–31)
+          </Label>
+          <Input
+            id="tum-anchor-day"
+            type="number"
+            min={1}
+            max={31}
+            value={anchorDay}
+            onChange={setAnchorDay}
+          />
+        </Stack>
+        <Stack direction="horizontal" align="center" gap={3}>
+          <Button
+            onClick={handleSave}
+            disabled={mutation.isPending || limitInvalid || anchorDayInvalid}
+          >
+            {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
+          </Button>
+          {mutation.isSuccess && !mutation.isPending && (
+            <Text muted small>
+              Saved.
+            </Text>
+          )}
+          {mutation.isError && (
+            <Text small className="text-destructive">
+              Failed to save contract terms.
+            </Text>
+          )}
+        </Stack>
+      </Stack>
+
+      <div className="border-border border-t pt-6">
+        <ContractPriceEstimator
+          baselineTokens={estimatorBaseline}
+          cycles={cycles}
         />
-      </Stack>
-      <Stack gap={2}>
-        <Label htmlFor="tum-alert-email">Alert email</Label>
-        <Input
-          id="tum-alert-email"
-          type="email"
-          placeholder="billing-alerts@customer.com"
-          value={alertEmail}
-          onChange={setAlertEmail}
-        />
-      </Stack>
-      <Stack gap={2}>
-        <Label htmlFor="tum-anchor-day">Billing cycle anchor day (1–31)</Label>
-        <Input
-          id="tum-anchor-day"
-          type="number"
-          min={1}
-          max={31}
-          value={anchorDay}
-          onChange={setAnchorDay}
-        />
-      </Stack>
-      <Stack direction="horizontal" align="center" gap={3}>
-        <Button
-          onClick={handleSave}
-          disabled={mutation.isPending || limitInvalid || anchorDayInvalid}
-        >
-          {mutation.isPending ? "SAVING..." : "SAVE CONTRACT TERMS"}
-        </Button>
-        {mutation.isSuccess && !mutation.isPending && (
-          <Text muted small>
-            Saved.
-          </Text>
-        )}
-        {mutation.isError && (
-          <Text small className="text-destructive">
-            Failed to save contract terms.
-          </Text>
-        )}
-      </Stack>
+      </div>
     </Stack>
   );
 }

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -13,6 +13,8 @@ import {
 import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { Suspense, useMemo, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { handleError, toError } from "@/lib/errors";
 import { cyclesFromTum } from "./billing-cycles";
 
 // Split out of the initial bundle. The contract terms are what an admin comes
@@ -183,23 +185,47 @@ function ContractForm({
       </Stack>
 
       <div className="border-border border-t pt-6">
-        <Suspense
-          fallback={
-            <div className="space-y-4">
-              <Skeleton className="h-5 w-48" />
-              <Skeleton className="h-9 w-full max-w-lg" />
-              <div className="grid gap-4 md:grid-cols-2">
-                <Skeleton className="h-44 w-full" />
-                <Skeleton className="h-44 w-full" />
-              </div>
-            </div>
-          }
+        {/* Suspense covers the chunk being in flight; it does NOT catch a
+            rejected dynamic import. Without this boundary a failed chunk
+            fetch — most often a stale tab requesting a hash that a deploy
+            has since replaced — would propagate to the Page.Body boundary
+            and take the contract form down with it. The estimate is an
+            optional aside, so its failure has to stay inside this box. */}
+        <ErrorBoundary
+          onError={(error) => handleError(toError(error), { silent: true })}
+          fallbackRender={() => (
+            <Text muted small>
+              The contract estimate couldn't load. Your contract terms above are
+              unaffected —{" "}
+              <button
+                type="button"
+                className="underline underline-offset-2"
+                onClick={() => window.location.reload()}
+              >
+                reload the page
+              </button>{" "}
+              to try again.
+            </Text>
+          )}
         >
-          <ContractPriceEstimator
-            baselineTokens={estimatorBaseline}
-            cycles={cycles}
-          />
-        </Suspense>
+          <Suspense
+            fallback={
+              <div className="space-y-4">
+                <Skeleton className="h-5 w-48" />
+                <Skeleton className="h-9 w-full max-w-lg" />
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Skeleton className="h-44 w-full" />
+                  <Skeleton className="h-44 w-full" />
+                </div>
+              </div>
+            }
+          >
+            <ContractPriceEstimator
+              baselineTokens={estimatorBaseline}
+              cycles={cycles}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </div>
     </Stack>
   );

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -12,9 +12,19 @@ import {
 } from "@gram/client/react-query/getTokensUnderManagement.js";
 import { useSetBillingMetadataMutation } from "@gram/client/react-query/setBillingMetadata.js";
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import React, { Suspense, useMemo, useState } from "react";
 import { cyclesFromTum } from "./billing-cycles";
-import { ContractPriceEstimator } from "./contract-price-estimator";
+
+// Split out of the initial bundle. The contract terms are what an admin comes
+// to this section to change; the estimate is a read-only aside built entirely
+// from data already on the page. Loading it lazily keeps the pricing module
+// and its arithmetic off the billing page's first paint — the form is
+// interactive before the estimator's chunk has even been fetched.
+const ContractPriceEstimator = React.lazy(() =>
+  import("./contract-price-estimator").then((mod) => ({
+    default: mod.ContractPriceEstimator,
+  })),
+);
 
 // Platform-admin form for the org's contracted tokens-under-management
 // terms: monthly allowance, alert email, and the billing cycle anchor day.
@@ -173,10 +183,23 @@ function ContractForm({
       </Stack>
 
       <div className="border-border border-t pt-6">
-        <ContractPriceEstimator
-          baselineTokens={estimatorBaseline}
-          cycles={cycles}
-        />
+        <Suspense
+          fallback={
+            <div className="space-y-4">
+              <Skeleton className="h-5 w-48" />
+              <Skeleton className="h-9 w-full max-w-lg" />
+              <div className="grid gap-4 md:grid-cols-2">
+                <Skeleton className="h-44 w-full" />
+                <Skeleton className="h-44 w-full" />
+              </div>
+            </div>
+          }
+        >
+          <ContractPriceEstimator
+            baselineTokens={estimatorBaseline}
+            cycles={cycles}
+          />
+        </Suspense>
       </div>
     </Stack>
   );


### PR DESCRIPTION
Adds a **contract value estimator** to the TUM Contract (Platform Admin View) section of `/billing`, so platform admins can see roughly what an enterprise account is worth under either commercial model without leaving the page.

Implements the two models from the 7/30 pricing doc:

- **Platform + Overage** — an annual platform fee plus graduated overage bands keyed on *multiples of the contracted monthly baseline*, so the tier boundaries move with the contract.
- **Pay As You Go** — graduated bands keyed on absolute monthly volume.

Both are marginal/graduated, matching the worked examples in the doc (there are unit tests asserting the doc's own 80B/month PAYG figure of \$22,850/mo and its ~\$189k committed contract at a 75B baseline, so the estimator and whatever sales quotes can't silently drift apart).

## What an admin sees

Each model renders its per-band breakdown — volume, rate, cost — then an annual headline, a monthly figure, and a blended \$/M so the two are directly comparable. Underneath, two derived signals:

- **Overage as a share of the base contract**, escalating from "well-sized" through "worth an expansion conversation" to "size up the baseline at renewal". The pricing doc frames rising overage as an expansion trigger rather than just a penalty line; this surfaces it.
- **The PAYG-vs-committed delta**, which is the number to point at in a "should we commit?" conversation.

## Inputs

The **monthly volume basis** is selectable: trailing multi-cycle mean, last full cycle, peak cycle, a projection of the active cycle, or a typed hypothetical for sizing a new contract. Bases the account has no data for stay visible but disabled, so the gap is legible rather than invisible. The default lands on the steadiest basis the account can actually support instead of a fixed one.

Two guards keep the defaults honest:

- The **projection is withheld until 25% of the cycle has elapsed** — on day 2 of a 31-day cycle, extrapolating amplifies one quiet weekend roughly fifteen-fold into what reads as a headline contract number.
- The **trailing average requires two closed cycles** and is labelled with the count actually averaged. With one, it is not a mean at all — it is exactly "last full cycle" — so the default falls through to that instead.

The **baseline** is read live off the contract-terms form above, so a limit typed into that field moves the estimate before it is saved — that's the sizing workflow.

The **platform fee** defaults to the baseline priced at the model's committed effective rate and is overridable with the real negotiated figure.

Estimate only: nothing here is billed from and nothing is persisted.

## Loading

The estimator is `React.lazy`-loaded behind a scoped Suspense boundary. It is a read-only aside built entirely from data already on the page, whereas the contract-terms form is what an admin comes to this section to change — so the form is interactive before the estimator's chunk has been fetched, and the prices are computed after load rather than on the render path.

Verified against a production build: the pricing module resolves to `assets/contract-price-estimator-*.js` (9.8 KB) and is absent from `assets/main-*.js`, which the statically-imported billing route would otherwise have pulled it into for every dashboard page load.

## One thing worth a look

**The pricing doc contradicts itself at the top overage band.** It states as the model's load-bearing constraint that "every tier stays at or above the baseline rate" — but its own table prices the 8×+ band at \$0.19/M, below the ~\$0.21/M baseline rate. The PAYG section then refers to "\$0.19/M" as "our lowest contract overage tier", so the table looks authoritative and the prose invariant looks like the error. I implemented the table and documented the discrepancy in a comment. Worth confirming which one is intended — if the invariant is the real rule, the 8×+ rate should go up.

<details>
<summary>Resolved: rate card in the client bundle</summary>

Raised during review (and independently by cubic): the tier rates ship in dashboard JS, so any customer can read them by inspecting the bundle — the platform-admin gate is render-time only and does not keep constants out of what everyone downloads.

**Decision: these are list prices, so displaying them is fine.** No server-side move needed. The lazy-loading above is a load-time change, not a confidentiality one.

</details>

## Verification

- 22 unit tests over the pricing math (`contract-pricing.test.ts`) — pass
- `tsc -b --noEmit --force` — clean
- `oxlint --type-aware` — clean
- `knip` — clean
- `oxfmt --check` — clean
- Rendered and screenshotted in Storybook, light and dark, across baseline / no-baseline / single-closed-cycle states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xbtxcrJVzVcdx1FFuAPjz