### PR TITLE
fix(hooks): restore the Claude CLI on PATH for the MCP inventory snapshot

### DIFF
--- a/.changeset/hooks-bootstrap-claude-cli-path.md
+++ b/.changeset/hooks-bootstrap-claude-cli-path.md
@@ -1,0 +1,14 @@
+---
+"server": patch
+---
+
+Restore the Claude CLI on PATH before running the hooks binary, so MCP tool
+calls stop being reported as shadow MCP on desktop and MDM-launched machines.
+The binary shells out to `claude mcp list` to identify which MCP server a tool
+call reached — the only source for connectors configured in claude.ai, which
+appear in no local config file — and that lookup is a bare PATH search that
+fails silently. A session launched from a GUI or by MDM routinely hands hooks a
+minimal PATH without the CLI, so the lookup returned nothing and every MCP call
+from that machine was reported with no server identity, which classifies as
+shadow MCP. The bootstrap now probes the documented install locations, matching
+what the Codex install script already does for `codex`.

--- a/.changeset/hooks-bootstrap-claude-cli-path.md
+++ b/.changeset/hooks-bootstrap-claude-cli-path.md
@@ -2,13 +2,12 @@
 "server": patch
 ---
 
-Restore the Claude CLI on PATH before running the hooks binary, so MCP tool
-calls stop being reported as shadow MCP on desktop and MDM-launched machines.
-The binary shells out to `claude mcp list` to identify which MCP server a tool
-call reached — the only source for connectors configured in claude.ai, which
-appear in no local config file — and that lookup is a bare PATH search that
-fails silently. A session launched from a GUI or by MDM routinely hands hooks a
-minimal PATH without the CLI, so the lookup returned nothing and every MCP call
-from that machine was reported with no server identity, which classifies as
-shadow MCP. The bootstrap now probes the documented install locations, matching
-what the Codex install script already does for `codex`.
+Restore the Claude CLI on PATH before running the hooks binary, so the MCP
+inventory snapshot is collected on desktop and MDM-launched machines. The
+relay shells out to `claude mcp list` at session start to build the snapshot
+behind the Shadow MCP inventory page, and resolves the CLI with a bare PATH
+search that fails silently. A session launched from a GUI or by MDM routinely
+passes a minimal PATH without the CLI, so the snapshot was never collected and
+the inventory stayed empty for that machine. The bootstrap now probes the
+documented install locations, matching what the Codex install script already
+does for `codex`.

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -368,7 +368,7 @@ const mcpGeneratorVersion = "10"
 // line when it pins a new binary, because new checksums always change the
 // rendered bootstrap script. Any other change to hooks generation needs a
 // manual bump, which the Plugin Generate Check CI workflow enforces.
-const hooksGeneratorVersion = "27"
+const hooksGeneratorVersion = "28"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -2297,3 +2297,41 @@ func TestMCPFingerprintsChangeWithDistributedSkills(t *testing.T) {
 	require.NotEqual(t, withSkill["plugin-a"], withNewVersion["plugin-a"], "a new resolved skill version must change the plugin's fingerprint")
 	require.Equal(t, base["plugin-b"], withSkill["plugin-b"], "plugins not carrying the skill must be untouched")
 }
+
+// Desktop and MDM-launched sessions hand hooks a minimal PATH. The binary
+// shells out to `claude mcp list` to identify which MCP server a tool call
+// reached, and a lookup that fails leaves the call reported as shadow MCP —
+// so the bootstrap must restore the CLI before exec'ing the binary.
+func TestHooksBootstrapRestoresClaudeOnPath(t *testing.T) {
+	t.Parallel()
+
+	// Everything up to the first exec — running further would download the
+	// pinned binary.
+	head, _, ok := strings.Cut(string(renderHooksBootstrap(GenerateConfig{})), "if cache_valid; then")
+	require.True(t, ok, "bootstrap must reach its cache check")
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".local", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "claude"), []byte("#!/bin/sh\n"), 0o755))
+
+	run := func(extraPath string) string {
+		t.Helper()
+		cmd := exec.Command("bash", "-c", head+"\ncommand -v claude || echo MISSING")
+		cmd.Env = []string{"HOME=" + home, "PATH=" + extraPath}
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+		return strings.TrimSpace(string(out))
+	}
+
+	require.Equal(t, filepath.Join(binDir, "claude"), run("/usr/bin:/bin"),
+		"a minimal PATH must be repaired from the documented install locations")
+
+	// An unfindable CLI must not abort the hook: reporting without MCP
+	// attribution beats not reporting at all.
+	cmd := exec.Command("bash", "-c", head+"\ncommand -v claude || echo MISSING")
+	cmd.Env = []string{"HOME=" + t.TempDir(), "PATH=/usr/bin:/bin"}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.Equal(t, "MISSING", strings.TrimSpace(string(out)))
+}

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -136,6 +136,31 @@ case "$target" in
 %s  *) install_failure "unsupported target ${target}" ;;
 esac
 
