### PR TITLE
feat: add MS Teams assistant trigger

### DIFF
--- a/.changeset/msteams-trigger.md
+++ b/.changeset/msteams-trigger.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add Microsoft Teams as an assistant trigger source. Bot Framework activities (messages, reactions, membership and installation updates) posted to a trigger webhook are verified against Microsoft's signing keys and dispatched to assistants with the same filtering (event type allowlist + CEL) as other webhook triggers.

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -49,6 +49,7 @@ const (
 	StatusPaused = "paused"
 
 	sourceKindSlack     = bgtriggers.DefinitionSlugSlack
+	sourceKindMSTeams   = bgtriggers.DefinitionSlugMSTeams
 	sourceKindLinear    = bgtriggers.DefinitionSlugLinear
 	sourceKindGithub    = bgtriggers.DefinitionSlugGithub
 	sourceKindCron      = bgtriggers.DefinitionSlugCron
@@ -1960,8 +1961,16 @@ func (s *ServiceCore) CheckDashboardChatOwnership(ctx context.Context, projectID
 }
 
 func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, []byte, error) {
+	sourcePayloadJSON := task.RawPayload
+	if !json.Valid(sourcePayloadJSON) {
+		wrapped, err := json.Marshal(map[string]string{"raw": string(task.RawPayload)})
+		if err != nil {
+			return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
+		}
+		sourcePayloadJSON = wrapped
+	}
 	switch task.DefinitionSlug {
-	case "slack":
+	case sourceKindSlack:
 		var event slackEventPayload
 		if err := json.Unmarshal(task.EventJSON, &event); err != nil {
 			return "", nil, nil, nil, fmt.Errorf("decode slack trigger event: %w", err)
@@ -1978,14 +1987,22 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 		if err != nil {
 			return "", nil, nil, nil, fmt.Errorf("marshal slack source ref: %w", err)
 		}
-		sourcePayloadJSON := task.RawPayload
-		if !json.Valid(sourcePayloadJSON) {
-			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
-			if err != nil {
-				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
-			}
-		}
 		return sourceKindSlack, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
+	case sourceKindMSTeams:
+		var event msteamsEventPayload
+		if err := json.Unmarshal(task.EventJSON, &event); err != nil {
+			return "", nil, nil, nil, fmt.Errorf("decode msteams trigger event: %w", err)
+		}
+		sourceRefJSON, err := json.Marshal(msteamsSourceRef{
+			TenantID:       event.TenantID,
+			ConversationID: event.ConversationID,
+			ServiceURL:     event.ServiceURL,
+			UserID:         event.UserID,
+		})
+		if err != nil {
+			return "", nil, nil, nil, fmt.Errorf("marshal msteams source ref: %w", err)
+		}
+		return sourceKindMSTeams, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	case sourceKindLinear:
 		var event linearEventPayload
 		if err := json.Unmarshal(task.EventJSON, &event); err != nil {
@@ -1997,13 +2014,6 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 		})
 		if err != nil {
 			return "", nil, nil, nil, fmt.Errorf("marshal linear source ref: %w", err)
-		}
-		sourcePayloadJSON := task.RawPayload
-		if !json.Valid(sourcePayloadJSON) {
-			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
-			if err != nil {
-				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
-			}
 		}
 		return sourceKindLinear, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	case sourceKindGithub:
@@ -2019,13 +2029,6 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 		if err != nil {
 			return "", nil, nil, nil, fmt.Errorf("marshal github source ref: %w", err)
 		}
-		sourcePayloadJSON := task.RawPayload
-		if !json.Valid(sourcePayloadJSON) {
-			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
-			if err != nil {
-				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
-			}
-		}
 		return sourceKindGithub, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	case sourceKindCron:
 		var event cronEventPayload
@@ -2038,13 +2041,6 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 		})
 		if err != nil {
 			return "", nil, nil, nil, fmt.Errorf("marshal cron source ref: %w", err)
-		}
-		sourcePayloadJSON := task.RawPayload
-		if !json.Valid(sourcePayloadJSON) {
-			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
-			if err != nil {
-				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
-			}
 		}
 		return sourceKindCron, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	case sourceKindWake:
@@ -2059,13 +2055,6 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 		if err != nil {
 			return "", nil, nil, nil, fmt.Errorf("marshal wake source ref: %w", err)
 		}
-		sourcePayloadJSON := task.RawPayload
-		if !json.Valid(sourcePayloadJSON) {
-			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
-			if err != nil {
-				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
-			}
-		}
 		return sourceKindWake, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	case sourceKindDashboard:
 		var event dashboardEventPayload
