### PR TITLE
chore: report booting, seeding and failed worktree stack states

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -20,20 +20,16 @@ workinit = "mise run git:workinit"
 # Background: brings the worktree's stack up on the ports workinit just
 # assigned — compose infra, migrations, dev-idp, the pitchfork daemons, then
 # seed. Non-blocking, so worktree creation returns without waiting on it;
-# `wt config state logs` has the output.
-#
-# INFRA_READINESS_TIMEOUT is raised from its 30s default because a new worktree
-# always starts from a cold volume: Postgres has to finish initdb before it
-# accepts queries, and several worktree stacks may be booting at once. At 30s
-# infra:start gives up mid-initdb and zero aborts before migrations run,
-# leaving the daemons pointed at an empty database.
+# `wt config state logs` has the output. The task also publishes a pid marker
+# while it runs, which is what lets `wt status` say "booting" rather than
+# "down". Keep the hook key `stack` — the log file is named after it.
 #
 # Set GRAM_WT_NO_BOOT=1 to skip the stack for branches that don't need it (a
 # README tweak, a config change). `new-branch <branch> --no-boot` sets it.
 # workinit still runs, so the worktree is complete — boot it later with
 # `./zero --agent`.
 [post-start]
-stack = 'if [ -n "$GRAM_WT_NO_BOOT" ]; then echo "GRAM_WT_NO_BOOT set — skipping stack boot. Run ./zero --agent when you need it."; else INFRA_READINESS_TIMEOUT=300 ./zero --agent; fi'
+stack = "mise run git:workboot"
 
 # Runs inside the worktree before deletion — nuke needs this worktree's
 # COMPOSE_PROJECT_NAME (mise.local.toml) and local/ dir to tear down the right

--- a/.mise-tasks/git/workboot.sh
+++ b/.mise-tasks/git/workboot.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#MISE dir="{{ config_root }}"
+#MISE hide="true"
+#MISE description="Boot this worktree's stack, publishing a marker while it runs"
+
+set -e
+
+# Runs as the `post-start` hook (see .config/wt.toml). The hook is backgrounded,
+# so a fresh worktree spends several minutes with its ports closed while the
+# stack comes up. `git:workstatus` can't tell that apart from a stack that was
+# never booted, so publish a marker for the duration: the pid of this script,
+# in the worktree's own git dir (never committed, removed with the worktree).
+# A boot that exits nonzero leaves a second marker behind holding the exit
+# code, so the failure survives for `git:workstatus` to report -- otherwise a
+# stack that died halfway through is indistinguishable from one never started.
+gitdir="$(git rev-parse --absolute-git-dir)"
+marker="$gitdir/gram-stack-boot.pid"
+failed="$gitdir/gram-stack-boot.failed"
+
+if [ -n "${GRAM_WT_NO_BOOT:-}" ]; then
+    echo "GRAM_WT_NO_BOOT set — skipping stack boot. Run ./zero --agent when you need it."
+    exit 0
+fi
+
+echo $$ > "$marker"
+rm -f "$failed"
+trap 'code=$?; rm -f "$marker"; [ "$code" -eq 0 ] || echo "$code" > "$failed"' EXIT
+
+# Re-booting a worktree whose stack is already running fails for a reason that
+# has nothing to do with the worktree: `mise run start` kills the previous
+# daemons, pitchfork records the kill as a daemon failure, `start` reports
+# failure, and `zero` never reaches `mise run seed` -- leaving the org on the
+# demo gate. Stop cleanly first so a retry is a real retry. No-op on a fresh
+# worktree, where nothing is running yet.
+mise run stop || true
+
+# INFRA_READINESS_TIMEOUT is raised from its 30s default because a new worktree
+# always starts from a cold volume: Postgres has to finish initdb before it
+# accepts queries, and several worktree stacks may be booting at once. At 30s
+# infra:start gives up mid-initdb and zero aborts before migrations run,
+# leaving the daemons pointed at an empty database.
+if INFRA_READINESS_TIMEOUT=300 ./zero --agent; then
+    exit 0
+fi
+
+# `mise run seed` is `zero`'s last step and its flakiest: it authenticates
+# through dev-idp, and that handshake 307s while a just-restarted server
+# settles ("auth.callback did not return a session"). Seeding is also the step
+# that lifts the org off the demo gate, so a boot that stops here leaves a
+# dashboard that looks broken. Retry the seed alone -- if `zero` failed earlier
+# than seeding, these retries fail too and the boot is reported failed anyway.
+for delay in 15 30 60; do
+    sleep "$delay"
+    echo "Retrying seed after a ${delay}s wait..."
+    if mise run seed; then
+        exit 0
+    fi
+done
+
+exit 1

