### PR TITLE
chore: centralize external link opening in dashboard

### DIFF
--- a/client/dashboard/src/components/billing/usage-controls.tsx
+++ b/client/dashboard/src/components/billing/usage-controls.tsx
@@ -2,6 +2,7 @@ import { Page } from "@/components/page-layout";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { Button } from "@/components/ui/Button";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { cn } from "@/lib/utils";
 import { useCallback, useState } from "react";
 
@@ -18,7 +19,7 @@ export const TopUpCTA = (): JSX.Element => {
         telemetry.capture("topup_checkout_error", { error: "empty link" });
         return;
       }
-      window.open(link, "_blank");
+      openSafeExternalUrl(link);
     } catch (err) {
       telemetry.capture("topup_checkout_error", {
         error: err instanceof Error ? err.message : "unknown",

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  openSafeExternalUrl,
+  safeExternalHttpUrl,
+  safeSameOriginUrl,
+} from "./safe-external-url";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("safeExternalHttpUrl", () => {
+  it("accepts and normalizes absolute HTTP(S) URLs", () => {
+    expect(safeExternalHttpUrl("https://example.com/docs/../start")).toBe(
+      "https://example.com/start",
+    );
+    expect(safeExternalHttpUrl("HTTP://EXAMPLE.COM:80/path")).toBe(
+      "http://example.com/path",
+    );
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "blob:https://example.com/id",
+    "file:///etc/passwd",
+    "custom://example.com/path",
+  ])("rejects the non-HTTP scheme in %s", (raw) => {
+    expect(safeExternalHttpUrl(raw)).toBeNull();
+  });
+
+  it.each([
+    "//evil.com",
+    "/relative/path",
+    "relative/path",
+    "",
+    "not a url",
+    "https://",
+  ])("rejects the non-absolute or malformed value %j", (raw) => {
+    expect(safeExternalHttpUrl(raw)).toBeNull();
+  });
+
+  it("rejects absent values", () => {
+    expect(safeExternalHttpUrl(null)).toBeNull();
+    expect(safeExternalHttpUrl(undefined)).toBeNull();
+  });
+});
+
+describe("openSafeExternalUrl", () => {
+  it("opens the normalized URL in an isolated tab", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    expect(openSafeExternalUrl("HTTPS://EXAMPLE.COM:443/docs")).toBe(true);
+    expect(open).toHaveBeenCalledWith(
+      "https://example.com/docs",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("does not open a rejected URL", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    expect(openSafeExternalUrl("javascript:alert(1)")).toBe(false);
+    expect(open).not.toHaveBeenCalled();
+  });
+});
+
+describe("safeSameOriginUrl", () => {
+  it("accepts relative paths", () => {
+    expect(safeSameOriginUrl("/mcp/tools?tab=overview#details")).toBe(
+      new URL("/mcp/tools?tab=overview#details", window.location.origin).href,
+    );
+  });
+
+  it("accepts same-origin absolute URLs", () => {
+    const absolute = new URL("/plugins?installed=true", window.location.origin);
+    expect(safeSameOriginUrl(absolute.href)).toBe(absolute.href);
+  });
+
+  it.each([
+    "https://evil.example/path",
+    "javascript:alert(1)",
+    "//evil.example/path",
+  ])("rejects the unsafe redirect %s", (raw) => {
+    expect(safeSameOriginUrl(raw)).toBeNull();
+  });
+});

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -49,20 +49,38 @@ describe("safeExternalHttpUrl", () => {
 });
 
 describe("openSafeExternalUrl", () => {
-  it("opens the normalized URL in an isolated tab", () => {
+  it("opens the normalized URL in an isolated tab without a referrer", () => {
     const opened = { opener: window } as unknown as Window;
     const open = vi.spyOn(window, "open").mockImplementation(() => opened);
+    let clicked: HTMLAnchorElement | undefined;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      function (this: HTMLAnchorElement) {
+        clicked = this;
+      },
+    );
 
     expect(openSafeExternalUrl("HTTPS://EXAMPLE.COM:443/docs")).toBe(true);
-    expect(open).toHaveBeenCalledWith("https://example.com/docs", "_blank");
+
+    const target = open.mock.calls[0]?.[1];
+    expect(open).toHaveBeenCalledWith(
+      "",
+      expect.stringMatching(/^gram-external-\d+$/),
+    );
     expect(opened.opener).toBeNull();
+    expect(clicked?.href).toBe("https://example.com/docs");
+    expect(clicked?.target).toBe(target);
+    expect(clicked?.referrerPolicy).toBe("no-referrer");
   });
 
   it("reports a popup-blocked tab as not opened", () => {
     const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
 
     expect(openSafeExternalUrl("https://example.com/docs")).toBe(false);
     expect(open).toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
   });
 
   it("does not open a rejected URL", () => {

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -50,14 +50,19 @@ describe("safeExternalHttpUrl", () => {
 
 describe("openSafeExternalUrl", () => {
   it("opens the normalized URL in an isolated tab", () => {
-    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    const opened = { opener: window } as unknown as Window;
+    const open = vi.spyOn(window, "open").mockImplementation(() => opened);
 
     expect(openSafeExternalUrl("HTTPS://EXAMPLE.COM:443/docs")).toBe(true);
-    expect(open).toHaveBeenCalledWith(
-      "https://example.com/docs",
-      "_blank",
-      "noopener,noreferrer",
-    );
+    expect(open).toHaveBeenCalledWith("https://example.com/docs", "_blank");
+    expect(opened.opener).toBeNull();
+  });
+
+  it("reports a popup-blocked tab as not opened", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    expect(openSafeExternalUrl("https://example.com/docs")).toBe(false);
+    expect(open).toHaveBeenCalled();
   });
 
   it("does not open a rejected URL", () => {

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -52,12 +52,9 @@ describe("openSafeExternalUrl", () => {
   it("opens the normalized URL in an isolated tab without a referrer", () => {
     const opened = { opener: window } as unknown as Window;
     const open = vi.spyOn(window, "open").mockImplementation(() => opened);
-    let clicked: HTMLAnchorElement | undefined;
-    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
-      function (this: HTMLAnchorElement) {
-        clicked = this;
-      },
-    );
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
 
     expect(openSafeExternalUrl("HTTPS://EXAMPLE.COM:443/docs")).toBe(true);
 
@@ -67,6 +64,7 @@ describe("openSafeExternalUrl", () => {
       expect.stringMatching(/^gram-external-\d+$/),
     );
     expect(opened.opener).toBeNull();
+    const clicked = click.mock.contexts[0] as HTMLAnchorElement | undefined;
     expect(clicked?.href).toBe("https://example.com/docs");
     expect(clicked?.target).toBe(target);
     expect(clicked?.referrerPolicy).toBe("no-referrer");

--- a/client/dashboard/src/lib/safe-external-url.test.ts
+++ b/client/dashboard/src/lib/safe-external-url.test.ts
@@ -61,7 +61,7 @@ describe("openSafeExternalUrl", () => {
     const target = open.mock.calls[0]?.[1];
     expect(open).toHaveBeenCalledWith(
       "",
-      expect.stringMatching(/^gram-external-\d+$/),
+      expect.stringMatching(/^gram-external-[0-9a-f-]+$/),
     );
     expect(opened.opener).toBeNull();
     const clicked = click.mock.contexts[0] as HTMLAnchorElement | undefined;

--- a/client/dashboard/src/lib/safe-external-url.ts
+++ b/client/dashboard/src/lib/safe-external-url.ts
@@ -22,7 +22,12 @@ export function openSafeExternalUrl(raw: string | null | undefined): boolean {
   const url = safeExternalHttpUrl(raw);
   if (!url) return false;
 
-  window.open(url, "_blank", "noopener,noreferrer");
+  // A "noopener" feature string makes window.open return null even on
+  // success, hiding popup-blocker failures — sever the opener manually so a
+  // null return reliably means the tab did not open.
+  const opened = window.open(url, "_blank");
+  if (!opened) return false;
+  opened.opener = null;
   return true;
 }
 

--- a/client/dashboard/src/lib/safe-external-url.ts
+++ b/client/dashboard/src/lib/safe-external-url.ts
@@ -17,17 +17,27 @@ export function safeExternalHttpUrl(
   }
 }
 
+let externalTabCounter = 0;
+
 /** Keep scheme validation and isolated-tab flags together at navigation sinks. */
 export function openSafeExternalUrl(raw: string | null | undefined): boolean {
   const url = safeExternalHttpUrl(raw);
   if (!url) return false;
 
-  // A "noopener" feature string makes window.open return null even on
-  // success, hiding popup-blocker failures — sever the opener manually so a
-  // null return reliably means the tab did not open.
-  const opened = window.open(url, "_blank");
+  // A "noopener"/"noreferrer" feature string makes window.open return null
+  // even on success, hiding popup-blocker failures. Instead, open a uniquely
+  // named blank tab so null reliably means the popup was blocked, disown it,
+  // then navigate it through an anchor that strips the Referer header.
+  const target = `gram-external-${externalTabCounter++}`;
+  const opened = window.open("", target);
   if (!opened) return false;
   opened.opener = null;
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.target = target;
+  anchor.referrerPolicy = "no-referrer";
+  anchor.click();
   return true;
 }
 

--- a/client/dashboard/src/lib/safe-external-url.ts
+++ b/client/dashboard/src/lib/safe-external-url.ts
@@ -17,8 +17,6 @@ export function safeExternalHttpUrl(
   }
 }
 
-let externalTabCounter = 0;
-
 /** Keep scheme validation and isolated-tab flags together at navigation sinks. */
 export function openSafeExternalUrl(raw: string | null | undefined): boolean {
   const url = safeExternalHttpUrl(raw);
@@ -27,8 +25,9 @@ export function openSafeExternalUrl(raw: string | null | undefined): boolean {
   // A "noopener"/"noreferrer" feature string makes window.open return null
   // even on success, hiding popup-blocker failures. Instead, open a uniquely
   // named blank tab so null reliably means the popup was blocked, disown it,
-  // then navigate it through an anchor that strips the Referer header.
-  const target = `gram-external-${externalTabCounter++}`;
+  // then navigate it through an anchor that strips the Referer header. The
+  // random name keeps opens from ever reusing an earlier external tab.
+  const target = `gram-external-${crypto.randomUUID()}`;
   const opened = window.open("", target);
   if (!opened) return false;
   opened.opener = null;

--- a/client/dashboard/src/lib/safe-external-url.ts
+++ b/client/dashboard/src/lib/safe-external-url.ts
@@ -1,0 +1,45 @@
+/**
+ * API and upstream URLs cross a trust boundary, so parse without a base to
+ * keep relative and protocol-relative inputs from becoming navigable.
+ */
+export function safeExternalHttpUrl(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Keep scheme validation and isolated-tab flags together at navigation sinks. */
+export function openSafeExternalUrl(raw: string | null | undefined): boolean {
+  const url = safeExternalHttpUrl(raw);
+  if (!url) return false;
+
+  window.open(url, "_blank", "noopener,noreferrer");
+  return true;
+}
+
+/**
+ * Resolve a redirect produced by this SPA while preventing external or
+ * executable schemes from escaping the dashboard origin.
+ */
+export function safeSameOriginUrl(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+
+  try {
+    const url = new URL(raw, window.location.origin);
+    const isHttp = url.protocol === "http:" || url.protocol === "https:";
+    return isHttp && url.origin === window.location.origin ? url.href : null;
+  } catch {
+    return null;
+  }
+}

--- a/client/dashboard/src/pages/billing/Billing.tsx
+++ b/client/dashboard/src/pages/billing/Billing.tsx
@@ -10,6 +10,7 @@ import { useIsPlatformAdmin } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { ProductTier, useProductTier } from "@/hooks/useProductTier";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { getServerURL } from "@/lib/utils";
 import { TierLimits } from "@gram/client/models/components/tierlimits.js";
 import { useGetCreditUsage } from "@gram/client/react-query/getCreditUsage.js";
@@ -284,7 +285,7 @@ const UsageTiers = () => {
                 });
                 return;
               }
-              window.open(link, "_blank");
+              openSafeExternalUrl(link);
             } catch (error) {
               console.error("Error creating customer session:", error);
               telemetry.capture("customer_session_error", {

--- a/client/dashboard/src/pages/cli/CliCallback.tsx
+++ b/client/dashboard/src/pages/cli/CliCallback.tsx
@@ -191,7 +191,8 @@ function generateHooksKeyName(): string {
   return `Hooks Key (Generated) - ${timestamp}`.slice(0, maxLength);
 }
 
-const errInvalidCallback = "Callback URL must be localhost or 127.0.0.1";
+const errInvalidCallback =
+  "Callback URL must use HTTP or HTTPS on localhost or 127.0.0.1";
 const errWrongOrganization =
   "This connection link belongs to a different organization. Switch to that organization in the dashboard, then retry the connection.";
 const PREFERRED_PROJECT_KEY = "preferredProject";
@@ -200,8 +201,9 @@ function isCallbackLocal(callbackUrl: string): boolean {
   try {
     const url = new URL(callbackUrl);
     const hostname = url.hostname.toLowerCase();
+    const isHttp = url.protocol === "http:" || url.protocol === "https:";
 
-    return hostname === "localhost" || hostname === "127.0.0.1";
+    return isHttp && (hostname === "localhost" || hostname === "127.0.0.1");
   } catch {
     return false;
   }

--- a/client/dashboard/src/pages/login/Register.tsx
+++ b/client/dashboard/src/pages/login/Register.tsx
@@ -1,4 +1,5 @@
 import { useSession } from "@/contexts/Auth";
+import { safeSameOriginUrl } from "@/lib/safe-external-url";
 import { useRoutes } from "@/routes";
 import { AuthShell } from "./components/auth-shell";
 import { RegisterPanel } from "./components/register-panel";
@@ -20,7 +21,7 @@ export default function Register(): JSX.Element {
   }
 
   if (session.activeOrganizationId !== "") {
-    const redirect = searchParams.get("redirect");
+    const redirect = safeSameOriginUrl(searchParams.get("redirect"));
     if (redirect) {
       window.location.href = redirect;
     } else {

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -5,6 +5,7 @@ import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { Text } from "@/components/ui/Text";
 import { useOrganization, useSessionData } from "@/contexts/Auth";
 import { useTelemetry } from "@/contexts/Telemetry";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { useOrgRoutes } from "@/routes";
 import { useGenerateWorkOSAdminPortalLinkMutation } from "@gram/client/react-query/generateWorkOSAdminPortalLink.js";
 import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
@@ -113,7 +114,7 @@ function SSOConfigureButton() {
       },
       {
         onSuccess: (data) => {
-          window.open(data.url, "_blank", "noopener,noreferrer");
+          openSafeExternalUrl(data.url);
           toast.info("Continue setup in the WorkOS portal");
         },
       },
@@ -162,7 +163,7 @@ function DirectorySyncConfigureButton() {
       },
       {
         onSuccess: (data) => {
-          window.open(data.url, "_blank", "noopener,noreferrer");
+          openSafeExternalUrl(data.url);
           toast.info("Continue setup in the WorkOS portal");
         },
       },

--- a/client/dashboard/src/pages/org/OrgIdentity.tsx
+++ b/client/dashboard/src/pages/org/OrgIdentity.tsx
@@ -114,8 +114,11 @@ function SSOConfigureButton() {
       },
       {
         onSuccess: (data) => {
-          openSafeExternalUrl(data.url);
-          toast.info("Continue setup in the WorkOS portal");
+          if (openSafeExternalUrl(data.url)) {
+            toast.info("Continue setup in the WorkOS portal");
+          } else {
+            toast.error("Unable to open the WorkOS portal");
+          }
         },
       },
     );
@@ -163,8 +166,11 @@ function DirectorySyncConfigureButton() {
       },
       {
         onSuccess: (data) => {
-          openSafeExternalUrl(data.url);
-          toast.info("Continue setup in the WorkOS portal");
+          if (openSafeExternalUrl(data.url)) {
+            toast.info("Continue setup in the WorkOS portal");
+          } else {
+            toast.error("Unable to open the WorkOS portal");
+          }
         },
       },
     );

--- a/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
@@ -1,5 +1,8 @@
 import { Text } from "@/components/ui/Text";
-import { safeExternalHttpUrl } from "@/lib/safe-external-url";
+import {
+  openSafeExternalUrl,
+  safeExternalHttpUrl,
+} from "@/lib/safe-external-url";
 import type { Toolset } from "@/lib/toolTypes";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { ToolFallback } from "@/elements";
@@ -508,7 +511,9 @@ async function handleIframeRequest(init: {
         if (!safeUrl) {
           return err(message.id, -32602, "Unsupported URL");
         }
-        window.open(safeUrl, "_blank", "noopener,noreferrer");
+        if (!openSafeExternalUrl(safeUrl)) {
+          return err(message.id, -32000, "Failed to open URL");
+        }
         return ok(message.id, {});
       }
       case "resources/read":

--- a/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
+++ b/client/dashboard/src/pages/playground/PlaygroundMcpApps.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@/components/ui/Text";
+import { safeExternalHttpUrl } from "@/lib/safe-external-url";
 import type { Toolset } from "@/lib/toolTypes";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { ToolFallback } from "@/elements";
@@ -503,10 +504,11 @@ async function handleIframeRequest(init: {
         if (!url) {
           return err(message.id, -32602, "Missing URL");
         }
-        if (!isSafeExternalUrl(url)) {
+        const safeUrl = safeExternalHttpUrl(url);
+        if (!safeUrl) {
           return err(message.id, -32602, "Unsupported URL");
         }
-        window.open(url, "_blank", "noopener,noreferrer");
+        window.open(safeUrl, "_blank", "noopener,noreferrer");
         return ok(message.id, {});
       }
       case "resources/read":
@@ -572,18 +574,6 @@ async function requestMcpJsonRpc<T>(
   }
 
   return payload.result as T;
-}
-
-// Links surfaced by an embedded MCP app are untrusted input; only allow
-// navigation to web URLs so a frame cannot open javascript:, file:, or
-// arbitrary custom-scheme links from the host page.
-function isSafeExternalUrl(raw: string): boolean {
-  try {
-    const parsed = new URL(raw);
-    return parsed.protocol === "https:" || parsed.protocol === "http:";
-  } catch {
-    return false;
-  }
 }
 
 function ok(id: JsonRpcId, result: unknown): JsonRpcResponse {

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -10,6 +10,7 @@ import { Dialog } from "@/components/ui/Dialog";
 import { DotCard } from "@/components/ui/DotCard";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Text } from "@/components/ui/Text";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { cn } from "@/lib/utils";
 import { mcpServerRouteParam } from "@/lib/sources";
 import {
@@ -227,7 +228,7 @@ export default function PluginDetail(): JSX.Element | null {
         action: {
           label: "Open",
           onClick: () => {
-            void window.open(data.repoUrl, "_blank", "noopener,noreferrer");
+            openSafeExternalUrl(data.repoUrl);
           },
         },
       });

--- a/client/dashboard/src/pages/plugins/Plugins.tsx
+++ b/client/dashboard/src/pages/plugins/Plugins.tsx
@@ -6,6 +6,7 @@ import { Dialog } from "@/components/ui/Dialog";
 import { DotCard } from "@/components/ui/DotCard";
 import { Text } from "@/components/ui/Text";
 import { useFetcher } from "@/contexts/Fetcher";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { useRoutes } from "@/routes";
 import type { PublishStatusResult } from "@gram/client/models/components/publishstatusresult.js";
 import { Plugin } from "@gram/client/models/components/plugin.js";
@@ -125,7 +126,7 @@ export default function Plugins(): JSX.Element {
         action: {
           label: "Open",
           onClick: () => {
-            void window.open(data.repoUrl, "_blank", "noopener,noreferrer");
+            openSafeExternalUrl(data.repoUrl);
           },
         },
       });

--- a/client/dashboard/src/pages/remote-identity-providers/issuerDocumentationLinks.ts
+++ b/client/dashboard/src/pages/remote-identity-providers/issuerDocumentationLinks.ts
@@ -1,4 +1,5 @@
 import type { RemoteSessionIssuer } from "@gram/client/models/components/remotesessionissuer.js";
+import { safeExternalHttpUrl } from "@/lib/safe-external-url";
 
 export type IssuerDocumentationLink = {
   label: string;
@@ -12,14 +13,7 @@ export type IssuerDocumentationLink = {
 // past a write path would execute on click. Checking again at the render sink
 // keeps that from depending on an invariant held one layer away.
 export function isAbsoluteHttpUrl(raw: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    return false;
-  }
-
-  return parsed.protocol === "http:" || parsed.protocol === "https:";
+  return safeExternalHttpUrl(raw) !== null;
 }
 
 // The documentation URLs an issuer can carry, in the order they are shown.

--- a/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/connect-idp-step.tsx
@@ -14,6 +14,7 @@ import { StepContainer } from "../step-container";
 import { IDP_PROVIDERS } from "../../providers";
 import type { IdpProvider } from "../../types";
 import { Input } from "@/components/ui/Input";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { cn, getServerURL } from "@/lib/utils";
 
 function ProviderIcon({
@@ -102,8 +103,7 @@ export function ConnectIdpStep({
       },
       {
         onSuccess: (data) => {
-          window.open(data.url, "_blank", "noopener,noreferrer");
-          setPortalOpened(true);
+          if (openSafeExternalUrl(data.url)) setPortalOpened(true);
         },
       },
     );

--- a/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/directory-sync-step.tsx
@@ -4,6 +4,7 @@ import { useGenerateWorkOSAdminPortalLinkMutation } from "@gram/client/react-que
 import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
 import { toast } from "sonner";
 import { StepContainer } from "../step-container";
+import { openSafeExternalUrl } from "@/lib/safe-external-url";
 import { getServerURL } from "@/lib/utils";
 
 interface DirectorySyncStepProps {
@@ -42,8 +43,7 @@ export function DirectorySyncStep({
       },
       {
         onSuccess: (data) => {
-          window.open(data.url, "_blank", "noopener,noreferrer");
-          setPortalOpened(true);
+          if (openSafeExternalUrl(data.url)) setPortalOpened(true);
         },
       },
     );


### PR DESCRIPTION
Fixes [SEC-48](https://linear.app/speakeasy/issue/SEC-48)

Introduces a shared `safe-external-url` helper in the dashboard and routes the various places that open external links (WorkOS portal, plugin repos, billing, playground, CLI callback, auth redirects) through it. This keeps URL handling consistent — one place owns parsing, normalization, and the `noopener,noreferrer` window options — instead of each call site rolling its own. Includes unit tests for the new helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized external link handling in the dashboard with a shared `safe-external-url` helper that only allows HTTP(S) and opens links in a referrer-free, isolated tab. Surfaces popup-blocked tabs and fixes SEC-48 by blocking unsafe schemes and cross-origin redirects; external tabs now use a random unique name to avoid reuse.

- **Refactors**
  - Added `safe-external-url` (`safeExternalHttpUrl`, `openSafeExternalUrl`, `safeSameOriginUrl`) with unit tests.
  - Routed external opens in WorkOS portal, billing, plugins, and MCP playground through `openSafeExternalUrl`; issuer documentation links now reuse `safeExternalHttpUrl`.
  - Hardened navigations: same-origin validation for the auth redirect; CLI callback now requires HTTP(S) on localhost/127.0.0.1.

- **Bug Fixes**
  - `openSafeExternalUrl` now opens a randomly named blank tab, clears `opener`, then navigates via an anchor with `referrerPolicy="no-referrer"` to hide the referrer and reliably detect blocked popups; toasts are gated on the boolean result.
  - Test cleanup to satisfy oxlint’s no-this-alias rule.

<sup>Written for commit ce51d4d5e8bd64060cfe28230c797373f4a5a521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

