### PR TITLE
feat: summarize project assistant tool calls with activity phrases

### DIFF
--- a/.changeset/tool-group-summaries.md
+++ b/.changeset/tool-group-summaries.md
@@ -1,0 +1,6 @@
+---
+"dashboard": minor
+"server": patch
+---
+
+Project assistant tool calls now render Claude-style: the assistant precedes each tool batch with a terse activity phrase ("Investigating failures in the last 30 days") which becomes the heading of a single collapsed tool group. Consecutive batches merge into one group whose heading advances (with shimmer) as the investigation progresses, groups never auto-expand, and the global thinking loader hides while a tool group is streaming. The dashboard output-channel guidance instructs the model to emit the phrase before every tool call.

--- a/client/dashboard/src/elements/components/assistant-ui/thinking-indicator.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thinking-indicator.tsx
@@ -3,6 +3,7 @@
 import { useAuiState } from "@assistant-ui/react";
 import { type FC, useEffect, useMemo, useState } from "react";
 
+import { isToolCallAnnotation } from "@/elements/lib/toolCallAnnotation";
 import { cn } from "@/lib/utils";
 
 /**
@@ -181,10 +182,27 @@ export const ThinkingIndicator: FC = () => {
   const active = useAuiState(({ message }) => {
     if (message.status?.type !== "running") return false;
     const parts = message.parts;
-    if (parts.length === 0) return true;
-    const last = parts[parts.length - 1];
+    // Skip trailing empty text and lone annotations (the next batch's
+    // heading, mid-flight) — they don't end the current tool run.
+    let i = parts.length - 1;
+    while (i >= 0) {
+      const part = parts[i];
+      if (
+        part?.type === "text" &&
+        (part.text.trim().length === 0 || isToolCallAnnotation(part.text))
+      ) {
+        i--;
+        continue;
+      }
+      break;
+    }
+    if (i < 0) return true;
+    const last = parts[i];
     if (!last) return true;
-    if (last.type === "tool-call" || last.type === "reasoning") return true;
+    // A trailing tool group is still "open" (shimmering heading) for the
+    // whole streaming run — a second global loader would be noise.
+    if (last.type === "tool-call") return false;
+    if (last.type === "reasoning") return true;
     if (last.type === "text") return last.text.trim().length === 0;
     return false;
   });

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -22,9 +22,11 @@ import {
   ErrorPrimitive,
   ImageMessagePartProps,
   MessagePrimitive,
+  TextMessagePartProvider,
   ThreadPrimitive,
   useAui,
   useAuiState,
+  type TextMessagePartComponent,
 } from "@assistant-ui/react";
 
 import {
@@ -44,6 +46,7 @@ import {
   useRef,
   useState,
   type FC,
+  type PropsWithChildren,
 } from "react";
 
 import {
@@ -83,6 +86,11 @@ import { useThemeProps } from "@/elements/hooks/useThemeProps";
 import { useToolMentions } from "@/elements/hooks/useToolMentions";
 import { getApiUrl } from "@/elements/lib/api";
 import { EASE_OUT_QUINT } from "@/elements/lib/easing";
+import { groupAssistantMessageParts } from "@/elements/lib/messagePartGrouping";
+import {
+  stripTrailingAnnotationLine,
+  trailingAnnotationLine,
+} from "@/elements/lib/toolCallAnnotation";
 import { MODELS } from "@/elements/lib/models";
 import type { ComposerSkill, SkillContextConfig } from "@/elements/types";
 import {
@@ -1335,26 +1343,85 @@ const MessageError: FC = () => {
   );
 };
 
+// The trailing terse line of a text part immediately followed by tool calls
+// is the group's annotation — ToolGroup renders it as the group heading, so
+// the prose render here drops it to avoid showing it twice. A pure annotation
+// part renders nothing; a mixed prose+annotation part renders the prose only.
+const withToolCallAnnotationSuppression = (
+  Inner: TextMessagePartComponent,
+): TextMessagePartComponent => {
+  const AssistantText: TextMessagePartComponent = (props) => {
+    const aui = useAui();
+    const partQuery = aui.part.query;
+    const partIndex = partQuery?.type === "index" ? partQuery.index : undefined;
+    const followedByToolCall = useAuiState(
+      ({ message }) =>
+        partIndex !== undefined &&
+        message.parts[partIndex + 1]?.type === "tool-call",
+    );
+    if (!followedByToolCall || !trailingAnnotationLine(props.text)) {
+      return <Inner {...props} />;
+    }
+    const remainder = stripTrailingAnnotationLine(props.text);
+    if (!remainder) return null;
+    // MarkdownText reads its text from part context, not props — override the
+    // context so the annotation line disappears from the prose render.
+    return (
+      <TextMessagePartProvider
+        text={remainder}
+        isRunning={props.status?.type === "running"}
+      >
+        <Inner {...props} text={remainder} />
+      </TextMessagePartProvider>
+    );
+  };
+  return AssistantText;
+};
+
 const AssistantMessage: FC = () => {
   const { config } = useElements();
   const toolsConfig = config.tools ?? {};
   const components = config.components;
   const toolsComponents = toolsConfig.components;
 
-  const partsComponents = useMemo(
-    () => ({
-      Text: components?.Text ?? MarkdownText,
+  const partsComponents = useMemo(() => {
+    const ToolGroupComponent = components?.ToolGroup ?? ToolGroup;
+    const ReasoningGroupComponent =
+      components?.ReasoningGroup ?? ReasoningGroup;
+    // Dispatches each cluster from groupAssistantMessageParts: tool runs get
+    // the ToolGroup treatment, reasoning runs the ReasoningGroup one, and
+    // ungrouped parts render bare.
+    const Group: FC<
+      PropsWithChildren<{ groupKey: string | undefined; indices: number[] }>
+    > = ({ groupKey, indices, children }) => {
+      if (groupKey?.startsWith("tools-")) {
+        return (
+          <ToolGroupComponent indices={indices}>{children}</ToolGroupComponent>
+        );
+      }
+      if (groupKey?.startsWith("reasoning-")) {
+        return (
+          <ReasoningGroupComponent
+            startIndex={indices[0] ?? 0}
+            endIndex={indices[indices.length - 1] ?? 0}
+          >
+            {children}
+          </ReasoningGroupComponent>
+        );
+      }
+      return children;
+    };
+    return {
+      Text: withToolCallAnnotationSuppression(components?.Text ?? MarkdownText),
       Image: components?.Image ?? Image,
       tools: {
         by_name: toolsComponents,
         Fallback: components?.ToolFallback ?? ToolFallback,
       },
       Reasoning: components?.Reasoning ?? Reasoning,
-      ReasoningGroup: components?.ReasoningGroup ?? ReasoningGroup,
-      ToolGroup: components?.ToolGroup ?? ToolGroup,
-    }),
-    [components, toolsComponents],
-  );
+      Group,
+    };
+  }, [components, toolsComponents]);
 
   return (
     <MessagePrimitive.Root asChild>
@@ -1363,7 +1430,10 @@ const AssistantMessage: FC = () => {
         data-role="assistant"
       >
         <div className="aui-assistant-message-content mx-2 leading-7 wrap-break-word text-foreground">
-          <MessagePrimitive.Parts components={partsComponents} />
+          <MessagePrimitive.Unstable_PartsGrouped
+            groupingFunction={groupAssistantMessageParts}
+            components={partsComponents}
+          />
           <ThinkingIndicator />
           <MessageError />
         </div>

--- a/client/dashboard/src/elements/components/assistant-ui/tool-group.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/tool-group.tsx
@@ -2,45 +2,122 @@ import { useAuiState } from "@assistant-ui/react";
 import { useMemo, type FC, type PropsWithChildren } from "react";
 import { useElements } from "@/elements/hooks/useElements";
 import { humanizeToolName } from "@/elements/lib/humanize";
+import {
+  isToolCallAnnotation,
+  toolCallAnnotationTitle,
+  trailingAnnotationLine,
+} from "@/elements/lib/toolCallAnnotation";
 import { ToolUIGroup } from "@/elements/components/ui/tool-ui";
 
-export const ToolGroup: FC<
-  PropsWithChildren<{ startIndex: number; endIndex: number }>
-> = ({ children, startIndex, endIndex }) => {
-  // startIndex/endIndex are inclusive indices into message.parts.
-  // assistant-ui only groups consecutive tool-call parts, so every part
-  // in the range is a tool-call — the count is simply the range size.
-  const toolCount = endIndex - startIndex + 1;
+/**
+ * Renders one tool run: a cluster of tool-call parts plus the terse
+ * annotation text parts the assistant emits before each batch (see
+ * messagePartGrouping.ts). The heading is the latest annotation in the run,
+ * so it advances as the investigation progresses; the annotations' prose
+ * renders are suppressed in thread.tsx.
+ */
+export const ToolGroup: FC<PropsWithChildren<{ indices: number[] }>> = ({
+  children,
+  indices,
+}) => {
+  const toolCount = useAuiState(({ message }) => {
+    let count = 0;
+    for (const i of indices) {
+      if (message.parts[i]?.type === "tool-call") count++;
+    }
+    return count;
+  });
 
   const firstToolName = useAuiState(({ message }) => {
-    const part = message.parts[startIndex];
-    return part?.type === "tool-call" ? part.toolName : undefined;
+    for (const i of indices) {
+      const part = message.parts[i];
+      if (part?.type === "tool-call") return part.toolName;
+    }
+    return undefined;
   });
+
   const anyMessagePartsAreRunning = useAuiState(({ message }) => {
-    for (let i = startIndex; i <= endIndex; i++) {
+    for (const i of indices) {
       if (message.parts[i]?.status?.type === "running") return true;
     }
     return false;
+  });
+
+  // While the message is still streaming and nothing has been emitted after
+  // this run, the next annotation may still replace the heading — keep the
+  // group in its running state so the swap shimmers in instead of snapping
+  // from a "done" state.
+  const isTrailingWhileStreaming = useAuiState(({ message }) => {
+    if (message.status?.type !== "running") return false;
+    const lastIndex = indices[indices.length - 1] ?? -1;
+    for (let i = lastIndex + 1; i < message.parts.length; i++) {
+      const part = message.parts[i];
+      // An empty text part or a lone annotation (the next batch's heading,
+      // mid-flight) doesn't end the run.
+      if (
+        part?.type === "text" &&
+        (part.text.trim().length === 0 || isToolCallAnnotation(part.text))
+      ) {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  });
+
+  const isRunning = anyMessagePartsAreRunning || isTrailingWhileStreaming;
+
+  // Latest annotation in the run wins — the heading tracks where the
+  // investigation currently is. Mixed prose+annotation blocks stay outside
+  // the run (only pure annotations join it), so also check the part just
+  // before the run for a trailing annotation line.
+  const annotation = useAuiState(({ message }) => {
+    for (let k = indices.length - 1; k >= 0; k--) {
+      const part = message.parts[indices[k]!];
+      if (part?.type === "text" && isToolCallAnnotation(part.text)) {
+        return toolCallAnnotationTitle(part.text);
+      }
+    }
+    const first = indices[0] ?? 0;
+    const prev = first > 0 ? message.parts[first - 1] : undefined;
+    if (prev?.type === "text") {
+      const line = trailingAnnotationLine(prev.text);
+      if (line) return toolCallAnnotationTitle(line);
+    }
+    return undefined;
   });
 
   const { config } = useElements();
   const defaultExpanded = config.tools?.expandToolGroupsByDefault ?? false;
 
   const groupTitle = useMemo(() => {
-    if (toolCount === 0) return "No tools called";
-    if (toolCount === 1) {
-      return firstToolName
-        ? `Calling ${humanizeToolName(firstToolName)}...`
-        : "Calling tool...";
+    if (annotation) return annotation;
+    if (toolCount === 1 && firstToolName) {
+      const name = humanizeToolName(firstToolName);
+      return anyMessagePartsAreRunning ? `Calling ${name}...` : `Ran ${name}`;
     }
     return anyMessagePartsAreRunning
-      ? `Calling ${toolCount} tools...`
-      : `Executed ${toolCount} tools`;
-  }, [toolCount, firstToolName, anyMessagePartsAreRunning]);
+      ? `Running ${toolCount} tools...`
+      : `Ran ${toolCount} tools`;
+  }, [annotation, toolCount, firstToolName, anyMessagePartsAreRunning]);
 
-  // If there's a custom component for the single tool, render children directly
-  if (firstToolName && config.tools?.components?.[firstToolName]) {
-    return children;
+  const status = isRunning ? ("running" as const) : ("complete" as const);
+
+  // If there's a custom component for the single tool, render children
+  // directly — but keep the annotation visible, since AssistantText has
+  // suppressed its prose render.
+  if (
+    toolCount === 1 &&
+    firstToolName &&
+    config.tools?.components?.[firstToolName]
+  ) {
+    if (!annotation) return children;
+    return (
+      <>
+        <div className="my-1 text-sm text-muted-foreground">{annotation}</div>
+        {children}
+      </>
+    );
   }
 
   // Single and multiple tool calls must share one wrapper element type —
@@ -49,9 +126,8 @@ export const ToolGroup: FC<
   return (
     <div className="my-4 w-full max-w-xl">
       <ToolUIGroup
-        headerless={toolCount === 1}
         title={groupTitle}
-        status={anyMessagePartsAreRunning ? "running" : "complete"}
+        status={status}
         defaultExpanded={defaultExpanded}
       >
         {children}

--- a/client/dashboard/src/elements/components/ui/tool-ui.tsx
+++ b/client/dashboard/src/elements/components/ui/tool-ui.tsx
@@ -1176,31 +1176,17 @@ function ToolUIGroup({
 }: ToolUIGroupProps): React.JSX.Element {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 
-  // A headerless group shows its children unconditionally; when it gains a
-  // header mid-stream, start expanded — collapsing would hide content the
-  // user was already looking at.
-  const [prevHeaderless, setPrevHeaderless] = useState(headerless);
-  if (prevHeaderless !== headerless) {
-    setPrevHeaderless(headerless);
-    if (prevHeaderless) setIsExpanded(true);
-  }
-
   const showChildren = headerless || isExpanded;
 
   return (
-    <div
-      data-slot="tool-ui-group"
-      className={cn(
-        "overflow-hidden rounded-lg border border-border bg-card",
-        className,
-      )}
-    >
-      {/* Group header */}
+    <div data-slot="tool-ui-group" className={className}>
+      {/* Group header — a bare annotation line; the chrome lives on the
+          expanded content below. */}
       {!headerless && (
         <button
           onClick={() => setIsExpanded(!isExpanded)}
           aria-expanded={isExpanded}
-          className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-accent/50"
+          className="flex w-fit cursor-pointer items-center gap-1.5 py-1 text-left"
         >
           {icon || (
             <StatusIndicator
@@ -1209,27 +1195,29 @@ function ToolUIGroup({
           )}
           <span
             className={cn(
-              "flex-1 text-sm font-medium",
+              "text-sm font-medium text-muted-foreground",
               status === "running" && "shimmer",
             )}
           >
             {title}
           </span>
-          <ChevronDownIcon
+          <ChevronRightIcon
             className={cn(
               "size-4 text-muted-foreground transition-transform duration-200",
-              isExpanded && "rotate-180",
+              isExpanded && "rotate-90",
             )}
           />
         </button>
       )}
 
       {/* Collapsed children are hidden, not unmounted — unmounting would
-          reset their state (expansion, async syntax highlighting). */}
+          reset their state (expansion, async syntax highlighting). The border
+          wraps all tools; the cards inside render borderless. */}
       <div
         data-slot="tool-ui-group-content"
         className={cn(
-          !headerless && "border-t border-border",
+          "overflow-hidden rounded-lg border border-border bg-card",
+          !headerless && "mt-2",
           !showChildren && "hidden",
         )}
       >

--- a/client/dashboard/src/elements/lib/messagePartGrouping.ts
+++ b/client/dashboard/src/elements/lib/messagePartGrouping.ts
@@ -1,0 +1,58 @@
+import { isToolCallAnnotation } from "./toolCallAnnotation";
+
+export type MessagePartGroup = {
+  groupKey: string | undefined;
+  indices: number[];
+};
+
+type PartLike = { readonly type: string; readonly text?: string };
+
+/**
+ * Groups an assistant message's parts for rendering:
+ *
+ * - Consecutive reasoning parts form a `reasoning-*` group.
+ * - A run of tool calls — including the terse annotation text parts the
+ *   assistant emits before each batch (see toolCallAnnotation.ts) — forms a
+ *   single `tools-*` group, so a multi-step investigation renders as one
+ *   block whose heading tracks the latest annotation instead of one box per
+ *   batch.
+ * - Everything else (real prose, images, …) stays ungrouped and breaks runs.
+ */
+export function groupAssistantMessageParts(
+  parts: readonly PartLike[],
+): MessagePartGroup[] {
+  const groups: MessagePartGroup[] = [];
+  let i = 0;
+  while (i < parts.length) {
+    if (parts[i]?.type === "reasoning") {
+      const indices: number[] = [];
+      while (i < parts.length && parts[i]?.type === "reasoning") {
+        indices.push(i++);
+      }
+      groups.push({ groupKey: `reasoning-${indices[0]}`, indices });
+      continue;
+    }
+    if (isToolRunMember(parts, i)) {
+      const indices: number[] = [];
+      while (i < parts.length && isToolRunMember(parts, i)) {
+        indices.push(i++);
+      }
+      groups.push({ groupKey: `tools-${indices[0]}`, indices });
+      continue;
+    }
+    groups.push({ groupKey: undefined, indices: [i] });
+    i++;
+  }
+  return groups;
+}
+
+function isToolRunMember(parts: readonly PartLike[], i: number): boolean {
+  const part = parts[i];
+  if (!part) return false;
+  if (part.type === "tool-call") return true;
+  return (
+    part.type === "text" &&
+    isToolCallAnnotation(part.text ?? "") &&
+    parts[i + 1]?.type === "tool-call"
+  );
+}

--- a/client/dashboard/src/elements/lib/toolCallAnnotation.ts
+++ b/client/dashboard/src/elements/lib/toolCallAnnotation.ts
@@ -1,0 +1,60 @@
+/**
+ * The dashboard assistant is instructed to precede tool calls with a terse
+ * activity phrase (e.g. "Investigating failures in the last 30 days"). When a
+ * text part looks like such a phrase and is immediately followed by tool
+ * calls, the UI renders it as the tool group's heading instead of as message
+ * prose.
+ */
+
+// Instructed phrases are 3–8 words; anything longer is commentary, not an
+// annotation, and renders as prose.
+export const TOOL_CALL_ANNOTATION_MAX_LENGTH = 100;
+
+/**
+ * Strict shape gate: a heading must read like "Investigating X" / "Deep
+ * diving into Y". Length alone is not enough — the model sometimes narrates
+ * setbacks in a single short sentence, and promoting those to the heading
+ * looks broken. Require a present-participle opener and reject sentence or
+ * Markdown punctuation.
+ */
+export function isToolCallAnnotation(text: string): boolean {
+  const trimmed = text.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > TOOL_CALL_ANNOTATION_MAX_LENGTH ||
+    trimmed.includes("\n")
+  ) {
+    return false;
+  }
+  // Multi-sentence commentary or Markdown formatting → prose.
+  if (/[.!?] /.test(trimmed) || /[`*_#[\]]/.test(trimmed)) return false;
+  // Doing-phrase opener: one of the first two words is a present participle
+  // ("Investigating…", "Deep diving…", "Cross-referencing…").
+  const words = trimmed.split(/\s+/);
+  const isGerund = (word: string | undefined) =>
+    !!word && /ing$/i.test(word.replace(/[^a-zA-Z-]/g, ""));
+  return isGerund(words[0]) || isGerund(words[1]);
+}
+
+/** Normalize an annotation for display as a group heading. */
+export function toolCallAnnotationTitle(text: string): string {
+  return text.trim().replace(/[.…:]+$/, "");
+}
+
+/**
+ * The model sometimes emits prose and the activity phrase in one text block.
+ * The last line still works as the annotation when it is terse; the remainder
+ * renders as regular prose (see stripTrailingAnnotationLine).
+ */
+export function trailingAnnotationLine(text: string): string | undefined {
+  const lines = text.trim().split("\n");
+  const last = lines[lines.length - 1]?.trim() ?? "";
+  return isToolCallAnnotation(last) ? last : undefined;
+}
+
+/** The text minus its trailing annotation line (empty for a pure annotation). */
+export function stripTrailingAnnotationLine(text: string): string {
+  const trimmed = text.trimEnd();
+  const idx = trimmed.lastIndexOf("\n");
+  return idx === -1 ? "" : trimmed.slice(0, idx).trimEnd();
+}

--- a/client/dashboard/src/elements/types/index.ts
+++ b/client/dashboard/src/elements/types/index.ts
@@ -721,11 +721,11 @@ export interface ComponentOverrides {
   ReasoningGroup?: ReasoningGroupComponent;
 
   /**
-   * The component to use for the tool group (a group of tool calls returned by the LLM in a single message).
+   * The component to use for the tool group (a run of tool calls, including
+   * the terse annotation text parts preceding each batch). `indices` are the
+   * positions of the run's parts within the assistant message.
    */
-  ToolGroup?: ComponentType<
-    PropsWithChildren<{ startIndex: number; endIndex: number }>
-  >;
+  ToolGroup?: ComponentType<PropsWithChildren<{ indices: number[] }>>;
 }
 
 export type ToolsFilter =

--- a/server/internal/assistants/source_adapter_dashboard.go
+++ b/server/internal/assistants/source_adapter_dashboard.go
@@ -65,8 +65,27 @@ Only link an entity when you actually have its id from a tool result, and the li
 		"\n### Chart code blocks\n\n" +
 		elementsChartPrompt +
 		"\n### Generative UI code blocks\n\n" +
-		elementsGenerativeUIPrompt
+		elementsGenerativeUIPrompt +
+		"\n\n" + dashboardToolCallNarrationRule
 }
+
+// Appended last in OutputChannelGuidance so it lands closest to the model's
+// generation point — the Elements prompts above are long, and this rule must
+// not get lost in the middle of them.
+const dashboardToolCallNarrationRule = `## Narrating tool calls
+
+Every time you are about to call tools — even a single tool — the text you emit alongside must be EXACTLY ONE activity phrase and nothing else. The dashboard promotes the phrase to the tool-group heading ONLY when it matches this contract; anything else renders as stray prose and breaks the UX:
+
+- Starts with a present-participle verb phrase: "Investigating…", "Comparing…", "Deep diving…"
+- 3 to 8 words, one line, under 90 characters
+- No first person (never "I", "let me", "we"), no tool names, no Markdown or backticks, no periods
+
+Good: "Aggregating token spend server-side"
+Good: "Retrying via metrics surfaces"
+Bad: "That returned huge payloads. Let me aggregate compactly server-side." (narrated prose — never do this)
+Bad: "The log-search endpoint returned an empty page, so pulling metrics instead" (commentary, not a phrase)
+
+When a tool result changes your plan or fails, do NOT narrate the setback — just write a fresh activity phrase for the new approach and call the next tools. If a later batch continues the same goal, write nothing between the calls. Save ALL prose, explanations, tables, and widgets for your final answer after the tool results are in.`
 
 // ChatID: the dashboard's correlation key already IS the server-minted chat id
 // (round-tripped by the client). Use it directly; fall back to a deterministic


### PR DESCRIPTION
## What

Claude-style tool-call narration for the in-dashboard project assistant: the assistant emits a terse activity phrase ("Investigating failures in the last 30 days") before each tool batch, and the chat UI renders that phrase as the heading of a collapsed tool group instead of showing raw tool cards and narration prose.

Replaces the summarize-per-tool-call approach from #4823 with the annotation approach discussed in Slack: the text block that accompanies tool calls _is_ the summary — no extra LLM invocation, heading renders the moment the tool call fires.

## How

**Server** (`source_adapter_dashboard.go`): a narration rule appended to the dashboard output-channel guidance — one present-participle phrase (3–8 words, no first person, no tool names, no Markdown) before every tool batch, with good/bad examples; setbacks get a fresh phrase, never prose. Appended last so it sits closest to the generation point after the long Elements prompts.

**Elements chat UI**:

- `lib/toolCallAnnotation.ts` — strict shape gate for promoting text to a heading (≤100 chars, single line, present-participle opener, no sentence/Markdown punctuation) so stray commentary stays prose; trailing-line extraction for mixed prose+phrase blocks.
- `lib/messagePartGrouping.ts` + `MessagePrimitive.Unstable_PartsGrouped` — a whole run of tool calls (including interleaved annotations) coalesces into **one** group, so multi-step investigations render as a single block whose heading advances with the latest annotation instead of one box per batch. Reasoning runs keep their existing grouped rendering.
- `ToolGroup` — always renders a header (doing-phrase fallbacks like "Running 3 tools..." when the model gave none); stays in running/shimmer state while it is the trailing content of a streaming message, so the next heading replaces the old one under shimmer instead of snapping from a done state.
- `ToolUIGroup` — collapsed by default (removed the auto-expand on gaining a header mid-stream); bare grey heading line with a right chevron, border chrome only around the expanded tool list.
- `ThinkingIndicator` — hidden while a trailing tool group is streaming; exactly one loading affordance is visible at any time.

The annotation's prose render is suppressed once its tool call arrives (`TextMessagePartProvider` override for mixed blocks, since `MarkdownText` reads from part context).

## Testing

- Exercised end to end against the local stack (new chats in the project assistant side panel + full-page chat) across several multi-batch investigations.
- `pnpm -F dashboard type-check`, `pnpm -F dashboard lint`, `mise lint:server` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Claude‑style activity phrases for project assistant tool calls and group consecutive runs into one collapsed block with a live‑updating heading. Adds server guidance to emit the phrase before each batch and simplifies loaders in the chat UI.

- New Features
  - Assistant emits a short activity phrase before each tool batch; the UI promotes it to the tool group header (no extra model call).
  - Consecutive tool runs merge into one group; the header updates as new phrases arrive and shimmers while streaming, with fallbacks when no phrase is present.
  - Tool groups are collapsed by default; the global thinking indicator hides while a trailing tool group is streaming so only one loader shows.
  - Strict phrase gating and prose suppression: only single‑line present‑participle phrases become headers; trailing annotation lines are extracted and not duplicated in prose. Server output guidance enforces 3–8 words, no first person, no tool names, no punctuation/Markdown.

- Migration
  - If you override `ToolGroup` in `ComponentOverrides`, update the prop to `{ indices: number[] }` (replaces `startIndex`/`endIndex`).
  - Tool groups no longer auto‑expand when a header appears mid‑stream; they start collapsed unless `expandToolGroupsByDefault` is true.

<sup>Written for commit fb948292678bf58cb31aea979d8fc15c417affa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

