### PR TITLE
feat: correlate LiteLLM agent sessions

### DIFF
--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -16,7 +16,7 @@ describe("LiteLLM configuration", () => {
       "api_base: https://api.getgram.ai/rpc/litellm.ingest",
     );
     expect(config).toContain("Gram-Key: os.environ/GRAM_LITELLM_INGEST_KEY");
-    expect(config).toContain(`extra_headers:
+    expect(config).toContain(`      extra_headers:
         - x-gram-session-id
         - x-claude-code-session-id
         - session-id

--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -16,6 +16,12 @@ describe("LiteLLM configuration", () => {
       "api_base: https://api.getgram.ai/rpc/litellm.ingest",
     );
     expect(config).toContain("Gram-Key: os.environ/GRAM_LITELLM_INGEST_KEY");
+    expect(config).toContain(`extra_headers:
+        - x-gram-session-id
+        - x-claude-code-session-id
+        - session-id
+        - thread-id
+        - x-session-id`);
     expect(config).toContain("streaming_end_of_stream_only: true");
     expect(config).toContain("unreachable_fallback: fail_closed");
   });

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -30,6 +30,10 @@ export function buildLiteLLMGuardrailConfig(
         Gram-Project: os.environ/GRAM_PROJECT_SLUG
       extra_headers:
         - x-gram-session-id
+        - x-claude-code-session-id
+        - session-id
+        - thread-id
+        - x-session-id
       default_on: true
       streaming_end_of_stream_only: true
       fail_on_error: true

--- a/local/litellm/contract-fixtures/config.yaml
+++ b/local/litellm/contract-fixtures/config.yaml
@@ -42,4 +42,9 @@ guardrails:
       api_base: os.environ/FIXTURE_GUARDRAIL_BASE
       default_on: true
       streaming_end_of_stream_only: true
-      extra_headers: [x-gram-session-id]
+      extra_headers:
+        - x-gram-session-id
+        - x-claude-code-session-id
+        - session-id
+        - thread-id
+        - x-session-id

--- a/server/internal/litellm/fixtures/litellm-v1.94.0/README.md
+++ b/server/internal/litellm/fixtures/litellm-v1.94.0/README.md
@@ -26,10 +26,15 @@ guardrails:
         Gram-Project: os.environ/GRAM_PROJECT_SLUG
       default_on: true
       streaming_end_of_stream_only: true
-      extra_headers: [x-gram-session-id]
+      extra_headers:
+        - x-gram-session-id
+        - x-claude-code-session-id
+        - session-id
+        - thread-id
+        - x-session-id
 ```
 
-`extra_headers` is required to forward the session value rather than LiteLLM's `[present]` placeholder.
+`extra_headers` is required to forward Gram's explicit session header and native session headers from supported agent clients rather than LiteLLM's `[present]` placeholder.
 
 ## Coverage
 
@@ -62,6 +67,7 @@ The suite starts the exact image in `manifest.json` and uses a synthetic local i
 The test clones the canonical stanza with `default_on: false` only so each normal and outage posture can be selected independently; customer configuration keeps the documented `default_on: true`.
 
 - Safe non-streaming requests return the fixture completion and capture exactly one user and one assistant message in the explicit session.
+- Native Claude Code, Codex, and OpenCode session headers each correlate two turns into one ordered four-message conversation.
 - A synthetic-secret policy violation returns the configured block message before a provider call, captures one blocked user message, and produces a durable gitleaks finding tied to that message.
 - Safe streaming returns valid SSE and captures the user and assistant messages; a blocked stream is rejected before the provider and captures only the user message.
 - A 503 guardrail outage fails closed before provider execution and captures nothing.

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -415,8 +415,17 @@ func joinedTexts(texts []string) string {
 }
 
 func sessionHeader(headers map[string]string) string {
-	for key, value := range headers {
-		if strings.EqualFold(strings.TrimSpace(key), "x-gram-session-id") {
+	for _, header := range []string{
+		"x-gram-session-id",
+		"x-claude-code-session-id",
+		"session-id",
+		"thread-id",
+		"x-session-id",
+	} {
+		for key, value := range headers {
+			if !strings.EqualFold(strings.TrimSpace(key), header) {
+				continue
+			}
 			value = strings.TrimSpace(value)
 			if value != "" && !strings.EqualFold(value, "[present]") {
 				return value

--- a/server/internal/litellm/ingest_test.go
+++ b/server/internal/litellm/ingest_test.go
@@ -277,6 +277,30 @@ func TestIngestUsesTextsAndSessionFallbacks(t *testing.T) {
 	require.Equal(t, "call-3", *ingester.calls[2].payload.Session.ID)
 }
 
+func TestSessionHeaderUsesNativeClientHeadersInPrecedenceOrder(t *testing.T) {
+	t.Parallel()
+	headers := map[string]string{
+		"X-Session-ID":             "opencode-session",
+		"Thread-ID":                "codex-thread",
+		"Session-ID":               "codex-session",
+		"X-Claude-Code-Session-ID": "claude-session",
+		"X-Gram-Session-ID":        "gram-session",
+	}
+
+	require.Equal(t, "gram-session", sessionHeader(headers))
+	delete(headers, "X-Gram-Session-ID")
+	require.Equal(t, "claude-session", sessionHeader(headers))
+	delete(headers, "X-Claude-Code-Session-ID")
+	require.Equal(t, "codex-session", sessionHeader(headers))
+	delete(headers, "Session-ID")
+	require.Equal(t, "codex-thread", sessionHeader(headers))
+	delete(headers, "Thread-ID")
+	require.Equal(t, "opencode-session", sessionHeader(headers))
+
+	headers["X-Gram-Session-ID"] = "[present]"
+	require.Equal(t, "opencode-session", sessionHeader(headers))
+}
+
 func TestIngestResponseUsesCachedActorAndSession(t *testing.T) {
 	t.Parallel()
 	authCtx := testAuthContext()

--- a/server/internal/litellm/litellm_proxy_e2e_test.go
+++ b/server/internal/litellm/litellm_proxy_e2e_test.go
@@ -278,6 +278,7 @@ type proxyResponse struct {
 func TestLiteLLMProxyE2E(t *testing.T) { //nolint:paralleltest // Scenarios intentionally share one proxy container.
 	test := newProxyHarness(t)
 	test.safeNonStreaming()
+	test.nativeSessionHeaders()
 	test.blockedNonStreaming()
 	test.safeStreaming()
 	test.blockedStreaming()
@@ -478,7 +479,13 @@ func buildProxyConfig(t *testing.T, providerURL, timeoutProviderURL, gramURL, fa
 	require.Equal(t, true, guardrail.Params["streaming_end_of_stream_only"])
 	require.NotEmpty(t, guardrail.Params["api_base"])
 	require.ElementsMatch(t, []any{"pre_call", "post_call"}, guardrail.Params["mode"])
-	require.Equal(t, []any{"x-gram-session-id"}, guardrail.Params["extra_headers"])
+	require.Equal(t, []any{
+		"x-gram-session-id",
+		"x-claude-code-session-id",
+		"session-id",
+		"thread-id",
+		"x-session-id",
+	}, guardrail.Params["extra_headers"])
 	headers, ok := guardrail.Params["headers"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "os.environ/GRAM_LITELLM_INGEST_KEY", headers["Gram-Key"])
@@ -538,7 +545,7 @@ func serverPort(t *testing.T, rawURL string) int {
 	return value
 }
 
-func (h *proxyHarness) request(scenario, sessionID, callID, guardrail, text string, stream bool) proxyResponse {
+func (h *proxyHarness) request(scenario, sessionHeader, sessionID, callID, guardrail, text string, stream bool) proxyResponse {
 	h.t.Helper()
 	prompt := h.prompt(scenario, sessionID, callID, text)
 	model := "fixture-openai"
@@ -554,7 +561,7 @@ func (h *proxyHarness) request(scenario, sessionID, callID, guardrail, text stri
 	require.NoError(h.t, err)
 	req.Header.Set("Authorization", "Bearer "+proxyMasterKey)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-gram-session-id", sessionID)
+	req.Header.Set(sessionHeader, sessionID)
 	req.Header.Set("x-litellm-call-id", callID)
 	response, err := h.httpClient.Do(req)
 	require.NoError(h.t, err)
@@ -656,16 +663,43 @@ func (h *proxyHarness) requireSSE(body []byte) {
 
 func (h *proxyHarness) safeNonStreaming() {
 	scenario, sessionID, callID := "safe", "e2e-safe-session", "e2e-safe-call"
-	response := h.request(scenario, sessionID, callID, "gram-e2e", "safe prompt", false)
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e", "safe prompt", false)
 	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
 	h.requireCompletion(response.Body)
 	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
 	h.requireConversation(h.messages(sessionID, 2), h.prompt(scenario, sessionID, callID, "safe prompt"))
 }
 
+func (h *proxyHarness) nativeSessionHeaders() {
+	for _, header := range []string{"x-claude-code-session-id", "session-id", "thread-id", "x-session-id"} {
+		scenario := "native-" + header
+		sessionID := "e2e-" + header + "-session"
+		for turn := 1; turn <= 2; turn++ {
+			callID := fmt.Sprintf("e2e-%s-call-%d", header, turn)
+			text := fmt.Sprintf("turn %d", turn)
+			response := h.request(scenario, header, sessionID, callID, "gram-e2e", text, false)
+			require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
+			h.requireCompletion(response.Body)
+			require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
+		}
+
+		messages := h.messages(sessionID, 4)
+		require.Equal(h.t, []string{"user", "assistant", "user", "assistant"}, []string{
+			messages[0].Role,
+			messages[1].Role,
+			messages[2].Role,
+			messages[3].Role,
+		})
+		require.Equal(h.t, h.prompt(scenario, sessionID, "e2e-"+header+"-call-1", "turn 1"), messages[0].Content)
+		require.Equal(h.t, fixtureAnswer, messages[1].Content)
+		require.Equal(h.t, h.prompt(scenario, sessionID, "e2e-"+header+"-call-2", "turn 2"), messages[2].Content)
+		require.Equal(h.t, fixtureAnswer, messages[3].Content)
+	}
+}
+
 func (h *proxyHarness) blockedNonStreaming() {
 	scenario, sessionID, callID := "blocked", "e2e-blocked-session", "e2e-blocked-call"
-	response := h.request(scenario, sessionID, callID, "gram-e2e", "token="+syntheticSecret, false)
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e", "token="+syntheticSecret, false)
 	require.Equal(h.t, http.StatusBadRequest, response.Status, string(response.Body))
 	h.requireBlocked(response.Body)
 	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
@@ -678,7 +712,7 @@ func (h *proxyHarness) blockedNonStreaming() {
 
 func (h *proxyHarness) safeStreaming() {
 	scenario, sessionID, callID := "stream-safe", "e2e-stream-safe-session", "e2e-stream-safe-call"
-	response := h.request(scenario, sessionID, callID, "gram-e2e", "safe streaming prompt", true)
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e", "safe streaming prompt", true)
 	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
 	require.Contains(h.t, response.Header.Get("Content-Type"), "text/event-stream")
 	h.requireSSE(response.Body)
@@ -688,7 +722,7 @@ func (h *proxyHarness) safeStreaming() {
 
 func (h *proxyHarness) blockedStreaming() {
 	scenario, sessionID, callID := "stream-blocked", "e2e-stream-blocked-session", "e2e-stream-blocked-call"
-	response := h.request(scenario, sessionID, callID, "gram-e2e", "token="+syntheticSecret, true)
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e", "token="+syntheticSecret, true)
 	require.Equal(h.t, http.StatusBadRequest, response.Status, string(response.Body))
 	h.requireBlocked(response.Body)
 	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
@@ -700,7 +734,7 @@ func (h *proxyHarness) blockedStreaming() {
 
 func (h *proxyHarness) failClosed() {
 	scenario, sessionID, callID := "fail-closed", "e2e-fail-closed-session", "e2e-fail-closed-call"
-	response := h.request(scenario, sessionID, callID, "gram-e2e-fail-closed", "outage prompt", false)
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e-fail-closed", "outage prompt", false)
 	require.NotContains(h.t, []int{http.StatusOK, http.StatusCreated, http.StatusNoContent}, response.Status, string(response.Body))
 	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
 	h.noMessages(sessionID)
@@ -708,7 +742,7 @@ func (h *proxyHarness) failClosed() {
 
 func (h *proxyHarness) failOpen() {
 	scenario, sessionID, callID := "fail-open", "e2e-fail-open-session", "e2e-fail-open-call"
-	response := h.request(scenario, sessionID, callID, "gram-e2e-fail-open", "outage prompt", false)
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e-fail-open", "outage prompt", false)
 	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
 	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
 	h.noMessages(sessionID)
@@ -718,7 +752,7 @@ func (h *proxyHarness) timeoutAndResend() {
 	// LiteLLM 1.94.0 does not retry a timed-out guardrail callback. A gateway may
 	// safely resend with the same call ID; an ordinary retry with a new call ID is distinct.
 	scenario, sessionID, callID := "timeout", "e2e-timeout-session", "e2e-timeout-call"
-	first := h.request(scenario, sessionID, callID, "gram-e2e-timeout", "timeout prompt", false)
+	first := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e-timeout", "timeout prompt", false)
 	require.NotEqual(h.t, http.StatusOK, first.Status, string(first.Body))
 	require.Zero(h.t, h.provider.count(h.key(scenario, sessionID, callID)))
 	require.Equal(h.t, "user", h.messages(sessionID, 1)[0].Role)
@@ -729,7 +763,7 @@ func (h *proxyHarness) timeoutAndResend() {
 	require.Never(h.t, func() bool {
 		return h.provider.count(h.key(scenario, sessionID, callID)) > 0
 	}, 3*time.Second, 10*time.Millisecond)
-	second := h.request(scenario, sessionID, callID, "gram-e2e-timeout", "timeout prompt", false)
+	second := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e-timeout", "timeout prompt", false)
 	require.Equal(h.t, http.StatusOK, second.Status, string(second.Body))
 	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
 	h.requireConversation(h.messages(sessionID, 2), h.prompt(scenario, sessionID, callID, "timeout prompt"))

--- a/server/internal/litellm/litellm_proxy_e2e_test.go
+++ b/server/internal/litellm/litellm_proxy_e2e_test.go
@@ -545,7 +545,7 @@ func serverPort(t *testing.T, rawURL string) int {
 	return value
 }
 
-func (h *proxyHarness) request(scenario, sessionHeader, sessionID, callID, guardrail, text string, stream bool) proxyResponse {
+func (h *proxyHarness) request(scenario, sessionHeader, sessionID, callID, guardrail, text string, stream bool, additionalSessionHeaders ...map[string]string) proxyResponse {
 	h.t.Helper()
 	prompt := h.prompt(scenario, sessionID, callID, text)
 	model := "fixture-openai"
@@ -562,6 +562,11 @@ func (h *proxyHarness) request(scenario, sessionHeader, sessionID, callID, guard
 	req.Header.Set("Authorization", "Bearer "+proxyMasterKey)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(sessionHeader, sessionID)
+	for _, headers := range additionalSessionHeaders {
+		for name, value := range headers {
+			req.Header.Set(name, value)
+		}
+	}
 	req.Header.Set("x-litellm-call-id", callID)
 	response, err := h.httpClient.Do(req)
 	require.NoError(h.t, err)
@@ -695,6 +700,18 @@ func (h *proxyHarness) nativeSessionHeaders() {
 		require.Equal(h.t, h.prompt(scenario, sessionID, "e2e-"+header+"-call-2", "turn 2"), messages[2].Content)
 		require.Equal(h.t, fixtureAnswer, messages[3].Content)
 	}
+
+	scenario, sessionID, callID := "session-header-precedence", "e2e-gram-session", "e2e-precedence-call"
+	response := h.request(scenario, "x-gram-session-id", sessionID, callID, "gram-e2e", "precedence prompt", false, map[string]string{
+		"x-claude-code-session-id": "e2e-claude-session",
+		"session-id":               "e2e-codex-session",
+		"thread-id":                "e2e-codex-thread",
+		"x-session-id":             "e2e-opencode-session",
+	})
+	require.Equal(h.t, http.StatusOK, response.Status, string(response.Body))
+	h.requireCompletion(response.Body)
+	require.Equal(h.t, 1, h.provider.count(h.key(scenario, sessionID, callID)))
+	h.requireConversation(h.messages(sessionID, 2), h.prompt(scenario, sessionID, callID, "precedence prompt"))
 }
 
 func (h *proxyHarness) blockedNonStreaming() {


### PR DESCRIPTION
## Summary
- forward native Claude Code, Codex, and OpenCode session headers through the generated LiteLLM guardrail configuration
- normalize supported client headers into Gram session IDs with explicit precedence
- verify two-turn correlation through the pinned LiteLLM proxy contract suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable reliable session correlation for agent chats by forwarding native session headers through the generated `LiteLLM` guardrail config and mapping them to Gram session IDs with clear precedence. Adds E2E contract checks so Claude Code, Codex, and OpenCode clients stitch multi-turn conversations correctly.

- New Features
  - Forward native session headers via `extra_headers`: `x-gram-session-id`, `x-claude-code-session-id`, `session-id`, `thread-id`, `x-session-id`.
  - Normalize headers to a single Gram session ID with precedence: Gram > Claude Code > Codex (`session-id`) > Codex (`thread-id`) > OpenCode; ignore `[present]`.
  - Verified two-turn correlation for each header in the `LiteLLM` proxy E2E suite and added a precedence scenario; assert guardrail config includes the full `extra_headers` list.
  - Updated fixtures/config generation and README to document required headers.

- Migration
  - If you maintain a custom `LiteLLM` guardrail config, add the headers above under `extra_headers` to enable session forwarding and correlation.

<sup>Written for commit dedfaccab024608025316f8dbfaea6b805dcf9e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

