### PR TITLE
feat: add LiteLLM integration dashboard

### DIFF
--- a/client/dashboard/src/components/code.tsx
+++ b/client/dashboard/src/components/code.tsx
@@ -52,6 +52,7 @@ export function CodeBlock({
   onCopy,
   preClassName,
   slots,
+  copyLabel = "code",
 }: {
   children: string;
   language?: string;
@@ -61,6 +62,7 @@ export function CodeBlock({
   onCopy?: () => void;
   preClassName?: string;
   slots?: Record<string, CodeBlockSlot>;
+  copyLabel?: string;
 }): React.JSX.Element {
   const { theme } = useMoonshineConfig();
   const hasSlots = !!slots && Object.keys(slots).length > 0;
@@ -221,7 +223,7 @@ export function CodeBlock({
             )}
           </Button.LeftIcon>
           <Button.Text className="sr-only">
-            {copied ? "Copied" : "Copy code"}
+            {copied ? `Copied ${copyLabel}` : `Copy ${copyLabel}`}
           </Button.Text>
         </Button>
       )}

--- a/client/dashboard/src/pages/org/OrgAIIntegrations.test.tsx
+++ b/client/dashboard/src/pages/org/OrgAIIntegrations.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OrgAIIntegrationsInner } from "./OrgAIIntegrations";
+
+const state = vi.hoisted(() => ({
+  enabled: false,
+  isAdmin: false,
+}));
+
+vi.mock("@/components/page-layout", () => {
+  const Section = ({ children }: { children: React.ReactNode }) => (
+    <section>{children}</section>
+  );
+  Section.Title = ({ children }: { children: React.ReactNode }) => (
+    <h1>{children}</h1>
+  );
+  Section.Description = ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  );
+  Section.Body = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  );
+  return { Page: { Section } };
+});
+
+vi.mock("@/hooks/useRBAC", () => ({
+  useRBAC: () => ({
+    hasScope: (scope: string) => scope === "org:admin" && state.isAdmin,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/productFeatures.js", () => ({
+  useProductFeatures: () => ({
+    data: { aiPlatformPushIntegrationsEnabled: state.enabled },
+  }),
+}));
+
+vi.mock("@/pages/org/ai-integration-connection-row", () => ({
+  AIIntegrationConnectionRow: ({
+    provider,
+  }: {
+    provider: { name: string };
+  }) => <div>{provider.name}</div>,
+}));
+
+vi.mock("@/pages/org/litellm-integration-row", () => ({
+  LiteLLMIntegrationRow: () => <div>LiteLLM push integration</div>,
+}));
+
+beforeEach(() => {
+  state.enabled = false;
+  state.isAdmin = false;
+});
+
+afterEach(cleanup);
+
+describe("OrgAIIntegrationsInner", () => {
+  it("hides LiteLLM when the product feature is disabled", () => {
+    state.isAdmin = true;
+
+    render(<OrgAIIntegrationsInner />);
+
+    expect(screen.queryByText("LiteLLM push integration")).toBeNull();
+  });
+
+  it("hides LiteLLM from non-admins without mounting its query surface", () => {
+    state.enabled = true;
+
+    render(<OrgAIIntegrationsInner />);
+
+    expect(screen.queryByText("LiteLLM push integration")).toBeNull();
+  });
+
+  it("shows LiteLLM to admins when the product feature is enabled", () => {
+    state.enabled = true;
+    state.isAdmin = true;
+
+    render(<OrgAIIntegrationsInner />);
+
+    expect(screen.getByText("LiteLLM push integration")).toBeDefined();
+  });
+});

--- a/client/dashboard/src/pages/org/OrgAIIntegrations.tsx
+++ b/client/dashboard/src/pages/org/OrgAIIntegrations.tsx
@@ -2,6 +2,9 @@ import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { AIIntegrationConnectionRow } from "@/pages/org/ai-integration-connection-row";
 import { AI_INTEGRATION_PROVIDERS } from "@/pages/org/ai-integration-providers";
+import { LiteLLMIntegrationRow } from "@/pages/org/litellm-integration-row";
+import { useRBAC } from "@/hooks/useRBAC";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
 
 // AI Integrations: one row per provider connection that expands to reveal its
 // event and metric streams, each with its own status and pause toggle.
@@ -20,7 +23,13 @@ export default function OrgAIIntegrations(): JSX.Element {
   );
 }
 
-function OrgAIIntegrationsInner() {
+export function OrgAIIntegrationsInner(): JSX.Element {
+  const { hasScope } = useRBAC();
+  const { data: productFeatures } = useProductFeatures(undefined, undefined, {
+    staleTime: 30_000,
+    throwOnError: false,
+  });
+
   return (
     <Page.Section>
       <Page.Section.Title>AI Integrations</Page.Section.Title>
@@ -31,6 +40,10 @@ function OrgAIIntegrationsInner() {
       </Page.Section.Description>
       <Page.Section.Body>
         <div className="border-border bg-card divide-border divide-y overflow-hidden rounded-lg border">
+          {productFeatures?.aiPlatformPushIntegrationsEnabled === true &&
+          hasScope("org:admin") ? (
+            <LiteLLMIntegrationRow />
+          ) : null}
           {AI_INTEGRATION_PROVIDERS.map((provider) => (
             <AIIntegrationConnectionRow
               key={provider.provider}

--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -37,7 +37,7 @@ describe("LiteLLM configuration", () => {
     );
     expect(environment).toContain('export GRAM_PROJECT_SLUG="my-project"');
     expect(environment).toContain(
-      'export OTEL_ENDPOINT="https://api.getgram.ai/rpc/litellm.otel"',
+      'export OTEL_ENDPOINT="https://api.getgram.ai/rpc/hooks.otel"',
     );
     expect(environment).toContain(
       'export OTEL_HEADERS="Gram-Key=${GRAM_LITELLM_INGEST_KEY},Gram-Project=${GRAM_PROJECT_SLUG}"',
@@ -50,14 +50,10 @@ describe("LiteLLM configuration", () => {
     ).toThrow("LiteLLM integration endpoints require HTTPS");
     expect(
       buildLiteLLMEnvironment("http://localhost:8080", "my-project"),
-    ).toContain(
-      'export OTEL_ENDPOINT="http://localhost:8080/rpc/litellm.otel"',
-    );
+    ).toContain('export OTEL_ENDPOINT="http://localhost:8080/rpc/hooks.otel"');
     expect(
       buildLiteLLMEnvironment("http://127.0.0.2:8080", "my-project"),
-    ).toContain(
-      'export OTEL_ENDPOINT="http://127.0.0.2:8080/rpc/litellm.otel"',
-    );
+    ).toContain('export OTEL_ENDPOINT="http://127.0.0.2:8080/rpc/hooks.otel"');
     expect(() =>
       buildLiteLLMEnvironment("ftp://localhost", "my-project"),
     ).toThrow("LiteLLM integration endpoints require HTTPS");

--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLiteLLMEnvironment,
+  buildLiteLLMGuardrailConfig,
+  liteLLMVerificationCommands,
+} from "./litellm-config";
+
+describe("LiteLLM configuration", () => {
+  it("references the secret from the environment and preserves fail-closed defaults", () => {
+    const config = buildLiteLLMGuardrailConfig(
+      "https://api.getgram.ai/",
+      "fail_closed",
+    );
+
+    expect(config).toContain(
+      "api_base: https://api.getgram.ai/rpc/litellm.ingest",
+    );
+    expect(config).toContain("Gram-Key: os.environ/GRAM_LITELLM_INGEST_KEY");
+    expect(config).toContain("streaming_end_of_stream_only: true");
+    expect(config).toContain("unreachable_fallback: fail_closed");
+  });
+
+  it("renders the explicit fail-open posture", () => {
+    expect(
+      buildLiteLLMGuardrailConfig("https://api.getgram.ai", "fail_open"),
+    ).toContain("unreachable_fallback: fail_open");
+  });
+
+  it("builds project-bound OTel environment variables", () => {
+    const environment = buildLiteLLMEnvironment(
+      "https://api.getgram.ai/",
+      "my-project",
+    );
+
+    expect(environment).toContain(
+      'export GRAM_LITELLM_INGEST_KEY="<PASTE_KEY_SHOWN_ABOVE>"',
+    );
+    expect(environment).toContain('export GRAM_PROJECT_SLUG="my-project"');
+    expect(environment).toContain(
+      'export OTEL_ENDPOINT="https://api.getgram.ai/rpc/litellm.otel"',
+    );
+    expect(environment).toContain(
+      'export OTEL_HEADERS="Gram-Key=${GRAM_LITELLM_INGEST_KEY},Gram-Project=${GRAM_PROJECT_SLUG}"',
+    );
+  });
+
+  it("provides safe and synthetic-block verification commands", () => {
+    expect(liteLLMVerificationCommands.safe).toContain("Reply with OK.");
+    expect(liteLLMVerificationCommands.blocked).toContain("ghp_R2D2C3POL");
+  });
+});

--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -44,6 +44,20 @@ describe("LiteLLM configuration", () => {
     );
   });
 
+  it("rejects cleartext non-loopback endpoints", () => {
+    expect(() =>
+      buildLiteLLMEnvironment("http://api.example.com", "my-project"),
+    ).toThrow("LiteLLM integration endpoints require HTTPS");
+    expect(
+      buildLiteLLMEnvironment("http://localhost:8080", "my-project"),
+    ).toContain(
+      'export OTEL_ENDPOINT="http://localhost:8080/rpc/litellm.otel"',
+    );
+    expect(() =>
+      buildLiteLLMEnvironment("ftp://localhost", "my-project"),
+    ).toThrow("LiteLLM integration endpoints require HTTPS");
+  });
+
   it("provides safe and synthetic-block verification commands", () => {
     expect(liteLLMVerificationCommands.safe).toContain("Reply with OK.");
     expect(liteLLMVerificationCommands.blocked).toContain("ghp_R2D2C3POL");

--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -61,6 +61,9 @@ describe("LiteLLM configuration", () => {
     expect(() =>
       buildLiteLLMEnvironment("ftp://localhost", "my-project"),
     ).toThrow("LiteLLM integration endpoints require HTTPS");
+    expect(() =>
+      buildLiteLLMEnvironment("http://127.example.com", "my-project"),
+    ).toThrow("LiteLLM integration endpoints require HTTPS");
   });
 
   it("provides safe and synthetic-block verification commands", () => {

--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -53,6 +53,11 @@ describe("LiteLLM configuration", () => {
     ).toContain(
       'export OTEL_ENDPOINT="http://localhost:8080/rpc/litellm.otel"',
     );
+    expect(
+      buildLiteLLMEnvironment("http://127.0.0.2:8080", "my-project"),
+    ).toContain(
+      'export OTEL_ENDPOINT="http://127.0.0.2:8080/rpc/litellm.otel"',
+    );
     expect(() =>
       buildLiteLLMEnvironment("ftp://localhost", "my-project"),
     ).toThrow("LiteLLM integration endpoints require HTTPS");

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -2,7 +2,10 @@ import type { LiteLLMInstanceFailurePosture } from "@gram/client/models/componen
 
 function apiBase(serverURL: string): string {
   const url = new URL(serverURL);
-  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  const loopback =
+    url.hostname === "localhost" ||
+    url.hostname === "[::1]" ||
+    url.hostname.startsWith("127.");
   if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
     throw new Error("LiteLLM integration endpoints require HTTPS");
   }

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -1,7 +1,12 @@
 import type { LiteLLMInstanceFailurePosture } from "@gram/client/models/components/litellminstance.js";
 
 function apiBase(serverURL: string): string {
-  return serverURL.replace(/\/$/, "");
+  const url = new URL(serverURL);
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error("LiteLLM integration endpoints require HTTPS");
+  }
+  return url.toString().replace(/\/$/, "");
 }
 
 export function buildLiteLLMGuardrailConfig(

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -1,0 +1,53 @@
+import type { LiteLLMInstanceFailurePosture } from "@gram/client/models/components/litellminstance.js";
+
+function apiBase(serverURL: string): string {
+  return serverURL.replace(/\/$/, "");
+}
+
+export function buildLiteLLMGuardrailConfig(
+  serverURL: string,
+  failurePosture: LiteLLMInstanceFailurePosture,
+): string {
+  return `guardrails:
+  - guardrail_name: gram-risk
+    litellm_params:
+      guardrail: generic_guardrail_api
+      mode: [pre_call, post_call]
+      api_base: ${apiBase(serverURL)}/rpc/litellm.ingest
+      headers:
+        Gram-Key: os.environ/GRAM_LITELLM_INGEST_KEY
+        Gram-Project: os.environ/GRAM_PROJECT_SLUG
+      extra_headers:
+        - x-gram-session-id
+      default_on: true
+      streaming_end_of_stream_only: true
+      fail_on_error: true
+      unreachable_fallback: ${failurePosture}`;
+}
+
+export function buildLiteLLMEnvironment(
+  serverURL: string,
+  projectSlug: string,
+): string {
+  return `export GRAM_LITELLM_INGEST_KEY="<PASTE_KEY_SHOWN_ABOVE>"
+export GRAM_PROJECT_SLUG="${projectSlug}"
+export LITELLM_OTEL_V2=true
+export OTEL_EXPORTER=otlp_http
+export OTEL_ENDPOINT="${apiBase(serverURL)}/rpc/litellm.otel"
+export OTEL_HEADERS="Gram-Key=\${GRAM_LITELLM_INGEST_KEY},Gram-Project=\${GRAM_PROJECT_SLUG}"
+export OTEL_SERVICE_NAME=litellm
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=no_content
+export LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true
+export LITELLM_OTEL_LEGACY_COMPAT=false`;
+}
+
+export const liteLLMVerificationCommands = {
+  safe: `curl "\${LITELLM_PROXY_URL:-http://localhost:4000}/v1/chat/completions" \\
+  --header "Authorization: Bearer $LITELLM_VIRTUAL_KEY" \\
+  --header "Content-Type: application/json" \\
+  --data '{"model":"'"$LITELLM_MODEL"'","messages":[{"role":"user","content":"Reply with OK."}]}'`,
+  blocked: `curl "\${LITELLM_PROXY_URL:-http://localhost:4000}/v1/chat/completions" \\
+  --header "Authorization: Bearer $LITELLM_VIRTUAL_KEY" \\
+  --header "Content-Type: application/json" \\
+  --data '{"model":"'"$LITELLM_MODEL"'","messages":[{"role":"user","content":"token=ghp_R2D2C3POLuk3Skywalker1234567890ab"}]}'`,
+} as const;

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -2,10 +2,13 @@ import type { LiteLLMInstanceFailurePosture } from "@gram/client/models/componen
 
 function apiBase(serverURL: string): string {
   const url = new URL(serverURL);
+  const ipv4Parts = url.hostname.split(".");
+  const ipv4Loopback =
+    ipv4Parts.length === 4 &&
+    ipv4Parts[0] === "127" &&
+    ipv4Parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
   const loopback =
-    url.hostname === "localhost" ||
-    url.hostname === "[::1]" ||
-    url.hostname.startsWith("127.");
+    url.hostname === "localhost" || url.hostname === "[::1]" || ipv4Loopback;
   if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
     throw new Error("LiteLLM integration endpoints require HTTPS");
   }

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -44,7 +44,7 @@ export function buildLiteLLMEnvironment(
 export GRAM_PROJECT_SLUG="${projectSlug}"
 export LITELLM_OTEL_V2=true
 export OTEL_EXPORTER=otlp_http
-export OTEL_ENDPOINT="${apiBase(serverURL)}/rpc/litellm.otel"
+export OTEL_ENDPOINT="${apiBase(serverURL)}/rpc/hooks.otel"
 export OTEL_HEADERS="Gram-Key=\${GRAM_LITELLM_INGEST_KEY},Gram-Project=\${GRAM_PROJECT_SLUG}"
 export OTEL_SERVICE_NAME=litellm
 export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=no_content

--- a/client/dashboard/src/pages/org/litellm-integration-row.test.tsx
+++ b/client/dashboard/src/pages/org/litellm-integration-row.test.tsx
@@ -1,0 +1,206 @@
+import type { LiteLLMInstance } from "@gram/client/models/components/litellminstance.js";
+import type { LitellmInstanceKeyResult } from "@gram/client/models/components/litellminstancekeyresult.js";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CreateInstanceDialog,
+  DiagnosticsPanel,
+  RevokeInstanceDialog,
+  RotateKeyDialog,
+} from "./litellm-integration-row";
+
+const state = vi.hoisted(() => ({
+  createOptions: undefined as
+    | { onSuccess?: (data: LitellmInstanceKeyResult) => void }
+    | undefined,
+  createMutation: {
+    data: undefined as LitellmInstanceKeyResult | undefined,
+    error: null as Error | null,
+    isPending: false,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+  },
+  invalidate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({}),
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/utils")>()),
+  getServerURL: () => "https://api.example.com",
+}));
+
+vi.mock("@gram/client/react-query/createLiteLLMInstance.js", () => ({
+  useCreateLiteLLMInstanceMutation: (options: typeof state.createOptions) => {
+    state.createOptions = options;
+    return state.createMutation;
+  },
+}));
+
+vi.mock("@gram/client/react-query/liteLLMInstances.js", () => ({
+  invalidateAllLiteLLMInstances: state.invalidate,
+  useLiteLLMInstances: vi.fn(),
+}));
+
+vi.mock("@/components/code", () => ({
+  CodeBlock: ({
+    children,
+    copyLabel = "code",
+  }: {
+    children: string;
+    copyLabel?: string;
+  }) => (
+    <div>
+      <button aria-label={`Copy ${copyLabel}`} />
+      <pre>{children}</pre>
+    </div>
+  ),
+}));
+
+const instance: LiteLLMInstance = {
+  active: true,
+  createdAt: new Date("2026-08-03T12:00:00Z"),
+  createdByUserId: "user-test",
+  diagnostics: {
+    lastGuardrailEventAt: new Date("2026-08-03T12:01:00Z"),
+    lastOtelEventAt: new Date("2026-08-03T12:02:00Z"),
+    platformUserPct24h: 75,
+    reportedLitellmVersion: "1.95.0",
+    status: "success",
+    virtualKeyEmailPct24h: 80,
+  },
+  failurePosture: "fail_closed",
+  id: "instance-test",
+  keyPrefix: "gram_local_test",
+  name: "Production",
+  organizationId: "org-test",
+  project: { id: "project-test", name: "Project", slug: "project" },
+  updatedAt: new Date("2026-08-03T12:02:00Z"),
+};
+
+const result: LitellmInstanceKeyResult = {
+  instance,
+  key: "gram_local_one_time_key",
+};
+
+beforeEach(() => {
+  state.createOptions = undefined;
+  state.createMutation.data = undefined;
+  state.createMutation.error = null;
+  state.createMutation.isPending = false;
+  state.createMutation.mutate.mockReset();
+  state.createMutation.reset.mockReset();
+  state.invalidate.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("LiteLLM integration dialogs", () => {
+  it("shows connection health in diagnostics", () => {
+    render(<DiagnosticsPanel instance={instance} />);
+
+    expect(screen.getByText("Connection health")).toBeDefined();
+    expect(screen.getByText("Connected")).toBeDefined();
+  });
+
+  it("keeps a rotated key visible until explicit acknowledgement", () => {
+    const onClose = vi.fn<() => void>(() => {});
+    render(
+      <RotateKeyDialog
+        target={instance}
+        result={result}
+        error={null}
+        isPending={false}
+        onConfirm={() => {}}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText(result.key)).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Copy integration key" }),
+    ).toBeDefined();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "I have saved the key" }),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows a created key before an unresolved list refresh and requires acknowledgement", () => {
+    state.createMutation.data = result;
+    const onOpenChange = vi.fn<(open: boolean) => void>(() => {});
+    render(
+      <CreateInstanceDialog
+        open
+        onOpenChange={onOpenChange}
+        projects={[{ id: "project-test", name: "Project", slug: "project" }]}
+        onProjectCreated={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(result.key)).toBeDefined();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "I have saved the key" }),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(state.createMutation.reset).toHaveBeenCalledOnce();
+  });
+
+  it("does not await list invalidation before publishing create success", () => {
+    state.invalidate.mockReturnValue(new Promise(() => {}));
+    const onProjectCreated = vi.fn<(projectSlug: string) => void>(() => {});
+    render(
+      <CreateInstanceDialog
+        open
+        onOpenChange={() => {}}
+        projects={[{ id: "project-test", name: "Project", slug: "project" }]}
+        onProjectCreated={onProjectCreated}
+      />,
+    );
+
+    const callbackResult = state.createOptions?.onSuccess?.(result);
+
+    expect(callbackResult).toBeUndefined();
+    expect(state.invalidate).toHaveBeenCalledOnce();
+    expect(onProjectCreated).toHaveBeenCalledWith("project");
+  });
+
+  it("prevents dismissal while revocation is pending and confirms explicitly", () => {
+    const onClose = vi.fn<() => void>(() => {});
+    const onConfirm = vi.fn<() => void>(() => {});
+    const view = render(
+      <RevokeInstanceDialog
+        target={instance}
+        isPending
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      (screen.getByRole("button", { name: "Working…" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    view.rerender(
+      <RevokeInstanceDialog
+        target={instance}
+        isPending={false}
+        onConfirm={onConfirm}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Revoke integration" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+});

--- a/client/dashboard/src/pages/org/litellm-integration-row.test.tsx
+++ b/client/dashboard/src/pages/org/litellm-integration-row.test.tsx
@@ -139,6 +139,7 @@ describe("LiteLLM integration dialogs", () => {
         open
         onOpenChange={onOpenChange}
         projects={[{ id: "project-test", name: "Project", slug: "project" }]}
+        initialProjectSlug="project"
         onProjectCreated={() => {}}
       />,
     );
@@ -162,6 +163,7 @@ describe("LiteLLM integration dialogs", () => {
         open
         onOpenChange={() => {}}
         projects={[{ id: "project-test", name: "Project", slug: "project" }]}
+        initialProjectSlug="project"
         onProjectCreated={onProjectCreated}
       />,
     );

--- a/client/dashboard/src/pages/org/litellm-integration-row.tsx
+++ b/client/dashboard/src/pages/org/litellm-integration-row.tsx
@@ -82,11 +82,14 @@ export function LiteLLMIntegrationRow(): JSX.Element {
   const diagnosticsInstance =
     instances.find((instance) => instance.id === diagnosticsInstanceID) ?? null;
   const activeCount = instances.filter((instance) => instance.active).length;
+  let instanceSummary = `${activeCount} active ${activeCount === 1 ? "instance" : "instances"}`;
+  if (instancesQuery.isPending) instanceSummary = "Loading instances";
+  if (instancesQuery.error) instanceSummary = "Unable to load instances";
 
   const rotateMutation = useRotateLiteLLMInstanceKeyMutation({
     gcTime: 0,
-    onSuccess: async () => {
-      await invalidateAllLiteLLMInstances(queryClient);
+    onSuccess: () => {
+      void invalidateAllLiteLLMInstances(queryClient);
     },
   });
   const revokeMutation = useRevokeLiteLLMInstanceMutation({
@@ -244,9 +247,7 @@ export function LiteLLMIntegrationRow(): JSX.Element {
             </Stack>
             <Stack direction="horizontal" align="center" gap={3}>
               <Text muted small className="hidden whitespace-nowrap @3xl:block">
-                {instancesQuery.isPending
-                  ? "Loading instances"
-                  : `${activeCount} active ${activeCount === 1 ? "instance" : "instances"}`}
+                {instanceSummary}
               </Text>
               <ChevronDown
                 aria-hidden
@@ -397,19 +398,26 @@ function CreateInstanceDialog({
     useState<FailurePosture>("fail_closed");
   const mutation = useCreateLiteLLMInstanceMutation({
     gcTime: 0,
-    onSuccess: async (data) => {
-      await invalidateAllLiteLLMInstances(queryClient);
+    onSuccess: (data) => {
+      void invalidateAllLiteLLMInstances(queryClient);
       onProjectCreated(data.instance.project.slug);
     },
   });
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen && mutation.isPending) return;
-    onOpenChange(nextOpen);
-    if (nextOpen) return;
+  const closeDialog = () => {
+    onOpenChange(false);
     setName("");
     setFailurePosture("fail_closed");
     mutation.reset();
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      onOpenChange(true);
+      return;
+    }
+    if (mutation.isPending || mutation.data) return;
+    closeDialog();
   };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -428,7 +436,7 @@ function CreateInstanceDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <Dialog.Content
-        closeable={!mutation.isPending}
+        closeable={!mutation.isPending && !mutation.data}
         className={
           mutation.data ? "max-h-[90vh] max-w-3xl overflow-y-auto" : undefined
         }
@@ -444,7 +452,7 @@ function CreateInstanceDialog({
             </Dialog.Header>
             <SetupContent result={mutation.data} />
             <Dialog.Footer>
-              <Button onClick={() => handleOpenChange(false)}>Close</Button>
+              <Button onClick={closeDialog}>I have saved the key</Button>
             </Dialog.Footer>
           </>
         ) : (
@@ -614,11 +622,11 @@ function RotateKeyDialog({
     <Dialog
       open={target !== null}
       onOpenChange={(open) => {
-        if (!open && !isPending) onClose();
+        if (!open && !isPending && !result) onClose();
       }}
     >
       <Dialog.Content
-        closeable={!isPending}
+        closeable={!isPending && !result}
         className={
           result ? "max-h-[90vh] max-w-3xl overflow-y-auto" : undefined
         }
@@ -633,7 +641,7 @@ function RotateKeyDialog({
             </Dialog.Header>
             <SetupContent result={result} />
             <Dialog.Footer>
-              <Button onClick={onClose}>Close</Button>
+              <Button onClick={onClose}>I have saved the key</Button>
             </Dialog.Footer>
           </>
         ) : (
@@ -693,14 +701,14 @@ function SetupContent({
           title="Integration key"
           description="Store this dedicated project-bound key securely. Gram cannot show it again."
         >
-          <CodeBlock>{result.key}</CodeBlock>
+          <CodeBlock copyLabel="integration key">{result.key}</CodeBlock>
         </SetupSection>
       ) : null}
       <SetupSection
         title="Environment variables"
         description="Paste the key into the first variable, then set these on the LiteLLM proxy."
       >
-        <CodeBlock language="shell">
+        <CodeBlock language="shell" copyLabel="environment variables">
           {buildLiteLLMEnvironment(serverURL, instance.project.slug)}
         </CodeBlock>
       </SetupSection>
@@ -708,7 +716,7 @@ function SetupContent({
         title="LiteLLM configuration"
         description="Merge this guardrail fragment into your LiteLLM configuration."
       >
-        <CodeBlock language="yaml">
+        <CodeBlock language="yaml" copyLabel="LiteLLM configuration">
           {buildLiteLLMGuardrailConfig(serverURL, instance.failurePosture)}
         </CodeBlock>
       </SetupSection>
@@ -716,7 +724,7 @@ function SetupContent({
         title="Verify safe traffic"
         description="Set LITELLM_VIRTUAL_KEY and LITELLM_MODEL in your shell, then run this against the proxy."
       >
-        <CodeBlock language="shell">
+        <CodeBlock language="shell" copyLabel="safe traffic command">
           {liteLLMVerificationCommands.safe}
         </CodeBlock>
       </SetupSection>
@@ -724,7 +732,7 @@ function SetupContent({
         title="Verify blocking"
         description="This synthetic credential should be blocked when the project secret policy is enabled."
       >
-        <CodeBlock language="shell">
+        <CodeBlock language="shell" copyLabel="blocking test command">
           {liteLLMVerificationCommands.blocked}
         </CodeBlock>
       </SetupSection>
@@ -743,7 +751,9 @@ function SetupSection({
 }): JSX.Element {
   return (
     <Stack gap={2}>
-      <Text className="font-medium">{title}</Text>
+      <Text as="h3" className="font-medium">
+        {title}
+      </Text>
       <Text muted small>
         {description}
       </Text>

--- a/client/dashboard/src/pages/org/litellm-integration-row.tsx
+++ b/client/dashboard/src/pages/org/litellm-integration-row.tsx
@@ -1,0 +1,860 @@
+import { CodeBlock } from "@/components/code";
+import { InputField } from "@/components/moon/input-field";
+import { Alert, ErrorAlert } from "@/components/ui/Alert";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Label } from "@/components/ui/Label";
+import { MoreActions } from "@/components/ui/MoreActions";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
+import { SkeletonTable } from "@/components/ui/Skeleton";
+import { Stack } from "@/components/ui/Stack";
+import { Column, Table } from "@/components/ui/Table";
+import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
+import { HumanizeDateTime } from "@/lib/dates";
+import { getServerURL } from "@/lib/utils";
+import type { LiteLLMInstance } from "@gram/client/models/components/litellminstance.js";
+import type { LitellmInstanceKeyResult } from "@gram/client/models/components/litellminstancekeyresult.js";
+import { useCreateLiteLLMInstanceMutation } from "@gram/client/react-query/createLiteLLMInstance.js";
+import {
+  invalidateAllLiteLLMInstances,
+  useLiteLLMInstances,
+} from "@gram/client/react-query/liteLLMInstances.js";
+import { useRevokeLiteLLMInstanceMutation } from "@gram/client/react-query/revokeLiteLLMInstance.js";
+import { useRotateLiteLLMInstanceKeyMutation } from "@gram/client/react-query/rotateLiteLLMInstanceKey.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, Network, Plus, RefreshCw } from "lucide-react";
+import { FormEvent, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { ConfirmDialog } from "../remote-identity-providers/ConfirmDialog";
+import {
+  buildLiteLLMEnvironment,
+  buildLiteLLMGuardrailConfig,
+  liteLLMVerificationCommands,
+} from "./litellm-config";
+
+type FailurePosture = LiteLLMInstance["failurePosture"];
+
+export function LiteLLMIntegrationRow(): JSX.Element {
+  const organization = useOrganization();
+  const projects = useMemo(
+    () =>
+      [...organization.projects].sort((a, b) => a.name.localeCompare(b.name)),
+    [organization.projects],
+  );
+  const defaultProject =
+    projects.find((project) => project.slug === "default") ?? projects[0];
+  const [expanded, setExpanded] = useState(false);
+  const [projectSlug, setProjectSlug] = useState(defaultProject?.slug ?? "");
+  const selectedProjectSlug = projectSlug || defaultProject?.slug || "";
+  const [createOpen, setCreateOpen] = useState(false);
+  const [setupInstance, setSetupInstance] = useState<LiteLLMInstance | null>(
+    null,
+  );
+  const [diagnosticsInstanceID, setDiagnosticsInstanceID] = useState<
+    string | null
+  >(null);
+  const [rotateTarget, setRotateTarget] = useState<LiteLLMInstance | null>(
+    null,
+  );
+  const [revokeTarget, setRevokeTarget] = useState<LiteLLMInstance | null>(
+    null,
+  );
+  const queryClient = useQueryClient();
+  const instancesQuery = useLiteLLMInstances(
+    { gramProject: selectedProjectSlug },
+    undefined,
+    {
+      enabled: selectedProjectSlug !== "",
+      refetchInterval: expanded ? 10_000 : false,
+      throwOnError: false,
+    },
+  );
+  const instances = instancesQuery.data?.instances ?? [];
+  const diagnosticsInstance =
+    instances.find((instance) => instance.id === diagnosticsInstanceID) ?? null;
+  const activeCount = instances.filter((instance) => instance.active).length;
+
+  const rotateMutation = useRotateLiteLLMInstanceKeyMutation({
+    gcTime: 0,
+    onSuccess: async () => {
+      await invalidateAllLiteLLMInstances(queryClient);
+    },
+  });
+  const revokeMutation = useRevokeLiteLLMInstanceMutation({
+    onSuccess: async () => {
+      await invalidateAllLiteLLMInstances(queryClient);
+      setRevokeTarget(null);
+      toast.success("LiteLLM integration revoked");
+    },
+    onError: () => toast.error("Failed to revoke LiteLLM integration"),
+  });
+
+  const columns: Column<LiteLLMInstance>[] = [
+    {
+      key: "name",
+      header: "Instance",
+      width: "1fr",
+      render: (instance) => (
+        <Stack gap={1}>
+          <Stack direction="horizontal" gap={2} align="center">
+            <Text className="font-medium">{instance.name}</Text>
+            {!instance.active && <Badge variant="neutral">Revoked</Badge>}
+          </Stack>
+          <Text muted small>
+            {instance.project.name}
+          </Text>
+        </Stack>
+      ),
+    },
+    {
+      key: "health",
+      header: "Health",
+      width: "130px",
+      render: (instance) => <HealthBadge instance={instance} />,
+    },
+    {
+      key: "keyPrefix",
+      header: "Key prefix",
+      width: "150px",
+      render: (instance) => (
+        <Text mono small>
+          {instance.keyPrefix}
+        </Text>
+      ),
+    },
+    {
+      key: "failurePosture",
+      header: "Failure posture",
+      width: "150px",
+      render: (instance) => (
+        <FailurePostureBadge posture={instance.failurePosture} />
+      ),
+    },
+    {
+      key: "createdAt",
+      header: "Created",
+      width: "160px",
+      render: (instance) => <HumanizeDateTime date={instance.createdAt} />,
+    },
+    {
+      key: "lastUsedAt",
+      header: "Last used",
+      width: "160px",
+      render: (instance) =>
+        instance.lastUsedAt ? (
+          <HumanizeDateTime date={instance.lastUsedAt} />
+        ) : (
+          <Text muted small>
+            Never
+          </Text>
+        ),
+    },
+    {
+      key: "actions",
+      header: "",
+      width: "52px",
+      render: (instance) =>
+        instance.active ? (
+          <MoreActions
+            actions={[
+              {
+                label: "View diagnostics",
+                onClick: () => setDiagnosticsInstanceID(instance.id),
+              },
+              {
+                label: "View setup",
+                onClick: () => setSetupInstance(instance),
+              },
+              {
+                label: "Rotate key",
+                onClick: () => setRotateTarget(instance),
+              },
+              {
+                label: "Revoke",
+                destructive: true,
+                onClick: () => setRevokeTarget(instance),
+              },
+            ]}
+          />
+        ) : null,
+    },
+  ];
+
+  const handleRotate = () => {
+    if (!rotateTarget) return;
+    rotateMutation.mutate({
+      request: {
+        gramProject: rotateTarget.project.slug,
+        riskIDRequestBody: { id: rotateTarget.id },
+      },
+    });
+  };
+
+  const closeRotateDialog = () => {
+    setRotateTarget(null);
+    rotateMutation.reset();
+  };
+
+  const handleRevoke = () => {
+    if (!revokeTarget) return;
+    revokeMutation.mutate({
+      request: {
+        gramProject: revokeTarget.project.slug,
+        id: revokeTarget.id,
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="hover:bg-muted/50 p-4 transition-colors">
+        <Stack
+          direction="horizontal"
+          justify="space-between"
+          align="center"
+          gap={4}
+        >
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-controls="litellm-instances-panel"
+            aria-label={`${expanded ? "Hide" : "Show"} LiteLLM integrations`}
+            onClick={() => setExpanded((current) => !current)}
+            className="flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-4 text-left focus-visible:outline-2 focus-visible:outline-offset-4"
+          >
+            <Stack gap={1} className="min-w-0 flex-1">
+              <Stack direction="horizontal" align="center" gap={2}>
+                <Network className="text-foreground h-4 w-4 shrink-0" />
+                <Text className="font-medium">LiteLLM</Text>
+                <Badge variant="information">Push</Badge>
+              </Stack>
+              <Text muted small className="ml-6 truncate">
+                Enforce Gram risk policies and send LiteLLM usage telemetry to
+                Gram.
+              </Text>
+            </Stack>
+            <Stack direction="horizontal" align="center" gap={3}>
+              <Text muted small className="hidden whitespace-nowrap @3xl:block">
+                {instancesQuery.isPending
+                  ? "Loading instances"
+                  : `${activeCount} active ${activeCount === 1 ? "instance" : "instances"}`}
+              </Text>
+              <ChevronDown
+                aria-hidden
+                className={`text-muted-foreground h-4 w-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+              />
+            </Stack>
+          </button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setCreateOpen(true)}
+            disabled={projects.length === 0}
+          >
+            <Button.LeftIcon>
+              <Plus className="size-3.5" />
+            </Button.LeftIcon>
+            <Button.Text>New instance</Button.Text>
+          </Button>
+        </Stack>
+      </div>
+
+      {expanded && (
+        <div id="litellm-instances-panel">
+          <Stack gap={4} className="px-4 pb-4 pl-10">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <Stack gap={1}>
+                <Label htmlFor="litellm-project">Project</Label>
+                <Select
+                  value={selectedProjectSlug}
+                  onValueChange={setProjectSlug}
+                >
+                  <SelectTrigger id="litellm-project" className="min-w-56">
+                    <SelectValue placeholder="Choose a project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.slug}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Stack>
+              <Stack direction="horizontal" align="center" gap={2}>
+                <Text muted small>
+                  Each instance has its own project-bound ingestion key.
+                </Text>
+                <Button
+                  variant="tertiary"
+                  size="sm"
+                  onClick={() => void instancesQuery.refetch()}
+                  disabled={instancesQuery.isFetching}
+                >
+                  <Button.LeftIcon>
+                    <RefreshCw
+                      className={`size-3.5 ${instancesQuery.isFetching ? "animate-spin" : ""}`}
+                    />
+                  </Button.LeftIcon>
+                  <Button.Text>Refresh</Button.Text>
+                </Button>
+              </Stack>
+            </div>
+
+            {instancesQuery.isPending ? <SkeletonTable /> : null}
+            {instancesQuery.error ? (
+              <ErrorAlert
+                title="Unable to load LiteLLM integrations"
+                error={instancesQuery.error}
+              />
+            ) : null}
+            {!instancesQuery.isPending && !instancesQuery.error ? (
+              <Table
+                columns={columns}
+                data={instances}
+                rowKey={(instance) => instance.id}
+                noResultsMessage={
+                  <Text muted>No LiteLLM instances in this project.</Text>
+                }
+              />
+            ) : null}
+          </Stack>
+        </div>
+      )}
+
+      {createOpen ? (
+        <CreateInstanceDialog
+          open
+          onOpenChange={setCreateOpen}
+          projects={projects}
+          onProjectCreated={setProjectSlug}
+        />
+      ) : null}
+      <SetupDialog
+        instance={setupInstance}
+        onOpenChange={(open) => {
+          if (!open) setSetupInstance(null);
+        }}
+      />
+      <DiagnosticsDialog
+        instance={diagnosticsInstance}
+        onOpenChange={(open) => {
+          if (!open) setDiagnosticsInstanceID(null);
+        }}
+      />
+      <RotateKeyDialog
+        target={rotateTarget}
+        result={rotateMutation.data}
+        error={rotateMutation.error}
+        isPending={rotateMutation.isPending}
+        onConfirm={handleRotate}
+        onClose={closeRotateDialog}
+      />
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open && !revokeMutation.isPending) setRevokeTarget(null);
+        }}
+        title="Revoke LiteLLM integration"
+        description={
+          <>
+            Revoke <strong>{revokeTarget?.name}</strong> and immediately
+            invalidate its ingestion key? This cannot be undone.
+          </>
+        }
+        confirmLabel="Revoke integration"
+        onConfirm={handleRevoke}
+        isPending={revokeMutation.isPending}
+      />
+    </div>
+  );
+}
+
+function CreateInstanceDialog({
+  open,
+  onOpenChange,
+  projects,
+  onProjectCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projects: Array<{ id: string; name: string; slug: string }>;
+  onProjectCreated: (projectSlug: string) => void;
+}): JSX.Element {
+  const queryClient = useQueryClient();
+  const [projectSlug, setProjectSlug] = useState("");
+  const [name, setName] = useState("");
+  const [failurePosture, setFailurePosture] =
+    useState<FailurePosture>("fail_closed");
+  const mutation = useCreateLiteLLMInstanceMutation({
+    gcTime: 0,
+    onSuccess: async (data) => {
+      await invalidateAllLiteLLMInstances(queryClient);
+      onProjectCreated(data.instance.project.slug);
+    },
+  });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && mutation.isPending) return;
+    onOpenChange(nextOpen);
+    if (nextOpen) return;
+    setName("");
+    setFailurePosture("fail_closed");
+    mutation.reset();
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    mutation.mutate({
+      request: {
+        gramProject: projectSlug,
+        createInstanceRequestBody: {
+          name: name.trim(),
+          failurePosture,
+        },
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Content
+        closeable={!mutation.isPending}
+        className={
+          mutation.data ? "max-h-[90vh] max-w-3xl overflow-y-auto" : undefined
+        }
+      >
+        {mutation.data ? (
+          <>
+            <Dialog.Header>
+              <Dialog.Title>LiteLLM integration created</Dialog.Title>
+              <Dialog.Description>
+                Copy the key and generated configuration before closing this
+                dialog.
+              </Dialog.Description>
+            </Dialog.Header>
+            <SetupContent result={mutation.data} />
+            <Dialog.Footer>
+              <Button onClick={() => handleOpenChange(false)}>Close</Button>
+            </Dialog.Footer>
+          </>
+        ) : (
+          <>
+            <Dialog.Header>
+              <Dialog.Title>Create LiteLLM integration</Dialog.Title>
+              <Dialog.Description>
+                Provision a dedicated ingestion key for one LiteLLM deployment
+                and Gram project.
+              </Dialog.Description>
+            </Dialog.Header>
+            <form className="space-y-5" onSubmit={handleSubmit}>
+              <Stack gap={2}>
+                <Label htmlFor="litellm-create-project">Project</Label>
+                <Select value={projectSlug} onValueChange={setProjectSlug}>
+                  <SelectTrigger id="litellm-create-project" className="w-full">
+                    <SelectValue placeholder="Choose a project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((project) => (
+                      <SelectItem key={project.id} value={project.slug}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Stack>
+              <InputField
+                label="Instance name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Production LiteLLM"
+                maxLength={255}
+                required
+                autoFocus
+              />
+              <Stack gap={2}>
+                <Label id="litellm-failure-posture-label">
+                  Failure posture
+                </Label>
+                <RadioGroup
+                  aria-labelledby="litellm-failure-posture-label"
+                  value={failurePosture}
+                  onValueChange={(value) =>
+                    setFailurePosture(value as FailurePosture)
+                  }
+                >
+                  <label className="border-border flex cursor-pointer gap-3 rounded-md border p-3">
+                    <RadioGroupItem value="fail_closed" />
+                    <Stack gap={1}>
+                      <Text className="font-medium">
+                        Fail closed (recommended)
+                      </Text>
+                      <Text muted small>
+                        Block model requests when Gram cannot evaluate them.
+                      </Text>
+                    </Stack>
+                  </label>
+                  <label className="border-warning-softest flex cursor-pointer gap-3 rounded-md border p-3">
+                    <RadioGroupItem value="fail_open" />
+                    <Stack gap={1}>
+                      <Text className="font-medium">Fail open</Text>
+                      <Text muted small>
+                        Allow model requests during a Gram outage. This is an
+                        explicit security posture decision.
+                      </Text>
+                    </Stack>
+                  </label>
+                </RadioGroup>
+              </Stack>
+              {mutation.error ? <ErrorAlert error={mutation.error} /> : null}
+              <Dialog.Footer>
+                <Button
+                  type="button"
+                  variant="tertiary"
+                  onClick={() => handleOpenChange(false)}
+                  disabled={mutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={
+                    mutation.isPending ||
+                    projectSlug === "" ||
+                    name.trim() === ""
+                  }
+                >
+                  {mutation.isPending ? "Creating…" : "Create integration"}
+                </Button>
+              </Dialog.Footer>
+            </form>
+          </>
+        )}
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+function SetupDialog({
+  instance,
+  onOpenChange,
+}: {
+  instance: LiteLLMInstance | null;
+  onOpenChange: (open: boolean) => void;
+}): JSX.Element {
+  return (
+    <Dialog open={instance !== null} onOpenChange={onOpenChange}>
+      <Dialog.Content className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        <Dialog.Header>
+          <Dialog.Title>Configure {instance?.name}</Dialog.Title>
+          <Dialog.Description>
+            Add the generated YAML and environment variables to your LiteLLM
+            proxy.
+          </Dialog.Description>
+        </Dialog.Header>
+        {instance ? <SetupContent instance={instance} /> : null}
+        <Dialog.Footer>
+          <Button onClick={() => onOpenChange(false)}>Close</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+function DiagnosticsDialog({
+  instance,
+  onOpenChange,
+}: {
+  instance: LiteLLMInstance | null;
+  onOpenChange: (open: boolean) => void;
+}): JSX.Element {
+  return (
+    <Dialog open={instance !== null} onOpenChange={onOpenChange}>
+      <Dialog.Content className="max-w-3xl">
+        <Dialog.Header>
+          <Dialog.Title>{instance?.name} diagnostics</Dialog.Title>
+          <Dialog.Description>
+            Connection health and identity attribution for the last 24 hours.
+          </Dialog.Description>
+        </Dialog.Header>
+        {instance ? <DiagnosticsPanel instance={instance} /> : null}
+        <Dialog.Footer>
+          <Button onClick={() => onOpenChange(false)}>Close</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+function RotateKeyDialog({
+  target,
+  result,
+  error,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  target: LiteLLMInstance | null;
+  result: LitellmInstanceKeyResult | undefined;
+  error: Error | null;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}): JSX.Element {
+  return (
+    <Dialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open && !isPending) onClose();
+      }}
+    >
+      <Dialog.Content
+        closeable={!isPending}
+        className={
+          result ? "max-h-[90vh] max-w-3xl overflow-y-auto" : undefined
+        }
+      >
+        {result ? (
+          <>
+            <Dialog.Header>
+              <Dialog.Title>LiteLLM key rotated</Dialog.Title>
+              <Dialog.Description>
+                Replace the old key immediately. It is no longer valid.
+              </Dialog.Description>
+            </Dialog.Header>
+            <SetupContent result={result} />
+            <Dialog.Footer>
+              <Button onClick={onClose}>Close</Button>
+            </Dialog.Footer>
+          </>
+        ) : (
+          <>
+            <Dialog.Header>
+              <Dialog.Title>Rotate LiteLLM key</Dialog.Title>
+              <Dialog.Description>
+                Rotate the key for <strong>{target?.name}</strong>? The current
+                key stops working immediately.
+              </Dialog.Description>
+            </Dialog.Header>
+            {error ? <ErrorAlert error={error} /> : null}
+            <Dialog.Footer>
+              <Button variant="tertiary" onClick={onClose} disabled={isPending}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive-primary"
+                onClick={onConfirm}
+                disabled={isPending}
+              >
+                {isPending ? "Rotating…" : "Rotate key"}
+              </Button>
+            </Dialog.Footer>
+          </>
+        )}
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+function SetupContent({
+  instance: instanceProp,
+  result,
+}: {
+  instance?: LiteLLMInstance;
+  result?: LitellmInstanceKeyResult;
+}): JSX.Element {
+  const instance = result?.instance ?? instanceProp;
+  if (!instance) return <></>;
+  const serverURL = getServerURL();
+
+  return (
+    <Stack gap={5}>
+      {result ? (
+        <Alert variant="warning">
+          This key is shown once. Copy it now and store it securely.
+        </Alert>
+      ) : (
+        <Alert variant="info">
+          Gram no longer has the plaintext key. Replace the placeholder with the
+          key stored by your team.
+        </Alert>
+      )}
+      {result ? (
+        <SetupSection
+          title="Integration key"
+          description="Store this dedicated project-bound key securely. Gram cannot show it again."
+        >
+          <CodeBlock>{result.key}</CodeBlock>
+        </SetupSection>
+      ) : null}
+      <SetupSection
+        title="Environment variables"
+        description="Paste the key into the first variable, then set these on the LiteLLM proxy."
+      >
+        <CodeBlock language="shell">
+          {buildLiteLLMEnvironment(serverURL, instance.project.slug)}
+        </CodeBlock>
+      </SetupSection>
+      <SetupSection
+        title="LiteLLM configuration"
+        description="Merge this guardrail fragment into your LiteLLM configuration."
+      >
+        <CodeBlock language="yaml">
+          {buildLiteLLMGuardrailConfig(serverURL, instance.failurePosture)}
+        </CodeBlock>
+      </SetupSection>
+      <SetupSection
+        title="Verify safe traffic"
+        description="Set LITELLM_VIRTUAL_KEY and LITELLM_MODEL in your shell, then run this against the proxy."
+      >
+        <CodeBlock language="shell">
+          {liteLLMVerificationCommands.safe}
+        </CodeBlock>
+      </SetupSection>
+      <SetupSection
+        title="Verify blocking"
+        description="This synthetic credential should be blocked when the project secret policy is enabled."
+      >
+        <CodeBlock language="shell">
+          {liteLLMVerificationCommands.blocked}
+        </CodeBlock>
+      </SetupSection>
+    </Stack>
+  );
+}
+
+function SetupSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Stack gap={2}>
+      <Text className="font-medium">{title}</Text>
+      <Text muted small>
+        {description}
+      </Text>
+      {children}
+    </Stack>
+  );
+}
+
+function HealthBadge({ instance }: { instance: LiteLLMInstance }): JSX.Element {
+  if (!instance.active) return <Badge variant="neutral">Revoked</Badge>;
+  switch (instance.diagnostics.status) {
+    case "success":
+      return <Badge variant="success">Connected</Badge>;
+    case "failed":
+      return <Badge variant="destructive">Error</Badge>;
+    case "pending":
+      return <Badge variant="neutral">Waiting for traffic</Badge>;
+  }
+}
+
+function FailurePostureBadge({
+  posture,
+}: {
+  posture: FailurePosture;
+}): JSX.Element {
+  return posture === "fail_closed" ? (
+    <Badge variant="neutral">Fail closed</Badge>
+  ) : (
+    <Badge variant="warning">Fail open</Badge>
+  );
+}
+
+function DiagnosticsPanel({
+  instance,
+}: {
+  instance: LiteLLMInstance;
+}): JSX.Element {
+  const diagnostics = instance.diagnostics;
+  return (
+    <div className="bg-muted/20 grid grid-cols-1 gap-px border-t sm:grid-cols-2 lg:grid-cols-4">
+      <Diagnostic
+        label="LiteLLM version"
+        value={diagnostics.reportedLitellmVersion ?? "Not reported"}
+      />
+      <Diagnostic
+        label="Last ingestion"
+        date={diagnostics.lastGuardrailEventAt}
+      />
+      <Diagnostic label="Last OTel event" date={diagnostics.lastOtelEventAt} />
+      <Diagnostic
+        label="Last error"
+        date={diagnostics.lastErrorAt}
+        value={errorKindLabel(diagnostics.lastErrorKind)}
+      />
+      <Diagnostic
+        label="Virtual-key email (24h)"
+        value={formatPercentage(diagnostics.virtualKeyEmailPct24h)}
+      />
+      <Diagnostic
+        label="Gram user attribution (24h)"
+        value={formatPercentage(diagnostics.platformUserPct24h)}
+      />
+      <Diagnostic label="Created" date={instance.createdAt} />
+      <Diagnostic label="Project" value={instance.project.name} />
+    </div>
+  );
+}
+
+function Diagnostic({
+  label,
+  value,
+  date,
+}: {
+  label: string;
+  value?: string;
+  date?: Date;
+}): JSX.Element {
+  return (
+    <Stack gap={1} className="bg-background p-3">
+      <Text muted small>
+        {label}
+      </Text>
+      {value ? <Text small>{value}</Text> : null}
+      {date ? (
+        <Text small>
+          <HumanizeDateTime date={date} />
+        </Text>
+      ) : !value ? (
+        <Text muted small>
+          Not received
+        </Text>
+      ) : null}
+    </Stack>
+  );
+}
+
+function formatPercentage(value: number | undefined): string {
+  return value === undefined ? "No recent traffic" : `${value.toFixed(1)}%`;
+}
+
+function errorKindLabel(
+  kind: LiteLLMInstance["diagnostics"]["lastErrorKind"],
+): string | undefined {
+  switch (kind) {
+    case "auth_failure":
+      return "Authentication failure";
+    case "decode_failure":
+      return "Invalid payload";
+    case "limit_exceeded":
+      return "Payload limit exceeded";
+    case undefined:
+      return undefined;
+  }
+}

--- a/client/dashboard/src/pages/org/litellm-integration-row.tsx
+++ b/client/dashboard/src/pages/org/litellm-integration-row.tsx
@@ -360,27 +360,17 @@ export function LiteLLMIntegrationRow(): JSX.Element {
         onConfirm={handleRotate}
         onClose={closeRotateDialog}
       />
-      <ConfirmDialog
-        open={revokeTarget !== null}
-        onOpenChange={(open) => {
-          if (!open && !revokeMutation.isPending) setRevokeTarget(null);
-        }}
-        title="Revoke LiteLLM integration"
-        description={
-          <>
-            Revoke <strong>{revokeTarget?.name}</strong> and immediately
-            invalidate its ingestion key? This cannot be undone.
-          </>
-        }
-        confirmLabel="Revoke integration"
-        onConfirm={handleRevoke}
+      <RevokeInstanceDialog
+        target={revokeTarget}
         isPending={revokeMutation.isPending}
+        onConfirm={handleRevoke}
+        onClose={() => setRevokeTarget(null)}
       />
     </div>
   );
 }
 
-function CreateInstanceDialog({
+export function CreateInstanceDialog({
   open,
   onOpenChange,
   projects,
@@ -603,7 +593,7 @@ function DiagnosticsDialog({
   );
 }
 
-function RotateKeyDialog({
+export function RotateKeyDialog({
   target,
   result,
   error,
@@ -670,6 +660,37 @@ function RotateKeyDialog({
         )}
       </Dialog.Content>
     </Dialog>
+  );
+}
+
+export function RevokeInstanceDialog({
+  target,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  target: LiteLLMInstance | null;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}): JSX.Element {
+  return (
+    <ConfirmDialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open && !isPending) onClose();
+      }}
+      title="Revoke LiteLLM integration"
+      description={
+        <>
+          Revoke <strong>{target?.name}</strong> and immediately invalidate its
+          ingestion key? This cannot be undone.
+        </>
+      }
+      confirmLabel="Revoke integration"
+      onConfirm={onConfirm}
+      isPending={isPending}
+    />
   );
 }
 
@@ -786,7 +807,7 @@ function FailurePostureBadge({
   );
 }
 
-function DiagnosticsPanel({
+export function DiagnosticsPanel({
   instance,
 }: {
   instance: LiteLLMInstance;
@@ -794,6 +815,10 @@ function DiagnosticsPanel({
   const diagnostics = instance.diagnostics;
   return (
     <div className="bg-muted/20 grid grid-cols-1 gap-px border-t sm:grid-cols-2 lg:grid-cols-4">
+      <Diagnostic
+        label="Connection health"
+        content={<HealthBadge instance={instance} />}
+      />
       <Diagnostic
         label="LiteLLM version"
         value={diagnostics.reportedLitellmVersion ?? "Not reported"}
@@ -826,22 +851,25 @@ function Diagnostic({
   label,
   value,
   date,
+  content,
 }: {
   label: string;
   value?: string;
   date?: Date;
+  content?: React.ReactNode;
 }): JSX.Element {
   return (
     <Stack gap={1} className="bg-background p-3">
       <Text muted small>
         {label}
       </Text>
+      {content}
       {value ? <Text small>{value}</Text> : null}
       {date ? (
         <Text small>
           <HumanizeDateTime date={date} />
         </Text>
-      ) : !value ? (
+      ) : !value && !content ? (
         <Text muted small>
           Not received
         </Text>

--- a/client/dashboard/src/pages/org/litellm-integration-row.tsx
+++ b/client/dashboard/src/pages/org/litellm-integration-row.tsx
@@ -337,6 +337,7 @@ export function LiteLLMIntegrationRow(): JSX.Element {
           open
           onOpenChange={setCreateOpen}
           projects={projects}
+          initialProjectSlug={selectedProjectSlug}
           onProjectCreated={setProjectSlug}
         />
       ) : null}
@@ -374,15 +375,17 @@ export function CreateInstanceDialog({
   open,
   onOpenChange,
   projects,
+  initialProjectSlug,
   onProjectCreated,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   projects: Array<{ id: string; name: string; slug: string }>;
+  initialProjectSlug: string;
   onProjectCreated: (projectSlug: string) => void;
 }): JSX.Element {
   const queryClient = useQueryClient();
-  const [projectSlug, setProjectSlug] = useState("");
+  const [projectSlug, setProjectSlug] = useState(initialProjectSlug);
   const [name, setName] = useState("");
   const [failurePosture, setFailurePosture] =
     useState<FailurePosture>("fail_closed");

--- a/client/dashboard/src/pages/remote-identity-providers/ConfirmDialog.tsx
+++ b/client/dashboard/src/pages/remote-identity-providers/ConfirmDialog.tsx
@@ -31,8 +31,14 @@ export function ConfirmDialog({
   };
 }): JSX.Element {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && isPending) return;
+        onOpenChange(nextOpen);
+      }}
+    >
+      <Dialog.Content closeable={!isPending}>
         <Dialog.Header>
           <Dialog.Title>{title}</Dialog.Title>
           <Dialog.Description>{description}</Dialog.Description>


### PR DESCRIPTION
## Summary
- add the feature- and admin-gated LiteLLM push integration to organization AI integrations
- guide admins through project selection, failure posture, one-time key display, and generated proxy configuration
- expose diagnostics, verification commands, and key rotation/revocation controls

Stacked on #4841.

Part of [DNO-714](https://linear.app/speakeasy/issue/DNO-714/feat-litellm-integration-dashboard-page).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-gated LiteLLM push integration dashboard in Org → AI Integrations. Implements DNO-714 so admins can create per-project instances, generate config/env with safe defaults, verify wiring, view diagnostics, and rotate or revoke keys.

- **New Features**
  - Visible only to admins when `aiPlatformPushIntegrationsEnabled` is on.
  - Create flow: choose project, name, and failure posture (default fail-closed) with a one-time key.
  - Instances table: health, posture, key prefix, created/last used; actions for setup, diagnostics, rotate, revoke; per-project picker with manual refresh and auto-refresh while expanded.
  - Setup and diagnostics: generated guardrail YAML with safe defaults and posture-driven fallback (forwards `x-gram-session-id`); OTel v2 env (`LITELLM_OTEL_V2=true`, `OTEL_EXPORTER=otlp_http`, metrics on, no content capture, service `litellm`, legacy compat off); safe and synthetic-block `curl` commands; copy buttons with contextual labels; diagnostics include LiteLLM version and attribution stats.

- **Bug Fixes**
  - Protect one-time keys: show only on create/rotate; require acknowledgement before closing; setup view uses secret placeholders.
  - Harden setup validation: require HTTPS for ingest/OTel endpoints; allow HTTP only for strict loopback hosts (`localhost`, `[::1]`, and `127.0.0.0/8`), rejecting lookalikes.
  - Hide LiteLLM from non-admins and when the feature is off without mounting queries.
  - Confirm dialogs can’t close while pending.
  - Point the OTLP exporter to the canonical endpoint at `/rpc/hooks.otel`.

<sup>Written for commit 09e796bf97340e3f07410a894e0fe01775036554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

