### PR TITLE
fix(hooks): resolve claude.ai MCP connectors from the session inventory

### DIFF
--- a/.changeset/ingest-shadow-mcp-inventory-resolution.md
+++ b/.changeset/ingest-shadow-mcp-inventory-resolution.md
@@ -1,0 +1,15 @@
+---
+"server": patch
+---
+
+Stop labelling hosted MCP servers reached through a claude.ai connector as
+shadow MCP. Such a connector appears in no local config file, so the device
+cannot resolve its URL and reports the tool call with a server name but no
+transport. The unified ingest path then never consulted the MCP inventory the
+same session already shipped at session start — the one place that URL exists —
+so the call reached enforcement and telemetry with no server URL: the
+shadow-MCP guard denied a sanctioned server on missing evidence rather than on
+evidence of a shadow one, and the hook row landed without
+`gram.mcp.server_url`, leaving it classified as a shadow MCP server. The
+inventory is now cached per session and consulted when an event carries no
+transport of its own.

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -742,6 +742,13 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 			s.resolveEvidenceFromSessionInventory(ctx, &evidence, canonicalSessionID(payload))
 		}
 	}
+	// A claude.ai connector appears in no local config file, so the device
+	// reports its tool calls with a name but no transport. The inventory is the
+	// only place that URL exists, and without it the guard denies a hosted
+	// server for lack of evidence.
+	if evidence.FullURL == "" {
+		applyMCPEntryToEvidence(&evidence, s.canonicalMCPEntry(ctx, canonicalSessionID(payload), rawToolName))
+	}
 	if detail, denied := s.enforceShadowMCPToolAccess(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), actor.UserID, policy, toolName, evidence); denied {
 		auditReason := fmt.Sprintf("Speakeasy blocked this tool call: matched policy %q (%s)", policy.Name, detail)
 		userReason := s.renderShadowMCPUserBlockReason(ctx, shadowMCPRequestLinkParams{
@@ -797,6 +804,35 @@ func (s *Service) resolveEvidenceFromSessionInventory(ctx context.Context, evide
 		return
 	}
 	applyMCPEntryToEvidence(evidence, matchCodexCachedMCPServerEntry(entries, evidence.ServerIdentity))
+}
+
+// canonicalMCPEntry resolves the server behind an mcp__<server>__<tool> call
+// against the cached session inventory. Nil when the name is not mcp__-shaped,
+// the cache is empty, or the prefix is ambiguous.
+//
+// mcp__ only: Cursor's "MCP:<tool>" puts the tool where this form puts the
+// server, and OpenCode ships bare names. Neither needs this — both resolve on
+// the device.
+func (s *Service) canonicalMCPEntry(ctx context.Context, sessionID string, rawToolName string) *MCPServerEntry {
+	if sessionID == "" || !strings.HasPrefix(rawToolName, "mcp__") || !toolref.IsMCPToolName(rawToolName) {
+		return nil
+	}
+	entries, err := s.getCachedMCPList(ctx, sessionID)
+	if err != nil {
+		return nil
+	}
+	prefix := toolref.MCPServerOf(rawToolName)
+	if matched := matchCachedMCPEntry(entries, prefix); matched != nil {
+		return matched
+	}
+	// ponytail: the relay strips "claude.ai " from connector names, so no
+	// derived prefix carries the qualifier the tool name does. Retry without
+	// it; ties still resolve to nil. Drop once the relay sends the real prefix
+	// as server_identity.
+	if bare, ok := strings.CutPrefix(prefix, "claude_ai_"); ok {
+		return matchCachedMCPEntry(entries, bare)
+	}
+	return nil
 }
 
 // cacheCanonicalMCPList stores a session's MCP inventory under the same key
@@ -1143,6 +1179,16 @@ func (s *Service) writeCanonicalTelemetry(ctx context.Context, payload *gen.Inge
 			attrs[attr.MCPMatchKey] = url
 		} else if command := strings.TrimSpace(conv.PtrValOr(mcp.Command, "")); command != "" {
 			attrs[attr.MCPMatchKey] = command
+		}
+	}
+	// Fall back to the session inventory: a row with no server URL classifies
+	// as shadow MCP no matter where the call actually went.
+	if _, resolved := attrs[attr.MCPServerURLKey]; !resolved {
+		if matched := s.canonicalMCPEntry(ctx, canonicalSessionID(payload), toolName); matched != nil {
+			if match := resolvedMCPMatch(matched, toolref.MCPServerOf(toolName)); match != "" {
+				attrs[attr.MCPMatchKey] = match
+			}
+			applyMCPInventoryAttrs(attrs, matched)
 		}
 	}
 	skill := canonicalSkillName(payload)

--- a/server/internal/hooks/ingest_shadow_mcp_inventory_test.go
+++ b/server/internal/hooks/ingest_shadow_mcp_inventory_test.go
@@ -1,0 +1,159 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// tool.requested carries no data.mcp, so without the session inventory the
+// guard sees an empty URL — which can never be Gram-hosted — and denies a
+// server the inventory proves is hosted.
+func TestIngest_ShadowMCPGuardResolvesGramHostedServerFromSessionInventory(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	ti.service.riskScanner = stubBlockingShadowMCPScanner{}
+
+	sessionID := "canonical-inventory-hosted-" + uuid.NewString()
+	// What the relay sends: it strips "claude.ai " before shipping.
+	serverName := "Platform - Search"
+	serverURL := "https://app.getgram.ai/mcp/platform-search"
+
+	inventory := canonicalIngestPayload("claude", "session.started", sessionID)
+	inventory.Data = &gen.HookIngestData{
+		McpInventory: []*gen.HookMCPData{{
+			ServerName:     &serverName,
+			ServerIdentity: &serverName,
+			URL:            &serverURL,
+		}},
+	}
+	inventoryResult, err := ti.service.Ingest(ctx, inventory)
+	require.NoError(t, err)
+	require.Equal(t, "allow", inventoryResult.Decision)
+
+	toolName := "mcp__claude_ai_Platform_-_Search__search--query"
+	toolCallID := "call-inventory-hosted"
+	call := canonicalIngestPayload("claude", "tool.requested", sessionID)
+	call.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"pullNumber": 1},
+		},
+	}
+
+	result, err := ti.service.Ingest(ctx, call)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "allow", result.Decision,
+		"the session inventory resolves this server to a Gram-hosted URL, so the guard must not treat it as shadow MCP")
+}
+
+// Same gap, quieter effect: a row with no gram.mcp.server_url classifies as
+// shadow MCP no matter where the call went.
+func TestIngest_MCPToolCallStampsProvenanceFromSessionInventory(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	chClient := enableHookTelemetryLogger(t, ctx, ti)
+	authCtx := hookAuthContext(t, ctx)
+
+	sessionID := "canonical-inventory-provenance-" + uuid.NewString()
+	// What the relay sends: it strips "claude.ai " before shipping.
+	serverName := "Platform - Search"
+	serverURL := "https://app.getgram.ai/mcp/platform-search"
+
+	inventory := canonicalIngestPayload("claude", "session.started", sessionID)
+	inventory.Data = &gen.HookIngestData{
+		McpInventory: []*gen.HookMCPData{{
+			ServerName:     &serverName,
+			ServerIdentity: &serverName,
+			URL:            &serverURL,
+		}},
+	}
+	_, err := ti.service.Ingest(ctx, inventory)
+	require.NoError(t, err)
+
+	timestamp := time.Now().UTC()
+	toolName := "mcp__claude_ai_Platform_-_Search__search--query"
+	toolCallID := "call-inventory-provenance"
+	rawEventName := "PreToolUse"
+	call := canonicalIngestPayload("claude", "tool.requested", sessionID)
+	call.Source.RawEventName = &rawEventName
+	call.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"pullNumber": 1},
+		},
+	}
+
+	_, err = ti.service.Ingest(ctx, call)
+	require.NoError(t, err)
+
+	// Hook rows have an empty gram.tool.urn, so GramURNs can't select them.
+	var logs []telemetryrepo.TelemetryLog
+	require.Eventually(t, func() bool {
+		logs, err = chClient.ListTelemetryLogs(ctx, telemetryrepo.ListTelemetryLogsParams{
+			GramProjectID: authCtx.ProjectID.String(),
+			TimeStart:     timestamp.Add(-2 * time.Minute).UnixNano(),
+			TimeEnd:       time.Now().Add(time.Minute).UnixNano(),
+			GramURNs:      nil,
+			SortOrder:     "desc",
+			Cursor:        "",
+			Limit:         10,
+		})
+		return err == nil && len(logs) == 2
+	}, 5*time.Second, 50*time.Millisecond, "expected the SessionStart and PreToolUse rows to land in telemetry")
+
+	var toolRow telemetryrepo.TelemetryLog
+	for _, row := range logs {
+		if strings.Contains(row.Attributes, toolName) {
+			toolRow = row
+		}
+	}
+	require.NotEmpty(t, toolRow.Attributes, "the MCP tool call must produce a hook row")
+
+	// ClickHouse escapes forward slashes in the stored JSON.
+	attributes := strings.ReplaceAll(toolRow.Attributes, `\/`, "/")
+	require.Contains(t, attributes, serverURL,
+		"the row must carry gram.mcp.server_url so the offline scanner resolves the server instead of guessing")
+	require.Contains(t, attributes, serverName,
+		"the row must carry the inventory's display name as gram.tool_call.source")
+}
+
+// Only mcp__ names carry a server segment. Resolving Cursor's "MCP:<tool>" or
+// OpenCode's bare names against the inventory would attach an unrelated server.
+func TestIngest_NonClaudeToolNameDialectsDoNotResolveAgainstServerInventory(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+
+	sessionID := "canonical-inventory-dialects-" + uuid.NewString()
+	// Names collide with the tool names below: a match would be misattribution.
+	sendMessage := "send_message"
+	github := "github"
+	serverURL := "https://mcp.example.com/mcp"
+
+	inventory := canonicalIngestPayload("cursor", "session.started", sessionID)
+	inventory.Data = &gen.HookIngestData{
+		McpInventory: []*gen.HookMCPData{
+			{ServerName: &sendMessage, URL: &serverURL},
+			{ServerName: &github, URL: &serverURL},
+		},
+	}
+	_, err := ti.service.Ingest(ctx, inventory)
+	require.NoError(t, err)
+
+	require.Nil(t, ti.service.canonicalMCPEntry(ctx, sessionID, "MCP:send_message"),
+		"a Cursor MCP: name must not resolve against the server inventory")
+	require.Nil(t, ti.service.canonicalMCPEntry(ctx, sessionID, "github_pull_request_read"),
+		"a bare OpenCode tool name must not resolve against the server inventory")
+}


