### PR TITLE
fix(dashboard): route dev SDK calls through the vite proxy

### DIFF
--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -1,7 +1,7 @@
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
 import { isProjectOverviewQueryKey } from "@/components/project/projectOverviewQuery";
 import { clearStorageForLogout } from "@/lib/logout-storage";
-import { getServerURL } from "@/lib/utils";
+import { getApiBaseURL } from "@/lib/utils";
 import { datadogRum } from "@datadog/browser-rum";
 import { Gram } from "@gram/client";
 import { HTTPClient } from "@gram/client/lib/http.js";
@@ -72,7 +72,7 @@ export const SdkProvider = ({
     });
 
     const gram = new Gram({
-      serverURL: getServerURL(),
+      serverURL: getApiBaseURL(),
       httpClient,
     });
 

--- a/client/dashboard/src/lib/utils.ts
+++ b/client/dashboard/src/lib/utils.ts
@@ -38,6 +38,18 @@ export function getServerURL(): string {
   return __GRAM_SERVER_URL__ ?? window.location.origin;
 }
 
+// Base URL for the dashboard's SDK calls. In dev the dashboard and the server
+// listen on different ports (and worktrees remap both), so every SDK call is
+// cross-origin — and because the requests carry custom headers (gram-project,
+// gram-session, …) each one pays a CORS preflight that the server never lets
+// the browser cache. Vite proxies /rpc (and /chat, /mcp, …) to the server, so
+// pointing the SDK at the dashboard's own origin in dev makes the calls
+// same-origin and the preflights disappear. In prod the dashboard is served
+// from the server's origin, so getServerURL() is already same-origin.
+export function getApiBaseURL(): string {
+  return import.meta.env.DEV ? window.location.origin : getServerURL();
+}
+
 // tunnel.speakeasy.com in prod, tunnel-pr-N.<env> in previews (single label
 // keeps the wildcard cert valid), tunnel.<host> otherwise.
 export function tunnelGatewayURL(): string {


### PR DESCRIPTION
## What

In dev, every dashboard SDK call paid a CORS preflight. This points the SDK at the dashboard's own origin in dev so the calls ride the vite proxy and become same-origin.

## Why

- The dashboard and the server listen on different ports in dev (`:5173` / `:8080`, and worktrees remap both), so every SDK request was cross-origin.
- The requests carry custom headers (`gram-project`, `gram-session`, `X-Gram-Scope-Override`), which makes them non-simple — a preflight is mandatory.
- `server/internal/middleware/cors.go` sets no `Access-Control-Max-Age`, so the browser falls back to its ~5s default cache and re-issues `OPTIONS` before nearly every RPC.

Vite already proxies `/rpc` (and `/chat`, `/mcp`, …) to the server, so the fix is just to use it.

## How

- `lib/utils.ts`: new `getApiBaseURL()` — `import.meta.env.DEV ? window.location.origin : getServerURL()`.
- `contexts/SdkProvider.tsx`: the `Gram` client uses it. That's the only `new Gram(...)` in the app, so all RPCs are covered.

`getServerURL()` is untouched everywhere else — MCP configs, callback URLs, and the tunnel host still report the server's authoritative URL. Prod is unaffected (the dashboard is served from the server's origin there).

## Testing

Verified in a worktree stack (dashboard and server on remapped ports), logged in, reloaded:

- All `/rpc/*` requests now go to the dashboard origin and return 200 through the proxy.
- Zero `OPTIONS` requests, and zero requests to the server port.
- `pnpm -F dashboard type-check` passes.

## Follow-up (not in this PR)

Elements/Storybook still hit the server directly via `__GRAM_API_URL__`, so they still preflight. Fixing that means adding `Access-Control-Max-Age` in `cors.go` and the chat-sessions `OPTIONS` branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route dashboard SDK calls through the `vite` dev proxy to make them same-origin, removing CORS preflights and speeding up RPCs in development.

- **Bug Fixes**
  - Added `getApiBaseURL()` for SDK base URL (dev: `window.location.origin`; prod: `getServerURL()`).
  - Updated `SdkProvider` to use it when creating the `Gram` client; production behavior and other URLs remain unchanged.

<sup>Written for commit f74b1a2db2d00edc9944b76b5fbbbce34ba8a990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

