### PR TITLE
feat(auth): start a 14-day enterprise trial on self-signup

### DIFF
--- a/.changeset/enterprise-trial-provisioning.md
+++ b/.changeset/enterprise-trial-provisioning.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Signing up for Gram now starts a 14-day enterprise trial. Your new organization opens on the enterprise tier with the full enterprise feature set enabled, and the trial window is recorded so the tier returns to free when it ends.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1220,6 +1220,8 @@ func newStartCommand() *cli.Command {
 				posthogClient,
 				cache.NewRedisCacheAdapter(redisClient),
 				authzProvisioner,
+				productfeatures.SeedEnterpriseTrialBundleTx,
+				auditLogger,
 			))
 			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, serverURL.String(), siteURL.String(), auditLogger, svixClient)
 			organizations.Attach(mux, organizationsService)

--- a/server/internal/audit/organizations.go
+++ b/server/internal/audit/organizations.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	organizationsgen "github.com/speakeasy-api/gram/server/gen/organizations"
@@ -23,6 +24,8 @@ const (
 	ActionOrganizationHooksFailOpenDisabled Action = "organization:hooks_fail_open_disabled"
 
 	ActionOrganizationDeviceAgentConfigurationUpdated Action = "organization:device_agent_configuration_updated"
+
+	ActionOrganizationEnterpriseTrialArmed Action = "organization:enterprise_trial_armed"
 )
 
 type LogOrganizationInviteCreateEvent struct {
@@ -320,4 +323,51 @@ func (l *Logger) LogOrganizationDeviceAgentConfigurationUpdated(
 		Params:      entry,
 		OutboxEvent: events.OrganizationDeviceAgentConfigurationV1,
 	})
