### PR TITLE
fix: URL-encode OAuth client credentials in client_secret_basic requests

### DIFF
--- a/.changeset/oauth-basic-auth-credential-encoding.md
+++ b/.changeset/oauth-basic-auth-credential-encoding.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix OAuth token exchanges failing with invalid_client against providers that strictly decode HTTP Basic credentials (e.g. Snowflake): client id and secret are now form-urlencoded before being placed in the Authorization header, per RFC 6749 §2.3.1.

--- a/server/internal/assistants/mcp_auth_handler.go
+++ b/server/internal/assistants/mcp_auth_handler.go
@@ -421,7 +421,10 @@ func (s *Service) consumeMCPAuthGrant(ctx context.Context, claims *assistanttoke
 		return fmt.Errorf("build token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(claims.ClientID, clientSecret)
+	// RFC 6749 §2.3.1: client credentials must be form-urlencoded before
+	// going into the Basic authorization header. Upstreams that decode per
+	// spec (e.g. Snowflake) reject raw credentials containing '+' or '%'.
+	req.SetBasicAuth(url.QueryEscape(claims.ClientID), url.QueryEscape(clientSecret))
 	resp, err := s.core.guardianPolicy.Client(guardian.WithDefaultRetryConfig()).Do(req)
 	if err != nil {
 		return fmt.Errorf("send token request: %w", err)

--- a/server/internal/gateway/security.go
+++ b/server/internal/gateway/security.go
@@ -444,7 +444,10 @@ func retryTokenRequestWithBasicAuth(ctx context.Context, client *guardian.HTTPCl
 	}
 
 	retryReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	retryReq.SetBasicAuth(clientID, clientSecret)
+	// RFC 6749 §2.3.1: client credentials must be form-urlencoded before
+	// going into the Basic authorization header. Upstreams that decode per
+	// spec (e.g. Snowflake) reject raw credentials containing '+' or '%'.
+	retryReq.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
 
 	resp, err := client.Do(retryReq)
 	if err != nil {

--- a/server/internal/oauth/providers/custom.go
+++ b/server/internal/oauth/providers/custom.go
@@ -202,7 +202,10 @@ func (p *CustomProvider) ExchangeToken(
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	if useBasicAuth {
-		req.SetBasicAuth(clientID, clientSecret)
+		// RFC 6749 §2.3.1: client credentials must be form-urlencoded before
+		// going into the Basic authorization header. Upstreams that decode per
+		// spec (e.g. Snowflake) reject raw credentials containing '+' or '%'.
+		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
 	}
 
 	tokenResp, err := http.DefaultClient.Do(req)
@@ -284,7 +287,10 @@ func (p *CustomProvider) RefreshToken(
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	if useBasicAuth {
-		req.SetBasicAuth(clientID, clientSecret)
+		// RFC 6749 §2.3.1: client credentials must be form-urlencoded before
+		// going into the Basic authorization header. Upstreams that decode per
+		// spec (e.g. Snowflake) reject raw credentials containing '+' or '%'.
+		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
 	}
 
 	tokenResp, err := http.DefaultClient.Do(req)

--- a/server/internal/oauth/providers/custom_test.go
+++ b/server/internal/oauth/providers/custom_test.go
@@ -74,11 +74,12 @@ func TestCustomProvider_RefreshToken_NoRotation(t *testing.T) {
 func TestCustomProvider_RefreshToken_BasicAuth(t *testing.T) {
 	t.Parallel()
 
-	var gotAuth string
+	var gotUser, gotPass string
+	var gotOK bool
 	var formHasClientID bool
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
+		gotUser, gotPass, gotOK = r.BasicAuth()
 		_ = r.ParseForm()
 		_, formHasClientID = r.PostForm["client_id"]
 
@@ -92,12 +93,15 @@ func TestCustomProvider_RefreshToken_BasicAuth(t *testing.T) {
 
 	prov := baseProvider(srv.URL + "/token")
 	prov.TokenEndpointAuthMethodsSupported = []string{"client_secret_basic"}
+	prov.Secrets = []byte(`{"client_id":"ab+cd/ef=","client_secret":"s+e/c=="}`)
 
 	_, err := newProvider(t).RefreshToken(t.Context(), "rt", prov, &toolsets_repo.Toolset{})
 	require.NoError(t, err)
 
-	require.Contains(t, gotAuth, "Basic ", "should use Basic auth header")
+	require.True(t, gotOK, "should use Basic auth header")
 	require.False(t, formHasClientID, "client_id should NOT be in form body for basic auth")
+	require.Equal(t, "ab%2Bcd%2Fef%3D", gotUser, "client_id must be form-urlencoded per RFC 6749 §2.3.1")
+	require.Equal(t, "s%2Be%2Fc%3D%3D", gotPass, "client_secret must be form-urlencoded per RFC 6749 §2.3.1")
 }
 
 func TestCustomProvider_RefreshToken_PostAuth(t *testing.T) {

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -77,7 +77,10 @@ func newTokenEndpointRequest(ctx context.Context, endpoint string, form url.Valu
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 	if method == TokenEndpointAuthMethodBasic {
-		req.SetBasicAuth(clientID, clientSecret)
+		// RFC 6749 §2.3.1: client credentials must be form-urlencoded before
+		// going into the Basic authorization header. Upstreams that decode per
+		// spec (e.g. Snowflake) reject raw credentials containing '+' or '%'.
+		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
 	}
 	return req, nil
 }

--- a/server/internal/remotesessions/tokenservice_credentials_internal_test.go
+++ b/server/internal/remotesessions/tokenservice_credentials_internal_test.go
@@ -1,0 +1,31 @@
+// tokenservice_credentials_internal_test.go verifies that client credentials
+// are form-urlencoded before entering the Basic authorization header (RFC
+// 6749 §2.3.1). White-box so the shared request builder is exercised directly.
+
+package remotesessions
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTokenEndpointRequest_BasicAuthEncodesCredentials(t *testing.T) {
+	t.Parallel()
+
+	req, err := newTokenEndpointRequest(
+		t.Context(),
+		"https://idp.example.com/token",
+		url.Values{},
+		TokenEndpointAuthMethodBasic,
+		"ab+cd/ef=",
+		"s+e/c==",
+	)
+	require.NoError(t, err)
+
+	user, pass, ok := req.BasicAuth()
+	require.True(t, ok)
+	require.Equal(t, "ab%2Bcd%2Fef%3D", user, "client_id must be form-urlencoded per RFC 6749 §2.3.1")
+	require.Equal(t, "s%2Be%2Fc%3D%3D", pass, "client_secret must be form-urlencoded per RFC 6749 §2.3.1")
+}


### PR DESCRIPTION
## Summary

- Form-urlencode `client_id` and `client_secret` before placing them in the Basic authorization header at every OAuth token-endpoint call site, per RFC 6749 §2.3.1 (matching `golang.org/x/oauth2`): `oauth/providers/custom.go` (ExchangeToken + RefreshToken), `remotesessions/tokenservice.go` (newTokenEndpointRequest), `assistants/mcp_auth_handler.go` (consumeMCPAuthGrant), `gateway/security.go` (retryTokenRequestWithBasicAuth).
- Upstreams that decode credentials per spec (e.g. Snowflake) URL-decode each half of the header after splitting, so a raw credential containing `+` arrives mangled and the exchange fails with `invalid_client`. Confirmed live against a Snowflake custom OAuth security integration.
- For credentials without reserved characters the encoding is a byte-for-byte no-op, so working integrations are unaffected. The tradeoff for a non-decoding upstream whose credentials contain reserved characters is the same one x/oauth2 makes ecosystem-wide.
- Deliberately unchanged: `gateway/security.go` tool basic auth, `marketplace/handler.go`, and `thirdparty/cursor/client.go` — those are generic RFC 7617 basic auth, not OAuth client credentials, where raw is correct.
- Tests assert the encoded header at the two central builders (custom provider refresh, remotesessions token request) using credentials containing `+ / =`.

Closes [DNO-744](https://linear.app/speakeasy/issue/DNO-744/fix-url-encode-oauth-client-credentials-in-client-secret-basic-token)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Form-urlencoded the OAuth `client_id` and `client_secret` before placing them in the Basic auth header for `client_secret_basic` token requests, per RFC 6749 §2.3.1. This prevents `invalid_client` errors with strict providers like Snowflake and matches `golang.org/x/oauth2`.

- **Bug Fixes**
  - Encode credentials in: `oauth/providers/custom.go` (ExchangeToken, RefreshToken), `remotesessions/tokenservice.go` (builder), `assistants/mcp_auth_handler.go`, and `gateway/security.go` (retry path).
  - Left generic RFC 7617 Basic auth untouched for non-OAuth uses.
  - Added tests to assert encoded headers with `+ / =` characters.

Satisfies Linear DNO-744.

<sup>Written for commit d863366ac6b09dcdcb7e090123ee5acc96abf348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

