### PR TITLE
feat: freeze external key identity and guard deletion

### DIFF
--- a/.changeset/external-key-immutable-identity.md
+++ b/.changeset/external-key-immutable-identity.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Freeze external key identity: `externalKeys.updateAwsKms` and `externalKeys.updateGcpKms` no longer accept `key_arn` / `resource_name` or `algorithm` and cover only `name`, `external_credential_id` and `customer_grant_reference`, so changing what a key is now means deleting it and creating a new one (a breaking change to those two methods). Deleting a key is refused with a conflict while a JSON Web Key Set or published key still references it, and `createGcpKms` now requires a fully-qualified crypto key version path.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -16043,7 +16043,7 @@ paths:
         name: CreateGcpKmsKey
   /rpc/externalKeys.deleteAwsKms:
     delete:
-      description: Soft-delete an AWS KMS external key by ID. Requires org:admin.
+      description: Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
       operationId: deleteAwsKmsKey
       parameters:
         - allowEmptyValue: true
@@ -16130,7 +16130,7 @@ paths:
         name: DeleteAwsKmsKey
   /rpc/externalKeys.deleteGcpKms:
     delete:
-      description: Soft-delete a GCP KMS external key by ID. Requires org:admin.
+      description: Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
       operationId: deleteGcpKmsKey
       parameters:
         - allowEmptyValue: true
@@ -16655,7 +16655,7 @@ paths:
         name: ListGcpKmsKeys
   /rpc/externalKeys.updateAwsKms:
     post:
-      description: Replace an AWS KMS external key's configuration. Requires org:admin.
+      description: 'Update an AWS KMS external key''s name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.'
       operationId: updateAwsKmsKey
       parameters:
         - allowEmptyValue: true
@@ -16743,7 +16743,7 @@ paths:
         name: UpdateAwsKmsKey
   /rpc/externalKeys.updateGcpKms:
     post:
-      description: Replace a GCP KMS external key's configuration. Requires org:admin.
+      description: 'Update a GCP KMS external key''s name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.'
       operationId: updateGcpKmsKey
       parameters:
         - allowEmptyValue: true
@@ -72066,37 +72066,42 @@ components:
       required:
         - id
         - name
+    UpdateAwsKmsKeyForm:
+      type: object
+      properties:
+        customer_grant_reference:
+          type: string
+          description: Optional. The AWS principal ARN the customer granted on the key in its key policy. Not a secret.
+        external_credential_id:
+          type: string
+          description: The external credential Gram uses to authenticate to the key. Must be an aws_iam credential belonging to the same organization.
+          format: uuid
+        name:
+          type: string
+          description: A human-readable name for the key.
+      required:
+        - external_credential_id
+        - name
     UpdateAwsKmsKeyRequestBody:
       type: object
       properties:
-        algorithm:
-          type: string
-          description: The signing algorithm of the key.
-          enum:
-            - RS256
-            - ES256
         customer_grant_reference:
           type: string
-          description: Optional. The Gram identity (GCP service-account email or AWS principal ARN) the customer granted on the key for the key-policy / IAM-grant model. Not a secret.
+          description: Optional. The AWS principal ARN the customer granted on the key in its key policy. Not a secret.
         external_credential_id:
           type: string
-          description: The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+          description: The external credential Gram uses to authenticate to the key. Must be an aws_iam credential belonging to the same organization.
           format: uuid
         id:
           type: string
           description: The ID of the key to update.
           format: uuid
-        key_arn:
-          type: string
-          description: The ARN of the AWS KMS key.
         name:
           type: string
           description: A human-readable name for the key.
       required:
         - id
-        - key_arn
         - external_credential_id
-        - algorithm
         - name
     UpdateConfigurationRequestBody:
       type: object
@@ -72243,21 +72248,31 @@ components:
       required:
         - id
         - name
+    UpdateGcpKmsKeyForm:
+      type: object
+      properties:
+        customer_grant_reference:
+          type: string
+          description: Optional. The Gram service-account email the customer granted on the key in an IAM binding. Not a secret.
+        external_credential_id:
+          type: string
+          description: The external credential Gram uses to authenticate to the key. Must be a gcp_iam credential belonging to the same organization.
+          format: uuid
+        name:
+          type: string
+          description: A human-readable name for the key.
+      required:
+        - external_credential_id
+        - name
     UpdateGcpKmsKeyRequestBody:
       type: object
       properties:
-        algorithm:
-          type: string
-          description: The signing algorithm of the key.
-          enum:
-            - RS256
-            - ES256
         customer_grant_reference:
           type: string
-          description: Optional. The Gram identity (GCP service-account email or AWS principal ARN) the customer granted on the key for the key-policy / IAM-grant model. Not a secret.
+          description: Optional. The Gram service-account email the customer granted on the key in an IAM binding. Not a secret.
         external_credential_id:
           type: string
-          description: The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+          description: The external credential Gram uses to authenticate to the key. Must be a gcp_iam credential belonging to the same organization.
           format: uuid
         id:
           type: string
@@ -72266,14 +72281,9 @@ components:
         name:
           type: string
           description: A human-readable name for the key.
-        resource_name:
-          type: string
-          description: The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).
       required:
         - id
-        - resource_name
         - external_credential_id
-        - algorithm
         - name
     UpdateInviteRoleRequestBody:
       type: object

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -7737,7 +7737,7 @@ examples:
   updateAwsKmsKey:
     speakeasy-default-update-aws-kms-key:
       requestBody:
-        application/json: {"algorithm": "ES256", "external_credential_id": "767efd9e-72ba-4d37-8c1d-121b40001df6", "id": "8231ba93-c0dc-4784-bea2-0bd650f4a7e3", "key_arn": "<value>", "name": "<value>"}
+        application/json: {"external_credential_id": "767efd9e-72ba-4d37-8c1d-121b40001df6", "id": "8231ba93-c0dc-4784-bea2-0bd650f4a7e3", "name": "<value>"}
       responses:
         "200":
           application/json: {"algorithm": "ES256", "created_at": "2026-06-20T04:28:23.176Z", "external_credential_id": "4b8171b0-f222-41e6-b3cd-bfc184ecd7ab", "id": "f85c191f-247c-4c50-bc07-94e8654c09c7", "key_arn": "<value>", "name": "<value>", "organization_id": "<id>", "provider": "gcp_kms", "updated_at": "2024-01-24T06:54:53.273Z"}
@@ -7828,7 +7828,7 @@ examples:
   updateGcpKmsKey:
     speakeasy-default-update-gcp-kms-key:
       requestBody:
-        application/json: {"algorithm": "RS256", "external_credential_id": "a8be83fd-214d-4c1f-8d08-91c90f8bc01e", "id": "9fb1d7bd-6dbe-43e9-b91f-95d3af8f4e05", "name": "<value>", "resource_name": "<value>"}
+        application/json: {"external_credential_id": "a8be83fd-214d-4c1f-8d08-91c90f8bc01e", "id": "9fb1d7bd-6dbe-43e9-b91f-95d3af8f4e05", "name": "<value>"}
       responses:
         "200":
           application/json: {"algorithm": "RS256", "created_at": "2026-08-17T16:12:16.667Z", "external_credential_id": "6652bf84-a4b7-4595-9ab9-f37eb46e38fb", "id": "b8ea1a4f-c136-4185-8f4e-2fb6dc1a48a5", "name": "<value>", "organization_id": "<id>", "provider": "aws_kms", "resource_name": "<value>", "updated_at": "2026-10-31T16:16:26.096Z"}

--- a/client/dashboard/src/sdk/src/funcs/externalKeysDeleteAwsKms.ts
+++ b/client/dashboard/src/sdk/src/funcs/externalKeysDeleteAwsKms.ts
@@ -38,7 +38,7 @@ import { Result } from "../types/fp.js";
  * deleteAwsKmsKey externalKeys
  *
  * @remarks
