### PR TITLE
fix: treat bare "claude" hook adapter as ambiguous Claude surface

### DIFF
--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -878,8 +878,8 @@ func (s *Service) canonicalSessionMetadata(ctx context.Context, payload *gen.Ing
 		// Surface-specificity merge: the OTEL path caches "cowork" from the
 		// resource service.name, which must survive this event's re-cache —
 		// cowork ships the same "claude-code-desktop" adapter slug as Claude
-		// Code Desktop, so the adapter alone can never downgrade it. The
-		// adapter in turn beats a cached ambiguous "claude-code".
+		// Code Desktop, so the adapter alone can never downgrade it. See
+		// claudeServiceNameSpecificity for the full ranking.
 		metadata.ServiceName = preferClaudeServiceName(metadata.ServiceName, cached.ServiceName)
 		metadata.Provider = cached.Provider
 		metadata.ExternalOrgID = cached.ExternalOrgID

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -86,19 +86,22 @@ func claudeSurfaceFromServiceName(name string) string {
 // claudeServiceNameSpecificity ranks how precisely a service name or adapter
 // slug identifies the product surface. "cowork" is unambiguous; the desktop
 // adapter slug narrows to CCD; "claude-code" is the OTEL name shared by the
-// CLI and CCD, so it is the least specific Claude value. Non-Claude values
-// rank zero.
+// CLI and CCD; the bare "claude" adapter slug the hooks binary sends for
+// Claude Code marks a Claude-family sender with no surface information at
+// all. Non-Claude values rank zero.
 func claudeServiceNameSpecificity(name string) int {
 	switch claudeSurfaceFromServiceName(name) {
 	case agentVariantCowork:
-		return 3
+		return 4
 	case surfaceClaudeCodeDesktop:
-		return 2
+		return 3
 	case agentVariantClaudeCode:
-		return 1
-	default:
-		return 0
+		return 2
 	}
+	if strings.ToLower(strings.TrimSpace(name)) == "claude" {
+		return 1
+	}
+	return 0
 }
 
 // preferClaudeServiceName merges a freshly reported service name (or adapter
@@ -106,18 +109,21 @@ func claudeServiceNameSpecificity(name string) int {
 // the Claude product surface more precisely. This is what lets the two signals
 // compose: the OTEL stream's "cowork" upgrades a cached desktop adapter slug,
 // while a cached "claude-code-desktop" survives OTEL batches that only report
-// the ambiguous "claude-code". Ties keep the fresh value. A non-empty incoming
-// value that identifies no Claude surface (Cursor, Codex, unknown adapters)
-// always wins: non-Claude senders keep their reported name instead of being
-// overwritten by a Claude value cached under the same session id.
+// the ambiguous "claude-code", and an OTEL-cached "claude-code" survives hook
+// events carrying only the bare "claude" adapter slug. Ties keep the fresh
+// value. A non-empty incoming value that identifies no Claude sender at all
+// (Cursor, Codex, unknown adapters) always wins: non-Claude senders keep their
+// reported name instead of being overwritten by a Claude value cached under
+// the same session id.
 func preferClaudeServiceName(incoming, cached string) string {
 	if incoming == "" {
 		return cached
 	}
-	if claudeSurfaceFromServiceName(incoming) == "" {
+	specificity := claudeServiceNameSpecificity(incoming)
+	if specificity == 0 {
 		return incoming
 	}
-	if claudeServiceNameSpecificity(cached) > claudeServiceNameSpecificity(incoming) {
+	if claudeServiceNameSpecificity(cached) > specificity {
 		return cached
 	}
 	return incoming

--- a/server/internal/hooks/session_capture_test.go
+++ b/server/internal/hooks/session_capture_test.go
@@ -168,6 +168,15 @@ func TestPreferClaudeServiceName(t *testing.T) {
 	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "claude-code"))
 	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "claude-code-desktop"))
 	assert.Equal(t, "cursor", preferClaudeServiceName("cursor", "cowork"))
+	// The bare "claude" adapter slug the hooks binary sends for Claude Code
+	// marks a Claude-family sender without naming a surface, so any cached
+	// surface survives it instead of being clobbered.
+	assert.Equal(t, "claude-code", preferClaudeServiceName("claude", "claude-code"))
+	assert.Equal(t, "claude-code-desktop", preferClaudeServiceName("claude", "claude-code-desktop"))
+	assert.Equal(t, "cowork", preferClaudeServiceName("claude", "cowork"))
+	assert.Equal(t, "claude", preferClaudeServiceName("claude", ""))
+	// And any Claude surface upgrades a cached bare slug.
+	assert.Equal(t, "claude-code", preferClaudeServiceName("claude-code", "claude"))
 }
 
 // A session whose OTEL stream reports service.name "cowork" must persist its


### PR DESCRIPTION
## What

Claude Code sessions captured through `/rpc/hooks.ingest` were showing up as **Claude Chat Desktop** in the agent-sessions tab. The hooks binary sends the legacy adapter slug `"claude"` for Claude Code, and surface resolution treated that slug as a *non-Claude* sender: `preferClaudeServiceName` let it clobber the OTEL-cached `claude-code` service name, so chat messages were persisted with `source='claude'` — which the dashboard renders as Claude Chat Desktop. In the affected org sample, chats labeled `claude` outnumbered `claude-code` ~90:1 over 7 days.

This PR teaches surface resolution that bare `"claude"` is an **ambiguous Claude-family value**, not a foreign sender:

- `claudeServiceNameSpecificity` ranks it above non-Claude values but below every concrete surface (`claude-code` < `claude-code-desktop` < `cowork`).
- `preferClaudeServiceName` now keys its "non-Claude sender wins" branch on specificity, so a cached OTEL `claude-code` (or CCD/cowork) survives hook events that carry only the bare adapter slug, while any concrete surface still upgrades a cached bare slug.
- Non-Claude adapters (cursor, codex, opencode) are unaffected — they still always keep their reported name.

## Why not change the binary?

Old binaries in the field will keep sending `"claude"` regardless, and the server keys other behavior (spend gate, telemetry vocabulary) on that slug. Fixing resolution server-side corrects every client version at once.

## Notes

- Sessions with no OTEL stream cached still fall back to `claude`; the chat label is derived from the latest message source, so such chats self-correct as soon as the session's OTEL batch lands.
- No backfill included: existing mislabeled chats keep their stored source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mislabeling of Claude Code sessions from `/rpc/hooks.ingest` by treating the bare `"claude"` adapter slug as an ambiguous Claude value and preferring more specific OTEL service names. Dashboard labels now show Claude Code and CCD correctly instead of Claude Chat Desktop.

- **Bug Fixes**
  - Added specificity ranking: `cowork` > `claude-code-desktop` > `claude-code` > `"claude"`; non-Claude = 0.
  - Merge now uses specificity so OTEL-cached `claude-code`/CCD/`cowork` survive bare `"claude"`; concrete surfaces still upgrade a cached bare slug.
  - Non-Claude adapters (e.g., `cursor`) always keep their reported name.
  - Sessions without OTEL still fallback to `"claude"` and self-correct when OTEL arrives.
  - Added tests covering bare `"claude"` merge behavior.

<sup>Written for commit 1ebbe0e88494a2806052b0f80436c598a608715e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

