### PR TITLE
chore: keep shared Presidio stack up during worktree removal

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -34,8 +34,9 @@ stack = "mise run git:workboot"
 # Runs inside the worktree before deletion — nuke needs this worktree's
 # COMPOSE_PROJECT_NAME (mise.local.toml) and local/ dir to tear down the right
 # compose stack. post-remove would run in the primary worktree instead.
+# --keep-shared leaves the shared Presidio stack up for the other worktrees.
 [[pre-remove]]
-nuke = "mise run nuke"
+nuke = "mise run nuke --keep-shared"
 
 # Dashboard URL in the `wt list` URL column, dimmed when the port isn't
 # listening — so it doubles as a "is this worktree's stack up?" indicator.

--- a/.mise-tasks/git/workclean.sh
+++ b/.mise-tasks/git/workclean.sh
@@ -50,7 +50,7 @@ fi
 # Loop through each selected worktree and remove it
 while IFS= read -r worktree; do
     echo "Cleaning up worktree: $worktree"
-    (cd "$worktree" && mise run nuke)
+    (cd "$worktree" && mise run nuke --keep-shared)
     git worktree remove "${flags[@]}" "$worktree"
 done <<< "$selected_worktrees"
 echo "Selected worktrees have been cleaned up successfully."

--- a/.mise-tasks/nuke.sh
+++ b/.mise-tasks/nuke.sh
@@ -4,6 +4,16 @@
 
 set -e
 
+# --keep-shared: leave the shared stack (compose.shared.yml: Presidio) running.
+# Worktree removal passes this — other worktrees depend on the shared services.
+keep_shared=0
+for arg in "$@"; do
+    case "$arg" in
+        --keep-shared) keep_shared=1 ;;
+        *) echo "unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
+
 # Best-effort: stop this worktree's pitchfork daemons and prune stopped
 # entries from `pitchfork list` (clean is global across worktrees)
 if pitchfork supervisor status &> /dev/null; then
@@ -15,8 +25,11 @@ docker compose --profile "*" down --volumes --remove-orphans
 
 # The shared Presidio analyzer lives under a fixed project (compose.shared.yml).
 # nuke means "destroy all infra", so tear it down too — `./zero` recreates it.
-# Note this affects every worktree that shares it.
-docker compose -f compose.shared.yml -p gram-shared down --volumes --remove-orphans
+# Note this affects every worktree that shares it, hence --keep-shared for
+# worktree removal.
+if [ "$keep_shared" -eq 0 ]; then
+    docker compose -f compose.shared.yml -p gram-shared down --volumes --remove-orphans
+fi
 
 # dev-idp's SQLite database lives outside docker -- nuke it too so a
 # follow-up `./zero` boots from a clean mock-workos/oauth2 state.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Because `post-start` is backgrounded, `wt switch` returns before the stack is re
 + old-experiment  ○ down https://localhost:62875
 ```
 
-`wt remove` runs `mise run nuke` inside the worktree first, so the right Compose stack is torn down before the directory disappears. Removing a worktree by hand (`git worktree remove`) skips that and leaves its containers and volumes running.
+`wt remove` runs `mise run nuke --keep-shared` inside the worktree first, so the right Compose stack is torn down before the directory disappears (the shared Presidio stack stays up for other worktrees). Removing a worktree by hand (`git worktree remove`) skips that and leaves its containers and volumes running.
 
 #### Recommended shell setup
 


### PR DESCRIPTION
## What

Removing a worktree (`wt remove`, `mise run git:workclean`) no longer tears down the shared Presidio analyzer stack.

## Why

The `pre-remove` hook runs `mise run nuke`, and nuke destroys the shared `gram-shared` compose project (`compose.shared.yml`) along with the worktree's own stack. Since Presidio is shared across all worktrees, removing any one worktree degraded PII scanning for every other worktree until someone booted a stack again.

## How

- `nuke.sh` gains a `--keep-shared` flag that skips the shared-stack teardown. Bare `mise run nuke` is unchanged and still means "destroy all infra".
- The `wt.toml` `pre-remove` hook and `git:workclean` now pass `--keep-shared`.
- `CONTRIBUTING.md` updated to match.

Note: the hook command change means worktrunk re-prompts for approval on the next `wt remove` (one-time, template-hash gate).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Worktree removal no longer shuts down the shared Presidio analyzer stack, so other worktrees keep PII scanning. `wt remove` and `mise run git:workclean` now call `nuke` with `--keep-shared`.

- **Bug Fixes**
  - Added `--keep-shared` flag to `mise-tasks/nuke.sh` to skip tearing down the shared `gram-shared` compose project; default `mise run nuke` still destroys all infra.
  - Updated `.config/wt.toml` pre-remove hook and `mise-tasks/git/workclean.sh` to pass `--keep-shared`.
  - Updated `CONTRIBUTING.md` to reflect the new behavior.

- **Migration**
  - On the next `wt remove`, worktrunk will re-prompt to approve the updated hook command (one-time).

<sup>Written for commit 54587da10b65726677181eb1d1b84716086746b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

