### PR TITLE
feat: emit RFC 9207 iss on user-session OAuth authorization responses

### DIFF
--- a/.changeset/rfc-9207-authorization-response-iss.md
+++ b/.changeset/rfc-9207-authorization-response-iss.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+The user-session OAuth authorization server now emits the RFC 9207 `iss` parameter on every authorization response, success and error alike, and advertises `authorization_response_iss_parameter_supported` in its metadata document. This satisfies the MCP 2026-07-28 Authorization Response Validation requirement and lets MCP clients holding concurrent flows against several authorization servers detect a mix-up attack.

--- a/server/internal/mcp/authnchallenge.go
+++ b/server/internal/mcp/authnchallenge.go
@@ -130,6 +130,33 @@ func (a AuthnChallengeState) CacheKey() string { return "authnChallenge:" + a.ID
 // TTL implements cache.CacheableObject.
 func (a AuthnChallengeState) TTL() time.Duration { return 10 * time.Minute }
 
+// mintOriginOr returns the public origin this challenge was minted under: the
+// mint-time snapshot when present, the supplied fallback otherwise.
+//
+// Every URL a resuming handler builds — the consent redirect and the RFC 9207
+// `iss` on the authorization response — hangs off this origin rather than off
+// the resuming request, because a challenge can be resumed on an origin other
+// than the one it was minted under. HandleIDPCallback is mounted at the global
+// server URL and carries no customdomains.Context at all, and the upstream
+// remote-session login returns the user to the platform origin, so even the
+// consent POST — which does carry a custom-domain context — can be serving a
+// challenge minted under a different one. A client that recorded
+// https://<custom-domain>/mcp/<slug> as the issuer rejects a response carrying
+// the platform origin and is forbidden from displaying the error it discarded,
+// so a wrong origin here surfaces as nothing at all.
+//
+// The fallback is per-caller because the right one differs: a handler holding
+// the request's custom-domain context falls back to that origin, while
+// HandleIDPCallback can only fall back to the server default. It covers states
+// carrying no snapshot at all, the one case where the true mint origin is
+// unrecoverable.
+func (a AuthnChallengeState) mintOriginOr(fallback string) string {
+	if a.Endpoint.BaseURL == "" {
+		return fallback
+	}
+	return a.Endpoint.BaseURL
+}
+
 // UserSessionGrant is the short-lived OAuth authorization grant minted by
 // HandleConsent's POST and consumed by HandleToken's authorization_code
 // grant. Stored in Redis under

--- a/server/internal/mcp/authnchallenge_authorize.go
+++ b/server/internal/mcp/authnchallenge_authorize.go
@@ -125,6 +125,12 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		return writeAuthorizeError(ctx, w, logger, http.StatusBadRequest, "invalid_request", "redirect_uri is not registered for this client")
 	}
 
+	// The origin this request was addressed at. It is the mint origin by
+	// definition — the challenge below snapshots it — and it is what the AS
+	// metadata document advertises as the issuer, so both the error redirect
+	// below and every response built later in the flow agree on it.
+	baseURL := s.BaseURLForRequest(r)
+
 	// At this point the redirect_uri is trusted (matched against the
 	// registered set on the client row), so RFC 6749 §4.1.2.1 requires that
 	// any remaining validation errors are forwarded to the client by 302
@@ -132,7 +138,11 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 	// observe the failure. The two-phase Validate split exists to make this
 	// switch unambiguous.
 	if err := req.ValidatePostRedirect(); err != nil {
-		return redirectAuthorizeOAuthError(ctx, w, r, logger, req.RedirectURI, req.State, err)
+		issuer, issErr := endpoint.RootURL(baseURL)
+		if issErr != nil {
+			return oops.E(oops.CodeUnexpected, issErr, "build authorization response issuer").LogError(ctx, logger)
+		}
+		return redirectAuthorizeOAuthError(ctx, w, r, logger, issuer, req.RedirectURI, req.State, err)
 	}
 
 	challengeID := uuid.NewString()
@@ -162,7 +172,6 @@ func (s *Service) ServeAuthorize(w http.ResponseWriter, r *http.Request, endpoin
 		subject = &sub
 	}
 
-	baseURL := s.BaseURLForRequest(r)
 	challengeState := AuthnChallengeState{
 		ID:                  challengeID,
 		FlowID:              flowID,
@@ -234,12 +243,12 @@ func writeAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, logger
 }
 
 // redirectAuthorizeOAuthError redirects the user agent back to the (already
-// trusted) redirect_uri with `error` / `error_description` / `state` query
-// parameters per RFC 6749 §4.1.2.1. Callers must only invoke this AFTER the
-// supplied redirect_uri has been validated against the registered set on
-// the OAuth client row — passing through an untrusted URI here would turn
-// the AS into an open redirector.
-func redirectAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, redirectURI, originalState string, err error) error {
+// trusted) redirect_uri with `iss` / `error` / `error_description` / `state`
+// query parameters per RFC 6749 §4.1.2.1 and RFC 9207 §2. Callers must only
+// invoke this AFTER the supplied redirect_uri has been validated against the
+// registered set on the OAuth client row — passing through an untrusted URI
+// here would turn the AS into an open redirector.
+func redirectAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, issuer, redirectURI, originalState string, err error) error {
 	code := "invalid_request"
 	description := err.Error()
 	var oauthErr *oauthwire.Error
@@ -251,7 +260,18 @@ func redirectAuthorizeOAuthError(ctx context.Context, w http.ResponseWriter, r *
 		attr.SlogOAuthError(code),
 		attr.SlogOAuthErrorDescription(description),
 	)
-	http.Redirect(w, r, buildClientRedirect(redirectURI, "", originalState, code, description), http.StatusFound)
+	redirect, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      redirectURI,
+		Issuer:           issuer,
+		Code:             "",
+		State:            originalState,
+		ErrorCode:        code,
+		ErrorDescription: description,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "build client redirect").LogError(ctx, logger)
+	}
+	http.Redirect(w, r, redirect, http.StatusFound)
 	return nil
 }
 

--- a/server/internal/mcp/authnchallenge_authorize_test.go
+++ b/server/internal/mcp/authnchallenge_authorize_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -76,6 +77,101 @@ func TestAuthorize_CustomDomainPrivateChallengeUsesGramIDPCallback(t *testing.T)
 	require.Equal(t, toolset.McpSlug.String, stored.Endpoint.McpSlug)
 	require.True(t, stored.Endpoint.CustomDomainID.Valid)
 	require.Equal(t, domain.ID, stored.Endpoint.CustomDomainID.UUID)
