### PR TITLE
fix: stop leaking the API key to unproxied MCP servers

### DIFF
--- a/.changeset/unproxied-mcp-plugin-api-key-leak.md
+++ b/.changeset/unproxied-mcp-plugin-api-key-leak.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix a credential leak in published plugin configs: an unproxied MCP server (one whose URL points directly at a vendor, never through the platform's own gateway) could have the org's API key attached as a static Authorization header, sending it straight to the third-party vendor's server instead of the platform. Unproxied servers now carry no Gram-managed credential in any generated client config (Claude, Cursor, Codex, OpenCode), and no longer trigger an unnecessary API-key prompt during install.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -34,6 +34,12 @@ type PluginServerInfo struct {
 	// IsOAuth indicates the toolset uses OAuth (proxy or external). OAuth servers are emitted
 	// as stdio mcp-remote entries instead of HTTP-with-headers entries.
 	IsOAuth bool
+	// IsUnproxied indicates the server is an unproxied MCP server: MCPURL
+	// points directly at the vendor, never through Gram's gateway. No
+	// Authorization header may be attached — the Gram API key would leak to
+	// the vendor's own server, which was never meant to receive it, and
+	// Gram has no way to inject vendor-specific credentials on its behalf.
+	IsUnproxied bool
 	// EnvConfigs are user-facing environment variables for public servers.
 	EnvConfigs []ServerEnvConfig
 }
