### PR TITLE
fix: probe the unified ChatGPT desktop app for the codex binary

### DIFF
--- a/.changeset/codex-unified-app-probe.md
+++ b/.changeset/codex-unified-app-probe.md
@@ -1,0 +1,12 @@
+---
+"server": patch
+---
+
+Probe the unified ChatGPT desktop app when installing the Codex plugin
+(DNO-737). OpenAI merged the standalone Codex app into the ChatGPT desktop
+app, which ships the codex CLI at
+`/Applications/ChatGPT.app/Contents/Resources/codex`; the install script only
+probed the legacy `/Applications/Codex.app` path, so on any machine with just
+the post-merge app it failed to find the binary and degraded to printing
+manual instructions. The unified bundle is now probed first, with the legacy
+path kept for pre-merge installs.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1695,10 +1695,15 @@ func renderCodexInstallScript(marketplaceURL, marketplace, plugin string, approv
   fi
   local codex_home="${CODEX_HOME:-$HOME/.codex}"
   local candidate
+  # ChatGPT.app is the unified desktop app (Chat + Work + Codex modes) OpenAI
+  # merged the standalone Codex app into on 2026-07-09; it embeds the same
+  # codex CLI and still reads ~/.codex/config.toml. It is probed before the
+  # legacy Codex.app bundle, which is frozen post-merge.
   for candidate in \
     "${codex_home}/packages/standalone/current/bin/codex" \
     "${HOME}/.local/bin/codex" \
     /usr/local/bin/codex \
+    "/Applications/ChatGPT.app/Contents/Resources/codex" \
     "/Applications/Codex.app/Contents/Resources/codex"; do
     if [ -f "${candidate}" ] && [ -x "${candidate}" ]; then
       printf '%s\n' "${candidate}"

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1567,18 +1567,52 @@ func TestGenerateCodexInstallScriptProbesForCodexBinary(t *testing.T) {
 // different bundle path. Without this probe the script silently degrades to
 // "codex executable not found" manual instructions on every machine that only
 // has the post-merge app — the common case now that the legacy app is frozen.
-func TestGenerateCodexInstallScriptProbesUnifiedChatGPTAppBundle(t *testing.T) {
+// find_codex walks a candidate list in order when no codex is on PATH. Run
+// the script against two seeded candidates and observe which binary it
+// actually invokes, so this covers the lookup and its precedence rather than
+// the generated text.
+func TestGenerateCodexInstallScriptResolvesCodexByProbeOrder(t *testing.T) {
 	t.Parallel()
 
 	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
 	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
 	require.NoError(t, err)
 
-	unified := strings.Index(string(script), "/Applications/ChatGPT.app/Contents/Resources/codex")
-	legacy := strings.Index(string(script), "/Applications/Codex.app/Contents/Resources/codex")
-	require.Positive(t, unified, "unified ChatGPT.app bundle must be probed")
-	require.Positive(t, legacy, "legacy Codex.app bundle stays probed for pre-merge installs")
-	require.Less(t, unified, legacy, "the maintained unified app is probed before the frozen legacy bundle")
+	home := t.TempDir()
+	callLog := filepath.Join(home, "codex-calls.log")
+	for marker, dir := range map[string]string{
+		// Candidate 1: the standalone package install.
+		"standalone-wins": filepath.Join(home, ".codex", "packages", "standalone", "current", "bin"),
+		// Candidate 2: ~/.local/bin, which must lose to the earlier match.
+		"local-bin-ran": filepath.Join(home, ".local", "bin"),
+	} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		stub := "#!/bin/sh\nprintf '" + marker + "\\n' >> \"" + callLog + "\"\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "codex"), []byte(stub), 0o755))
+	}
+
+	execCodexInstallScript(t, script, home)
+
+	calls := string(requireFileBytes(t, callLog))
+	require.Contains(t, calls, "standalone-wins", "the first matching candidate must be the one invoked")
+	require.NotContains(t, calls, "local-bin-ran", "a later candidate must not run once an earlier one matches")
+}
+
+// The two /Applications candidates cannot be executed here — a test cannot
+// place a bundle under the system Applications directory — so their presence
+// is pinned instead. OpenAI merged the standalone Codex app into the unified
+// ChatGPT app, which is where the codex CLI now ships; dropping that entry
+// silently returns install to "codex executable not found" on any machine
+// with only the post-merge app (verified by hand against 0.146, DNO-737).
+func TestGenerateCodexInstallScriptProbesBothMacAppBundles(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	require.Contains(t, string(script), "/Applications/ChatGPT.app/Contents/Resources/codex")
+	require.Contains(t, string(script), "/Applications/Codex.app/Contents/Resources/codex")
 }
 
 // Root-level dotted keys (features.hooks = true) implicitly define the

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1598,21 +1598,54 @@ func TestGenerateCodexInstallScriptResolvesCodexByProbeOrder(t *testing.T) {
 	require.NotContains(t, calls, "local-bin-ran", "a later candidate must not run once an earlier one matches")
 }
 
-// The two /Applications candidates cannot be executed here — a test cannot
-// place a bundle under the system Applications directory — so their presence
-// is pinned instead. OpenAI merged the standalone Codex app into the unified
-// ChatGPT app, which is where the codex CLI now ships; dropping that entry
-// silently returns install to "codex executable not found" on any machine
-// with only the post-merge app (verified by hand against 0.146, DNO-737).
-func TestGenerateCodexInstallScriptProbesBothMacAppBundles(t *testing.T) {
+// The /Applications candidates cannot be executed here — a test cannot place
+// a bundle under the system Applications directory — so the candidate list is
+// read out of the generated script and asserted whole. That pins both which
+// paths are probed and the order they are tried in, and a failure prints the
+// actual list rather than an index comparison.
+//
+// ChatGPT.app leads the bundle pair because OpenAI merged the standalone
+// Codex app into the unified ChatGPT app, which is where the maintained codex
+// CLI now ships (verified by hand against 0.146, DNO-737); the frozen legacy
+// bundle stays as a fallback for machines that never migrated. Dropping the
+// unified entry silently returns install to "codex executable not found" on
+// any post-merge machine.
+func TestGenerateCodexInstallScriptProbesCandidatesInOrder(t *testing.T) {
 	t.Parallel()
 
 	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
 	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
 	require.NoError(t, err)
 
-	require.Contains(t, string(script), "/Applications/ChatGPT.app/Contents/Resources/codex")
-	require.Contains(t, string(script), "/Applications/Codex.app/Contents/Resources/codex")
+	require.Equal(t, []string{
+		"${codex_home}/packages/standalone/current/bin/codex",
+		"${HOME}/.local/bin/codex",
+		"/usr/local/bin/codex",
+		"/Applications/ChatGPT.app/Contents/Resources/codex",
+		"/Applications/Codex.app/Contents/Resources/codex",
+	}, codexProbeCandidates(t, script))
+}
+
+// codexProbeCandidates reads find_codex's ordered candidate list out of the
+// generated script.
+func codexProbeCandidates(t *testing.T, script []byte) []string {
+	t.Helper()
+
+	const marker = "for candidate in"
+	start := strings.Index(string(script), marker)
+	require.Positive(t, start, "generated script must declare a candidate list")
+	body := string(script)[start+len(marker):]
+	end := strings.Index(body, "; do")
+	require.Positive(t, end, "candidate list must terminate with '; do'")
+
+	candidates := make([]string, 0, 8)
+	for field := range strings.FieldsSeq(body[:end]) {
+		field = strings.Trim(field, "\\\"")
+		if field != "" {
+			candidates = append(candidates, field)
+		}
+	}
+	return candidates
 }
 
 // Root-level dotted keys (features.hooks = true) implicitly define the

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1562,6 +1562,25 @@ func TestGenerateCodexInstallScriptProbesForCodexBinary(t *testing.T) {
 	require.Contains(t, calls, "plugin marketplace upgrade "+conv.ToSlug(cfg.OrgName)+"-speakeasy")
 }
 
+// The unified ChatGPT desktop app (Chat + Work + Codex modes) that OpenAI
+// merged the standalone Codex app into on 2026-07-09 ships the codex CLI at a
+// different bundle path. Without this probe the script silently degrades to
+// "codex executable not found" manual instructions on every machine that only
+// has the post-merge app — the common case now that the legacy app is frozen.
+func TestGenerateCodexInstallScriptProbesUnifiedChatGPTAppBundle(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Acme", ServerURL: "https://app.getgram.ai"}
+	script, err := GenerateCodexInstallScript("https://example.com/gram-marketplace", cfg)
+	require.NoError(t, err)
+
+	unified := strings.Index(string(script), "/Applications/ChatGPT.app/Contents/Resources/codex")
+	legacy := strings.Index(string(script), "/Applications/Codex.app/Contents/Resources/codex")
+	require.Positive(t, unified, "unified ChatGPT.app bundle must be probed")
+	require.Positive(t, legacy, "legacy Codex.app bundle stays probed for pre-merge installs")
+	require.Less(t, unified, legacy, "the maintained unified app is probed before the frozen legacy bundle")
+}
+
 // Root-level dotted keys (features.hooks = true) implicitly define the
 // [features] table and make Codex reject the whole config with a duplicate-key
 // error when an explicit [features] table is also present — which is the


### PR DESCRIPTION
Part of DNO-737 (unified ChatGPT desktop app verification).

OpenAI merged the standalone Codex app into the unified ChatGPT desktop app. The merged app ships the same codex CLI, but at a different bundle path — and our generated install script only probed the legacy one:

```
"/Applications/Codex.app/Contents/Resources/codex"     # legacy, frozen post-merge
```

So on any machine with only the post-merge app — now the only app OpenAI ships — `find_codex` returned nothing and the script degraded to printing "codex executable not found, run manually…" instead of registering the marketplace and installing the plugin.

## Verified against a real install

Installed the unified app (`brew install --cask chatgpt`, v26.727.51351) and confirmed:

| Check            | Result                                                                                                             |
| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
| Bundle path      | `/Applications/ChatGPT.app/Contents/Resources/codex` — `codex-cli 0.146.0-alpha.9.2`                               |
| Bundle id        | `com.openai.codex` — **unchanged**, so MDM guidance keyed on it is still correct                                   |
| Config file      | `codex doctor` reports `config.toml ~/.codex/config.toml … parse ok` — our config-patching path survives the merge |
| `CODEX_HOME`     | still honored (`--profile` layers `$CODEX_HOME/<name>.config.toml`)                                                |
| Probe (pre-fix)  | resolves **nothing** on this machine                                                                               |
| Probe (post-fix) | resolves the embedded binary                                                                                       |

Only the binary path moved, so this is a one-line probe addition. The unified bundle is probed before the legacy one (it's the maintained app; the standalone bundle is frozen), and the legacy path stays for machines that never migrated.

`hooks/install.ps1` needs no change — it installs the hooks binary and has no codex probe.

## Still open on DNO-737

This PR closes the install-script half. Remaining (tracked on the ticket): Codex-mode OTEL/hooks capture smoke test, whether desktop Codex-mode sessions appear in the CODEX_LOG compliance feed (which decides the desktop-app skip in #4910 and the promotion exclusion in #4908), and the VS Code extension's config handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe the unified ChatGPT desktop app for the Codex CLI during plugin install to stop “codex not found” fallbacks on post-merge machines. Keeps the legacy probe for pre-merge installs (DNO-737).

- **Bug Fixes**
  - Probe `/Applications/ChatGPT.app/Contents/Resources/codex` before `/Applications/Codex.app/Contents/Resources/codex`.
  - Update tests: add a behavior-based precedence check and assert the full generated candidate list and order (including ChatGPT-before-Codex).

<sup>Written for commit 968c0cb98b88c2760a937debaf0cff28f487645e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

