### PR TITLE
chore(deps): ignore mcp-setup-docs go module in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Bumped on release by speakeasy-api/mcp-setup-docs (go-module-consumer-bump).
+      - dependency-name: "github.com/speakeasy-api/mcp-setup-docs/go"
     groups:
       otel:
         patterns:


### PR DESCRIPTION
## Summary

Adds an `ignore` entry to the `gomod` Dependabot update for `github.com/speakeasy-api/mcp-setup-docs/go`.

That module is now bumped here by its own repo. `speakeasy-api/mcp-setup-docs` gained a `go-module-consumer-bump` workflow that fires on every `go/vX.Y.Z` tag and opens/refreshes a PR on this repo (branch `chore/bump-mcp-setup-docs-go`) with the new pin. Without this ignore, Dependabot opens a competing PR for the same module. This leaves one owner for the bump.

## Notes

- Only `.github/dependabot.yml` changes. `go.mod` and `go.sum` are untouched.
- The ignore also suppresses Dependabot security updates for that module. That is acceptable: the module declares no dependencies of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Dependabot updates for `github.com/speakeasy-api/mcp-setup-docs/go` to prevent duplicate bump PRs. The `speakeasy-api/mcp-setup-docs` repo now auto-opens a bump PR here on each `go/vX.Y.Z` release.

- **Dependencies**
  - Added an `ignore` rule in `.github/dependabot.yml`; no changes to `go.mod` or `go.sum`.
  - Security updates for this module are also ignored; safe since it has no dependencies.

<sup>Written for commit 2e50509febdf8604237499bdb01e7839e94fd94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

