### PR TITLE
fix: capture codex OTEL from every client mode, not just the interactive CLI

### DIFF
--- a/.changeset/codex-editor-extension-probe.md
+++ b/.changeset/codex-editor-extension-probe.md
@@ -1,0 +1,11 @@
+---
+"hooks": patch
+---
+
+Find the codex binary bundled with the ChatGPT editor extensions. A machine
+that runs Codex only from VS Code, Cursor or a remote editor session has no CLI
+on PATH and no app bundle, so codex was unresolvable there — costing the
+relay's email attribution and, once the shadow-MCP guard resolves targets
+against the MCP inventory, blocking meta-tool reads of servers that are in fact
+Gram-hosted. Both path segments carry versions, so they are globbed and probed
+newest-first, ranked below a real CLI install and above the frozen Codex.app.

--- a/.changeset/codex-otel-event-urn-classification.md
+++ b/.changeset/codex-otel-event-urn-classification.md
@@ -1,0 +1,14 @@
+---
+"server": patch
+---
+
+Classify Codex OTEL rows as provider OTel telemetry, matching Claude's. The
+canonical event URN had cases for `claude-code:otel:logs` but none for
+`codex:otel:logs` or `codex:otel:metrics`, so Codex's provider-native stream
+fell through to the agent-hook default and was typed
+`urn:telemetry:agent_hook:log:unknown` — with no event name, since those rows
+carry a producer `event.name` rather than a Gram hook event. Any filter that
+selects provider-OTel rows by URN prefix therefore excluded Codex while
+including the equivalent Claude traffic. Codex OTEL logs now type on their
+producer event name (`codex.sse_event`, ...) and metric points on their
+metric name.

--- a/.changeset/codex-otel-service-name-family.md
+++ b/.changeset/codex-otel-service-name-family.md
@@ -4,9 +4,10 @@
 
 Route Codex OTEL telemetry from every client mode to the Codex stream, not
 just the interactive CLI. Codex reports a different OTEL `service.name` per
-mode — `codex_exec` for headless `codex exec` (what CI and scripted runs
-use), plus `codex_tui` and `codex_mcp` — but the ingest matched only
-`codex_cli_rs`. Those payloads were not dropped: they fell through to the
+mode and does not use one separator convention — `codex_exec` for headless
+`codex exec` (what CI and scripted runs use), `codex_tui`, `codex_mcp`, and
+`codex-app-server` for Codex mode in the unified ChatGPT desktop app — but
+the ingest matched only `codex_cli_rs`. Those payloads were not dropped: they fell through to the
 Claude path and were persisted as `claude-code:otel:logs` rows carrying
 Claude's hook source and account attribution, so Codex traffic silently
 inflated Claude surfaces while never being metered as Codex usage. The

--- a/.changeset/codex-otel-service-name-family.md
+++ b/.changeset/codex-otel-service-name-family.md
@@ -1,0 +1,11 @@
+---
+"server": patch
+---
+
+Capture Codex OTEL telemetry from every client mode, not just the interactive
+CLI. Codex reports a different OTEL `service.name` per mode — `codex_exec`
+for headless `codex exec` (what CI and scripted runs use), plus `codex_tui`
+and `codex_mcp` — but the ingest matched only `codex_cli_rs`, so every other
+mode's telemetry was dropped with no rows, no token metering, and no error.
+The ingest now matches the `codex_` service-name family, so a new client mode
+is captured on arrival instead of being discovered later as missing data.

--- a/.changeset/codex-otel-service-name-family.md
+++ b/.changeset/codex-otel-service-name-family.md
@@ -11,7 +11,8 @@ the ingest matched only `codex_cli_rs`. Those payloads were not dropped: they fe
 Claude path and were persisted as `claude-code:otel:logs` rows carrying
 Claude's hook source and account attribution, so Codex traffic silently
 inflated Claude surfaces while never being metered as Codex usage. The
-ingest now matches the `codex_` service-name family.
+ingest now matches the whole Codex service-name family, both separators
+included.
 
 Routing is also now per OTEL resource rather than per payload: a collector
 that fans several clients into one export previously had the whole batch

--- a/.changeset/codex-otel-service-name-family.md
+++ b/.changeset/codex-otel-service-name-family.md
@@ -2,10 +2,17 @@
 "server": patch
 ---
 
-Capture Codex OTEL telemetry from every client mode, not just the interactive
-CLI. Codex reports a different OTEL `service.name` per mode — `codex_exec`
-for headless `codex exec` (what CI and scripted runs use), plus `codex_tui`
-and `codex_mcp` — but the ingest matched only `codex_cli_rs`, so every other
-mode's telemetry was dropped with no rows, no token metering, and no error.
-The ingest now matches the `codex_` service-name family, so a new client mode
-is captured on arrival instead of being discovered later as missing data.
+Route Codex OTEL telemetry from every client mode to the Codex stream, not
+just the interactive CLI. Codex reports a different OTEL `service.name` per
+mode — `codex_exec` for headless `codex exec` (what CI and scripted runs
+use), plus `codex_tui` and `codex_mcp` — but the ingest matched only
+`codex_cli_rs`. Those payloads were not dropped: they fell through to the
+Claude path and were persisted as `claude-code:otel:logs` rows carrying
+Claude's hook source and account attribution, so Codex traffic silently
+inflated Claude surfaces while never being metered as Codex usage. The
+ingest now matches the `codex_` service-name family.
+
+Routing is also now per OTEL resource rather than per payload: a collector
+that fans several clients into one export previously had the whole batch
+routed by whichever client matched first, mislabeling the other client's
+records.

