### PR TITLE
chore: add cross-table safety test for the demo seed

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1463,6 +1463,49 @@ jobs:
       - name: Test
         run: mise run test:server --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
+  # Standalone gate for the demo seed: TestDemoSeedSafety proves the seed
+  # cannot touch other tenants' data, cleans up stray demo-org rows, and stays
+  # idempotent across runs. The test is build-tagged (demoseed_safety) so the
+  # sharded server-test job skips it; this job is its only runner and reports
+  # as its own required check so a failure is immediately attributable.
+  demo-seed-safety:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    needs: changes
+    if: needs.changes.outputs.server == 'true'
+    env:
+      GOMAXPROCS: 8
+      TESTCONTAINERS_RYUK_DISABLED: true
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install: true
+          cache: true
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: Cache Go
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ env.GH_CACHE_GO_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_GO_KEY }}
+            ${{ env.GH_CACHE_GO_KEY_PARTIAL }}
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+
+      - name: Install Go deps
+        run: mise run install:go
+
+      - name: Test
+        run: mise run test:server -count=1 -tags=demoseed_safety ./internal/demoseed/...
+
   docker-build-client:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
@@ -2117,6 +2160,7 @@ jobs:
       - format-check
       - server-build-lint
       - server-test
+      - demo-seed-safety
       - docker-build-server
       - docker-build-client
       - upload-dashboard-assets

--- a/server/.golangci.yaml
+++ b/server/.golangci.yaml
@@ -8,6 +8,10 @@ issues:
 
 run:
   relative-path-mode: wd
+  # The demo seed safety test is build-tagged out of the sharded test suite
+  # (it has its own CI job); the tag here keeps its files linted.
+  build-tags:
+    - demoseed_safety
 
 linters:
   enable:

--- a/server/internal/demoseed/clickhouse.sql
+++ b/server/internal/demoseed/clickhouse.sql
@@ -49,23 +49,23 @@ SET mutations_sync = 1;
 
 -- Scoped deletes: telemetry source + every MV target + the org-keyed tables.
 ALTER TABLE telemetry_logs DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE trace_summaries DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE metrics_summaries DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE attribute_metrics_summaries DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE chat_token_summaries DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE chat_session_summaries DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE spend_rule_usage_summaries DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE attribute_keys DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE shadow_mcp_inventory_urls DELETE WHERE gram_project_id IN