+# The hooks binary shells out to 'claude mcp list' to learn which MCP server a
+# tool call reached — the only source for connectors configured in claude.ai,
+# which appear in no local config file. Both lookups are a bare PATH search
+# that fails silently, and a call whose server cannot be identified is reported
+# as shadow MCP. Desktop and MDM-launched sessions routinely hand hooks a
+# minimal PATH without the CLI, so put it back when it is missing.
+#
+# ponytail: probes documented install locations only; version-manager installs
+# (mise, asdf, volta) are not discoverable this way. Set GRAM_HOOKS_CLAUDE_BIN
+# to the executable if yours lives elsewhere.
+if ! command -v claude >/dev/null 2>&1; then
+  for claude_candidate in \
+    "${GRAM_HOOKS_CLAUDE_BIN:-}" \
+    "${HOME}/.local/bin/claude" \
+    "${HOME}/.claude/local/claude" \
+    /usr/local/bin/claude \
+    /opt/homebrew/bin/claude; do
+    if [ -n "$claude_candidate" ] && [ -x "$claude_candidate" ]; then
+      PATH="$(dirname "$claude_candidate"):${PATH}"
+      export PATH
+      break
+    fi
+  done
+fi
+
 if [ -n "${GRAM_HOOKS_HOME:-}" ]; then
   cache_root=$GRAM_HOOKS_HOME
 elif [ "$os" = darwin ]; then


### PR DESCRIPTION
## Problem

The Shadow MCP inventory page is empty for machines where the Claude CLI is not on the hook's PATH.

`collectClaudeMCPInventory` (`hooks/relay/mcp_inventory.go:26`) shells out to `claude mcp list` at SessionStart and ConfigChange to build the snapshot that populates `shadow_mcp_inventory_urls`. It resolves the CLI with a bare PATH search and returns `nil` silently when that fails:

```go
bin, err := exec.LookPath("claude")
if err != nil {
    return nil
}
```

Desktop and MDM-launched sessions routinely hand hooks a minimal PATH. The snapshot is then never collected, never shipped, and the inventory page shows nothing for that machine. Server-side this surfaces as a recurring `failed to read cached MCP list for shadow inventory capture / cache: key is missing` — 17,751 occurrences in 7 days for a single org, across 5 orgs.

This is a known failure mode in this repo. `renderCodexInstallScript` says so verbatim and works around it with `find_codex()`:

> *"Desktop-only and MDM-deployed machines run without codex on PATH; probe the managed-install and app-bundle locations."*

There is no equivalent for `claude`.

## Change

`bootstrap.sh` probes the documented install locations and prepends to PATH when the CLI is missing, before exec'ing the hooks binary. The relay runs inside that binary, so it inherits the repaired PATH. 25 lines, all additions, plus a `hooksGeneratorVersion` bump — without which the plugin never republishes and the change reaches nobody.

## Scope: this is now the inventory-snapshot fix only

Originally this PR also covered per-call MCP attribution, where the same missing CLI cost every tool call its server identity and made it read as shadow MCP. **speakeasy-api/agenthooks#10 fixes that properly** — it recovers the executable from `CLAUDE_PID`, the way `runCodexMCPList` already does for Codex, so it works for any install method instead of probing a static list.

That fix cannot reach this code path: `procExecutable` is unexported in agenthooks, and the relay's collector does its own lookup. So the two are complementary — agenthooks#10 for per-call attribution, this for the inventory snapshot.

## Known limits

Version-manager installs (mise, asdf, volta) are not discoverable from a static path list — marked `ponytail:` in place, with `GRAM_HOOKS_CLAUDE_BIN` as the escape hatch. `cowork` has no CLI at all and relies on its existing `.mcp.json` scrape.

This also does not make the failure observable: a probe that finds nothing is still indistinguishable from a machine with no MCP servers. Worth a follow-up.

## Testing

`TestHooksBootstrapRestoresClaudeOnPath` executes the generated script (truncated at the first `exec` so it never downloads) against a minimal PATH with a fake CLI in a temp `$HOME`, asserting both that PATH is repaired and that an unfindable CLI does not abort the hook. Verified to fail without the change.