@@ -873,6 +879,10 @@ func generateOpenCodePlugin(files map[string][]byte, p PluginInfo, cfg GenerateC
 // APIKey plus all-public-no-env servers means the plugin is install-silent.
 func codexAuthPolicy(p PluginInfo, cfg GenerateConfig) string {
 	for _, s := range p.Servers {
+		if s.IsUnproxied {
+			// No credential of any kind is ever collected for these.
+			continue
+		}
 		if s.IsPublic {
 			if len(s.EnvConfigs) > 0 {
 				return "ON_INSTALL"
@@ -948,18 +958,22 @@ func generateCodexPluginInDir(files map[string][]byte, subdir, name string, p Pl
 			EnvHTTPHeaders:    nil,
 		}
 
-		if s.IsOAuth {
+		switch {
+		case s.IsUnproxied:
+			// Never attach the Gram API key: MCPURL points straight at the
+			// vendor's own server, which was never meant to receive it.
+		case s.IsOAuth:
 			// OAuth servers handle identity at the HTTP layer — no auth credential needed.
-		} else if s.IsPublic {
+		case s.IsPublic:
 			if len(s.EnvConfigs) > 0 {
 				entry.EnvHTTPHeaders = make(map[string]string, len(s.EnvConfigs))
 				for _, ec := range s.EnvConfigs {
 					entry.EnvHTTPHeaders[ec.DisplayName] = ec.VariableName
 				}
 			}
-		} else if cfg.APIKey != "" {
+		case cfg.APIKey != "":
 			entry.HTTPHeaders = map[string]string{"Authorization": "Bearer " + cfg.APIKey}
-		} else {
+		default:
 			entry.BearerTokenEnvVar = "GRAM_API_KEY"
 		}
 
@@ -1874,7 +1888,7 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	// Determine if any private server needs a Gram API key prompt.
 	needsGramKeyPrompt := false
 	for _, s := range p.Servers {
-		if !s.IsPublic && !s.IsOAuth && cfg.APIKey == "" {
+		if !s.IsUnproxied && !s.IsPublic && !s.IsOAuth && cfg.APIKey == "" {
 			needsGramKeyPrompt = true
 		}
 		// Public non-OAuth servers may need user-provided env vars.
@@ -1916,7 +1930,10 @@ func generateClaudePluginInDir(files map[string][]byte, subdir string, p PluginI
 	for _, s := range p.Servers {
 		var headers map[string]string
 
-		if s.IsOAuth {
+		if s.IsUnproxied {
+			// Never attach the Gram API key: MCPURL points straight at the
+			// vendor's own server, which was never meant to receive it.
+		} else if s.IsOAuth {
 			// OAuth servers handle identity at the HTTP layer — no Authorization header needed.
 		} else if s.IsPublic {
 			headers = make(map[string]string)
@@ -2055,7 +2072,10 @@ func generateCursorPluginInDir(files map[string][]byte, subdir, name string, p P
 	for _, s := range p.Servers {
 		var headers map[string]string
 
-		if s.IsOAuth {
+		if s.IsUnproxied {
+			// Never attach the Gram API key: MCPURL points straight at the
+			// vendor's own server, which was never meant to receive it.
+		} else if s.IsOAuth {
 			// OAuth servers handle identity at the HTTP layer — no Authorization header needed.
 		} else if s.IsPublic {
 			headers = make(map[string]string)
@@ -2116,7 +2136,10 @@ func generateOpenCodePluginInDir(files map[string][]byte, subdir string, p Plugi
 	for _, s := range p.Servers {
 		var headers map[string]string
 
-		if s.IsOAuth {
+		if s.IsUnproxied {
+			// Never attach the Gram API key: MCPURL points straight at the
+			// vendor's own server, which was never meant to receive it.
+		} else if s.IsOAuth {
 			// OpenCode auto-detects OAuth on remote servers and runs the
 			// authorization flow itself — no headers needed.
 		} else if s.IsPublic {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -342,6 +342,92 @@ func TestGenerateClaudeMixedOAuthAndHTTPServers(t *testing.T) {
 	require.Contains(t, pluginMeta.UserConfig, "GRAM_API_KEY")
 }
 
+// TestGenerateUnproxiedServerNeverGetsGramCredential guards against
+// reintroducing the leak fixed alongside this test: an unproxied server's
+// MCPURL points straight at the vendor, so no format may attach a Gram
+// credential (static header, env-header, or bearer-token-env-var) to it —
+// checked across all four generated formats, and with cfg.APIKey both set
+// and unset, since the leak only reproduced with a baked key present.
+func TestGenerateUnproxiedServerNeverGetsGramCredential(t *testing.T) {
+	t.Parallel()
+
+	for _, cfg := range []GenerateConfig{
+		{OrgName: "Test Org", ServerURL: "https://app.getgram.ai", APIKey: "gram_live_leaked_key"},
+		{OrgName: "Test Org", ServerURL: "https://app.getgram.ai"},
+	} {
+		plugins := []PluginInfo{
+			{
+				Name: "Test",
+				Slug: "test",
+				Servers: []PluginServerInfo{
+					{DisplayName: "vendor-widget", MCPURL: "https://vendor.example.com/mcp", IsUnproxied: true},
+				},
+			},
+		}
+
+		files, err := GeneratePluginPackages(plugins, cfg)
+		require.NoError(t, err)
+
+		var claudeConfig claudeMCPConfig
+		require.NoError(t, json.Unmarshal(files["test/.mcp.json"], &claudeConfig))
+		claudeServer := claudeConfig.MCPServers["vendor-widget"]
+		require.Equal(t, "https://vendor.example.com/mcp", claudeServer.URL)
+		require.Empty(t, claudeServer.Headers, "Claude must not attach a Gram credential to an unproxied server")
+
+		var cursorConfig cursorMCPConfig
+		require.NoError(t, json.Unmarshal(files["cursor-plugins/test-cursor/mcp.json"], &cursorConfig))
+		cursorServer := cursorConfig.MCPServers["vendor-widget"]
+		require.Equal(t, "https://vendor.example.com/mcp", cursorServer.URL)
+		require.Empty(t, cursorServer.Headers, "Cursor must not attach a Gram credential to an unproxied server")
+
+		var codexConfig codexMCPConfig
+		require.NoError(t, json.Unmarshal(files["test-codex/.mcp.json"], &codexConfig))
+		codexServer := codexConfig.MCPServers["vendor-widget"]
+		require.Equal(t, "https://vendor.example.com/mcp", codexServer.URL)
+		require.Empty(t, codexServer.HTTPHeaders, "Codex must not attach a Gram credential to an unproxied server")
+		require.Empty(t, codexServer.BearerTokenEnvVar, "Codex must not set a bearer_token_env_var for an unproxied server")
+
+		var opencodeConfig opencodeMCPConfig
+		require.NoError(t, json.Unmarshal(files["opencode-plugins/test/test/mcp.json"], &opencodeConfig))
+		opencodeServer := opencodeConfig.MCP["vendor-widget"]
+		require.Equal(t, "https://vendor.example.com/mcp", opencodeServer.URL)
+		require.Empty(t, opencodeServer.Headers, "OpenCode must not attach a Gram credential to an unproxied server")
+
+		require.Equal(t, "ON_USE", codexAuthPolicy(plugins[0], cfg),
+			"an all-unproxied plugin needs no install-time secret prompt")
+	}
+}
+
+// TestGenerateClaudeUnproxiedDoesNotForcePrompt mirrors
+// TestGenerateClaudeMixedOAuthAndHTTPServers: a private HTTP server still
+// forces the GRAM_API_KEY prompt, but an unproxied server standing alone
+// must not — needsGramKeyPrompt has the same IsOAuth/IsPublic-only gap the
+// header-attachment branches had.
+func TestGenerateClaudeUnproxiedDoesNotForcePrompt(t *testing.T) {
+	t.Parallel()
+	plugins := []PluginInfo{
+		{
+			Name: "Test",
+			Slug: "test",
+			Servers: []PluginServerInfo{
+				{DisplayName: "vendor-widget", MCPURL: "https://vendor.example.com/mcp", IsUnproxied: true},
+			},
+		},
+	}
+
+	files, err := GeneratePluginPackages(plugins, GenerateConfig{
+		OrgName:   "Test Org",
+		ServerURL: "https://app.getgram.ai",
+	})
+	require.NoError(t, err)
+
+	var pluginMeta claudePluginMeta
+	err = json.Unmarshal(files["test/.claude-plugin/plugin.json"], &pluginMeta)
+	require.NoError(t, err)
+	require.NotContains(t, pluginMeta.UserConfig, "GRAM_API_KEY",
+		"a plugin with only an unproxied server needs no Gram API key prompt")
+}
+
 func TestGenerateCodexMCPConfigUsesBearerTokenEnvVar(t *testing.T) {
 	t.Parallel()
 	plugins := []PluginInfo{

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -2655,6 +2655,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				MCPURL:      fmt.Sprintf("%s/mcp/%s", mcpBase, *mcpSlug),
 				IsPublic:    r.ToolsetIsPublic,
 				IsOAuth:     r.ToolsetIsOauth,
+				IsUnproxied: false,
 				EnvConfigs:  nil,
 			}
 
@@ -2711,6 +2712,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 		// Gram host/slug and no Gram-managed OAuth apply.
 		mcpURL := ""
 		isOAuth := false
+		isUnproxied := false
 		switch {
 		case m.EndpointSlug != "":
 			// Custom-domain endpoints are served from the domain host; platform
@@ -2727,6 +2729,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 			isOAuth = true
 		default:
 			mcpURL = conv.FromPGTextOrEmpty[string](m.UnproxiedUrl)
+			isUnproxied = true
 		}
 
 		// Environments are not yet wired to mcp_servers, so there are no
@@ -2738,6 +2741,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				MCPURL:      mcpURL,
 				IsPublic:    false,
 				IsOAuth:     isOAuth,
+				IsUnproxied: isUnproxied,
 				EnvConfigs:  nil,
 			},
 			sortOrder: m.ServerSortOrder,

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -2706,14 +2706,21 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 	for _, m := range mcpRows {
 		pb := ensurePlugin(m.PluginID, m.PluginName, m.PluginSlug, m.PluginDescription)
 
-		// An unproxied-backed server has no mcp_endpoints row (Gram never
-		// proxies it), so the query resolves its own vendor URL instead of an
-		// endpoint slug. The customer connects straight to the vendor, so no
-		// Gram host/slug and no Gram-managed OAuth apply.
+		// Classify from the authoritative backend signal (unproxied_url, set
+		// only when s.unproxied_mcp_server_id resolved a live row), not from
+		// endpoint presence/absence: nothing stops an mcp_endpoints row from
+		// existing for an unproxied-backed server (verifyEndpointReferenceOwnership
+		// only checks project ownership, not backend type), and mcp_servers'
+		// own backend-exclusivity check doesn't cover mcp_endpoints either.
+		// An unproxied-backed server's URL always wins so it's never routed
+		// through a Gram endpoint it can't actually be served from.
 		mcpURL := ""
 		isOAuth := false
 		isUnproxied := false
 		switch {
+		case m.UnproxiedUrl.Valid:
+			mcpURL = m.UnproxiedUrl.String
+			isUnproxied = true
 		case m.EndpointSlug != "":
 			// Custom-domain endpoints are served from the domain host; platform
 			// endpoints from the Gram server URL. The query already resolved the
@@ -2727,9 +2734,6 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 			// issuer (OAuth), so the generated config carries no static
 			// Authorization header (IsOAuth).
 			isOAuth = true
-		default:
-			mcpURL = conv.FromPGTextOrEmpty[string](m.UnproxiedUrl)
-			isUnproxied = true
 		}
 
 		// Environments are not yet wired to mcp_servers, so there are no

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -953,7 +953,8 @@ func TestPluginsService_PublishPlugins_UnproxiedBackedServerAppearsInBundle(t *t
 
 	var config struct {
 		MCPServers map[string]struct {
-			URL string `json:"url"`
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
 		} `json:"mcpServers"`
 	}
 	require.NoError(t, json.Unmarshal(mcpConfig, &config))
@@ -962,6 +963,9 @@ func TestPluginsService_PublishPlugins_UnproxiedBackedServerAppearsInBundle(t *t
 	require.True(t, ok, "unproxied server missing from published .mcp.json")
 	require.Equal(t, "https://vendor.example.com/mcp", server.URL,
 		"unproxied server must publish its own vendor URL, not a Gram-hosted endpoint")
+	require.Empty(t, server.Headers,
+		"unproxied server must never carry Gram's API key (or any other Gram-managed credential): "+
+			"MCPURL points straight at the vendor, so any header here leaks a Gram credential to a third party")
 }
 
 // Reproduces the plugin_github_connections_installation_repo_key conflict:


### PR DESCRIPTION
## Why

Unproxied MCP servers point straight at the vendor, not through the platform's gateway. But every plugin-config generator (Claude, Cursor, Codex, OpenCode) picked auth from `IsOAuth`/`IsPublic` alone, and unproxied servers are neither — so they fell into the branch meant for private, platform-hosted servers and got the org's live API key attached as a static `Authorization` header, sent straight to the third-party vendor on every call.

Found live: a Figma MCP entry generated from a published plugin was sending a `gram_live_...` key to `https://mcp.figma.com/mcp`, which Figma rejected with a 401 (and which blocked the normal OAuth flow, since a static header was present).

## What changed

Added an `IsUnproxied` flag to `PluginServerInfo`, checked first in all four generators and the two install-prompt-policy checks (Codex's `codexAuthPolicy`, Claude's `needsGramKeyPrompt`) that had the same gap. Extended the existing publish test to assert no headers leak, and confirmed it reproduces the leak against the pre-fix code.

### Before/After

Before: unproxied server entries carried the org's API key as a Bearer token to the vendor's own server.
After: no Gram-managed credential is attached, and no unnecessary API-key prompt during install.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaking the org API key to unproxied MCP servers by never attaching Gram credentials to vendor-hosted URLs and by correctly classifying unproxied servers from backend data. Also removes unnecessary API key prompts during install for unproxied servers.

- **Bug Fixes**
  - Added `IsUnproxied` to `PluginServerInfo` and set it in `resolvePluginInfos` from `unproxied_url` so it always wins over endpoint rows; published configs now use the vendor URL.
  - Generators (`generateClaudePluginInDir`, `generateCursorPluginInDir`, `generateCodexPluginInDir`, `generateOpenCodePluginInDir`) check `IsUnproxied` first and skip all Authorization headers and bearer token env vars.
  - Updated install policies: `codexAuthPolicy` and Claude’s `needsGramKeyPrompt` ignore unproxied servers and don’t prompt for a Gram key.
  - Expanded tests to cover all four formats and both policies; publish-bundle test asserts unproxied entries include the vendor URL with no headers.

<sup>Written for commit 7650f90b3ea8e924454805bf4da10bfeb40313e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

