### PR TITLE
feat: classify codex account identity and billing mode

### DIFF
--- a/.changeset/codex-account-identity.md
+++ b/.changeset/codex-account-identity.md
@@ -1,0 +1,14 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Classify Codex account identity and billing mode (DNO-734). Codex sessions on
+every capture path (legacy hooks, OTEL logs, ingest adapter) now stamp
+account_type from email resolution — resolved work email is team, anything
+else personal — and team sessions resolve the org-level billing mode declared
+on the codex_compliance integration config (the session provider "openai" now
+maps to that config, fixing the mapping bug that made the config's
+billing_mode unreachable). Compliance COSTS import rows (codex and
+ChatGPT/Work) carry account_type=team and the config's billing mode directly.
+The estimated-cost tooltip copy mentions ChatGPT plans alongside Claude's.

--- a/client/dashboard/src/components/estimated-cost-utils.ts
+++ b/client/dashboard/src/components/estimated-cost-utils.ts
@@ -11,13 +11,13 @@
 //
 // We therefore label the measure conditionally: a scope we positively know is
 // metered is real "Cost"; anything else is "Est. cost" with a disclaimer.
-// Claude exposes no plan/billing signal in telemetry, so metered status can't be
-// inferred from a session — it comes from an out-of-band, admin-declared
-// billing_mode (ai_integration_configs / user_accounts). Until that signal
-// exists, no scope is known-metered and every surface shows the estimate. When
-// it lands, metered scopes render a plain, confident "Cost" with no asterisk.
+// Neither Claude nor Codex exposes a plan/billing signal in telemetry, so
+// metered status can't be inferred from a session — it comes from an
+// out-of-band, admin-declared billing_mode (ai_integration_configs /
+// user_accounts). Scopes with no declaration show the estimate; metered scopes
+// render a plain, confident "Cost" with no asterisk.
 export const ESTIMATED_COST_TOOLTIP =
