### PR TITLE
fix: classify idle-timeout termination of proxied MCP SSE streams

### DIFF
--- a/.changeset/mcp-proxy-idle-stream-classification.md
+++ b/.changeset/mcp-proxy-idle-stream-classification.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Classify idle-timeout terminations of proxied MCP SSE streams correctly. The standalone GET listen stream ending on the proxy's 60s idle bound is now a clean close (200, no error log) instead of a 500 "unexpected error" — clients reconnect per spec, so quiet upstreams no longer produce one spurious 5xx per minute per connected client. A POST response stream going idle mid-reply now returns a 502 gateway error naming the idle bound instead of a bare context cancellation. Access logs also no longer relabel an already-committed response's status when a late error-path WriteHeader fires.

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -21,21 +21,33 @@ import (
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode int
+	// wroteHeader tracks whether the response headers have been sent (via
+	// WriteHeader, first body Write, or Flush). Once sent, net/http
+	// ignores further WriteHeader calls, so the recorded statusCode must
+	// not change either — a late error-path WriteHeader would otherwise
+	// relabel an already-sent response in access logs.
+	wroteHeader bool
 }
 
 func newResponseWriter(w http.ResponseWriter) *responseWriter {
 	return &responseWriter{
 		ResponseWriter: w,
 		statusCode:     http.StatusOK,
+		wroteHeader:    false,
 	}
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
+	if rw.wroteHeader {
+		return
+	}
+	rw.wroteHeader = true
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
 }
 
 func (rw *responseWriter) Write(b []byte) (int, error) {
+	rw.wroteHeader = true
 	n, err := rw.ResponseWriter.Write(b)
 	if err != nil {
 		return n, fmt.Errorf("responseWriter.Write: %w", err)
@@ -50,8 +62,12 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 // until it fills) for every handler behind this middleware.
 func (rw *responseWriter) Flush() {
 	// ResponseController finds flush support through FlushError and Unwrap
-	// chains that a direct http.Flusher assert would miss.
-	_ = http.NewResponseController(rw.ResponseWriter).Flush()
+	// chains that a direct http.Flusher assert would miss. A successful
+	// flush commits the response headers on the wire; an unsupported or
+	// failed flush commits nothing, so a later WriteHeader must still count.
+	if err := http.NewResponseController(rw.ResponseWriter).Flush(); err == nil {
+		rw.wroteHeader = true
+	}
 }
 
 // Unwrap lets http.ResponseController reach controls of the underlying

--- a/server/internal/middleware/logging_test.go
+++ b/server/internal/middleware/logging_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -76,4 +78,47 @@ func TestLogSafeURL(t *testing.T) {
 			require.Equal(t, tt.want, logSafeURL(u))
 		})
 	}
+}
+
+// A late error-path WriteHeader after the response has committed is ignored
+// by net/http; the wrapper's recorded status must not change either, or
+// access logs relabel an already-sent response (e.g. a relayed SSE stream
+// that dies mid-flight gets logged as a 500 despite a 200 on the wire).
+func TestResponseWriterIgnoresWriteHeaderAfterWriteHeader(t *testing.T) {
+	t.Parallel()
+
+	inner := httptest.NewRecorder()
+	rw := newResponseWriter(inner)
+
+	rw.WriteHeader(http.StatusOK)
+	rw.WriteHeader(http.StatusInternalServerError)
+
+	require.Equal(t, http.StatusOK, rw.statusCode)
+	require.Equal(t, http.StatusOK, inner.Code)
+}
+
+func TestResponseWriterIgnoresWriteHeaderAfterWrite(t *testing.T) {
+	t.Parallel()
+
+	inner := httptest.NewRecorder()
+	rw := newResponseWriter(inner)
+
+	_, err := rw.Write([]byte("body"))
+	require.NoError(t, err)
+	rw.WriteHeader(http.StatusInternalServerError)
+
+	require.Equal(t, http.StatusOK, rw.statusCode)
+	require.Equal(t, http.StatusOK, inner.Code)
+}
+
+func TestResponseWriterIgnoresWriteHeaderAfterFlush(t *testing.T) {
+	t.Parallel()
+
+	inner := httptest.NewRecorder()
+	rw := newResponseWriter(inner)
+
+	rw.Flush()
+	rw.WriteHeader(http.StatusInternalServerError)
+
+	require.Equal(t, http.StatusOK, rw.statusCode)
 }

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -424,7 +424,17 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, nil, nil, nil, nil)
 		responseBytes = n
 		if streamErr != nil {
-			return streamErr
+			// The standalone GET stream is idle by nature — most upstreams
+			// never send unsolicited server-initiated messages, so the
+			// per-event idle bound firing is the stream's expected end, not
+			// a fault. End the response cleanly; the client re-opens the
+			// stream per spec § Listening for Messages from the Server.
+			if sr, ok := upstreamResp.Body.(*streamReader); ok && sr.IdleTimedOut() {
+				p.Logger.DebugContext(ctx, "closing idle remote mcp listen stream",
+					attr.SlogComponent("remotemcp.proxy"))
+				return nil
+			}
+			return oops.E(oops.CodeUnexpected, streamErr, "relay mcp listen stream").LogError(ctx, p.Logger)
 		}
 		return nil
 	}
