### PR TITLE
fix: apply shadow-MCP policy to codex MCP meta-tools on ingest

### DIFF
--- a/.changeset/codex-mcp-meta-tools-shadow-guard.md
+++ b/.changeset/codex-mcp-meta-tools-shadow-guard.md
@@ -1,0 +1,16 @@
+---
+"server": patch
+---
+
+Apply shadow-MCP policy to Codex's built-in MCP resource tools. Codex reaches
+MCP servers through three meta-tools — `list_mcp_resources`,
+`list_mcp_resource_templates` and `read_mcp_resource` — that carry no `mcp__`
+prefix and name their target in `tool_input.server`. The unified ingest
+endpoint decides whether a call is an MCP call from resolved MCP data or an
+MCP-shaped tool name, and neither recognizes these, so they were classified as
+ordinary tool calls: the risk scan ran but the shadow-MCP policy never did. A
+`block_all` policy therefore did not stop a Codex session from reading any MCP
+server's resources, while the legacy Codex endpoint denied the same call. The
+gate now recognizes them for the codex adapter, and a meta-tool whose server
+cannot be read is denied rather than allowed — an unproven target is not an
+absent one.

--- a/.changeset/codex-mcp-meta-tools-shadow-guard.md
+++ b/.changeset/codex-mcp-meta-tools-shadow-guard.md
@@ -18,3 +18,11 @@ allowed and a denied one is named. A meta-tool whose server cannot be resolved
 is denied rather than allowed — an unproven target is not an absent one.
 Sessions now cache their MCP inventory on the ingest path under the same key
 and TTL the legacy per-provider endpoints use.
+
+Rolled out on client capability rather than deploy order: releases before this
+one report no adapter version and no MCP inventory, so enforcing on them would
+deny every meta-tool call — including reads of Gram-hosted servers that work
+today. Those clients keep their current behavior and are counted in the logs
+until they upgrade. A client that does report a version but no inventory has no
+MCP servers configured, so a meta-tool call has nothing legitimate to target
+and is denied.

--- a/.changeset/codex-mcp-meta-tools-shadow-guard.md
+++ b/.changeset/codex-mcp-meta-tools-shadow-guard.md
@@ -10,7 +10,11 @@ endpoint decides whether a call is an MCP call from resolved MCP data or an
 MCP-shaped tool name, and neither recognizes these, so they were classified as
 ordinary tool calls: the risk scan ran but the shadow-MCP policy never did. A
 `block_all` policy therefore did not stop a Codex session from reading any MCP
-server's resources, while the legacy Codex endpoint denied the same call. The
-gate now recognizes them for the codex adapter, and a meta-tool whose server
-cannot be read is denied rather than allowed — an unproven target is not an
-absent one.
+server's resources, while the legacy Codex endpoint denied the same call.
+
+The gate now recognizes them for the codex adapter, and the named server is
+resolved against the session's MCP inventory so a Gram-hosted target is still
+allowed and a denied one is named. A meta-tool whose server cannot be resolved
+is denied rather than allowed — an unproven target is not an absent one.
+Sessions now cache their MCP inventory on the ingest path under the same key
+and TTL the legacy per-provider endpoints use.

--- a/.changeset/codex-mcp-meta-tools-shadow-guard.md
+++ b/.changeset/codex-mcp-meta-tools-shadow-guard.md
@@ -23,6 +23,11 @@ Rolled out on client capability rather than deploy order: releases before this
 one report no adapter version and no MCP inventory, so enforcing on them would
 deny every meta-tool call — including reads of Gram-hosted servers that work
 today. Those clients keep their current behavior and are counted in the logs
-until they upgrade. A client that does report a version but no inventory has no
-MCP servers configured, so a meta-tool call has nothing legitimate to target
-and is denied.
+until they upgrade.
+
+A capable client that reports no inventory is denied. That can mean no MCP
+servers are configured, but collection is best-effort and also comes back empty
+when the codex binary cannot be located, `codex mcp list` fails, or the
+session's inventory never reached the cache — in which case a meta-tool call is
+denied even though servers are configured. That is the intended fail-closed
+posture rather than an accident: the guard cannot clear a target it cannot see.

--- a/.changeset/codex-relay-mcp-inventory.md
+++ b/.changeset/codex-relay-mcp-inventory.md
@@ -6,6 +6,13 @@ Collect the Codex MCP server inventory at session start, as the relay already
 does for Claude. The shadow-MCP guard resolves a tool call's target against
 that snapshot, which is what lets a Gram-hosted server be told apart from a
 shadow one — without it the guard can only reach its generic "not Gram-hosted"
-verdict. Best-effort: a missing or slow Codex CLI leaves the hook unaffected,
-and an explicitly disabled server is left out so it cannot vouch for a call
-that routed elsewhere.
+verdict. The list is taken from the session's working directory, since Codex
+resolves its project config layer relative to it. Best-effort: a missing or
+slow Codex CLI leaves the hook unaffected, and an explicitly disabled server is
+left out so it cannot vouch for a call that routed elsewhere.
+
+Hook events now also report the relay's version. The server reads its presence
+as "this client can report MCP inventory" and holds back the Codex meta-tool
+guard for clients that cannot, so enforcement arrives with the upgrade rather
+than depending on a server deploy and a hooks release landing in the right
+order.

--- a/.changeset/codex-relay-mcp-inventory.md
+++ b/.changeset/codex-relay-mcp-inventory.md
@@ -3,9 +3,9 @@
 ---
 
 Collect the Codex MCP server inventory at session start, as the relay already
-does for Claude. The shadow-MCP guard uses the snapshot to say why a blocked
-target is not allowed — an external URL or a local stdio server, named — rather
-than the generic "MCP server is not Gram-hosted", and to scope a bypass grant
-to the server the call actually routes to. Best-effort: a missing or slow Codex
-CLI leaves the hook unaffected, and an explicitly disabled server is left out
-so it cannot vouch for a call that routed elsewhere.
+does for Claude. The shadow-MCP guard resolves a tool call's target against
+that snapshot, which is what lets a Gram-hosted server be told apart from a
+shadow one — without it the guard can only reach its generic "not Gram-hosted"
+verdict. Best-effort: a missing or slow Codex CLI leaves the hook unaffected,
+and an explicitly disabled server is left out so it cannot vouch for a call
+that routed elsewhere.

--- a/.changeset/codex-relay-mcp-inventory.md
+++ b/.changeset/codex-relay-mcp-inventory.md
@@ -1,0 +1,11 @@
+---
+"hooks": patch
+---
+
+Collect the Codex MCP server inventory at session start, as the relay already
+does for Claude. The shadow-MCP guard uses the snapshot to say why a blocked
+target is not allowed — an external URL or a local stdio server, named — rather
+than the generic "MCP server is not Gram-hosted", and to scope a bypass grant
+to the server the call actually routes to. Best-effort: a missing or slow Codex
+CLI leaves the hook unaffected, and an explicitly disabled server is left out
+so it cannot vouch for a call that routed elsewhere.