@@ -2075,13 +2064,6 @@ func buildAssistantEventPayload(task bgtriggers.Task) (string, []byte, []byte, [
 		sourceRefJSON, err := json.Marshal(dashboardSourceRef{UserID: event.UserID})
 		if err != nil {
 			return "", nil, nil, nil, fmt.Errorf("marshal dashboard source ref: %w", err)
-		}
-		sourcePayloadJSON := task.RawPayload
-		if !json.Valid(sourcePayloadJSON) {
-			sourcePayloadJSON, err = json.Marshal(map[string]string{"raw": string(task.RawPayload)})
-			if err != nil {
-				return "", nil, nil, nil, fmt.Errorf("marshal fallback source payload: %w", err)
-			}
 		}
 		return sourceKindDashboard, sourceRefJSON, task.EventJSON, sourcePayloadJSON, nil
 	default:

--- a/server/internal/assistants/source_adapter.go
+++ b/server/internal/assistants/source_adapter.go
@@ -33,6 +33,7 @@ func (deterministicChatIDAdapter) ChatID(assistantID uuid.UUID, correlationID st
 
 var sourceAdapters = map[string]sourceAdapter{
 	sourceKindSlack:     slackAdapter{deterministicChatIDAdapter: deterministicChatIDAdapter{}},
+	sourceKindMSTeams:   msteamsAdapter{deterministicChatIDAdapter: deterministicChatIDAdapter{}},
 	sourceKindLinear:    linearAdapter{deterministicChatIDAdapter: deterministicChatIDAdapter{}},
 	sourceKindGithub:    githubAdapter{deterministicChatIDAdapter: deterministicChatIDAdapter{}},
 	sourceKindCron:      cronAdapter{deterministicChatIDAdapter: deterministicChatIDAdapter{}},

--- a/server/internal/assistants/source_adapter_msteams.go
+++ b/server/internal/assistants/source_adapter_msteams.go
@@ -1,0 +1,118 @@
+package assistants
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type msteamsSourceRef struct {
+	TenantID       string `json:"tenant_id,omitempty"`
+	ConversationID string `json:"conversation_id"`
+	ServiceURL     string `json:"service_url,omitempty"`
+	UserID         string `json:"user_id,omitempty"`
+}
+
+// msteamsEventPayload mirrors the JSON shape of the trigger package's
+// msteamsTriggerEvent.
+type msteamsEventPayload struct {
+	EventType        string   `json:"event_type,omitempty"`
+	ActivityID       string   `json:"activity_id,omitempty"`
+	ConversationID   string   `json:"conversation_id,omitempty"`
+	ConversationType string   `json:"conversation_type,omitempty"`
+	TenantID         string   `json:"tenant_id,omitempty"`
+	ServiceURL       string   `json:"service_url,omitempty"`
+	TeamsChannelID   string   `json:"teams_channel_id,omitempty"`
+	TeamsTeamID      string   `json:"teams_team_id,omitempty"`
+	UserID           string   `json:"user_id,omitempty"`
+	UserName         string   `json:"user_name,omitempty"`
+	UserAADObjectID  string   `json:"user_aad_object_id,omitempty"`
+	BotID            string   `json:"bot_id,omitempty"`
+	Text             string   `json:"text,omitempty"`
+	ReplyToID        string   `json:"reply_to_id,omitempty"`
+	Timestamp        string   `json:"timestamp,omitempty"`
+	Action           string   `json:"action,omitempty"`
+	ReactionsAdded   []string `json:"reactions_added,omitempty"`
+	ReactionsRemoved []string `json:"reactions_removed,omitempty"`
+	MembersAdded     []string `json:"members_added,omitempty"`
+	MembersRemoved   []string `json:"members_removed,omitempty"`
+}
+
+type msteamsAdapter struct{ deterministicChatIDAdapter }
+
+func (msteamsAdapter) ThreadContext(sourceRefJSON []byte) (string, error) {
+	var ref msteamsSourceRef
+	if err := json.Unmarshal(sourceRefJSON, &ref); err != nil {
+		return "", fmt.Errorf("decode msteams source ref: %w", err)
+	}
+	var b bytes.Buffer
+	b.WriteString("## Conversation context\n\n")
+	b.WriteString("Conversation originated on: Microsoft Teams\n")
+	if ref.TenantID != "" {
+		fmt.Fprintf(&b, "TenantID: %s\n", ref.TenantID)
+	}
+	if ref.ConversationID != "" {
+		fmt.Fprintf(&b, "ConversationID: %s\n", ref.ConversationID)
+	}
+	if ref.ServiceURL != "" {
+		fmt.Fprintf(&b, "ServiceURL: %s\n", ref.ServiceURL)
+	}
+	if ref.UserID != "" {
+		fmt.Fprintf(&b, "UserID: %s\n", ref.UserID)
+	}
+	return b.String(), nil
+}
+
+func (msteamsAdapter) OutputChannelGuidance() string {
+	return `## Microsoft Teams output preferences
+
+Text responses are not delivered to Microsoft Teams. To communicate, call a Microsoft Teams post tool if one is available. If no suitable tool is available, the user will not see your reply — log the situation and stop.
+
+## Deciding whether to respond
+
+Not every Teams activity needs a reply. ALWAYS reply when the message clearly addresses you (an @-mention, a personal chat message, a direct question to you, or a follow-up to your last reply). For ambient channel messages and passive events (reactions, membership changes), first evaluate whether a reply adds value. Stay silent — call no Teams post tool — when the message is clearly directed at another human, when it asks nothing you can help with, or when you would only restate what has already been said. When staying silent, end the turn without posting anything. Never post a message explaining a tool error or announcing your decision to stay silent.`
+}
+
+func (msteamsAdapter) DecodeTurn(event assistantThreadEventRecord) (string, error) {
+	var payload msteamsEventPayload
+	if err := json.Unmarshal(event.NormalizedPayloadJSON, &payload); err != nil {
+		return "", fmt.Errorf("decode msteams event payload: %w", err)
+	}
+	var b bytes.Buffer
+	b.WriteString("<message-context>\n")
+	fmt.Fprintf(&b, "EventID: %s\n", event.EventID)
+	if payload.EventType != "" {
+		fmt.Fprintf(&b, "EventType: %s\n", payload.EventType)
+	}
+	if payload.UserID != "" {
+		fmt.Fprintf(&b, "UserID: %s\n", payload.UserID)
+	}
+	if payload.UserName != "" {
+		fmt.Fprintf(&b, "UserName: %s\n", payload.UserName)
+	}
+	if payload.Timestamp != "" {
+		fmt.Fprintf(&b, "Timestamp: %s\n", payload.Timestamp)
+	}
+	if payload.ReplyToID != "" {
+		fmt.Fprintf(&b, "ReplyToID: %s\n", payload.ReplyToID)
+	}
+	if payload.Action != "" {
+		fmt.Fprintf(&b, "Action: %s\n", payload.Action)
+	}
+	if len(payload.ReactionsAdded) > 0 {
+		fmt.Fprintf(&b, "ReactionsAdded: %s\n", strings.Join(payload.ReactionsAdded, ", "))
+	}
+	if len(payload.ReactionsRemoved) > 0 {
+		fmt.Fprintf(&b, "ReactionsRemoved: %s\n", strings.Join(payload.ReactionsRemoved, ", "))
+	}
+	if len(payload.MembersAdded) > 0 {
+		fmt.Fprintf(&b, "MembersAdded: %s\n", strings.Join(payload.MembersAdded, ", "))
+	}
+	if len(payload.MembersRemoved) > 0 {
+		fmt.Fprintf(&b, "MembersRemoved: %s\n", strings.Join(payload.MembersRemoved, ", "))
+	}
+	b.WriteString("</message-context>\n\n")
+	b.WriteString(payload.Text)
+	return b.String(), nil
+}

--- a/server/internal/assistants/source_adapter_msteams.go
+++ b/server/internal/assistants/source_adapter_msteams.go
@@ -85,6 +85,11 @@ func (msteamsAdapter) DecodeTurn(event assistantThreadEventRecord) (string, erro
 	if payload.EventType != "" {
 		fmt.Fprintf(&b, "EventType: %s\n", payload.EventType)
 	}
+	// The output guidance keys "always reply" on personal chats, so the turn
+	// must carry the conversation type for the model to apply it.
+	if payload.ConversationType != "" {
+		fmt.Fprintf(&b, "ConversationType: %s\n", payload.ConversationType)
+	}
 	if payload.UserID != "" {
 		fmt.Fprintf(&b, "UserID: %s\n", payload.UserID)
 	}

--- a/server/internal/assistants/source_adapter_test.go
+++ b/server/internal/assistants/source_adapter_test.go
@@ -240,11 +240,12 @@ func TestMSTeamsAdapterDecodeTurnRendersContextAndText(t *testing.T) {
 
 	got, err := msteamsAdapter{}.DecodeTurn(assistantThreadEventRecord{
 		EventID:               "evt-1",
-		NormalizedPayloadJSON: []byte(`{"event_type":"message","user_id":"29:user","user_name":"Jo Doe","reply_to_id":"123","text":"hello bot"}`),
+		NormalizedPayloadJSON: []byte(`{"event_type":"message","conversation_type":"personal","user_id":"29:user","user_name":"Jo Doe","reply_to_id":"123","text":"hello bot"}`),
 	})
 	require.NoError(t, err)
 	require.Contains(t, got, "<message-context>")
 	require.Contains(t, got, "EventType: message")
+	require.Contains(t, got, "ConversationType: personal")
 	require.Contains(t, got, "UserName: Jo Doe")
 	require.Contains(t, got, "ReplyToID: 123")
 	require.True(t, strings.HasSuffix(got, "hello bot"))

--- a/server/internal/assistants/source_adapter_test.go
+++ b/server/internal/assistants/source_adapter_test.go
@@ -234,3 +234,29 @@ func TestGitHubAdapterDecodeTurnOmitsEmptyPayload(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, got, "<event-payload>")
 }
+
+func TestMSTeamsAdapterDecodeTurnRendersContextAndText(t *testing.T) {
+	t.Parallel()
+
+	got, err := msteamsAdapter{}.DecodeTurn(assistantThreadEventRecord{
+		EventID:               "evt-1",
+		NormalizedPayloadJSON: []byte(`{"event_type":"message","user_id":"29:user","user_name":"Jo Doe","reply_to_id":"123","text":"hello bot"}`),
+	})
+	require.NoError(t, err)
+	require.Contains(t, got, "<message-context>")
+	require.Contains(t, got, "EventType: message")
+	require.Contains(t, got, "UserName: Jo Doe")
+	require.Contains(t, got, "ReplyToID: 123")
+	require.True(t, strings.HasSuffix(got, "hello bot"))
+}
+
+func TestMSTeamsAdapterThreadContextRendersRef(t *testing.T) {
+	t.Parallel()
+
+	got, err := msteamsAdapter{}.ThreadContext([]byte(`{"tenant_id":"tenant-1","conversation_id":"19:chan@thread.tacv2;messageid=1","service_url":"https://smba.trafficmanager.net/teams/","user_id":"29:user"}`))
+	require.NoError(t, err)
+	require.Contains(t, got, "Microsoft Teams")
+	require.Contains(t, got, "TenantID: tenant-1")
+	require.Contains(t, got, "ConversationID: 19:chan@thread.tacv2;messageid=1")
+	require.Contains(t, got, "ServiceURL: https://smba.trafficmanager.net/teams/")
+}

--- a/server/internal/background/triggers/app.go
+++ b/server/internal/background/triggers/app.go
@@ -38,6 +38,7 @@ const (
 	StatusCancelled     = "cancelled"
 
 	DefinitionSlugSlack     = "slack"
+	DefinitionSlugMSTeams   = "msteams"
 	DefinitionSlugLinear    = "linear"
 	DefinitionSlugGithub    = "github"
 	DefinitionSlugCron      = "cron"
@@ -720,7 +721,7 @@ func (a *App) ProcessWebhook(ctx context.Context, instanceID uuid.UUID, body []b
 		}
 	}
 
-	if err := definition.AuthenticateWebhook(body, headers, envMap, config); err != nil {
+	if err := definition.AuthenticateWebhook(ctx, body, headers, envMap, config); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrAuthFailed, err)
 	}
 

--- a/server/internal/background/triggers/definitions.go
+++ b/server/internal/background/triggers/definitions.go
@@ -1,6 +1,7 @@
 package triggers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,7 +50,7 @@ type Definition struct {
 	EnvRequirements      []EnvRequirement
 	EventType            reflect.Type
 	DecodeConfig         func(raw map[string]any) (Config, error)
-	AuthenticateWebhook  func(body []byte, headers http.Header, env map[string]string, config Config) error
+	AuthenticateWebhook  func(ctx context.Context, body []byte, headers http.Header, env map[string]string, config Config) error
 	HandleWebhook        func(body []byte, headers http.Header, config Config) (*WebhookIngressResult, error)
 	BuildScheduledEvent  func(instance triggerrepo.TriggerInstance, config Config, firedAt time.Time) (*EventEnvelope, error)
 	BuildDirectEvent     func(instance triggerrepo.TriggerInstance, config Config, payload []byte, receivedAt time.Time) (*EventEnvelope, error)
@@ -167,6 +168,7 @@ type wakeTriggerEvent struct {
 
 var registry = map[string]Definition{
 	DefinitionSlugSlack:     newSlackDefinition(),
+	DefinitionSlugMSTeams:   newMSTeamsDefinition(),
 	DefinitionSlugLinear:    newLinearDefinition(),
 	DefinitionSlugGithub:    newGitHubDefinition(),
 	DefinitionSlugCron:      newCronDefinition(),

--- a/server/internal/background/triggers/definitions_test.go
+++ b/server/internal/background/triggers/definitions_test.go
@@ -16,13 +16,14 @@ func TestListIncludesAllDefinitions(t *testing.T) {
 	t.Parallel()
 
 	definitions := List()
-	// cron, github, linear, slack, wake (dashboard is direct-ingress, excluded).
-	require.Len(t, definitions, 5)
+	// cron, github, linear, msteams, slack, wake (dashboard is direct-ingress, excluded).
+	require.Len(t, definitions, 6)
 	require.Equal(t, "cron", definitions[0].Slug)
 	require.Equal(t, "github", definitions[1].Slug)
 	require.Equal(t, "linear", definitions[2].Slug)
-	require.Equal(t, "slack", definitions[3].Slug)
-	require.Equal(t, "wake", definitions[4].Slug)
+	require.Equal(t, "msteams", definitions[3].Slug)
+	require.Equal(t, "slack", definitions[4].Slug)
+	require.Equal(t, "wake", definitions[5].Slug)
 	for _, d := range definitions {
 		require.NotEmpty(t, d.ConfigSchema, d.Slug)
 	}

--- a/server/internal/background/triggers/github.go
+++ b/server/internal/background/triggers/github.go
@@ -212,6 +212,7 @@ func newGitHubDefinition() Definition {
 			TimestampSkew:   0,
 		},
 		SupportedEventTypes: supportedGitHubEventTypes,
+		Authenticate:        nil,
 		PreVerify:           nil,
 		Ingest:              githubIngest,
 	}

--- a/server/internal/background/triggers/github_test.go
+++ b/server/internal/background/triggers/github_test.go
@@ -67,7 +67,7 @@ func TestGitHubSignatureVerification(t *testing.T) {
 	headers.Set("X-GitHub-Event", "pull_request")
 	headers.Set("X-GitHub-Delivery", "del-1")
 
-	require.NoError(t, definition.AuthenticateWebhook(body, headers, map[string]string{
+	require.NoError(t, definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"GITHUB_WEBHOOK_SECRET": "shh",
 	}, config))
 }
@@ -87,7 +87,7 @@ func TestGitHubSignatureRejectsBadSecret(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 
-	err = definition.AuthenticateWebhook(body, headers, map[string]string{
+	err = definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"GITHUB_WEBHOOK_SECRET": "wrong",
 	}, config)
 	require.Error(t, err)

--- a/server/internal/background/triggers/linear.go
+++ b/server/internal/background/triggers/linear.go
@@ -170,6 +170,7 @@ func newLinearDefinition() Definition {
 			TimestampSkew:   0,
 		},
 		SupportedEventTypes: supportedLinearEventTypes,
+		Authenticate:        nil,
 		PreVerify:           nil,
 		Ingest:              linearIngest,
 	}

--- a/server/internal/background/triggers/linear_test.go
+++ b/server/internal/background/triggers/linear_test.go
@@ -66,7 +66,7 @@ func TestLinearSignatureVerification(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Linear-Signature", hex.EncodeToString(mac.Sum(nil)))
 
-	require.NoError(t, definition.AuthenticateWebhook(body, headers, map[string]string{
+	require.NoError(t, definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"LINEAR_SIGNING_SECRET": "shh",
 	}, config))
 }
@@ -86,7 +86,7 @@ func TestLinearSignatureRejectsBadSecret(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("Linear-Signature", hex.EncodeToString(mac.Sum(nil)))
 
-	err = definition.AuthenticateWebhook(body, headers, map[string]string{
+	err = definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"LINEAR_SIGNING_SECRET": "wrong",
 	}, config)
 	require.Error(t, err)

--- a/server/internal/background/triggers/msteams.go
+++ b/server/internal/background/triggers/msteams.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -231,13 +232,16 @@ type botFrameworkAuthenticator struct {
 	// init (the registry constructs definitions as a package-level var) so the
 	// global tracer provider is real by the time the first webhook arrives.
 	clientFn func() *guardian.HTTPClient
+	// fetchGroup coalesces concurrent metadata fetches so cold-start or
+	// post-outage delivery bursts share one request instead of queueing.
+	fetchGroup singleflight.Group
 
 	mu     sync.Mutex
 	keySet oidc.KeySet
 	// retryAfter negative-caches metadata fetch failures. Deliveries arriving
-	// before it return immediately instead of piling up behind the mutex for a
-	// 10s fetch each — Teams retries failed deliveries, so a metadata endpoint
-	// blip would otherwise self-amplify.
+	// before it return immediately instead of waiting out a 10s fetch each —
+	// Teams retries failed deliveries, so a metadata endpoint blip would
+	// otherwise self-amplify.
 	retryAfter time.Time
 }
 
@@ -250,6 +254,7 @@ func newBotFrameworkAuthenticator(metadataURL, issuer string) *botFrameworkAuthe
 			client.Timeout = 10 * time.Second
 			return client
 		}),
+		fetchGroup: singleflight.Group{},
 		mu:         sync.Mutex{},
 		keySet:     nil,
 		retryAfter: time.Time{},
@@ -258,26 +263,45 @@ func newBotFrameworkAuthenticator(metadataURL, issuer string) *botFrameworkAuthe
 
 func (b *botFrameworkAuthenticator) remoteKeySet() (oidc.KeySet, error) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.keySet != nil {
-		return b.keySet, nil
+	cached, retryAfter := b.keySet, b.retryAfter
+	b.mu.Unlock()
+	if cached != nil {
+		return cached, nil
 	}
-	if time.Now().Before(b.retryAfter) {
+	if time.Now().Before(retryAfter) {
 		return nil, fmt.Errorf("openid metadata unavailable, retrying later")
 	}
-	client := b.clientFn()
 
-	jwksURI, err := b.fetchJWKSURI(client)
+	// The fetch runs outside the mutex so deliveries never queue behind the
+	// network round-trip; singleflight collapses a concurrent burst into one
+	// request whose result (or failure) they all share.
+	keySet, err, _ := b.fetchGroup.Do("keyset", func() (any, error) {
+		client := b.clientFn()
+		jwksURI, err := b.fetchJWKSURI(client)
+		if err != nil {
+			b.mu.Lock()
+			b.retryAfter = time.Now().Add(30 * time.Second)
+			b.mu.Unlock()
+			return nil, err
+		}
+		// The key set outlives this request: it caches Microsoft's signing
+		// keys and re-fetches them on rotation, so it is bound to a background
+		// context carrying our bounded-timeout client rather than the request
+		// context.
+		keySet := oidc.NewRemoteKeySet(oidc.ClientContext(context.Background(), client), jwksURI)
+		b.mu.Lock()
+		b.keySet = keySet
+		b.mu.Unlock()
+		return keySet, nil
+	})
 	if err != nil {
-		b.retryAfter = time.Now().Add(30 * time.Second)
 		return nil, err
 	}
-
-	// The key set outlives this request: it caches Microsoft's signing keys
-	// and re-fetches them on rotation, so it is bound to a background context
-	// carrying our bounded-timeout client rather than the request context.
-	b.keySet = oidc.NewRemoteKeySet(oidc.ClientContext(context.Background(), client), jwksURI)
-	return b.keySet, nil
+	set, ok := keySet.(oidc.KeySet)
+	if !ok {
+		return nil, fmt.Errorf("unexpected key set type %T", keySet)
+	}
+	return set, nil
 }
 
 // fetchJWKSURI deliberately detaches from the inbound delivery's context: the

--- a/server/internal/background/triggers/msteams.go
+++ b/server/internal/background/triggers/msteams.go
@@ -276,6 +276,19 @@ func (b *botFrameworkAuthenticator) remoteKeySet() (oidc.KeySet, error) {
 	// network round-trip; singleflight collapses a concurrent burst into one
 	// request whose result (or failure) they all share.
 	keySet, err, _ := b.fetchGroup.Do("keyset", func() (any, error) {
+		// Re-check under the flight: a caller that read the empty cache
+		// before a flight completed enters here after it, and without this it
+		// would start a redundant fetch — or bypass the failure backoff.
+		b.mu.Lock()
+		cached, retryAfter := b.keySet, b.retryAfter
+		b.mu.Unlock()
+		if cached != nil {
+			return cached, nil
+		}
+		if time.Now().Before(retryAfter) {
+			return nil, fmt.Errorf("openid metadata unavailable, retrying later")
+		}
+
 		client := b.clientFn()
 		jwksURI, err := b.fetchJWKSURI(client)
 		if err != nil {

--- a/server/internal/background/triggers/msteams.go
+++ b/server/internal/background/triggers/msteams.go
@@ -1,0 +1,417 @@
+package triggers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/google/cel-go/cel"
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+// msteamsAppIDEnv holds the bot's Microsoft App ID. It is the JWT audience
+// Bot Framework tokens are issued for, so it doubles as the webhook
+// authentication anchor for a trigger instance.
+const msteamsAppIDEnv = "MSTEAMS_APP_ID"
+
+// Bot Framework connector-to-bot authentication constants. See
+// https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication
+// — the metadata URL is documented as static and safe to hardcode; the issuer
+// is fixed for protocol v3.1/v3.2.
+const (
+	botFrameworkIssuer          = "https://api.botframework.com"
+	botFrameworkOpenIDConfigURL = "https://login.botframework.com/v1/.well-known/openidconfiguration"
+)
+
+// msteamsTriggerConfig is the instance config for the MS Teams trigger,
+// exposing the shared webhook filter knobs: a CEL filter expression and an
+// activity-type allowlist narrowing the default-deny
+// supportedMSTeamsEventTypes set.
+type msteamsTriggerConfig struct {
+	FilterExpr string   `json:"filter,omitempty"`
+	EventTypes []string `json:"event_types,omitempty"`
+
+	// compiledFilter is set during DecodeConfig when FilterExpr is non-empty.
+	compiledFilter cel.Program
+}
+
+func (c msteamsTriggerConfig) Filter(event any) (bool, error) {
+	teamsEvent, ok := event.(msteamsTriggerEvent)
+	if !ok {
+		return false, fmt.Errorf("expected msteamsTriggerEvent, got %T", event)
+	}
+	return evalWebhookFilter(c.compiledFilter, c.EventTypes, event, teamsEvent.EventType, supportedMSTeamsEventTypes)
+}
+
+// msteamsActivity is the subset of the Bot Framework Activity object posted to
+// the bot's webhook endpoint. The `type` field discriminates the activity
+// shape (message, messageReaction, conversationUpdate, installationUpdate, …).
+// See https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference#activity-object
+type msteamsActivity struct {
+	Type         string                     `json:"type"`
+	ID           string                     `json:"id,omitempty"`
+	Timestamp    string                     `json:"timestamp,omitempty"`
+	ServiceURL   string                     `json:"serviceUrl,omitempty"`
+	From         msteamsChannelAccount      `json:"from"`
+	Recipient    msteamsChannelAccount      `json:"recipient"`
+	Conversation msteamsConversationAccount `json:"conversation"`
+	Text         string                     `json:"text,omitempty"`
+	ReplyToID    string                     `json:"replyToId,omitempty"`
+	// Action is set on installationUpdate activities: "add" or "remove".
+	Action           string                  `json:"action,omitempty"`
+	ReactionsAdded   []msteamsReaction       `json:"reactionsAdded,omitempty"`
+	ReactionsRemoved []msteamsReaction       `json:"reactionsRemoved,omitempty"`
+	MembersAdded     []msteamsChannelAccount `json:"membersAdded,omitempty"`
+	MembersRemoved   []msteamsChannelAccount `json:"membersRemoved,omitempty"`
+	ChannelData      *msteamsChannelData     `json:"channelData,omitempty"`
+}
+
+type msteamsChannelAccount struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	AADObjectID string `json:"aadObjectId,omitempty"`
+}
+
+type msteamsConversationAccount struct {
+	ID               string `json:"id,omitempty"`
+	ConversationType string `json:"conversationType,omitempty"`
+	TenantID         string `json:"tenantId,omitempty"`
+}
+
+type msteamsReaction struct {
+	Type string `json:"type,omitempty"`
+}
+
+// msteamsChannelData carries the Teams-specific envelope Bot Framework tucks
+// under channelData: the human-facing team/channel identity (Activity's own
+// channelId is always the literal platform id "msteams") and the tenant.
+type msteamsChannelData struct {
+	Channel *msteamsChannelDataRef `json:"channel,omitempty"`
+	Team    *msteamsChannelDataRef `json:"team,omitempty"`
+	Tenant  *msteamsChannelDataRef `json:"tenant,omitempty"`
+}
+
+type msteamsChannelDataRef struct {
+	ID string `json:"id,omitempty"`
+}
+
+// msteamsTriggerEvent is the normalized event surfaced to CEL filters and the
+// assistant adapter. EventType is the Bot Framework activity type.
+type msteamsTriggerEvent struct {
+	EventType        string `json:"event_type" cel:"event_type"`
+	ActivityID       string `json:"activity_id,omitempty" cel:"activity_id"`
+	ConversationID   string `json:"conversation_id,omitempty" cel:"conversation_id"`
+	ConversationType string `json:"conversation_type,omitempty" cel:"conversation_type"`
+	TenantID         string `json:"tenant_id,omitempty" cel:"tenant_id"`
+	// ServiceURL is the Bot Framework connector endpoint replies must be sent
+	// to; outbound tools need it to address the conversation.
+	ServiceURL string `json:"service_url,omitempty" cel:"service_url"`
+	// TeamsChannelID / TeamsTeamID identify the Teams channel + team for
+	// channel conversations (empty in personal and group chats).
+	TeamsChannelID string `json:"teams_channel_id,omitempty" cel:"teams_channel_id"`
+	TeamsTeamID    string `json:"teams_team_id,omitempty" cel:"teams_team_id"`
+	// UserID is the sender's channel account id; UserAADObjectID its Entra ID
+	// object id when Teams supplies one.
+	UserID          string `json:"user_id,omitempty" cel:"user_id"`
+	UserName        string `json:"user_name,omitempty" cel:"user_name"`
+	UserAADObjectID string `json:"user_aad_object_id,omitempty" cel:"user_aad_object_id"`
+	// BotID is the recipient bot's channel account id.
+	BotID     string `json:"bot_id,omitempty" cel:"bot_id"`
+	Text      string `json:"text,omitempty" cel:"text"`
+	ReplyToID string `json:"reply_to_id,omitempty" cel:"reply_to_id"`
+	Timestamp string `json:"timestamp,omitempty" cel:"timestamp"`
+	// Action is set on installationUpdate activities: "add" or "remove".
+	Action string `json:"action,omitempty" cel:"action"`
+
+	ReactionsAdded   []string `json:"reactions_added,omitempty" cel:"reactions_added"`
+	ReactionsRemoved []string `json:"reactions_removed,omitempty" cel:"reactions_removed"`
+	MembersAdded     []string `json:"members_added,omitempty" cel:"members_added"`
+	MembersRemoved   []string `json:"members_removed,omitempty" cel:"members_removed"`
+}
+
+// supportedMSTeamsEventTypes lists the Bot Framework activity types the
+// trigger dispatches. Teams also delivers "typing" activities, deliberately
+// excluded: an empty event_types config defaults to this whole list, and
+// typing indicators would flood every default-config trigger.
+var supportedMSTeamsEventTypes = []string{
+	"conversationUpdate",
+	"endOfConversation",
+	"installationUpdate",
+	"message",
+	"messageDelete",
+	"messageReaction",
+	"messageUpdate",
+}
+
+func msteamsIngest(body []byte, _ http.Header) (*WebhookIngest, error) {
+	var activity msteamsActivity
+	if err := json.Unmarshal(body, &activity); err != nil {
+		return nil, fmt.Errorf("decode msteams activity: %w", err)
+	}
+	if activity.Type == "" {
+		return nil, fmt.Errorf("decode msteams activity: missing type")
+	}
+
+	tenantID := activity.Conversation.TenantID
+	var teamsChannelID, teamsTeamID string
+	if cd := activity.ChannelData; cd != nil {
+		if cd.Channel != nil {
+			teamsChannelID = cd.Channel.ID
+		}
+		if cd.Team != nil {
+			teamsTeamID = cd.Team.ID
+		}
+		if tenantID == "" && cd.Tenant != nil {
+			tenantID = cd.Tenant.ID
+		}
+	}
+
+	normalized := msteamsTriggerEvent{
+		EventType:        activity.Type,
+		ActivityID:       activity.ID,
+		ConversationID:   activity.Conversation.ID,
+		ConversationType: activity.Conversation.ConversationType,
+		TenantID:         tenantID,
+		ServiceURL:       activity.ServiceURL,
+		TeamsChannelID:   teamsChannelID,
+		TeamsTeamID:      teamsTeamID,
+		UserID:           activity.From.ID,
+		UserName:         activity.From.Name,
+		UserAADObjectID:  activity.From.AADObjectID,
+		BotID:            activity.Recipient.ID,
+		Text:             activity.Text,
+		ReplyToID:        activity.ReplyToID,
+		Timestamp:        activity.Timestamp,
+		Action:           activity.Action,
+		ReactionsAdded:   lo.Map(activity.ReactionsAdded, func(r msteamsReaction, _ int) string { return r.Type }),
+		ReactionsRemoved: lo.Map(activity.ReactionsRemoved, func(r msteamsReaction, _ int) string { return r.Type }),
+		MembersAdded:     lo.Map(activity.MembersAdded, func(m msteamsChannelAccount, _ int) string { return m.ID }),
+		MembersRemoved:   lo.Map(activity.MembersRemoved, func(m msteamsChannelAccount, _ int) string { return m.ID }),
+	}
+
+	// Teams conversation ids are already thread-scoped where threads exist —
+	// replies in a channel carry the thread root in the id's ";messageid=…"
+	// suffix — and stable per chat in personal/group conversations, so the
+	// conversation id alone is the correct correlation key. Conversation-less
+	// activities fall back to the tenant.
+	return &WebhookIngest{
+		Response:      nil,
+		EventID:       activity.ID,
+		CorrelationID: conv.Default(activity.Conversation.ID, tenantID),
+		Event:         normalized,
+	}, nil
+}
+
+// botFrameworkAuthenticator validates the signed JWT the Bot Framework
+// connector attaches to every request it sends a bot, per
+// https://learn.microsoft.com/azure/bot-service/rest-api/bot-framework-rest-connector-authentication:
+// RS256 signature against the JWKS advertised by the OpenID metadata document,
+// issuer https://api.botframework.com, audience = the bot's Microsoft App ID,
+// and a serviceurl claim matching the activity's serviceUrl. The remote key
+// set is fetched lazily and cached across requests (go-oidc re-fetches on
+// unknown key ids, covering Microsoft's key rotation).
+type botFrameworkAuthenticator struct {
+	metadataURL string
+	issuer      string
+	// clientFn lazily builds the guardian-backed client. Deferred past package
+	// init (the registry constructs definitions as a package-level var) so the
+	// global tracer provider is real by the time the first webhook arrives.
+	clientFn func() *guardian.HTTPClient
+
+	mu     sync.Mutex
+	keySet oidc.KeySet
+	// retryAfter negative-caches metadata fetch failures. Deliveries arriving
+	// before it return immediately instead of piling up behind the mutex for a
+	// 10s fetch each — Teams retries failed deliveries, so a metadata endpoint
+	// blip would otherwise self-amplify.
+	retryAfter time.Time
+}
+
+func newBotFrameworkAuthenticator(metadataURL, issuer string) *botFrameworkAuthenticator {
+	return &botFrameworkAuthenticator{
+		metadataURL: metadataURL,
+		issuer:      issuer,
+		clientFn: sync.OnceValue(func() *guardian.HTTPClient {
+			client := guardian.NewDefaultPolicy(otel.GetTracerProvider()).PooledClient()
+			client.Timeout = 10 * time.Second
+			return client
+		}),
+		mu:         sync.Mutex{},
+		keySet:     nil,
+		retryAfter: time.Time{},
+	}
+}
+
+func (b *botFrameworkAuthenticator) remoteKeySet() (oidc.KeySet, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.keySet != nil {
+		return b.keySet, nil
+	}
+	if time.Now().Before(b.retryAfter) {
+		return nil, fmt.Errorf("openid metadata unavailable, retrying later")
+	}
+	client := b.clientFn()
+
+	jwksURI, err := b.fetchJWKSURI(client)
+	if err != nil {
+		b.retryAfter = time.Now().Add(30 * time.Second)
+		return nil, err
+	}
+
+	// The key set outlives this request: it caches Microsoft's signing keys
+	// and re-fetches them on rotation, so it is bound to a background context
+	// carrying our bounded-timeout client rather than the request context.
+	b.keySet = oidc.NewRemoteKeySet(oidc.ClientContext(context.Background(), client), jwksURI)
+	return b.keySet, nil
+}
+
+// fetchJWKSURI deliberately detaches from the inbound delivery's context: the
+// metadata result is process-global, and a fetch cancelled by one client's
+// disconnect would otherwise write the 30s negative cache and reject every
+// subsequent delivery for a failure we caused ourselves.
+func (b *botFrameworkAuthenticator) fetchJWKSURI(client *guardian.HTTPClient) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, b.metadataURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build openid metadata request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch openid metadata: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch openid metadata: status %d", resp.StatusCode)
+	}
+	var metadata struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&metadata); err != nil {
+		return "", fmt.Errorf("decode openid metadata: %w", err)
+	}
+	if metadata.JWKSURI == "" {
+		return "", fmt.Errorf("openid metadata missing jwks_uri")
+	}
+	return metadata.JWKSURI, nil
+}
+
+// authenticate verifies the bearer token for a webhook delivery whose raw body
+// is the activity JSON. appID is the bot's Microsoft App ID (the expected
+// token audience).
+func (b *botFrameworkAuthenticator) authenticate(ctx context.Context, body []byte, headers http.Header, appID string) error {
+	authorization := headers.Get("Authorization")
+	scheme, rawToken, found := strings.Cut(authorization, " ")
+	if !found || !strings.EqualFold(scheme, "Bearer") || rawToken == "" {
+		return fmt.Errorf("missing bearer token")
+	}
+
+	keySet, err := b.remoteKeySet()
+	if err != nil {
+		return err
+	}
+
+	verifier := oidc.NewVerifier(b.issuer, keySet, &oidc.Config{ //nolint:exhaustruct // third-party struct; remaining fields keep default verification behavior
+		ClientID:             appID,
+		SupportedSigningAlgs: []string{"RS256"},
+	})
+	token, err := verifier.Verify(ctx, rawToken)
+	if err != nil {
+		return fmt.Errorf("verify bot framework token: %w", err)
+	}
+
+	// Bot Framework binds the token to the connector endpoint the activity
+	// claims to originate from; a mismatch means the activity was replayed
+	// against a different service URL. The claim key is lowercase "serviceurl"
+	// (per botbuilder's AuthenticationConstants); encoding/json's
+	// case-insensitive fallback also absorbs the camelCase spelling the
+	// protocol docs use.
+	var claims struct {
+		ServiceURL string `json:"serviceurl"`
+	}
+	if err := token.Claims(&claims); err != nil {
+		return fmt.Errorf("decode bot framework token claims: %w", err)
+	}
+	if claims.ServiceURL == "" {
+		return fmt.Errorf("bot framework token missing serviceurl claim")
+	}
+
+	var activity struct {
+		ServiceURL string `json:"serviceUrl"`
+	}
+	if err := json.Unmarshal(body, &activity); err != nil {
+		return fmt.Errorf("decode msteams activity: %w", err)
+	}
+	if strings.TrimRight(claims.ServiceURL, "/") != strings.TrimRight(activity.ServiceURL, "/") {
+		return fmt.Errorf("activity serviceUrl does not match token serviceurl claim")
+	}
+
+	return nil
+}
+
+func newMSTeamsDefinition() Definition {
+	schema := buildInputSchema[msteamsTriggerConfig](
+		withArrayItemsEnum("event_types", toAnySlice(supportedMSTeamsEventTypes)...),
+	)
+	compiled := mustCompileSchema(schema)
+	authenticator := newBotFrameworkAuthenticator(botFrameworkOpenIDConfigURL, botFrameworkIssuer)
+	vendor := WebhookVendor{
+		Slug:        DefinitionSlugMSTeams,
+		Title:       "Microsoft Teams",
+		Description: "Receive Bot Framework activities from Microsoft Teams and map them to Gram trigger events.",
+		EventType:   reflect.TypeFor[msteamsTriggerEvent](),
+		EnvRequirements: []EnvRequirement{{
+			Name:        msteamsAppIDEnv,
+			Description: "Microsoft App ID of the bot; incoming Bot Framework tokens are validated against it.",
+			Required:    true,
+		}},
+		SecretEnv: "",
+		Signature: HMACScheme{NewHash: nil, Header: "", Encoding: "", Prefix: "", Template: "", TimestampHeader: "", TimestampSkew: 0},
+		// Bot Framework authenticates with a Microsoft-signed JWT, not an HMAC
+		// over the body.
+		Authenticate: func(ctx context.Context, body []byte, headers http.Header, env map[string]string) error {
+			appID := toolconfig.CIEnvFrom(env).Get(msteamsAppIDEnv)
+			if appID == "" {
+				return fmt.Errorf("missing %s", msteamsAppIDEnv)
+			}
+			return authenticator.authenticate(ctx, body, headers, appID)
+		},
+		SupportedEventTypes: supportedMSTeamsEventTypes,
+		PreVerify:           nil,
+		Ingest:              msteamsIngest,
+	}
+	return NewWebhookDefinition(vendor, schema, compiled, func(raw map[string]any) (Config, error) {
+		cfg, err := decodeConfig[msteamsTriggerConfig](raw, compiled)
+		if err != nil {
+			return nil, err
+		}
+		for _, eventType := range cfg.EventTypes {
+			if !slices.Contains(supportedMSTeamsEventTypes, eventType) {
+				return nil, fmt.Errorf("unsupported msteams event type %q", eventType)
+			}
+		}
+		prog, err := compileCELFilter(reflect.TypeFor[msteamsTriggerEvent](), cfg.FilterExpr)
+		if err != nil {
+			return nil, err
+		}
+		cfg.compiledFilter = prog
+		return cfg, nil
+	})
+}

--- a/server/internal/background/triggers/msteams_test.go
+++ b/server/internal/background/triggers/msteams_test.go
@@ -1,0 +1,428 @@
+package triggers
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMSTeamsConfigSchemaConstrainsEventTypeItems(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	var schema struct {
+		Properties struct {
+			EventTypes struct {
+				Items struct {
+					Enum []string `json:"enum"`
+				} `json:"items"`
+			} `json:"event_types"`
+		} `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(definition.ConfigSchema, &schema))
+	require.ElementsMatch(t, supportedMSTeamsEventTypes, schema.Properties.EventTypes.Items.Enum)
+}
+
+func TestMSTeamsDecodeConfigRejectsUnsupportedEventType(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	_, err := definition.DecodeConfig(map[string]any{
+		"event_types": []any{"typing"},
+	})
+	require.Error(t, err)
+}
+
+func TestMSTeamsDecodeConfigRejectsInvalidFilter(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	_, err := definition.DecodeConfig(map[string]any{
+		"filter": "event.does_not_exist == ",
+	})
+	require.Error(t, err)
+}
+
+func TestMSTeamsIngestMessageActivity(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"type": "message",
+		"id": "1485983408511",
+		"timestamp": "2026-07-01T12:00:00.000Z",
+		"serviceUrl": "https://smba.trafficmanager.net/teams/",
+		"channelId": "msteams",
+		"from": {"id": "29:user-id", "name": "Jo Doe", "aadObjectId": "aad-1"},
+		"recipient": {"id": "28:bot-app-id", "name": "Gram"},
+		"conversation": {"id": "19:channel@thread.tacv2;messageid=123", "conversationType": "channel", "tenantId": "tenant-1"},
+		"text": "hello bot",
+		"replyToId": "123",
+		"channelData": {"channel": {"id": "19:channel@thread.tacv2"}, "team": {"id": "19:team@thread.tacv2"}, "tenant": {"id": "tenant-1"}}
+	}`)
+
+	ingest, err := msteamsIngest(body, http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, "1485983408511", ingest.EventID)
+	require.Equal(t, "19:channel@thread.tacv2;messageid=123", ingest.CorrelationID)
+
+	event, ok := ingest.Event.(msteamsTriggerEvent)
+	require.True(t, ok)
+	require.Equal(t, "message", event.EventType)
+	require.Equal(t, "hello bot", event.Text)
+	require.Equal(t, "29:user-id", event.UserID)
+	require.Equal(t, "Jo Doe", event.UserName)
+	require.Equal(t, "aad-1", event.UserAADObjectID)
+	require.Equal(t, "28:bot-app-id", event.BotID)
+	require.Equal(t, "tenant-1", event.TenantID)
+	require.Equal(t, "https://smba.trafficmanager.net/teams/", event.ServiceURL)
+	require.Equal(t, "19:channel@thread.tacv2", event.TeamsChannelID)
+	require.Equal(t, "19:team@thread.tacv2", event.TeamsTeamID)
+	require.Equal(t, "123", event.ReplyToID)
+	require.Equal(t, "channel", event.ConversationType)
+}
+
+func TestMSTeamsIngestMessageReaction(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"type": "messageReaction",
+		"id": "act-2",
+		"from": {"id": "29:user-id"},
+		"conversation": {"id": "a:personal-chat", "conversationType": "personal", "tenantId": "tenant-1"},
+		"reactionsAdded": [{"type": "like"}],
+		"reactionsRemoved": [{"type": "heart"}]
+	}`)
+
+	ingest, err := msteamsIngest(body, http.Header{})
+	require.NoError(t, err)
+
+	event, ok := ingest.Event.(msteamsTriggerEvent)
+	require.True(t, ok)
+	require.Equal(t, "messageReaction", event.EventType)
+	require.Equal(t, []string{"like"}, event.ReactionsAdded)
+	require.Equal(t, []string{"heart"}, event.ReactionsRemoved)
+}
+
+func TestMSTeamsIngestConversationUpdateMembers(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"type": "conversationUpdate",
+		"conversation": {"id": "19:group-chat"},
+		"membersAdded": [{"id": "29:new-user"}, {"id": "28:bot-app-id"}],
+		"membersRemoved": [{"id": "29:old-user"}],
+		"channelData": {"tenant": {"id": "tenant-2"}}
+	}`)
+
+	ingest, err := msteamsIngest(body, http.Header{})
+	require.NoError(t, err)
+	// conversationUpdate can arrive without an activity id; the dispatcher
+	// applies the instance-scoped content-hash fallback.
+	require.Empty(t, ingest.EventID)
+
+	event, ok := ingest.Event.(msteamsTriggerEvent)
+	require.True(t, ok)
+	require.Equal(t, []string{"29:new-user", "28:bot-app-id"}, event.MembersAdded)
+	require.Equal(t, []string{"29:old-user"}, event.MembersRemoved)
+	// Tenant falls back to channelData when conversation.tenantId is absent.
+	require.Equal(t, "tenant-2", event.TenantID)
+}
+
+func TestMSTeamsIngestInstallationUpdate(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"type": "installationUpdate",
+		"action": "add",
+		"conversation": {"id": "a:install", "tenantId": "tenant-3"}
+	}`)
+
+	ingest, err := msteamsIngest(body, http.Header{})
+	require.NoError(t, err)
+
+	event, ok := ingest.Event.(msteamsTriggerEvent)
+	require.True(t, ok)
+	require.Equal(t, "installationUpdate", event.EventType)
+	require.Equal(t, "add", event.Action)
+}
+
+func TestMSTeamsIngestMissingTypeErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := msteamsIngest([]byte(`{"text":"no type"}`), http.Header{})
+	require.Error(t, err)
+}
+
+func TestMSTeamsCorrelationFallsBackToTenant(t *testing.T) {
+	t.Parallel()
+
+	ingest, err := msteamsIngest([]byte(`{"type":"installationUpdate","action":"remove","channelData":{"tenant":{"id":"tenant-9"}}}`), http.Header{})
+	require.NoError(t, err)
+	require.Equal(t, "tenant-9", ingest.CorrelationID)
+}
+
+func TestMSTeamsFilterMatchesEventTypeAndCEL(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	config, err := definition.DecodeConfig(map[string]any{
+		"event_types": []any{"message"},
+		"filter":      `event.text.contains("deploy")`,
+	})
+	require.NoError(t, err)
+
+	match, err := config.Filter(msteamsTriggerEvent{EventType: "message", Text: "please deploy now"})
+	require.NoError(t, err)
+	require.True(t, match)
+
+	match, err = config.Filter(msteamsTriggerEvent{EventType: "message", Text: "unrelated"})
+	require.NoError(t, err)
+	require.False(t, match)
+}
+
+func TestMSTeamsFilterRejectsDisabledEventType(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	config, err := definition.DecodeConfig(map[string]any{
+		"event_types": []any{"message"},
+	})
+	require.NoError(t, err)
+
+	match, err := config.Filter(msteamsTriggerEvent{EventType: "messageReaction"})
+	require.NoError(t, err)
+	require.False(t, match)
+}
+
+func TestMSTeamsAuthenticateRejectsMissingAppID(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	config, err := definition.DecodeConfig(nil)
+	require.NoError(t, err)
+
+	err = definition.AuthenticateWebhook(t.Context(), []byte(`{"type":"message"}`), http.Header{}, map[string]string{}, config)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MSTEAMS_APP_ID")
+}
+
+func TestMSTeamsAuthenticateRejectsMissingBearer(t *testing.T) {
+	t.Parallel()
+
+	definition, ok := GetDefinition("msteams")
+	require.True(t, ok)
+
+	config, err := definition.DecodeConfig(nil)
+	require.NoError(t, err)
+
+	err = definition.AuthenticateWebhook(t.Context(), []byte(`{"type":"message"}`), http.Header{}, map[string]string{
+		"MSTEAMS_APP_ID": "app-1",
+	}, config)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing bearer token")
+}
+
+// botFrameworkTestServer stands in for Microsoft's OpenID metadata + JWKS
+// endpoints and signs tokens with a matching test key.
+type botFrameworkTestServer struct {
+	authenticator *botFrameworkAuthenticator
+	key           *rsa.PrivateKey
+}
+
+// botFrameworkTestKey is shared across the auth tests; generating a fresh
+// 2048-bit key per test server wastes ~1s of wall clock across the suite.
+var botFrameworkTestKey = sync.OnceValues(func() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, 2048)
+})
+
+func newBotFrameworkTestServer(t *testing.T) *botFrameworkTestServer {
+	t.Helper()
+
+	key, err := botFrameworkTestKey()
+	require.NoError(t, err)
+
+	jwks, err := json.Marshal(jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{
+			Key:       key.Public(),
+			KeyID:     "test-key",
+			Algorithm: "RS256",
+			Use:       "sig",
+		}},
+	})
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	mux.HandleFunc("/metadata", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"jwks_uri": server.URL + "/keys"})
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(jwks)
+	})
+
+	authenticator := newBotFrameworkAuthenticator(server.URL+"/metadata", botFrameworkIssuer)
+	// The production client's guardian policy blocks loopback, so reach the
+	// httptest JWKS server with its own client instead.
+	authenticator.clientFn = server.Client
+
+	return &botFrameworkTestServer{
+		authenticator: authenticator,
+		key:           key,
+	}
+}
+
+func (s *botFrameworkTestServer) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	raw, err := token.SignedString(s.key)
+	require.NoError(t, err)
+	return raw
+}
+
+func bearerHeaders(token string) http.Header {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+token)
+	return headers
+}
+
+func TestMSTeamsAuthenticateAcceptsValidToken(t *testing.T) {
+	t.Parallel()
+
+	server := newBotFrameworkTestServer(t)
+	token := server.sign(t, jwt.MapClaims{
+		"iss":        botFrameworkIssuer,
+		"aud":        "app-1",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+		"serviceurl": "https://smba.trafficmanager.net/teams",
+	})
+
+	body := []byte(`{"type":"message","serviceUrl":"https://smba.trafficmanager.net/teams/"}`)
+	err := server.authenticator.authenticate(t.Context(), body, bearerHeaders(token), "app-1")
+	require.NoError(t, err)
+}
+
+func TestMSTeamsAuthenticateRejectsWrongAudience(t *testing.T) {
+	t.Parallel()
+
+	server := newBotFrameworkTestServer(t)
+	token := server.sign(t, jwt.MapClaims{
+		"iss":        botFrameworkIssuer,
+		"aud":        "some-other-app",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+		"serviceurl": "https://smba.trafficmanager.net/teams",
+	})
+
+	body := []byte(`{"type":"message","serviceUrl":"https://smba.trafficmanager.net/teams"}`)
+	err := server.authenticator.authenticate(t.Context(), body, bearerHeaders(token), "app-1")
+	require.Error(t, err)
+}
+
+func TestMSTeamsAuthenticateRejectsWrongIssuer(t *testing.T) {
+	t.Parallel()
+
+	server := newBotFrameworkTestServer(t)
+	token := server.sign(t, jwt.MapClaims{
+		"iss":        "https://evil.example.com",
+		"aud":        "app-1",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+		"serviceurl": "https://smba.trafficmanager.net/teams",
+	})
+
+	body := []byte(`{"type":"message","serviceUrl":"https://smba.trafficmanager.net/teams"}`)
+	err := server.authenticator.authenticate(t.Context(), body, bearerHeaders(token), "app-1")
+	require.Error(t, err)
+}
+
+func TestMSTeamsAuthenticateRejectsExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	server := newBotFrameworkTestServer(t)
+	token := server.sign(t, jwt.MapClaims{
+		"iss":        botFrameworkIssuer,
+		"aud":        "app-1",
+		"exp":        time.Now().Add(-time.Hour).Unix(),
+		"serviceurl": "https://smba.trafficmanager.net/teams",
+	})
+
+	body := []byte(`{"type":"message","serviceUrl":"https://smba.trafficmanager.net/teams"}`)
+	err := server.authenticator.authenticate(t.Context(), body, bearerHeaders(token), "app-1")
+	require.Error(t, err)
+}
+
+func TestMSTeamsAuthenticateRejectsServiceURLMismatch(t *testing.T) {
+	t.Parallel()
+
+	server := newBotFrameworkTestServer(t)
+	token := server.sign(t, jwt.MapClaims{
+		"iss":        botFrameworkIssuer,
+		"aud":        "app-1",
+		"exp":        time.Now().Add(time.Hour).Unix(),
+		"serviceurl": "https://smba.trafficmanager.net/teams",
+	})
+
+	body := []byte(`{"type":"message","serviceUrl":"https://attacker.example.com"}`)
+	err := server.authenticator.authenticate(t.Context(), body, bearerHeaders(token), "app-1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "serviceUrl")
+}
+
+func TestMSTeamsAuthenticateRejectsMissingServiceURLClaim(t *testing.T) {
+	t.Parallel()
+
+	server := newBotFrameworkTestServer(t)
+	token := server.sign(t, jwt.MapClaims{
+		"iss": botFrameworkIssuer,
+		"aud": "app-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	body := []byte(`{"type":"message","serviceUrl":"https://smba.trafficmanager.net/teams"}`)
+	err := server.authenticator.authenticate(t.Context(), body, bearerHeaders(token), "app-1")
+	require.Error(t, err)
+}
+
+func TestMSTeamsAuthenticateNegativeCachesMetadataFailure(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	mux.HandleFunc("/metadata", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	authenticator := newBotFrameworkAuthenticator(server.URL+"/metadata", botFrameworkIssuer)
+	authenticator.clientFn = server.Client
+
+	err := authenticator.authenticate(t.Context(), []byte(`{"type":"message"}`), bearerHeaders("x.y.z"), "app-1")
+	require.ErrorContains(t, err, "fetch openid metadata")
+
+	// The failure is negative-cached: the next delivery fails fast without
+	// re-fetching the metadata document.
+	err = authenticator.authenticate(t.Context(), []byte(`{"type":"message"}`), bearerHeaders("x.y.z"), "app-1")
+	require.ErrorContains(t, err, "retrying later")
+}

--- a/server/internal/background/triggers/slack.go
+++ b/server/internal/background/triggers/slack.go
@@ -581,6 +581,7 @@ func newSlackDefinition() Definition {
 			TimestampSkew:   300 * time.Second,
 		},
 		SupportedEventTypes: supportedSlackEventTypes,
+		Authenticate:        nil,
 		PreVerify: func(body []byte, _ http.Header) (bool, error) {
 			// Slack's URL verification handshake must echo the challenge before
 			// any signing secret has necessarily been configured. Allow it

--- a/server/internal/background/triggers/slack_test.go
+++ b/server/internal/background/triggers/slack_test.go
@@ -81,7 +81,7 @@ func TestSlackHandleWebhookChallenge(t *testing.T) {
 	body := []byte(`{"type":"url_verification","challenge":"abc123"}`)
 	headers := signedSlackHeaders(t, body, "secret")
 
-	err = definition.AuthenticateWebhook(body, headers, map[string]string{
+	err = definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"SLACK_SIGNING_SECRET": "secret",
 	}, config)
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestSlackHandleWebhookBlockActionsRoutesToThread(t *testing.T) {
 	headers := signedSlackHeaders(t, body, "secret")
 	headers.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	require.NoError(t, definition.AuthenticateWebhook(body, headers, map[string]string{
+	require.NoError(t, definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"SLACK_SIGNING_SECRET": "secret",
 	}, config))
 
@@ -362,7 +362,7 @@ func TestSlackHandleWebhookEventTopLevelMessageKeysOnEventTs(t *testing.T) {
 	body := []byte(`{"type":"event_callback","team_id":"T1","event_id":"Ev1","event":{"type":"message","channel":"C1","user":"U1","text":"hello","ts":"1700000050.000900"}}`)
 	headers := signedSlackHeaders(t, body, "secret")
 
-	require.NoError(t, definition.AuthenticateWebhook(body, headers, map[string]string{
+	require.NoError(t, definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"SLACK_SIGNING_SECRET": "secret",
 	}, config))
 
@@ -432,7 +432,7 @@ func TestSlackSignatureRejectionOnBadSecret(t *testing.T) {
 	body := []byte(`{"type":"event_callback","event":{"type":"message","channel":"C1","user":"U1","ts":"1.0"}}`)
 	headers := signedSlackHeaders(t, body, "correct-secret")
 
-	err = definition.AuthenticateWebhook(body, headers, map[string]string{
+	err = definition.AuthenticateWebhook(t.Context(), body, headers, map[string]string{
 		"SLACK_SIGNING_SECRET": "wrong-secret",
 	}, config)
 	require.Error(t, err)

--- a/server/internal/background/triggers/webhook.go
+++ b/server/internal/background/triggers/webhook.go
@@ -1,6 +1,7 @@
 package triggers
 
 import (
+	"context"
 	"crypto/hmac"
 	"encoding/base64"
 	"encoding/hex"
@@ -145,6 +146,12 @@ type WebhookVendor struct {
 	SecretEnv           string
 	Signature           HMACScheme
 	SupportedEventTypes []string
+	// Authenticate replaces HMAC signature verification for vendors whose
+	// scheme is not a shared-secret MAC over the body (e.g. Bot Framework's
+	// Microsoft-signed JWTs). Exactly one of Authenticate and Signature.NewHash
+	// must be set; NewWebhookDefinition enforces this at construction so a
+	// vendor can never be silently wired with no authentication at all.
+	Authenticate func(ctx context.Context, body []byte, headers http.Header, env map[string]string) error
 	// PreVerify inspects the request before signature verification. Return
 	// skipSignature=true to authorize the request without checking the HMAC
 	// (e.g. Slack's url_verification handshake, which must echo a challenge
@@ -183,6 +190,9 @@ func NewWebhookDefinition(
 	compiled *jsonschema.Schema,
 	decodeConfigFn func(raw map[string]any) (Config, error),
 ) Definition {
+	if (vendor.Authenticate == nil) == (vendor.Signature.NewHash == nil) {
+		panic(fmt.Errorf("webhook vendor %q must set exactly one of Authenticate and Signature.NewHash", vendor.Slug))
+	}
 	return Definition{
 		Slug:                 vendor.Slug,
 		Title:                vendor.Title,
@@ -193,7 +203,7 @@ func NewWebhookDefinition(
 		EnvRequirements:      vendor.EnvRequirements,
 		EventType:            vendor.EventType,
 		DecodeConfig:         decodeConfigFn,
-		AuthenticateWebhook: func(body []byte, headers http.Header, env map[string]string, _ Config) error {
+		AuthenticateWebhook: func(ctx context.Context, body []byte, headers http.Header, env map[string]string, _ Config) error {
 			if vendor.PreVerify != nil {
 				skip, err := vendor.PreVerify(body, headers)
 				if err != nil {
@@ -203,8 +213,8 @@ func NewWebhookDefinition(
 					return nil
 				}
 			}
-			if vendor.Signature.NewHash == nil {
-				return nil
+			if vendor.Authenticate != nil {
+				return vendor.Authenticate(ctx, body, headers, env)
 			}
 			ciEnv := toolconfig.CIEnvFrom(env)
 			secret := ciEnv.Get(vendor.SecretEnv)

--- a/server/internal/background/triggers/webhook_test.go
+++ b/server/internal/background/triggers/webhook_test.go
@@ -1,6 +1,7 @@
 package triggers
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -133,6 +134,9 @@ func TestWebhookHandleDefersEventIDFallback(t *testing.T) {
 	vendor := WebhookVendor{
 		Slug:      "test-vendor",
 		EventType: reflect.TypeFor[struct{}](),
+		Authenticate: func(_ context.Context, _ []byte, _ http.Header, _ map[string]string) error {
+			return nil
+		},
 		Ingest: func(_ []byte, _ http.Header) (*WebhookIngest, error) {
 			// No vendor delivery id and no correlation id.
 			return &WebhookIngest{Event: map[string]any{"ok": true}}, nil


### PR DESCRIPTION
## Summary

- Adds Microsoft Teams as an assistant trigger source (slug `msteams`), registered in the trigger definition registry — the dashboard trigger dialog picks it up automatically from the config schema, so no frontend or SDK changes are needed.
- **Webhook auth**: Bot Framework does not sign requests with an HMAC; it sends Microsoft-signed JWTs. Adds a first-class `Authenticate` hook to `WebhookVendor` (with construction-time enforcement that every vendor sets exactly one of `Authenticate` / `Signature.NewHash`, so a vendor can never be wired with no auth), and implements Bot Framework validation per [Microsoft's connector auth spec](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0): RS256 signature against the JWKS advertised by the static OpenID metadata document, issuer `https://api.botframework.com`, audience = the bot's Microsoft App ID (from the `MSTEAMS_APP_ID` environment entry), and `serviceurl` claim ↔ activity `serviceUrl` match. Metadata/JWKS fetches go through a guardian-backed client, are cached, and metadata failures are negative-cached for 30s so a Microsoft blip can't pile deliveries up behind the fetch mutex.
- **Event normalization**: Bot Framework `Activity` payloads (`message`, `messageUpdate`, `messageDelete`, `messageReaction`, `conversationUpdate`, `installationUpdate`, `endOfConversation`) are decoded into a CEL-filterable event (conversation/tenant/team/channel identity, sender, text, reactions, membership changes). `typing` is deliberately excluded from the supported list since an empty allowlist defaults to all supported types. Correlation key is the Teams conversation id (already thread-scoped in channels via the `;messageid=` suffix), falling back to the tenant.
- **Assistants**: new `msteams` source adapter (thread context, output guidance, turn decoding) and event payload case; `AuthenticateWebhook` now takes a `ctx` (the JWT path does network I/O); the per-case raw-payload JSON fallback in `buildAssistantEventPayload` is hoisted to one place.

## Scope note vs the issue

DNO-117 (written in May) also called for `msteams_apps`/`msteams_registrations` tables, a Goa `msteams` service, and dashboard pages mirroring the Slack app feature — but that entire pattern was removed in #3309 ("remove legacy Slack app feature"), and the live Slack path is the trigger registry this PR extends. Per-install bot identity is covered by environment entries (`MSTEAMS_APP_ID` per trigger instance), so no new tables or RPC surface are needed. Outbound Teams platform tools remain DNO-118.

Closes [DNO-117](https://linear.app/speakeasy/issue/DNO-117/ms-teams-trigger)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Microsoft Teams as an assistant trigger (`msteams`) with JWT-verified Bot Framework webhooks (closes DNO-117). Events are normalized for CEL filtering and routed to assistants via a new Teams source adapter.

- **New Features**
  - New `msteams` webhook trigger; supports messages, reactions, membership and installation updates (excludes typing).
  - Webhook auth via `WebhookVendor.Authenticate`: verifies Microsoft-signed JWTs (issuer, audience `MSTEAMS_APP_ID`, and `serviceurl` match) using OpenID JWKS. Caches keys, coalesces metadata fetches with singleflight (with an in-flight cache re-check), and negative-caches failures for 30s.
  - Event normalization: conversation/tenant/team/channel IDs, sender, text, reactions, membership changes, and `conversation_type`; correlation id is `conversation.id` (thread-aware) or tenant.
  - Assistants: new Teams source adapter adds thread context, output guidance, and turn decoding (includes `ConversationType`). `AuthenticateWebhook` now takes a `ctx`. The raw-payload JSON fallback is centralized.

- **Migration**
  - Set `MSTEAMS_APP_ID` in the trigger instance’s environment.
  - No new tables or RPC services; the dashboard trigger dialog picks up `msteams` from the schema.
  - No frontend or SDK changes required.

<sup>Written for commit 818b4616f2b31268ccb14e9c840cc25e570f4b64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