+	// The snapshot every later response in this flow derives its origin from.
+	// Stamping the platform origin here would make each of them emit an `iss`
+	// the client discards, with no error it is allowed to display.
+	require.Equal(t, "https://"+domain.Domain, stored.Endpoint.BaseURL)
+}
+
+// The end-to-end shape the mint-time snapshot exists for: /authorize runs on a
+// custom domain and the consent POST completing the flow arrives on the
+// platform origin, which is what the remote-session return leg produces. The
+// `iss` the client finally receives has to be the custom-domain issuer it
+// recorded from the metadata document, not the origin of whichever request
+// happened to finish the flow.
+func TestAuthorize_CustomDomainIssSurvivesPlatformOriginConsent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "iss-cd-e2e-" + uuid.New().String()[:8]
+	toolset, issuer := createPrivateIssuerGatedToolset(t, ctx, ti, authCtx, slug)
+	// Public so /authorize stamps an anonymous subject and goes straight to
+	// consent, keeping this test on the origin question rather than the IDP
+	// round-trip. The local copy is updated too because attachCustomDomainToToolset
+	// writes the whole row back from the struct it is handed.
+	require.NoError(t, toolsets_repo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true,
+		ID:          toolset.ID,
+		ProjectID:   toolset.ProjectID,
+	}))
+	toolset.McpIsPublic = true
+	toolset, domain := attachCustomDomainToToolset(t, ctx, ti, authCtx, toolset, "iss-cd-e2e.example.com")
+
+	clientID := "iss-e2e-client"
+	// The redirect_uri insertUserSessionClient registers for this client.
+	clientRedirectURI := "http://example.com/cb"
+	insertUserSessionClient(t, ctx, ti.conn, issuer.ID, clientID)
+
+	domainCtx := customdomains.WithContext(ctx, &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	// What the client records before it ever calls /authorize.
+	advertisedIssuer, supported := fetchAdvertisedIssuer(t, domainCtx, ti, slug)
+	require.Equal(t, true, supported)
+	require.Equal(t, "https://"+domain.Domain+"/mcp/"+slug, advertisedIssuer)
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", clientRedirectURI)
+	q.Set("state", "client-state")
+	q.Set("code_challenge", "challenge")
+	q.Set("code_challenge_method", "S256")
+	authReq := httptest.NewRequest(http.MethodGet, "/mcp/"+slug+"/authorize?"+q.Encode(), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", slug)
+	authReq = authReq.WithContext(context.WithValue(domainCtx, chi.RouteCtxKey, rctx))
+
+	authResp := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleAuthorize(authResp, authReq))
+	require.Equal(t, http.StatusFound, authResp.Code)
+
+	consentLoc, err := url.Parse(authResp.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Contains(t, consentLoc.Path, "/connect")
+	stateID := consentLoc.Query().Get("state")
+	require.NotEmpty(t, stateID)
+
+	stored, err := ti.authnChallengeCache.Get(ctx, "authnChallenge:"+stateID)
+	require.NoError(t, err)
+
+	// The consent POST arrives with no custom-domain context at all.
+	form := url.Values{}
+	form.Set("state", stateID)
+	form.Set("csrf_token", stored.CSRFToken)
+	form.Set("action", "approve")
+	consentReq := httptest.NewRequest(http.MethodPost, "/mcp/"+slug+"/connect", strings.NewReader(form.Encode()))
+	consentReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	consentRctx := chi.NewRouteContext()
+	consentRctx.URLParams.Add("mcpSlug", slug)
+	consentReq = consentReq.WithContext(context.WithValue(ctx, chi.RouteCtxKey, consentRctx))
+
+	consentResp := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(consentResp, consentReq))
+	require.Equal(t, http.StatusSeeOther, consentResp.Code)
+
+	clientLoc, err := url.Parse(consentResp.Header().Get("Location"))
+	require.NoError(t, err)
+	require.NotEmpty(t, clientLoc.Query().Get("code"))
+	require.Equal(t, advertisedIssuer, clientLoc.Query().Get("iss"))
 }
 
 func TestIDPCallback_StaticRouteResolvesToolsetFromChallengeState(t *testing.T) {
@@ -180,6 +276,45 @@ func TestAuthorize_PublicToolset_IgnoresAmbientSessionCredentials(t *testing.T) 
 		"public /authorize must not promote ambient credentials to a user subject")
 	require.NotEqual(t, authCtx.UserID, stored.Subject.ID)
 	require.NotEqual(t, bearerUserID, stored.Subject.ID)
+}
+
+// Authorize rejects in two shapes — inline JSON while the redirect_uri is
+// still untrusted, and a redirect once it is. Only the redirect shape is an
+// authorization response, and it is the one that carries iss.
+func TestAuthorize_PostRedirectErrorEmitsIss(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedIssuer, _ := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+
+	// redirect_uri is registered, so validation moves past the inline-error
+	// phase; response_type=token then fails ValidatePostRedirect and must be
+	// reported by redirect rather than inline.
+	q := url.Values{}
+	q.Set("response_type", "token")
+	q.Set("client_id", client.ClientID)
+	q.Set("redirect_uri", client.RedirectUris[0])
+	q.Set("state", "client-state")
+	q.Set("code_challenge", "challenge")
+	q.Set("code_challenge_method", "S256")
+	req := httptest.NewRequest(http.MethodGet, "/mcp/"+mcpSlug+"/authorize?"+q.Encode(), nil)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleAuthorize(w, req))
+	require.Equal(t, http.StatusFound, w.Code, "a trusted redirect_uri means errors go back by redirect")
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.NotEmpty(t, loc.Query().Get("error"))
+	require.Equal(t, "client-state", loc.Query().Get("state"))
+	require.Equal(t, advertisedIssuer, loc.Query().Get("iss"))
 }
 
 func createPrivateIssuerGatedToolset(

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/urls"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	users_repo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/cimd"
@@ -394,23 +395,51 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 	}
 
 	// Explicit action required: fail closed on missing / unknown values so
-	// a malformed form post can't trigger the approval path.
+	// a malformed form post can't trigger the approval path. Checked before
+	// any flow-outcome metric is recorded, so a crafted action stays in the
+	// attacker-controllable bucket the guards above describe rather than
+	// counting against a config's health signal.
 	action := r.PostForm.Get("action")
