### PR TITLE
chore: stacked time bars for tool insights and humanized demo seed usage

### DIFF
--- a/client/dashboard/src/components/observe/InsightsTools.tsx
+++ b/client/dashboard/src/components/observe/InsightsTools.tsx
@@ -72,7 +72,7 @@ import {
   type Scale,
 } from "chart.js";
 import ZoomPlugin from "chartjs-plugin-zoom";
-import { Bar, Line } from "react-chartjs-2";
+import { Bar } from "react-chartjs-2";
 import { Settings } from "lucide-react";
 import { useCallback, useEffect, useMemo } from "react";
 import { Link } from "react-router";
@@ -1343,9 +1343,10 @@ function ChartNoData({
   );
 }
 
-function MultiLineChart({
+function StackedTimeBarChart({
   labels,
   timestamps,
+  bucketMs,
   tooltipLabels,
   datasets,
   tooltipAfterBody,
@@ -1354,13 +1355,14 @@ function MultiLineChart({
 }: {
   labels: string[];
   timestamps: number[];
+  bucketMs: number;
   tooltipLabels: string[];
   datasets: TimeSeriesDataset[];
   tooltipAfterBody?: (dataIndex: number) => string[];
   onRangeSelect?: (from: Date, to: Date) => void;
   height?: number;
 }) {
-  const { chartRef, zoomPluginOptions, resetZoom } = useChartZoom({
+  const { chartRef, zoomPluginOptions, resetZoom } = useChartZoom<"bar">({
     onRangeSelect,
     resolveRange: (min, max) => {
       if (timestamps.length === 0) return null;
@@ -1369,7 +1371,9 @@ function MultiLineChart({
       const from = timestamps[fromIndex];
       const to = timestamps[toIndex];
       if (from == null || to == null) return null;
-      return { from: new Date(from), to: new Date(to) };
+      // `to` is a bucket start; extend by the bucket width so the selection
+      // covers the last bucket's events.
+      return { from: new Date(from), to: new Date(to + bucketMs) };
     },
   });
 
@@ -1381,7 +1385,7 @@ function MultiLineChart({
     return <ChartNoData />;
   }
 
-  const options: ChartOptions<"line"> = {
+  const options: ChartOptions<"bar"> = {
     responsive: true,
     maintainAspectRatio: false,
     interaction: { mode: "index", intersect: false },
@@ -1413,17 +1417,15 @@ function MultiLineChart({
     },
     scales: {
       x: {
-        grid: {
-          display: true,
-          color: "rgba(128, 128, 128, 0.1)",
-          lineWidth: 1,
-        },
-        ticks: { maxTicksLimit: 8 },
+        stacked: true,
+        grid: { display: false },
+        ticks: { maxTicksLimit: 8, color: CHART_COLORS.labelFaded },
       },
       y: {
+        stacked: true,
         beginAtZero: true,
         grid: { color: "rgba(128, 128, 128, 0.2)" },
-        ticks: { precision: 0 },
+        ticks: { precision: 0, color: CHART_COLORS.labelFaded },
       },
     },
     transitions: SHARED_RESIZE_TRANSITION,
@@ -1434,7 +1436,7 @@ function MultiLineChart({
       className="relative transition-all duration-200 ease-in-out"
       style={{ height }}
     >
-      <Line ref={chartRef} data={{ labels, datasets }} options={options} />
+      <Bar ref={chartRef} data={{ labels, datasets }} options={options} />
     </div>
   );
 }
@@ -1466,18 +1468,18 @@ function ServerUsageTimeSeries({
 }) {
   const chartId = "server-usage";
   const expanded = expandedChart === chartId;
-  const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, timestamps, tooltipLabels, datasets } = useMemo(
+  const { labels, timestamps, tooltipLabels, datasets, bucketMs } = useMemo(
     () =>
       buildToolUsageTimeSeries(
         timeSeries,
         (pt) =>
           displayTargetLabel(pt.targetLabel, pt.targetType, serverNameMappings),
-        timeRangeMs,
+        from,
+        to,
         undefined,
         USER_SOURCE_COLORS,
       ),
-    [timeSeries, timeRangeMs, serverNameMappings],
+    [timeSeries, from, to, serverNameMappings],
   );
   return (
     <ChartCard
@@ -1491,9 +1493,10 @@ function ServerUsageTimeSeries({
       isZoomed={isZoomed}
       onResetZoom={onResetZoom}
     >
-      <MultiLineChart
+      <StackedTimeBarChart
         labels={labels}
         timestamps={timestamps}
+        bucketMs={bucketMs}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
         onRangeSelect={onRangeSelect}
@@ -1530,17 +1533,17 @@ function UserUsageTimeSeries({
 }) {
   const chartId = "user-usage";
   const expanded = expandedChart === chartId;
-  const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, timestamps, tooltipLabels, datasets } = useMemo(
+  const { labels, timestamps, tooltipLabels, datasets, bucketMs } = useMemo(
     () =>
       buildToolUsageTimeSeries(
         timeSeries,
         (pt) => pt.userLabel,
-        timeRangeMs,
+        from,
+        to,
         undefined,
         USER_SOURCE_COLORS,
       ),
-    [timeSeries, timeRangeMs],
+    [timeSeries, from, to],
   );
   return (
     <ChartCard
@@ -1554,9 +1557,10 @@ function UserUsageTimeSeries({
       isZoomed={isZoomed}
       onResetZoom={onResetZoom}
     >
-      <MultiLineChart
+      <StackedTimeBarChart
         labels={labels}
         timestamps={timestamps}
+        bucketMs={bucketMs}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
         onRangeSelect={onRangeSelect}
@@ -1593,17 +1597,17 @@ function SkillUsageTimeSeries({
 }) {
   const chartId = "skill-usage";
   const expanded = expandedChart === chartId;
-  const timeRangeMs = to.getTime() - from.getTime();
-  const { labels, timestamps, tooltipLabels, datasets } = useMemo(
+  const { labels, timestamps, tooltipLabels, datasets, bucketMs } = useMemo(
     () =>
       buildToolUsageTimeSeries(
         skillTimeSeries,
         (pt) => pt.targetLabel,
-        timeRangeMs,
+        from,
+        to,
         undefined,
         USER_SOURCE_COLORS,
       ),
-    [skillTimeSeries, timeRangeMs],
+    [skillTimeSeries, from, to],
   );
   return (
     <ChartCard
@@ -1617,9 +1621,10 @@ function SkillUsageTimeSeries({
       isZoomed={isZoomed}
       onResetZoom={onResetZoom}
     >
-      <MultiLineChart
+      <StackedTimeBarChart
         labels={labels}
         timestamps={timestamps}
+        bucketMs={bucketMs}
         tooltipLabels={tooltipLabels}
         datasets={datasets}
         onRangeSelect={onRangeSelect}
@@ -1741,10 +1746,10 @@ function ErrorsOverTimeChart({
   isZoomed?: boolean;
   onResetZoom?: () => void;
 }) {
-  const timeRangeMs = to.getTime() - from.getTime();
   const {
     labels,
     timestamps,
+    bucketMs,
     tooltipLabels,
     datasets,
     hasErrors,
@@ -1753,21 +1758,15 @@ function ErrorsOverTimeChart({
     const built = buildToolUsageTimeSeries(
       timeSeries,
       () => "errors",
-      timeRangeMs,
+      from,
+      to,
       (pt) => pt.failureCount,
       ["#ef4444"],
     );
-    const errorColor = "#ef4444";
-    const recoloredDatasets = built.datasets.map((ds) => ({
+    const renamedDatasets = built.datasets.map((ds) => ({
       ...ds,
       label: "Errors",
-      borderColor: errorColor,
-      backgroundColor: errorColor + "1a",
-      pointBackgroundColor: errorColor,
     }));
-    const tsIndex = new Map<number, number>(
-      built.timestamps.map((ts, i): [number, number] => [ts, i]),
-    );
     const total = built.datasets[0]?.data.reduce((s, p) => s + p, 0) ?? 0;
 
     const accumulator = new Map<number, Map<string, number>>(
@@ -1777,12 +1776,15 @@ function ErrorsOverTimeChart({
       ]),
     );
 
+    const fromMs = from.getTime();
     for (const pt of timeSeries) {
       if (pt.failureCount === 0) continue;
       const ms = bucketStartNsToMs(pt.bucketStartNs);
       if (ms == null) continue;
-      const idx = tsIndex.get(ms);
-      if (idx === undefined) continue;
+      const idx = Math.min(
+        Math.max(Math.floor((ms - fromMs) / built.bucketMs), 0),
+        built.timestamps.length - 1,
+      );
       const displayName = displayTargetLabel(
         pt.targetLabel,
         pt.targetType,
@@ -1803,12 +1805,13 @@ function ErrorsOverTimeChart({
     return {
       labels: built.labels,
       timestamps: built.timestamps,
+      bucketMs: built.bucketMs,
       tooltipLabels: built.tooltipLabels,
-      datasets: recoloredDatasets,
+      datasets: renamedDatasets,
       hasErrors: total > 0,
       perServerByIndex,
     };
-  }, [timeSeries, timeRangeMs, serverNameMappings]);
+  }, [timeSeries, from, to, serverNameMappings]);
 
   const chartId = "errors-over-time";
   const expanded = expandedChart === chartId;
@@ -1828,9 +1831,10 @@ function ErrorsOverTimeChart({
       {!hasErrors ? (
         <ChartNoData message="No errors in this period" />
       ) : (
-        <MultiLineChart
+        <StackedTimeBarChart
           labels={labels}
           timestamps={timestamps}
+          bucketMs={bucketMs}
           tooltipLabels={tooltipLabels}
           datasets={datasets}
           onRangeSelect={onRangeSelect}

--- a/client/dashboard/src/components/observe/InsightsToolsTimeSeries.test.ts
+++ b/client/dashboard/src/components/observe/InsightsToolsTimeSeries.test.ts
@@ -1,6 +1,27 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { buildToolUsageTimeSeries } from "./toolUsageTimeSeriesChartData";
+import {
+  buildToolUsageTimeSeries,
+  pickTimeBucketMs,
+} from "./toolUsageTimeSeriesChartData";
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+
+function nsFor(ms: number): string {
+  return `${BigInt(ms) * BigInt(1_000_000)}`;
+}
+
+describe("pickTimeBucketMs", () => {
+  it("keeps hourly buckets for short ranges", () => {
+    expect(pickTimeBucketMs(24 * HOUR_MS)).toBe(HOUR_MS);
+  });
+
+  it("coarsens buckets so long ranges stay under the bucket cap", () => {
+    expect(pickTimeBucketMs(7 * DAY_MS)).toBe(6 * HOUR_MS);
+    expect(pickTimeBucketMs(90 * DAY_MS)).toBe(2 * DAY_MS);
+  });
+});
 
 describe("buildToolUsageTimeSeries", () => {
   it("preserves bucketed chart data and returns timestamps for zoom", () => {
@@ -10,22 +31,76 @@ describe("buildToolUsageTimeSeries", () => {
     const result = buildToolUsageTimeSeries(
       [
         {
-          bucketStartNs: `${BigInt(first) * BigInt(1_000_000)}`,
+          bucketStartNs: nsFor(first),
           eventCount: 3,
           targetLabel: "Server A",
         },
         {
-          bucketStartNs: `${BigInt(second) * BigInt(1_000_000)}`,
+          bucketStartNs: nsFor(second),
           eventCount: 5,
           targetLabel: "Server A",
         },
       ],
       (point) => point.targetLabel,
-      second - first,
+      new Date(first),
+      new Date(second),
     );
 
     expect(result.timestamps).toEqual([first, second]);
     expect(result.datasets[0]?.data).toEqual([3, 5]);
+  });
+
+  it("fills quiet buckets with zeros so the time axis stays dense", () => {
+    const from = Date.UTC(2026, 0, 1, 12, 0);
+
+    const result = buildToolUsageTimeSeries(
+      [
+        {
+          bucketStartNs: nsFor(from),
+          eventCount: 2,
+          targetLabel: "Server A",
+        },
+        {
+          bucketStartNs: nsFor(from + 3 * HOUR_MS),
+          eventCount: 4,
+          targetLabel: "Server A",
+        },
+      ],
+      (point) => point.targetLabel,
+      new Date(from),
+      new Date(from + 3 * HOUR_MS),
+    );
+
+    expect(result.timestamps).toEqual([
+      from,
+      from + HOUR_MS,
+      from + 2 * HOUR_MS,
+      from + 3 * HOUR_MS,
+    ]);
+    expect(result.datasets[0]?.data).toEqual([2, 0, 0, 4]);
+  });
+
+  it("re-aggregates fine-grained points into coarser buckets for long ranges", () => {
+    const from = Date.UTC(2026, 0, 1);
+    const to = from + 7 * DAY_MS;
+
+    // Hourly points across a 7-day range should collapse into 6h buckets.
+    const points = [0, 1, 2, 3, 4, 5].map((hour) => ({
+      bucketStartNs: nsFor(from + hour * HOUR_MS),
+      eventCount: 1,
+      targetLabel: "Server A",
+    }));
+
+    const result = buildToolUsageTimeSeries(
+      points,
+      (point) => point.targetLabel,
+      new Date(from),
+      new Date(to),
+    );
+
+    expect(result.bucketMs).toBe(6 * HOUR_MS);
+    expect(result.datasets[0]?.data[0]).toBe(6);
+    expect(result.timestamps.length).toBeLessThanOrEqual(49);
   });
 
   it("skips malformed bucket timestamps instead of throwing", () => {
@@ -39,17 +114,44 @@ describe("buildToolUsageTimeSeries", () => {
           targetLabel: "Server A",
         },
         {
-          bucketStartNs: `${BigInt(valid) * BigInt(1_000_000)}`,
+          bucketStartNs: nsFor(valid),
           eventCount: 5,
           targetLabel: "Server A",
         },
       ],
       (point) => point.targetLabel,
-      60 * 60 * 1000,
+      new Date(valid),
+      new Date(valid + HOUR_MS),
     );
 
-    expect(result.timestamps).toEqual([valid]);
-    expect(result.datasets[0]?.data).toEqual([5]);
+    expect(result.timestamps).toEqual([valid, valid + HOUR_MS]);
+    expect(result.datasets[0]?.data).toEqual([5, 0]);
+  });
+
+  it("folds series beyond the palette into an Other bucket instead of cycling colors", () => {
+    const from = Date.UTC(2026, 0, 1, 12, 0);
+    const colors = ["#111111", "#222222", "#333333"];
+
+    const points = ["a", "b", "c", "d", "e"].map((label, i) => ({
+      bucketStartNs: nsFor(from),
+      eventCount: 10 - i,
+      targetLabel: label,
+    }));
+
+    const result = buildToolUsageTimeSeries(
+      points,
+      (point) => point.targetLabel,
+      new Date(from),
+      new Date(from + HOUR_MS),
+      undefined,
+      colors,
+    );
+
+    expect(result.datasets.map((ds) => ds.label)).toEqual(["a", "b", "Other"]);
+    // c + d + e event counts merge into Other.
+    expect(result.datasets[2]?.data[0]).toBe(8 + 7 + 6);
+    const usedColors = result.datasets.map((ds) => ds.backgroundColor);
+    expect(new Set(usedColors).size).toBe(usedColors.length);
   });
 });
 
@@ -67,7 +169,7 @@ describe("InsightsTools chart zoom wiring", () => {
     expect(callsite).toContain("onResetZoom={onResetZoom}");
   });
 
-  it("filters zero-value series out of the multi-line chart tooltip", () => {
+  it("filters zero-value series out of the stacked bar tooltip", () => {
     const source = readFileSync(
       "src/components/observe/InsightsTools.tsx",
       "utf8",

--- a/client/dashboard/src/components/observe/toolUsageTimeSeriesChartData.ts
+++ b/client/dashboard/src/components/observe/toolUsageTimeSeriesChartData.ts
@@ -13,7 +13,35 @@ const DEFAULT_TIME_SERIES_COLORS = [
   "#a3e635",
 ];
 
-export type TimeSeriesDataset = ChartDataset<"line", number[]>;
+// Series beyond the palette fold into a single neutral "Other" bucket instead
+// of cycling colors — two series sharing a hue are indistinguishable.
+const OTHER_SERIES_LABEL = "Other";
+const OTHER_SERIES_COLOR = "#9ca3af";
+
+export type TimeSeriesDataset = ChartDataset<"bar", number[]>;
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+const TIME_BUCKET_STEPS_MS = [
+  HOUR_MS,
+  3 * HOUR_MS,
+  6 * HOUR_MS,
+  12 * HOUR_MS,
+  DAY_MS,
+  2 * DAY_MS,
+  7 * DAY_MS,
+] as const;
+
+// Sparse event counts need coarse-enough buckets to show a shape: ~48 bars max
+// keeps a 7-day range at 6h buckets and a 90-day range at 2-day buckets.
+const MAX_TIME_BUCKETS = 48;
+
+export function pickTimeBucketMs(timeRangeMs: number): number {
+  for (const step of TIME_BUCKET_STEPS_MS) {
+    if (timeRangeMs / step <= MAX_TIME_BUCKETS) return step;
+  }
+  return TIME_BUCKET_STEPS_MS[TIME_BUCKET_STEPS_MS.length - 1]!;
+}
 
 export function bucketStartNsToMs(bucketStartNs: string): number | null {
   try {
@@ -24,12 +52,35 @@ export function bucketStartNsToMs(bucketStartNs: string): number | null {
   }
 }
 
+function formatTooltipLabel(ts: number, bucketMs: number): string {
+  const date = new Date(ts);
+  if (bucketMs >= DAY_MS) {
+    return date.toLocaleDateString([], { month: "short", day: "numeric" });
+  }
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Re-buckets raw time series points onto a dense, evenly spaced grid spanning
+ * [from, to], anchored at `from`, and returns stacked-bar datasets ordered by
+ * series total (largest first, so it sits at the bottom of the stack).
+ *
+ * The dense grid matters: a category axis only shows the labels it is given,
+ * so charting just the buckets that contain data silently deletes the quiet
+ * periods and distorts the time dimension.
+ */
 export function buildToolUsageTimeSeries<
   T extends { bucketStartNs: string; eventCount: number },
 >(
   timeSeries: T[],
   keyFn: (p: T) => string,
-  timeRangeMs: number,
+  from: Date,
+  to: Date,
   valueFn: (p: T) => number = (p) => p.eventCount,
   colors: readonly string[] = DEFAULT_TIME_SERIES_COLORS,
 ): {
@@ -37,61 +88,97 @@ export function buildToolUsageTimeSeries<
   labels: string[];
   tooltipLabels: string[];
   datasets: TimeSeriesDataset[];
+  bucketMs: number;
 } {
-  if (timeSeries.length === 0) {
-    return { timestamps: [], labels: [], tooltipLabels: [], datasets: [] };
-  }
+  const fromMs = from.getTime();
+  const toMs = to.getTime();
+  const timeRangeMs = Math.max(toMs - fromMs, HOUR_MS);
+  const bucketMs = pickTimeBucketMs(timeRangeMs);
+  // +1 so a server bucket starting exactly at `to` still has a slot.
+  const bucketCount = Math.floor(timeRangeMs / bucketMs) + 1;
 
-  const seriesMap = new Map<string, Map<number, number>>();
+  const seriesMap = new Map<string, number[]>();
 
   for (const pt of timeSeries) {
     const key = keyFn(pt);
     if (!key) continue;
     const ms = bucketStartNsToMs(pt.bucketStartNs);
     if (ms == null) continue;
-    const series = seriesMap.get(key) ?? new Map<number, number>();
-    series.set(ms, (series.get(ms) ?? 0) + valueFn(pt));
+    // Data is range-filtered server-side; clamp edge buckets (e.g. the bucket
+    // containing `from`) into the grid rather than dropping their counts.
+    const idx = Math.min(
+      Math.max(Math.floor((ms - fromMs) / bucketMs), 0),
+      bucketCount - 1,
+    );
+    const series =
+      seriesMap.get(key) ?? Array.from({ length: bucketCount }, () => 0);
+    series[idx] = (series[idx] ?? 0) + valueFn(pt);
     seriesMap.set(key, series);
   }
 
   if (seriesMap.size === 0) {
-    return { timestamps: [], labels: [], tooltipLabels: [], datasets: [] };
+    return {
+      timestamps: [],
+      labels: [],
+      tooltipLabels: [],
+      datasets: [],
+      bucketMs,
+    };
   }
 
-  const allTimestamps = new Set<number>();
-  for (const series of seriesMap.values()) {
-    for (const ts of series.keys()) allTimestamps.add(ts);
-  }
-  const timestamps = Array.from(allTimestamps).sort((a, b) => a - b);
+  const timestamps = Array.from(
+    { length: bucketCount },
+    (_, i) => fromMs + i * bucketMs,
+  );
   const labels = timestamps.map((ts) =>
     formatChartLabel(new Date(ts), timeRangeMs),
   );
   const tooltipLabels = timestamps.map((ts) =>
-    new Date(ts).toLocaleString([], {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    }),
+    formatTooltipLabel(ts, bucketMs),
   );
 
-  const datasets: TimeSeriesDataset[] = Array.from(seriesMap.entries()).map(
-    ([key, series], i) => {
-      const color = colors[i % colors.length] ?? DEFAULT_TIME_SERIES_COLORS[0]!;
-      return {
-        label: key,
-        data: timestamps.map((ts) => series.get(ts) ?? 0),
-        borderColor: color,
-        backgroundColor: color + "1a",
-        pointBackgroundColor: color,
-        fill: false,
-        tension: 0.45,
-        borderWidth: 1.5,
-        pointRadius: 0,
-        pointHoverRadius: 4,
-      };
-    },
-  );
+  const sortedSeries = Array.from(seriesMap.entries())
+    .map(([key, data]) => ({
+      key,
+      data,
+      total: data.reduce((a, b) => a + b, 0),
+    }))
+    .sort((a, b) => b.total - a.total);
 
-  return { timestamps, labels, tooltipLabels, datasets };
+  // Fold overflow series into "Other" rather than cycling the palette.
+  const visible =
+    sortedSeries.length > colors.length
+      ? sortedSeries.slice(0, colors.length - 1)
+      : sortedSeries;
+  const overflow = sortedSeries.slice(visible.length);
+  if (overflow.length > 0) {
+    const otherData = Array.from({ length: bucketCount }, () => 0);
+    for (const series of overflow) {
+      for (let i = 0; i < bucketCount; i++) {
+        otherData[i] = (otherData[i] ?? 0) + (series.data[i] ?? 0);
+      }
+    }
+    visible.push({
+      key: OTHER_SERIES_LABEL,
+      data: otherData,
+      total: otherData.reduce((a, b) => a + b, 0),
+    });
+  }
+
+  const datasets: TimeSeriesDataset[] = visible.map(({ key, data }, i) => {
+    const isOther = overflow.length > 0 && i === visible.length - 1;
+    const color = isOther
+      ? OTHER_SERIES_COLOR
+      : (colors[i] ?? DEFAULT_TIME_SERIES_COLORS[0]!);
+    return {
+      label: key,
+      data,
+      backgroundColor: color,
+      hoverBackgroundColor: color + "cc",
+      stack: "total",
+      maxBarThickness: 32,
+    };
+  });
+
+  return { timestamps, labels, tooltipLabels, datasets, bucketMs };
 }

--- a/seed/demo/verify.md
+++ b/seed/demo/verify.md
@@ -22,7 +22,7 @@ when its check passes.
 A check FAILS when the page shows an empty state, an error boundary, or zero
 where a value is expected.
 
-1. **Agent sessions list** — sessions list shows ~60 sessions with varied
+1. **Agent sessions list** — sessions list shows ~180 sessions with varied
    titles ("Incident triage… #10xx"), spread over the last ~2 weeks, owners
    `*@demo.getgram.ai`.
 2. **Risk events** — findings list non-empty; each finding is

--- a/server/internal/demoseed/clickhouse.sql
+++ b/server/internal/demoseed/clickhouse.sql
@@ -71,15 +71,18 @@ ALTER TABLE risk_findings DELETE WHERE organization_id = 'org_gram_demo_workspac
 ALTER TABLE skill_session_versions DELETE WHERE organization_id = 'org_gram_demo_workspace';
 ALTER TABLE skill_efficacy_scores DELETE WHERE organization_id = 'org_gram_demo_workspace';
 
--- Tool-execution rows: 2 per chat. gram.toolset.slug makes the Insights CTE's
--- direct branch classify each trace as hosted MCP traffic; unique per-call
--- trace ids keep trace_summaries from merging them. ~7% non-200.
+-- Tool-execution rows: 3-12 per chat (hash-picked, so busy chats and quick
+-- ones both exist). gram.toolset.slug makes the Insights CTE's direct branch
+-- classify each trace as hosted MCP traffic; unique per-call trace ids keep
+-- trace_summaries from merging them. Failures cluster into a process_refund
+-- incident over the last ~3 days plus a low background rate (~5% overall)
+-- instead of an evenly spread modulus.
 INSERT INTO telemetry_logs
   (time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id,
    attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id)
 SELECT
-  nano + toUInt64(k * 1000000),
-  nano + toUInt64(k * 1000000),
+  nano + toInt64(k) * 75000000000 + toInt64(cityHash64('gap', i, k) % 45000000000),
+  nano + toInt64(k) * 75000000000 + toInt64(cityHash64('gap', i, k) % 45000000000),
   'INFO',
   concat('Tool call: ', tool_name),
   lower(hex(MD5(concat('gram-demo-tooltrace-', toString(i), '-', toString(k))))),
@@ -87,7 +90,9 @@ SELECT
     '{"gram.tool.urn":"tools:http:acme:', tool_name, '"',
     ',"gram.tool.name":"', tool_name, '"',
     ',"gram.toolset.slug":"', if(i % 5 = 0, 'acme-ops', 'acme-support-tools'), '"',
-    ',"http.response.status_code":', toString(if((i + k) % 14 = 0, 500, 200)),
+    ',"http.response.status_code":', toString(if(
+        (tool_name = 'process_refund' AND day_off <= 2 AND cityHash64('err', i, k) % 2 = 0)
+        OR cityHash64('errbg', i, k) % 30 = 0, 500, 200)),
     ',"http.server.request.duration":', toString(round(0.05 + (cityHash64(i, k) % 200) / 100, 3)),
     ',"gen_ai.conversation.id":"', chat_id, '"',
     ',"gram.project.id":"', toString(proj), '"',
@@ -110,8 +115,9 @@ SELECT
 FROM (
   SELECT
     number + 1 AS i,
-    arrayJoin([1, 2]) AS k,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayJoin(range(1, toUInt64(4 + reinterpretAsUInt8(unhex(substring(h, 9, 2))) % 10))) AS k,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -130,10 +136,16 @@ FROM (
     arrayElement(['search_logs', 'get_metrics', 'query_db', 'get_customer',
                   'list_deploys', 'process_refund', 'fetch_traces', 'check_health'],
                  1 + (cityHash64('tool', number, k) % 8)) AS tool_name,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
 );
 
 -- Claude provenance (odd chats): one claude_code.api_request row per turn.
@@ -156,7 +168,7 @@ SELECT
     ',"output_tokens":', toString(out_tok),
     ',"cache_read_tokens":', toString(in_tok * 6),
     ',"cache_creation_tokens":', toString(intDiv(in_tok, 4)),
-    ',"cost_usd":', toString(round((in_tok * 48 + out_tok * 150) / 10000000, 6)),
+    ',"cost_usd":', toString(round((in_tok * 57375 + out_tok * 150000) / 10000000000, 4)),
     ',"model":"', model, '"',
     ',"query_source":"user"',
     ',"skill.name":"', arrayElement(['', 'triage-incident', 'support-refunds'], 1 + (cityHash64('skill', i, turn) % 3)), '"',
@@ -189,7 +201,8 @@ FROM (
   SELECT
     number + 1 AS i,
     arrayJoin([1, 2, 3]) AS turn,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -205,12 +218,18 @@ FROM (
     arrayElement(['["developer","viewer"]', '["developer"]', '["admin","developer"]', '["developer"]', '["analyst","viewer"]', '["admin","viewer"]'], uidx) AS rolesjson,
     arrayElement(['amara-mbp.local', 'jonas-mbp.local', 'priya-mbp.local', 'mateo-mbp.local', 'hana-mbp.local', 'lucas-mbp.local'], uidx) AS hostname,
     if(cityHash64('model', number) % 3 = 0, 'claude-opus-4-5', 'claude-sonnet-4-6') AS model,
-    toUInt64(20000 + cityHash64('in', number, turn) % 120000) AS in_tok,
-    toUInt64(800 + cityHash64('out', number, turn) % 3500) AS out_tok,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    toUInt64(500000 + cityHash64('in', number, turn) % 3000000) AS in_tok,
+    toUInt64(2000 + cityHash64('out', number, turn) % 28000) AS out_tok,
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 1
 );
 
@@ -233,7 +252,7 @@ SELECT
     ',"tool_name":"', tool_name, '"',
     ',"tool_input_size_bytes":', toString(200 + cityHash64('tin', i, k) % 1800),
     ',"tool_result_size_bytes":', toString(500 + cityHash64('tout', i, k) % 8000),
-    ',"success":', if((i + k) % 17 = 0, 'false', 'true'),
+    ',"success":', if(cityHash64('cres', i, k) % 15 = 0, 'false', 'true'),
     ',"gen_ai.conversation.id":"', chat_id, '"',
     ',"gram.project.id":"', toString(proj), '"',
     ',"user.email":"', email, '"',
@@ -256,7 +275,8 @@ FROM (
   SELECT
     number + 1 AS i,
     arrayJoin([1, 2]) AS k,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -274,25 +294,33 @@ FROM (
     arrayElement(['search_logs', 'get_metrics', 'query_db', 'get_customer',
                   'list_deploys', 'process_refund', 'fetch_traces', 'check_health'],
                  1 + (cityHash64('tool', number, k) % 8)) AS tool_name,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 1
 );
 
--- Odd chats: one Skill hook row each — feeds the Insights "Skill Usage" /
--- "Users per Skill" panels (skill_name materializes only when
--- gram.tool.name = 'Skill').
+-- Odd chats: 1-2 Skill hook rows each with a hash-weighted skill pick —
+-- feeds the Insights "Skill Usage" / "Users per Skill" panels (skill_name
+-- materializes only when gram.tool.name = 'Skill'). Deliberately looser than
+-- the efficacy tables' fixed skill-per-chat formula: these rows only drive
+-- the usage charts, which should not look like a perfect rotation.
 INSERT INTO telemetry_logs
   (time_unix_nano, observed_time_unix_nano, severity_text, body, trace_id,
    attributes, resource_attributes, gram_project_id, gram_urn, service_name, gram_chat_id)
 SELECT
-  nano + 45000000000,
-  nano + 45000000000,
+  nano + toInt64(45000000000 + (j - 1) * 420000000000 + cityHash64('sklt', i, j) % 300000000000),
+  nano + toInt64(45000000000 + (j - 1) * 420000000000 + cityHash64('sklt', i, j) % 300000000000),
   'INFO',
   'Hook: Skill invoked',
-  lower(hex(MD5(concat('gram-demo-skilltrace-', toString(i))))),
+  lower(hex(MD5(concat('gram-demo-skilltrace-', toString(i), '-', toString(j))))),
   concat(
     '{"gram.event.source":"hook"',
     ',"gram.hook.source":"claude-code"',
@@ -313,7 +341,9 @@ SELECT
 FROM (
   SELECT
     number + 1 AS i,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayJoin(range(1, toUInt64(2 + reinterpretAsUInt8(unhex(substring(h, 11, 2))) % 2))) AS j,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -321,11 +351,19 @@ FROM (
     arrayElement(['amara@demo.getgram.ai', 'jonas@demo.getgram.ai', 'priya@demo.getgram.ai',
                   'mateo@demo.getgram.ai', 'hana@demo.getgram.ai', 'lucas@demo.getgram.ai'], uidx) AS email,
     arrayElement(['amara-mbp.local', 'jonas-mbp.local', 'priya-mbp.local', 'mateo-mbp.local', 'hana-mbp.local', 'lucas-mbp.local'], uidx) AS hostname,
-    arrayElement(['support-refunds', 'triage-incident', 'runbook'], 1 + (intDiv(number, 2) % 3)) AS skill,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    arrayElement(['triage-incident', 'support-refunds', 'triage-incident', 'runbook',
+                  'support-refunds', 'triage-incident', 'support-refunds', 'runbook'],
+                 1 + toUInt32(cityHash64('skl', i, j) % 8)) AS skill,
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 1
 );
 
@@ -371,7 +409,8 @@ SELECT
 FROM (
   SELECT
     number + 1 AS i,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -387,12 +426,18 @@ FROM (
     arrayElement(['["developer","viewer"]', '["developer"]', '["admin","developer"]', '["developer"]', '["analyst","viewer"]', '["admin","viewer"]'], uidx) AS rolesjson,
     arrayElement(['amara-mbp.local', 'jonas-mbp.local', 'priya-mbp.local', 'mateo-mbp.local', 'hana-mbp.local', 'lucas-mbp.local'], uidx) AS hostname,
     if(cityHash64('model', number) % 2 = 0, 'claude-sonnet-4-6', 'gpt-5.6') AS model,
-    toUInt64(15000 + cityHash64('in', number) % 90000) AS in_tok,
-    toUInt64(600 + cityHash64('out', number) % 4000) AS out_tok,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    toUInt64(800000 + cityHash64('in', number) % 7000000) AS in_tok,
+    toUInt64(3000 + cityHash64('out', number) % 40000) AS out_tok,
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 0
 );
 
@@ -412,10 +457,10 @@ SELECT
   concat(
     '{"gram.event.source":"hook"',
     ',"gram.hook.source":"cursor"',
-    ',"gram.hook.event":"', if((i + k) % 19 = 0, 'PostToolUseFailure', 'PostToolUse'), '"',
+    ',"gram.hook.event":"', if(cityHash64('hfail', i, k) % 16 = 0, 'PostToolUseFailure', 'PostToolUse'), '"',
     ',"gram.tool.name":"', tool_name, '"',
     ',"gram.tool_call.source":"acme-internal-mcp"',
-    if((i + k) % 19 = 0,
+    if(cityHash64('hfail', i, k) % 16 = 0,
        ',"gram.hook.error":"tool execution failed"',
        ',"gen_ai.tool.call.result":"ok"'),
     ',"gen_ai.tool.call.id":"call_demo_', toString(i), '_', toString(k), '"',
@@ -440,7 +485,8 @@ FROM (
   SELECT
     number + 1 AS i,
     arrayJoin([1, 2]) AS k,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -458,10 +504,16 @@ FROM (
     arrayElement(['search_logs', 'get_metrics', 'query_db', 'get_customer',
                   'list_deploys', 'process_refund', 'fetch_traces', 'check_health'],
                  1 + (cityHash64('tool', number, k) % 8)) AS tool_name,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 0
 );
 
@@ -479,8 +531,8 @@ SELECT
   lower(hex(MD5(concat('gram-demo-wutrace-', toString(i))))),
   concat(
     '{"gram.chat_analysis.work_units":', toString(1 + cityHash64('wu', i) % 5),
-    ',"gram.chat_analysis.scored_cost":', toString(round((200000 + cityHash64('sc', i) % 1300000) / 1000000, 6)),
-    ',"gram.chat_analysis.scored_tokens":', toString(50000 + cityHash64('st', i) % 400000),
+    ',"gram.chat_analysis.scored_cost":', toString(round((5000000 + cityHash64('sc', i) % 40000000) / 1000000, 4)),
+    ',"gram.chat_analysis.scored_tokens":', toString(2000000 + cityHash64('st', i) % 12000000),
     ',"gen_ai.conversation.id":"', chat_id, '"',
     ',"gen_ai.response.model":"', if(i % 2 = 1, 'claude-sonnet-4-6', 'gpt-5.6'), '"',
     ',"gram.project.id":"', toString(proj), '"',
@@ -505,7 +557,8 @@ SELECT
 FROM (
   SELECT
     number + 1 AS i,
-    1 + ((number + 1) % 6) AS uidx,
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 13, 2))) % 16) AS uidx,
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
@@ -520,10 +573,16 @@ FROM (
     arrayElement(['Frontline Support', 'Frontline Support', 'Infra', 'Reliability', 'Billing Ops', 'Leadership'], uidx) AS team,
     arrayElement(['["developer","viewer"]', '["developer"]', '["admin","developer"]', '["developer"]', '["analyst","viewer"]', '["admin","viewer"]'], uidx) AS rolesjson,
     arrayElement(['amara-mbp.local', 'jonas-mbp.local', 'priya-mbp.local', 'mateo-mbp.local', 'hana-mbp.local', 'lucas-mbp.local'], uidx) AS hostname,
-    toUnixTimestamp64Nano(
-      subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                      13 * toInt64((number + 1) % 7))) AS nano
-  FROM numbers(60)
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    toUnixTimestamp64Nano(chat_dt) AS nano
+  FROM numbers(180)
 );
 
 -- Shadow MCP inventory + companion hook telemetry (Shadow MCP page list,
@@ -554,26 +613,29 @@ SELECT
     '{"gram.event.source":"hook"',
     ',"gram.hook.source":"claude-code"',
     ',"gram.hook.event":"PostToolUse"',
-    ',"gram.tool.name":"', arrayElement(['lookup_ticket', 'run_ci_job', 'search_wiki'], 1 + (number % 3)), '"',
+    ',"gram.tool.name":"', arrayElement(['lookup_ticket', 'run_ci_job', 'search_wiki'], sidx), '"',
     ',"gram.mcp.server_url":"', arrayElement(
         ['https://mcp.internal.acme.example/mcp', 'https://tools.vendor-x.example/sse',
-         'https://ci-agents.acme.example/mcp'], 1 + (number % 3)), '"',
+         'https://ci-agents.acme.example/mcp'], sidx), '"',
     ',"gen_ai.tool.call.result":"ok"',
     ',"gram.project.id":"', toString(proj), '"',
     ',"user.email":"', arrayElement(
         ['amara@demo.getgram.ai', 'jonas@demo.getgram.ai', 'priya@demo.getgram.ai',
-         'mateo@demo.getgram.ai', 'hana@demo.getgram.ai', 'lucas@demo.getgram.ai'], 1 + (number % 6)), '"}'
+         'mateo@demo.getgram.ai', 'hana@demo.getgram.ai', 'lucas@demo.getgram.ai'],
+        arrayElement([3, 3, 3, 1, 1, 4, 2, 5], 1 + toUInt32(cityHash64('shu', number) % 8))), '"}'
   ),
   '{"gram.deployment.id":"demo-seed"}',
   proj,
-  concat('hooks:', arrayElement(['lookup_ticket', 'run_ci_job', 'search_wiki'], 1 + (number % 3))),
+  concat('hooks:', arrayElement(['lookup_ticket', 'run_ci_job', 'search_wiki'], sidx)),
   'gram-hooks',
   ''
 FROM (
   SELECT
     number,
+    1 + toUInt32(cityHash64('sht', number) % 3) AS sidx,
     toUUID('dec0de00-0000-4000-a000-000000000001') AS proj,
-    toUnixTimestamp64Nano(subtractHours(now64(9), 3 + toInt64(number) * 9)) AS nano
+    toUnixTimestamp64Nano(subtractMinutes(subtractHours(now64(9), 3 + toInt64(number) * 9),
+                                          toInt64(cityHash64('shj', number) % 300))) AS nano
   FROM numbers(24)
 );
 
@@ -647,9 +709,9 @@ SELECT
   concat(substring(hchat, 1, 8), '-', substring(hchat, 9, 4), '-5', substring(hchat, 14, 3), '-8',
          substring(hchat, 18, 3), '-', substring(hchat, 21, 12)),
   arrayElement(['user_demo_amara', 'user_demo_jonas', 'user_demo_priya',
-                'user_demo_mateo', 'user_demo_hana', 'user_demo_lucas'], 1 + (i % 6)),
+                'user_demo_mateo', 'user_demo_hana', 'user_demo_lucas'], uidx),
   arrayElement(['amara@demo.getgram.ai', 'jonas@demo.getgram.ai', 'priya@demo.getgram.ai',
-                'mateo@demo.getgram.ai', 'hana@demo.getgram.ai', 'lucas@demo.getgram.ai'], 1 + (i % 6)),
+                'mateo@demo.getgram.ai', 'hana@demo.getgram.ai', 'lucas@demo.getgram.ai'], uidx),
   'dec0de00-0000-4000-a000-00000000f001',
   1,
   arrayElement(['stripe-access-token', 'aws-access-token', 'pii.credit_card',
@@ -684,9 +746,18 @@ FROM (
     lower(hex(MD5(concat('gram-demo-msg-', toString((number + 1) * 3), '-',
                          if((number + 1) % 5 IN (2, 4), '1', '3'))))) AS hmsg,
     lower(hex(MD5(concat('gram-demo-chat-', toString((number + 1) * 3))))) AS hchat,
-    subtractMinutes(subtractHours(now64(9), 5 * toInt64((number + 1) * 3)),
-                    13 * toInt64(((number + 1) * 3) % 7) - 2) AS ts
-  FROM numbers(20)
+    arrayElement([3, 3, 3, 3, 3, 1, 1, 1, 1, 4, 4, 4, 2, 2, 5, 6],
+                 1 + reinterpretAsUInt8(unhex(substring(hchat, 13, 2))) % 16) AS uidx,
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(hchat, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(hchat, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(hchat, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    chat_dt + toIntervalMinute(2) AS ts
+  FROM numbers(60)
 );
 
 -- Skill efficacy mappings: one skill_session_versions row per Postgres
@@ -706,7 +777,7 @@ SELECT
   arrayElement([toUUID('dec0de00-0000-4000-a000-0000000051a1'),
                 toUUID('dec0de00-0000-4000-a000-0000000051a2'),
                 toUUID('dec0de00-0000-4000-a000-0000000051a3')], sidx),
-  if(sidx = 3 AND i <= 24, toUUID('dec0de00-0000-4000-a000-0000000052b3'),
+  if(sidx = 3 AND day_off <= 4, toUUID('dec0de00-0000-4000-a000-0000000052b3'),
      arrayElement([toUUID('dec0de00-0000-4000-a000-0000000052a1'),
                    toUUID('dec0de00-0000-4000-a000-0000000052a2'),
                    toUUID('dec0de00-0000-4000-a000-0000000052a3')], sidx)),
@@ -721,9 +792,16 @@ FROM (
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
-    subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                    13 * toInt64((number + 1) % 7)) + toIntervalSecond(45) + toIntervalMinute(2 * (k - 1)) AS ts
-  FROM numbers(60)
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    chat_dt + toIntervalSecond(45) + toIntervalMinute(2 * (k - 1)) AS ts
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 1
 );
 
@@ -745,7 +823,7 @@ SELECT
   arrayElement([toUUID('dec0de00-0000-4000-a000-0000000051a1'),
                 toUUID('dec0de00-0000-4000-a000-0000000051a2'),
                 toUUID('dec0de00-0000-4000-a000-0000000051a3')], sidx),
-  if(sidx = 3 AND i <= 24, toUUID('dec0de00-0000-4000-a000-0000000052b3'),
+  if(sidx = 3 AND day_off <= 4, toUUID('dec0de00-0000-4000-a000-0000000052b3'),
      arrayElement([toUUID('dec0de00-0000-4000-a000-0000000052a1'),
                    toUUID('dec0de00-0000-4000-a000-0000000052a2'),
                    toUUID('dec0de00-0000-4000-a000-0000000052a3')], sidx)),
@@ -756,7 +834,7 @@ SELECT
   -- Runbook v2 scores markedly lower than v1: surfaces the regression signal.
   least(0.99, greatest(0.05,
     arrayElement([0.87, 0.66, 0.42], sidx)
-    - if(sidx = 3 AND i <= 24, 0.14, 0)
+    - if(sidx = 3 AND day_off <= 4, 0.14, 0)
     + (toInt64(cityHash64('js', i) % 21) - 10) / 100)),
   arrayElement(['Agent followed the refund checklist and refused the pasted card number.',
                 'Triage steps mostly followed but escalation criteria applied loosely.',
@@ -780,9 +858,16 @@ FROM (
     lower(hex(MD5(concat('gram-demo-chat-', toString(number + 1))))) AS h,
     concat(substring(h, 1, 8), '-', substring(h, 9, 4), '-5', substring(h, 14, 3), '-8',
            substring(h, 18, 3), '-', substring(h, 21, 12)) AS chat_id,
-    subtractMinutes(subtractHours(now64(9), 5 * toInt64(number + 1)),
-                    13 * toInt64((number + 1) % 7)) + toIntervalSecond(45) AS ts
-  FROM numbers(60)
+    arrayElement([0, 0, 1, 1, 1, 2, 3, 3, 3, 3, 4, 5, 5, 7, 8, 11],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 1, 2))) % 16) AS day_off,
+    arrayElement([8, 9, 9, 10, 10, 11, 11, 13, 14, 14, 15, 16, 16, 17, 18, 20],
+                 1 + reinterpretAsUInt8(unhex(substring(h, 3, 2))) % 16) AS hour_off,
+    toDateTime64(toStartOfDay(now()), 9)
+      - toIntervalDay(day_off) + toIntervalHour(hour_off)
+      + toIntervalMinute(reinterpretAsUInt8(unhex(substring(h, 5, 2))) % 60) AS ts0,
+    if(ts0 > now64(9) - toIntervalMinute(30), ts0 - toIntervalDay(1), ts0) AS chat_dt,
+    chat_dt + toIntervalSecond(45) AS ts
+  FROM numbers(180)
   WHERE (number + 1) % 2 = 1
 );
 
@@ -792,13 +877,13 @@ FROM (
 SELECT throwIf(
   (SELECT count() FROM telemetry_logs WHERE gram_project_id IN
      (toUUID('dec0de00-0000-4000-a000-000000000001'))
-   ) < 400,
-  'demo seed postflight: expected >= 400 demo telemetry rows');
+   ) < 1500,
+  'demo seed postflight: expected >= 1500 demo telemetry rows');
 
 SELECT throwIf(
   (SELECT uniqExact(chat_id) FROM chat_session_summaries WHERE gram_project_id IN
      (toUUID('dec0de00-0000-4000-a000-000000000001'))
-   ) < 60,
+   ) < 180,
   'demo seed postflight: chat_session_summaries_mv missing sessions');
 
 SELECT throwIf(
@@ -813,15 +898,15 @@ SELECT throwIf(
   'demo seed postflight: authz_challenges empty');
 
 SELECT throwIf(
-  (SELECT count() FROM skill_session_versions WHERE organization_id = 'org_gram_demo_workspace') < 30,
+  (SELECT count() FROM skill_session_versions WHERE organization_id = 'org_gram_demo_workspace') < 90,
   'demo seed postflight: skill_session_versions missing rows');
 
 SELECT throwIf(
-  (SELECT count() FROM skill_efficacy_scores WHERE organization_id = 'org_gram_demo_workspace') < 30,
+  (SELECT count() FROM skill_efficacy_scores WHERE organization_id = 'org_gram_demo_workspace') < 90,
   'demo seed postflight: skill_efficacy_scores missing rows');
 
 SELECT throwIf(
-  (SELECT count() FROM risk_findings WHERE organization_id = 'org_gram_demo_workspace') < 20,
+  (SELECT count() FROM risk_findings WHERE organization_id = 'org_gram_demo_workspace') < 60,
   'demo seed postflight: risk_findings mirror missing rows');
 
 SELECT throwIf(

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -18,8 +18,8 @@
 --   chat ids     demo.det_uuid('gram-demo-chat-' || n) — md5 with RFC nibbles
 --   message ids  demo.det_uuid('gram-demo-msg-' || n || '-' || m)
 --   users        user_demo_* / *@demo.getgram.ai (parallel arrays below; the
---                per-chat owner index formula 1 + (n % 6) is mirrored in the
---                ClickHouse seed's arrayElement calls)
+--                per-chat owner comes from demo.chat_owner_idx(n), mirrored
+--                in the ClickHouse seed's arrayElement calls)
 
 CREATE SCHEMA IF NOT EXISTS demo;
 
@@ -31,6 +31,49 @@ CREATE SCHEMA IF NOT EXISTS demo;
 CREATE OR REPLACE FUNCTION demo.det_uuid(name text) RETURNS uuid
 LANGUAGE sql IMMUTABLE
 RETURN (overlay(overlay(md5(name) placing '5' from 13) placing '8' from 17))::uuid;
+
+-- Humanized chat schedule. Bytes of md5('gram-demo-chat-' || n) pick a
+-- weighted day offset (busy days, quiet days, dead days), a work-hours-biased
+-- hour, and a minute — replacing the old uniform every-5-hours drumbeat that
+-- made every usage chart a flat repeating pattern. Deterministic per n, but
+-- relative to now() so the window keeps trailing. The ClickHouse seed
+-- reproduces this arithmetic exactly (see clickhouse.sql).
+CREATE OR REPLACE FUNCTION demo.chat_ts(n int) RETURNS timestamptz
+LANGUAGE plpgsql STABLE
+AS $fn$
+DECLARE
+  h text := md5('gram-demo-chat-' || n);
+  hour_offs CONSTANT int[] := ARRAY[8,9,9,10,10,11,11,13,14,14,15,16,16,17,18,20];
+  ts timestamptz;
+BEGIN
+  ts := date_trunc('day', now())
+    - make_interval(days => demo.chat_day_off(n))
+    + make_interval(
+        hours => hour_offs[1 + get_byte(decode(substring(h, 3, 2), 'hex'), 0) % 16],
+        mins => get_byte(decode(substring(h, 5, 2), 'hex'), 0) % 60);
+  -- A day-0 chat placed later than "now" slides back a day so the seed never
+  -- writes future timestamps.
+  IF ts > now() - interval '30 minutes' THEN
+    ts := ts - interval '1 day';
+  END IF;
+  RETURN ts;
+END;
+$fn$;
+
+-- Weighted chat owner (index into the parallel demo user arrays): priya and
+-- amara dominate, hana and lucas are occasional users — replacing the old
+-- perfect 1 + (n % 6) rotation. Mirrored in the ClickHouse seed.
+-- The day offset (0 = today) a chat lands on; also used to key "recent"
+-- behavior like the runbook v2 rollout split.
+CREATE OR REPLACE FUNCTION demo.chat_day_off(n int) RETURNS int
+LANGUAGE sql IMMUTABLE
+RETURN (ARRAY[0,0,1,1,1,2,3,3,3,3,4,5,5,7,8,11])
+  [1 + get_byte(decode(substring(md5('gram-demo-chat-' || n), 1, 2), 'hex'), 0) % 16];
+
+CREATE OR REPLACE FUNCTION demo.chat_owner_idx(n int) RETURNS int
+LANGUAGE sql IMMUTABLE
+RETURN (ARRAY[3,3,3,3,3,1,1,1,1,4,4,4,2,2,5,6])
+  [1 + get_byte(decode(substring(md5('gram-demo-chat-' || n), 13, 2), 'hex'), 0) % 16];
 
 CREATE OR REPLACE FUNCTION demo.ensure_demo_org() RETURNS void
 LANGUAGE plpgsql
@@ -48,7 +91,7 @@ DECLARE
   rule_monthly CONSTANT uuid := 'dec0de00-0000-4000-a000-00000000e001';
   rule_weekly  CONSTANT uuid := 'dec0de00-0000-4000-a000-00000000e002';
 
-  bulk_chats CONSTANT int := 60;
+  bulk_chats CONSTANT int := 180;
 
   titles CONSTANT text[] := ARRAY[
     'Incident triage: payment 401s', 'Refund request for order 4823',
@@ -503,13 +546,15 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
     -- Same skill-per-chat formula as the ClickHouse Skill hook rows and the
     -- efficacy mappings: skill_pos = 1 + (((i-1)/2) % 3).
     skill_pos := 1 + (((i - 1) / 2) % 3);
-    -- Runbook activations within the last ~5 days (i <= 24) are on v2: the
-    -- activation timeline shows the version rollout, and the drift split
-    -- below stays consistent with it.
-    version_id := CASE WHEN skill_pos = 3 AND i <= 24
+    -- Runbook activations within the last ~5 days (demo.chat_day_off(i) <= 4)
+    -- are on v2: the activation timeline shows the version rollout, and the
+    -- drift split below stays consistent with it. Mirrored in the ClickHouse
+    -- efficacy inserts (day_off <= 4).
+    version_id := CASE WHEN skill_pos = 3 AND demo.chat_day_off(i) <= 4
                        THEN 'dec0de00-0000-4000-a000-0000000052b3'::uuid
                        ELSE demo_skill_versions[skill_pos] END;
-    chat_ts := now() - (interval '5 hours' * i) - (interval '13 minutes' * (i % 7));
+    chat_ts := demo.chat_ts(i);
+    owner_idx := demo.chat_owner_idx(i);
     FOR m IN 1 .. 1 + (i % 3) LOOP
       INSERT INTO skill_observations (id, project_id, idempotency_key, provider,
         user_id, user_email, hostname, session_id, skill_name, source,
@@ -517,8 +562,8 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
         skill_version_id, reconciled_at, metrics_synced_at, efficacy_enqueued_at)
       VALUES (demo.det_uuid('gram-demo-skillobs-' || i || '-' || m), proj_a,
         'demo-skillobs-' || i || '-' || m, 'claude-code',
-        demo_user_ids[1 + (i % 6)], demo_user_emails[1 + (i % 6)],
-        demo_hostnames[1 + (i % 6)],
+        demo_user_ids[owner_idx], demo_user_emails[owner_idx],
+        demo_hostnames[owner_idx],
         demo.det_uuid('gram-demo-chat-' || i)::text,
         demo_skill_names[skill_pos], 'plugin', 'project',
         '.claude/skills/' || demo_skill_names[skill_pos] || '/SKILL.md',
@@ -586,10 +631,11 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
     chat_id := demo.det_uuid('gram-demo-chat-' || i);
     chat_proj := proj_a;
     chat_policy := policy_a;
-    owner_idx := 1 + (i % array_length(demo_user_ids, 1));
-    -- 5h spacing = ~12.5 days for 60 chats: inside the session/cost MV date
-    -- cutoffs and the 90-day TTLs; matches the ClickHouse formula exactly.
-    chat_ts := now() - (interval '5 hours' * i) - (interval '13 minutes' * (i % 7));
+    owner_idx := demo.chat_owner_idx(i);
+    -- Hash-picked slot inside the trailing ~12 days: inside the session/cost
+    -- MV date cutoffs and the 90-day TTLs; matches the ClickHouse formula
+    -- exactly (both derive from md5('gram-demo-chat-' || i)).
+    chat_ts := demo.chat_ts(i);
 
     INSERT INTO chats (id, project_id, organization_id, user_id, external_user_id,
                        title, created_at, updated_at)
@@ -737,8 +783,9 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
   END LOOP;
 
   ------------------------------------------------------------------
-  -- Spend rules calibrated to the seeded ClickHouse usage (~$0.37 top monthly
-  -- spender) so the rules page shows one breach and one warning per rule.
+  -- Spend rules calibrated to the seeded ClickHouse usage (top spenders in
+  -- the low thousands of dollars per month) so the rules page shows one
+  -- breach and one warning per rule.
   -- Events are pre-inserted because the evaluator is flag-gated; the dedupe
   -- key (rule, type, email, window_start) keeps a live evaluator idempotent.
   ------------------------------------------------------------------
@@ -751,7 +798,7 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
   VALUES
     (rule_monthly, demo_org, 'Monthly agent budget', 'monthly-agent-budget',
      'Per-person monthly cap on agent/CLI spend.',
-     'email.endsWith("@demo.getgram.ai")', 350, 'monthly', 80, 'flag', TRUE, 1,
+     'email.endsWith("@demo.getgram.ai")', 200000, 'monthly', 80, 'flag', TRUE, 1,
      now() - interval '20 days'),
     -- Builder-representable condition: the rule edit sheet cannot round-trip
     -- 'email in [...]' CEL (no is-one-of operator), which left the condition
@@ -759,26 +806,26 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
     (rule_weekly, demo_org, 'Support weekly cap', 'support-weekly-cap',
      'Weekly guardrail for the support rotation.',
      'department_name == "Support Engineering"',
-     200, 'weekly', 75, 'block', TRUE, 1, now() - interval '15 days');
+     60000, 'weekly', 75, 'block', TRUE, 1, now() - interval '15 days');
 
   INSERT INTO spend_rule_events (organization_id, spend_rule_id, rule_urn, event_type,
                                  user_id, email, display_name, spend_usd_cents,
                                  limit_usd_cents, window_start, window_end, created_at)
   VALUES
     (demo_org, rule_monthly, 'spend_rule:monthly-agent-budget:v1', 'breach',
-     'user_demo_mateo', 'mateo@demo.getgram.ai', 'Mateo Alvarez', 409, 350,
+     'user_demo_mateo', 'mateo@demo.getgram.ai', 'Mateo Alvarez', 231900, 200000,
      date_trunc('month', now()), date_trunc('month', now()) + interval '1 month',
      now() - interval '1 day'),
     (demo_org, rule_monthly, 'spend_rule:monthly-agent-budget:v1', 'warning',
-     'user_demo_lucas', 'lucas@demo.getgram.ai', 'Lucas Meyer', 305, 350,
+     'user_demo_lucas', 'lucas@demo.getgram.ai', 'Lucas Meyer', 171400, 200000,
      date_trunc('month', now()), date_trunc('month', now()) + interval '1 month',
      now() - interval '2 days'),
     (demo_org, rule_weekly, 'spend_rule:support-weekly-cap:v1', 'breach',
-     'user_demo_jonas', 'jonas@demo.getgram.ai', 'Jonas Lindqvist', 267, 200,
+     'user_demo_jonas', 'jonas@demo.getgram.ai', 'Jonas Lindqvist', 74200, 60000,
      date_trunc('week', now()), date_trunc('week', now()) + interval '1 week',
      now() - interval '6 hours'),
     (demo_org, rule_weekly, 'spend_rule:support-weekly-cap:v1', 'warning',
-     'user_demo_amara', 'amara@demo.getgram.ai', 'Amara Okafor', 152, 200,
+     'user_demo_amara', 'amara@demo.getgram.ai', 'Amara Okafor', 48700, 60000,
      date_trunc('week', now()), date_trunc('week', now()) + interval '1 week',
      now() - interval '10 hours');
 


### PR DESCRIPTION
## What

Two related fixes for the MCP Servers & Tool Insights page looking like noise on the demo org (and any low/sparse-volume project):

### 1. Time-series charts: smoothed multi-line → stacked bars

The four time charts (Activity by Source, User Usage, Skill Usage, Errors Over Time) rendered sparse integer counts as `tension: 0.45` bezier lines over a category axis containing only buckets that had data. Result: sine-wave spaghetti with a distorted time dimension.

- `buildToolUsageTimeSeries` now re-buckets onto a **dense, evenly spaced grid** anchored at the filter's `from` (quiet buckets render as empty space, not skipped), with an **adaptive bucket size** (1h → 7d steps, ≤48 bars per range).
- Datasets are stacked bar datasets sorted by series total; series beyond the palette fold into a neutral **"Other"** instead of cycling colors.
- `MultiLineChart` → `StackedTimeBarChart` (still Chart.js, keeps drag-to-zoom range selection and the zero-filtered shared tooltip; range selection extends to cover the last bucket's width).

### 2. Demo seed: humanized usage data

The seed placed one chat exactly every 5 hours, rotated users with `1 + (i % 6)`, alternated skills with `intDiv(i, 2) % 3`, and spread errors with `% 14` — so every chart showed a flat repeating pattern, and org spend totaled ~$44.

- **Schedule**: chats land on hash-picked weighted days (busy days, quiet days, dead days) at work-hours-biased times, derived from bytes of `md5('gram-demo-chat-' || n)` so Postgres (`demo.chat_ts` / `demo.chat_owner_idx` / `demo.chat_day_off`) and ClickHouse reproduce the same placement.
- **Owners**: weighted user distribution (two heavy users, two occasional) instead of perfect rotation.
- **Volume**: 180 chats (was 60); 3–12 gateway tool calls per chat (was 2) → ~1.3k tool events per window.
- **Costs**: token counts and pricing scaled to realistic agentic usage → ~$5k per trailing ~12-day window (~$12k/month pace); spend rules recalibrated to keep one breach + one warning per rule.
- **Errors**: clustered `process_refund` incident over the last ~3 days plus low background noise, instead of an even modulus spread.
- Runbook v2 rollout split keyed on the chat's day (`day_off <= 4`) instead of the now-meaningless `i <= 24`.

Transcript join contracts unchanged: `demo-prompt-<i>-<turn>` / `call_demo_<i>-<k>` families keep their fixed counts.

## Testing

- `pnpm -F dashboard test` (new coverage: dense grid fill, adaptive bucketing, malformed timestamps, Other-fold), `lint`, `type-check` — green.
- `mise run test:server -tags=demoseed_safety ./internal/demoseed/...` — green.
- `mise run seed:demo` applied locally; verified per-day (62–340 events, dead days), per-user (all 6 active, weighted), 5.1% clustered error rate, ~$5k window spend.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Tool Insights time-series charts to stacked bars on a dense time grid for clearer trends, especially in low-volume orgs. Revamps the demo seed to generate realistic, work-hours-weighted usage, spend, and error patterns.

- **New Features**
  - Replaced multiline charts with stacked bar charts using `chart.js`/`react-chartjs-2` and kept drag-to-zoom; selection now covers the last bucket’s width.
  - `buildToolUsageTimeSeries` now re-buckets onto a dense, evenly spaced grid anchored at the filter’s from; adaptive bucket size (1h→7d) caps at ≤48 bars.
  - Series are sorted by total and overflow folds into an “Other” stack to avoid color collisions; shared tooltip hides zero-value series.
  - Unified errors-over-time to the same stacked pipeline; consistent labels and faded tick colors for readability.

- **Refactors**
  - Added tests for adaptive bucketing, dense grid fill, malformed timestamps, and “Other” folding.
  - Demo seed overhaul: 180 chats on a weighted schedule, 3–12 tool calls per chat, clustered `process_refund` incident, weighted user distribution, realistic tokens/costs (~$5k per trailing ~12 days), and updated spend rules.
  - Introduced `demo.chat_ts`, `demo.chat_owner_idx`, and `demo.chat_day_off` in Postgres and mirrored in ClickHouse for deterministic, humanized placement; raised postflight thresholds and updated verify docs.

<sup>Written for commit 8deeb56bab0e2ee93003fadc2ec7b654f1b3d289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

