### PR TITLE
ci: cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -6,6 +6,10 @@ on:
       - main
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-pr:
     name: Lint PR Title and Changesets

--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/plugin-generate-check.yml
+++ b/.github/workflows/plugin-generate-check.yml
@@ -8,7 +8,7 @@ on:
       - "hooks/relay/config.go"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/plugin-generate-check.yml
+++ b/.github/workflows/plugin-generate-check.yml
@@ -7,6 +7,10 @@ on:
       - "server/cmd/export-hook-plugin/**"
       - "hooks/relay/config.go"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   check-generator-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,10 +10,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# A new commit on a PR supersedes the previous run's images, so cancel the
-# in-flight run instead of building and pushing a fleet nobody will deploy.
-# Non-PR events (main, merge queue, dispatch) group by run_id: never queued
-# behind each other, never cancelled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+# A new commit on a PR supersedes the previous run's images, so cancel the
+# in-flight run instead of building and pushing a fleet nobody will deploy.
+# Non-PR events (main, merge queue, dispatch) group by run_id: never queued
+# behind each other, never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ on:
 # Non-PR events (main, merge queue, dispatch) group by run_id: never queued
 # behind each other, never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
## Why

Every commit pushed to a PR runs the full **Pull Request** workflow to completion — building and pushing images for all services (`gram`, `gram-dashboard`, `gram-assistant-runtime`, `gram-pystreams`) to the speakeasy-common registry, even when a newer commit has already superseded that run.

Measured impact (last 7.5 days): **12,168 image digests** pushed to `us-docker.pkg.dev/linen-analyst-344721/gcr.io`, ≈ 1,600/day. Each digest is billed **$0.26** by GCP Container Scanning → **~$500/day**, plus build minutes and registry storage (repo is at 2.87 TB). Rapid iteration — especially agent-assisted, with commits landing every few minutes — multiplies this: one commit ≈ 3–4 service builds ≈ ~10 billed digests ≈ ~$2.60.

## What

Workflow-level `concurrency` on the three PR-triggered workflows:

- **pr.yaml** — new commit on a PR cancels the previous in-flight run. Non-PR triggers (push to `main`, merge queue, `workflow_dispatch`) group by `run_id`, so they are never cancelled and never queue behind one another — zero behavior change outside PRs. The existing job-level `atlas-push` concurrency group is untouched.
- **hygiene.yaml** — same pattern (runs on every `synchronize`/`edited`/`labeled` event, so it churns the most runs).
- **plugin-generate-check.yml** — PR-only trigger, plain `cancel-in-progress: true` keyed on `head_ref`.

## Notes

- A cancelled run may have already pushed some images before cancellation — this reduces waste, it doesn't eliminate it. Path-filtered builds and push-on-label are follow-up candidates.
- Part of the container-scanning cost investigation; the scanning API itself is being addressed separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancel superseded PR workflow runs to stop wasteful builds and image pushes. Reduces unnecessary digests (≈12k over 7.5 days) and lowers container-scanning and compute costs.

- **Refactors**
  - PR events use workflow-level `concurrency` keyed by PR number with `cancel-in-progress: true` to cancel previous runs and avoid cross-fork branch-name collisions.
  - Non-PR events group by `run_id`; behavior unchanged (never canceled or queued).
  - Applied to `pr.yaml`, `hygiene.yaml`, and `plugin-generate-check.yml`; removed a redundant comment.

<sup>Written for commit f88ae7efa4224355230d20c94fba3d0913e94c1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

