### PR TITLE
fix: sanitize judge model output instead of poison-retrying

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -278,6 +278,10 @@ const (
 	OpenRouterKeyPreviousLimitKey     = attribute.Key("gram.openrouter.key.previous_limit")
 	OpenRouterKeyTypeKey              = attribute.Key("gram.openrouter.key.type")
 	OpenRouterResponseBodyKey         = attribute.Key("gram.openrouter.response.body")
+	OpenRouterRateLimitLimitKey       = attribute.Key("gram.openrouter.ratelimit.limit")
+	OpenRouterRateLimitRemainingKey   = attribute.Key("gram.openrouter.ratelimit.remaining")
+	OpenRouterRateLimitResetKey       = attribute.Key("gram.openrouter.ratelimit.reset")
+	OpenRouterRetryAfterKey           = attribute.Key("gram.openrouter.retry_after")
 	OrganizationAccountTypeKey        = attribute.Key("gram.org.account_type")
 	OrganizationInviteIDKey           = attribute.Key("gram.org.invite.id")
 	OrganizationInviteEmailKey        = attribute.Key("gram.org.invite.email")
@@ -1243,6 +1247,20 @@ func OpenRouterResponseBody(v string) attribute.KeyValue { return OpenRouterResp
 func SlogOpenRouterResponseBody(v string) slog.Attr {
 	return slog.String(string(OpenRouterResponseBodyKey), v)
 }
+
+func OpenRouterRateLimitLimit(v string) attribute.KeyValue {
+	return OpenRouterRateLimitLimitKey.String(v)
+}
+
+func OpenRouterRateLimitRemaining(v string) attribute.KeyValue {
+	return OpenRouterRateLimitRemainingKey.String(v)
+}
+
+func OpenRouterRateLimitReset(v string) attribute.KeyValue {
+	return OpenRouterRateLimitResetKey.String(v)
+}
+
+func OpenRouterRetryAfter(v string) attribute.KeyValue { return OpenRouterRetryAfterKey.String(v) }
 
 func AccessMemberID(v string) attribute.KeyValue { return AccessMemberIDKey.String(v) }
 func SlogAccessMemberID(v string) slog.Attr      { return slog.String(string(AccessMemberIDKey), v) }

--- a/server/internal/businessmemory/judge.go
+++ b/server/internal/businessmemory/judge.go
@@ -12,7 +12,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	pgvector_go "github.com/pgvector/pgvector-go"
@@ -192,7 +194,15 @@ func (j *Judge) Judge(ctx context.Context, in analysis.JudgeInput) (analysis.Jud
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return analysis.JudgeResult{}, fmt.Errorf("persist business memories: %w: %w", analysis.ErrRetryable, err)
+		sentinel := analysis.ErrRetryable
+		// A data exception means the model produced content the schema can
+		// never accept: a retry re-buys the same inference and the same
+		// rejection, so charge the model's attempt budget instead of looping
+		// forever as an infrastructure failure.
+		if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok && pgerrcode.IsDataException(pgErr.Code) {
+			sentinel = analysis.ErrModelFailure
+		}
+		return analysis.JudgeResult{}, fmt.Errorf("persist business memories: %w: %w", sentinel, err)
 	}
 
 	summary := extractionSummary{
@@ -232,6 +242,13 @@ func normalizeExtraction(raw string, transcriptTurns map[int]struct{}) ([]extrac
 
 	normalized := make([]extractionCandidate, 0, len(verdict.Memories))
 	for _, candidate := range verdict.Memories {
+		// A NUL codepoint here is almost always the model echoing a \u0000
+		// escape it saw in the marshaled transcript without re-escaping it
+		// for its own JSON output. No Postgres string type can store the
+		// codepoint, and at temperature zero a retry reproduces it — so
+		// restore the literal text the model meant instead of failing the
+		// extraction.
+		candidate.Body = strings.ReplaceAll(candidate.Body, "\x00", `\u0000`)
 		candidate.Body = strings.TrimSpace(candidate.Body)
 		if candidate.Body == "" || len(candidate.Body) > maxMemoryBodyBytes || !utf8.ValidString(candidate.Body) {
 			return nil, fmt.Errorf("invalid memory body")

--- a/server/internal/businessmemory/judge_test.go
+++ b/server/internal/businessmemory/judge_test.go
@@ -29,6 +29,19 @@ func TestNormalizeExtraction(t *testing.T) {
 	}}, got)
 }
 
+// A decoded NUL is re-escaped to its literal \u0000 text rather than
+// failing the extraction; Postgres cannot store the codepoint.
+func TestNormalizeExtractionEscapesNUL(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"memories":[{"body":"broken \u0000 memory","memory_type":"result","content_scope":[],"source_turn":1}]}`
+	got, err := normalizeExtraction(raw, map[int]struct{}{1: {}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "broken "+`\u0000`+" memory", got[0].Body)
+	require.NotContains(t, got[0].Body, "\x00")
+}
+
 func TestNormalizeExtractionRejectsInvalidCandidates(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -48,6 +48,10 @@ func IsBadRequest(err error) bool {
 	return errors.Is(err, ErrBadRequest)
 }
 
+// ErrRateLimited signals OpenRouter rejected the request with a 429.
+// Retrying after backoff is legitimate, so callers treat it as transient.
+var ErrRateLimited = errors.New("openrouter: rate limited")
+
 // ErrContentPolicy signals the provider refused the request on content grounds:
 // a moderation, safety or content-filter rejection rather than a credential or
 // entitlement problem. The verdict is a property of the payload, so re-sending
@@ -86,13 +90,26 @@ func diagnosticBody(body []byte) string {
 // status is diagnosed: spans are the one sink already trusted with request
 // payloads (the empty-choices path records the same attribute), and without it
 // widening the marker lists means guessing at what upstream actually sent.
-func classifyHTTPError(ctx context.Context, status int, body []byte) error {
-	trace.SpanFromContext(ctx).SetAttributes(
+func classifyHTTPError(ctx context.Context, status int, header http.Header, body []byte) error {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
 		attr.HTTPResponseStatusCode(status),
 		attr.OpenRouterResponseBody(diagnosticBody(body)),
 	)
 
 	switch status {
+	case http.StatusTooManyRequests:
+		// A 429 alone cannot be diagnosed: OpenRouter throttles on the key's
+		// credit-scaled ceiling, on account-wide surge protection, and on
+		// upstream provider capacity, and only the rate-limit headers say
+		// which. Record them so the span answers that without a reproduction.
+		span.SetAttributes(
+			attr.OpenRouterRateLimitLimit(header.Get("X-RateLimit-Limit")),
+			attr.OpenRouterRateLimitRemaining(header.Get("X-RateLimit-Remaining")),
+			attr.OpenRouterRateLimitReset(header.Get("X-RateLimit-Reset")),
+			attr.OpenRouterRetryAfter(header.Get("Retry-After")),
+		)
+		return fmt.Errorf("OpenRouter API error (status %d), response body omitted: %w", status, ErrRateLimited)
 	case http.StatusPaymentRequired:
 		return fmt.Errorf("OpenRouter API error (status %d), response body omitted: %w", status, ErrInsufficientCredits)
 	case http.StatusBadRequest, http.StatusUnprocessableEntity:

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -12,6 +12,7 @@ import (
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
@@ -172,7 +173,7 @@ func TestClassifyHTTPError_RecordsBoundedBodyOnSpan(t *testing.T) {
 	ctx, span := provider.Tracer("test").Start(t.Context(), "completion")
 
 	body := []byte(`{"error":{"message":"no auth credentials found"},"echo":"` + strings.Repeat("é", 4000) + `"}`)
-	err := classifyHTTPError(ctx, http.StatusForbidden, body)
+	err := classifyHTTPError(ctx, http.StatusForbidden, http.Header{}, body)
 	span.End()
 
 	require.Error(t, err)
@@ -196,6 +197,38 @@ func TestClassifyHTTPError_RecordsBoundedBodyOnSpan(t *testing.T) {
 	require.Contains(t, recorded, "no auth credentials found")
 	require.LessOrEqual(t, len(recorded), maxDiagnosticBodyBytes)
 	require.True(t, utf8.ValidString(recorded), "a truncated body must stay valid UTF-8")
+}
+
+func TestClassifyHTTPError_RateLimited_RecordsHeadersOnSpan(t *testing.T) {
+	t.Parallel()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(t.Context(), "completion")
+
+	header := http.Header{}
+	header.Set("X-RateLimit-Limit", "60")
+	header.Set("X-RateLimit-Remaining", "0")
+	header.Set("X-RateLimit-Reset", "1785748157000")
+	header.Set("Retry-After", "12")
+
+	err := classifyHTTPError(ctx, http.StatusTooManyRequests, header, []byte(`{"error":{"message":"rate limit exceeded: free tier"}}`))
+	span.End()
+
+	require.ErrorIs(t, err, ErrRateLimited)
+	require.NotContains(t, err.Error(), "free tier")
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+
+	recorded := map[attribute.Key]string{}
+	for _, kv := range spans[0].Attributes() {
+		recorded[kv.Key] = kv.Value.Emit()
+	}
+	require.Equal(t, "60", recorded[attr.OpenRouterRateLimitLimitKey])
+	require.Equal(t, "0", recorded[attr.OpenRouterRateLimitRemainingKey])
+	require.Equal(t, "1785748157000", recorded[attr.OpenRouterRateLimitResetKey])
+	require.Equal(t, "12", recorded[attr.OpenRouterRetryAfterKey])
 }
 
 func TestChatClient_GetCompletion_EmptyChoices_EmbedsResponseBody(t *testing.T) {

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -330,7 +330,7 @@ func (c *ChatClient) requestCompletion(ctx context.Context, apiKey string, reqBo
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		return OpenAIChatResponse{}, body, classifyHTTPError(ctx, httpResp.StatusCode, body)
+		return OpenAIChatResponse{}, body, classifyHTTPError(ctx, httpResp.StatusCode, httpResp.Header, body)
 	}
 
 	var chatResp OpenAIChatResponse
@@ -470,7 +470,7 @@ func (c *ChatClient) GetCompletionStream(ctx context.Context, req CompletionRequ
 	if httpResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(httpResp.Body)
 		o11y.NoLogDefer(func() error { return httpResp.Body.Close() })
-		return nil, classifyHTTPError(ctx, httpResp.StatusCode, body)
+		return nil, classifyHTTPError(ctx, httpResp.StatusCode, httpResp.Header, body)
 	}
 
 	// Wrap the response body with SSE parser that accumulates metadata


### PR DESCRIPTION
## Context

The `PublishChatAnalysisBatch` activity-failure monitor fired repeatedly: the business-memory extractor returned a memory body containing a NUL byte (`\u0000`). NUL is valid UTF-8 and passes JSON decoding, but no Postgres string type can store it (C-string internals; SQLSTATE 22021), so `InsertBusinessMemory` failed deterministically — and because persist errors were classified as infrastructure (`ErrRetryable`), the same doomed inference was retried until the workflow failed. A concurrent burst of OpenRouter 429s in the same window was undiagnosable because the client logs `response body omitted` and drops the rate-limit headers.

## Changes

**Re-escape NUL in extracted memories.** `normalizeExtraction` replaces a decoded NUL codepoint with the literal text `\u0000` before validation. The codepoint is almost always the model echoing an escape it saw in the marshaled transcript without re-escaping it for its own JSON output — so the literal text is what it meant to write, and no Postgres string type can store the codepoint anyway. Judges run at temperature zero, so rejecting would reproduce the same output on every retry and permanently fail the extraction after `MaxModelAttempts` paid inferences. Everything else invalid still rejects as a model failure, exactly as before.

**Backstop: Postgres data exceptions are the model's failure, not infrastructure's.** If persist still hits a data exception (SQLSTATE class 22 — any future schema-unacceptable model content), the business-memory judge now classifies it as `ErrModelFailure` instead of `ErrRetryable`. The publisher already handles that class correctly: the evaluation's attempt budget is charged, the unit terminates, and the rest of the batch keeps running instead of poison-retrying.

**429 observability.**

- New `ErrRateLimited` sentinel: OpenRouter 429s now classify to a typed error instead of the anonymous default, so the wrapped error text says `openrouter: rate limited`.
- The 429 response's `X-RateLimit-Limit` / `X-RateLimit-Remaining` / `X-RateLimit-Reset` / `Retry-After` headers are recorded on the active span. A 429 alone cannot distinguish the key's credit-scaled ceiling from account-wide surge protection from an upstream provider shedding load — the headers say which, so the next incident is diagnosable from the trace.

## Circuit breaker?

There is precedent and ready infrastructure: `internal/guardian` ships a per-partition breaker (`WithResilience`, adopted by the WorkOS client), 429/5xx already count as breaker failures, and the OpenRouter client is already a guardian `HTTPClient` — enabling it is a config change at client construction. Deliberately **not** enabled here: the same unified client serves live customer chat completions, so a host-partitioned breaker tripped by judge-driven 429 bursts would shed customer traffic. If we want one, a follow-up should partition via `guardian.WithSubset` (e.g. by key type) so internal judge traffic breaks independently of customer chats.
