### PR TITLE
fix: allow the renamed codex MCP client user-agent at the figma gate

### DIFF
--- a/.changeset/figma-codex-mcp-client-ua.md
+++ b/.changeset/figma-codex-mcp-client-ua.md
@@ -1,0 +1,10 @@
+---
+"server": patch
+---
+
+Stop rejecting current Codex clients at the Figma MCP allowlist (DNO-765).
+Codex renamed its MCP client User-Agent — 0.144 sent `codex_cli_rs/…`, the
+0.146 unified-app build sends `codex-mcp-client/…` — and the allowlist only
+carried the old token, so every Codex → Figma MCP call proxied through Gram
+was rejected as an unapproved client. Both tokens are now listed so neither
+older deployed clients nor current ones are blocked.

--- a/server/internal/remotemcp/interceptors/figma.go
+++ b/server/internal/remotemcp/interceptors/figma.go
@@ -26,8 +26,12 @@ var figmaAllowedUserAgents = []string{
 	"claude-code/",
 	"cursor/",
 	"visual studio code/",
-	"copilot/",      // GitHub Copilot CLI
-	"codex_cli_rs/", // Codex CLI
+	"copilot/", // GitHub Copilot CLI
+	// Codex renamed its MCP client User-Agent: 0.144 sent codex_cli_rs/…,
+	// the 0.146 unified-app build sends codex-mcp-client/… . Both are listed
+	// so neither the deployed older clients nor current ones are rejected.
+	"codex_cli_rs/",
+	"codex-mcp-client/",
 	"openai-mcp/",   // ChatGPT and OpenAI Agent Builder
 	"chatgpt-user/", // ChatGPT server-side fetches
 	"zed/",

--- a/server/internal/remotemcp/interceptors/figma_test.go
+++ b/server/internal/remotemcp/interceptors/figma_test.go
@@ -39,6 +39,10 @@ func TestFigma_AllowsCatalogClients(t *testing.T) {
 		"Visual Studio Code/1.128.0",
 		"copilot/1.0.70 (darwin v24.16.0) term/Apple_Terminal",
 		"codex_cli_rs/0.144.1 (Mac OS 26.4.0; arm64) iTerm.app/3.6.7",
+		// Captured from the shipped unified ChatGPT desktop app's codex 0.146
+		// by pointing an MCP server at a local listener; the earlier
+		// codex_cli_rs/ token does not match it (DNO-765).
+		"codex-mcp-client/0.146.0-alpha.9.2",
 		"openai-mcp/1.0.0 (ChatGPT)",
 		"Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot",
 		"Zed/1.9.0+stable.316.ced90fc636c4ede05402befc38a63bae7fd741bd (macos; aarch64)",


### PR DESCRIPTION
Closes DNO-765. Found during the DNO-737 unified-app verification, surfaced by the review of #4913.

## The bug

`figmaAllowedUserAgents` mirrors Figma's MCP-catalog client allowlist so proxied traffic gets a clean error instead of an opaque upstream rejection. Its Codex entry is `codex_cli_rs/` — which current Codex no longer sends.

Captured from the shipped unified app by pointing a Codex MCP server at a local listener and reading the request header:

```
User-Agent: codex-mcp-client/0.146.0-alpha.9.2
```

`codex-mcp-client/` contains none of the allowlist tokens (hyphens, not underscores), so **every Codex → Figma MCP call proxied through Gram is rejected today**:

```
client "codex-mcp-client/0.146.0-alpha.9.2" is not an approved client for this MCP server
```

That's the literal output of the new test run against `main`.

The existing test's production sample is `codex_cli_rs/0.144.1 …`, so the rename landed between 0.144 and 0.146 — meaning both tokens are live in the field right now.

## The fix

List both. Older clients are still deployed, and the interceptor is explicitly "a policy gate, not a security boundary" — so permissive is the correct failure direction: wrongly blocking a client Figma would accept is worse than forwarding one Figma may reject with its own message.

## Note for follow-up

This entry sat in the "observed in Gram traffic" group and drifted silently. Worth a pass over the other entries in that group to see whether any others have been renamed the same way — I only verified Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-765 by accepting the renamed Codex MCP client user-agent at the Figma allowlist so current Codex → Figma MCP calls aren’t rejected. Keeps the old token to avoid blocking older installs.

- **Bug Fixes**
  - Allow both "codex-mcp-client/" and "codex_cli_rs/" in figmaAllowedUserAgents.
  - Update tests to cover the new UA.

<sup>Written for commit 0fae20fef2ec678540324d83f009f2e56bdc0c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

