### PR TITLE
feat: emit MCP protocol version telemetry on all inbound MCP paths

### DIFF
--- a/.changeset/mcp-protocol-version-telemetry.md
+++ b/.changeset/mcp-protocol-version-telemetry.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Emit the MCP protocol version to OpenTelemetry on all five inbound MCP paths. Traces now carry `gram.mcp.requested_protocol_version` and `gram.mcp.negotiated_protocol_version`, and a new unsampled `mcp.initialize` counter breaks handshakes down by revision, so client version adoption can be measured and a version-specific failure can be diagnosed.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1090,9 +1090,10 @@ func newStartCommand() *cli.Command {
 				)
 			})
 			mux.Use(middleware.RouteLabelerMiddleware)
-			// Must stay below otelhttp: it stamps attributes onto the span
+			// Must stay below otelhttp: they stamp attributes onto the span
 			// otelhttp opened for the request.
 			mux.Use(middleware.HookDeviceTelemetry)
+			mux.Use(middleware.MCPProtocolVersionTelemetry)
 			mux.Use(middleware.NewHTTPLoggingMiddleware(logger))
 			mux.Use(middleware.NewRecovery(logger))
 			mux.Use(middleware.CORSMiddleware(c.String("environment"), c.String("server-url"), chatSessionsManager))

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -261,18 +261,38 @@ const (
 	AccessRequestSentCountKey           = attribute.Key("gram.access_request.sent_count")
 	AccessRequestRecipientKey           = attribute.Key("gram.access_request.recipient")
 	McpMethodKey                        = attribute.Key("gram.mcp.method")
-	McpRequestedTagsKey                 = attribute.Key("gram.mcp.requested_tags")
-	McpToolsReturnedKey                 = attribute.Key("gram.mcp.tools_returned")
-	McpToolsFilteredKey                 = attribute.Key("gram.mcp.tools_filtered")
-	McpServerIDKey                      = attribute.Key("gram.mcp_server.id")
-	McpURLKey                           = attribute.Key("gram.mcp.url")
-	ToolVariationsGroupIDKey            = attribute.Key("gram.tool_variations_group.id")
-	MetricNameKey                       = attribute.Key("gram.metric.name")
-	MimeTypeKey                         = attribute.Key("mime.type")
-	OAuthAuthorizationEndpointKey       = attribute.Key("gram.oauth.authorization_endpoint")
-	OAuthClientIDKey                    = attribute.Key("gram.oauth.client_id")
-	OAuthClientNameKey                  = attribute.Key("gram.oauth.client_name")
-	OAuthClientSecretGeneratedKey       = attribute.Key("gram.oauth.client_secret_generated")
+	// McpRequestedProtocolVersionKey is the MCP protocol revision a client
+	// asked for in its `initialize` request params, before any negotiation.
+	// Only the handshake-based revisions (2025-11-25 and earlier) have this
+	// concept: 2026-07-28 removed `initialize`, so requests from clients on
+	// that revision carry only McpNegotiatedProtocolVersionKey.
+	McpRequestedProtocolVersionKey = attribute.Key("gram.mcp.requested_protocol_version")
+	// McpNegotiatedProtocolVersionKey is the MCP protocol revision actually in
+	// effect for a request. Under the handshake-based revisions this is what
+	// the serving side answered at `initialize` — which on Gram's own hosted
+	// and platform paths is the surface's mcpversions.Served* constant,
+	// answered unconditionally regardless of what the client asked for, and on
+	// the proxy paths is whatever the upstream server answered. Under
+	// 2026-07-28 there is no negotiation at all and the value is simply what
+	// the client declared on this request.
+	//
+	// Sourced from the `MCP-Protocol-Version` header where present (it carries
+	// the negotiated value per the Streamable HTTP transport spec, and mirrors
+	// the `io.modelcontextprotocol/protocolVersion` `_meta` key under
+	// 2026-07-28), otherwise from the observed `initialize` response.
+	McpNegotiatedProtocolVersionKey = attribute.Key("gram.mcp.negotiated_protocol_version")
+	McpRequestedTagsKey             = attribute.Key("gram.mcp.requested_tags")
+	McpToolsReturnedKey             = attribute.Key("gram.mcp.tools_returned")
+	McpToolsFilteredKey             = attribute.Key("gram.mcp.tools_filtered")
+	McpServerIDKey                  = attribute.Key("gram.mcp_server.id")
+	McpURLKey                       = attribute.Key("gram.mcp.url")
+	ToolVariationsGroupIDKey        = attribute.Key("gram.tool_variations_group.id")
+	MetricNameKey                   = attribute.Key("gram.metric.name")
+	MimeTypeKey                     = attribute.Key("mime.type")
+	OAuthAuthorizationEndpointKey   = attribute.Key("gram.oauth.authorization_endpoint")
+	OAuthClientIDKey                = attribute.Key("gram.oauth.client_id")
+	OAuthClientNameKey              = attribute.Key("gram.oauth.client_name")
+	OAuthClientSecretGeneratedKey   = attribute.Key("gram.oauth.client_secret_generated")
 	// OAuthErrorKey / OAuthErrorDescriptionKey carry the `error` /
 	// `error_description` parameters from RFC 6749 / RFC 7591 error responses
 	// — used across DCR registration, /authorize, /token, and /revoke.
@@ -1768,6 +1788,20 @@ func SlogMcpURL(v string) slog.Attr      { return slog.String(string(McpURLKey),
 
 func McpMethod(v string) attribute.KeyValue { return McpMethodKey.String(v) }
 func SlogMcpMethod(v string) slog.Attr      { return slog.String(string(McpMethodKey), v) }
+
+func MCPRequestedProtocolVersion(v string) attribute.KeyValue {
+	return McpRequestedProtocolVersionKey.String(v)
+}
+func SlogMCPRequestedProtocolVersion(v string) slog.Attr {
+	return slog.String(string(McpRequestedProtocolVersionKey), v)
+}
+
+func MCPNegotiatedProtocolVersion(v string) attribute.KeyValue {
+	return McpNegotiatedProtocolVersionKey.String(v)
+}
+func SlogMCPNegotiatedProtocolVersion(v string) slog.Attr {
+	return slog.String(string(McpNegotiatedProtocolVersionKey), v)
+}
 
 func MCPRequestedTags(v []string) attribute.KeyValue { return McpRequestedTagsKey.StringSlice(v) }
 func SlogMCPRequestedTags(v []string) slog.Attr {

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -396,6 +396,17 @@ func (s *Service) requestAccessURL(ctx context.Context, serverID string, serverN
 	})
 }
 
+// PublicServerRoute is the chi route pattern for the public MCP endpoint: the
+// JSON-RPC surface of a hosted MCP server. All three Streamable HTTP verbs
+// mount here — POST for JSON-RPC messages, GET for the standalone SSE stream,
+// and DELETE for session termination.
+//
+// The OAuth, metadata, and install routes extend this pattern with a further
+// path segment. They are not the MCP endpoint itself, which is why anything
+// keyed on "is this an MCP endpoint" has to match the pattern exactly rather
+// than as a prefix.
+const PublicServerRoute = "/mcp/{mcpSlug}"
+
 func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Service) {
 	o11y.AttachHandler(mux, "POST", PlatformToolsetRoute, oops.ErrHandle(service.logger, service.ServePlatformToolset).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
@@ -408,31 +419,31 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	// (not slug-scoped): clients are addressed by their globally unique id.
 	o11y.AttachHandler(mux, "GET", "/.well-known/oauth-client/{id}", oops.ErrHandle(service.logger, service.HandleClientMetadataDocument).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/.well-known/openai-apps-challenge", oops.ErrHandle(service.logger, service.HandleOpenAIAppsChallenge).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, service.ServePublic).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
+	o11y.AttachHandler(mux, "POST", PublicServerRoute, oops.MCPErrHandle(service.logger, service.ServePublic).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute, oops.MCPErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
 		return service.HandleGetServer(w, r, metadataService)
 	}).ServeHTTP)
-	o11y.AttachHandler(mux, "DELETE", "/mcp/{mcpSlug}", oops.MCPErrHandle(service.logger, service.HandleDeleteServer).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/install", oops.ErrHandle(service.logger, metadataService.ServeInstallPage).ServeHTTP)
+	o11y.AttachHandler(mux, "DELETE", PublicServerRoute, oops.MCPErrHandle(service.logger, service.HandleDeleteServer).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute+"/install", oops.ErrHandle(service.logger, metadataService.ServeInstallPage).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/install-page-{hash}.js", oops.ErrHandle(service.logger, metadataService.ServeInstallPageScript).ServeHTTP)
 
 	// OAuth metadata at the canonical RFC paths. The handlers in
 	// authnchallenge.go dispatch internally on toolsets.user_session_issuer_id:
 	// issuer-gated toolsets get the new metadata shape; legacy toolsets fall
 	// through to wellknown.Resolve* (preserving the prior behaviour).
-	o11y.AttachHandler(mux, "GET", wellknown.OAuthProtectedResourcePath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleGetProtectedResource).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", wellknown.OAuthAuthorizationServerPath+"/mcp/{mcpSlug}", oops.ErrHandle(service.logger, service.HandleGetAuthorizationServer).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/register", oops.ErrHandle(service.logger, service.HandleRegister).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/authorize", oops.ErrHandle(service.logger, service.HandleAuthorize).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/connect/remote-session", oops.ErrHandle(service.logger, service.HandleConsentAction).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/connect/first-party", oops.ErrHandle(service.logger, service.HandleFirstPartyConnect).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", wellknown.OAuthProtectedResourcePath+PublicServerRoute, oops.ErrHandle(service.logger, service.HandleGetProtectedResource).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", wellknown.OAuthAuthorizationServerPath+PublicServerRoute, oops.ErrHandle(service.logger, service.HandleGetAuthorizationServer).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", PublicServerRoute+"/register", oops.ErrHandle(service.logger, service.HandleRegister).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute+"/authorize", oops.ErrHandle(service.logger, service.HandleAuthorize).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute+"/idp_callback", oops.ErrHandle(service.logger, service.HandleIDPCallback).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute+"/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", PublicServerRoute+"/connect", oops.ErrHandle(service.logger, service.HandleConsent).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", PublicServerRoute+"/connect/remote-session", oops.ErrHandle(service.logger, service.HandleConsentAction).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute+"/connect/first-party", oops.ErrHandle(service.logger, service.HandleFirstPartyConnect).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/mcp/consent-page-{hash}.js", oops.ErrHandle(service.logger, service.ServeConsentScript).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/token", oops.ErrHandle(service.logger, service.HandleToken).ServeHTTP)
-	o11y.AttachHandler(mux, "POST", "/mcp/{mcpSlug}/revoke", oops.ErrHandle(service.logger, service.HandleRevoke).ServeHTTP)
-	o11y.AttachHandler(mux, "GET", "/mcp/{mcpSlug}/remote_login_callback", oops.ErrHandle(service.logger, service.HandleRemoteLoginCallback).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", PublicServerRoute+"/token", oops.ErrHandle(service.logger, service.HandleToken).ServeHTTP)
+	o11y.AttachHandler(mux, "POST", PublicServerRoute+"/revoke", oops.ErrHandle(service.logger, service.HandleRevoke).ServeHTTP)
+	o11y.AttachHandler(mux, "GET", PublicServerRoute+"/remote_login_callback", oops.ErrHandle(service.logger, service.HandleRemoteLoginCallback).ServeHTTP)
 }
 
 // HandleRemoteLoginCallback is the chi handler at

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1240,7 +1240,7 @@ func (s *Service) handleRequest(ctx context.Context, payload *mcpInputs, req *ra
 	case "ping":
 		return handlePing(ctx, s.logger, req.ID)
 	case "initialize":
-		return handleInitialize(ctx, s.logger, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo, s.sessionClientInfo)
+		return handleInitialize(ctx, s.logger, s.metrics, req, payload, s.posthog, s.toolsetsRepo, s.mcpMetadataRepo, s.sessionClientInfo)
 	case "notifications/initialized", "notifications/cancelled":
 		return nil, nil
 	case "tools/list":

--- a/server/internal/mcp/mcpversions/doc.go
+++ b/server/internal/mcp/mcpversions/doc.go
@@ -1,0 +1,16 @@
+// Package mcpversions is the single registry of MCP protocol revision
+// identifiers Gram recognizes.
+//
+// Protocol versions reach Gram as client-supplied input — the
+// `MCP-Protocol-Version` HTTP header on Streamable HTTP, or the
+// `protocolVersion` field of an `initialize` request under the handshake-based
+// revisions. That makes the value unbounded in principle: a broken or hostile
+// client can send anything. This package draws the line between the revisions
+// we know about and everything else, so callers can keep raw values on spans
+// (high cardinality, sampled, diagnostic) while metric dimensions stay bounded
+// by [Clamp] (low cardinality, unsampled, aggregatable).
+//
+// The list is deliberately inclusive: recognizing a revision Gram does not
+// otherwise implement costs nothing, whereas omitting one that real clients
+// send silently buckets live traffic into [Other] and hides it.
+package mcpversions

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -1,0 +1,150 @@
+package mcpversions
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+)
+
+// Published MCP protocol revisions, oldest first. Sourced from the
+// specification's revision list (https://modelcontextprotocol.io/specification/versioning).
+//
+// These are NOT a statement of what Gram implements or accepts; the Served*
+// constants below carry the revision each Gram surface answers with. They exist
+// so telemetry can distinguish "a revision we know about" from "something else
+// entirely".
+const (
+	Version20241105 = "2024-11-05"
+	Version20250326 = "2025-03-26"
+	Version20250618 = "2025-06-18"
+	Version20251125 = "2025-11-25"
+	Version20260728 = "2026-07-28"
+)
+
+// The protocol revision each Gram surface that terminates an MCP session
+// answers with. Both are answered unconditionally, without regard to what the
+// client requested — which is precisely why requested and negotiated are
+// tracked as separate telemetry attributes rather than collapsed into one.
+//
+// They are split per surface deliberately, despite currently holding the same
+// value. The surfaces face different client populations, so raising one is not
+// the same decision as raising the other, and a supported-version ceiling is
+// expected to move them on different schedules.
+//
+// The remote MCP proxy has no entry here by design: it never answers a
+// version, it relays whatever the client and the upstream negotiate between
+// themselves. Gram's outbound remote-URL verification probe is also absent —
+// that is Gram acting as a client, so the version it sends is a requested one
+// rather than a served one, and it lives with the probe.
+const (
+	// ServedHostedToolset is answered on /mcp/{slug} and on the
+	// toolset-backed /x/mcp/{slug}, which share a handler. This surface faces
+	// arbitrary third-party MCP clients, so changing it is a compatibility
+	// event with external blast radius.
+	ServedHostedToolset = Version20250326
+
+	// ServedPlatformToolset is answered on /platform/mcp/{slug}, which accepts
+	// only the assistant token — user OAuth, API keys, and chat sessions are
+	// deliberately not honored there. That closed, first-party client set
+	// means this can move without third-party exposure.
+	ServedPlatformToolset = Version20250326
+)
+
+// HTTPHeader is the header MCP clients stamp on every request once the
+// protocol version is established. Under the handshake-based revisions it
+// carries the version negotiated at `initialize`; under 2026-07-28 it mirrors
+// the per-request `io.modelcontextprotocol/protocolVersion` `_meta` key.
+// Either way it is the version in effect for the request carrying it.
+//
+// It is absent from the `initialize` request itself, since nothing is
+// negotiated yet at that point.
+const HTTPHeader = "MCP-Protocol-Version"
+
+// Other and None are the two synthetic buckets [Clamp] emits, so that every
+// point on a versioned metric carries the same dimensions and a breakdown by
+// version accounts for all traffic rather than silently dropping the awkward
+// cases. Neither can collide with a real revision, which is always a date; a
+// client that literally sends "other" or "none" is unrecognized and buckets
+// into Other like any other unknown value.
+const (
+	// Other collects every unrecognized version. Sustained traffic here means
+	// either a new revision shipped and this package has gone stale, or a
+	// client is sending garbage; both are worth an alert.
+	Other = "other"
+
+	// None marks a client that supplied no version at all. Distinct from Other
+	// because the two imply different things about the client: Other is a
+	// client naming a revision nobody here knows, None is a client that named
+	// none, which on a handshake means it omitted a field the protocol
+	// requires. That cohort is the likeliest to break under a version ceiling,
+	// so it needs to be countable rather than absent.
+	None = "none"
+)
+
+// maxRawLength bounds a client-supplied version before it becomes a span
+// attribute. Every real revision identifier is exactly 10 characters; the
+// allowance leaves room to see what a malformed sender actually sent without
+// letting it write an unbounded string into telemetry.
+const maxRawLength = 32
+
+// all lists every recognized revision, oldest first. Order is part of the
+// contract: it is the basis for any "is this revision older than X" comparison
+// a version ceiling would need.
+var all = []string{
+	Version20241105,
+	Version20250326,
+	Version20250618,
+	Version20251125,
+	Version20260728,
+}
+
+// All returns the recognized protocol revisions, oldest first.
+func All() []string {
+	return slices.Clone(all)
+}
+
+// Known reports whether v is a protocol revision this package recognizes.
+func Known(v string) bool {
+	return slices.Contains(all, v)
+}
+
+// Clamp bounds a client-supplied version for use as a metric dimension: a
+// recognized revision passes through, an absent one becomes [None], and
+// anything else becomes [Other].
+//
+// The result is never empty, so callers record the dimension unconditionally.
+// Omitting it instead would emit a differently-shaped series for the clients
+// that supplied nothing, leaving that cohort countable only by subtracting the
+// labelled series from a total that is not itself recorded.
+//
+// Span attributes want the opposite treatment and use [Sanitize]: on a trace an
+// absent attribute already reads as absent, and a synthetic bucket would be
+// noise.
+func Clamp(v string) string {
+	switch {
+	case v == "":
+		return None
+	case Known(v):
+		return v
+	default:
+		return Other
+	}
+}
+
+// Sanitize bounds an untrusted, client-supplied version before it is recorded
+// as a span attribute. The value is trimmed and length-capped, and is rejected
+// outright if it carries anything beyond printable ASCII, so a hostile sender
+// cannot write control bytes into telemetry. Unlike [Clamp] the
+// result is not restricted to known revisions: the raw value is the diagnostic
+// payload, and seeing what an unrecognized client actually sent is the point.
+func Sanitize(v string) string {
+	v = conv.TruncateString(strings.TrimSpace(v), maxRawLength)
+	for _, r := range v {
+		if r < 0x20 || r > 0x7e {
+			return ""
+		}
+	}
+
+	return v
+}

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -1,0 +1,140 @@
+package mcpversions_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
+
+func TestAllIsChronologicallyOrdered(t *testing.T) {
+	t.Parallel()
+
+	versions := mcpversions.All()
+	require.True(t, slices.IsSorted(versions), "revision identifiers are YYYY-MM-DD, so chronological order is lexical order")
+}
+
+func TestAllHasNoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	versions := mcpversions.All()
+	deduped := slices.Compact(slices.Clone(versions))
+	require.Equal(t, versions, deduped)
+}
+
+func TestAllReturnsACopy(t *testing.T) {
+	t.Parallel()
+
+	first := mcpversions.All()
+	first[0] = "mutated"
+
+	require.Equal(t, mcpversions.Version20241105, mcpversions.All()[0], "All must not hand out a mutable view of package state")
+}
+
+// TestServedVersionsAreKnown guards every surface's served revision against
+// drifting out of the registry. Add a case here when a surface is added.
+func TestServedVersionsAreKnown(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, mcpversions.Known(mcpversions.ServedHostedToolset))
+	require.True(t, mcpversions.Known(mcpversions.ServedPlatformToolset))
+}
+
+func TestKnownAcceptsEveryPublishedRevision(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range mcpversions.All() {
+		require.True(t, mcpversions.Known(v), "expected %q to be recognized", v)
+	}
+}
+
+func TestKnownRejectsUnrecognizedValues(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, mcpversions.Known(""))
+	require.False(t, mcpversions.Known("2025-03-27"))
+	require.False(t, mcpversions.Known("garbage"))
+	require.False(t, mcpversions.Known(" 2025-03-26"), "Known matches exactly; callers sanitize first")
+}
+
+func TestClampPassesThroughKnownVersions(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range mcpversions.All() {
+		require.Equal(t, v, mcpversions.Clamp(v))
+	}
+}
+
+func TestClampBucketsUnknownVersions(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, mcpversions.Other, mcpversions.Clamp("2999-01-01"))
+	require.Equal(t, mcpversions.Other, mcpversions.Clamp("not-a-version"))
+}
+
+func TestClampBucketsAnAbsentVersionAsNone(t *testing.T) {
+	t.Parallel()
+
+	// "the client said nothing" and "the client said something unrecognized"
+	// are different facts, so they get different buckets — but both get one,
+	// so a breakdown by version accounts for every point.
+	require.Equal(t, mcpversions.None, mcpversions.Clamp(""))
+}
+
+func TestClampNeverReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Metric callers record the dimension unconditionally and rely on this.
+	for _, v := range []string{"", " ", "garbage", "2999-01-01", mcpversions.Version20250618} {
+		require.NotEmpty(t, mcpversions.Clamp(v), "input %q", v)
+	}
+}
+
+// TestClampDoesNotLetClientsForgeSyntheticBuckets pins that the two synthetic
+// bucket names are not reachable by a client sending them literally.
+func TestClampDoesNotLetClientsForgeSyntheticBuckets(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, mcpversions.Other, mcpversions.Clamp(mcpversions.None))
+	require.Equal(t, mcpversions.Other, mcpversions.Clamp(mcpversions.Other))
+}
+
+func TestSanitizeTrimsSurroundingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, mcpversions.Version20250618, mcpversions.Sanitize("  2025-06-18\t"))
+}
+
+func TestSanitizeCapsLength(t *testing.T) {
+	t.Parallel()
+
+	got := mcpversions.Sanitize(strings.Repeat("a", 500))
+	require.Len(t, got, 32)
+}
+
+func TestSanitizeRejectsNonPrintableASCII(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, mcpversions.Sanitize("2025-06-18\x00"))
+	require.Empty(t, mcpversions.Sanitize("2025\n06-18"))
+	require.Empty(t, mcpversions.Sanitize("2025-06-18é"))
+}
+
+func TestSanitizeTrimsRatherThanRejectsSurroundingControlBytes(t *testing.T) {
+	t.Parallel()
+
+	// Trimming runs before the printable-ASCII check, so a header value with
+	// stray leading/trailing whitespace is cleaned up rather than discarded.
+	require.Equal(t, mcpversions.Version20250618, mcpversions.Sanitize("2025-06-18\n"))
+}
+
+func TestSanitizePreservesUnknownButWellFormedValues(t *testing.T) {
+	t.Parallel()
+
+	// The raw value is the diagnostic payload — Sanitize bounds it, it does
+	// not restrict it to known revisions the way Clamp does.
+	require.Equal(t, "1999-12-31", mcpversions.Sanitize("1999-12-31"))
+}

