### PR TITLE
fix: oauth callback url does not render properly in mcp setup docs

### DIFF
--- a/.changeset/render-setup-docs-callback-url.md
+++ b/.changeset/render-setup-docs-callback-url.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Substitute the OAuth callback URL into the setup guide content that `mcpRegistries.getSetupDocs` returns. Published guides ship with a `{{ gram.oauth.callback_url }}` template key wherever the reader has to register a redirect URI on an upstream provider's OAuth app. The endpoint now replaces that key with this deployment's remote-login callback URL, so `external_markdown` and `speakeasy_markdown` carry a value the reader can paste directly.

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
 	github.com/speakeasy-api/agenthooks v0.4.0
-	github.com/speakeasy-api/mcp-setup-docs/go v0.1.4
+	github.com/speakeasy-api/mcp-setup-docs/go v0.3.0
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,8 @@ github.com/speakeasy-api/agenthooks v0.4.0 h1:3dbu1ab5lc0Ij5KRr8D3DQtHGtcpJ9hO85
 github.com/speakeasy-api/agenthooks v0.4.0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
-github.com/speakeasy-api/mcp-setup-docs/go v0.1.4 h1:NN0+F+YntAkZl8wRCeCLfrqo/VeiWsM/uUeuGVg/dgA=
-github.com/speakeasy-api/mcp-setup-docs/go v0.1.4/go.mod h1:epqh0bWWTc4FNmoRXGGv1pkuB9AetNJUzZHAsKuytW4=
+github.com/speakeasy-api/mcp-setup-docs/go v0.3.0 h1:y6/KsyZErJegJJR4P9l1PFXU+jyBWKKhnLmzl96ikgc=
+github.com/speakeasy-api/mcp-setup-docs/go v0.3.0/go.mod h1:epqh0bWWTc4FNmoRXGGv1pkuB9AetNJUzZHAsKuytW4=
 github.com/speakeasy-api/openapi v1.24.0 h1:opoD27rupX7zBVPq1HkIGLeMOzNNA7JalhYP8q34i04=
 github.com/speakeasy-api/openapi v1.24.0/go.mod h1:g3+dIMe0AYgbbGvnlQZqesmjAVWSm9BmsjLevnefQrg=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1265,7 +1265,7 @@ func newStartCommand() *cli.Command {
 			oauth.Attach(mux, oauthService)
 			instances.Attach(mux, instances.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, env, encryptionClient, cache.NewRedisCacheAdapter(redisClient), guardianPolicy, functionsOrchestrator, platformSvc, billingTracker, telemLogger, productFeatures, serverURL, authzEngine))
 			mcpmetadata.Attach(mux, mcpMetadataService)
-			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine))
+			externalmcp.Attach(mux, externalmcp.NewService(logger, tracerProvider, db, sessionManager, mcpRegistryClient, authzEngine, serverURL))
 			collections.Attach(mux, collections.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, serverURL))
 			mcp.Attach(mux, mcpService, mcpMetadataService)
 			chat.Attach(mux, chatService)

--- a/server/internal/externalmcp/get_setup_docs_test.go
+++ b/server/internal/externalmcp/get_setup_docs_test.go
@@ -16,13 +16,10 @@ import (
 
 const callbackTemplateKey = "{{ gram.oauth.callback_url }}"
 
-// setupDocsFixture picks a published guide that exercises both lookup keys
-// unambiguously: one registry alias and one endpoint URL each resolve to that
-// guide alone. The guide also carries the callback template key, so the
-// rendering assertions have a substitution to observe. Deriving the fixture from
-// the SDK rather than naming a vendor keeps these tests pinned to the endpoint's
-// resolution and mapping behaviour, so re-publishing the guide catalog can't
-// silently break them.
+// setupDocsFixture picks a published guide that resolves unambiguously by both
+// lookup keys and carries the callback template key. Deriving it from the SDK
+// rather than naming a vendor pins these tests to endpoint behaviour, not to the
+// catalog.
 func setupDocsFixture(t *testing.T) (guides.Guide, string, guides.Remote) {
 	t.Helper()
 
@@ -42,7 +39,7 @@ func setupDocsFixture(t *testing.T) (guides.Guide, string, guides.Remote) {
 		}
 	}
 
-	t.Fatal("no published setup guide carries the callback template key and resolves unambiguously by both registry alias and endpoint URL")
+	t.Fatal("no published setup guide carries the callback template key and resolves unambiguously by both lookup keys")
 
 	return guides.Guide{}, "", guides.Remote{}
 }
