### PR TITLE
mig: add tags column to skills (DNO-774)

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -273,6 +273,7 @@ CREATE TABLE IF NOT EXISTS skills (
   summary TEXT,
   source_kind TEXT NOT NULL DEFAULT 'manual',
   classification TEXT NOT NULL DEFAULT 'custom',
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[] CHECK (array_length(tags, 1) <= 40),
 
   first_seen_at timestamptz,
   last_seen_at timestamptz,
@@ -291,6 +292,7 @@ CREATE INDEX IF NOT EXISTS skills_project_id_idx ON skills (project_id);
 CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_id_key ON skills (project_id, id);
 CREATE UNIQUE INDEX IF NOT EXISTS skills_project_id_name_key ON skills (project_id, name) WHERE archived_at IS NULL;
 CREATE INDEX IF NOT EXISTS skills_suggestion_sweep_idx ON skills (project_id, last_seen_at DESC, id DESC) WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS skills_tags_gin ON skills USING gin (tags) WHERE archived_at IS NULL;
 
 CREATE TABLE IF NOT EXISTS skill_versions (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1893,6 +1893,7 @@ type Skill struct {
 	Summary        pgtype.Text
 	SourceKind     string
 	Classification string
+	Tags           []string
 	FirstSeenAt    pgtype.Timestamptz
 	LastSeenAt     pgtype.Timestamptz
 	SeenCount      int64

--- a/server/internal/skills/repo/models.go
+++ b/server/internal/skills/repo/models.go
@@ -17,6 +17,7 @@ type Skill struct {
 	Summary        pgtype.Text
 	SourceKind     string
 	Classification string
+	Tags           []string
 	FirstSeenAt    pgtype.Timestamptz
 	LastSeenAt     pgtype.Timestamptz
 	SeenCount      int64

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -67,7 +67,7 @@ SET archived_at = clock_timestamp(),
 WHERE project_id = $1
   AND id = $2
   AND archived_at IS NULL
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type ArchiveSkillParams struct {
@@ -86,6 +86,7 @@ func (q *Queries) ArchiveSkill(ctx context.Context, arg ArchiveSkillParams) (Ski
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -695,7 +696,7 @@ INSERT INTO skills (
 )
 ON CONFLICT (project_id, name) WHERE archived_at IS NULL
 DO NOTHING
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type CreateCapturedSkillParams struct {
@@ -721,6 +722,7 @@ func (q *Queries) CreateCapturedSkill(ctx context.Context, arg CreateCapturedSki
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -749,7 +751,7 @@ INSERT INTO skills (
 )
 ON CONFLICT (project_id, name) WHERE archived_at IS NULL
 DO NOTHING
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type CreateObservedSkillParams struct {
@@ -769,6 +771,7 @@ func (q *Queries) CreateObservedSkill(ctx context.Context, arg CreateObservedSki
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -882,7 +885,7 @@ INSERT INTO skills (
 )
 ON CONFLICT (project_id, name) WHERE archived_at IS NULL
 DO NOTHING
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type CreateSkillParams struct {
@@ -908,6 +911,7 @@ func (q *Queries) CreateSkill(ctx context.Context, arg CreateSkillParams) (Skill
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -1591,7 +1595,7 @@ func (q *Queries) FailSkillObservationReconciliations(ctx context.Context, arg F
 }
 
 const getActiveSkillByName = `-- name: GetActiveSkillByName :one
-SELECT id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+SELECT id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 FROM skills
 WHERE project_id = $1
   AND name = $2
@@ -1614,6 +1618,7 @@ func (q *Queries) GetActiveSkillByName(ctx context.Context, arg GetActiveSkillBy
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -1960,7 +1965,7 @@ func (q *Queries) GetSharedSkillByToken(ctx context.Context, token string) (GetS
 }
 
 const getSkill = `-- name: GetSkill :one
-SELECT id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+SELECT id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 FROM skills
 WHERE project_id = $1
   AND id = $2
@@ -1983,6 +1988,7 @@ func (q *Queries) GetSkill(ctx context.Context, arg GetSkillParams) (Skill, erro
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -2031,7 +2037,7 @@ func (q *Queries) GetSkillAdoptionStats(ctx context.Context, arg GetSkillAdoptio
 }
 
 const getSkillByNameForUpdate = `-- name: GetSkillByNameForUpdate :one
-SELECT id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+SELECT id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 FROM skills
 WHERE project_id = $1
   AND name = $2
@@ -2055,6 +2061,7 @@ func (q *Queries) GetSkillByNameForUpdate(ctx context.Context, arg GetSkillByNam
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -2067,7 +2074,7 @@ func (q *Queries) GetSkillByNameForUpdate(ctx context.Context, arg GetSkillByNam
 
 const getSkillDetails = `-- name: GetSkillDetails :one
 SELECT
-  s.id, s.project_id, s.name, s.display_name, s.summary, s.source_kind, s.classification, s.first_seen_at, s.last_seen_at, s.seen_count, s.archived_at, s.created_at, s.updated_at,
+  s.id, s.project_id, s.name, s.display_name, s.summary, s.source_kind, s.classification, s.tags, s.first_seen_at, s.last_seen_at, s.seen_count, s.archived_at, s.created_at, s.updated_at,
   l.token AS share_token,
   COALESCE(state.latest_version_id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
   COALESCE(state.version_count, 0)::bigint AS version_count,
@@ -2132,6 +2139,7 @@ func (q *Queries) GetSkillDetails(ctx context.Context, arg GetSkillDetailsParams
 		&i.Skill.Summary,
 		&i.Skill.SourceKind,
 		&i.Skill.Classification,
+		&i.Skill.Tags,
 		&i.Skill.FirstSeenAt,
 		&i.Skill.LastSeenAt,
 		&i.Skill.SeenCount,
@@ -2598,7 +2606,7 @@ func (q *Queries) GetSkillFeedbackMetrics(ctx context.Context, arg GetSkillFeedb
 }
 
 const getSkillForUpdate = `-- name: GetSkillForUpdate :one
-SELECT id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+SELECT id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 FROM skills
 WHERE project_id = $1
   AND id = $2
@@ -2622,6 +2630,7 @@ func (q *Queries) GetSkillForUpdate(ctx context.Context, arg GetSkillForUpdatePa
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -4028,7 +4037,7 @@ func (q *Queries) ListRecentSkillFeedback(ctx context.Context, arg ListRecentSki
 }
 
 const listRecentlyActiveSkills = `-- name: ListRecentlyActiveSkills :many
-SELECT id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+SELECT id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 FROM skills
 WHERE project_id = $1
   AND archived_at IS NULL
@@ -4081,6 +4090,7 @@ func (q *Queries) ListRecentlyActiveSkills(ctx context.Context, arg ListRecently
 			&i.Summary,
 			&i.SourceKind,
 			&i.Classification,
+			&i.Tags,
 			&i.FirstSeenAt,
 			&i.LastSeenAt,
 			&i.SeenCount,
@@ -4708,7 +4718,7 @@ func (q *Queries) ListSkillVersions(ctx context.Context, arg ListSkillVersionsPa
 
 const listSkills = `-- name: ListSkills :many
 SELECT
-  s.id, s.project_id, s.name, s.display_name, s.summary, s.source_kind, s.classification, s.first_seen_at, s.last_seen_at, s.seen_count, s.archived_at, s.created_at, s.updated_at,
+  s.id, s.project_id, s.name, s.display_name, s.summary, s.source_kind, s.classification, s.tags, s.first_seen_at, s.last_seen_at, s.seen_count, s.archived_at, s.created_at, s.updated_at,
   l.token AS share_token,
   COALESCE(latest.id, '00000000-0000-0000-0000-000000000000'::uuid) AS latest_version_id,
   COALESCE(latest.version_count, 0)::bigint AS version_count,
@@ -4839,6 +4849,7 @@ func (q *Queries) ListSkills(ctx context.Context, arg ListSkillsParams) ([]ListS
 			&i.Skill.Summary,
 			&i.Skill.SourceKind,
 			&i.Skill.Classification,
+			&i.Skill.Tags,
 			&i.Skill.FirstSeenAt,
 			&i.Skill.LastSeenAt,
 			&i.Skill.SeenCount,
@@ -5227,7 +5238,7 @@ WHERE project_id = $1
   AND id = $2
   AND source_kind = 'captured'
   AND archived_at IS NULL
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type PromoteObservedSkillToManualParams struct {
@@ -5246,6 +5257,7 @@ func (q *Queries) PromoteObservedSkillToManual(ctx context.Context, arg PromoteO
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -6040,7 +6052,7 @@ SET summary = $1::text,
 WHERE project_id = $2
   AND id = $3
   AND archived_at IS NULL
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type SyncSkillSummaryParams struct {
@@ -6060,6 +6072,7 @@ func (q *Queries) SyncSkillSummary(ctx context.Context, arg SyncSkillSummaryPara
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,
@@ -6184,7 +6197,7 @@ SET name = $1,
 WHERE project_id = $4
   AND id = $5
   AND archived_at IS NULL
-RETURNING id, project_id, name, display_name, summary, source_kind, classification, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
+RETURNING id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 `
 
 type UpdateSkillDetailsParams struct {
@@ -6212,6 +6225,7 @@ func (q *Queries) UpdateSkillDetails(ctx context.Context, arg UpdateSkillDetails
 		&i.Summary,
 		&i.SourceKind,
 		&i.Classification,
+		&i.Tags,
 		&i.FirstSeenAt,
 		&i.LastSeenAt,
 		&i.SeenCount,

--- a/server/migrations/20260805161737_skills-add-tags.sql
+++ b/server/migrations/20260805161737_skills-add-tags.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Modify "skills" table
+ALTER TABLE "skills" ADD CONSTRAINT "skills_tags_check" CHECK (array_length(tags, 1) <= 40), ADD COLUMN "tags" text[] NOT NULL DEFAULT ARRAY[]::text[];
+-- Create index "skills_tags_gin" to table: "skills"
+CREATE INDEX CONCURRENTLY "skills_tags_gin" ON "skills" USING gin ("tags") WHERE (archived_at IS NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8DIRitjtt0nnlEw0LW7hDebAsFDbCNYXKAbtYxpK/vU=
+h1:EFDT/zBYZ/QppJJDMLnGdnysGQpxx2boVv9ozFY+/SY=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -315,3 +315,4 @@ h1:8DIRitjtt0nnlEw0LW7hDebAsFDbCNYXKAbtYxpK/vU=
 20260803193050_litellm-instances.sql h1:tXo5MT2gc1ofWtT8ndwAo5Ms2G4vUKhF8wUuZr1r+Zc=
 20260803194013_litellm-instance-health.sql h1:xocULUVta5ICjDnH83WT/zQbXN0ZyzRbmpQvGXU0JW0=
 20260805004742_platform-mcp-oauth-state.sql h1:+pwpYW0oQ41e7Quo61ZKnmJa7vNm8NVBXUmYjxdGfr0=
+20260805161737_skills-add-tags.sql h1:aiav/5wPpriD/TI9TaFSNeDe8YgYjfZHv24iMM3zwSc=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `tags TEXT[]` column on `skills` (max 40 tags, default empty) plus a partial GIN index on active skills. This is the schema half of DNO-774 (tag skills and filter the Skills tab by tag).

Follow-up application PR: **#4965**

## Notes

- **Migration-only PR** — no application code. #4965 wires tags through the skills API and dashboard Skills tab.
- Backwards compatible: existing rows get `{}`; deployed code does not read/write `tags` yet.
- The `skills_tags_check` constraint uses the same Atlas one-step form as prior tag columns (e.g. `function_tool_definitions`). Skills tables are small, so the table scan under `ACCESS EXCLUSIVE` is acceptable; no `NOT VALID` split.
- Index is created `CONCURRENTLY` (`atlas:txmode none`).

## Test plan

- [x] `mise run db:migrate` applies cleanly locally
- [ ] CI migration lint / apply passes

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-774](https://linear.app/speakeasy/issue/DNO-774/feat-add-tags-to-skills-in-the-skills-tab-and-filter-results-by-tag)

<div><a href="https://cursor.com/agents/bc-8553c46e-a793-4162-8eeb-af2a5cd2026a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8553c46e-a793-4162-8eeb-af2a5cd2026a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `tags` array to `skills` and index it to enable categorizing skills and fast tag filtering in the Skills tab. Regenerated SQLc so repo models and queries include `tags`; this delivers the schema part of DNO-774.

- **Migration**
  - Add `tags TEXT[]` to `skills` with default `[]` and a 40-tag limit.
  - Add a partial GIN index on `tags` for active skills, created concurrently.
  - Regenerate SQLc to include `tags` in `Skill` models and query SELECT/RETURNING lists; backward compatible and not used by app code yet.

<sup>Written for commit 659b579fcb9a5ef85b829aba88e6c4f5075cef9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

