### PR TITLE
fix: harden token revocation, playground link handling, and dependency

### DIFF
--- a/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
@@ -503,6 +503,9 @@ async function handleIframeRequest(init: {
         if (!url) {
           return err(message.id, -32602, "Missing URL");
         }
+        if (!isSafeExternalUrl(url)) {
+          return err(message.id, -32602, "Unsupported URL");
+        }
         window.open(url, "_blank", "noopener,noreferrer");
         return ok(message.id, {});
       }
@@ -569,6 +572,18 @@ async function requestMcpJsonRpc<T>(
   }
 
   return payload.result as T;
+}
+
+// Links surfaced by an embedded MCP app are untrusted input; only allow
+// navigation to web URLs so a frame cannot open javascript:, file:, or
+// arbitrary custom-scheme links from the host page.
+function isSafeExternalUrl(raw: string): boolean {
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
 }
 
 function ok(id: JsonRpcId, result: unknown): JsonRpcResponse {

--- a/server/internal/mcp/authnchallenge_revoke.go
+++ b/server/internal/mcp/authnchallenge_revoke.go
@@ -54,10 +54,12 @@ func (s *Service) HandleRevoke(w http.ResponseWriter, r *http.Request) error {
 //     unified revocation cache so the still-live access token is invalidated
 //     too.
 //   - If `token_type_hint=access_token` (or the hint is missing and the
-//     token parses as a JWT): extract the jti without verifying the
-//     signature -- the client_secret check above establishes authenticity --
-//     and push it into the revocation cache. We do NOT have to find a
-//     matching user_sessions row to honour the request.
+//     token parses as a JWT): verify our HS256 signature (tolerating expiry),
+//     extract the jti, and — when the signed token's user_sessions row belongs
+//     to the authenticated client — push the jti into the revocation cache.
+//     Signature verification is required because public clients present no
+//     client_secret, so holding a validly-signed token is what proves the
+//     caller may revoke it.
 func (s *Service) ServeRevoke(w http.ResponseWriter, r *http.Request, endpoint *ResolvedMcpEndpoint) error {
 	ctx := r.Context()
 
@@ -136,17 +138,18 @@ func (s *Service) ServeRevoke(w http.ResponseWriter, r *http.Request, endpoint *
 	return nil
 }
 
-// tryRevokeAccessToken parses the token as a JWT, looks up the
-// user_sessions row by jti, and — when the row belongs to the
-// authenticated client — pushes the jti into the revocation cache.
-// Signature verification on the JWT is intentionally skipped; the
-// client_secret check in HandleRevoke establishes authenticity per RFC
-// 7009 §2.1. Returns true only when the row was found AND owned by the
-// caller; ownership mismatches return false so the dispatch falls through
-// to the refresh-token attempt (and ultimately surfaces as the success
-// silent-no-op per §2.2).
+// tryRevokeAccessToken parses the token as a JWT (verifying our HS256
+// signature, but tolerating expired claims so stale tokens can still be
+// revoked), looks up the user_sessions row by jti, and — when the row
+// belongs to the authenticated client — pushes the jti into the revocation
+// cache. Signature verification matters here: public clients present no
+// client_secret, so holding a validly-signed token is what proves the
+// caller may revoke it. Returns true only when the row was found AND owned
+// by the caller; ownership mismatches return false so the dispatch falls
+// through to the refresh-token attempt (and ultimately surfaces as the
+// success silent-no-op per RFC 7009 §2.2).
 func (s *Service) tryRevokeAccessToken(ctx context.Context, logger *slog.Logger, issuerID, clientID uuid.UUID, token string) bool {
-	jti, err := s.userSessionSigner.ParseUnverifiedJTI(token)
+	jti, err := s.userSessionSigner.VerifiedJTI(token)
 	if err != nil || jti == "" {
 		return false
 	}

--- a/server/internal/usersessions/jwt.go
+++ b/server/internal/usersessions/jwt.go
@@ -146,7 +146,7 @@ func (s *Signer) Validate(token, expectedAudience string) (*SessionClaims, error
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return s.key, nil
-	}, jwt.WithAudience(expectedAudience))
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}), jwt.WithAudience(expectedAudience))
 	if err != nil {
 		return nil, fmt.Errorf("validate token: %w", err)
 	}
@@ -202,12 +202,13 @@ func (s *Signer) ValidateBearer(ctx context.Context, token, expectedAudience str
 	return ValidatedSession{Subject: subject, JTI: claims.ID, ClientID: claims.ClientID}, nil
 }
 
