### PR TITLE
fix: forward Flush through response writer wrappers to unblock SSE streaming

### DIFF
--- a/server/internal/middleware/admin_security.go
+++ b/server/internal/middleware/admin_security.go
@@ -131,9 +131,9 @@ func (c *adminCookieRewriter) Flush() {
 		c.rewrite()
 		c.wroteHeader = true
 	}
-	if f, ok := c.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
+	// ResponseController finds flush support through FlushError and Unwrap
+	// chains that a direct http.Flusher assert would miss.
+	_ = http.NewResponseController(c.ResponseWriter).Flush()
 }
 
 // Unwrap lets http.ResponseController reach controls of the underlying

--- a/server/internal/middleware/admin_security.go
+++ b/server/internal/middleware/admin_security.go
@@ -123,6 +123,25 @@ func (c *adminCookieRewriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
+// Flush must be forwarded explicitly — the embedded interface hides the
+// underlying writer's Flush from type asserts, breaking streaming. Flushing
+// commits headers, so the cookie rewrite has to happen first.
+func (c *adminCookieRewriter) Flush() {
+	if !c.wroteHeader {
+		c.rewrite()
+		c.wroteHeader = true
+	}
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap lets http.ResponseController reach controls of the underlying
+// writer that this wrapper does not forward.
+func (c *adminCookieRewriter) Unwrap() http.ResponseWriter {
+	return c.ResponseWriter
+}
+
 func (c *adminCookieRewriter) rewrite() {
 	h := c.Header()
 	cookies := h.Values("Set-Cookie")

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -44,6 +44,22 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 	return n, nil
 }
 
+// Flush must be forwarded explicitly: embedding the http.ResponseWriter
+// interface hides the underlying writer's Flush from type asserts, which
+// silently disables streaming (SSE events sit in the server's write buffer
+// until it fills) for every handler behind this middleware.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap lets http.ResponseController reach controls of the underlying
+// writer that this wrapper does not forward.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 // logSafeURL renders a request URL for logs and observability context with
 // secret-bearing parts redacted. Several public capability-URL endpoints
 // carry a live credential in a "token" query parameter (e.g. skills.getShared,

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -49,9 +49,9 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 // silently disables streaming (SSE events sit in the server's write buffer
 // until it fills) for every handler behind this middleware.
 func (rw *responseWriter) Flush() {
-	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
+	// ResponseController finds flush support through FlushError and Unwrap
+	// chains that a direct http.Flusher assert would miss.
+	_ = http.NewResponseController(rw.ResponseWriter).Flush()
 }
 
 // Unwrap lets http.ResponseController reach controls of the underlying

--- a/server/internal/middleware/response_writer_flush_test.go
+++ b/server/internal/middleware/response_writer_flush_test.go
@@ -29,7 +29,7 @@ func TestResponseWriterWrappersForwardFlush(t *testing.T) {
 
 	inner := &flushRecorder{ResponseRecorder: httptest.NewRecorder(), flushed: false}
 	wrappers := map[string]http.ResponseWriter{
-		"logging.responseWriter":            newResponseWriter(inner),
+		"logging.responseWriter":             newResponseWriter(inner),
 		"admin_security.adminCookieRewriter": &adminCookieRewriter{ResponseWriter: inner, domain: "example.com", wroteHeader: false},
 	}
 

--- a/server/internal/middleware/response_writer_flush_test.go
+++ b/server/internal/middleware/response_writer_flush_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// flushRecorder records whether Flush reached the innermost writer.
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (f *flushRecorder) Flush() {
+	f.flushed = true
+	f.ResponseRecorder.Flush()
+}
+
+// Every ResponseWriter wrapper in this package must forward Flush to the
+// writer it wraps. A wrapper that hides Flush silently disables streaming
+// (SSE events sit in the server's write buffer until it fills) for every
+// handler behind it — and the failure is invisible in httptest-based
+// handler tests, which never exercise the real middleware chain.
+func TestResponseWriterWrappersForwardFlush(t *testing.T) {
+	t.Parallel()
+
+	inner := &flushRecorder{ResponseRecorder: httptest.NewRecorder(), flushed: false}
+	wrappers := map[string]http.ResponseWriter{
+		"logging.responseWriter":            newResponseWriter(inner),
+		"admin_security.adminCookieRewriter": &adminCookieRewriter{ResponseWriter: inner, domain: "example.com", wroteHeader: false},
+	}
+
+	for name, w := range wrappers {
+		inner.flushed = false
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok, "%s must implement http.Flusher", name)
+		flusher.Flush()
+		require.True(t, inner.flushed, "%s must forward Flush to the wrapped writer", name)
+
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		require.True(t, ok, "%s must implement Unwrap for http.ResponseController", name)
+		require.Equal(t, http.ResponseWriter(inner), unwrapper.Unwrap(), "%s must unwrap to the wrapped writer", name)
+	}
+}


### PR DESCRIPTION
## Problem

The global HTTP logging middleware wraps every handler's `http.ResponseWriter` in a `responseWriter` struct that embeds the `http.ResponseWriter` interface. Embedding an interface only promotes the interface's own methods, so the wrapper does not satisfy `http.Flusher` even when the underlying writer does. Every `w.(http.Flusher)` assert behind the middleware chain (`remotemcp/proxy`, `chat`, `gateway`) silently gets `ok == false`, and explicit flushes become no-ops.

The observable effect: response bytes only leave the server when Go's 4KB write buffer fills or the handler returns. Completed responses are unaffected (everything flushes at handler return), and high-throughput streams like chat appear to work because tokens fill 4KB quickly. But low-rate long-lived streams — the MCP standalone GET SSE stream unblocked by #4955, SSE keepalives, progress notifications — deliver nothing to the client until the stream ends. Verified end-to-end: a server-initiated MCP notification relayed by the proxy never reached the client (0 bytes over 35s), while pushing ~4KB through the same stream made all buffered events arrive at once.

`adminCookieRewriter` in the admin security middleware has the same latent bug on admin routes.

## Change

- `middleware/logging.go`: `responseWriter` forwards `Flush()` to the wrapped writer and implements `Unwrap()` for `http.ResponseController`.
- `middleware/admin_security.go`: same for `adminCookieRewriter`; its `Flush` performs the Set-Cookie rewrite first since flushing commits headers.
- `TestResponseWriterWrappersForwardFlush` covers every writer wrapper in the package so a future wrapper that hides `Flush` fails the suite. This failure mode is invisible to `httptest`-based handler tests (`ResponseRecorder` implements `Flush` directly), which is how it went unnoticed.

Verified on the local dev stack against a remote-backed MCP server: before the change a standalone GET SSE stream delivered 0 bytes to the client; after it, server-initiated notifications arrive in under a second.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hidden `Flush()` in response writer wrappers so SSE and other low-rate streams flush promptly instead of buffering until 4KB or handler return. Flush is now forwarded via `http.ResponseController` to cover `FlushError`/`Unwrap` chains; applies to routes behind logging and admin middleware.

- **Bug Fixes**
  - `middleware/logging.go`: `responseWriter` now implements `http.Flusher` and forwards `Flush()` via `http.ResponseController`; adds `Unwrap()` for `http.ResponseController`.
  - `middleware/admin_security.go`: `adminCookieRewriter` forwards `Flush()` via `http.ResponseController` after the Set-Cookie rewrite; adds `Unwrap()`.
  - Added `TestResponseWriterWrappersForwardFlush` to ensure wrappers implement `http.Flusher`, forward `Flush()`, and support `Unwrap()`.

<sup>Written for commit 4f04363f5dad4043303cbcb0d232c1fc1a39dc4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

