### PR TITLE
fix(dashboard): announce the estimator load failure

### DIFF
--- a/.changeset/tum-estimator-alert-role.md
+++ b/.changeset/tum-estimator-alert-role.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Announce the contract estimator's load failure to screen readers. The message replaces a loading skeleton after the page has settled, so without a live region there was no indication the estimate had failed or that reloading was the way to recover.

--- a/client/dashboard/src/components/billing/tum-admin-section.test.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.test.tsx
@@ -87,9 +87,11 @@ describe("TumAdminSection", () => {
   it("keeps the contract form usable when the estimator chunk fails to load", async () => {
     await renderSection();
 
-    // The estimator's failure is contained and explained...
+    // The estimator's failure is contained and explained — and announced,
+    // since it lands asynchronously well after the page has settled.
     await waitFor(() => {
-      expect(screen.getByText(/contract estimate couldn't load/i)).toBeTruthy();
+      const alert = screen.getByRole("alert");
+      expect(alert.textContent).toMatch(/contract estimate couldn't load/i);
     });
 
     // ...and the form beside it — the thing an admin actually came to change

--- a/client/dashboard/src/components/billing/tum-admin-section.tsx
+++ b/client/dashboard/src/components/billing/tum-admin-section.tsx
@@ -194,7 +194,10 @@ function ContractForm({
         <ErrorBoundary
           onError={(error) => handleError(toError(error), { silent: true })}
           fallbackRender={() => (
-            <Text muted small>
+            // Announced, because this replaces a skeleton long after the page
+            // has settled — with no live region a screen reader user is never
+            // told the estimate failed, or that a reload is the way back.
+            <Text muted small role="alert">
               The contract estimate couldn't load. Your contract terms above are
               unaffected —{" "}
               <button


### PR DESCRIPTION
Follow-up to #4828, which merged while this was in flight — the branch was frozen in the merge queue, and dequeuing an approved PR for a one-liner wasn't worth it.

Flagged by cubic on #4828: the contract estimator's error fallback was a plain paragraph. It replaces a loading skeleton **asynchronously, after the page has settled**, so with no live region a screen reader user gets no indication that the estimate failed or that reloading is the way to recover. `role="alert"` announces it without moving focus.

`Text` already spreads `React.ComponentProps<"p">`, so the role forwards without touching the component.

The existing containment test now asserts via `getByRole("alert")` rather than matching on text, so dropping the role fails the suite instead of passing quietly.

## Verification

- 23 tests pass (`vitest run src/components/billing`)
- `tsc -b --noEmit --force` — clean
- `oxlint --type-aware` — clean
- `oxfmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xbtxcrJVzVcdx1FFuAPjz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announces the contract estimator load failure with role="alert" so screen reader users are notified when the async fallback replaces the skeleton, without shifting focus.
Updates the test to assert via getByRole("alert") and adds a patch changeset.

<sup>Written for commit c5eb1d8d2684125c7ec218de4b77578cd4b29d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

