### PR TITLE
fix: search agent sessions by resolved email

### DIFF
--- a/.changeset/resolved-session-email-search.md
+++ b/.changeset/resolved-session-email-search.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Search agent sessions by resolved member and AI account email addresses.

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -440,6 +440,28 @@ func TestListChats_Filter_Search(t *testing.T) {
 	require.Contains(t, result.Chats[0].Title, "needle")
 }
 
+func TestListChats_Filter_SearchUnresolvedExternalUserID(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+	chatID := seedChat(t, ctx, ti, "", "opaque-provider-user-id", "unresolved chat")
+
+	search := "provider-user"
+	payload := defaultPayload()
+	payload.Search = &search
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, chatID.String(), result.Chats[0].ID)
+
+	search = "missing@example.com"
+	result, err = ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Zero(t, result.Total)
+	require.Empty(t, result.Chats)
+}
+
 func TestListChats_Filter_SearchResolvedUserEmail(t *testing.T) {
 	t.Parallel()
 	ti := newTestChatService(t)

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	hooksrepo "github.com/speakeasy-api/gram/server/internal/hooks/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -437,6 +438,88 @@ func TestListChats_Filter_Search(t *testing.T) {
 	require.Equal(t, 1, result.Total)
 	require.Len(t, result.Chats, 1)
 	require.Contains(t, result.Chats[0].Title, "needle")
+}
+
+func TestListChats_Filter_SearchResolvedUserEmail(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.Email)
+
+	now := time.Now().UTC()
+	chatID, err := repo.New(ti.conn).UpsertExternalChat(ctx, repo.UpsertExternalChatParams{
+		ID:             uuid.New(),
+		ProjectID:      ti.projectID,
+		OrganizationID: ti.orgID,
+		UserID:         conv.ToPGTextEmpty(authCtx.UserID),
+		ExternalUserID: conv.ToPGTextEmpty("opaque-provider-user-id"),
+		ExternalChatID: conv.ToPGText("external-chat-" + uuid.NewString()),
+		Title:          conv.ToPGText("compliance imported chat"),
+		CreatedAt:      conv.ToPGTimestamptz(now),
+		UpdatedAt:      conv.ToPGTimestamptz(now),
+	})
+	require.NoError(t, err)
+
+	payload := defaultPayload()
+	payload.Search = authCtx.Email
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, chatID.String(), result.Chats[0].ID)
+
+	payload.Offset = 1
+	result, err = ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Empty(t, result.Chats)
+}
+
+func TestListChats_Filter_SearchUserAccountEmail(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+	accountEmail := "account-" + uuid.NewString() + "@example.com"
+
+	hooksQueries := hooksrepo.New(ti.conn)
+	account, err := hooksQueries.UpsertUserAccount(ctx, hooksrepo.UpsertUserAccountParams{
+		OrganizationID:      ti.orgID,
+		Provider:            "anthropic",
+		ExternalAccountUuid: uuid.NewString(),
+		UserID:              pgtype.Text{},
+		ExternalOrgID:       pgtype.Text{},
+		ExternalAccountID:   pgtype.Text{},
+		Email:               conv.ToPGText(accountEmail),
+		AccountType:         conv.ToPGText("personal"),
+	})
+	require.NoError(t, err)
+
+	chatID, err := hooksQueries.UpsertClaudeCodeSession(ctx, hooksrepo.UpsertClaudeCodeSessionParams{
+		ID:             uuid.New(),
+		ProjectID:      ti.projectID,
+		OrganizationID: ti.orgID,
+		UserID:         pgtype.Text{},
+		ExternalUserID: conv.ToPGText("opaque-account-user-id"),
+		UserAccountID:  uuid.NullUUID{UUID: account.ID, Valid: true},
+		Title:          conv.ToPGText("account-linked chat"),
+	})
+	require.NoError(t, err)
+
+	payload := defaultPayload()
+	payload.Search = &accountEmail
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, chatID.String(), result.Chats[0].ID)
+
+	payload.Offset = 1
+	result, err = ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Empty(t, result.Chats)
 }
 
 // TestListChats_Filter_HasRisk_True verifies that has_risk=true returns only chats that have at

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -372,7 +372,7 @@ candidate_chats AS (
   FROM chats c
   LEFT JOIN risk_counts rc ON rc.chat_id = c.id
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
-  -- Join users table to enable searching by user display name
+  -- Join users table to enable searching by resolved user identity
   LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = @project_id
     AND c.deleted IS FALSE
@@ -389,6 +389,8 @@ candidate_chats AS (
       OR c.external_user_id ILIKE '%' || @search || '%'
       OR c.title ILIKE '%' || @search || '%'
       OR u.display_name ILIKE '%' || @search || '%'
+      OR u.email ILIKE '%' || @search || '%'
+      OR ua.email ILIKE '%' || @search || '%'
     )
     AND (
       @assistant_id = ''
@@ -497,7 +499,7 @@ candidate_chats AS (
   -- Resolve the AI account that produced the chat (chats.user_account_id has no FK,
   -- matching chats.user_id) to expose its team/personal classification.
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
-  -- Join users table to enable searching by user display name
+  -- Join users table to enable searching by resolved user identity
   LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = @project_id
     AND c.deleted IS FALSE
@@ -514,6 +516,8 @@ candidate_chats AS (
       OR c.external_user_id ILIKE '%' || @search || '%'
       OR c.title ILIKE '%' || @search || '%'
       OR u.display_name ILIKE '%' || @search || '%'
+      OR u.email ILIKE '%' || @search || '%'
+      OR ua.email ILIKE '%' || @search || '%'
     )
     AND (
       @assistant_id = ''

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -96,7 +96,7 @@ candidate_chats AS (
   FROM chats c
   LEFT JOIN risk_counts rc ON rc.chat_id = c.id
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
-  -- Join users table to enable searching by user display name
+  -- Join users table to enable searching by resolved user identity
   LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = $5
     AND c.deleted IS FALSE
@@ -113,6 +113,8 @@ candidate_chats AS (
       OR c.external_user_id ILIKE '%' || $9 || '%'
       OR c.title ILIKE '%' || $9 || '%'
       OR u.display_name ILIKE '%' || $9 || '%'
+      OR u.email ILIKE '%' || $9 || '%'
+      OR ua.email ILIKE '%' || $9 || '%'
     )
     AND (
       $10 = ''
@@ -1941,7 +1943,7 @@ candidate_chats AS (
   -- Resolve the AI account that produced the chat (chats.user_account_id has no FK,
   -- matching chats.user_id) to expose its team/personal classification.
   LEFT JOIN user_accounts ua ON ua.id = c.user_account_id AND ua.organization_id = c.organization_id AND ua.deleted_at IS NULL
-  -- Join users table to enable searching by user display name
+  -- Join users table to enable searching by resolved user identity
   LEFT JOIN users u ON u.id = c.user_id AND u.deleted_at IS NULL
   WHERE c.project_id = $1
     AND c.deleted IS FALSE
@@ -1958,6 +1960,8 @@ candidate_chats AS (
       OR c.external_user_id ILIKE '%' || $7 || '%'
       OR c.title ILIKE '%' || $7 || '%'
       OR u.display_name ILIKE '%' || $7 || '%'
+      OR u.email ILIKE '%' || $7 || '%'
+      OR ua.email ILIKE '%' || $7 || '%'
     )
     AND (
       $8 = ''


### PR DESCRIPTION
## Summary
- match Agent Sessions search against resolved member emails
- match linked AI account emails and cover paginated count fallback

Closes [DNO-754](https://linear.app/speakeasy/issue/DNO-754/agent-sessions-search-does-not-match-resolved-user-email-uemail)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Agent Sessions search to match resolved member emails and linked AI account emails so email queries return all relevant sessions across ingest paths, while keeping unresolved chats searchable by external_user_id. Closes DNO-754.

- **Bug Fixes**
  - Added `u.email` and `ua.email` to the `candidate_chats` search filter in both list and count queries.
  - Added tests for compliance-imported chats, AI-account email search, paginated count behavior, and unresolved external_user_id search to prevent regressions.

<sup>Written for commit eaaac0acc9909d09cd742204a809f1d093cb3f7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

