### PR TITLE
fix: revert "perf(assistants): widen project assistant warm window" (#4820)

### DIFF
--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -38,34 +38,8 @@ const (
 
 	// Schema defaults for the assistants table, applied explicitly so the
 	// managed assistant's intent is visible at the call site.
-	//
-	// warmTTL is how long the assistant's Fly VM is kept alive after it goes
-	// idle. One VM serves every thread (chat) under an assistant, so the window
-	// is per-VM: it stays up until the assistant's *last* active thread has been
-	// quiet for warmTTL. The managed ("Project") assistant is an interactive
-	// dashboard chat: a user reads a reply, thinks, and follows up — gaps of a
-	// minute or two between turns are the norm. At 60s the VM was torn down
-	// inside that think-time gap, so nearly every follow-up (and every re-opened
-	// or newly opened chat that found the VM idle) paid a full Fly cold boot —
-	// the dominant contributor to the multi-second "first response" latency.
-	// Widen the window to cover ordinary think-time so an active project stays on
-	// a warm VM across back-to-back chats. The cost is a shared-CPU/1GB machine
-	// staying up longer between turns; tune here if that trade shifts.
-	managedAssistantWarmTTLSeconds int64 = 300
+	managedAssistantWarmTTLSeconds int64 = 60
 	managedAssistantMaxConcurrency int64 = 10
-
-	// legacyManagedAssistantWarmTTLSeconds is the warm window managed assistants
-	// were provisioned with before managedAssistantWarmTTLSeconds was widened to
-	// 300. The lazy heal targets this exact value — not "anything below the new
-	// default" — so a custom window set to any *other* value (e.g. a deliberately
-	// shorter 120s, set via UpdateAssistant) is left untouched. The one value it
-	// cannot distinguish is this legacy default itself: a window a user
-	// deliberately set to exactly 60s is indistinguishable from an un-migrated row
-	// and will be raised to 300. Inferring "stale default" from the stored value
-	// accepts that narrow ambiguity rather than paying for durable per-row
-	// "customized" metadata on a platform-managed field. If the managed default is
-	// bumped again, add the intervening prior default(s) here.
-	legacyManagedAssistantWarmTTLSeconds int64 = 60
 )
 
 // ErrManagedAssistantNameTaken is returned by EnableManagedAssistant when a
@@ -120,8 +94,6 @@ func (s *ServiceCore) EnableManagedAssistant(
 		if err := s.ensureDashboardTrigger(ctx, s.db, organizationID, projectID, existing.ID, existing.Name); err != nil {
 			return assistantRecord{}, err
 		}
-		// GetManagedAssistant already healed a stale warm window (see there), so
-		// `existing` carries the current value — nothing to repair here.
 		return existing, nil
 	case errors.Is(err, pgx.ErrNoRows):
 		// fall through to create
@@ -154,33 +126,6 @@ func (s *ServiceCore) EnableManagedAssistant(
 	return assistantRecord{}, err
 }
 
-// raiseManagedAssistantWarmTTL heals a managed assistant still on the legacy
-// warm window: it sets warm_ttl_seconds to the current managed default only when
-// the row currently holds exactly legacyManagedAssistantWarmTTLSeconds. Matching
-// the exact prior default (rather than "anything below the new default") means a
-// custom window set to any other value — e.g. a deliberately shorter 120s set via
-// UpdateAssistant — is left untouched; only a window still equal to the legacy
-// default is raised (a value a user deliberately set to exactly that default is
-// indistinguishable from an un-migrated row — see the constant's doc). The
-// predicate lives in SQL, so
-// the heal is a single effective write under concurrent chat-opens (later racers
-// match no row) and updated_at is left untouched (this is an internal backfill,
-// not a user edit). Returns the number of rows written: 1 when this call
-// performed the heal, 0 when the row no longer holds the legacy value (already
-// healed, or a custom window).
-func (s *ServiceCore) raiseManagedAssistantWarmTTL(ctx context.Context, projectID, assistantID uuid.UUID) (int64, error) {
-	rows, err := assistantrepo.New(s.db).RaiseAssistantWarmTtlSeconds(ctx, assistantrepo.RaiseAssistantWarmTtlSecondsParams{
-		WarmTtlSeconds:     managedAssistantWarmTTLSeconds,
-		AssistantID:        assistantID,
-		ProjectID:          projectID,
-		FromWarmTtlSeconds: legacyManagedAssistantWarmTTLSeconds,
-	})
-	if err != nil {
-		return 0, fmt.Errorf("raise managed assistant warm ttl: %w", err)
-	}
-	return rows, nil
-}
-
 // GetManagedAssistant resolves a project's managed assistant and hydrates its
 // management read model. Returns pgx.ErrNoRows when the feature isn't enabled for the project.
 func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UUID) (assistantRecord, error) {
@@ -189,45 +134,6 @@ func (s *ServiceCore) GetManagedAssistant(ctx context.Context, projectID uuid.UU
 		return assistantRecord{}, fmt.Errorf("get managed assistant: %w", err)
 	}
 	record := assistantRecordFromManagedRow(row)
-	// Lazily heal an assistant still on the legacy warm window. warm_ttl_seconds
-	// is stored per-row at create time, so widening managedAssistantWarmTTLSeconds
-	// only reaches assistants created before it by rewriting the row. The
-	// dashboard resolves the managed assistant through here on every chat open —
-	// the only path that reliably runs for an already-provisioned assistant (the
-	// write-scoped ensure path fires only when one is missing) — so an assistant
-	// on the legacy default is raised the next time its owner opens the chat, with
-	// no data migration. The guard is the *exact* legacy value, not "below the new
-	// default", so a custom window (warm_ttl is user-settable via UpdateAssistant)
-	// set to any value other than the legacy default is left alone — the lone
-	// ambiguity being a window deliberately set to exactly the legacy default, which
-	// reads as un-migrated (see legacyManagedAssistantWarmTTLSeconds). The heal is
-	// one-time: once healed the
-	// guard is false and this stays a pure read, so the steady state is read-only.
-	// updated_at is left untouched (see raiseManagedAssistantWarmTTL). A repair
-	// failure must not fail the read: the assistant still works at its stored TTL,
-	// so log and carry on.
-	if record.WarmTTLSeconds == int(legacyManagedAssistantWarmTTLSeconds) {
-		switch rows, err := s.raiseManagedAssistantWarmTTL(ctx, projectID, record.ID); {
-		case err != nil:
-			s.logger.WarnContext(ctx, "heal managed assistant warm ttl", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
-		case rows > 0:
-			// This call performed the heal, so the row now holds the default.
-			record.WarmTTLSeconds = int(managedAssistantWarmTTLSeconds)
-		default:
-			// No row written: a concurrent update changed warm_ttl away from the
-			// legacy value between the read and the heal. The value read before the
-			// heal is stale, so re-read the authoritative one rather than assuming
-			// the default.
-			if fresh, err := assistantrepo.New(s.db).GetAssistant(ctx, assistantrepo.GetAssistantParams{
-				AssistantID: record.ID,
-				ProjectID:   projectID,
-			}); err != nil {
-				s.logger.WarnContext(ctx, "re-read managed assistant warm ttl after no-op heal", attr.SlogError(err), attr.SlogAssistantID(record.ID.String()))
-			} else {
-				record.WarmTTLSeconds = conv.SafeInt(fresh.WarmTtlSeconds)
-			}
-		}
-	}
 	if err := s.hydrateAssistantToolSources(ctx, projectID, &record); err != nil {
 		return assistantRecord{}, err
 	}

--- a/server/internal/assistants/provisioning_test.go
+++ b/server/internal/assistants/provisioning_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
-	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
@@ -164,114 +163,6 @@ func TestGetManagedAssistantNoRows(t *testing.T) {
 
 	_, err = core.GetManagedAssistant(ctx, projectID)
 	require.ErrorIs(t, err, pgx.ErrNoRows)
-}
-
-// TestGetManagedAssistantHealsStaleWarmTTL verifies the lazy warm-window heal:
-// an assistant left on an older, shorter warm_ttl is raised to the current
-// managed default the next time it is resolved (the path the dashboard hits on
-// every chat open), and the new value is persisted — not merely reflected in the
-// response.
-func TestGetManagedAssistantHealsStaleWarmTTL(t *testing.T) {
-	t.Parallel()
-
-	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_heal_warm_ttl")
-	require.NoError(t, err)
-	ctx := t.Context()
-
-	core := newProvisioningCore(t, conn)
-	projectID := newProvisioningProject(t, conn, "managed-heal-warm-ttl")
-
-	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
-	require.NoError(t, err)
-
-	// Simulate an assistant provisioned under the old, shorter default.
-	stale := int64(60)
-	require.Less(t, stale, managedAssistantWarmTTLSeconds, "test premise: stale value must be below the current default")
-	_, err = assistantrepo.New(conn).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
-		WarmTtlSeconds: pgtype.Int8{Int64: stale, Valid: true},
-		AssistantID:    enabled.ID,
-		ProjectID:      projectID,
-	})
-	require.NoError(t, err)
-
-	got, err := core.GetManagedAssistant(ctx, projectID)
-	require.NoError(t, err)
-	require.Equal(t, int(managedAssistantWarmTTLSeconds), got.WarmTTLSeconds, "resolve must heal a stale warm window to the managed default")
-
-	stored, err := assistantrepo.New(conn).GetAssistant(ctx, assistantrepo.GetAssistantParams{AssistantID: enabled.ID, ProjectID: projectID})
-	require.NoError(t, err)
-	require.Equal(t, managedAssistantWarmTTLSeconds, stored.WarmTtlSeconds, "heal must persist the raised warm window")
-}
-
-// TestGetManagedAssistantPreservesLongerWarmTTL verifies the heal is raise-only:
-// a deliberately longer warm window is never lowered to the managed default, and
-// the resolve reports the true stored value rather than assuming the default.
-func TestGetManagedAssistantPreservesLongerWarmTTL(t *testing.T) {
-	t.Parallel()
-
-	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_preserve_warm_ttl")
-	require.NoError(t, err)
-	ctx := t.Context()
-
-	core := newProvisioningCore(t, conn)
-	projectID := newProvisioningProject(t, conn, "managed-preserve-warm-ttl")
-
-	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
-	require.NoError(t, err)
-
-	longer := managedAssistantWarmTTLSeconds * 2
-	_, err = assistantrepo.New(conn).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
-		WarmTtlSeconds: pgtype.Int8{Int64: longer, Valid: true},
-		AssistantID:    enabled.ID,
-		ProjectID:      projectID,
-	})
-	require.NoError(t, err)
-
-	got, err := core.GetManagedAssistant(ctx, projectID)
-	require.NoError(t, err)
-	require.Equal(t, int(longer), got.WarmTTLSeconds, "resolve must not lower a longer warm window")
-
-	stored, err := assistantrepo.New(conn).GetAssistant(ctx, assistantrepo.GetAssistantParams{AssistantID: enabled.ID, ProjectID: projectID})
-	require.NoError(t, err)
-	require.Equal(t, longer, stored.WarmTtlSeconds, "raise-only heal must leave a longer window untouched")
-}
-
-// TestGetManagedAssistantPreservesCustomShorterWarmTTL guards the heal's
-// exact-match guard: a deliberately chosen window below the default but not equal
-// to the legacy default must never be clobbered up to the default. Warm TTL is
-// user-settable via UpdateAssistant, so healing "anything below the default"
-// would silently overwrite such a choice on every chat open.
-func TestGetManagedAssistantPreservesCustomShorterWarmTTL(t *testing.T) {
-	t.Parallel()
-
-	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_managed_custom_warm_ttl")
-	require.NoError(t, err)
-	ctx := t.Context()
-
-	core := newProvisioningCore(t, conn)
-	projectID := newProvisioningProject(t, conn, "managed-custom-warm-ttl")
-
-	enabled, err := core.EnableManagedAssistant(ctx, "org-test", projectID, "user-1")
-	require.NoError(t, err)
-
-	// A custom window that is below the default yet not the legacy default.
-	custom := int64(120)
-	require.Less(t, custom, managedAssistantWarmTTLSeconds)
-	require.NotEqual(t, legacyManagedAssistantWarmTTLSeconds, custom, "test premise: custom value must differ from the legacy default")
-	_, err = assistantrepo.New(conn).UpdateAssistant(ctx, assistantrepo.UpdateAssistantParams{
-		WarmTtlSeconds: pgtype.Int8{Int64: custom, Valid: true},
-		AssistantID:    enabled.ID,
-		ProjectID:      projectID,
-	})
-	require.NoError(t, err)
-
-	got, err := core.GetManagedAssistant(ctx, projectID)
-	require.NoError(t, err)
-	require.Equal(t, int(custom), got.WarmTTLSeconds, "resolve must not overwrite a deliberately chosen sub-default window")
-
-	stored, err := assistantrepo.New(conn).GetAssistant(ctx, assistantrepo.GetAssistantParams{AssistantID: enabled.ID, ProjectID: projectID})
-	require.NoError(t, err)
-	require.Equal(t, custom, stored.WarmTtlSeconds, "the heal must leave a custom window untouched")
 }
 
 // TestEnableManagedAssistantFailsWhenNameTaken: a user assistant already

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -493,14 +493,6 @@ WHERE id = @assistant_id
   AND deleted IS FALSE
 RETURNING id, project_id, organization_id, created_by_user_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status, created_at, updated_at, deleted_at;
 
