### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86180fa9e4d311eed10c9cc49854c53dab5d517a # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -857,7 +857,7 @@ jobs:
           env: false
 
       - name: Lint PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/lint@v1.15.6
+        uses: ariga/atlas-action/migrate/lint@ba65b510ea74c2886c9c52ce7aa54fd7f5fc6293 # v1.15.6
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -868,7 +868,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Lint ClickHouse migrations
-        uses: ariga/atlas-action/migrate/lint@v1.15.6
+        uses: ariga/atlas-action/migrate/lint@ba65b510ea74c2886c9c52ce7aa54fd7f5fc6293 # v1.15.6
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -969,7 +969,7 @@ jobs:
           fi
 
       - name: Push PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/push@v1.15.6
+        uses: ariga/atlas-action/migrate/push@ba65b510ea74c2886c9c52ce7aa54fd7f5fc6293 # v1.15.6
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -977,7 +977,7 @@ jobs:
           tag: ${{ steps.tag.outputs.tag }}
 
       - name: Push ClickHouse migrations
-        uses: ariga/atlas-action/migrate/push@v1.15.6
+        uses: ariga/atlas-action/migrate/push@ba65b510ea74c2886c9c52ce7aa54fd7f5fc6293 # v1.15.6
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse


### PR DESCRIPTION
Pins the remaining tag-referenced third-party actions in `claude.yml` and `pr.yaml` to full commit SHAs (with the tag kept as a comment), matching how every other third-party action in these workflows is already referenced.

Fixes [SEC-45](https://linear.app/speakeasy/issue/SEC-45)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned the remaining tag-referenced third-party GitHub Actions in `claude.yml` and `pr.yaml` to exact commit SHAs to prevent drift and meet SEC-45. No behavior change; tags are kept as comments.

- **Dependencies**
  - Pinned `anthropics/claude-code-action` in `claude.yml`.
  - Pinned `ariga/atlas-action/migrate/lint` and `ariga/atlas-action/migrate/push` in `pr.yaml` for PostgreSQL and ClickHouse jobs.

<sup>Written for commit c309d085e175d4deb70e87181d4ec13c2a057878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

