### PR TITLE
feat: import codex cloud task transcripts as agent sessions

### DIFF
--- a/.changeset/codex-cloud-transcript-import.md
+++ b/.changeset/codex-cloud-transcript-import.md
@@ -1,0 +1,16 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Import Codex cloud task transcripts as agent sessions (DNO-752). A new
+codex_cloud_sessions schedule on the chatgpt_compliance integration polls the
+workspace-scoped CODEX_LOG compliance feed and persists cloud web-task
+prompts and responses as external chats + messages under the new codex-web
+chat source, with prompt-derived titles and idempotent replays. Only
+CODEX_WEB client events are imported (desktop-app events are counted and
+skipped pending the unified-app verification), and the feed's per-turn token
+counts are deliberately not persisted — cloud tokens meter through the
+compliance COSTS promotion, so carrying them here would double count.
+Enforcement over cloud runs remains impossible (post-hoc batch feed); this
+provides visibility and post-hoc review only.

--- a/.changeset/codex-cloud-transcript-import.md
+++ b/.changeset/codex-cloud-transcript-import.md
@@ -13,4 +13,8 @@ skipped pending the unified-app verification), and the feed's per-turn token
 counts are deliberately not persisted — cloud tokens meter through the
 compliance COSTS promotion, so carrying them here would double count.
 Enforcement over cloud runs remains impossible (post-hoc batch feed); this
-provides visibility and post-hoc review only.
+provides visibility and post-hoc review only. Also fixes a latent
+multi-schedule reset gap: a key or external-scope change on an integration
+now resets every synced sibling schedule's watermark (previously only the
+provider-named schedule reset, so a workspace/org change could leave a
+sibling feed silently skipping the new scope's history).

