### PR TITLE
docs(dashboard): refresh codex setup copy for the unified ChatGPT app

### DIFF
--- a/.changeset/codex-unified-app-setup-copy.md
+++ b/.changeset/codex-unified-app-setup-copy.md
@@ -1,0 +1,10 @@
+---
+"dashboard": patch
+---
+
+Refresh the Codex setup copy for the unified ChatGPT desktop app (DNO-737).
+The tile referred to a standalone "Codex desktop app" that OpenAI has since
+merged into the ChatGPT app, and now states that Codex mode there is covered
+while Chat and Work modes are not — those are captured through the OpenAI
+Compliance API integration instead. The two OpenAI hook/plugin doc links were
+redirecting and now point at their current destinations.

--- a/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
+++ b/client/dashboard/src/pages/hooks/HooksSetupDialog.tsx
@@ -408,7 +408,7 @@ function CodexInstallContent({
       <div className="flex items-center gap-3">
         <Button variant="secondary" size="sm" asChild>
           <a
-            href="https://developers.openai.com/codex/hooks"
+            href="https://learn.chatgpt.com/docs/hooks"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2"
@@ -419,7 +419,7 @@ function CodexInstallContent({
         </Button>
         <Button variant="secondary" size="sm" asChild>
           <a
-            href="https://developers.openai.com/codex/plugins/build"
+            href="https://developers.openai.com/plugins/build/plugins"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2"

--- a/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
+++ b/client/dashboard/src/pages/plugins/InstallInstructionsDialog.tsx
@@ -642,11 +642,11 @@ function CodexInstallContent({
         <RelatedLinks
           links={[
             {
-              href: "https://developers.openai.com/codex/hooks",
+              href: "https://learn.chatgpt.com/docs/hooks",
               label: "Hooks Docs",
             },
             {
-              href: "https://developers.openai.com/codex/plugins/build",
+              href: "https://developers.openai.com/plugins/build/plugins",
               label: "Plugin Docs",
             },
           ]}

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -140,7 +140,7 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
   {
     id: "codex",
     name: "OpenAI Codex",
-    description: "OpenAI Codex CLI & the ChatGPT desktop app",
+    description: "Codex CLI & Codex mode in the ChatGPT app",
     icon: "codex",
     connected: false,
     setupSteps: [

--- a/client/dashboard/src/pages/setup/setup-data.ts
+++ b/client/dashboard/src/pages/setup/setup-data.ts
@@ -140,14 +140,14 @@ export const AGENT_PLATFORMS: AgentPlatform[] = [
   {
     id: "codex",
     name: "OpenAI Codex",
-    description: "OpenAI Codex CLI & desktop app",
+    description: "OpenAI Codex CLI & the ChatGPT desktop app",
     icon: "codex",
     connected: false,
     setupSteps: [
       {
         title: "Deploy the Speakeasy device agent via MDM",
         description:
-          "Codex is instrumented centrally by the Speakeasy device agent — this covers both the Codex CLI and the Codex desktop app. Roll the agent out through your MDM (Kandji, Jamf, Intune, ...) using the Fleet (MDM) path, then select Codex as a managed platform so its configuration is applied to every developer with no per-user setup.",
+          "Codex is instrumented centrally by the Speakeasy device agent — this covers the Codex CLI and Codex mode in the ChatGPT desktop app, which OpenAI merged the standalone Codex app into. Chat and Work modes in that same app are not covered here; they are captured through the OpenAI Compliance API integration instead. Roll the agent out through your MDM (Kandji, Jamf, Intune, ...) using the Fleet (MDM) path, then select Codex as a managed platform so its configuration is applied to every developer with no per-user setup.",
         helpLink: {
           url: "{{GRAM_DEVICE_AGENT_URL}}",
           linkLabel: "device agent setup",


### PR DESCRIPTION
Part of DNO-737. Split out of #4912 — this commit was pushed to that branch shortly after it merged, so it never shipped.

## What changed

The Codex setup tile described a standalone "Codex desktop app" that no longer exists: OpenAI merged it into the unified ChatGPT app. The copy now says Codex mode there is covered, and states plainly that **Chat and Work modes in the same app are not** — those are captured through the OpenAI Compliance API integration instead.

That boundary is the likeliest source of customer confusion about what the device agent actually captures, and it's the one thing the tile never said.

The two OpenAI doc links were also redirecting:

| Link | Now resolves to |
| --- | --- |
| `developers.openai.com/codex/hooks` | `learn.chatgpt.com/docs/hooks` |
| `developers.openai.com/codex/plugins/build` | `developers.openai.com/plugins/build/plugins` |

Both repointed at their current destinations (verified with `curl -IL`).

## Verified, not assumed

The claim that Codex mode in the unified app is covered is backed by an end-to-end run on a real install (details on DNO-737): our generated plugin installed via our generated `install.sh`, then a Codex session emitting the full hook lifecycle — `session.started` → `prompt.submitted` → `tool.requested` → `tool.completed` → `assistant.responded` → `session.ended` — to `/rpc/hooks.ingest`, plus a confirmed prompt block when the control plane rejected.

The managed-config path the tile recommends (`/etc/codex/managed_config.toml`, `com.openai.codex`) was also re-checked against the shipped 0.146 binary and is still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes Codex setup copy for the unified ChatGPT app to meet DNO-737. The tile tagline now explicitly says it covers Codex mode only; Chat and Work are captured via the OpenAI Compliance API, and hooks/plugin doc links now point to current URLs.

<sup>Written for commit 5f6584ac48f22a5fb58663538eb2155d26f48af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