--- name: RaiseAssistantWarmTtlSeconds :execrows
-UPDATE assistants
-SET warm_ttl_seconds = @warm_ttl_seconds
-WHERE id = @assistant_id
-  AND project_id = @project_id
-  AND deleted IS FALSE
-  AND warm_ttl_seconds = @from_warm_ttl_seconds;
-
 -- name: DeleteAssistant :exec
 UPDATE assistants
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -2559,35 +2559,6 @@ func (q *Queries) MarkAssistantRuntimeReaped(ctx context.Context, arg MarkAssist
 	return err
 }
 
-const raiseAssistantWarmTtlSeconds = `-- name: RaiseAssistantWarmTtlSeconds :execrows
-UPDATE assistants
-SET warm_ttl_seconds = $1
-WHERE id = $2
-  AND project_id = $3
-  AND deleted IS FALSE
-  AND warm_ttl_seconds = $4
-`
-
-type RaiseAssistantWarmTtlSecondsParams struct {
-	WarmTtlSeconds     int64
-	AssistantID        uuid.UUID
-	ProjectID          uuid.UUID
-	FromWarmTtlSeconds int64
-}
-
-func (q *Queries) RaiseAssistantWarmTtlSeconds(ctx context.Context, arg RaiseAssistantWarmTtlSecondsParams) (int64, error) {
-	result, err := q.db.Exec(ctx, raiseAssistantWarmTtlSeconds,
-		arg.WarmTtlSeconds,
-		arg.AssistantID,
-		arg.ProjectID,
-		arg.FromWarmTtlSeconds,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const reapStuckAssistantRuntimes = `-- name: ReapStuckAssistantRuntimes :many
 UPDATE assistant_runtimes
 SET

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -31,13 +31,6 @@ const (
 	defaultFlyRuntimeHealthTimeout  = 45 * time.Second
 	defaultFlyRuntimeRequestTimeout = 2 * time.Minute
 
-	// flyRuntimeHealthPollInterval is the gap between /healthz probes while
-	// waiting for a freshly started runner to come up. The runner becomes ready
-	// at an arbitrary point within an interval, so the interval is the worst-case
-	// slack added to a cold boot after the process is already serving. Kept short
-	// so that slack stays small; the probes are cheap and only run during a boot.
-	flyRuntimeHealthPollInterval = 250 * time.Millisecond
-
 	// flyRuntimeReapCallTimeout caps a single Fly API call during reap so
 	// one wedged row cannot consume the parent activity's deadline.
 	flyRuntimeReapCallTimeout = 30 * time.Second
@@ -1135,7 +1128,7 @@ func (f *FlyRuntimeBackend) waitForRuntimeHealth(ctx context.Context, target fly
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("wait for runtime health: %w", ctx.Err())
-		case <-time.After(flyRuntimeHealthPollInterval):
+		case <-time.After(500 * time.Millisecond):
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Reverts #4820 ("perf(assistants): widen project assistant warm window to cut cold-start latency").

This restores the previous assistant warm-window behavior by reverting merge commit `ef820187`. Clean revert, no conflicts:

- `server/internal/assistants/provisioning.go` — removes the widened warm-window logic
- `server/internal/assistants/provisioning_test.go` — removes associated tests
- `server/internal/assistants/queries.sql` / `repo/queries.sql.go` — removes the added query
- `server/internal/assistants/runtime_fly.go` — restores prior runtime behavior

## Why

Rolling back the warm-window change from #4820.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the warm-window widening for project assistants from #4820, restoring the previous 60s warm TTL and runtime behavior. Removes the lazy-heal migration and associated SQL/tests.

- **Bug Fixes**
  - Set managed assistant warm TTL back to 60s in `server/internal/assistants/provisioning.go`.
  - Remove lazy heal path and `RaiseAssistantWarmTtlSeconds` query from `server/internal/assistants/queries.sql` and generated repo code.
  - Delete related tests in `server/internal/assistants/provisioning_test.go`.
  - Restore prior Fly runtime health polling in `server/internal/assistants/runtime_fly.go`.

<sup>Written for commit 221bc46c7599e5db1abe792746f0e7f7d97f4061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

