### PR TITLE
fix(dashboard): stop login redirect loop on proxied MCP upstream 401s

### DIFF
--- a/client/dashboard/src/contexts/Sdk.tsx
+++ b/client/dashboard/src/contexts/Sdk.tsx
@@ -1,5 +1,8 @@
 import { handleError } from "@/lib/errors";
-import { isUnauthorizedError } from "@/lib/route-errors";
+import {
+  isGramSessionUnauthorizedError,
+  isUnauthorizedError,
+} from "@/lib/route-errors";
 import { redirectToLoginOnUnauthorized } from "@/lib/session-expired";
 import { Gram } from "@gram/client";
 import { GramError } from "@gram/client/models/errors/gramerror.js";
@@ -29,13 +32,17 @@ export const useSdkClient = (): Gram => {
 // Preserve QueryClient across HMR to prevent cache loss
 const createQueryClient = () =>
   new QueryClient({
-    // A 401 means the session is dead (expired, revoked, or — in local dev —
-    // overwritten by another worktree's stack, since the cookie is scoped to
-    // `localhost` and cookies ignore ports). Send the user to /login instead
-    // of letting it throw to the error boundary.
+    // A Gram API 401 means the session is dead (expired, revoked, or — in
+    // local dev — overwritten by another worktree's stack, since the cookie is
+    // scoped to `localhost` and cookies ignore ports). Send the user to /login
+    // instead of letting it throw to the error boundary. Only Gram errors
+    // qualify: queries that talk to non-Gram endpoints (e.g. useProxiedMcpTools
+    // listing a proxied MCP server's tools) 401 when the *upstream* wants
+    // credentials, which their hooks handle inline — redirecting on those loops
+    // the page through /login forever since the Gram session is still valid.
     queryCache: new QueryCache({
       onError: (error) => {
-        if (isUnauthorizedError(error)) {
+        if (isGramSessionUnauthorizedError(error)) {
           redirectToLoginOnUnauthorized();
         }
       },
@@ -43,9 +50,11 @@ const createQueryClient = () =>
     defaultOptions: {
       queries: {
         // Suppress 403s so RBAC-restricted queries degrade gracefully
-        // instead of crashing the page, and 401s because the cache handler
-        // above is already navigating away. All other errors still throw to
-        // the nearest error boundary.
+        // instead of crashing the page, and 401s because they are auth
+        // states, not crashes: Gram 401s are already navigating away via the
+        // cache handler above, and non-Gram 401s (e.g. a proxied MCP upstream
+        // wanting credentials) are surfaced inline by their hooks. All other
+        // errors still throw to the nearest error boundary.
         throwOnError: (error) =>
           !isUnauthorizedError(error) &&
           !(error instanceof GramError && error.statusCode === 403),

--- a/client/dashboard/src/lib/route-errors.test.ts
+++ b/client/dashboard/src/lib/route-errors.test.ts
@@ -1,0 +1,54 @@
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+import { describe, expect, it } from "vitest";
+import {
+  isGramSessionUnauthorizedError,
+  isUnauthorizedError,
+} from "./route-errors";
+
+function gramError(status: number): GramError {
+  return new GramError("request failed", {
+    response: new Response(null, { status }),
+    request: new Request("https://app.getgram.ai/rpc/example"),
+    body: "",
+  });
+}
+
+/**
+ * Mimics the AI SDK's MCPClientError: a plain Error subclass carrying the
+ * HTTP status as `statusCode`, thrown when a proxied MCP upstream rejects
+ * its credentials. Not a Gram error, so it must never be read as Gram
+ * session expiry.
+ */
+function mcpClientError(statusCode: number): Error {
+  const error = new Error(
+    `MCP HTTP Transport Error: POSTing to endpoint (HTTP ${statusCode})`,
+  );
+  Object.assign(error, { statusCode });
+  return error;
+}
+
+describe("isGramSessionUnauthorizedError", () => {
+  it("matches a Gram API 401", () => {
+    expect(isGramSessionUnauthorizedError(gramError(401))).toBe(true);
+  });
+
+  it("ignores Gram errors with other statuses", () => {
+    expect(isGramSessionUnauthorizedError(gramError(403))).toBe(false);
+    expect(isGramSessionUnauthorizedError(gramError(500))).toBe(false);
+  });
+
+  it("ignores non-Gram 401s such as a proxied MCP upstream rejection", () => {
+    const error = mcpClientError(401);
+    // The broad predicate still sees a 401 — that contrast is the point:
+    // only the Gram-scoped predicate may drive the /login redirect.
+    expect(isUnauthorizedError(error)).toBe(true);
+    expect(isGramSessionUnauthorizedError(error)).toBe(false);
+  });
+
+  it("ignores errors with no status at all", () => {
+    expect(isGramSessionUnauthorizedError(new Error("network down"))).toBe(
+      false,
+    );
+    expect(isGramSessionUnauthorizedError(null)).toBe(false);
+  });
+});

--- a/client/dashboard/src/lib/route-errors.ts
+++ b/client/dashboard/src/lib/route-errors.ts
@@ -28,6 +28,20 @@ export function isUnauthorizedError(error: unknown): boolean {
   return getHttpStatusCode(error) === 401;
 }
 
+/**
+ * A 401 from the Gram API itself, meaning the dashboard session is dead.
+ *
+ * This is deliberately narrower than {@link isUnauthorizedError}: non-Gram
+ * clients also surface errors with a 401 status — e.g. the AI SDK's
+ * MCPClientError when a proxied MCP upstream rejects its credentials — and
+ * those say nothing about the Gram session. Treating them as session expiry
+ * causes a redirect loop: /login sees a valid session and bounces straight
+ * back to the page whose query 401s again.
+ */
+export function isGramSessionUnauthorizedError(error: unknown): boolean {
+  return error instanceof GramError && error.statusCode === 401;
+}
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 


### PR DESCRIPTION
## Problem

Opening the Inspect tab of a proxied MCP server whose upstream hasn't been connected yet (or whose upstream token expired) put the dashboard into an infinite refresh loop instead of showing the "Connect" prompt.

The chain:

1. `useProxiedMcpTools` connects to the proxied `/mcp/<slug>` endpoint to list tools. When the upstream wants credentials, the gateway answers **401 — an expected state** the hook maps to `needsAuth` so the tab can render its Connect prompt.
2. The global `QueryCache.onError` in `Sdk.tsx` treated _any_ query error carrying a 401 status as a dead Gram session and hard-navigated to `/login`. The AI SDK's `MCPClientError` carries `statusCode`, so the upstream 401 was indistinguishable from session expiry.
3. The Gram session is actually valid, so `/login` immediately bounces back to the page. The hard navigation drops the React Query cache, the tools query re-fires, 401s again → loop forever. The `redirecting` guard in `session-expired.ts` is module state and resets on every reload, so it never breaks the cycle.

## Fix

Scope the login redirect to 401s from the Gram API itself: new `isGramSessionUnauthorizedError` predicate (`instanceof GramError && statusCode === 401`) drives `redirectToLoginOnUnauthorized`. All SDK errors that carry an HTTP status extend `GramError`, so real session expiry still redirects exactly as before.

Non-Gram 401s no longer redirect; they stay suppressed from error boundaries (per the existing `throwOnError` default) and surface inline through their hooks — the Inspect tab now shows its Connect prompt as designed. Since the fix is at the QueryCache level, it also covers the playground's proxied MCP connection and any future query hitting a non-Gram endpoint.

## Testing

- New unit tests in `route-errors.test.ts`: Gram 401 matches; Gram 403/500 don't; an MCP-transport-shaped 401 (the regression case) doesn't; status-less errors don't.
- `pnpm -F dashboard type-check`, `pnpm -F dashboard test src/lib/route-errors.test.ts`, and the full `pnpm -F dashboard lint` gate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite /login redirect loop when a proxied MCP server’s upstream returns 401. We now only redirect to login on 401s from the Gram API, so the Inspect tab shows its Connect prompt as expected.

- **Bug Fixes**
  - Added `isGramSessionUnauthorizedError` to detect only `@gram/client` 401s and drive the login redirect.
  - Updated `QueryCache.onError` to use the new predicate; non‑Gram 401s stay inline (e.g., `needsAuth` in Inspect).
  - Kept 403 suppression via `throwOnError`; other errors still surface to error boundaries.
  - Added unit tests covering Gram 401 match, Gram 403/500 ignore, MCP‑style 401 ignore, and status‑less errors.

<sup>Written for commit 9ebdbb8c5c37fd1b344bb7cd15db64b698e1e336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

