### PR TITLE
chore(deps): bump github.com/speakeasy-api/mcp-setup-docs/go from v0.1.2 to v0.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
 	github.com/speakeasy-api/agenthooks v0.4.0
-	github.com/speakeasy-api/mcp-setup-docs/go v0.1.2
+	github.com/speakeasy-api/mcp-setup-docs/go v0.1.4
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,8 @@ github.com/speakeasy-api/agenthooks v0.4.0 h1:3dbu1ab5lc0Ij5KRr8D3DQtHGtcpJ9hO85
 github.com/speakeasy-api/agenthooks v0.4.0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
-github.com/speakeasy-api/mcp-setup-docs/go v0.1.2 h1:Dmuil8IVBk2IJnG/RxDRkfwl3uJIqUSz94E6zXluj78=
-github.com/speakeasy-api/mcp-setup-docs/go v0.1.2/go.mod h1:epqh0bWWTc4FNmoRXGGv1pkuB9AetNJUzZHAsKuytW4=
+github.com/speakeasy-api/mcp-setup-docs/go v0.1.4 h1:NN0+F+YntAkZl8wRCeCLfrqo/VeiWsM/uUeuGVg/dgA=
+github.com/speakeasy-api/mcp-setup-docs/go v0.1.4/go.mod h1:epqh0bWWTc4FNmoRXGGv1pkuB9AetNJUzZHAsKuytW4=
 github.com/speakeasy-api/openapi v1.24.0 h1:opoD27rupX7zBVPq1HkIGLeMOzNNA7JalhYP8q34i04=
 github.com/speakeasy-api/openapi v1.24.0/go.mod h1:g3+dIMe0AYgbbGvnlQZqesmjAVWSm9BmsjLevnefQrg=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=


### PR DESCRIPTION
## Summary
- Pin `github.com/speakeasy-api/mcp-setup-docs/go` to `v0.1.4` (was `v0.1.2`)
- Opened by `go-module-consumer-bump` in speakeasy-api/mcp-setup-docs after the `go/v0.1.4` release
- Branch is machine-owned — the next release force-pushes over it
- If this bump breaks CI, branch off `chore/bump-mcp-setup-docs-go`, fix it there, and close this PR.
  Commits pushed onto this branch are lost on the next release.

## Release notes
[`go/v0.1.4`](https://github.com/speakeasy-api/mcp-setup-docs/releases/tag/go/v0.1.4)

Go module `github.com/speakeasy-api/mcp-setup-docs/go@v0.1.4`

```bash
go get github.com/speakeasy-api/mcp-setup-docs/go@v0.1.4
```

### Changes since go/v0.1.3
- **Updated guides:** `google-compute-engine`
- **Other:** `go/index_gen.go`


## Test plan
- [ ] Consumer CI is green (`go mod tidy` leaves the tree clean)
- [ ] Setup docs lookups still resolve the guides the release changed