-  (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'));
+  (toUUID('dec0de00-0000-4000-a000-000000000001'));
 ALTER TABLE authz_challenges DELETE WHERE organization_id = 'org_gram_demo_workspace';
 ALTER TABLE risk_findings DELETE WHERE organization_id = 'org_gram_demo_workspace';
 ALTER TABLE skill_session_versions DELETE WHERE organization_id = 'org_gram_demo_workspace';
@@ -791,19 +791,19 @@ FROM (
 -- exit for the runner) when violated.
 SELECT throwIf(
   (SELECT count() FROM telemetry_logs WHERE gram_project_id IN
-     (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'))
+     (toUUID('dec0de00-0000-4000-a000-000000000001'))
    ) < 400,
   'demo seed postflight: expected >= 400 demo telemetry rows');
 
 SELECT throwIf(
   (SELECT uniqExact(chat_id) FROM chat_session_summaries WHERE gram_project_id IN
-     (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'))
+     (toUUID('dec0de00-0000-4000-a000-000000000001'))
    ) < 60,
   'demo seed postflight: chat_session_summaries_mv missing sessions');
 
 SELECT throwIf(
   (SELECT count() FROM attribute_metrics_summaries WHERE gram_project_id IN
-     (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'))
+     (toUUID('dec0de00-0000-4000-a000-000000000001'))
      AND department_name != ''
    ) = 0,
   'demo seed postflight: attribute_metrics_summaries has no identity dimensions');
@@ -828,7 +828,7 @@ SELECT throwIf(
   (SELECT count() FROM telemetry_logs
    WHERE toString(resource_attributes.gram.deployment.id) = 'demo-seed'
      AND gram_project_id NOT IN
-       (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'))
+       (toUUID('dec0de00-0000-4000-a000-000000000001'))
    ) > 0,
   'demo seed postflight: demo-seed rows leaked outside demo projects');
 
@@ -838,7 +838,7 @@ SELECT throwIf(
 SELECT throwIf(
   (SELECT count() FROM telemetry_logs
    WHERE gram_project_id IN
-       (toUUID('dec0de00-0000-4000-a000-000000000001'), toUUID('dec0de00-0000-4000-a000-000000000002'))
+       (toUUID('dec0de00-0000-4000-a000-000000000001'))
      AND toString(resource_attributes.gram.deployment.id) != 'demo-seed'
    ) > 0,
   'demo seed postflight: demo-project telemetry rows missing the demo-seed marker');

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -1,0 +1,268 @@
+// Package demoseedtest holds the generic database snapshot/exec helpers behind
+// TestDemoSeedSafety. They live outside the _test.go files because the safety
+// test is deliberately schema-agnostic — it snapshots EVERY table via
+// information_schema/system.tables with dynamically built SQL, which cannot be
+// expressed through SQLc queries (and the glint no-testing-raw-sql rule bans
+// raw SQL in _test.go files for exactly the fixture-writing cases that SQLc
+// does cover).
+package demoseedtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ExecPostgresScript applies a multi-statement SQL script using the simple
+// query protocol, mirroring how demoseed.Run applies the real seed.
+func ExecPostgresScript(ctx context.Context, db *pgxpool.Pool, script string) error {
+	conn, err := db.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire postgres connection: %w", err)
+	}
+	defer conn.Release()
+
+	if err := conn.Conn().PgConn().Exec(ctx, script).Close(); err != nil {
+		return fmt.Errorf("exec postgres script: %w", err)
+	}
+	return nil
+}
+
+// ExecClickHouseStatements runs pre-split statements one by one, skipping SET
+// lines, mirroring how demoseed.Run applies the ClickHouse seed.
+func ExecClickHouseStatements(ctx context.Context, ch driver.Conn, stmts []string) error {
+	for _, stmt := range stmts {
+		if strings.HasPrefix(strings.ToUpper(stmt), "SET ") {
+			continue
+		}
+		if err := ch.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("exec clickhouse statement: %w: %.120s", err, stmt)
+		}
+	}
+	return nil
+}
+
+// PostgresSnapshot is a per-table multiset of full row fingerprints:
+// table name -> row JSON -> occurrence count. Full row text (not a digest) is
+// kept so tests can inspect rows that appear between snapshots.
+type PostgresSnapshot map[string]map[string]int
+
+// SnapshotPostgres fingerprints every row of every public base table. Row
+// identity is the record's JSON representation, so ANY column change, delete,
+// or insert is visible in the multiset.
+func SnapshotPostgres(ctx context.Context, db *pgxpool.Pool) (PostgresSnapshot, error) {
+	rows, err := db.Query(ctx, `
+		SELECT table_name FROM information_schema.tables
+		WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+		ORDER BY table_name`)
+	if err != nil {
+		return nil, fmt.Errorf("list postgres tables: %w", err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan postgres table name: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate postgres tables: %w", err)
+	}
+
+	snap := make(PostgresSnapshot, len(tables))
+	for _, table := range tables {
+		hashes := map[string]int{}
+		q := fmt.Sprintf(`SELECT to_jsonb(t)::text FROM %s t`, pgx.Identifier{"public", table}.Sanitize())
+		rows, err := db.Query(ctx, q)
+		if err != nil {
+			return nil, fmt.Errorf("hash rows of %s: %w", table, err)
+		}
+		for rows.Next() {
+			var h string
+			if err := rows.Scan(&h); err != nil {
+				return nil, fmt.Errorf("scan row hash of %s: %w", table, err)
+			}
+			hashes[h]++
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterate row hashes of %s: %w", table, err)
+		}
+		snap[table] = hashes
+	}
+	return snap, nil
+}
+
+// ClickHouseTableState captures one table's demo/non-demo split. Rows are
+// classified by the table's organization_id / gram_project_id columns; tables
+// with neither column treat every row as outside the demo scope.
+type ClickHouseTableState struct {
+	Engine string
+	// OutsideCount/OutsideHash cover rows NOT belonging to the demo org or
+	// demo projects. The hash is an order-independent sum of per-row
+	// cityHash64 over all stringifiable columns.
+	OutsideCount uint64
+	OutsideHash  uint64
+	// DemoCount covers rows in the demo scope.
+	DemoCount uint64
+}
+
+// SnapshotClickHouse captures the state of every MergeTree-family table in the
+// current database. Each table is OPTIMIZE ... FINAL'd first so background
+// merges (which collapse rows in Summing/Aggregating tables) cannot shift
+// counts between two snapshots.
+func SnapshotClickHouse(ctx context.Context, ch driver.Conn, orgID string, projectIDs []string) (map[string]ClickHouseTableState, error) {
+	rows, err := ch.Query(ctx, `
+		SELECT name, engine FROM system.tables
+		WHERE database = currentDatabase() AND engine LIKE '%MergeTree%'
+		ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("list clickhouse tables: %w", err)
+	}
+	type tbl struct{ name, engine string }
+	var tables []tbl
+	for rows.Next() {
+		var t tbl
+		if err := rows.Scan(&t.name, &t.engine); err != nil {
+			return nil, fmt.Errorf("scan clickhouse table: %w", err)
+		}
+		tables = append(tables, t)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close clickhouse tables cursor: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate clickhouse tables: %w", err)
+	}
+
+	quotedProjects := make([]string, len(projectIDs))
+	for i, p := range projectIDs {
+		quotedProjects[i] = fmt.Sprintf("toUUID('%s')", p)
+	}
+	projectList := strings.Join(quotedProjects, ", ")
+
+	snap := make(map[string]ClickHouseTableState, len(tables))
+	for _, t := range tables {
+		if err := ch.Exec(ctx, fmt.Sprintf("OPTIMIZE TABLE `%s` FINAL", t.name)); err != nil {
+			return nil, fmt.Errorf("optimize %s: %w", t.name, err)
+		}
+
+		cols, err := ch.Query(ctx, `
+			SELECT name, type, default_kind FROM system.columns
+			WHERE database = currentDatabase() AND table = $1
+			ORDER BY position`, t.name)
+		if err != nil {
+			return nil, fmt.Errorf("list columns of %s: %w", t.name, err)
+		}
+		var hashParts []string
+		var demoPreds []string
+		for cols.Next() {
+			var name, typ, defaultKind string
+			if err := cols.Scan(&name, &typ, &defaultKind); err != nil {
+				return nil, fmt.Errorf("scan column of %s: %w", t.name, err)
+			}
+			// Skipped from the hash:
+			//   - AggregateFunction states (no stable string form);
+			//   - array-valued SimpleAggregateFunction columns
+			//     (groupUniqArrayArray & co. — element order is not
+			//     deterministic across part merges);
+			//   - MATERIALIZED/ALIAS columns (derived, not part of SELECT *).
+			// Rows stay covered by their stored scalar columns and the count.
+			hashable := !strings.HasPrefix(typ, "AggregateFunction") &&
+				(!strings.HasPrefix(typ, "SimpleAggregateFunction") || !strings.Contains(typ, "Array")) &&
+				(defaultKind == "" || defaultKind == "DEFAULT")
+			if hashable {
+				hashParts = append(hashParts, fmt.Sprintf("ifNull(toString(`%s`), '<null>')", name))
+			}
+			switch name {
+			case "organization_id":
+				demoPreds = append(demoPreds, fmt.Sprintf("organization_id = '%s'", orgID))
+			case "gram_project_id":
+				demoPreds = append(demoPreds, fmt.Sprintf("gram_project_id IN (%s)", projectList))
+			}
+		}
+		if err := cols.Close(); err != nil {
+			return nil, fmt.Errorf("close columns cursor of %s: %w", t.name, err)
+		}
+		if err := cols.Err(); err != nil {
+			return nil, fmt.Errorf("iterate columns of %s: %w", t.name, err)
+		}
+
+		demoPred := "0" // no scoping column: nothing in this table is demo data
+		if len(demoPreds) > 0 {
+			demoPred = strings.Join(demoPreds, " OR ")
+		}
+
+		q := fmt.Sprintf(`
+			SELECT
+				countIf(NOT inDemo),
+				sumIf(cityHash64(%s), NOT inDemo),
+				countIf(inDemo)
+			FROM (SELECT *, (%s) AS inDemo FROM `+"`%s`"+`)`,
+			strings.Join(hashParts, ", "), demoPred, t.name)
+
+		var state ClickHouseTableState
+		state.Engine = t.engine
+		if err := ch.QueryRow(ctx, q).Scan(&state.OutsideCount, &state.OutsideHash, &state.DemoCount); err != nil {
+			return nil, fmt.Errorf("snapshot %s: %w", t.name, err)
+		}
+		snap[t.name] = state
+	}
+	return snap, nil
+}
+
+// TamperDemoRows plants stray rows inside the demo scope — a duplicated chat
+// in Postgres and a duplicated telemetry row in ClickHouse — so a subsequent
+// seed run can be shown to clean up unexpected demo-org data, not merely
+// re-assert its own rows.
+func TamperDemoRows(ctx context.Context, db *pgxpool.Pool, ch driver.Conn, orgID string, projectID string) error {
+	// Generated columns (e.g. chats.deleted) cannot be written, so the
+	// duplicated row is built column by column from the non-generated set.
+	colRows, err := db.Query(ctx, `
+		SELECT column_name FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = 'chats' AND is_generated = 'NEVER'
+		ORDER BY ordinal_position`)
+	if err != nil {
+		return fmt.Errorf("list chats columns: %w", err)
+	}
+	var cols []string
+	for colRows.Next() {
+		var name string
+		if err := colRows.Scan(&name); err != nil {
+			return fmt.Errorf("scan chats column: %w", err)
+		}
+		cols = append(cols, pgx.Identifier{name}.Sanitize())
+	}
+	colRows.Close()
+	if err := colRows.Err(); err != nil {
+		return fmt.Errorf("iterate chats columns: %w", err)
+	}
+	colList := strings.Join(cols, ", ")
+
+	tag, err := db.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO chats (%s)
+		SELECT %s FROM jsonb_populate_record(
+			NULL::chats,
+			(SELECT to_jsonb(c) || jsonb_build_object('id', gen_random_uuid())
+			 FROM chats c WHERE organization_id = $1 LIMIT 1))`, colList, colList), orgID)
+	if err != nil {
+		return fmt.Errorf("tamper postgres chat: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("tamper postgres chat: expected 1 row inserted, got %d", tag.RowsAffected())
+	}
+
+	err = ch.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO telemetry_logs
+		SELECT * FROM telemetry_logs WHERE gram_project_id = toUUID('%s') LIMIT 1`, projectID))
+	if err != nil {
+		return fmt.Errorf("tamper clickhouse telemetry row: %w", err)
+	}
+	return nil
+}

--- a/server/internal/demoseed/demoseedtest/demoseedtest.go
+++ b/server/internal/demoseed/demoseedtest/demoseedtest.go
@@ -198,6 +198,11 @@ func SnapshotClickHouse(ctx context.Context, ch driver.Conn, orgID string, proje
 		if len(demoPreds) > 0 {
 			demoPred = strings.Join(demoPreds, " OR ")
 		}
+		// cityHash64 needs at least one argument; a table whose every column
+		// is excluded above still gets counted, just with a constant hash.
+		if len(hashParts) == 0 {
+			hashParts = []string{"''"}
+		}
 
 		q := fmt.Sprintf(`
 			SELECT

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -14,7 +14,7 @@
 -- Constants (must match seed/demo/clickhouse.sql):
 --   org id       org_gram_demo_workspace
 --   project id   dec0de00-0000-4000-a000-000000000001 ('Default' — the only
---                project; ...0002 survives only as a legacy delete scope)
+--                project)
 --   chat ids     demo.det_uuid('gram-demo-chat-' || n) — md5 with RFC nibbles
 --   message ids  demo.det_uuid('gram-demo-msg-' || n || '-' || m)
 --   users        user_demo_* / *@demo.getgram.ai (parallel arrays below; the
@@ -38,7 +38,6 @@ AS $$
 DECLARE
   demo_org  CONSTANT text := 'org_gram_demo_workspace';
   proj_a    CONSTANT uuid := 'dec0de00-0000-4000-a000-000000000001';
-  proj_b    CONSTANT uuid := 'dec0de00-0000-4000-a000-000000000002';
   policy_a  CONSTANT uuid := 'dec0de00-0000-4000-a000-00000000f001';
 
   asset_id     CONSTANT uuid := 'dec0de00-0000-4000-a000-00000000a001';
@@ -184,7 +183,7 @@ BEGIN
 
   IF EXISTS (
     SELECT 1 FROM projects
-    WHERE id IN (proj_a, proj_b) AND organization_id <> demo_org
+    WHERE id = proj_a AND organization_id <> demo_org
   ) THEN
     RAISE EXCEPTION 'demo seed aborted: demo project id owned by another org';
   END IF;
@@ -209,14 +208,13 @@ BEGIN
   DELETE FROM toolsets WHERE organization_id = demo_org;
   DELETE FROM deployment_statuses WHERE deployment_id IN
     (SELECT id FROM deployments WHERE organization_id = demo_org);
-  DELETE FROM deployment_logs WHERE project_id IN (proj_a, proj_b);
+  DELETE FROM deployment_logs WHERE project_id = proj_a;
   DELETE FROM deployments WHERE organization_id = demo_org;
-  DELETE FROM assets WHERE project_id IN (proj_a, proj_b);
+  DELETE FROM assets WHERE project_id = proj_a;
   DELETE FROM projects WHERE organization_id = demo_org;
 
   -- Single project: the demo org intentionally has exactly one project so
-  -- new users land somewhere obvious. proj_b remains declared ONLY as a
-  -- legacy-cleanup delete scope from when the seed created two projects.
+  -- new users land somewhere obvious.
   INSERT INTO projects (id, name, slug, organization_id) VALUES
     (proj_a, 'Default', 'default', demo_org);
 
@@ -812,7 +810,7 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
   END IF;
 
   SELECT count(*) INTO stray
-  FROM chats WHERE project_id IN (proj_a, proj_b) AND organization_id <> demo_org;
+  FROM chats WHERE project_id = proj_a AND organization_id <> demo_org;
   IF stray > 0 THEN
     RAISE EXCEPTION 'demo seed postflight: % chats on demo projects belong to another org', stray;
   END IF;

--- a/server/internal/demoseed/safety_test.go
+++ b/server/internal/demoseed/safety_test.go
@@ -45,11 +45,6 @@ func asOtherTenant(t *testing.T, script string) string {
 	return script
 }
 
-// legacyDemoProjectID is the retired second demo project (…0002) that survives
-// in the seed only as a delete scope; it is part of the demo isolation
-// boundary in ClickHouse.
-const legacyDemoProjectID = "dec0de00-0000-4000-a000-000000000002"
-
 // TestDemoSeedSafety is the generic cross-table guard for the demo seed. With
 // a second tenant provisioned from a transformed copy of the seed itself, it
 // verifies that running the real seed:
@@ -91,7 +86,7 @@ func TestDemoSeedSafety(t *testing.T) {
 	require.NoError(t, demoseedtest.ExecPostgresScript(ctx, db, asOtherTenant(t, postgresSQL)))
 	require.NoError(t, demoseedtest.ExecClickHouseStatements(ctx, ch, splitStatements(asOtherTenant(t, clickhouseSQL))))
 
-	demoProjects := []string{demoProjectID, legacyDemoProjectID}
+	demoProjects := []string{demoProjectID}
 
 	pgBefore, err := demoseedtest.SnapshotPostgres(ctx, db)
 	require.NoError(t, err)
@@ -153,11 +148,19 @@ func TestDemoSeedSafety(t *testing.T) {
 	// asserted (above), not exact demo-scope counts.
 	for table, s1 := range chAfter1 {
 		s2 := chAfter2[table]
-		if s1.Engine == "MergeTree" {
+		if isPlainMergeTree(s1.Engine) {
 			require.Equal(t, s1.DemoCount, s2.DemoCount,
 				"clickhouse table %s: demo row count changed between seed runs — reseed is not cleaning up or not idempotent", table)
 		}
 	}
+}
+
+// isPlainMergeTree reports whether the engine stores rows verbatim (including
+// the Replicated variant), as opposed to the Summing/Aggregating/Replacing/
+// Collapsing family members that merge same-key rows and so cannot promise
+// stable row counts.
+func isPlainMergeTree(engine string) bool {
+	return engine == "MergeTree" || engine == "ReplicatedMergeTree"
 }
 
 func requirePostgresRowsPreserved(t *testing.T, before, after demoseedtest.PostgresSnapshot) {

--- a/server/internal/demoseed/safety_test.go
+++ b/server/internal/demoseed/safety_test.go
@@ -1,0 +1,241 @@
+package demoseed
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/assets/assetstest"
+	"github.com/speakeasy-api/gram/server/internal/constants"
+	"github.com/speakeasy-api/gram/server/internal/demoseed/demoseedtest"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// otherTenantReplacements rewrites every demo identifier in the embedded seed
+// scripts so the same SQL provisions a second, unrelated tenant. Running the
+// seed "against itself" plants adversarial fixture data in exactly the tables
+// the seed touches — including tables added in the future — so any unscoped
+// DELETE/UPDATE someone introduces will, by construction, hit fixture rows.
+//
+// Ordering matters: the backslash-escaped LIKE pattern must be rewritten
+// before the plain user id prefix, or the postflight patterns stop matching
+// the rewritten ids.
+var otherTenantReplacements = [][2]string{
+	{`user\_demo\_`, `user\_othr\_`},                       // postflight LIKE patterns
+	{"user_demo_", "user_othr_"},                           // user ids (feed workos_/directory ids too)
+	{"org_gram_demo_workspace", "org_gram_othr_workspace"}, // org id
+	{"dec0de00", "0ddba110"},                               // uuid prefix + embedded sha literal
+	{"gram-demo-", "gram-othr-"},                           // det_uuid / trace id name seeds
+	{"@demo.getgram.ai", "@othr.getgram.ai"},               // users.email is globally unique
+	{"acme-demo", "acme-othr"},                             // org slug + mcp_slug are globally unique
+	{"demo_grp_", "othr_grp_"},                             // workos_directory_group_id is globally unique
+	{"demo-seed", "othr-seed"},                             // telemetry marker the real postflight leak-checks
+}
+
+func asOtherTenant(t *testing.T, script string) string {
+	t.Helper()
+
+	for _, r := range otherTenantReplacements {
+		script = strings.ReplaceAll(script, r[0], r[1])
+	}
+	return script
+}
+
+// legacyDemoProjectID is the retired second demo project (…0002) that survives
+// in the seed only as a delete scope; it is part of the demo isolation
+// boundary in ClickHouse.
+const legacyDemoProjectID = "dec0de00-0000-4000-a000-000000000002"
+
+// TestDemoSeedSafety is the generic cross-table guard for the demo seed. With
+// a second tenant provisioned from a transformed copy of the seed itself, it
+// verifies that running the real seed:
+//
+//  1. never modifies or deletes a single pre-existing row outside the demo
+//     scope (full-database row fingerprints in Postgres, per-table
+//     count+hash of non-demo rows in ClickHouse);
+//  2. cleans up stray demo-scope data left behind between runs (tampered
+//     rows are planted after the first run);
+//  3. is idempotent — per-table row counts are identical after every run.
+func TestDemoSeedSafety(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+
+	db, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	ch, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	blob := assetstest.NewTestBlobStore(t)
+
+	// The critical identifiers must appear in the embedded scripts; if a
+	// rename breaks a replacement the fixture silently stops being
+	// adversarial, so fail loudly instead.
+	for _, needle := range []string{"org_gram_demo_workspace", "dec0de00", "user_demo_"} {
+		require.Contains(t, postgresSQL, needle, "postgres.sql lost literal %q; update otherTenantReplacements", needle)
+	}
+	for _, needle := range []string{"org_gram_demo_workspace", "dec0de00", "demo-seed"} {
+		require.Contains(t, clickhouseSQL, needle, "clickhouse.sql lost literal %q; update otherTenantReplacements", needle)
+	}
+
+	// Baseline BEFORE the fixture: everything the fixture adds on top of it is
+	// "another tenant's data", and its ids feed the leak check below.
+	pgBaseline, err := demoseedtest.SnapshotPostgres(ctx, db)
+	require.NoError(t, err)
+
+	// Provision the other tenant from the transformed seed scripts.
+	require.NoError(t, demoseedtest.ExecPostgresScript(ctx, db, asOtherTenant(t, postgresSQL)))
+	require.NoError(t, demoseedtest.ExecClickHouseStatements(ctx, ch, splitStatements(asOtherTenant(t, clickhouseSQL))))
+
+	demoProjects := []string{demoProjectID, legacyDemoProjectID}
+
+	pgBefore, err := demoseedtest.SnapshotPostgres(ctx, db)
+	require.NoError(t, err)
+	fixtureUUIDs := collectUUIDs(addedRows(pgBaseline, pgBefore))
+	chBefore, err := demoseedtest.SnapshotClickHouse(ctx, ch, constants.DemoOrganizationID, demoProjects)
+	require.NoError(t, err)
+
+	// Nothing is in the demo scope yet: the fixture must be fully outside it,
+	// otherwise the isolation assertions below would be vacuous.
+	fixtureOutside := false
+	for table, state := range chBefore {
+		require.Zero(t, state.DemoCount, "clickhouse table %s: fixture rows landed inside the demo scope", table)
+		fixtureOutside = fixtureOutside || state.OutsideCount > 0
+	}
+	require.True(t, fixtureOutside, "fixture produced no clickhouse rows; the isolation check would be vacuous")
+
+	// First real seed run.
+	require.NoError(t, Run(ctx, logger, db, ch, blob))
+
+	pgAfter1, err := demoseedtest.SnapshotPostgres(ctx, db)
+	require.NoError(t, err)
+	chAfter1, err := demoseedtest.SnapshotClickHouse(ctx, ch, constants.DemoOrganizationID, demoProjects)
+	require.NoError(t, err)
+
+	requirePostgresRowsPreserved(t, pgBefore, pgAfter1)
+	requireNoLeakIntoOtherTenants(t, addedRows(pgBefore, pgAfter1), fixtureUUIDs)
+	requireClickHouseOutsideUnchanged(t, chBefore, chAfter1)
+
+	// Plant stray demo-scope rows: the next run must clean them up, restoring
+	// the exact per-table counts of the first run.
+	require.NoError(t, demoseedtest.TamperDemoRows(ctx, db, ch, constants.DemoOrganizationID, demoProjectID))
+
+	// Second real seed run.
+	require.NoError(t, Run(ctx, logger, db, ch, blob))
+
+	pgAfter2, err := demoseedtest.SnapshotPostgres(ctx, db)
+	require.NoError(t, err)
+	chAfter2, err := demoseedtest.SnapshotClickHouse(ctx, ch, constants.DemoOrganizationID, demoProjects)
+	require.NoError(t, err)
+
+	requirePostgresRowsPreserved(t, pgBefore, pgAfter2)
+	requireNoLeakIntoOtherTenants(t, addedRows(pgBefore, pgAfter2), fixtureUUIDs)
+	requireClickHouseOutsideUnchanged(t, chBefore, chAfter2)
+
+	// Idempotence + cleanup: every Postgres table holds exactly as many rows
+	// as after the first run (the tampered chat included would be +1).
+	for table, hashes := range pgAfter1 {
+		require.Equal(t, totalRows(hashes), totalRows(pgAfter2[table]),
+			"postgres table %s: row count changed between seed runs — reseed is not cleaning up or not idempotent", table)
+	}
+	for table := range pgAfter2 {
+		_, ok := pgAfter1[table]
+		require.True(t, ok, "postgres table %s appeared between seed runs", table)
+	}
+
+	// ClickHouse: the seed writes deterministic row counts into plain
+	// MergeTree tables. Summing/Aggregating MV targets collapse rows by
+	// time-bucketed keys that shift with now(), so only their isolation is
+	// asserted (above), not exact demo-scope counts.
+	for table, s1 := range chAfter1 {
+		s2 := chAfter2[table]
+		if s1.Engine == "MergeTree" {
+			require.Equal(t, s1.DemoCount, s2.DemoCount,
+				"clickhouse table %s: demo row count changed between seed runs — reseed is not cleaning up or not idempotent", table)
+		}
+	}
+}
+
+func requirePostgresRowsPreserved(t *testing.T, before, after demoseedtest.PostgresSnapshot) {
+	t.Helper()
+
+	for table, hashes := range before {
+		for hash, n := range hashes {
+			require.GreaterOrEqual(t, after[table][hash], n,
+				"postgres table %s: a pre-existing row of another tenant was modified or deleted by the demo seed", table)
+		}
+	}
+}
+
+func requireClickHouseOutsideUnchanged(t *testing.T, before, after map[string]demoseedtest.ClickHouseTableState) {
+	t.Helper()
+
+	for table, b := range before {
+		a := after[table]
+		require.Equal(t, b.OutsideCount, a.OutsideCount,
+			"clickhouse table %s: non-demo row count changed — the demo seed touched another tenant's rows", table)
+		require.Equal(t, b.OutsideHash, a.OutsideHash,
+			"clickhouse table %s: non-demo row content changed — the demo seed touched another tenant's rows", table)
+	}
+}
+
+// addedRows returns, per table, the rows present in after beyond their
+// occurrence count in before.
+func addedRows(before, after demoseedtest.PostgresSnapshot) map[string][]string {
+	added := map[string][]string{}
+	for table, rows := range after {
+		for row, n := range rows {
+			if extra := n - before[table][row]; extra > 0 {
+				added[table] = append(added[table], row)
+			}
+		}
+	}
+	return added
+}
+
+var uuidRe = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+func collectUUIDs(rowsByTable map[string][]string) map[string]bool {
+	uuids := map[string]bool{}
+	for _, rows := range rowsByTable {
+		for _, row := range rows {
+			for _, u := range uuidRe.FindAllString(row, -1) {
+				uuids[u] = true
+			}
+		}
+	}
+	return uuids
+}
+
+// requireNoLeakIntoOtherTenants asserts that no row the seed run added
+// references the fixture tenant — neither by its marker identifiers (org id,
+// user ids, emails, ...) nor by any uuid that appears in the fixture's rows
+// (project ids, chat ids, foreign keys). Together with the preserved-rows
+// check this proves the seed neither rewrites other tenants' rows nor attaches
+// new rows to them.
+func requireNoLeakIntoOtherTenants(t *testing.T, added map[string][]string, fixtureUUIDs map[string]bool) {
+	t.Helper()
+
+	for table, rows := range added {
+		for _, row := range rows {
+			for _, r := range otherTenantReplacements {
+				require.NotContains(t, row, r[1],
+					"postgres table %s: a row added by the demo seed references the other tenant's identifier %q: %s", table, r[1], row)
+			}
+			for _, u := range uuidRe.FindAllString(row, -1) {
+				require.False(t, fixtureUUIDs[u],
+					"postgres table %s: a row added by the demo seed references the other tenant's id %s: %s", table, u, row)
+			}
+		}
+	}
+}
+
+func totalRows(hashes map[string]int) int {
+	n := 0
+	for _, c := range hashes {
+		n += c
+	}
+	return n
+}

--- a/server/internal/demoseed/safety_test.go
+++ b/server/internal/demoseed/safety_test.go
@@ -1,3 +1,5 @@
+//go:build demoseed_safety
+
 package demoseed
 
 import (

--- a/server/internal/demoseed/setup_test.go
+++ b/server/internal/demoseed/setup_test.go
@@ -1,0 +1,32 @@
+package demoseed
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{
+		Postgres:   true,
+		ClickHouse: true,
+	})
+	if err != nil {
+		log.Fatalf("Failed to launch test infrastructure: %v", err)
+	}
+
+	infra = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Fatalf("Failed to cleanup test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}

--- a/server/internal/demoseed/setup_test.go
+++ b/server/internal/demoseed/setup_test.go
@@ -1,3 +1,11 @@
+// The demo seed safety test runs as its own CI job (demo-seed-safety in
+// pr.yaml), not inside the sharded server test suite — hence the build tag.
+// Run locally with:
+//
+//	mise run test:server -tags=demoseed_safety ./internal/demoseed/...
+//
+//go:build demoseed_safety
+
 package demoseed
 
 import (


### PR DESCRIPTION
## What

A standalone CI gate for the demo seed before we schedule it in prod: `TestDemoSeedSafety` proves the seed can never touch data outside the demo workspace, always cleans up stale demo data, and is idempotent. It runs as its own required check (`demo-seed-safety` in `pr.yaml`, wired into `ci-gate`), build-tagged out of the sharded server test suite so a failure is immediately attributable. No production code changes.

## The strategy

The seed will run daily in prod against the shared database, so the risk we care about is: **someone edits `postgres.sql`/`clickhouse.sql` later and a DELETE/UPDATE/INSERT escapes the demo org's scope.** A hand-written fixture ("create a customer org with a few chats") only protects the tables someone thought to cover. This test avoids that trap with three ideas:

**1. The fixture is the seed itself, re-targeted at a fake customer.**
The test takes the seed's own SQL and string-rewrites every demo identifier (org id, project uuid prefix, user ids, emails, slugs, telemetry markers) into a second "customer" tenant, then runs it. Result: the fake customer has realistic rows in _exactly_ the set of tables the seed writes to — by construction. If a future seed version adds a table, the fixture covers it automatically, and an unscoped statement is guaranteed to collide with fixture rows.

**2. Snapshot everything, not per-table assertions.**

- **Postgres**: fingerprint every row of every table (`to_jsonb(row)`) before the seed runs. After each run, every pre-existing row must still exist, byte-identical → the seed modified or deleted nothing outside its scope. Then look at the _added_ rows: none may contain the fake customer's identifiers or any UUID that appears in its rows → the seed also inserted nothing into (or referencing) another tenant.
- **ClickHouse**: per-table row count + order-independent hash of every row _outside_ the demo scope (scope inferred generically from `organization_id`/`gram_project_id` columns) must be exactly equal before and after → no modification, deletion, or addition outside the demo projects.

No assertion names a specific table, so agents editing the seed can't silently walk around the test.

**3. Run the seed twice, with sabotage in between.**
After run 1 the test plants stray rows inside the demo workspace (a duplicated demo chat in Postgres, a duplicated demo telemetry row in ClickHouse) — simulating leftover data from an older seed version. Run 2 must wipe them and land on exactly run 1's per-table row counts. That proves both cleanup (we can roll forward seed changes) and idempotence (re-running never accumulates data).

The only carve-out: ClickHouse Summing/Aggregating MV targets are exempt from the exact-count idempotence check, because their time-bucket keys shift with `now()` between runs. They remain fully covered by the isolation checks and by the seed's own `throwIf` postflights.

## Mechanics

- Test files are build-tagged `demoseed_safety`: the sharded `server-test` job skips the package (the shard tool sees no test files), and the dedicated `demo-seed-safety` job runs it with the tag. `server/.golangci.yaml` gains the tag so the files stay linted.
- Snapshot/exec helpers live in the non-test `demoseedtest` package: the test needs dynamically built SQL over `information_schema`/`system.tables`, which SQLc cannot express (and the glint `no-testing-raw-sql` rule bans raw SQL in `_test.go` for the cases SQLc does cover).
- Runs in ~30–60s including Postgres + ClickHouse testcontainers.
- Local run: `mise run test:server -tags=demoseed_safety ./internal/demoseed/...`

## Testing

- `TestDemoSeedSafety` green across repeated local runs.
- The identifier rewrite guards itself: the test fails loudly if a seed refactor renames one of the rewritten literals, so the fixture can't silently stop being adversarial.
- `mise lint:server` clean; verified the untagged suite skips the package and the shard tool no longer lists it.