+}
+
+type LogOrganizationEnterpriseTrialArmedEvent struct {
+	OrganizationID string
+
+	Actor            urn.Principal
+	ActorDisplayName *string
+	ActorSlug        *string
+
+	OrganizationName string
+	OrganizationSlug string
+
+	TrialEndsAt time.Time
+}
+
+func (l *Logger) LogOrganizationEnterpriseTrialArmed(ctx context.Context, dbtx repo.DBTX, event LogOrganizationEnterpriseTrialArmedEvent) error {
+	action := ActionOrganizationEnterpriseTrialArmed
+
+	metadata, err := marshalAuditPayload(map[string]any{
+		"trial_ends_at": event.TrialEndsAt,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s metadata: %w", action, err)
+	}
+
+	entry := repo.InsertAuditLogParams{
+		OrganizationID: event.OrganizationID,
+		ProjectID:      uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+
+		ActorID:          event.Actor.ID,
+		ActorType:        string(event.Actor.Type),
+		ActorDisplayName: conv.PtrToPGTextEmpty(event.ActorDisplayName),
+		ActorSlug:        conv.PtrToPGTextEmpty(event.ActorSlug),
+
+		Action: string(action),
+
+		SubjectID:          event.OrganizationID,
+		SubjectType:        "organization",
+		SubjectDisplayName: conv.ToPGTextEmpty(event.OrganizationName),
+		SubjectSlug:        conv.ToPGTextEmpty(event.OrganizationSlug),
+
+		Metadata:       metadata,
+		BeforeSnapshot: nil,
+		AfterSnapshot:  nil,
+	}
+
+	return l.log(ctx, dbtx, auditEntry{Params: entry, OutboxEvent: events.OrganizationEnterpriseTrialV1})
 }

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 func TestService_Callback(t *testing.T) {
@@ -640,7 +641,12 @@ func TestService_Callback_SignupIntent(t *testing.T) {
 		org, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, session.ActiveOrganizationID)
 		require.NoError(t, err)
 		require.Equal(t, "Acme Inc", org.Name)
-		require.False(t, org.Whitelisted, "signup orgs match register and stay gated")
+		require.True(t, org.Whitelisted, "signup orgs match register and clear the demo gate")
+		require.Equal(t, "enterprise", org.GramAccountType)
+
+		trial, err := trialsRepo.New(instance.conn).GetTrial(ctx, session.ActiveOrganizationID)
+		require.NoError(t, err)
+		require.Equal(t, "enterprise", trial.Tier)
 	})
 
 	t.Run("intent is consumed so it cannot be replayed", func(t *testing.T) {

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -14,6 +14,7 @@ import (
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
 	accessRepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -25,10 +26,12 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgid "github.com/speakeasy-api/gram/server/internal/organizations/id"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/users"
 	usersRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
@@ -172,7 +175,7 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthogClient, nonceStore, authzProvisioner)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthogClient, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger())
 
 	ti := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	return ctx, &e2eInstance{testInstance: *ti, fetcher: fetcher}
@@ -466,7 +469,8 @@ func TestSyncMembershipsFromWorkOS_EmptyResponseRevokesWorkOSRelationships(t *te
 }
 
 // TestE2E_Callback_NewUserNoWorkOSOrgs_AssistantsDisposition verifies that a
-// new user with zero orgs and the "assistants" disposition gets auto-provisioned.
+// new user with zero orgs and the "assistants" disposition gets auto-provisioned,
+// and that the organization it provisions arms no enterprise trial.
 func TestE2E_Callback_NewUserNoWorkOSOrgs_AssistantsDisposition(t *testing.T) {
 	t.Parallel()
 
@@ -493,6 +497,25 @@ func TestE2E_Callback_NewUserNoWorkOSOrgs_AssistantsDisposition(t *testing.T) {
 	require.NotContains(t, result.Location, "signin_error=")
 	assert.Contains(t, result.Location, "assistants")
 	require.NotEmpty(t, result.SessionToken)
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, result.SessionToken)
+	require.NoError(t, err)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	organizationID := authCtx.ActiveOrganizationID
+	require.NotEmpty(t, organizationID)
+
+	// An assistants organization is a live product for a user who never asked for
+	// a trial, so arming one here would strip entitlements two weeks later. The
+	// account type stays whatever the billing provider reports, the stub's "pro".
+	org, err := orgRepo.New(inst.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.NotEqual(t, "enterprise", org.GramAccountType)
+	require.True(t, org.Whitelisted)
+
+	_, err = trialsRepo.New(inst.conn).GetTrial(ctx, organizationID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 // TestE2E_Callback_ExistingUserWithDBOrgs verifies the happy path: user

--- a/server/internal/auth/enterprise_trial.go
+++ b/server/internal/auth/enterprise_trial.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// enterpriseTrialDuration bounds a self-signup enterprise trial. The trials
+// table gives ends_at no default, so a change here leaves already-armed trials
+// on the date they were given.
+const enterpriseTrialDuration = 14 * 24 * time.Hour
+
+// EnterpriseTrialBundleSeeder enables the entitlements an enterprise trial
+// organization starts with. The dependency travels as a function because the
+// productfeatures package that implements it imports auth.
+type EnterpriseTrialBundleSeeder func(ctx context.Context, tx pgx.Tx, organizationID string) error
+
+// armEnterpriseTrialTx turns an organization the caller's transaction just
+// created into an enterprise trial. Every write joins that transaction, so a
+// signup produces either a complete trial or no organization.
+//
+// A trial sits on the real enterprise tier rather than a tier of its own, so
+// every account-type lookup downstream, including the OpenRouter credit
+// ceiling, resolves against a value it already knows.
+func (s *Service) armEnterpriseTrialTx(ctx context.Context, tx pgx.Tx, org orgRepo.OrganizationMetadatum, userID string) error {
+	if err := orgRepo.New(tx).SetAccountType(ctx, orgRepo.SetAccountTypeParams{
+		ID:              org.ID,
+		GramAccountType: string(billing.TierEnterprise),
+	}); err != nil {
+		return fmt.Errorf("set enterprise trial account type: %w", err)
+	}
+
+	if err := s.trialBundleSeeder(ctx, tx, org.ID); err != nil {
+		return fmt.Errorf("seed enterprise trial entitlements: %w", err)
+	}
+
+	endsAt := time.Now().UTC().Add(enterpriseTrialDuration)
+	if err := trialsRepo.New(tx).CreateTrial(ctx, trialsRepo.CreateTrialParams{
+		OrganizationID: org.ID,
+		Tier:           string(billing.TierEnterprise),
+		EndsAt:         conv.ToPGTimestamptz(endsAt),
+	}); err != nil {
+		return fmt.Errorf("create enterprise trial: %w", err)
+	}
+
+	var actorDisplayName *string
+	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil {
+		actorDisplayName = authCtx.Email
+	}
+
+	if err := s.auditLogger.LogOrganizationEnterpriseTrialArmed(ctx, tx, audit.LogOrganizationEnterpriseTrialArmedEvent{
+		OrganizationID:   org.ID,
+		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, userID),
+		ActorDisplayName: actorDisplayName,
+		ActorSlug:        nil,
+		OrganizationName: org.Name,
+		OrganizationSlug: org.Slug,
+		TrialEndsAt:      endsAt,
+	}); err != nil {
+		return fmt.Errorf("log enterprise trial armed: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/auth/enterprise_trial_test.go
+++ b/server/internal/auth/enterprise_trial_test.go
@@ -1,0 +1,121 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/auth"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	orgid "github.com/speakeasy-api/gram/server/internal/organizations/id"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featureRepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+// signUpWithoutOrganization drives a user with no organizations through
+// Callback and Authenticate, leaving them on a session with no active
+// organization: the state a public self-signup reaches just before Register.
+func signUpWithoutOrganization(t *testing.T, workosUserID, email string) (context.Context, *e2eInstance, string) {
+	t.Helper()
+
+	fetcher := &mockWorkOSFetcher{
+		members: map[string][]workos.Member{},
+		orgs:    map[string]*workos.Organization{},
+	}
+	userInfo := &MockUserInfo{
+		UserID:        workosUserID,
+		Email:         email,
+		Organizations: []MockOrganizationEntry{},
+	}
+
+	ctx, inst := newE2EAuthService(t, userInfo, fetcher)
+
+	callbackResult, err := inst.callbackWithNonce(ctx, t)
+	require.NoError(t, err)
+	require.NotEmpty(t, callbackResult.SessionToken)
+
+	ctx, err = inst.sessionManager.Authenticate(ctx, callbackResult.SessionToken)
+	require.NoError(t, err)
+
+	return ctx, inst, callbackResult.SessionToken
+}
+
+func TestRegister_ArmsEnterpriseTrial(t *testing.T) {
+	t.Parallel()
+
+	ctx, inst, _ := signUpWithoutOrganization(t, "user_01TRIAL_ARMED", "trial-armed@example.com")
+
+	auditsBefore, err := audittest.AuditLogCountByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+
+	const orgName = "Enterprise Trial Org"
+	organizationID := orgid.FromWorkOSID("workos_org_" + orgName)
+
+	armedAt := time.Now().UTC()
+	require.NoError(t, inst.service.Register(ctx, &gen.RegisterPayload{OrgName: orgName}))
+
+	org, err := orgRepo.New(inst.conn).GetOrganizationMetadata(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", org.GramAccountType)
+	require.True(t, org.Whitelisted, "a trial organization must clear the whitelist gate")
+
+	trial, err := trialsRepo.New(inst.conn).GetTrial(ctx, organizationID)
+	require.NoError(t, err)
+	require.Equal(t, "enterprise", trial.Tier)
+	require.WithinDuration(t, armedAt.Add(14*24*time.Hour), trial.EndsAt.Time, time.Minute)
+
+	// One canary feature is enough here. This test only has to prove the signup
+	// path reached the seeder, not what the seeder enables.
+	seeded, err := featureRepo.New(inst.conn).IsFeatureEnabled(ctx, featureRepo.IsFeatureEnabledParams{
+		OrganizationID: organizationID,
+		FeatureName:    string(productfeatures.FeatureSSO),
+	})
+	require.NoError(t, err)
+	require.True(t, seeded, "the signup path seeds the entitlement bundle")
+
+	auditsAfter, err := audittest.AuditLogCountByAction(ctx, inst.conn, audit.ActionOrganizationEnterpriseTrialArmed)
+	require.NoError(t, err)
+	require.Equal(t, auditsBefore+1, auditsAfter)
+}
+
+// TestRegister_EnterpriseTrialResolvesThroughInfo checks the tier survives the
+// Info round trip, so the enterprise surfaces appear straight after signup
+// without a re-login.
+func TestRegister_EnterpriseTrialResolvesThroughInfo(t *testing.T) {
+	t.Parallel()
+
+	ctx, inst, sessionToken := signUpWithoutOrganization(t, "user_01TRIAL_RESOLVE", "trial-resolve@example.com")
+
+	const orgName = "Enterprise Resolve Org"
+	organizationID := orgid.FromWorkOSID("workos_org_" + orgName)
+
+	armedAt := time.Now().UTC()
+	require.NoError(t, inst.service.Register(ctx, &gen.RegisterPayload{OrgName: orgName}))
+
+	// Pick up the organization Register just created, as the dashboard does on
+	// its next request.
+	ctx, err := inst.sessionManager.Authenticate(ctx, sessionToken)
+	require.NoError(t, err)
+
+	infoResult, err := inst.service.Info(ctx, &gen.InfoPayload{})
+	require.NoError(t, err)
+	require.Equal(t, organizationID, infoResult.ActiveOrganizationID)
+	require.Equal(t, "enterprise", infoResult.GramAccountType)
+	require.True(t, infoResult.HasActiveSubscription, "an enterprise organization short-circuits the billing lookup")
+	require.True(t, infoResult.Whitelisted)
+	require.Len(t, infoResult.Organizations, 1)
+	require.Equal(t, orgName, infoResult.Organizations[0].Name)
+
+	// Info reads the trials table, so the row Register wrote is what feeds the
+	// dashboard countdown.
+	require.NotNil(t, infoResult.Trial)
+	endsAt, err := time.Parse(time.RFC3339, infoResult.Trial.EndsAt)
+	require.NoError(t, err)
+	require.WithinDuration(t, armedAt.Add(14*24*time.Hour), endsAt, time.Minute)
+}

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -29,6 +29,7 @@ import (
 	srv "github.com/speakeasy-api/gram/server/gen/http/auth/server"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/orgslug"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -115,6 +116,8 @@ type Service struct {
 	envRepo             *envRepo.Queries
 	orgRepo             *orgRepo.Queries
 	authzProvisioner    *authz.Provisioner
+	trialBundleSeeder   EnterpriseTrialBundleSeeder
+	auditLogger         *audit.Logger
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -132,6 +135,8 @@ func NewService(
 	posthogClient *posthog.Posthog,
 	nonceStore cache.Cache,
 	authzProvisioner *authz.Provisioner,
+	trialBundleSeeder EnterpriseTrialBundleSeeder,
+	auditLogger *audit.Logger,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("auth"))
 
@@ -151,6 +156,8 @@ func NewService(
 		envRepo:             envRepo.New(db),
 		orgRepo:             orgRepo.New(db),
 		authzProvisioner:    authzProvisioner,
+		trialBundleSeeder:   trialBundleSeeder,
+		auditLogger:         auditLogger,
 	}
 }
 
@@ -317,7 +324,10 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 		// A user-typed name beats a generated one, so this wins over the
 		// assistants disposition below.
 		if intent != nil && intent.OrgName != "" {
-			org, err := s.provisionOrgForUser(ctx, userID, intent.OrgName, false)
+			org, err := s.provisionOrgForUser(ctx, userID, intent.OrgName, orgProvisionOptions{
+				Whitelisted:    true,
+				ProvisionTrial: true,
+			})
 			if err != nil {
 				return s.redirectSignupError(ctx, err)
 			}
@@ -893,6 +903,19 @@ func loadActiveTrial(
 	}
 }
 
+// orgProvisionOptions carries the per-caller choices for a new organization.
+// The choices are a struct rather than positional booleans because every call
+// site then names what it asks for, and exhaustruct forces a new field to be
+// answered everywhere instead of defaulting to false.
+type orgProvisionOptions struct {
+	// Whitelisted clears the dashboard's book-a-demo gate for the organization.
+	Whitelisted bool
+
+	// ProvisionTrial arms a 14-day enterprise trial in the same transaction
+	// that creates the organization.
+	ProvisionTrial bool
+}
+
 // provisionOrgForUser creates an organization and attaches a user to it as the
 // first member. Shared by the three paths that create orgs: self-serve register,
 // signup with a company name carried through login, and assistants
@@ -901,10 +924,7 @@ func loadActiveTrial(
 // Session mutation is deliberately left to the caller. Register updates an
 // already-stored session; the callback-side callers assign
 // ActiveOrganizationID on an in-memory session before storing it once.
-//
-// whitelisted is a parameter because the callers disagree: register and signup
-// create gated orgs, assistants auto-provisioning does not.
-func (s *Service) provisionOrgForUser(ctx context.Context, userID, orgName string, whitelisted bool) (orgRepo.OrganizationMetadatum, error) {
+func (s *Service) provisionOrgForUser(ctx context.Context, userID, orgName string, opts orgProvisionOptions) (orgRepo.OrganizationMetadatum, error) {
 	var empty orgRepo.OrganizationMetadatum
 
 	slug, err := orgslug.FindUnique(ctx, s.orgRepo, orgslug.Slugify(orgName))
@@ -918,10 +938,10 @@ func (s *Service) provisionOrgForUser(ctx context.Context, userID, orgName strin
 		return empty, fmt.Errorf("provision org in WorkOS: %w", err)
 	}
 
-	// Metadata, the user relationship, and the admin grant all land in one
-	// transaction, so a failure part-way cannot leave an organization a user
-	// can authenticate into without access control.
-	org, err := s.persistProvisionedOrganization(ctx, provisionedOrg, orgName, slug, userID, whitelisted)
+	// Metadata, the user relationship, the admin grant, and any trial all land
+	// in one transaction, so a failure part-way cannot leave an organization a
+	// user can authenticate into without access control.
+	org, err := s.persistProvisionedOrganization(ctx, provisionedOrg, orgName, slug, userID, opts)
 	if err != nil {
 		return empty, fmt.Errorf("persist provisioned organization: %w", err)
 	}
@@ -947,7 +967,10 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 		return err
 	}
 
-	org, err := s.provisionOrgForUser(ctx, authCtx.UserID, payload.OrgName, false)
+	org, err := s.provisionOrgForUser(ctx, authCtx.UserID, payload.OrgName, orgProvisionOptions{
+		Whitelisted:    true,
+		ProvisionTrial: true,
+	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "error creating organization").LogError(ctx, s.logger)
 	}
@@ -967,7 +990,12 @@ func (s *Service) Register(ctx context.Context, payload *gen.RegisterPayload) (e
 func (s *Service) autoProvisionForAssistants(ctx context.Context, userInfo *sessions.CachedUserInfo, session *sessions.Session) (string, error) {
 	orgName := generateLegibleOrgName()
 
-	org, err := s.provisionOrgForUser(ctx, userInfo.UserID, orgName, true)
+	// Assistants is a live product for users who never asked for a trial, so a
+	// trial armed here would strip their entitlements two weeks later.
+	org, err := s.provisionOrgForUser(ctx, userInfo.UserID, orgName, orgProvisionOptions{
+		Whitelisted:    true,
+		ProvisionTrial: false,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -1013,13 +1041,17 @@ func (s *Service) autoProvisionForAssistants(ctx context.Context, userInfo *sess
 	return fmt.Sprintf("/%s/projects/%s/assistants/new?disposition=%s", org.Slug, projects[0].Slug, dispositionAssistants), nil
 }
 
+// persistProvisionedOrganization writes the Gram-side records for an
+// organization that already exists in WorkOS, and returns the row as it stood
+// before any trial arming. A trial armed under opts.ProvisionTrial joins the
+// same transaction, so a failure leaves neither behind.
 func (s *Service) persistProvisionedOrganization(
 	ctx context.Context,
 	provisionedOrg identity.ProvisionedOrganization,
 	orgName string,
 	slug string,
 	userID string,
-	whitelisted bool,
+	opts orgProvisionOptions,
 ) (orgRepo.OrganizationMetadatum, error) {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
@@ -1033,7 +1065,7 @@ func (s *Service) persistProvisionedOrganization(
 		Name:        orgName,
 		Slug:        slug,
 		WorkosID:    pgtype.Text{String: provisionedOrg.WorkOSOrganizationID, Valid: provisionedOrg.WorkOSOrganizationID != ""},
-		Whitelisted: pgtype.Bool{Bool: whitelisted, Valid: true},
+		Whitelisted: pgtype.Bool{Bool: opts.Whitelisted, Valid: true},
 	})
 	if err != nil {
 		return orgRepo.OrganizationMetadatum{}, fmt.Errorf("create organization metadata: %w", err)
@@ -1052,6 +1084,12 @@ func (s *Service) persistProvisionedOrganization(
 		WorkOSMembershipID: provisionedOrg.WorkOSMembershipID,
 	}); err != nil {
 		return orgRepo.OrganizationMetadatum{}, fmt.Errorf("provision organization access: %w", err)
+	}
+
+	if opts.ProvisionTrial {
+		if err := s.armEnterpriseTrialTx(ctx, tx, org, userID); err != nil {
+			return orgRepo.OrganizationMetadatum{}, fmt.Errorf("arm enterprise trial: %w", err)
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/workos/workos-go/v6/pkg/usermanagement"
 
 	gen "github.com/speakeasy-api/gram/server/gen/auth"
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -26,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -169,7 +171,7 @@ func newTestAuthServiceWithWorkOSClient(t *testing.T, userInfo *MockUserInfo, wo
 
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger())
 	result := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	result.authorizer = auth.New(logger, conn, sessionManager, authzEngine)
 
@@ -236,7 +238,7 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner)
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger())
 	result := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	result.authorizer = auth.New(logger, conn, sessionManager, authzEngine)
 

--- a/server/internal/outbox/events/audit_log.go
+++ b/server/internal/outbox/events/audit_log.go
@@ -43,6 +43,7 @@ var (
 	ModelProviderKeyV1                     = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.model_provider_key_event_v1", "Emitted when changes to customer model provider keys are made")
 	OrganizationHooksFailOpenV1            = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_hooks_fail_open_event_v1", "Emitted when the organization's hooks fail-open setting is toggled")
 	OrganizationDeviceAgentConfigurationV1 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_device_agent_configuration_event_v1", "Emitted when the organization's device-agent configuration is changed")
+	OrganizationEnterpriseTrialV1          = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_enterprise_trial_event_v1", "Emitted when the organization's enterprise trial is armed or demoted")
 	OrganizationInviteV1                   = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_invite_event_v1", "Emitted when changes to organization invites are made")
 	OrganizationWebhooksV1                 = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.organization_webhooks_event_v1", "Emitted when changes to organization webhooks are made")
 	OtelForwardingV1                       = outbox.NewEventDef[AuditLogCreatedPayloadV1]("audit_log.otel_forwarding_event_v1", "Emitted when changes to OTEL forwarding configs are made")

--- a/server/internal/outbox/events/catalog_gen.go
+++ b/server/internal/outbox/events/catalog_gen.go
@@ -34,6 +34,7 @@ var All = []outbox.EventRegistration{
 	McpServerV1,
 	ModelProviderKeyV1,
 	OrganizationDeviceAgentConfigurationV1,
+	OrganizationEnterpriseTrialV1,
 	OrganizationHooksFailOpenV1,
 	OrganizationInviteV1,
 	OrganizationWebhooksV1,

--- a/server/internal/outbox/events/catalog_gen.yaml
+++ b/server/internal/outbox/events/catalog_gen.yaml
@@ -1516,6 +1516,60 @@ webhooks:
                                 - subject_type
                             type: object
                 required: true
+    audit_log.organization_enterprise_trial_event_v1:
+        post:
+            description: Emitted when the organization's enterprise trial is armed or demoted
+            operationId: audit_log.organization_enterprise_trial_event_v1
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            additionalProperties: false
+                            properties:
+                                action:
+                                    type: string
+                                actor_display_name:
+                                    type: string
+                                actor_id:
+                                    type: string
+                                actor_slug:
+                                    type: string
+                                actor_type:
+                                    type: string
+                                after_snapshot:
+                                    additionalProperties: true
+                                before_snapshot:
+                                    additionalProperties: true
+                                id:
+                                    format: uuid
+                                    type: string
+                                metadata:
+                                    additionalProperties: true
+                                organization_id:
+                                    type: string
+                                project_id:
+                                    format: uuid
+                                    type:
+                                        - string
+                                        - "null"
+                                subject_display_name:
+                                    type: string
+                                subject_id:
+                                    type: string
+                                subject_slug:
+                                    type: string
+                                subject_type:
+                                    type: string
+                            required:
+                                - id
+                                - organization_id
+                                - actor_id
+                                - actor_type
+                                - action
+                                - subject_id
+                                - subject_type
+                            type: object
+                required: true
     audit_log.organization_hooks_fail_open_event_v1:
         post:
             description: Emitted when the organization's hooks fail-open setting is toggled

--- a/server/internal/productfeatures/bundle_test.go
+++ b/server/internal/productfeatures/bundle_test.go
@@ -1,0 +1,41 @@
+package productfeatures_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestSeedEnterpriseTrialBundleTx_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestProductFeaturesService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	seedOrganization(t, ctx, ti.conn, organizationID)
+
+	for range 2 {
+		tx := testenv.BeginTx(t, ctx, ti.conn)
+		require.NoError(t, productfeatures.SeedEnterpriseTrialBundleTx(ctx, tx, organizationID))
+		require.NoError(t, tx.Commit(ctx))
+	}
+
+	// Skills sits outside the bundle: EnableSkillsTx enables it alongside the
+	// role grants it needs. slices.Concat rather than append, so this never
+	// writes into spare capacity the exported bundle might grow.
+	entitlements := slices.Concat(productfeatures.EnterpriseTrialBundle, []productfeatures.Feature{productfeatures.FeatureSkills})
+
+	poolRepo := featurerepo.New(ti.conn)
+	for _, feature := range entitlements {
+		enabled, err := poolRepo.IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		})
+		require.NoError(t, err)
+		require.Truef(t, enabled, "feature %s should remain enabled after a replayed seed", feature)
+	}
+}

--- a/server/internal/productfeatures/client.go
+++ b/server/internal/productfeatures/client.go
@@ -147,6 +147,52 @@ func provisionSkillsSystemRoleGrantsTx(ctx context.Context, dbtx repo.DBTX, orga
 	return nil
 }
 
+// EnterpriseTrialBundle is the entitlement set an enterprise trial organization
+// receives at signup. A trial gates only on the time window, so identity (SSO,
+// SCIM) is included rather than held back as a conversion lever.
+//
+// FeatureSkills is absent because Skills is generally available. The bundle
+// still calls EnableSkillsTx, which provisions the Skills role grants that the
+// entitlement cannot work without. FeatureHooksFailOpen and
+// FeatureSkillCaptureMetadataOnly are absent because they change how an
+// entitlement behaves rather than granting one.
+var EnterpriseTrialBundle = []Feature{
+	FeatureLogs,
+	FeatureToolIOLogs,
+	FeatureSessionCapture,
+	FeatureAuthzChallengeLogging,
+	FeatureSSO,
+	FeatureSCIM,
+	FeatureHooksBrowserLogin,
+	FeatureCustomModelKeys,
+	FeatureAIPlatformPushIntegrations,
+	FeaturePlatformMCP,
+	FeatureCustomerManagedEncryptionKeys,
+}
+
+// SeedEnterpriseTrialBundleTx enables the enterprise trial entitlements in the
+// caller's transaction. Idempotent, so a replayed signup is safe. The feature
+// cache is left untouched: the organization is created in the same transaction,
+// so no reader can have cached a state for it yet.
+func SeedEnterpriseTrialBundleTx(ctx context.Context, tx pgx.Tx, organizationID string) error {
+	q := repo.New(tx)
+
+	for _, feature := range EnterpriseTrialBundle {
+		if _, err := q.EnableFeature(ctx, repo.EnableFeatureParams{
+			OrganizationID: organizationID,
+			FeatureName:    string(feature),
+		}); err != nil {
+			return fmt.Errorf("enable %s for enterprise trial: %w", feature, err)
+		}
+	}
+
+	if err := EnableSkillsTx(ctx, tx, organizationID); err != nil {
+		return fmt.Errorf("enable Skills for enterprise trial: %w", err)
+	}
+
+	return nil
+}
+
 // EnableSkillsTx provisions the built-in Skills grants and enables the
 // org-level Skills feature in the caller's transaction. Existing grants and
 // exclusions are preserved.

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -1,3 +1,14 @@
+-- name: CreateTrial :exec
+-- One row per organization forever: extend a trial by moving ends_at forward,
+-- never by inserting a second row.
+INSERT INTO trials (organization_id, tier, ends_at)
+VALUES (@organization_id, @tier, @ends_at);
+
+-- name: GetTrial :one
+SELECT *
+FROM trials
+WHERE organization_id = @organization_id;
+
 -- name: GetActiveTrial :one
 SELECT organization_id, created_at, ends_at
 FROM trials

--- a/server/internal/trials/repo/models.go
+++ b/server/internal/trials/repo/models.go
@@ -3,3 +3,17 @@
 //   sqlc v1.31.1
 
 package repo
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type Trial struct {
+	OrganizationID string
+	Tier           string
+	EndsAt         pgtype.Timestamptz
+	ConvertedAt    pgtype.Timestamptz
+	DemotedAt      pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -11,6 +11,24 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const createTrial = `-- name: CreateTrial :exec
+INSERT INTO trials (organization_id, tier, ends_at)
+VALUES ($1, $2, $3)
+`
+
+type CreateTrialParams struct {
+	OrganizationID string
+	Tier           string
+	EndsAt         pgtype.Timestamptz
+}
+
+// One row per organization forever: extend a trial by moving ends_at forward,
+// never by inserting a second row.
+func (q *Queries) CreateTrial(ctx context.Context, arg CreateTrialParams) error {
+	_, err := q.db.Exec(ctx, createTrial, arg.OrganizationID, arg.Tier, arg.EndsAt)
+	return err
+}
+
 const getActiveTrial = `-- name: GetActiveTrial :one
 SELECT organization_id, created_at, ends_at
 FROM trials
@@ -30,6 +48,27 @@ func (q *Queries) GetActiveTrial(ctx context.Context, organizationID string) (Ge
 	row := q.db.QueryRow(ctx, getActiveTrial, organizationID)
 	var i GetActiveTrialRow
 	err := row.Scan(&i.OrganizationID, &i.CreatedAt, &i.EndsAt)
+	return i, err
+}
+
+const getTrial = `-- name: GetTrial :one
+SELECT organization_id, tier, ends_at, converted_at, demoted_at, created_at, updated_at
+FROM trials
+WHERE organization_id = $1
+`
+
+func (q *Queries) GetTrial(ctx context.Context, organizationID string) (Trial, error) {
+	row := q.db.QueryRow(ctx, getTrial, organizationID)
+	var i Trial
+	err := row.Scan(
+		&i.OrganizationID,
+		&i.Tier,
+		&i.EndsAt,
+		&i.ConvertedAt,
+		&i.DemotedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
 	return i, err
 }
 


### PR DESCRIPTION
## Summary

Self-signup now arms a 14-day enterprise trial on the organization it creates. Every write joins the transaction that already creates the organization and seeds its admin grants, so a signup produces either a complete trial or no organization at all.

An armed trial gets:

- `gram_account_type = enterprise`
- the enterprise entitlement bundle: eleven features plus Skills and the role grants it needs
- `whitelisted = true`
- a row in `trials` with `tier = enterprise` and `ends_at` 14 days out
- an `organization:enterprise_trial_armed` audit entry

## What this PR owns

The `trials` table landed in #4982 and gained its `tier` column in #5029. #4994 taught `auth.Info` to read it, and #5059 gave the table a package of its own. All merged. Nothing writes a row yet. This PR adds the write side:

- `CreateTrial` and `GetTrial` in `server/internal/trials`, alongside the read queries #5059 put there
- `events.OrganizationEnterpriseTrialV1` — the outbox event definition the audit entry publishes under

The hourly demotion sweeper in #4983 adds its own queries to the same package.

## Which signup doors arm a trial

| Path                                 | Trial |
| ------------------------------------ | ----- |
| `Register`, public self-signup       | yes   |
| `/sign-up` intent, inside `Callback` | yes   |
| assistants auto-provisioning         | no    |

Assistants organizations are a live product for users who never asked for a trial. Arming one there would strip their entitlements two weeks later.

The three doors share `provisionOrgForUser`, which now takes an `orgProvisionOptions` struct instead of positional booleans. Each call site names what it asks for, and `exhaustruct` forces a new option to be answered at every door rather than defaulting to false.

## Notes for reviewers

- **The tier is the real `enterprise` value, not a tier of its own.** It is both the organization's account type and the `trials.tier` value. `creditsAccountTypeMap` in `openrouter.go` maps an account type to a credit ceiling, and a miss returns Go's zero value rather than the `""` default, so a `'trial'` tier would mint zero-dollar OpenRouter keys. Reusing `enterprise` also picks up the short-circuit in `mv.DescribeOrganization` that stops the billing provider from overwriting the tier back to free on the next login.
- **The $100 OpenRouter ceiling applies.** It is a ceiling, not an allocation, and the sweeper disables the keys at expiry.
- **No feature flag.** Rollback is a revert and a deploy. Trials already armed still demote correctly.
- **`whitelisted` now covers every self-provisioned organization.** Nothing server-side reads it for an authorization decision. Its only live consumer is the dashboard's book-a-demo gate, which a fresh enterprise trial has no reason to see.
- **Failures are hard.** The whole arm sits in the one transaction, so there is no degraded half-provisioned state to reason about.
- **Bundle membership is a plain allow-list.** `FeatureHooksFailOpen` and `FeatureSkillCaptureMetadataOnly` stay out because they change how an entitlement behaves rather than granting one.

## Tests

- `auth/enterprise_trial_test.go`: `Register` writes the tier, the bundle, the trial row with `tier = enterprise`, and the audit entry; `Info` returns the trial window and resolves `enterprise` immediately after signup; the assistants door arms nothing.
- `auth/callback_test.go`: the `/sign-up` intent door creates an enterprise organization with a trial row.
- `productfeatures/bundle_test.go`: a replayed seed leaves the whole bundle enabled.

## Stack

1. #4982, merged: the `trials` table
2. #5029, merged: the `tier` column
3. #4994, merged: `Info` reads the table
4. #5059, merged: the `trials` package
5. this PR: the write queries, and the signup insert
6. #4983: the hourly demotion sweeper

## Follow-ups, each its own PR

- Enforce `whitelisted` at the four non-session auth entry points
- Stamp `converted_at` when sales converts a trial
- Notify the customer before the window closes
