### PR TITLE
fix: relay standalone SSE stream and session termination for proxy-backed MCP servers

### DIFF
--- a/server/internal/mcp/handle_get_server_proxy_test.go
+++ b/server/internal/mcp/handle_get_server_proxy_test.go
@@ -1,0 +1,159 @@
+// handle_get_server_proxy_test.go verifies that GET (standalone SSE stream)
+// and DELETE (session termination) on /mcp/{mcpSlug} dispatch through the
+// remote proxy for proxy-backed mcp_servers, while toolset-backed servers
+// keep the legacy 405 behavior.
+package mcp_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+// serveRuntimeMethod invokes HandleGetServer or HandleDeleteServer with a
+// chi-routed request the way the /mcp/{mcpSlug} mux does. The nil metadata
+// service passed to HandleGetServer is deliberate: it is only consulted on
+// the browser (HTML Accept) branch, which these tests never take.
+func serveRuntimeMethod(
+	t *testing.T,
+	ctx context.Context,
+	ti *testInstance,
+	method, mcpSlug, authToken string,
+	extraHeaders map[string]string,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	req := httptest.NewRequest(method, "/mcp/"+mcpSlug, nil)
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	switch method {
+	case http.MethodGet:
+		if err := ti.service.HandleGetServer(w, req, nil); err != nil {
+			return w, fmt.Errorf("handle get server: %w", err)
+		}
+	case http.MethodDelete:
+		if err := ti.service.HandleDeleteServer(w, req); err != nil {
+			return w, fmt.Errorf("handle delete server: %w", err)
+		}
+	default:
+		t.Fatalf("unsupported method %s", method)
+	}
+	return w, nil
+}
+
+func requireMethodNotAllowed(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeMethodNotAllowed, oopsErr.Code)
+}
+
+func TestRuntimeMethods_RemoteBacked_ProxiedUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	type upstreamHit struct {
+		method  string
+		accept  string
+		session string
+	}
+	var hits []upstreamHit
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, upstreamHit{
+			method:  r.Method,
+			accept:  r.Header.Get("Accept"),
+			session: r.Header.Get("Mcp-Session-Id"),
+		})
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{\"level\":\"info\",\"data\":\"standalone stream hello\"}}\n\n"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	endpointSlug := "endpoint-" + uuid.NewString()
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	mcpServer, _ := createRemoteMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, upstream.URL, endpointSlug, "public", issuerID)
+	token := mintIssuerBearerForEndpoint(t, ctx, ti, endpointSlug, mcpServer, authCtx.ActiveOrganizationID)
+
+	// A GET without Accept: text/event-stream must keep the legacy 405 and
+	// never reach upstream — the SSE gate is what keeps stray probes local.
+	_, err := serveRuntimeMethod(t, ctx, ti, http.MethodGet, endpointSlug, token, map[string]string{"Accept": "application/json"})
+	requireMethodNotAllowed(t, err)
+	require.Empty(t, hits, "non-SSE GET must not be forwarded upstream")
+
+	// The standalone SSE stream relays upstream with the session header.
+	w, err := serveRuntimeMethod(t, ctx, ti, http.MethodGet, endpointSlug, token, map[string]string{
+		"Accept":         "text/event-stream",
+		"Mcp-Session-Id": "sess-abc",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Len(t, hits, 1)
+	require.Equal(t, http.MethodGet, hits[0].method, "standalone stream GET must be relayed upstream")
+	require.Contains(t, hits[0].accept, "text/event-stream")
+	require.Equal(t, "sess-abc", hits[0].session, "session header must be forwarded upstream")
+	require.Contains(t, w.Body.String(), "standalone stream hello", "upstream SSE events must be relayed back")
+
+	// DELETE (session termination) relays upstream as well.
+	w, err = serveRuntimeMethod(t, ctx, ti, http.MethodDelete, endpointSlug, token, map[string]string{"Mcp-Session-Id": "sess-to-end"})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
+	require.Len(t, hits, 2)
+	require.Equal(t, http.MethodDelete, hits[1].method, "session termination must be relayed upstream")
+	require.Equal(t, "sess-to-end", hits[1].session, "session header must be forwarded upstream")
+}
+
+func TestRuntimeMethods_ToolsetBacked_Keep405(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "toolset-slug-"+uuid.NewString()[:8])
+	endpointSlug := "endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, uuid.Nil)
+
+	_, err := serveRuntimeMethod(t, ctx, ti, http.MethodGet, endpointSlug, "", map[string]string{"Accept": "text/event-stream"})
+	requireMethodNotAllowed(t, err)
+
+	_, err = serveRuntimeMethod(t, ctx, ti, http.MethodDelete, endpointSlug, "", nil)
+	requireMethodNotAllowed(t, err)
+
+	// Unknown slugs fall through the endpoint lookup and keep the 405 too.
+	_, err = serveRuntimeMethod(t, ctx, ti, http.MethodGet, "no-such-slug-"+uuid.NewString(), "", map[string]string{"Accept": "text/event-stream"})
+	requireMethodNotAllowed(t, err)
+}

