### PR TITLE
feat: add root helper .deb/.rpm install step to Linux device-agent setup

### DIFF
--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -119,6 +119,9 @@ type OsSpec = {
   verify: string;
   // Manifest platform keys to surface as direct-download links for this OS.
   downloadKeys: string[];
+  // The OS ships a root-helper install package (.deb/.rpm on Linux) that gets
+  // its own setup step. See HelperPackageStep.
+  hasHelperPackage?: boolean;
 };
 
 const OS_CONFIG: Record<OsKey, OsSpec> = {
@@ -198,6 +201,7 @@ sudo mv speakeasyd speakeasy /usr/local/bin/`,
 speakeasyd -service start`,
     verify: `speakeasyd status`,
     downloadKeys: ["linux/amd64", "linux/arm64"],
+    hasHelperPackage: true,
   },
 };
 
@@ -439,6 +443,68 @@ function BinaryLegend() {
           and enrollment.
         </span>
       </div>
+    </div>
+  );
+}
+
+// HelperPackageStep is the Linux-only step for the speakeasy-helper root
+// helper. The daemon runs as the logged-in user and can't write the root-owned
+// managed config layer itself, so enforcement of "managed" tools needs the
+// helper installed as a systemd system service — which ships as a .deb/.rpm
+// (the Linux analog of the macOS .pkg). The packages are mirrored to the same
+// public bucket as the binaries but are deliberately NOT in the release
+// manifest (a root binary updates only via a package push, never the
+// user-context auto-updater), so the URLs are built from the resolved version
+// rather than read from manifest artifacts.
+function HelperPackageStep() {
+  const { data } = useAgentReleases();
+  const version = data?.latest["speakeasyd"]?.version ?? null;
+
+  const script = (fmt: "deb" | "rpm", install: string) =>
+    `${bashVersionAssign(version)}
+BASE=${RELEASES_BASE}/v$VERSION
+curl -fSLO "$BASE/speakeasy-helper_\${VERSION}_linux_amd64.${fmt}"
+${install}`;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Text muted>
+        The daemon runs as the logged-in user and can't write root-owned config,
+        so enforcing tools your org marks{" "}
+        <strong className="font-medium">managed</strong> needs the{" "}
+        <code>speakeasy-helper</code> package: it installs a privileged writer
+        as a systemd system service. Without it the agent still runs and
+        reports, but can't enforce the managed layer.
+      </Text>
+      <div className="flex flex-col gap-2">
+        <SubLabel>Debian / Ubuntu (.deb)</SubLabel>
+        <StepNote>
+          amd64 shown — swap <code>linux_amd64</code> for{" "}
+          <code>linux_arm64</code> on ARM.
+        </StepNote>
+        <CodeBlock language="bash">
+          {script(
+            "deb",
+            `sudo apt install "./speakeasy-helper_\${VERSION}_linux_amd64.deb"`,
+          )}
+        </CodeBlock>
+      </div>
+      <OrDivider />
+      <div className="flex flex-col gap-2">
+        <SubLabel>RHEL / Fedora (.rpm)</SubLabel>
+        <CodeBlock language="bash">
+          {script(
+            "rpm",
+            `sudo rpm -i "speakeasy-helper_\${VERSION}_linux_amd64.rpm"`,
+          )}
+        </CodeBlock>
+      </div>
+      <Text small muted>
+        Verify with <code>systemctl status com.speakeasy.helper</code>. The
+        helper is deliberately outside the agent's auto-update channel — it
+        updates only via a package push (apt/dnf upgrade or your config
+        management).
+      </Text>
     </div>
   );
 }
@@ -821,6 +887,12 @@ function buildSteps(os: OsKey): SetupStep[] {
     title: "Verify it's running",
     body: <CodeBlock language={cfg.lang}>{cfg.verify}</CodeBlock>,
   });
+  if (cfg.hasHelperPackage) {
+    steps.push({
+      title: "Install the root helper package",
+      body: <HelperPackageStep />,
+    });
+  }
   steps.push({ title: "Set the user's identity", body: <IdentityStep /> });
   return steps;
 }

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -86,12 +86,23 @@ const OS_ORDER: OsKey[] = ["macos", "windows", "linux"];
 // we inline it (a concrete, copy-and-run value); otherwise we fall back to a
 // self-resolving one-liner so the snippet still works before the fetch lands
 // or if it fails.
