### PR TITLE
chore: warn when cached infra images run under emulation

### DIFF
--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -11,13 +11,37 @@
 # skipped because a re-pull cannot change what a digest points at.
 host_arch="$(docker version --format '{{.Server.Arch}}' 2>/dev/null)"
 if [ -n "$host_arch" ]; then
+    # Keep this advisory check to two daemon round-trips no matter how many
+    # images the stack declares: list local tags once, intersect with the
+    # compose images, then inspect the cached subset in a single call (its
+    # output lines map back to the input by position). A per-image inspect
+    # would add a slow serial round-trip per image on Docker Desktop.
+    local_tags="$(docker image ls --format '{{.Repository}}:{{.Tag}}' 2>/dev/null)"
+    cached_imgs=()
     while IFS= read -r img; do
         case "$img" in *@sha256:*) continue ;; esac
-        img_arch="$(docker image inspect "$img" --format '{{.Architecture}}' 2>/dev/null)"
-        if [ -n "$img_arch" ] && [ "$img_arch" != "$host_arch" ]; then
-            echo "⚠️  Cached image $img is $img_arch but this Docker host is $host_arch — it runs emulated and can crash under load. Fix: docker pull $img" >&2
+        case "$img" in *:*) tag="$img" ;; *) tag="$img:latest" ;; esac
+        if grep -qxF "$tag" <<< "$local_tags"; then
+            cached_imgs+=("$img")
         fi
     done < <(docker compose config --images 2>/dev/null | sort -u)
+    # `docker pull` honors an exported DOCKER_DEFAULT_PLATFORM, so while it is
+    # set the pull just re-fetches the same foreign-arch variant and the
+    # warning would never clear — tell the user to unset it first.
+    fix_prefix=""
+    if [ -n "${DOCKER_DEFAULT_PLATFORM:-}" ]; then
+        fix_prefix="unset DOCKER_DEFAULT_PLATFORM, then "
+    fi
+    if [ "${#cached_imgs[@]}" -gt 0 ]; then
+        i=0
+        while IFS= read -r img_arch; do
+            img="${cached_imgs[$i]}"
+            i=$((i + 1))
+            if [ -n "$img_arch" ] && [ "$img_arch" != "$host_arch" ]; then
+                echo "⚠️  Cached image $img is $img_arch but this Docker host is $host_arch — it runs emulated and can crash under load. Fix: ${fix_prefix}docker pull $img" >&2
+            fi
+        done < <(docker image inspect "${cached_imgs[@]}" --format '{{.Architecture}}' 2>/dev/null)
+    fi
 fi
 
 # This worktree's own stack, first — with --remove-orphans. A pre-existing

--- a/.mise-tasks/infra/start.sh
+++ b/.mise-tasks/infra/start.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 #MISE description="Start up databases, caches and so on"
 
+# Warn when a cached image's architecture differs from the Docker host's.
+# `compose up` never re-pulls a tag that already exists locally, so an image
+# pulled while DOCKER_DEFAULT_PLATFORM=linux/amd64 was exported keeps running
+# under emulation on every stack — on Apple Silicon an emulated Postgres
+# backend segfaults under load (exit code 2 → crash recovery → every daemon
+# fails its DB ping mid-boot). Warn-only: emulation mostly works, and a hard
+# fail would strand hosts that have no native variant. Digest-pinned images are
+# skipped because a re-pull cannot change what a digest points at.
+host_arch="$(docker version --format '{{.Server.Arch}}' 2>/dev/null)"
+if [ -n "$host_arch" ]; then
+    while IFS= read -r img; do
+        case "$img" in *@sha256:*) continue ;; esac
+        img_arch="$(docker image inspect "$img" --format '{{.Architecture}}' 2>/dev/null)"
+        if [ -n "$img_arch" ] && [ "$img_arch" != "$host_arch" ]; then
+            echo "⚠️  Cached image $img is $img_arch but this Docker host is $host_arch — it runs emulated and can crash under load. Fix: docker pull $img" >&2
+        fi
+    done < <(docker compose config --images 2>/dev/null | sort -u)
+fi
+
 # This worktree's own stack, first — with --remove-orphans. A pre-existing
 # worktree (and the main tree) still runs a gram-presidio container under its own
 # project that compose.yml no longer declares; removing it here, BEFORE asserting


### PR DESCRIPTION
## What

Adds a preflight to `infra:start` that warns when a cached Docker image's architecture differs from the Docker host's (e.g. an amd64 image on an Apple Silicon arm64 host).

## Why

`docker compose up` never re-pulls a tag that already exists locally. An image pulled while `DOCKER_DEFAULT_PLATFORM=linux/amd64` was exported stays amd64 forever and runs under Rosetta emulation on every stack — invisibly. Under load an emulated Postgres backend segfaults (`server process exited with exit code 2`), throwing the DB into crash recovery right as the daemons boot; they fail their DB ping and the worktree boot is marked failed. This presented as "many new worktrees go straight to `failed` in `wt status`" and took a log dive to attribute.

The warning names the image, both architectures, and the one-step fix (`docker pull <image>`).

## Notes

- Warn-only: emulation mostly works, and a hard fail would strand hosts with no native image variant.
- Digest-pinned images are skipped — a re-pull cannot change what a digest resolves to.
- Locally-built, not-yet-built images produce no arch and are silently ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a preflight to `infra:start` that warns when a cached Docker image’s architecture differs from the Docker host, to avoid running services under emulation. The warning now tells users to unset `DOCKER_DEFAULT_PLATFORM` first, then run `docker pull <image>`.

- **New Features**
  - Detect host arch via `docker version`, and image arch via a batched `docker image inspect` of cached compose images from `docker compose config --images` intersected with `docker image ls` (kept to two daemon calls).
  - Skip digest-pinned images; ignore images with no reported arch; warn-only to avoid stranding hosts.

<sup>Written for commit 02aae1088b1cac6383ebbb2e25864f1a7640e80b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

