### PR TITLE
chore: assert which Svix app a webhook is addressed to

### DIFF
--- a/server/internal/background/activities/outbox_relay/relay_test.go
+++ b/server/internal/background/activities/outbox_relay/relay_test.go
@@ -315,7 +315,7 @@ func TestRelayEvents_SuccessfulDelivery(t *testing.T) {
 	enableWebhooksFeature(t, inst.conn, orgID)
 	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"action": "created"}))
 
-	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything, mock.Anything).
 		Return(&models.MessageOut{
 			Id:        "svix-msg-abc",
 			EventType: "test.event",
@@ -362,7 +362,7 @@ func testRelayPermanentError(t *testing.T, httpStatus int) {
 	enableWebhooksFeature(t, inst.conn, orgID)
 	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"x": 1}))
 
-	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, &svixtest.HTTPStatusError{Code: httpStatus})
 
 	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
@@ -398,7 +398,7 @@ func testRelayTransientError(t *testing.T, httpStatus int) {
 	enableWebhooksFeature(t, inst.conn, orgID)
 	outboxID := seedOutboxEntry(t, inst.conn, orgID, "test.event", mustMarshal(t, map[string]any{"x": 1}))
 
-	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, &svixtest.HTTPStatusError{Code: httpStatus})
 
 	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{
@@ -428,7 +428,7 @@ func TestRelayEvents_MaxAttemptsExceeded(t *testing.T) {
 	// Pre-seed 9 failed attempts — next failure (attempt 10) should dead-letter.
 	preloadAttempts(t, inst.conn, outboxID, 9)
 
-	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything).
+	inst.svixSrv.On("CreateMessage", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, &svixtest.HTTPStatusError{Code: 500})
 
 	err := inst.relay.RelayEvents(ctx, []*outbox_relay.Event{

--- a/server/internal/thirdparty/svix/svixtest/server.go
+++ b/server/internal/thirdparty/svix/svixtest/server.go
@@ -89,8 +89,13 @@ func (m *MockServer) handleGetOrCreateApp(w http.ResponseWriter, r *http.Request
 	}
 }
 
-func (m *MockServer) CreateMessage(ctx context.Context, inp *models.MessageIn) (*models.MessageOut, error) {
-	args := m.Called(ctx, inp)
+// CreateMessage receives the application id as its own argument rather than
+// letting it stay buried in the request path, so a test can assert which Svix
+// application a message was addressed to. That is the only signal that
+// distinguishes a correctly routed webhook from one delivered to the wrong
+// organization, and the body does not carry it.
+func (m *MockServer) CreateMessage(ctx context.Context, appID string, inp *models.MessageIn) (*models.MessageOut, error) {
+	args := m.Called(ctx, appID, inp)
 
 	msg, _ := args.Get(0).(*models.MessageOut)
 	return msg, args.Error(1)
@@ -105,7 +110,7 @@ func (m *MockServer) handleMessageCreate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	out, err := m.CreateMessage(ctx, &inp)
+	out, err := m.CreateMessage(ctx, r.PathValue("appID"), &inp)
 	if err != nil {
 		code := http.StatusInternalServerError
 		var httpErr *HTTPStatusError

--- a/server/internal/thirdparty/svix/svixtest/server_test.go
+++ b/server/internal/thirdparty/svix/svixtest/server_test.go
@@ -128,6 +128,7 @@ func TestMockServer_CreateMessage_Success(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	eventID := "evt_1"
+	appID := "app_123"
 	wantOut := &models.MessageOut{
 		Id:        "msg_123",
 		EventId:   &eventID,
@@ -136,7 +137,10 @@ func TestMockServer_CreateMessage_Success(t *testing.T) {
 		Timestamp: time.Now().UTC().Truncate(time.Second),
 	}
 
-	srv.On("CreateMessage", mock.Anything, mock.MatchedBy(func(in *models.MessageIn) bool {
+	// Matching on the concrete app id pins down that the id in the request path
+	// reaches CreateMessage: it is the only signal that says which Svix
+	// application a message was addressed to.
+	srv.On("CreateMessage", mock.Anything, appID, mock.MatchedBy(func(in *models.MessageIn) bool {
 		return in != nil && in.EventType == "user.created" &&
 			in.EventId != nil && *in.EventId == eventID &&
 			in.Payload["hello"] == "world"
@@ -144,7 +148,7 @@ func TestMockServer_CreateMessage_Success(t *testing.T) {
 
 	client := newSDKClient(t, srv.URL())
 
-	got, err := client.Message.Create(context.Background(), "app_123", models.MessageIn{
+	got, err := client.Message.Create(context.Background(), appID, models.MessageIn{
 		EventId:   &eventID,
 		EventType: "user.created",
 		Payload:   map[string]any{"hello": "world"},
@@ -164,7 +168,7 @@ func TestMockServer_CreateMessage_Error(t *testing.T) {
 	srv := svixtest.NewMockServer(logger)
 	t.Cleanup(srv.Close)
 
-	srv.On("CreateMessage", mock.Anything, mock.AnythingOfType("*models.MessageIn")).
+	srv.On("CreateMessage", mock.Anything, mock.Anything, mock.AnythingOfType("*models.MessageIn")).
 		Return((*models.MessageOut)(nil), errors.New("publish failed")).Once()
 
 	client := newSDKClient(t, srv.URL())


### PR DESCRIPTION
## What

`svixtest.MockServer.CreateMessage` now takes the Svix application id as its own argument (`ctx, appID, inp`) instead of only the decoded request body.

## Why

The mock decoded the message body and dropped the application id from the URL path, so no test could observe the one value that distinguishes a correctly routed webhook from one delivered to the wrong organization. Every handler test seeded a single org, which meant a resolver returning the same Svix application for everyone would have satisfied the whole suite.

Making the id its own argument makes routing assertable. `TestMockServer_CreateMessage_Success` now matches on the concrete app id the client was pointed at rather than `mock.Anything`, so the path-to-mock plumbing is exercised here.

## Notes

- Test infrastructure only — no runtime or customer-visible surface, so no changeset.
- Call sites in `outbox_relay/relay_test.go` gain one more `mock.Anything` to match the new arity.
- This is a prerequisite split out of https://github.com/speakeasy-api/gram/pull/4962, where a new Svix subscriber resolves a per-organization application; this assertion is what makes cross-org misrouting detectable there.

## Verification

- `mise run test:server ./internal/thirdparty/svix/... ./internal/background/activities/outbox_relay/ -race` — passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Svix webhook routing assertable in tests by passing the app ID explicitly through the mock server. This detects cross‑org misrouting; no runtime impact.

- **Refactors**
  - Changed `svixtest.MockServer.CreateMessage` to `CreateMessage(ctx, appID, inp)`.
  - Updated `server_test` to assert the concrete `appID`; relay tests add one extra `mock.Anything`.
  - Test infrastructure only; no production code or customer-visible changes.

<sup>Written for commit 97b9a9bdec4a584fc32c54c818c68a1287504567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

