### PR TITLE
feat: meter OTEL-invisible codex cloud surfaces from compliance COSTS

### DIFF
--- a/.changeset/codex-cloud-token-metering.md
+++ b/.changeset/codex-cloud-token-metering.md
@@ -2,13 +2,8 @@
 "server": minor
 ---
 
-Meter OTEL-invisible Codex cloud surfaces from the compliance COSTS feed
-(DNO-751). Codex rows whose payload.client is on the cloud allowlist (github,
-web) now promote their preserved codex.compliance.\*\_tokens counts to
-gen_ai.usage.\* and count toward usage metering and TUM — these surfaces
-(GitHub code review, Codex web tasks) have no OTEL stream, so the compliance
-feed is their only token source. Device clients (cli, exec) stay cost-only
-(OTEL remains their token source of truth) and ambiguous clients
-(desktop_app, unknown) stay un-metered until desktop OTEL coverage is
-verified; the allowlist means new surfaces default to un-metered rather than
-double counting.
+Meter Codex cloud usage (GitHub code review, web tasks) from the compliance
+COSTS feed — those surfaces have no OTEL stream, so their token counts now
+promote to `gen_ai.usage.*` and count toward TUM. Device clients keep
+metering via OTEL, and unrecognized clients stay un-metered so a new surface
+cannot silently double count.

--- a/.changeset/codex-cloud-token-metering.md
+++ b/.changeset/codex-cloud-token-metering.md
@@ -1,0 +1,14 @@
+---
+"server": minor
+---
+
+Meter OTEL-invisible Codex cloud surfaces from the compliance COSTS feed
+(DNO-751). Codex rows whose payload.client is on the cloud allowlist (github,
+web) now promote their preserved codex.compliance.\*\_tokens counts to
+gen_ai.usage.\* and count toward usage metering and TUM — these surfaces
+(GitHub code review, Codex web tasks) have no OTEL stream, so the compliance
+feed is their only token source. Device clients (cli, exec) stay cost-only
+(OTEL remains their token source of truth) and ambiguous clients
+(desktop_app, unknown) stay un-metered until desktop OTEL coverage is
+verified; the allowlist means new surfaces default to un-metered rather than
+double counting.

--- a/server/internal/aiintegrations/codex_cost_import.go
+++ b/server/internal/aiintegrations/codex_cost_import.go
@@ -51,6 +51,22 @@ const (
 	codexCreditValueUSD         = 0.04
 )
 
