### PR TITLE
feat(server): add a stable redirect to the current device-agent pkg

### DIFF
--- a/.changeset/device-agent-install-redirect.md
+++ b/.changeset/device-agent-install-redirect.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add `GET /v1/install/device-agent-macos.pkg`, a stable redirect to the current signed macOS device-agent installer. Resolves the current version from the public device-agent releases manifest server-side and 302s to the versioned pkg, so docs and IT-admin instructions can link to one URL instead of hardcoding a version that goes stale every release.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1128,7 +1128,7 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("create spend gate: %w", err)
 			}
 
-			about.Attach(mux, about.NewService(logger, tracerProvider))
+			about.Attach(mux, about.NewService(logger, tracerProvider, guardianPolicy))
 			external.AttachWebhookHandler(mux, external.NewWebhookHandler(logger, tracerProvider, newWorkOSWebhooksClient(c), temporalEnv))
 			roleManager := access.NewRoleManager(logger, db, roleClient, auditLogger)
 			access.Attach(mux, access.NewService(logger, tracerProvider, db, chDB, sessionManager, roleManager, authzEngine, productFeatures, auditLogger))

--- a/server/internal/about/impl.go
+++ b/server/internal/about/impl.go
@@ -4,29 +4,60 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"time"
 
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 
 	gen "github.com/speakeasy-api/gram/server/gen/about"
 	srv "github.com/speakeasy-api/gram/server/gen/http/about/server"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 )
+
+// deviceAgentReleasesBaseURL is the public, unauthenticated bucket the
+// device-agent release pipeline publishes to (device-agent's release.yml,
+// release-pkg-macos job). The pkg itself has no "latest" alias there, same as
+// the raw daemon/CLI binaries — every consumer resolves the current version
+// off releases.json and builds the versioned URL, which is what this handler
+// does server-side so docs/IT-admin instructions have one stable link.
+const deviceAgentReleasesBaseURL = "https://storage.googleapis.com/speakeasy-device-agent-releases-prod"
+
+const installDeviceAgentMacOSPath = "/v1/install/device-agent-macos.pkg"
+
+type deviceAgentReleasesManifest struct {
+	Latest struct {
+		Speakeasyd struct {
+			Version string `json:"version"`
+		} `json:"speakeasyd"`
+	} `json:"latest"`
+}
 
 type Service struct {
 	logger *slog.Logger
 	tracer trace.Tracer
+
+	guardianPolicy         *guardian.Policy
+	deviceAgentManifestURL string
+	deviceAgentReleasesURL string
 }
 
 var _ gen.Service = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy) *Service {
 	return &Service{
-		logger: logger.With(attr.SlogComponent("about")),
-		tracer: tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/about"),
+		logger:                 logger.With(attr.SlogComponent("about")),
+		tracer:                 tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/about"),
+		guardianPolicy:         guardianPolicy,
+		deviceAgentManifestURL: deviceAgentReleasesBaseURL + "/releases.json",
+		deviceAgentReleasesURL: deviceAgentReleasesBaseURL,
 	}
 }
 
@@ -38,6 +69,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		mux,
 		srv.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, nil, nil),
 	)
+
+	// Raw HTTP handler: a stable, version-agnostic link to the current signed
+	// macOS device-agent pkg, for docs/IT-admin instructions that can't run
+	// the dashboard's own version-resolution logic.
+	mux.Handle("GET", installDeviceAgentMacOSPath, service.handleInstallDeviceAgentMacOS)
 }
 
 // Openapi implements about.Service.
@@ -46,4 +82,58 @@ func (s *Service) Openapi(context.Context) (res *gen.OpenapiResult, body io.Read
 		ContentType:   "text/yaml",
 		ContentLength: int64(len(openapiDoc)),
 	}, io.NopCloser(bytes.NewReader(openapiDoc)), nil