-	switch action {
-	case "approve":
-		// fall through
-	case "deny":
+	if action != "approve" && action != "deny" {
+		return oops.E(oops.CodeBadRequest, nil, `action must be "approve" or "deny"`).LogError(ctx, logger)
+	}
+
+	// The RFC 9207 `iss` both branches below emit, resolved once so the deny
+	// and success responses cannot disagree. It hangs off the origin the
+	// challenge was minted under, not this request's: the remote-session
+	// return leg re-enters consent on the platform origin, so a POST carrying
+	// a custom-domain context can still be completing a flow the client
+	// recorded under a different origin (or vice versa).
+	issuer, err := endpoint.RootURL(challengeState.mintOriginOr(s.BaseURLForRequest(r)))
+	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
+		return oops.E(oops.CodeUnexpected, err, "build authorization response issuer").LogError(ctx, logger)
+	}
+
+	if action == "deny" {
 		// Cancel: 303 (POST → GET) the MCP client back to its redirect_uri
 		// with access_denied per RFC 6749 §4.1.2.1, preserving the original
 		// state. The user reached the consent screen and chose "no" — a
 		// decline, not an errant config.
+		denyURL, err := buildClientRedirect(clientRedirectParams{
+			RedirectURI:      challengeState.RedirectURI,
+			Issuer:           issuer,
+			Code:             "",
+			State:            challengeState.State,
+			ErrorCode:        "access_denied",
+			ErrorDescription: "user denied consent",
+		})
+		if err != nil {
+			// Recorded as failed, not declined: the user's decline never
+			// reached the client, so this flow ended on a fault. Exactly one
+			// terminal outcome is counted per started flow either way.
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
+			return oops.E(oops.CodeUnexpected, err, "build client redirect").LogError(ctx, logger)
+		}
 		s.metrics.RecordOAuthFlowDeclined(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
 		logger.InfoContext(ctx, "oauth flow declined at consent", attr.SlogOAuthError("access_denied"))
-		denyURL := buildClientRedirect(challengeState.RedirectURI, "", challengeState.State, "access_denied", "user denied consent")
 		http.Redirect(w, r, denyURL, http.StatusSeeOther)
 		return nil
-	default:
-		return oops.E(oops.CodeBadRequest, nil, `action must be "approve" or "deny"`).LogError(ctx, logger)
 	}
 
 	if challengeState.Subject == nil || challengeState.Subject.IsZero() {
@@ -470,7 +499,18 @@ func (s *Service) serveConsentPost(w http.ResponseWriter, r *http.Request, endpo
 		return oops.E(oops.CodeUnexpected, err, "store user session grant").LogError(ctx, logger)
 	}
 
-	clientRedirect := buildClientRedirect(challengeState.RedirectURI, code, challengeState.State, "", "")
+	clientRedirect, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      challengeState.RedirectURI,
+		Issuer:           issuer,
+		Code:             code,
+		State:            challengeState.State,
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	if err != nil {
+		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageConsent)
+		return oops.E(oops.CodeUnexpected, err, "build client redirect").LogError(ctx, logger)
+	}
 	// 303 See Other (POST → GET): the consent submit is a POST; we want
 	// the user agent to GET the redirect target with NO body re-submission.
 	http.Redirect(w, r, clientRedirect, http.StatusSeeOther)
@@ -499,31 +539,85 @@ func resolveSubjectDisplay(ctx context.Context, db users_repo.DBTX, subject urn.
 	return fallback
 }
 
+// clientRedirectParams is the field set of one client-facing authorization
+// response.
+type clientRedirectParams struct {
+	// Code is the authorization code on a success response, empty on an error.
+	Code string
+
+	// ErrorCode carries an RFC 6749 §4.1.2.1 error code. Empty on a success
+	// response.
+	ErrorCode string
+
+	// ErrorDescription carries an RFC 6749 §4.1.2.1 error description. Empty on
+	// a success response.
+	ErrorDescription string
+
+	// Issuer is the RFC 9207 `iss` parameter — the endpoint's root URL, byte
+	// identical to the `issuer` advertised by the AS metadata document. Required
+	// on every authorization response, success and error alike (RFC 9207 §2).
+	// Clients compare it without any normalization (no case folding, default-port
+	// elision, trailing-slash or percent-encoding fixups), so it must be derived
+	// the same way ServeGetAuthorizationServer derives the advertised value.
+	Issuer string
+
+	// RedirectURI is the client's redirect_uri. Callers must only reach this
+	// helper with a URI already validated against the registered set on the
+	// client row; passing an untrusted URI turns the AS into an open redirector.
+	RedirectURI string
+
+	// State echoes the client's original `state` when it sent one.
+	State string
+}
+
+// responseOwnedParams are the query parameters an authorization response
+// defines. A registered redirect_uri may carry a query string of the client's
+// own, which is preserved, but any of these it contains is cleared before the
+// response is written: a client that reads `code` before `error` would
+// otherwise see a redirect_uri-supplied `code=…` on a decline as a grant, and
+// a redirect_uri-supplied `iss` could be chosen to pass the RFC 9207 §2.4
+// comparison the response is meant to fail.
+var responseOwnedParams = []string{"iss", "code", "error", "error_description", "state"}
+
 // buildClientRedirect produces the URL to redirect the MCP client to,
-// preserving any prior query string on redirectURI and adding `code` (success)
-// or `error` / `error_description` (failure) plus the original `state`.
-func buildClientRedirect(redirectURI, code, originalState, errCode, errDescription string) string {
-	u, err := url.Parse(redirectURI)
+// preserving any prior query string on RedirectURI and adding `iss` plus
+// `code` (success) or `error` / `error_description` (failure) and the
+// original `state`.
+func buildClientRedirect(p clientRedirectParams) (string, error) {
+	// The issuer has to be the absolute URL the metadata document advertises.
+	// A relative or empty value is one a client validating per RFC 9207 §2.4
+	// discards without surfacing anything to the user, so it fails here where
+	// it is still visible. url.JoinPath returns no error for an empty base, so
+	// a missing origin arrives as a relative path rather than as a failure.
+	if !urls.IsAbsoluteHTTP(p.Issuer) {
+		return "", fmt.Errorf("authorization response issuer is not an absolute http(s) url: %q", p.Issuer)
+	}
+	u, err := url.Parse(p.RedirectURI)
 	if err != nil {
 		// Should never happen — redirect_uri was validated at HandleAuthorize
-		// time. Fall back to a best-effort string concatenation.
-		return redirectURI
+		// time. An unparseable URI has nowhere to carry the response
+		// parameters, so this is terminal for the flow.
+		return "", fmt.Errorf("parse client redirect_uri: %w", err)
 	}
 	q := u.Query()
-	if code != "" {
-		q.Set("code", code)
+	for _, param := range responseOwnedParams {
+		q.Del(param)
 	}
-	if errCode != "" {
-		q.Set("error", errCode)
-		if errDescription != "" {
-			q.Set("error_description", errDescription)
+	q.Set("iss", p.Issuer)
+	if p.Code != "" {
+		q.Set("code", p.Code)
+	}
+	if p.ErrorCode != "" {
+		q.Set("error", p.ErrorCode)
+		if p.ErrorDescription != "" {
+			q.Set("error_description", p.ErrorDescription)
 		}
 	}
-	if originalState != "" {
-		q.Set("state", originalState)
+	if p.State != "" {
+		q.Set("state", p.State)
 	}
 	u.RawQuery = q.Encode()
-	return u.String()
+	return u.String(), nil
 }
 
 // isUniqueViolation reports whether err is a Postgres unique-constraint

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -572,12 +572,16 @@ type clientRedirectParams struct {
 
 // responseOwnedParams are the query parameters an authorization response
 // defines. A registered redirect_uri may carry a query string of the client's
-// own, which is preserved, but any of these it contains is cleared before the
-// response is written: a client that reads `code` before `error` would
-// otherwise see a redirect_uri-supplied `code=…` on a decline as a grant, and
-// a redirect_uri-supplied `iss` could be chosen to pass the RFC 9207 §2.4
-// comparison the response is meant to fail.
-var responseOwnedParams = []string{"iss", "code", "error", "error_description", "state"}
+// own, which is preserved per RFC 6749 §3.1.2, but any of these it contains is
+// cleared before the response is written: a client that reads `code` before
+// `error` would otherwise see a redirect_uri-supplied `code=…` on a decline as
+// a grant, and a redirect_uri-supplied `iss` could be chosen to pass the RFC
+// 9207 §2.4 comparison the response is meant to fail. `state` is deliberately
+// exempt: it is client-owned round-trip data with no spoofing value, and a
+// registered redirect_uri that embeds one relies on receiving it back on every
+// response. When the client sent a request `state`, the response value
+// overwrites any embedded one below.
+var responseOwnedParams = []string{"iss", "code", "error", "error_description"}
 
 // buildClientRedirect produces the URL to redirect the MCP client to,
 // preserving any prior query string on RedirectURI and adding `iss` plus

--- a/server/internal/mcp/authnchallenge_consent_internal_test.go
+++ b/server/internal/mcp/authnchallenge_consent_internal_test.go
@@ -119,13 +119,14 @@ func TestBuildClientRedirect_ClearsRedirectURIErrorOnSuccess(t *testing.T) {
 	require.Empty(t, u.Query().Get("error_description"))
 }
 
-// A client that sent no `state` must receive none, even if its registered
-// redirect_uri carries one.
-func TestBuildClientRedirect_ClearsRedirectURIStateWhenUnset(t *testing.T) {
+// `state` is exempt from response-owned clearing: a registered redirect_uri
+// that embeds one relies on receiving it back, and RFC 6749 §3.1.2 requires
+// the redirect URI's own query component to be retained.
+func TestBuildClientRedirect_PreservesRedirectURIStateWhenUnset(t *testing.T) {
 	t.Parallel()
 
 	got, err := buildClientRedirect(clientRedirectParams{
-		RedirectURI:      "http://localhost:3000/callback?state=STALE",
+		RedirectURI:      "http://localhost:3000/callback?state=route-token",
 		Issuer:           testRedirectIssuer,
 		Code:             "auth-code",
 		State:            "",
@@ -136,7 +137,27 @@ func TestBuildClientRedirect_ClearsRedirectURIStateWhenUnset(t *testing.T) {
 
 	u, err := url.Parse(got)
 	require.NoError(t, err)
-	require.Empty(t, u.Query().Get("state"))
+	require.Equal(t, "route-token", u.Query().Get("state"))
+}
+
+// When the client sent a request `state`, the response value replaces any
+// embedded one outright, leaving exactly one.
+func TestBuildClientRedirect_OverwritesRedirectURIStateWhenSet(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback?state=STALE",
+		Issuer:           testRedirectIssuer,
+		Code:             "auth-code",
+		State:            "client-state",
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, []string{"client-state"}, u.Query()["state"], "exactly one state value must survive")
 }
 
 // An issuer that is empty, or relative because it was built off a missing

--- a/server/internal/mcp/authnchallenge_consent_internal_test.go
+++ b/server/internal/mcp/authnchallenge_consent_internal_test.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testRedirectIssuer = "https://app.example.com/mcp/my-server"
+
+func TestBuildClientRedirect_SuccessCarriesIss(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback",
+		Issuer:           testRedirectIssuer,
+		Code:             "auth-code",
+		State:            "client-state",
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, testRedirectIssuer, u.Query().Get("iss"))
+	require.Equal(t, "auth-code", u.Query().Get("code"))
+	require.Equal(t, "client-state", u.Query().Get("state"))
+}
+
+// RFC 9207 §2 puts `iss` on error responses too, not just successful ones —
+// mix-up defense is worthless if the error leg is unauthenticated.
+func TestBuildClientRedirect_ErrorCarriesIss(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback",
+		Issuer:           testRedirectIssuer,
+		Code:             "",
+		State:            "client-state",
+		ErrorCode:        "access_denied",
+		ErrorDescription: "user denied consent",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, testRedirectIssuer, u.Query().Get("iss"))
+	require.Equal(t, "access_denied", u.Query().Get("error"))
+	require.Equal(t, "user denied consent", u.Query().Get("error_description"))
+	require.Empty(t, u.Query().Get("code"))
+}
+
+// A registered redirect_uri may legitimately carry its own query string, and a
+// malicious one may carry an `iss` chosen to survive the client's comparison.
+// The response value must replace it outright, leaving exactly one.
+func TestBuildClientRedirect_OverwritesPreexistingIss(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback?iss=https%3A%2F%2Fattacker.example&keep=me",
+		Issuer:           testRedirectIssuer,
+		Code:             "auth-code",
+		State:            "",
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, []string{testRedirectIssuer}, u.Query()["iss"], "exactly one iss value must survive")
+	require.Equal(t, "me", u.Query().Get("keep"), "unrelated query parameters must be preserved")
+}
+
+// A redirect_uri may legitimately carry a query string of the client's own,
+// but a response parameter sitting in it must not merge into the response: a
+// client that reads `code` before `error` would read this decline as a grant.
+func TestBuildClientRedirect_ClearsRedirectURICodeOnError(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback?code=INJECTED&keep=me",
+		Issuer:           testRedirectIssuer,
+		Code:             "",
+		State:            "client-state",
+		ErrorCode:        "access_denied",
+		ErrorDescription: "user denied consent",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Empty(t, u.Query().Get("code"), "an error response must carry no code at all")
+	require.Equal(t, "access_denied", u.Query().Get("error"))
+	require.Equal(t, "me", u.Query().Get("keep"))
+}
+
+// The mirror case: a redirect_uri carrying `error` must not make a successful
+// authorization read as a failure.
+func TestBuildClientRedirect_ClearsRedirectURIErrorOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback?error=access_denied&error_description=nope",
+		Issuer:           testRedirectIssuer,
+		Code:             "auth-code",
+		State:            "client-state",
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, "auth-code", u.Query().Get("code"))
+	require.Empty(t, u.Query().Get("error"))
+	require.Empty(t, u.Query().Get("error_description"))
+}
+
+// A client that sent no `state` must receive none, even if its registered
+// redirect_uri carries one.
+func TestBuildClientRedirect_ClearsRedirectURIStateWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "http://localhost:3000/callback?state=STALE",
+		Issuer:           testRedirectIssuer,
+		Code:             "auth-code",
+		State:            "",
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	require.NoError(t, err)
+
+	u, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Empty(t, u.Query().Get("state"))
+}
+
+// An issuer that is empty, or relative because it was built off a missing
+// origin, produces a response a spec-compliant client rejects without
+// surfacing anything. url.JoinPath reports no error for an empty base, so the
+// relative case has to be caught here or not at all.
+func TestBuildClientRedirect_NonAbsoluteIssuerErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, issuer := range []string{"", "mcp/my-server", "/mcp/my-server", "ftp://app.example.com/mcp/s"} {
+		_, err := buildClientRedirect(clientRedirectParams{
+			RedirectURI:      "http://localhost:3000/callback",
+			Issuer:           issuer,
+			Code:             "auth-code",
+			State:            "",
+			ErrorCode:        "",
+			ErrorDescription: "",
+		})
+		require.ErrorContains(t, err, "not an absolute http(s) url", "issuer %q must be rejected", issuer)
+	}
+}
+
+// A redirect_uri that cannot be parsed has nowhere to put the response
+// parameters, so the only safe outcome is an error. Redirecting to it anyway
+// would hand the client a response carrying no iss, which it must reject.
+func TestBuildClientRedirect_UnparseableRedirectURIErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildClientRedirect(clientRedirectParams{
+		RedirectURI:      "://not-a-url",
+		Issuer:           testRedirectIssuer,
+		Code:             "auth-code",
+		State:            "",
+		ErrorCode:        "",
+		ErrorDescription: "",
+	})
+	require.ErrorContains(t, err, "parse client redirect_uri")
+}

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -86,6 +86,13 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// at the resolved endpoint's canonical slug for the flow-metric dimension.
 	mcpSlug = endpoint.Slug
 
+	// This handler is registered at a global URL and so has no
+	// customdomains.Context of its own; every URL it emits hangs off the
+	// mint-time origin instead. Both responses it can produce — the forwarded
+	// IDP error and the consent redirect — use this one value, so the client
+	// sees the same origin whichever way the flow goes.
+	baseURL := challengeState.mintOriginOr(s.serverURL.String())
+
 	// If the IDP returned an error (user cancelled at the IDP, IDP refused
 	// to authenticate, etc.) per OAuth 2.0, forward it back to the MCP
 	// client with the same error code so the client can render an
@@ -113,7 +120,23 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 			}
 			return oops.E(oops.CodeUnexpected, nil, "idp returned an error: %s", idpErr).LogError(ctx, logger)
 		}