+//
+// The manifest value is fetched at runtime and pasted by the user into a
+// (often sudo-adjacent) shell, so only a strictly semver-shaped version is
+// ever inlined — anything else (e.g. a tampered manifest smuggling `$(...)`)
+// takes the fallback path instead of landing in the snippet.
+const INLINABLE_VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+function inlinableVersion(version: string | null) {
+  return version !== null && INLINABLE_VERSION.test(version) ? version : null;
+}
 function bashVersionAssign(version: string | null) {
+  version = inlinableVersion(version);
   return version
     ? `VERSION=${version}`
     : `VERSION=$(curl -s ${MANIFEST_URL} | jq -r '.latest.speakeasyd.version')`;
 }
 function psVersionAssign(version: string | null) {
+  version = inlinableVersion(version);
   return version
     ? `$VERSION = "${version}"`
     : `$VERSION = (Invoke-RestMethod ${MANIFEST_URL}).latest.speakeasyd.version`;
@@ -466,6 +477,15 @@ BASE=${RELEASES_BASE}/v$VERSION
 curl -fSLO "$BASE/speakeasy-helper_\${VERSION}_linux_amd64.${fmt}"
 ${install}`;
 
+  // Both package flavors ship amd64 + arm64; the swap note sits above each
+  // snippet it applies to, matching the archNote convention in DownloadStep.
+  const archNote = (
+    <StepNote>
+      amd64 shown — swap <code>linux_amd64</code> for <code>linux_arm64</code>{" "}
+      on ARM.
+    </StepNote>
+  );
+
   return (
     <div className="flex flex-col gap-6">
       <Text muted>
@@ -478,10 +498,7 @@ ${install}`;
       </Text>
       <div className="flex flex-col gap-2">
         <SubLabel>Debian / Ubuntu (.deb)</SubLabel>
-        <StepNote>
-          amd64 shown — swap <code>linux_amd64</code> for{" "}
-          <code>linux_arm64</code> on ARM.
-        </StepNote>
+        {archNote}
         <CodeBlock language="bash">
           {script(
             "deb",
@@ -492,6 +509,7 @@ ${install}`;
       <OrDivider />
       <div className="flex flex-col gap-2">
         <SubLabel>RHEL / Fedora (.rpm)</SubLabel>
+        {archNote}
         <CodeBlock language="bash">
           {script(
             "rpm",

--- a/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-setup.tsx
@@ -108,6 +108,16 @@ function psVersionAssign(version: string | null) {
     : `$VERSION = (Invoke-RestMethod ${MANIFEST_URL}).latest.speakeasyd.version`;
 }
 
+// Every Linux artifact — the raw binaries and both helper package flavors —
+// ships amd64 + arm64 under the same *_linux_{arch} naming, so the swap note
+// is shared by the download step and the helper-package step.
+const LINUX_ARCH_SWAP_NOTE = (
+  <>
+    amd64 shown — swap <code>linux_amd64</code> for <code>linux_arm64</code> on
+    ARM.
+  </>
+);
+
 type OsSpec = {
   label: string;
   tileDesc: string;
@@ -191,12 +201,7 @@ Invoke-WebRequest "$BASE/speakeasy_\${VERSION}_windows_amd64.exe"  -OutFile spea
     logo: "/icons/platforms/linux.svg",
     logoSize: "h-9 w-9",
     lang: "bash",
-    archNote: (
-      <>
-        amd64 shown — swap <code>linux_amd64</code> for <code>linux_arm64</code>{" "}
-        on ARM.
-      </>
-    ),
+    archNote: LINUX_ARCH_SWAP_NOTE,
     download: (version) => `${bashVersionAssign(version)}
 BASE=${RELEASES_BASE}/v$VERSION
 curl -fSL -o speakeasyd "$BASE/speakeasyd_\${VERSION}_linux_amd64"
@@ -477,14 +482,9 @@ BASE=${RELEASES_BASE}/v$VERSION
 curl -fSLO "$BASE/speakeasy-helper_\${VERSION}_linux_amd64.${fmt}"
 ${install}`;
 
-  // Both package flavors ship amd64 + arm64; the swap note sits above each
-  // snippet it applies to, matching the archNote convention in DownloadStep.
-  const archNote = (
-    <StepNote>
-      amd64 shown — swap <code>linux_amd64</code> for <code>linux_arm64</code>{" "}
-      on ARM.
-    </StepNote>
-  );
+  // The swap note sits above each snippet it applies to, matching the
+  // archNote convention in DownloadStep.
+  const archNote = <StepNote>{LINUX_ARCH_SWAP_NOTE}</StepNote>;
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
## What

Adds a Linux-only step to the device-agent setup sheet: **Install the root helper package** (`.deb`/`.rpm`), between "Verify it's running" and the identity step.

## Why

The Linux walkthrough only covered the raw `speakeasyd`/`speakeasy` binaries. Those run fine, but the daemon runs as the logged-in user and can't write the root-owned managed config layer — enforcing tools an org marks "managed" requires the `speakeasy-helper` package, which installs the privileged writer as a systemd system service (the Linux analog of the macOS `.pkg`).

## How

- New `HelperPackageStep` component with copy-paste snippets for both flavors (`apt install ./…deb`, `rpm -i …rpm`), using the page's existing resolved-version + arm64-swap conventions, plus a `systemctl status com.speakeasy.helper` verify note.
- The daemon/CLI deliberately stay on the raw-binary flow; the helper is deliberately outside the auto-update manifest (root binaries update only via a package push), so URLs are built from the resolved version rather than manifest artifacts.
- Wired via a `hasHelperPackage` flag in the per-OS config table.

## Notes

- Stacked on #4966 (touches the same file); targets that branch.
- The package URLs go live once speakeasy-api/device-agent#132 ships and the next release is cut — earlier versions (≤0.1.18) have no packages in the public bucket unless backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Linux-only setup step to install the `speakeasy-helper` root package (`.deb`/`.rpm`) so managed config can be enforced. The step appears between "Verify it's running" and the identity step.

- **New Features**
  - Added `HelperPackageStep` with `apt`/`rpm` snippets, version/arch swap, and a verify hint: `systemctl status com.speakeasy.helper`.
  - Controlled by `hasHelperPackage` in the Linux OS config; helper stays outside auto-update and URLs are built from the resolved version.

- **Bug Fixes**
  - Only semver-shaped manifest versions are inlined into shell snippets; others use the self-resolving fallback.
  - Added the amd64→arm64 swap note to the `.rpm` block to match the `.deb` block.
  - Shared the Linux arch swap note between the download and helper steps.

<sup>Written for commit f1e4c24006afc8a0641e479831b8b2a2ced89472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

