### PR TITLE
fix(assistants): scope assistant workflow ids to the task queue

### DIFF
--- a/server/internal/background/assistants.go
+++ b/server/internal/background/assistants.go
@@ -288,12 +288,20 @@ func AssistantThreadWorkflow(ctx workflow.Context, input AssistantThreadWorkflow
 	return workflow.NewContinueAsNewError(ctx, AssistantThreadWorkflow, input)
 }
 
-func assistantCoordinatorWorkflowID(assistantID uuid.UUID) string {
-	return "v1:assistant-coordinator:" + assistantID.String()
+// Workflow ids are scoped to the task queue that will poll them. Preview
+// environments share this Temporal namespace (and database) with the
+// long-lived environment but poll their own task queues, and SignalWithStart
+// only starts a workflow when no run with the id is open: an unscoped id let
+// a preview claim THE coordinator for an assistant on a queue that stops
+// being polled when the preview is torn down. The stranded run then swallowed
+// every later kick — signals are accepted by an open workflow regardless of
+// whether anything polls its queue — and no turn was ever admitted again.
+func assistantCoordinatorWorkflowID(taskQueue string, assistantID uuid.UUID) string {
+	return "v1:assistant-coordinator:" + taskQueue + ":" + assistantID.String()
 }
 
-func assistantThreadWorkflowID(threadID uuid.UUID) string {
-	return "v1:assistant-thread:" + threadID.String()
+func assistantThreadWorkflowID(taskQueue string, threadID uuid.UUID) string {
+	return "v1:assistant-thread:" + taskQueue + ":" + threadID.String()
 }
 
 type AssistantWorkflowSignaler struct {
@@ -301,7 +309,7 @@ type AssistantWorkflowSignaler struct {
 }
 
 func (s *AssistantWorkflowSignaler) SignalCoordinator(ctx context.Context, assistantID uuid.UUID) error {
-	wfID := assistantCoordinatorWorkflowID(assistantID)
+	wfID := assistantCoordinatorWorkflowID(string(s.TemporalEnv.Queue()), assistantID)
 	_, err := s.TemporalEnv.Client().SignalWithStartWorkflow(
 		ctx,
 		wfID,
@@ -322,7 +330,7 @@ func (s *AssistantWorkflowSignaler) SignalCoordinator(ctx context.Context, assis
 }
 
 func (s *AssistantWorkflowSignaler) SignalThread(ctx context.Context, threadID, projectID uuid.UUID) error {
-	wfID := assistantThreadWorkflowID(threadID)
+	wfID := assistantThreadWorkflowID(string(s.TemporalEnv.Queue()), threadID)
 	_, err := s.TemporalEnv.Client().SignalWithStartWorkflow(
 		ctx,
 		wfID,

--- a/server/internal/skills/efficacy/reserve_test.go
+++ b/server/internal/skills/efficacy/reserve_test.go
@@ -745,31 +745,36 @@ func TestRecoverStaleReservationsBoundsConcurrentBatches(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, reserved, 3)
 
-	var first RecoveryResult
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		var recoverErr error
-		first, recoverErr = RecoverStaleReservations(ctx, fixture.db, fixture.projectID, time.Millisecond, 2)
-		assert.NoError(collect, recoverErr)
-		assert.Equal(collect, RecoveryResult{Recovered: 2, DeadLettered: 0}, first)
-	}, 5*time.Second, 10*time.Millisecond)
+	// Backdate rather than wait out a lease: retrying the sweep until it
+	// reports Recovered == 2 is not idempotent — a pass that catches only some
+	// rows past the cutoff, followed by a retry that catches the rest, recovers
+	// all three while the final call still reports two.
+	aged, err := repo.New(fixture.db).BackdateReservedSkillEfficacyEvaluationsFixture(ctx, repo.BackdateReservedSkillEfficacyEvaluationsFixtureParams{
+		BackdateBy: pgtype.Interval{Microseconds: time.Hour.Microseconds(), Days: 0, Months: 0, Valid: true},
+		ProjectID:  fixture.projectID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, aged)
+
+	first, err := RecoverStaleReservations(ctx, fixture.db, fixture.projectID, time.Millisecond, 2)
+	require.NoError(t, err)
+	require.Equal(t, RecoveryResult{Recovered: 2, DeadLettered: 0}, first)
 	require.Len(t, fixture.pendingEvaluations(t), 2)
 	require.Len(t, fixture.reservedEvaluations(t, 3), 1, "one bounded row remains")
 
 	var group sync.WaitGroup
 	results := make([]RecoveryResult, 2)
 	errs := make([]error, 2)
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		for i := range results {
-			group.Go(func() {
-				results[i], errs[i] = RecoverStaleReservations(ctx, fixture.db, fixture.projectID, time.Millisecond, 2)
-			})
-		}
-		group.Wait()
+	for i := range results {
+		group.Go(func() {
+			results[i], errs[i] = RecoverStaleReservations(ctx, fixture.db, fixture.projectID, time.Millisecond, 2)
+		})
+	}
+	group.Wait()
 
-		assert.NoError(collect, errs[0])
-		assert.NoError(collect, errs[1])
-		assert.Equal(collect, int64(1), results[0].Recovered+results[1].Recovered)
-	}, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	require.Equal(t, int64(1), results[0].Recovered+results[1].Recovered)
 	require.Len(t, fixture.pendingEvaluations(t), 3)
 }
 

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -2252,6 +2252,15 @@ WHERE project_id = @project_id
   AND state = 'reserved'
   AND claim_token IS NULL;
 
+-- name: BackdateReservedSkillEfficacyEvaluationsFixture :execrows
+-- Test-only fixture: age a project's reserved rows past a recovery lease so a
+-- test can make staleness deterministic instead of retrying a sweep that
+-- recovers rows cumulatively.
+UPDATE skill_efficacy_evaluations
+SET updated_at = updated_at - @backdate_by::interval
+WHERE project_id = @project_id
+  AND state = 'reserved';
+
 -- name: ClearSkillEfficacyClaimTokenFixture :execrows
 -- Test-only fixture for a reservation written before claim_token existed.
 UPDATE skill_efficacy_evaluations

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -96,6 +96,29 @@ func (q *Queries) ArchiveSkill(ctx context.Context, arg ArchiveSkillParams) (Ski
 	return i, err
 }
 
+const backdateReservedSkillEfficacyEvaluationsFixture = `-- name: BackdateReservedSkillEfficacyEvaluationsFixture :execrows
+UPDATE skill_efficacy_evaluations
+SET updated_at = updated_at - $1::interval
+WHERE project_id = $2
+  AND state = 'reserved'
+`
+
+type BackdateReservedSkillEfficacyEvaluationsFixtureParams struct {
+	BackdateBy pgtype.Interval
+	ProjectID  uuid.UUID
+}
+
+// Test-only fixture: age a project's reserved rows past a recovery lease so a
+// test can make staleness deterministic instead of retrying a sweep that
+// recovers rows cumulatively.
+func (q *Queries) BackdateReservedSkillEfficacyEvaluationsFixture(ctx context.Context, arg BackdateReservedSkillEfficacyEvaluationsFixtureParams) (int64, error) {
+	result, err := q.db.Exec(ctx, backdateReservedSkillEfficacyEvaluationsFixture, arg.BackdateBy, arg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const backfillSkillObservationsForCapturedVersion = `-- name: BackfillSkillObservationsForCapturedVersion :execrows
 UPDATE skill_observations so
 SET skill_id = $1::uuid,


### PR DESCRIPTION
## What

Scope the assistant coordinator and thread Temporal workflow ids to the task queue that will poll them (`v1:assistant-coordinator:<task-queue>:<assistant-id>`, same for threads).

## Why

Preview environments share the long-lived environment's Temporal namespace and database but poll their own per-PR task queues. Workflow ids were keyed by assistant/thread id alone, and `SignalWithStart` only starts a new run when no run with that id is open. So the first environment to touch an assistant claimed THE coordinator workflow for it, pinned to that environment's task queue.

When that environment was a PR preview, tearing it down left the workflow open on a queue nobody polls. Every later turn from the long-lived environment still `SignalWithStart`ed the same id — signals are accepted by an open workflow regardless of whether its queue has pollers — so the kick vanished, no thread was ever admitted, and the assistant went permanently silent while `sendMessage` kept returning 200. All currently-running assistant workflows in the dev namespace are stranded on torn-down `gram-dev-pr-*` queues, one of them for months.

With queue-scoped ids each environment drives its own workflow chain, so a preview can no longer hijack dispatch for the shared row.

## Rollout

No migration needed. Existing open runs under old ids stop receiving signals after deploy and drain via their idle timeouts on still-polled queues; runs already stranded on dead preview queues stay inert (they were unreachable anyway) and can be terminated by hand.

## Testing

- `go build ./server/...`, `go test ./server/internal/background/ ./server/internal/assistants/`, `mise lint:server` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped assistant coordinator and thread Temporal workflow IDs to the task queue to prevent stranded runs and silent assistants. Also made the stale-reservation recovery test deterministic with a test-only backdate fixture.

- **Bug Fixes**
  - IDs now include the queue: `v1:assistant-coordinator:<queue>:<assistant-id>` and `v1:assistant-thread:<queue>:<thread-id>`.
  - Ensures each environment drives its own workflows; `SignalWithStart` no longer targets runs stuck on dead preview queues.
  - Added `BackdateReservedSkillEfficacyEvaluationsFixture` to age reserved rows past the recovery lease and updated the bounded recovery test to avoid flaky retries.

- **Migration**
  - No migration. Old runs drain on active queues; preview-stranded runs can be terminated manually.

<sup>Written for commit dd41c0318cda66f18c582a1cd13e78e6b9e8e461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

