### PR TITLE
mig: index json_web_key_sets and json_web_keys on external key tenancy

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -5672,6 +5672,18 @@ CREATE TABLE IF NOT EXISTS json_web_key_sets (
 CREATE UNIQUE INDEX IF NOT EXISTS json_web_key_sets_organization_id_id_key
 ON json_web_key_sets (organization_id, id);
 
+-- Non-partial index backing json_web_key_sets_external_key_tenant_fkey, which
+-- has no ON DELETE clause (NO ACTION). Postgres does not index the referencing
+-- side automatically, so without this the check on every hard-deleted
+-- external_keys row falls back to the (organization_id, id) unique index above
+-- and filters external_key_id from the heap. Also serves the external key
+-- delete guard, which reads the same two columns. Non-partial because the
+-- foreign-key check has to see soft-deleted rows, which a
+-- WHERE deleted IS FALSE index would exclude; the delete guard alone would be
+-- happy with a partial one.
+CREATE INDEX IF NOT EXISTS json_web_key_sets_external_key_tenant_idx
+ON json_web_key_sets (organization_id, external_key_id);
+
 -- Individual published key entries within a JSON Web Key Set. Each row is one
 -- public JWK (identified by `kid`) with a lifecycle state.
 CREATE TABLE IF NOT EXISTS json_web_keys (
@@ -5711,6 +5723,17 @@ WHERE deleted IS FALSE;
 -- rows that the partial unique indexes above exclude.
 CREATE INDEX IF NOT EXISTS json_web_keys_set_tenant_idx
 ON json_web_keys (organization_id, json_web_key_set_id);
+
+-- Non-partial index backing json_web_keys_external_key_tenant_fkey, which has
+-- no ON DELETE clause (NO ACTION). Postgres does not index the referencing side
+-- automatically, so without this the check on every hard-deleted external_keys
+-- row falls back to json_web_keys_set_tenant_idx above and filters
+-- external_key_id from the heap. Also serves the external key delete guard,
+-- which reads the same two columns. Non-partial for the same reason as
+-- json_web_keys_set_tenant_idx: the foreign-key check has to see soft-deleted
+-- rows.
+CREATE INDEX IF NOT EXISTS json_web_keys_external_key_tenant_idx
+ON json_web_keys (organization_id, external_key_id);
 
 -- Customer-supplied model provider API keys (BYOK), scoped per project and
 -- responsibility slot (completion surface). The 'default' slot applies to

--- a/server/migrations/20260812140226_jwks-index-external-key-tenant.sql
+++ b/server/migrations/20260812140226_jwks-index-external-key-tenant.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Create index "json_web_key_sets_external_key_tenant_idx" to table: "json_web_key_sets"
+CREATE INDEX CONCURRENTLY "json_web_key_sets_external_key_tenant_idx" ON "json_web_key_sets" ("organization_id", "external_key_id");
+-- Create index "json_web_keys_external_key_tenant_idx" to table: "json_web_keys"
+CREATE INDEX CONCURRENTLY "json_web_keys_external_key_tenant_idx" ON "json_web_keys" ("organization_id", "external_key_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Bs0pT+vnoPML6h15n8czWE8J3jHtihvAmPMIhtTW1TQ=
+h1:rTaQ3oLZdRCNIEvcCRLDYowm8yl7Pei4AhJEGqNLA/w=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -331,3 +331,4 @@ h1:Bs0pT+vnoPML6h15n8czWE8J3jHtihvAmPMIhtTW1TQ=
 20260811183332_mcp-approval-workflow.sql h1:UwCSdC5Xh39xdlv47ACNaCw9VkOa/S1Gxsp0pIeFzeM=
 20260811225530_expand-assets-tiers.sql h1:K5IvMnYVFRA8qmUXXPvH5S0HtFWPUNYWbd7KCGlUFC4=
 20260811225943_assets-tier-dedupe-indexes.sql h1:thYfONo6SYry2Aew/GXLvIn/9WZtmZv82BfL7c5jp4A=
+20260812140226_jwks-index-external-key-tenant.sql h1:uuAVtFJtvI9Fh8P1g0lZCvFFIlUUoUraHM+HvBKT1dY=


### PR DESCRIPTION
[AGE-3111](https://linear.app/speakeasy/issue/AGE-3111/mig-index-json-web-key-sets-json-web-keys-on-organization-id-external)

Neither table had an index covering its `..._external_key_tenant_fkey` composite foreign key to `external_keys (organization_id, id)`. Postgres does not index the referencing side automatically, so the `NO ACTION` check on every hard-deleted `external_keys` row falls back to the `organization_id` leading index on each table and filters `external_key_id` from the heap.

Both indexes are non-partial, matching `json_web_keys_set_tenant_idx`: the foreign-key check has to see soft-deleted rows, which a `WHERE deleted IS FALSE` index would exclude. They also serve the upcoming external key delete guard (AGE-3090), which reads the same two columns and on its own would prefer a partial index.

This is preventative rather than a performance fix. Both tables are empty in every environment, so the concurrent build is free, and no query or code path exercises these checks yet.

**Migration only**, no application code, per the `postgresql` skill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Per AGE-3111, add non-partial indexes `json_web_key_sets_external_key_tenant_idx` and `json_web_keys_external_key_tenant_idx` on `(organization_id, external_key_id)` to back the external key foreign key and prevent scans during hard deletes. Built concurrently via migration; preventative (tables are empty) and supports the upcoming external key delete guard.

<sup>Written for commit 4abfc229b95546d56fa91045ce906b7b811bad34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

