### PR TITLE
chore(ci): remove blocking job dependencies to enable parallel execution

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -359,7 +359,7 @@ jobs:
 
   docker-build-pystreams:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes, pystreams-build-lint]
+    needs: [changes]
     if: needs.changes.outputs.pystreams == 'true'
     steps:
       - name: Checkout
@@ -1465,11 +1465,10 @@ jobs:
 
   docker-build-client:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes, sdk-gen-check]
+    needs: [changes]
     # Build dashboard docker image when server OR client changes exist (needed for preview environments)
     if: |
       !cancelled() &&
-      needs.sdk-gen-check.result != 'failure' &&
       (needs.changes.outputs.client == 'true' || needs.changes.outputs.server == 'true')
     env:
       GRAM_GIT_SHA: "${{ github.sha }}"
@@ -1625,10 +1624,9 @@ jobs:
 
   client-build-lint:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes, sdk-gen-check]
+    needs: [changes]
     if: |
       !cancelled() &&
-      needs.sdk-gen-check.result != 'failure' &&
       needs.changes.outputs.client == 'true'
     steps:
       - name: Checkout
@@ -1679,10 +1677,9 @@ jobs:
 
   client-test:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [changes, sdk-gen-check]
+    needs: [changes]
     if: |
       !cancelled() &&
-      needs.sdk-gen-check.result != 'failure' &&
       needs.changes.outputs.client == 'true'
     steps:
       - name: Checkout


### PR DESCRIPTION
Removes unnecessary job dependencies that were serializing the CI pipeline:
- docker-build-pystreams no longer waits for pystreams-build-lint
- docker-build-client, client-build-lint, and client-test no longer wait for sdk-gen-check

These jobs can proceed independently without blocking on upstream steps, reducing overall CI runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up PR CI by removing blocking dependencies so `pystreams` and client jobs run in parallel. Eliminates gates on `pystreams-build-lint` and `sdk-gen-check` without changing build steps.

- **Refactors**
  - `docker-build-pystreams` now only needs `changes` (no wait on `pystreams-build-lint`).
  - `docker-build-client`, `client-build-lint`, and `client-test` now only need `changes` (no wait on `sdk-gen-check`).
  - Removed `needs.sdk-gen-check.result != 'failure'` guards from client jobs.

<sup>Written for commit a3b1cae7a3896bdc2a74f69375ba512ae88581f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