@@ -585,7 +595,16 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 		n, streamErr := p.relaySSEStream(ctx, w, r, upstreamReq, upstreamResp, toolsCallReq, toolsListReq, resourcesReadReq, resourcesListReq)
 		responseBytes = n
 		if streamErr != nil {
-			return streamErr
+			// Unlike the standalone GET stream, a POST response stream going
+			// idle means the upstream stalled mid-reply — the client is still
+			// owed a terminal response event. Surface it as an upstream
+			// fault with the idle bound named, not a bare context error.
+			if sr, ok := upstreamResp.Body.(*streamReader); ok && sr.IdleTimedOut() {
+				return oops.E(oops.CodeGatewayError, streamErr,
+					"remote MCP server went idle mid-response (no data for %s)", p.StreamingTimeout,
+				).LogWarn(ctx, p.Logger)
+			}
+			return oops.E(oops.CodeUnexpected, streamErr, "relay mcp response stream").LogError(ctx, p.Logger)
 		}
 		return nil
 	}

--- a/server/internal/remotemcp/proxy/proxy.go
+++ b/server/internal/remotemcp/proxy/proxy.go
@@ -429,7 +429,7 @@ func (p *Proxy) Get(w http.ResponseWriter, r *http.Request) (err error) {
 			// per-event idle bound firing is the stream's expected end, not
 			// a fault. End the response cleanly; the client re-opens the
 			// stream per spec § Listening for Messages from the Server.
-			if sr, ok := upstreamResp.Body.(*streamReader); ok && sr.IdleTimedOut() {
+			if streamIdledOut(upstreamResp.Body) {
 				p.Logger.DebugContext(ctx, "closing idle remote mcp listen stream",
 					attr.SlogComponent("remotemcp.proxy"))
 				return nil
@@ -599,7 +599,7 @@ func (p *Proxy) Post(w http.ResponseWriter, r *http.Request) (err error) {
 			// idle means the upstream stalled mid-reply — the client is still
 			// owed a terminal response event. Surface it as an upstream
 			// fault with the idle bound named, not a bare context error.
-			if sr, ok := upstreamResp.Body.(*streamReader); ok && sr.IdleTimedOut() {
+			if streamIdledOut(upstreamResp.Body) {
 				return oops.E(oops.CodeGatewayError, streamErr,
 					"remote MCP server went idle mid-response (no data for %s)", p.StreamingTimeout,
 				).LogWarn(ctx, p.Logger)

--- a/server/internal/remotemcp/proxy/proxy_test.go
+++ b/server/internal/remotemcp/proxy/proxy_test.go
@@ -766,13 +766,12 @@ func TestProxy_Get_LongStreamStaysAliveOnActivity(t *testing.T) {
 	require.Len(t, observed, eventCount, "every event must reach the interceptor — none lost to a premature timeout")
 }
 
-func TestProxy_Get_StreamTerminatesOnIdleTimeout(t *testing.T) {
-	t.Parallel()
-
-	// Upstream sends headers + one event, then goes silent. The
-	// StreamingTimeout idle bound must fire and tear down the stream
-	// even though NonStreamingTimeout is much larger.
-	const idleTimeout = 100 * time.Millisecond
+// newStallingSSEUpstream returns an httptest server that answers with SSE
+// headers plus one progress event, then holds the stream silent until the
+// proxy disconnects or test cleanup releases the handler — the proxy's idle
+// timer should beat the cleanup channel.
+func newStallingSSEUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
 
 	handlerDone := make(chan struct{})
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -786,9 +785,6 @@ func TestProxy_Get_StreamTerminatesOnIdleTimeout(t *testing.T) {
 		if flusher != nil {
 			flusher.Flush()
 		}
-		// Hold the connection silent until either the proxy disconnects or
-		// test cleanup releases the handler — the proxy's idle timer should
-		// beat the cleanup channel.
 		select {
 		case <-r.Context().Done():
 		case <-handlerDone:
@@ -799,6 +795,19 @@ func TestProxy_Get_StreamTerminatesOnIdleTimeout(t *testing.T) {
 	// handler before upstream.Close waits for it to drain.
 	t.Cleanup(func() { close(handlerDone) })
 
+	return upstream
+}
+
+func TestProxy_Get_StreamTerminatesOnIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Upstream sends headers + one event, then goes silent. The
+	// StreamingTimeout idle bound must fire and tear down the stream
+	// even though NonStreamingTimeout is much larger.
+	const idleTimeout = 100 * time.Millisecond
+
+	upstream := newStallingSSEUpstream(t)
+
 	p := newProxyForTest(t, upstream.URL)
 	p.NonStreamingTimeout = 5 * time.Second // deliberately too long to be load-bearing
 	p.StreamingTimeout = idleTimeout
@@ -808,11 +817,39 @@ func TestProxy_Get_StreamTerminatesOnIdleTimeout(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	start := time.Now()
-	_ = p.Get(rr, req) // an error here is acceptable; the stream was torn down mid-flight
+	err := p.Get(rr, req)
 	elapsed := time.Since(start)
 
+	require.NoError(t, err, "idle termination of the standalone listen stream is its expected end, not a fault")
 	require.Less(t, elapsed, 1*time.Second, "idle stream must terminate within ~StreamingTimeout, not wait for NonStreamingTimeout")
 	require.Contains(t, rr.Body.String(), `"step":0`, "first event must have reached the client before idle terminated the stream")
+}
+
+func TestProxy_Post_StreamIdleTimeoutReturnsGatewayError(t *testing.T) {
+	t.Parallel()
+
+	// Upstream answers the POST with an SSE stream, sends one progress
+	// event, then stalls without ever delivering the terminal response
+	// event. Unlike the standalone GET stream, the client is still owed a
+	// reply here, so the idle bound firing is an upstream fault.
+	const idleTimeout = 100 * time.Millisecond
+
+	upstream := newStallingSSEUpstream(t)
+
+	p := newProxyForTest(t, upstream.URL)
+	p.NonStreamingTimeout = 5 * time.Second
+	p.StreamingTimeout = idleTimeout
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/x/mcp/id", strings.NewReader(initializeRequest))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	rr := httptest.NewRecorder()
+	err := p.Post(rr, req)
+
+	var serr *oops.ShareableError
+	require.ErrorAs(t, err, &serr, "idle timeout mid-POST-response must surface as a shareable error")
+	require.Equal(t, oops.CodeGatewayError, serr.Code, "idle timeout mid-POST-response is an upstream fault")
 }
 
 func TestProxy_Post_UpstreamUnreachableReturnsGatewayError(t *testing.T) {

--- a/server/internal/remotemcp/proxy/stream_reader.go
+++ b/server/internal/remotemcp/proxy/stream_reader.go
@@ -88,6 +88,16 @@ func (r *streamReader) IdleTimedOut() bool {
 	return r.idleFired.Load()
 }
 
+// streamIdledOut reports whether a relayed upstream body was terminated by
+// the per-event idle watchdog rather than a genuine failure. Centralizes the
+// coupling to the concrete *streamReader wrapper: if the body is ever
+// wrapped again between forwardRequest and the relay callers, this returns
+// false and idle terminations fall back to being reported as errors.
+func streamIdledOut(body io.ReadCloser) bool {
+	sr, ok := body.(*streamReader)
+	return ok && sr.IdleTimedOut()
+}
+
 // Read forwards to the underlying body verbatim — including io.EOF, which
 // the SSE parser relies on as the clean end-of-stream signal. Any
 // byte-level activity (n>0) resets the idle timer for another timeout


### PR DESCRIPTION
## Summary

- The remote MCP proxy's per-event idle watchdog (`StreamingTimeout`, 60s) cancels the forward context when a relayed SSE stream goes silent. Since #4955 enabled the standalone GET listen stream, that cancellation surfaced as a raw `scan sse stream: context canceled` → logged as an unexpected 500, once per minute per connected client of any quiet upstream (fires monitor 177912089).
- Classify relay errors via `streamReader.IdleTimedOut()` (existing, previously unwired):
  - **GET listen stream** idle-closing is its expected end per MCP spec § Listening for Messages from the Server → clean close, `nil`, debug log; client reconnects per spec.
  - **POST response stream** going idle mid-reply is an upstream fault → `oops.CodeGatewayError` naming the idle bound, logged at warn, instead of a bare context cancellation.
  - Other relay errors now wrap in `oops.E` so client-disconnect cancels get the existing #3299 499/info treatment instead of the raw-error 500 path.
- The logging middleware's `responseWriter` no longer lets a late error-path `WriteHeader` overwrite the recorded status once headers have gone out (via WriteHeader, first Write, or successful Flush) — access logs now report the wire status.

Closes [AGE-3109](https://linear.app/speakeasy/issue/AGE-3109/remote-mcp-proxy-idle-watchdog-termination-of-standalone-get-sse)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes spurious 500s from idle MCP listen streams by classifying SSE idle timeouts correctly. GET listen streams now end cleanly with 200; POST response streams that stall mid-reply return a gateway error. Addresses AGE-3109.

- **Bug Fixes**
  - Detect idle timeouts via `streamReader.IdleTimedOut()`; centralize detection with `streamIdledOut()` to avoid wrapper coupling.
  - GET listen: treat idle as expected end; return 200 with a debug log; client reconnects per spec.
  - POST response: treat idle mid-reply as upstream fault; return `oops.CodeGatewayError` naming the `StreamingTimeout`.
  - Wrap other relay errors with `oops.E` so client disconnects keep their 499/info behavior.
  - Logging fix: `responseWriter` ignores late `WriteHeader` after headers/body/successful `Flush` so access logs reflect the wire status.

<sup>Written for commit bddced97dad7e4c8a62bddbcfda4e96cf1d9970f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