-		clientRedirect := buildClientRedirect(challengeState.RedirectURI, "", challengeState.State, idpErr, errDescription)
+		issuer, err := endpoint.RootURL(baseURL)
+		if err != nil {
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			return oops.E(oops.CodeUnexpected, err, "build authorization response issuer").LogError(ctx, logger)
+		}
+		clientRedirect, err := buildClientRedirect(clientRedirectParams{
+			RedirectURI:      challengeState.RedirectURI,
+			Issuer:           issuer,
+			Code:             "",
+			State:            challengeState.State,
+			ErrorCode:        idpErr,
+			ErrorDescription: errDescription,
+		})
+		if err != nil {
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			return oops.E(oops.CodeUnexpected, err, "build client redirect").LogError(ctx, logger)
+		}
 		http.Redirect(w, r, clientRedirect, http.StatusFound)
 		return nil
 	}
@@ -165,17 +188,8 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 		return oops.E(oops.CodeUnexpected, err, "failed to update authn challenge state").LogError(ctx, logger)
 	}
 
-	// challengeState.Endpoint.BaseURL was stamped at mint time. New
-	// mints always populate it; the IDP callback can rebuild the
-	// consent redirect from cache alone without a fresh custom_domains
-	// lookup (the callback is registered at a global URL and loses the
-	// request's customdomains.Context). Empty value falls back to the
-	// server default for in-flight states minted before this field
-	// landed.
-	baseURL := challengeState.Endpoint.BaseURL
-	if baseURL == "" {
-		baseURL = s.serverURL.String()
-	}
+	// The mint-time origin puts the consent page back on the host the user
+	// started on, without a fresh custom_domains lookup.
 	consentURL, err := endpoint.ConsentURL(baseURL, challengeState.ID)
 	if err != nil {
 		s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)

