### PR TITLE
fix(risk): cap sync gating enforcement scans at 1s (DNO-745)

### DIFF
--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -37,6 +37,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
 )
 
+// enforcementScanBudget caps wall time for blocking risk scans on the sync
+// hooks path (canonical ingest / classic hooks). Matches the documented gating
+// evaluation deadline (~1s). OpenRouter PI judges still carry a longer per-call
+// timeout for async batch work; the earlier deadline wins when nested.
+// Exceeding this fails open (allow) via the hooks ingest path.
+var enforcementScanBudget = time.Second
+
 // RiskScanner checks text against blocking risk policies.
 type RiskScanner interface {
 	// ScanForEnforcement scans text against enabled blocking policies that
@@ -44,6 +51,7 @@ type RiskScanner interface {
 	// targeted policies require a matching risk_policy:evaluate grant.
 	// toolName is the tool-call name for tool_request/tool_response messages
 	// ("" otherwise); it is surfaced to prompt-based policies.
+	// Bounded by enforcementScanBudget (~1s); a shorter parent deadline still wins.
 	ScanForEnforcement(ctx context.Context, organizationID string, projectID uuid.UUID, userID string, text string, messageType message.Type, toolName string) (*ScanResult, error)
 	// LookupShadowMCPBlockingPolicy returns the first enabled shadow-MCP
 	// policy that applies to the given user. Returns nil when no such policy
@@ -254,6 +262,12 @@ func (s *Scanner) ScanForEnforcement(
 		return nil, nil
 	}
 
+	// Cap sync-path scanners (Presidio, OpenRouter PI, prompt-policy judges)
+	// so a slow model call cannot hold the gating RPC for multi-seconds.
+	// Parent contexts with a tighter deadline still win.
+	ctx, cancel := context.WithTimeout(ctx, enforcementScanBudget)
+	defer cancel()
+
 	// Root span for the scan as a unit of work: gitleaks/presidio/judge spans
 	// spawned downstream (through gctx) attribute under this span and its
 	// per-policy children instead of dangling as siblings of the RPC span.
@@ -399,6 +413,14 @@ func (s *Scanner) ScanForEnforcement(
 		// separately in dashboards/metrics and don't inflate the block count.
 		s.recordScan(ctx, projectID.String(), "warned", time.Since(start))
 		return hit, nil
+	}
+
+	// Scanners often fail open on their own deadline (e.g. PI → SAFE with no
+	// error). Surface expiry so hooks fail-open explicitly and metrics record
+	// failure instead of a false clean allow.
+	if err := ctx.Err(); err != nil {
+		s.recordScan(ctx, projectID.String(), o11y.OutcomeFailure, time.Since(start))
+		return nil, fmt.Errorf("enforcement scan deadline exceeded: %w", err)
 	}
 
 	s.recordScan(ctx, projectID.String(), o11y.OutcomeSuccess, time.Since(start))

--- a/server/internal/risk/scanner_budget_internal_test.go
+++ b/server/internal/risk/scanner_budget_internal_test.go
@@ -1,0 +1,15 @@
+package risk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnforcementScanBudgetMatchesGatingDeadline(t *testing.T) {
+	t.Parallel()
+	// Sync gating monitor documents an ~1s evaluation deadline; keep the
+	// ScanForEnforcement cap aligned with that (not the PI judge's 10s window).
+	require.Equal(t, time.Second, enforcementScanBudget)
+}

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -268,6 +268,49 @@ func TestScanner_FanOutAcrossPoliciesIsConcurrent(t *testing.T) {
 		"wall time %v >= half-of-sequential %v — fan-out not happening", elapsed, maxAllowed)
 }
 
+// TestScanner_ScanForEnforcement_RespectsDeadline verifies that a slow scanner
+// cannot hold the sync enforcement path past the context deadline. Production
+// applies a ~1s enforcementScanBudget via WithTimeout; a shorter parent
+// deadline still wins, which is what this test exercises without waiting a
+// full second.
+func TestScanner_ScanForEnforcement_RespectsDeadline(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+	insertPresidioBlockPolicy(t, ti, ctx, "slow-pii", []string{"EMAIL_ADDRESS"})
+
+	pii := &instrumentedPIIScanner{delay: 2 * time.Second}
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		newTestCustomRuleAnalyzer(t, ti.conn),
+		pii,
+		nil,
+		nil,
+		nil,
+		testCELEngine(t),
+	)
+	require.NoError(t, err)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	deadlineCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	result, err := scanner.ScanForEnforcement(deadlineCtx, authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "reach me at user@example.com", message.User, "")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "enforcement scan deadline exceeded")
+	require.Nil(t, result)
+	require.Less(t, elapsed, 500*time.Millisecond,
+		"scan should abort near the deadline, not wait for the 2s Presidio delay")
+	require.Positive(t, pii.cancellations.Load(),
+		"Presidio AnalyzeBatch should observe context cancellation")
+}
+
 func TestScanner_ScanForEnforcement_SkipsGrantResolutionWhenNoPolicies(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestRiskService(t)

--- a/server/internal/scanners/promptinjection/openrouter/judge.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	// judgeTimeout bounds a single judge completion call. The judge runs inline
-	// on the realtime hook path, so this is also the worst-case added latency
-	// before a fail-open allow on a stuck model.
+	// judgeTimeout bounds a single judge completion call. Async batch analysis
+	// and streams can use the full window. Sync hooks enforcement nests this
+	// under risk.ScanForEnforcement's ~1s budget, so the earlier deadline wins
+	// and a stuck model cannot hold gating for the full 10s.
 	judgeTimeout = 10 * time.Second
 	// defaultModel is the prompt-injection judge. Gemini 3.1 Flash Lite, chosen from a
 	// multi-model sweep over real speakeasy-team traffic (POC-193). On the


### PR DESCRIPTION
## Summary

Investigates and mitigates [AIS-535](https://linear.app/speakeasy/issue/AIS-535/investigation-gating-p95-latency-has-trended-up) (gating p95 latency trending up).

Sync gating on canonical hook events (`tool.requested`, `prompt.submitted`) was spending multi-seconds inside `risk.ScanForEnforcement` → OpenRouter prompt-injection classify. Classic Claude hook events stayed \~15–20ms; scanned canonical events drove the dashboard spikes (p99 multi-second).

## Fix

* Apply a **1s** `context.WithTimeout` in `ScanForEnforcement` (documented gating evaluation deadline). Nested parent deadlines still win.
* When the deadline expires with no block/warn match, return an error so hooks **fail open** (existing ingest behavior) and metrics record failure instead of a false clean allow.
* Clarify that the PI judge’s 10s timeout is for async/batch; sync enforcement is capped by this budget.
* Tests: budget constant = 1s; slow Presidio path aborts near a short deadline and cancels in-flight AnalyzeBatch.

## Investigation notes (Datadog)

* Metric: `hooks.event.duration` (dashboard Hooks & Otel Ingestion)
* Drivers: `tool.requested` / `prompt.submitted` with `risk_scanned:true`; onset \~ mid-July when canonical ingest + PI enforcement volume rose
* Slow traces dominated by `risk.prompt_injection.classify` → OpenRouter chat completions (often \~2.5–3.6s when successful)
* No customer identifiers in this PR

## Linear

Could not comment on [AIS-535](https://linear.app/speakeasy/issue/AIS-535/investigation-gating-p95-latency-has-trended-up) from this environment (Linear MCP unauthenticated). Please paste findings onto the issue when reviewing.

## Test plan

- [X] `go test ./server/internal/risk/ -run 'TestScanner_ScanForEnforcement|TestScanner_FanOut|TestEnforcementScanBudget'`
- [X] `mise run lint:server`
- [ ] After deploy: confirm `hooks.event.duration` p95/p99 for scanned canonical events stay near ≤1s (fail-open on timeout) rather than multi-second successful judge calls

Linear Issue: [AIS-535](https://linear.app/speakeasy/issue/AIS-535/investigation-gating-p95-latency-has-trended-up)

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

---

## Summary by cubic

Cap sync gating enforcement scans to a 1s budget in `risk.ScanForEnforcement` to stop multi-second delays from OpenRouter PI classify and bring p95/p99 back in line ([AIS-535](https://linear.app/speakeasy/issue/AIS-535/investigation-gating-p95-latency-has-trended-up)). On timeout, we fail open and record a failure; shorter parent deadlines still win.

* **Bug Fixes**
  * Add a 1s `context.WithTimeout` in `ScanForEnforcement`; return an error on deadline to fail open and record failure.
  * Clarify that the 10s OpenRouter judge timeout is for async/batch; sync enforcement is capped by the 1s budget.
  * Add tests for the budget and cancellation behavior to keep the gating deadline aligned with docs.

Written for commit 54789ce8cf702942634ce9c64585d78ba6ffb705. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)