--- a/client/dashboard/src/lib/formatPlatform.test.ts
+++ b/client/dashboard/src/lib/formatPlatform.test.ts
@@ -20,6 +20,11 @@ describe("formatPlatform", () => {
   it("uses canonical labels for other known surfaces", () => {
     expect(formatPlatform("cursor")).toBe("Cursor");
     expect(formatPlatform("codex")).toBe("Codex");
+    // Codex cloud tasks import under their own surface, kept separate from
+    // the device-captured Codex agent.
+    expect(formatPlatform("codex-web")).toBe("Codex Web");
+    expect(formatPlatform("Codex Web")).toBe("Codex Web");
+    expect(formatPlatform("CODEX_WEB")).toBe("Codex Web");
     expect(formatPlatform("chatgpt")).toBe("ChatGPT");
     expect(formatPlatform("ChatGPT")).toBe("ChatGPT");
     expect(formatPlatform("chatgpt-work")).toBe("ChatGPT Work");

--- a/client/dashboard/src/lib/formatPlatform.ts
+++ b/client/dashboard/src/lib/formatPlatform.ts
@@ -18,6 +18,7 @@ const PRODUCT_SURFACE_LABELS: Record<string, string> = {
   "claude-cowork": "Claude Cowork",
   cursor: "Cursor",
   codex: "Codex",
+  "codex-web": "Codex Web",
   // ChatGPT (web/desktop chat) and ChatGPT Work, observed via the OpenAI
   // compliance import — distinct surfaces from the Codex agent, split at
   // ingest by hook_source so they stay separable in the summaries.

--- a/client/dashboard/src/pages/org/ai-integration-providers.tsx
+++ b/client/dashboard/src/pages/org/ai-integration-providers.tsx
@@ -311,6 +311,16 @@ const CHATGPT_AI_INTEGRATION: AIIntegrationProvider = {
       signal: "chatgpt.chat.message",
       destination: { label: "Agent Sessions", path: "agent-sessions" },
     },
+    {
+      schedule: "codex_cloud_sessions",
+      name: "Codex cloud task transcripts",
+      description:
+        "Imports Codex cloud web-task prompts and responses from Compliance Logs files for review.",
+      cadence: "Every 5m",
+      kind: "events",
+      signal: "codex.cloud.chat.message",
+      destination: { label: "Agent Sessions", path: "agent-sessions" },
+    },
   ],
   onboardingDescription:
     "Connect OpenAI's Compliance Logs API so the platform can import ChatGPT conversations for review workflows.",

--- a/server/internal/aiintegrations/chatgpt_conversation_import.go
+++ b/server/internal/aiintegrations/chatgpt_conversation_import.go
@@ -472,6 +472,8 @@ func (src *chatgptConversationSource) upsertConversationChat(ctx context.Context
 		Title:          conv.ToPGTextEmpty(state.title),
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),
 		UpdatedAt:      conv.ToPGTimestamptz(createdAt),
+		// Feed titles are authoritative: newest non-null title wins.
+		PreferStoredTitle: false,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "upsert chatgpt compliance chat")

--- a/server/internal/aiintegrations/codex_cloud_import.go
+++ b/server/internal/aiintegrations/codex_cloud_import.go
@@ -155,15 +155,15 @@ func (s *CodexCloudImportService) SyncCodexCloudSessions(ctx context.Context, cf
 	}
 
 	source := &codexCloudSource{
-		client:     codexapi.NewWorkspaceClient(s.guardianPolicy, *cfg.ExternalOrganizationID, codexapi.WithAPIKey(cfg.APIKey)),
-		svc:        s,
-		cfg:        cfg,
-		pageLimit:  codexCloudPageLimit,
-		users:      newConnectedUserResolver(s.db, cfg.OrganizationID),
-		chatIDs:    map[string]uuid.UUID{},
-		chatTitles: map[string]string{},
-		progressMu: sync.Mutex{},
-		progress:   progress,
+		client:         codexapi.NewWorkspaceClient(s.guardianPolicy, *cfg.ExternalOrganizationID, codexapi.WithAPIKey(cfg.APIKey)),
+		svc:            s,
+		cfg:            cfg,
+		pageLimit:      codexCloudPageLimit,
+		users:          newConnectedUserResolver(s.db, cfg.OrganizationID),
+		chatIDs:        map[string]uuid.UUID{},
+		titledSessions: map[string]bool{},
+		progressMu:     sync.Mutex{},
+		progress:       progress,
 	}
 
 	runner := &timewindowpoller.Poller[[]codexapi.LogFile]{
@@ -203,12 +203,13 @@ type codexCloudSource struct {
 	pageLimit int
 	users     *connectedUserResolver
 	// chatIDs caches session id -> chat row id for the run so link rows and
-	// id lookups happen once per session, not once per event. chatTitles
-	// remembers which sessions have a title recorded this run, so a prompt
-	// arriving in a later file than the session's first upsert still lands
-	// its title (the feed itself carries none).
-	chatIDs    map[string]uuid.UUID
-	chatTitles map[string]string
+	// id lookups happen once per session, not once per event. titledSessions
+	// marks the sessions that have already been offered a title this run, so
+	// a prompt arriving in a later file than the session's first upsert still
+	// lands its title (the feed itself carries none) while later prompts for
+	// the same session skip a re-upsert the first-wins query would ignore.
+	chatIDs        map[string]uuid.UUID
+	titledSessions map[string]bool
 	// progressMu guards progress: the poller pipelines FetchPage (producer
 	// goroutine) with ProcessPage (consumer goroutine), and both record
 	// progress.
@@ -346,13 +347,14 @@ func (src *codexCloudSource) RetryAfter(err error) (time.Duration, bool) {
 }
 
 // codexCloudSessionState carries per-session metadata accumulated across one
-// file's events: the earliest admitted event (its timestamp approximates the
-// session start within the window), the newest one (freshest actor identity),
-// and the first prompt text seen, which seeds the chat title.
+// file's events: the earliest admitted event's resolved timestamp (which
+// approximates the session start within the window), the newest event
+// (freshest actor identity), and the first prompt text seen, which seeds the
+// chat title.
 type codexCloudSessionState struct {
-	first       codexCloudEvent
-	latest      codexCloudEvent
-	firstPrompt string
+	firstCreatedAt time.Time
+	latest         codexCloudEvent
+	firstPrompt    string
 }
 
 // writeFile persists one log file's web-task events: each session is upserted
@@ -370,6 +372,12 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 	order := make([]string, 0, len(events))
 	skippedClients, skippedDetails := 0, 0
 	admitted := make([]codexCloudEvent, 0, len(events))
+	// Each admitted event's timestamp is resolved exactly once, here, and then
+	// reused by both the chat row and the event's message row: resolving it
+	// per reader would count a single malformed value twice in the
+	// TimestampFallbacks canary.
+	admittedAt := make([]time.Time, 0, len(events))
+	fallbacksBefore := src.timestampFallbacks()
 	for _, event := range events {
 		if !strings.EqualFold(strings.TrimSpace(event.ClientID), codexCloudClientWeb) {
 			skippedClients++
@@ -383,10 +391,12 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 		if event.EventDetails.SessionID == "" || event.EventID == "" {
 			continue
 		}
+		createdAt := src.eventCreatedAt(event)
 		admitted = append(admitted, event)
+		admittedAt = append(admittedAt, createdAt)
 		state, ok := sessions[event.EventDetails.SessionID]
 		if !ok {
-			state = &codexCloudSessionState{first: event, latest: event, firstPrompt: ""}
+			state = &codexCloudSessionState{firstCreatedAt: createdAt, latest: event, firstPrompt: ""}
 			sessions[event.EventDetails.SessionID] = state
 			order = append(order, event.EventDetails.SessionID)
 		}
@@ -403,15 +413,20 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 		src.progress.SkippedDetails += skippedDetails
 		src.progressMu.Unlock()
 	}
+	if fallbacks := src.timestampFallbacks() - fallbacksBefore; fallbacks > 0 {
+		src.svc.logger.WarnContext(ctx, "codex cloud event timestamps failed to parse; messages stamped with import time",
+			attr.SlogFilePath(file.FileName),
+			attr.SlogCodexCloudTimestampFallbacks(fallbacks),
+		)
+	}
 	for _, sessionID := range order {
 		if err := src.upsertSessionChat(ctx, sessionID, sessions[sessionID]); err != nil {
 			return err
 		}
 	}
 
-	fallbacksBefore := src.timestampFallbacks()
 	rows := make([]chatrepo.CreateExternalChatMessageParams, 0, len(admitted))
-	for _, event := range admitted {
+	for i, event := range admitted {
 		var role, content string
 		switch event.EventDetails.DetailType {
 		case codexCloudDetailPromptSent:
@@ -458,14 +473,8 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 			Source:      conv.ToPGText(codexCloudSourceSlug),
 			ContentHash: nil,
 			Generation:  0,
-			CreatedAt:   conv.ToPGTimestamptz(src.eventCreatedAt(event)),
+			CreatedAt:   conv.ToPGTimestamptz(admittedAt[i]),
 		})
-	}
-	if fallbacks := src.timestampFallbacks() - fallbacksBefore; fallbacks > 0 {
-		src.svc.logger.WarnContext(ctx, "codex cloud event timestamps failed to parse; messages stamped with import time",
-			attr.SlogFilePath(file.FileName),
-			attr.SlogCodexCloudTimestampFallbacks(fallbacks),
-		)
 	}
 	if len(rows) == 0 {
 		return nil
@@ -486,9 +495,9 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 
 // upsertSessionChat writes the session's chat row with a prompt-derived title
 // (the feed itself carries none). A session already upserted this run is
-// re-upserted only when a title has newly become available — a PROMPT_SENT
-// can land in a later file than the session's first-seen (response-only)
-// window — and the query's COALESCE preserves stored titles on replays.
+// re-upserted only once a title first becomes available — a PROMPT_SENT can
+// land in a later file than the session's first-seen (response-only) window —
+// and the query's COALESCE preserves stored titles on replays.
 // The chat's created_at comes from the window's earliest admitted event, the
 // closest available approximation of the session start.
 //
@@ -500,11 +509,14 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 func (src *codexCloudSource) upsertSessionChat(ctx context.Context, sessionID string, state *codexCloudSessionState) error {
 	title := codexCloudChatTitle(state.firstPrompt)
 	_, known := src.chatIDs[sessionID]
-	if known && (title == "" || title == src.chatTitles[sessionID]) {
+	// A title already offered this run is terminal: the query is first-wins,
+	// so no later prompt can change what is stored and re-upserting for one
+	// would only burn a write.
+	if known && (title == "" || src.titledSessions[sessionID]) {
 		return nil
 	}
 
-	createdAt := src.parseEventTime(state.first.Timestamp, time.Now())
+	createdAt := state.firstCreatedAt
 	userID, err := src.users.resolve(ctx, state.latest.Actor.UserEmail)
 	if err != nil {
 		return err
@@ -544,15 +556,17 @@ func (src *codexCloudSource) upsertSessionChat(ctx context.Context, sessionID st
 
 	src.chatIDs[sessionID] = chatID
 	if title != "" {
-		src.chatTitles[sessionID] = title
+		src.titledSessions[sessionID] = true
 	}
 	return nil
 }
 
-// eventCreatedAt resolves a message event's timestamp, counting a fallback to
-// import time — the outcome that rewrites chronology — as a canary for
-// upstream format changes. Used for message rows, where every event is
-// expected to carry a timestamp, so absence counts too.
+// eventCreatedAt resolves an admitted event's timestamp, counting a fallback
+// to import time — the outcome that rewrites chronology — as a canary for
+// upstream format changes. Every event is expected to carry a timestamp, so
+// absence counts too. Called once per admitted event (see writeFile), whose
+// result both the chat row and the message row read, so one bad value cannot
+// count twice.
 func (src *codexCloudSource) eventCreatedAt(event codexCloudEvent) time.Time {
 	if event.Timestamp != "" {
 		if t, err := time.Parse(time.RFC3339, event.Timestamp); err == nil {
@@ -563,24 +577,6 @@ func (src *codexCloudSource) eventCreatedAt(event codexCloudEvent) time.Time {
 	src.progress.TimestampFallbacks++
 	src.progressMu.Unlock()
 	return time.Now().UTC()
-}
-
-// parseEventTime resolves the chat row's timestamp with template semantics:
-// an absent value takes the fallback silently (expected, and the same event
-// already counted once on the message path), while a present-yet-malformed
-// value counts as a format-change canary.
-func (src *codexCloudSource) parseEventTime(value string, fallback time.Time) time.Time {
-	if value == "" {
-		return fallback.UTC()
-	}
-	t, err := time.Parse(time.RFC3339, value)
-	if err != nil {
-		src.progressMu.Lock()
-		src.progress.TimestampFallbacks++
-		src.progressMu.Unlock()
-		return fallback.UTC()
-	}
-	return t.UTC()
 }
 
 func (src *codexCloudSource) timestampFallbacks() int {

--- a/server/internal/aiintegrations/codex_cloud_import.go
+++ b/server/internal/aiintegrations/codex_cloud_import.go
@@ -41,11 +41,13 @@ const (
 	// live device sessions captured by hooks/OTEL.
 	codexCloudSourceSlug = "codex-web"
 	// codexCloudClientWeb is the client_id marking cloud web-task events —
-	// the only client this import admits. CODEX_DESKTOP_APP events also
-	// appear (trace volume) but describe a device surface that may gain hook
-	// capture; importing them here could collide with live-captured sessions
-	// (same session-id UUID space), so they are counted and skipped until the
-	// unified-desktop-app verification settles that boundary.
+	// the only client this import admits. The feed also carries DEVICE
+	// clients (CODEX_CLI became its dominant client in early August 2026,
+	// plus CODEX_DESKTOP_APP and CODEX_SDK_TS): those sessions are hook/OTEL
+	// captured live, and importing them here would create a duplicate chat
+	// for every device session (same session-id UUID space). This allowlist
+	// is the sole guard against that duplication, so SkippedClients running
+	// hot is expected, not a fault.
 	codexCloudClientWeb = "CODEX_WEB"
 	// Codex cloud event shapes: a prompt submission and the model's reply.
 	codexCloudDetailPromptSent       = "PROMPT_SENT"

--- a/server/internal/aiintegrations/codex_cloud_import.go
+++ b/server/internal/aiintegrations/codex_cloud_import.go
@@ -95,6 +95,14 @@ type CodexCloudSyncProgress struct {
 	// (tool calls, lifecycle events) that would otherwise import as silently
 	// incomplete transcripts.
 	SkippedDetails int `json:"skipped_details"`
+	// SkippedMissingIDs counts prompt/response events dropped because they
+	// carry no session id or event id — a canary for the feed dropping the
+	// fields the import is keyed on. Without it a feed that stopped emitting
+	// session_id would import nothing while every other counter read zero and
+	// the run reported success, which is indistinguishable from a quiet
+	// window. event_id is also the message dedupe key, so losing it silently
+	// would take replay safety with it.
+	SkippedMissingIDs int `json:"skipped_missing_ids"`
 	// TimestampFallbacks counts events whose timestamps failed RFC3339
 	// parsing and fell back to import time — a canary for upstream format
 	// changes that would otherwise silently rewrite history chronology.
@@ -150,6 +158,7 @@ func (s *CodexCloudImportService) SyncCodexCloudSessions(ctx context.Context, cf
 		ChatsUpserted:      0,
 		SkippedClients:     0,
 		SkippedDetails:     0,
+		SkippedMissingIDs:  0,
 		TimestampFallbacks: 0,
 		WatermarkReached:   cfg.PollWatermarkAt,
 	}
@@ -378,6 +387,7 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 	// TimestampFallbacks canary.
 	admittedAt := make([]time.Time, 0, len(events))
 	fallbacksBefore := src.timestampFallbacks()
+	skippedMissingIDs := 0
 	for _, event := range events {
 		if !strings.EqualFold(strings.TrimSpace(event.ClientID), codexCloudClientWeb) {
 			skippedClients++
@@ -389,6 +399,7 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 			continue
 		}
 		if event.EventDetails.SessionID == "" || event.EventID == "" {
+			skippedMissingIDs++
 			continue
 		}
 		createdAt := src.eventCreatedAt(event)
@@ -407,10 +418,11 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 			state.firstPrompt = strings.TrimSpace(event.EventDetails.PromptText)
 		}
 	}
-	if skippedClients > 0 || skippedDetails > 0 {
+	if skippedClients > 0 || skippedDetails > 0 || skippedMissingIDs > 0 {
 		src.progressMu.Lock()
 		src.progress.SkippedClients += skippedClients
 		src.progress.SkippedDetails += skippedDetails
+		src.progress.SkippedMissingIDs += skippedMissingIDs
 		src.progressMu.Unlock()
 	}
 	if fallbacks := src.timestampFallbacks() - fallbacksBefore; fallbacks > 0 {

--- a/server/internal/aiintegrations/codex_cloud_import.go
+++ b/server/internal/aiintegrations/codex_cloud_import.go
@@ -67,14 +67,12 @@ type codexCloudEvent struct {
 		UserEmail string `json:"user_email"`
 	} `json:"actor"`
 	EventDetails struct {
-		DetailType      string `json:"detail_type"`
-		SessionID       string `json:"session_id"`
-		Model           string `json:"model"`
-		PromptText      string `json:"prompt_text"`
-		ResponseText    string `json:"response_text"`
-		Status          string `json:"status"`
-		ServiceTier     string `json:"service_tier"`
-		ReasoningEffort string `json:"reasoning_effort"`
+		DetailType   string `json:"detail_type"`
+		SessionID    string `json:"session_id"`
+		Model        string `json:"model"`
+		PromptText   string `json:"prompt_text"`
+		ResponseText string `json:"response_text"`
+		Status       string `json:"status"`
 	} `json:"event_details"`
 }
 
@@ -90,6 +88,11 @@ type CodexCloudSyncProgress struct {
 	// CODEX_WEB (see codexCloudClientWeb) — a canary for new cloud surfaces
 	// appearing in the feed.
 	SkippedClients int `json:"skipped_clients"`
+	// SkippedDetails counts web events dropped because their detail_type is
+	// not a known prompt/response shape — a canary for new event kinds
+	// (tool calls, lifecycle events) that would otherwise import as silently
+	// incomplete transcripts.
+	SkippedDetails int `json:"skipped_details"`
 	// TimestampFallbacks counts events whose timestamps failed RFC3339
 	// parsing and fell back to import time — a canary for upstream format
 	// changes that would otherwise silently rewrite history chronology.
@@ -144,6 +147,7 @@ func (s *CodexCloudImportService) SyncCodexCloudSessions(ctx context.Context, cf
 		MessagesWritten:    0,
 		ChatsUpserted:      0,
 		SkippedClients:     0,
+		SkippedDetails:     0,
 		TimestampFallbacks: 0,
 		WatermarkReached:   cfg.PollWatermarkAt,
 	}
@@ -155,6 +159,7 @@ func (s *CodexCloudImportService) SyncCodexCloudSessions(ctx context.Context, cf
 		pageLimit:  codexCloudPageLimit,
 		users:      newConnectedUserResolver(s.db, cfg.OrganizationID),
 		chatIDs:    map[string]uuid.UUID{},
+		chatTitles: map[string]string{},
 		progressMu: sync.Mutex{},
 		progress:   progress,
 	}
@@ -196,8 +201,12 @@ type codexCloudSource struct {
 	pageLimit int
 	users     *connectedUserResolver
 	// chatIDs caches session id -> chat row id for the run so link rows and
-	// id lookups happen once per session, not once per event.
-	chatIDs map[string]uuid.UUID
+	// id lookups happen once per session, not once per event. chatTitles
+	// remembers which sessions have a title recorded this run, so a prompt
+	// arriving in a later file than the session's first upsert still lands
+	// its title (the feed itself carries none).
+	chatIDs    map[string]uuid.UUID
+	chatTitles map[string]string
 	// progressMu guards progress: the poller pipelines FetchPage (producer
 	// goroutine) with ProcessPage (consumer goroutine), and both record
 	// progress.
@@ -206,7 +215,9 @@ type codexCloudSource struct {
 }
 
 func (src *codexCloudSource) UpperBound(ctx context.Context, endTime time.Time) (time.Time, error) {
-	after := codexCloudUpperBoundStart(src.cfg, endTime)
+	// Same resume-precedence and lookback as the sibling workspace feed; one
+	// helper keeps the checkpoint/watermark semantics from drifting.
+	after := chatgptUpperBoundStart(src.cfg, endTime)
 	watermark := time.Time{}
 	for pageNum := 0; ; pageNum++ {
 		// The poller only heartbeats before UpperBound; a 30-day first sync
@@ -333,9 +344,11 @@ func (src *codexCloudSource) RetryAfter(err error) (time.Duration, bool) {
 }
 
 // codexCloudSessionState carries per-session metadata accumulated across one
-// file's events: the newest event (actor identity, timestamps) and the first
-// prompt text seen, which seeds the chat title.
+// file's events: the earliest admitted event (its timestamp approximates the
+// session start within the window), the newest one (freshest actor identity),
+// and the first prompt text seen, which seeds the chat title.
 type codexCloudSessionState struct {
+	first       codexCloudEvent
 	latest      codexCloudEvent
 	firstPrompt string
 }
@@ -343,18 +356,26 @@ type codexCloudSessionState struct {
 // writeFile persists one log file's web-task events: each session is upserted
 // as a chat, then every prompt/response lands in one batched write. The feed
 // carries no conversation titles, so a session's title derives from the first
-// prompt seen for it (truncated by runes, matching live capture); the
-// upsert's COALESCE preserves an existing title on replays and later files.
-// Non-web clients (CODEX_DESKTOP_APP) are counted and skipped — see
-// codexCloudClientWeb.
+// prompt seen for it (truncated by runes, matching live capture); a prompt
+// arriving in a later file still lands its title via a title-refresh
+// re-upsert, and the upsert's COALESCE preserves stored titles on replays.
+// Only prompt/response events on the web client are admitted: non-web clients
+// (CODEX_DESKTOP_APP) and unknown detail types are counted and skipped, so a
+// window carrying only lifecycle events can never create an empty, untitled
+// chat.
 func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFile, events []codexCloudEvent) error {
 	sessions := map[string]*codexCloudSessionState{}
 	order := make([]string, 0, len(events))
-	skipped := 0
+	skippedClients, skippedDetails := 0, 0
 	admitted := make([]codexCloudEvent, 0, len(events))
 	for _, event := range events {
 		if !strings.EqualFold(strings.TrimSpace(event.ClientID), codexCloudClientWeb) {
-			skipped++
+			skippedClients++
+			continue
+		}
+		if event.EventDetails.DetailType != codexCloudDetailPromptSent &&
+			event.EventDetails.DetailType != codexCloudDetailResponseReceived {
+			skippedDetails++
 			continue
 		}
 		if event.EventDetails.SessionID == "" || event.EventID == "" {
@@ -363,7 +384,7 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 		admitted = append(admitted, event)
 		state, ok := sessions[event.EventDetails.SessionID]
 		if !ok {
-			state = &codexCloudSessionState{latest: event, firstPrompt: ""}
+			state = &codexCloudSessionState{first: event, latest: event, firstPrompt: ""}
 			sessions[event.EventDetails.SessionID] = state
 			order = append(order, event.EventDetails.SessionID)
 		}
@@ -374,13 +395,14 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 			state.firstPrompt = strings.TrimSpace(event.EventDetails.PromptText)
 		}
 	}
-	if skipped > 0 {
+	if skippedClients > 0 || skippedDetails > 0 {
 		src.progressMu.Lock()
-		src.progress.SkippedClients += skipped
+		src.progress.SkippedClients += skippedClients
+		src.progress.SkippedDetails += skippedDetails
 		src.progressMu.Unlock()
 	}
 	for _, sessionID := range order {
-		if err := src.upsertSessionChat(ctx, sessions[sessionID]); err != nil {
+		if err := src.upsertSessionChat(ctx, sessionID, sessions[sessionID]); err != nil {
 			return err
 		}
 	}
@@ -395,6 +417,7 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 		case codexCloudDetailResponseReceived:
 			role, content = "assistant", event.EventDetails.ResponseText
 		default:
+			// Unreachable: admission above only passes the two shapes.
 			continue
 		}
 
@@ -439,7 +462,7 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 	if fallbacks := src.timestampFallbacks() - fallbacksBefore; fallbacks > 0 {
 		src.svc.logger.WarnContext(ctx, "codex cloud event timestamps failed to parse; messages stamped with import time",
 			attr.SlogFilePath(file.FileName),
-			attr.SlogChatGPTComplianceTimestampFallbacks(fallbacks),
+			attr.SlogCodexCloudTimestampFallbacks(fallbacks),
 		)
 	}
 	if len(rows) == 0 {
@@ -459,17 +482,27 @@ func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFil
 	return nil
 }
 
-// upsertSessionChat writes the session's chat row. The feed has no titles, so
-// a prompt-derived title is sent only on the first upsert of the run; the
-// query's COALESCE preserves any title already stored, so replays and later
-// files never clobber it.
-func (src *codexCloudSource) upsertSessionChat(ctx context.Context, state *codexCloudSessionState) error {
-	sessionID := state.latest.EventDetails.SessionID
-	if _, known := src.chatIDs[sessionID]; known {
+// upsertSessionChat writes the session's chat row with a prompt-derived title
+// (the feed itself carries none). A session already upserted this run is
+// re-upserted only when a title has newly become available — a PROMPT_SENT
+// can land in a later file than the session's first-seen (response-only)
+// window — and the query's COALESCE preserves stored titles on replays.
+// The chat's created_at comes from the window's earliest admitted event, the
+// closest available approximation of the session start.
+//
+// The title is deliberately a raw truncated prompt, not the DefaultChatTitle
+// sentinel the async LLM titler replaces: external imports never enter that
+// pipeline today, and a sentinel here would leave every chat titled "New
+// Chat" indefinitely. If imports ever join the titler, this divergence must
+// be revisited (a raw-prompt title reads as deliberately set and is skipped).
+func (src *codexCloudSource) upsertSessionChat(ctx context.Context, sessionID string, state *codexCloudSessionState) error {
+	title := codexCloudChatTitle(state.firstPrompt)
+	_, known := src.chatIDs[sessionID]
+	if known && (title == "" || title == src.chatTitles[sessionID]) {
 		return nil
 	}
 
-	createdAt := src.eventCreatedAt(state.latest)
+	createdAt := src.parseEventTime(state.first.Timestamp, time.Now())
 	userID, err := src.users.resolve(ctx, state.latest.Actor.UserEmail)
 	if err != nil {
 		return err
@@ -484,30 +517,36 @@ func (src *codexCloudSource) upsertSessionChat(ctx context.Context, state *codex
 		UserID:         conv.ToPGTextEmpty(userID),
 		ExternalUserID: conv.ToPGTextEmpty(state.latest.Actor.UserID),
 		ExternalChatID: conv.ToPGText(sessionID),
-		Title:          conv.ToPGTextEmpty(codexCloudChatTitle(state.firstPrompt)),
+		Title:          conv.ToPGTextEmpty(title),
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),
 		UpdatedAt:      conv.ToPGTimestamptz(createdAt),
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "upsert codex cloud chat")
 	}
-	if _, err := chatrepo.New(src.svc.db).LinkAIIntegrationConfigChat(ctx, chatrepo.LinkAIIntegrationConfigChatParams{
-		AiIntegrationConfigID: src.cfg.ID,
-		ChatID:                chatID,
-	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "link codex cloud chat")
+	if !known {
+		if _, err := chatrepo.New(src.svc.db).LinkAIIntegrationConfigChat(ctx, chatrepo.LinkAIIntegrationConfigChatParams{
+			AiIntegrationConfigID: src.cfg.ID,
+			ChatID:                chatID,
+		}); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "link codex cloud chat")
+		}
+		src.progressMu.Lock()
+		src.progress.ChatsUpserted++
+		src.progressMu.Unlock()
 	}
-	src.progressMu.Lock()
-	src.progress.ChatsUpserted++
-	src.progressMu.Unlock()
 
 	src.chatIDs[sessionID] = chatID
+	if title != "" {
+		src.chatTitles[sessionID] = title
+	}
 	return nil
 }
 
-// eventCreatedAt resolves an event's timestamp, counting a fallback to import
-// time — the outcome that rewrites chronology — as a canary for upstream
-// format changes.
+// eventCreatedAt resolves a message event's timestamp, counting a fallback to
+// import time — the outcome that rewrites chronology — as a canary for
+// upstream format changes. Used for message rows, where every event is
+// expected to carry a timestamp, so absence counts too.
 func (src *codexCloudSource) eventCreatedAt(event codexCloudEvent) time.Time {
 	if event.Timestamp != "" {
 		if t, err := time.Parse(time.RFC3339, event.Timestamp); err == nil {
@@ -518,6 +557,24 @@ func (src *codexCloudSource) eventCreatedAt(event codexCloudEvent) time.Time {
 	src.progress.TimestampFallbacks++
 	src.progressMu.Unlock()
 	return time.Now().UTC()
+}
+
+// parseEventTime resolves the chat row's timestamp with template semantics:
+// an absent value takes the fallback silently (expected, and the same event
+// already counted once on the message path), while a present-yet-malformed
+// value counts as a format-change canary.
+func (src *codexCloudSource) parseEventTime(value string, fallback time.Time) time.Time {
+	if value == "" {
+		return fallback.UTC()
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		src.progressMu.Lock()
+		src.progress.TimestampFallbacks++
+		src.progressMu.Unlock()
+		return fallback.UTC()
+	}
+	return t.UTC()
 }
 
 func (src *codexCloudSource) timestampFallbacks() int {
@@ -557,23 +614,5 @@ func parseCodexCloudEvents(file codexapi.LogFile, body []byte) ([]codexCloudEven
 // truncated by runes so multi-byte text stays valid. Empty when no prompt was
 // seen — the upsert then sends NULL and preserves any stored title.
 func codexCloudChatTitle(prompt string) string {
-	prompt = strings.TrimSpace(prompt)
-	if prompt == "" {
-		return ""
-	}
-	runes := []rune(prompt)
-	if len(runes) <= codexCloudTitleMaxRunes {
-		return prompt
-	}
-	return string(runes[:codexCloudTitleMaxRunes])
-}
-
-func codexCloudUpperBoundStart(cfg Config, endTime time.Time) time.Time {
-	if cfg.PollCheckpoint.Partial() {
-		return cfg.PollCheckpoint.Watermark
-	}
-	if !cfg.PollWatermarkAt.IsZero() {
-		return cfg.PollWatermarkAt
-	}
-	return endTime.UTC().Add(-chatgptComplianceInitialLookback)
+	return conv.TruncateString(strings.TrimSpace(prompt), codexCloudTitleMaxRunes)
 }

--- a/server/internal/aiintegrations/codex_cloud_import.go
+++ b/server/internal/aiintegrations/codex_cloud_import.go
@@ -520,6 +520,10 @@ func (src *codexCloudSource) upsertSessionChat(ctx context.Context, sessionID st
 		Title:          conv.ToPGTextEmpty(title),
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),
 		UpdatedAt:      conv.ToPGTimestamptz(createdAt),
+		// First-wins: the title is DERIVED from the window's first prompt, and
+		// a later poll window would derive a mid-session prompt as its
+		// "first" — newest-wins would retitle the chat on every window.
+		PreferStoredTitle: true,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "upsert codex cloud chat")

--- a/server/internal/aiintegrations/codex_cloud_import.go
+++ b/server/internal/aiintegrations/codex_cloud_import.go
@@ -1,0 +1,579 @@
+package aiintegrations
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations/timewindowpoller"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	codexapi "github.com/speakeasy-api/gram/server/internal/thirdparty/codex"
+)
+
+const (
+	// codexCloudEventType is the Compliance Logs Platform file family carrying
+	// Codex cloud task transcripts. The feed is workspace-scoped like
+	// CONVERSATION_MESSAGE: one NDJSON event per prompt or response, files
+	// finalized on the API's end_time watermark.
+	codexCloudEventType = "CODEX_LOG"
+	codexCloudPageLimit = 100
+	// codexCloudSourceSlug is the canonical chat source for imported Codex
+	// cloud sessions (see chat/sources.go) — distinct from "codex", which tags
+	// live device sessions captured by hooks/OTEL.
+	codexCloudSourceSlug = "codex-web"
+	// codexCloudClientWeb is the client_id marking cloud web-task events —
+	// the only client this import admits. CODEX_DESKTOP_APP events also
+	// appear (trace volume) but describe a device surface that may gain hook
+	// capture; importing them here could collide with live-captured sessions
+	// (same session-id UUID space), so they are counted and skipped until the
+	// unified-desktop-app verification settles that boundary.
+	codexCloudClientWeb = "CODEX_WEB"
+	// Codex cloud event shapes: a prompt submission and the model's reply.
+	codexCloudDetailPromptSent       = "PROMPT_SENT"
+	codexCloudDetailResponseReceived = "PROMPT_RESPONSE_RECEIVED"
+	// codexCloudTitleMaxRunes bounds prompt-derived chat titles, matching the
+	// live-capture convention (canonicalChatTitle).
+	codexCloudTitleMaxRunes = 80
+)
+
+// codexCloudEvent is one CODEX_LOG NDJSON event.
+type codexCloudEvent struct {
+	EventID   string `json:"event_id"`
+	Type      string `json:"type"`
+	Timestamp string `json:"timestamp"`
+	ClientID  string `json:"client_id"`
+	Actor     struct {
+		Type      string `json:"type"`
+		UserID    string `json:"user_id"`
+		UserEmail string `json:"user_email"`
+	} `json:"actor"`
+	EventDetails struct {
+		DetailType      string `json:"detail_type"`
+		SessionID       string `json:"session_id"`
+		Model           string `json:"model"`
+		PromptText      string `json:"prompt_text"`
+		ResponseText    string `json:"response_text"`
+		Status          string `json:"status"`
+		ServiceTier     string `json:"service_tier"`
+		ReasoningEffort string `json:"reasoning_effort"`
+	} `json:"event_details"`
+}
+
+// CodexCloudSyncProgress reports how far one sync run got.
+type CodexCloudSyncProgress struct {
+	WindowStart     time.Time `json:"window_start"`
+	LogPages        int       `json:"log_pages"`
+	LogFiles        int       `json:"log_files"`
+	Events          int       `json:"events"`
+	MessagesWritten int64     `json:"messages_written"`
+	ChatsUpserted   int       `json:"chats_upserted"`
+	// SkippedClients counts events dropped because their client_id is not
+	// CODEX_WEB (see codexCloudClientWeb) — a canary for new cloud surfaces
+	// appearing in the feed.
+	SkippedClients int `json:"skipped_clients"`
+	// TimestampFallbacks counts events whose timestamps failed RFC3339
+	// parsing and fell back to import time — a canary for upstream format
+	// changes that would otherwise silently rewrite history chronology.
+	TimestampFallbacks int       `json:"timestamp_fallbacks"`
+	WatermarkReached   time.Time `json:"watermark_reached"`
+}
+
+type CodexCloudImportService struct {
+	logger         *slog.Logger
+	store          *Store
+	guardianPolicy *guardian.Policy
+	db             *pgxpool.Pool
+	writer         *chat.ChatMessageWriter
+	heartbeat      func(ctx context.Context, page int)
+}
+
+func NewCodexCloudImportService(logger *slog.Logger, store *Store, db *pgxpool.Pool, guardianPolicy *guardian.Policy, writer *chat.ChatMessageWriter, heartbeat func(ctx context.Context, page int)) *CodexCloudImportService {
+	if heartbeat == nil {
+		panic("codex cloud import service requires heartbeat")
+	}
+	return &CodexCloudImportService{
+		logger:         logger.With(attr.SlogComponent("aiintegrations.codex_cloud")),
+		store:          store,
+		guardianPolicy: guardianPolicy,
+		db:             db,
+		writer:         writer,
+		heartbeat:      heartbeat,
+	}
+}
+
+// SyncCodexCloudSessions imports Codex cloud task transcripts (CODEX_LOG
+// compliance files) through the shared time-window poller and persists them
+// as external chats + messages, mirroring the ChatGPT conversation import.
+// Replays are idempotent: chats upsert on the session id and messages land
+// under ON CONFLICT (chat_id, external_message_id) DO NOTHING. Token counts
+// in the feed are deliberately NOT persisted anywhere metering reads: cloud
+// tokens are metered from the compliance COSTS promotion, and carrying them
+// here too would double count.
+func (s *CodexCloudImportService) SyncCodexCloudSessions(ctx context.Context, cfg Config, endTime time.Time) error {
+	if cfg.Provider != ProviderChatGPTCompliance {
+		return oops.E(oops.CodeInvalid, nil, "unsupported ai integration provider for codex cloud import: %s", cfg.Provider)
+	}
+	if cfg.ExternalOrganizationID == nil {
+		return oops.E(oops.CodeInvalid, nil, "external_organization_id (workspace id) is required for codex cloud import")
+	}
+
+	progress := &CodexCloudSyncProgress{
+		WindowStart:        cfg.PollWatermarkAt,
+		LogPages:           0,
+		LogFiles:           0,
+		Events:             0,
+		MessagesWritten:    0,
+		ChatsUpserted:      0,
+		SkippedClients:     0,
+		TimestampFallbacks: 0,
+		WatermarkReached:   cfg.PollWatermarkAt,
+	}
+
+	source := &codexCloudSource{
+		client:     codexapi.NewWorkspaceClient(s.guardianPolicy, *cfg.ExternalOrganizationID, codexapi.WithAPIKey(cfg.APIKey)),
+		svc:        s,
+		cfg:        cfg,
+		pageLimit:  codexCloudPageLimit,
+		users:      newConnectedUserResolver(s.db, cfg.OrganizationID),
+		chatIDs:    map[string]uuid.UUID{},
+		progressMu: sync.Mutex{},
+		progress:   progress,
+	}
+
+	runner := &timewindowpoller.Poller[[]codexapi.LogFile]{
+		Store:    s.store,
+		Schedule: ScheduleCodexCloudSessions,
+		State: timewindowpoller.SyncState{
+			SyncID:      cfg.SyncID,
+			WatermarkAt: cfg.PollWatermarkAt,
+			Checkpoint:  cfg.PollCheckpoint,
+		},
+		Source:  source,
+		EndTime: endTime,
+		Heartbeat: func(ctx context.Context, page int) {
+			s.heartbeat(ctx, page)
+		},
+		InitialLookback: chatgptComplianceInitialLookback,
+		MaxWindow:       0,
+		Granularity:     0,
+		ResumeOffset:    0,
+	}
+	if err := runner.Do(ctx); err != nil {
+		return newSyncError("sync codex cloud sessions", *progress,
+			SyncStageError{Stage: "import_codex_cloud_logs", Err: err},
+		)
+	}
+	return nil
+}
+
+// codexCloudSource pages CODEX_LOG compliance files. Its listing state
+// machine is a deliberate copy of chatgptConversationSource's — the shared
+// pagination suite (logfile_source_pagination_test.go) runs the same protocol
+// edge cases against every copy so a fix cannot silently miss one.
+type codexCloudSource struct {
+	client    codexComplianceClient
+	svc       *CodexCloudImportService
+	cfg       Config
+	pageLimit int
+	users     *connectedUserResolver
+	// chatIDs caches session id -> chat row id for the run so link rows and
+	// id lookups happen once per session, not once per event.
+	chatIDs map[string]uuid.UUID
+	// progressMu guards progress: the poller pipelines FetchPage (producer
+	// goroutine) with ProcessPage (consumer goroutine), and both record
+	// progress.
+	progressMu sync.Mutex
+	progress   *CodexCloudSyncProgress
+}
+
+func (src *codexCloudSource) UpperBound(ctx context.Context, endTime time.Time) (time.Time, error) {
+	after := codexCloudUpperBoundStart(src.cfg, endTime)
+	watermark := time.Time{}
+	for pageNum := 0; ; pageNum++ {
+		// The poller only heartbeats before UpperBound; a 30-day first sync
+		// can page for longer than the activity's 1-minute heartbeat timeout,
+		// so heartbeat per listing page.
+		src.svc.heartbeat(ctx, pageNum)
+		page, err := src.client.ListLogs(ctx, codexapi.ListLogsParams{
+			EventType: codexCloudEventType,
+			After:     after,
+			Limit:     src.pageLimit,
+		})
+		if err != nil {
+			return time.Time{}, err //nolint:wrapcheck // Preserve HTTPError classification upstream.
+		}
+		if page.LastEndTime.After(watermark) {
+			watermark = page.LastEndTime
+		}
+		if !page.HasMore {
+			if watermark.IsZero() {
+				return after, nil
+			}
+			return watermark, nil
+		}
+		if page.LastEndTime.IsZero() {
+			return time.Time{}, fmt.Errorf("codex cloud logs page had has_more without last_end_time")
+		}
+		if err := validateCodexLastEndTimeAdvanced(after, page.LastEndTime); err != nil {
+			return time.Time{}, err
+		}
+		after = page.LastEndTime
+	}
+}
+
+func (src *codexCloudSource) FetchPage(ctx context.Context, start, end time.Time, pageToken string) (timewindowpoller.Page[[]codexapi.LogFile], error) {
+	after := start
+	if pageToken != "" {
+		parsed, err := time.Parse(time.RFC3339Nano, pageToken)
+		if err != nil {
+			return timewindowpoller.Page[[]codexapi.LogFile]{Payload: nil, NextPage: "", HasMore: false}, fmt.Errorf("parse codex cloud page token: %w", err)
+		}
+		after = parsed
+	}
+
+	page, err := src.client.ListLogs(ctx, codexapi.ListLogsParams{
+		EventType: codexCloudEventType,
+		After:     after,
+		Limit:     src.pageLimit,
+	})
+	if err != nil {
+		return timewindowpoller.Page[[]codexapi.LogFile]{Payload: nil, NextPage: "", HasMore: false}, err //nolint:wrapcheck // Preserve HTTPError classification upstream.
+	}
+	src.progressMu.Lock()
+	src.progress.LogPages++
+	if page.LastEndTime.After(src.progress.WatermarkReached) {
+		src.progress.WatermarkReached = page.LastEndTime
+	}
+	src.progressMu.Unlock()
+
+	files := make([]codexapi.LogFile, 0, len(page.Data))
+	for _, file := range page.Data {
+		if file.EventType != "" && file.EventType != codexCloudEventType {
+			continue
+		}
+		if file.EndTime.After(end) {
+			return timewindowpoller.Page[[]codexapi.LogFile]{Payload: files, NextPage: "", HasMore: false}, nil
+		}
+		files = append(files, file)
+	}
+
+	nextPage := ""
+	if page.HasMore {
+		if page.LastEndTime.IsZero() {
+			return timewindowpoller.Page[[]codexapi.LogFile]{Payload: nil, NextPage: "", HasMore: false}, fmt.Errorf("codex cloud logs page had has_more without last_end_time")
+		}
+		if err := validateCodexLastEndTimeAdvanced(after, page.LastEndTime); err != nil {
+			return timewindowpoller.Page[[]codexapi.LogFile]{Payload: nil, NextPage: "", HasMore: false}, err
+		}
+		nextPage = page.LastEndTime.UTC().Format(time.RFC3339Nano)
+	}
+	return timewindowpoller.Page[[]codexapi.LogFile]{
+		Payload:  files,
+		NextPage: nextPage,
+		HasMore:  page.HasMore,
+	}, nil
+}
+
+func (src *codexCloudSource) ProcessPage(ctx context.Context, files []codexapi.LogFile) error {
+	for i, file := range files {
+		// The poller only heartbeats around FetchPage; a page holds up to
+		// pageLimit dense per-event files, so heartbeat per file to stay
+		// inside the activity's 1-minute heartbeat timeout.
+		src.svc.heartbeat(ctx, i)
+
+		body, err := src.client.DownloadLog(ctx, file.ID)
+		if err != nil {
+			return err //nolint:wrapcheck // Preserve HTTPError classification upstream.
+		}
+
+		events, err := parseCodexCloudEvents(file, body)
+		if err != nil {
+			return err
+		}
+		if err := src.writeFile(ctx, file, events); err != nil {
+			return err
+		}
+
+		src.progressMu.Lock()
+		src.progress.LogFiles++
+		src.progress.Events += len(events)
+		if file.EndTime.After(src.progress.WatermarkReached) {
+			src.progress.WatermarkReached = file.EndTime
+		}
+		src.progressMu.Unlock()
+	}
+	return nil
+}
+
+func (src *codexCloudSource) RetryAfter(err error) (time.Duration, bool) {
+	var httpErr *codexapi.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusTooManyRequests {
+		return 0, false
+	}
+	return 0, true
+}
+
+// codexCloudSessionState carries per-session metadata accumulated across one
+// file's events: the newest event (actor identity, timestamps) and the first
+// prompt text seen, which seeds the chat title.
+type codexCloudSessionState struct {
+	latest      codexCloudEvent
+	firstPrompt string
+}
+
+// writeFile persists one log file's web-task events: each session is upserted
+// as a chat, then every prompt/response lands in one batched write. The feed
+// carries no conversation titles, so a session's title derives from the first
+// prompt seen for it (truncated by runes, matching live capture); the
+// upsert's COALESCE preserves an existing title on replays and later files.
+// Non-web clients (CODEX_DESKTOP_APP) are counted and skipped — see
+// codexCloudClientWeb.
+func (src *codexCloudSource) writeFile(ctx context.Context, file codexapi.LogFile, events []codexCloudEvent) error {
+	sessions := map[string]*codexCloudSessionState{}
+	order := make([]string, 0, len(events))
+	skipped := 0
+	admitted := make([]codexCloudEvent, 0, len(events))
+	for _, event := range events {
+		if !strings.EqualFold(strings.TrimSpace(event.ClientID), codexCloudClientWeb) {
+			skipped++
+			continue
+		}
+		if event.EventDetails.SessionID == "" || event.EventID == "" {
+			continue
+		}
+		admitted = append(admitted, event)
+		state, ok := sessions[event.EventDetails.SessionID]
+		if !ok {
+			state = &codexCloudSessionState{latest: event, firstPrompt: ""}
+			sessions[event.EventDetails.SessionID] = state
+			order = append(order, event.EventDetails.SessionID)
+		}
+		// Events within a file are chronological, so the last one seen is the
+		// newest.
+		state.latest = event
+		if state.firstPrompt == "" && event.EventDetails.DetailType == codexCloudDetailPromptSent {
+			state.firstPrompt = strings.TrimSpace(event.EventDetails.PromptText)
+		}
+	}
+	if skipped > 0 {
+		src.progressMu.Lock()
+		src.progress.SkippedClients += skipped
+		src.progressMu.Unlock()
+	}
+	for _, sessionID := range order {
+		if err := src.upsertSessionChat(ctx, sessions[sessionID]); err != nil {
+			return err
+		}
+	}
+
+	fallbacksBefore := src.timestampFallbacks()
+	rows := make([]chatrepo.CreateExternalChatMessageParams, 0, len(admitted))
+	for _, event := range admitted {
+		var role, content string
+		switch event.EventDetails.DetailType {
+		case codexCloudDetailPromptSent:
+			role, content = "user", event.EventDetails.PromptText
+		case codexCloudDetailResponseReceived:
+			role, content = "assistant", event.EventDetails.ResponseText
+		default:
+			continue
+		}
+
+		userID, err := src.users.resolve(ctx, event.Actor.UserEmail)
+		if err != nil {
+			return err
+		}
+
+		rows = append(rows, chatrepo.CreateExternalChatMessageParams{
+			ChatID:            src.chatIDs[event.EventDetails.SessionID],
+			Role:              role,
+			ProjectID:         src.cfg.ProjectID,
+			Content:           content,
+			ContentRaw:        nil,
+			ContentAssetUrl:   pgtype.Text{String: "", Valid: false},
+			StorageError:      pgtype.Text{String: "", Valid: false},
+			Model:             conv.ToPGTextEmpty(event.EventDetails.Model),
+			MessageID:         pgtype.Text{String: "", Valid: false},
+			ToolCallID:        pgtype.Text{String: "", Valid: false},
+			UserID:            conv.ToPGText(userID),
+			ExternalUserID:    conv.ToPGText(event.Actor.UserID),
+			ExternalMessageID: conv.ToPGText(event.EventID),
+			FinishReason:      conv.ToPGTextEmpty(event.EventDetails.Status),
+			ToolCalls:         nil,
+			// Per-turn token_usage from the feed is deliberately dropped:
+			// cloud tokens meter through the compliance COSTS promotion, and
+			// recording them here as well would double count.
+			PromptTokens:     0,
+			CompletionTokens: 0,
+			TotalTokens:      0,
+			Origin:           pgtype.Text{String: "", Valid: false},
+			// The client_id (CODEX_WEB) is the closest surface signal the
+			// feed carries; it rides this column for per-client analysis.
+			UserAgent:   conv.ToPGTextEmpty(event.ClientID),
+			IpAddress:   pgtype.Text{String: "", Valid: false},
+			Source:      conv.ToPGText(codexCloudSourceSlug),
+			ContentHash: nil,
+			Generation:  0,
+			CreatedAt:   conv.ToPGTimestamptz(src.eventCreatedAt(event)),
+		})
+	}
+	if fallbacks := src.timestampFallbacks() - fallbacksBefore; fallbacks > 0 {
+		src.svc.logger.WarnContext(ctx, "codex cloud event timestamps failed to parse; messages stamped with import time",
+			attr.SlogFilePath(file.FileName),
+			attr.SlogChatGPTComplianceTimestampFallbacks(fallbacks),
+		)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// WriteExternal inserts row by row, so a mid-batch failure still leaves
+	// the earlier rows durable — record the partial count before propagating
+	// the error so failure details describe the replay-safe work accurately.
+	written, err := src.svc.writer.WriteExternal(ctx, src.cfg.ProjectID, rows)
+	src.progressMu.Lock()
+	src.progress.MessagesWritten += written
+	src.progressMu.Unlock()
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "write codex cloud messages")
+	}
+	return nil
+}
+
+// upsertSessionChat writes the session's chat row. The feed has no titles, so
+// a prompt-derived title is sent only on the first upsert of the run; the
+// query's COALESCE preserves any title already stored, so replays and later
+// files never clobber it.
+func (src *codexCloudSource) upsertSessionChat(ctx context.Context, state *codexCloudSessionState) error {
+	sessionID := state.latest.EventDetails.SessionID
+	if _, known := src.chatIDs[sessionID]; known {
+		return nil
+	}
+
+	createdAt := src.eventCreatedAt(state.latest)
+	userID, err := src.users.resolve(ctx, state.latest.Actor.UserEmail)
+	if err != nil {
+		return err
+	}
+
+	chatID, err := chatrepo.New(src.svc.db).UpsertExternalChat(ctx, chatrepo.UpsertExternalChatParams{
+		ID:             uuid.New(),
+		ProjectID:      src.cfg.ProjectID,
+		OrganizationID: src.cfg.OrganizationID,
+		// NULL when unresolved so the upsert's COALESCE preserves a user
+		// resolved by an earlier event.
+		UserID:         conv.ToPGTextEmpty(userID),
+		ExternalUserID: conv.ToPGTextEmpty(state.latest.Actor.UserID),
+		ExternalChatID: conv.ToPGText(sessionID),
+		Title:          conv.ToPGTextEmpty(codexCloudChatTitle(state.firstPrompt)),
+		CreatedAt:      conv.ToPGTimestamptz(createdAt),
+		UpdatedAt:      conv.ToPGTimestamptz(createdAt),
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "upsert codex cloud chat")
+	}
+	if _, err := chatrepo.New(src.svc.db).LinkAIIntegrationConfigChat(ctx, chatrepo.LinkAIIntegrationConfigChatParams{
+		AiIntegrationConfigID: src.cfg.ID,
+		ChatID:                chatID,
+	}); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "link codex cloud chat")
+	}
+	src.progressMu.Lock()
+	src.progress.ChatsUpserted++
+	src.progressMu.Unlock()
+
+	src.chatIDs[sessionID] = chatID
+	return nil
+}
+
+// eventCreatedAt resolves an event's timestamp, counting a fallback to import
+// time — the outcome that rewrites chronology — as a canary for upstream
+// format changes.
+func (src *codexCloudSource) eventCreatedAt(event codexCloudEvent) time.Time {
+	if event.Timestamp != "" {
+		if t, err := time.Parse(time.RFC3339, event.Timestamp); err == nil {
+			return t.UTC()
+		}
+	}
+	src.progressMu.Lock()
+	src.progress.TimestampFallbacks++
+	src.progressMu.Unlock()
+	return time.Now().UTC()
+}
+
+func (src *codexCloudSource) timestampFallbacks() int {
+	src.progressMu.Lock()
+	defer src.progressMu.Unlock()
+	return src.progress.TimestampFallbacks
+}
+
+func parseCodexCloudEvents(file codexapi.LogFile, body []byte) ([]codexCloudEvent, error) {
+	if file.FileSHA256 != "" {
+		sum := sha256.Sum256(body)
+		actual := hex.EncodeToString(sum[:])
+		if !strings.EqualFold(actual, file.FileSHA256) {
+			return nil, oops.E(oops.CodeUnexpected, nil, "codex cloud log sha256 mismatch for %s", file.ID)
+		}
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	events := make([]codexCloudEvent, 0)
+	for {
+		var event codexCloudEvent
+		if err := decoder.Decode(&event); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, oops.E(oops.CodeUnexpected, err, "decode codex cloud log event in %s", file.ID)
+		}
+		if event.Type != "" && event.Type != codexCloudEventType {
+			continue
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+// codexCloudChatTitle derives a chat title from a session's first prompt,
+// truncated by runes so multi-byte text stays valid. Empty when no prompt was
+// seen — the upsert then sends NULL and preserves any stored title.
+func codexCloudChatTitle(prompt string) string {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return ""
+	}
+	runes := []rune(prompt)
+	if len(runes) <= codexCloudTitleMaxRunes {
+		return prompt
+	}
+	return string(runes[:codexCloudTitleMaxRunes])
+}
+
+func codexCloudUpperBoundStart(cfg Config, endTime time.Time) time.Time {
+	if cfg.PollCheckpoint.Partial() {
+		return cfg.PollCheckpoint.Watermark
+	}
+	if !cfg.PollWatermarkAt.IsZero() {
+		return cfg.PollWatermarkAt
+	}
+	return endTime.UTC().Add(-chatgptComplianceInitialLookback)
+}

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -116,13 +116,13 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 			listParams: nil,
 			downloads:  map[string][]byte{file.ID: []byte(codexCloudFixture)},
 		},
-		svc:        svc,
-		cfg:        cfg,
-		pageLimit:  codexCloudPageLimit,
-		users:      newConnectedUserResolver(conn, orgID),
-		chatIDs:    map[string]uuid.UUID{},
-		chatTitles: map[string]string{},
-		progress:   &CodexCloudSyncProgress{},
+		svc:            svc,
+		cfg:            cfg,
+		pageLimit:      codexCloudPageLimit,
+		users:          newConnectedUserResolver(conn, orgID),
+		chatIDs:        map[string]uuid.UUID{},
+		titledSessions: map[string]bool{},
+		progress:       &CodexCloudSyncProgress{},
 	}
 
 	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
@@ -171,7 +171,7 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 	// Replaying the same file must not duplicate messages: the insert
 	// dedupes on (chat_id, external_message_id).
 	src.chatIDs = map[string]uuid.UUID{}
-	src.chatTitles = map[string]string{}
+	src.titledSessions = map[string]bool{}
 	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
 	messages, err = chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 	laterFile := codexCloudFixtureFile(laterWindow)
 	laterFile.ID = "eclf_codex_cloud_2"
 	src.chatIDs = map[string]uuid.UUID{}
-	src.chatTitles = map[string]string{}
+	src.titledSessions = map[string]bool{}
 	src.client = &stubCodexComplianceClient{
 		listPages:  nil,
 		listParams: nil,
@@ -203,14 +203,14 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 
 func newCodexCloudTestSource(cfg Config, client codexComplianceClient) *codexCloudSource {
 	return &codexCloudSource{
-		client:     client,
-		svc:        &CodexCloudImportService{logger: nil, store: nil, guardianPolicy: nil, db: nil, writer: nil, heartbeat: func(context.Context, int) {}},
-		cfg:        cfg,
-		pageLimit:  codexCloudPageLimit,
-		users:      nil,
-		chatIDs:    map[string]uuid.UUID{},
-		chatTitles: map[string]string{},
-		progress:   &CodexCloudSyncProgress{},
+		client:         client,
+		svc:            &CodexCloudImportService{logger: nil, store: nil, guardianPolicy: nil, db: nil, writer: nil, heartbeat: func(context.Context, int) {}},
+		cfg:            cfg,
+		pageLimit:      codexCloudPageLimit,
+		users:          nil,
+		chatIDs:        map[string]uuid.UUID{},
+		titledSessions: map[string]bool{},
+		progress:       &CodexCloudSyncProgress{},
 	}
 }
 
@@ -284,13 +284,13 @@ func TestCodexCloudTitleBackfillsWhenPromptArrivesInLaterFile(t *testing.T) {
 				fileB.ID: []byte(promptLater),
 			},
 		},
-		svc:        svc,
-		cfg:        cfg,
-		pageLimit:  codexCloudPageLimit,
-		users:      newConnectedUserResolver(conn, orgID),
-		chatIDs:    map[string]uuid.UUID{},
-		chatTitles: map[string]string{},
-		progress:   &CodexCloudSyncProgress{},
+		svc:            svc,
+		cfg:            cfg,
+		pageLimit:      codexCloudPageLimit,
+		users:          newConnectedUserResolver(conn, orgID),
+		chatIDs:        map[string]uuid.UUID{},
+		titledSessions: map[string]bool{},
+		progress:       &CodexCloudSyncProgress{},
 	}
 
 	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{fileA, fileB}))
@@ -302,24 +302,82 @@ func TestCodexCloudTitleBackfillsWhenPromptArrivesInLaterFile(t *testing.T) {
 	require.Equal(t, "Now update the rollback plan", chatRow.Title.String)
 	// The link row is created once; the title refresh only re-upserts.
 	require.Equal(t, 1, src.progress.ChatsUpserted)
+	// The session is now marked titled, so a third file's distinct prompt is
+	// skipped rather than re-upserted: the query is first-wins, so the write
+	// could not change the stored title anyway.
+	require.True(t, src.titledSessions["22222222-3333-4444-8555-666666666666"])
+
+	promptAgain := `{"event_id":"cdx_p2","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T11:10:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"22222222-3333-4444-8555-666666666666","model":"gpt-5.5","prompt_text":"And note the owner"}}` + "\n"
+	fileC := codexCloudFixtureFile(promptAgain)
+	fileC.ID = "eclf_backfill_c"
+	fileC.EndTime = fileB.EndTime.Add(time.Minute)
+	src.client = &stubCodexComplianceClient{
+		listPages:  nil,
+		listParams: nil,
+		downloads:  map[string][]byte{fileC.ID: []byte(promptAgain)},
+	}
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{fileC}))
+	chatRow, err = chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, "Now update the rollback plan", chatRow.Title.String,
+		"a later prompt in the same run must not retitle the chat")
+	require.Equal(t, 1, src.progress.ChatsUpserted)
 }
 
-// TestCodexCloudParseEventTimeCountsOnlyMalformedValues: the chat-row
-// timestamp path treats an absent value as expected (fallback, no canary) —
-// the same event already counted once on the message path — while a
-// present-yet-malformed value counts as a format-change canary.
-func TestCodexCloudParseEventTimeCountsOnlyMalformedValues(t *testing.T) {
+// TestCodexCloudMalformedTimestampCountsOncePerEvent: a session's opening
+// event feeds both the chat row's created_at and its own message row, so its
+// timestamp must be resolved once — resolving it per reader would report two
+// TimestampFallbacks canaries for one bad upstream value.
+func TestCodexCloudMalformedTimestampCountsOncePerEvent(t *testing.T) {
 	t.Parallel()
 
-	source := newCodexCloudTestSource(chatgptConversationConfig(), nil)
-	fallback := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	ctx, conn, store, orgID := newStoreTestDB(t)
 
-	require.Equal(t, time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC), source.parseEventTime("2026-07-28T10:00:00Z", fallback))
-	require.Zero(t, source.progress.TimestampFallbacks)
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Codex Cloud Timestamp Canary Project",
+		Slug:           "project-" + uuid.NewString()[:8],
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
 
-	require.Equal(t, fallback, source.parseEventTime("", fallback))
-	require.Zero(t, source.progress.TimestampFallbacks)
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", true, true, &workspaceID, nil)
+	cfg := created.Config
+	cfg.ProjectID = project.ID
 
-	require.Equal(t, fallback, source.parseEventTime("1753694400", fallback))
-	require.Equal(t, 1, source.progress.TimestampFallbacks)
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	// A single admitted event whose timestamp is a unix epoch rather than
+	// RFC3339 — the shape an upstream format change would produce.
+	malformed := `{"event_id":"cdx_bad_ts","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"1753694400","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"33333333-4444-4555-8666-777777777777","model":"gpt-5.5","prompt_text":"Rerun the migration"}}` + "\n"
+	file := codexCloudFixtureFile(malformed)
+	file.ID = "eclf_bad_ts"
+
+	svc := NewCodexCloudImportService(testenv.NewLogger(t), store, conn, nil, writer, func(context.Context, int) {})
+	src := &codexCloudSource{
+		client: &stubCodexComplianceClient{
+			listPages:  nil,
+			listParams: nil,
+			downloads:  map[string][]byte{file.ID: []byte(malformed)},
+		},
+		svc:            svc,
+		cfg:            cfg,
+		pageLimit:      codexCloudPageLimit,
+		users:          newConnectedUserResolver(conn, orgID),
+		chatIDs:        map[string]uuid.UUID{},
+		titledSessions: map[string]bool{},
+		progress:       &CodexCloudSyncProgress{},
+	}
+
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
+	require.Equal(t, int64(1), src.progress.MessagesWritten)
+	require.Equal(t, 1, src.progress.TimestampFallbacks)
+
+	chatID, ok := src.chatIDs["33333333-4444-4555-8666-777777777777"]
+	require.True(t, ok)
+	chatRow, err := chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	// Chat and message share the one resolved import-time fallback.
+	require.WithinDuration(t, time.Now().UTC(), chatRow.CreatedAt.Time.UTC(), time.Minute)
 }

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -185,3 +185,29 @@ func newCodexCloudTestSource(cfg Config, client codexComplianceClient) *codexClo
 		progress:  &CodexCloudSyncProgress{},
 	}
 }
+
+// TestCodexCloudEventCreatedAtCountsFallbacks: a valid event timestamp is
+// used directly; a malformed or absent one falls back to import time and
+// counts the canary that flags upstream format changes.
+func TestCodexCloudEventCreatedAtCountsFallbacks(t *testing.T) {
+	t.Parallel()
+
+	source := newCodexCloudTestSource(chatgptConversationConfig(), nil)
+	event := codexCloudEvent{}
+
+	event.Timestamp = "2026-07-28T10:00:00Z"
+	require.Equal(t, time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC), source.eventCreatedAt(event))
+	require.Zero(t, source.progress.TimestampFallbacks)
+
+	// Malformed: import time is used and the canary counts it.
+	event.Timestamp = "1753694400"
+	got := source.eventCreatedAt(event)
+	require.WithinDuration(t, time.Now().UTC(), got, time.Minute)
+	require.Equal(t, 1, source.progress.TimestampFallbacks)
+
+	// Absent entirely: also a counted import-time fallback.
+	event.Timestamp = ""
+	got = source.eventCreatedAt(event)
+	require.WithinDuration(t, time.Now().UTC(), got, time.Minute)
+	require.Equal(t, 2, source.progress.TimestampFallbacks)
+}

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -24,8 +24,9 @@ import (
 // The fixture exercises the importer's edge handling: a web prompt/response
 // pair (imported), a CODEX_DESKTOP_APP event (counted and skipped — device
 // surface pending the unified-app verification), an unknown detail_type on
-// the web client (admitted as an event but skipped from message rows), and a
-// foreign event type (dropped at parse).
+// the web client (counted and skipped at admission, so it can neither create
+// a chat nor land a message row), and a foreign event type (dropped at
+// parse).
 const codexCloudFixture = `{"event_id":"cdx_1","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:00:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"11111111-2222-4333-8444-555555555555","model":"gpt-5.5","prompt_text":"Fix the flaky retry test in CI"}}
 {"event_id":"cdx_2","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:00:20Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_RESPONSE_RECEIVED","session_id":"11111111-2222-4333-8444-555555555555","model":"gpt-5.5","response_text":"I updated the retry helper to poll instead of sleeping.","status":"completed","service_tier":"default","reasoning_effort":"medium","token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25,"reasoning_output_tokens":10}}}
 {"event_id":"cdx_3","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_2","user_email":"lin@example.com"},"timestamp":"2026-07-28T10:01:00Z","client_id":"CODEX_DESKTOP_APP","event_details":{"detail_type":"PROMPT_SENT","session_id":"99999999-8888-4777-8666-555555555555","model":"gpt-5.5","prompt_text":"desktop prompt"}}
@@ -115,12 +116,13 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 			listParams: nil,
 			downloads:  map[string][]byte{file.ID: []byte(codexCloudFixture)},
 		},
-		svc:       svc,
-		cfg:       cfg,
-		pageLimit: codexCloudPageLimit,
-		users:     newConnectedUserResolver(conn, orgID),
-		chatIDs:   map[string]uuid.UUID{},
-		progress:  &CodexCloudSyncProgress{},
+		svc:        svc,
+		cfg:        cfg,
+		pageLimit:  codexCloudPageLimit,
+		users:      newConnectedUserResolver(conn, orgID),
+		chatIDs:    map[string]uuid.UUID{},
+		chatTitles: map[string]string{},
+		progress:   &CodexCloudSyncProgress{},
 	}
 
 	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
@@ -131,6 +133,8 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 	// The desktop-app event is counted and skipped, never imported.
 	require.Equal(t, 1, src.progress.SkippedClients)
 	require.NotContains(t, src.chatIDs, "99999999-8888-4777-8666-555555555555")
+	// The unknown detail_type (SESSION_ARCHIVED) trips its own canary.
+	require.Equal(t, 1, src.progress.SkippedDetails)
 
 	chatID, ok := src.chatIDs["11111111-2222-4333-8444-555555555555"]
 	require.True(t, ok, "web session must be upserted")
@@ -140,6 +144,9 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 	require.Equal(t, "Fix the flaky retry test in CI", chatRow.Title.String)
 	require.Equal(t, "11111111-2222-4333-8444-555555555555", chatRow.ExternalChatID.String)
 	require.Equal(t, userRow.ID, chatRow.UserID.String)
+	// created_at comes from the window's earliest admitted event (the session
+	// start), not the newest — a trailing lifecycle event must not skew it.
+	require.Equal(t, time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC), chatRow.CreatedAt.Time.UTC())
 
 	messages, err := chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
 	require.NoError(t, err)
@@ -164,6 +171,7 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 	// Replaying the same file must not duplicate messages: the insert
 	// dedupes on (chat_id, external_message_id).
 	src.chatIDs = map[string]uuid.UUID{}
+	src.chatTitles = map[string]string{}
 	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
 	messages, err = chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
 	require.NoError(t, err)
@@ -176,13 +184,14 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 
 func newCodexCloudTestSource(cfg Config, client codexComplianceClient) *codexCloudSource {
 	return &codexCloudSource{
-		client:    client,
-		svc:       &CodexCloudImportService{logger: nil, store: nil, guardianPolicy: nil, db: nil, writer: nil, heartbeat: func(context.Context, int) {}},
-		cfg:       cfg,
-		pageLimit: codexCloudPageLimit,
-		users:     nil,
-		chatIDs:   map[string]uuid.UUID{},
-		progress:  &CodexCloudSyncProgress{},
+		client:     client,
+		svc:        &CodexCloudImportService{logger: nil, store: nil, guardianPolicy: nil, db: nil, writer: nil, heartbeat: func(context.Context, int) {}},
+		cfg:        cfg,
+		pageLimit:  codexCloudPageLimit,
+		users:      nil,
+		chatIDs:    map[string]uuid.UUID{},
+		chatTitles: map[string]string{},
+		progress:   &CodexCloudSyncProgress{},
 	}
 }
 
@@ -210,4 +219,88 @@ func TestCodexCloudEventCreatedAtCountsFallbacks(t *testing.T) {
 	got = source.eventCreatedAt(event)
 	require.WithinDuration(t, time.Now().UTC(), got, time.Minute)
 	require.Equal(t, 2, source.progress.TimestampFallbacks)
+}
+
+// TestCodexCloudTitleBackfillsWhenPromptArrivesInLaterFile: a session first
+// seen through a response-only file (its opening prompt straddled a file
+// boundary) is created untitled; when the prompt lands in a later file of the
+// same run, the title-refresh re-upsert writes it instead of the known-cache
+// skipping the session forever.
+func TestCodexCloudTitleBackfillsWhenPromptArrivesInLaterFile(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Codex Cloud Title Backfill Project",
+		Slug:           "project-" + uuid.NewString()[:8],
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", true, true, &workspaceID, nil)
+	cfg := created.Config
+	cfg.ProjectID = project.ID
+
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	responseOnly := `{"event_id":"cdx_r1","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T11:00:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_RESPONSE_RECEIVED","session_id":"22222222-3333-4444-8555-666666666666","model":"gpt-5.5","response_text":"Done, the migration is applied.","status":"completed"}}` + "\n"
+	promptLater := `{"event_id":"cdx_p1","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T11:05:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"22222222-3333-4444-8555-666666666666","model":"gpt-5.5","prompt_text":"Now update the rollback plan"}}` + "\n"
+
+	fileA := codexCloudFixtureFile(responseOnly)
+	fileA.ID = "eclf_backfill_a"
+	fileB := codexCloudFixtureFile(promptLater)
+	fileB.ID = "eclf_backfill_b"
+	fileB.EndTime = fileA.EndTime.Add(time.Minute)
+
+	svc := NewCodexCloudImportService(testenv.NewLogger(t), store, conn, nil, writer, func(context.Context, int) {})
+	src := &codexCloudSource{
+		client: &stubCodexComplianceClient{
+			listPages:  nil,
+			listParams: nil,
+			downloads: map[string][]byte{
+				fileA.ID: []byte(responseOnly),
+				fileB.ID: []byte(promptLater),
+			},
+		},
+		svc:        svc,
+		cfg:        cfg,
+		pageLimit:  codexCloudPageLimit,
+		users:      newConnectedUserResolver(conn, orgID),
+		chatIDs:    map[string]uuid.UUID{},
+		chatTitles: map[string]string{},
+		progress:   &CodexCloudSyncProgress{},
+	}
+
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{fileA, fileB}))
+
+	chatID, ok := src.chatIDs["22222222-3333-4444-8555-666666666666"]
+	require.True(t, ok)
+	chatRow, err := chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, "Now update the rollback plan", chatRow.Title.String)
+	// The link row is created once; the title refresh only re-upserts.
+	require.Equal(t, 1, src.progress.ChatsUpserted)
+}
+
+// TestCodexCloudParseEventTimeCountsOnlyMalformedValues: the chat-row
+// timestamp path treats an absent value as expected (fallback, no canary) —
+// the same event already counted once on the message path — while a
+// present-yet-malformed value counts as a format-change canary.
+func TestCodexCloudParseEventTimeCountsOnlyMalformedValues(t *testing.T) {
+	t.Parallel()
+
+	source := newCodexCloudTestSource(chatgptConversationConfig(), nil)
+	fallback := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+
+	require.Equal(t, time.Date(2026, 7, 28, 10, 0, 0, 0, time.UTC), source.parseEventTime("2026-07-28T10:00:00Z", fallback))
+	require.Zero(t, source.progress.TimestampFallbacks)
+
+	require.Equal(t, fallback, source.parseEventTime("", fallback))
+	require.Zero(t, source.progress.TimestampFallbacks)
+
+	require.Equal(t, fallback, source.parseEventTime("1753694400", fallback))
+	require.Equal(t, 1, source.progress.TimestampFallbacks)
 }

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -445,3 +445,63 @@ func TestCodexCloudRetryAfterOnlyBacksOffOnRateLimits(t *testing.T) {
 		require.False(t, retry, "only a 429 is retryable: %v", err)
 	}
 }
+
+// TestCodexCloudCountsEventsMissingIdentifiers: a web prompt/response event
+// with no session id (or no event id) clears the client and detail-type
+// filters and is then dropped. Uncounted, a feed that stopped emitting
+// session_id would import nothing while every other canary read zero and the
+// run reported success — indistinguishable from a window with no cloud
+// activity. event_id matters doubly: it is the message dedupe key.
+func TestCodexCloudCountsEventsMissingIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Codex Cloud Missing IDs Project",
+		Slug:           "project-" + uuid.NewString()[:8],
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", true, true, &workspaceID, nil)
+	cfg := created.Config
+	cfg.ProjectID = project.ID
+
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	// Both clear the client and detail-type gates; one lacks session_id, the
+	// other lacks event_id.
+	noSession := `{"event_id":"cdx_ns","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T12:00:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"","model":"gpt-5.5","prompt_text":"orphan prompt"}}` + "\n"
+	noEventID := `{"event_id":"","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T12:01:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"44444444-5555-4666-8777-888888888888","model":"gpt-5.5","prompt_text":"unidentified prompt"}}` + "\n"
+	body := noSession + noEventID
+
+	file := codexCloudFixtureFile(body)
+	file.ID = "eclf_missing_ids"
+
+	svc := NewCodexCloudImportService(testenv.NewLogger(t), store, conn, nil, writer, func(context.Context, int) {})
+	src := &codexCloudSource{
+		client:         &stubCodexComplianceClient{downloads: map[string][]byte{file.ID: []byte(body)}},
+		svc:            svc,
+		cfg:            cfg,
+		pageLimit:      codexCloudPageLimit,
+		users:          newConnectedUserResolver(conn, orgID),
+		chatIDs:        map[string]uuid.UUID{},
+		titledSessions: map[string]bool{},
+		progress:       &CodexCloudSyncProgress{},
+	}
+
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
+
+	require.Equal(t, 2, src.progress.SkippedMissingIDs,
+		"an event dropped for a missing identifier must be counted, not silently discarded")
+	require.Zero(t, src.progress.SkippedClients)
+	require.Zero(t, src.progress.SkippedDetails)
+	require.Zero(t, src.progress.ChatsUpserted, "an unidentifiable event must not create a chat")
+	require.Zero(t, src.progress.MessagesWritten)
+
+	// The canary must be visible in the failure report operators read.
+	require.Contains(t, src.progress.String(), "skipped_missing_ids=2")
+}

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -1,0 +1,187 @@
+package aiintegrations
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/chat"
+	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	codexapi "github.com/speakeasy-api/gram/server/internal/thirdparty/codex"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+// The fixture exercises the importer's edge handling: a web prompt/response
+// pair (imported), a CODEX_DESKTOP_APP event (counted and skipped — device
+// surface pending the unified-app verification), an unknown detail_type on
+// the web client (admitted as an event but skipped from message rows), and a
+// foreign event type (dropped at parse).
+const codexCloudFixture = `{"event_id":"cdx_1","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:00:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"11111111-2222-4333-8444-555555555555","model":"gpt-5.5","prompt_text":"Fix the flaky retry test in CI"}}
+{"event_id":"cdx_2","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:00:20Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_RESPONSE_RECEIVED","session_id":"11111111-2222-4333-8444-555555555555","model":"gpt-5.5","response_text":"I updated the retry helper to poll instead of sleeping.","status":"completed","service_tier":"default","reasoning_effort":"medium","token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":25,"reasoning_output_tokens":10}}}
+{"event_id":"cdx_3","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_2","user_email":"lin@example.com"},"timestamp":"2026-07-28T10:01:00Z","client_id":"CODEX_DESKTOP_APP","event_details":{"detail_type":"PROMPT_SENT","session_id":"99999999-8888-4777-8666-555555555555","model":"gpt-5.5","prompt_text":"desktop prompt"}}
+{"event_id":"cdx_4","type":"CODEX_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:02:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"SESSION_ARCHIVED","session_id":"11111111-2222-4333-8444-555555555555","model":"gpt-5.5"}}
+{"event_id":"cdx_5","type":"AUDIT_LOG","workspace_id":"ws_1","principal":{"id":"ws_1","type":"CHATGPT_WORKSPACE"},"actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:03:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"","session_id":"","model":""}}
+`
+
+func codexCloudFixtureFile(body string) codexapi.LogFile {
+	sum := sha256.Sum256([]byte(body))
+	return codexapi.LogFile{
+		ID:         "eclf_codex_cloud_1",
+		EventType:  codexCloudEventType,
+		EndTime:    time.Date(2026, 7, 28, 10, 19, 31, 0, time.UTC),
+		FileName:   "CODEX_LOG_2026-07-28T10:19:31.jsonl",
+		FileSize:   int64(len(body)),
+		FileSHA256: hex.EncodeToString(sum[:]),
+	}
+}
+
+func TestParseCodexCloudEventsVerifiesSHAAndSkipsForeignTypes(t *testing.T) {
+	t.Parallel()
+
+	file := codexCloudFixtureFile(codexCloudFixture)
+	events, err := parseCodexCloudEvents(file, []byte(codexCloudFixture))
+	require.NoError(t, err)
+	// The AUDIT_LOG line is dropped at parse; everything else survives.
+	require.Len(t, events, 4)
+	require.Equal(t, "cdx_1", events[0].EventID)
+	require.Equal(t, codexCloudDetailPromptSent, events[0].EventDetails.DetailType)
+
+	file.FileSHA256 = "not-the-right-hash"
+	_, err = parseCodexCloudEvents(file, []byte(codexCloudFixture))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sha256 mismatch")
+}
+
+func TestCodexCloudChatTitleTruncatesByRunes(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, codexCloudChatTitle("   "))
+	require.Equal(t, "Fix the CI", codexCloudChatTitle("  Fix the CI  "))
+
+	long := strings.Repeat("界", 100)
+	title := codexCloudChatTitle(long)
+	require.Len(t, []rune(title), codexCloudTitleMaxRunes)
+}
+
+func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Codex Cloud Import Test Project",
+		Slug:           "project-" + uuid.NewString()[:8],
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	userRow, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          "user_" + uuid.NewString(),
+		Email:       "grace@example.com",
+		DisplayName: "Grace",
+		PhotoUrl:    conv.ToPGTextEmpty(""),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, testrepo.New(conn).CreateOrganizationUserRelationshipFixture(ctx, testrepo.CreateOrganizationUserRelationshipFixtureParams{
+		OrganizationID: orgID,
+		UserID:         conv.ToPGText(userRow.ID),
+	}))
+
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", true, true, &workspaceID, nil)
+	cfg := created.Config
+	cfg.ProjectID = project.ID
+
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	heartbeats := 0
+	svc := NewCodexCloudImportService(testenv.NewLogger(t), store, conn, nil, writer, func(context.Context, int) { heartbeats++ })
+	file := codexCloudFixtureFile(codexCloudFixture)
+	src := &codexCloudSource{
+		client: &stubCodexComplianceClient{
+			listPages:  nil,
+			listParams: nil,
+			downloads:  map[string][]byte{file.ID: []byte(codexCloudFixture)},
+		},
+		svc:       svc,
+		cfg:       cfg,
+		pageLimit: codexCloudPageLimit,
+		users:     newConnectedUserResolver(conn, orgID),
+		chatIDs:   map[string]uuid.UUID{},
+		progress:  &CodexCloudSyncProgress{},
+	}
+
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
+	// ProcessPage must heartbeat per file: dense pages otherwise exceed the
+	// activity's 1-minute heartbeat timeout.
+	require.Positive(t, heartbeats)
+	require.Equal(t, int64(2), src.progress.MessagesWritten)
+	// The desktop-app event is counted and skipped, never imported.
+	require.Equal(t, 1, src.progress.SkippedClients)
+	require.NotContains(t, src.chatIDs, "99999999-8888-4777-8666-555555555555")
+
+	chatID, ok := src.chatIDs["11111111-2222-4333-8444-555555555555"]
+	require.True(t, ok, "web session must be upserted")
+	chatRow, err := chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	// The feed carries no titles: the first prompt seeds the chat title.
+	require.Equal(t, "Fix the flaky retry test in CI", chatRow.Title.String)
+	require.Equal(t, "11111111-2222-4333-8444-555555555555", chatRow.ExternalChatID.String)
+	require.Equal(t, userRow.ID, chatRow.UserID.String)
+
+	messages, err := chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
+	require.NoError(t, err)
+	// The unknown detail_type event is skipped; only prompt + response land.
+	require.Len(t, messages, 2)
+	require.Equal(t, "user", messages[0].Role)
+	require.Equal(t, "Fix the flaky retry test in CI", messages[0].Content)
+	require.Equal(t, "assistant", messages[1].Role)
+	require.Equal(t, "I updated the retry helper to poll instead of sleeping.", messages[1].Content)
+	require.Equal(t, "gpt-5.5", messages[1].Model.String)
+	require.Equal(t, "completed", messages[1].FinishReason.String)
+	require.Equal(t, codexCloudSourceSlug, messages[0].Source.String)
+	require.Equal(t, "cdx_1", messages[0].ExternalMessageID.String)
+	require.Equal(t, codexCloudClientWeb, messages[0].UserAgent.String)
+	require.Equal(t, userRow.ID, messages[0].UserID.String)
+	// Per-turn token_usage is deliberately dropped: cloud tokens meter via
+	// the compliance COSTS promotion, not imported transcripts.
+	require.Zero(t, messages[1].PromptTokens)
+	require.Zero(t, messages[1].CompletionTokens)
+	require.Zero(t, messages[1].TotalTokens)
+
+	// Replaying the same file must not duplicate messages: the insert
+	// dedupes on (chat_id, external_message_id).
+	src.chatIDs = map[string]uuid.UUID{}
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{file}))
+	messages, err = chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+	// The replay re-sends the same prompt-derived title, never a stale one.
+	chatRow, err = chatrepo.New(conn).GetChat(ctx, chatID)
+	require.NoError(t, err)
+	require.Equal(t, "Fix the flaky retry test in CI", chatRow.Title.String)
+}
+
+func newCodexCloudTestSource(cfg Config, client codexComplianceClient) *codexCloudSource {
+	return &codexCloudSource{
+		client:    client,
+		svc:       &CodexCloudImportService{logger: nil, store: nil, guardianPolicy: nil, db: nil, writer: nil, heartbeat: func(context.Context, int) {}},
+		cfg:       cfg,
+		pageLimit: codexCloudPageLimit,
+		users:     nil,
+		chatIDs:   map[string]uuid.UUID{},
+		progress:  &CodexCloudSyncProgress{},
+	}
+}

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -176,10 +176,29 @@ func TestCodexCloudProcessPageWritesChatAndMessagesIdempotently(t *testing.T) {
 	messages, err = chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
 	require.NoError(t, err)
 	require.Len(t, messages, 2)
-	// The replay re-sends the same prompt-derived title, never a stale one.
+
+	// A later poll window (fresh run: empty caches) sees only the session's
+	// later turns and derives a MID-SESSION prompt as its "first". First-wins
+	// title semantics must keep the original title — newest-wins would
+	// retitle the chat on every window.
+	laterWindow := `{"event_id":"cdx_6","type":"CODEX_LOG","actor":{"type":"ACCOUNT_USER","user_id":"oai_user_1","user_email":"grace@example.com"},"timestamp":"2026-07-28T10:10:00Z","client_id":"CODEX_WEB","event_details":{"detail_type":"PROMPT_SENT","session_id":"11111111-2222-4333-8444-555555555555","model":"gpt-5.5","prompt_text":"Also add a changelog entry"}}` + "\n"
+	laterFile := codexCloudFixtureFile(laterWindow)
+	laterFile.ID = "eclf_codex_cloud_2"
+	src.chatIDs = map[string]uuid.UUID{}
+	src.chatTitles = map[string]string{}
+	src.client = &stubCodexComplianceClient{
+		listPages:  nil,
+		listParams: nil,
+		downloads:  map[string][]byte{laterFile.ID: []byte(laterWindow)},
+	}
+	require.NoError(t, src.ProcessPage(ctx, []codexapi.LogFile{laterFile}))
+	messages, err = chatrepo.New(conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{ChatID: chatID, ProjectID: project.ID})
+	require.NoError(t, err)
+	require.Len(t, messages, 3)
 	chatRow, err = chatrepo.New(conn).GetChat(ctx, chatID)
 	require.NoError(t, err)
-	require.Equal(t, "Fix the flaky retry test in CI", chatRow.Title.String)
+	require.Equal(t, "Fix the flaky retry test in CI", chatRow.Title.String,
+		"a mid-session prompt from a later window must not retitle the chat")
 }
 
 func newCodexCloudTestSource(cfg Config, client codexComplianceClient) *codexCloudSource {

--- a/server/internal/aiintegrations/codex_cloud_import_test.go
+++ b/server/internal/aiintegrations/codex_cloud_import_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -380,4 +383,65 @@ func TestCodexCloudMalformedTimestampCountsOncePerEvent(t *testing.T) {
 	require.NoError(t, err)
 	// Chat and message share the one resolved import-time fallback.
 	require.WithinDuration(t, time.Now().UTC(), chatRow.CreatedAt.Time.UTC(), time.Minute)
+}
+
+// TestSyncCodexCloudSessionsRejectsMisconfiguredIntegrations: the cloud
+// transcript feed is workspace-scoped and lives on chatgpt_compliance, while
+// Codex cost data lives on codex_compliance. Pointing this importer at the
+// wrong provider must fail loudly — running it anyway would import against the
+// wrong credential and surface as confusing data rather than an error. The
+// workspace id is likewise required: without it the client cannot scope its
+// requests at all.
+func TestSyncCodexCloudSessionsRejectsMisconfiguredIntegrations(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, _ := newStoreTestDB(t)
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), conn, nil)
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	svc := NewCodexCloudImportService(testenv.NewLogger(t), store, conn, nil, writer, func(context.Context, int) {})
+
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	now := time.Now().UTC()
+
+	err := svc.SyncCodexCloudSessions(ctx, Config{
+		Provider:               ProviderCodexCompliance,
+		ExternalOrganizationID: &workspaceID,
+	}, now)
+	require.Error(t, err, "the codex cost provider must not drive the cloud transcript import")
+	require.Contains(t, err.Error(), ProviderCodexCompliance)
+
+	err = svc.SyncCodexCloudSessions(ctx, Config{
+		Provider:               ProviderChatGPTCompliance,
+		ExternalOrganizationID: nil,
+	}, now)
+	require.Error(t, err, "the workspace id scopes every request and cannot be absent")
+	require.Contains(t, err.Error(), "external_organization_id")
+}
+
+// TestCodexCloudRetryAfterOnlyBacksOffOnRateLimits: a 429 must park the sync
+// for the poller to retry, while any other failure surfaces. The match is an
+// errors.As against the client's typed error, so wrapping changes upstream can
+// silently turn a retryable rate limit into a hard failure — or worse, make
+// every error look retryable and spin.
+func TestCodexCloudRetryAfterOnlyBacksOffOnRateLimits(t *testing.T) {
+	t.Parallel()
+
+	src := &codexCloudSource{}
+
+	_, retry := src.RetryAfter(&codexapi.HTTPError{StatusCode: http.StatusTooManyRequests})
+	require.True(t, retry, "a 429 must be retried")
+
+	// Still a rate limit after the poller wraps it on the way up.
+	_, retry = src.RetryAfter(fmt.Errorf("fetch page: %w", &codexapi.HTTPError{StatusCode: http.StatusTooManyRequests}))
+	require.True(t, retry, "wrapping must not hide the rate limit")
+
+	for _, err := range []error{
+		&codexapi.HTTPError{StatusCode: http.StatusInternalServerError},
+		&codexapi.HTTPError{StatusCode: http.StatusUnauthorized},
+		errors.New("connection reset"),
+		nil,
+	} {
+		_, retry = src.RetryAfter(err)
+		require.False(t, retry, "only a 429 is retryable: %v", err)
+	}
 }

--- a/server/internal/aiintegrations/compliance_import.go
+++ b/server/internal/aiintegrations/compliance_import.go
@@ -421,6 +421,8 @@ func (s *ComplianceImportService) upsertActivityChat(ctx context.Context, cfg Co
 		Title:     pgtype.Text{String: "", Valid: false},
 		CreatedAt: conv.ToPGTimestamptz(createdAt),
 		UpdatedAt: conv.ToPGTimestamptz(createdAt),
+		// Feed titles are authoritative: newest non-null title wins.
+		PreferStoredTitle: false,
 	})
 	if err != nil {
 		return uuid.Nil, "", oops.E(oops.CodeUnexpected, err, "upsert anthropic compliance chat")
@@ -511,6 +513,8 @@ func (s *ComplianceImportService) upsertMessagePageChat(ctx context.Context, cfg
 		Title:          conv.ToPGText(page.Name),
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),
 		UpdatedAt:      conv.ToPGTimestamptz(updatedAt),
+		// Feed titles are authoritative: newest non-null title wins.
+		PreferStoredTitle: false,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "upsert anthropic compliance chat metadata")

--- a/server/internal/aiintegrations/logfile_source_pagination_test.go
+++ b/server/internal/aiintegrations/logfile_source_pagination_test.go
@@ -56,6 +56,15 @@ func logFileSourceCases() []logFileSourceCase {
 				return newChatGPTTestSource(cfg, client)
 			},
 		},
