### PR TITLE
fix(auth): enforce project:read on Gram-Project header (AIS-425)

### DIFF
--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -69,7 +69,34 @@ func (s *Auth) Authorize(ctx context.Context, key string, scheme *security.APIKe
 		return ctx, oops.E(oops.CodeUnexpected, err, "load access grants").LogError(ctx, s.logger)
 	}
 
+	// After resolving Gram-Project, require the caller holds project:read on
+	// that project. When RBAC is off (or the caller is an API key), Require is
+	// a no-op and org/project-bound key scoping above remains authoritative.
+	if scheme.Name == constants.ProjectSlugSecuritySchema {
+		if err := s.requireResolvedProjectAccess(ctx); err != nil {
+			return ctx, err
+		}
+	}
+
 	return ctx, nil
+}
+
+// requireResolvedProjectAccess ensures the authenticated principal is granted
+// project:read on the project selected via the Gram-Project header. This closes
+// the gap where checkProjectAccess only verified the project belonged to the
+// caller's organization (AIS-425).
+func (s *Auth) requireResolvedProjectAccess(ctx context.Context) error {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ProjectID == nil {
+		return oops.E(oops.CodeUnauthorized, nil, "no session found")
+	}
+
+	return s.authz.Require(ctx, authz.Check{
+		Scope:        authz.ScopeProjectRead,
+		ResourceKind: "",
+		ResourceID:   authCtx.ProjectID.String(),
+		Dimensions:   nil,
+	})
 }
 
 func (s *Auth) checkProjectAccess(ctx context.Context, logger *slog.Logger, projectSlug string) (context.Context, error) {

--- a/server/internal/auth/authorize_test.go
+++ b/server/internal/auth/authorize_test.go
@@ -8,13 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"goa.design/goa/v3/security"
 
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
 var (
@@ -88,14 +91,18 @@ func TestAuthorizeOrganizationWideKeyAllowsProjectSlug(t *testing.T) {
 	require.Equal(t, projects[1].Slug, *authCtx.ProjectSlug)
 }
 
-func TestAuthorizeSessionCanSelectEitherOrganizationProject(t *testing.T) {
+func TestAuthorizeSessionCanSelectGrantedOrganizationProjects(t *testing.T) {
 	t.Parallel()
 
 	ctx, instance, projects := newProjectAccessTest(t, "first-project", "second-project")
+	userInfo := defaultMockUserInfo()
+	seedUserProjectGrant(t, ctx, instance, userInfo.Organizations[0].ID, userInfo.UserID, projects[0].ID.String())
+	seedUserProjectGrant(t, ctx, instance, userInfo.Organizations[0].ID, userInfo.UserID, projects[1].ID.String())
+
 	session := sessions.Session{
 		SessionID:            "project-access-session",
-		ActiveOrganizationID: defaultMockUserInfo().Organizations[0].ID,
-		UserID:               defaultMockUserInfo().UserID,
+		ActiveOrganizationID: userInfo.Organizations[0].ID,
+		UserID:               userInfo.UserID,
 		WorkOSSessionID:      "workos-project-access-session",
 	}
 	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
@@ -115,6 +122,33 @@ func TestAuthorizeSessionCanSelectEitherOrganizationProject(t *testing.T) {
 	secondAuthCtx, ok := contextvalues.GetAuthContext(secondCtx)
 	require.True(t, ok)
 	require.Equal(t, projects[1].ID, *secondAuthCtx.ProjectID)
+}
+
+func TestAuthorizeSessionRejectsUngrantedOrganizationProject(t *testing.T) {
+	t.Parallel()
+
+	ctx, instance, projects := newProjectAccessTest(t, "granted-project", "ungranted-project")
+	userInfo := defaultMockUserInfo()
+	seedUserProjectGrant(t, ctx, instance, userInfo.Organizations[0].ID, userInfo.UserID, projects[0].ID.String())
+
+	session := sessions.Session{
+		SessionID:            "project-access-session-ungranted",
+		ActiveOrganizationID: userInfo.Organizations[0].ID,
+		UserID:               userInfo.UserID,
+		WorkOSSessionID:      "workos-project-access-session-ungranted",
+	}
+	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
+
+	authedCtx, err := instance.authorizer.Authorize(t.Context(), session.SessionID, sessionScheme)
+	require.NoError(t, err)
+
+	_, err = instance.authorizer.Authorize(authedCtx, projects[0].Slug, projectSlugScheme)
+	require.NoError(t, err)
+
+	_, err = instance.authorizer.Authorize(authedCtx, projects[1].Slug, projectSlugScheme)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeForbidden, oopsErr.Code)
 }
 
 func TestAuthorizeProjectBoundKeyAllowsEmptySlugForSingleProjectOrganization(t *testing.T) {
@@ -177,4 +211,19 @@ func createTestAPIKey(t *testing.T, ctx context.Context, instance *testInstance,
 	require.NoError(t, err)
 
 	return key
+}
+
+func seedUserProjectGrant(t *testing.T, ctx context.Context, instance *testInstance, organizationID string, userID string, projectID string) {
+	t.Helper()
+
+	selectors, err := authz.NewSelector(authz.ScopeProjectRead, projectID).MarshalJSON()
+	require.NoError(t, err)
+
+	_, err = accessrepo.New(instance.conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		OrganizationID: organizationID,
+		PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeUser, userID),
+		Scope:          string(authz.ScopeProjectRead),
+		Selectors:      selectors,
+	})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **AIS-425** (Cross-Project Privilege Escalation).

`checkProjectAccess` previously only verified that the `Gram-Project` header referenced a project in the caller's organization. Session users with RBAC-limited project grants (visible in `auth.info`) could still select any sibling project and perform project-scoped mutations (reproduced via `assets.uploadOpenAPIv3`).

After resolving the project slug, authorization now requires `project:read` on that project. When RBAC is disabled, or the caller is an API key, `authz.Require` remains a no-op (`ShouldEnforce`), so existing org-wide / project-bound API key behavior is unchanged.

## Changes

- `server/internal/auth/auth.go`: after `PrepareContext` on the project-slug scheme, call `requireResolvedProjectAccess` (`project:read`)
- `server/internal/auth/authorize_test.go`:
  - Session can select projects it is granted
  - Session is **forbidden** from selecting an ungranted sibling project (regression for AIS-425)

## Test plan

- [x] `go test ./server/internal/auth/ -run TestAuthorize`
- [x] Full `go test ./server/internal/auth/`
- [x] `mise run lint:server`
- [ ] Manual: with RBAC on, low-privilege session limited to one project; `Gram-Project: <other-slug>` on `assets.uploadOpenAPIv3` returns 403

Refs: AIS-425

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-425](https://linear.app/speakeasy/issue/AIS-425/security-cross-project-privilege-escalation)

<div><a href="https://cursor.com/agents/bc-80638b58-ca36-4f7d-a2c5-8cacfc58d30f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80638b58-ca36-4f7d-a2c5-8cacfc58d30f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces project-level authorization (`project:read`) after resolving the `Gram-Project` header to block cross-project privilege escalation. Addresses AIS-425; API key behavior and non‑RBAC orgs remain unchanged.

- **Bug Fixes**
  - In `server/internal/auth/auth.go`, after project-slug resolution in `Authorize`, call `requireResolvedProjectAccess` to require `project:read`; fixes the gap where `checkProjectAccess` only validated org ownership.
  - In `server/internal/auth/authorize_test.go`, added tests to allow selecting granted projects and forbid ungranted sibling projects (403), plus a helper to seed grants.

<sup>Written for commit 905f5884196fd6dbda953f89fcb6e5194332b863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