--- a/hooks/relay/envelope.go
+++ b/hooks/relay/envelope.go
@@ -139,8 +139,13 @@ func buildEnvelope(typed any, hostname string) components.IngestRequestBody {
 	payload := components.IngestRequestBody{
 		SchemaVersion: schemaVersion,
 		Source: components.HookIngestSource{
-			Adapter:        adapterSlug(base.Provider),
-			AdapterVersion: nil,
+			Adapter: adapterSlug(base.Provider),
+			// Doubles as the relay's capability marker: releases before this
+			// one left the field unset, so the server reads its absence as
+			// "this client cannot report MCP inventory" and degrades the
+			// codex meta-tool guard rather than denying traffic that works
+			// today (DNO-767).
+			AdapterVersion: optStr(BinaryVersion),
 			RawEventName:   optStr(base.NativeName),
 			Hostname:       optStr(hostname),
 			UserEmail:      nil,

--- a/hooks/relay/mcp_inventory.go
+++ b/hooks/relay/mcp_inventory.go
@@ -101,7 +101,17 @@ func parseClaudeMCPInventory(out string) []mcpInventoryEntry {
 // and the shadow-MCP guard needs it to prove where a tool call actually
 // routes. Best-effort for the same reason as the Claude collector: a missing
 // or slow CLI must not hold up the hook.
-func collectCodexMCPInventory(ctx context.Context) []mcpInventoryEntry {
+// Codex merges managed, user and project config layers, and the project layer
+// is resolved relative to the working directory — so the list must be taken
+// from the session's cwd, exactly as the Claude collector does.
+//
+// Not replayed: per-session launch overrides (--profile, -c). agenthooks
+// replays them for its own resolution because they change the effective server
+// set. Without them a profile-only server is missing from the snapshot (its
+// meta-tool reads then deny), and a `-c mcp_servers.x.url=…` override is
+// invisible (the snapshot reports the default target for that name). See
+// DNO-770.
+func collectCodexMCPInventory(ctx context.Context, cwd string) []mcpInventoryEntry {
 	binary := findCodexBinary()
 	if binary == "" {
 		return nil
@@ -109,7 +119,11 @@ func collectCodexMCPInventory(ctx context.Context) []mcpInventoryEntry {
 
 	ctx, cancel := context.WithTimeout(ctx, codexMCPInventoryTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, binary, "mcp", "list", "--json").Output()
+	cmd := exec.CommandContext(ctx, binary, "mcp", "list", "--json")
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	out, err := cmd.Output()
 	if err != nil && len(out) == 0 {
 		return nil
 	}

--- a/hooks/relay/mcp_inventory.go
+++ b/hooks/relay/mcp_inventory.go
@@ -97,13 +97,12 @@ func parseClaudeMCPInventory(out string) []mcpInventoryEntry {
 
 // collectCodexMCPInventory asks Codex for its effective server list. Codex has
 // no plugin/connector servers of its own, but the list still resolves the
-// merged config layers (managed, user, project) that a hook event cannot see,
-// and the shadow-MCP guard needs it to prove where a tool call actually
-// routes. Best-effort for the same reason as the Claude collector: a missing
-// or slow CLI must not hold up the hook.
-// Codex merges managed, user and project config layers, and the project layer
-// is resolved relative to the working directory — so the list must be taken
-// from the session's cwd, exactly as the Claude collector does.
+// merged managed/user/project config layers that a hook event cannot see, and
+// the shadow-MCP guard needs it to prove where a tool call actually routes.
+// The project layer resolves relative to the working directory, so the list is
+// taken from the session's cwd exactly as the Claude collector does.
+// Best-effort for the same reason: a missing or slow CLI must not hold up the
+// hook.
 //
 // Not replayed: per-session launch overrides (--profile, -c). agenthooks
 // replays them for its own resolution because they change the effective server

--- a/hooks/relay/mcp_inventory.go
+++ b/hooks/relay/mcp_inventory.go
@@ -1,7 +1,9 @@
 package relay
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -10,7 +12,12 @@ import (
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
 
-const claudeMCPInventoryTimeout = 15 * time.Second
+const (
+	claudeMCPInventoryTimeout = 15 * time.Second
+	// Codex resolves its list from config layers rather than by probing
+	// servers, so it returns far faster than Claude's.
+	codexMCPInventoryTimeout = 5 * time.Second
+)
 
 type mcpInventoryEntry struct {
 	Name    string
@@ -84,6 +91,70 @@ func parseClaudeMCPInventory(out string) []mcpInventoryEntry {
 			entry.Command = target
 		}
 		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// collectCodexMCPInventory asks Codex for its effective server list. Codex has
+// no plugin/connector servers of its own, but the list still resolves the
+// merged config layers (managed, user, project) that a hook event cannot see,
+// and the shadow-MCP guard needs it to prove where a tool call actually
+// routes. Best-effort for the same reason as the Claude collector: a missing
+// or slow CLI must not hold up the hook.
+func collectCodexMCPInventory(ctx context.Context) []mcpInventoryEntry {
+	binary := findCodexBinary()
+	if binary == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, codexMCPInventoryTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binary, "mcp", "list", "--json").Output()
+	if err != nil && len(out) == 0 {
+		return nil
+	}
+	return parseCodexMCPInventory(out)
+}
+
+// parseCodexMCPInventory reads `codex mcp list --json`. The server parses the
+// same document (hooks.ParseCodexMCPList) for the legacy Codex endpoint, so
+// the two must agree on the shape: an array of servers, each with a transport
+// object holding either a url or a command plus args.
+func parseCodexMCPInventory(out []byte) []mcpInventoryEntry {
+	var servers []struct {
+		Name      string `json:"name"`
+		Enabled   *bool  `json:"enabled"`
+		Transport struct {
+			URL     string   `json:"url"`
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+		} `json:"transport"`
+	}
+	if json.Unmarshal(bytes.TrimSpace(out), &servers) != nil {
+		return nil
+	}
+
+	var entries []mcpInventoryEntry
+	for _, server := range servers {
+		// An explicitly disabled server cannot serve the call, so listing it
+		// would let a disabled entry vouch for a tool that routed elsewhere.
+		if server.Enabled != nil && !*server.Enabled {
+			continue
+		}
+		name := strings.TrimSpace(server.Name)
+		url := strings.TrimSpace(server.Transport.URL)
+		command := strings.TrimSpace(server.Transport.Command)
+		if command != "" {
+			for _, arg := range server.Transport.Args {
+				if arg = strings.TrimSpace(arg); arg != "" {
+					command += " " + arg
+				}
+			}
+		}
+		if name == "" || (url == "" && command == "") {
+			continue
+		}
+		entries = append(entries, mcpInventoryEntry{Name: name, URL: url, Command: command})
 	}
 	return entries
 }

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -1649,3 +1649,51 @@ func TestEnvelopeReportsBinaryVersion(t *testing.T) {
 	require.NotNil(t, payload.Source.AdapterVersion)
 	require.Equal(t, "9.9.9", *payload.Source.AdapterVersion)
 }
+
+// TestCodexSessionStartRelaysMCPInventoryFromSessionCWD: Codex merges managed,
+// user and project config layers, and resolves the project layer relative to
+// the working directory — so the inventory must be listed from the session's
+// cwd, not the hook host's. Getting this wrong yields a snapshot missing the
+// session's real servers, and the shadow-MCP guard then denies meta-tool reads
+// of servers that are in fact Gram-hosted. Mirrors the Claude coverage.
+func TestCodexSessionStartRelaysMCPInventoryFromSessionCWD(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake codex executable uses a POSIX shell")
+	}
+
+	binDir := t.TempDir()
+	// Only the `mcp` invocation records its cwd: SessionStart also shells out
+	// to `codex app-server` for identity, and letting that write would race the
+	// assertion with the hook host's directory.
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "codex"), []byte(
+		"#!/bin/sh\n"+
+			"if [ \"$1\" = \"mcp\" ]; then\n"+
+			"  pwd > \"$FAKE_CODEX_CWD_FILE\"\n"+
+			"  printf '%s\\n' \"$FAKE_CODEX_MCP_LIST\"\n"+
+			"  exit 0\n"+
+			"fi\n"+
+			"exit 1\n"), 0o700))
+	t.Setenv("PATH", binDir)
+	cwdFile := filepath.Join(t.TempDir(), "cwd")
+	t.Setenv("FAKE_CODEX_CWD_FILE", cwdFile)
+	t.Setenv("FAKE_CODEX_MCP_LIST",
+		`[{"name":"gram","enabled":true,"transport":{"type":"streamable_http","url":"https://app.example.test/mcp"}}]`)
+
+	fs := newFakeServer(t, nil)
+	cfg := authedConfig(t, fs.URL)
+	cwd := t.TempDir()
+	payload := []byte(`{"session_id":"sess-codex-inventory","cwd":"` + cwd + `","hook_event_name":"SessionStart"}`)
+
+	res := agenthookstest.Invoke(t, NewRunner(cfg), agenthooks.ProviderCodex, payload, "--variant=cli")
+
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, 1, fs.count())
+	require.NotNil(t, fs.last().Data)
+	require.Len(t, fs.last().Data.McpInventory, 1)
+	require.Equal(t, "gram", *fs.last().Data.McpInventory[0].ServerName)
+
+	invocationCWD, err := os.ReadFile(cwdFile)
+	require.NoError(t, err)
+	require.Equal(t, cwd, strings.TrimSpace(string(invocationCWD)),
+		"codex mcp list must run from the session cwd so the project config layer resolves")
+}

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -1626,3 +1626,26 @@ func TestParseCodexMCPInventory(t *testing.T) {
 	require.Empty(t, parseCodexMCPInventory([]byte("not json")))
 	require.Empty(t, parseCodexMCPInventory(nil))
 }
+
+// TestEnvelopeReportsBinaryVersion: the server reads adapter_version's presence
+// as "this relay can report MCP inventory" and degrades the codex meta-tool
+// shadow-MCP guard without it. Dropping this field would silently disable that
+// enforcement for every user rather than failing visibly.
+func TestEnvelopeReportsBinaryVersion(t *testing.T) {
+	previous := BinaryVersion
+	t.Cleanup(func() { BinaryVersion = previous })
+	BinaryVersion = "9.9.9"
+
+	payload := buildEnvelope(&agenthooks.PromptEvent{
+		Event: agenthooks.Event{
+			Provider:   agenthooks.ProviderCodex,
+			Kind:       agenthooks.KindPromptSubmitted,
+			NativeName: "UserPromptSubmit",
+			Session:    agenthooks.SessionInfo{ID: "s1"},
+		},
+		Prompt: "hello",
+	}, "host")
+
+	require.NotNil(t, payload.Source.AdapterVersion)
+	require.Equal(t, "9.9.9", *payload.Source.AdapterVersion)
+}

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -1563,3 +1563,66 @@ func TestSendBoundsTotalRetryTime(t *testing.T) {
 	require.Equal(t, 0, res.statusCode, "a hung endpoint yields a transport failure, not a verdict")
 	require.Less(t, time.Since(start), 10*time.Second, "the send budget must bound retries end to end")
 }
+
+// TestParseCodexMCPInventory: the guard uses this snapshot to decide whether a
+// tool call routes to a Gram-hosted server, so a stdio server must surface its
+// full command and a disabled server must not appear at all — a disabled entry
+// left in the list would vouch for a call that routed somewhere else.
+func TestParseCodexMCPInventory(t *testing.T) {
+	// Verbatim `codex mcp list --json` from the shipped 0.146 build (server
+	// names and the disabled entry are ours; every key, the null-heavy
+	// transport fields, and the auth_status values are as Codex emitted them).
+	entries := parseCodexMCPInventory([]byte(`[
+	  {
+	    "name": "everything",
+	    "enabled": true,
+	    "disabled_reason": null,
+	    "transport": {
+	      "type": "stdio",
+	      "command": "npx",
+	      "args": ["-y", "@modelcontextprotocol/server-everything"],
+	      "env": null,
+	      "env_vars": [],
+	      "cwd": null
+	    },
+	    "startup_timeout_sec": null,
+	    "tool_timeout_sec": null,
+	    "auth_status": "unsupported"
+	  },
+	  {
+	    "name": "remote_example",
+	    "enabled": true,
+	    "disabled_reason": null,
+	    "transport": {
+	      "type": "streamable_http",
+	      "url": "https://mcp.example.test/mcp",
+	      "bearer_token_env_var": null,
+	      "http_headers": null,
+	      "env_http_headers": null
+	    },
+	    "startup_timeout_sec": null,
+	    "tool_timeout_sec": null,
+	    "auth_status": "o_auth"
+	  },
+	  {
+	    "name": "disabled_example",
+	    "enabled": false,
+	    "disabled_reason": null,
+	    "transport": {"type": "stdio", "command": "npx", "args": [], "env": null, "env_vars": [], "cwd": null},
+	    "startup_timeout_sec": null,
+	    "tool_timeout_sec": null,
+	    "auth_status": "unsupported"
+	  }
+	]`))
+
+	require.Len(t, entries, 2)
+	require.Equal(t, "everything", entries[0].Name)
+	require.Equal(t, "npx -y @modelcontextprotocol/server-everything", entries[0].Command)
+	require.Empty(t, entries[0].URL)
+	require.Equal(t, "remote_example", entries[1].Name)
+	require.Equal(t, "https://mcp.example.test/mcp", entries[1].URL)
+	require.Empty(t, entries[1].Command)
+
+	require.Empty(t, parseCodexMCPInventory([]byte("not json")))
+	require.Empty(t, parseCodexMCPInventory(nil))
+}

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -185,7 +185,7 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	// against, so a block_all policy cannot tell a Gram-hosted server from a
 	// shadow one (DNO-767).
 	if base.Provider == agenthooks.ProviderCodex && base.Kind == agenthooks.KindSessionStart {
-		attachMCPInventory(&payload, collectCodexMCPInventory(ctx))
+		attachMCPInventory(&payload, collectCodexMCPInventory(ctx, base.Session.CWD))
 	}
 	promptAttachmentAdvance := promptAttachmentHighWaterAdvance{}
 	if entries, advance, err := collectClaudePromptAttachments(base); err == nil {

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -180,6 +180,13 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		(base.Kind == agenthooks.KindSessionStart || base.NativeName == "ConfigChange") {
 		attachMCPInventory(&payload, collectClaudeMCPInventory(ctx, base.Session.CWD))
 	}
+	// Codex needs the same snapshot for the shadow-MCP guard to prove where a
+	// tool call routes. Without it the guard has nothing to check the call
+	// against, so a block_all policy cannot tell a Gram-hosted server from a
+	// shadow one (DNO-767).
+	if base.Provider == agenthooks.ProviderCodex && base.Kind == agenthooks.KindSessionStart {
+		attachMCPInventory(&payload, collectCodexMCPInventory(ctx))
+	}
 	promptAttachmentAdvance := promptAttachmentHighWaterAdvance{}
 	if entries, advance, err := collectClaudePromptAttachments(base); err == nil {
 		attachPromptAttachments(&payload, entries)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -586,7 +586,7 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 				return auditReason, s.appendCanonicalBlockURL(ctx, authCtx, actor, payload, auditReason, toolName, scanResult.PolicyID, userReason)
 			}
 		}
-		if canonicalMCPData(payload) != nil || toolref.IsMCPToolName(toolName) {
+		if canonicalMCPData(payload) != nil || toolref.IsMCPToolName(toolName) || canonicalCodexMetaTool(payload, toolName, toolInput) {
 			ev := hookevents.NewBeforeMCPExecution(event, hookevents.BeforeMCPExecutionParams{
 				ToolName:  toolName,
 				ToolInput: toolInput,
@@ -723,6 +723,15 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 
 	toolName := toolref.MCPFunctionOf(rawToolName)
 	evidence := canonicalShadowMCPEvidence(payload, rawToolName)
+	// A Codex meta-tool names its target in tool_input.server, so nothing above
+	// can derive an identity from the tool name. Attaching it lets the deny name
+	// the server and lets a bypass grant be scoped to it; leaving it empty still
+	// denies under block_all, just without saying which server.
+	if evidence.ServerIdentity == "" && evidence.FullURL == "" {
+		if server, isMetaTool := codexMetaToolServer(rawToolName, toolInput); isMetaTool {
+			evidence.ServerIdentity = server
+		}
+	}
 	if detail, denied := s.enforceShadowMCPToolAccess(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), actor.UserID, policy, toolName, evidence); denied {
 		auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
 		userReason := s.renderShadowMCPUserBlockReason(ctx, shadowMCPRequestLinkParams{
@@ -748,8 +757,13 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 				UserID:         actor.UserID,
 				RiskPolicyID:   conv.StringToNullUUID(policy.ID),
 				RiskResultID:   uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-				ChatID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-				ChatMessageID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+				// Deliberately unlinked. chat_id carries an FK to chats, and a
+				// shadow-MCP deny can land before the session's chat row is
+				// persisted — passing chatIDForBlock here violates the FK and
+				// the whole block insert is lost, taking the block URL with it.
+				// Linking needs the chat row guaranteed first (DNO-767).
+				ChatID:        uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+				ChatMessageID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 			}); bURL != "" {
 				userReason = appendBlockURL(userReason, bURL)
 			}
@@ -757,6 +771,19 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 		return auditReason, userReason
 	}
 	return "", ""
+}
+
+// canonicalCodexMetaTool reports whether this event is one of Codex's built-in
+// MCP resource tools. They carry no mcp__ prefix and agenthooks resolves MCP
+// data by that same prefix, so without this check they reach neither arm of the
+// gate and a shadow-MCP policy never sees them (DNO-767). Scoped to the codex
+// adapter: another agent's unrelated tool of the same name is not an MCP call.
+func canonicalCodexMetaTool(payload *gen.IngestPayload, toolName string, toolInput any) bool {
+	if payload == nil || !strings.EqualFold(strings.TrimSpace(payload.Source.Adapter), "codex") {
+		return false
+	}
+	_, isMetaTool := codexMetaToolServer(toolName, toolInput)
+	return isMetaTool
 }
 
 func canonicalShadowMCPEvidence(payload *gen.IngestPayload, rawToolName string) shadowmcp.AccessEvidence {

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -593,7 +593,7 @@ func (s *Service) evaluateCanonicalHook(ctx context.Context, payload *gen.Ingest
 				return auditReason, s.appendCanonicalBlockURL(ctx, authCtx, actor, payload, auditReason, toolName, scanResult.PolicyID, userReason)
 			}
 		}
-		if canonicalMCPData(payload) != nil || toolref.IsMCPToolName(toolName) || canonicalCodexMetaTool(payload, toolName, toolInput) {
+		if canonicalMCPData(payload) != nil || toolref.IsMCPToolName(toolName) || s.canonicalCodexMetaTool(ctx, payload, toolName, toolInput) {
 			ev := hookevents.NewBeforeMCPExecution(event, hookevents.BeforeMCPExecutionParams{
 				ToolName:  toolName,
 				ToolInput: toolInput,
@@ -828,12 +828,44 @@ func (s *Service) cacheCanonicalMCPList(ctx context.Context, sessionID string, e
 // data by that same prefix, so without this check they reach neither arm of the
 // gate and a shadow-MCP policy never sees them (DNO-767). Scoped to the codex
 // adapter: another agent's unrelated tool of the same name is not an MCP call.
-func canonicalCodexMetaTool(payload *gen.IngestPayload, toolName string, toolInput any) bool {
+func (s *Service) canonicalCodexMetaTool(ctx context.Context, payload *gen.IngestPayload, toolName string, toolInput any) bool {
 	if payload == nil || !strings.EqualFold(strings.TrimSpace(payload.Source.Adapter), "codex") {
 		return false
 	}
 	_, isMetaTool := codexMetaToolServer(toolName, toolInput)
-	return isMetaTool
+	if !isMetaTool {
+		return false
+	}
+	if !canonicalClientReportsMCPInventory(payload) {
+		// Counts the un-upgraded population: once this stops firing, the
+		// capability check can go and the guard can apply unconditionally.
+		s.logger.InfoContext(ctx, "skipping codex meta-tool shadow-mcp guard: client cannot report MCP inventory",
+			attr.SlogEvent("shadow_mcp_meta_tool_client_incapable"),
+			attr.SlogToolName(toolName),
+		)
+		return false
+	}
+	return true
+}
+
+// canonicalClientReportsMCPInventory reports whether the sending client is new
+// enough to collect the Codex MCP inventory the meta-tool guard resolves
+// against.
+//
+// Every relay released before that change left adapter_version unset, and
+// nothing else has ever populated it, so its absence identifies them exactly.
+// Enforcing regardless would deny every meta-tool call from those clients —
+// including reads of Gram-hosted servers that work today — because they send
+// no inventory for the guard to clear the target against. Degrading instead
+// keeps them at their current behavior and lets enforcement arrive with the
+// hooks upgrade, rather than depending on a server deploy and a hooks release
+// being ordered correctly.
+//
+// A capable client that reports no inventory is a different case: that means
+// no MCP servers are configured, so a meta-tool call has nothing legitimate to
+// target and the guard denies it.
+func canonicalClientReportsMCPInventory(payload *gen.IngestPayload) bool {
+	return payload != nil && strings.TrimSpace(conv.PtrValOr(payload.Source.AdapterVersion, "")) != ""
 }
 
 func canonicalShadowMCPEvidence(payload *gen.IngestPayload, rawToolName string) shadowmcp.AccessEvidence {

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -235,13 +235,15 @@ func (s *Service) ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 		// claimed, so a client disconnect here would otherwise drop the event
 		// for good — the retry gets marked duplicate and skips persistence.
 		persistCtx := context.WithoutCancel(ctx)
+		inventory := canonicalMCPInventoryEntries(payload)
 		s.upsertShadowMCPInventoryURLs(
 			persistCtx,
 			authCtx.ActiveOrganizationID,
 			authCtx.ProjectID.String(),
 			canonicalSessionID(payload),
-			canonicalMCPInventoryEntries(payload),
+			inventory,
 		)
+		s.cacheCanonicalMCPList(persistCtx, canonicalSessionID(payload), inventory)
 		s.recordCanonicalHook(persistCtx, payload, authCtx, actor, timestamp, blockReason)
 	}
 	// Transcript-derived MCP attribution (Claude Stop/SubagentStop): stash
@@ -724,12 +726,15 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 	toolName := toolref.MCPFunctionOf(rawToolName)
 	evidence := canonicalShadowMCPEvidence(payload, rawToolName)
 	// A Codex meta-tool names its target in tool_input.server, so nothing above
-	// can derive an identity from the tool name. Attaching it lets the deny name
-	// the server and lets a bypass grant be scoped to it; leaving it empty still
-	// denies under block_all, just without saying which server.
+	// can derive an identity from the tool name. Resolving that name against the
+	// session's inventory is what lets a Gram-hosted target be allowed at all —
+	// without a URL the guard can only reach its generic "not Gram-hosted" deny,
+	// which would block legitimate reads the legacy endpoint permits. A name we
+	// cannot resolve still denies: unproven is not absent.
 	if evidence.ServerIdentity == "" && evidence.FullURL == "" {
 		if server, isMetaTool := codexMetaToolServer(rawToolName, toolInput); isMetaTool {
 			evidence.ServerIdentity = server
+			s.resolveEvidenceFromSessionInventory(ctx, &evidence, canonicalSessionID(payload))
 		}
 	}
 	if detail, denied := s.enforceShadowMCPToolAccess(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), actor.UserID, policy, toolName, evidence); denied {
@@ -771,6 +776,48 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 		return auditReason, userReason
 	}
 	return "", ""
+}
+
+// resolveEvidenceFromSessionInventory upgrades evidence carrying only a server
+// name to the target that name resolves to in the session's inventory: the URL
+// for HTTP servers, the launch command for stdio ones. Mirrors the legacy
+// codexShadowMCPEvidence resolution — stdio identity is pinned to the command
+// so a bypass grant cannot follow a renamed config alias.
+func (s *Service) resolveEvidenceFromSessionInventory(ctx context.Context, evidence *shadowmcp.AccessEvidence, sessionID string) {
+	if evidence.ServerIdentity == "" || sessionID == "" {
+		return
+	}
+	entries, err := s.getCachedMCPList(ctx, sessionID)
+	if err != nil {
+		return
+	}
+	matched := matchCodexCachedMCPServerEntry(entries, evidence.ServerIdentity)
+	if matched == nil {
+		return
+	}
+	if matched.URL != "" {
+		evidence.FullURL = matched.URL
+	}
+	if matched.Command != "" {
+		evidence.ServerIdentity = matched.Command
+	}
+}
+
+// cacheCanonicalMCPList stores a session's MCP inventory under the same key
+// and TTL the legacy per-provider endpoints use, so the shadow-MCP guard can
+// resolve a later tool call's target to a configured server. Best-effort: a
+// cache miss downgrades a deny's detail, it never changes the decision.
+func (s *Service) cacheCanonicalMCPList(ctx context.Context, sessionID string, entries []MCPServerEntry) {
+	if sessionID == "" || len(entries) == 0 {
+		return
+	}
+	if err := s.cache.Set(ctx, sessionMCPListCacheKey(sessionID), entries, sessionMCPListTTL); err != nil {
+		s.logger.WarnContext(ctx, "failed to cache MCP list snapshot",
+			attr.SlogEvent("hook_mcp_list_cache_set_failed"),
+			attr.SlogError(err),
+			attr.SlogGenAIConversationID(sessionID),
+		)
+	}
 }
 
 // canonicalCodexMetaTool reports whether this event is one of Codex's built-in

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -235,17 +235,22 @@ func (s *Service) ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 		// claimed, so a client disconnect here would otherwise drop the event
 		// for good — the retry gets marked duplicate and skips persistence.
 		persistCtx := context.WithoutCancel(ctx)
-		inventory := canonicalMCPInventoryEntries(payload)
 		s.upsertShadowMCPInventoryURLs(
 			persistCtx,
 			authCtx.ActiveOrganizationID,
 			authCtx.ProjectID.String(),
 			canonicalSessionID(payload),
-			inventory,
+			canonicalMCPInventoryEntries(payload),
 		)
-		s.cacheCanonicalMCPList(persistCtx, canonicalSessionID(payload), inventory)
 		s.recordCanonicalHook(persistCtx, payload, authCtx, actor, timestamp, blockReason)
 	}
+	// Cache the inventory and extend its TTL for duplicates too, for the same
+	// reason captureMCPAttribution does below: the write is idempotent, and
+	// skipping retries would leave a session whose first delivery claimed the
+	// idempotency key but failed its cache write with no inventory for its
+	// whole life — under block_all every later meta-tool call would then deny,
+	// including Gram-hosted targets, with no path to recover.
+	s.cacheCanonicalMCPList(context.WithoutCancel(ctx), canonicalSessionID(payload), canonicalMCPInventoryEntries(payload))
 	// Transcript-derived MCP attribution (Claude Stop/SubagentStop): stash
 	// tuples for the scheduled staged-telemetry sweep to join. Runs for
 	// duplicate deliveries too — the Redis Set is idempotent, and skipping
@@ -808,7 +813,14 @@ func (s *Service) resolveEvidenceFromSessionInventory(ctx context.Context, evide
 // resolve a later tool call's target to a configured server. Best-effort: a
 // cache miss downgrades a deny's detail, it never changes the decision.
 func (s *Service) cacheCanonicalMCPList(ctx context.Context, sessionID string, entries []MCPServerEntry) {
-	if sessionID == "" || len(entries) == 0 {
+	if sessionID == "" {
+		return
+	}
+	if len(entries) == 0 {
+		// Every other event in the session extends the snapshot's life, as the
+		// legacy endpoints do. Without this a session outliving the TTL loses
+		// its inventory and every later meta-tool call denies.
+		s.refreshMCPListTTL(ctx, sessionID)
 		return
 	}
 	if err := s.cache.Set(ctx, sessionMCPListCacheKey(sessionID), entries, sessionMCPListTTL); err != nil {
@@ -1820,23 +1832,36 @@ func canonicalMCPInventoryEntries(payload *gen.IngestPayload) []MCPServerEntry {
 	if payload == nil || payload.Data == nil || len(payload.Data.McpInventory) == 0 {
 		return nil
 	}
+	adapter := strings.TrimSpace(payload.Source.Adapter)
+	isCodex := strings.EqualFold(adapter, "codex")
 	entries := make([]MCPServerEntry, 0, len(payload.Data.McpInventory))
 	for _, mcp := range payload.Data.McpInventory {
 		if mcp == nil {
 			continue
 		}
+		name := strings.TrimSpace(conv.PtrValOr(mcp.ServerName, ""))
+		// Codex addresses a server by its sanitized tool prefix as well as its
+		// configured name, and the prefix is the only thing the cached-entry
+		// fallback matches on. Leaving it empty makes a hyphenated server
+		// ("platform-logs", addressed as "platform_logs") unresolvable here
+		// while the legacy endpoint resolves it — a Gram-hosted target would
+		// be denied. Mirrors ParseCodexMCPList.
+		toolPrefix := ""
+		if isCodex {
+			toolPrefix = codexSanitizeToolName(name)
+		}
 		entries = append(entries, MCPServerEntry{
 			RawLine:       "",
-			Source:        strings.TrimSpace(payload.Source.Adapter),
+			Source:        adapter,
 			PluginName:    "",
-			Name:          strings.TrimSpace(conv.PtrValOr(mcp.ServerName, "")),
+			Name:          name,
 			URL:           strings.TrimSpace(conv.PtrValOr(mcp.URL, "")),
 			Command:       strings.TrimSpace(conv.PtrValOr(mcp.Command, "")),
 			Transport:     "",
 			Status:        "unknown",
 			StatusRaw:     "",
 			ConnectorUUID: "",
-			ToolPrefix:    "",
+			ToolPrefix:    toolPrefix,
 		})
 	}
 	return entries

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -796,16 +796,7 @@ func (s *Service) resolveEvidenceFromSessionInventory(ctx context.Context, evide
 	if err != nil {
 		return
 	}
-	matched := matchCodexCachedMCPServerEntry(entries, evidence.ServerIdentity)
-	if matched == nil {
-		return
-	}
-	if matched.URL != "" {
-		evidence.FullURL = matched.URL
-	}
-	if matched.Command != "" {
-		evidence.ServerIdentity = matched.Command
-	}
+	applyMCPEntryToEvidence(evidence, matchCodexCachedMCPServerEntry(entries, evidence.ServerIdentity))
 }
 
 // cacheCanonicalMCPList stores a session's MCP inventory under the same key

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -861,9 +861,12 @@ func (s *Service) canonicalCodexMetaTool(ctx context.Context, payload *gen.Inges
 // hooks upgrade, rather than depending on a server deploy and a hooks release
 // being ordered correctly.
 //
-// A capable client that reports no inventory is a different case: that means
-// no MCP servers are configured, so a meta-tool call has nothing legitimate to
-// target and the guard denies it.
+// A capable client that reports no inventory is a different case and is denied
+// — deliberately, not because no servers exist. It may have none configured,
+// but collection is best-effort and can also come back empty when the codex
+// binary cannot be located, `codex mcp list` errors or times out, or the
+// session's inventory never reached the cache. All of those leave the target
+// unproven, and an unproven target is not an absent one.
 func canonicalClientReportsMCPInventory(payload *gen.IngestPayload) bool {
 	return payload != nil && strings.TrimSpace(conv.PtrValOr(payload.Source.AdapterVersion, "")) != ""
 }

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -2085,3 +2085,33 @@ func TestIngest_ShadowMCPResolvesCodexMetaToolAgainstInventory(t *testing.T) {
 		})
 	}
 }
+
+// TestCanonicalMCPInventoryEntriesCarryCodexToolPrefix: Codex addresses a
+// server by its sanitized tool prefix as well as its configured name, and the
+// cached-entry fallback matches only on ToolPrefix. Without it a hyphenated
+// server is unresolvable on the ingest path while the legacy endpoint resolves
+// it, so a Gram-hosted target would be denied.
+func TestCanonicalMCPInventoryEntriesCarryCodexToolPrefix(t *testing.T) {
+	t.Parallel()
+
+	name := "platform-logs"
+	url := "https://app.getgram.ai/mcp/platform-logs"
+	payload := canonicalIngestPayload("codex", "session.started", "codex-tool-prefix")
+	payload.Data = &gen.HookIngestData{
+		McpInventory: []*gen.HookMCPData{{ServerName: &name, URL: &url}},
+	}
+
+	entries := canonicalMCPInventoryEntries(payload)
+	require.Len(t, entries, 1)
+	require.Equal(t, "platform_logs", entries[0].ToolPrefix)
+
+	// The sanitized form must resolve to the configured server, as it does on
+	// the legacy endpoint.
+	matched := matchCodexCachedMCPServerEntry(entries, "platform_logs")
+	require.NotNil(t, matched)
+	require.Equal(t, url, matched.URL)
+
+	// Other adapters keep no codex-specific prefix.
+	payload.Source.Adapter = "claude"
+	require.Empty(t, canonicalMCPInventoryEntries(payload)[0].ToolPrefix)
+}

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1977,6 +1977,7 @@ func TestIngest_ShadowMCPGuardCoversCodexMetaTools(t *testing.T) {
 				ti.service.riskScanner = stubBlockingShadowMCPScanner{}
 
 				payload := canonicalIngestPayload("codex", "tool.requested", "codex-meta-"+toolName+"-"+name)
+				payload.Source.AdapterVersion = new("1.2.3")
 				callID := "call-1"
 				payload.Data = &gen.HookIngestData{
 					ToolCall: &gen.HookToolCallData{
@@ -2008,6 +2009,7 @@ func TestIngest_ShadowMCPGuardIgnoresMetaToolNamesFromOtherAdapters(t *testing.T
 	toolName := "read_mcp_resource"
 	callID := "call-1"
 	payload := canonicalIngestPayload("custom-adapter", "tool.requested", "non-codex-meta-tool")
+	payload.Source.AdapterVersion = new("1.2.3")
 	payload.Data = &gen.HookIngestData{
 		ToolCall: &gen.HookToolCallData{
 			ID:    &callID,
@@ -2066,6 +2068,7 @@ func TestIngest_ShadowMCPResolvesCodexMetaToolAgainstInventory(t *testing.T) {
 			toolName := "read_mcp_resource"
 			callID := "call-1"
 			payload := canonicalIngestPayload("codex", "tool.requested", sessionID)
+			payload.Source.AdapterVersion = new("1.2.3")
 			payload.Data = &gen.HookIngestData{
 				ToolCall: &gen.HookToolCallData{
 					ID: &callID, Name: &toolName,
@@ -2114,4 +2117,43 @@ func TestCanonicalMCPInventoryEntriesCarryCodexToolPrefix(t *testing.T) {
 	// Other adapters keep no codex-specific prefix.
 	payload.Source.Adapter = "claude"
 	require.Empty(t, canonicalMCPInventoryEntries(payload)[0].ToolPrefix)
+}
+
+// TestIngest_ShadowMCPMetaToolGateDegradesForIncapableClients: the server-side
+// deny ships independently of the hooks release that starts collecting the
+// Codex MCP inventory. A relay predating that release sends no inventory, so
+// the guard would have nothing to clear a target against and every meta-tool
+// call would deny — including reads of Gram-hosted servers that work today.
+// Those clients are identified by an absent adapter_version (nothing else has
+// ever set it) and keep their current behavior until they upgrade.
+func TestIngest_ShadowMCPMetaToolGateDegradesForIncapableClients(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	toolName := "read_mcp_resource"
+	callID := "call-1"
+	payload := canonicalIngestPayload("codex", "tool.requested", "codex-legacy-relay")
+	// An old relay: adapter_version left unset.
+	payload.Source.AdapterVersion = nil
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID: &callID, Name: &toolName,
+			Input: map[string]any{"server": "platform-logs"},
+		},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEqual(t, "deny", result.Decision,
+		"a relay that cannot report MCP inventory must not have its meta-tool calls blanket-denied")
+
+	// An empty string is as good as absent — it proves no capability either.
+	payload.Source.AdapterVersion = new("")
+	result, err = ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEqual(t, "deny", result.Decision)
 }

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -2021,3 +2021,67 @@ func TestIngest_ShadowMCPGuardIgnoresMetaToolNamesFromOtherAdapters(t *testing.T
 	require.NotNil(t, result)
 	require.NotEqual(t, "deny", result.Decision)
 }
+
+// TestIngest_ShadowMCPResolvesCodexMetaToolAgainstInventory: bringing the
+// meta-tools under the guard must not blanket-deny them. The guard can only
+// reach its generic "not Gram-hosted" deny without a URL, so a meta-tool
+// reading resources from a Gram-hosted server would be blocked — traffic the
+// legacy endpoint permits. Resolving the name against the session inventory is
+// what separates allowed from denied, and it must name the server when denying.
+func TestIngest_ShadowMCPResolvesCodexMetaToolAgainstInventory(t *testing.T) {
+	t.Parallel()
+
+	gramHosted := MCPServerEntry{
+		Source: "codex", Name: "speakeasy-team",
+		URL:    "https://app.getgram.ai/mcp/speakeasy-team-8g3az",
+		Status: "unknown",
+	}
+	external := MCPServerEntry{
+		Source: "codex", Name: "someone-else",
+		URL:    "https://mcp.example.test/mcp",
+		Status: "unknown",
+	}
+
+	tests := []struct {
+		name       string
+		entry      MCPServerEntry
+		target     string
+		wantDenied bool
+	}{
+		{"gram-hosted target is allowed", gramHosted, "speakeasy-team", false},
+		{"external target is denied", external, "someone-else", true},
+		{"target absent from inventory is denied", gramHosted, "unlisted", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestHooksService(t)
+			ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+			sessionID := "codex-meta-inventory-" + tc.name
+			require.NoError(t, ti.service.cache.Set(ctx,
+				sessionMCPListCacheKey(sessionID), []MCPServerEntry{tc.entry}, sessionMCPListTTL))
+
+			toolName := "read_mcp_resource"
+			callID := "call-1"
+			payload := canonicalIngestPayload("codex", "tool.requested", sessionID)
+			payload.Data = &gen.HookIngestData{
+				ToolCall: &gen.HookToolCallData{
+					ID: &callID, Name: &toolName,
+					Input: map[string]any{"server": tc.target},
+				},
+			}
+
+			result, err := ti.service.Ingest(ctx, payload)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			if !tc.wantDenied {
+				require.NotEqual(t, "deny", result.Decision,
+					"a Gram-hosted meta-tool target must not be blocked")
+				return
+			}
+			require.Equal(t, "deny", result.Decision)
+		})
+	}
+}

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -1952,3 +1952,72 @@ func TestCanonicalSessionMetadata_CodexReattributionDropsStaleCachedUserID(t *te
 	require.Empty(t, metadata.BillingMode)
 	require.Equal(t, "stranger@personal.example", metadata.ObservedUserEmail)
 }
+
+// TestIngest_ShadowMCPGuardCoversCodexMetaTools: Codex's built-in MCP resource
+// tools carry no mcp__ prefix and their target lives in tool_input.server, so
+// neither arm of the gate (resolved MCP data, MCP-shaped tool name) recognizes
+// them. Before DNO-767 they were classified as ordinary tool calls and a
+// block_all shadow-MCP policy never ran, letting a Codex session read any MCP
+// server's resources. A meta-tool whose server cannot be read must still deny —
+// an unproven target is not an absent one.
+func TestIngest_ShadowMCPGuardCoversCodexMetaTools(t *testing.T) {
+	t.Parallel()
+
+	for _, toolName := range []string{"list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource"} {
+		for name, toolInput := range map[string]any{
+			"named server":      map[string]any{"server": "platform-logs"},
+			"missing server":    map[string]any{},
+			"blank server":      map[string]any{"server": "  "},
+			"non-string server": map[string]any{"server": 42},
+			"nil input":         nil,
+		} {
+			t.Run(toolName+"/"+name, func(t *testing.T) {
+				t.Parallel()
+				ctx, ti := newTestHooksService(t)
+				ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+				payload := canonicalIngestPayload("codex", "tool.requested", "codex-meta-"+toolName+"-"+name)
+				callID := "call-1"
+				payload.Data = &gen.HookIngestData{
+					ToolCall: &gen.HookToolCallData{
+						ID:    &callID,
+						Name:  &toolName,
+						Input: toolInput,
+					},
+				}
+
+				result, err := ti.service.Ingest(ctx, payload)
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, "deny", result.Decision,
+					"a codex MCP meta-tool must be evaluated by the shadow-MCP policy")
+			})
+		}
+	}
+}
+
+// TestIngest_ShadowMCPGuardIgnoresMetaToolNamesFromOtherAdapters: the meta-tool
+// names are Codex's, so an unrelated tool of the same name on another agent
+// must not be reclassified as an MCP call.
+func TestIngest_ShadowMCPGuardIgnoresMetaToolNamesFromOtherAdapters(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	toolName := "read_mcp_resource"
+	callID := "call-1"
+	payload := canonicalIngestPayload("custom-adapter", "tool.requested", "non-codex-meta-tool")
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &callID,
+			Name:  &toolName,
+			Input: map[string]any{"server": "platform-logs"},
+		},
+	}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotEqual(t, "deny", result.Decision)
+}

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -137,16 +137,27 @@ func (s *Service) codexShadowMCPEvidence(ctx context.Context, payload *gen.Codex
 			// matched entry carries the full sanitized prefix.
 			evidence.ServerIdentity = matched.ToolPrefix
 		}
-		if matched.URL != "" {
-			evidence.FullURL = matched.URL
-		}
-		if matched.Command != "" {
-			// Pin stdio identity to the launch command, mirroring the Claude
-			// guard — a bypass grant must not follow a renamed config alias.
-			evidence.ServerIdentity = matched.Command
-		}
+		applyMCPEntryToEvidence(&evidence, matched)
 	}
 	return evidence, matched
+}
+
+// applyMCPEntryToEvidence upgrades evidence to the target a matched inventory
+// entry actually routes to. Shared by the legacy Codex endpoint and the
+// canonical ingest guard so the two cannot drift on what a resolved entry
+// means — the guard's allow/deny turns on exactly this mapping.
+func applyMCPEntryToEvidence(evidence *shadowmcp.AccessEvidence, matched *MCPServerEntry) {
+	if matched == nil {
+		return
+	}
+	if matched.URL != "" {
+		evidence.FullURL = matched.URL
+	}
+	if matched.Command != "" {
+		// Pin stdio identity to the launch command, mirroring the Claude
+		// guard — a bypass grant must not follow a renamed config alias.
+		evidence.ServerIdentity = matched.Command
+	}
 }
 
 func codexMCPMetaToolServer(payload *gen.CodexPayload) (string, bool) {

--- a/server/internal/hooks/shadow_mcp_access.go
+++ b/server/internal/hooks/shadow_mcp_access.go
@@ -153,12 +153,23 @@ func codexMCPMetaToolServer(payload *gen.CodexPayload) (string, bool) {
 	if payload == nil {
 		return "", false
 	}
-	switch conv.PtrValOr(payload.ToolName, "") {
+	return codexMetaToolServer(conv.PtrValOr(payload.ToolName, ""), payload.ToolInput)
+}
+
+// codexMetaToolServer reports whether a tool call is one of Codex's built-in
+// MCP resource tools and, if so, the server it targets. These are the only MCP
+// calls Codex makes that carry no mcp__ prefix — the target lives in
+// tool_input.server instead — so every gate that decides "is this an MCP call"
+// has to ask here as well as checking the tool name. An unreadable input still
+// reports true with an empty server: it is an MCP call whose target could not
+// be established, which callers must treat as unproven rather than absent.
+func codexMetaToolServer(toolName string, toolInput any) (string, bool) {
+	switch toolName {
 	case "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource":
 	default:
 		return "", false
 	}
-	input, ok := payload.ToolInput.(map[string]any)
+	input, ok := toolInput.(map[string]any)
 	if !ok {
 		return "", true
 	}


### PR DESCRIPTION
Closes DNO-767.

Codex reaches MCP servers through three built-in meta-tools — `list_mcp_resources`, `list_mcp_resource_templates`, `read_mcp_resource` — that carry no `mcp__` prefix and name their target in `tool_input.server`.

The unified ingest endpoint decides whether a call is an MCP call from resolved MCP data or an MCP-shaped tool name (`ingest_hooks.go`), and neither recognizes these:

- `toolref.IsMCPToolName` matches only `mcp__…` / `MCP:…`
- agenthooks' `resolveCodexMCP` matches on that same prefix, so `tc.MCP` stays nil and `canonicalMCPData` is nil

So they were classified as ordinary tool calls: the risk scan ran, the shadow-MCP policy never did. A `block_all` policy did not stop a Codex session from reading any MCP server's resources, while the legacy `/rpc/hooks.codex` endpoint denied the same call. agenthooks has no knowledge of these three names either, so nothing upstream compensated.

## What changed

- The ingest gate recognizes the meta-tools, scoped to the `codex` adapter so another agent's unrelated tool of the same name is not reclassified as an MCP call.
- `codexMetaToolServer(toolName, toolInput)` is now shared by the legacy and ingest paths, so there is one definition of what these tools are.
- Shadow-MCP evidence falls back to `tool_input.server` when nothing else yields an identity, so the deny names the server and a bypass grant can scope to it. A meta-tool whose server cannot be read still denies — an unproven target is not an absent one.
- The relay collects the Codex MCP inventory at session start, as it already does for Claude. This is what lets a deny say *why* a target is bad (external URL vs local stdio) instead of the generic "not Gram-hosted".

## Notes for review

The parser test fixture is verbatim `codex mcp list --json` output from the shipped 0.146 build, including the null-heavy transport fields and real `auth_status` values — not a hand-written approximation.

I verified the enforcement test fails without the fix: reverting the gate fails all 15 subtests.

**Deliberately not included.** DNO-767 also listed linking shadow-MCP blocks to their chat (`ChatID: uuid.Nil`). `tool_call_blocks.chat_id` carries an FK to `chats(id)`, and a shadow-MCP deny can land before the session's chat row is persisted — passing `chatIDForBlock` there violates the FK, which kills the whole async block insert and takes the block URL with it. It needs the chat row guaranteed first; left unlinked with the reasoning in a comment.

Two corrections to the original DNO-767 filing, both verified and recorded on the ticket: ingest is **fail-closed**, not fail-open, for any call that reaches the guard (`enforceShadowMCPToolAccess` ends at `return detail, true` under `block_all`); and porting the legacy provenance checks as filed would deny **every** codex MCP call, because nothing in the repo produces `mcp_inventory_codex` so `matched` is always nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the shadow‑MCP policy to Codex’s MCP meta‑tools on ingest; resolve `tool_input.server` via the session MCP inventory so Gram‑hosted targets pass and denials name the server. Enforcement is gated on client capability (DNO‑767).

- **Bug Fixes**
  - Ingest recognizes Codex meta‑tools (codex‑only) and routes them through shadow‑MCP; evidence falls back to `tool_input.server`, and unresolved names still deny under `block_all`.
  - Targets resolve against the session MCP inventory; stdio identity is pinned to the launch command; matched‑entry→evidence mapping is shared; tests cover meta‑tools, adapter scoping, inventory‑based resolution, and session‑CWD collection.

- **New Features**
  - Relay collects Codex MCP inventory at session start (best‑effort; disabled servers omitted; runs from the session CWD) and reports `AdapterVersion` as a capability marker; capable clients that send no inventory are denied by design (e.g., missing CLI, list failure, or cache miss).
  - Ingest caches the snapshot for the session, refreshes TTL on later events, and writes on duplicate deliveries; Codex entries include `ToolPrefix` for hyphenated servers.

<sup>Written for commit ce18e2ffbea44b3e16f5318073ffddf94bdac8cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

