### PR TITLE
feat(skills): surface prompt-injection verdict on skill versions

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -67749,6 +67749,16 @@ components:
           type: string
           description: The skill version ID.
           format: uuid
+        injection_flagged:
+          type: boolean
+          description: Whether the prompt-injection judge flagged this manifest. Absent until scanned.
+        injection_rationale:
+          type: string
+          description: The judge's reasoning when the manifest was flagged for prompt injection.
+        injection_scanned_at:
+          type: string
+          description: When the manifest was scanned for prompt injection. Absent until the background sweep classifies this version.
+          format: date-time
         last_seen_at:
           type: string
           description: When this exact version was most recently activated.

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -298,6 +298,9 @@ function SkillDetailSections({
             {latestVersion && !latestVersion.specValid && (
               <ValidationErrors errors={latestVersion.validationErrors} />
             )}
+            {latestVersion?.injectionFlagged && (
+              <InjectionWarning rationale={latestVersion.injectionRationale} />
+            )}
             <div className="overflow-x-auto">
               {latestVersion ? (
                 <ManifestBody body={body} />
@@ -632,6 +635,28 @@ function ValidationErrors({
   );
 }
 
+// Surfaces the prompt-injection judge's verdict on the current manifest. Renders
+// only when the background scan flagged the version, mirroring ValidationErrors
+// so a flagged manifest carries the same visual weight as an invalid one.
+function InjectionWarning({
+  rationale,
+}: {
+  rationale: SkillVersion["injectionRationale"];
+}): JSX.Element {
+  return (
+    <div className="border-destructive/40 bg-destructive/5 rounded-lg border p-4">
+      <Text variant="subheading" className="text-destructive mb-2">
+        Manifest flagged for prompt injection
+      </Text>
+      {rationale && (
+        <Text small className="text-destructive">
+          {rationale}
+        </Text>
+      )}
+    </div>
+  );
+}
+
 function versionColumns({
   currentVersionId,
   comparable,
@@ -688,9 +713,19 @@ function versionColumns({
       width: "2fr",
       render: (version) => (
         <div className="space-y-2">
-          <Badge variant={version.specValid ? "success" : "destructive"}>
-            {version.specValid ? "Valid" : "Invalid"}
-          </Badge>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={version.specValid ? "success" : "destructive"}>
+              {version.specValid ? "Valid" : "Invalid"}
+            </Badge>
+            {version.injectionFlagged && (
+              <Badge
+                variant="destructive"
+                title={version.injectionRationale ?? undefined}
+              >
+                Injection flagged
+              </Badge>
+            )}
+          </div>
           {!version.specValid && (
             <SkillValidationErrors errors={version.validationErrors} />
           )}

--- a/client/dashboard/src/sdk/src/models/components/skillversion.ts
+++ b/client/dashboard/src/sdk/src/models/components/skillversion.ts
@@ -53,6 +53,18 @@ export type SkillVersion = {
    */
   id: string;
   /**
+   * Whether the prompt-injection judge flagged this manifest. Absent until scanned.
+   */
+  injectionFlagged?: boolean | undefined;
+  /**
+   * The judge's reasoning when the manifest was flagged for prompt injection.
+   */
+  injectionRationale?: string | undefined;
+  /**
+   * When the manifest was scanned for prompt injection. Absent until the background sweep classifies this version.
+   */
+  injectionScannedAt?: Date | undefined;
+  /**
    * When this exact version was most recently activated.
    */
   lastSeenAt?: Date | undefined;
@@ -100,6 +112,11 @@ export const SkillVersion$inboundSchema: z.ZodMiniType<SkillVersion, unknown> =
       ),
       frontmatter: z.record(z.string(), z.any()),
       id: z.string(),
+      injection_flagged: z.optional(z.boolean()),
+      injection_rationale: z.optional(z.string()),
+      injection_scanned_at: z.optional(
+        z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
+      ),
       last_seen_at: z.optional(
         z.pipe(z.iso.datetime({ offset: true }), z.transform(v => new Date(v))),
       ),
@@ -117,6 +134,9 @@ export const SkillVersion$inboundSchema: z.ZodMiniType<SkillVersion, unknown> =
         "created_by_user_id": "createdByUserId",
         "derived_from_version_id": "derivedFromVersionId",
         "first_seen_at": "firstSeenAt",
+        "injection_flagged": "injectionFlagged",
+        "injection_rationale": "injectionRationale",
+        "injection_scanned_at": "injectionScannedAt",
         "last_seen_at": "lastSeenAt",
         "raw_sha256": "rawSha256",
         "seen_count": "seenCount",

--- a/server/design/skills/design.go
+++ b/server/design/skills/design.go
@@ -907,6 +907,9 @@ var SkillVersion = Type("SkillVersion", func() {
 	Attribute("first_seen_at", String, "When this exact version was first activated.", func() { Format(FormatDateTime) })
 	Attribute("last_seen_at", String, "When this exact version was most recently activated.", func() { Format(FormatDateTime) })
 	Attribute("seen_count", Int64, "The number of activations attributed to this exact version.")
+	Attribute("injection_scanned_at", String, "When the manifest was scanned for prompt injection. Absent until the background sweep classifies this version.", func() { Format(FormatDateTime) })
+	Attribute("injection_flagged", Boolean, "Whether the prompt-injection judge flagged this manifest. Absent until scanned.")
+	Attribute("injection_rationale", String, "The judge's reasoning when the manifest was flagged for prompt injection.")
 
 	Required("id", "skill_id", "content", "canonical_sha256", "raw_sha256", "metadata", "frontmatter", "spec_valid", "validation_errors", "created_at", "created_by_user_id", "seen_count")
 })

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -68014,6 +68014,16 @@ components:
                     type: string
                     description: The skill version ID.
                     format: uuid
+                injection_flagged:
+                    type: boolean
+                    description: Whether the prompt-injection judge flagged this manifest. Absent until scanned.
+                injection_rationale:
+                    type: string
+                    description: The judge's reasoning when the manifest was flagged for prompt injection.
+                injection_scanned_at:
+                    type: string
+                    description: When the manifest was scanned for prompt injection. Absent until the background sweep classifies this version.
+                    format: date-time
                 last_seen_at:
                     type: string
                     description: When this exact version was most recently activated.

--- a/server/gen/http/skills/client/encode_decode.go
+++ b/server/gen/http/skills/client/encode_decode.go
@@ -5373,6 +5373,9 @@ func unmarshalSkillVersionResponseBodyToTypesSkillVersion(v *SkillVersionRespons
 		FirstSeenAt:          v.FirstSeenAt,
 		LastSeenAt:           v.LastSeenAt,
 		SeenCount:            *v.SeenCount,
+		InjectionScannedAt:   v.InjectionScannedAt,
+		InjectionFlagged:     v.InjectionFlagged,
+		InjectionRationale:   v.InjectionRationale,
 	}
 	res.Metadata = make(map[string]any, len(v.Metadata))
 	for key, val := range v.Metadata {

--- a/server/gen/http/skills/client/types.go
+++ b/server/gen/http/skills/client/types.go
@@ -4499,6 +4499,14 @@ type SkillVersionResponseBody struct {
 	LastSeenAt *string `form:"last_seen_at,omitempty" json:"last_seen_at,omitempty" xml:"last_seen_at,omitempty"`
 	// The number of activations attributed to this exact version.
 	SeenCount *int64 `form:"seen_count,omitempty" json:"seen_count,omitempty" xml:"seen_count,omitempty"`
+	// When the manifest was scanned for prompt injection. Absent until the
+	// background sweep classifies this version.
+	InjectionScannedAt *string `form:"injection_scanned_at,omitempty" json:"injection_scanned_at,omitempty" xml:"injection_scanned_at,omitempty"`
+	// Whether the prompt-injection judge flagged this manifest. Absent until
+	// scanned.
+	InjectionFlagged *bool `form:"injection_flagged,omitempty" json:"injection_flagged,omitempty" xml:"injection_flagged,omitempty"`
+	// The judge's reasoning when the manifest was flagged for prompt injection.
+	InjectionRationale *string `form:"injection_rationale,omitempty" json:"injection_rationale,omitempty" xml:"injection_rationale,omitempty"`
 }
 
 // SkillValidationErrorResponseBody is used to define fields on response body
@@ -14448,6 +14456,9 @@ func ValidateSkillVersionResponseBody(body *SkillVersionResponseBody) (err error
 	}
 	if body.LastSeenAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.last_seen_at", *body.LastSeenAt, goa.FormatDateTime))
+	}
+	if body.InjectionScannedAt != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.injection_scanned_at", *body.InjectionScannedAt, goa.FormatDateTime))
 	}
 	return
 }

--- a/server/gen/http/skills/server/encode_decode.go
+++ b/server/gen/http/skills/server/encode_decode.go
@@ -5358,6 +5358,9 @@ func marshalTypesSkillVersionToSkillVersionResponseBody(v *types.SkillVersion) *
 		FirstSeenAt:          v.FirstSeenAt,
 		LastSeenAt:           v.LastSeenAt,
 		SeenCount:            v.SeenCount,
+		InjectionScannedAt:   v.InjectionScannedAt,
+		InjectionFlagged:     v.InjectionFlagged,
+		InjectionRationale:   v.InjectionRationale,
 	}
 	if v.Metadata != nil {
 		res.Metadata = make(map[string]any, len(v.Metadata))

--- a/server/gen/http/skills/server/types.go
+++ b/server/gen/http/skills/server/types.go
@@ -4501,6 +4501,14 @@ type SkillVersionResponseBody struct {
 	LastSeenAt *string `form:"last_seen_at,omitempty" json:"last_seen_at,omitempty" xml:"last_seen_at,omitempty"`
 	// The number of activations attributed to this exact version.
 	SeenCount int64 `form:"seen_count" json:"seen_count" xml:"seen_count"`
+	// When the manifest was scanned for prompt injection. Absent until the
+	// background sweep classifies this version.
+	InjectionScannedAt *string `form:"injection_scanned_at,omitempty" json:"injection_scanned_at,omitempty" xml:"injection_scanned_at,omitempty"`
+	// Whether the prompt-injection judge flagged this manifest. Absent until
+	// scanned.
+	InjectionFlagged *bool `form:"injection_flagged,omitempty" json:"injection_flagged,omitempty" xml:"injection_flagged,omitempty"`
+	// The judge's reasoning when the manifest was flagged for prompt injection.
+	InjectionRationale *string `form:"injection_rationale,omitempty" json:"injection_rationale,omitempty" xml:"injection_rationale,omitempty"`
 }
 
 // SkillValidationErrorResponseBody is used to define fields on response body

--- a/server/gen/types/skill_version.go
+++ b/server/gen/types/skill_version.go
@@ -41,4 +41,12 @@ type SkillVersion struct {
 	LastSeenAt *string
 	// The number of activations attributed to this exact version.
 	SeenCount int64
+	// When the manifest was scanned for prompt injection. Absent until the
+	// background sweep classifies this version.
+	InjectionScannedAt *string
+	// Whether the prompt-injection judge flagged this manifest. Absent until
+	// scanned.
+	InjectionFlagged *bool
+	// The judge's reasoning when the manifest was flagged for prompt injection.
+	InjectionRationale *string
 }

--- a/server/internal/mv/skill.go
+++ b/server/internal/mv/skill.go
@@ -115,6 +115,9 @@ func BuildSkillVersionView(version repo.SkillVersion, derivedFromVersionID uuid.
 		FirstSeenAt:          conv.PtrEmpty(conv.FromPGTimestamptz(sightings.FirstSeenAt)),
 		LastSeenAt:           conv.PtrEmpty(conv.FromPGTimestamptz(sightings.LastSeenAt)),
 		SeenCount:            sightings.SeenCount,
+		InjectionScannedAt:   conv.PtrEmpty(conv.FromPGTimestamptz(version.InjectionScannedAt)),
+		InjectionFlagged:     conv.FromPGBool[bool](version.InjectionFlagged),
+		InjectionRationale:   conv.FromPGText[string](version.InjectionRationale),
 	}, nil
 }
 


### PR DESCRIPTION
## What

Surfaces the manifest prompt-injection verdict (already computed by the background sweep in the parent PRs) through the skills API and dashboard.

- **Design**: adds `injection_scanned_at` / `injection_flagged` / `injection_rationale` (all optional) to the `SkillVersion` type; regenerated Goa types, OpenAPI, and the TS SDK.
- **Model view** (`mv/skill.go`): maps the three `repo.SkillVersion` columns via existing `conv` helpers.
- **Frontend** (`SkillDetail.tsx`): a flagged banner on the current manifest (mirrors the `ValidationErrors` banner) plus an "Injection flagged" badge with the rationale as tooltip in the version table.

Mirrors the existing spec-validation UX end to end. No new scanning logic — this is the surfacing layer the scanner's `WarnContext` was standing in for.

## Stack

Tip of the skills-injection stack; targets `skills-injection-pipeline`.

https://claude.ai/code/session_01Cc1f92Se8Cp64627fnHuxk