--- a/server/internal/mcp/handle_get_server_proxy_test.go
+++ b/server/internal/mcp/handle_get_server_proxy_test.go
@@ -14,9 +14,14 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
 
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
 
@@ -131,6 +136,48 @@ func TestRuntimeMethods_RemoteBacked_ProxiedUpstream(t *testing.T) {
 	require.Len(t, hits, 2)
 	require.Equal(t, http.MethodDelete, hits[1].method, "session termination must be relayed upstream")
 	require.Equal(t, "sess-to-end", hits[1].session, "session header must be forwarded upstream")
+}
+
+// TestRuntimeMethods_MountedOnMux drives GET and DELETE through the real
+// /mcp/{mcpSlug} route registrations rather than invoking the handlers
+// directly, so a regression in the mux wiring fails here. The distinctive
+// oops error messages prove our handlers ran instead of the muxer's own
+// method-not-allowed fallback.
+func TestRuntimeMethods_MountedOnMux(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	metadataService := mcpmetadata.NewService(
+		ti.logger,
+		ti.tracerProvider,
+		ti.conn,
+		ti.sessionManager,
+		ti.serverURL,
+		ti.siteURL,
+		ti.cacheAdapter,
+		authz.NewEngine(ti.logger, ti.conn, chConn, nil, nil, workos.NewStubClient()),
+		ti.audit,
+	)
+
+	mux := goahttp.NewMuxer()
+	mcp.Attach(mux, ti.service, metadataService)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp/no-such-slug-"+uuid.NewString(), nil).WithContext(ctx)
+	req.Header.Set("Accept", "text/event-stream")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.Contains(t, rr.Body.String(), "compatibility probe", "GET must be routed to HandleGetServer")
+
+	req = httptest.NewRequest(http.MethodDelete, "/mcp/no-such-slug-"+uuid.NewString(), nil).WithContext(ctx)
+	rr = httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	require.Contains(t, rr.Body.String(), "session termination is not supported", "DELETE must be routed to HandleDeleteServer")
 }
 
 func TestRuntimeMethods_ToolsetBacked_Keep405(t *testing.T) {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -478,8 +479,13 @@ func (s *Service) HandleOpenAIAppsChallenge(w http.ResponseWriter, r *http.Reque
 func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metadataService *mcpmetadata.Service) error {
 	var wantsHTML, wantsSSE bool
 	for mediaTypeFull := range strings.SplitSeq(r.Header.Get("Accept"), ",") {
-		mediatype, _, err := mime.ParseMediaType(mediaTypeFull)
+		mediatype, params, err := mime.ParseMediaType(mediaTypeFull)
 		if err != nil {
+			continue
+		}
+		// An explicit q=0 marks the media type as not acceptable (RFC 9110
+		// § 12.4.2) — never route toward a representation the client rejected.
+		if q, qErr := strconv.ParseFloat(params["q"], 64); qErr == nil && q == 0 {
 			continue
 		}
 		switch mediatype {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -400,6 +400,7 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
 		return service.HandleGetServer(w, r, metadataService)
 	}).ServeHTTP)
+	o11y.AttachHandler(mux, "DELETE", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, service.HandleDeleteServer).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/install", oops.ErrHandle(service.logger, metadataService.ServeInstallPage).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/install-page-{hash}.js", oops.ErrHandle(service.logger, metadataService.ServeInstallPageScript).ServeHTTP)
 
