### PR TITLE
fix(dashboard): stop Policy Center rows repeating the name as categories/prompt

### DIFF
--- a/.changeset/policy-table-name-detail-dedupe.md
+++ b/.changeset/policy-table-name-detail-dedupe.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Stop the Policy Center table from printing the same thing twice per row. The "Categories / Prompt" column has been folded into the policy column as a second line that only appears when the policy name doesn't already convey it — so "Secrets Exposure Flagger" no longer sits next to "Secrets", and a prompt-based policy whose name is an excerpt of its guardrail shows the name alone. Policies whose name omits a category (or whose guardrail says more than its name) still show the detail, now with the freed-up width.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -96,7 +96,6 @@ import {
   ALL_POLICY_MESSAGE_TYPES,
   categoriesToPayload,
   policyMessageTypesForForm,
-  policyToCategories,
 } from "./policy-form";
 import {
   getPolicyDeleteImpactText,
@@ -104,6 +103,7 @@ import {
   getPolicyRuleGroupNamesForDeleteDialog,
 } from "./policy-delete-dialog";
 import { SeverityBadge } from "./risk-ui";
+import { policySummary } from "./policy-summary";
 
 /** Per-policy config for the Non-Corporate Accounts category: the list of
  *  email domains treated as corporate. Rendered inside the category's
@@ -378,14 +378,6 @@ const TOOL_CALL_MESSAGE_TYPES = new Set<PolicyMessageType>([
   "tool_response",
 ]);
 
-/** Map sources to display categories for the table row badges. */
-function sourcesToCategories(
-  sources: string[],
-  presidioEntities?: string[],
-): RuleCategory[] {
-  return [...policyToCategories(sources, presidioEntities)];
-}
-
 function policyMessageTypesForDisplay(
   messageTypes?: string[],
 ): PolicyMessageType[] {
@@ -500,16 +492,43 @@ function messageTypesSummary(
   return `${selectedMessageTypes.size} of ${ALL_POLICY_MESSAGE_TYPES.length} types selected`;
 }
 
-function truncatePrompt(prompt: string, maxLength = 60): string {
-  const singleLine = prompt.trim().replace(/\s+/g, " ");
-  if (singleLine.length <= maxLength) {
-    return singleLine;
-  }
-  return `${singleLine.slice(0, maxLength - 1)}…`;
-}
-
 function isPromptPolicy(policy: RiskPolicy): boolean {
   return policy.policyType === "prompt_based";
+}
+
+/** Policy name over what the policy detects. The second line is dropped when
+ *  the name already says it, which is the common case for auto-generated names
+ *  ("Secrets Exposure Flagger" over "Secrets"). */
+function PolicyNameCell({ row }: { row: PolicyRow }): JSX.Element {
+  const summary = policySummary(row.policy);
+
+  return (
+    <span className="flex min-w-0 flex-col gap-0.5 py-0.5">
+      <span className="flex min-w-0 items-center gap-1.5 font-medium">
+        <span className="truncate">{row.policy.name}</span>
+        {row.kind === "prompt" && (
+          <SimpleTooltip tooltip="Prompt-based policy">
+            <Sparkles
+              aria-label="Prompt-based policy"
+              className="text-muted-foreground h-3.5 w-3.5 shrink-0"
+            />
+          </SimpleTooltip>
+        )}
+      </span>
+      {summary && (
+        <SimpleTooltip tooltip={summary.text}>
+          <span
+            className={cn(
+              "text-muted-foreground truncate text-xs",
+              summary.kind === "prompt" && "italic",
+            )}
+          >
+            {summary.text}
+          </span>
+        </SimpleTooltip>
+      )}
+    </span>
+  );
 }
 
 /** Compact relative date for the policy table's Created/Updated columns, with
@@ -716,21 +735,9 @@ function PolicyCenterContent() {
   const policyColumns: Column<PolicyRow>[] = [
     {
       key: "name",
-      header: "Name",
-      width: "1fr",
-      render: (row) => (
-        <span className="flex min-w-0 items-center gap-1.5 font-medium">
-          <span className="truncate">{row.policy.name}</span>
-          {row.kind === "prompt" && (
-            <SimpleTooltip tooltip="Prompt-based policy">
-              <Sparkles
-                aria-label="Prompt-based policy"
-                className="text-muted-foreground h-3.5 w-3.5 shrink-0"
-              />
-            </SimpleTooltip>
-          )}
-        </span>
-      ),
+      header: "Policy",
+      width: "3fr",
+      render: (row) => <PolicyNameCell row={row} />,
     },
     {
       key: "action",
@@ -751,42 +758,6 @@ function PolicyCenterContent() {
           <SeverityBadge score={row.policy.score} />
         </span>
       ),
-    },
-    {
-      key: "sources",
-      header: nlEnabled ? "Categories / Prompt" : "Categories",
-      width: "2fr",
-      render: (row) => {
-        if (row.kind === "prompt") {
-          const prompt = row.policy.prompt ?? "";
-          return (
-            <SimpleTooltip tooltip={prompt}>
-              <span className="text-muted-foreground block max-w-full truncate text-sm italic">
-                {truncatePrompt(prompt)}
-              </span>
-            </SimpleTooltip>
-          );
-        }
-
-        const riskPolicy = row.policy;
-        const categories = sourcesToCategories(
-          riskPolicy.sources,
-          riskPolicy.presidioEntities,
-        );
-        if (riskPolicy.customRuleIds?.length) {
-          categories.push("custom");
-        }
-
-        if (categories.length === 0) {
-          return <span className="text-muted-foreground text-sm">—</span>;
-        }
-
-        return (
-          <span className="text-muted-foreground text-sm">
-            {categories.map((cat) => RULE_CATEGORY_META[cat].label).join(", ")}
-          </span>
-        );
-      },
     },
     {
       key: "messageTypes",

--- a/client/dashboard/src/pages/security/policy-summary.test.ts
+++ b/client/dashboard/src/pages/security/policy-summary.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import type { RuleCategory } from "./policy-data";
+import { categoriesToPayload } from "./policy-form";
+import {
+  categoriesSummaryForName,
+  policySummary,
+  promptSummaryForName,
+  type PolicySummaryPolicy,
+} from "./policy-summary";
+
+describe("categoriesSummaryForName", () => {
+  it("hides categories the auto-generated name already names", () => {
+    expect(
+      categoriesSummaryForName("Secrets Exposure Flagger", ["secrets"]),
+    ).toBeNull();
+    expect(
+      categoriesSummaryForName("Prompt Injection Scanner", [
+        "prompt_injection",
+      ]),
+    ).toBeNull();
+    expect(
+      categoriesSummaryForName("Non-Corporate Account Flagger", [
+        "account_identity",
+      ]),
+    ).toBeNull();
+    expect(
+      categoriesSummaryForName("Shadow MCP Server Policy (Allow-All)", [
+        "shadow_mcp",
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores filler words in the category label", () => {
+    expect(
+      categoriesSummaryForName("Healthcare Scanner", ["healthcare"]),
+    ).toBeNull();
+    expect(
+      categoriesSummaryForName("Financial Blocker", ["financial"]),
+    ).toBeNull();
+  });
+
+  it("accepts the abbreviation a name uses for a long label", () => {
+    expect(categoriesSummaryForName("PII Scanner", ["pii"])).toBeNull();
+    expect(
+      categoriesSummaryForName("Government ID Blocker", ["government_ids"]),
+    ).toBeNull();
+  });
+
+  it("shows the labels when the name leaves a category out", () => {
+    expect(categoriesSummaryForName("Secret Blocker", ["secrets", "pii"])).toBe(
+      "Secrets, Personal Identifiable Information",
+    );
+    expect(categoriesSummaryForName("Compliance Sweep", ["custom"])).toBe(
+      "Custom Rules",
+    );
+  });
+
+  it("shows nothing when the policy has no categories", () => {
+    expect(categoriesSummaryForName("Secret Blocker", [])).toBeNull();
+  });
+});
+
+describe("promptSummaryForName", () => {
+  const prompt =
+    "Flag only tool calls that perform irreversible destructive actions on production data.";
+
+  it("hides a prompt the name is an excerpt of", () => {
+    expect(
+      promptSummaryForName("Flag only tool calls that perform", prompt),
+    ).toBeNull();
+    expect(promptSummaryForName(prompt, prompt)).toBeNull();
+  });
+
+  it("hides a prompt behind a name excerpt cut mid-word", () => {
+    expect(
+      promptSummaryForName(
+        "Flag only tool calls that perform irreversible destructive a",
+        prompt,
+      ),
+    ).toBeNull();
+  });
+
+  it("hides a prompt behind the server's derived name prefix", () => {
+    expect(
+      promptSummaryForName("Prompt Policy: Flag only tool calls", prompt),
+    ).toBeNull();
+  });
+
+  it("shows the prompt next to a name that summarizes it", () => {
+    expect(promptSummaryForName("Destructive Delete Guard", prompt)).toBe(
+      prompt,
+    );
+  });
+
+  it("keeps a prompt when only a one-word name partially matches it", () => {
+    const anyPrompt = "Any tool call that writes to a production database.";
+    expect(promptSummaryForName("A", anyPrompt)).toBe(anyPrompt);
+  });
+
+  it("shows the prompt when the policy has no name yet", () => {
+    expect(promptSummaryForName("", prompt)).toBe(prompt);
+  });
+
+  it("collapses to nothing when there is no prompt", () => {
+    expect(promptSummaryForName("Destructive Delete Guard", "   ")).toBeNull();
+  });
+});
+
+function standardPolicy(
+  name: string,
+  categories: RuleCategory[],
+  customRuleIds: string[] = [],
+): PolicySummaryPolicy {
+  const { sources, presidioEntities } = categoriesToPayload(
+    new Set(categories),
+    new Set(),
+  );
+  return {
+    name,
+    policyType: "standard",
+    sources,
+    presidioEntities,
+    customRuleIds,
+  };
+}
+
+describe("policySummary", () => {
+  it("summarizes a standard policy by the categories its name omits", () => {
+    expect(
+      policySummary(standardPolicy("Secrets Exposure Flagger", ["secrets"])),
+    ).toBeNull();
+    expect(
+      policySummary(standardPolicy("Secret Blocker", ["secrets", "pii"])),
+    ).toEqual({
+      kind: "categories",
+      text: "Secrets, Personal Identifiable Information",
+    });
+  });
+
+  it("counts attached custom rules as a category", () => {
+    expect(
+      policySummary(standardPolicy("Secret Blocker", ["secrets"], ["rule-1"])),
+    ).toEqual({ kind: "categories", text: "Secrets, Custom Rules" });
+  });
+
+  it("summarizes a prompt policy by its guardrail, on one line", () => {
+    expect(
+      policySummary({
+        name: "Destructive Delete Guard",
+        policyType: "prompt_based",
+        prompt: "Any tool call that performs\na destructive operation.",
+        sources: [],
+      }),
+    ).toEqual({
+      kind: "prompt",
+      text: "Any tool call that performs a destructive operation.",
+    });
+  });
+
+  it("drops the guardrail when the prompt policy name is an excerpt of it", () => {
+    expect(
+      policySummary({
+        name: "Any tool call that performs",
+        policyType: "prompt_based",
+        prompt: "Any tool call that performs a destructive operation.",
+        sources: [],
+      }),
+    ).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/security/policy-summary.ts
+++ b/client/dashboard/src/pages/security/policy-summary.ts
@@ -1,0 +1,182 @@
+import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
+import { RULE_CATEGORY_META, type RuleCategory } from "./policy-data";
+import { policyToCategories } from "./policy-form";
+
+/** Words that pad out a category label without distinguishing it, so a name
+ *  that leaves them out ("Healthcare Scanner" for "Healthcare Information")
+ *  still says everything the label says. */
+const GENERIC_LABEL_WORDS = new Set([
+  "information",
+  "identifiable",
+  "content",
+  "data",
+]);
+
+/** Short forms a policy name may use in place of the full category label. */
+const CATEGORY_LABEL_ALIASES: Partial<Record<RuleCategory, string>> = {
+  pii: "PII",
+  government_ids: "Government IDs",
+};
+
+/** Prefix the server puts on prompt-policy names it derives from the guardrail
+ *  itself (see fallbackPromptPolicyName in server/internal/risk/impl.go). */
+const DERIVED_PROMPT_NAME_PREFIX = ["prompt", "policy"];
+
+/** A short final prefix word only counts as a partial match once enough words
+ *  before it matched exactly; on its own it is more likely a coincidence than a
+ *  truncation. */
+const MIN_PARTIAL_TOKEN_LENGTH = 4;
+const MIN_ANCHORING_TOKENS = 3;
+
+export type PolicySummaryPolicy = Pick<
+  RiskPolicy,
+  | "name"
+  | "policyType"
+  | "prompt"
+  | "sources"
+  | "presidioEntities"
+  | "customRuleIds"
+>;
+
+export type PolicySummary = {
+  kind: "prompt" | "categories";
+  text: string;
+};
+
+/** Crude plural fold so "Destructive Tools" matches "Destructive Tool Flagger".
+ *  Both sides of every comparison run through it, so the odd mangled token
+ *  ("ops" -> "op") still lines up. */
+function singularize(token: string): string {
+  return token.length > 2 && token.endsWith("s") ? token.slice(0, -1) : token;
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .split(" ")
+    .filter((token) => token.length > 0)
+    .map(singularize);
+}
+
+function labelIsCoveredByName(label: string, nameTokens: Set<string>): boolean {
+  const tokens = tokenize(label).filter(
+    (token) => !GENERIC_LABEL_WORDS.has(token),
+  );
+  return tokens.length > 0 && tokens.every((token) => nameTokens.has(token));
+}
+
+function categoryIsCoveredByName(
+  category: RuleCategory,
+  nameTokens: Set<string>,
+): boolean {
+  const alias = CATEGORY_LABEL_ALIASES[category];
+  return (
+    labelIsCoveredByName(RULE_CATEGORY_META[category].label, nameTokens) ||
+    (alias !== undefined && labelIsCoveredByName(alias, nameTokens))
+  );
+}
+
+/** True when `tokens` opens with the words in `prefix`. The final prefix word
+ *  only has to start the word it lines up with, so an excerpt cut mid-word
+ *  ("… destructive a") still counts. */
+function tokensStartWith(tokens: string[], prefix: string[]): boolean {
+  if (prefix.length === 0 || prefix.length > tokens.length) {
+    return false;
+  }
+  return prefix.every((token, index) => {
+    const candidate = tokens[index]!;
+    if (candidate === token) {
+      return true;
+    }
+    if (index !== prefix.length - 1 || !candidate.startsWith(token)) {
+      return false;
+    }
+    return (
+      token.length >= MIN_PARTIAL_TOKEN_LENGTH ||
+      prefix.length >= MIN_ANCHORING_TOKENS
+    );
+  });
+}
+
+/** The category list worth showing next to `name`, or null when the name
+ *  already names every category the policy detects. Policy names are
+ *  auto-generated from the detectors ("Secrets Exposure Flagger" for the
+ *  Secrets category), so repeating the labels adds nothing to the row. */
+export function categoriesSummaryForName(
+  name: string,
+  categories: RuleCategory[],
+): string | null {
+  if (categories.length === 0) {
+    return null;
+  }
+
+  const nameTokens = new Set(tokenize(name));
+  if (
+    categories.every((category) =>
+      categoryIsCoveredByName(category, nameTokens),
+    )
+  ) {
+    return null;
+  }
+
+  return categories
+    .map((category) => RULE_CATEGORY_META[category].label)
+    .join(", ");
+}
+
+/** The guardrail prompt worth showing next to `name`, or null when the name is
+ *  just an excerpt of that prompt. Prompt-policy names are summarized from the
+ *  guardrail, so a name like "Flag only tool calls that perform" repeats the
+ *  opening of the prompt it came from. */
+export function promptSummaryForName(
+  name: string,
+  prompt: string,
+): string | null {
+  const trimmedPrompt = prompt.trim();
+  if (trimmedPrompt === "") {
+    return null;
+  }
+
+  let nameTokens = tokenize(name);
+  if (tokensStartWith(nameTokens, DERIVED_PROMPT_NAME_PREFIX)) {
+    nameTokens = nameTokens.slice(DERIVED_PROMPT_NAME_PREFIX.length);
+  }
+
+  return tokensStartWith(tokenize(trimmedPrompt), nameTokens)
+    ? null
+    : trimmedPrompt;
+}
+
+/** The categories a standard policy detects, in display order. */
+function policyCategories(policy: PolicySummaryPolicy): RuleCategory[] {
+  const categories = [
+    ...policyToCategories(policy.sources, policy.presidioEntities),
+  ];
+  if (policy.customRuleIds?.length) {
+    categories.push("custom");
+  }
+  return categories;
+}
+
+/** What a policy detects, for the second line of its row in the policy table:
+ *  the guardrail prompt for prompt-based policies, the detection categories
+ *  otherwise. Null when the policy name already conveys it — names are
+ *  generated from these same inputs, so most rows would otherwise say the same
+ *  thing twice. */
+export function policySummary(
+  policy: PolicySummaryPolicy,
+): PolicySummary | null {
+  if (policy.policyType === "prompt_based") {
+    const prompt = promptSummaryForName(policy.name, policy.prompt ?? "");
+    return prompt === null
+      ? null
+      : { kind: "prompt", text: prompt.replace(/\s+/g, " ") };
+  }
+
+  const categories = categoriesSummaryForName(
+    policy.name,
+    policyCategories(policy),
+  );
+  return categories === null ? null : { kind: "categories", text: categories };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The Policy Center table had a **Name** column and, right beside it, a **Categories / Prompt** column that mostly restated the name (AIS-444). That is not a coincidence: policy names are generated from exactly those inputs — from the detector categories for standard policies, and from the guardrail text itself for prompt-based ones — so the second column had nothing left to say.

Before:

![Policy table with Name and Categories / Prompt columns repeating each other](https://cursor.com/artifacts/c/art-9b00ef6a-1f5c-4188-8c59-673d3fcfdb69)

## Change

- The separate column is gone. The policy column now renders the name with the detail (categories, or the guardrail prompt in italics) as a muted second line, and the freed width goes to that column.
- The second line is **dropped when the name already conveys it**, so redundant rows collapse to just the name. Rows that carry real extra information — a name that omits a category, or a guardrail that says more than its summarized name — still show it.
- The matching logic lives in `policy-summary.ts` and is unit tested: word-level comparison that tolerates plurals ("Destructive Tools" vs "Destructive Tool Flagger"), filler words in labels ("Healthcare Information" vs "Healthcare Scanner"), known abbreviations ("PII", "Government IDs"), and prompt names that are excerpts of their guardrail, including the server's `Prompt Policy: …` fallback prefix.

After — the five redundant rows are down to their names, "Customer Data Sweep" keeps its three categories, and "Outbound Transfer Guard" keeps its guardrail:

![Policy table with a single Policy column showing the detail only when it adds information](https://cursor.com/artifacts/c/art-e2a8fb64-40b2-4d63-89ff-f1c66ed5c3cd)

## Testing

- `pnpm -F dashboard test` — 1490 passed, including 16 new unit tests over the redundancy rules.
- `pnpm -F dashboard type-check`, `pnpm -F dashboard lint`.
- Screenshots above are the same local dashboard and the same eight policies, captured before and after the change.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-444](https://linear.app/speakeasy/issue/AIS-444/column-name-and-categoriesprompt-are-duplicated-redundant-information)

<div><a href="https://cursor.com/agents/bc-51ec80f5-d394-4e95-9db1-5d4e8448fb42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51ec80f5-d394-4e95-9db1-5d4e8448fb42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the Policy Center table by folding “Categories / Prompt” into the Policy column and hiding it when the name already conveys the same info. Improves readability and addresses Linear AIS-444.

- **Bug Fixes**
  - Policy column shows the name with a muted second line (categories or prompt) only when it adds information; column renamed to “Policy” and widened.
  - Redundancy detection in `policy-summary.ts` handles plurals, filler words, abbreviations, and derived prompt-name prefixes to avoid repeating the same content.
  - Added unit tests (`policy-summary.test.ts`) for the matching rules.

<sup>Written for commit 829de8e3825115cb1eba886de58d89d94ad0a757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

