### PR TITLE
fix(security): pass build-args via env to avoid template injection

### DIFF
--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -81,9 +81,10 @@ runs:
 
     - name: Validate and sanitize build arguments
       shell: bash
+      env:
+        ARGS: ${{ inputs.build-args }}
       run: |
         set -e
-        ARGS="${{ inputs.build-args }}"
 
         # Comprehensive validation
         echo "Validating build arguments..."


### PR DESCRIPTION
Recreates #4843 (closed Aikido autofix PR) with a human author.

Inline `${{ inputs.build-args }}` inside the `run` script of the composite build-push action allows GitHub expression expansion directly into shell code, i.e. template injection. Passing the value through `env` keeps it inert until the validation step reads `$ARGS`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes `inputs.build-args` to the composite build-push action via an `env` variable (`ARGS`) instead of inlining it in the `run` script to prevent template injection. The value stays inert until the validation step reads `$ARGS`.

<sup>Written for commit 0d823d9b78a822897ae7af16cc4c18903f0dc093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