### PR DESCRIPTION
## Problem

A hosted MCP server reached through a **claude.ai connector** is labelled shadow MCP.

Such a connector appears in no local config file, so the device cannot resolve its transport — it reports the tool call with a server name but no URL:

```
gram.tool.name       mcp__claude_ai_<Connector>__<tool>
gram.tool_call.source claude_ai_<Connector>
gram.mcp.server_url   (absent)
```

The ingest path never consulted the MCP inventory the same session already ships at session start — the one place that URL exists. Two consequences:

- **Enforcement**: an empty URL can never be platform-hosted, so the shadow-MCP guard denies a sanctioned server for lack of evidence rather than on evidence of a shadow one.
- **Classification**: the row lands without `gram.mcp.server_url`, so no hosted-toolset matcher can claim it and it falls through to `shadow_mcp_server`.

The scale is not one connector. Fleet-wide over 14 days, `risk.shadow_mcp.resolution` shows **73% of scanned MCP calls resolve to `unresolved`** (9,293 of 12,687) — every one of those is decided by a fallback rather than by knowing the server. `cowork` and `claude-code-desktop` are 100% unresolved; the unified-ingest population is 78%.

## Change

Consult the cached session inventory when an event carries no transport of its own — for the guard's evidence and for the telemetry row.

Reuses what #4923 just added: `cacheCanonicalMCPList` already caches the snapshot, and `applyMCPEntryToEvidence` already merges an entry into evidence. This adds the lookup those two were missing for `mcp__<server>__<tool>` names — 46 lines, all additions.