- * Soft-delete an AWS KMS external key by ID. Requires org:admin.
+ * Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
  */
 export function externalKeysDeleteAwsKms(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/funcs/externalKeysDeleteGcpKms.ts
+++ b/client/dashboard/src/sdk/src/funcs/externalKeysDeleteGcpKms.ts
@@ -38,7 +38,7 @@ import { Result } from "../types/fp.js";
  * deleteGcpKmsKey externalKeys
  *
  * @remarks
- * Soft-delete a GCP KMS external key by ID. Requires org:admin.
+ * Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
  */
 export function externalKeysDeleteGcpKms(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/funcs/externalKeysUpdateAwsKms.ts
+++ b/client/dashboard/src/sdk/src/funcs/externalKeysUpdateAwsKms.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * updateAwsKmsKey externalKeys
  *
  * @remarks
- * Replace an AWS KMS external key's configuration. Requires org:admin.
+ * Update an AWS KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.
  */
 export function externalKeysUpdateAwsKms(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/funcs/externalKeysUpdateGcpKms.ts
+++ b/client/dashboard/src/sdk/src/funcs/externalKeysUpdateGcpKms.ts
@@ -42,7 +42,7 @@ import { Result } from "../types/fp.js";
  * updateGcpKmsKey externalKeys
  *
  * @remarks
- * Replace a GCP KMS external key's configuration. Requires org:admin.
+ * Update a GCP KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.
  */
 export function externalKeysUpdateGcpKms(
   client: GramCore,

--- a/client/dashboard/src/sdk/src/models/components/updateawskmskeyrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/updateawskmskeyrequestbody.ts
@@ -4,33 +4,14 @@
 
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
-import { ClosedEnum } from "../../types/enums.js";
-
-/**
- * The signing algorithm of the key.
- */
-export const UpdateAwsKmsKeyRequestBodyAlgorithm = {
-  Rs256: "RS256",
-  Es256: "ES256",
-} as const;
-/**
- * The signing algorithm of the key.
- */
-export type UpdateAwsKmsKeyRequestBodyAlgorithm = ClosedEnum<
-  typeof UpdateAwsKmsKeyRequestBodyAlgorithm
->;
 
 export type UpdateAwsKmsKeyRequestBody = {
   /**
-   * The signing algorithm of the key.
-   */
-  algorithm: UpdateAwsKmsKeyRequestBodyAlgorithm;
-  /**
-   * Optional. The Gram identity (GCP service-account email or AWS principal ARN) the customer granted on the key for the key-policy / IAM-grant model. Not a secret.
+   * Optional. The AWS principal ARN the customer granted on the key in its key policy. Not a secret.
    */
   customerGrantReference?: string | undefined;
   /**
-   * The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+   * The external credential Gram uses to authenticate to the key. Must be an aws_iam credential belonging to the same organization.
    */
   externalCredentialId: string;
   /**
@@ -38,27 +19,16 @@ export type UpdateAwsKmsKeyRequestBody = {
    */
   id: string;
   /**
-   * The ARN of the AWS KMS key.
-   */
-  keyArn: string;
-  /**
    * A human-readable name for the key.
    */
   name: string;
 };
 
 /** @internal */
-export const UpdateAwsKmsKeyRequestBodyAlgorithm$outboundSchema: z.ZodMiniEnum<
-  typeof UpdateAwsKmsKeyRequestBodyAlgorithm
-> = z.enum(UpdateAwsKmsKeyRequestBodyAlgorithm);
-
-/** @internal */
 export type UpdateAwsKmsKeyRequestBody$Outbound = {
-  algorithm: string;
   customer_grant_reference?: string | undefined;
   external_credential_id: string;
   id: string;
-  key_arn: string;
   name: string;
 };
 
@@ -68,18 +38,15 @@ export const UpdateAwsKmsKeyRequestBody$outboundSchema: z.ZodMiniType<
   UpdateAwsKmsKeyRequestBody
 > = z.pipe(
   z.object({
-    algorithm: UpdateAwsKmsKeyRequestBodyAlgorithm$outboundSchema,
     customerGrantReference: z.optional(z.string()),
     externalCredentialId: z.string(),
     id: z.string(),
-    keyArn: z.string(),
     name: z.string(),
   }),
   z.transform((v) => {
     return remap$(v, {
       customerGrantReference: "customer_grant_reference",
       externalCredentialId: "external_credential_id",
-      keyArn: "key_arn",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/models/components/updategcpkmskeyrequestbody.ts
+++ b/client/dashboard/src/sdk/src/models/components/updategcpkmskeyrequestbody.ts
@@ -4,33 +4,14 @@
 
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
-import { ClosedEnum } from "../../types/enums.js";
-
-/**
- * The signing algorithm of the key.
- */
-export const UpdateGcpKmsKeyRequestBodyAlgorithm = {
-  Rs256: "RS256",
-  Es256: "ES256",
-} as const;
-/**
- * The signing algorithm of the key.
- */
-export type UpdateGcpKmsKeyRequestBodyAlgorithm = ClosedEnum<
-  typeof UpdateGcpKmsKeyRequestBodyAlgorithm
->;
 
 export type UpdateGcpKmsKeyRequestBody = {
   /**
-   * The signing algorithm of the key.
-   */
-  algorithm: UpdateGcpKmsKeyRequestBodyAlgorithm;
-  /**
-   * Optional. The Gram identity (GCP service-account email or AWS principal ARN) the customer granted on the key for the key-policy / IAM-grant model. Not a secret.
+   * Optional. The Gram service-account email the customer granted on the key in an IAM binding. Not a secret.
    */
   customerGrantReference?: string | undefined;
   /**
-   * The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+   * The external credential Gram uses to authenticate to the key. Must be a gcp_iam credential belonging to the same organization.
    */
   externalCredentialId: string;
   /**
@@ -41,25 +22,14 @@ export type UpdateGcpKmsKeyRequestBody = {
    * A human-readable name for the key.
    */
   name: string;
-  /**
-   * The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).
-   */
-  resourceName: string;
 };
 
 /** @internal */
-export const UpdateGcpKmsKeyRequestBodyAlgorithm$outboundSchema: z.ZodMiniEnum<
-  typeof UpdateGcpKmsKeyRequestBodyAlgorithm
-> = z.enum(UpdateGcpKmsKeyRequestBodyAlgorithm);
-
-/** @internal */
 export type UpdateGcpKmsKeyRequestBody$Outbound = {
-  algorithm: string;
   customer_grant_reference?: string | undefined;
   external_credential_id: string;
   id: string;
   name: string;
-  resource_name: string;
 };
 
 /** @internal */
@@ -68,18 +38,15 @@ export const UpdateGcpKmsKeyRequestBody$outboundSchema: z.ZodMiniType<
   UpdateGcpKmsKeyRequestBody
 > = z.pipe(
   z.object({
-    algorithm: UpdateGcpKmsKeyRequestBodyAlgorithm$outboundSchema,
     customerGrantReference: z.optional(z.string()),
     externalCredentialId: z.string(),
     id: z.string(),
     name: z.string(),
-    resourceName: z.string(),
   }),
   z.transform((v) => {
     return remap$(v, {
       customerGrantReference: "customer_grant_reference",
       externalCredentialId: "external_credential_id",
-      resourceName: "resource_name",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/react-query/deleteAwsKmsKey.ts
+++ b/client/dashboard/src/sdk/src/react-query/deleteAwsKmsKey.ts
@@ -53,7 +53,7 @@ export type DeleteAwsKmsKeyMutationError =
  * deleteAwsKmsKey externalKeys
  *
  * @remarks
- * Soft-delete an AWS KMS external key by ID. Requires org:admin.
+ * Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
  */
 export function useDeleteAwsKmsKeyMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/react-query/deleteGcpKmsKey.ts
+++ b/client/dashboard/src/sdk/src/react-query/deleteGcpKmsKey.ts
@@ -53,7 +53,7 @@ export type DeleteGcpKmsKeyMutationError =
  * deleteGcpKmsKey externalKeys
  *
  * @remarks
- * Soft-delete a GCP KMS external key by ID. Requires org:admin.
+ * Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
  */
 export function useDeleteGcpKmsKeyMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/react-query/updateAwsKmsKey.ts
+++ b/client/dashboard/src/sdk/src/react-query/updateAwsKmsKey.ts
@@ -54,7 +54,7 @@ export type UpdateAwsKmsKeyMutationError =
  * updateAwsKmsKey externalKeys
  *
  * @remarks
- * Replace an AWS KMS external key's configuration. Requires org:admin.
+ * Update an AWS KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.
  */
 export function useUpdateAwsKmsKeyMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/react-query/updateGcpKmsKey.ts
+++ b/client/dashboard/src/sdk/src/react-query/updateGcpKmsKey.ts
@@ -54,7 +54,7 @@ export type UpdateGcpKmsKeyMutationError =
  * updateGcpKmsKey externalKeys
  *
  * @remarks
- * Replace a GCP KMS external key's configuration. Requires org:admin.
+ * Update a GCP KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.
  */
 export function useUpdateGcpKmsKeyMutation(
   options?: MutationHookOptions<

--- a/client/dashboard/src/sdk/src/sdk/externalkeys.ts
+++ b/client/dashboard/src/sdk/src/sdk/externalkeys.ts
@@ -106,7 +106,7 @@ export class ExternalKeys extends ClientSDK {
    * deleteAwsKmsKey externalKeys
    *
    * @remarks
-   * Soft-delete an AWS KMS external key by ID. Requires org:admin.
+   * Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
    */
   async deleteAwsKms(
     request: DeleteAwsKmsKeyRequest,
@@ -125,7 +125,7 @@ export class ExternalKeys extends ClientSDK {
    * deleteGcpKmsKey externalKeys
    *
    * @remarks
-   * Soft-delete a GCP KMS external key by ID. Requires org:admin.
+   * Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
    */
   async deleteGcpKms(
     request: DeleteGcpKmsKeyRequest,
@@ -239,7 +239,7 @@ export class ExternalKeys extends ClientSDK {
    * updateAwsKmsKey externalKeys
    *
    * @remarks
-   * Replace an AWS KMS external key's configuration. Requires org:admin.
+   * Update an AWS KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.
    */
   async updateAwsKms(
     request: UpdateAwsKmsKeyRequest,
@@ -258,7 +258,7 @@ export class ExternalKeys extends ClientSDK {
    * updateGcpKmsKey externalKeys
    *
    * @remarks
-   * Replace a GCP KMS external key's configuration. Requires org:admin.
+   * Update a GCP KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.
    */
   async updateGcpKms(
     request: UpdateGcpKmsKeyRequest,

--- a/server/design/externalkeys/design.go
+++ b/server/design/externalkeys/design.go
@@ -39,15 +39,19 @@ var _ = Service("externalKeys", func() {
 	})
 
 	Method("updateAwsKmsKey", func() {
-		Description("Replace an AWS KMS external key's configuration. Requires org:admin.")
+		Description("Update an AWS KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.")
 
 		Payload(func() {
 			Attribute("id", String, "The ID of the key to update.", func() {
 				Format(FormatUUID)
 			})
-			Extend(CreateAwsKmsKeyForm)
+			Extend(UpdateAwsKmsKeyForm)
 			Required("id")
 			security.SessionPayload()
+			// Named explicitly for the same reason as updateGcpKmsKey below: the
+			// two payloads are structurally identical and Goa deduplicates
+			// request bodies by shape.
+			Meta("openapi:typename", "UpdateAwsKmsKeyRequestBody")
 		})
 
 		Result(AwsKmsKey)
@@ -85,15 +89,21 @@ var _ = Service("externalKeys", func() {
 	})
 
 	Method("updateGcpKmsKey", func() {
-		Description("Replace a GCP KMS external key's configuration. Requires org:admin.")
+		Description("Update a GCP KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.")
 
 		Payload(func() {
 			Attribute("id", String, "The ID of the key to update.", func() {
 				Format(FormatUUID)
 			})
-			Extend(CreateGcpKmsKeyForm)
+			Extend(UpdateGcpKmsKeyForm)
 			Required("id")
 			security.SessionPayload()
+			// The AWS and GCP update payloads are structurally identical, and
+			// Goa's OpenAPI emitter deduplicates request bodies by shape (not by
+			// description), so without an explicit name both methods share one
+			// UpdateAwsKmsKeyRequestBody schema and the generated SDK has
+			// updateGcpKms taking an AWS-named body type.
+			Meta("openapi:typename", "UpdateGcpKmsKeyRequestBody")
 		})
 
 		Result(GcpKmsKey)
@@ -224,7 +234,7 @@ var _ = Service("externalKeys", func() {
 	})
 
 	Method("deleteAwsKmsKey", func() {
-		Description("Soft-delete an AWS KMS external key by ID. Requires org:admin.")
+		Description("Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.")
 
 		Payload(func() {
 			Attribute("id", String, "The ID of the key to delete.", func() {
@@ -247,7 +257,7 @@ var _ = Service("externalKeys", func() {
 	})
 
 	Method("deleteGcpKmsKey", func() {
-		Description("Soft-delete a GCP KMS external key by ID. Requires org:admin.")
+		Description("Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.")
 
 		Payload(func() {
 			Attribute("id", String, "The ID of the key to delete.", func() {

--- a/server/design/externalkeys/types.go
+++ b/server/design/externalkeys/types.go
@@ -59,9 +59,10 @@ var GcpKmsKey = Type("GcpKmsKey", func() {
 	Required("resource_name")
 })
 
-// CreateExternalKeyFields holds the provider-independent inputs shared by every
-// create/update form: the backing credential, algorithm, name, and the optional
-// customer grant reference.
+// CreateExternalKeyFields holds the provider-independent inputs shared by the
+// create forms: the backing credential, algorithm, name, and the optional
+// customer grant reference. The update forms deliberately do not extend this —
+// see UpdateAwsKmsKeyForm.
 var CreateExternalKeyFields = Type("CreateExternalKeyFields", func() {
 	Attribute("external_credential_id", String, "The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).", func() {
 		Format(FormatUUID)
@@ -75,7 +76,7 @@ var CreateExternalKeyFields = Type("CreateExternalKeyFields", func() {
 	Required("external_credential_id", "algorithm", "name")
 })
 
-// CreateAwsKmsKeyForm is the input for creating (or replacing) an AWS KMS key.
+// CreateAwsKmsKeyForm is the input for creating an AWS KMS key.
 var CreateAwsKmsKeyForm = Type("CreateAwsKmsKeyForm", func() {
 	Extend(CreateExternalKeyFields)
 
@@ -84,13 +85,67 @@ var CreateAwsKmsKeyForm = Type("CreateAwsKmsKeyForm", func() {
 	Required("key_arn")
 })
 
-// CreateGcpKmsKeyForm is the input for creating (or replacing) a GCP KMS key.
+// CreateGcpKmsKeyForm is the input for creating a GCP KMS key.
 var CreateGcpKmsKeyForm = Type("CreateGcpKmsKeyForm", func() {
 	Extend(CreateExternalKeyFields)
 
 	Attribute("resource_name", String, "The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).")
 
 	Required("resource_name")
+})
+
+// UpdateAwsKmsKeyForm is the input for updating an AWS KMS key's mutable
+// configuration. It is deliberately a strict subset of CreateAwsKmsKeyForm
+// rather than an extension of it: a key's provider identity (key_arn) and its
+// algorithm are set at creation and never change, because an external_keys row
+// must identify exactly one signable key permanently. A published JWK pins its
+// kid to the row it was minted from, so re-pointing the row would silently make
+// every already-published kid sign with the wrong key. Changing what a key is
+// means delete and recreate, which mints a new id.
+//
+// external_credential_id stays editable on purpose: repairing which credential
+// reaches a key does not change the key material being signed with. Note the
+// guarantee is narrower than it looks — validateBackingCredential only checks
+// the cloud family (aws_kms needs aws_iam, gcp_kms needs gcp_iam), so a
+// credential for a different AWS account or GCP project still passes.
+//
+// Within that subset the update replaces rather than patches: the optional
+// customer_grant_reference is cleared when omitted. That is what makes clearing
+// it possible at all, since an absent field and an explicit null are
+// indistinguishable once decoded.
+//
+// The AWS and GCP update forms spell their attributes out separately instead of
+// extending a shared parent, which is deliberate and worth not "cleaning up".
+// A shared parent forces one set of descriptions on both providers, and Extend
+// does not let a child override an inherited attribute — the parent's definition
+// wins. Writing them out is what allows the provider-specific wording, which
+// documents each provider better than one sentence covering both.
+//
+// Separately, the two forms are structurally identical, and Goa's OpenAPI
+// emitter deduplicates request bodies by shape, so the update methods carry an
+// explicit `openapi:typename` to keep their generated schemas (and so their SDK
+// types) distinct. Descriptions alone do not break that tie.
+var UpdateAwsKmsKeyForm = Type("UpdateAwsKmsKeyForm", func() {
+	Attribute("external_credential_id", String, "The external credential Gram uses to authenticate to the key. Must be an aws_iam credential belonging to the same organization.", func() {
+		Format(FormatUUID)
+	})
+	Attribute("name", String, "A human-readable name for the key.")
+	Attribute("customer_grant_reference", String, "Optional. The AWS principal ARN the customer granted on the key in its key policy. Not a secret.")
+
+	Required("external_credential_id", "name")
+})
+
+// UpdateGcpKmsKeyForm is the input for updating a GCP KMS key's mutable
+// configuration. See UpdateAwsKmsKeyForm for why the two forms do not share a
+// parent type.
+var UpdateGcpKmsKeyForm = Type("UpdateGcpKmsKeyForm", func() {
+	Attribute("external_credential_id", String, "The external credential Gram uses to authenticate to the key. Must be a gcp_iam credential belonging to the same organization.", func() {
+		Format(FormatUUID)
+	})
+	Attribute("name", String, "A human-readable name for the key.")
+	Attribute("customer_grant_reference", String, "Optional. The Gram service-account email the customer granted on the key in an IAM binding. Not a secret.")
+
+	Required("external_credential_id", "name")
 })
 
 // ListExternalKeysResult wraps the generic, supertype-only list items.

--- a/server/gen/external_keys/service.go
+++ b/server/gen/external_keys/service.go
@@ -19,11 +19,23 @@ import (
 type Service interface {
 	// Create an AWS KMS external key. Requires org:admin.
 	CreateAwsKmsKey(context.Context, *CreateAwsKmsKeyPayload) (res *AwsKmsKey, err error)
-	// Replace an AWS KMS external key's configuration. Requires org:admin.
+	// Update an AWS KMS external key's name, backing credential and customer grant
+	// reference. Requires org:admin. These three fields are replaced, not patched:
+	// omitting the optional customer_grant_reference clears it. The key ARN and
+	// algorithm are immutable: an external key identifies exactly one signable key
+	// permanently, so changing what the key is means deleting it and creating a
+	// new one. The backing credential stays editable because repairing the path to
+	// a key does not change the key material Gram signs with.
 	UpdateAwsKmsKey(context.Context, *UpdateAwsKmsKeyPayload) (res *AwsKmsKey, err error)
 	// Create a GCP KMS external key. Requires org:admin.
 	CreateGcpKmsKey(context.Context, *CreateGcpKmsKeyPayload) (res *GcpKmsKey, err error)
-	// Replace a GCP KMS external key's configuration. Requires org:admin.
+	// Update a GCP KMS external key's name, backing credential and customer grant
+	// reference. Requires org:admin. These three fields are replaced, not patched:
+	// omitting the optional customer_grant_reference clears it. The resource name
+	// and algorithm are immutable: an external key identifies exactly one signable
+	// crypto key version permanently, so changing what the key is means deleting
+	// it and creating a new one. The backing credential stays editable because
+	// repairing the path to a key does not change the key material Gram signs with.
 	UpdateGcpKmsKey(context.Context, *UpdateGcpKmsKeyPayload) (res *GcpKmsKey, err error)
 	// List the organization's external keys (provider-independent summary).
 	// Optionally filter by provider. Requires org:read.
@@ -36,9 +48,15 @@ type Service interface {
 	GetAwsKmsKey(context.Context, *GetAwsKmsKeyPayload) (res *AwsKmsKey, err error)
 	// Get a GCP KMS external key by ID. Requires org:read.
 	GetGcpKmsKey(context.Context, *GetGcpKmsKeyPayload) (res *GcpKmsKey, err error)
-	// Soft-delete an AWS KMS external key by ID. Requires org:admin.
+	// Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with
+	// a conflict while any JSON Web Key Set or published JSON Web Key still
+	// references the key, since deleting it would break verification for every
+	// already-published kid.
 	DeleteAwsKmsKey(context.Context, *DeleteAwsKmsKeyPayload) (err error)
-	// Soft-delete a GCP KMS external key by ID. Requires org:admin.
+	// Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a
+	// conflict while any JSON Web Key Set or published JSON Web Key still
+	// references the key, since deleting it would break verification for every
+	// already-published kid.
 	DeleteGcpKmsKey(context.Context, *DeleteGcpKmsKeyPayload) (err error)
 }
 
@@ -247,19 +265,13 @@ type UpdateAwsKmsKeyPayload struct {
 	// The ID of the key to update.
 	ID           string
 	SessionToken *string
-	// The ARN of the AWS KMS key.
-	KeyArn string
-	// The external credential Gram uses to authenticate to the key. Must belong to
-	// the same organization and matching cloud family (an aws_kms key requires an
-	// aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+	// The external credential Gram uses to authenticate to the key. Must be an
+	// aws_iam credential belonging to the same organization.
 	ExternalCredentialID string
-	// The signing algorithm of the key.
-	Algorithm string
 	// A human-readable name for the key.
 	Name string
-	// Optional. The Gram identity (GCP service-account email or AWS principal ARN)
-	// the customer granted on the key for the key-policy / IAM-grant model. Not a
-	// secret.
+	// Optional. The AWS principal ARN the customer granted on the key in its key
+	// policy. Not a secret.
 	CustomerGrantReference *string
 }
 
@@ -269,19 +281,13 @@ type UpdateGcpKmsKeyPayload struct {
 	// The ID of the key to update.
 	ID           string
 	SessionToken *string
-	// The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).
-	ResourceName string
-	// The external credential Gram uses to authenticate to the key. Must belong to
-	// the same organization and matching cloud family (an aws_kms key requires an
-	// aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+	// The external credential Gram uses to authenticate to the key. Must be a
+	// gcp_iam credential belonging to the same organization.
 	ExternalCredentialID string
-	// The signing algorithm of the key.
-	Algorithm string
 	// A human-readable name for the key.
 	Name string
-	// Optional. The Gram identity (GCP service-account email or AWS principal ARN)
-	// the customer granted on the key for the key-policy / IAM-grant model. Not a
-	// secret.
+	// Optional. The Gram service-account email the customer granted on the key in
+	// an IAM binding. Not a secret.
 	CustomerGrantReference *string
 }
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11317,16 +11317,16 @@ func externalKeysUsage() {
 	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] external-keys COMMAND [flags]\n\n", os.Args[0])
 	fmt.Fprintln(os.Stderr, "COMMAND:")
 	fmt.Fprintln(os.Stderr, `    create-aws-kms-key: Create an AWS KMS external key. Requires org:admin.`)
-	fmt.Fprintln(os.Stderr, `    update-aws-kms-key: Replace an AWS KMS external key's configuration. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `    update-aws-kms-key: Update an AWS KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.`)
 	fmt.Fprintln(os.Stderr, `    create-gcp-kms-key: Create a GCP KMS external key. Requires org:admin.`)
-	fmt.Fprintln(os.Stderr, `    update-gcp-kms-key: Replace a GCP KMS external key's configuration. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `    update-gcp-kms-key: Update a GCP KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.`)
 	fmt.Fprintln(os.Stderr, `    list-external-keys: List the organization's external keys (provider-independent summary). Optionally filter by provider. Requires org:read.`)
 	fmt.Fprintln(os.Stderr, `    list-aws-kms-keys: List the organization's AWS KMS external keys. Requires org:read.`)
 	fmt.Fprintln(os.Stderr, `    list-gcp-kms-keys: List the organization's GCP KMS external keys. Requires org:read.`)
 	fmt.Fprintln(os.Stderr, `    get-aws-kms-key: Get an AWS KMS external key by ID. Requires org:read.`)
 	fmt.Fprintln(os.Stderr, `    get-gcp-kms-key: Get a GCP KMS external key by ID. Requires org:read.`)
-	fmt.Fprintln(os.Stderr, `    delete-aws-kms-key: Soft-delete an AWS KMS external key by ID. Requires org:admin.`)
-	fmt.Fprintln(os.Stderr, `    delete-gcp-kms-key: Soft-delete a GCP KMS external key by ID. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `    delete-aws-kms-key: Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.`)
+	fmt.Fprintln(os.Stderr, `    delete-gcp-kms-key: Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s external-keys COMMAND --help\n", os.Args[0])
@@ -11360,7 +11360,7 @@ func externalKeysUpdateAwsKmsKeyUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Replace an AWS KMS external key's configuration. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `Update an AWS KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)
@@ -11368,7 +11368,7 @@ func externalKeysUpdateAwsKmsKeyUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "external-keys update-aws-kms-key --body '{\n      \"algorithm\": \"ES256\",\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"key_arn\": \"abc123\",\n      \"name\": \"abc123\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "external-keys update-aws-kms-key --body '{\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"abc123\"\n   }' --session-token \"abc123\"")
 }
 
 func externalKeysCreateGcpKmsKeyUsage() {
@@ -11400,7 +11400,7 @@ func externalKeysUpdateGcpKmsKeyUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Replace a GCP KMS external key's configuration. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `Update a GCP KMS external key's name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)
@@ -11408,7 +11408,7 @@ func externalKeysUpdateGcpKmsKeyUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "external-keys update-gcp-kms-key --body '{\n      \"algorithm\": \"ES256\",\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"abc123\",\n      \"resource_name\": \"abc123\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "external-keys update-gcp-kms-key --body '{\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"abc123\"\n   }' --session-token \"abc123\"")
 }
 
 func externalKeysListExternalKeysUsage() {
@@ -11516,7 +11516,7 @@ func externalKeysDeleteAwsKmsKeyUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Soft-delete an AWS KMS external key by ID. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -id STRING: `)
@@ -11536,7 +11536,7 @@ func externalKeysDeleteGcpKmsKeyUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Soft-delete a GCP KMS external key by ID. Requires org:admin.`)
+	fmt.Fprintln(os.Stderr, `Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -id STRING: `)

--- a/server/gen/http/external_keys/client/cli.go
+++ b/server/gen/http/external_keys/client/cli.go
@@ -59,13 +59,10 @@ func BuildUpdateAwsKmsKeyPayload(externalKeysUpdateAwsKmsKeyBody string, externa
 	{
 		err = json.Unmarshal([]byte(externalKeysUpdateAwsKmsKeyBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"algorithm\": \"ES256\",\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"key_arn\": \"abc123\",\n      \"name\": \"abc123\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"abc123\"\n   }'")
 		}
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", body.ID, goa.FormatUUID))
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.external_credential_id", body.ExternalCredentialID, goa.FormatUUID))
-		if !(body.Algorithm == "RS256" || body.Algorithm == "ES256") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.algorithm", body.Algorithm, []any{"RS256", "ES256"}))
-		}
 		if err != nil {
 			return nil, err
 		}
@@ -78,9 +75,7 @@ func BuildUpdateAwsKmsKeyPayload(externalKeysUpdateAwsKmsKeyBody string, externa
 	}
 	v := &externalkeys.UpdateAwsKmsKeyPayload{
 		ID:                     body.ID,
-		KeyArn:                 body.KeyArn,
 		ExternalCredentialID:   body.ExternalCredentialID,
-		Algorithm:              body.Algorithm,
 		Name:                   body.Name,
 		CustomerGrantReference: body.CustomerGrantReference,
 	}
@@ -133,13 +128,10 @@ func BuildUpdateGcpKmsKeyPayload(externalKeysUpdateGcpKmsKeyBody string, externa
 	{
 		err = json.Unmarshal([]byte(externalKeysUpdateGcpKmsKeyBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"algorithm\": \"ES256\",\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"abc123\",\n      \"resource_name\": \"abc123\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"customer_grant_reference\": \"abc123\",\n      \"external_credential_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"name\": \"abc123\"\n   }'")
 		}
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", body.ID, goa.FormatUUID))
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.external_credential_id", body.ExternalCredentialID, goa.FormatUUID))
-		if !(body.Algorithm == "RS256" || body.Algorithm == "ES256") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.algorithm", body.Algorithm, []any{"RS256", "ES256"}))
-		}
 		if err != nil {
 			return nil, err
 		}
@@ -152,9 +144,7 @@ func BuildUpdateGcpKmsKeyPayload(externalKeysUpdateGcpKmsKeyBody string, externa
 	}
 	v := &externalkeys.UpdateGcpKmsKeyPayload{
 		ID:                     body.ID,
-		ResourceName:           body.ResourceName,
 		ExternalCredentialID:   body.ExternalCredentialID,
-		Algorithm:              body.Algorithm,
 		Name:                   body.Name,
 		CustomerGrantReference: body.CustomerGrantReference,
 	}

--- a/server/gen/http/external_keys/client/types.go
+++ b/server/gen/http/external_keys/client/types.go
@@ -36,19 +36,13 @@ type CreateAwsKmsKeyRequestBody struct {
 type UpdateAwsKmsKeyRequestBody struct {
 	// The ID of the key to update.
 	ID string `form:"id" json:"id" xml:"id"`
-	// The ARN of the AWS KMS key.
-	KeyArn string `form:"key_arn" json:"key_arn" xml:"key_arn"`
-	// The external credential Gram uses to authenticate to the key. Must belong to
-	// the same organization and matching cloud family (an aws_kms key requires an
-	// aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+	// The external credential Gram uses to authenticate to the key. Must be an
+	// aws_iam credential belonging to the same organization.
 	ExternalCredentialID string `form:"external_credential_id" json:"external_credential_id" xml:"external_credential_id"`
-	// The signing algorithm of the key.
-	Algorithm string `form:"algorithm" json:"algorithm" xml:"algorithm"`
 	// A human-readable name for the key.
 	Name string `form:"name" json:"name" xml:"name"`
-	// Optional. The Gram identity (GCP service-account email or AWS principal ARN)
-	// the customer granted on the key for the key-policy / IAM-grant model. Not a
-	// secret.
+	// Optional. The AWS principal ARN the customer granted on the key in its key
+	// policy. Not a secret.
 	CustomerGrantReference *string `form:"customer_grant_reference,omitempty" json:"customer_grant_reference,omitempty" xml:"customer_grant_reference,omitempty"`
 }
 
@@ -76,19 +70,13 @@ type CreateGcpKmsKeyRequestBody struct {
 type UpdateGcpKmsKeyRequestBody struct {
 	// The ID of the key to update.
 	ID string `form:"id" json:"id" xml:"id"`
-	// The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).
-	ResourceName string `form:"resource_name" json:"resource_name" xml:"resource_name"`
-	// The external credential Gram uses to authenticate to the key. Must belong to
-	// the same organization and matching cloud family (an aws_kms key requires an
-	// aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+	// The external credential Gram uses to authenticate to the key. Must be a
+	// gcp_iam credential belonging to the same organization.
 	ExternalCredentialID string `form:"external_credential_id" json:"external_credential_id" xml:"external_credential_id"`
-	// The signing algorithm of the key.
-	Algorithm string `form:"algorithm" json:"algorithm" xml:"algorithm"`
 	// A human-readable name for the key.
 	Name string `form:"name" json:"name" xml:"name"`
-	// Optional. The Gram identity (GCP service-account email or AWS principal ARN)
-	// the customer granted on the key for the key-policy / IAM-grant model. Not a
-	// secret.
+	// Optional. The Gram service-account email the customer granted on the key in
+	// an IAM binding. Not a secret.
 	CustomerGrantReference *string `form:"customer_grant_reference,omitempty" json:"customer_grant_reference,omitempty" xml:"customer_grant_reference,omitempty"`
 }
 
@@ -2384,9 +2372,7 @@ func NewCreateAwsKmsKeyRequestBody(p *externalkeys.CreateAwsKmsKeyPayload) *Crea
 func NewUpdateAwsKmsKeyRequestBody(p *externalkeys.UpdateAwsKmsKeyPayload) *UpdateAwsKmsKeyRequestBody {
 	body := &UpdateAwsKmsKeyRequestBody{
 		ID:                     p.ID,
-		KeyArn:                 p.KeyArn,
 		ExternalCredentialID:   p.ExternalCredentialID,
-		Algorithm:              p.Algorithm,
 		Name:                   p.Name,
 		CustomerGrantReference: p.CustomerGrantReference,
 	}
@@ -2411,9 +2397,7 @@ func NewCreateGcpKmsKeyRequestBody(p *externalkeys.CreateGcpKmsKeyPayload) *Crea
 func NewUpdateGcpKmsKeyRequestBody(p *externalkeys.UpdateGcpKmsKeyPayload) *UpdateGcpKmsKeyRequestBody {
 	body := &UpdateGcpKmsKeyRequestBody{
 		ID:                     p.ID,
-		ResourceName:           p.ResourceName,
 		ExternalCredentialID:   p.ExternalCredentialID,
-		Algorithm:              p.Algorithm,
 		Name:                   p.Name,
 		CustomerGrantReference: p.CustomerGrantReference,
 	}

--- a/server/gen/http/external_keys/server/types.go
+++ b/server/gen/http/external_keys/server/types.go
@@ -36,19 +36,13 @@ type CreateAwsKmsKeyRequestBody struct {
 type UpdateAwsKmsKeyRequestBody struct {
 	// The ID of the key to update.
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	// The ARN of the AWS KMS key.
-	KeyArn *string `form:"key_arn,omitempty" json:"key_arn,omitempty" xml:"key_arn,omitempty"`
-	// The external credential Gram uses to authenticate to the key. Must belong to
-	// the same organization and matching cloud family (an aws_kms key requires an
-	// aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+	// The external credential Gram uses to authenticate to the key. Must be an
+	// aws_iam credential belonging to the same organization.
 	ExternalCredentialID *string `form:"external_credential_id,omitempty" json:"external_credential_id,omitempty" xml:"external_credential_id,omitempty"`
-	// The signing algorithm of the key.
-	Algorithm *string `form:"algorithm,omitempty" json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 	// A human-readable name for the key.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// Optional. The Gram identity (GCP service-account email or AWS principal ARN)
-	// the customer granted on the key for the key-policy / IAM-grant model. Not a
-	// secret.
+	// Optional. The AWS principal ARN the customer granted on the key in its key
+	// policy. Not a secret.
 	CustomerGrantReference *string `form:"customer_grant_reference,omitempty" json:"customer_grant_reference,omitempty" xml:"customer_grant_reference,omitempty"`
 }
 
@@ -76,19 +70,13 @@ type CreateGcpKmsKeyRequestBody struct {
 type UpdateGcpKmsKeyRequestBody struct {
 	// The ID of the key to update.
 	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
-	// The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).
-	ResourceName *string `form:"resource_name,omitempty" json:"resource_name,omitempty" xml:"resource_name,omitempty"`
-	// The external credential Gram uses to authenticate to the key. Must belong to
-	// the same organization and matching cloud family (an aws_kms key requires an
-	// aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+	// The external credential Gram uses to authenticate to the key. Must be a
+	// gcp_iam credential belonging to the same organization.
 	ExternalCredentialID *string `form:"external_credential_id,omitempty" json:"external_credential_id,omitempty" xml:"external_credential_id,omitempty"`
-	// The signing algorithm of the key.
-	Algorithm *string `form:"algorithm,omitempty" json:"algorithm,omitempty" xml:"algorithm,omitempty"`
 	// A human-readable name for the key.
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
-	// Optional. The Gram identity (GCP service-account email or AWS principal ARN)
-	// the customer granted on the key for the key-policy / IAM-grant model. Not a
-	// secret.
+	// Optional. The Gram service-account email the customer granted on the key in
+	// an IAM binding. Not a secret.
 	CustomerGrantReference *string `form:"customer_grant_reference,omitempty" json:"customer_grant_reference,omitempty" xml:"customer_grant_reference,omitempty"`
 }
 
@@ -4123,9 +4111,7 @@ func NewCreateAwsKmsKeyPayload(body *CreateAwsKmsKeyRequestBody, sessionToken *s
 func NewUpdateAwsKmsKeyPayload(body *UpdateAwsKmsKeyRequestBody, sessionToken *string) *externalkeys.UpdateAwsKmsKeyPayload {
 	v := &externalkeys.UpdateAwsKmsKeyPayload{
 		ID:                     *body.ID,
-		KeyArn:                 *body.KeyArn,
 		ExternalCredentialID:   *body.ExternalCredentialID,
-		Algorithm:              *body.Algorithm,
 		Name:                   *body.Name,
 		CustomerGrantReference: body.CustomerGrantReference,
 	}
@@ -4154,9 +4140,7 @@ func NewCreateGcpKmsKeyPayload(body *CreateGcpKmsKeyRequestBody, sessionToken *s
 func NewUpdateGcpKmsKeyPayload(body *UpdateGcpKmsKeyRequestBody, sessionToken *string) *externalkeys.UpdateGcpKmsKeyPayload {
 	v := &externalkeys.UpdateGcpKmsKeyPayload{
 		ID:                     *body.ID,
-		ResourceName:           *body.ResourceName,
 		ExternalCredentialID:   *body.ExternalCredentialID,
-		Algorithm:              *body.Algorithm,
 		Name:                   *body.Name,
 		CustomerGrantReference: body.CustomerGrantReference,
 	}
@@ -4265,14 +4249,8 @@ func ValidateUpdateAwsKmsKeyRequestBody(body *UpdateAwsKmsKeyRequestBody) (err e
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
-	if body.KeyArn == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("key_arn", "body"))
-	}
 	if body.ExternalCredentialID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("external_credential_id", "body"))
-	}
-	if body.Algorithm == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("algorithm", "body"))
 	}
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
@@ -4282,11 +4260,6 @@ func ValidateUpdateAwsKmsKeyRequestBody(body *UpdateAwsKmsKeyRequestBody) (err e
 	}
 	if body.ExternalCredentialID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.external_credential_id", *body.ExternalCredentialID, goa.FormatUUID))
-	}
-	if body.Algorithm != nil {
-		if !(*body.Algorithm == "RS256" || *body.Algorithm == "ES256") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.algorithm", *body.Algorithm, []any{"RS256", "ES256"}))
-		}
 	}
 	return
 }
@@ -4323,14 +4296,8 @@ func ValidateUpdateGcpKmsKeyRequestBody(body *UpdateGcpKmsKeyRequestBody) (err e
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
-	if body.ResourceName == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("resource_name", "body"))
-	}
 	if body.ExternalCredentialID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("external_credential_id", "body"))
-	}
-	if body.Algorithm == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("algorithm", "body"))
 	}
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
@@ -4340,11 +4307,6 @@ func ValidateUpdateGcpKmsKeyRequestBody(body *UpdateGcpKmsKeyRequestBody) (err e
 	}
 	if body.ExternalCredentialID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.external_credential_id", *body.ExternalCredentialID, goa.FormatUUID))
-	}
-	if body.Algorithm != nil {
-		if !(*body.Algorithm == "RS256" || *body.Algorithm == "ES256") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.algorithm", *body.Algorithm, []any{"RS256", "ES256"}))
-		}
 	}
 	return
 }

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -16641,7 +16641,7 @@ paths:
                 name: CreateGcpKmsKey
     /rpc/externalKeys.deleteAwsKms:
         delete:
-            description: Soft-delete an AWS KMS external key by ID. Requires org:admin.
+            description: Soft-delete an AWS KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
             operationId: deleteAwsKmsKey
             parameters:
                 - allowEmptyValue: true
@@ -16727,7 +16727,7 @@ paths:
                 name: DeleteAwsKmsKey
     /rpc/externalKeys.deleteGcpKms:
         delete:
-            description: Soft-delete a GCP KMS external key by ID. Requires org:admin.
+            description: Soft-delete a GCP KMS external key by ID. Requires org:admin. Refused with a conflict while any JSON Web Key Set or published JSON Web Key still references the key, since deleting it would break verification for every already-published kid.
             operationId: deleteGcpKmsKey
             parameters:
                 - allowEmptyValue: true
@@ -17246,7 +17246,7 @@ paths:
                 name: ListGcpKmsKeys
     /rpc/externalKeys.updateAwsKms:
         post:
-            description: Replace an AWS KMS external key's configuration. Requires org:admin.
+            description: 'Update an AWS KMS external key''s name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The key ARN and algorithm are immutable: an external key identifies exactly one signable key permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.'
             operationId: updateAwsKmsKey
             parameters:
                 - allowEmptyValue: true
@@ -17333,7 +17333,7 @@ paths:
                 name: UpdateAwsKmsKey
     /rpc/externalKeys.updateGcpKms:
         post:
-            description: Replace a GCP KMS external key's configuration. Requires org:admin.
+            description: 'Update a GCP KMS external key''s name, backing credential and customer grant reference. Requires org:admin. These three fields are replaced, not patched: omitting the optional customer_grant_reference clears it. The resource name and algorithm are immutable: an external key identifies exactly one signable crypto key version permanently, so changing what the key is means deleting it and creating a new one. The backing credential stays editable because repairing the path to a key does not change the key material Gram signs with.'
             operationId: updateGcpKmsKey
             parameters:
                 - allowEmptyValue: true
@@ -72319,37 +72319,42 @@ components:
             required:
                 - id
                 - name
+        UpdateAwsKmsKeyForm:
+            type: object
+            properties:
+                customer_grant_reference:
+                    type: string
+                    description: Optional. The AWS principal ARN the customer granted on the key in its key policy. Not a secret.
+                external_credential_id:
+                    type: string
+                    description: The external credential Gram uses to authenticate to the key. Must be an aws_iam credential belonging to the same organization.
+                    format: uuid
+                name:
+                    type: string
+                    description: A human-readable name for the key.
+            required:
+                - external_credential_id
+                - name
         UpdateAwsKmsKeyRequestBody:
             type: object
             properties:
-                algorithm:
-                    type: string
-                    description: The signing algorithm of the key.
-                    enum:
-                        - RS256
-                        - ES256
                 customer_grant_reference:
                     type: string
-                    description: Optional. The Gram identity (GCP service-account email or AWS principal ARN) the customer granted on the key for the key-policy / IAM-grant model. Not a secret.
+                    description: Optional. The AWS principal ARN the customer granted on the key in its key policy. Not a secret.
                 external_credential_id:
                     type: string
-                    description: The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+                    description: The external credential Gram uses to authenticate to the key. Must be an aws_iam credential belonging to the same organization.
                     format: uuid
                 id:
                     type: string
                     description: The ID of the key to update.
                     format: uuid
-                key_arn:
-                    type: string
-                    description: The ARN of the AWS KMS key.
                 name:
                     type: string
                     description: A human-readable name for the key.
             required:
                 - id
-                - key_arn
                 - external_credential_id
-                - algorithm
                 - name
         UpdateConfigurationRequestBody:
             type: object
@@ -72496,21 +72501,31 @@ components:
             required:
                 - id
                 - name
+        UpdateGcpKmsKeyForm:
+            type: object
+            properties:
+                customer_grant_reference:
+                    type: string
+                    description: Optional. The Gram service-account email the customer granted on the key in an IAM binding. Not a secret.
+                external_credential_id:
+                    type: string
+                    description: The external credential Gram uses to authenticate to the key. Must be a gcp_iam credential belonging to the same organization.
+                    format: uuid
+                name:
+                    type: string
+                    description: A human-readable name for the key.
+            required:
+                - external_credential_id
+                - name
         UpdateGcpKmsKeyRequestBody:
             type: object
             properties:
-                algorithm:
-                    type: string
-                    description: The signing algorithm of the key.
-                    enum:
-                        - RS256
-                        - ES256
                 customer_grant_reference:
                     type: string
-                    description: Optional. The Gram identity (GCP service-account email or AWS principal ARN) the customer granted on the key for the key-policy / IAM-grant model. Not a secret.
+                    description: Optional. The Gram service-account email the customer granted on the key in an IAM binding. Not a secret.
                 external_credential_id:
                     type: string
-                    description: The external credential Gram uses to authenticate to the key. Must belong to the same organization and matching cloud family (an aws_kms key requires an aws_iam credential; a gcp_kms key requires a gcp_iam credential).
+                    description: The external credential Gram uses to authenticate to the key. Must be a gcp_iam credential belonging to the same organization.
                     format: uuid
                 id:
                     type: string
@@ -72519,14 +72534,9 @@ components:
                 name:
                     type: string
                     description: A human-readable name for the key.
-                resource_name:
-                    type: string
-                    description: The resource name of the GCP KMS key (projects/.../cryptoKeyVersions/...).
             required:
                 - id
-                - resource_name
                 - external_credential_id
-                - algorithm
                 - name
         UpdateInviteRoleRequestBody:
             type: object

--- a/server/internal/externalkeys/creategcpkmskey_test.go
+++ b/server/internal/externalkeys/creategcpkmskey_test.go
@@ -66,6 +66,47 @@ func TestCreateGcpKmsKey_MissingResourceName(t *testing.T) {
 	requireOopsCode(t, err, oops.CodeBadRequest)
 }
 
+// TestCreateGcpKmsKey_VersionlessResourceName verifies a `.../cryptoKeys/<k>`
+// path without a version suffix is rejected at creation. Asymmetric-sign keys
+// have no primary version, so such a path never resolves to anything signable,
+// and the resource name is frozen once written — catching it here is what keeps
+// "delete and recreate" from being a routine correction.
+func TestCreateGcpKmsKey_VersionlessResourceName(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredential(t, ctx, ti, "backing-cred")
+
+	_, err := ti.service.CreateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.CreateGcpKmsKeyPayload{
+		SessionToken:           nil,
+		ResourceName:           "projects/gram/locations/global/keyRings/signing/cryptoKeys/k",
+		ExternalCredentialID:   credID,
+		Algorithm:              "ES256",
+		Name:                   "versionless",
+		CustomerGrantReference: nil,
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// TestCreateGcpKmsKey_MalformedResourceName verifies a resource name that is not
+// a GCP KMS path at all is rejected at creation.
+func TestCreateGcpKmsKey_MalformedResourceName(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredential(t, ctx, ti, "backing-cred")
+
+	_, err := ti.service.CreateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.CreateGcpKmsKeyPayload{
+		SessionToken:           nil,
+		ResourceName:           "arn:aws:kms:us-east-1:123456789012:key/abcd-1234",
+		ExternalCredentialID:   credID,
+		Algorithm:              "ES256",
+		Name:                   "malformed",
+		CustomerGrantReference: nil,
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
 // TestCreateGcpKmsKey_WrongFamilyCredential verifies a gcp_kms key cannot be
 // backed by an aws_iam credential.
 func TestCreateGcpKmsKey_WrongFamilyCredential(t *testing.T) {

--- a/server/internal/externalkeys/crossorg_test.go
+++ b/server/internal/externalkeys/crossorg_test.go
@@ -48,9 +48,7 @@ func TestExternalKeys_CrossOrgIsolation(t *testing.T) {
 	_, err = ti.service.UpdateAwsKmsKey(otherCtx, &gen.UpdateAwsKmsKeyPayload{
 		ID:                     created.ID,
 		SessionToken:           nil,
-		KeyArn:                 "arn:aws:kms:us-east-1:999999999999:key/attacker",
 		ExternalCredentialID:   credID,
-		Algorithm:              "RS256",
 		Name:                   "hijacked",
 		CustomerGrantReference: nil,
 	})

--- a/server/internal/externalkeys/impl.go
+++ b/server/internal/externalkeys/impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/gcp/gcpkms"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -206,11 +207,6 @@ func (s *Service) UpdateAwsKmsKey(ctx context.Context, payload *gen.UpdateAwsKms
 		return nil, oops.E(oops.CodeBadRequest, nil, "name is required").LogError(ctx, logger)
 	}
 
-	keyArn := strings.TrimSpace(payload.KeyArn)
-	if keyArn == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "key_arn is required").LogError(ctx, logger)
-	}
-
 	credentialID, err := uuid.Parse(payload.ExternalCredentialID)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid external credential id").LogError(ctx, logger)
@@ -243,7 +239,6 @@ func (s *Service) UpdateAwsKmsKey(ctx context.Context, payload *gen.UpdateAwsKms
 
 	ek, err := q.UpdateExternalKey(ctx, repo.UpdateExternalKeyParams{
 		ExternalCredentialID:   credentialID,
-		Algorithm:              payload.Algorithm,
 		Name:                   name,
 		CustomerGrantReference: grantReference,
 		ID:                     id,
@@ -256,13 +251,9 @@ func (s *Service) UpdateAwsKmsKey(ctx context.Context, payload *gen.UpdateAwsKms
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating external key").LogError(ctx, logger)
 	}
 
-	aws, err := q.UpdateAwsKmsKey(ctx, repo.UpdateAwsKmsKeyParams{
-		KeyArn:        keyArn,
-		ExternalKeyID: id,
-	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating aws kms key").LogError(ctx, logger)
-	}
+	// The subtype row is immutable, so the copy read above is still current and
+	// there is no subtype update to perform.
+	aws := current.AwsKmsKey
 
 	if err := s.audit.LogAwsKmsKeyUpdate(ctx, dbtx, audit.LogAwsKmsKeyUpdateEvent{
 		OrganizationID:    authCtx.ActiveOrganizationID,
@@ -296,9 +287,14 @@ func (s *Service) CreateGcpKmsKey(ctx context.Context, payload *gen.CreateGcpKms
 		return nil, oops.E(oops.CodeBadRequest, nil, "name is required").LogError(ctx, logger)
 	}
 
+	// The resource name is validated here rather than only at first signing use
+	// because it is frozen once written: with identity immutable, a version-less
+	// `.../cryptoKeys/<k>` path could only be corrected by deleting the key and
+	// creating a new one. Asymmetric-sign keys have no primary version, so such a
+	// path is not resolvable to anything signable.
 	resourceName := strings.TrimSpace(payload.ResourceName)
-	if resourceName == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "resource_name is required").LogError(ctx, logger)
+	if err := gcpkms.ValidateKeyVersionName(resourceName); err != nil {
+		return nil, oops.E(oops.CodeBadRequest, err, "resource_name must be a fully-qualified GCP KMS crypto key version (projects/<p>/locations/<l>/keyRings/<r>/cryptoKeys/<k>/cryptoKeyVersions/<v>)").LogError(ctx, logger)
 	}
 
 	credentialID, err := uuid.Parse(payload.ExternalCredentialID)
@@ -379,11 +375,6 @@ func (s *Service) UpdateGcpKmsKey(ctx context.Context, payload *gen.UpdateGcpKms
 		return nil, oops.E(oops.CodeBadRequest, nil, "name is required").LogError(ctx, logger)
 	}
 
-	resourceName := strings.TrimSpace(payload.ResourceName)
-	if resourceName == "" {
-		return nil, oops.E(oops.CodeBadRequest, nil, "resource_name is required").LogError(ctx, logger)
-	}
-
 	credentialID, err := uuid.Parse(payload.ExternalCredentialID)
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid external credential id").LogError(ctx, logger)
@@ -416,7 +407,6 @@ func (s *Service) UpdateGcpKmsKey(ctx context.Context, payload *gen.UpdateGcpKms
 
 	ek, err := q.UpdateExternalKey(ctx, repo.UpdateExternalKeyParams{
 		ExternalCredentialID:   credentialID,
-		Algorithm:              payload.Algorithm,
 		Name:                   name,
 		CustomerGrantReference: grantReference,
 		ID:                     id,
@@ -429,13 +419,9 @@ func (s *Service) UpdateGcpKmsKey(ctx context.Context, payload *gen.UpdateGcpKms
 		return nil, oops.E(oops.CodeUnexpected, err, "error updating external key").LogError(ctx, logger)
 	}
 
-	gcp, err := q.UpdateGcpKmsKey(ctx, repo.UpdateGcpKmsKeyParams{
-		ResourceName:  resourceName,
-		ExternalKeyID: id,
-	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error updating gcp kms key").LogError(ctx, logger)
-	}
+	// The subtype row is immutable, so the copy read above is still current and
+	// there is no subtype update to perform.
+	gcp := current.GcpKmsKey
 
 	if err := s.audit.LogGcpKmsKeyUpdate(ctx, dbtx, audit.LogGcpKmsKeyUpdateEvent{
 		OrganizationID:    authCtx.ActiveOrganizationID,
@@ -558,13 +544,18 @@ func (s *Service) DeleteGcpKmsKey(ctx context.Context, payload *gen.DeleteGcpKms
 // provider-specific audit event. A missing (or wrong-provider) id is a no-op so
 // deletes stay idempotent.
 //
-// Delete is a soft delete: the external_keys row and its id are preserved. A
-// caller changes a key's provider by delete + recreate, which mints a NEW
-// external_keys.id. Once json_web_key_sets / json_web_keys reference
-// external_keys(organization_id, id) (a foreign key with no ON DELETE, i.e.
-// RESTRICT), such a swap orphans the old key material under the previous id and
-// the new key must be re-pointed by the JWKS layer (AGE-2869 / AGE-2870).
-// Nothing references external_keys today, so this is safe for now.
+// Delete is a soft delete: the external_keys row and its id are preserved. It is
+// refused while a live json_web_key_sets or json_web_keys row references the key,
+// because a published JWK is a permanent, externally cached promise — verifiers
+// cache a kid and expect it to keep verifying for as long as it is published.
+// The guard is application-level and has to be: `deleted` is a generated column,
+// so a soft delete never fires either foreign key. See
+// ExternalKeyHasJsonWebKeyReferences for why the lock mode below matters and why
+// the foreign keys are deliberately NO ACTION rather than RESTRICT.
+//
+// The refusal path has no test here: no Go package owns json_web_key_sets /
+// json_web_keys yet, and tests may not write raw SQL. AIS-240 introduces that
+// repo and owns the coverage.
 func (s *Service) deleteExternalKey(ctx context.Context, provider, rawID string) error {
 	authCtx, logger, err := s.requireOrgAccess(ctx, authz.ScopeOrgAdmin)
 	if err != nil {
@@ -583,6 +574,31 @@ func (s *Service) deleteExternalKey(ctx context.Context, provider, rawID string)
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	q := repo.New(dbtx)
+
+	// Lock the key before checking for references so a concurrent JWKS write
+	// cannot commit between the check and the delete.
+	_, err = q.LockExternalKeyForDelete(ctx, repo.LockExternalKeyForDeleteParams{
+		ID:             id,
+		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
+		Provider:       provider,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return nil
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "error deleting external key").LogError(ctx, logger)
+	}
+
+	referenced, err := q.ExternalKeyHasJsonWebKeyReferences(ctx, repo.ExternalKeyHasJsonWebKeyReferencesParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ExternalKeyID:  id,
+	})
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "error checking external key references").LogError(ctx, logger)
+	}
+	if referenced {
+		return oops.E(oops.CodeConflict, nil, "external key is still in use by a JSON Web Key Set or a published JSON Web Key")
+	}
 
 	deleted, err := q.SoftDeleteExternalKey(ctx, repo.SoftDeleteExternalKeyParams{
 		ID:             id,
@@ -678,6 +694,10 @@ func credentialProviderForKey(keyProvider string) (string, bool) {
 	}
 }
 
+// awsSnapshot and gcpSnapshot capture full key state, including the frozen
+// identity fields. On an update those are identical before and after by
+// construction, which is the point: the audit trail then evidences that the key
+// material did not move, rather than leaving a reader to infer it from absence.
 func awsSnapshot(ek repo.ExternalKey, aws repo.AwsKmsKey) *audit.AwsKmsKeySnapshot {
 	return &audit.AwsKmsKeySnapshot{
 		Name:                   ek.Name,

--- a/server/internal/externalkeys/queries.sql
+++ b/server/internal/externalkeys/queries.sql
@@ -70,10 +70,16 @@ WHERE organization_id = @organization_id
   AND (sqlc.narg('provider')::text IS NULL OR provider = sqlc.narg('provider')::text)
 ORDER BY id DESC;
 
+-- Updates only the mutable columns. algorithm is absent on purpose, alongside
+-- the subtype identity columns (aws_kms_keys.key_arn, gcp_kms_keys.resource_name)
+-- which have no update query at all: an external_keys row must identify exactly
+-- one signable key permanently, because json_web_keys pins each published kid to
+-- the row it was minted from. There is deliberately no subtype update query to
+-- pair with this one, so aws_kms_keys / gcp_kms_keys rows are write-once and
+-- their updated_at always equals created_at.
 -- name: UpdateExternalKey :one
 UPDATE external_keys
 SET external_credential_id = @external_credential_id,
-    algorithm = @algorithm,
     name = @name,
     customer_grant_reference = sqlc.narg('customer_grant_reference'),
     updated_at = clock_timestamp()
@@ -82,25 +88,62 @@ WHERE id = @id
   AND deleted IS FALSE
 RETURNING *;
 
--- Subtype update: keyed on external_key_id only. Callers must first verify org +
--- provider ownership via GetAwsKmsKey (scoped by organization_id, provider, and
--- deleted IS FALSE) in the same transaction.
--- name: UpdateAwsKmsKey :one
-UPDATE aws_kms_keys
-SET key_arn = @key_arn,
-    updated_at = clock_timestamp()
-WHERE external_key_id = @external_key_id
-RETURNING *;
+-- Locks the external key row so the JWKS reference check below cannot be raced
+-- by a concurrent JWKS write. FOR UPDATE is load-bearing and must not be
+-- weakened to FOR NO KEY UPDATE: inserting a json_web_key_sets / json_web_keys
+-- row takes FOR KEY SHARE on this parent row, which conflicts with FOR UPDATE
+-- but NOT with FOR NO KEY UPDATE. Downgrading the lock mode would silently
+-- reopen the TOCTOU window where a JWKS insert commits between the reference
+-- check and the soft delete. The JWKS create path takes the counterpart
+-- FOR SHARE on this row (AIS-240).
+-- name: LockExternalKeyForDelete :one
+SELECT id
+FROM external_keys
+WHERE id = @id
+  AND organization_id = @organization_id
+  AND provider = @provider
+  AND deleted IS FALSE
+FOR UPDATE;
 
--- Subtype update: keyed on external_key_id only. Callers must first verify org +
--- provider ownership via GetGcpKmsKey (scoped by organization_id, provider, and
--- deleted IS FALSE) in the same transaction.
--- name: UpdateGcpKmsKey :one
-UPDATE gcp_kms_keys
-SET resource_name = @resource_name,
-    updated_at = clock_timestamp()
-WHERE external_key_id = @external_key_id
-RETURNING *;
+-- Reports whether any live JSON Web Key Set or published JSON Web Key still
+-- references the external key. Run inside the delete transaction, after
+-- LockExternalKeyForDelete.
+--
+-- Soft-deleted references do not count. Both JWKS tables use the same
+-- deleted_at / generated deleted pattern as external_keys, a revoked key is
+-- soft-deleted, and soft-deleting a set cascade-soft-deletes its keys (AIS-240),
+-- so `deleted IS FALSE` is the live-reference test on both sides. The sets arm
+-- is not redundant with the keys arm: a set that has published no keys yet, or
+-- whose keys were all revoked, still references the external key.
+--
+-- The database will not enforce this. Both foreign keys omit ON DELETE, which is
+-- NO ACTION (end-of-statement) rather than RESTRICT (immediate) — a distinction
+-- that is load-bearing, because organization deletion cascades into external_keys
+-- and json_web_key_sets in one statement and NO ACTION survives that ordering
+-- while RESTRICT would abort it. Neither variant fires on the soft-delete path
+-- anyway, since `deleted` is a generated column.
+-- The parameters are explicitly cast because both tables carry an
+-- organization_id / external_key_id column, which leaves sqlc unable to infer a
+-- named parameter's type from the column reference alone. The two arms are one
+-- EXISTS over a UNION ALL rather than two OR'd EXISTS so the result is a
+-- non-nullable bool: sqlc types `EXISTS(...) OR EXISTS(...)` as pgtype.Bool,
+-- which would make an unset value read as "not referenced" and fail this guard
+-- open. UNION ALL is still short-circuiting here, since EXISTS stops at the
+-- first row.
+-- name: ExternalKeyHasJsonWebKeyReferences :one
+SELECT EXISTS (
+  SELECT 1
+  FROM json_web_key_sets
+  WHERE organization_id = @organization_id::text
+    AND external_key_id = @external_key_id::uuid
+    AND deleted IS FALSE
+  UNION ALL
+  SELECT 1
+  FROM json_web_keys
+  WHERE organization_id = @organization_id::text
+    AND external_key_id = @external_key_id::uuid
+    AND deleted IS FALSE
+) AS referenced;
 
 -- name: SoftDeleteExternalKey :one
 UPDATE external_keys

--- a/server/internal/externalkeys/repo/queries.sql.go
+++ b/server/internal/externalkeys/repo/queries.sql.go
@@ -115,6 +115,59 @@ func (q *Queries) CreateGcpKmsKey(ctx context.Context, arg CreateGcpKmsKeyParams
 	return i, err
 }
 
+const externalKeyHasJsonWebKeyReferences = `-- name: ExternalKeyHasJsonWebKeyReferences :one
+SELECT EXISTS (
+  SELECT 1
+  FROM json_web_key_sets
+  WHERE organization_id = $1::text
+    AND external_key_id = $2::uuid
+    AND deleted IS FALSE
+  UNION ALL
+  SELECT 1
+  FROM json_web_keys
+  WHERE organization_id = $1::text
+    AND external_key_id = $2::uuid
+    AND deleted IS FALSE
+) AS referenced
+`
+
+type ExternalKeyHasJsonWebKeyReferencesParams struct {
+	OrganizationID string
+	ExternalKeyID  uuid.UUID
+}
+
+// Reports whether any live JSON Web Key Set or published JSON Web Key still
+// references the external key. Run inside the delete transaction, after
+// LockExternalKeyForDelete.
+//
+// Soft-deleted references do not count. Both JWKS tables use the same
+// deleted_at / generated deleted pattern as external_keys, a revoked key is
+// soft-deleted, and soft-deleting a set cascade-soft-deletes its keys (AIS-240),
+// so `deleted IS FALSE` is the live-reference test on both sides. The sets arm
+// is not redundant with the keys arm: a set that has published no keys yet, or
+// whose keys were all revoked, still references the external key.
+//
+// The database will not enforce this. Both foreign keys omit ON DELETE, which is
+// NO ACTION (end-of-statement) rather than RESTRICT (immediate) — a distinction
+// that is load-bearing, because organization deletion cascades into external_keys
+// and json_web_key_sets in one statement and NO ACTION survives that ordering
+// while RESTRICT would abort it. Neither variant fires on the soft-delete path
+// anyway, since `deleted` is a generated column.
+// The parameters are explicitly cast because both tables carry an
+// organization_id / external_key_id column, which leaves sqlc unable to infer a
+// named parameter's type from the column reference alone. The two arms are one
+// EXISTS over a UNION ALL rather than two OR'd EXISTS so the result is a
+// non-nullable bool: sqlc types `EXISTS(...) OR EXISTS(...)` as pgtype.Bool,
+// which would make an unset value read as "not referenced" and fail this guard
+// open. UNION ALL is still short-circuiting here, since EXISTS stops at the
+// first row.
+func (q *Queries) ExternalKeyHasJsonWebKeyReferences(ctx context.Context, arg ExternalKeyHasJsonWebKeyReferencesParams) (bool, error) {
+	row := q.db.QueryRow(ctx, externalKeyHasJsonWebKeyReferences, arg.OrganizationID, arg.ExternalKeyID)
+	var referenced bool
+	err := row.Scan(&referenced)
+	return referenced, err
+}
+
 const getAwsKmsKey = `-- name: GetAwsKmsKey :one
 SELECT ek.id, ek.organization_id, ek.project_id, ek.external_credential_id, ek.provider, ek.algorithm, ek.name, ek.customer_grant_reference, ek.created_at, ek.updated_at, ek.deleted_at, ek.deleted, aws.external_key_id, aws.external_keys_provider, aws.key_arn, aws.created_at, aws.updated_at
 FROM external_keys AS ek
@@ -283,6 +336,37 @@ func (q *Queries) ListExternalKeys(ctx context.Context, arg ListExternalKeysPara
 	return items, nil
 }
 
+const lockExternalKeyForDelete = `-- name: LockExternalKeyForDelete :one
+SELECT id
+FROM external_keys
+WHERE id = $1
+  AND organization_id = $2
+  AND provider = $3
+  AND deleted IS FALSE
+FOR UPDATE
+`
+
+type LockExternalKeyForDeleteParams struct {
+	ID             uuid.UUID
+	OrganizationID pgtype.Text
+	Provider       string
+}
+
+// Locks the external key row so the JWKS reference check below cannot be raced
+// by a concurrent JWKS write. FOR UPDATE is load-bearing and must not be
+// weakened to FOR NO KEY UPDATE: inserting a json_web_key_sets / json_web_keys
+// row takes FOR KEY SHARE on this parent row, which conflicts with FOR UPDATE
+// but NOT with FOR NO KEY UPDATE. Downgrading the lock mode would silently
+// reopen the TOCTOU window where a JWKS insert commits between the reference
+// check and the soft delete. The JWKS create path takes the counterpart
+// FOR SHARE on this row (AIS-240).
+func (q *Queries) LockExternalKeyForDelete(ctx context.Context, arg LockExternalKeyForDeleteParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, lockExternalKeyForDelete, arg.ID, arg.OrganizationID, arg.Provider)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const softDeleteExternalKey = `-- name: SoftDeleteExternalKey :one
 UPDATE external_keys
 SET deleted_at = clock_timestamp()
@@ -319,61 +403,36 @@ func (q *Queries) SoftDeleteExternalKey(ctx context.Context, arg SoftDeleteExter
 	return i, err
 }
 
-const updateAwsKmsKey = `-- name: UpdateAwsKmsKey :one
-UPDATE aws_kms_keys
-SET key_arn = $1,
-    updated_at = clock_timestamp()
-WHERE external_key_id = $2
-RETURNING external_key_id, external_keys_provider, key_arn, created_at, updated_at
-`
-
-type UpdateAwsKmsKeyParams struct {
-	KeyArn        string
-	ExternalKeyID uuid.UUID
-}
-
-// Subtype update: keyed on external_key_id only. Callers must first verify org +
-// provider ownership via GetAwsKmsKey (scoped by organization_id, provider, and
-// deleted IS FALSE) in the same transaction.
-func (q *Queries) UpdateAwsKmsKey(ctx context.Context, arg UpdateAwsKmsKeyParams) (AwsKmsKey, error) {
-	row := q.db.QueryRow(ctx, updateAwsKmsKey, arg.KeyArn, arg.ExternalKeyID)
-	var i AwsKmsKey
-	err := row.Scan(
-		&i.ExternalKeyID,
-		&i.ExternalKeysProvider,
-		&i.KeyArn,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
 const updateExternalKey = `-- name: UpdateExternalKey :one
 UPDATE external_keys
 SET external_credential_id = $1,
-    algorithm = $2,
-    name = $3,
-    customer_grant_reference = $4,
+    name = $2,
+    customer_grant_reference = $3,
     updated_at = clock_timestamp()
-WHERE id = $5
-  AND organization_id = $6
+WHERE id = $4
+  AND organization_id = $5
   AND deleted IS FALSE
 RETURNING id, organization_id, project_id, external_credential_id, provider, algorithm, name, customer_grant_reference, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateExternalKeyParams struct {
 	ExternalCredentialID   uuid.UUID
-	Algorithm              string
 	Name                   string
 	CustomerGrantReference pgtype.Text
 	ID                     uuid.UUID
 	OrganizationID         pgtype.Text
 }
 
+// Updates only the mutable columns. algorithm is absent on purpose, alongside
+// the subtype identity columns (aws_kms_keys.key_arn, gcp_kms_keys.resource_name)
+// which have no update query at all: an external_keys row must identify exactly
+// one signable key permanently, because json_web_keys pins each published kid to
+// the row it was minted from. There is deliberately no subtype update query to
+// pair with this one, so aws_kms_keys / gcp_kms_keys rows are write-once and
+// their updated_at always equals created_at.
 func (q *Queries) UpdateExternalKey(ctx context.Context, arg UpdateExternalKeyParams) (ExternalKey, error) {
 	row := q.db.QueryRow(ctx, updateExternalKey,
 		arg.ExternalCredentialID,
-		arg.Algorithm,
 		arg.Name,
 		arg.CustomerGrantReference,
 		arg.ID,
@@ -393,35 +452,6 @@ func (q *Queries) UpdateExternalKey(ctx context.Context, arg UpdateExternalKeyPa
 		&i.UpdatedAt,
 		&i.DeletedAt,
 		&i.Deleted,
-	)
-	return i, err
-}
-
-const updateGcpKmsKey = `-- name: UpdateGcpKmsKey :one
-UPDATE gcp_kms_keys
-SET resource_name = $1,
-    updated_at = clock_timestamp()
-WHERE external_key_id = $2
-RETURNING external_key_id, external_keys_provider, resource_name, created_at, updated_at
-`
-
-type UpdateGcpKmsKeyParams struct {
-	ResourceName  string
-	ExternalKeyID uuid.UUID
-}
-
-// Subtype update: keyed on external_key_id only. Callers must first verify org +
-// provider ownership via GetGcpKmsKey (scoped by organization_id, provider, and
-// deleted IS FALSE) in the same transaction.
-func (q *Queries) UpdateGcpKmsKey(ctx context.Context, arg UpdateGcpKmsKeyParams) (GcpKmsKey, error) {
-	row := q.db.QueryRow(ctx, updateGcpKmsKey, arg.ResourceName, arg.ExternalKeyID)
-	var i GcpKmsKey
-	err := row.Scan(
-		&i.ExternalKeyID,
-		&i.ExternalKeysProvider,
-		&i.ResourceName,
-		&i.CreatedAt,
-		&i.UpdatedAt,
 	)
 	return i, err
 }

--- a/server/internal/externalkeys/updateawskmskey_test.go
+++ b/server/internal/externalkeys/updateawskmskey_test.go
@@ -27,9 +27,7 @@ func TestUpdateAwsKmsKey_Success(t *testing.T) {
 	updated, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		KeyArn:                 "arn:aws:kms:eu-west-1:123456789012:key/rotated",
 		ExternalCredentialID:   credID,
-		Algorithm:              "ES256",
 		Name:                   "after",
 		CustomerGrantReference: new("arn:aws:iam::210987654321:role/gram-signer"),
 	})
@@ -37,8 +35,6 @@ func TestUpdateAwsKmsKey_Success(t *testing.T) {
 
 	require.Equal(t, key.ID, updated.ID)
 	require.Equal(t, "after", updated.Name)
-	require.Equal(t, "ES256", updated.Algorithm)
-	require.Equal(t, "arn:aws:kms:eu-west-1:123456789012:key/rotated", updated.KeyArn)
 	require.NotNil(t, updated.CustomerGrantReference)
 	require.Equal(t, "arn:aws:iam::210987654321:role/gram-signer", *updated.CustomerGrantReference)
 
@@ -47,8 +43,84 @@ func TestUpdateAwsKmsKey_Success(t *testing.T) {
 	require.Equal(t, before+1, after)
 }
 
+// TestUpdateAwsKmsKey_IdentityIsImmutable verifies an update cannot re-point the
+// row at different key material: the ARN and algorithm are set at creation and
+// are not part of the update payload, so they survive an update untouched. A
+// published JWK pins its kid to this row, so re-pointing it would silently sign
+// with the wrong key.
+func TestUpdateAwsKmsKey_IdentityIsImmutable(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createAwsIamCredential(t, ctx, ti, "backing-cred")
+	key := createAwsKmsKey(t, ctx, ti, "before", credID)
+
+	updated, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
+		ID:                     key.ID,
+		SessionToken:           nil,
+		ExternalCredentialID:   credID,
+		Name:                   "after",
+		CustomerGrantReference: nil,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, key.KeyArn, updated.KeyArn)
+	require.Equal(t, key.Algorithm, updated.Algorithm)
+
+	// Re-read so the assertion covers what was persisted, not just the view the
+	// update handler assembled.
+	got, err := ti.service.GetAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, authz.WildcardResource)), &gen.GetAwsKmsKeyPayload{
+		ID:           key.ID,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, key.KeyArn, got.KeyArn)
+	require.Equal(t, key.Algorithm, got.Algorithm)
+	require.Equal(t, "after", got.Name)
+}
+
+// TestUpdateAwsKmsKey_ClearsOmittedGrantReference pins the replace-not-patch
+// semantics of the mutable subset: omitting the optional customer_grant_reference
+// clears it. Keeping omission meaningful is what makes clearing possible at all,
+// since an absent field and an explicit null are indistinguishable once decoded.
+func TestUpdateAwsKmsKey_ClearsOmittedGrantReference(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createAwsIamCredential(t, ctx, ti, "backing-cred")
+
+	key, err := ti.service.CreateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.CreateAwsKmsKeyPayload{
+		SessionToken:           nil,
+		KeyArn:                 "arn:aws:kms:us-east-1:123456789012:key/" + uuid.NewString(),
+		ExternalCredentialID:   credID,
+		Algorithm:              "RS256",
+		Name:                   "granted",
+		CustomerGrantReference: new("arn:aws:iam::210987654321:role/gram-signer"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, key.CustomerGrantReference)
+
+	updated, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
+		ID:                     key.ID,
+		SessionToken:           nil,
+		ExternalCredentialID:   credID,
+		Name:                   "granted",
+		CustomerGrantReference: nil,
+	})
+	require.NoError(t, err)
+	require.Nil(t, updated.CustomerGrantReference)
+
+	got, err := ti.service.GetAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, authz.WildcardResource)), &gen.GetAwsKmsKeyPayload{
+		ID:           key.ID,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+	require.Nil(t, got.CustomerGrantReference)
+}
+
 // TestUpdateAwsKmsKey_SwapCredential verifies the backing credential can be
-// replaced with another same-family credential.
+// replaced with another same-family credential. The path to the key stays
+// editable even though the key material is frozen.
 func TestUpdateAwsKmsKey_SwapCredential(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestService(t)
@@ -60,9 +132,7 @@ func TestUpdateAwsKmsKey_SwapCredential(t *testing.T) {
 	updated, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		KeyArn:                 key.KeyArn,
 		ExternalCredentialID:   otherCredID,
-		Algorithm:              "RS256",
 		Name:                   "key",
 		CustomerGrantReference: nil,
 	})
@@ -83,9 +153,7 @@ func TestUpdateAwsKmsKey_WrongFamilyCredential(t *testing.T) {
 	_, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		KeyArn:                 key.KeyArn,
 		ExternalCredentialID:   gcpCredID,
-		Algorithm:              "RS256",
 		Name:                   "key",
 		CustomerGrantReference: nil,
 	})
@@ -101,9 +169,7 @@ func TestUpdateAwsKmsKey_NotFound(t *testing.T) {
 	_, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
 		ID:                     uuid.NewString(),
 		SessionToken:           nil,
-		KeyArn:                 "arn:aws:kms:us-east-1:123456789012:key/abcd-1234",
 		ExternalCredentialID:   credID,
-		Algorithm:              "RS256",
 		Name:                   "missing",
 		CustomerGrantReference: nil,
 	})
@@ -123,9 +189,7 @@ func TestUpdateAwsKmsKey_WrongProvider(t *testing.T) {
 	_, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
 		ID:                     gcpKey.ID,
 		SessionToken:           nil,
-		KeyArn:                 "arn:aws:kms:us-east-1:123456789012:key/abcd-1234",
 		ExternalCredentialID:   awsCredID,
-		Algorithm:              "RS256",
 		Name:                   "hijack",
 		CustomerGrantReference: nil,
 	})
@@ -142,9 +206,7 @@ func TestUpdateAwsKmsKey_ForbiddenForReadOnly(t *testing.T) {
 	_, err := ti.service.UpdateAwsKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, authz.WildcardResource)), &gen.UpdateAwsKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		KeyArn:                 key.KeyArn,
 		ExternalCredentialID:   credID,
-		Algorithm:              "RS256",
 		Name:                   "forbidden",
 		CustomerGrantReference: nil,
 	})

--- a/server/internal/externalkeys/updategcpkmskey_test.go
+++ b/server/internal/externalkeys/updategcpkmskey_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/external_keys"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -21,21 +23,124 @@ func TestUpdateGcpKmsKey_Success(t *testing.T) {
 	credID := createGcpIamCredential(t, ctx, ti, "backing-cred")
 	key := createGcpKmsKey(t, ctx, ti, "before", credID)
 
+	before, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionGcpKmsKeyUpdate)
+	require.NoError(t, err)
+
 	updated, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		ResourceName:           "projects/gram/locations/global/keyRings/signing/cryptoKeys/k/cryptoKeyVersions/2",
 		ExternalCredentialID:   credID,
-		Algorithm:              "RS256",
 		Name:                   "after",
-		CustomerGrantReference: nil,
+		CustomerGrantReference: new("gram-signer@gram.iam.gserviceaccount.com"),
 	})
 	require.NoError(t, err)
 
 	require.Equal(t, key.ID, updated.ID)
 	require.Equal(t, "after", updated.Name)
-	require.Equal(t, "RS256", updated.Algorithm)
-	require.Equal(t, "projects/gram/locations/global/keyRings/signing/cryptoKeys/k/cryptoKeyVersions/2", updated.ResourceName)
+	require.NotNil(t, updated.CustomerGrantReference)
+	require.Equal(t, "gram-signer@gram.iam.gserviceaccount.com", *updated.CustomerGrantReference)
+
+	after, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionGcpKmsKeyUpdate)
+	require.NoError(t, err)
+	require.Equal(t, before+1, after)
+}
+
+// TestUpdateGcpKmsKey_WrongFamilyCredential verifies the update rejects a swap
+// to an aws_iam credential.
+func TestUpdateGcpKmsKey_WrongFamilyCredential(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredential(t, ctx, ti, "gcp-cred")
+	key := createGcpKmsKey(t, ctx, ti, "key", credID)
+	awsCredID := createAwsIamCredential(t, ctx, ti, "aws-cred")
+
+	_, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
+		ID:                     key.ID,
+		SessionToken:           nil,
+		ExternalCredentialID:   awsCredID,
+		Name:                   "key",
+		CustomerGrantReference: nil,
+	})
+	requireOopsCode(t, err, oops.CodeBadRequest)
+}
+
+// TestUpdateGcpKmsKey_WrongProvider verifies an aws_kms key id cannot be updated
+// through the gcp_kms endpoint.
+func TestUpdateGcpKmsKey_WrongProvider(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	gcpCredID := createGcpIamCredential(t, ctx, ti, "gcp-cred")
+	awsCredID := createAwsIamCredential(t, ctx, ti, "aws-cred")
+	awsKey := createAwsKmsKey(t, ctx, ti, "aws-key", awsCredID)
+
+	_, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
+		ID:                     awsKey.ID,
+		SessionToken:           nil,
+		ExternalCredentialID:   gcpCredID,
+		Name:                   "hijack",
+		CustomerGrantReference: nil,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+// TestUpdateGcpKmsKey_IdentityIsImmutable verifies an update cannot re-point the
+// row at a different crypto key version: the resource name and algorithm are set
+// at creation and are not part of the update payload, so they survive an update
+// untouched. A published JWK pins its kid to this row, so re-pointing it would
+// silently sign with the wrong key.
+func TestUpdateGcpKmsKey_IdentityIsImmutable(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredential(t, ctx, ti, "backing-cred")
+	key := createGcpKmsKey(t, ctx, ti, "before", credID)
+
+	updated, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
+		ID:                     key.ID,
+		SessionToken:           nil,
+		ExternalCredentialID:   credID,
+		Name:                   "after",
+		CustomerGrantReference: nil,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, key.ResourceName, updated.ResourceName)
+	require.Equal(t, key.Algorithm, updated.Algorithm)
+
+	// Re-read so the assertion covers what was persisted, not just the view the
+	// update handler assembled.
+	got, err := ti.service.GetGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, authz.WildcardResource)), &gen.GetGcpKmsKeyPayload{
+		ID:           key.ID,
+		SessionToken: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, key.ResourceName, got.ResourceName)
+	require.Equal(t, key.Algorithm, got.Algorithm)
+	require.Equal(t, "after", got.Name)
+}
+
+// TestUpdateGcpKmsKey_SwapCredential verifies the backing credential can be
+// replaced with another same-family credential. The path to the key stays
+// editable even though the key material is frozen.
+func TestUpdateGcpKmsKey_SwapCredential(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+
+	credID := createGcpIamCredential(t, ctx, ti, "cred-a")
+	key := createGcpKmsKey(t, ctx, ti, "key", credID)
+	otherCredID := createGcpIamCredential(t, ctx, ti, "cred-b")
+
+	updated, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
+		ID:                     key.ID,
+		SessionToken:           nil,
+		ExternalCredentialID:   otherCredID,
+		Name:                   "key",
+		CustomerGrantReference: nil,
+	})
+	require.NoError(t, err)
+	require.Equal(t, otherCredID, updated.ExternalCredentialID)
 }
 
 func TestUpdateGcpKmsKey_NotFound(t *testing.T) {
@@ -47,9 +152,7 @@ func TestUpdateGcpKmsKey_NotFound(t *testing.T) {
 	_, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
 		ID:                     uuid.NewString(),
 		SessionToken:           nil,
-		ResourceName:           "projects/gram/locations/global/keyRings/signing/cryptoKeys/k/cryptoKeyVersions/1",
 		ExternalCredentialID:   credID,
-		Algorithm:              "ES256",
 		Name:                   "missing",
 		CustomerGrantReference: nil,
 	})
@@ -66,9 +169,7 @@ func TestUpdateGcpKmsKey_ForbiddenForReadOnly(t *testing.T) {
 	_, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgRead, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		ResourceName:           key.ResourceName,
 		ExternalCredentialID:   credID,
-		Algorithm:              "RS256",
 		Name:                   "forbidden",
 		CustomerGrantReference: nil,
 	})
@@ -88,9 +189,7 @@ func TestUpdateGcpKmsKey_ForbiddenWithoutEntitlement(t *testing.T) {
 	_, err := ti.service.UpdateGcpKmsKey(authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, authz.WildcardResource)), &gen.UpdateGcpKmsKeyPayload{
 		ID:                     key.ID,
 		SessionToken:           nil,
-		ResourceName:           key.ResourceName,
 		ExternalCredentialID:   credentialID,
-		Algorithm:              key.Algorithm,
 		Name:                   "gcp-key-entitlement-update-renamed",
 		CustomerGrantReference: nil,
 	})


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AGE-3090/feat-immutable-external-key-identity-freeze-resource-name-key-arn

An `external_keys` row now identifies exactly one signable key permanently. `updateAwsKms` and `updateGcpKms` drop `key_arn`, `resource_name` and `algorithm` from their payloads and cover only `name`, `external_credential_id` and `customer_grant_reference`. **This is a breaking change to both methods**, which previously had full-replace semantics and could re-point a row at entirely different key material while keeping its id. Nothing outside the generated SDK consumes them. Changing what a key is now means delete and recreate, which matches both providers: GCP asymmetric-sign keys have no primary version, so a resource name is already version-pinned, and rotating an asymmetric AWS CMK produces a new ARN. The backing credential stays editable, because repairing the path to a key does not change the key material Gram signs with. Within the mutable subset the update still replaces rather than patches, so omitting `customer_grant_reference` clears it.

Deleting a key is refused with a conflict while a live `json_web_key_sets` or `json_web_keys` row references it, taking `SELECT ... FOR UPDATE` on the `external_keys` row so the check cannot be raced by a concurrent JWKS write. The lock mode is load-bearing: a JWKS insert takes `FOR KEY SHARE` on the parent, which conflicts with `FOR UPDATE` but not with `FOR NO KEY UPDATE`. The guard has to live in the application because `deleted` is a generated column, so a soft delete never fires either foreign key. Deleting an unreferenced key stays idempotent. [AIS-240](https://linear.app/speakeasy/issue/AIS-240/feat-management-api-organization-level-crud-of-jwks-sets-keys) introduces the first Go repo over those tables and owns the test for the refusal path.

`createGcpKms` now validates that `resource_name` is a fully-qualified crypto key version path. A version-less path resolves to nothing signable, and with identity frozen it could otherwise only be corrected by deleting the key.

The two update forms are separate types that do not share a parent, and both update payloads carry an explicit `openapi:typename`. Goa ignores a re-declared inherited attribute and deduplicates request bodies by shape, so without these the generated SDK gives `updateGcpKms` a body type named `UpdateAwsKmsKeyRequestBody`.

## Follow-ups filed

- [AGE-3110](https://linear.app/speakeasy/issue/AGE-3110/feat-guard-external-credential-deletion-while-a-live-external-key): `SoftDeleteExternalCredential` has the same unguarded soft-delete hazard one table over, and soft-deleting the credential behind a live key breaks signing just as thoroughly.
- [AGE-3111](https://linear.app/speakeasy/issue/AGE-3111/mig-index-json-web-key-sets-json-web-keys-on-organization-id-external): neither JWKS table is indexed on `external_key_id`, leaving both `NO ACTION` foreign keys unindexed on the referencing side. Migration-only, so it ships separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes external key identity and guards deletion. `updateAwsKmsKey`/`updateGcpKmsKey` now only update name, credential, and customer grant (ARN/resource name and algorithm are immutable). Adds a conflict on delete when referenced by JWKS and validates GCP resource names as versioned crypto key paths (AGE-3090).

- **New Features**
  - External key identity is immutable; change key material by delete + create.
  - Delete is refused (409) while any JWKS or JWK references the key.
  - `createGcpKmsKey` requires a fully-qualified cryptoKeyVersion path.
  - OpenAPI and generated SDK updated with separate update forms and clearer docs.

- **Migration**
  - Remove `key_arn`/`resource_name` and `algorithm` from update calls; only send `name`, `external_credential_id`, `customer_grant_reference` (omit to clear).
  - To rotate keys, delete the old key and create a new one.
  - Handle 409 on delete by removing JWKS/JWK references first.
  - Expect 400 if a GCP resource name is version-less.

<sup>Written for commit 52b807d7dbbc2058d08096f13e3501bf6bbd20d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

