### PR TITLE
fix(dashboard): keep chart tooltips from covering multi-series charts

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -1389,14 +1389,18 @@ function MultiLineChart({
       legend: SHARED_LEGEND,
       tooltip: {
         ...SHARED_TOOLTIP,
+        // Index-mode hover activates every series at that x. Drop zeros so a
+        // sparse multi-series chart doesn't build a tooltip listing every
+        // inactive source (which balloons until it covers the chart). Returning
+        // `undefined` from `label` is not enough — Chart.js treats that as
+        // "use the default callback" and still renders the line.
+        filter: (item) => (item.parsed.y ?? 0) !== 0,
         callbacks: {
           title: (items) => tooltipLabels[items[0]?.dataIndex ?? 0] ?? "",
-          label: (item) => {
-            if ((item.parsed.y ?? 0) === 0) return undefined;
-            return item.formattedValue
+          label: (item) =>
+            item.formattedValue
               ? `${item.dataset.label}: ${item.formattedValue}`
-              : "";
-          },
+              : "",
           ...(tooltipAfterBody
             ? {
                 afterBody: (items) =>

--- a/client/dashboard/src/components/observe/InsightsToolsTimeSeries.test.ts
+++ b/client/dashboard/src/components/observe/InsightsToolsTimeSeries.test.ts
@@ -66,4 +66,21 @@ describe("InsightsTools chart zoom wiring", () => {
     expect(callsite).toContain("isZoomed={isZoomed}");
     expect(callsite).toContain("onResetZoom={onResetZoom}");
   });
+
+  it("filters zero-value series out of the multi-line chart tooltip", () => {
+    const source = readFileSync(
+      "src/components/observe/InsightsTools.tsx",
+      "utf8",
+    );
+
+    // Guard against regressing to `return undefined` in the label callback —
+    // Chart.js treats that as "use default" and re-lists every series,
+    // ballooning the tooltip over the chart (DNO-717).
+    expect(source).toMatch(
+      /filter:\s*\(item\)\s*=>\s*\(item\.parsed\.y\s*\?\?\s*0\)\s*!==\s*0/,
+    );
+    expect(source).not.toMatch(
+      /if \(\(item\.parsed\.y \?\? 0\) === 0\) return undefined;/,
+    );
+  });
 });

--- a/client/dashboard/src/pages/security/SecurityOverview.tsx
+++ b/client/dashboard/src/pages/security/SecurityOverview.tsx
@@ -668,6 +668,12 @@ function RiskTrendChart({
         borderWidth: 1,
         padding: 12,
         boxPadding: 4,
+        // Index-mode hover activates every series at that x. Drop zeros so a
+        // sparse multi-series chart doesn't list every inactive category
+        // (which balloons the tooltip until it covers the chart). Returning
+        // `undefined` from `label` is not enough — Chart.js treats that as
+        // "use the default callback" and still renders the line.
+        filter: (item) => (item.parsed.y ?? 0) !== 0,
         callbacks: {
           title: (items) => {
             const x = items[0]?.parsed.x;
@@ -680,12 +686,10 @@ function RiskTrendChart({
               minute: "2-digit",
             });
           },
-          label: (item) => {
-            if ((item.parsed.y ?? 0) === 0) return undefined;
-            return item.formattedValue
+          label: (item) =>
+            item.formattedValue
               ? `${item.dataset.label}: ${item.formattedValue}`
-              : "";
-          },
+              : "",
         },
       },
       zoom: zoomPluginOptions,


### PR DESCRIPTION
## Summary
- Fixes [DNO-717](https://linear.app/speakeasy/issue/DNO-717): hovering multi-series charts (e.g. Activity by Source) produced a tooltip listing every series — mostly zeros — that covered the chart.
- Root cause: returning `undefined` from the Chart.js `label` callback falls back to the default callback, so zeros were still rendered. Use `tooltip.filter` to drop zero-y items instead.
- Same fix applied to the Security risk-trend chart, which had the identical pattern.

## Test plan
- [ ] Open Insights → Tools with many sources; hover Activity by Source — tooltip should only list series with non-zero values at that point and not cover the chart
- [ ] Confirm Skill Usage / User Usage / Errors time-series tooltips still work
- [ ] Open Security overview risk-trend chart; hover and confirm sparse categories don't inflate the tooltip
- [ ] `pnpm -F dashboard exec vitest run src/components/observe/InsightsToolsTimeSeries.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop tooltips from covering multi‑series charts by filtering out zero‑value series on hover. Fixes DNO-717 and applies to Insights “Activity by Source” and the Security risk trend chart.

- **Bug Fixes**
  - Use `tooltip.filter` in `Chart.js` to drop zero‑value items in index mode, instead of returning `undefined` in `label`.
  - Updated `InsightsTools` MultiLineChart and `SecurityOverview` RiskTrendChart.
  - Added a unit test to guard against reverting to the old `label` callback pattern.

<sup>Written for commit f03eaa707273166d0c21c81baf447c6931f77da8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