+		{
+			name:      "codex_cloud_sessions",
+			eventType: codexCloudEventType,
+			lookback:  chatgptComplianceInitialLookback,
+			newConfig: chatgptConversationConfig,
+			newSource: func(cfg Config, client codexComplianceClient) logFilePager {
+				return newCodexCloudTestSource(cfg, client)
+			},
+		},
 	}
 }
 

--- a/server/internal/aiintegrations/store.go
+++ b/server/internal/aiintegrations/store.go
@@ -430,6 +430,7 @@ func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, orgID string, 
 	// poller begin with its initial lookback; cursor-kind schedules
 	// checkpoint through last_cursor_id, so their watermark starts at now.
 	var syncRow repo.EnsureSyncRow
+	syncRows := map[string]repo.EnsureSyncRow{}
 	for _, sched := range syncSchedulesFor(provider) {
 		initialAt := time.Now().UTC()
 		if sched.kind == SyncKindTime {
@@ -445,6 +446,7 @@ func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, orgID string, 
 		if err != nil {
 			return UpsertResult{}, oops.E(oops.CodeUnexpected, err, "failed to save ai integration sync")
 		}
+		syncRows[sched.schedule] = r
 		if sched.schedule == providerSched.schedule {
 			syncRow = r
 		}
@@ -464,13 +466,32 @@ func (s *Store) upsertWithTx(ctx context.Context, dbtx repo.DBTX, orgID string, 
 		syncRow.ConsecutiveFailures = 0
 		syncRow.PollCheckpoint = pgtype.Text{String: "", Valid: false}
 		syncRow.LastCursorID = pgtype.Text{String: "", Valid: false}
-		if err := q.ResetUsagePollState(ctx, repo.ResetUsagePollStateParams{
-			AiIntegrationConfigID: row.ID,
-			Schedule:              provider,
-			PollWatermarkAt:       syncRow.PollWatermarkAt,
-			NextPollAfter:         syncRow.NextPollAfter,
-		}); err != nil {
-			return UpsertResult{}, oops.E(oops.CodeUnexpected, err, "failed to reset ai integration sync watermark")
+		// Reset every schedule on the config that has actually synced, not just
+		// the provider-named one: all of a provider's feeds key on the same
+		// credentials and external scope, so a key or org/workspace change
+		// invalidates every sibling watermark too. A sibling left on the old
+		// scope's watermark would silently skip the new scope's history —
+		// e.g. changing the ChatGPT workspace id would re-backfill
+		// conversations but resume the Codex cloud transcript feed from the
+		// old workspace's position. Never-synced siblings (epoch watermark)
+		// are left untouched: the epoch sentinel drives their first-sync
+		// behavior (initial lookback, finality probing) and overwriting it
+		// would erase that state.
+		for _, sched := range syncSchedulesFor(provider) {
+			if sched.schedule != providerSched.schedule {
+				existing, ok := syncRows[sched.schedule]
+				if !ok || !existing.PollWatermarkAt.Time.After(epochTime()) {
+					continue
+				}
+			}
+			if err := q.ResetUsagePollState(ctx, repo.ResetUsagePollStateParams{
+				AiIntegrationConfigID: row.ID,
+				Schedule:              sched.schedule,
+				PollWatermarkAt:       syncRow.PollWatermarkAt,
+				NextPollAfter:         conv.ToPGTimestamptz(resetPollWatermarkAt.UTC().Add(pollIntervalForSchedule(sched.schedule))),
+			}); err != nil {
+				return UpsertResult{}, oops.E(oops.CodeUnexpected, err, "failed to reset ai integration sync watermark")
+			}
 		}
 	}
 

--- a/server/internal/aiintegrations/store.go
+++ b/server/internal/aiintegrations/store.go
@@ -54,6 +54,10 @@ const (
 	ScheduleAnthropicAnalyticsCost  = "anthropic_analytics_cost"
 	ScheduleCodexCompliance         = ProviderCodexCompliance
 	ScheduleChatGPTCompliance       = ProviderChatGPTCompliance
+	// ScheduleCodexCloudSessions imports Codex cloud task transcripts
+	// (CODEX_LOG files) — a second schedule on the chatgpt_compliance config,
+	// which owns the workspace scope both feeds are served under.
+	ScheduleCodexCloudSessions = "codex_cloud_sessions"
 )
 
 // Sync kinds record how a schedule checkpoints progress.
@@ -92,6 +96,10 @@ const (
 	// messages from the Compliance Logs Platform CONVERSATION_MESSAGE feed —
 	// discrete activity events like claude.chat.message, not metrics.
 	StreamChatGPTChatMessage = "chatgpt.chat.message"
+	// codex.cloud.chat.message carries Codex cloud task transcripts (web
+	// tasks; GitHub code review has no CODEX_LOG presence) from the
+	// Compliance Logs Platform CODEX_LOG feed — discrete activity events.
+	StreamCodexCloudChatMessage = "codex.cloud.chat.message"
 )
 
 // streamInfo names the product-level stream a schedule writes.
@@ -120,6 +128,8 @@ func streamForSchedule(schedule string) streamInfo {
 		return streamInfo{name: StreamCodexCostUSD, kind: StreamKindMetrics}
 	case ScheduleChatGPTCompliance:
 		return streamInfo{name: StreamChatGPTChatMessage, kind: StreamKindEvents}
+	case ScheduleCodexCloudSessions:
+		return streamInfo{name: StreamCodexCloudChatMessage, kind: StreamKindEvents}
 	default:
 		return streamInfo{name: "", kind: ""}
 	}
@@ -160,6 +170,11 @@ func syncSchedulesFor(provider string) []syncSchedule {
 		}
 	case ProviderCodexCompliance:
 		return []syncSchedule{providerSyncSchedule(provider)}
+	case ProviderChatGPTCompliance:
+		return []syncSchedule{
+			providerSyncSchedule(provider),
+			{schedule: ScheduleCodexCloudSessions, kind: SyncKindTime},
+		}
 	default:
 		return []syncSchedule{providerSyncSchedule(provider)}
 	}
@@ -224,7 +239,7 @@ func pollIntervalForSchedule(schedule string) time.Duration {
 		return anthropicAnalyticsPollInterval
 	case ScheduleCodexCompliance:
 		return codexComplianceUsagePollInterval
-	case ScheduleChatGPTCompliance:
+	case ScheduleChatGPTCompliance, ScheduleCodexCloudSessions:
 		return chatgptCompliancePollInterval
 	default:
 		return cursorUsagePollInterval

--- a/server/internal/aiintegrations/store_test.go
+++ b/server/internal/aiintegrations/store_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/aiintegrations/repo"
+	"github.com/speakeasy-api/gram/server/internal/aiintegrations/timewindowpoller"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 )
 
 func TestUpsertWithTxCreatesConfigGeneration(t *testing.T) {
@@ -420,4 +423,69 @@ func TestUpsertWithTxStartsChatGPTSchedules(t *testing.T) {
 		ScheduleChatGPTCompliance:  SyncKindTime,
 		ScheduleCodexCloudSessions: SyncKindTime,
 	}, listSyncSchedules(t, ctx, conn, created.Config.ID))
+}
+
+// TestUpsertResetsAllProviderScheduleWatermarks: a key or external-scope
+// change resets every SYNCED schedule on the config, not just the
+// provider-named one — all of a provider's feeds key on the same
+// credentials/scope, and a sibling left on the old scope's watermark would
+// silently skip the new scope's history (e.g. a ChatGPT workspace-id fix
+// re-backfilling conversations but not Codex cloud transcripts). A
+// never-synced sibling keeps its epoch sentinel: that state drives first-sync
+// behavior (initial lookback, finality probing) and must not be erased.
+func TestUpsertResetsAllProviderScheduleWatermarks(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", true, true, &workspaceID, nil)
+
+	// The transcript sibling has synced: its stale watermark must reset.
+	syncedAt := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	siblingCfg, err := store.GetUsagePollConfig(ctx, created.Config.ID, ScheduleCodexCloudSessions)
+	require.NoError(t, err)
+	require.NoError(t, store.AdvanceWatermark(ctx, siblingCfg.SyncID, timewindowpoller.CompletedCheckpoint(syncedAt)))
+
+	resetAt := time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
+	otherWorkspace := "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
+	upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", false, true, &otherWorkspace, &resetAt)
+
+	rows, err := repo.New(conn).ListSyncSchedules(ctx, created.Config.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for _, row := range rows {
+		require.Equal(t, resetAt.Add(chatgptCompliancePollInterval), row.NextPollAfter.Time.UTC(), row.Schedule)
+	}
+	siblingCfg, err = store.GetUsagePollConfig(ctx, created.Config.ID, ScheduleCodexCloudSessions)
+	require.NoError(t, err)
+	require.Equal(t, resetAt, siblingCfg.PollWatermarkAt.UTC())
+
+	// A fresh config's never-synced sibling keeps its epoch sentinel through
+	// a reset (only the provider-named schedule always resets).
+	orgB := "org_" + uuid.NewString()
+	_, err = orgrepo.New(conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgB,
+		Name:        "Reset Fresh Org",
+		Slug:        orgB,
+		WorkosID:    pgtype.Text{String: orgB, Valid: true},
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+	_, err = projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Reset Fresh Project",
+		Slug:           "project-" + uuid.NewString()[:8],
+		OrganizationID: orgB,
+	})
+	require.NoError(t, err)
+	freshWorkspace := "cccccccc-dddd-4eee-8fff-000000000000"
+	fresh := upsertConfigWithTx(t, ctx, conn, store, orgB, ProviderChatGPTCompliance, "chatgpt-key", true, true, &freshWorkspace, &resetAt)
+	freshRows, err := repo.New(conn).ListSyncSchedules(ctx, fresh.Config.ID)
+	require.NoError(t, err)
+	require.Len(t, freshRows, 2)
+	for _, row := range freshRows {
+		if row.Schedule == ScheduleCodexCloudSessions {
+			require.Equal(t, time.Unix(0, 0).UTC(), row.NextPollAfter.Time.UTC(), "never-synced sibling stays due-immediately at epoch")
+		}
+	}
 }

--- a/server/internal/aiintegrations/store_test.go
+++ b/server/internal/aiintegrations/store_test.go
@@ -403,3 +403,21 @@ func TestUpsertRejectsNonUUIDWorkspaceIDForChatGPTCompliance(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "ChatGPT workspace UUID")
 }