+// codexCloudMeteredClients are the payload.client values whose Codex usage
+// executes in OpenAI's cloud and is therefore invisible to the OTEL stream —
+// the compliance feed is their only token source, so those rows are metered
+// here. Deliberately an allowlist: an unrecognized client defaults to
+// un-metered, because under-counting a new surface beats double counting a
+// device one. cli/exec meter via OTEL; desktop_app and unknown stay excluded
+// until DNO-737 settles whether the unified desktop app exports OTEL.
+var codexCloudMeteredClients = map[string]bool{
+	"github": true,
+	"web":    true,
+}
+
+func codexCloudMeteredClient(client string) bool {
+	return codexCloudMeteredClients[strings.ToLower(strings.TrimSpace(client))]
+}
+
 type codexComplianceClient interface {
 	ListLogs(ctx context.Context, params codexapi.ListLogsParams) (*codexapi.LogsPage, error)
 	DownloadLog(ctx context.Context, logID string) ([]byte, error)
@@ -380,15 +396,17 @@ func buildCodexCostEventLogParam(cfg Config, file codexapi.LogFile, event codexC
 	if cfg.ExternalOrganizationID != nil {
 		addStringAttr(attrs, attr.ExternalOrgIDKey, *cfg.ExternalOrganizationID)
 	}
-	// Codex rows meter cost only: the codex:usage URN is admitted by the
-	// ClickHouse agent-usage predicates, so gen_ai.usage token counts here
-	// would double count metering for orgs that also export the Codex OTEL
-	// stream — the token source of truth for Codex. The raw counts are still
-	// preserved under codex.compliance.* keys (which nothing sums) because the
-	// feed also covers surfaces OTEL never sees (cloud-delegated tasks, GitHub
-	// code review); a later surface-partitioned metering pass can promote
-	// them. Parked non-Codex rows keep gen_ai.usage token counts because the
-	// compliance feed is ChatGPT/Work's only usage source.
+	// Codex token metering is surface-partitioned (DNO-736/DNO-751). Device
+	// surfaces (cli, exec) meter through the Codex OTEL stream — the token
+	// source of truth — so their compliance rows stay cost-only: gen_ai.usage
+	// counts here would double count for orgs that also export OTEL. Cloud
+	// surfaces OTEL never sees (GitHub code review, web tasks) have tokens
+	// ONLY in this feed, so their rows promote the counts to gen_ai.usage.*
+	// and meter (and bill TUM) from here. The raw codex.compliance.* copies
+	// (which nothing sums) ride on every Codex row regardless, so un-promoted
+	// surfaces stay inspectable. Parked non-Codex rows keep gen_ai.usage
+	// token counts because the compliance feed is ChatGPT/Work's only usage
+	// source.
 	if isCodex {
 		if usage.TextInputTokens > 0 {
 			attrs[attr.CodexComplianceInputTokensKey] = usage.TextInputTokens
@@ -402,7 +420,8 @@ func buildCodexCostEventLogParam(cfg Config, file codexapi.LogFile, event codexC
 		if totalTokens > 0 {
 			attrs[attr.CodexComplianceTotalTokensKey] = totalTokens
 		}
-	} else {
+	}
+	if !isCodex || codexCloudMeteredClient(event.Payload.Client) {
 		if usage.TextInputTokens > 0 {
 			attrs[attr.GenAIUsageInputTokensKey] = usage.TextInputTokens
 		}

--- a/server/internal/aiintegrations/codex_cost_import_test.go
+++ b/server/internal/aiintegrations/codex_cost_import_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,14 +65,13 @@ func TestBuildCodexCostLogParamsVerifiesSHAAndMapsTelemetry(t *testing.T) {
 	require.Equal(t, "GPT-5.5 - Output,GPT-5.5 - Input,GPT-5.5 - Cached Input", attrs[attr.CodexComplianceBillingSKUsKey])
 	require.Equal(t, "org-openai", attrs[attr.ExternalOrgIDKey])
 	require.Equal(t, "gpt-5.5", attrs[attr.GenAIResponseModelKey])
-	// Codex rows meter cost only: gen_ai.usage token counts would double
-	// count metering against the Codex OTEL stream, the token source of
-	// truth. The raw counts are preserved under codex.compliance.* keys,
-	// which nothing sums.
-	require.NotContains(t, attrs, attr.GenAIUsageInputTokensKey)
-	require.NotContains(t, attrs, attr.GenAIUsageCacheReadInputTokensKey)
-	require.NotContains(t, attrs, attr.GenAIUsageOutputTokensKey)
-	require.NotContains(t, attrs, attr.GenAIUsageTotalTokensKey)
+	// client=github is a cloud surface OTEL never sees, so this row promotes
+	// its token counts to gen_ai.usage.* and meters from the compliance feed
+	// (DNO-751); the raw codex.compliance.* copies still ride along.
+	require.Equal(t, int64(75348), attrs[attr.GenAIUsageInputTokensKey])
+	require.Equal(t, int64(879616), attrs[attr.GenAIUsageCacheReadInputTokensKey])
+	require.Equal(t, int64(4858), attrs[attr.GenAIUsageOutputTokensKey])
+	require.Equal(t, int64(959822), attrs[attr.GenAIUsageTotalTokensKey])
 	require.Equal(t, int64(75348), attrs[attr.CodexComplianceInputTokensKey])
 	require.Equal(t, int64(879616), attrs[attr.CodexComplianceCachedInputTokensKey])
 	require.Equal(t, int64(4858), attrs[attr.CodexComplianceOutputTokensKey])
@@ -356,4 +356,53 @@ func TestBuildCodexCostLogParamsStampsConfigBillingMode(t *testing.T) {
 	chatgptRow := logParams[1]
 	require.Equal(t, complianceAccountTypeTeam, chatgptRow.Attributes[attr.AccountTypeKey])
 	require.NotContains(t, chatgptRow.Attributes, attr.BillingModeKey)
+}
+
+// TestBuildCodexCostLogParamsPartitionsMeteringByClient pins the DNO-751
+// surface partition: cloud clients (github, web) promote token counts to
+// gen_ai.usage.* and meter from the compliance feed; device clients (cli,
+// exec) meter via OTEL so their rows stay cost-only, and ambiguous clients
+// (desktop_app, unknown, absent) default to un-metered — the allowlist means
+// a new surface can never silently double count.
+func TestBuildCodexCostLogParamsPartitionsMeteringByClient(t *testing.T) {
+	t.Parallel()
+
+	cfg := codexCostConfig()
+	promoted := map[string]bool{"github": true, "web": true, "GitHub": true}
+	for _, client := range []string{"github", "web", "GitHub", "cli", "exec", "desktop_app", "unknown", ""} {
+		clientField := ""
+		if client != "" {
+			clientField = `"client":"` + client + `",`
+		}
+		body := []byte(`{"event_id":"event_` + strings.ToLower(strings.TrimSpace(client)) + `_partition","type":"COSTS","timestamp":"2026-07-19T15:59:59Z","payload":{"identity":{"user_id":"user_1","email":"dev@example.com"},"product":"codex",` + clientField + `"measures":{"usage":{"text_input_tokens":100,"text_cached_input_tokens":40,"text_output_tokens":10},"billing":[]}}}` + "\n")
+		file := codexapi.LogFile{
+			ID:         "eclf_partition",
+			EventType:  codexComplianceCostsEventType,
+			EndTime:    time.Date(2026, 7, 19, 16, 0, 0, 0, time.UTC),
+			FileName:   "COSTS_2026-07-19T16:00:00.000000+00:00.jsonl",
+			FileSize:   int64(len(body)),
+			FileSHA256: "",
+		}
+
+		logParams, err := buildCodexCostLogParams(cfg, file, body)
+		require.NoError(t, err, client)
+		require.Len(t, logParams, 1, client)
+		attrs := logParams[0].Attributes
+
+		// Raw copies ride on every codex row regardless of promotion.
+		require.Equal(t, int64(100), attrs[attr.CodexComplianceInputTokensKey], client)
+		require.Equal(t, int64(150), attrs[attr.CodexComplianceTotalTokensKey], client)
+
+		if promoted[client] {
+			require.Equal(t, int64(100), attrs[attr.GenAIUsageInputTokensKey], client)
+			require.Equal(t, int64(40), attrs[attr.GenAIUsageCacheReadInputTokensKey], client)
+			require.Equal(t, int64(10), attrs[attr.GenAIUsageOutputTokensKey], client)
+			require.Equal(t, int64(150), attrs[attr.GenAIUsageTotalTokensKey], client)
+		} else {
+			require.NotContains(t, attrs, attr.GenAIUsageInputTokensKey, client)
+			require.NotContains(t, attrs, attr.GenAIUsageCacheReadInputTokensKey, client)
+			require.NotContains(t, attrs, attr.GenAIUsageOutputTokensKey, client)
+			require.NotContains(t, attrs, attr.GenAIUsageTotalTokensKey, client)
+		}
+	}
 }

--- a/server/internal/aiintegrations/codex_cost_import_test.go
+++ b/server/internal/aiintegrations/codex_cost_import_test.go
@@ -368,6 +368,13 @@ func TestBuildCodexCostLogParamsPartitionsMeteringByClient(t *testing.T) {
 	t.Parallel()
 
 	cfg := codexCostConfig()
+
+	// Pin the production allowlist itself: expectations below are hand-declared
+	// on purpose (deriving them from codexCloudMeteredClients would make the
+	// assertions tautological), so this equality check is what forces anyone
+	// adding a surface to consciously extend the client list and expectations.
+	require.Equal(t, map[string]bool{"github": true, "web": true}, codexCloudMeteredClients)
+
 	promoted := map[string]bool{"github": true, "web": true, "GitHub": true}
 	for _, client := range []string{"github", "web", "GitHub", "cli", "exec", "desktop_app", "unknown", ""} {
 		clientField := ""


### PR DESCRIPTION
Closes DNO-751 (from the DNO-736 investigation).

Codex cloud usage — GitHub code review and web tasks — executes on OpenAI's infrastructure and has no OTEL stream; its tokens exist only in the compliance COSTS feed, where DNO-733 parked them un-metered under `codex.compliance.*_tokens` to avoid double-counting device usage.

## What changed

`buildCodexCostEventLogParam` now promotes those counts to `gen_ai.usage.*` for codex-product rows whose `payload.client` is on a cloud **allowlist** (`github`, `web`), so cloud usage meters and bills TUM (decision confirmed: log-only integrations count, same as Claude desktop/cloud).

- **Allowlist, not denylist**: an unrecognized client defaults to un-metered — under-counting a new surface beats double-counting a device one.
- `cli`/`exec` stay cost-only: OTEL remains their token source of truth (the DNO-733 invariant).
- `desktop_app`/`unknown` stay un-metered until DNO-737 settles whether the unified desktop app exports OTEL.
- Promoted input counts are already disjoint from cached (compliance semantics: `total = input + cached + output`), matching the canonical shape the metering MV's generic `gen_ai.usage.*` branch expects. Promoted cache-read counts stay out of TUM by definition (TUM = input + output + cache writes).
- Raw `codex.compliance.*` copies still ride on every codex row, so un-promoted surfaces stay inspectable.

Not changed: the `schema.sql` comments describing codex:usage rows as "cost-only since DNO-733" live inside the `attribute_metrics_summaries_mv` SELECT body — updating prose there is a DDL diff requiring a MODIFY QUERY migration, so the wording will be refreshed with the next real MV migration instead.

## Testing

The full-fixture mapping test now asserts promotion (its fixture is client=github), the product-routing test pins the un-promoted `exec` row, and a new partition test sweeps `github`/`web`/`GitHub` (case-insensitive) vs `cli`/`exec`/`desktop_app`/`unknown`/absent. Full `aiintegrations` suite + `mise lint:server` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Meters OTEL-invisible Codex cloud usage by promoting `codex.compliance.*_tokens` to `gen_ai.usage.*` for allowlisted clients, enabling TUM billing for GitHub code review and web tasks. Addresses DNO-751 and avoids double-counting for device clients; tests pin the cloud allowlist to prevent silent changes.

- **New Features**
  - Promotes token counts in `buildCodexCostEventLogParam` for cloud clients `github` and `web` (case-insensitive, trimmed) so these surfaces meter and bill TUM.
  - Keeps `cli` and `exec` cost-only; leaves `desktop_app`, `unknown`, and absent client unmetered by default.
  - Always includes raw `codex.compliance.*` counts on Codex rows; tests assert promotion/non-promotion and pin the allowlist with an explicit map check (including `GitHub` casing).

<sup>Written for commit c3ff86d9a801d32d42e37edc3a981ba8203ee665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