--- a/server/internal/mcp/authnchallenge_idp_callback.go
+++ b/server/internal/mcp/authnchallenge_idp_callback.go
@@ -100,24 +100,17 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 	// required" 400.
 	if idpErr := q.Get("error"); idpErr != "" {
 		errDescription := q.Get("error_description")
-		// access_denied is the user opting out at the IDP — a decline, not an
-		// errant config. Any other IDP error code (server_error, invalid_scope,
-		// ...) points at IDP/config trouble. Both are terminal; bucket them
-		// accordingly before bouncing the error back to the client.
-		if idpErr == "access_denied" {
-			s.metrics.RecordOAuthFlowDeclined(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-			logger.InfoContext(ctx, "oauth flow declined at idp", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
-		} else {
-			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
-			logger.InfoContext(ctx, "oauth flow failed at idp callback", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
-		}
 		// First-party challenges have no MCP client to bounce the error back to
 		// (no RedirectURI), so surface it directly. Declines are forbidden;
 		// anything else is config/IDP trouble.
 		if challengeState.FirstParty {
 			if idpErr == "access_denied" {
+				s.metrics.RecordOAuthFlowDeclined(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+				logger.InfoContext(ctx, "oauth flow declined at idp", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
 				return oops.E(oops.CodeForbidden, nil, "login was declined").LogError(ctx, logger)
 			}
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			logger.InfoContext(ctx, "oauth flow failed at idp callback", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
 			return oops.E(oops.CodeUnexpected, nil, "idp returned an error: %s", idpErr).LogError(ctx, logger)
 		}
 		issuer, err := endpoint.RootURL(baseURL)
@@ -134,8 +127,22 @@ func (s *Service) HandleIDPCallback(w http.ResponseWriter, r *http.Request) erro
 			ErrorDescription: errDescription,
 		})
 		if err != nil {
+			// Recorded as failed even for access_denied: the IDP error never
+			// reached the client, so this flow ended on a fault. Exactly one
+			// terminal outcome is counted per started flow either way.
 			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
 			return oops.E(oops.CodeUnexpected, err, "build client redirect").LogError(ctx, logger)
+		}
+		// access_denied is the user opting out at the IDP — a decline, not an
+		// errant config. Any other IDP error code (server_error, invalid_scope,
+		// ...) points at IDP/config trouble. Both are terminal; bucket them
+		// accordingly before bouncing the error back to the client.
+		if idpErr == "access_denied" {
+			s.metrics.RecordOAuthFlowDeclined(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			logger.InfoContext(ctx, "oauth flow declined at idp", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
+		} else {
+			s.metrics.RecordOAuthFlowFailed(ctx, issuerID, mcpSlug, oauthFlowStageIDPCallback)
+			logger.InfoContext(ctx, "oauth flow failed at idp callback", attr.SlogOAuthError(idpErr), attr.SlogOAuthErrorDescription(errDescription))
 		}
 		http.Redirect(w, r, clientRedirect, http.StatusFound)
 		return nil

--- a/server/internal/mcp/authnchallenge_internal_test.go
+++ b/server/internal/mcp/authnchallenge_internal_test.go
@@ -1,0 +1,24 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthnChallengeState_MintOriginOr_PrefersSnapshot(t *testing.T) {
+	t.Parallel()
+
+	state := AuthnChallengeState{Endpoint: EndpointRef{BaseURL: "https://custom.example.com"}}
+	require.Equal(t, "https://custom.example.com", state.mintOriginOr("https://app.example.com"))
+}
+
+// An empty snapshot is the one case where the true mint origin is
+// unrecoverable and the caller's fallback is all there is, so pin the choice
+// explicitly rather than letting a change alter it unnoticed.
+func TestAuthnChallengeState_MintOriginOr_EmptySnapshotUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	state := AuthnChallengeState{Endpoint: EndpointRef{BaseURL: ""}}
+	require.Equal(t, "https://app.example.com", state.mintOriginOr("https://app.example.com"))
+}

--- a/server/internal/mcp/authnchallenge_test.go
+++ b/server/internal/mcp/authnchallenge_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -111,6 +112,94 @@ func seedPrivateToolsetWithIssuer(
 	require.NoError(t, err)
 
 	return toolset, issuer, client
+}
+
+// fetchAdvertisedIssuer returns the `issuer` from the AS metadata document as
+// served, plus the RFC 9207 support flag.
+//
+// Clients compare the `iss` on an authorization response to this value with no
+// normalization of their own — no case folding, default-port elision,
+// trailing-slash or percent-encoding fixups — so the two must match byte for
+// byte. Tests assert against the served document rather than a recomputed
+// literal, which is what makes them fail when both sides are derived wrong in
+// the same way.
+func fetchAdvertisedIssuer(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug string) (string, any) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/mcp/"+mcpSlug, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", mcpSlug)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleGetAuthorizationServer(w, req))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &meta))
+
+	issuer, ok := meta["issuer"].(string)
+	require.True(t, ok, "metadata must carry a string issuer: %s", w.Body.String())
+	return issuer, meta["authorization_response_iss_parameter_supported"]
+}
+
+type consentPostOpts struct {
+	mcpSlug        string
+	issuerID       uuid.UUID
+	clientID       string
+	redirectURI    string
+	baseURL        string
+	customDomainID uuid.NullUUID
+	action         string
+}
+
+// postConsent seeds an approved-subject challenge and drives the consent POST,
+// returning the parsed client redirect. requestCtx is the context the POST is
+// served under; opts.baseURL is the mint-time origin snapshot, deliberately
+// independent of it so tests can exercise the cross-origin resume.
+func postConsent(t *testing.T, ctx context.Context, requestCtx context.Context, ti *testInstance, opts consentPostOpts) *url.URL {
+	t.Helper()
+
+	subject := urn.NewUserSubject("consent-user-" + uuid.NewString())
+	stateID := uuid.NewString()
+	csrfToken := "csrf-" + uuid.NewString()
+
+	require.NoError(t, ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: opts.issuerID,
+		Endpoint: mcp.EndpointRef{
+			McpSlug:        opts.mcpSlug,
+			CustomDomainID: opts.customDomainID,
+			BaseURL:        opts.baseURL,
+		},
+		ClientID:            opts.clientID,
+		RedirectURI:         opts.redirectURI,
+		State:               "client-state",
+		CodeChallenge:       "abc",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           csrfToken,
+		Subject:             &subject,
+		CreatedAt:           time.Now(),
+	}))
+
+	form := url.Values{}
+	form.Set("state", stateID)
+	form.Set("csrf_token", csrfToken)
+	form.Set("action", opts.action)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+opts.mcpSlug+"/connect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("mcpSlug", opts.mcpSlug)
+	req = req.WithContext(context.WithValue(requestCtx, chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleConsent(w, req))
+	require.Equal(t, http.StatusSeeOther, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	return loc
 }
 
 func TestHandleAuthorize_PrivateToolset_RedirectsToIDP(t *testing.T) {
@@ -461,6 +550,129 @@ func TestHandleConsentPost_PropagatesFlowIDIntoGrant(t *testing.T) {
 	require.Equal(t, flowID, grant.FlowID, "flow id must propagate into the grant")
 }
 
+// The flagship invariant: the code-carrying success response is what a client
+// validates on the critical path, and its `iss` must equal the advertised
+// issuer exactly.
+func TestHandleConsentPost_ApproveEmitsIssMatchingAdvertisedIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedIssuer, supported := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+	require.Equal(t, true, supported)
+
+	loc := postConsent(t, ctx, ctx, ti, consentPostOpts{
+		mcpSlug:     mcpSlug,
+		issuerID:    toolset.UserSessionIssuerID.UUID,
+		clientID:    client.ClientID,
+		redirectURI: client.RedirectUris[0],
+		baseURL:     ti.serverURL.String(),
+		action:      "approve",
+	})
+
+	require.NotEmpty(t, loc.Query().Get("code"), "approve must still mint a code")
+	require.Equal(t, advertisedIssuer, loc.Query().Get("iss"))
+}
+
+// RFC 9207 §2 covers error responses too: a user declining consent still gets
+// a response the client must be able to attribute to this issuer.
+func TestHandleConsentPost_DenyEmitsIss(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	advertisedIssuer, _ := fetchAdvertisedIssuer(t, ctx, ti, mcpSlug)
+
+	loc := postConsent(t, ctx, ctx, ti, consentPostOpts{
+		mcpSlug:     mcpSlug,
+		issuerID:    toolset.UserSessionIssuerID.UUID,
+		clientID:    client.ClientID,
+		redirectURI: client.RedirectUris[0],
+		baseURL:     ti.serverURL.String(),
+		action:      "deny",
+	})
+
+	require.Equal(t, "access_denied", loc.Query().Get("error"))
+	require.Equal(t, advertisedIssuer, loc.Query().Get("iss"))
+	require.Empty(t, loc.Query().Get("code"))
+}
+
+// A challenge minted under a custom domain can be resumed on the platform
+// origin: the remote-session return leg bounces through the server URL, so the
+// consent POST's own custom-domain context (here, absent) is not the origin the
+// client recorded. `iss` must come from the mint-time snapshot regardless.
+func TestHandleConsentPost_IssUsesMintOriginNotRequestOrigin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	const mintOrigin = "https://mcp.customer.example"
+
+	// Deliberately no customdomains context on the request: this is the
+	// platform-origin re-entry shape.
+	loc := postConsent(t, ctx, ctx, ti, consentPostOpts{
+		mcpSlug:     mcpSlug,
+		issuerID:    toolset.UserSessionIssuerID.UUID,
+		clientID:    client.ClientID,
+		redirectURI: client.RedirectUris[0],
+		baseURL:     mintOrigin,
+		action:      "approve",
+	})
+
+	require.Equal(t, mintOrigin+"/mcp/"+mcpSlug, loc.Query().Get("iss"),
+		"iss must be rebuilt from the mint-time origin, not from the resuming request")
+	require.NotContains(t, loc.Query().Get("iss"), ti.serverURL.Host,
+		"falling back to the server default origin here silently breaks the client's comparison")
+}
+
+// A custom-domain flow that stays on the custom domain end to end: the
+// advertised issuer and the emitted iss must both be the custom-domain origin.
+func TestHandleConsentPost_CustomDomainIssMatchesAdvertisedIssuer(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti, _ := newTestMCPServiceWithDevIDP(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "iss-cd-" + uuid.New().String()[:8]
+	toolset, issuer := createPrivateIssuerGatedToolset(t, ctx, ti, authCtx, slug)
+	toolset, domain := attachCustomDomainToToolset(t, ctx, ti, authCtx, toolset, "iss-cd.example.com")
+
+	clientID := "iss-custom-domain-client"
+	clientRedirectURI := "http://localhost:3000/callback"
+	insertUserSessionClient(t, ctx, ti.conn, issuer.ID, clientID)
+
+	domainCtx := customdomains.WithContext(ctx, &customdomains.Context{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		Domain:         domain.Domain,
+		DomainID:       domain.ID,
+	})
+
+	advertisedIssuer, supported := fetchAdvertisedIssuer(t, domainCtx, ti, slug)
+	require.Equal(t, true, supported)
+	require.Contains(t, advertisedIssuer, domain.Domain, "sanity: the custom domain must drive the advertised issuer")
+
+	loc := postConsent(t, ctx, domainCtx, ti, consentPostOpts{
+		mcpSlug:        slug,
+		issuerID:       issuer.ID,
+		clientID:       clientID,
+		redirectURI:    clientRedirectURI,
+		baseURL:        "https://" + domain.Domain,
+		customDomainID: toolset.CustomDomainID,
+		action:         "approve",
+	})
+
+	require.Equal(t, advertisedIssuer, loc.Query().Get("iss"))
+}
+
 func TestHandleIDPCallback_ExchangesCodeAndRedirectsToConsent(t *testing.T) {
 	t.Parallel()
 
@@ -780,6 +992,55 @@ func TestHandleIDPCallback_IDPError_ForwardsToClient(t *testing.T) {
 	loc := w.Header().Get("Location")
 	require.Contains(t, loc, "error=access_denied", "should forward IDP error to client redirect")
 	require.Contains(t, loc, "localhost:3000/callback", "should redirect to client's redirect_uri")
+}
+
+// HandleIDPCallback is mounted at the global server URL and never has a
+// custom-domain context, so its forwarded-error response is the most exposed
+// of the four.
+func TestHandleIDPCallback_IDPErrorIssUsesMintOrigin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{})
+	toolset, _, client := seedPrivateToolsetWithIssuer(t, ctx, ti)
+	mcpSlug := toolset.McpSlug.String
+
+	const mintOrigin = "https://idp-cb.customer.example"
+
+	stateID := uuid.NewString()
+	require.NoError(t, ti.authnChallengeCache.Store(ctx, mcp.AuthnChallengeState{
+		ID:                  stateID,
+		UserSessionIssuerID: toolset.UserSessionIssuerID.UUID,
+		Endpoint: mcp.EndpointRef{
+			McpSlug:        mcpSlug,
+			CustomDomainID: toolset.CustomDomainID,
+			BaseURL:        mintOrigin,
+		},
+		ClientID:            client.ClientID,
+		RedirectURI:         client.RedirectUris[0],
+		State:               "client-state",
+		CodeChallenge:       "abc",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-token",
+		CreatedAt:           time.Now(),
+	}))
+
+	q := url.Values{
+		"state":             {stateID},
+		"error":             {"access_denied"},
+		"error_description": {"user cancelled"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/mcp/idp_callback?"+q.Encode(), nil)
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	require.NoError(t, ti.service.HandleIDPCallback(w, req))
+	require.Equal(t, http.StatusFound, w.Code)
+
+	loc, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, "access_denied", loc.Query().Get("error"))
+	require.Equal(t, mintOrigin+"/mcp/"+mcpSlug, loc.Query().Get("iss"),
+		"the IDP callback has no custom-domain context and must use the mint-time snapshot")
 }
 
 func TestHandleIDPCallback_ExpiredState_ReturnsUnauthorized(t *testing.T) {

--- a/server/internal/mcp/authnchallenge_well_known.go
+++ b/server/internal/mcp/authnchallenge_well_known.go
@@ -72,6 +72,20 @@ type oauthAuthorizationServerMetadata struct {
 	TokenEndpointAuthMethodsSupported    []string `json:"token_endpoint_auth_methods_supported"`
 	CodeChallengeMethodsSupported        []string `json:"code_challenge_methods_supported"`
 	RefreshTokenExpirationTypesSupported []string `json:"refresh_token_expiration_types_supported"`
+
+	// AuthorizationResponseIssParameterSupported advertises RFC 9207 §3. Always
+	// true: every authorization response on this surface carries `iss`
+	// (RFC 9207 §2), and an omitted field means false to a client, so the
+	// value tracks a property of the surface rather than any configuration.
+	//
+	// The coupling with emission is asymmetric. A client seeing `iss` without
+	// the flag compares it anyway, which is what lets this document lag behind
+	// the responses it describes by up to the cache TTL below. A client seeing
+	// the flag without `iss` rejects the response outright, which is what
+	// makes turning this off — or serving it from a build whose response paths
+	// omit `iss` — a client-visible break.
+	AuthorizationResponseIssParameterSupported bool `json:"authorization_response_iss_parameter_supported"`
+
 	// ClientIDMetadataDocumentSupported advertises inbound CIMD support
 	// (draft-ietf-oauth-client-id-metadata-document-02 §6). Emitted as true
 	// only when the issuer organization's gram-user-session-cimd flag is
@@ -433,20 +447,21 @@ func (s *Service) ServeGetAuthorizationServer(w http.ResponseWriter, r *http.Req
 		cimdSupported = conv.PtrEmpty(true)
 	}
 	return writeJSONMetadata(ctx, w, r, s.logger, oauthAuthorizationServerMetadata{
-		Issuer:                            urls.Issuer,
-		AuthorizationEndpoint:             urls.Authorize,
-		TokenEndpoint:                     urls.Token,
-		RegistrationEndpoint:              urls.Register,
-		RevocationEndpoint:                urls.Revoke,
-		ScopesSupported:                   nil,
-		ResponseTypesSupported:            usersessions.SupportedResponseTypes,
-		GrantTypesSupported:               usersessions.SupportedGrantTypes,
-		TokenEndpointAuthMethodsSupported: usersessions.SupportedAuthMethods,
-		CodeChallengeMethodsSupported:     usersessions.SupportedCodeChallengeMethods,
+		AuthorizationEndpoint:                      urls.Authorize,
+		AuthorizationResponseIssParameterSupported: true,
+		ClientIDMetadataDocumentSupported:          cimdSupported,
+		CodeChallengeMethodsSupported:              usersessions.SupportedCodeChallengeMethods,
+		GrantTypesSupported:                        usersessions.SupportedGrantTypes,
+		Issuer:                                     urls.Issuer,
 		RefreshTokenExpirationTypesSupported: []string{
 			"authorization",
 		},
-		ClientIDMetadataDocumentSupported: cimdSupported,
+		RegistrationEndpoint:              urls.Register,
+		ResponseTypesSupported:            usersessions.SupportedResponseTypes,
+		RevocationEndpoint:                urls.Revoke,
+		ScopesSupported:                   nil,
+		TokenEndpoint:                     urls.Token,
+		TokenEndpointAuthMethodsSupported: usersessions.SupportedAuthMethods,
 	})
 }
 

--- a/server/internal/mcp/resolved_mcp_endpoint.go
+++ b/server/internal/mcp/resolved_mcp_endpoint.go
@@ -244,6 +244,16 @@ func (e *ResolvedMcpEndpoint) ValidateRef(ref EndpointRef) error {
 	if e.CustomDomainID != ref.CustomDomainID {
 		return errToolsetEndpointMismatch
 	}
+	// The route surface is part of the endpoint's identity: the same slug can
+	// resolve on both /mcp and /x/mcp, and the RFC 9207 `iss` on every
+	// authorization response is built from the resolved endpoint's RouteBase.
+	// Resuming a challenge on the other surface would emit an issuer that
+	// differs from the one the client recorded at mint time, which an
+	// iss-validating client rejects as a mix-up. Empty ref.RouteBase is
+	// treated as "mcp" for states minted before EndpointRef.RouteBase existed.
+	if e.RouteBase != conv.Default(ref.RouteBase, "mcp") {
+		return errToolsetEndpointMismatch
+	}
 	return nil
 }
 

--- a/server/internal/mcp/resolved_mcp_endpoint_internal_test.go
+++ b/server/internal/mcp/resolved_mcp_endpoint_internal_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRef_Matches(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:      "my-server",
+		RouteBase: "x/mcp",
+	}
+	require.NoError(t, endpoint.ValidateRef(EndpointRef{
+		McpSlug:   "my-server",
+		RouteBase: "x/mcp",
+	}))
+}
+
+// A challenge minted on one route surface must not be resumable on the other:
+// the RFC 9207 `iss` is built from the resolved endpoint's RouteBase, so a
+// cross-surface resume would emit an issuer differing from the one the client
+// recorded at mint time.
+func TestValidateRef_RejectsCrossSurfaceResume(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:      "my-server",
+		RouteBase: "mcp",
+	}
+	err := endpoint.ValidateRef(EndpointRef{
+		McpSlug:   "my-server",
+		RouteBase: "x/mcp",
+	})
+	require.ErrorIs(t, err, errToolsetEndpointMismatch)
+}
+
+// States minted before EndpointRef.RouteBase existed carry an empty value,
+// which is treated as "mcp".
+func TestValidateRef_LegacyEmptyRouteBaseMeansMcp(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:      "my-server",
+		RouteBase: "mcp",
+	}
+	require.NoError(t, endpoint.ValidateRef(EndpointRef{
+		McpSlug: "my-server",
+	}))
+
+	xmcpEndpoint := &ResolvedMcpEndpoint{
+		Slug:      "my-server",
+		RouteBase: "x/mcp",
+	}
+	require.ErrorIs(t, xmcpEndpoint.ValidateRef(EndpointRef{
+		McpSlug: "my-server",
+	}), errToolsetEndpointMismatch)
+}
+
+func TestValidateRef_RejectsCustomDomainMismatch(t *testing.T) {
+	t.Parallel()
+
+	endpoint := &ResolvedMcpEndpoint{
+		Slug:           "my-server",
+		CustomDomainID: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+		RouteBase:      "mcp",
+	}
+	err := endpoint.ValidateRef(EndpointRef{
+		McpSlug:        "my-server",
+		CustomDomainID: uuid.NullUUID{},
+		RouteBase:      "mcp",
+	})
+	require.ErrorIs(t, err, errToolsetEndpointMismatch)
+}

