### PR TITLE
mig(skills): add injection-scan columns and queries for skill versions

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -304,6 +304,13 @@ CREATE TABLE IF NOT EXISTS skill_versions (
   spec_valid boolean NOT NULL,
   validation_errors JSONB NOT NULL DEFAULT '[]'::jsonb,
 
+  -- Prompt-injection scan of the manifest content. injection_scanned_at is null
+  -- until the background sweep classifies the version; injection_flagged records
+  -- the verdict and injection_rationale the judge's reasoning when flagged.
+  injection_scanned_at timestamptz,
+  injection_flagged boolean,
+  injection_rationale TEXT,
+
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   promoted_at timestamptz,
   created_by_user_id TEXT NOT NULL,
@@ -317,6 +324,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_canonical_sha256_key O
 CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_id_key ON skill_versions (skill_id, id);
 CREATE INDEX IF NOT EXISTS skill_versions_skill_id_created_at_id_idx ON skill_versions (skill_id, created_at DESC, id DESC);
 CREATE INDEX IF NOT EXISTS skill_versions_skill_id_effective_at_id_idx ON skill_versions (skill_id, COALESCE(promoted_at, created_at) DESC, id DESC);
+CREATE INDEX IF NOT EXISTS skill_versions_injection_scan_idx ON skill_versions (id) WHERE injection_scanned_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS skill_version_lineages (
   skill_version_id uuid NOT NULL,

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -317,7 +317,8 @@ CREATE TABLE IF NOT EXISTS skill_versions (
 
   CONSTRAINT skill_versions_pkey PRIMARY KEY (id),
   CONSTRAINT skill_versions_skill_id_fkey FOREIGN KEY (skill_id) REFERENCES skills (id) ON DELETE CASCADE,
-  CONSTRAINT skill_versions_content_size_check CHECK (octet_length(content) <= 65536)
+  CONSTRAINT skill_versions_content_size_check CHECK (octet_length(content) <= 65536),
+  CONSTRAINT skill_versions_injection_verdict_check CHECK (injection_scanned_at IS NULL OR injection_flagged IS NOT NULL)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS skill_versions_skill_id_canonical_sha256_key ON skill_versions (skill_id, canonical_sha256);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1979,18 +1979,21 @@ type SkillSyncReceipt struct {
 }
 
 type SkillVersion struct {
-	ID               uuid.UUID
-	SkillID          uuid.UUID
-	Content          string
-	CanonicalSha256  string
-	RawSha256        string
-	Description      pgtype.Text
-	Metadata         []byte
-	SpecValid        bool
-	ValidationErrors []byte
-	CreatedAt        pgtype.Timestamptz
-	PromotedAt       pgtype.Timestamptz
-	CreatedByUserID  string
+	ID                 uuid.UUID
+	SkillID            uuid.UUID
+	Content            string
+	CanonicalSha256    string
+	RawSha256          string
+	Description        pgtype.Text
+	Metadata           []byte
+	SpecValid          bool
+	ValidationErrors   []byte
+	InjectionScannedAt pgtype.Timestamptz
+	InjectionFlagged   pgtype.Bool
+	InjectionRationale pgtype.Text
+	CreatedAt          pgtype.Timestamptz
+	PromotedAt         pgtype.Timestamptz
+	CreatedByUserID    string
 }
 
 type SkillVersionLineage struct {

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -2654,3 +2654,32 @@ WHERE link.project_id = @project_id
   AND link.change_id = @change_id
 ORDER BY feedback.created_at DESC, feedback.id DESC
 LIMIT GREATEST(@page_limit::int, 0);
+
+-- name: ListUnscannedSkillVersions :many
+-- Cross-project scan queue for prompt-injection classification. Rows drop out of
+-- the partial index once injection_scanned_at is set, so a plain LIMIT re-query
+-- walks the backlog without a cursor. organization_id/project_id ride along so
+-- the judge attributes to and rate-limits by the owning tenant.
+SELECT
+  sv.id AS skill_version_id,
+  sv.skill_id,
+  s.project_id,
+  p.organization_id,
+  sv.content
+FROM skill_versions sv
+JOIN skills s ON s.id = sv.skill_id
+JOIN projects p ON p.id = s.project_id
+WHERE sv.injection_scanned_at IS NULL
+ORDER BY sv.id
+LIMIT @batch_size;
+
+-- name: MarkSkillVersionInjectionScan :execrows
+UPDATE skill_versions sv
+SET
+  injection_scanned_at = clock_timestamp(),
+  injection_flagged = @injection_flagged,
+  injection_rationale = @injection_rationale
+FROM skills s
+WHERE sv.skill_id = s.id
+  AND s.project_id = @project_id
+  AND sv.id = @skill_version_id;

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -2670,6 +2670,7 @@ FROM skill_versions sv
 JOIN skills s ON s.id = sv.skill_id
 JOIN projects p ON p.id = s.project_id
 WHERE sv.injection_scanned_at IS NULL
+  AND s.archived_at IS NULL
 ORDER BY sv.id
 LIMIT @batch_size;
 
@@ -2682,4 +2683,5 @@ SET
 FROM skills s
 WHERE sv.skill_id = s.id
   AND s.project_id = @project_id
-  AND sv.id = @skill_version_id;
+  AND sv.id = @skill_version_id
+  AND sv.injection_scanned_at IS NULL;

--- a/server/internal/skills/repo/models.go
+++ b/server/internal/skills/repo/models.go
@@ -155,18 +155,21 @@ type SkillShareLink struct {
 }
 
 type SkillVersion struct {
-	ID               uuid.UUID
-	SkillID          uuid.UUID
-	Content          string
-	CanonicalSha256  string
-	RawSha256        string
-	Description      pgtype.Text
-	Metadata         []byte
-	SpecValid        bool
-	ValidationErrors []byte
-	CreatedAt        pgtype.Timestamptz
-	PromotedAt       pgtype.Timestamptz
-	CreatedByUserID  string
+	ID                 uuid.UUID
+	SkillID            uuid.UUID
+	Content            string
+	CanonicalSha256    string
+	RawSha256          string
+	Description        pgtype.Text
+	Metadata           []byte
+	SpecValid          bool
+	ValidationErrors   []byte
+	InjectionScannedAt pgtype.Timestamptz
+	InjectionFlagged   pgtype.Bool
+	InjectionRationale pgtype.Text
+	CreatedAt          pgtype.Timestamptz
+	PromotedAt         pgtype.Timestamptz
+	CreatedByUserID    string
 }
 
 type SkillVersionOrigin struct {

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -1227,7 +1227,7 @@ WHERE s.project_id = $9
   AND s.archived_at IS NULL
 ON CONFLICT (skill_id, canonical_sha256)
 DO NOTHING
-RETURNING id, skill_id, content, canonical_sha256, raw_sha256, description, metadata, spec_valid, validation_errors, created_at, promoted_at, created_by_user_id
+RETURNING id, skill_id, content, canonical_sha256, raw_sha256, description, metadata, spec_valid, validation_errors, injection_scanned_at, injection_flagged, injection_rationale, created_at, promoted_at, created_by_user_id
 `
 
 type CreateSkillVersionParams struct {
@@ -1267,6 +1267,9 @@ func (q *Queries) CreateSkillVersion(ctx context.Context, arg CreateSkillVersion
 		&i.Metadata,
 		&i.SpecValid,
 		&i.ValidationErrors,
+		&i.InjectionScannedAt,
+		&i.InjectionFlagged,
+		&i.InjectionRationale,
 		&i.CreatedAt,
 		&i.PromotedAt,
 		&i.CreatedByUserID,
@@ -1857,7 +1860,7 @@ func (q *Queries) GetPluginForDistribution(ctx context.Context, arg GetPluginFor
 }
 
 const getProjectSkillVersion = `-- name: GetProjectSkillVersion :one
-SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
+SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.injection_scanned_at, sv.injection_flagged, sv.injection_rationale, sv.created_at, sv.promoted_at, sv.created_by_user_id
 FROM skill_versions sv
 JOIN skills s ON s.id = sv.skill_id
 WHERE s.project_id = $1
@@ -1882,6 +1885,9 @@ func (q *Queries) GetProjectSkillVersion(ctx context.Context, arg GetProjectSkil
 		&i.Metadata,
 		&i.SpecValid,
 		&i.ValidationErrors,
+		&i.InjectionScannedAt,
+		&i.InjectionFlagged,
+		&i.InjectionRationale,
 		&i.CreatedAt,
 		&i.PromotedAt,
 		&i.CreatedByUserID,
@@ -2695,7 +2701,7 @@ func (q *Queries) GetSkillState(ctx context.Context, arg GetSkillStateParams) (G
 }
 
 const getSkillVersionByHash = `-- name: GetSkillVersionByHash :one
-SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
+SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.injection_scanned_at, sv.injection_flagged, sv.injection_rationale, sv.created_at, sv.promoted_at, sv.created_by_user_id
 FROM skill_versions sv
 JOIN skills s ON s.id = sv.skill_id
 WHERE s.project_id = $1
@@ -2723,6 +2729,9 @@ func (q *Queries) GetSkillVersionByHash(ctx context.Context, arg GetSkillVersion
 		&i.Metadata,
 		&i.SpecValid,
 		&i.ValidationErrors,
+		&i.InjectionScannedAt,
+		&i.InjectionFlagged,
+		&i.InjectionRationale,
 		&i.CreatedAt,
 		&i.PromotedAt,
 		&i.CreatedByUserID,
@@ -2732,7 +2741,7 @@ func (q *Queries) GetSkillVersionByHash(ctx context.Context, arg GetSkillVersion
 
 const getSkillVersionDetails = `-- name: GetSkillVersionDetails :one
 SELECT
-  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id,
+  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.injection_scanned_at, sv.injection_flagged, sv.injection_rationale, sv.created_at, sv.promoted_at, sv.created_by_user_id,
   svl.derived_from_version_id,
   sightings.first_seen_at,
   sightings.last_seen_at,
@@ -2787,6 +2796,9 @@ func (q *Queries) GetSkillVersionDetails(ctx context.Context, arg GetSkillVersio
 		&i.SkillVersion.Metadata,
 		&i.SkillVersion.SpecValid,
 		&i.SkillVersion.ValidationErrors,
+		&i.SkillVersion.InjectionScannedAt,
+		&i.SkillVersion.InjectionFlagged,
+		&i.SkillVersion.InjectionRationale,
 		&i.SkillVersion.CreatedAt,
 		&i.SkillVersion.PromotedAt,
 		&i.SkillVersion.CreatedByUserID,
@@ -4588,7 +4600,7 @@ func (q *Queries) ListSkillSuggestionProjects(ctx context.Context, arg ListSkill
 
 const listSkillVersions = `-- name: ListSkillVersions :many
 SELECT
-  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id,
+  sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.injection_scanned_at, sv.injection_flagged, sv.injection_rationale, sv.created_at, sv.promoted_at, sv.created_by_user_id,
   svl.derived_from_version_id,
   sightings.first_seen_at,
   sightings.last_seen_at,
@@ -4665,6 +4677,9 @@ func (q *Queries) ListSkillVersions(ctx context.Context, arg ListSkillVersionsPa
 			&i.SkillVersion.Metadata,
 			&i.SkillVersion.SpecValid,
 			&i.SkillVersion.ValidationErrors,
+			&i.SkillVersion.InjectionScannedAt,
+			&i.SkillVersion.InjectionFlagged,
+			&i.SkillVersion.InjectionRationale,
 			&i.SkillVersion.CreatedAt,
 			&i.SkillVersion.PromotedAt,
 			&i.SkillVersion.CreatedByUserID,
@@ -4960,6 +4975,59 @@ func (q *Queries) ListUnreviewedSkillFeedback(ctx context.Context, arg ListUnrev
 	return items, nil
 }
 
+const listUnscannedSkillVersions = `-- name: ListUnscannedSkillVersions :many
+SELECT
+  sv.id AS skill_version_id,
+  sv.skill_id,
+  s.project_id,
+  p.organization_id,
+  sv.content
+FROM skill_versions sv
+JOIN skills s ON s.id = sv.skill_id
+JOIN projects p ON p.id = s.project_id
+WHERE sv.injection_scanned_at IS NULL
+ORDER BY sv.id
+LIMIT $1
+`
+
+type ListUnscannedSkillVersionsRow struct {
+	SkillVersionID uuid.UUID
+	SkillID        uuid.UUID
+	ProjectID      uuid.UUID
+	OrganizationID string
+	Content        string
+}
+
+// Cross-project scan queue for prompt-injection classification. Rows drop out of
+// the partial index once injection_scanned_at is set, so a plain LIMIT re-query
+// walks the backlog without a cursor. organization_id/project_id ride along so
+// the judge attributes to and rate-limits by the owning tenant.
+func (q *Queries) ListUnscannedSkillVersions(ctx context.Context, batchSize int32) ([]ListUnscannedSkillVersionsRow, error) {
+	rows, err := q.db.Query(ctx, listUnscannedSkillVersions, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUnscannedSkillVersionsRow
+	for rows.Next() {
+		var i ListUnscannedSkillVersionsRow
+		if err := rows.Scan(
+			&i.SkillVersionID,
+			&i.SkillID,
+			&i.ProjectID,
+			&i.OrganizationID,
+			&i.Content,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const loadReservedSkillEfficacyEvaluations = `-- name: LoadReservedSkillEfficacyEvaluations :many
 UPDATE skill_efficacy_evaluations e
 SET claim_token = $1::uuid,
@@ -5195,6 +5263,38 @@ func (q *Queries) MarkSkillSessionVersionsSynced(ctx context.Context, arg MarkSk
 	return result.RowsAffected(), nil
 }
 
+const markSkillVersionInjectionScan = `-- name: MarkSkillVersionInjectionScan :execrows
+UPDATE skill_versions sv
+SET
+  injection_scanned_at = clock_timestamp(),
+  injection_flagged = $1,
+  injection_rationale = $2
+FROM skills s
+WHERE sv.skill_id = s.id
+  AND s.project_id = $3
+  AND sv.id = $4
+`
+
+type MarkSkillVersionInjectionScanParams struct {
+	InjectionFlagged   pgtype.Bool
+	InjectionRationale pgtype.Text
+	ProjectID          uuid.UUID
+	SkillVersionID     uuid.UUID
+}
+
+func (q *Queries) MarkSkillVersionInjectionScan(ctx context.Context, arg MarkSkillVersionInjectionScanParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markSkillVersionInjectionScan,
+		arg.InjectionFlagged,
+		arg.InjectionRationale,
+		arg.ProjectID,
+		arg.SkillVersionID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const promoteObservedSkillToManual = `-- name: PromoteObservedSkillToManual :one
 UPDATE skills
 SET source_kind = 'manual',
@@ -5243,7 +5343,7 @@ WHERE s.project_id = $1
   AND sv.skill_id = s.id
   AND sv.id = $3
   AND sv.spec_valid IS TRUE
-RETURNING sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
+RETURNING sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.injection_scanned_at, sv.injection_flagged, sv.injection_rationale, sv.created_at, sv.promoted_at, sv.created_by_user_id
 `
 
 type PromoteSkillVersionParams struct {
@@ -5265,6 +5365,9 @@ func (q *Queries) PromoteSkillVersion(ctx context.Context, arg PromoteSkillVersi
 		&i.Metadata,
 		&i.SpecValid,
 		&i.ValidationErrors,
+		&i.InjectionScannedAt,
+		&i.InjectionFlagged,
+		&i.InjectionRationale,
 		&i.CreatedAt,
 		&i.PromotedAt,
 		&i.CreatedByUserID,
@@ -5633,7 +5736,7 @@ func (q *Queries) ResolveSkillRegressionBases(ctx context.Context, arg ResolveSk
 
 const resolveSkillSuggestionBase = `-- name: ResolveSkillSuggestionBase :one
 WITH base AS (
-  SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.created_at, sv.promoted_at, sv.created_by_user_id
+  SELECT sv.id, sv.skill_id, sv.content, sv.canonical_sha256, sv.raw_sha256, sv.description, sv.metadata, sv.spec_valid, sv.validation_errors, sv.injection_scanned_at, sv.injection_flagged, sv.injection_rationale, sv.created_at, sv.promoted_at, sv.created_by_user_id
   FROM skills s
   JOIN skill_versions sv ON sv.skill_id = s.id
   LEFT JOIN skill_version_origins svo

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -4986,6 +4986,7 @@ FROM skill_versions sv
 JOIN skills s ON s.id = sv.skill_id
 JOIN projects p ON p.id = s.project_id
 WHERE sv.injection_scanned_at IS NULL
+  AND s.archived_at IS NULL
 ORDER BY sv.id
 LIMIT $1
 `
@@ -5273,6 +5274,7 @@ FROM skills s
 WHERE sv.skill_id = s.id
   AND s.project_id = $3
   AND sv.id = $4
+  AND sv.injection_scanned_at IS NULL
 `
 
 type MarkSkillVersionInjectionScanParams struct {

--- a/server/migrations/20260804182231_skill-versions-injection-scan.sql
+++ b/server/migrations/20260804182231_skill-versions-injection-scan.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "skill_versions" table
+ALTER TABLE "skill_versions" ADD COLUMN "injection_scanned_at" timestamptz NULL, ADD COLUMN "injection_flagged" boolean NULL, ADD COLUMN "injection_rationale" text NULL;
+-- Create index "skill_versions_injection_scan_idx" to table: "skill_versions"
+CREATE INDEX CONCURRENTLY "skill_versions_injection_scan_idx" ON "skill_versions" ("id") WHERE (injection_scanned_at IS NULL);

--- a/server/migrations/20260804182231_skill-versions-injection-scan.sql
+++ b/server/migrations/20260804182231_skill-versions-injection-scan.sql
@@ -1,6 +1,0 @@
--- atlas:txmode none
-
--- Modify "skill_versions" table
-ALTER TABLE "skill_versions" ADD COLUMN "injection_scanned_at" timestamptz NULL, ADD COLUMN "injection_flagged" boolean NULL, ADD COLUMN "injection_rationale" text NULL;
--- Create index "skill_versions_injection_scan_idx" to table: "skill_versions"
-CREATE INDEX CONCURRENTLY "skill_versions_injection_scan_idx" ON "skill_versions" ("id") WHERE (injection_scanned_at IS NULL);

--- a/server/migrations/20260804220336_skill-versions-injection-scan.sql
+++ b/server/migrations/20260804220336_skill-versions-injection-scan.sql
@@ -1,6 +1,7 @@
 -- atlas:txmode none
 
 -- Modify "skill_versions" table
-ALTER TABLE "skill_versions" ADD CONSTRAINT "skill_versions_injection_verdict_check" CHECK ((injection_scanned_at IS NULL) OR (injection_flagged IS NOT NULL)), ADD COLUMN "injection_scanned_at" timestamptz NULL, ADD COLUMN "injection_flagged" boolean NULL, ADD COLUMN "injection_rationale" text NULL;
+ALTER TABLE "skill_versions" ADD CONSTRAINT "skill_versions_injection_verdict_check" CHECK ((injection_scanned_at IS NULL) OR (injection_flagged IS NOT NULL)) NOT VALID, ADD COLUMN "injection_scanned_at" timestamptz NULL, ADD COLUMN "injection_flagged" boolean NULL, ADD COLUMN "injection_rationale" text NULL;
+ALTER TABLE "skill_versions" VALIDATE CONSTRAINT "skill_versions_injection_verdict_check";
 -- Create index "skill_versions_injection_scan_idx" to table: "skill_versions"
 CREATE INDEX CONCURRENTLY "skill_versions_injection_scan_idx" ON "skill_versions" ("id") WHERE (injection_scanned_at IS NULL);

--- a/server/migrations/20260804220336_skill-versions-injection-scan.sql
+++ b/server/migrations/20260804220336_skill-versions-injection-scan.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "skill_versions" table
+ALTER TABLE "skill_versions" ADD CONSTRAINT "skill_versions_injection_verdict_check" CHECK ((injection_scanned_at IS NULL) OR (injection_flagged IS NOT NULL)), ADD COLUMN "injection_scanned_at" timestamptz NULL, ADD COLUMN "injection_flagged" boolean NULL, ADD COLUMN "injection_rationale" text NULL;
+-- Create index "skill_versions_injection_scan_idx" to table: "skill_versions"
+CREATE INDEX CONCURRENTLY "skill_versions_injection_scan_idx" ON "skill_versions" ("id") WHERE (injection_scanned_at IS NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:umUhmpAOlIEnwcUTdLyguoDfHJyolmiEDekS77Hk6ug=
+h1:LFFtYYrfB6E5LVNVZOengSp/Eh+1zAoYvrEZDh1I91w=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -314,4 +314,4 @@ h1:umUhmpAOlIEnwcUTdLyguoDfHJyolmiEDekS77Hk6ug=
 20260803183323_add-unproxied-mcp-servers.sql h1:qzO4JQBZcDOdBk+J5bKitwZToe5vocZryD2n+GFhK8U=
 20260803193050_litellm-instances.sql h1:tXo5MT2gc1ofWtT8ndwAo5Ms2G4vUKhF8wUuZr1r+Zc=
 20260803194013_litellm-instance-health.sql h1:xocULUVta5ICjDnH83WT/zQbXN0ZyzRbmpQvGXU0JW0=
-20260804220336_skill-versions-injection-scan.sql h1:oMcew9WKRCrV2opoTDuwfHHVmODoaol3SwUGUwF5+XA=
+20260804220336_skill-versions-injection-scan.sql h1:BFMK1JCMbDM1eQydH5ESFRmux3ZCuTO0GPRjwP9p37s=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:bJG/8unDwS6Prr5eNZ1JH9JMni14naedF5z3O3r2I1Y=
+h1:umUhmpAOlIEnwcUTdLyguoDfHJyolmiEDekS77Hk6ug=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -314,4 +314,4 @@ h1:bJG/8unDwS6Prr5eNZ1JH9JMni14naedF5z3O3r2I1Y=
 20260803183323_add-unproxied-mcp-servers.sql h1:qzO4JQBZcDOdBk+J5bKitwZToe5vocZryD2n+GFhK8U=
 20260803193050_litellm-instances.sql h1:tXo5MT2gc1ofWtT8ndwAo5Ms2G4vUKhF8wUuZr1r+Zc=
 20260803194013_litellm-instance-health.sql h1:xocULUVta5ICjDnH83WT/zQbXN0ZyzRbmpQvGXU0JW0=
-20260804182231_skill-versions-injection-scan.sql h1:IobHHgbrsdgZM9K3HvrRuQW3a6fXh5NoU3sV6P/iruk=
+20260804220336_skill-versions-injection-scan.sql h1:oMcew9WKRCrV2opoTDuwfHHVmODoaol3SwUGUwF5+XA=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:audzYMW9ec4AtJg4LAygTKLtogLdaADFaYaqBu2h1Js=
+h1:bJG/8unDwS6Prr5eNZ1JH9JMni14naedF5z3O3r2I1Y=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -314,3 +314,4 @@ h1:audzYMW9ec4AtJg4LAygTKLtogLdaADFaYaqBu2h1Js=
 20260803183323_add-unproxied-mcp-servers.sql h1:qzO4JQBZcDOdBk+J5bKitwZToe5vocZryD2n+GFhK8U=
 20260803193050_litellm-instances.sql h1:tXo5MT2gc1ofWtT8ndwAo5Ms2G4vUKhF8wUuZr1r+Zc=
 20260803194013_litellm-instance-health.sql h1:xocULUVta5ICjDnH83WT/zQbXN0ZyzRbmpQvGXU0JW0=
+20260804182231_skill-versions-injection-scan.sql h1:IobHHgbrsdgZM9K3HvrRuQW3a6fXh5NoU3sV6P/iruk=


### PR DESCRIPTION
Part 1/3 of splitting #4917.

Adds `injection_flagged` / `injection_rationale` columns to `skill_versions`, the migration, and the sqlc repo queries used to fetch unscanned versions and record verdicts. No behavior change yet — later parts consume these.

The sqlc query source (`server/internal/skills/queries.sql`) ships here because it references the new columns and cannot be generated/compiled without them. [skip migration check]

Stack:
1. **skills-injection-db** ← this PR
2. skills-injection-scanner
3. skills-injection-pipeline

Surfacing the results in the API/dashboard is deferred (draft #4922) until we decide where they belong.

Part of AIS-438.