-  "Estimated from token usage at standard API rates. Flat-fee plans (Claude Max/Pro/Team) include usage in the subscription, so real spend may be lower.";
+  "Estimated from token usage at standard API rates. Flat-fee plans (Claude Max/Pro/Team, ChatGPT plans covering Codex) include usage in the subscription, so real spend may be lower.";
 
 /**
  * Whether a scope is confidently billed per token. Only then is the cost figure

--- a/server/clickhouse/scripts/seed-costs.mjs
+++ b/server/clickhouse/scripts/seed-costs.mjs
@@ -625,6 +625,12 @@ for (const p of people) {
           chatgptProduct === "Work" ? "chatgpt-work" : "chatgpt",
         "gram.provider": "openai",
         "gram.resource.urn": "chatgpt:usage:metrics",
+        // Compliance rows come from the org's own enterprise feed, so the
+        // importer stamps them team; billing mode mirrors an admin-declared
+        // codex_compliance config (DNO-734). Constant across rows because it
+        // is an org-level declaration, not a per-row signal.
+        "gram.account_type": "team",
+        "gram.billing_mode": "flat_rate",
         "codex.compliance.product": chatgptProduct,
         "gen_ai.response.model": rnd() < 0.6 ? "gpt-5.6" : "gpt-5.4-mini",
         "gen_ai.usage.input_tokens": inputTokens,

--- a/server/internal/aiintegrations/anthropic_analytics_polling.go
+++ b/server/internal/aiintegrations/anthropic_analytics_polling.go
@@ -44,10 +44,13 @@ const (
 	anthropicAnalyticsPageLimit   = 1000
 
 	anthropicAnalyticsProviderTag = "anthropic"
-	// anthropicAnalyticsAccountType classifies analytics rows as team
-	// accounts: the Admin Analytics API only reports seat users of the
-	// organization's Claude Enterprise plan.
-	anthropicAnalyticsAccountType = "team"
+	// complianceAccountTypeTeam classifies imported provider-feed rows as
+	// team accounts: every enterprise compliance/analytics feed only reports
+	// the organization's own seat users, so the account behind a row is the
+	// company's by construction — unlike session telemetry, which must
+	// classify from email resolution (see hooks.classifyAccount). The value
+	// matches the hooks package's account_type "team".
+	complianceAccountTypeTeam = "team"
 )
 
 const (
@@ -453,7 +456,7 @@ func newClaudeChatLogParams(cfg Config, urn string, body string, bucketStart tim
 		attr.HookSourceKey:            anthropicAnalyticsHookSource,
 		attr.AIIntegrationConfigIDKey: cfg.ID.String(),
 		attr.ProviderKey:              anthropicAnalyticsProviderTag,
-		attr.AccountTypeKey:           anthropicAnalyticsAccountType,
+		attr.AccountTypeKey:           complianceAccountTypeTeam,
 	}
 	if model != "" {
 		attrs[attr.GenAIResponseModelKey] = model

--- a/server/internal/aiintegrations/codex_cost_import.go
+++ b/server/internal/aiintegrations/codex_cost_import.go
@@ -48,12 +48,7 @@ const (
 	codexComplianceProductCodex = "codex"
 	codexComplianceProductWork  = "work"
 	codexProviderOpenAI         = "openai"
-	// codexAccountTypeTeam matches the hooks package's account_type "team"
-	// value. Every compliance COSTS row comes from the org's own enterprise
-	// feed, so the account behind it is the company's by construction — unlike
-	// session telemetry, which must classify from email resolution.
-	codexAccountTypeTeam = "team"
-	codexCreditValueUSD  = 0.04
+	codexCreditValueUSD         = 0.04
 )
 
 type codexComplianceClient interface {
@@ -358,13 +353,18 @@ func buildCodexCostEventLogParam(cfg Config, file codexapi.LogFile, event codexC
 		attr.ProviderKey:              codexProviderOpenAI,
 		attr.GenAIProviderNameKey:     codexProviderOpenAI,
 		attr.AIIntegrationConfigIDKey: cfg.ID.String(),
-		attr.AccountTypeKey:           codexAccountTypeTeam,
+		attr.AccountTypeKey:           complianceAccountTypeTeam,
 	}
-	// The config's admin-declared billing mode applies to every row of its
-	// feed — this is the org-level tier of the billing-mode cascade, keyed
-	// here directly instead of via session attribution (compliance rows have
-	// no session).
-	addStringAttr(attrs, attr.BillingModeKey, cfg.BillingMode)
+	// The config's admin-declared billing mode is stamped on Codex rows only —
+	// the org-level tier of the billing-mode cascade, keyed here directly
+	// since compliance rows have no session. ChatGPT/Work rows stay unlabeled
+	// (estimate treatment): the single declaration cannot describe both
+	// surfaces, and Codex credits vs ChatGPT seats routinely bill differently,
+	// so labeling seat usage with a "metered" Codex declaration would render
+	// token-priced estimates as confident real cost downstream.
+	if isCodex {
+		addStringAttr(attrs, attr.BillingModeKey, cfg.BillingMode)
+	}
 	addStringAttr(attrs, attr.CodexComplianceEventIDKey, eventID)
 	addStringAttr(attrs, attr.CodexComplianceEventHashKey, generateCodexCostEventHash(eventID))
 	addStringAttr(attrs, attr.CodexComplianceLogIDKey, file.ID)

--- a/server/internal/aiintegrations/codex_cost_import.go
+++ b/server/internal/aiintegrations/codex_cost_import.go
@@ -48,7 +48,12 @@ const (
 	codexComplianceProductCodex = "codex"
 	codexComplianceProductWork  = "work"
 	codexProviderOpenAI         = "openai"
-	codexCreditValueUSD         = 0.04
+	// codexAccountTypeTeam matches the hooks package's account_type "team"
+	// value. Every compliance COSTS row comes from the org's own enterprise
+	// feed, so the account behind it is the company's by construction — unlike
+	// session telemetry, which must classify from email resolution.
+	codexAccountTypeTeam = "team"
+	codexCreditValueUSD  = 0.04
 )
 
 type codexComplianceClient interface {
@@ -353,7 +358,13 @@ func buildCodexCostEventLogParam(cfg Config, file codexapi.LogFile, event codexC
 		attr.ProviderKey:              codexProviderOpenAI,
 		attr.GenAIProviderNameKey:     codexProviderOpenAI,
 		attr.AIIntegrationConfigIDKey: cfg.ID.String(),
+		attr.AccountTypeKey:           codexAccountTypeTeam,
 	}
+	// The config's admin-declared billing mode applies to every row of its
+	// feed — this is the org-level tier of the billing-mode cascade, keyed
+	// here directly instead of via session attribution (compliance rows have
+	// no session).
+	addStringAttr(attrs, attr.BillingModeKey, cfg.BillingMode)
 	addStringAttr(attrs, attr.CodexComplianceEventIDKey, eventID)
 	addStringAttr(attrs, attr.CodexComplianceEventHashKey, generateCodexCostEventHash(eventID))
 	addStringAttr(attrs, attr.CodexComplianceLogIDKey, file.ID)

--- a/server/internal/aiintegrations/codex_cost_import_test.go
+++ b/server/internal/aiintegrations/codex_cost_import_test.go
@@ -47,6 +47,11 @@ func TestBuildCodexCostLogParamsVerifiesSHAAndMapsTelemetry(t *testing.T) {
 	require.Equal(t, "api", attrs[attr.EventSourceKey])
 	require.Equal(t, "codex", attrs[attr.HookSourceKey])
 	require.Equal(t, "openai", attrs[attr.ProviderKey])
+	// Compliance rows come from the org's own enterprise feed, so they are
+	// team by construction; billing mode only rides when the config declares
+	// one (this fixture doesn't).
+	require.Equal(t, codexAccountTypeTeam, attrs[attr.AccountTypeKey])
+	require.NotContains(t, attrs, attr.BillingModeKey)
 	require.Equal(t, cfg.ID.String(), attrs[attr.AIIntegrationConfigIDKey])
 	require.Equal(t, "event_1", attrs[attr.CodexComplianceEventIDKey])
 	require.Equal(t, "90eb39010cad917b66d5b9d7ce27fe9b7217b93b02760406e55aee41eb5433c3", attrs[attr.CodexComplianceEventHashKey])
@@ -430,4 +435,31 @@ type captureWatermarkStore struct {
 func (s *captureWatermarkStore) AdvanceWatermark(_ context.Context, _ uuid.UUID, checkpoint timewindowpoller.PollCheckpoint) error {
 	s.checkpoints = append(s.checkpoints, checkpoint)
 	return nil
+}
+
+// TestBuildCodexCostLogParamsStampsConfigBillingMode: the admin-declared
+// billing mode on the codex_compliance config applies to every row of its
+// feed — the org-level tier of the billing-mode cascade, keyed directly since
+// compliance rows have no session to attribute through (DNO-734).
+func TestBuildCodexCostLogParamsStampsConfigBillingMode(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"event_id":"event_billing","type":"COSTS","timestamp":"2026-07-19T15:59:59Z","payload":{"identity":{"user_id":"user_1","email":"dev@example.com"},"product":"codex","measures":{"usage":{"text_input_tokens":10},"billing":[]}}}` + "\n")
+
+	cfg := codexCostConfig()
+	cfg.BillingMode = "flat_rate"
+	file := codexapi.LogFile{
+		ID:         "eclf_billing",
+		EventType:  codexComplianceCostsEventType,
+		EndTime:    time.Date(2026, 7, 19, 16, 0, 0, 0, time.UTC),
+		FileName:   "COSTS_2026-07-19T16:00:00.000000+00:00.jsonl",
+		FileSize:   int64(len(body)),
+		FileSHA256: "",
+	}
+
+	logParams, err := buildCodexCostLogParams(cfg, file, body)
+	require.NoError(t, err)
+	require.Len(t, logParams, 1)
+	require.Equal(t, codexAccountTypeTeam, logParams[0].Attributes[attr.AccountTypeKey])
+	require.Equal(t, "flat_rate", logParams[0].Attributes[attr.BillingModeKey])
 }

--- a/server/internal/aiintegrations/codex_cost_import_test.go
+++ b/server/internal/aiintegrations/codex_cost_import_test.go
@@ -50,7 +50,7 @@ func TestBuildCodexCostLogParamsVerifiesSHAAndMapsTelemetry(t *testing.T) {
 	// Compliance rows come from the org's own enterprise feed, so they are
 	// team by construction; billing mode only rides when the config declares
 	// one (this fixture doesn't).
-	require.Equal(t, codexAccountTypeTeam, attrs[attr.AccountTypeKey])
+	require.Equal(t, complianceAccountTypeTeam, attrs[attr.AccountTypeKey])
 	require.NotContains(t, attrs, attr.BillingModeKey)
 	require.Equal(t, cfg.ID.String(), attrs[attr.AIIntegrationConfigIDKey])
 	require.Equal(t, "event_1", attrs[attr.CodexComplianceEventIDKey])
@@ -438,13 +438,19 @@ func (s *captureWatermarkStore) AdvanceWatermark(_ context.Context, _ uuid.UUID,
 }
 
 // TestBuildCodexCostLogParamsStampsConfigBillingMode: the admin-declared
-// billing mode on the codex_compliance config applies to every row of its
-// feed — the org-level tier of the billing-mode cascade, keyed directly since
-// compliance rows have no session to attribute through (DNO-734).
+// billing mode on the codex_compliance config rides on Codex rows only — the
+// org-level tier of the billing-mode cascade, keyed directly since compliance
+// rows have no session to attribute through (DNO-734). ChatGPT/Work rows stay
+// unlabeled: the single declaration cannot describe both surfaces, and
+// labeling seat usage with a metered Codex declaration would render
+// token-priced estimates as confident real cost.
 func TestBuildCodexCostLogParamsStampsConfigBillingMode(t *testing.T) {
 	t.Parallel()
 
-	body := []byte(`{"event_id":"event_billing","type":"COSTS","timestamp":"2026-07-19T15:59:59Z","payload":{"identity":{"user_id":"user_1","email":"dev@example.com"},"product":"codex","measures":{"usage":{"text_input_tokens":10},"billing":[]}}}` + "\n")
+	body := []byte(
+		`{"event_id":"event_billing","type":"COSTS","timestamp":"2026-07-19T15:59:59Z","payload":{"identity":{"user_id":"user_1","email":"dev@example.com"},"product":"codex","measures":{"usage":{"text_input_tokens":10},"billing":[]}}}` + "\n" +
+			`{"event_id":"event_billing_chat","type":"COSTS","timestamp":"2026-07-19T16:59:59Z","payload":{"identity":{"user_id":"user_2","email":"dev2@example.com"},"product":"ChatGPT","measures":{"usage":{"text_input_tokens":20},"billing":[]}}}` + "\n",
+	)
 
 	cfg := codexCostConfig()
 	cfg.BillingMode = "flat_rate"
@@ -459,7 +465,13 @@ func TestBuildCodexCostLogParamsStampsConfigBillingMode(t *testing.T) {
 
 	logParams, err := buildCodexCostLogParams(cfg, file, body)
 	require.NoError(t, err)
-	require.Len(t, logParams, 1)
-	require.Equal(t, codexAccountTypeTeam, logParams[0].Attributes[attr.AccountTypeKey])
-	require.Equal(t, "flat_rate", logParams[0].Attributes[attr.BillingModeKey])
+	require.Len(t, logParams, 2)
+
+	codexRow := logParams[0]
+	require.Equal(t, complianceAccountTypeTeam, codexRow.Attributes[attr.AccountTypeKey])
+	require.Equal(t, "flat_rate", codexRow.Attributes[attr.BillingModeKey])
+
+	chatgptRow := logParams[1]
+	require.Equal(t, complianceAccountTypeTeam, chatgptRow.Attributes[attr.AccountTypeKey])
+	require.NotContains(t, chatgptRow.Attributes, attr.BillingModeKey)
 }

--- a/server/internal/hooks/account_attribution.go
+++ b/server/internal/hooks/account_attribution.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -100,6 +101,19 @@ func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) e
 	// account entity to persist — the account_type stamped above is the signal
 	// the cost surfaces consume. Stop here for these sessions.
 	if meta.ExternalAccountUUID == "" {
+		// Codex sessions NEVER carry an account UUID, so their billing mode
+		// must resolve here rather than after the entity upsert. Gate on team:
+		// the codex_compliance config describes the company's OpenAI org, and
+		// only a team-classified session (resolved work email) is presumed to
+		// run under it — a personal Codex session must not inherit the
+		// company's declared mode.
+		if meta.Provider == providerOpenAI && meta.AccountType == accountTypeTeam {
+			billingMode, err := s.resolveBillingMode(ctx, meta, "")
+			if err != nil {
+				return fmt.Errorf("resolve billing mode: %w", err)
+			}
+			meta.BillingMode = billingMode
+		}
 		return nil
 	}
 
@@ -131,12 +145,15 @@ func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) e
 // identifier used on ai_integration_configs, where org-level billing modes are
 // declared. Claude sessions tag provider "anthropic", but its integration config
 // (the Compliance API integration that carries the external org) is stored under
-// "anthropic_compliance". Providers without a distinct config identifier map to
-// themselves.
+// "anthropic_compliance"; Codex sessions tag "openai" and their config lives
+// under "codex_compliance". Providers without a distinct config identifier map
+// to themselves.
 func providerBillingConfigProvider(provider string) string {
 	switch provider {
 	case providerAnthropic:
 		return "anthropic_compliance"
+	case providerOpenAI:
+		return "codex_compliance"
 	default:
 		return provider
 	}
@@ -153,18 +170,42 @@ func (s *Service) resolveBillingMode(ctx context.Context, meta *SessionMetadata,
 		return accountOverride, nil
 	}
 
-	orgMode, err := s.repo.GetProviderOrgBillingMode(ctx, repo.GetProviderOrgBillingModeParams{
+	orgMode, err := s.providerOrgBillingMode(ctx, meta)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", err
+	}
+	return conv.FromPGTextOrEmpty[string](orgMode), nil
+}
+
+// providerOrgBillingMode dispatches the org-level tier of the cascade. Sessions
+// that carry an external org id (or whose provider's configs are org-scoped in
+// a way sessions can match) go through the org-matched lookup. Codex sessions
+// carry no org identity at any layer while codex_compliance configs always pin
+// one, so for openai with no session org the provider-wide declaration applies
+// instead.
+func (s *Service) providerOrgBillingMode(ctx context.Context, meta *SessionMetadata) (pgtype.Text, error) {
+	if meta.Provider == providerOpenAI && meta.ExternalOrgID == "" {
+		mode, err := s.repo.GetProviderBillingModeAnyOrg(ctx, repo.GetProviderBillingModeAnyOrgParams{
+			OrganizationID: meta.GramOrgID,
+			Provider:       providerBillingConfigProvider(meta.Provider),
+		})
+		if err != nil {
+			return pgtype.Text{}, fmt.Errorf("get provider billing mode: %w", err)
+		}
+		return mode, nil
+	}
+	mode, err := s.repo.GetProviderOrgBillingMode(ctx, repo.GetProviderOrgBillingModeParams{
 		OrganizationID: meta.GramOrgID,
 		Provider:       providerBillingConfigProvider(meta.Provider),
 		ExternalOrgID:  conv.ToPGTextEmpty(meta.ExternalOrgID),
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return "", nil
-		}
-		return "", fmt.Errorf("get provider org billing mode: %w", err)
+		return pgtype.Text{}, fmt.Errorf("get provider org billing mode: %w", err)
 	}
-	return conv.FromPGTextOrEmpty[string](orgMode), nil
+	return mode, nil
 }
 
 // classifyAccount determines whether the session's account is team or personal.
@@ -212,7 +253,12 @@ func (s *Service) classifyAccount(ctx context.Context, meta *SessionMetadata) (s
 	// Accepted: both slices are small and the prior behavior — an entire
 	// company-credential org parked under an unclassified account type — was the
 	// far larger distortion.
-	if meta.ExternalAccountUUID == "" {
+	//
+	// The signal is Anthropic-specific: Codex emits no account identity at any
+	// layer (no UUID, org id, or auth mode — DNO-734), so for other providers a
+	// missing UUID says nothing about how the session authenticated and
+	// classification falls through to email resolution below.
+	if meta.ExternalAccountUUID == "" && meta.Provider == providerAnthropic {
 		return accountTypeTeam, nil
 	}
 

--- a/server/internal/hooks/account_attribution.go
+++ b/server/internal/hooks/account_attribution.go
@@ -57,10 +57,12 @@ func classifyAccountType(emailResolvedUserID string) string {
 // bridge (keyed on the per-device id) is taught/consulted whenever a DeviceID
 // is present — both including sessions that carry no provider account UUID (a
 // company-credential session — see classifyAccount). The user_accounts entity
-// and billing mode, however, key on that UUID, so they are skipped when it is
-// absent: there is no account entity to persist. All failures are returned to
-// the caller, which logs and continues: account attribution must never block
-// session capture or enforcement.
+// keys on that UUID, so it is skipped when the UUID is absent: there is no
+// account entity to persist. Billing mode normally rides on the entity, with
+// one exception: openai sessions never carry a UUID, so their org-level
+// billing mode resolves without one (team-gated — see providerOrgBillingMode).
+// All failures are returned to the caller, which logs and continues: account
+// attribution must never block session capture or enforcement.
 func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) error {
 	// Classify before consulting the device bridge: meta.UserID at this point
 	// reflects email resolution only.
@@ -94,12 +96,13 @@ func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) e
 		}
 	}
 
-	// The user_accounts entity and its billing mode key on the provider account
-	// UUID (user_accounts.external_account_uuid is NOT NULL and is the entity
+	// The user_accounts entity keys on the provider account UUID
+	// (user_accounts.external_account_uuid is NOT NULL and is the entity
 	// key). A session authenticated by company credentials (an API key, a
 	// gateway/proxy, Bedrock, or Vertex) carries no such UUID, so there is no
 	// account entity to persist — the account_type stamped above is the signal
-	// the cost surfaces consume. Stop here for these sessions.
+	// the cost surfaces consume. Stop here for these sessions, after the one
+	// piece of the cascade that does not need an entity: openai billing mode.
 	if meta.ExternalAccountUUID == "" {
 		// Codex sessions NEVER carry an account UUID, so their billing mode
 		// must resolve here rather than after the entity upsert. The

--- a/server/internal/hooks/account_attribution.go
+++ b/server/internal/hooks/account_attribution.go
@@ -102,12 +102,10 @@ func (s *Service) attributeSession(ctx context.Context, meta *SessionMetadata) e
 	// the cost surfaces consume. Stop here for these sessions.
 	if meta.ExternalAccountUUID == "" {
 		// Codex sessions NEVER carry an account UUID, so their billing mode
-		// must resolve here rather than after the entity upsert. Gate on team:
-		// the codex_compliance config describes the company's OpenAI org, and
-		// only a team-classified session (resolved work email) is presumed to
-		// run under it — a personal Codex session must not inherit the
-		// company's declared mode.
-		if meta.Provider == providerOpenAI && meta.AccountType == accountTypeTeam {
+		// must resolve here rather than after the entity upsert. The
+		// team-only gate lives in providerOrgBillingMode so it also holds on
+		// the entity path should an openai session ever carry a UUID.
+		if meta.Provider == providerOpenAI {
 			billingMode, err := s.resolveBillingMode(ctx, meta, "")
 			if err != nil {
 				return fmt.Errorf("resolve billing mode: %w", err)
@@ -180,26 +178,28 @@ func (s *Service) resolveBillingMode(ctx context.Context, meta *SessionMetadata,
 	return conv.FromPGTextOrEmpty[string](orgMode), nil
 }
 
-// providerOrgBillingMode dispatches the org-level tier of the cascade. Sessions
-// that carry an external org id (or whose provider's configs are org-scoped in
-// a way sessions can match) go through the org-matched lookup. Codex sessions
-// carry no org identity at any layer while codex_compliance configs always pin
-// one, so for openai with no session org the provider-wide declaration applies
-// instead.
+// providerOrgBillingMode resolves the org-level tier of the cascade. Sessions
+// that carry an external org id go through the org-matched lookup. Codex
+// sessions carry no org identity at any layer while codex_compliance configs
+// always pin one, so for openai with no session org the provider-wide
+// declaration applies instead — gated on team: the config describes the
+// company's OpenAI org, and only a team-classified session (resolved work
+// email) is presumed to run under it. A personal Codex session must never
+// inherit the company's declared mode, on any path.
+//
+// The gate reads meta.AccountType, so callers must run classification first —
+// attributeSession stamps AccountType before either resolveBillingMode call
+// site; a pre-classification caller would silently resolve empty for openai.
 func (s *Service) providerOrgBillingMode(ctx context.Context, meta *SessionMetadata) (pgtype.Text, error) {
-	if meta.Provider == providerOpenAI && meta.ExternalOrgID == "" {
-		mode, err := s.repo.GetProviderBillingModeAnyOrg(ctx, repo.GetProviderBillingModeAnyOrgParams{
-			OrganizationID: meta.GramOrgID,
-			Provider:       providerBillingConfigProvider(meta.Provider),
-		})
-		if err != nil {
-			return pgtype.Text{}, fmt.Errorf("get provider billing mode: %w", err)
-		}
-		return mode, nil
+	matchAnyOrg := meta.Provider == providerOpenAI && meta.ExternalOrgID == ""
+	if matchAnyOrg && meta.AccountType != accountTypeTeam {
+		var none pgtype.Text
+		return none, nil
 	}
 	mode, err := s.repo.GetProviderOrgBillingMode(ctx, repo.GetProviderOrgBillingModeParams{
 		OrganizationID: meta.GramOrgID,
 		Provider:       providerBillingConfigProvider(meta.Provider),
+		MatchAnyOrg:    matchAnyOrg,
 		ExternalOrgID:  conv.ToPGTextEmpty(meta.ExternalOrgID),
 	})
 	if err != nil {

--- a/server/internal/hooks/account_attribution_test.go
+++ b/server/internal/hooks/account_attribution_test.go
@@ -908,3 +908,86 @@ func TestStampAccountAttribution_SkipsEmptyFields(t *testing.T) {
 	require.NotContains(t, partial, attr.BillingModeKey)
 	require.NotContains(t, partial, attr.DeviceIDKey)
 }
+
+// TestAttributeSession_CodexPersonalWithAccountUUIDDoesNotInheritOrgBillingMode:
+// the team-only gate on the openai provider-wide billing lookup lives in
+// providerOrgBillingMode, so it also holds on the entity path — should a
+// Codex session ever carry an account UUID, a personal classification still
+// never inherits the company's declared mode.
+func TestAttributeSession_CodexPersonalWithAccountUUIDDoesNotInheritOrgBillingMode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	meta := &SessionMetadata{
+		SessionID:           "codex-billing-personal-uuid",
+		ServiceName:         "Codex",
+		Provider:            providerOpenAI,
+		UserEmail:           "someone@personal.example",
+		UserID:              "",
+		ExternalAccountUUID: "codex-personal-acct-uuid",
+		GramOrgID:           authCtx.ActiveOrganizationID,
+		ProjectID:           authCtx.ProjectID.String(),
+	}
+	require.NoError(t, ti.service.attributeSession(ctx, meta))
+	require.Equal(t, accountTypePersonal, meta.AccountType)
+	require.Empty(t, meta.BillingMode)
+	// The UUID means an account entity IS persisted, unlike UUID-less codex.
+	require.NotEmpty(t, meta.UserAccountID)
+}
+
+// TestLogs_DoesNotAdoptCodexCachedAttribution: session ids are client-reported
+// and the session cache is keyed on them alone, so the Claude OTEL fast path
+// must not adopt an entry the codex OTEL writer seeded — its shape (account
+// type set, no account UUID) would otherwise satisfy the company-credential
+// arm and stamp Claude rows with Codex attribution.
+func TestLogs_DoesNotAdoptCodexCachedAttribution(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	orgID := authCtx.ActiveOrganizationID
+
+	userID := "claude-collision-user"
+	workEmail := "collision@example.com"
+	seedHookUser(t, ctx, ti.conn, orgID, userID, workEmail)
+
+	sessionID := "codex-claude-collision-session"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "Codex",
+		UserEmail:   workEmail,
+		UserID:      userID,
+		Provider:    providerOpenAI,
+		AccountType: accountTypePersonal,
+		BillingMode: "flat_rate",
+		GramOrgID:   orgID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}, 0))
+
+	// A company-credential Claude session (no account UUID / org / device):
+	// it carries no identity the cached entry lacks, so before the provider
+	// guard the fast path would have adopted the codex entry wholesale.
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, ti.service.Logs(ctx, claudeLogsPayload(
+		[]*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")},
+		nil,
+		&gen.OTELLogRecord{
+			TimeUnixNano: new(nanoString(now)),
+			Body:         &gen.OTELLogBody{StringValue: new("api request")},
+			Attributes: []*gen.OTELAttribute{
+				strAttr("session.id", sessionID),
+				strAttr("user.email", workEmail),
+			},
+		},
+	)))
+
+	var cached SessionMetadata
+	require.NoError(t, ti.service.cache.Get(ctx, sessionCacheKey(sessionID), &cached))
+	require.Equal(t, providerAnthropic, cached.Provider)
+	// Claude semantics: no account UUID means company credentials → team.
+	require.Equal(t, accountTypeTeam, cached.AccountType)
+	require.Empty(t, cached.BillingMode)
+}

--- a/server/internal/hooks/account_attribution_test.go
+++ b/server/internal/hooks/account_attribution_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	aiintegrationsrepo "github.com/speakeasy-api/gram/server/internal/aiintegrations/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
@@ -765,14 +767,123 @@ func TestResolveBillingMode_EmptyWhenNoDeclaration(t *testing.T) {
 // TestProviderBillingConfigProvider verifies the mapping from a session provider
 // tag to the ai_integration_configs provider identifier where org-level billing
 // modes are declared. Claude sessions tag 'anthropic' but the config lives under
-// 'anthropic_compliance'; other providers map to themselves.
+// 'anthropic_compliance'; Codex sessions tag 'openai' and their config lives
+// under 'codex_compliance'; other providers map to themselves.
 func TestProviderBillingConfigProvider(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, "anthropic_compliance", providerBillingConfigProvider(providerAnthropic))
 	require.Equal(t, providerCursor, providerBillingConfigProvider(providerCursor))
-	require.Equal(t, providerOpenAI, providerBillingConfigProvider(providerOpenAI))
+	require.Equal(t, "codex_compliance", providerBillingConfigProvider(providerOpenAI))
 	require.Empty(t, providerBillingConfigProvider(""))
+}
+
+// seedCodexBillingConfig inserts an enabled codex_compliance integration config
+// with an admin-declared billing mode. The external org id is always set (the
+// UI requires it), which is exactly why openai billing-mode resolution must be
+// provider-wide: Codex sessions carry no external org to match it with.
+func seedCodexBillingConfig(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, projectID uuid.UUID, billingMode string) {
+	t.Helper()
+
+	_, err := aiintegrationsrepo.New(conn).InsertConfig(ctx, aiintegrationsrepo.InsertConfigParams{
+		OrganizationID:         organizationID,
+		Provider:               "codex_compliance",
+		ProjectID:              projectID,
+		ExternalOrganizationID: conv.ToPGTextEmpty("org-codex-billing"),
+		ApiKeyEncrypted:        "test-encrypted-key",
+		Enabled:                true,
+		BillingMode:            conv.ToPGTextEmpty(billingMode),
+	})
+	require.NoError(t, err)
+}
+
+// TestClassifyAccount_CodexTeamOnResolvedEmail: Codex sessions never carry an
+// account UUID, so the Claude company-credential rule (missing UUID → team)
+// must not apply; classification is email-based, and a resolved work email is
+// team.
+func TestClassifyAccount_CodexTeamOnResolvedEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+
+	got, err := ti.service.classifyAccount(ctx, &SessionMetadata{
+		GramOrgID: authCtx.ActiveOrganizationID,
+		Provider:  providerOpenAI,
+		UserID:    "user-123",
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountTypeTeam, got)
+}
+
+// TestClassifyAccount_CodexPersonalOnUnresolvedEmail: an unresolved (or absent)
+// email on a Codex session classifies personal — under the Claude rule the
+// missing UUID would have forced team, which is wrong for a provider that
+// never emits one.
+func TestClassifyAccount_CodexPersonalOnUnresolvedEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+
+	got, err := ti.service.classifyAccount(ctx, &SessionMetadata{
+		GramOrgID: authCtx.ActiveOrganizationID,
+		Provider:  providerOpenAI,
+		UserID:    "",
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountTypePersonal, got)
+}
+
+// TestAttributeSession_CodexTeamResolvesOrgWideBillingMode: a team-classified
+// Codex session resolves the org-level billing mode from the codex_compliance
+// config even though it carries no account UUID (no user_accounts entity) and
+// no external org id to match the config's scope with.
+func TestAttributeSession_CodexTeamResolvesOrgWideBillingMode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	meta := &SessionMetadata{
+		SessionID:   "codex-billing-team",
+		ServiceName: "Codex",
+		Provider:    providerOpenAI,
+		UserEmail:   "dev@example.com",
+		UserID:      "user-123",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	require.NoError(t, ti.service.attributeSession(ctx, meta))
+	require.Equal(t, accountTypeTeam, meta.AccountType)
+	require.Equal(t, "flat_rate", meta.BillingMode)
+	// No account UUID → no user_accounts entity is persisted.
+	require.Empty(t, meta.UserAccountID)
+}
+
+// TestAttributeSession_CodexPersonalDoesNotInheritOrgBillingMode: the org-level
+// declaration describes the company's OpenAI org; a personal Codex session
+// (unresolved email) must not inherit it.
+func TestAttributeSession_CodexPersonalDoesNotInheritOrgBillingMode(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	meta := &SessionMetadata{
+		SessionID:   "codex-billing-personal",
+		ServiceName: "Codex",
+		Provider:    providerOpenAI,
+		UserEmail:   "someone@personal.example",
+		UserID:      "",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}
+	require.NoError(t, ti.service.attributeSession(ctx, meta))
+	require.Equal(t, accountTypePersonal, meta.AccountType)
+	require.Empty(t, meta.BillingMode)
 }
 
 // TestStampAccountAttribution_SkipsEmptyFields verifies an unclassified or

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -350,12 +350,11 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 		UserEmail:   strings.TrimSpace(conv.PtrValOr(payload.UserEmail, "")),
 		UserID:      "",
 		Provider:    providerOpenAI,
-		// Account-scope attribution (external org/account identity, account
-		// type, billing mode) is wired only for Anthropic sessions today. The
-		// Codex payload carries no account identity for attributeSession to
-		// key on, and ai_integration_configs has no "openai" provider to
-		// declare an org-level billing mode, so these fields stay empty and
-		// cost surfaces treat Codex spend as unclassified (an estimate).
+		// The Codex payload carries no account-scope identity (no account
+		// UUID, org id, or auth mode), so these fields stay empty and
+		// classification below is email-based: a resolved work email is team,
+		// anything else personal, with the org-level codex_compliance billing
+		// mode riding on team sessions (DNO-734).
 		ExternalOrgID:       "",
 		ExternalAccountUUID: "",
 		ExternalAccountID:   "",
@@ -369,9 +368,12 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 		ProjectID:           projectID,
 	}
 
+	var cached SessionMetadata
+	cachedOK := false
 	if metadata.SessionID != "" {
-		cached, err := s.getSessionMetadata(ctx, metadata.SessionID)
-		if err == nil && cached.ServiceName == "Codex" && cached.GramOrgID == orgID && cached.ProjectID == projectID {
+		c, err := s.getSessionMetadata(ctx, metadata.SessionID)
+		if err == nil && c.ServiceName == "Codex" && c.GramOrgID == orgID && c.ProjectID == projectID {
+			cached, cachedOK = c, true
 			if metadata.UserEmail == "" {
 				metadata.UserEmail = cached.UserEmail
 			}
@@ -385,6 +387,26 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, orgID)
 	} else {
 		metadata.UserID = ""
+	}
+	// On this path user_email is the account's own report (the authenticated
+	// ChatGPT account), so it doubles as the observed email consumers keep
+	// separate from actor identity.
+	metadata.ObservedUserEmail = metadata.UserEmail
+
+	// Attribute the account. Codex identity is the email alone, so when the
+	// cached classification was computed from the same email this event brings
+	// nothing new — adopt it instead of re-resolving per event. Otherwise
+	// classify fresh (email-based for openai; billing mode rides on team
+	// sessions — see classifyAccount / attributeSession). Failures leave the
+	// session unclassified rather than blocking capture or enforcement.
+	if cachedOK && cached.AccountType != "" && metadata.UserEmail == cached.UserEmail {
+		metadata.AccountType = cached.AccountType
+		metadata.BillingMode = cached.BillingMode
+	} else if err := s.attributeSession(ctx, metadata); err != nil {
+		s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",
+			attr.SlogEvent("account_attribution_failed"),
+			attr.SlogError(err),
+		)
 	}
 
 	return metadata
@@ -440,8 +462,10 @@ func (s *Service) buildCodexTelemetryAttributes(ctx context.Context, payload *ge
 		attr.ProjectIDKey:      metadata.ProjectID,
 		attr.OrganizationIDKey: metadata.GramOrgID,
 		attr.HookSourceKey:     "codex",
-		attr.ProviderKey:       providerOpenAI,
 	}
+	// Provider plus the session's account attribution (account_type,
+	// billing_mode) — stamped up front so both return paths below carry it.
+	stampAccountAttribution(attrs, *metadata)
 
 	if payload.Model != nil && *payload.Model != "" {
 		attrs[attr.GenAIResponseModelKey] = *payload.Model

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -383,11 +383,6 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 		}
 	}
 
-	if metadata.UserEmail != "" {
-		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, orgID)
-	} else {
-		metadata.UserID = ""
-	}
 	// On this path user_email is the account's own report (the authenticated
 	// ChatGPT account), so it doubles as the observed email consumers keep
 	// separate from actor identity.
@@ -395,20 +390,47 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 
 	// Attribute the account. Codex identity is the email alone, so when the
 	// cached classification was computed from the same email this event brings
-	// nothing new — adopt it instead of re-resolving per event. Otherwise
-	// classify fresh (email-based for openai; billing mode rides on team
-	// sessions — see classifyAccount / attributeSession). Failures leave the
+	// nothing new — adopt it, including the resolved UserID, instead of
+	// re-resolving per event. Otherwise resolve and classify fresh (email-based
+	// for openai; billing mode rides on team sessions — see classifyAccount /
+	// attributeSession) and write the result back so later events, and the
+	// OTEL/ingest paths, inherit it regardless of which event seeded it.
+	// Billing mode is frozen with the classification for the cache lifetime,
+	// matching the Claude path's attribute-once semantics. Failures leave the
 	// session unclassified rather than blocking capture or enforcement.
-	if cachedOK && cached.AccountType != "" &&
-		conv.NormalizeEmail(metadata.UserEmail) == conv.NormalizeEmail(cached.UserEmail) {
+	if cachedOK && cached.AccountType != "" && sameCodexIdentity(cached.UserEmail, metadata.UserEmail) {
+		metadata.UserID = cached.UserID
 		metadata.AccountType = cached.AccountType
 		metadata.BillingMode = cached.BillingMode
-	} else if err := s.attributeSession(ctx, metadata); err != nil {
+		return metadata
+	}
+
+	if metadata.UserEmail != "" {
+		metadata.UserID = s.resolveUserByEmail(ctx, metadata.UserEmail, orgID)
+	}
+	if err := s.attributeSession(ctx, metadata); err != nil {
 		s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",
 			attr.SlogEvent("account_attribution_failed"),
 			attr.SlogError(err),
 			attr.SlogGenAIConversationID(metadata.SessionID),
 		)
+		// Leave the session unclassified rather than half-attributed:
+		// attributeSession stamps AccountType before the step that failed,
+		// and the fast path above (plus recordCodexHook's SessionStart cache
+		// write) keys on AccountType alone — keeping the half state would
+		// freeze an empty billing mode for the cache lifetime.
+		metadata.AccountType = ""
+		metadata.BillingMode = ""
+	} else if metadata.SessionID != "" && metadata.AccountType != "" && payload.HookEventName != "SessionStart" {
+		// SessionStart is excluded: recordCodexHook already persists this
+		// metadata (attribution included) for that event; this write-back
+		// exists for sessions whose SessionStart was never seen.
+		if err := s.cache.Set(ctx, sessionCacheKey(metadata.SessionID), *metadata, 24*time.Hour); err != nil {
+			s.logger.WarnContext(ctx, "failed to cache Codex session metadata",
+				attr.SlogError(err),
+				attr.SlogGenAIConversationID(metadata.SessionID),
+			)
+		}
 	}
 
 	return metadata

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -399,13 +399,15 @@ func (s *Service) codexSessionMetadata(ctx context.Context, payload *gen.CodexPa
 	// classify fresh (email-based for openai; billing mode rides on team
 	// sessions — see classifyAccount / attributeSession). Failures leave the
 	// session unclassified rather than blocking capture or enforcement.
-	if cachedOK && cached.AccountType != "" && metadata.UserEmail == cached.UserEmail {
+	if cachedOK && cached.AccountType != "" &&
+		conv.NormalizeEmail(metadata.UserEmail) == conv.NormalizeEmail(cached.UserEmail) {
 		metadata.AccountType = cached.AccountType
 		metadata.BillingMode = cached.BillingMode
 	} else if err := s.attributeSession(ctx, metadata); err != nil {
 		s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",
 			attr.SlogEvent("account_attribution_failed"),
 			attr.SlogError(err),
+			attr.SlogGenAIConversationID(metadata.SessionID),
 		)
 	}
 

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -694,3 +694,105 @@ func TestCodexSessionMetadata_IgnoresCachedUserIDWhenEmailDoesNotResolve(t *test
 	require.Equal(t, email, metadata.UserEmail)
 	require.Empty(t, metadata.UserID)
 }
+
+// TestCodexSessionMetadata_ClassifiesTeamAndResolvesBillingMode: a Codex hook
+// whose user_email resolves to an org member classifies team and picks up the
+// org-level billing mode declared on the codex_compliance config (DNO-734).
+func TestCodexSessionMetadata_ClassifiesTeamAndResolvesBillingMode(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	sessionID := "codex-session-attribution-team"
+	email := "dev@example.com"
+	metadata := ti.service.codexSessionMetadata(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &email,
+	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
+
+	require.Equal(t, accountTypeTeam, metadata.AccountType)
+	require.Equal(t, "flat_rate", metadata.BillingMode)
+	// user_email is the ChatGPT account's own report, kept as the observed
+	// email separate from actor identity.
+	require.Equal(t, email, metadata.ObservedUserEmail)
+}
+
+// TestCodexSessionMetadata_PersonalEmailClassifiesPersonal: an email that does
+// not resolve to an org member classifies personal and never inherits the
+// company's declared billing mode.
+func TestCodexSessionMetadata_PersonalEmailClassifiesPersonal(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	sessionID := "codex-session-attribution-personal"
+	email := "someone@personal.example"
+	metadata := ti.service.codexSessionMetadata(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &email,
+	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
+
+	require.Equal(t, accountTypePersonal, metadata.AccountType)
+	require.Empty(t, metadata.BillingMode)
+}
+
+// TestCodexSessionMetadata_AdoptsCachedAttributionForSameEmail: when the cached
+// classification was computed from the same email this event carries, the
+// event adopts it instead of re-resolving. No config is seeded, so a fresh
+// resolution could not produce the cached billing mode — proving adoption.
+func TestCodexSessionMetadata_AdoptsCachedAttributionForSameEmail(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := "codex-session-attribution-cached"
+	email := "dev@example.com"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:   sessionID,
+		ServiceName: "Codex",
+		UserEmail:   email,
+		Provider:    providerOpenAI,
+		AccountType: accountTypeTeam,
+		BillingMode: "flat_rate",
+		GramOrgID:   authCtx.ActiveOrganizationID,
+		ProjectID:   authCtx.ProjectID.String(),
+	}, 0))
+
+	metadata := ti.service.codexSessionMetadata(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
+
+	require.Equal(t, accountTypeTeam, metadata.AccountType)
+	require.Equal(t, "flat_rate", metadata.BillingMode)
+}
+
+// TestBuildCodexTelemetryAttributes_StampsAccountAttribution verifies the
+// session's account attribution materializes onto the telemetry attribute map
+// (and so into the ClickHouse account_type / billing_mode columns).
+func TestBuildCodexTelemetryAttributes_StampsAccountAttribution(t *testing.T) {
+	t.Parallel()
+	_, ti := newTestHooksService(t)
+
+	email := "dev@example.com"
+	attrs := ti.service.buildCodexTelemetryAttributes(t.Context(), &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		UserEmail:     &email,
+	}, &SessionMetadata{
+		ServiceName: "Codex",
+		UserEmail:   email,
+		Provider:    providerOpenAI,
+		AccountType: accountTypeTeam,
+		BillingMode: "flat_rate",
+		GramOrgID:   "org-id",
+		ProjectID:   "project-id",
+	})
+
+	require.Equal(t, providerOpenAI, attrs[attr.ProviderKey])
+	require.Equal(t, accountTypeTeam, attrs[attr.AccountTypeKey])
+	require.Equal(t, "flat_rate", attrs[attr.BillingModeKey])
+}

--- a/server/internal/hooks/codex_hooks_test.go
+++ b/server/internal/hooks/codex_hooks_test.go
@@ -755,6 +755,7 @@ func TestCodexSessionMetadata_AdoptsCachedAttributionForSameEmail(t *testing.T) 
 		SessionID:   sessionID,
 		ServiceName: "Codex",
 		UserEmail:   email,
+		UserID:      "cached-user-id",
 		Provider:    providerOpenAI,
 		AccountType: accountTypeTeam,
 		BillingMode: "flat_rate",
@@ -769,6 +770,34 @@ func TestCodexSessionMetadata_AdoptsCachedAttributionForSameEmail(t *testing.T) 
 
 	require.Equal(t, accountTypeTeam, metadata.AccountType)
 	require.Equal(t, "flat_rate", metadata.BillingMode)
+	// The adopted classification includes the resolved user — no per-event
+	// re-resolution.
+	require.Equal(t, "cached-user-id", metadata.UserID)
+}
+
+// TestCodexSessionMetadata_CachesFreshAttributionOnAnyEvent: attribution
+// computed on a non-SessionStart event is written back to the session cache,
+// so later events (and the OTEL/ingest paths) adopt it instead of
+// re-classifying — a session whose SessionStart was lost does not pay
+// attribution per event forever.
+func TestCodexSessionMetadata_CachesFreshAttributionOnAnyEvent(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := "codex-session-attribution-recache"
+	email := "someone@personal.example"
+	metadata := ti.service.codexSessionMetadata(ctx, &gen.CodexPayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &email,
+	}, authCtx.ActiveOrganizationID, authCtx.ProjectID.String())
+	require.Equal(t, accountTypePersonal, metadata.AccountType)
+
+	var cached SessionMetadata
+	require.NoError(t, ti.service.cache.Get(ctx, sessionCacheKey(sessionID), &cached))
+	require.Equal(t, accountTypePersonal, cached.AccountType)
+	require.Equal(t, email, cached.UserEmail)
 }
 
 // TestBuildCodexTelemetryAttributes_StampsAccountAttribution verifies the

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -53,9 +53,11 @@ func isCodexLogsPayload(payload *gen.LogsPayload) bool {
 // off token-bearing response.completed rows, replacing the deprecated derived
 // codex:usage:metrics rows.
 //
-// Unlike the Claude path there is no session/account attribution here: Codex
-// OTEL payloads carry no account identity for attributeSession to key on (see
-// codexSessionMetadata), so rows are attributed by user.email only.
+// Codex OTEL payloads carry no account identity beyond user.email, so account
+// attribution here is email-based (see classifyAccount): each conversation is
+// attributed once per payload (memoized, with the session cache as the
+// cross-payload fast path) and its rows are stamped with account_type /
+// billing_mode so the cost surfaces can classify Codex spend (DNO-734).
 func (s *Service) writeCodexOTELLogsToClickHouse(ctx context.Context, payload *gen.LogsPayload, orgID string, projectID string) {
 	if s.telemetryLogger == nil || payload == nil {
 		return
@@ -79,8 +81,10 @@ func (s *Service) writeCodexOTELLogsToClickHouse(ctx context.Context, payload *g
 
 	params := make([]telemetry.LogParams, 0)
 	// Memoize email resolution: a Codex export batches many records for the
-	// same user, so resolve each distinct email once per payload.
+	// same user, so resolve each distinct email once per payload. Session
+	// attribution is likewise memoized per conversation id.
 	emailToUserID := make(map[string]string)
+	attributionBySession := make(map[string]SessionMetadata)
 	for _, resourceLog := range payload.ResourceLogs {
 		if resourceLog == nil {
 			continue
@@ -132,11 +136,21 @@ func (s *Service) writeCodexOTELLogsToClickHouse(ctx context.Context, payload *g
 					logAttrs[attr.SpanIDKey] = spanID
 				}
 
+				userInfo, email, userID := s.codexOTELUserInfo(ctx, logAttrs, emailToUserID, orgID)
+				sessionMeta := s.codexOTELSessionAttribution(ctx, attributionBySession, codexOTELIdentity{
+					SessionID: stringAttr(logAttrs, attr.GenAIConversationIDKey),
+					Email:     email,
+					UserID:    userID,
+					OrgID:     orgID,
+					ProjectID: projectID,
+				})
+				stampAccountAttribution(logAttrs, sessionMeta)
+
 				timestamp, observedTimestamp := otelLogTimestamps(logRecord)
 				params = append(params, telemetry.WithOTELMetadata(telemetry.LogParams{
 					Timestamp:  timestamp,
 					ToolInfo:   toolInfo,
-					UserInfo:   s.codexOTELUserInfo(ctx, logAttrs, emailToUserID, orgID),
+					UserInfo:   userInfo,
 					Attributes: logAttrs,
 				}, observedTimestamp, resourceAttrs))
 			}
@@ -248,10 +262,11 @@ func (s *Service) writeCodexMetricsToClickHouse(ctx context.Context, payload *ge
 						}
 					}
 
+					userInfo, _, _ := s.codexOTELUserInfo(ctx, attrs, emailToUserID, orgID)
 					params = append(params, telemetry.WithOTELMetadata(telemetry.LogParams{
 						Timestamp:  timestamp,
 						ToolInfo:   toolInfo,
-						UserInfo:   s.codexOTELUserInfo(ctx, attrs, emailToUserID, orgID),
+						UserInfo:   userInfo,
 						Attributes: attrs,
 					}, timestamp, resourceAttrs))
 				}
@@ -279,10 +294,12 @@ func normalizeCodexLogAttributes(attrs map[attr.Key]any) {
 
 // codexOTELUserInfo attributes a row to the Gram user resolved from the
 // record's user.email, memoizing lookups in emailToUserID across the payload.
-func (s *Service) codexOTELUserInfo(ctx context.Context, attrs map[attr.Key]any, emailToUserID map[string]string, orgID string) telemetry.UserInfo {
+// The resolved email and user id are returned alongside the UserInfo so the
+// session-attribution path can reuse them without a second resolution.
+func (s *Service) codexOTELUserInfo(ctx context.Context, attrs map[attr.Key]any, emailToUserID map[string]string, orgID string) (telemetry.UserInfo, string, string) {
 	email := strings.TrimSpace(stringAttr(attrs, attr.UserEmailKey))
 	if email == "" {
-		return telemetry.UserInfoByEmail("")
+		return telemetry.UserInfoByEmail(""), "", ""
 	}
 
 	lookup := conv.NormalizeEmail(email)
@@ -292,7 +309,89 @@ func (s *Service) codexOTELUserInfo(ctx context.Context, attrs map[attr.Key]any,
 		emailToUserID[lookup] = userID
 	}
 	if userID == "" {
-		return telemetry.UserInfoByEmail(email)
+		return telemetry.UserInfoByEmail(email), email, ""
 	}
-	return telemetry.UserInfoByIDAndEmail(userID, email)
+	return telemetry.UserInfoByIDAndEmail(userID, email), email, userID
+}
+
+// codexOTELIdentity carries the per-record identity inputs for session
+// attribution on the Codex OTEL stream.
+type codexOTELIdentity struct {
+	SessionID string
+	Email     string
+	UserID    string
+	OrgID     string
+	ProjectID string
+}
+
+// codexOTELSessionAttribution returns the account attribution for a Codex OTEL
+// record's session, computing it at most once per (payload, session). The
+// session cache is the cross-payload fast path — Codex exports every few
+// seconds and its identity (the email alone) rarely changes mid-session — and
+// is re-seeded after a fresh classification so the legacy hook path and the
+// ingest adapter inherit the same attribution. A record without a conversation
+// id stays email-attributed only: the zero metadata stamps nothing.
+func (s *Service) codexOTELSessionAttribution(ctx context.Context, memo map[string]SessionMetadata, id codexOTELIdentity) SessionMetadata {
+	var none SessionMetadata
+	if id.SessionID == "" {
+		return none
+	}
+	if meta, ok := memo[id.SessionID]; ok && (id.Email == "" || meta.UserEmail == id.Email) {
+		return meta
+	}
+
+	var cached SessionMetadata
+	if err := s.cache.Get(ctx, sessionCacheKey(id.SessionID), &cached); err != nil ||
+		cached.ServiceName != "Codex" || cached.GramOrgID != id.OrgID || cached.ProjectID != id.ProjectID {
+		cached = none
+	}
+	// Reuse a prior classification when this record brings no identity the
+	// cache lacks; recompute when the email is new or the entry predates
+	// classification (empty AccountType).
+	if cached.AccountType != "" && (id.Email == "" || cached.UserEmail == id.Email) {
+		memo[id.SessionID] = cached
+		return cached
+	}
+
+	userEmail, userID := id.Email, id.UserID
+	if userEmail == "" {
+		userEmail, userID = cached.UserEmail, cached.UserID
+	}
+	meta := SessionMetadata{
+		SessionID:           id.SessionID,
+		ServiceName:         "Codex",
+		UserEmail:           userEmail,
+		UserID:              userID,
+		Provider:            providerOpenAI,
+		ExternalOrgID:       "",
+		ExternalAccountUUID: "",
+		ExternalAccountID:   "",
+		DeviceID:            "",
+		Hostname:            cached.Hostname,
+		AccountType:         "",
+		BillingMode:         "",
+		UserAccountID:       "",
+		// user.email is the authenticated ChatGPT account's own report, so it
+		// doubles as the observed email kept separate from actor identity.
+		ObservedUserEmail: userEmail,
+		GramOrgID:         id.OrgID,
+		ProjectID:         id.ProjectID,
+	}
+	if err := s.attributeSession(ctx, &meta); err != nil {
+		s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",
+			attr.SlogEvent("account_attribution_failed"),
+			attr.SlogError(err),
+			attr.SlogGenAIConversationID(id.SessionID),
+		)
+	}
+	memo[id.SessionID] = meta
+	// An entry whose attribution failed (empty AccountType) is still cached —
+	// the fast path above rejects it, so the next payload retries.
+	if err := s.cache.Set(ctx, sessionCacheKey(id.SessionID), meta, 24*time.Hour); err != nil {
+		s.logger.WarnContext(ctx, "failed to cache Codex session metadata",
+			attr.SlogError(err),
+			attr.SlogGenAIConversationID(id.SessionID),
+		)
+	}
+	return meta
 }

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -210,6 +210,7 @@ func (s *Service) writeCodexMetricsToClickHouse(ctx context.Context, payload *ge
 
 	params := make([]telemetry.LogParams, 0)
 	emailToUserID := make(map[string]string)
+	attributionBySession := make(map[string]SessionMetadata)
 	for _, resourceMetric := range payload.ResourceMetrics {
 		if resourceMetric == nil {
 			continue
@@ -262,7 +263,18 @@ func (s *Service) writeCodexMetricsToClickHouse(ctx context.Context, payload *ge
 						}
 					}
 
-					userInfo, _, _ := s.codexOTELUserInfo(ctx, attrs, emailToUserID, orgID)
+					// Stamp the same account attribution as the logs stream so
+					// a session's rows classify consistently across both.
+					userInfo, email, userID := s.codexOTELUserInfo(ctx, attrs, emailToUserID, orgID)
+					sessionMeta := s.codexOTELSessionAttribution(ctx, attributionBySession, codexOTELIdentity{
+						SessionID: stringAttr(attrs, attr.GenAIConversationIDKey),
+						Email:     email,
+						UserID:    userID,
+						OrgID:     orgID,
+						ProjectID: projectID,
+					})
+					stampAccountAttribution(attrs, sessionMeta)
+
 					params = append(params, telemetry.WithOTELMetadata(telemetry.LogParams{
 						Timestamp:  timestamp,
 						ToolInfo:   toolInfo,
@@ -338,8 +350,11 @@ type codexOTELIdentity struct {
 // session cache is the cross-payload fast path — Codex exports every few
 // seconds and its identity (the email alone) rarely changes mid-session — and
 // is re-seeded after a fresh classification so the legacy hook path and the
-// ingest adapter inherit the same attribution. A record without a conversation
-// id stays email-attributed only: the zero metadata stamps nothing.
+// ingest adapter inherit the same attribution. Billing mode is frozen with the
+// classification for the cache lifetime (a declaration made mid-session is
+// picked up on the next session), matching the Claude path's attribute-once
+// semantics. A record without a conversation id stays email-attributed only:
+// the zero metadata stamps nothing.
 func (s *Service) codexOTELSessionAttribution(ctx context.Context, memo map[string]SessionMetadata, id codexOTELIdentity) SessionMetadata {
 	var none SessionMetadata
 	if id.SessionID == "" {
@@ -392,10 +407,16 @@ func (s *Service) codexOTELSessionAttribution(ctx context.Context, memo map[stri
 			attr.SlogError(err),
 			attr.SlogGenAIConversationID(id.SessionID),
 		)
+		// Leave the session unclassified rather than half-attributed:
+		// attributeSession stamps AccountType before the step that failed,
+		// and every fast path keys on AccountType alone — caching the half
+		// state would freeze an empty billing mode for the full TTL.
+		meta.AccountType = ""
+		meta.BillingMode = ""
 	}
 	memo[id.SessionID] = meta
-	// An entry whose attribution failed (empty AccountType) is still cached —
-	// the fast path above rejects it, so the next payload retries.
+	// A failed attribution is cached with empty AccountType — the fast path
+	// above rejects it, so the next payload retries.
 	if err := s.cache.Set(ctx, sessionCacheKey(id.SessionID), meta, 24*time.Hour); err != nil {
 		s.logger.WarnContext(ctx, "failed to cache Codex session metadata",
 			attr.SlogError(err),

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -314,6 +314,15 @@ func (s *Service) codexOTELUserInfo(ctx context.Context, attrs map[attr.Key]any,
 	return telemetry.UserInfoByIDAndEmail(userID, email), email, userID
 }
 
+// sameCodexIdentity reports whether an incoming record's email brings no
+// identity a prior attribution lacks: either the record carries none, or it
+// matches the attributed email (case-insensitively — Codex surfaces report
+// case-variant emails, e.g. "Dev@Example.com" in the compliance feed).
+func sameCodexIdentity(attributedEmail, incomingEmail string) bool {
+	return incomingEmail == "" ||
+		conv.NormalizeEmail(attributedEmail) == conv.NormalizeEmail(incomingEmail)
+}
+
 // codexOTELIdentity carries the per-record identity inputs for session
 // attribution on the Codex OTEL stream.
 type codexOTELIdentity struct {
@@ -336,7 +345,7 @@ func (s *Service) codexOTELSessionAttribution(ctx context.Context, memo map[stri
 	if id.SessionID == "" {
 		return none
 	}
-	if meta, ok := memo[id.SessionID]; ok && (id.Email == "" || meta.UserEmail == id.Email) {
+	if meta, ok := memo[id.SessionID]; ok && sameCodexIdentity(meta.UserEmail, id.Email) {
 		return meta
 	}
 
@@ -348,7 +357,7 @@ func (s *Service) codexOTELSessionAttribution(ctx context.Context, memo map[stri
 	// Reuse a prior classification when this record brings no identity the
 	// cache lacks; recompute when the email is new or the entry predates
 	// classification (empty AccountType).
-	if cached.AccountType != "" && (id.Email == "" || cached.UserEmail == id.Email) {
+	if cached.AccountType != "" && sameCodexIdentity(cached.UserEmail, id.Email) {
 		memo[id.SessionID] = cached
 		return cached
 	}

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -416,3 +416,68 @@ func TestMetrics_CodexPayloadDoesNotWriteClaudeUsageRows(t *testing.T) {
 		return err == nil && len(logs) > 0
 	}, 300*time.Millisecond, 50*time.Millisecond)
 }
+
+// TestLogs_StampsCodexAccountAttribution: a Codex OTEL record whose user.email
+// resolves to an org member is classified team and stamped with the org-level
+// billing mode from the codex_compliance config (DNO-734) — the columns the
+// cost surfaces classify Codex spend by.
+func TestLogs_StampsCodexAccountAttribution(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	userID := uuid.NewString()
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, userID, "codex-account-attr@example.com")
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	rec := &gen.OTELLogRecord{
+		TimeUnixNano: new(nanoString(timestamp)),
+		Body:         &gen.OTELLogBody{StringValue: new("codex.user_prompt")},
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", "codex.user_prompt"),
+			strAttr("conversation.id", "conv-account-attribution"),
+			strAttr("user.email", "codex-account-attr@example.com"),
+		},
+	}
+
+	require.NoError(t, ti.service.Logs(ctx, codexLogsPayload(rec)))
+
+	// Attributes are stored as nested JSON (dotted keys expand to objects), so
+	// assert on the serialized "gram" object's fields.
+	logs := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexOTELLogsURN, timestamp, 1)
+	require.Contains(t, logs[0].Attributes, `"account_type":"team"`)
+	require.Contains(t, logs[0].Attributes, `"billing_mode":"flat_rate"`)
+	require.Contains(t, logs[0].Attributes, `"provider":"openai"`)
+}
+
+// TestLogs_ClassifiesUnresolvedCodexEmailPersonal: an email no org member owns
+// classifies personal, and the company's declared billing mode must not ride
+// on the row.
+func TestLogs_ClassifiesUnresolvedCodexEmailPersonal(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	rec := &gen.OTELLogRecord{
+		TimeUnixNano: new(nanoString(timestamp)),
+		Body:         &gen.OTELLogBody{StringValue: new("codex.user_prompt")},
+		Attributes: []*gen.OTELAttribute{
+			strAttr("event.name", "codex.user_prompt"),
+			strAttr("conversation.id", "conv-personal-attribution"),
+			strAttr("user.email", "someone@personal.example"),
+		},
+	}
+
+	require.NoError(t, ti.service.Logs(ctx, codexLogsPayload(rec)))
+
+	logs := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexOTELLogsURN, timestamp, 1)
+	require.Contains(t, logs[0].Attributes, `"account_type":"personal"`)
+	require.NotContains(t, logs[0].Attributes, "billing_mode")
+}

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -371,6 +371,9 @@ func TestMetrics_PersistsCodexOTELMetricDataPoints(t *testing.T) {
 	require.Contains(t, row.Attributes, "tool_name")
 	require.Contains(t, row.Attributes, "shell")
 	require.Contains(t, row.Attributes, providerOpenAI)
+	// Metrics rows carry the same account attribution as the logs stream
+	// (dev@example.com resolves to the test org member → team).
+	require.Contains(t, row.Attributes, `"account_type":"team"`)
 	require.Contains(t, row.ResourceAttributes, codexServiceName)
 }
 

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -895,22 +895,45 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 
 	// Codex sessions delivered only through the relay never pass the legacy
 	// hook or OTEL paths that normally attribute the account, so classify here
-	// when no cached attribution exists (email-based for openai — see
-	// classifyAccount; the Set in Ingest persists the result for later
-	// events). Claude adapters are untouched: their attribution belongs to the
-	// OTEL path, which carries the account identity this payload lacks.
+	// when no cached attribution exists or when this event's actor email is
+	// not the one the cached classification was computed from (the same
+	// identity rule the legacy-hook and OTEL paths apply). A fresh result is
+	// written back so later events on any path adopt it instead of
+	// re-classifying. Claude adapters are untouched: their attribution belongs
+	// to the OTEL path, which carries the account identity this payload lacks.
 	if strings.EqualFold(strings.TrimSpace(payload.Source.Adapter), "codex") {
 		metadata.Provider = providerOpenAI
-		if metadata.ObservedUserEmail == "" {
+		if metadata.AccountType == "" || !sameCodexIdentity(metadata.ObservedUserEmail, metadata.UserEmail) {
 			metadata.ObservedUserEmail = metadata.UserEmail
-		}
-		if metadata.AccountType == "" {
 			if err := s.attributeSession(ctx, &metadata); err != nil {
 				s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",
 					attr.SlogEvent("account_attribution_failed"),
 					attr.SlogError(err),
 					attr.SlogGenAIConversationID(metadata.SessionID),
 				)
+				// Leave the session unclassified rather than half-attributed:
+				// attributeSession stamps AccountType before the step that
+				// failed, and both this branch's gate and recordCanonicalHook's
+				// session.started cache write key on AccountType alone —
+				// keeping the half state would freeze an empty billing mode
+				// for the cache lifetime.
+				metadata.AccountType = ""
+				metadata.BillingMode = ""
+			} else if metadata.SessionID != "" && metadata.AccountType != "" &&
+				!strings.EqualFold(strings.TrimSpace(payload.Event.Type), "session.started") {
+				// session.started is excluded: recordCanonicalHook already
+				// persists this metadata (attribution included) for that
+				// event; this write-back exists for sessions whose started
+				// event was never seen.
+				cacheCtx, cancel := context.WithTimeout(ctx, canonicalSessionCacheWriteTimeout)
+				err := s.cache.Set(cacheCtx, sessionCacheKey(metadata.SessionID), metadata, 24*time.Hour)
+				cancel()
+				if err != nil {
+					s.logger.WarnContext(ctx, "failed to cache Codex session metadata",
+						attr.SlogError(err),
+						attr.SlogGenAIConversationID(metadata.SessionID),
+					)
+				}
 			}
 		}
 	}

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -903,7 +903,20 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 	// to the OTEL path, which carries the account identity this payload lacks.
 	if strings.EqualFold(strings.TrimSpace(payload.Source.Adapter), "codex") {
 		metadata.Provider = providerOpenAI
-		if metadata.AccountType == "" || !sameCodexIdentity(metadata.ObservedUserEmail, metadata.UserEmail) {
+		identityChanged := !sameCodexIdentity(metadata.ObservedUserEmail, metadata.UserEmail)
+		if metadata.AccountType == "" || identityChanged {
+			if identityChanged {
+				// The identity fallback above fills UserID from the cache
+				// independently of the email, so on an identity change it can
+				// still hold the PRIOR actor's resolved id — and
+				// classifyAccount reads UserID as the resolution of the email
+				// being classified, which would label a new unresolved email
+				// team (and unlock the team-gated billing mode) off the old
+				// actor. Restore the resolved actor's own id: an identity
+				// change means UserEmail is the actor's email, whose
+				// resolution resolveCanonicalActor already computed.
+				metadata.UserID = actor.UserID
+			}
 			metadata.ObservedUserEmail = metadata.UserEmail
 			if err := s.attributeSession(ctx, &metadata); err != nil {
 				s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -892,6 +892,28 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 			}
 		}
 	}
+
+	// Codex sessions delivered only through the relay never pass the legacy
+	// hook or OTEL paths that normally attribute the account, so classify here
+	// when no cached attribution exists (email-based for openai — see
+	// classifyAccount; the Set in Ingest persists the result for later
+	// events). Claude adapters are untouched: their attribution belongs to the
+	// OTEL path, which carries the account identity this payload lacks.
+	if strings.EqualFold(strings.TrimSpace(payload.Source.Adapter), "codex") {
+		metadata.Provider = providerOpenAI
+		if metadata.ObservedUserEmail == "" {
+			metadata.ObservedUserEmail = metadata.UserEmail
+		}
+		if metadata.AccountType == "" {
+			if err := s.attributeSession(ctx, &metadata); err != nil {
+				s.logger.WarnContext(ctx, "failed to attribute AI account for Codex session",
+					attr.SlogEvent("account_attribution_failed"),
+					attr.SlogError(err),
+					attr.SlogGenAIConversationID(metadata.SessionID),
+				)
+			}
+		}
+	}
 	return metadata
 }
 

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1912,3 +1912,43 @@ func TestCanonicalSessionMetadata_CodexReattributesOnNewActorEmail(t *testing.T)
 	require.Empty(t, metadata.BillingMode)
 	require.Equal(t, newActorEmail, metadata.ObservedUserEmail)
 }
+
+// TestCanonicalSessionMetadata_CodexReattributionDropsStaleCachedUserID: when
+// the actor email changes to one that resolves to no org member, the
+// re-classification must not run with the PRIOR actor's UserID (the session
+// identity fallback fills UserID from the cache independently of the email).
+// A stale id would classify the unresolved email team and unlock the
+// team-gated org billing mode; the fresh actor must come back personal with
+// no billing mode even though a flat_rate declaration exists.
+func TestCanonicalSessionMetadata_CodexReattributionDropsStaleCachedUserID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	sessionID := "codex-ingest-stale-user-id"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:         sessionID,
+		ServiceName:       "codex",
+		UserEmail:         "teammate@example.com",
+		UserID:            "teammate-user-id",
+		Provider:          providerOpenAI,
+		AccountType:       accountTypeTeam,
+		BillingMode:       "flat_rate",
+		ObservedUserEmail: "teammate@example.com",
+		GramOrgID:         authCtx.ActiveOrganizationID,
+		ProjectID:         authCtx.ProjectID.String(),
+	}, 0))
+
+	payload := canonicalIngestPayload("codex", "tool.requested", sessionID)
+	metadata := ti.service.canonicalSessionMetadata(ctx, payload, authCtx, canonicalActor{UserID: "", Email: "stranger@personal.example"})
+
+	require.Equal(t, providerOpenAI, metadata.Provider)
+	require.Empty(t, metadata.UserID, "cached teammate id must not survive the identity change")
+	require.Equal(t, accountTypePersonal, metadata.AccountType)
+	require.Empty(t, metadata.BillingMode)
+	require.Equal(t, "stranger@personal.example", metadata.ObservedUserEmail)
+}

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1822,3 +1822,49 @@ func (r *recordingRiskFindingInserter) InsertRiskFindings(_ context.Context, row
 	r.rows = rows
 	return nil
 }
+
+// TestCanonicalSessionMetadata_AttributesCodexAdapter: a Codex session
+// delivered only through the relay (Ingest is its sole path) is attributed at
+// ingest — provider openai, email-based classification, and the org-level
+// billing mode from the codex_compliance config for team sessions (DNO-734).
+func TestCanonicalSessionMetadata_AttributesCodexAdapter(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	payload := canonicalIngestPayload("codex", "tool.requested", "codex-ingest-attribution")
+	metadata := ti.service.canonicalSessionMetadata(ctx, payload, authCtx, canonicalActor{UserID: "user-123", Email: "dev@example.com"})
+
+	require.Equal(t, providerOpenAI, metadata.Provider)
+	require.Equal(t, accountTypeTeam, metadata.AccountType)
+	require.Equal(t, "flat_rate", metadata.BillingMode)
+}
+
+// TestCanonicalSessionMetadata_CodexAdapterUnresolvedActorIsPersonal: an actor
+// whose email did not resolve to an org member classifies personal and does
+// not inherit the company's billing mode. Claude adapters remain untouched —
+// their attribution belongs to the OTEL path.
+func TestCanonicalSessionMetadata_CodexAdapterUnresolvedActorIsPersonal(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	seedCodexBillingConfig(t, ctx, ti.conn, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "flat_rate")
+
+	payload := canonicalIngestPayload("Codex", "prompt.submitted", "codex-ingest-personal")
+	metadata := ti.service.canonicalSessionMetadata(ctx, payload, authCtx, canonicalActor{UserID: "", Email: "someone@personal.example"})
+
+	require.Equal(t, providerOpenAI, metadata.Provider)
+	require.Equal(t, accountTypePersonal, metadata.AccountType)
+	require.Empty(t, metadata.BillingMode)
+
+	claudeMetadata := ti.service.canonicalSessionMetadata(ctx, canonicalIngestPayload("claude-code", "prompt.submitted", "claude-ingest-untouched"), authCtx, canonicalActor{UserID: "", Email: ""})
+	require.Empty(t, claudeMetadata.Provider)
+	require.Empty(t, claudeMetadata.AccountType)
+}

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1868,3 +1868,47 @@ func TestCanonicalSessionMetadata_CodexAdapterUnresolvedActorIsPersonal(t *testi
 	require.Empty(t, claudeMetadata.Provider)
 	require.Empty(t, claudeMetadata.AccountType)
 }
+
+// TestCanonicalSessionMetadata_CodexReattributesOnNewActorEmail: a cached
+// classification is only adopted when this event's actor email is the one it
+// was computed from — the same identity rule the legacy-hook and OTEL paths
+// apply — so a different resolved actor on the same session re-classifies
+// instead of inheriting the prior attribution. Re-attribution is observable
+// through the billing mode: the cache carries flat_rate, but no config exists
+// in this test, so a fresh resolution must come back empty.
+func TestCanonicalSessionMetadata_CodexReattributesOnNewActorEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	newActorID := "codex-ingest-new-actor"
+	newActorEmail := "new-actor@example.com"
+	seedHookUser(t, ctx, ti.conn, authCtx.ActiveOrganizationID, newActorID, newActorEmail)
+
+	sessionID := "codex-ingest-actor-change"
+	require.NoError(t, ti.service.cache.Set(ctx, sessionCacheKey(sessionID), SessionMetadata{
+		SessionID:         sessionID,
+		ServiceName:       "codex",
+		UserEmail:         "teammate@example.com",
+		UserID:            "teammate-user-id",
+		Provider:          providerOpenAI,
+		AccountType:       accountTypeTeam,
+		BillingMode:       "flat_rate",
+		ObservedUserEmail: "teammate@example.com",
+		GramOrgID:         authCtx.ActiveOrganizationID,
+		ProjectID:         authCtx.ProjectID.String(),
+	}, 0))
+
+	payload := canonicalIngestPayload("codex", "tool.requested", sessionID)
+	metadata := ti.service.canonicalSessionMetadata(ctx, payload, authCtx, canonicalActor{UserID: newActorID, Email: newActorEmail})
+
+	require.Equal(t, providerOpenAI, metadata.Provider)
+	require.Equal(t, accountTypeTeam, metadata.AccountType)
+	// The cached flat_rate must NOT survive: a fresh resolution ran and found
+	// no config declaration.
+	require.Empty(t, metadata.BillingMode)
+	require.Equal(t, newActorEmail, metadata.ObservedUserEmail)
+}

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -92,8 +92,14 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		// alone would freeze a session whose entity persistence transiently failed
 		// (classified but never persisted, linked, or billing-resolved) instead of
 		// retrying on the next batch.
+		// Only an entry this Claude path owns may be adopted: the codex OTEL
+		// writer seeds the same key space (session ids are client-reported)
+		// with provider=openai entries whose shape — AccountType set, no
+		// account UUID — would otherwise satisfy the company-credential arm
+		// below and stamp Claude rows with Codex attribution.
 		var cached SessionMetadata
 		if err := s.cache.Get(ctx, sessionCacheKey(session.SessionID), &cached); err == nil &&
+			cached.Provider == providerAnthropic && cached.GramOrgID == orgID && cached.ProjectID == projectID &&
 			(cached.UserAccountID != "" || (cached.AccountType != "" && cached.ExternalAccountUUID == "")) &&
 			!sessionEnrichesAttribution(session, cached) {
 			attributionBySession[session.SessionID] = cached

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -269,6 +269,23 @@ WHERE organization_id = @organization_id
 ORDER BY (external_organization_id = @external_org_id) DESC NULLS LAST
 LIMIT 1;
 
+-- name: GetProviderBillingModeAnyOrg :one
+-- Org-level billing mode for providers whose sessions never carry an external
+-- org id. Codex emits no org identity on any layer (hooks, OTEL), while the
+-- codex_compliance config always pins one, so the org-matched lookup above can
+-- never hit for those sessions. Only one live config per (org, provider) can
+-- exist today, so the provider-wide declaration is the applicable one; the
+-- ordering is defensive against historical duplicates.
+SELECT billing_mode
+FROM ai_integration_configs
+WHERE organization_id = @organization_id
+  AND provider = @provider
+  AND enabled = TRUE
+  AND deleted IS FALSE
+  AND billing_mode IS NOT NULL
+ORDER BY updated_at DESC
+LIMIT 1;
+
 -- name: GetDeviceOwner :one
 SELECT * FROM device_owners
 WHERE organization_id = @organization_id

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -251,9 +251,13 @@ ORDER BY user_id, account_type DESC, provider, last_seen_at DESC;
 -- provider org; a config with none applies provider-wide. Exact-org matches are
 -- preferred over provider-wide (NULLS LAST because the comparison is NULL for a
 -- NULL-scoped row, and DESC would otherwise sort NULL ahead of an exact match).
--- Only one live config per (org, provider) can exist today, so the ordering is
--- defensive. Only configs with a non-null billing_mode are considered, so an
--- undeclared org returns no rows (treated as unknown upstream).
+-- @match_any_org disables the org scoping entirely: Codex sessions carry no org
+-- identity on any layer while codex_compliance configs always pin one, so for
+-- them the provider-wide declaration applies regardless of config scope. Only
+-- one live config per (org, provider) can exist today, so the ordering (with
+-- updated_at as the tiebreak against historical duplicates) is defensive. Only
+-- configs with a non-null billing_mode are considered, so an undeclared org
+-- returns no rows (treated as unknown upstream).
 SELECT billing_mode
 FROM ai_integration_configs
 WHERE organization_id = @organization_id
@@ -262,28 +266,12 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE
   AND billing_mode IS NOT NULL
   AND (
-    external_organization_id IS NULL
+    @match_any_org::bool
+    OR external_organization_id IS NULL
     OR external_organization_id = ''
     OR external_organization_id = @external_org_id
   )
-ORDER BY (external_organization_id = @external_org_id) DESC NULLS LAST
-LIMIT 1;
-
--- name: GetProviderBillingModeAnyOrg :one
--- Org-level billing mode for providers whose sessions never carry an external
--- org id. Codex emits no org identity on any layer (hooks, OTEL), while the
--- codex_compliance config always pins one, so the org-matched lookup above can
--- never hit for those sessions. Only one live config per (org, provider) can
--- exist today, so the provider-wide declaration is the applicable one; the
--- ordering is defensive against historical duplicates.
-SELECT billing_mode
-FROM ai_integration_configs
-WHERE organization_id = @organization_id
-  AND provider = @provider
-  AND enabled = TRUE
-  AND deleted IS FALSE
-  AND billing_mode IS NOT NULL
-ORDER BY updated_at DESC
+ORDER BY (external_organization_id = @external_org_id) DESC NULLS LAST, updated_at DESC
 LIMIT 1;
 
 -- name: GetDeviceOwner :one

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -162,6 +162,36 @@ func (q *Queries) GetDeviceOwner(ctx context.Context, arg GetDeviceOwnerParams) 
 	return i, err
 }
 
+const getProviderBillingModeAnyOrg = `-- name: GetProviderBillingModeAnyOrg :one
+SELECT billing_mode
+FROM ai_integration_configs
+WHERE organization_id = $1
+  AND provider = $2
+  AND enabled = TRUE
+  AND deleted IS FALSE
+  AND billing_mode IS NOT NULL
+ORDER BY updated_at DESC
+LIMIT 1
+`
+
+type GetProviderBillingModeAnyOrgParams struct {
+	OrganizationID string
+	Provider       string
+}
+
+// Org-level billing mode for providers whose sessions never carry an external
+// org id. Codex emits no org identity on any layer (hooks, OTEL), while the
+// codex_compliance config always pins one, so the org-matched lookup above can
+// never hit for those sessions. Only one live config per (org, provider) can
+// exist today, so the provider-wide declaration is the applicable one; the
+// ordering is defensive against historical duplicates.
+func (q *Queries) GetProviderBillingModeAnyOrg(ctx context.Context, arg GetProviderBillingModeAnyOrgParams) (pgtype.Text, error) {
+	row := q.db.QueryRow(ctx, getProviderBillingModeAnyOrg, arg.OrganizationID, arg.Provider)
+	var billing_mode pgtype.Text
+	err := row.Scan(&billing_mode)
+	return billing_mode, err
+}
+
 const getProviderOrgBillingMode = `-- name: GetProviderOrgBillingMode :one
 SELECT billing_mode
 FROM ai_integration_configs

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -162,36 +162,6 @@ func (q *Queries) GetDeviceOwner(ctx context.Context, arg GetDeviceOwnerParams) 
 	return i, err
 }
 
-const getProviderBillingModeAnyOrg = `-- name: GetProviderBillingModeAnyOrg :one
-SELECT billing_mode
-FROM ai_integration_configs
-WHERE organization_id = $1
-  AND provider = $2
-  AND enabled = TRUE
-  AND deleted IS FALSE
-  AND billing_mode IS NOT NULL
-ORDER BY updated_at DESC
-LIMIT 1
-`
-
-type GetProviderBillingModeAnyOrgParams struct {
-	OrganizationID string
-	Provider       string
-}
-
-// Org-level billing mode for providers whose sessions never carry an external
-// org id. Codex emits no org identity on any layer (hooks, OTEL), while the
-// codex_compliance config always pins one, so the org-matched lookup above can
-// never hit for those sessions. Only one live config per (org, provider) can
-// exist today, so the provider-wide declaration is the applicable one; the
-// ordering is defensive against historical duplicates.
-func (q *Queries) GetProviderBillingModeAnyOrg(ctx context.Context, arg GetProviderBillingModeAnyOrgParams) (pgtype.Text, error) {
-	row := q.db.QueryRow(ctx, getProviderBillingModeAnyOrg, arg.OrganizationID, arg.Provider)
-	var billing_mode pgtype.Text
-	err := row.Scan(&billing_mode)
-	return billing_mode, err
-}
-
 const getProviderOrgBillingMode = `-- name: GetProviderOrgBillingMode :one
 SELECT billing_mode
 FROM ai_integration_configs
@@ -201,17 +171,19 @@ WHERE organization_id = $1
   AND deleted IS FALSE
   AND billing_mode IS NOT NULL
   AND (
-    external_organization_id IS NULL
+    $3::bool
+    OR external_organization_id IS NULL
     OR external_organization_id = ''
-    OR external_organization_id = $3
+    OR external_organization_id = $4
   )
-ORDER BY (external_organization_id = $3) DESC NULLS LAST
+ORDER BY (external_organization_id = $4) DESC NULLS LAST, updated_at DESC
 LIMIT 1
 `
 
 type GetProviderOrgBillingModeParams struct {
 	OrganizationID string
 	Provider       string
+	MatchAnyOrg    bool
 	ExternalOrgID  pgtype.Text
 }
 
@@ -221,11 +193,20 @@ type GetProviderOrgBillingModeParams struct {
 // provider org; a config with none applies provider-wide. Exact-org matches are
 // preferred over provider-wide (NULLS LAST because the comparison is NULL for a
 // NULL-scoped row, and DESC would otherwise sort NULL ahead of an exact match).
-// Only one live config per (org, provider) can exist today, so the ordering is
-// defensive. Only configs with a non-null billing_mode are considered, so an
-// undeclared org returns no rows (treated as unknown upstream).
+// @match_any_org disables the org scoping entirely: Codex sessions carry no org
+// identity on any layer while codex_compliance configs always pin one, so for
+// them the provider-wide declaration applies regardless of config scope. Only
+// one live config per (org, provider) can exist today, so the ordering (with
+// updated_at as the tiebreak against historical duplicates) is defensive. Only
+// configs with a non-null billing_mode are considered, so an undeclared org
+// returns no rows (treated as unknown upstream).
 func (q *Queries) GetProviderOrgBillingMode(ctx context.Context, arg GetProviderOrgBillingModeParams) (pgtype.Text, error) {
-	row := q.db.QueryRow(ctx, getProviderOrgBillingMode, arg.OrganizationID, arg.Provider, arg.ExternalOrgID)
+	row := q.db.QueryRow(ctx, getProviderOrgBillingMode,
+		arg.OrganizationID,
+		arg.Provider,
+		arg.MatchAnyOrg,
+		arg.ExternalOrgID,
+	)
 	var billing_mode pgtype.Text
 	err := row.Scan(&billing_mode)
 	return billing_mode, err


### PR DESCRIPTION
Closes DNO-734.

Codex sessions carried no account classification: every row showed account_type "(unset)", and the `billing_mode` field on the `codex_compliance` config was unreachable because the session provider `openai` never mapped to it.

## What changed

**Classification** (`account_attribution.go`)

- The "no account UUID → team" rule is gated to `anthropic`. It encodes Claude OAuth semantics (a personal Max/Pro account always emits `user.account_uuid`, so its absence means company credentials); Codex emits no account identity at any layer, so a missing UUID says nothing there. Codex classifies from email resolution: resolved work email → `team`, otherwise `personal`.
- Session provider `openai` now maps to the `codex_compliance` config for billing-mode resolution. Codex sessions carry no external org id while the config always pins one, so the org-matched lookup can never hit — a new provider-wide query (`GetProviderBillingModeAnyOrg`) applies instead. Billing mode resolves despite there being no `user_accounts` entity (no UUID), gated to team-classified sessions so a personal Codex account never inherits the company's declared mode.

**All three Codex capture paths now attribute and stamp `account_type` / `billing_mode`:**

- **OTEL logs** (the token-bearing rows that drive the cost surfaces): per-conversation attribution, memoized per payload with the session cache as the cross-payload fast path; re-seeds the cache so the other paths inherit.
- **Legacy hooks** (`codexSessionMetadata`): attributes with a cached fast-path (adopts the cached classification when the event carries the same email); `buildCodexTelemetryAttributes` stamps via `stampAccountAttribution`.
- **Ingest adapter** (the relay's only delivery method): codex-adapter events get provider `openai` and attribution on cache miss. Claude adapters deliberately untouched — attributing them at ingest would mislabel sessions whose OTEL identity hasn't arrived yet.

**Compliance COSTS importer**: rows now carry `account_type=team` (the feed is the org's own enterprise feed, by construction) and the config's admin-declared billing mode directly — this covers the ChatGPT/Work usage rows too.

**Smaller surfaces**: the billing-mode field already renders for OpenAI configs (it's unconditional in the configure sheet — no UI change); "Est. cost" tooltip copy now mentions ChatGPT plans; `seed-costs.mjs` ChatGPT fixtures carry the new columns. No ClickHouse changes — the `account_type`/`billing_mode` columns already exist and materialize from attributes.

## Testing

15 new tests: classification (team/personal per provider semantics), billing-mode cascade incl. the provider-wide path against a real config row, all three capture paths (incl. a ClickHouse row assertion that the columns materialize), cached-adoption fast path, and importer stamping. Full `hooks` + `aiintegrations` suites and `mise lint:server` pass.

## Out of scope (follow-ups)

- Cursor parity: same email-based classification is one condition away in the ingest hook.
- Using the compliance feed's identity emails to classify not-yet-provisioned employees as team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Codex sessions and resolves billing mode across OTEL, legacy hooks, and ingest so rows carry account_type and billing_mode. Implements DNO-734 and fixes the `openai` → `codex_compliance` mapping so org billing applies to Codex.

- New Features
  - Email-based classification for `openai`: work email → team; else personal. Stamps account_type/billing_mode on OTEL logs and metrics, legacy hooks, and ingest; memoizes per session, writes back to cache on any event, and re-attributes at ingest when the actor email changes. Claude adapters stay untouched.
  - Compliance COSTS importer: rows are team by construction; stamps the config’s billing_mode on Codex product rows only. ChatGPT/Work rows remain estimate-only.
  - Updated estimated-cost tooltip to mention ChatGPT plans; added seed fixtures for new columns.

- Bug Fixes
  - Mapped `openai` to `codex_compliance` for billing-mode resolution, with a provider-wide lookup when sessions lack an external org id; team-gated so personal Codex never inherits the company mode.
  - Gated the “no account UUID → team” rule to `anthropic`.
  - Normalized email comparison in Codex attribution fast paths; legacy-path warnings now include the session id.
  - Prevented Claude OTEL from adopting Codex-seeded cache entries by requiring org/project/provider ownership before fast-path attribution.
  - Dropped stale cached user_id on Codex ingest re-attribution when the actor email changes, preventing personal sessions from being mislabeled team or inheriting team-gated billing.

<sup>Written for commit 2269c35a9bb1fda3ea66d15ff9eb14713b164da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

