### PR TITLE
mig: add publish_outbox.lease_token

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4970,6 +4970,7 @@ CREATE TABLE IF NOT EXISTS publish_outbox (
   last_error TEXT,
   retry_after timestamptz,
   locked_until timestamptz,
+  lease_token uuid,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
@@ -4989,6 +4990,7 @@ COMMENT ON COLUMN publish_outbox.message IS 'proto.Marshal of that message, publ
 COMMENT ON COLUMN publish_outbox.attributes IS 'Pub/Sub message attributes. Carries the producer traceparent so the trace survives the database hop. content-type and schema are derived at publish time and cannot be overridden from here.';
 COMMENT ON COLUMN publish_outbox.attempts IS 'Incremented when a row is claimed, not when it fails, so it counts deliveries attempted — the number dead-lettering acts on.';
 COMMENT ON COLUMN publish_outbox.locked_until IS 'Claim lease held by the draining relay. Deliberately absent from every index predicate: predicate columns are HOT-blocking, so indexing this would force a new index tuple on every claim.';
+COMMENT ON COLUMN publish_outbox.lease_token IS 'Identifies the claim currently holding the row, minted by the drainer. Settlement matches on it so a drain that outlived its lease cannot delete, dead-letter or release a row another drainer has since claimed. NULL means unclaimed. Unindexed, like locked_until, so claiming stays a HOT update.';
 
 CREATE UNIQUE INDEX IF NOT EXISTS publish_outbox_public_id_key
 ON publish_outbox (public_id);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1659,8 +1659,10 @@ type PublishOutbox struct {
 	RetryAfter pgtype.Timestamptz
 	// Claim lease held by the draining relay. Deliberately absent from every index predicate: predicate columns are HOT-blocking, so indexing this would force a new index tuple on every claim.
 	LockedUntil pgtype.Timestamptz
-	CreatedAt   pgtype.Timestamptz
-	UpdatedAt   pgtype.Timestamptz
+	// Identifies the claim currently holding the row, minted by the drainer. Settlement matches on it so a drain that outlived its lease cannot delete, dead-letter or release a row another drainer has since claimed. NULL means unclaimed. Unindexed, like locked_until, so claiming stays a HOT update.
+	LeaseToken uuid.NullUUID
+	CreatedAt  pgtype.Timestamptz
+	UpdatedAt  pgtype.Timestamptz
 }
 
 type PublishOutboxDeadLetter struct {

--- a/server/migrations/20260805222807_publish-outbox-lease-token.sql
+++ b/server/migrations/20260805222807_publish-outbox-lease-token.sql
@@ -1,0 +1,4 @@
+-- Modify "publish_outbox" table
+ALTER TABLE "publish_outbox" ADD COLUMN "lease_token" uuid NULL;
+-- Set comment to column: "lease_token" on table: "publish_outbox"
+COMMENT ON COLUMN "publish_outbox"."lease_token" IS 'Identifies the claim currently holding the row, minted by the drainer. Settlement matches on it so a drain that outlived its lease cannot delete, dead-letter or release a row another drainer has since claimed. NULL means unclaimed. Unindexed, like locked_until, so claiming stays a HOT update.';

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:4MpfgHazBzKahPwhRyknW+FqwouuwnqKmeZKNSxCMog=
+h1:GiiKbYRSXyAts/yCz2pYagAP2dH480W4GbWY3MebzXU=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -318,3 +318,4 @@ h1:4MpfgHazBzKahPwhRyknW+FqwouuwnqKmeZKNSxCMog=
 20260805161737_skills-add-tags.sql h1:aiav/5wPpriD/TI9TaFSNeDe8YgYjfZHv24iMM3zwSc=
 20260805191625_publish-outbox.sql h1:dqHs3CK4gTejbarFRGVwP1pqTPSXBkkuRnha8s2hrUY=
 20260805211101_enterprise-trials.sql h1:7NH6ss0phB6SS9BuHVEgy8fq7j3Ca0Sq10cgdDADW3A=
+20260805222807_publish-outbox-lease-token.sql h1:UkZ7i59bP6G3xZBSOQUlepqDLK4yjJMplJcUkBS3i5Y=


### PR DESCRIPTION
Adds `publish_outbox.lease_token`, ahead of the relay change that uses it in
#4962.

## Why

The relay claims a batch of rows under a 60-second lease, publishes them, then
settles each one — deleting, dead-lettering or scheduling a retry. Settlement
matches on the row id alone, so a drain that outlives its lease can act on a
row another drainer has since claimed: clearing a live lease so a third worker
publishes the same event, dead-lettering a row that was about to be delivered,
or decrementing `attempts`, which is the counter the dead-letter threshold
reads.

Reaching that is not exotic — the Pub/Sub publish timeout alone is 30s of the
60s lease, before a stalled worker or a slow settle.

A fencing token is the fix: the drainer mints one per claim, and every
settlement statement carries it, so a late result finds no row to update rather
than trampling the claim that replaced it.

## Shape

- **Nullable, no default.** `NULL` reads as unclaimed. Without a default the
  column add is a catalog-only change — no rewrite, no scan. (The table is
  empty in every environment anyway, since nothing writes to it yet.)
- **Unindexed**, for the same reason `locked_until` is: an indexed column would
  make every claim allocate a new index tuple instead of staying a HOT update,
  and the claim path is the hot one here.
- **Minted by the drainer, not by the database.** `gen_random_uuid()` is
  volatile, so a `DEFAULT` or a `SET lease_token = gen_random_uuid()` would
  evaluate per row and hand every row in one claim a different token — leaving
  the settlement statements no single value to match on.

`locked_until` was considered as the token instead, since a re-claim can only
happen after the previous lease elapsed and each claim therefore stamps a
strictly greater value. It works, but it ties the fence to the wall clock and
to the lease's exact value: adding lease renewal later — the natural response
to the slow drains this exists to guard — would have the drainer extend its own
lease and then fail to settle against the token it was given.

## Risk

Additive. Nothing reads or writes the column until #4962 lands.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable `publish_outbox.lease_token` to fence relay claims during settlement. This prevents a stale drainer from acting on rows after its 60s lease expires and another worker has claimed them.

- **Migration**
  - Add `lease_token uuid` (nullable, unindexed, no default). NULL means unclaimed.
  - No table rewrite or backfill; safe to ship before the relay uses it.

<sup>Written for commit 8c938a8eae73bf6fab8408c31b24a8251545da51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