-// ParseUnverifiedJTI extracts the `jti` claim from a token without verifying
-// the signature. Used by /revoke to push the JTI into the revocation cache —
-// the token's authenticity is established by the client_secret check in the
-// revoke handler, not by signature verification (RFC 7009 doesn't require it).
-func (s *Signer) ParseUnverifiedJTI(token string) (string, error) {
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+// VerifiedJTI extracts the `jti` claim from a token after verifying its
+// signature. Used by /revoke to push the JTI into the revocation cache.
+// Claims validation (expiry etc.) is deliberately skipped so an expired
+// token can still be revoked, but the signature must be ours: for public
+// clients the client_secret check does not apply, so signature verification
+// is what proves the caller actually holds the token being revoked.
+func (s *Signer) VerifiedJTI(token string) (string, error) {
 	claims := SessionClaims{RegisteredClaims: jwt.RegisteredClaims{
 		Issuer:    "",
 		Subject:   "",
@@ -217,8 +218,14 @@ func (s *Signer) ParseUnverifiedJTI(token string) (string, error) {
 		IssuedAt:  nil,
 		ID:        "",
 	}, ClientID: ""}
-	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
-		return "", fmt.Errorf("parse unverified token: %w", err)
+	_, err := jwt.ParseWithClaims(token, &claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return s.key, nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}), jwt.WithoutClaimsValidation())
+	if err != nil {
+		return "", fmt.Errorf("parse token: %w", err)
 	}
 	if claims.ID == "" {
 		return "", errors.New("token missing jti claim")

--- a/server/internal/usersessions/jwt_test.go
+++ b/server/internal/usersessions/jwt_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -85,4 +86,94 @@ func TestSigner_MintWithoutClientIDOmitsClaim(t *testing.T) {
 	session, err := signer.ValidateBearer(t.Context(), token, "aud", neverRevoked{})
 	require.NoError(t, err)
 	require.Empty(t, session.ClientID)
+}
+
+// forgeHSToken hand-mints a token with the given signing method, key, and jti,
+// bypassing Signer.Mint so tests can produce tokens an attacker would try
+// (wrong key, alg confusion, alg=none).
+func forgeHSToken(t *testing.T, method jwt.SigningMethod, key []byte, jti string) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(method, jwt.RegisteredClaims{ID: jti})
+	signed, err := tok.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+// TestSigner_VerifiedJTI is the security contract behind token revocation:
+// only a token bearing our valid HS256 signature yields its jti. A forged or
+// wrong-key token must be rejected, so a public client (which presents no
+// client_secret) cannot revoke another session using a guessed/leaked jti.
+func TestSigner_VerifiedJTI(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-jwt-secret"
+	signer := usersessions.NewSigner(secret)
+
+	mint := func(lifetime time.Duration) (token, jti string) {
+		token, jti, err := signer.Mint(usersessions.MintParams{
+			Subject:  urn.NewUserSubject("user-1"),
+			Audience: "aud",
+			Issuer:   "https://example.test/mcp/slug",
+			Lifetime: lifetime,
+			ClientID: "client-abc",
+		})
+		require.NoError(t, err)
+		return token, jti
+	}
+
+	t.Run("valid token yields jti", func(t *testing.T) {
+		t.Parallel()
+		token, jti := mint(time.Hour)
+		got, err := signer.VerifiedJTI(token)
+		require.NoError(t, err)
+		require.Equal(t, jti, got)
+	})
+
+	t.Run("expired token still yields jti", func(t *testing.T) {
+		t.Parallel()
+		// Revocation must work on stale tokens — that is the whole point of
+		// skipping claims validation while keeping signature verification.
+		token, jti := mint(-time.Hour)
+		got, err := signer.VerifiedJTI(token)
+		require.NoError(t, err)
+		require.Equal(t, jti, got)
+	})
+
+	t.Run("wrong signing key is rejected", func(t *testing.T) {
+		t.Parallel()
+		forged := forgeHSToken(t, jwt.SigningMethodHS256, []byte("attacker-secret"), "victim-jti")
+		_, err := signer.VerifiedJTI(forged)
+		require.Error(t, err)
+	})
+
+	t.Run("alg=none is rejected", func(t *testing.T) {
+		t.Parallel()
+		tok := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.RegisteredClaims{ID: "victim-jti"})
+		unsigned, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		require.NoError(t, err)
+		_, err = signer.VerifiedJTI(unsigned)
+		require.Error(t, err)
+	})
+
+	t.Run("HS384 with the signing key is rejected (exact alg pinning)", func(t *testing.T) {
+		t.Parallel()
+		// Even signed with our real secret, a non-HS256 algorithm must not pass:
+		// method pinning is what stops an attacker steering the verifier.
+		forged := forgeHSToken(t, jwt.SigningMethodHS384, []byte(secret), "victim-jti")
+		_, err := signer.VerifiedJTI(forged)
+		require.Error(t, err)
+	})
+
+	t.Run("token missing jti is rejected", func(t *testing.T) {
+		t.Parallel()
+		forged := forgeHSToken(t, jwt.SigningMethodHS256, []byte(secret), "")
+		_, err := signer.VerifiedJTI(forged)
+		require.Error(t, err)
+	})
+
+	t.Run("garbage is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := signer.VerifiedJTI("not-a-jwt")
+		require.Error(t, err)
+	})
 }

--- a/uv.lock
+++ b/uv.lock
@@ -38,14 +38,14 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.1"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fixes [SEC-42](https://linear.app/speakeasy/issue/SEC-42)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens token revocation and MCP playground open-link handling to address SEC-42. We now verify HS256 signatures before using JWT jti and only allow http/https links; added tests and bumped `anyio`.

- **Bug Fixes**
  - Revoke: verify HS256 signature (exact alg pinning) before extracting jti, tolerate expired tokens, and revoke only when the session belongs to the authenticated client.
  - JWT: add VerifiedJTI and pin HS256 in Validate; tests cover valid, expired, wrong-key, alg=none/HS384, missing-jti, and malformed tokens.
  - Playground: allowlist http/https before `window.open` for MCP `ui/open-link`.

- **Dependencies**
  - Bumped `anyio` from 4.14.1 to 4.14.2.

<sup>Written for commit 3eda4646bf48a632cb18f47866e7dbe41d448406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