Restricted to the `mcp__` form on purpose: Cursor's `MCP:<tool>` puts the tool where that form puts the server, and OpenCode ships bare names. Both already resolve on the device, and matching either against server prefixes could attach an unrelated server.

## Known shortcut

The relay strips the `claude.ai ` qualifier from connector names before shipping the inventory, so no derived prefix carries the qualifier the tool name does. The lookup retries without it, marked `ponytail:` in place. The root-cause fix is for the relay to send the derived prefix as `server_identity`; this arm goes away once devices ship that. Doing it here means the fix lands without a device rollout.

## Testing

Three tests, each failing before the change:

- guard allows a hosted connector resolved through the inventory (was `deny`)
- hook row carries `gram.mcp.server_url` and `gram.tool_call.source` (was absent)
- Cursor `MCP:` and OpenCode bare names stay inert against a colliding inventory

`mise lint:server` clean; full `server/internal/hooks` suite green.

## Note for reviewers

Rows previously had an empty `gram.tool_call.source` and so classified as **Local Tools**. They now get a source, which means genuinely-shadow servers reported via ingest will start appearing as shadow MCP where they were previously hidden. That is more correct, but shadow counts will rise for ingest-reporting orgs. Hosted servers land on `hosted_mcp` via the `/mcp/<slug>` matcher and do not inflate it.
