### PR TITLE
fix(dashboard): show warn policy in Shadow MCP inventory

### DIFF
--- a/.changeset/curvy-shields-warn.md
+++ b/.changeset/curvy-shields-warn.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Display enabled warning policies in the Shadow MCP inventory status card.

--- a/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyStatus.tsx
+++ b/client/dashboard/src/components/shadow-mcp/ShadowMCPPolicyStatus.tsx
@@ -30,6 +30,13 @@ function policyStatusText(
         description:
           "Block policy is enabled. Servers without allow rules are not allowed.",
       };
+    case "warning":
+      return {
+        label: "Warning",
+        icon: "shield-alert",
+        description:
+          "Warn policy is enabled. Users must acknowledge warnings before continuing.",
+      };
     case "flagging":
       return {
         label: "Flagging",

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.test.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.test.ts
@@ -76,13 +76,18 @@ describe("eligibleShadowMCPAllowRulePolicies", () => {
 });
 
 describe("shadowMCPPolicyState", () => {
-  it("prioritizes blocking policies over flagging policies", () => {
+  it("prioritizes blocking policies over warning and flagging policies", () => {
     expect(
       shadowMCPPolicyState([
         policy({ action: "flag", id: "flag" }),
+        policy({ action: "warn", id: "warn" }),
         policy({ action: "block", id: "block" }),
       ]),
     ).toBe("blocking");
+  });
+
+  it("returns warning for enabled warn policy without blocking policy", () => {
+    expect(shadowMCPPolicyState([policy({ action: "warn" })])).toBe("warning");
   });
 
   it("returns flagging for enabled flag policy without blocking policy", () => {

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.test.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.test.ts
@@ -90,6 +90,15 @@ describe("shadowMCPPolicyState", () => {
     expect(shadowMCPPolicyState([policy({ action: "warn" })])).toBe("warning");
   });
 
+  it("prioritizes warning policies over flagging policies", () => {
+    expect(
+      shadowMCPPolicyState([
+        policy({ action: "flag", id: "flag" }),
+        policy({ action: "warn", id: "warn" }),
+      ]),
+    ).toBe("warning");
+  });
+
   it("returns flagging for enabled flag policy without blocking policy", () => {
     expect(shadowMCPPolicyState([policy({ action: "flag" })])).toBe("flagging");
   });
@@ -133,6 +142,9 @@ describe("shadowMCPInventoryStatus", () => {
   });
 
   it("shows observed when blocking is inactive", () => {
+    expect(
+      shadowMCPInventoryStatus(server({ access: "none" }), "warning"),
+    ).toBe("observed");
     expect(
       shadowMCPInventoryStatus(server({ access: "none" }), "flagging"),
     ).toBe("observed");

--- a/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.ts
+++ b/client/dashboard/src/components/shadow-mcp/shadowMCPInventoryStatus.ts
@@ -4,6 +4,7 @@ import { type BadgeProps } from "@/components/ui/Badge";
 
 export type ShadowMCPPolicyState =
   | "blocking"
+  | "warning"
   | "flagging"
   | "none"
   | "unavailable";
@@ -56,6 +57,10 @@ export function shadowMCPPolicyState(
 
   if (shadowPolicies.some((policy) => policy.action === "block")) {
     return "blocking";
+  }
+
+  if (shadowPolicies.some((policy) => policy.action === "warn")) {
+    return "warning";
   }
 
   if (shadowPolicies.some((policy) => policy.action === "flag")) {

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.test.tsx
@@ -143,7 +143,7 @@ describe("ShadowMCP", () => {
     id = `${action}-policy`,
     sources = ["shadow_mcp"],
   }: {
-    action: "block" | "flag";
+    action: "block" | "flag" | "warn";
     enabled?: boolean;
     id?: string;
     sources?: string[];
@@ -247,6 +247,28 @@ describe("ShadowMCP", () => {
     ).toBeTruthy();
     expect(screen.getByText("Roles: Admin")).toBeTruthy();
     expect(screen.getByText("Members: Admin User")).toBeTruthy();
+  });
+
+  it("renders warning policy status when no blocking policy is enabled", () => {
+    mocks.useRiskListPolicies.mockReturnValue({
+      data: { policies: [riskPolicy({ action: "warn" })] },
+      isError: false,
+      isLoading: false,
+    });
+
+    render(<ShadowMCP />);
+
+    expect(screen.getByText("Warning")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Warn policy is enabled. Users must acknowledge warnings before continuing.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Shadow MCP inventory for project-1 with policy warning",
+      ),
+    ).toBeTruthy();
   });
 
   it("renders flagging policy status when no blocking policy is enabled", () => {


### PR DESCRIPTION
## Summary

- recognize enabled Shadow MCP warn policies in inventory status derivation
- show a Warning status card that explains acknowledgment behavior
- preserve block-over-warn-over-flag precedence and non-blocking row behavior

## Testing

- `pnpm -F dashboard test`
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint:format`
- `pnpm changeset status`

Linear: DNO-749

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Shadow MCP inventory status not updating when a warn policy is enabled. Adds a Warning status card and correct precedence (block > warn > flag) per DNO-749.

- **Bug Fixes**
  - Recognize `warn` policies and render a "Warning" status with `shield-alert` icon and clear acknowledgment text.
  - Preserve precedence: block > warn > flag; rows remain non-blocking.
  - Add tests for warning precedence and observed state when blocking is inactive.

<sup>Written for commit 89a01c681de2734eb4c503b6ebae15e07a1d5891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

