### PR TITLE
chore(ci): auto-close stale pull requests

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,22 @@
+name: "Close stale PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write # needed for delete-branch option
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
+        with:
+          stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          delete-branch: true
+          exempt-draft-pr: true
+          days-before-stale: 30
+          days-before-close: 5


### PR DESCRIPTION
PRs left open with no activity accumulate and make it harder to see which work is actually active; auto-closing after a grace period keeps the PR list actionable without requiring manual triage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow to auto-mark and close stale PRs to keep the PR list clean and focused. PRs go stale after 30 days of inactivity and close 5 days later; branches are deleted and drafts are exempt.

- **New Features**
  - Scheduled daily at 01:30 UTC and supports manual runs.
  - Marks PRs stale after 30 days; posts a notice; closes after 5 more days if no activity.
  - Deletes the PR branch on close; draft PRs are exempt.
  - Uses `actions/stale` v11 pinned to a commit with required write permissions.

<sup>Written for commit 63754d73b4fd7261c0892f9838bb52599f89fe6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

