### PR TITLE
feat: install Figma from the catalog as an unproxied server

### DIFF
--- a/.changeset/catalog-figma-unproxied.md
+++ b/.changeset/catalog-figma-unproxied.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Adding Figma from the MCP catalog now connects your project directly to Figma's official server instead of routing through a proxy, so there's nothing to authorize or allowlist.

--- a/client/dashboard/src/pages/catalog/remotes.test.ts
+++ b/client/dashboard/src/pages/catalog/remotes.test.ts
@@ -8,6 +8,7 @@ import {
   collectibleHeaders,
   dedupeRemotesByUrl,
   filterToHttpRemotes,
+  isFigmaCatalogServer,
   normalizeRemoteUrl,
 } from "./remotes";
 import type { PulseMCPServer } from "./hooks";
@@ -30,10 +31,13 @@ function remote(
   };
 }
 
-function server(remotes: ExternalMCPRemote[]): PulseMCPServer {
+function server(
+  remotes: ExternalMCPRemote[],
+  registrySpecifier = "test/server",
+): PulseMCPServer {
   return {
     description: "test",
-    registrySpecifier: "test/server",
+    registrySpecifier,
     version: "0.1.0",
     meta: {},
     toolCount: 0,
@@ -76,6 +80,16 @@ describe("dedupeRemotesByUrl", () => {
 
   it("handles an empty list", () => {
     expect(dedupeRemotesByUrl([])).toEqual([]);
+  });
+});
+
+describe("isFigmaCatalogServer", () => {
+  it("returns true for Figma's registry specifier", () => {
+    expect(isFigmaCatalogServer(server([], "com.figma.mcp/mcp"))).toBe(true);
+  });
+
+  it("returns false for a non-Figma server", () => {
+    expect(isFigmaCatalogServer(server([], "test/server"))).toBe(false);
   });
 });
 

--- a/client/dashboard/src/pages/catalog/remotes.ts
+++ b/client/dashboard/src/pages/catalog/remotes.ts
@@ -6,7 +6,7 @@ import type { ExternalMCPRemoteHeader } from "@gram/client/models/components/ext
 // Installing this catalog entry creates an unproxied MCP server (see
 // useRemoteMcpInstallWorkflow) instead of a Gram-proxied remote one, since
 // Speakeasy never needs to manage OAuth for it.
-export const FIGMA_REGISTRY_SPECIFIER = "com.figma.mcp/mcp";
+const FIGMA_REGISTRY_SPECIFIER = "com.figma.mcp/mcp";
 
 export function isFigmaCatalogServer(server: PulseMCPServer): boolean {
   return server.registrySpecifier === FIGMA_REGISTRY_SPECIFIER;

--- a/client/dashboard/src/pages/catalog/remotes.ts
+++ b/client/dashboard/src/pages/catalog/remotes.ts
@@ -2,6 +2,16 @@ import type { PulseMCPServer } from "@/pages/catalog/hooks";
 import type { ExternalMCPRemote } from "@gram/client/models/components/externalmcpremote.js";
 import type { ExternalMCPRemoteHeader } from "@gram/client/models/components/externalmcpremoteheader.js";
 
+// Pulse MCP registry specifier for Figma's official remote MCP server.
+// Installing this catalog entry creates an unproxied MCP server (see
+// useRemoteMcpInstallWorkflow) instead of a Gram-proxied remote one, since
+// Speakeasy never needs to manage OAuth for it.
+export const FIGMA_REGISTRY_SPECIFIER = "com.figma.mcp/mcp";
+
+export function isFigmaCatalogServer(server: PulseMCPServer): boolean {
+  return server.registrySpecifier === FIGMA_REGISTRY_SPECIFIER;
+}
+
 export function filterToHttpRemotes(server: PulseMCPServer): PulseMCPServer {
   const httpRemotes = server.remotes?.filter(
     (r) => r.transportType === "streamable-http",

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.test.ts
@@ -8,6 +8,8 @@ const mockDiscoverProtectedResourceMetadata = vi.fn();
 const mockMcpServersCreate = vi.fn();
 const mockMcpEndpointsCreate = vi.fn();
 const mockAuthedFetch = vi.fn();
+const mockUnproxiedCreateServer = vi.fn();
+const mockUnproxiedDeleteServer = vi.fn();
 
 // Return a stable client reference to avoid re-render loops from useCallback deps
 const mockClient = {
@@ -22,6 +24,10 @@ const mockClient = {
   },
   mcpEndpoints: {
     create: mockMcpEndpointsCreate,
+  },
+  unproxiedMcp: {
+    createServer: mockUnproxiedCreateServer,
+    deleteServer: mockUnproxiedDeleteServer,
   },
 };
 
@@ -41,6 +47,10 @@ vi.mock("sonner", () => ({
 vi.mock("@gram/client/react-query/remoteMcpServers.js", () => ({
   useRemoteMcpServers: vi.fn(() => ({ data: undefined })),
   invalidateAllRemoteMcpServers: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@gram/client/react-query/unproxiedMcpServers.js", () => ({
+  useUnproxiedMcpServers: vi.fn(() => ({ data: undefined })),
+  invalidateAllUnproxiedMcpServers: vi.fn(() => Promise.resolve()),
 }));
 vi.mock("@gram/client/react-query/remoteMcpServerHeaders.js", () => ({
   invalidateAllRemoteMcpServerHeaders: vi.fn(() => Promise.resolve()),
@@ -133,6 +143,13 @@ describe("useRemoteMcpInstallWorkflow", () => {
       slug: "test-org-abc123",
     });
     mockDeleteServer.mockResolvedValue(undefined);
+    mockUnproxiedCreateServer.mockResolvedValue({
+      id: "unproxied-1",
+      slug: "unproxied-slug",
+      url: "https://mcp.figma.com/mcp",
+      name: "Figma",
+    });
+    mockUnproxiedDeleteServer.mockResolvedValue(undefined);
   });
 
   // -------------------------------------------------------------------------
@@ -334,6 +351,47 @@ describe("useRemoteMcpInstallWorkflow", () => {
       mcpServerParam: "mcp-server-slug",
     });
     expect(state.statuses[0]!.mcpEndpointUrl).toContain("/mcp/test-org-abc123");
+  });
+
+  it("creates an unproxied MCP server for Figma instead of a remote one", async () => {
+    const servers = [
+      makeServer({
+        title: "Figma",
+        registrySpecifier: "com.figma.mcp/mcp",
+        remotes: [remote("https://mcp.figma.com/mcp")],
+      }),
+    ];
+    const { result } = renderHook(() =>
+      useRemoteMcpInstallWorkflow({ servers }),
+    );
+
+    await startInstall(result);
+
+    await waitFor(() => expect(result.current.phase).toBe("complete"));
+    expect(mockUnproxiedCreateServer).toHaveBeenCalledWith(
+      {
+        createUnproxiedMcpServerForm: {
+          name: "Figma",
+          url: "https://mcp.figma.com/mcp",
+          description: "A test server",
+        },
+      },
+      undefined,
+      undefined,
+    );
+    expect(mockCreateServer).not.toHaveBeenCalled();
+    expect(mockMcpServersCreate).toHaveBeenCalledWith(
+      {
+        createMcpServerForm: expect.objectContaining({
+          name: "Figma",
+          unproxiedMcpServerId: "unproxied-1",
+          visibility: "public",
+        }),
+      },
+      undefined,
+      undefined,
+    );
+    expect(mockMcpEndpointsCreate).not.toHaveBeenCalled();
   });
 
   it("sends gram-project request options for cross-project installs", async () => {

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
@@ -10,9 +10,11 @@ import type { PulseMCPServer } from "@/pages/catalog/hooks";
 import {
   collectibleHeaders,
   getRemoteDisplayInfo,
+  isFigmaCatalogServer,
   normalizeRemoteUrl,
 } from "@/pages/catalog/remotes";
 import { autoConfigureRemoteMcpAuth } from "@/pages/sources/remote-mcp/autoConfigureAuth";
+import type { Gram } from "@gram/client";
 import type { RequestOptions } from "@gram/client/lib/sdks.js";
 import type { ExternalMCPRemote } from "@gram/client/models/components/externalmcpremote.js";
 import type { ExternalMCPRemoteHeader } from "@gram/client/models/components/externalmcpremoteheader.js";
@@ -181,6 +183,73 @@ function buildInstallTargets(config: ServerConfig): InstallTarget[] {
       return value ? [{ header, value }] : [];
     }),
   }));
+}
+
+/**
+ * Installs one target as an unproxied MCP server instead of a Gram-proxied
+ * remote one: creates the unproxied_mcp_servers row, links an mcp_servers
+ * wrapper (rolling back the former on failure, mirroring installTarget's own
+ * remote-server path), and returns the same shape installTarget does. There
+ * is no OAuth to auto-configure and no Gram endpoint to pre-stage — the
+ * customer connects straight to the vendor.
+ */
+async function installUnproxiedTarget(
+  client: Gram,
+  target: InstallTarget,
+  reqOpts: RequestOptions | undefined,
+): Promise<{
+  mcpServer: McpServer;
+  mcpEndpointUrl?: string;
+  authConfigured: boolean;
+}> {
+  const unproxiedMcpServer = await client.unproxiedMcp.createServer(
+    {
+      createUnproxiedMcpServerForm: {
+        name: target.name,
+        url: target.remote.url,
+      },
+    },
+    undefined,
+    reqOpts,
+  );
+
+  let mcpServer: McpServer;
+  try {
+    mcpServer = await client.mcpServers.create(
+      {
+        createMcpServerForm: {
+          name: target.name,
+          unproxiedMcpServerId: unproxiedMcpServer.id,
+          // Unproxied servers have no Gram-hosted endpoint, so
+          // disabled/private/public gates nothing Gram actually serves.
+          visibility: "public",
+        },
+      },
+      undefined,
+      reqOpts,
+    );
+  } catch (linkError) {
+    try {
+      await client.unproxiedMcp.deleteServer(
+        { id: unproxiedMcpServer.id },
+        undefined,
+        reqOpts,
+      );
+    } catch (rollbackError) {
+      const linkMsg =
+        linkError instanceof Error ? linkError.message : String(linkError);
+      const rollbackMsg =
+        rollbackError instanceof Error
+          ? rollbackError.message
+          : String(rollbackError);
+      throw new Error(
+        `Created unproxied MCP server ${unproxiedMcpServer.id} but failed to link an MCP server, and the rollback also failed. Delete it manually before retrying. Cause: ${linkMsg}. Rollback: ${rollbackMsg}.`,
+      );
+    }
+    throw linkError instanceof Error ? linkError : new Error(String(linkError));
+  }
+
+  return { mcpServer, mcpEndpointUrl: undefined, authConfigured: false };
 }
 
 /**
@@ -405,6 +474,10 @@ export function useRemoteMcpInstallWorkflow({
       mcpEndpointUrl?: string;
       authConfigured: boolean;
     }> => {
+      if (isFigmaCatalogServer(target.server)) {
+        return installUnproxiedTarget(client, target, reqOpts);
+      }
+
       const remoteMcpServer = await client.remoteMcp.createServer(
         {
           createServerForm: {

--- a/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
+++ b/client/dashboard/src/pages/catalog/useRemoteMcpInstallWorkflow.ts
@@ -28,6 +28,10 @@ import {
 } from "@gram/client/react-query/remoteMcpServers.js";
 import { invalidateAllRemoteSessionClients } from "@gram/client/react-query/remoteSessionClients.js";
 import { invalidateAllRemoteSessionIssuers } from "@gram/client/react-query/remoteSessionIssuers.js";
+import {
+  invalidateAllUnproxiedMcpServers,
+  useUnproxiedMcpServers,
+} from "@gram/client/react-query/unproxiedMcpServers.js";
 import { invalidateAllUserSessionIssuers } from "@gram/client/react-query/userSessionIssuers.js";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -207,6 +211,7 @@ async function installUnproxiedTarget(
       createUnproxiedMcpServerForm: {
         name: target.name,
         url: target.remote.url,
+        description: target.server.description || undefined,
       },
     },
     undefined,
@@ -271,18 +276,27 @@ export function useRemoteMcpInstallWorkflow({
   const { orgSlug } = useSlugs();
 
   // Informational "already installed" signal: a remote MCP server with a
-  // matching URL already exists in the target project.
+  // matching URL already exists in the target project. Unproxied servers
+  // (e.g. Figma, installed via installUnproxiedTarget) live in a separate
+  // resource entirely, so their URLs are checked alongside the remote ones.
   const { data: remoteServersData } = useRemoteMcpServers(
+    projectSlug ? { gramProject: projectSlug } : undefined,
+  );
+  const { data: unproxiedServersData } = useUnproxiedMcpServers(
     projectSlug ? { gramProject: projectSlug } : undefined,
   );
   const installedUrls = useMemo(
     () =>
       new Set(
-        (remoteServersData?.remoteMcpServers ?? []).map((server) =>
-          normalizeRemoteUrl(server.url),
-        ),
+        [
+          ...(remoteServersData?.remoteMcpServers ?? []),
+          ...(unproxiedServersData?.unproxiedMcpServers ?? []),
+        ].map((server) => normalizeRemoteUrl(server.url)),
       ),
-    [remoteServersData?.remoteMcpServers],
+    [
+      remoteServersData?.remoteMcpServers,
+      unproxiedServersData?.unproxiedMcpServers,
+    ],
   );
   const isServerAlreadyInstalled = useCallback(
     (server: PulseMCPServer) =>
@@ -643,11 +657,13 @@ export function useRemoteMcpInstallWorkflow({
     };
 
     let anyAuthConfigured = false;
+    let anyUnproxiedInstalled = false;
     for (const [index, target] of targets.entries()) {
       setStatusAt(index, { status: "creating" });
       try {
         const result = await installTarget(target, reqOpts);
         anyAuthConfigured ||= result.authConfigured;
+        anyUnproxiedInstalled ||= isFigmaCatalogServer(target.server);
         setStatusAt(index, {
           status: "completed",
           mcpServerId: result.mcpServer.id,
@@ -678,6 +694,14 @@ export function useRemoteMcpInstallWorkflow({
       invalidations.push(
         invalidateAllRemoteSessionIssuers(queryClient, { refetchType: "all" }),
         invalidateAllRemoteSessionClients(queryClient, { refetchType: "all" }),
+      );
+    }
+    // Unproxied installs (e.g. Figma) don't touch any of the remote-server
+    // caches above, so the Sources page's unproxied listing needs its own
+    // invalidation.
+    if (anyUnproxiedInstalled) {
+      invalidations.push(
+        invalidateAllUnproxiedMcpServers(queryClient, { refetchType: "all" }),
       );
     }
     await Promise.all(invalidations);


### PR DESCRIPTION
## Why

Figma's official remote MCP server (`com.figma.mcp/mcp`) is a well-known, established vendor endpoint. The generic catalog-install flow creates a Gram-proxied `remote_mcp_servers` entry and mints a user-session issuer for OAuth brokering — overhead that exists specifically to negotiate OAuth callback allowlisting per vendor, which isn't needed for a vendor this well-known. Unproxied MCP servers (shipped in #4886) exist for exactly this case: list a vendor's server without Gram ever proxying it.

## What changed

`useRemoteMcpInstallWorkflow`'s `installTarget` now special-cases Figma's registry specifier (`isFigmaCatalogServer`, in `pages/catalog/remotes.ts`): instead of `remoteMcp.createServer` + a user-session issuer, it calls `unproxiedMcp.createServer` + links an `mcp_servers` wrapper, mirroring the existing `useCreateUnproxiedMcpSource` hook's create-and-rollback logic. Every other catalog entry (Notion, Linear, Slack, etc.) is unaffected and keeps installing as a Gram-proxied remote server.

Note: creating an unproxied MCP server is currently gated to Speakeasy staff (`access.RequireStaffForUnproxiedMcp`) while that workflow is being validated — this PR doesn't change that gate, so a non-staff user picking Figma from the catalog will see the same "Speakeasy staff only" error the direct "Add Source → Unproxied MCP Server" flow already surfaces today.

## Demo

![demo](https://gist.githubusercontent.com/mfbx9da4/69942b499bbfc1e4beb647af0415cc40/raw/demo.gif)

What it shows:
1. Figma's catalog detail page, clicking "Add"
2. The install dialog — just a server name, no header/OAuth configuration to fill in
3. "Server added successfully", then the new server's Overview page showing "Figma / UNPROXIED MCP" in the sidebar with the upstream URL `mcp.figma.com/mcp`

### Before

Picking Figma from the catalog created a Gram-proxied remote server and a user-session issuer for OAuth brokering, the same as any other catalog entry.

### After

Picking Figma from the catalog creates an unproxied MCP server pointing straight at Figma's own endpoint — no OAuth brokering, no Gram-managed credential.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installing Figma from the catalog now creates an unproxied MCP server that connects directly to Figma’s official endpoint (`com.figma.mcp/mcp`), removing the Gram proxy and OAuth brokering. All other catalog entries install as before.

- **New Features**
  - Special-cases Figma in `useRemoteMcpInstallWorkflow` to create an unproxied server via `unproxiedMcp.createServer` and link an `mcp_servers` wrapper; carries the catalog description into the new source.
  - Adds `isFigmaCatalogServer` and updates the “already installed” check to include unproxied URLs; the `access.RequireStaffForUnproxiedMcp` gate remains.

- **Bug Fixes**
  - Invalidates the unproxied-server cache after a Figma install so Sources refreshes immediately; stops exporting `FIGMA_REGISTRY_SPECIFIER`.

<sup>Written for commit a04ada4a2816b4e5c268c08354bc46fee9d8bd91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