+}
+
+// handleInstallDeviceAgentMacOS resolves the current device-agent version from
+// the public releases manifest and 302-redirects to that version's signed
+// pkg. Never hardcode the pkg URL elsewhere; link here instead so every
+// consumer stays current without a docs edit on every release.
+func (s *Service) handleInstallDeviceAgentMacOS(w http.ResponseWriter, r *http.Request) {
+	ctx, span := s.tracer.Start(r.Context(), "about.handleInstallDeviceAgentMacOS")
+	defer span.End()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.deviceAgentManifestURL, nil)
+	if err != nil {
+		span.SetStatus(codes.Error, "build manifest request")
+		s.logger.ErrorContext(ctx, "build device-agent manifest request", attr.SlogError(err))
+		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
+		return
+	}
+
+	client := s.guardianPolicy.Client()
+	client.Timeout = 5 * time.Second
+	resp, err := client.Do(req)
+	if err != nil {
+		span.SetStatus(codes.Error, "fetch manifest")
+		s.logger.ErrorContext(ctx, "fetch device-agent releases manifest", attr.SlogError(err))
+		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		span.SetStatus(codes.Error, "manifest non-200")
+		s.logger.ErrorContext(ctx, "device-agent releases manifest returned non-200", attr.SlogHTTPResponseStatusCode(resp.StatusCode))
+		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
+		return
+	}
+
+	var manifest deviceAgentReleasesManifest
+	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+		span.SetStatus(codes.Error, "decode manifest")
+		s.logger.ErrorContext(ctx, "decode device-agent releases manifest", attr.SlogError(err))
+		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
+		return
+	}
+
+	version := manifest.Latest.Speakeasyd.Version
+	if version == "" {
+		span.SetStatus(codes.Error, "empty version")
+		s.logger.ErrorContext(ctx, "device-agent releases manifest missing latest.speakeasyd.version")
+		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
+		return
+	}
+
+	pkgURL := fmt.Sprintf("%s/v%s/speakeasy-agent_%s.pkg", s.deviceAgentReleasesURL, version, version)
+	http.Redirect(w, r, pkgURL, http.StatusFound)
 }

--- a/server/internal/about/impl.go
+++ b/server/internal/about/impl.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
@@ -31,6 +33,17 @@ import (
 const deviceAgentReleasesBaseURL = "https://storage.googleapis.com/speakeasy-device-agent-releases-prod"
 
 const installDeviceAgentMacOSPath = "/v1/install/device-agent-macos.pkg"
+
+// maxManifestSize bounds how much of the releases manifest response we will
+// read; releases.json is tiny, so this is generous headroom against a large
+// or malicious upstream response.
+const maxManifestSize = 1 << 20 // 1MiB
+
+// deviceAgentVersionPattern matches the semver shape produced by the
+// device-agent release pipeline (e.g. "1.2.3" or "1.2.3-beta.1"), so a
+// malformed manifest can't smuggle path-traversal or other unexpected
+// characters into the redirect target.
+var deviceAgentVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`)
 
 type deviceAgentReleasesManifest struct {
 	Latest struct {
@@ -118,18 +131,30 @@ func (s *Service) handleInstallDeviceAgentMacOS(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, maxManifestSize))
+
 	var manifest deviceAgentReleasesManifest
-	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
+	if err := decoder.Decode(&manifest); err != nil {
 		span.SetStatus(codes.Error, "decode manifest")
 		s.logger.ErrorContext(ctx, "decode device-agent releases manifest", attr.SlogError(err))
 		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
 		return
 	}
 
+	if err := decoder.Decode(new(json.RawMessage)); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("manifest body has trailing data after the JSON object")
+		}
+		span.SetStatus(codes.Error, "trailing data after manifest")
+		s.logger.ErrorContext(ctx, "device-agent releases manifest has trailing data after JSON object", attr.SlogError(err))
+		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
+		return
+	}
+
 	version := manifest.Latest.Speakeasyd.Version
-	if version == "" {
-		span.SetStatus(codes.Error, "empty version")
-		s.logger.ErrorContext(ctx, "device-agent releases manifest missing latest.speakeasyd.version")
+	if !deviceAgentVersionPattern.MatchString(version) {
+		span.SetStatus(codes.Error, "invalid version")
+		s.logger.ErrorContext(ctx, "device-agent releases manifest has invalid latest.speakeasyd.version")
 		http.Error(w, "device-agent installer temporarily unavailable", http.StatusBadGateway)
 		return
 	}

--- a/server/internal/about/impl_test.go
+++ b/server/internal/about/impl_test.go
@@ -1,0 +1,143 @@
+package about
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func newTestService(t *testing.T, manifestURL string) *Service {
+	t.Helper()
+
+	tracerProvider := testenv.NewTracerProvider(t)
+
+	// NewUnsafePolicy: httptest servers listen on 127.0.0.1, which the
+	// default guardian policy blocks as a loopback SSRF target. Tests only,
+	// never production (see the assets service's setup_test.go for the same
+	// pattern).
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	return &Service{
+		logger:                 slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		tracer:                 tracerProvider.Tracer("test"),
+		guardianPolicy:         guardianPolicy,
+		deviceAgentManifestURL: manifestURL,
+		deviceAgentReleasesURL: deviceAgentReleasesBaseURL,
+	}
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+func TestHandleInstallDeviceAgentMacOS_RedirectsToVersionedPkg(t *testing.T) {
+	t.Parallel()
+
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schema_version":1,"latest":{"speakeasyd":{"version":"0.1.18"}}}`))
+	}))
+	defer manifest.Close()
+
+	svc := newTestService(t, manifest.URL)
+
+	req := httptest.NewRequest(http.MethodGet, installDeviceAgentMacOSPath, nil)
+	rec := httptest.NewRecorder()
+	// http.Redirect resolves a relative Location against the request URL if
+	// it can't parse it as absolute; our client should never receive one, so
+	// assert absolute-ness explicitly below rather than relying on that.
+	req.URL, _ = url.Parse("https://app.getgram.ai" + installDeviceAgentMacOSPath)
+
+	svc.handleInstallDeviceAgentMacOS(rec, req)
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	require.Equal(t,
+		fmt.Sprintf("%s/v0.1.18/speakeasy-agent_0.1.18.pkg", deviceAgentReleasesBaseURL),
+		rec.Header().Get("Location"),
+	)
+}
+
+func TestHandleInstallDeviceAgentMacOS_ManifestUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// A closed server: connections to it fail immediately.
+	manifest := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	manifest.Close()
+
+	svc := newTestService(t, manifest.URL)
+
+	req := httptest.NewRequest(http.MethodGet, installDeviceAgentMacOSPath, nil)
+	rec := httptest.NewRecorder()
+
+	svc.handleInstallDeviceAgentMacOS(rec, req)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestHandleInstallDeviceAgentMacOS_ManifestNon200(t *testing.T) {
+	t.Parallel()
+
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer manifest.Close()
+
+	svc := newTestService(t, manifest.URL)
+
+	req := httptest.NewRequest(http.MethodGet, installDeviceAgentMacOSPath, nil)
+	rec := httptest.NewRecorder()
+
+	svc.handleInstallDeviceAgentMacOS(rec, req)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestHandleInstallDeviceAgentMacOS_MalformedManifest(t *testing.T) {
+	t.Parallel()
+
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer manifest.Close()
+
+	svc := newTestService(t, manifest.URL)
+
+	req := httptest.NewRequest(http.MethodGet, installDeviceAgentMacOSPath, nil)
+	rec := httptest.NewRecorder()
+
+	svc.handleInstallDeviceAgentMacOS(rec, req)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestHandleInstallDeviceAgentMacOS_MissingVersion(t *testing.T) {
+	t.Parallel()
+
+	manifest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schema_version":1,"latest":{}}`))
+	}))
+	defer manifest.Close()
+
+	svc := newTestService(t, manifest.URL)
+
+	req := httptest.NewRequest(http.MethodGet, installDeviceAgentMacOSPath, nil)
+	rec := httptest.NewRecorder()
+
+	svc.handleInstallDeviceAgentMacOS(rec, req)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}