--- a/.mise-tasks/git/workstatus.sh
+++ b/.mise-tasks/git/workstatus.sh
@@ -20,7 +20,7 @@ fi
 # default to schema 2, which wraps the array in an envelope this jq would miss.
 rows=$(wt --config-set 'list.json-schema=1' list --format json \
     | jq -r '.[] | select(.url // "" != "")
-             | [(if .is_current then "@" else "+" end), .branch, (.url_active | tostring), .url]
+             | [(if .is_current then "@" else "+" end), .branch, (.url_active | tostring), .url, .path]
              | @tsv')
 
 if [ -z "$rows" ]; then
@@ -28,15 +28,62 @@ if [ -z "$rows" ]; then
     exit 0
 fi
 
+# A worktree whose stack is still coming up, and one whose boot died, both look
+# exactly like one that was never booted -- the port isn't listening in any of
+# the three cases, and worktrunk tracks no hook liveness. `git:workboot` (the
+# post-start hook) closes that gap with two markers in the worktree's git dir:
+# its pid while the boot runs, and the exit code if the boot failed. Echoes
+# `booting`, `failed`, or nothing.
+boot_state() {
+    local gitdir pid
+    gitdir="$(git -C "$1" rev-parse --absolute-git-dir 2>/dev/null)"
+
+    if [ -f "$gitdir/gram-stack-boot.pid" ]; then
+        pid=$(cat "$gitdir/gram-stack-boot.pid")
+        # Guards against a pid recycled after a hard kill, which would
+        # otherwise leave the worktree reading as booting forever.
+        if ps -o command= -p "$pid" 2>/dev/null | grep -q workboot; then
+            echo booting
+            return
+        fi
+    fi
+
+    # Not `[ -f ... ] && echo`: under `set -e` a false test as the last command
+    # would fail the whole script through the caller's assignment.
+    if [ -f "$gitdir/gram-stack-boot.failed" ]; then
+        echo failed
+    fi
+}
+
 width=$(printf '%s\n' "$rows" | cut -f2 | awk '{ if (length($0) > m) m = length($0) } END { print m }')
 
-printf '  \033[1m%-*s  %-6s %s\033[0m\n' "$width" "Branch" "State" "URL"
+printf '  \033[1m%-*s  %-9s %s\033[0m\n' "$width" "Branch" "State" "URL"
 
-printf '%s\n' "$rows" | while IFS=$'\t' read -r marker branch active url; do
-    if [ "$active" = "true" ]; then
-        state=$'\033[32m● up\033[0m  '
-    else
-        state=$'\033[31m○ down\033[0m'
-    fi
+failures=0
+
+# Here-string, not a pipe: a piped `while` runs in a subshell and the failure
+# count wouldn't survive it.
+while IFS=$'\t' read -r marker branch active url path; do
+    # A listening port is the weakest signal here, so the markers outrank it.
+    # `zero` runs `mise run start` before `mise run seed`, so the dashboard
+    # answers while the org is still on the unseeded demo gate: port open plus a
+    # live boot means seeding, and port open plus a failed boot usually means
+    # the daemons came up but seeding never ran -- reporting either as `up`
+    # sends you to a dashboard that looks broken. Clear a `failed` with another
+    # `mise run git:workboot`.
+    case "$(boot_state "$path"),$active" in
+        booting,true) state=$'\033[33m◐ seeding\033[0m' ;;
+        booting,*) state=$'\033[33m◐ booting\033[0m' ;;
+        failed,*) state=$'\033[31m✗ failed\033[0m ' ; failures=$((failures + 1)) ;;
+        *,true) state=$'\033[32m● up\033[0m     ' ;;
+        *) state=$'\033[31m○ down\033[0m   ' ;;
+    esac
     printf '%s %-*s  %b %s\n' "$marker" "$width" "$branch" "$state" "$url"
