### PR TITLE
feat(skills): expose prompt-injection scan result on skill versions

### DIFF
--- a/.changeset/skill-injection-scan.md
+++ b/.changeset/skill-injection-scan.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Scan captured and authored skill manifests for prompt-injection content as part of the skills pipeline. A scheduled Temporal sweep runs unscanned skill versions through the existing prompt-injection judge and records the verdict (`injectionFlagged` / `injectionRationale`) on the version, which the dashboard surfaces as a warning banner on the skill detail page.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -67749,6 +67749,12 @@ components:
           type: string
           description: The skill version ID.
           format: uuid
+        injection_flagged:
+          type: boolean
+          description: Whether the prompt-injection scan flagged this manifest version. Absent until the version has been scanned.
+        injection_rationale:
+          type: string
+          description: The judge's reasoning when the prompt-injection scan flagged this version.
         last_seen_at:
           type: string
           description: When this exact version was most recently activated.

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -4,7 +4,7 @@ import {
   RouteNotFoundState,
   SecondaryRouteAction,
 } from "@/components/route-not-found-state";
-import { ErrorAlert } from "@/components/ui/Alert";
+import { Alert, ErrorAlert } from "@/components/ui/Alert";
 import { Button } from "@/components/ui/Button";
 import { Checkbox } from "@/components/ui/Checkbox";
 import { Skeleton, SkeletonTable } from "@/components/ui/Skeleton";