--- a/.changeset/codex-relay-chatgpt-app-probe.md
+++ b/.changeset/codex-relay-chatgpt-app-probe.md
@@ -1,0 +1,10 @@
+---
+"hooks": patch
+---
+
+Look for the codex binary inside the unified ChatGPT app when resolving a
+Codex user's email. OpenAI merged the standalone Codex app into the ChatGPT
+app, so on a machine that has only the unified app and no `codex` on PATH the
+relay could not shell out to `codex app-server` and fell through to the
+`auth.json` and payload fallbacks. The install script already learned this
+path; the relay probe had not.

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -349,13 +350,38 @@ func probeCodexBinary(candidates []string) string {
 // a machine carrying both prefers the maintained copy. Mirrors the ordering
 // the generated install script's find_codex uses.
 func codexBinaryCandidates(home, codexHome string) []string {
-	return []string{
+	candidates := []string{
 		filepath.Join(codexHome, "packages", "standalone", "current", "bin", "codex"),
 		filepath.Join(home, ".local", "bin", "codex"),
 		"/usr/local/bin/codex",
 		"/Applications/ChatGPT.app/Contents/Resources/codex",
-		"/Applications/Codex.app/Contents/Resources/codex",
 	}
+	// The editor extensions ship their own copy, and on a machine that runs
+	// Codex only from an editor it is the only one there is.
+	candidates = append(candidates, codexEditorExtensionBinaries(home)...)
+	// Frozen: superseded by the unified ChatGPT app, so it ranks last.
+	return append(candidates, "/Applications/Codex.app/Contents/Resources/codex")
+}
+
+// codexEditorExtensionBinaries finds the codex copies bundled with the ChatGPT
+// editor extensions. Both path segments vary — the extension directory carries
+// the version and platform, the inner directory the target triple — so they are
+// globbed rather than listed. Matches are returned newest-first by name, which
+// puts the highest version first for the version scheme observed in the wild.
+func codexEditorExtensionBinaries(home string) []string {
+	if home == "" {
+		return nil
+	}
+	var found []string
+	for _, editorDir := range []string{".vscode", ".vscode-insiders", ".vscode-server", ".cursor", ".windsurf"} {
+		matches, err := filepath.Glob(filepath.Join(home, editorDir, "extensions", "openai.chatgpt-*", "bin", "*", "codex"))
+		if err != nil {
+			continue
+		}
+		sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+		found = append(found, matches...)
+	}
+	return found
 }
 
 func codexAuthFileEmail() string {

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -331,6 +331,10 @@ func findCodexBinary() string {
 		filepath.Join(codexHome, "packages", "standalone", "current", "bin", "codex"),
 		filepath.Join(home, ".local", "bin", "codex"),
 		"/usr/local/bin/codex",
+		// OpenAI merged the standalone Codex app into the ChatGPT app, which
+		// bundles the codex binary at this path. Ordered ahead of the frozen
+		// Codex.app so a machine carrying both prefers the maintained copy.
+		"/Applications/ChatGPT.app/Contents/Resources/codex",
 		"/Applications/Codex.app/Contents/Resources/codex",
 	} {
 		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() && info.Mode()&0o111 != 0 {

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -14,7 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -366,22 +367,85 @@ func codexBinaryCandidates(home, codexHome string) []string {
 // codexEditorExtensionBinaries finds the codex copies bundled with the ChatGPT
 // editor extensions. Both path segments vary — the extension directory carries
 // the version and platform, the inner directory the target triple — so they are
-// globbed rather than listed. Matches are returned newest-first by name, which
-// puts the highest version first for the version scheme observed in the wild.
+// globbed rather than listed. Matches come back newest-first by the version
+// parsed out of the extension directory name: an editor leaves the superseded
+// build on disk across an upgrade, and probing a stale codex first means
+// running a binary the user already replaced. The whole set is ordered at once
+// rather than per editor, because the newest build on a machine may live under
+// any of them.
 func codexEditorExtensionBinaries(home string) []string {
 	if home == "" {
 		return nil
 	}
 	var found []string
+	versions := map[string][]int{}
 	for _, editorDir := range []string{".vscode", ".vscode-insiders", ".vscode-server", ".cursor", ".windsurf"} {
 		matches, err := filepath.Glob(filepath.Join(home, editorDir, "extensions", "openai.chatgpt-*", "bin", "*", "codex"))
 		if err != nil {
 			continue
 		}
-		sort.Sort(sort.Reverse(sort.StringSlice(matches)))
-		found = append(found, matches...)
+		for _, match := range matches {
+			versions[match] = codexExtensionVersion(match)
+			found = append(found, match)
+		}
 	}
+	// Stable so equally-versioned copies keep glob order and the probe order
+	// stays reproducible run to run.
+	slices.SortStableFunc(found, func(a, b string) int {
+		return compareCodexExtensionVersions(versions[a], versions[b])
+	})
 	return found
+}
+
+// codexExtensionVersion reads the version out of an
+// openai.chatgpt-<version>-<platform> extension directory as its numeric
+// components, so 26.10.0 can outrank 26.9.0 — a lexical comparison gets that
+// backwards the moment a component grows a digit. A name we cannot read yields
+// nil, which the ordering treats as unknown rather than as version zero.
+func codexExtensionVersion(binary string) []int {
+	// <extensions>/openai.chatgpt-<version>-<platform>/bin/<triple>/codex
+	name := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(binary))))
+	rest, ok := strings.CutPrefix(name, "openai.chatgpt-")
+	if !ok {
+		return nil
+	}
+	version, _, _ := strings.Cut(rest, "-")
+	var components []int
+	for field := range strings.SplitSeq(version, ".") {
+		number, err := strconv.Atoi(field)
+		if err != nil {
+			return nil
+		}
+		components = append(components, number)
+	}
+	return components
+}
+
+// compareCodexExtensionVersions orders parsed versions newest-first. An
+// unreadable version sorts last but is never dropped: a copy that exists on
+// disk is still worth probing when nothing better is installed.
+func compareCodexExtensionVersions(a, b []int) int {
+	switch {
+	case len(a) == 0 && len(b) == 0:
+		return 0
+	case len(a) == 0:
+		return 1
+	case len(b) == 0:
+		return -1
+	}
+	for i := range max(len(a), len(b)) {
+		var left, right int
+		if i < len(a) {
+			left = a[i]
+		}
+		if i < len(b) {
+			right = b[i]
+		}
+		if left != right {
+			return cmp.Compare(right, left)
+		}
+	}
+	return 0
 }
 
 func codexAuthFileEmail() string {

--- a/hooks/relay/identity.go
+++ b/hooks/relay/identity.go
@@ -327,21 +327,35 @@ func findCodexBinary() string {
 	}
 	home, _ := os.UserHomeDir()
 	codexHome := firstNonEmpty(os.Getenv("CODEX_HOME"), filepath.Join(home, ".codex"))
-	for _, candidate := range []string{
-		filepath.Join(codexHome, "packages", "standalone", "current", "bin", "codex"),
-		filepath.Join(home, ".local", "bin", "codex"),
-		"/usr/local/bin/codex",
-		// OpenAI merged the standalone Codex app into the ChatGPT app, which
-		// bundles the codex binary at this path. Ordered ahead of the frozen
-		// Codex.app so a machine carrying both prefers the maintained copy.
-		"/Applications/ChatGPT.app/Contents/Resources/codex",
-		"/Applications/Codex.app/Contents/Resources/codex",
-	} {
+	return probeCodexBinary(codexBinaryCandidates(home, codexHome))
+}
+
+// probeCodexBinary returns the first candidate that is a runnable file. A
+// present-but-non-executable path is skipped rather than returned: the caller
+// execs the result, so a path it cannot run is worse than none.
+func probeCodexBinary(candidates []string) string {
+	for _, candidate := range candidates {
 		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
 			return candidate
 		}
 	}
 	return ""
+}
+
+// codexBinaryCandidates lists the install locations to probe, in preference
+// order, when codex is not on PATH. A managed or user install outranks the
+// copies bundled inside an app: OpenAI merged the standalone Codex app into
+// the ChatGPT app, so ChatGPT.app is probed ahead of the frozen Codex.app and
+// a machine carrying both prefers the maintained copy. Mirrors the ordering
+// the generated install script's find_codex uses.
+func codexBinaryCandidates(home, codexHome string) []string {
+	return []string{
+		filepath.Join(codexHome, "packages", "standalone", "current", "bin", "codex"),
+		filepath.Join(home, ".local", "bin", "codex"),
+		"/usr/local/bin/codex",
+		"/Applications/ChatGPT.app/Contents/Resources/codex",
+		"/Applications/Codex.app/Contents/Resources/codex",
+	}
 }
 
 func codexAuthFileEmail() string {

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -238,22 +238,24 @@ func TestCodexBinaryCandidatesProbeTheUnifiedAppFirst(t *testing.T) {
 // an unprovable target and denies (DNO-771).
 func TestCodexBinaryCandidatesIncludeEditorExtensions(t *testing.T) {
 	home := t.TempDir()
-	// Two versions installed side by side, as an editor leaves them across an
-	// upgrade; the newer must be preferred.
-	older := filepath.Join(home, ".vscode", "extensions", "openai.chatgpt-26.7.1-darwin-arm64", "bin", "macos-aarch64", "codex")
-	newer := filepath.Join(home, ".vscode", "extensions", "openai.chatgpt-26.8.0-darwin-arm64", "bin", "macos-aarch64", "codex")
-	cursor := filepath.Join(home, ".cursor", "extensions", "openai.chatgpt-26.8.0-darwin-arm64", "bin", "macos-aarch64", "codex")
-	for _, path := range []string{older, newer, cursor} {
-		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
-		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700))
-	}
+	// Versions installed side by side, as an editor leaves them across an
+	// upgrade. 26.10.0 over 26.9.0 is the case a lexical sort inverts, and the
+	// .cursor copy must beat the older .vscode ones even though it is globbed
+	// from a later directory.
+	oldest := writeCodexExtension(t, home, ".vscode", "26.7.1")
+	older := writeCodexExtension(t, home, ".vscode", "26.9.0")
+	newer := writeCodexExtension(t, home, ".cursor", "26.10.0")
 
 	candidates := codexBinaryCandidates(home, filepath.Join(home, ".codex"))
 
 	require.Contains(t, candidates, newer)
-	require.Contains(t, candidates, cursor)
-	require.Less(t, slices.Index(candidates, newer), slices.Index(candidates, older),
+	require.Contains(t, candidates, older)
+	require.Less(t, slices.Index(candidates, older), slices.Index(candidates, oldest),
 		"a newer extension build must be probed before an older one left behind")
+	require.Less(t, slices.Index(candidates, newer), slices.Index(candidates, older),
+		"26.10.0 is newer than 26.9.0; comparing the version components as text gets that backwards")
+	require.Less(t, slices.Index(candidates, newer), slices.Index(candidates, oldest),
+		"the newest build wins wherever it is installed, not just within its own editor directory")
 	require.Less(t, slices.Index(candidates, newer),
 		slices.Index(candidates, "/Applications/Codex.app/Contents/Resources/codex"),
 		"a maintained extension copy outranks the frozen Codex.app")
@@ -261,4 +263,35 @@ func TestCodexBinaryCandidatesIncludeEditorExtensions(t *testing.T) {
 	// A home with no editor extensions contributes nothing.
 	require.Empty(t, codexEditorExtensionBinaries(t.TempDir()))
 	require.Empty(t, codexEditorExtensionBinaries(""))
+}
+
+// TestCodexEditorExtensionBinariesKeepUnreadableVersions: an extension
+// directory naming scheme we cannot parse must not cost us the binary. It
+// ranks below everything we can read a version for, but on a machine where it
+// is the only copy installed it is still the difference between an MCP
+// inventory and none.
+func TestCodexEditorExtensionBinariesKeepUnreadableVersions(t *testing.T) {
+	home := t.TempDir()
+	unreadable := writeCodexExtension(t, home, ".vscode", "nightly")
+	known := writeCodexExtension(t, home, ".windsurf", "26.9.0")
+
+	found := codexEditorExtensionBinaries(home)
+
+	require.Equal(t, []string{known, unreadable}, found,
+		"an unparseable version sorts last but is never dropped")
+
+	onlyUnreadable := t.TempDir()
+	require.Equal(t, []string{writeCodexExtension(t, onlyUnreadable, ".cursor", "nightly")},
+		codexEditorExtensionBinaries(onlyUnreadable))
+}
+
+// writeCodexExtension lays down the codex binary an openai.chatgpt editor
+// extension bundles and returns its path.
+func writeCodexExtension(t *testing.T, home, editorDir, version string) string {
+	t.Helper()
+
+	path := filepath.Join(home, editorDir, "extensions", "openai.chatgpt-"+version+"-darwin-arm64", "bin", "macos-aarch64", "codex")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+	return path
 }

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -230,3 +230,35 @@ func TestCodexBinaryCandidatesProbeTheUnifiedAppFirst(t *testing.T) {
 	require.Less(t, slices.Index(candidates, "/home/dev/.codex/packages/standalone/current/bin/codex"), unified)
 	require.Less(t, slices.Index(candidates, "/home/dev/.local/bin/codex"), unified)
 }
+
+// TestCodexBinaryCandidatesIncludeEditorExtensions: the ChatGPT editor
+// extensions bundle their own codex, and on a machine that runs Codex only
+// from an editor it is the only copy present — no CLI on PATH, no app bundle.
+// Missing it there means no MCP inventory, which the shadow-MCP guard reads as
+// an unprovable target and denies (DNO-771).
+func TestCodexBinaryCandidatesIncludeEditorExtensions(t *testing.T) {
+	home := t.TempDir()
+	// Two versions installed side by side, as an editor leaves them across an
+	// upgrade; the newer must be preferred.
+	older := filepath.Join(home, ".vscode", "extensions", "openai.chatgpt-26.7.1-darwin-arm64", "bin", "macos-aarch64", "codex")
+	newer := filepath.Join(home, ".vscode", "extensions", "openai.chatgpt-26.8.0-darwin-arm64", "bin", "macos-aarch64", "codex")
+	cursor := filepath.Join(home, ".cursor", "extensions", "openai.chatgpt-26.8.0-darwin-arm64", "bin", "macos-aarch64", "codex")
+	for _, path := range []string{older, newer, cursor} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+	}
+
+	candidates := codexBinaryCandidates(home, filepath.Join(home, ".codex"))
+
+	require.Contains(t, candidates, newer)
+	require.Contains(t, candidates, cursor)
+	require.Less(t, slices.Index(candidates, newer), slices.Index(candidates, older),
+		"a newer extension build must be probed before an older one left behind")
+	require.Less(t, slices.Index(candidates, newer),
+		slices.Index(candidates, "/Applications/Codex.app/Contents/Resources/codex"),
+		"a maintained extension copy outranks the frozen Codex.app")
+
+	// A home with no editor extensions contributes nothing.
+	require.Empty(t, codexEditorExtensionBinaries(t.TempDir()))
+	require.Empty(t, codexEditorExtensionBinaries(""))
+}

--- a/hooks/relay/identity_test.go
+++ b/hooks/relay/identity_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -187,4 +188,45 @@ func TestCodexAuthFileEmailPrefersAccessToken(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.json"), []byte(auth), 0o600))
 
 	require.Equal(t, "access@example.com", codexAuthFileEmail())
+}
+
+// TestProbeCodexBinarySkipsUnrunnableCandidates: the probe's result is exec'd,
+// so it must return the first candidate that is actually runnable and skip a
+// path that merely exists. Driven through explicit candidates rather than the
+// process environment — pointing PATH or CODEX_HOME at a fixture would let a
+// miss fall through to the real /Applications copy and execute it.
+func TestProbeCodexBinarySkipsUnrunnableCandidates(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable-bit fixture is POSIX-only")
+	}
+
+	dir := t.TempDir()
+	notExecutable := filepath.Join(dir, "present-but-not-runnable")
+	runnable := filepath.Join(dir, "codex")
+	require.NoError(t, os.WriteFile(notExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o600))
+	require.NoError(t, os.WriteFile(runnable, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+
+	candidates := []string{filepath.Join(dir, "missing"), notExecutable, runnable}
+	require.Equal(t, runnable, probeCodexBinary(candidates))
+
+	require.Empty(t, probeCodexBinary([]string{filepath.Join(dir, "missing")}))
+	require.Empty(t, probeCodexBinary(nil))
+}
+
+// TestCodexBinaryCandidatesProbeTheUnifiedAppFirst pins the ordering the
+// /Applications entries cannot exercise on a test machine: the frozen
+// Codex.app must never win over the ChatGPT app that supersedes it.
+func TestCodexBinaryCandidatesProbeTheUnifiedAppFirst(t *testing.T) {
+	candidates := codexBinaryCandidates("/home/dev", "/home/dev/.codex")
+
+	unified := slices.Index(candidates, "/Applications/ChatGPT.app/Contents/Resources/codex")
+	frozen := slices.Index(candidates, "/Applications/Codex.app/Contents/Resources/codex")
+
+	require.NotEqual(t, -1, unified, "the unified ChatGPT app bundles the codex binary and must be probed")
+	require.NotEqual(t, -1, frozen)
+	require.Less(t, unified, frozen)
+
+	// Both app bundles rank below a managed or user-owned install.
+	require.Less(t, slices.Index(candidates, "/home/dev/.codex/packages/standalone/current/bin/codex"), unified)
+	require.Less(t, slices.Index(candidates, "/home/dev/.local/bin/codex"), unified)
 }

--- a/server/internal/aiintegrations/codex_cost_import.go
+++ b/server/internal/aiintegrations/codex_cost_import.go
@@ -56,8 +56,10 @@ const (
 // the compliance feed is their only token source, so those rows are metered
 // here. Deliberately an allowlist: an unrecognized client defaults to
 // un-metered, because under-counting a new surface beats double counting a
-// device one. cli/exec meter via OTEL; desktop_app and unknown stay excluded
-// until DNO-737 settles whether the unified desktop app exports OTEL.
+// device one. Every device client meters via OTEL and so must stay out of this
+// map: cli, exec, and — settled under DNO-737 — desktop_app, which is Codex
+// mode in the unified ChatGPT app and reports OTEL under the service name
+// codex-app-server. Adding a device client here would double count it.
 var codexCloudMeteredClients = map[string]bool{
 	"github": true,
 	"web":    true,

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -15,14 +15,27 @@ import (
 )
 
 const (
-	// codexServiceName is the OTEL resource service.name the Codex CLI reports.
-	codexServiceName = "codex_cli_rs"
+	// codexServiceNamePrefix matches the OTEL resource service.name family the
+	// Codex clients report. The name varies by mode — codex_cli_rs
+	// (interactive), codex_exec (headless `codex exec`, what CI and scripted
+	// runs use), plus codex_tui and codex_mcp in the shipped binary — so
+	// matching the single interactive name silently dropped every other
+	// mode's telemetry. Prefix-matching the family means a new mode is
+	// captured on arrival rather than discovered later as missing data;
+	// Claude reports "claude-code"-style names, so it cannot collide.
+	codexServiceNamePrefix = "codex_"
 	// codexOTELLogsURN types a raw Codex OTEL log row, mirroring the
 	// "claude-code:otel:logs" convention.
 	codexOTELLogsURN = "codex:otel:logs"
 	// codexOTELMetricsURN types a raw Codex OTEL metric data point row.
 	codexOTELMetricsURN = "codex:otel:metrics"
 )
+
+// isCodexServiceName reports whether an OTEL resource service.name belongs to
+// the Codex client family (see codexServiceNamePrefix).
+func isCodexServiceName(serviceName string) bool {
+	return strings.HasPrefix(serviceName, codexServiceNamePrefix)
+}
 
 // isCodexLogsPayload reports whether an OTLP logs payload originated from the
 // Codex CLI, identified by its resource service.name. Claude Code reports a
@@ -35,7 +48,7 @@ func isCodexLogsPayload(payload *gen.LogsPayload) bool {
 		if rl == nil {
 			continue
 		}
-		if extractResourceAttribute(rl.Resource, "service.name") == codexServiceName {
+		if isCodexServiceName(extractResourceAttribute(rl.Resource, "service.name")) {
 			return true
 		}
 	}
@@ -173,7 +186,7 @@ func isCodexMetricsPayload(payload *gen.MetricsPayload) bool {
 		if rm == nil {
 			continue
 		}
-		if extractResourceAttribute(rm.Resource, "service.name") == codexServiceName {
+		if isCodexServiceName(extractResourceAttribute(rm.Resource, "service.name")) {
 			return true
 		}
 	}

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -15,19 +15,23 @@ import (
 )
 
 const (
-	// codexServiceNamePrefix matches the OTEL resource service.name family the
-	// Codex clients report. The name varies by mode — codex_cli_rs
-	// (interactive), codex_exec (headless `codex exec`, what CI and scripted
-	// runs use), plus codex_tui and codex_mcp in the shipped binary. Matching
-	// only the interactive name did not drop the other modes: their payloads
-	// fell through to the Claude path and were persisted as
-	// claude-code:otel:logs rows with Claude's hook source and attribution,
-	// so Codex traffic silently inflated Claude surfaces (and, keyed on the
-	// wrong URN, was never metered as Codex usage). Prefix-matching the
-	// family means a new mode routes correctly on arrival rather than being
-	// discovered later as mislabeled data; Claude reports "claude-code"-style
-	// names, so the prefix cannot collide.
-	codexServiceNamePrefix = "codex_"
+	// codexServiceName and the codexServiceName*Prefix pair match the OTEL
+	// resource service.name family the Codex clients report. The name varies
+	// by mode and does NOT use one separator convention — observed against
+	// the shipped 0.146 build: codex_cli_rs (interactive), codex_exec
+	// (headless `codex exec`, what CI and scripted runs use), codex_tui,
+	// codex_mcp, and codex-app-server (Codex mode in the unified ChatGPT
+	// desktop app, hyphenated). Matching a single name did not drop the other
+	// modes: their payloads fell through to the Claude path and were
+	// persisted as claude-code:otel:logs rows with Claude's hook source and
+	// attribution, so Codex traffic silently inflated Claude surfaces (and,
+	// keyed on the wrong URN, was never metered as Codex usage). Matching the
+	// whole family means a new mode routes correctly on arrival rather than
+	// being discovered later as mislabeled data; Claude reports
+	// "claude-code"-style names, so this cannot collide.
+	codexServiceName                 = "codex"
+	codexServiceNameUnderscorePrefix = "codex_"
+	codexServiceNameHyphenPrefix     = "codex-"
 	// codexOTELLogsURN types a raw Codex OTEL log row, mirroring the
 	// "claude-code:otel:logs" convention.
 	codexOTELLogsURN = "codex:otel:logs"
@@ -36,9 +40,13 @@ const (
 )
 
 // isCodexServiceName reports whether an OTEL resource service.name belongs to
-// the Codex client family (see codexServiceNamePrefix).
+// the Codex client family (see codexServiceName). Both separators are matched
+// because Codex uses both; a bare "codex" counts, while an unrelated name
+// that merely starts with those letters does not.
 func isCodexServiceName(serviceName string) bool {
-	return strings.HasPrefix(serviceName, codexServiceNamePrefix)
+	return serviceName == codexServiceName ||
+		strings.HasPrefix(serviceName, codexServiceNameUnderscorePrefix) ||
+		strings.HasPrefix(serviceName, codexServiceNameHyphenPrefix)
 }
 
 // splitCodexLogsPayload partitions a logs payload by resource service.name.

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	// codexServiceName and the codexServiceName*Prefix pair match the OTEL
-	// resource service.name family the Codex clients report. The name varies
-	// by mode and does NOT use one separator convention — observed against
+	// codexServiceName is the stem of the OTEL resource service.name family
+	// the Codex clients report (see isCodexServiceName). The name varies by
+	// mode and does NOT use one separator convention — observed against
 	// the shipped 0.146 build: codex_cli_rs (interactive), codex_exec
 	// (headless `codex exec`, what CI and scripted runs use), codex_tui,
 	// codex_mcp, and codex-app-server (Codex mode in the unified ChatGPT
@@ -29,9 +29,7 @@ const (
 	// whole family means a new mode routes correctly on arrival rather than
 	// being discovered later as mislabeled data; Claude reports
 	// "claude-code"-style names, so this cannot collide.
-	codexServiceName                 = "codex"
-	codexServiceNameUnderscorePrefix = "codex_"
-	codexServiceNameHyphenPrefix     = "codex-"
+	codexServiceName = "codex"
 	// codexOTELLogsURN types a raw Codex OTEL log row, mirroring the
 	// "claude-code:otel:logs" convention.
 	codexOTELLogsURN = "codex:otel:logs"
@@ -40,13 +38,16 @@ const (
 )
 
 // isCodexServiceName reports whether an OTEL resource service.name belongs to
-// the Codex client family (see codexServiceName). Both separators are matched
-// because Codex uses both; a bare "codex" counts, while an unrelated name
-// that merely starts with those letters does not.
+// the Codex client family (see codexServiceName): "codex" itself, or "codex"
+// followed by a mode suffix on either separator. Requiring the separator is
+// what keeps an unrelated name that merely starts with those letters —
+// "codexish-tool" — from matching.
 func isCodexServiceName(serviceName string) bool {
-	return serviceName == codexServiceName ||
-		strings.HasPrefix(serviceName, codexServiceNameUnderscorePrefix) ||
-		strings.HasPrefix(serviceName, codexServiceNameHyphenPrefix)
+	suffix, ok := strings.CutPrefix(serviceName, codexServiceName)
+	if !ok {
+		return false
+	}
+	return suffix == "" || suffix[0] == '_' || suffix[0] == '-'
 }
 
 // splitCodexLogsPayload partitions a logs payload by resource service.name.

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -123,24 +123,6 @@ func splitCodexMetricsPayload(payload *gen.MetricsPayload) (codex, claude *gen.M
 	return codex, claude
 }
 
-// isCodexLogsPayload reports whether an OTLP logs payload originated from the
-// Codex CLI, identified by its resource service.name. Claude Code reports a
-// different service name and is handled by the session-seeding path instead.
-func isCodexLogsPayload(payload *gen.LogsPayload) bool {
-	if payload == nil {
-		return false
-	}
-	for _, rl := range payload.ResourceLogs {
-		if rl == nil {
-			continue
-		}
-		if isCodexServiceName(extractResourceAttribute(rl.Resource, "service.name")) {
-			return true
-		}
-	}
-	return false
-}
-
 // writeCodexOTELLogsToClickHouse persists every Codex OTEL log record as a raw
 // telemetry row, mirroring the Claude raw-log stream (claude-code:otel:logs).
 // The rows keep Codex's native attributes (event.name, event.kind, tool_name,
@@ -259,24 +241,6 @@ func (s *Service) writeCodexOTELLogsToClickHouse(ctx context.Context, payload *g
 	if err := s.telemetryLogger.LogBulk(ctx, params); err != nil {
 		s.logger.ErrorContext(ctx, "failed to write Codex OTEL logs to ClickHouse", attr.SlogError(err))
 	}
-}
-
-// isCodexMetricsPayload reports whether an OTLP metrics payload originated
-// from the Codex CLI, identified by its resource service.name — the metrics
-// twin of isCodexLogsPayload.
-func isCodexMetricsPayload(payload *gen.MetricsPayload) bool {
-	if payload == nil {
-		return false
-	}
-	for _, rm := range payload.ResourceMetrics {
-		if rm == nil {
-			continue
-		}
-		if isCodexServiceName(extractResourceAttribute(rm.Resource, "service.name")) {
-			return true
-		}
-	}
-	return false
 }
 
 // writeCodexMetricsToClickHouse persists each Codex Sum metric data point as a

--- a/server/internal/hooks/codex_otel.go
+++ b/server/internal/hooks/codex_otel.go
@@ -18,11 +18,15 @@ const (
 	// codexServiceNamePrefix matches the OTEL resource service.name family the
 	// Codex clients report. The name varies by mode — codex_cli_rs
 	// (interactive), codex_exec (headless `codex exec`, what CI and scripted
-	// runs use), plus codex_tui and codex_mcp in the shipped binary — so
-	// matching the single interactive name silently dropped every other
-	// mode's telemetry. Prefix-matching the family means a new mode is
-	// captured on arrival rather than discovered later as missing data;
-	// Claude reports "claude-code"-style names, so it cannot collide.
+	// runs use), plus codex_tui and codex_mcp in the shipped binary. Matching
+	// only the interactive name did not drop the other modes: their payloads
+	// fell through to the Claude path and were persisted as
+	// claude-code:otel:logs rows with Claude's hook source and attribution,
+	// so Codex traffic silently inflated Claude surfaces (and, keyed on the
+	// wrong URN, was never metered as Codex usage). Prefix-matching the
+	// family means a new mode routes correctly on arrival rather than being
+	// discovered later as mislabeled data; Claude reports "claude-code"-style
+	// names, so the prefix cannot collide.
 	codexServiceNamePrefix = "codex_"
 	// codexOTELLogsURN types a raw Codex OTEL log row, mirroring the
 	// "claude-code:otel:logs" convention.
@@ -35,6 +39,80 @@ const (
 // the Codex client family (see codexServiceNamePrefix).
 func isCodexServiceName(serviceName string) bool {
 	return strings.HasPrefix(serviceName, codexServiceNamePrefix)
+}
+
+// splitCodexLogsPayload partitions a logs payload by resource service.name.
+// Routing must be per resource, not per payload: an OpenTelemetry Collector
+// fanning in several clients can re-batch Claude and Codex resources into one
+// export, and an any-resource match would hand the whole batch to one writer —
+// stamping Claude records as Codex rows (or vice versa) and skipping the
+// Claude session/attribution chain entirely. Either return value is nil when
+// that side has no resources, so a single-client payload allocates nothing.
+func splitCodexLogsPayload(payload *gen.LogsPayload) (codex, claude *gen.LogsPayload) {
+	if payload == nil {
+		return nil, nil
+	}
+	var codexLogs, claudeLogs []*gen.OTELResourceLog
+	for _, rl := range payload.ResourceLogs {
+		if rl == nil {
+			continue
+		}
+		if isCodexServiceName(extractResourceAttribute(rl.Resource, "service.name")) {
+			codexLogs = append(codexLogs, rl)
+			continue
+		}
+		claudeLogs = append(claudeLogs, rl)
+	}
+	// Both halves keep the envelope's auth fields: the split is a routing
+	// concern and must not strip credentials a downstream writer may read.
+	if len(codexLogs) > 0 {
+		codex = &gen.LogsPayload{
+			ResourceLogs:     codexLogs,
+			ApikeyToken:      payload.ApikeyToken,
+			ProjectSlugInput: payload.ProjectSlugInput,
+		}
+	}
+	if len(claudeLogs) > 0 {
+		claude = &gen.LogsPayload{
+			ResourceLogs:     claudeLogs,
+			ApikeyToken:      payload.ApikeyToken,
+			ProjectSlugInput: payload.ProjectSlugInput,
+		}
+	}
+	return codex, claude
+}
+
+// splitCodexMetricsPayload is splitCodexLogsPayload's metrics twin.
+func splitCodexMetricsPayload(payload *gen.MetricsPayload) (codex, claude *gen.MetricsPayload) {
+	if payload == nil {
+		return nil, nil
+	}
+	var codexMetrics, claudeMetrics []*gen.OTELResourceMetrics
+	for _, rm := range payload.ResourceMetrics {
+		if rm == nil {
+			continue
+		}
+		if isCodexServiceName(extractResourceAttribute(rm.Resource, "service.name")) {
+			codexMetrics = append(codexMetrics, rm)
+			continue
+		}
+		claudeMetrics = append(claudeMetrics, rm)
+	}
+	if len(codexMetrics) > 0 {
+		codex = &gen.MetricsPayload{
+			ResourceMetrics:  codexMetrics,
+			ApikeyToken:      payload.ApikeyToken,
+			ProjectSlugInput: payload.ProjectSlugInput,
+		}
+	}
+	if len(claudeMetrics) > 0 {
+		claude = &gen.MetricsPayload{
+			ResourceMetrics:  claudeMetrics,
+			ApikeyToken:      payload.ApikeyToken,
+			ProjectSlugInput: payload.ProjectSlugInput,
+		}
+	}
+	return codex, claude
 }
 
 // isCodexLogsPayload reports whether an OTLP logs payload originated from the

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -381,6 +381,79 @@ func TestMetrics_PersistsCodexOTELMetricDataPoints(t *testing.T) {
 	require.Contains(t, row.ResourceAttributes, codexTestServiceName)
 }
 
+// TestMetrics_MixedCollectorBatchRoutesEachResourceToItsOwnStream is the
+// metrics twin of the logs mixed-batch test. It is the case that caught a
+// real asymmetry: the logs handler narrowed its payload to the Claude half
+// but the metrics handler did not, so Codex resources still reached the
+// Claude usage extractor — which rejects Codex's cumulative temporality and
+// would have dropped the batch's Claude rows along with it.
+func TestMetrics_MixedCollectorBatchRoutesEachResourceToItsOwnStream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+
+	codexMetric := "codex.tool.call"
+	unit := "1"
+	claudeMetric := "claude_code.token.usage"
+	mixed := &gen.MetricsPayload{ResourceMetrics: []*gen.OTELResourceMetrics{
+		{
+			Resource: &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", "codex_exec")}},
+			ScopeMetrics: []*gen.OTELScopeMetrics{{Metrics: []*gen.OTELMetric{{
+				Name: &codexMetric,
+				Unit: &unit,
+				Sum: &gen.OTELSum{
+					// Codex exports cumulative counters — the temporality the
+					// Claude extractor rejects outright.
+					AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
+					DataPoints: []*gen.OTELNumberDataPoint{{
+						TimeUnixNano: new(nanoString(timestamp)),
+						AsInt:        "3",
+						Attributes: []*gen.OTELAttribute{
+							strAttr("conversation.id", "conv-mixed-metrics"),
+							strAttr("user.email", "mixed-codex@example.com"),
+						},
+					}},
+				},
+			}}}},
+		},
+		{
+			Resource: &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")}},
+			ScopeMetrics: []*gen.OTELScopeMetrics{{Metrics: []*gen.OTELMetric{{
+				Name: &claudeMetric,
+				Unit: &unit,
+				Sum: &gen.OTELSum{
+					AggregationTemporality: "AGGREGATION_TEMPORALITY_DELTA",
+					DataPoints: []*gen.OTELNumberDataPoint{{
+						TimeUnixNano: new(nanoString(timestamp)),
+						AsInt:        "7",
+						Attributes: []*gen.OTELAttribute{
+							strAttr("session.id", "session-mixed-metrics"),
+							strAttr("type", "input"),
+						},
+					}},
+				},
+			}}}},
+		},
+	}}
+
+	require.NoError(t, ti.service.Metrics(ctx, mixed))
+
+	// The Codex half lands verbatim on its own stream...
+	codexRows := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexOTELMetricsURN, timestamp, 1)
+	require.Contains(t, codexRows[0].Attributes, "codex.tool.call")
+	require.Contains(t, codexRows[0].ResourceAttributes, "codex_exec")
+
+	// ...and the Claude half still produces its usage rows. This is the
+	// assertion that fails when the Claude path is handed the unsplit
+	// payload: the extractor rejects Codex's cumulative temporality and
+	// returns, taking the batch's Claude rows down with it.
+	claudeRows := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), "claude-code:usage:metrics", timestamp, 1)
+	require.Contains(t, claudeRows[0].Attributes, "session-mixed-metrics")
+}
+
 func TestMetrics_CodexPayloadDoesNotWriteClaudeUsageRows(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -518,5 +518,62 @@ func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
 			ScopeLogs: nil,
 		}}}
 		require.False(t, isCodexLogsPayload(logs), serviceName)
+
+		metrics := &gen.MetricsPayload{ResourceMetrics: []*gen.OTELResourceMetrics{{
+			Resource:     &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
+			ScopeMetrics: nil,
+		}}}
+		require.False(t, isCodexMetricsPayload(metrics), serviceName)
 	}
+}
+
+// TestLogs_MixedCollectorBatchRoutesEachResourceToItsOwnStream: an
+// OpenTelemetry Collector fanning in several clients can re-batch Claude and
+// Codex resources into one export. Routing the whole payload on an
+// any-resource match would stamp one client's records with the other's URN,
+// hook source, and attribution — so the split must be per resource.
+func TestLogs_MixedCollectorBatchRoutesEachResourceToItsOwnStream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	timestamp := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	mixed := &gen.LogsPayload{ResourceLogs: []*gen.OTELResourceLog{
+		{
+			Resource: &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", "codex_exec")}},
+			ScopeLogs: []*gen.OTELScopeLog{{LogRecords: []*gen.OTELLogRecord{{
+				TimeUnixNano: new(nanoString(timestamp)),
+				Body:         &gen.OTELLogBody{StringValue: new("codex.user_prompt")},
+				Attributes: []*gen.OTELAttribute{
+					strAttr("event.name", "codex.user_prompt"),
+					strAttr("conversation.id", "conv-mixed-batch"),
+					strAttr("user.email", "mixed-codex@example.com"),
+				},
+			}}}},
+		},
+		{
+			Resource: &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", "claude-code")}},
+			ScopeLogs: []*gen.OTELScopeLog{{LogRecords: []*gen.OTELLogRecord{{
+				TimeUnixNano: new(nanoString(timestamp)),
+				Body:         &gen.OTELLogBody{StringValue: new("claude api request")},
+				Attributes: []*gen.OTELAttribute{
+					strAttr("session.id", "session-mixed-batch"),
+					strAttr("user.email", "mixed-claude@example.com"),
+				},
+			}}}},
+		},
+	}}
+
+	require.NoError(t, ti.service.Logs(ctx, mixed))
+
+	codexRows := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexOTELLogsURN, timestamp, 1)
+	require.Contains(t, codexRows[0].Attributes, "codex.user_prompt")
+	require.Contains(t, codexRows[0].ResourceAttributes, "codex_exec")
+
+	claudeRows := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), claudeOTELLogsURN, timestamp, 1)
+	require.Contains(t, claudeRows[0].ResourceAttributes, "claude-code")
+	// The Claude record must NOT have been stamped as Codex traffic.
+	require.NotContains(t, claudeRows[0].Attributes, providerOpenAI)
 }

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -265,25 +265,6 @@ func TestLogs_CodexUsageRollsUpToAttributeMetrics(t *testing.T) {
 	}, 15*time.Second, 200*time.Millisecond)
 }
 
