### PR TITLE
mig: add LiteLLM instance health fields

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -773,6 +773,12 @@ CREATE TABLE IF NOT EXISTS litellm_instances (
 
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 255),
   failure_posture TEXT NOT NULL DEFAULT 'fail_closed',
+  last_guardrail_event_at timestamptz,
+  last_otel_event_at timestamptz,
+  last_error_at timestamptz,
+  last_error_kind TEXT,
+  reported_litellm_version TEXT,
+  reported_litellm_version_at timestamptz,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1027,17 +1027,23 @@ type JsonWebKeySet struct {
 }
 
 type LitellmInstance struct {
-	ID              uuid.UUID
-	OrganizationID  string
-	ProjectID       uuid.UUID
-	ApiKeyID        uuid.UUID
-	CreatedByUserID string
-	Name            string
-	FailurePosture  string
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
-	DeletedAt       pgtype.Timestamptz
-	Deleted         bool
+	ID                       uuid.UUID
+	OrganizationID           string
+	ProjectID                uuid.UUID
+	ApiKeyID                 uuid.UUID
+	CreatedByUserID          string
+	Name                     string
+	FailurePosture           string
+	LastGuardrailEventAt     pgtype.Timestamptz
+	LastOtelEventAt          pgtype.Timestamptz
+	LastErrorAt              pgtype.Timestamptz
+	LastErrorKind            pgtype.Text
+	ReportedLitellmVersion   pgtype.Text
+	ReportedLitellmVersionAt pgtype.Timestamptz
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
 }
 
 type McpEndpoint struct {

--- a/server/internal/litellm/repo/models.go
+++ b/server/internal/litellm/repo/models.go
@@ -10,15 +10,21 @@ import (
 )
 
 type LitellmInstance struct {
-	ID              uuid.UUID
-	OrganizationID  string
-	ProjectID       uuid.UUID
-	ApiKeyID        uuid.UUID
-	CreatedByUserID string
-	Name            string
-	FailurePosture  string
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
-	DeletedAt       pgtype.Timestamptz
-	Deleted         bool
+	ID                       uuid.UUID
+	OrganizationID           string
+	ProjectID                uuid.UUID
+	ApiKeyID                 uuid.UUID
+	CreatedByUserID          string
+	Name                     string
+	FailurePosture           string
+	LastGuardrailEventAt     pgtype.Timestamptz
+	LastOtelEventAt          pgtype.Timestamptz
+	LastErrorAt              pgtype.Timestamptz
+	LastErrorKind            pgtype.Text
+	ReportedLitellmVersion   pgtype.Text
+	ReportedLitellmVersionAt pgtype.Timestamptz
+	CreatedAt                pgtype.Timestamptz
+	UpdatedAt                pgtype.Timestamptz
+	DeletedAt                pgtype.Timestamptz
+	Deleted                  bool
 }

--- a/server/internal/litellm/repo/queries.sql.go
+++ b/server/internal/litellm/repo/queries.sql.go
@@ -28,7 +28,7 @@ INSERT INTO litellm_instances (
   , $5
   , $6
 )
-RETURNING id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, last_guardrail_event_at, last_otel_event_at, last_error_at, last_error_kind, reported_litellm_version, reported_litellm_version_at, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateLiteLLMInstanceParams struct {
@@ -58,6 +58,12 @@ func (q *Queries) CreateLiteLLMInstance(ctx context.Context, arg CreateLiteLLMIn
 		&i.CreatedByUserID,
 		&i.Name,
 		&i.FailurePosture,
+		&i.LastGuardrailEventAt,
+		&i.LastOtelEventAt,
+		&i.LastErrorAt,
+		&i.LastErrorKind,
+		&i.ReportedLitellmVersion,
+		&i.ReportedLitellmVersionAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -67,7 +73,7 @@ func (q *Queries) CreateLiteLLMInstance(ctx context.Context, arg CreateLiteLLMIn
 }
 
 const getLiteLLMInstanceForUpdate = `-- name: GetLiteLLMInstanceForUpdate :one
-SELECT id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, created_at, updated_at, deleted_at, deleted
+SELECT id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, last_guardrail_event_at, last_otel_event_at, last_error_at, last_error_kind, reported_litellm_version, reported_litellm_version_at, created_at, updated_at, deleted_at, deleted
 FROM litellm_instances
 WHERE id = $1
   AND project_id = $2
@@ -93,6 +99,12 @@ func (q *Queries) GetLiteLLMInstanceForUpdate(ctx context.Context, arg GetLiteLL
 		&i.CreatedByUserID,
 		&i.Name,
 		&i.FailurePosture,
+		&i.LastGuardrailEventAt,
+		&i.LastOtelEventAt,
+		&i.LastErrorAt,
+		&i.LastErrorKind,
+		&i.ReportedLitellmVersion,
+		&i.ReportedLitellmVersionAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -195,7 +207,7 @@ WHERE id = $1
   AND project_id = $2
   AND organization_id = $3
   AND deleted IS FALSE
-RETURNING id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, last_guardrail_event_at, last_otel_event_at, last_error_at, last_error_kind, reported_litellm_version, reported_litellm_version_at, created_at, updated_at, deleted_at, deleted
 `
 
 type RevokeLiteLLMInstanceParams struct {
@@ -215,6 +227,12 @@ func (q *Queries) RevokeLiteLLMInstance(ctx context.Context, arg RevokeLiteLLMIn
 		&i.CreatedByUserID,
 		&i.Name,
 		&i.FailurePosture,
+		&i.LastGuardrailEventAt,
+		&i.LastOtelEventAt,
+		&i.LastErrorAt,
+		&i.LastErrorKind,
+		&i.ReportedLitellmVersion,
+		&i.ReportedLitellmVersionAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,
@@ -232,7 +250,7 @@ WHERE id = $2
   AND organization_id = $4
   AND api_key_id = $5
   AND deleted IS FALSE
-RETURNING id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, created_at, updated_at, deleted_at, deleted
+RETURNING id, organization_id, project_id, api_key_id, created_by_user_id, name, failure_posture, last_guardrail_event_at, last_otel_event_at, last_error_at, last_error_kind, reported_litellm_version, reported_litellm_version_at, created_at, updated_at, deleted_at, deleted
 `
 
 type RotateLiteLLMInstanceKeyParams struct {
@@ -260,6 +278,12 @@ func (q *Queries) RotateLiteLLMInstanceKey(ctx context.Context, arg RotateLiteLL
 		&i.CreatedByUserID,
 		&i.Name,
 		&i.FailurePosture,
+		&i.LastGuardrailEventAt,
+		&i.LastOtelEventAt,
+		&i.LastErrorAt,
+		&i.LastErrorKind,
+		&i.ReportedLitellmVersion,
+		&i.ReportedLitellmVersionAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DeletedAt,

--- a/server/migrations/20260803194013_litellm-instance-health.sql
+++ b/server/migrations/20260803194013_litellm-instance-health.sql
@@ -1,0 +1,2 @@
+-- Modify "litellm_instances" table
+ALTER TABLE "litellm_instances" ADD COLUMN "last_guardrail_event_at" timestamptz NULL, ADD COLUMN "last_otel_event_at" timestamptz NULL, ADD COLUMN "last_error_at" timestamptz NULL, ADD COLUMN "last_error_kind" text NULL, ADD COLUMN "reported_litellm_version" text NULL, ADD COLUMN "reported_litellm_version_at" timestamptz NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WQ13Z6ucP7BJqOTJTGuHk0GbMKdbpd6QXtfqZXHu7/Y=
+h1:audzYMW9ec4AtJg4LAygTKLtogLdaADFaYaqBu2h1Js=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -313,3 +313,4 @@ h1:WQ13Z6ucP7BJqOTJTGuHk0GbMKdbpd6QXtfqZXHu7/Y=
 20260803143506_device_agent_configurations.sql h1:YpqUdgZ+/o0LmPn8B8ioz3Kxvdo2xehJbJtNoJDVGCs=
 20260803183323_add-unproxied-mcp-servers.sql h1:qzO4JQBZcDOdBk+J5bKitwZToe5vocZryD2n+GFhK8U=
 20260803193050_litellm-instances.sql h1:tXo5MT2gc1ofWtT8ndwAo5Ms2G4vUKhF8wUuZr1r+Zc=
+20260803194013_litellm-instance-health.sql h1:xocULUVta5ICjDnH83WT/zQbXN0ZyzRbmpQvGXU0JW0=


### PR DESCRIPTION
## Summary
- add nullable per-instance guardrail and OTel event timestamps
- store categorized last-error state without raw request or credential data
- retain the reported LiteLLM version for diagnostics

Part of [DNO-713](https://linear.app/speakeasy/issue/DNO-713/feat-litellm-integration-health-and-attribution-diagnostics).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-instance health fields to `litellm_instances` to track last guardrail/OTel events, last error (with kind), and reported LiteLLM version, each with timestamps; models and SQL queries were regenerated so create/get/revoke/rotate include and return these fields. Supports DNO-713 push-integration health and attribution diagnostics.

- **Migration**
  - Adds nullable columns: `last_guardrail_event_at`, `last_otel_event_at`, `last_error_at`, `last_error_kind`, `reported_litellm_version`, `reported_litellm_version_at`.
  - Backward compatible; apply before ingest paths write these fields.

<sup>Written for commit e96280cf18a01fcc22c431c7968cff26d5b5ee46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