@@ -295,6 +295,17 @@ function SkillDetailSections({
         </SettingsSection.Header>
         <SettingsSection.Panel>
           <SettingsSection.Body>
+            {latestVersion?.injectionFlagged && (
+              <Alert variant="warning">
+                <div>
+                  <span className="font-medium">
+                    Possible prompt injection detected.
+                  </span>{" "}
+                  {latestVersion.injectionRationale ??
+                    "This manifest was flagged by the prompt-injection scan. Review it before distributing this skill."}
+                </div>
+              </Alert>
+            )}
             {latestVersion && !latestVersion.specValid && (
               <ValidationErrors errors={latestVersion.validationErrors} />
             )}

--- a/client/dashboard/src/sdk/src/models/components/skillversion.ts
+++ b/client/dashboard/src/sdk/src/models/components/skillversion.ts
@@ -53,6 +53,14 @@ export type SkillVersion = {
    */
   id: string;
   /**
+   * Whether the prompt-injection scan flagged this manifest version. Absent until the version has been scanned.
+   */
+  injectionFlagged?: boolean | undefined;
+  /**
+   * The judge's reasoning when the prompt-injection scan flagged this version.
+   */
+  injectionRationale?: string | undefined;
+  /**
    * When this exact version was most recently activated.
    */
   lastSeenAt?: Date | undefined;
@@ -100,6 +108,8 @@ export const SkillVersion$inboundSchema: z.ZodMiniType<SkillVersion, unknown> =
       ),
       frontmatter: z.record(z.string(), z.any()),
       id: z.string(),
+      injection_flagged: z.optional(z.boolean()),
+      injection_rationale: z.optional(z.string()),
       last_seen_at: z.optional(
         z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
       ),
@@ -117,6 +127,8 @@ export const SkillVersion$inboundSchema: z.ZodMiniType<SkillVersion, unknown> =
         "created_by_user_id": "createdByUserId",
         "derived_from_version_id": "derivedFromVersionId",
         "first_seen_at": "firstSeenAt",
+        "injection_flagged": "injectionFlagged",
+        "injection_rationale": "injectionRationale",
         "last_seen_at": "lastSeenAt",
         "raw_sha256": "rawSha256",
         "seen_count": "seenCount",

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -907,6 +907,8 @@ var SkillVersion = Type("SkillVersion", func() {
 	Attribute("first_seen_at", String, "When this exact version was first activated.", func() { Format(FormatDateTime) })
 	Attribute("last_seen_at", String, "When this exact version was most recently activated.", func() { Format(FormatDateTime) })
 	Attribute("seen_count", Int64, "The number of activations attributed to this exact version.")
+	Attribute("injection_flagged", Boolean, "Whether the prompt-injection scan flagged this manifest version. Absent until the version has been scanned.")
+	Attribute("injection_rationale", String, "The judge's reasoning when the prompt-injection scan flagged this version.")
 
 	Required("id", "skill_id", "content", "canonical_sha256", "raw_sha256", "metadata", "frontmatter", "spec_valid", "validation_errors", "created_at", "created_by_user_id", "seen_count")
 })

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -68014,6 +68014,12 @@ components:
                     type: string
                     description: The skill version ID.
                     format: uuid
+                injection_flagged:
+                    type: boolean
+                    description: Whether the prompt-injection scan flagged this manifest version. Absent until the version has been scanned.
+                injection_rationale:
+                    type: string
+                    description: The judge's reasoning when the prompt-injection scan flagged this version.
                 last_seen_at:
                     type: string
                     description: When this exact version was most recently activated.

--- a/server/gen/http/skills/client/encode_decode.go
+++ b/server/gen/http/skills/client/encode_decode.go
@@ -5373,6 +5373,8 @@ func unmarshalSkillVersionResponseBodyToTypesSkillVersion(v *SkillVersionRespons
 		FirstSeenAt:          v.FirstSeenAt,
 		LastSeenAt:           v.LastSeenAt,
 		SeenCount:            *v.SeenCount,
+		InjectionFlagged:     v.InjectionFlagged,
+		InjectionRationale:   v.InjectionRationale,
 	}
 	res.Metadata = make(map[string]any, len(v.Metadata))
 	for key, val := range v.Metadata {

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -4499,6 +4499,11 @@ type SkillVersionResponseBody struct {
 	LastSeenAt *string `form:"last_seen_at,omitempty" json:"last_seen_at,omitempty" xml:"last_seen_at,omitempty"`
 	// The number of activations attributed to this exact version.
 	SeenCount *int64 `form:"seen_count,omitempty" json:"seen_count,omitempty" xml:"seen_count,omitempty"`
+	// Whether the prompt-injection scan flagged this manifest version. Absent
+	// until the version has been scanned.
+	InjectionFlagged *bool `form:"injection_flagged,omitempty" json:"injection_flagged,omitempty" xml:"injection_flagged,omitempty"`
+	// The judge's reasoning when the prompt-injection scan flagged this version.
+	InjectionRationale *string `form:"injection_rationale,omitempty" json:"injection_rationale,omitempty" xml:"injection_rationale,omitempty"`
 }
 
 // SkillValidationErrorResponseBody is used to define fields on response body

--- a/server/gen/http/skills/server/encode_decode.go
+++ b/server/gen/http/skills/server/encode_decode.go
@@ -5358,6 +5358,8 @@ func marshalTypesSkillVersionToSkillVersionResponseBody(v *types.SkillVersion) *
 		FirstSeenAt:          v.FirstSeenAt,
 		LastSeenAt:           v.LastSeenAt,
 		SeenCount:            v.SeenCount,
+		InjectionFlagged:     v.InjectionFlagged,
+		InjectionRationale:   v.InjectionRationale,
 	}
 	if v.Metadata != nil {
 		res.Metadata = make(map[string]any, len(v.Metadata))

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -4501,6 +4501,11 @@ type SkillVersionResponseBody struct {
 	LastSeenAt *string `form:"last_seen_at,omitempty" json:"last_seen_at,omitempty" xml:"last_seen_at,omitempty"`
 	// The number of activations attributed to this exact version.
 	SeenCount int64 `form:"seen_count" json:"seen_count" xml:"seen_count"`
+	// Whether the prompt-injection scan flagged this manifest version. Absent
+	// until the version has been scanned.
+	InjectionFlagged *bool `form:"injection_flagged,omitempty" json:"injection_flagged,omitempty" xml:"injection_flagged,omitempty"`
+	// The judge's reasoning when the prompt-injection scan flagged this version.
+	InjectionRationale *string `form:"injection_rationale,omitempty" json:"injection_rationale,omitempty" xml:"injection_rationale,omitempty"`
 }
 
 // SkillValidationErrorResponseBody is used to define fields on response body

--- a/server/gen/types/skill_version.go
+++ b/server/gen/types/skill_version.go
@@ -41,4 +41,9 @@ type SkillVersion struct {
 	LastSeenAt *string
 	// The number of activations attributed to this exact version.
 	SeenCount int64
+	// Whether the prompt-injection scan flagged this manifest version. Absent
+	// until the version has been scanned.
+	InjectionFlagged *bool
+	// The judge's reasoning when the prompt-injection scan flagged this version.
+	InjectionRationale *string
 }

--- a/server/internal/mv/skill.go
+++ b/server/internal/mv/skill.go
@@ -115,6 +115,8 @@ func BuildSkillVersionView(version repo.SkillVersion, derivedFromVersionID uuid.
 		FirstSeenAt:          conv.PtrEmpty(conv.FromPGTimestamptz(sightings.FirstSeenAt)),
 		LastSeenAt:           conv.PtrEmpty(conv.FromPGTimestamptz(sightings.LastSeenAt)),
 		SeenCount:            sightings.SeenCount,
+		InjectionFlagged:     conv.FromPGBool[bool](version.InjectionFlagged),
+		InjectionRationale:   conv.FromPGText[string](version.InjectionRationale),
 	}, nil
 }
 


### PR DESCRIPTION
**Deferred (draft).** Split out of the active 3-PR stack (#4919 → #4920 → #4921) until we decide where prompt-injection scan results should surface. Verdicts are already persisted and logged by the pipeline; this PR only adds the presentation layer.

Surfaces `injection_flagged` / `injection_rationale` through the skills API (design, generated types, model view) and shows the flag in the dashboard skill detail page. Includes the changeset.

Base: `skills-injection-pipeline`.

Part of AIS-438.