+
+// TestUpsertWithTxStartsChatGPTSchedules: the chatgpt_compliance config owns
+// BOTH workspace-scoped feeds — conversation messages and Codex cloud task
+// transcripts — so saving it must start both time-kind schedules. This is
+// also the wiring ensureActiveSyncSchedules reconciles onto existing configs.
+func TestUpsertWithTxStartsChatGPTSchedules(t *testing.T) {
+	t.Parallel()
+
+	ctx, conn, store, orgID := newStoreTestDB(t)
+
+	workspaceID := "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+	created := upsertConfigWithTx(t, ctx, conn, store, orgID, ProviderChatGPTCompliance, "chatgpt-key", true, true, &workspaceID, nil)
+
+	require.Equal(t, map[string]string{
+		ScheduleChatGPTCompliance:  SyncKindTime,
+		ScheduleCodexCloudSessions: SyncKindTime,
+	}, listSyncSchedules(t, ctx, conn, created.Config.ID))
+}

--- a/server/internal/aiintegrations/sync_error.go
+++ b/server/internal/aiintegrations/sync_error.go
@@ -152,6 +152,13 @@ func (p ChatGPTConversationSyncProgress) String() string {
 	)
 }
 
+func (p CodexCloudSyncProgress) String() string {
+	return fmt.Sprintf(
+		"window_start=%s log_pages=%d log_files=%d events=%d messages_written=%d chats_upserted=%d skipped_clients=%d timestamp_fallbacks=%d watermark_reached=%s",
+		p.WindowStart.Format(time.RFC3339Nano), p.LogPages, p.LogFiles, p.Events, p.MessagesWritten, p.ChatsUpserted, p.SkippedClients, p.TimestampFallbacks, p.WatermarkReached.Format(time.RFC3339Nano),
+	)
+}
+
 func (p CodexCostSyncProgress) String() string {
 	return fmt.Sprintf(
 		"window_start=%s log_pages=%d log_files=%d cost_events=%d cost_events_written=%d watermark_reached=%s",

--- a/server/internal/aiintegrations/sync_error.go
+++ b/server/internal/aiintegrations/sync_error.go
@@ -154,8 +154,8 @@ func (p ChatGPTConversationSyncProgress) String() string {
 
 func (p CodexCloudSyncProgress) String() string {
 	return fmt.Sprintf(
-		"window_start=%s log_pages=%d log_files=%d events=%d messages_written=%d chats_upserted=%d skipped_clients=%d timestamp_fallbacks=%d watermark_reached=%s",
-		p.WindowStart.Format(time.RFC3339Nano), p.LogPages, p.LogFiles, p.Events, p.MessagesWritten, p.ChatsUpserted, p.SkippedClients, p.TimestampFallbacks, p.WatermarkReached.Format(time.RFC3339Nano),
+		"window_start=%s log_pages=%d log_files=%d events=%d messages_written=%d chats_upserted=%d skipped_clients=%d skipped_details=%d timestamp_fallbacks=%d watermark_reached=%s",
+		p.WindowStart.Format(time.RFC3339Nano), p.LogPages, p.LogFiles, p.Events, p.MessagesWritten, p.ChatsUpserted, p.SkippedClients, p.SkippedDetails, p.TimestampFallbacks, p.WatermarkReached.Format(time.RFC3339Nano),
 	)
 }
 

--- a/server/internal/aiintegrations/sync_error.go
+++ b/server/internal/aiintegrations/sync_error.go
@@ -154,8 +154,8 @@ func (p ChatGPTConversationSyncProgress) String() string {
 
 func (p CodexCloudSyncProgress) String() string {
 	return fmt.Sprintf(
-		"window_start=%s log_pages=%d log_files=%d events=%d messages_written=%d chats_upserted=%d skipped_clients=%d skipped_details=%d timestamp_fallbacks=%d watermark_reached=%s",
-		p.WindowStart.Format(time.RFC3339Nano), p.LogPages, p.LogFiles, p.Events, p.MessagesWritten, p.ChatsUpserted, p.SkippedClients, p.SkippedDetails, p.TimestampFallbacks, p.WatermarkReached.Format(time.RFC3339Nano),
+		"window_start=%s log_pages=%d log_files=%d events=%d messages_written=%d chats_upserted=%d skipped_clients=%d skipped_details=%d skipped_missing_ids=%d timestamp_fallbacks=%d watermark_reached=%s",
+		p.WindowStart.Format(time.RFC3339Nano), p.LogPages, p.LogFiles, p.Events, p.MessagesWritten, p.ChatsUpserted, p.SkippedClients, p.SkippedDetails, p.SkippedMissingIDs, p.TimestampFallbacks, p.WatermarkReached.Format(time.RFC3339Nano),
 	)
 }
 

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -547,6 +547,10 @@ const (
 	// events whose timestamps failed RFC3339 parsing in one log file and
 	// fell back to import time — a canary for upstream format changes.
 	ChatGPTComplianceTimestampFallbacksKey = attribute.Key("chatgpt.compliance.timestamp_fallbacks")
+	// CodexCloudTimestampFallbacksKey is the CODEX_LOG transcript import's
+	// counterpart, kept as its own key so a Codex cloud feed regression is
+	// never mis-attributed to the ChatGPT conversation import.
+	CodexCloudTimestampFallbacksKey = attribute.Key("codex.cloud.timestamp_fallbacks")
 
 	// GenAI evaluation keys (OTel semconv experimental - gen_ai.evaluation.*)
 	GenAIEvaluationNameKey        = attribute.Key("gen_ai.evaluation.name")        // Evaluation metric name (e.g., "chat_resolution")
@@ -725,6 +729,10 @@ func SlogTelemetryPublishFailedCount(v int) slog.Attr {
 
 func SlogChatGPTComplianceTimestampFallbacks(v int) slog.Attr {
 	return slog.Int(string(ChatGPTComplianceTimestampFallbacksKey), v)
+}
+
+func SlogCodexCloudTimestampFallbacks(v int) slog.Attr {
+	return slog.Int(string(CodexCloudTimestampFallbacksKey), v)
 }
 
 func TelemetryCHOperation(v string) attribute.KeyValue { return TelemetryCHOperationKey.String(v) }

--- a/server/internal/background/activities/poll_ai_data.go
+++ b/server/internal/background/activities/poll_ai_data.go
@@ -55,6 +55,7 @@ type PollAIData struct {
 	anthropicAnalyticsCostPoller  *aiintegrations.AnthropicAnalyticsPoller
 	codexCostImporter             *aiintegrations.CodexCostImportService
 	chatgptConversationImporter   *aiintegrations.ChatGPTConversationImportService
+	codexCloudImporter            *aiintegrations.CodexCloudImportService
 }
 
 func NewPollAIData(
@@ -91,6 +92,12 @@ func NewPollAIData(
 			"page":     page,
 		})
 	}
+	codexCloudHeartbeat := func(ctx context.Context, page int) {
+		activity.RecordHeartbeat(ctx, map[string]any{
+			"schedule": aiintegrations.ScheduleCodexCloudSessions,
+			"page":     page,
+		})
+	}
 	return &PollAIData{
 		integrations: store,
 		cursorUsagePoller: aiintegrations.NewUsagePollService(store, telemetryLogger, guardianPolicy, func(ctx context.Context, page int) {
@@ -104,6 +111,7 @@ func NewPollAIData(
 		anthropicAnalyticsCostPoller:  aiintegrations.NewAnthropicCostAnalyticsPoller(store, guardianPolicy, telemetryLogger, analyticsHeartbeat),
 		codexCostImporter:             aiintegrations.NewCodexCostImportService(logger, store, telemetryLogger, guardianPolicy, codexHeartbeat),
 		chatgptConversationImporter:   aiintegrations.NewChatGPTConversationImportService(logger, store, db, guardianPolicy, chatWriter, chatgptHeartbeat),
+		codexCloudImporter:            aiintegrations.NewCodexCloudImportService(logger, store, db, guardianPolicy, chatWriter, codexCloudHeartbeat),
 	}
 }
 
@@ -246,6 +254,25 @@ func (p *PollAIData) Do(ctx context.Context, input string) (err error) {
 		}
 		if err := p.integrations.RecordSchedulePollSuccess(ctx, cfg.ID, schedule, endTime); err != nil {
 			return oops.E(oops.CodeUnexpected, err, "record chatgpt compliance schedule success")
+		}
+	case aiintegrations.ScheduleCodexCloudSessions:
+		if cfg.Provider != aiintegrations.ProviderChatGPTCompliance {
+			return oops.E(oops.CodeInvalid, nil, "codex cloud sessions schedule cannot run for provider %s", cfg.Provider)
+		}
+		if err := p.codexCloudImporter.SyncCodexCloudSessions(ctx, cfg, endTime); err != nil {
+			var httpErr *codexapi.HTTPError
+			if errors.As(err, &httpErr) {
+				switch httpErr.StatusCode {
+				case 401, 403:
+					return oops.E(oops.CodeUnauthorized, err, "codex cloud import rejected the configured api key")
+				case 404:
+					return oops.E(oops.CodeNotFound, err, "codex cloud workspace not found or compliance api access not enabled")
+				}
+			}
+			return oops.E(oops.CodeUnexpected, err, "sync codex cloud session data")
+		}
+		if err := p.integrations.RecordSchedulePollSuccess(ctx, cfg.ID, schedule, endTime); err != nil {
+			return oops.E(oops.CodeUnexpected, err, "record codex cloud sessions schedule success")
 		}
 	default:
 		return oops.E(oops.CodeInvalid, nil, "unsupported ai integration sync schedule: %s", schedule)

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -122,7 +122,16 @@ DO UPDATE SET
     project_id = EXCLUDED.project_id
   , user_id = COALESCE(EXCLUDED.user_id, chats.user_id)
   , external_user_id = COALESCE(EXCLUDED.external_user_id, chats.external_user_id)
-  , title = COALESCE(EXCLUDED.title, chats.title)
+  -- Two title regimes share this upsert. Feeds with authoritative titles
+  -- (ChatGPT conversations, Anthropic compliance) are newest-wins: a non-null
+  -- incoming title refreshes the row. Feeds whose titles are DERIVED from
+  -- content (Codex cloud: the session's first prompt) are first-wins
+  -- (@prefer_stored_title): a later poll window derives a mid-session prompt
+  -- as its "first", and newest-wins would retitle the chat on every window.
+  , title = CASE
+      WHEN @prefer_stored_title::bool THEN COALESCE(chats.title, EXCLUDED.title)
+      ELSE COALESCE(EXCLUDED.title, chats.title)
+    END
   , updated_at = GREATEST(chats.updated_at, EXCLUDED.updated_at)
 RETURNING id;
 

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -3282,21 +3282,31 @@ DO UPDATE SET
     project_id = EXCLUDED.project_id
   , user_id = COALESCE(EXCLUDED.user_id, chats.user_id)
   , external_user_id = COALESCE(EXCLUDED.external_user_id, chats.external_user_id)
-  , title = COALESCE(EXCLUDED.title, chats.title)
+  -- Two title regimes share this upsert. Feeds with authoritative titles
+  -- (ChatGPT conversations, Anthropic compliance) are newest-wins: a non-null
+  -- incoming title refreshes the row. Feeds whose titles are DERIVED from
+  -- content (Codex cloud: the session's first prompt) are first-wins
+  -- (@prefer_stored_title): a later poll window derives a mid-session prompt
+  -- as its "first", and newest-wins would retitle the chat on every window.
+  , title = CASE
+      WHEN $10::bool THEN COALESCE(chats.title, EXCLUDED.title)
+      ELSE COALESCE(EXCLUDED.title, chats.title)
+    END
   , updated_at = GREATEST(chats.updated_at, EXCLUDED.updated_at)
 RETURNING id
 `
 
 type UpsertExternalChatParams struct {
-	ID             uuid.UUID
-	ProjectID      uuid.UUID
-	OrganizationID string
-	UserID         pgtype.Text
-	ExternalUserID pgtype.Text
-	ExternalChatID pgtype.Text
-	Title          pgtype.Text
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
+	ID                uuid.UUID
+	ProjectID         uuid.UUID
+	OrganizationID    string
+	UserID            pgtype.Text
+	ExternalUserID    pgtype.Text
+	ExternalChatID    pgtype.Text
+	Title             pgtype.Text
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	PreferStoredTitle bool
 }
 
 func (q *Queries) UpsertExternalChat(ctx context.Context, arg UpsertExternalChatParams) (uuid.UUID, error) {
@@ -3310,6 +3320,7 @@ func (q *Queries) UpsertExternalChat(ctx context.Context, arg UpsertExternalChat
 		arg.Title,
 		arg.CreatedAt,
 		arg.UpdatedAt,
+		arg.PreferStoredTitle,
 	)
 	var id uuid.UUID
 	err := row.Scan(&id)

--- a/server/internal/chat/sources.go
+++ b/server/internal/chat/sources.go
@@ -24,6 +24,10 @@ var sourceAliases = map[string][]string{
 	// ChatGPT (web/desktop chat + Work mode) — rows arrive via the OpenAI
 	// compliance import pipelines under the chatgpt hook source.
 	"chatgpt": {"chatgpt", "ChatGPT"},
+	// Codex cloud web tasks — transcripts imported from the CODEX_LOG
+	// compliance feed, distinct from "codex" (live device sessions captured
+	// by hooks/OTEL).
+	"codex-web": {"codex-web", "CodexWeb", "Codex Web"},
 }
 
 // rawToCanonicalSource is the reverse of sourceAliases: each known raw value

--- a/server/internal/chat/sources_test.go
+++ b/server/internal/chat/sources_test.go
@@ -52,6 +52,9 @@ func TestExpandSourceAliases_ExpandsCanonical(t *testing.T) {
 	// ChatGPT rows arrive from the compliance import under the chatgpt hook
 	// source; the display alias must round-trip through the filter.
 	require.Equal(t, []string{"chatgpt", "ChatGPT"}, expandSourceAliases([]string{"chatgpt"}))
+	// Codex cloud web-task transcripts import under codex-web — a distinct
+	// surface from live device codex sessions, which must not absorb it.
+	require.Equal(t, []string{"codex-web", "CodexWeb", "Codex Web"}, expandSourceAliases([]string{"codex-web"}))
 }
 
 func TestExpandSourceAliases_PassesThroughUnknown(t *testing.T) {

--- a/server/internal/chat/upsert_external_chat_title_test.go
+++ b/server/internal/chat/upsert_external_chat_title_test.go
@@ -1,0 +1,71 @@
+package chat_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpsertExternalChatTitleRegimes: two importers share this upsert with
+// opposite title rules, and the SQL CASE is the only thing separating them.
+// Feeds with authoritative titles (ChatGPT conversations, Anthropic compliance)
+// are newest-wins; Codex cloud titles are DERIVED from the session's first
+// prompt, so a later poll window would derive a mid-session prompt as its
+// "first" and retitle the chat on every window.
+//
+// The importer also guards this in memory (titledSessions), but that map is
+// per-run: on the next poll window it is empty and the CASE is the only
+// defense. Exercised at the query so an inverted branch cannot pass.
+func TestUpsertExternalChatTitleRegimes(t *testing.T) {
+	t.Parallel()
+
+	ti := newTestChatService(t)
+	ctx := initSessionCtx(t, ti)
+	queries := repo.New(ti.conn)
+
+	now := time.Now().UTC()
+	chatID := uuid.New()
+	externalChatID := "external-chat-" + uuid.NewString()
+
+	upsert := func(t *testing.T, title string, preferStored bool) string {
+		t.Helper()
+		id, err := queries.UpsertExternalChat(ctx, repo.UpsertExternalChatParams{
+			ID:                chatID,
+			ProjectID:         ti.projectID,
+			OrganizationID:    ti.orgID,
+			UserID:            conv.ToPGTextEmpty(""),
+			ExternalUserID:    conv.ToPGTextEmpty("opaque-provider-user-id"),
+			ExternalChatID:    conv.ToPGText(externalChatID),
+			Title:             conv.ToPGTextEmpty(title),
+			CreatedAt:         conv.ToPGTimestamptz(now),
+			UpdatedAt:         conv.ToPGTimestamptz(now),
+			PreferStoredTitle: preferStored,
+		})
+		require.NoError(t, err)
+		row, err := queries.GetChat(ctx, id)
+		require.NoError(t, err)
+		return row.Title.String
+	}
+
+	// A session whose opening prompt has not arrived yet is stored untitled.
+	require.Empty(t, upsert(t, "", true))
+
+	// first-wins backfills over a NULL title...
+	require.Equal(t, "first prompt", upsert(t, "first prompt", true))
+
+	// ...but a later prompt in the same session must not retitle it. This is
+	// the assertion the in-memory guard hides.
+	require.Equal(t, "first prompt", upsert(t, "a later prompt", true))
+
+	// newest-wins refreshes instead: an authoritative feed renaming a
+	// conversation must land.
+	require.Equal(t, "renamed upstream", upsert(t, "renamed upstream", false))
+
+	// Neither regime lets an absent incoming title erase a stored one.
+	require.Equal(t, "renamed upstream", upsert(t, "", false))
+	require.Equal(t, "renamed upstream", upsert(t, "", true))
+}


### PR DESCRIPTION
Closes DNO-752 (from the DNO-736 investigation).

Codex tasks executed in OpenAI's cloud (web tasks) had no transcript visibility in Gram. The workspace-scoped `CODEX_LOG` compliance feed carries per-turn transcripts — `PROMPT_SENT` (prompt text) / `PROMPT_RESPONSE_RECEIVED` (response text, model, status, token usage) with a session UUID and actor email/id per event — and its client taxonomy (`CODEX_WEB`, trace `CODEX_DESKTOP_APP`, no CLI client) means importing it cannot duplicate hook-captured device sessions.

## What changed

- **New `codex_cloud_sessions` schedule** on the existing `chatgpt_compliance` integration (same workspace scope both feeds are served under), stream `codex.cloud.chat.message`, 5m cadence, 30d initial lookback. `ensureActiveSyncSchedules` reconciles it onto existing configs — no reconnection needed.
- **New importer** (`codex_cloud_import.go`) mirroring the ChatGPT conversation import: same pagination state machine (registered as the third source in the shared `logfile_source_pagination_test.go` drift-guard suite), sha256-verified NDJSON, per-file heartbeats, chats keyed on the session UUID, messages deduped on `(chat_id, external_message_id)` with `event_id` as the external id.
- **Source slug `codex-web`** (+ `chat/sources.go` aliases) so cloud sessions are a distinct agent-type filter surface from live device `codex` sessions.
- **Prompt-derived titles**: the feed carries no conversation titles, so a session's first prompt (rune-truncated to 80, the live-capture convention) seeds the title; the upsert's COALESCE preserves it on replays.
- **Only `CODEX_WEB` events import.** `CODEX_DESKTOP_APP` events are counted (`skipped_clients` progress canary) and skipped — a device surface appearing in a cloud feed; importing it could collide with future hook-captured desktop sessions (same session-id UUID space). Boundary tracked on DNO-737.
- **Per-turn token counts are deliberately dropped** — cloud tokens meter through the compliance COSTS promotion (#4908); persisting them here too would double count.
- Dashboard: the ChatGPT integration card lists the new schedule (destination Agent Sessions).

Enforcement over cloud runs remains structurally impossible (post-hoc batch feed, no tool-call events) — this PR is visibility and post-hoc review, per the DNO-736 findings.

## Testing

Parse/SHA/foreign-type tests, title truncation (rune-safe), a DB-backed ProcessPage test covering the full write path (prompt-derived title, model/finish-reason mapping, desktop-client skip, zero token columns, replay idempotency), the shared pagination suite now sweeping all three sources, and the `codex-web` alias round-trip in `chat/sources_test.go`. Full `aiintegrations` + `background/activities` + `chat` suites, `mise lint:server`, and dashboard type-check pass.

Dogfood volume for sizing: ~100 files / ~156MB per month, max file 7.2MB (under the client's 15MB cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Imports Codex cloud web‑task transcripts from `CODEX_LOG` into Gram as agent sessions via the new `codex_cloud_sessions` schedule on `chatgpt_compliance`, making cloud Codex runs visible without reconnecting. Implements DNO-752.

- **New Features**
  - New schedule `codex_cloud_sessions` (stream `codex.cloud.chat.message`, 5m cadence, 30d lookback) reconciled onto existing configs.
  - Importer: SHA‑verified NDJSON with per‑file heartbeats; upserts chats/messages by session UUID with dedup; titles derive from the first prompt (rune‑safe to 80) and backfill if the prompt arrives later; `created_at` uses the earliest admitted event.
  - Scope: only `CODEX_WEB` `PROMPT_SENT`/`PROMPT_RESPONSE_RECEIVED` are imported; device clients and unknown detail types are counted and skipped; token counts aren’t stored to avoid double counting.
  - New source `codex-web` (+ aliases) separates cloud sessions from device `codex`; dashboard shows the schedule and “Codex Web” label.

- **Bug Fixes**
  - On API key or external scope changes, reset watermarks for all synced schedules on a config (not just the provider‑named one) so sibling feeds don’t skip the new scope’s history.
  - Title regime split in the shared chat upsert: Codex cloud uses first‑wins for derived titles; ChatGPT/Anthropic imports keep feed titles newest‑wins, preventing later windows from retitling chats.
  - Resolve event timestamps once per event and log fallback parsing under a Codex‑specific canary to avoid double‑counting and misattribution.
  - Include `skipped_details` in sync error progress so drops of unknown `detail_type` events are visible.
  - Count and report `skipped_missing_ids` (events missing `session_id` or `event_id`) so identifier gaps are visible and replays remain safe; drop these events.
  - Guard schedule execution by provider and retry on 429 rate limits for the Codex cloud import.

<sup>Written for commit b131bd4bdbee3123b89a876cc04671271c2b8eaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