@@ -466,25 +467,102 @@ func (s *Service) HandleOpenAIAppsChallenge(w http.ResponseWriter, r *http.Reque
 	return nil
 }
 
-// HandleGetServer handles GET requests to /mcp/{mcpSlug}, checking for HTML requests
-// and delegating to metadata service, or returning method not allowed for others.
+// HandleGetServer handles GET requests to /mcp/{mcpSlug}. Browser requests
+// (HTML Accept header) get the install page. SSE requests (Accept:
+// text/event-stream) against a proxy-backed (remote/tunneled) mcp_server are
+// the Streamable HTTP standalone server->client stream (spec § Listening for
+// Messages from the Server) and dispatch through the unified endpoint
+// dispatcher so the proxy relays them upstream. Everything else — including
+// SSE requests against toolset-backed servers, which never send
+// server-initiated messages — keeps the legacy 405.
 func (s *Service) HandleGetServer(w http.ResponseWriter, r *http.Request, metadataService *mcpmetadata.Service) error {
-	// Check if this is a browser request (HTML Accept header)
+	var wantsHTML, wantsSSE bool
 	for mediaTypeFull := range strings.SplitSeq(r.Header.Get("Accept"), ",") {
-		if mediatype, _, err := mime.ParseMediaType(mediaTypeFull); err == nil && (mediatype == "text/html" || mediatype == "application/xhtml+xml") {
-			// Intentionally NOT gated by enforceCustomDomainLockdown: the
-			// install page must remain reachable on the platform host even
-			// when the org's custom domain has an IP allowlist (private MCP
-			// install pages rely on the platform-host session cookie). Only
-			// the runtime POST path (ServePublic) is locked down.
-			if err := metadataService.ServeInstallPage(w, r); err != nil {
-				return fmt.Errorf("failed to serve install page: %w", err)
-			}
-			return nil
+		mediatype, _, err := mime.ParseMediaType(mediaTypeFull)
+		if err != nil {
+			continue
+		}
+		switch mediatype {
+		case "text/html", "application/xhtml+xml":
+			wantsHTML = true
+		case "text/event-stream":
+			wantsSSE = true
+		}
+	}
+
+	if wantsHTML {
+		// Intentionally NOT gated by enforceCustomDomainLockdown: the
+		// install page must remain reachable on the platform host even
+		// when the org's custom domain has an IP allowlist (private MCP
+		// install pages rely on the platform-host session cookie). Only
+		// the runtime paths (ServePublic, serveProxyBackedEndpoint) are
+		// locked down.
+		if err := metadataService.ServeInstallPage(w, r); err != nil {
+			return fmt.Errorf("failed to serve install page: %w", err)
+		}
+		return nil
+	}
+
+	// The Streamable HTTP spec requires clients to send Accept:
+	// text/event-stream on this GET; gating on it keeps health checkers and
+	// other stray probes answering locally instead of generating upstream
+	// noise.
+	if wantsSSE {
+		if handled, err := s.serveProxyBackedEndpoint(w, r); handled {
+			return err
 		}
 	}
 
 	return oops.E(oops.CodeMethodNotAllowed, nil, "This MCP server uses POST-based Streamable HTTP transport. This GET request is a normal compatibility probe by the MCP client and can be safely ignored. The client will automatically use POST for actual communication.")
+}
+
+// HandleDeleteServer handles DELETE requests to /mcp/{mcpSlug} — Streamable
+// HTTP session termination (spec § Session Management). Proxy-backed servers
+// relay it upstream so the remote session is actually torn down;
+// toolset-backed servers hold no upstream session state, so the method stays
+// unsupported there.
+func (s *Service) HandleDeleteServer(w http.ResponseWriter, r *http.Request) error {
+	if handled, err := s.serveProxyBackedEndpoint(w, r); handled {
+		return err
+	}
+	return oops.E(oops.CodeMethodNotAllowed, nil, "session termination is not supported for this MCP server")
+}
+
+// serveProxyBackedEndpoint resolves {mcpSlug} and, when it maps to a
+// proxy-backed (remote or tunneled) mcp_server, dispatches the request
+// through the unified endpoint dispatcher — the same issuer gate + backend
+// switch the POST path uses. handled=true means an authoritative outcome was
+// reached (dispatched, or failed in a way the caller must propagate);
+// handled=false means the slug does not resolve or resolves to a non-proxy
+// backend, so callers fall back to their legacy behavior.
+func (s *Service) serveProxyBackedEndpoint(w http.ResponseWriter, r *http.Request) (handled bool, err error) {
+	ctx := r.Context()
+
+	mcpSlug := chi.URLParam(r, "mcpSlug")
+	if mcpSlug == "" {
+		return false, nil
+	}
+	logger := s.logger.With(attr.SlogToolsetMCPSlug(mcpSlug))
+
+	mcpEndpoint, mcpServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
+	var shareErr *oops.ShareableError
+	switch {
+	case err == nil:
+	case errors.As(err, &shareErr) && shareErr.Code == oops.CodeNotFound:
+		return false, nil
+	default:
+		return true, err
+	}
+
+	if !mcpServer.RemoteMcpServerID.Valid && !mcpServer.TunneledMcpServerID.Valid {
+		return false, nil
+	}
+
+	if err := s.enforceCustomDomainLockdown(ctx, logger, mcpEndpoint.ProjectID); err != nil {
+		return true, err
+	}
+
+	return true, s.serveResolvedMCPEndpoint(w, r, logger, mcpEndpoint, mcpServer, mcpSlug, "mcp")
 }
 
 // writeOAuthServerMetadataResponse builds the OAuth server metadata body and


### PR DESCRIPTION
## Problem

On the `/mcp/{mcpSlug}` route, only POST reaches the MCP runtime. `HandleGetServer` serves the install page to browser requests and answers every other GET with a 405, and DELETE is not mounted at all. For remote/tunneled proxy-backed servers this makes two parts of the Streamable HTTP transport impossible:

- the standalone GET SSE stream (spec § Listening for Messages from the Server) — the server→client channel used for server-initiated messages and notifications
- DELETE session termination (spec § Session Management)

An upstream server whose tools depend on the reverse channel stalls until the client gives up, which surfaces to users as hung or truncated tool responses. Reproduced end-to-end against a production remote-backed server: the client's GET died at the 405 and was never forwarded, and a reverse-channel-dependent tool timed out via `/mcp` while completing in 0.5s both directly and via `/x/mcp` (which already mounts all three methods and anticipates this migration).

## Change

- `GET /mcp/{mcpSlug}` with `Accept: text/event-stream` now dispatches through the unified endpoint dispatcher (`serveResolvedMCPEndpoint`) when the slug resolves to a proxy-backed (remote or tunneled) `mcp_server`, so the proxy relays the standalone stream upstream — same issuer gate and custom-domain lockdown as the POST path. Browser requests keep the install page; toolset-backed servers and unknown slugs keep the legacy 405.
- `DELETE /mcp/{mcpSlug}` is now mounted and relays session termination upstream for proxy-backed servers; toolset-backed servers 405 (no upstream session to terminate).
- Accept-header inspection is a single `mime.ParseMediaType` pass shared by the HTML and SSE branches, replacing a substring match that would also fire on parameter values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing GET SSE stream and DELETE session termination on `/mcp/{mcpSlug}` for proxy-backed MCP servers by relaying both through the proxy. Also respects `q=0` in Accept headers and wires DELETE on the mux to avoid misroutes.

- **Bug Fixes**
  - Proxies `GET /mcp/{mcpSlug}` with `Accept: text/event-stream`; HTML Accept still serves the install page; non‑SSE GET remains 405; `q=0` media types are ignored during dispatch.
  - Mounts `DELETE /mcp/{mcpSlug}` and relays session termination upstream for proxy-backed servers; toolset-backed or unknown slugs return 405.
  - Applies the same issuer gating and custom-domain lockdown as the POST path.

- **Refactors**
  - Centralizes Accept parsing with `mime.ParseMediaType` and honors `q` values to avoid false positives.
  - Adds tests for proxied GET/DELETE behavior, 405s for toolset/unknown slugs, SSE relay content/session header forwarding, and mux wiring to ensure our handlers are invoked.

<sup>Written for commit df4f7601161e78b390e350bea009496932a0f5e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