--- a/server/internal/mcp/wellknown_test.go
+++ b/server/internal/mcp/wellknown_test.go
@@ -211,6 +211,11 @@ func TestHandleGetAuthorizationServer_IssuerGatedToolsetBackend(t *testing.T) {
 	expectedIssuer := "http://0.0.0.0/mcp/" + slug
 	require.Equal(t, expectedIssuer, metadata["issuer"])
 	require.Equal(t, expectedIssuer+"/authorize", metadata["authorization_endpoint"])
+
+	// RFC 9207 §3. Asserted per surface because the route base is baked into
+	// the issuer that the `iss` authorization-response parameter has to match,
+	// so a regression can land on one surface while the other stays correct.
+	require.Equal(t, true, metadata["authorization_response_iss_parameter_supported"])
 }
 
 // TestHandleGetAuthorizationServer_IssuerGatedRemoteBackend_DanglingIssuerFK

--- a/server/internal/xmcp/wellknown_test.go
+++ b/server/internal/xmcp/wellknown_test.go
@@ -196,6 +196,11 @@ func TestHandleWellKnownOAuthServerMetadata_IssuerGatedRemoteBackend(t *testing.
 	require.Equal(t, expectedIssuer+"/token", metadata["token_endpoint"])
 	require.Equal(t, expectedIssuer+"/register", metadata["registration_endpoint"])
 	require.Equal(t, expectedIssuer+"/revoke", metadata["revocation_endpoint"])
+
+	// RFC 9207 §3. Asserted per surface because the route base is baked into
+	// the issuer that `iss` has to match, so a regression can land on one
+	// surface while the other stays correct.
+	require.Equal(t, true, metadata["authorization_response_iss_parameter_supported"])
 }
 
 // TestHandleWellKnownOAuthServerMetadata_IssuerGatedToolsetBackend mirrors