-func TestIsCodexLogsPayload(t *testing.T) {
-	t.Parallel()
-
-	assert.True(t, isCodexLogsPayload(codexLogsPayload(tokenBearingRecord())))
-	assert.False(t, isCodexLogsPayload(nil))
-
-	claude := &gen.LogsPayload{
-		ResourceLogs: []*gen.OTELResourceLog{{
-			Resource: &gen.OTELResource{
-				Attributes: []*gen.OTELResourceAttribute{{
-					Key:   "service.name",
-					Value: &gen.OTELAttributeValue{StringValue: new("claude-code")},
-				}},
-			},
-		}},
-	}
-	assert.False(t, isCodexLogsPayload(claude))
-}
-
 func TestLogs_AttributesCodexOTELRecordsToResolvedUser(t *testing.T) {
 	t.Parallel()
 
@@ -312,24 +293,6 @@ func TestLogs_AttributesCodexOTELRecordsToResolvedUser(t *testing.T) {
 	logs := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexOTELLogsURN, timestamp, 1)
 	require.Contains(t, logs[0].Attributes, userID)
 	require.Contains(t, logs[0].Attributes, "codex-otel@example.com")
-}
-
-func TestIsCodexMetricsPayload(t *testing.T) {
-	t.Parallel()
-
-	assert.True(t, isCodexMetricsPayload(codexMetricsPayload()))
-	assert.False(t, isCodexMetricsPayload(nil))
-
-	claude := &gen.MetricsPayload{
-		ResourceMetrics: []*gen.OTELResourceMetrics{{
-			Resource: &gen.OTELResource{
-				Attributes: []*gen.OTELResourceAttribute{
-					resourceStrAttr("service.name", "claude-code"),
-				},
-			},
-		}},
-	}
-	assert.False(t, isCodexMetricsPayload(claude))
 }
 
 func TestMetrics_PersistsCodexOTELMetricDataPoints(t *testing.T) {
@@ -571,6 +534,13 @@ func TestLogs_ClassifiesUnresolvedCodexEmailPersonal(t *testing.T) {
 func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
 	t.Parallel()
 
+	nilCodexLogs, nilClaudeLogs := splitCodexLogsPayload(nil)
+	require.Nil(t, nilCodexLogs)
+	require.Nil(t, nilClaudeLogs)
+	nilCodexMetrics, nilClaudeMetrics := splitCodexMetricsPayload(nil)
+	require.Nil(t, nilCodexMetrics)
+	require.Nil(t, nilClaudeMetrics)
+
 	// Every name below was observed against the shipped 0.146 build.
 	// codex-app-server is Codex mode in the unified ChatGPT desktop app and
 	// is hyphenated, so an underscore-only match would still have misrouted
@@ -580,13 +550,17 @@ func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
 			Resource:  &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
 			ScopeLogs: nil,
 		}}}