@@ -88,8 +85,7 @@ func TestExternalMCP_GetSetupDocs_ByRegistrySpecifier(t *testing.T) {
 	require.Equal(t, guide.Summary, got.Summary)
 	require.Equal(t, guide.Aliases, got.Aliases)
 
-	// The callback URL belongs to the deployment, not to the guide, so the
-	// endpoint substitutes it on the way out.
+	// The callback URL belongs to the deployment, so the endpoint substitutes it.
 	vars := guides.Vars{OAuthCallbackURL: testCallbackURL}
 	require.Equal(t, string(guide.RenderExternal(vars)), got.ExternalMarkdown)
 	require.Equal(t, string(guide.RenderSpeakeasy(vars)), got.SpeakeasyMarkdown)

--- a/server/internal/externalmcp/get_setup_docs_test.go
+++ b/server/internal/externalmcp/get_setup_docs_test.go
@@ -14,17 +14,21 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
+const callbackTemplateKey = "{{ gram.oauth.callback_url }}"
+
 // setupDocsFixture picks a published guide that exercises both lookup keys
 // unambiguously: one registry alias and one endpoint URL each resolve to that
-// guide alone. Deriving the fixture from the SDK rather than naming a vendor
-// keeps these tests pinned to the endpoint's resolution and mapping behaviour,
-// so re-publishing the guide catalog can't silently break them.
+// guide alone. The guide also carries the callback template key, so the
+// rendering assertions have a substitution to observe. Deriving the fixture from
+// the SDK rather than naming a vendor keeps these tests pinned to the endpoint's
+// resolution and mapping behaviour, so re-publishing the guide catalog can't
+// silently break them.
 func setupDocsFixture(t *testing.T) (guides.Guide, string, guides.Remote) {
 	t.Helper()
 
 	for _, guide := range guides.Guides() {
 		alias, ok := unambiguousAlias(guide)
-		if !ok {
+		if !ok || !strings.Contains(string(guide.External)+string(guide.Speakeasy), callbackTemplateKey) {
 			continue
 		}
 
@@ -38,7 +42,7 @@ func setupDocsFixture(t *testing.T) (guides.Guide, string, guides.Remote) {
 		}
 	}
 
-	t.Fatal("no published setup guide resolves unambiguously by both registry alias and endpoint URL")
+	t.Fatal("no published setup guide carries the callback template key and resolves unambiguously by both registry alias and endpoint URL")
 
 	return guides.Guide{}, "", guides.Remote{}
 }
@@ -83,10 +87,17 @@ func TestExternalMCP_GetSetupDocs_ByRegistrySpecifier(t *testing.T) {
 	require.Equal(t, guide.Title, got.Title)
 	require.Equal(t, guide.Summary, got.Summary)
 	require.Equal(t, guide.Aliases, got.Aliases)
-	require.Equal(t, string(guide.External), got.ExternalMarkdown)
-	require.Equal(t, string(guide.Speakeasy), got.SpeakeasyMarkdown)
+
+	// The callback URL belongs to the deployment, not to the guide, so the
+	// endpoint substitutes it on the way out.
+	vars := guides.Vars{OAuthCallbackURL: testCallbackURL}
+	require.Equal(t, string(guide.RenderExternal(vars)), got.ExternalMarkdown)
+	require.Equal(t, string(guide.RenderSpeakeasy(vars)), got.SpeakeasyMarkdown)
 	require.NotEmpty(t, got.ExternalMarkdown)
 	require.NotEmpty(t, got.SpeakeasyMarkdown)
+	require.NotContains(t, got.ExternalMarkdown, callbackTemplateKey)
+	require.NotContains(t, got.SpeakeasyMarkdown, callbackTemplateKey)
+	require.Contains(t, got.ExternalMarkdown+got.SpeakeasyMarkdown, testCallbackURL)
 
 	require.Len(t, got.Remotes, len(guide.Remotes))
 	for i, remote := range guide.Remotes {

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -41,12 +41,13 @@ type Service struct {
 	authz          *authz.Engine
 	sessions       *sessions.Manager
 	registryClient *RegistryClient
+	serverURL      *url.URL
 }
 
 var _ gen.Service = (*Service)(nil)
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, registryClient *RegistryClient, authzEngine *authz.Engine) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessions *sessions.Manager, registryClient *RegistryClient, authzEngine *authz.Engine, serverURL *url.URL) *Service {
 	logger = logger.With(attr.SlogComponent("external_mcp"))
 
 	return &Service{
@@ -58,6 +59,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		authz:          authzEngine,
 		sessions:       sessions,
 		registryClient: registryClient,
+		serverURL:      serverURL,
 	}
 }
 
@@ -292,8 +294,13 @@ func (s *Service) GetSetupDocs(ctx context.Context, payload *gen.GetSetupDocsPay
 		return nil, oops.E(oops.CodeBadRequest, nil, "at least one of server_url or registry_specifier must be provided").LogError(ctx, s.logger)
 	}
 
+	// One stable redirect_uri for every provider and slug
+	// (canonicalCallbackRouteBase in remotesessions/challenge.go). oauth/impl.go
+	// and the dashboard derive it the same way.
+	callbackURL := s.serverURL.JoinPath("mcp", "remote_login_callback").String()
+
 	return &gen.GetSetupDocsResult{
-		Guides: resolveSetupGuides(registrySpecifier, serverURL),
+		Guides: resolveSetupGuides(registrySpecifier, serverURL, callbackURL),
 	}, nil
 }
 

--- a/server/internal/externalmcp/impl.go
+++ b/server/internal/externalmcp/impl.go
@@ -294,9 +294,8 @@ func (s *Service) GetSetupDocs(ctx context.Context, payload *gen.GetSetupDocsPay
 		return nil, oops.E(oops.CodeBadRequest, nil, "at least one of server_url or registry_specifier must be provided").LogError(ctx, s.logger)
 	}
 
-	// One stable redirect_uri for every provider and slug
-	// (canonicalCallbackRouteBase in remotesessions/challenge.go). oauth/impl.go
-	// and the dashboard derive it the same way.
+	// The one redirect_uri for every provider and slug. remotesessions/challenge.go,
+	// oauth/impl.go, and the dashboard derive it the same way.
 	callbackURL := s.serverURL.JoinPath("mcp", "remote_login_callback").String()
 
 	return &gen.GetSetupDocsResult{

--- a/server/internal/externalmcp/setup_test.go
+++ b/server/internal/externalmcp/setup_test.go
@@ -3,6 +3,7 @@ package externalmcp_test
 import (
 	"context"
 	"log"
+	"net/url"
 	"os"
 	"testing"
 
@@ -23,6 +24,10 @@ import (
 var (
 	infra *testenv.Environment
 )
+
+// Base URL the test service renders into setup guides, and the callback it yields.
+const testServerURL = "https://app.getgram.ai"
+const testCallbackURL = testServerURL + "/mcp/remote_login_callback"
 
 func TestMain(m *testing.M) {
 	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true})
@@ -73,7 +78,11 @@ func newTestExternalMCPService(t *testing.T) (context.Context, *testInstance) {
 	require.NoError(t, err)
 
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.RBACAlwaysEnabled, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := externalmcp.NewService(logger, tracerProvider, conn, sessionManager, mcpRegistryClient, authzEngine)
+
+	serverURL, err := url.Parse(testServerURL)
+	require.NoError(t, err)
+
+	svc := externalmcp.NewService(logger, tracerProvider, conn, sessionManager, mcpRegistryClient, authzEngine, serverURL)
 
 	return ctx, &testInstance{
 		service:        svc,

--- a/server/internal/externalmcp/setupdocs.go
+++ b/server/internal/externalmcp/setupdocs.go
@@ -38,7 +38,9 @@ func setupGuideMatchKind(kind guides.MatchKind) (wire string, ok bool) {
 // Both inputs can match the same guide, so results are deduplicated by slug: the
 // most specific match wins its match_kind, and the endpoint it selected lands in
 // matched_remote_id.
-func resolveSetupGuides(registrySpecifier, serverURL string) []*types.MCPSetupGuide {
+//
+// callbackURL is substituted into the returned content.
+func resolveSetupGuides(registrySpecifier, serverURL, callbackURL string) []*types.MCPSetupGuide {
 	// ByURL is the only source of endpoint matches and Resolve the only source of
 	// alias matches, so this order is descending specificity and the first match
 	// for a guide is its most specific one.
@@ -66,7 +68,7 @@ func resolveSetupGuides(registrySpecifier, serverURL string) []*types.MCPSetupGu
 				continue
 			}
 
-			view = toMCPSetupGuide(guide, wire)
+			view = toMCPSetupGuide(guide, wire, callbackURL)
 			bySlug[match.Ref.Guide] = view
 			views = append(views, view)
 		}
@@ -80,7 +82,7 @@ func resolveSetupGuides(registrySpecifier, serverURL string) []*types.MCPSetupGu
 	return views
 }
 
-func toMCPSetupGuide(guide guides.Guide, matchKind string) *types.MCPSetupGuide {
+func toMCPSetupGuide(guide guides.Guide, matchKind, callbackURL string) *types.MCPSetupGuide {
 	remotes := make([]*types.MCPSetupGuideRemote, 0, len(guide.Remotes))
 	for _, remote := range guide.Remotes {
 		remotes = append(remotes, &types.MCPSetupGuideRemote{
@@ -96,6 +98,8 @@ func toMCPSetupGuide(guide guides.Guide, matchKind string) *types.MCPSetupGuide 
 	aliases := make([]string, 0, len(guide.Aliases))
 	aliases = append(aliases, guide.Aliases...)
 
+	vars := guides.Vars{OAuthCallbackURL: callbackURL}
+
 	return &types.MCPSetupGuide{
 		Slug:              string(guide.Slug),
 		Title:             guide.Title,
@@ -105,7 +109,7 @@ func toMCPSetupGuide(guide guides.Guide, matchKind string) *types.MCPSetupGuide 
 		Remotes:           remotes,
 		MatchedRemoteID:   nil,
 		MatchKind:         matchKind,
-		ExternalMarkdown:  string(guide.External),
-		SpeakeasyMarkdown: string(guide.Speakeasy),
+		ExternalMarkdown:  string(guide.RenderExternal(vars)),
+		SpeakeasyMarkdown: string(guide.RenderSpeakeasy(vars)),
 	}
 }

--- a/server/internal/externalmcp/setupdocs.go
+++ b/server/internal/externalmcp/setupdocs.go
@@ -38,8 +38,6 @@ func setupGuideMatchKind(kind guides.MatchKind) (wire string, ok bool) {
 // Both inputs can match the same guide, so results are deduplicated by slug: the
 // most specific match wins its match_kind, and the endpoint it selected lands in
 // matched_remote_id.
-//
-// callbackURL is substituted into the returned content.
 func resolveSetupGuides(registrySpecifier, serverURL, callbackURL string) []*types.MCPSetupGuide {
 	// ByURL is the only source of endpoint matches and Resolve the only source of
 	// alias matches, so this order is descending specificity and the first match


### PR DESCRIPTION
`mcpRegistries.getSetupDocs` now returns setup guide content with the OAuth callback URL substituted in.

## Why

Published guides ship with a `{{ gram.oauth.callback_url }}` template key everywhere the reader has to paste a redirect URI into an upstream provider's OAuth app. Until now the endpoint served that key verbatim, so the reader had to go find the value.

## What the key resolves to

`<server-url>/mcp/remote_login_callback`: the single stable redirect URI Gram registers with every upstream provider, whatever the MCP server or slug (`canonicalCallbackRouteBase` in `remotesessions/challenge.go`). It is the same value the **Attach Remote Identity Provider** sheet shows back to the operator, which is what one guide step tells the reader to check it against.

## How

- `externalmcp.Service` takes `serverURL *url.URL` by constructor injection, matching `collections`, `instances`, `mcp`, `oauth`, and `remotesessions`.
- `GetSetupDocs` derives the callback URL per request and threads it through `resolveSetupGuides` into `toMCPSetupGuide`, which calls the SDK's `RenderExternal` / `RenderSpeakeasy`.
- The value is derived from the server URL at the call site rather than shared from `remotesessions`, the same way `oauth/impl.go` and the dashboard's `externalMcpUserSessions.ts` do it. The URL is deliberately frozen (a back-compat shim exists precisely because changing it breaks registered upstream apps), and importing the `remotesessions` service package for one string would pull encryption, guardian, environments, and customdomains into a small read-only service.
- Bumps `mcp-setup-docs/go` from v0.1.4 to v0.3.0, which is where the renderers land.

## Tests

`setupDocsFixture` now also requires its guide to carry the template key, so the existing round-trip test observes a real substitution: it compares each markdown field against `Render*(vars)`, asserts neither field still contains the key, and asserts the callback URL is present. 8 of the 18 published guides satisfy the fixture's conditions, so the added constraint has margin.

`mise run lint:server`, `go build ./server/...`, and `go test ./server/internal/externalmcp/` all pass.
