### PR TITLE
feat: make skills table columns sortable

### DIFF
--- a/.changeset/sortable-skills-columns.md
+++ b/.changeset/sortable-skills-columns.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Make Skills table columns sortable from their headers while preserving recently updated as the default order.

--- a/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
@@ -23,6 +23,8 @@ const testState = vi.hoisted(() => ({
     | undefined,
   insightsRefetch: vi.fn().mockResolvedValue(undefined),
   metricTotalCount: undefined as number | undefined,
+  metricPageSize: 200,
+  loadedMetricPageCount: 1,
   skillRequests: [] as unknown[],
   metricSkillRequests: [] as unknown[],
   searchValue: "example",
@@ -118,24 +120,31 @@ vi.mock("@gram/client/react-query/skills.js", () => ({
           String(skill.displayName).toLowerCase().includes(request.search!),
         )
       : testState.skills;
+    const pages = Array.from(
+      { length: testState.loadedMetricPageCount },
+      (_, page) => ({
+        result: {
+          skills: matchingSkills.slice(
+            page * testState.metricPageSize,
+            (page + 1) * testState.metricPageSize,
+          ),
+          totalCount: testState.metricTotalCount ?? matchingSkills.length,
+        },
+      }),
+    );
     return {
-      data: {
-        pages: [
-          {
-            result: {
-              skills: matchingSkills,
-              totalCount: testState.metricTotalCount ?? matchingSkills.length,
-            },
-          },
-        ],
-      },
+      data: { pages },
       isPending: false,
       isFetching: false,
       isFetchingNextPage: false,
       isFetchNextPageError: testState.isFetchNextPageError,
       hasNextPage: testState.hasNextPage,
       error: testState.error,
-      fetchNextPage: testState.fetchNextPage,
+      fetchNextPage: async () => {
+        testState.loadedMetricPageCount += 1;
+        testState.hasNextPage = false;
+        return testState.fetchNextPage();
+      },
       refetch: vi.fn(),
     };
   },
@@ -225,9 +234,18 @@ vi.mock("@/components/page-layout", () => {
       Apply search
     </button>
   );
+  const Filters = ({
+    onChange,
+  }: {
+    onChange: (id: string, value: string[]) => void;
+  }) => (
+    <button onClick={() => onChange("sourceKind", ["manual"])}>
+      Apply filters
+    </button>
+  );
   const Toolbar = Object.assign(Wrapper, {
     Search,
-    Filters: () => null,
+    Filters,
     Count: Wrapper,
     Actions: Wrapper,
     Refresh: () => null,
@@ -366,6 +384,8 @@ beforeEach(() => {
   testState.insightsRefetch.mockReset();
   testState.insightsRefetch.mockResolvedValue(undefined);
   testState.metricTotalCount = undefined;
+  testState.metricPageSize = 200;
+  testState.loadedMetricPageCount = 1;
   testState.skillRequests = [];
   testState.metricSkillRequests = [];
   testState.searchValue = "example";
@@ -502,6 +522,42 @@ describe("SkillsList pagination surfaces", () => {
     expect(renderedSkillNames()).toEqual(["High", "Low", "Missing"]);
   });
 
+  it("drains metric pages before sorting activations across the page boundary", async () => {
+    testState.skills = makeSkills(201);
+    testState.hasNextPage = true;
+    testState.insightsData = {
+      result: {
+        insights: [
+          { skillId: "skill_0", metrics: { activations: 90 } },
+          { skillId: "skill_200", metrics: { activations: 100 } },
+        ],
+      },
+    };
+    const { rerender } = render(<SkillsList />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
+    await waitFor(() => expect(testState.fetchNextPage).toHaveBeenCalledOnce());
+    rerender(<SkillsList />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) descending",
+      }),
+    );
+
+    expect(renderedSkillNames().slice(0, 2)).toEqual([
+      "Example 200",
+      "Example 0",
+    ]);
+    expect(screen.getByText("1-50 of 201")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(renderedSkillNames()[0]).toBe("Example 49");
+    expect(screen.getByText("51-100 of 201")).toBeTruthy();
+  });
+
   it("keeps an active header sort when search resets pagination", () => {
     render(<SkillsList />);
 
@@ -514,6 +570,26 @@ describe("SkillsList pagination surfaces", () => {
     expect(screen.getByText("Example 50")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Apply search" }));
+    expect(screen.getByText("Example 0")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) descending",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("keeps an active header sort when filters reset pagination", () => {
+    render(<SkillsList />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Example 50")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply filters" }));
     expect(screen.getByText("Example 0")).toBeTruthy();
     expect(
       screen.getByRole("button", {
@@ -657,6 +733,51 @@ describe("SkillsList pagination surfaces", () => {
       expect(screen.getAllByTestId("skill-row")).toHaveLength(50),
     );
     expect(testState.fetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("keeps metric sorting cleared after insights recover", async () => {
+    testState.skills = [
+      { ...makeSkills(1)[0], id: "zulu", displayName: "Zulu" },
+      { ...makeSkills(1)[0], id: "alpha", displayName: "Alpha" },
+      { ...makeSkills(1)[0], id: "mike", displayName: "Mike" },
+      ...makeSkills(48),
+    ];
+    const { rerender } = render(<SkillsList />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Example 47")).toBeTruthy();
+
+    testState.insightsData = undefined;
+    testState.insightsError = new Error("insights unavailable");
+    rerender(<SkillsList />);
+    await waitFor(() =>
+      expect(
+        screen
+          .getByRole("button", { name: "Previous" })
+          .hasAttribute("disabled"),
+      ).toBe(true),
+    );
+
+    testState.metricSkillRequests = [];
+    testState.insightsData = { result: { insights: [] } };
+    testState.insightsError = null;
+    rerender(<SkillsList />);
+
+    expect(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    ).toBeTruthy();
+    expect(testState.metricSkillRequests).toEqual([]);
+    expect(renderedSkillNames().slice(0, 3)).toEqual(["Zulu", "Alpha", "Mike"]);
+    expect(
+      screen.getByRole("button", { name: "Previous" }).hasAttribute("disabled"),
+    ).toBe(true);
   });
 
   it("badges skills with open suggestions and drains suggestion pages", async () => {

--- a/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
@@ -308,7 +308,9 @@ vi.mock("@/components/ui/Table", () => ({
     return (
       <div>
         {sortableColumns.map((column) => {
-          const label = column.sortLabel ?? column.header;
+          const label =
+            column.sortLabel ??
+            (typeof column.header === "string" ? column.header : column.key);
           const direction = sort?.id === column.key ? sort.direction : null;
           const action =
             direction === "asc"

--- a/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
@@ -105,8 +105,14 @@ vi.mock("@gram/client/react-query/skills.js", () => ({
       refetch: vi.fn(),
     };
   },
-  useSkillsInfinite: (request: { search?: string }) => {
-    testState.metricSkillRequests.push(request);
+  useSkillsInfinite: (
+    request: { search?: string },
+    _client: unknown,
+    options?: { enabled?: boolean },
+  ) => {
+    if (options?.enabled) {
+      testState.metricSkillRequests.push(request);
+    }
     const matchingSkills = request.search
       ? testState.skills.filter((skill) =>
           String(skill.displayName).toLowerCase().includes(request.search!),
@@ -219,13 +225,9 @@ vi.mock("@/components/page-layout", () => {
       Apply search
     </button>
   );
-  const SortBy = ({ onChange }: { onChange: (value: string) => void }) => (
-    <button onClick={() => onChange("activations")}>Apply metric sort</button>
-  );
   const Toolbar = Object.assign(Wrapper, {
     Search,
     Filters: () => null,
-    SortBy,
     Count: Wrapper,
     Actions: Wrapper,
     Refresh: () => null,
@@ -257,26 +259,67 @@ vi.mock("@/components/ui/Table", () => ({
     columns,
     data,
     noResultsMessage,
+    sort,
+    onSortChange,
   }: {
     columns: Array<{
       key: string;
+      header: ReactNode;
+      sortable?: boolean;
+      sortLabel?: string;
       render?: (row: Record<string, unknown>) => ReactNode;
     }>;
     data: Array<Record<string, unknown> & { id: string }>;
     noResultsMessage: ReactNode;
-  }) => (
-    <div>
-      {data.length === 0
-        ? noResultsMessage
-        : data.map((skill) => (
-            <div data-testid="skill-row" key={skill.id}>
-              {columns.slice(0, 1).map((column) => (
-                <div key={column.key}>{column.render?.(skill)}</div>
-              ))}
-            </div>
-          ))}
-    </div>
-  ),
+    sort: { id: string; direction: "asc" | "desc" } | null;
+    onSortChange: (
+      sort: { id: string; direction: "asc" | "desc" } | null,
+    ) => void;
+  }) => {
+    const sortableColumns = columns.filter((column) => column.sortable);
+    const nextSort = (column: (typeof columns)[number]) => {
+      if (sort?.id !== column.key) {
+        return { id: column.key, direction: "asc" as const };
+      }
+      if (sort.direction === "asc") {
+        return { id: column.key, direction: "desc" as const };
+      }
+      return null;
+    };
+
+    return (
+      <div>
+        {sortableColumns.map((column) => {
+          const label = column.sortLabel ?? column.header;
+          const direction = sort?.id === column.key ? sort.direction : null;
+          const action =
+            direction === "asc"
+              ? `Sort by ${label} descending`
+              : direction === "desc"
+                ? `Clear sort for ${label}`
+                : `Sort by ${label} ascending`;
+          return (
+            <button
+              data-sortable-id={column.key}
+              key={column.key}
+              onClick={() => onSortChange(nextSort(column))}
+            >
+              {action}
+            </button>
+          );
+        })}
+        {data.length === 0
+          ? noResultsMessage
+          : data.map((skill) => (
+              <div data-testid="skill-row" key={skill.id}>
+                {columns.slice(0, 1).map((column) => (
+                  <div key={column.key}>{column.render?.(skill)}</div>
+                ))}
+              </div>
+            ))}
+      </div>
+    );
+  },
 }));
 
 function makeSkills(count: number): Array<Record<string, unknown>> {
@@ -304,6 +347,12 @@ function makeSuggestion(index: number): Record<string, unknown> {
     skillName: `example-${index}`,
     status: "open",
   };
+}
+
+function renderedSkillNames(): string[] {
+  return screen
+    .getAllByTestId("skill-row")
+    .map((row) => row.querySelector("a")?.textContent ?? "");
 }
 
 beforeEach(() => {
@@ -344,6 +393,135 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("SkillsList pagination surfaces", () => {
+  it("sorts the approved columns through header controls without a toolbar sort", () => {
+    render(<SkillsList />);
+
+    expect(
+      screen
+        .getAllByRole("button", { name: /sort by .* ascending/i })
+        .map((button) => button.getAttribute("data-sortable-id")),
+    ).toEqual([
+      "name",
+      "source",
+      "activations",
+      "efficacy",
+      "estimatedSavings",
+      "updated",
+    ]);
+    expect(
+      screen.queryByRole("button", { name: "Apply metric sort" }),
+    ).toBeNull();
+  });
+
+  it("sorts the current server page by skill and clears back to backend order", () => {
+    testState.skills = [
+      { ...makeSkills(1)[0], id: "zulu", displayName: "Zulu" },
+      { ...makeSkills(1)[0], id: "alpha", displayName: "Alpha" },
+      { ...makeSkills(1)[0], id: "mike", displayName: "Mike" },
+    ];
+    render(<SkillsList />);
+
+    expect(renderedSkillNames()).toEqual(["Zulu", "Alpha", "Mike"]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sort by Skill ascending" }),
+    );
+    expect(renderedSkillNames()).toEqual(["Alpha", "Mike", "Zulu"]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sort by Skill descending" }),
+    );
+    expect(renderedSkillNames()).toEqual(["Zulu", "Mike", "Alpha"]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear sort for Skill" }),
+    );
+    expect(renderedSkillNames()).toEqual(["Zulu", "Alpha", "Mike"]);
+    expect(testState.metricSkillRequests).toEqual([]);
+  });
+
+  it("sorts activations across loaded pages and keeps missing efficacy values last", () => {
+    testState.skills = [
+      { ...makeSkills(1)[0], id: "missing", displayName: "Missing" },
+      { ...makeSkills(1)[0], id: "high", displayName: "High" },
+      { ...makeSkills(1)[0], id: "low", displayName: "Low" },
+    ];
+    testState.insightsData = {
+      result: {
+        insights: [
+          {
+            skillId: "high",
+            metrics: {
+              activations: 5,
+              efficacy: { averageScore: 0.9, estimatedMinutesSavedTotal: 9 },
+            },
+          },
+          {
+            skillId: "low",
+            metrics: {
+              activations: 2,
+              efficacy: { averageScore: 0.2, estimatedMinutesSavedTotal: 2 },
+            },
+          },
+        ],
+      },
+    };
+    render(<SkillsList />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
+    expect(renderedSkillNames()).toEqual(["Missing", "Low", "High"]);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) descending",
+      }),
+    );
+    expect(renderedSkillNames()).toEqual(["High", "Low", "Missing"]);
+    expect(testState.metricSkillRequests).not.toEqual([]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sort by Efficacy ascending" }),
+    );
+    expect(renderedSkillNames()).toEqual(["Low", "High", "Missing"]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sort by Efficacy descending" }),
+    );
+    expect(renderedSkillNames()).toEqual(["High", "Low", "Missing"]);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Estimated savings ascending",
+      }),
+    );
+    expect(renderedSkillNames()).toEqual(["Low", "High", "Missing"]);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Estimated savings descending",
+      }),
+    );
+    expect(renderedSkillNames()).toEqual(["High", "Low", "Missing"]);
+  });
+
+  it("keeps an active header sort when search resets pagination", () => {
+    render(<SkillsList />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Example 50")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply search" }));
+    expect(screen.getByText("Example 0")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) descending",
+      }),
+    ).toBeTruthy();
+  });
+
   it("requests suggestion pages with the exact supported limit", () => {
     render(<SkillsList />);
 
@@ -370,7 +548,11 @@ describe("SkillsList pagination surfaces", () => {
     testState.isFetchNextPageError = true;
     testState.error = new Error("next page failed");
     render(<SkillsList />);
-    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
 
     expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
     expect(screen.getByText("Unable to load more skills.")).toBeTruthy();
@@ -390,7 +572,11 @@ describe("SkillsList pagination surfaces", () => {
     testState.error = new Error("next page failed");
     render(<SkillsList />);
     fireEvent.click(screen.getByRole("button", { name: "Apply search" }));
-    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
 
     expect(
       screen.getByText("Search incomplete. Retry to check remaining skills."),
@@ -432,7 +618,11 @@ describe("SkillsList pagination surfaces", () => {
 
     expect(testState.fetchNextPage).not.toHaveBeenCalled();
     expect(screen.getAllByTestId("skill-row")).toHaveLength(50);
-    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
     await waitFor(() => expect(testState.fetchNextPage).toHaveBeenCalledOnce());
     expect(
       screen.getByText("Loading all skills to finish this view..."),
@@ -457,7 +647,11 @@ describe("SkillsList pagination surfaces", () => {
     testState.insightsError = new Error("insights unavailable");
     render(<SkillsList />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Apply metric sort" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Sort by Activations (30d) ascending",
+      }),
+    );
 
     await waitFor(() =>
       expect(screen.getAllByTestId("skill-row")).toHaveLength(50),

--- a/client/dashboard/src/pages/skills/SkillsList.test.ts
+++ b/client/dashboard/src/pages/skills/SkillsList.test.ts
@@ -1,10 +1,6 @@
 import type { Skill } from "@gram/client/models/components/skill.js";
 import { describe, expect, it } from "vitest";
-import {
-  filterSkills,
-  prioritizeAddableSkills,
-  sortSkills,
-} from "./skills-list-helpers";
+import { filterSkills, prioritizeAddableSkills } from "./skills-list-helpers";
 
 function skill(overrides: Partial<Skill>): Skill {
   return {
@@ -73,38 +69,5 @@ describe("SkillsList filtering", () => {
         availableSecond,
       ]).map((item) => item.id),
     ).toEqual(["b", "d", "a", "c"]);
-  });
-
-  it("sorts sampled metrics ahead of missing values", () => {
-    const first = skill({ id: "a", displayName: "Alpha" });
-    const second = skill({ id: "b", displayName: "Beta" });
-    const metrics = new Map([
-      [
-        second.id,
-        {
-          activations: 4,
-          activatedSessions: 3,
-          averageSessionCostUsd: 1,
-          sessionCostUsd: 3,
-          efficacy: {
-            averageScore: 0.8,
-            estimatedMinutesSavedAverage: 5,
-            estimatedMinutesSavedSamples: 1,
-            estimatedMinutesSavedTotal: 5,
-            estimatedTurnsSavedAverage: 1,
-            estimatedTurnsSavedSamples: 1,
-            estimatedTurnsSavedTotal: 1,
-            flagCounts: {},
-            roiConfidenceCounts: {},
-            scoredSessions: 1,
-          },
-        },
-      ],
-    ]);
-
-    expect(sortSkills([first, second], metrics, "efficacy")[0]?.id).toBe("b");
-    expect(sortSkills([first, second], metrics, "activations")[0]?.id).toBe(
-      "b",
-    );
   });
 });

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -21,7 +21,8 @@ import {
 } from "@gram/client/react-query/skills.js";
 import { Badge } from "@/components/ui/Badge";
 import { Icon } from "@/components/ui/Icon";
-import { type Column, Table } from "@/components/ui/Table";
+import { type Column, type SortDescriptor, Table } from "@/components/ui/Table";
+import { sortTableData } from "@/components/ui/Table/sorting";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { useRoutes } from "@/routes";
 import { useQueryState } from "nuqs";
@@ -36,7 +37,6 @@ import {
   SKILL_SOURCE_OPTIONS,
 } from "./skill-badge-options";
 import { SkillClassificationBadge, SkillSourceBadge } from "./skill-badges";
-import { type SkillSort, sortSkills } from "./skills-list-helpers";
 import { UnknownSkillActivationsSection } from "./UnknownSkillActivationsSection";
 import { useDrainSkillPages } from "./use-drain-skill-pages";
 import { useOpenSkillSuggestions } from "./use-open-skill-suggestions";
@@ -78,12 +78,11 @@ function ColumnHeaderTooltip({
 const RESULT_PAGE_SIZE = 50;
 const METRIC_SORT_BATCH_SIZE = 200;
 const EMPTY_SKILLS: Skill[] = [];
-const INSIGHT_SORT_OPTIONS = [
-  { value: "updated", label: "Recently updated" },
-  { value: "activations", label: "Most activated" },
-  { value: "efficacy", label: "Highest efficacy" },
-  { value: "estimated_savings", label: "Most estimated savings" },
-];
+const METRIC_SORT_IDS = [
+  "activations",
+  "efficacy",
+  "estimatedSavings",
+] as const;
 
 function formatEfficacy(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
@@ -105,7 +104,7 @@ export default function SkillsList(): JSX.Element {
   const navigate = useNavigate();
   const filters = useFilterState(SKILL_FILTERS);
   const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SkillSort>("updated");
+  const [sort, setSort] = useState<SortDescriptor | null>(null);
   const deferredSearch = useDeferredValue(search);
   const [dialogOpen, setDialogOpen] = useState(false);
   // Legacy deep links opened the skill as a sheet via ?skill=<id>; redirect
@@ -115,7 +114,11 @@ export default function SkillsList(): JSX.Element {
   const [pageCursors, setPageCursors] = useState<(string | undefined)[]>([
     undefined,
   ]);
-  const metricSort = sort !== "updated";
+  const metricSort =
+    sort &&
+    METRIC_SORT_IDS.includes(sort.id as (typeof METRIC_SORT_IDS)[number])
+      ? sort
+      : null;
   const searchQuery = deferredSearch.trim() || undefined;
   const sourceKinds = filters.values.sourceKind as SourceKinds[];
   const classifications = filters.values.classification as Classifications[];
@@ -141,7 +144,7 @@ export default function SkillsList(): JSX.Element {
     undefined,
     {
       throwOnError: false,
-      enabled: metricSort,
+      enabled: metricSort !== null,
     },
   );
   const metricSkills = useMemo(
@@ -177,25 +180,209 @@ export default function SkillsList(): JSX.Element {
     filters.values.sourceKind.length > 0 ||
     filters.values.classification.length > 0;
   const insightsUnavailable = !!insightsQuery.error && !insightsQuery.data;
-  const effectiveMetricSort = metricSort && !insightsUnavailable;
-  const effectiveSort = insightsUnavailable ? "updated" : sort;
+  const effectiveMetricSort = metricSort !== null && !insightsUnavailable;
+  const effectiveSort = insightsUnavailable && metricSort ? null : sort;
   const skills = effectiveMetricSort
     ? metricSkills
     : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
-  const visibleSkills = useMemo(
-    () =>
-      effectiveMetricSort
-        ? sortSkills(skills, metricsBySkill, effectiveSort)
-        : skills,
-    [effectiveMetricSort, effectiveSort, metricsBySkill, skills],
-  );
+
+  const columns: Column<Skill>[] = [
+    {
+      key: "name",
+      header: "Skill",
+      width: "1.5fr",
+      sortable: true,
+      sortValue: (skill) => skill.displayName.toLocaleLowerCase(),
+      render: (skill) => (
+        <div className="min-w-0">
+          <Link
+            to={routes.skills.detail.href(skill.id)}
+            className="font-medium hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {skill.displayName}
+          </Link>
+          {openSuggestions.skillIds.has(skill.id) && (
+            <Badge variant="information" className="ml-2">
+              Suggested edit
+            </Badge>
+          )}
+          <Text small muted className="truncate font-mono">
+            {skill.name}
+          </Text>
+        </div>
+      ),
+    },
+    {
+      key: "summary",
+      header: "Summary",
+      width: "2fr",
+      render: (skill) => (
+        <Text small muted className="line-clamp-2">
+          {skill.summary || "No summary"}
+        </Text>
+      ),
+    },
+    {
+      key: "source",
+      header: (
+        <ColumnHeaderTooltip
+          label="Source"
+          tooltip="How the skill entered the registry: added manually, or captured from agent use."
+        />
+      ),
+      width: "120px",
+      sortable: true,
+      sortLabel: "Source",
+      sortValue: (skill) =>
+        SKILL_SOURCE_OPTIONS.find((option) => option.value === skill.sourceKind)
+          ?.label ?? skill.sourceKind,
+      render: (skill) => <SkillSourceBadge value={skill.sourceKind} />,
+    },
+    {
+      key: "classification",
+      header: (
+        <ColumnHeaderTooltip
+          label="Classification"
+          tooltip="Custom skills belong to your organization; built-in skills come from plugins or platform defaults."
+        />
+      ),
+      width: "130px",
+      render: (skill) => (
+        <SkillClassificationBadge value={skill.classification} />
+      ),
+    },
+    {
+      key: "versions",
+      header: "Versions",
+      width: "90px",
+      render: (skill) => <Text small>{skill.versionCount}</Text>,
+    },
+    {
+      key: "activations",
+      header: "Activations (30d)",
+      width: "130px",
+      sortable: true,
+      sortValue: (skill) => metricsBySkill.get(skill.id)?.activations ?? 0,
+      render: (skill) => (
+        <Text small className="tabular-nums">
+          {metricsBySkill.get(skill.id)?.activations.toLocaleString() ??
+            (insightsQuery.data ? "0" : "-")}
+        </Text>
+      ),
+    },
+    {
+      key: "efficacy",
+      header: (
+        <ColumnHeaderTooltip
+          label="Efficacy"
+          tooltip="Average usefulness score from sampled sessions that used this skill."
+        />
+      ),
+      width: "110px",
+      sortable: true,
+      sortLabel: "Efficacy",
+      sortValue: (skill) =>
+        metricsBySkill.get(skill.id)?.efficacy?.averageScore,
+      render: (skill) => {
+        const efficacy = metricsBySkill.get(skill.id)?.efficacy;
+        return (
+          <Text
+            small
+            className="tabular-nums"
+            title={
+              efficacy
+                ? `${efficacy.scoredSessions.toLocaleString()} sampled sessions`
+                : "No sampled scores"
+            }
+          >
+            {efficacy ? formatEfficacy(efficacy.averageScore) : "-"}
+          </Text>
+        );
+      },
+    },
+    {
+      key: "estimatedSavings",
+      header: (
+        <ColumnHeaderTooltip
+          label="Estimated savings"
+          tooltip="Estimated time saved across scored sessions that used this skill."
+        />
+      ),
+      width: "150px",
+      sortable: true,
+      sortLabel: "Estimated savings",
+      sortValue: (skill) =>
+        metricsBySkill.get(skill.id)?.efficacy?.estimatedMinutesSavedTotal,
+      render: (skill) => {
+        const efficacy = metricsBySkill.get(skill.id)?.efficacy;
+        return (
+          <Text small className="tabular-nums">
+            {efficacy
+              ? formatSavings(efficacy.estimatedMinutesSavedTotal)
+              : "-"}
+          </Text>
+        );
+      },
+    },
+    {
+      key: "updated",
+      header: "Updated",
+      width: "150px",
+      sortable: true,
+      sortValue: (skill) => skill.updatedAt,
+      render: (skill) => (
+        <Text
+          small
+          muted
+          title={dateTimeFormatters.full.format(skill.updatedAt)}
+        >
+          <HumanizeDateTime date={skill.updatedAt} />
+        </Text>
+      ),
+    },
+    {
+      key: "share",
+      header: "",
+      width: "48px",
+      render: (skill) =>
+        skill.shareToken ? (
+          <CopyButton
+            size="sm"
+            text={skillShareUrl(skill.shareToken)}
+            tooltip="Copy public link"
+            onCopy={() => {
+              toast.success("Public link copied");
+            }}
+          />
+        ) : null,
+    },
+    {
+      key: "open",
+      header: "",
+      width: "48px",
+      render: () => (
+        <Icon
+          name="arrow-right"
+          className="text-muted-foreground h-4 w-4"
+          aria-hidden
+        />
+      ),
+    },
+  ];
+
+  const visibleSkills = sortTableData(
+    skills,
+    columns,
+    effectiveSort,
+  ) as Skill[];
 
   useEffect(() => {
-    if (!insightsUnavailable || sort === "updated") return;
-    setSort("updated");
+    if (!insightsUnavailable || !metricSort) return;
+    setSort(null);
     setPage(0);
     setPageCursors([undefined]);
-  }, [insightsUnavailable, sort]);
+  }, [insightsUnavailable, metricSort]);
 
   useDrainSkillPages({
     active: effectiveMetricSort,
@@ -240,172 +427,6 @@ export default function SkillsList(): JSX.Element {
     setPageCursors((current) => [...current.slice(0, page + 1), nextCursor]);
     setPage((current) => current + 1);
   };
-
-  const columns: Column<Skill>[] = [
-    {
-      key: "name",
-      header: "Skill",
-      width: "1.5fr",
-      render: (skill) => (
-        <div className="min-w-0">
-          <Link
-            to={routes.skills.detail.href(skill.id)}
-            className="font-medium hover:underline"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {skill.displayName}
-          </Link>
-          {openSuggestions.skillIds.has(skill.id) && (
-            <Badge variant="information" className="ml-2">
-              Suggested edit
-            </Badge>
-          )}
-          <Text small muted className="truncate font-mono">
-            {skill.name}
-          </Text>
-        </div>
-      ),
-    },
-    {
-      key: "summary",
-      header: "Summary",
-      width: "2fr",
-      render: (skill) => (
-        <Text small muted className="line-clamp-2">
-          {skill.summary || "No summary"}
-        </Text>
-      ),
-    },
-    {
-      key: "source",
-      header: (
-        <ColumnHeaderTooltip
-          label="Source"
-          tooltip="How the skill entered the registry: added manually, or captured from agent use."
-        />
-      ),
-      width: "120px",
-      render: (skill) => <SkillSourceBadge value={skill.sourceKind} />,
-    },
-    {
-      key: "classification",
-      header: (
-        <ColumnHeaderTooltip
-          label="Classification"
-          tooltip="Custom skills belong to your organization; built-in skills come from plugins or platform defaults."
-        />
-      ),
-      width: "130px",
-      render: (skill) => (
-        <SkillClassificationBadge value={skill.classification} />
-      ),
-    },
-    {
-      key: "versions",
-      header: "Versions",
-      width: "90px",
-      render: (skill) => <Text small>{skill.versionCount}</Text>,
-    },
-    {
-      key: "activations",
-      header: "Activations (30d)",
-      width: "130px",
-      render: (skill) => (
-        <Text small className="tabular-nums">
-          {metricsBySkill.get(skill.id)?.activations.toLocaleString() ??
-            (insightsQuery.data ? "0" : "-")}
-        </Text>
-      ),
-    },
-    {
-      key: "efficacy",
-      header: (
-        <ColumnHeaderTooltip
-          label="Efficacy"
-          tooltip="Average usefulness score from sampled sessions that used this skill."
-        />
-      ),
-      width: "110px",
-      render: (skill) => {
-        const efficacy = metricsBySkill.get(skill.id)?.efficacy;
-        return (
-          <Text
-            small
-            className="tabular-nums"
-            title={
-              efficacy
-                ? `${efficacy.scoredSessions.toLocaleString()} sampled sessions`
-                : "No sampled scores"
-            }
-          >
-            {efficacy ? formatEfficacy(efficacy.averageScore) : "-"}
-          </Text>
-        );
-      },
-    },
-    {
-      key: "estimatedSavings",
-      header: (
-        <ColumnHeaderTooltip
-          label="Estimated savings"
-          tooltip="Estimated time saved across scored sessions that used this skill."
-        />
-      ),
-      width: "150px",
-      render: (skill) => {
-        const efficacy = metricsBySkill.get(skill.id)?.efficacy;
-        return (
-          <Text small className="tabular-nums">
-            {efficacy
-              ? formatSavings(efficacy.estimatedMinutesSavedTotal)
-              : "-"}
-          </Text>
-        );
-      },
-    },
-    {
-      key: "updated",
-      header: "Updated",
-      width: "150px",
-      render: (skill) => (
-        <Text
-          small
-          muted
-          title={dateTimeFormatters.full.format(skill.updatedAt)}
-        >
-          <HumanizeDateTime date={skill.updatedAt} />
-        </Text>
-      ),
-    },
-    {
-      key: "share",
-      header: "",
-      width: "48px",
-      render: (skill) =>
-        skill.shareToken ? (
-          <CopyButton
-            size="sm"
-            text={skillShareUrl(skill.shareToken)}
-            tooltip="Copy public link"
-            onCopy={() => {
-              toast.success("Public link copied");
-            }}
-          />
-        ) : null,
-    },
-    {
-      key: "open",
-      header: "",
-      width: "48px",
-      render: () => (
-        <Icon
-          name="arrow-right"
-          className="text-muted-foreground h-4 w-4"
-          aria-hidden
-        />
-      ),
-    },
-  ];
 
   const countLabel = `${totalCount} skill${totalCount === 1 ? "" : "s"}`;
 
@@ -463,14 +484,6 @@ export default function SkillsList(): JSX.Element {
                     }}
                   />
                   <Page.Toolbar.Count>{countLabel}</Page.Toolbar.Count>
-                  <Page.Toolbar.SortBy
-                    value={effectiveSort}
-                    onChange={(value) => {
-                      setSort(value as SkillSort);
-                      resetPage();
-                    }}
-                    options={INSIGHT_SORT_OPTIONS}
-                  />
                   <Page.Toolbar.Actions>
                     <ApproveAllSkillSuggestions
                       suggestions={openSuggestions.suggestions}
@@ -562,6 +575,11 @@ export default function SkillsList(): JSX.Element {
                     columns={columns}
                     data={displayedSkills}
                     rowKey={(skill) => skill.id}
+                    sort={effectiveSort}
+                    onSortChange={(nextSort) => {
+                      setSort(nextSort);
+                      resetPage();
+                    }}
                     onRowClick={(skill) =>
                       void navigate(routes.skills.detail.href(skill.id))
                     }
@@ -584,8 +602,8 @@ export default function SkillsList(): JSX.Element {
                 <div className="flex items-center justify-between border-t px-4 py-3">
                   <Text small muted>
                     {page * RESULT_PAGE_SIZE + 1}-
-                    {Math.min((page + 1) * RESULT_PAGE_SIZE, totalCount)} of{" "}
-                    {totalCount}
+                    {Math.min((page + 1) * RESULT_PAGE_SIZE, paginationCount)}{" "}
+                    of {paginationCount}
                   </Text>
                   <div className="flex items-center gap-2">
                     <Button

--- a/client/dashboard/src/pages/skills/skills-list-helpers.ts
+++ b/client/dashboard/src/pages/skills/skills-list-helpers.ts
@@ -1,11 +1,4 @@
 import type { Skill } from "@gram/client/models/components/skill.js";
-import type { SkillInsightMetrics } from "@gram/client/models/components/skillinsightmetrics.js";
-
-export type SkillSort =
-  | "updated"
-  | "activations"
-  | "efficacy"
-  | "estimated_savings";
 
 export function filterSkills(
   skills: Skill[],
@@ -33,37 +26,4 @@ export function prioritizeAddableSkills(skills: Skill[]): Skill[] {
     (left, right) =>
       Number(right.hasValidVersion) - Number(left.hasValidVersion),
   );
-}
-
-export function sortSkills(
-  skills: Skill[],
-  metricsBySkill: ReadonlyMap<string, SkillInsightMetrics>,
-  sort: SkillSort,
-): Skill[] {
-  return [...skills].sort((left, right) => {
-    let difference = 0;
-    switch (sort) {
-      case "updated":
-        difference = right.updatedAt.getTime() - left.updatedAt.getTime();
-        break;
-      case "activations":
-        difference =
-          (metricsBySkill.get(right.id)?.activations ?? 0) -
-          (metricsBySkill.get(left.id)?.activations ?? 0);
-        break;
-      case "efficacy":
-        difference =
-          (metricsBySkill.get(right.id)?.efficacy?.averageScore ?? -1) -
-          (metricsBySkill.get(left.id)?.efficacy?.averageScore ?? -1);
-        break;
-      case "estimated_savings":
-        difference =
-          (metricsBySkill.get(right.id)?.efficacy?.estimatedMinutesSavedTotal ??
-            -1) -
-          (metricsBySkill.get(left.id)?.efficacy?.estimatedMinutesSavedTotal ??
-            -1);
-        break;
-    }
-    return difference || left.displayName.localeCompare(right.displayName);
-  });
 }


### PR DESCRIPTION
## Summary

- replace the Skills toolbar sort control with shared Table sortable headers for Skill, Source, Activations, Efficacy, Estimated savings, and Updated
- preserve the recently-updated server order by default and sort ordinary columns within the current server page
- retain all-result loading, local pagination, missing-value handling, and fallback behavior for metric sorts

## Testing

- pnpm -F dashboard test -- src/pages/skills/SkillsList.test.ts src/pages/skills/SkillsList.page.test.tsx
- pnpm -F dashboard type-check

Linear: DNO-725

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Skills table sortable from column headers while keeping the default “recently updated” server order. Addresses DNO-725.

- **New Features**
  - Header-based sorting for Skill, Source, Activations, Efficacy, Estimated savings, and Updated; server order remains default.
  - Non-metric sorts are local to the current server page; metric sorts drain pages in 200s, put missing metrics last, persist across search/filters, and clear if insights are unavailable (and stay cleared on recovery). Pagination shows the loaded count if draining fails.

- **Refactors**
  - Adopt shared Table sorting API (`SortDescriptor`, `sortTableData`); remove toolbar `SortBy`.
  - Remove `sortSkills` and its tests; add tests for header sorting, page-boundary drains, search/filter resets, and insights recovery. Add a `dashboard` patch changeset.

<sup>Written for commit e9ce0c5c451080dd72078f8b92103df5ac33a858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