-		require.True(t, isCodexLogsPayload(logs), serviceName)
+		codexLogs, claudeLogs := splitCodexLogsPayload(logs)
+		require.NotNil(t, codexLogs, serviceName)
+		require.Nil(t, claudeLogs, serviceName)
 
 		metrics := &gen.MetricsPayload{ResourceMetrics: []*gen.OTELResourceMetrics{{
 			Resource:     &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
 			ScopeMetrics: nil,
 		}}}
-		require.True(t, isCodexMetricsPayload(metrics), serviceName)
+		codexMetrics, claudeMetrics := splitCodexMetricsPayload(metrics)
+		require.NotNil(t, codexMetrics, serviceName)
+		require.Nil(t, claudeMetrics, serviceName)
 	}
 
 	for _, serviceName := range []string{"claude-code", "claude-code-desktop", "cowork", "codexish-other", ""} {
@@ -594,13 +568,17 @@ func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
 			Resource:  &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
 			ScopeLogs: nil,
 		}}}
-		require.False(t, isCodexLogsPayload(logs), serviceName)
+		codexLogs, claudeLogs := splitCodexLogsPayload(logs)
+		require.Nil(t, codexLogs, serviceName)
+		require.NotNil(t, claudeLogs, serviceName)
 
 		metrics := &gen.MetricsPayload{ResourceMetrics: []*gen.OTELResourceMetrics{{
 			Resource:     &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
 			ScopeMetrics: nil,
 		}}}