### PR DESCRIPTION
[AIS-369](https://linear.app/speakeasy/issue/AIS-369/feat-emit-rfc-9207-iss-authorization-response-parameter-on-the-user)

Brings the user-session OAuth surface in line with the MCP `2026-07-28` authorization specification, which lists RFC 9207 in its [standards compliance set](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#standards-compliance) and defines the client half of the exchange under [Authorization Response Validation](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#authorization-response-validation). Inclusion of `iss` by an authorization server is a **SHOULD** today, and the specification states that a future revision is expected to upgrade it to a **MUST**.

All four client-facing authorization responses on the `/mcp` and `/x/mcp` surfaces now carry an `iss` parameter, success and error alike per [RFC 9207 section 2](https://www.rfc-editor.org/rfc/rfc9207#section-2), and the authorization server metadata advertises `authorization_response_iss_parameter_supported` per [section 3](https://www.rfc-editor.org/rfc/rfc9207#section-3).

The emitted value has to equal the advertised `issuer` byte for byte, so it hangs off the origin the challenge was minted under rather than the origin of whichever request completes the flow. Two paths resume a challenge somewhere else: `HandleIDPCallback` is mounted at a global URL and has no custom domain context, and the remote-session return leg bounces through the platform origin. A client that sees a mismatched `iss` rejects the response and is forbidden from displaying the error it discarded, so getting this wrong surfaces as nothing at all.

`buildClientRedirect` now takes a params struct and returns an error. The struct makes `exhaustruct` enforce every field at each call site, and the error covers a non-absolute issuer and an unparseable `redirect_uri`, both of which would otherwise produce a response a client silently discards. It also clears the response-owned query parameters from the registered `redirect_uri`, so a `redirect_uri` carrying its own `code` cannot make a decline read as a grant.

Advertising and emitting ship together safely: a client holding a pre-deploy copy of the metadata sees `iss` without the flag and compares it anyway. **Rolling back is not symmetric**, because a client that cached the flag will reject responses from a server that no longer emits `iss`.

Follow-ups filed as [AIS-440](https://linear.app/speakeasy/issue/AIS-440/fix-consent-path-builds-the-rfc-9207-iss-from-the-requests-route-base) and [AIS-441](https://linear.app/speakeasy/issue/AIS-441/fix-remote-session-return-leg-drops-the-custom-domain).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RFC 9207 `iss` to all user-session OAuth authorization responses and advertises support in metadata per MCP 2026-07-28, enabling clients to verify issuer and prevent AS mix-up (AIS-369).

- **New Features**
  - Emit `iss` on success and error responses across `/mcp` and `/x/mcp`, matching the metadata `issuer` byte-for-byte.
  - Build `iss` from the mint-time origin for `HandleAuthorize`, `HandleConsent` (approve/deny), and `HandleIDPCallback`, not from the resuming request.
  - Advertise `authorization_response_iss_parameter_supported: true` in user-session AS metadata; legacy oauth-proxy docs still omit it.
  - Refactor `buildClientRedirect` to a params struct that returns errors; require absolute http(s) issuer, parse/sanitize `redirect_uri`, and clear response-owned params (`iss`, `code`, `error`, `error_description`) while preserving `state`.

- **Bug Fixes**
  - Pin endpoint route surface in `ValidateRef` to prevent cross-surface resumes (`/mcp` vs `/x/mcp`) that would emit a mismatched `iss`.
  - Count a single terminal flow metric in `HandleIDPCallback` error forwarding, only after a client redirect is confirmed buildable.

<sup>Written for commit 46718789f3ac1c3aa01a10b275f3493f3a598795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