-done
+done <<< "$rows"
+
+if [ "$failures" -gt 0 ]; then
+    echo
+    echo "✗ boot exited nonzero — the stack is incomplete (a failure before \`mise run seed\`"
+    echo "  leaves the org on the demo gate). Logs: \`wt config state logs get\`."
+    echo "  Retry from that worktree: \`mise run git:workboot\`."
+fi


### PR DESCRIPTION
## Problem

`wt status` (the repo alias for `mise run git:workstatus`) reported only `up` or `down`, derived from whether the dashboard port was listening. That hides two states a new worktree spends most of its early life in:

- **Still booting.** The `post-start` hook runs `./zero --agent` in the background, so a fresh worktree has a closed port for several minutes. Indistinguishable from a worktree that was never booted — nothing tells you to wait.
- **Booted but unseeded.** `zero` runs `mise run start` before `mise run seed`, so the dashboard answers while the org is still on the demo gate. That read as `up`, sending you to a dashboard that looks broken.

Worktrunk tracks no hook liveness, so the signal has to come from the hook itself.

## Change

- New `git:workboot` task, now the `post-start` hook body. It writes its pid into the worktree's git dir for the duration of the boot, and on a nonzero exit leaves a second marker holding the exit code. Markers live in `.git/worktrees/<name>/`, so they are never committed and disappear with the worktree.
- `git:workstatus` reads those markers and reports five states, markers outranking the port:

  | boot marker | port | state |
  |---|---|---|
  | alive | listening | `◐ seeding` |
  | alive | closed | `◐ booting` |
  | failed | — | `✗ failed` |
  | — | listening | `● up` |
  | — | closed | `○ down` |

  A failure also prints a footer pointing at the logs and the retry command.

Two boot bugs surfaced while testing this and are fixed in the same task:

- **Re-booting a running worktree always failed.** `mise run start` kills the previous daemons, pitchfork scores the kill as a daemon failure, `start` exits nonzero, and `zero` never reaches `mise run seed` — so retrying a broken worktree was guaranteed to leave it unseeded. `workboot` now runs `mise run stop` first (no-op on a fresh worktree).
- **Seed races the server it just started.** The dev-idp handshake 307s against a cold server (`auth.callback did not return a session`). `workboot` retries the seed alone at 15s/30s/60s. Retrying seed only, not all of `zero` — if `zero` died earlier, the retries fail fast and the boot is still reported failed.

## Testing

Exercised every state on real worktrees: live boot → `◐ booting`; boot over a listening port → `◐ seeding`; boot exiting 7 → `✗ failed` with the code in the marker; successful rerun clearing the failed marker; a pid recycled after a hard kill correctly falling back to `○ down` rather than sticking on `booting`.

End-to-end on a worktree that was sitting on the demo gate: confirmed unseeded at the database level (`devtools.seed_markers` absent), then `git:workboot` ran `stop` → `zero` → seed failed the 307 race → retry at 15s succeeded → `● up` with both markers cleaned up.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve `wt status` to report accurate worktree stack states: booting, seeding, failed, up, or down. Adds `git:workboot` as the `post-start` hook and fixes re-boot and seed race issues so status is clear and retries are reliable.

- **New Features**
  - Added `git:workboot` and set it as the `post-start` hook; it writes a PID marker while boot runs and a failure marker on nonzero exit in `.git/worktrees/<name>/`.
  - Updated `git:workstatus` to read these markers and show `◐ booting`, `◐ seeding`, `✗ failed`, `● up`, or `○ down`, with markers outranking port checks.
  - On failure, prints a short footer with logs hint (`wt config state logs get`) and a retry command (`mise run git:workboot`).

- **Bug Fixes**
  - Re-boot now runs `mise run stop` before `./zero --agent`, preventing false daemon failures that blocked seeding.
  - Seed is retried only (15s/30s/60s) to mitigate the dev-idp 307 race; if `zero` failed earlier, retries fail fast and failure is reported.

<sup>Written for commit 969756eb0faef708a12c692f6a67f37f445c4deb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