-		require.False(t, isCodexMetricsPayload(metrics), serviceName)
+		codexMetrics, claudeMetrics := splitCodexMetricsPayload(metrics)
+		require.Nil(t, codexMetrics, serviceName)
+		require.NotNil(t, claudeMetrics, serviceName)
 	}
 }
 

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -571,7 +571,11 @@ func TestLogs_ClassifiesUnresolvedCodexEmailPersonal(t *testing.T) {
 func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
 	t.Parallel()
 
-	for _, serviceName := range []string{"codex_cli_rs", "codex_exec", "codex_tui", "codex_mcp"} {
+	// Every name below was observed against the shipped 0.146 build.
+	// codex-app-server is Codex mode in the unified ChatGPT desktop app and
+	// is hyphenated, so an underscore-only match would still have misrouted
+	// the desktop surface.
+	for _, serviceName := range []string{"codex", "codex_cli_rs", "codex_exec", "codex_tui", "codex_mcp", "codex-app-server"} {
 		logs := &gen.LogsPayload{ResourceLogs: []*gen.OTELResourceLog{{
 			Resource:  &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
 			ScopeLogs: nil,
@@ -585,7 +589,7 @@ func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
 		require.True(t, isCodexMetricsPayload(metrics), serviceName)
 	}
 
-	for _, serviceName := range []string{"claude-code", "claude-code-desktop", "cowork", ""} {
+	for _, serviceName := range []string{"claude-code", "claude-code-desktop", "cowork", "codexish-other", ""} {
 		logs := &gen.LogsPayload{ResourceLogs: []*gen.OTELResourceLog{{
 			Resource:  &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
 			ScopeLogs: nil,

--- a/server/internal/hooks/codex_otel_test.go
+++ b/server/internal/hooks/codex_otel_test.go
@@ -12,6 +12,10 @@ import (
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
+// codexTestServiceName is the interactive CLI's reported service.name — one
+// member of the codex_ family the ingest matches (see codexServiceNamePrefix).
+const codexTestServiceName = "codex_cli_rs"
+
 // strAttr builds an OTLP string-valued log attribute, the shape Codex emits.
 func strAttr(key, val string) *gen.OTELAttribute {
 	return &gen.OTELAttribute{Key: key, Value: &gen.OTELAttributeValue{StringValue: new(val)}}
@@ -24,7 +28,7 @@ func codexLogsPayload(records ...*gen.OTELLogRecord) *gen.LogsPayload {
 			Resource: &gen.OTELResource{
 				Attributes: []*gen.OTELResourceAttribute{{
 					Key:   "service.name",
-					Value: &gen.OTELAttributeValue{StringValue: new(codexServiceName)},
+					Value: &gen.OTELAttributeValue{StringValue: new(codexTestServiceName)},
 				}},
 			},
 			ScopeLogs: []*gen.OTELScopeLog{{LogRecords: records}},
@@ -57,7 +61,7 @@ func codexMetricsPayload(metrics ...*gen.OTELMetric) *gen.MetricsPayload {
 		ResourceMetrics: []*gen.OTELResourceMetrics{{
 			Resource: &gen.OTELResource{
 				Attributes: []*gen.OTELResourceAttribute{
-					resourceStrAttr("service.name", codexServiceName),
+					resourceStrAttr("service.name", codexTestServiceName),
 				},
 			},
 			ScopeMetrics: []*gen.OTELScopeMetrics{{Metrics: metrics}},
@@ -125,7 +129,7 @@ func TestLogs_PersistsCodexOTELRecords(t *testing.T) {
 	require.Contains(t, first.Attributes, providerOpenAI)
 
 	require.Contains(t, first.ResourceAttributes, "service")
-	require.Contains(t, first.ResourceAttributes, codexServiceName)
+	require.Contains(t, first.ResourceAttributes, codexTestServiceName)
 
 	second := logs[0]
 	require.Equal(t, "codex.tool_decision", second.Body)
@@ -374,7 +378,7 @@ func TestMetrics_PersistsCodexOTELMetricDataPoints(t *testing.T) {
 	// Metrics rows carry the same account attribution as the logs stream
 	// (dev@example.com resolves to the test org member → team).
 	require.Contains(t, row.Attributes, `"account_type":"team"`)
-	require.Contains(t, row.ResourceAttributes, codexServiceName)
+	require.Contains(t, row.ResourceAttributes, codexTestServiceName)
 }
 
 func TestMetrics_CodexPayloadDoesNotWriteClaudeUsageRows(t *testing.T) {
@@ -483,4 +487,36 @@ func TestLogs_ClassifiesUnresolvedCodexEmailPersonal(t *testing.T) {
 	logs := waitForHookLogs(t, ctx, chClient, authCtx.ProjectID.String(), codexOTELLogsURN, timestamp, 1)
 	require.Contains(t, logs[0].Attributes, `"account_type":"personal"`)
 	require.NotContains(t, logs[0].Attributes, "billing_mode")
+}
+
+// TestIsCodexPayloadMatchesServiceNameFamily: Codex reports a different
+// service.name per mode — codex_exec is what headless `codex exec` (CI and
+// scripted runs) emits, verified against the shipped 0.146 binary, alongside
+// codex_tui and codex_mcp. Matching only the interactive codex_cli_rs
+// silently dropped every other mode's telemetry: no rows, no tokens, no
+// error. Claude's service names must still route to the session path.
+func TestIsCodexPayloadMatchesServiceNameFamily(t *testing.T) {
+	t.Parallel()
+
+	for _, serviceName := range []string{"codex_cli_rs", "codex_exec", "codex_tui", "codex_mcp"} {
+		logs := &gen.LogsPayload{ResourceLogs: []*gen.OTELResourceLog{{
+			Resource:  &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
+			ScopeLogs: nil,
+		}}}
+		require.True(t, isCodexLogsPayload(logs), serviceName)
+
+		metrics := &gen.MetricsPayload{ResourceMetrics: []*gen.OTELResourceMetrics{{
+			Resource:     &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
+			ScopeMetrics: nil,
+		}}}
+		require.True(t, isCodexMetricsPayload(metrics), serviceName)
+	}
+
+	for _, serviceName := range []string{"claude-code", "claude-code-desktop", "cowork", ""} {
+		logs := &gen.LogsPayload{ResourceLogs: []*gen.OTELResourceLog{{
+			Resource:  &gen.OTELResource{Attributes: []*gen.OTELResourceAttribute{resourceStrAttr("service.name", serviceName)}},
+			ScopeLogs: nil,
+		}}}
+		require.False(t, isCodexLogsPayload(logs), serviceName)
+	}
 }

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -811,6 +811,7 @@ func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) erro
 	if claudeMetrics == nil {
 		return nil
 	}
+	payload = claudeMetrics
 
 	logger.InfoContext(ctx, "Received Claude token metrics",
 		attr.SlogEvent("claude_metrics"),

--- a/server/internal/hooks/otel.go
+++ b/server/internal/hooks/otel.go
@@ -46,12 +46,19 @@ func (s *Service) Logs(ctx context.Context, payload *gen.LogsPayload) error {
 		attr.SlogProjectID(projectID),
 	)
 
-	// Codex payloads persist as a raw log stream like Claude's; they carry no
-	// Claude session to seed, so they skip the attribution path below.
-	if isCodexLogsPayload(payload) {
-		s.writeCodexOTELLogsToClickHouse(ctx, payload, orgID, projectID)
+	// Codex resources persist as a raw log stream like Claude's; they carry no
+	// Claude session to seed, so they skip the attribution path below. Split
+	// per resource rather than routing the whole payload: a collector can
+	// re-batch both clients into one export, and sending the batch to a single
+	// writer would mislabel the other client's records.
+	codexPayload, claudePayload := splitCodexLogsPayload(payload)
+	if codexPayload != nil {
+		s.writeCodexOTELLogsToClickHouse(ctx, codexPayload, orgID, projectID)
+	}
+	if claudePayload == nil {
 		return nil
 	}
+	payload = claudePayload
 
 	sessions := extractSessionMetadata(payload)
 
@@ -787,8 +794,11 @@ func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) erro
 
 	// Codex metrics (event counters, not token usage) must not run through the
 	// Claude usage extractor — it would find no claude_code.* metrics and can
-	// reject on temporality. Persist them verbatim instead.
-	if isCodexMetricsPayload(payload) {
+	// reject on temporality. Persist them verbatim instead, splitting per
+	// resource so a mixed collector batch routes each client's metrics to its
+	// own writer.
+	codexMetrics, claudeMetrics := splitCodexMetricsPayload(payload)
+	if codexMetrics != nil {
 		s.logger.InfoContext(ctx, "Received Codex OTEL metrics",
 			attr.SlogHookSource("codex"),
 			attr.SlogHookEvent("Metrics"),
@@ -796,7 +806,9 @@ func (s *Service) Metrics(ctx context.Context, payload *gen.MetricsPayload) erro
 			attr.SlogOrganizationID(orgID),
 			attr.SlogProjectID(projectID),
 		)
-		s.writeCodexMetricsToClickHouse(ctx, payload, orgID, projectID)
+		s.writeCodexMetricsToClickHouse(ctx, codexMetrics, orgID, projectID)
+	}
+	if claudeMetrics == nil {
 		return nil
 	}
 

--- a/server/internal/telemetry/event_urn.go
+++ b/server/internal/telemetry/event_urn.go
@@ -20,6 +20,8 @@ const eventTypeUsage = "usage"
 const (
 	legacyClaudeOTELLogsURN    = "claude-code:otel:logs"
 	legacyClaudeUsageURN       = "claude-code:usage:metrics"
+	legacyCodexOTELLogsURN     = "codex:otel:logs"
+	legacyCodexOTELMetricsURN  = "codex:otel:metrics"
 	legacyCodexUsageURN        = "codex:usage:metrics"
 	legacyCursorHookUsageURN   = "cursor:usage:metrics"
 	legacyClaudeOTELBodyPrefix = "claude_code."
@@ -80,6 +82,16 @@ func deriveHookEventURN(legacyURN string, attrs map[attr.Key]any) string {
 			}
 		}
 		return urn.NewTelemetryEvent(urn.TelemetryEventOriginProviderOTEL, urn.TelemetryEventKindLog, eventType).String()
+	case legacyCodexOTELLogsURN:
+		// Codex's provider-native OTel log records (codex.sse_event,
+		// codex.tool_decision, ...). Codex always sets event.name, so there is
+		// no body-prefix fallback like the one older Claude CLIs need.
+		return urn.NewTelemetryEvent(urn.TelemetryEventOriginProviderOTEL, urn.TelemetryEventKindLog, getString(attrs, rawEventNameKey)).String()
+	case legacyCodexOTELMetricsURN:
+		// Raw Codex OTel metric data points, typed by the metric name the
+		// writer stamps. Distinct from legacyCodexUsageURN below, which is the
+		// usage row synthesized from Codex response.completed *logs*.
+		return urn.NewTelemetryEvent(urn.TelemetryEventOriginProviderOTEL, urn.TelemetryEventKindMetric, getString(attrs, attr.MetricNameKey)).String()
 	case legacyClaudeUsageURN, legacyCodexUsageURN:
 		// Usage data points normalized from provider OTel metrics (Claude)
 		// or provider OTel logs (Codex response.completed events).

--- a/server/internal/telemetry/event_urn_test.go
+++ b/server/internal/telemetry/event_urn_test.go
@@ -95,6 +95,24 @@ func TestDeriveEventURN_ClassifiesKnownProducers(t *testing.T) {
 			want: "urn:telemetry:provider_otel:log:unknown",
 		},
 		{
+			name:      "it classifies codex OTEL logs by event name, like claude's",
+			legacyURN: "codex:otel:logs",
+			attrs: map[attr.Key]any{
+				attr.EventSourceKey: string(EventSourceHook),
+				rawEventNameKey:     "codex.sse_event",
+			},
+			want: "urn:telemetry:provider_otel:log:codex.sse_event",
+		},
+		{
+			name:      "it classifies codex OTEL metric points by metric name",
+			legacyURN: "codex:otel:metrics",
+			attrs: map[attr.Key]any{
+				attr.EventSourceKey: string(EventSourceHook),
+				attr.MetricNameKey:  "codex.tokens.used",
+			},
+			want: "urn:telemetry:provider_otel:metric:codex.tokens.used",
+		},
+		{
 			name:      "it classifies claude usage rows as provider_otel metrics",
 			legacyURN: "claude-code:usage:metrics",
 			attrs:     map[attr.Key]any{attr.EventSourceKey: string(EventSourceHook)},


### PR DESCRIPTION
Found while verifying the unified ChatGPT desktop app (DNO-737).

## The bug

`isCodexLogsPayload` / `isCodexMetricsPayload` route a payload to the Codex ingest only when its OTEL resource `service.name` is exactly `codex_cli_rs`. But Codex reports a **different service.name per client mode**, so everything else was dropped on the floor — no raw rows, no token metering, no session capture, and no error anywhere.

## How it was verified

Rather than reasoning from docs, I pointed a real Codex run's OTLP exporter at a local collector and read what it actually sent. Running `codex exec` from the shipped binary (`codex-cli 0.146.0-alpha.9.2` inside `/Applications/ChatGPT.app`) produced 4 OTLP payloads, all with:

```json
{ "key": "service.name", "value": { "stringValue": "codex_exec" } }
```

Not `codex_cli_rs`. The payloads were otherwise exactly what our ingest expects — `codex.sse_event` with `event.kind=response.completed` carrying `input_token_count` / `output_token_count` (our token-metering source), plus `codex.user_prompt`, `codex.api_request`, `codex.conversation_starts`, `codex.turn_ttft`.

Scanning the binary for the rest of the family turned up `codex_tui` and `codex_mcp` alongside `codex_cli_rs` and `codex_exec`.

## Impact

`codex exec` is the headless mode — CI, scripts, automation. Its telemetry has been silently discarded. The dogfood compliance feed independently shows an `exec` client surface in the COSTS data, so this is real usage, not a hypothetical.

This also corrects an assumption in #4908: `exec` was excluded from COSTS token promotion on the grounds that "OTEL is its token source of truth". With OTEL dropping exec, those tokens were metered **nowhere**. Fixing the matcher is the better repair — it recovers the full event stream (sessions, tool calls, prompts), not just token counts — and keeps that PR's exclusion correct.

## The fix

Match the `codex_` service-name family instead of one exact string, so a new client mode is captured on arrival rather than discovered later as missing data. Claude reports `claude-code`-style names, so the prefix cannot collide with the session-seeding path.

Test covers all four known family members routing to the Codex path for both logs and metrics, and asserts Claude's names still don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture Codex OTEL telemetry from every client mode and classify it as provider OTEL, while routing mixed OTLP batches per resource. Restores Codex rows and token metering (incl. `codex exec` and Desktop `codex-app-server`, DNO-737), stops Codex data inflating Claude surfaces, and improves relay email attribution on editor‑only machines (DNO-771).

- **Bug Fixes**
  - Match `service.name` equal to `codex` or with a suffix on `_`/`-` (covers `codex_cli_rs`, `codex_exec`, `codex_tui`, `codex_mcp`, `codex-app-server`; avoids near‑misses like `codexish-*`); `claude-code*` still bypasses.
  - Split logs and metrics per OTEL resource and pass only the Claude half to usage extraction, so mixed batches route each client correctly and keep Claude token rows when Codex cumulative metrics are present.
  - Classify Codex OTEL rows under provider OTEL URNs (`codex:otel:logs`, `codex:otel:metrics`) typed by event/metric name.
  - In the relay, probe `/Applications/ChatGPT.app/Contents/Resources/codex` ahead of `Codex.app`, skip non-executable candidates, and resolve Codex user email when only the unified app is installed.
  - Also probe Codex bundled with ChatGPT editor extensions (VS Code/Insiders, VS Code Server, Cursor, Windsurf), ranking copies newest-first by numeric version across editors; unreadable versions sort last but are still probed. Ranked below a real CLI and `ChatGPT.app` and above `Codex.app` (DNO-771).

<sup>Written for commit 6b17c3088a23fe14d57659cf535b6ead3959623a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