--- a/server/internal/mcp/metrics.go
+++ b/server/internal/mcp/metrics.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 )
 
 // oauthFlowStage is the closed set of coarse stages at which a user-facing
@@ -39,6 +40,13 @@ const (
 )
 
 type metrics struct {
+	// mcpInitializeCounter is the unsampled census of observed handshakes by
+	// protocol revision. A counter rather than a span attribute because traces
+	// are sampled and so cannot be counted, and separate from
+	// mcpRequestDuration because that histogram carries a per-server URL
+	// dimension this must not be multiplied by.
+	mcpInitializeCounter metric.Int64Counter
+
 	mcpToolCallCounter metric.Int64Counter
 	mcpRequestDuration metric.Float64Histogram
 
@@ -83,6 +91,15 @@ func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 		logger.ErrorContext(context.Background(), "failed to create mcp request duration", attr.SlogError(err))
 	}
 
+	mcpInitializeCounter, err := meter.Int64Counter(
+		"mcp.initialize",
+		metric.WithDescription("MCP handshakes observed, by requested and negotiated protocol revision"),
+		metric.WithUnit("{handshake}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create mcp initialize counter", attr.SlogError(err))
+	}
+
 	oauthFlowStartedCounter, err := meter.Int64Counter(
 		"oauth.flow.started",
 		metric.WithDescription("User-facing OAuth flow initiated at /authorize"),
@@ -122,6 +139,7 @@ func newMetrics(meter metric.Meter, logger *slog.Logger) *metrics {
 	return &metrics{
 		mcpToolCallCounter:        mcpToolCallCounter,
 		mcpRequestDuration:        mcpRequestDuration,
+		mcpInitializeCounter:      mcpInitializeCounter,
 		oauthFlowStartedCounter:   oauthFlowStartedCounter,
 		oauthFlowCompletedCounter: oauthFlowCompletedCounter,
 		oauthFlowFailedCounter:    oauthFlowFailedCounter,
@@ -140,6 +158,33 @@ func (m *metrics) RecordMCPToolCall(ctx context.Context, orgID string, mcpURL st
 		attr.OrganizationID(orgID),
 	}
 	m.mcpToolCallCounter.Add(ctx, 1, metric.WithAttributes(kv...))
+}
+
+// RecordMCPInitialize counts one observed MCP handshake, dimensioned by the
+// protocol revision the client requested and the one it was answered with.
+//
+// This is deliberately a counter and deliberately carries no per-server
+// dimension. Traces are sampled at a low fixed rate service-wide, so span
+// attributes answer "what version was this failing request?" but cannot answer
+// "how many clients are still on 2024-11-05?" — which is the census question
+// protocol-version gating decisions depend on. Omitting gram.mcp.url keeps this
+// instrument aggregatable across the whole fleet and keeps its series count
+// bounded to the version cross-product.
+//
+// Both dimensions are clamped to the known revision set so a hostile or broken
+// client cannot mint unbounded series; the unclamped values remain on the span.
+// Both are always recorded, so a breakdown by version accounts for every
+// handshake — including clients that named an unknown revision or none at all,
+// which are the two cohorts most likely to break under a version ceiling.
+func (m *metrics) RecordMCPInitialize(ctx context.Context, requested, negotiated string) {
+	if m == nil || m.mcpInitializeCounter == nil {
+		return
+	}
+
+	m.mcpInitializeCounter.Add(ctx, 1, metric.WithAttributes(
+		attr.MCPRequestedProtocolVersion(mcpversions.Clamp(mcpversions.Sanitize(requested))),
+		attr.MCPNegotiatedProtocolVersion(mcpversions.Clamp(mcpversions.Sanitize(negotiated))),
+	))
 }
 
 func (m *metrics) RecordMCPRequestDuration(ctx context.Context, mcpMethod string, mcpURL string, duration time.Duration) {

--- a/server/internal/mcp/protocolversion.go
+++ b/server/internal/mcp/protocolversion.go
@@ -1,0 +1,47 @@
+package mcp
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
+
+// recordMCPProtocolVersionSpan annotates the active span with the MCP protocol
+// revision a client asked for and the one actually in effect, so a trace can
+// be attributed to a protocol version and a pinned or downgraded negotiation
+// is visible rather than implied.
+//
+// Either value may be empty — a client can omit protocolVersion from its
+// initialize params — in which case that attribute is omitted rather than
+// recorded as "". Values are client-supplied, so they are bounded by
+// [mcpversions.Sanitize] before being recorded; the raw (sanitized) value is
+// kept deliberately, since an unrecognized revision is exactly what an
+// operator debugging a version-specific failure needs to see. Bucketing to
+// [mcpversions.Other] applies only to metric dimensions.
+//
+// This stamps whichever span is current. On the /mcp and /platform/mcp paths
+// that is the otelhttp server span; the remote MCP proxy sets its own
+// attributes on its per-request child span instead, so a downgrade there is
+// attributed to the upstream leg rather than to Gram.
+func recordMCPProtocolVersionSpan(ctx context.Context, requested, negotiated string) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if v := mcpversions.Sanitize(requested); v != "" {
+		attrs = append(attrs, attr.MCPRequestedProtocolVersion(v))
+	}
+	if v := mcpversions.Sanitize(negotiated); v != "" {
+		attrs = append(attrs, attr.MCPNegotiatedProtocolVersion(v))
+	}
+
+	if len(attrs) > 0 {
+		span.SetAttributes(attrs...)
+	}
+}

--- a/server/internal/mcp/protocolversion_internal_test.go
+++ b/server/internal/mcp/protocolversion_internal_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
+
+// recordedProtocolVersionAttrs runs recordMCPProtocolVersionSpan inside a
+// span and returns the attributes it left behind.
+func recordedProtocolVersionAttrs(t *testing.T, requested, negotiated string) map[string]string {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	ctx, span := provider.Tracer("test").Start(t.Context(), "mcp")
+	recordMCPProtocolVersionSpan(ctx, requested, negotiated)
+	span.End()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+
+	got := map[string]string{}
+	for _, kv := range ended[0].Attributes() {
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+
+	return got
+}
+
+// TestRecordMCPProtocolVersionSpan_RecordsGramsPinAsADiscrepancy is the case that
+// motivates tracking the two versions separately: the hosted path answers
+// ServedHostedToolset no matter what the client asked for, and collapsing them
+// into one attribute would hide that.
+func TestRecordMCPProtocolVersionSpan_RecordsGramsPinAsADiscrepancy(t *testing.T) {
+	t.Parallel()
+
+	got := recordedProtocolVersionAttrs(t, mcpversions.Version20260728, mcpversions.ServedHostedToolset)
+	require.Equal(t, mcpversions.Version20260728, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.Equal(t, mcpversions.ServedHostedToolset, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+func TestRecordMCPProtocolVersionSpan_OmitsAbsentRequestedVersion(t *testing.T) {
+	t.Parallel()
+
+	got := recordedProtocolVersionAttrs(t, "", mcpversions.ServedHostedToolset)
+	require.NotContains(t, got, string(attr.McpRequestedProtocolVersionKey))
+	require.Equal(t, mcpversions.ServedHostedToolset, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+// TestRecordMCPProtocolVersionSpan_OmitsAbsentNegotiatedVersion covers the
+// session-store propagation path, which knows what the client requested but
+// not what it was answered with.
+func TestRecordMCPProtocolVersionSpan_OmitsAbsentNegotiatedVersion(t *testing.T) {
+	t.Parallel()
+
+	got := recordedProtocolVersionAttrs(t, mcpversions.Version20250618, "")
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey))
+}
+
+func TestRecordMCPProtocolVersionSpan_RecordsNothingWhenBothAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := recordedProtocolVersionAttrs(t, "", "")
+	require.NotContains(t, got, string(attr.McpRequestedProtocolVersionKey))
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey))
+}
+
+// TestRecordMCPProtocolVersionSpan_KeepsUnrecognizedVersions pins that the span
+// carries the raw value. Bucketing to "other" is a metric-dimension concern;
+// on a span an unrecognized revision is the diagnostic payload.
+func TestRecordMCPProtocolVersionSpan_KeepsUnrecognizedVersions(t *testing.T) {
+	t.Parallel()
+
+	got := recordedProtocolVersionAttrs(t, "1999-12-31", mcpversions.ServedHostedToolset)
+	require.Equal(t, "1999-12-31", got[string(attr.McpRequestedProtocolVersionKey)])
+}
+
+func TestRecordMCPProtocolVersionSpan_BoundsHostileValues(t *testing.T) {
+	t.Parallel()
+
+	got := recordedProtocolVersionAttrs(t, strings.Repeat("a", 4096), "2025-06-18\x00injected")
+	require.Len(t, got[string(attr.McpRequestedProtocolVersionKey)], 32)
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey))
+}
+
+func TestRecordMCPProtocolVersionSpan_ToleratesNonRecordingSpan(t *testing.T) {
+	t.Parallel()
+
+	// Sampled-out requests reach handlers with a non-recording span; recording
+	// must be a no-op rather than a panic.
+	require.NotPanics(t, func() {
+		recordMCPProtocolVersionSpan(t.Context(), mcpversions.Version20250618, mcpversions.ServedHostedToolset)
+	})
+}

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -58,7 +59,7 @@ func parseInitializeParams(raw json.RawMessage) (initializeParams, []string, err
 	return params, slices.Sorted(maps.Keys(params.Capabilities)), nil
 }
 
-func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries, clientInfoStore sessionClientInfoStore) (json.RawMessage, error) {
+func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *metrics, req *rawRequest, payload *mcpInputs, productMetrics *posthog.Posthog, toolsetsRepoParam *toolsets_repo.Queries, metadataRepoParam *metadata_repo.Queries, clientInfoStore sessionClientInfoStore) (json.RawMessage, error) {
 	params, capabilities, err := parseInitializeParams(req.Params)
 	validParams := err == nil
 	if err != nil {
@@ -67,7 +68,14 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest,
 		logger.WarnContext(ctx, "failed to parse mcp initialize params", attr.SlogError(err))
 	}
 
-	storeSessionClientInfo(ctx, logger, clientInfoStore, payload, params.ClientInfo.Name, params.ClientInfo.Version)
+	// The requested version is what the client asked for; the negotiated one is
+	// what this handler answers below, which is ServedHostedToolset
+	// unconditionally. Recording both makes that pin visible rather than
+	// collapsing it — on this path they differ for most clients.
+	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, mcpversions.ServedHostedToolset)
+	telemetry.RecordMCPInitialize(ctx, params.ProtocolVersion, mcpversions.ServedHostedToolset)
+
+	storeSessionClientInfo(ctx, logger, clientInfoStore, payload, params.ClientInfo.Name, params.ClientInfo.Version, params.ProtocolVersion)
 
 	if requestContext, _ := contextvalues.GetRequestContext(ctx); requestContext != nil {
 		if err := productMetrics.CaptureEvent(ctx, "mcp_initialized", payload.sessionID, map[string]any{
@@ -91,7 +99,7 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest,
 	result := &result[initializeResult]{
 		ID: req.ID,
 		Result: initializeResult{
-			ProtocolVersion: "2025-03-26",
+			ProtocolVersion: mcpversions.ServedHostedToolset,
 			Capabilities: map[string]json.RawMessage{
 				"tools":     json.RawMessage("{}"),
 				"prompts":   json.RawMessage("{}"),

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
@@ -196,7 +197,7 @@ func (s *Service) handlePlatformToolsetRequest(
 	case "ping":
 		return handlePing(ctx, s.logger, req.ID)
 	case "initialize":
-		return handlePlatformInitialize(ctx, s.logger, req)
+		return handlePlatformInitialize(ctx, s.logger, s.metrics, req)
 	case "notifications/initialized", "notifications/cancelled":
 		return nil, nil
 	case "tools/list":
@@ -208,11 +209,26 @@ func (s *Service) handlePlatformToolsetRequest(
 	}
 }
 
-func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, req *rawRequest) (json.RawMessage, error) {
+func handlePlatformInitialize(ctx context.Context, logger *slog.Logger, telemetry *metrics, req *rawRequest) (json.RawMessage, error) {
+	// This path answers ServedPlatformToolset unconditionally and does not
+	// otherwise read the request params. Parsing them purely for telemetry is
+	// the point: without it the platform surface is the one inbound path where
+	// the client's requested revision is invisible, which reads as a hole in
+	// the data rather than as "platform clients don't negotiate". Malformed
+	// params must not fail the handshake, so a parse error is logged and the
+	// requested version is simply left unrecorded.
+	params, _, err := parseInitializeParams(req.Params)
+	if err != nil {
+		logger.WarnContext(ctx, "failed to parse platform mcp initialize params", attr.SlogError(err))
+	}
+
+	recordMCPProtocolVersionSpan(ctx, params.ProtocolVersion, mcpversions.ServedPlatformToolset)
+	telemetry.RecordMCPInitialize(ctx, params.ProtocolVersion, mcpversions.ServedPlatformToolset)
+
 	result := &result[initializeResult]{
 		ID: req.ID,
 		Result: initializeResult{
-			ProtocolVersion: "2025-03-26",
+			ProtocolVersion: mcpversions.ServedPlatformToolset,
 			Capabilities: map[string]json.RawMessage{
 				"tools": json.RawMessage("{}"),
 			},

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -109,13 +109,15 @@ func resolveClientIdentity(ctx context.Context, logger *slog.Logger, store sessi
 	// middleware.MCPProtocolVersionTelemetry; this fills the gap for clients
 	// predating that header, which is why it is best-effort by design.
 	//
-	// Stamped as the requested version, not the negotiated one: this is what
-	// the client asked for at initialize. What Gram answered on this path is
-	// always mcpversions.ServedHostedToolset.
-	//
-	// This store is only written by the hosted toolset handler, so that is the
-	// only surface whose served version is implied here.
-	recordMCPProtocolVersionSpan(ctx, info.ProtocolVersion, "")
+	// The stored value is what the client asked for at initialize. The
+	// negotiated half is deterministic rather than stored: this store is only
+	// written by the hosted toolset handler, which answers
+	// ServedHostedToolset unconditionally. Recording it here is what gives
+	// pre-header clients a negotiated attribute at all, since the middleware
+	// has no header to read for them. A session that handshaked before a
+	// change to that constant would be attributed the current value, which is
+	// the one inaccuracy the determinism costs.
+	recordMCPProtocolVersionSpan(ctx, info.ProtocolVersion, mcpversions.ServedHostedToolset)
 
 	return identity
 }

--- a/server/internal/mcp/sessionclientinfo.go
+++ b/server/internal/mcp/sessionclientinfo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
@@ -29,19 +30,27 @@ type sessionClientInfoStore interface {
 	Load(ctx context.Context, projectID uuid.UUID, toolsetSlug, sessionID string, nowMillis int64) (sessionclientinfo.Info, error)
 }
 
-// storeSessionClientInfo records the identity a client reported at initialize.
-// A client that reports no name leaves no record, and a write failure is
-// logged rather than surfaced: losing the identity must never fail the
-// handshake.
-func storeSessionClientInfo(ctx context.Context, logger *slog.Logger, store sessionClientInfoStore, payload *mcpInputs, name, version string) {
+// storeSessionClientInfo records what a client reported about itself at
+// initialize. A client that reports neither a name nor a protocol version
+// leaves no record, and a write failure is logged rather than surfaced: losing
+// this must never fail the handshake.
+//
+// Either field alone is enough to be worth recording. A client that omits
+// clientInfo.name but sends protocolVersion is still attributable to a protocol
+// generation for the rest of its session, which is the more useful of the two
+// for diagnosing version-specific behaviour. Admitting those records does not
+// affect how much can be stored: the per-server record cap is what bounds that.
+func storeSessionClientInfo(ctx context.Context, logger *slog.Logger, store sessionClientInfoStore, payload *mcpInputs, name, version, protocolVersion string) {
 	name = sanitizeClientInfoField(name)
-	if name == "" || payload.sessionID == "" {
+	protocolVersion = mcpversions.Sanitize(protocolVersion)
+	if payload.sessionID == "" || (name == "" && protocolVersion == "") {
 		return
 	}
 
 	err := store.Store(ctx, payload.projectID, payload.toolset, payload.sessionID, sessionclientinfo.Info{
-		Name:    name,
-		Version: sanitizeClientInfoField(version),
+		Name:            name,
+		Version:         sanitizeClientInfoField(version),
+		ProtocolVersion: protocolVersion,
 	}, time.Now().UnixMilli())
 	if err != nil {
 		logger.WarnContext(ctx, "failed to record mcp session client info", attr.SlogError(err))
@@ -91,6 +100,22 @@ func resolveClientIdentity(ctx context.Context, logger *slog.Logger, store sessi
 
 	identity.Name = info.Name
 	identity.Version = info.Version
+
+	// Attribute this request to the protocol generation its session handshaked
+	// with. Piggybacking on the Load above is deliberate: it makes propagation
+	// free on the one non-initialize request that already reads the store,
+	// rather than adding a Redis round-trip to every RPC. Clients that send the
+	// MCP-Protocol-Version header are already covered on every request by
+	// middleware.MCPProtocolVersionTelemetry; this fills the gap for clients
+	// predating that header, which is why it is best-effort by design.
+	//
+	// Stamped as the requested version, not the negotiated one: this is what
+	// the client asked for at initialize. What Gram answered on this path is
+	// always mcpversions.ServedHostedToolset.
+	//
+	// This store is only written by the hosted toolset handler, so that is the
+	// only surface whose served version is implied here.
+	recordMCPProtocolVersionSpan(ctx, info.ProtocolVersion, "")
 
 	return identity
 }

--- a/server/internal/mcp/sessionclientinfo/store.go
+++ b/server/internal/mcp/sessionclientinfo/store.go
@@ -42,6 +42,13 @@ var ErrNotFound = errors.New("session client info not found")
 type Info struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
+
+	// ProtocolVersion is the MCP protocol revision the client asked for in its
+	// initialize params — what it requested, not what it was answered with.
+	// Carried so later requests in the same session can be attributed to a
+	// protocol generation without the client having to repeat it. Empty when
+	// the client omits it, which callers treat as "generation unknown".
+	ProtocolVersion string `json:"protocol_version"`
 }
 
 // Store reads and writes session identities in Redis.
@@ -175,7 +182,12 @@ func (s *Store) Load(ctx context.Context, projectID uuid.UUID, toolsetSlug, sess
 	if err := json.Unmarshal([]byte(raw), &info); err != nil {
 		return Info{}, fmt.Errorf("unmarshal session client info: %w", err)
 	}
-	if info.Name == "" {
+	// A record carrying nothing tells a caller no more than a missing one, so
+	// it reports as absent. A record with only a protocol version is not empty
+	// in this sense: it still attributes the session to a protocol generation,
+	// which is the whole reason a client that omits clientInfo.name is worth
+	// recording at all.
+	if info.Name == "" && info.ProtocolVersion == "" {
 		return Info{}, ErrNotFound
 	}
 

--- a/server/internal/mcp/sessionclientinfo/store_test.go
+++ b/server/internal/mcp/sessionclientinfo/store_test.go
@@ -39,6 +39,63 @@ func TestLoadUnknownSessionIsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestStoreLoadRoundTripsProtocolVersion(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 0)
+	projectID := uuid.New()
+
+	require.NoError(t, store.Store(t.Context(), projectID, "widgets", "session-1", Info{
+		Name:            "claude-code",
+		Version:         "2.1",
+		ProtocolVersion: "2025-06-18",
+	}, 1))
+
+	got, err := store.Load(t.Context(), projectID, "widgets", "session-1", 2)
+	require.NoError(t, err)
+	require.Equal(t, "2025-06-18", got.ProtocolVersion)
+}
+
+// TestLoadReturnsRecordCarryingOnlyAProtocolVersion covers a client that omits
+// clientInfo.name: the record still attributes its session to a protocol
+// generation, so it must survive the round trip rather than reporting absent.
+func TestLoadReturnsRecordCarryingOnlyAProtocolVersion(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 0)
+	projectID := uuid.New()
+
+	require.NoError(t, store.Store(t.Context(), projectID, "widgets", "session-1", Info{
+		Name:            "",
+		Version:         "",
+		ProtocolVersion: "2025-06-18",
+	}, 1))
+
+	got, err := store.Load(t.Context(), projectID, "widgets", "session-1", 2)
+	require.NoError(t, err)
+	require.Empty(t, got.Name)
+	require.Equal(t, "2025-06-18", got.ProtocolVersion)
+}
+
+// TestLoadTreatsAnEmptyRecordAsAbsent pins the other side of that boundary: a
+// record with neither a name nor a protocol version tells a caller nothing a
+// missing record would not.
+func TestLoadTreatsAnEmptyRecordAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t, 0)
+	projectID := uuid.New()
+
+	require.NoError(t, store.Store(t.Context(), projectID, "widgets", "session-1", Info{
+		Name:            "",
+		Version:         "",
+		ProtocolVersion: "",
+	}, 1))
+
+	_, err := store.Load(t.Context(), projectID, "widgets", "session-1", 2)
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
 // TestRecordsAreScopedPerMCPServer covers the tenancy boundary: session ids
 // arrive on a client-supplied header, so a record must not be reachable from
 // another project or toolset.

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
@@ -70,7 +71,7 @@ func TestResolveClientIdentity_FallsBackToHandshake(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3", mcpversions.Version20250618)
 
 	identity := resolveClientIdentity(ctx, logger, store, payload, nil)
 	require.Equal(t, toolconfig.MCPClientIdentity{
@@ -91,7 +92,7 @@ func TestResolveClientIdentity_PerCallHintWins(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3", mcpversions.Version20250618)
 
 	identity := resolveClientIdentity(ctx, logger, store, payload, &mcpClientInfoHint{
 		Name:    "per-call-client",
@@ -110,7 +111,7 @@ func TestResolveClientIdentity_NamelessHintFallsBack(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3", mcpversions.Version20250618)
 
 	identity := resolveClientIdentity(ctx, logger, store, payload, &mcpClientInfoHint{
 		Name:    "",
@@ -145,25 +146,59 @@ func TestStoreSessionClientInfo_BoundsRecordedFields(t *testing.T) {
 	logger := testenv.NewLogger(t)
 	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, store, payload, "ev\x00il\nclient", "1.\t0")
+	storeSessionClientInfo(ctx, logger, store, payload, "ev\x00il\nclient", "1.\t0", "2025-06-18\x00injected")
 
 	info, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, 0)
 	require.NoError(t, err)
 	require.Equal(t, "evilclient", info.Name)
 	require.Equal(t, "1.0", info.Version)
+	require.Empty(t, info.ProtocolVersion, "a protocol version carrying control bytes is dropped, not cleaned")
 }
 
-func TestStoreSessionClientInfo_NamelessClientRecordsNothing(t *testing.T) {
+func TestStoreSessionClientInfo_AnonymousClientRecordsNothing(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	logger := testenv.NewLogger(t)
 	store, payload := newClientIdentityFixture(t)
 
-	storeSessionClientInfo(ctx, logger, store, payload, "", "1.2.3")
+	storeSessionClientInfo(ctx, logger, store, payload, "", "1.2.3", "")
 
 	_, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, 0)
 	require.ErrorIs(t, err, sessionclientinfo.ErrNotFound)
+}
+
+// TestStoreSessionClientInfo_NamelessClientStillRecordsProtocolVersion pins
+// that a protocol version alone is enough to earn a record: a client that omits
+// clientInfo.name stays attributable to a protocol generation for the rest of
+// its session.
+func TestStoreSessionClientInfo_NamelessClientStillRecordsProtocolVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	store, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, store, payload, "", "", mcpversions.Version20250618)
+
+	info, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, 0)
+	require.NoError(t, err)
+	require.Empty(t, info.Name)
+	require.Equal(t, mcpversions.Version20250618, info.ProtocolVersion)
+}
+
+func TestStoreSessionClientInfo_RecordsProtocolVersionAlongsideIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	store, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3", mcpversions.Version20251125)
+
+	info, err := store.Load(ctx, payload.projectID, payload.toolset, payload.sessionID, 0)
+	require.NoError(t, err)
+	require.Equal(t, mcpversions.Version20251125, info.ProtocolVersion)
 }
 
 // TestResolveClientIdentity_OAuthClientIsIndependent pins the split between the

--- a/server/internal/mcp/sessionclientinfo_internal_test.go
+++ b/server/internal/mcp/sessionclientinfo_internal_test.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
@@ -224,4 +227,38 @@ func TestResolveClientIdentity_UnknownCallerIsZero(t *testing.T) {
 	store, payload := newClientIdentityFixture(t)
 
 	require.True(t, resolveClientIdentity(ctx, logger, store, payload, nil).IsZero())
+}
+
+// TestResolveClientIdentity_StampsBothProtocolVersions covers the cohort this
+// propagation exists for: a client predating the MCP-Protocol-Version header
+// gets no attribute from middleware, so this is the only place either half of
+// the protocol version reaches the span on a tool call.
+func TestResolveClientIdentity_StampsBothProtocolVersions(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	logger := testenv.NewLogger(t)
+	store, payload := newClientIdentityFixture(t)
+
+	storeSessionClientInfo(ctx, logger, store, payload, "handshake-client", "1.2.3", mcpversions.Version20241105)
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	spanCtx, span := provider.Tracer("test").Start(ctx, "tools/call")
+	resolveClientIdentity(spanCtx, logger, store, payload, nil)
+	span.End()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+
+	got := map[string]string{}
+	for _, kv := range ended[0].Attributes() {
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+
+	require.Equal(t, mcpversions.Version20241105, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.Equal(t, mcpversions.ServedHostedToolset, got[string(attr.McpNegotiatedProtocolVersionKey)],
+		"this surface answers its served constant, so the negotiated half is deterministic here")
 }

--- a/server/internal/mcp/sessionclientinfo_test.go
+++ b/server/internal/mcp/sessionclientinfo_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 )
@@ -98,10 +99,12 @@ func TestServePublic_InitializeBoundsCachedClientInfo(t *testing.T) {
 	require.Equal(t, "1.0", info.Version)
 }
 
-// TestServePublic_InitializeWithoutClientInfoCachesNothing keeps the cache free
-// of nameless entries so readers can treat a miss and an anonymous client the
-// same way.
-func TestServePublic_InitializeWithoutClientInfoCachesNothing(t *testing.T) {
+// TestServePublic_InitializeWithoutClientInfoCachesProtocolVersionOnly covers a
+// client that reports a protocol version but no name. The record it leaves
+// carries the version and nothing else, keeping the session attributable to a
+// protocol generation while still resolving to an anonymous identity — readers
+// of the identity treat that the same as a cache miss.
+func TestServePublic_InitializeWithoutClientInfoCachesProtocolVersionOnly(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)
@@ -120,6 +123,9 @@ func TestServePublic_InitializeWithoutClientInfoCachesNothing(t *testing.T) {
 	sessionID := w.Header().Get("Mcp-Session-Id")
 	require.NotEmpty(t, sessionID)
 
-	_, err = newClientInfoStore(t).Load(ctx, *authCtx.ProjectID, toolset.Slug, sessionID, 0)
-	require.ErrorIs(t, err, sessionclientinfo.ErrNotFound)
+	info, err := newClientInfoStore(t).Load(ctx, *authCtx.ProjectID, toolset.Slug, sessionID, 0)
+	require.NoError(t, err)
+	require.Empty(t, info.Name)
+	require.Empty(t, info.Version)
+	require.Equal(t, mcpversions.Version20250326, info.ProtocolVersion)
 }

--- a/server/internal/middleware/mcp_protocol_version.go
+++ b/server/internal/middleware/mcp_protocol_version.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
+
+// MCPProtocolVersionTelemetry lifts the MCP-Protocol-Version header onto the
+// server span for requests to an MCP JSON-RPC endpoint, so a request that
+// carries one can be attributed to a protocol revision in traces.
+//
+// This is the only instrument covering all five inbound MCP paths and all three
+// Streamable HTTP verbs from a single place, but it sees only what the header
+// carries, which varies by revision. Clients on revisions before 2025-06-18 do
+// not send it at all. Clients that do send it omit it from an `initialize`
+// request, where no version is established yet; the initialize handlers record
+// what those clients asked for instead. Clients on 2026-07-28 have no
+// `initialize` to omit it from and declare a version on every request, so the
+// header is the only source for them.
+//
+// Must be registered after otelhttp so the span is in the request context.
+// Header values are client-supplied input and are sanitized before becoming
+// attributes; the raw (bounded) value is kept because seeing what a
+// non-conforming client actually sent is the diagnostic point. Non-MCP routes
+// are untouched.
+//
+// Gram is not the only reader: the remote MCP proxy forwards this header
+// upstream untouched, so nothing here may mutate it.
+func MCPProtocolVersionTelemetry(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isMCPJSONRPCEndpoint(r.URL.Path) {
+			if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
+				if v := mcpversions.Sanitize(r.Header.Get(mcpversions.HTTPHeader)); v != "" {
+					span.SetAttributes(attr.MCPNegotiatedProtocolVersion(v))
+				}
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isMCPJSONRPCEndpoint reports whether path addresses one of the MCP JSON-RPC
+// endpoints, as distinct from the OAuth, metadata, and install-page routes
+// that share the /mcp/ prefix.
+//
+// Matching is on segment shape rather than a bare prefix because
+// /mcp/{slug}/token, /register, /authorize, and /connect are not MCP endpoints
+// and never carry a protocol version. Route patterns are not available here:
+// this middleware is registered via goa's Muxer.Use, which delegates to chi's
+// Router.Use and therefore runs before routing.
+//
+// The shapes matched here are the MCP JSON-RPC routes the server registers. A
+// new MCP route that does not match one of them is served uninstrumented, with
+// no failure to signal it.
+func isMCPJSONRPCEndpoint(path string) bool {
+	rest, ok := strings.CutPrefix(path, "/")
+	if !ok {
+		return false
+	}
+
+	switch head, tail, _ := strings.Cut(rest, "/"); head {
+	case "mcp":
+		// /mcp/{mcpSlug} — the hosted toolset endpoint. A further slash means
+		// an OAuth or metadata sub-route, not the MCP endpoint itself.
+		return tail != "" && !strings.Contains(tail, "/")
+	case "x", "platform":
+		// /x/mcp/{slug} (toolset-backed, remote-backed, and tunneled) and
+		// /platform/mcp/{toolsetSlug}.
+		slug, ok := strings.CutPrefix(tail, "mcp/")
+		return ok && slug != "" && !strings.Contains(slug, "/")
+	default:
+		return false
+	}
+}

--- a/server/internal/middleware/mcp_protocol_version_test.go
+++ b/server/internal/middleware/mcp_protocol_version_test.go
@@ -11,8 +11,10 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/xmcp"
 )
 
 // recordSpanForRequest runs the middleware inside a recorded span, mimicking
@@ -78,6 +80,39 @@ func TestMCPProtocolVersionTelemetryCoversGetAndDelete(t *testing.T) {
 	for _, method := range []string{http.MethodGet, http.MethodDelete} {
 		got := recordSpanForRequest(t, method, "/x/mcp/my-server", mcpversions.Version20250618)
 		require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)], "method %s", method)
+	}
+}
+
+// routePathForSlug turns a chi route pattern into a concrete request path by
+// substituting a slug for its single parameter.
+func routePathForSlug(t *testing.T, pattern, slug string) string {
+	t.Helper()
+
+	open := strings.IndexByte(pattern, '{')
+	closing := strings.IndexByte(pattern, '}')
+	require.Greater(t, closing, open, "pattern %q has no route parameter", pattern)
+	require.GreaterOrEqual(t, open, 0, "pattern %q has no route parameter", pattern)
+
+	return pattern[:open] + slug + pattern[closing+1:]
+}
+
+// TestMCPProtocolVersionTelemetryMatchesRegisteredRoutes derives paths from the
+// route patterns the server actually registers rather than from string literals
+// repeated here. The middleware duplicates route knowledge outside the router,
+// so a route that moves out from under it would otherwise be served
+// uninstrumented with nothing to signal it.
+//
+// Covers the two MCP JSON-RPC endpoints that expose their pattern as a
+// constant. The hosted /mcp/{mcpSlug} route is registered as a bare literal, so
+// it has nothing to derive from and is asserted separately above.
+func TestMCPProtocolVersionTelemetryMatchesRegisteredRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, pattern := range []string{mcp.PlatformToolsetRoute, xmcp.RuntimePath} {
+		path := routePathForSlug(t, pattern, "my-server")
+		got := recordSpanForRequest(t, http.MethodPost, path, mcpversions.Version20250618)
+		require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)],
+			"route %q resolved to %q, which the middleware does not match", pattern, path)
 	}
 }
 

--- a/server/internal/middleware/mcp_protocol_version_test.go
+++ b/server/internal/middleware/mcp_protocol_version_test.go
@@ -102,17 +102,23 @@ func routePathForSlug(t *testing.T, pattern, slug string) string {
 // so a route that moves out from under it would otherwise be served
 // uninstrumented with nothing to signal it.
 //
-// Covers the two MCP JSON-RPC endpoints that expose their pattern as a
-// constant. The hosted /mcp/{mcpSlug} route is registered as a bare literal, so
-// it has nothing to derive from and is asserted separately above.
+// Every MCP endpoint mounts all three Streamable HTTP verbs, and the protocol
+// version is carried on all of them: POST for JSON-RPC messages, GET for the
+// standalone SSE stream, DELETE for session termination. Asserting the full
+// cross-product keeps a verb-specific gap from hiding behind a passing POST.
 func TestMCPProtocolVersionTelemetryMatchesRegisteredRoutes(t *testing.T) {
 	t.Parallel()
 
-	for _, pattern := range []string{mcp.PlatformToolsetRoute, xmcp.RuntimePath} {
+	patterns := []string{mcp.PublicServerRoute, mcp.PlatformToolsetRoute, xmcp.RuntimePath}
+	methods := []string{http.MethodPost, http.MethodGet, http.MethodDelete}
+
+	for _, pattern := range patterns {
 		path := routePathForSlug(t, pattern, "my-server")
-		got := recordSpanForRequest(t, http.MethodPost, path, mcpversions.Version20250618)
-		require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)],
-			"route %q resolved to %q, which the middleware does not match", pattern, path)
+		for _, method := range methods {
+			got := recordSpanForRequest(t, method, path, mcpversions.Version20250618)
+			require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)],
+				"route %q resolved to %q, which the middleware does not match for %s", pattern, path, method)
+		}
 	}
 }
 

--- a/server/internal/middleware/mcp_protocol_version_test.go
+++ b/server/internal/middleware/mcp_protocol_version_test.go
@@ -1,0 +1,179 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/middleware"
+)
+
+// recordSpanForRequest runs the middleware inside a recorded span, mimicking
+// otelhttp having already opened the server span, and returns the attributes
+// left on that span.
+func recordSpanForRequest(t *testing.T, method, path, headerValue string) map[string]string {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	handler := middleware.MCPProtocolVersionTelemetry(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(method, path, nil)
+	if headerValue != "" {
+		req.Header.Set("MCP-Protocol-Version", headerValue)
+	}
+
+	ctx, span := provider.Tracer("test").Start(t.Context(), "http")
+	handler.ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+	span.End()
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+
+	got := map[string]string{}
+	for _, kv := range ended[0].Attributes() {
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+
+	return got
+}
+
+func TestMCPProtocolVersionTelemetryRecordsHeaderOnHostedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	got := recordSpanForRequest(t, http.MethodPost, "/mcp/my-server", mcpversions.Version20250618)
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+func TestMCPProtocolVersionTelemetryRecordsHeaderOnXMCPEndpoint(t *testing.T) {
+	t.Parallel()
+
+	got := recordSpanForRequest(t, http.MethodPost, "/x/mcp/my-server", mcpversions.Version20260728)
+	require.Equal(t, mcpversions.Version20260728, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+func TestMCPProtocolVersionTelemetryRecordsHeaderOnPlatformEndpoint(t *testing.T) {
+	t.Parallel()
+
+	got := recordSpanForRequest(t, http.MethodPost, "/platform/mcp/my-toolset", mcpversions.Version20250326)
+	require.Equal(t, mcpversions.Version20250326, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+func TestMCPProtocolVersionTelemetryCoversGetAndDelete(t *testing.T) {
+	t.Parallel()
+
+	// Streamable HTTP uses GET to open an SSE stream and DELETE to terminate a
+	// session; both carry the header and both reach the remote MCP proxy.
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		got := recordSpanForRequest(t, method, "/x/mcp/my-server", mcpversions.Version20250618)
+		require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)], "method %s", method)
+	}
+}
+
+func TestMCPProtocolVersionTelemetryIgnoresOAuthSubRoutes(t *testing.T) {
+	t.Parallel()
+
+	// These share the /mcp/ prefix but are not MCP endpoints and never carry a
+	// protocol version.
+	for _, path := range []string{
+		"/mcp/my-server/token",
+		"/mcp/my-server/register",
+		"/mcp/my-server/authorize",
+		"/mcp/my-server/connect",
+		"/mcp/my-server/install",
+	} {
+		got := recordSpanForRequest(t, http.MethodPost, path, mcpversions.Version20250618)
+		require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey), "path %s", path)
+	}
+}
+
+func TestMCPProtocolVersionTelemetryIgnoresNonMCPRoutes(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{"/rpc/toolsets.list", "/healthz", "/", "/mcp", "/x/mcp", "/x/other/slug"} {
+		got := recordSpanForRequest(t, http.MethodPost, path, mcpversions.Version20250618)
+		require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey), "path %s", path)
+	}
+}
+
+func TestMCPProtocolVersionTelemetryOmitsAttributeWhenHeaderAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := recordSpanForRequest(t, http.MethodPost, "/mcp/my-server", "")
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey))
+}
+
+func TestMCPProtocolVersionTelemetryKeepsUnrecognizedButWellFormedValues(t *testing.T) {
+	t.Parallel()
+
+	// The span carries the raw value: an unrecognized revision is exactly what
+	// an operator needs to see. Bucketing to "other" applies to metric
+	// dimensions only.
+	got := recordSpanForRequest(t, http.MethodPost, "/mcp/my-server", "1999-12-31")
+	require.Equal(t, "1999-12-31", got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+func TestMCPProtocolVersionTelemetryDropsHostileHeaderValues(t *testing.T) {
+	t.Parallel()
+
+	got := recordSpanForRequest(t, http.MethodPost, "/mcp/my-server", "2025-06-18\x00injected")
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey))
+}
+
+func TestMCPProtocolVersionTelemetryBoundsOversizedHeaderValues(t *testing.T) {
+	t.Parallel()
+
+	got := recordSpanForRequest(t, http.MethodPost, "/mcp/my-server", strings.Repeat("a", 4096))
+	require.Len(t, got[string(attr.McpNegotiatedProtocolVersionKey)], 32)
+}
+
+func TestMCPProtocolVersionTelemetryPassesRequestThrough(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	var seenHeader string
+	handler := middleware.MCPProtocolVersionTelemetry(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		seenHeader = r.Header.Get("MCP-Protocol-Version")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/my-server", nil)
+	req.Header.Set("MCP-Protocol-Version", mcpversions.Version20250618)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// The proxy forwards this header upstream verbatim, so the middleware must
+	// not consume or rewrite it.
+	require.Equal(t, mcpversions.Version20250618, seenHeader)
+}
+
+func TestMCPProtocolVersionTelemetryToleratesMissingSpan(t *testing.T) {
+	t.Parallel()
+
+	// Requests short-circuited above otelhttp reach handlers with no recording
+	// span in context; the middleware must not panic.
+	handler := middleware.MCPProtocolVersionTelemetry(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/my-server", nil)
+	req.Header.Set("MCP-Protocol-Version", mcpversions.Version20250618)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/server/internal/remotemcp/initialize_posthog_event_interceptor.go
+++ b/server/internal/remotemcp/initialize_posthog_event_interceptor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 )
@@ -79,9 +80,20 @@ func (i *InitializePostHogEventInterceptor) InterceptInitializeRequest(ctx conte
 		sessionID = uuid.NewString()
 	}
 
+	// protocolVersion mirrors the property the hosted /mcp handler records on
+	// this same event. Without it the two runtimes emit the same event name
+	// with different schemas, and the proxy — the path with real version
+	// negotiation, since Gram is only passing through — is the one with no
+	// unsampled record of what clients ask for.
+	var protocolVersion string
+	if init.Params != nil {
+		protocolVersion = mcpversions.Sanitize(init.Params.ProtocolVersion)
+	}
+
 	if err := i.posthog.CaptureEvent(ctx, eventMCPInitialized, sessionID, map[string]any{
 		"project_id":             projectID,
 		"authenticated":          authenticated,
+		"protocol_version":       protocolVersion,
 		"remote_mcp_server_id":   i.identity.RemoteMCPServerID,
 		"tunneled_mcp_server_id": i.identity.TunneledMCPServerID,
 		"mcp_server_id":          i.identity.McpServerID,

--- a/server/internal/remotemcp/proxy/protocol_version.go
+++ b/server/internal/remotemcp/proxy/protocol_version.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
+
+// How the MCP protocol version reaches the proxy depends on the revision in
+// play, and no single source covers every client:
+//
+//   - Under the handshake-based revisions (2025-11-25 and earlier) the version
+//     is agreed by an `initialize` exchange. The request carries no
+//     MCP-Protocol-Version header, because nothing is agreed yet when it is
+//     sent, so the handshake is only observable from the two ends of that
+//     exchange. Clients on 2025-06-18 and later then repeat the agreed version
+//     in the header on every subsequent request; earlier clients never send it.
+//   - Under 2026-07-28 there is no `initialize` at all. Each request declares
+//     its own version, and on Streamable HTTP that declaration is carried in
+//     the header, making it the only source for those clients.
+//
+// The proxy therefore reads both: the header wherever it appears, and the
+// handshake where one happens. Gram is a pass-through on this path, so the
+// values are agreed between the client and the upstream server and are recorded
+// on the proxy's own spans, keeping them attributable to the upstream leg.
+//
+// Values reaching these functions are supplied by a client or by a server Gram
+// does not control, so they are bounded before being recorded. They are not
+// clamped to the known revision set: on a span an unrecognized revision is the
+// diagnostic payload, and bucketing belongs on metric dimensions, whose series
+// count is what needs protecting.
+
+// appendNegotiatedProtocolVersion appends the span attribute naming the
+// protocol revision in effect for r, read from its MCP-Protocol-Version header.
+// Returns attrs unchanged when the request names no revision.
+func appendNegotiatedProtocolVersion(attrs []attribute.KeyValue, r *http.Request) []attribute.KeyValue {
+	v := mcpversions.Sanitize(r.Header.Get(mcpversions.HTTPHeader))
+	if v == "" {
+		return attrs
+	}
+
+	return append(attrs, attr.MCPNegotiatedProtocolVersion(v))
+}
+
+// The record functions below take the span explicitly and the proxy calls them
+// against the span covering the inbound request, matching how tools/call and
+// resources/read attach their own request attributes.
+
+// recordRequestedProtocolVersion stamps the revision a client asked for in its
+// initialize params onto span. A no-op when the client asked for none.
+func recordRequestedProtocolVersion(span trace.Span, req *InitializeRequest) {
+	if !span.IsRecording() || req == nil || req.Params == nil {
+		return
+	}
+
+	if v := mcpversions.Sanitize(req.Params.ProtocolVersion); v != "" {
+		span.SetAttributes(attr.MCPRequestedProtocolVersion(v))
+	}
+}
+
+// recordNegotiatedProtocolVersion stamps the revision an upstream answered an
+// initialize request with onto span, reading it from msg. A no-op when msg is
+// not a decodable successful initialize response naming a revision, so a
+// rejected or malformed handshake is not recorded as a successful one.
+//
+// Callers must have established that msg replies to an initialize request; the
+// payload shape alone does not identify one.
+func recordNegotiatedProtocolVersion(span trace.Span, msg *RemoteMessage) {
+	if !span.IsRecording() || msg == nil {
+		return
+	}
+
+	rpcResp, ok := msg.Message.(*jsonrpc.Response)
+	if !ok || rpcResp.Error != nil || len(rpcResp.Result) == 0 {
+		return
+	}
+
+	// Decoded into a minimal shape rather than mcp.InitializeResult: the
+	// protocol version is the only field wanted, and a narrow target keeps this
+	// immune to unrelated churn in the SDK's result type.
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
+		return
+	}
+
+	if v := mcpversions.Sanitize(result.ProtocolVersion); v != "" {
+		span.SetAttributes(attr.MCPNegotiatedProtocolVersion(v))
+	}
+}

--- a/server/internal/remotemcp/proxy/protocol_version_test.go
+++ b/server/internal/remotemcp/proxy/protocol_version_test.go
@@ -5,75 +5,53 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
-	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
-// newRecordingProxyForTest mirrors newProxyForTest but installs a recording
-// tracer so the attributes the proxy stamps on its own spans can be asserted.
+// newRecordingProxyForTest builds the standard test proxy with a recording
+// tracer swapped in, so the attributes it stamps on its own spans can be
+// asserted. Deriving from newProxyForTest rather than rebuilding the struct
+// keeps the two from drifting as fields are added to proxy.Proxy.
 func newRecordingProxyForTest(t *testing.T, upstreamURL string) (*proxy.Proxy, *tracetest.SpanRecorder) {
 	t.Helper()
-
-	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
-	require.NoError(t, err)
 
 	recorder := tracetest.NewSpanRecorder()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
 	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
 
-	return &proxy.Proxy{
-		GuardianPolicy:        policy,
-		GuardianClientOptions: nil,
-		Logger:                testenv.NewLogger(t),
-		Tracer:                provider.Tracer("test"),
-		NonStreamingTimeout:   5 * time.Second,
-		StreamingTimeout:      5 * time.Second,
-		Metrics:               nil,
-		MaxBufferedBodyBytes:  proxy.DefaultMaxBufferedBodyBytes,
-		Identity: proxy.ServerIdentity{
-			RemoteMCPServerID:   "",
-			TunneledMCPServerID: "",
-			McpServerID:         "",
-		},
-		RemoteURL:                         upstreamURL,
-		Headers:                           nil,
-		AuthorizationOverride:             "",
-		UpstreamResponseRetryer:           nil,
-		UpstreamResponseInterceptor:       nil,
-		UserRequestInterceptors:           nil,
-		InitializeRequestInterceptors:     nil,
-		RemoteMessageInterceptors:         nil,
-		ToolsCallRequestInterceptors:      nil,
-		ToolsCallResponseInterceptors:     nil,
-		ToolsListRequestInterceptors:      nil,
-		ToolsListResponseInterceptors:     nil,
-		ResourcesReadRequestInterceptors:  nil,
-		ResourcesReadResponseInterceptors: nil,
-		ResourcesListRequestInterceptors:  nil,
-		ResourcesListResponseInterceptors: nil,
-	}, recorder
+	p := newProxyForTest(t, upstreamURL)
+	p.Tracer = provider.Tracer("test")
+
+	return p, recorder
 }
 
-// postSpanAttributes returns the attributes on the proxy's own request span.
+// postSpanAttributes returns the attributes on the span the proxy opens for the
+// inbound POST. Selected by name rather than position: spans end
+// children-before-parent, so any span added to the forward or relay path would
+// otherwise take the first slot and be silently asserted against instead.
 func postSpanAttributes(t *testing.T, recorder *tracetest.SpanRecorder) map[string]string {
 	t.Helper()
 
-	ended := recorder.Ended()
-	require.NotEmpty(t, ended)
-
 	got := map[string]string{}
-	for _, kv := range ended[0].Attributes() {
-		got[string(kv.Key)] = kv.Value.AsString()
+	found := false
+	for _, span := range recorder.Ended() {
+		if span.Name() != "remotemcp.proxy.Post" {
+			continue
+		}
+		require.False(t, found, "expected exactly one remotemcp.proxy.Post span")
+		found = true
+		for _, kv := range span.Attributes() {
+			got[string(kv.Key)] = kv.Value.AsString()
+		}
 	}
+	require.True(t, found, "no remotemcp.proxy.Post span was recorded")
 
 	return got
 }
@@ -268,4 +246,66 @@ func TestProxy_Post_BoundsOversizedProtocolVersionHeader(t *testing.T) {
 
 	got := postSpanAttributes(t, recorder)
 	require.Len(t, got[string(attr.McpNegotiatedProtocolVersionKey)], 32)
+}
+
+// TestProxy_Post_RecordsRequestedVersionWhenInterceptorRejects pins that a
+// handshake refused by the generic interceptor chain is still attributed to a
+// protocol revision. A rejected session is one of the more interesting things
+// to be able to slice by version.
+func TestProxy_Post_RecordsRequestedVersionWhenInterceptorRejects(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream must not be reached when the request is rejected")
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+	p.UserRequestInterceptors = []proxy.UserRequestInterceptor{
+		&mockUserRequestInterceptor{
+			name:    "rejector",
+			called:  nil,
+			order:   nil,
+			err:     &proxy.RejectError{Code: proxy.RejectCodeInvalidRequest, Message: "nope", Data: nil},
+			mutator: nil,
+		},
+	}
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey), "nothing was negotiated; the request never reached upstream")
+}
+
+// TestProxy_Post_IgnoresNegotiatedVersionFromMismatchedResponseID keeps an
+// upstream that answers with an id it was never asked about from being
+// attributed as this session's negotiation.
+func TestProxy_Post_IgnoresNegotiatedVersionFromMismatchedResponseID(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":99,"result":{"protocolVersion":"2024-11-05"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey))
 }

--- a/server/internal/remotemcp/proxy/protocol_version_test.go
+++ b/server/internal/remotemcp/proxy/protocol_version_test.go
@@ -1,0 +1,271 @@
+package proxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// newRecordingProxyForTest mirrors newProxyForTest but installs a recording
+// tracer so the attributes the proxy stamps on its own spans can be asserted.
+func newRecordingProxyForTest(t *testing.T, upstreamURL string) (*proxy.Proxy, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(t.Context()) })
+
+	return &proxy.Proxy{
+		GuardianPolicy:        policy,
+		GuardianClientOptions: nil,
+		Logger:                testenv.NewLogger(t),
+		Tracer:                provider.Tracer("test"),
+		NonStreamingTimeout:   5 * time.Second,
+		StreamingTimeout:      5 * time.Second,
+		Metrics:               nil,
+		MaxBufferedBodyBytes:  proxy.DefaultMaxBufferedBodyBytes,
+		Identity: proxy.ServerIdentity{
+			RemoteMCPServerID:   "",
+			TunneledMCPServerID: "",
+			McpServerID:         "",
+		},
+		RemoteURL:                         upstreamURL,
+		Headers:                           nil,
+		AuthorizationOverride:             "",
+		UpstreamResponseRetryer:           nil,
+		UpstreamResponseInterceptor:       nil,
+		UserRequestInterceptors:           nil,
+		InitializeRequestInterceptors:     nil,
+		RemoteMessageInterceptors:         nil,
+		ToolsCallRequestInterceptors:      nil,
+		ToolsCallResponseInterceptors:     nil,
+		ToolsListRequestInterceptors:      nil,
+		ToolsListResponseInterceptors:     nil,
+		ResourcesReadRequestInterceptors:  nil,
+		ResourcesReadResponseInterceptors: nil,
+		ResourcesListRequestInterceptors:  nil,
+		ResourcesListResponseInterceptors: nil,
+	}, recorder
+}
+
+// postSpanAttributes returns the attributes on the proxy's own request span.
+func postSpanAttributes(t *testing.T, recorder *tracetest.SpanRecorder) map[string]string {
+	t.Helper()
+
+	ended := recorder.Ended()
+	require.NotEmpty(t, ended)
+
+	got := map[string]string{}
+	for _, kv := range ended[0].Attributes() {
+		got[string(kv.Key)] = kv.Value.AsString()
+	}
+
+	return got
+}
+
+// TestProxy_Post_RecordsUpstreamDowngradeOnProxySpan is the case the whole
+// initialize-response path exists for: the client asks for a newer revision and
+// the upstream answers with an older one. Both values land on the proxy's own
+// span so the downgrade is attributable to the upstream leg rather than reading
+// as though Gram pinned the version.
+func TestProxy_Post_RecordsUpstreamDowngradeOnProxySpan(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.Equal(t, mcpversions.Version20250326, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+// TestProxy_Post_RecordsUpstreamUpgrade covers the direction that is easy to
+// forget: go-sdk answers with its own latest revision when it does not
+// recognize the client's, so upstreams upgrade as well as downgrade.
+func TestProxy_Post_RecordsUpstreamUpgrade(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20241105, got[string(attr.McpRequestedProtocolVersionKey)])
+	require.Equal(t, mcpversions.Version20251125, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+// TestProxy_Post_RecordsNegotiatedVersionFromSSEInitialize pins that an
+// upstream answering initialize over SSE is not a blind spot. Both response
+// shapes are legal for a JSON-RPC request under Streamable HTTP.
+func TestProxy_Post_RecordsNegotiatedVersionFromSSEInitialize(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sseBody(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`)))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20250326, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+// TestProxy_Post_OmitsNegotiatedVersionOnUpstreamError keeps a failed handshake
+// from being recorded as a successful negotiation.
+func TestProxy_Post_OmitsNegotiatedVersionOnUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"unsupported protocol version"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28"}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20260728, got[string(attr.McpRequestedProtocolVersionKey)], "the client's ask is still recorded")
+	require.NotContains(t, got, string(attr.McpNegotiatedProtocolVersionKey), "an error response negotiated nothing")
+}
+
+// TestProxy_Post_RecordsHeaderOnNonInitializeRequest covers the steady state:
+// after the handshake every request carries the negotiated version in a header,
+// which is what makes per-request attribution possible.
+func TestProxy_Post_RecordsHeaderOnNonInitializeRequest(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", mcpversions.Version20250618)
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Equal(t, mcpversions.Version20250618, got[string(attr.McpNegotiatedProtocolVersionKey)])
+}
+
+// TestProxy_Post_ForwardsProtocolVersionHeaderUpstream pins that reading the
+// header for telemetry does not stop the upstream from seeing it. The upstream
+// negotiated this version with the client and depends on it.
+func TestProxy_Post_ForwardsProtocolVersionHeaderUpstream(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("MCP-Protocol-Version")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, _ := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", mcpversions.Version20250618)
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	require.Equal(t, mcpversions.Version20250618, gotHeader)
+}
+
+// TestProxy_Post_BoundsOversizedProtocolVersionHeader pins that a
+// client-supplied header cannot write an unbounded string into telemetry.
+// Control bytes need no coverage here: Go's HTTP transport rejects them before
+// the request is forwarded, and middleware.MCPProtocolVersionTelemetry covers
+// the sanitizer directly.
+func TestProxy_Post_BoundsOversizedProtocolVersionHeader(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	p, recorder := newRecordingProxyForTest(t, upstream.URL)
+
+	body := `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", strings.Repeat("a", 4096))
+
+	require.NoError(t, p.Post(httptest.NewRecorder(), req))
+
+	got := postSpanAttributes(t, recorder)
+	require.Len(t, got[string(attr.McpNegotiatedProtocolVersionKey)], 32)
+}

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -504,6 +504,12 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		}
 	}
 
+	// Decoded before the generic chain so the requested version is recorded
+	// even when an interceptor rejects the request. A rejected handshake is
+	// still a handshake worth attributing to a protocol revision.
+	initializeReq, _ := initializeRequestFromUserRequest(userReq)
+	recordRequestedProtocolVersion(span, initializeReq)
+
 	if err := p.runUserRequestInterceptors(ctx, userReq); err != nil {
 		return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
 	}
@@ -514,10 +520,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	// for any request whose method does not match — the corresponding typed
 	// loop is skipped in that case. At most one of the three is non-nil for
 	// a given request.
-	initializeReq, _ := initializeRequestFromUserRequest(userReq)
 	if initializeReq != nil {
-		recordRequestedProtocolVersion(span, initializeReq)
-
 		if err := p.runInitializeRequestInterceptors(ctx, initializeReq); err != nil {
 			return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
 		}
@@ -667,8 +670,14 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 			return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
 		}
 
+		// The response id is matched against the request's even though this
+		// path carries exactly one message each way, so the check is symmetric
+		// with the SSE path and an upstream answering with an id it was never
+		// asked about is not attributed as this session's negotiation.
 		if initializeReq != nil {
-			recordNegotiatedProtocolVersion(span, remoteMsg)
+			if resp, ok := msg.(*jsonrpc.Response); ok && jsonrpcIDsEqual(resp.ID, userReqID) {
+				recordNegotiatedProtocolVersion(span, remoteMsg)
+			}
 		}
 
 		// Typed response dispatch runs after the generic chain, symmetric

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -324,7 +324,7 @@ type Proxy struct {
 // Management).
 func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) (err error) {
 	start := time.Now()
-	ctx, span := p.Tracer.Start(r.Context(), "remotemcp.proxy.Delete", trace.WithAttributes(p.requestSpanAttributes(http.MethodDelete)...))
+	ctx, span := p.Tracer.Start(r.Context(), "remotemcp.proxy.Delete", trace.WithAttributes(p.requestSpanAttributes(r, http.MethodDelete)...))
 	defer span.End()
 	defer func() {
 		if err != nil {
@@ -380,7 +380,7 @@ func (p *Proxy) Delete(w http.ResponseWriter, r *http.Request) (err error) {
 // runtime sees what upstream actually said.
 func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 	start := time.Now()
-	ctx, span := p.Tracer.Start(r.Context(), "remotemcp.proxy.Get", trace.WithAttributes(p.requestSpanAttributes(http.MethodGet)...))
+	ctx, span := p.Tracer.Start(r.Context(), "remotemcp.proxy.Get", trace.WithAttributes(p.requestSpanAttributes(r, http.MethodGet)...))
 	defer span.End()
 	defer func() {
 		if err != nil {
@@ -421,7 +421,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 	// the user's MCP runtime sees upstream's actual response instead of
 	// silently misparsing it as an SSE stream.
 	if isEventStream(upstreamResp.Header) {
-		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, nil, nil, nil, nil)
+		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, nil, nil, nil, nil, nil)
 		responseBytes = n
 		if streamErr != nil {
 			// The standalone GET stream is idle by nature — most upstreams
@@ -453,7 +453,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 // is a POST to the MCP endpoint (see spec § Sending Messages to the Server).
 func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	start := time.Now()
-	ctx, span := p.Tracer.Start(r.Context(), "remotemcp.proxy.Post", trace.WithAttributes(p.requestSpanAttributes(http.MethodPost)...))
+	ctx, span := p.Tracer.Start(r.Context(), "remotemcp.proxy.Post", trace.WithAttributes(p.requestSpanAttributes(r, http.MethodPost)...))
 	defer span.End()
 	defer func() {
 		if err != nil {
@@ -516,6 +516,8 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	// a given request.
 	initializeReq, _ := initializeRequestFromUserRequest(userReq)
 	if initializeReq != nil {
+		recordRequestedProtocolVersion(span, initializeReq)
+
 		if err := p.runInitializeRequestInterceptors(ctx, initializeReq); err != nil {
 			return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
 		}
@@ -592,7 +594,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 	// below is bypassed entirely for SSE responses because the body is
 	// not a single message to hand off — it's a stream of them.
 	if isEventStream(upstreamResp.Header) {
-		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, toolsCallReq, toolsListReq, resourcesReadReq, resourcesListReq)
+		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, initializeReq, toolsCallReq, toolsListReq, resourcesReadReq, resourcesListReq)
 		responseBytes = n
 		if streamErr != nil {
 			// Unlike the standalone GET stream, a POST response stream going
@@ -663,6 +665,10 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 
 		if err := p.runRemoteMessageInterceptors(ctx, remoteMsg); err != nil {
 			return p.dispatchInterceptorError(ctx, w, span, userReqID, err, &responseBytes)
+		}
+
+		if initializeReq != nil {
+			recordNegotiatedProtocolVersion(span, remoteMsg)
 		}
 
 		// Typed response dispatch runs after the generic chain, symmetric
@@ -873,6 +879,7 @@ func (p *Proxy) relaySSEStream(
 	userReq *http.Request,
 	remoteReq *http.Request,
 	upstreamResp *http.Response,
+	initializeReq *InitializeRequest,
 	toolsCallReq *ToolsCallRequest,
 	toolsListReq *ToolsListRequest,
 	resourcesReadReq *ResourcesReadRequest,
@@ -899,6 +906,11 @@ func (p *Proxy) relaySSEStream(
 	var terminalID jsonrpc.ID
 	var haveTerminalID bool
 	switch {
+	case initializeReq != nil && len(initializeReq.UserRequest.JSONRPCMessages) == 1:
+		if rpcReq, ok := initializeReq.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request); ok {
+			terminalID = rpcReq.ID
+			haveTerminalID = true
+		}
 	case toolsCallReq != nil && len(toolsCallReq.UserRequest.JSONRPCMessages) == 1:
 		if rpcReq, ok := toolsCallReq.UserRequest.JSONRPCMessages[0].(*jsonrpc.Request); ok {
 			terminalID = rpcReq.ID
@@ -966,6 +978,11 @@ func (p *Proxy) relaySSEStream(
 			if rejectionErr == nil && haveTerminalID {
 				if resp, ok := msg.(*jsonrpc.Response); ok && jsonrpcIDsEqual(resp.ID, terminalID) {
 					switch {
+					case initializeReq != nil:
+						// ctx still carries the span opened for the inbound
+						// POST, so the version lands on the same span as the
+						// buffered path rather than on a stream-local one.
+						recordNegotiatedProtocolVersion(trace.SpanFromContext(ctx), remoteMsg)
 					case toolsCallReq != nil:
 						if typedResp, typedOK := toolsCallResponseFromRemoteMessage(toolsCallReq, remoteMsg); typedOK {
 							if err := p.runToolsCallResponseInterceptors(ctx, typedResp); err != nil {
@@ -1057,12 +1074,14 @@ func (p *Proxy) relaySSEStream(
 
 // requestSpanAttributes returns the attribute set applied to every span the proxy
 // emits for an inbound request. Both correlation ids are optional on Proxy and
-// are omitted when empty rather than emitted as empty-string labels.
-func (p *Proxy) requestSpanAttributes(method string) []attribute.KeyValue {
+// are omitted when empty rather than emitted as empty-string labels, as is the
+// protocol version when the request does not name one.
+func (p *Proxy) requestSpanAttributes(r *http.Request, method string) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attr.HTTPRequestMethod(method),
 		attr.RemoteMCPServerURL(p.RemoteURL),
 	}
+	attrs = appendNegotiatedProtocolVersion(attrs, r)
 	return p.Identity.AppendAttributes(attrs)
 }
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-437/feat-emit-mcp-protocol-version-as-an-opentelemetry-attribute-on-all

The negotiated MCP protocol version was not reaching OpenTelemetry on any of the five inbound MCP paths, so a version-specific failure could not be diagnosed, and no gating decision could be made without adding instrumentation first.

Two span attributes are now emitted, kept separate because they differ on every path: `gram.mcp.requested_protocol_version` (what the client asked for in `initialize` params) and `gram.mcp.negotiated_protocol_version` (what is actually in effect). The hosted and platform surfaces answer a pinned version regardless of the request, and the proxy relays whatever the upstream decides, so collapsing the two would hide both facts.

Sources vary by revision, which is why no single instrument suffices. Clients before `2025-06-18` never send the `MCP-Protocol-Version` header; `2025-06-18` through `2025-11-25` send it on every request except `initialize`; `2026-07-28` removes `initialize` entirely and declares a version per request. New middleware covers the header on all five paths and all three Streamable HTTP verbs, the `initialize` handlers record what was requested, and the proxy reads the upstream's handshake response so an upstream that downgrades or upgrades a client is attributable to its own leg rather than to Gram.

A new `mcpversions` package holds the recognized revisions (ordered, so a future version ceiling can compare them), the header name, and per-surface served-version constants. `ServedHostedToolset` and `ServedPlatformToolset` replace two duplicated `"2025-03-26"` literals, split because the hosted surface faces arbitrary third-party clients while the platform surface accepts only the assistant token, so raising them is not one decision.

Traces are sampled at a low fixed rate, so span attributes cannot answer "how many clients are on this revision", which is the census a gating decision needs. A new unsampled `mcp.initialize` counter records that, dimensioned by clamped requested and negotiated version and deliberately carrying no per-server URL so its series count stays bounded. Unrecognized values bucket to `other` and absent ones to `none`, so a breakdown by version accounts for every handshake. The proxy's PostHog `mcp_initialized` event also gains `protocol_version`, which the hosted event already had.

`sessionclientinfo` now carries the requested version so tool calls stay attributable to a protocol generation. The read piggybacks on a lookup that already happens, adding no Redis round trip. Its write guard was widened to admit a client that reports a version but no name, and the read guard relaxed to match, since only a wholly empty record is absent.

No behaviour change: nothing gates, clamps, or alters negotiation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP protocol version telemetry across all inbound MCP paths so we can debug version-specific issues and measure client adoption (AIS-437). Two span attributes and an unsampled handshake counter make versions visible without changing behavior.

- New Features
  - Emit `gram.mcp.requested_protocol_version` and `gram.mcp.negotiated_protocol_version` on all five inbound paths.
    - New middleware records the `MCP-Protocol-Version` header on all MCP routes and verbs; excludes OAuth/metadata subroutes; registered after `otelhttp`.
    - `initialize` handlers record requested (from params) and negotiated (from served constants via `mcpversions.Served*`); platform path now parses params; `mcp.initialize` counter added with clamped dims (`other`, `none`) and no per-server URL.
    - Proxy stamps requested (from client `initialize`) and negotiated (from upstream response) on its request spans and records the header per request; PostHog `mcp_initialized` now includes `protocol_version`.
    - Introduce `server/internal/mcp/mcpversions` with known revisions, `HTTPHeader`, and served constants; `sessionclientinfo` stores `protocol_version` (sanitized) and tags later requests.

- Bug Fixes
  - Stamp negotiated version on tool-call spans for header-less clients using `ServedHostedToolset`.
  - Decode `initialize` before interceptors so rejected handshakes still record requested; match response IDs before recording negotiated (SSE path already matched).
  - Harden path matching, name `mcp.PublicServerRoute`, assert middleware coverage across all verbs; forward the header upstream unchanged.

<sup>Written for commit 3598771f601f8f4230414c043e02756e6d4ad6e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