### PR DESCRIPTION
## Why

The macOS device-agent pkg has no "latest" alias in its public release bucket, same as the raw daemon/CLI binaries: every consumer resolves the current version off the release manifest (`releases.json`) and builds the versioned URL. The dashboard already does this client-side, but static docs and customer-facing IT-admin instructions have no equivalent — they either hardcode a version (goes stale every release) or have no way to link to the pkg at all.

## What changed

Added `GET /v1/install/device-agent-macos.pkg`, a raw HTTP redirect handler (not a Goa RPC method — a dynamic-Location redirect doesn't fit that convention) mirrored in the `about` service, since it already serves unauthenticated platform info and has no service dependency of its own. On request it fetches the public releases manifest, resolves `latest.speakeasyd.version`, and 302s to `https://storage.googleapis.com/speakeasy-device-agent-releases-prod/v<version>/speakeasy-agent_<version>.pkg`. Outbound fetch goes through `guardian.Policy` (SSRF-safe client), same as every other outbound call in this codebase. Any failure (fetch error, non-200, malformed/incomplete manifest) returns 502 rather than panicking.

Also added test coverage for the redirect and every failure path, and a changeset.

### Before

No stable way to link to "the current device-agent pkg." Docs either hardcode a version number (`v0.1.18/speakeasy-agent_0.1.18.pkg`) that goes stale on the next release, or don't mention the pkg at all.

### After

`GET https://app.getgram.ai/v1/install/device-agent-macos.pkg` always redirects to the current signed, notarized pkg. Docs and IT-admin instructions can use this one URL indefinitely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `GET /v1/install/device-agent-macos.pkg`, a stable redirect to the latest signed macOS device‑agent installer. This gives docs and IT admins one URL that never goes stale.

- **New Features**
  - Resolves the current version from the public `releases.json` and 302 redirects to the versioned GCS pkg.
  - Implemented as a raw HTTP handler in the `about` service; no Goa method.
  - Outbound fetch uses `guardian.Policy` and times out after 5s; failures return 502.
  - Hardened manifest parsing: 1MiB read cap, reject trailing JSON, and strict semver validation for the resolved version.
  - Added tests for the redirect and all failure paths.

<sup>Written for commit d18574ef7da3618efc9711a87e654708325dc0ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

