### PR TITLE
feat(server): lock down and reinstate OpenRouter platform keys

### DIFF
--- a/.changeset/openrouter-disable-api-key.md
+++ b/.changeset/openrouter-disable-api-key.md
@@ -2,4 +2,4 @@
 "server": minor
 ---
 
-Add an OpenRouter key lockdown that drops the upstream spending ceiling to zero and disables the key, and make a limit refresh reinstate a locked-down key.
+Add an OpenRouter platform key lockdown. A locked-down key fails at key resolution with a distinct `inference_disabled` error rather than an upstream rejection, and a limit refresh reinstates it.

--- a/.changeset/openrouter-disable-api-key.md
+++ b/.changeset/openrouter-disable-api-key.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add an OpenRouter key lockdown that drops the upstream spending ceiling to zero and disables the key, and make a limit refresh reinstate a locked-down key.

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -731,6 +731,9 @@ func (d *devProvisioner) ProvisionAPIKey(_ context.Context, _ string, _ openrout
 func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openrouter.KeyType, _ *int) (int, error) {
 	return 0, fmt.Errorf("not implemented in bench")
 }
+func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
+	return fmt.Errorf("not implemented in bench")
+}
 func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openrouter.KeyType) (float64, int, error) {
 	return 0, 0, fmt.Errorf("not implemented in bench")
 }

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -285,6 +285,9 @@ func (d *devProvisioner) ProvisionAPIKey(_ context.Context, _ string, _ openrout
 func (d *devProvisioner) RefreshAPIKeyLimit(_ context.Context, _ string, _ openrouter.KeyType, _ *int) (int, error) {
 	return 0, fmt.Errorf("not implemented in bench")
 }
+func (d *devProvisioner) DisableAPIKey(_ context.Context, _ string, _ openrouter.KeyType) error {
+	return fmt.Errorf("not implemented in bench")
+}
 func (d *devProvisioner) GetCreditsUsed(_ context.Context, _ string, _ openrouter.KeyType) (float64, int, error) {
 	return 0, 0, fmt.Errorf("not implemented in bench")
 }

--- a/server/internal/background/activities/chat_resolutions/analyze_segment.go
+++ b/server/internal/background/activities/chat_resolutions/analyze_segment.go
@@ -89,6 +89,9 @@ func (a *AnalyzeSegment) Do(ctx context.Context, args AnalyzeSegmentArgs) error 
 
 	result, err := a.analyzeWithLLM(ctx, args.OrgID, args.ProjectID, segmentText, applicableUserFeedback)
 	if err != nil {
+		if openrouter.IsPlatformKeyDisabled(err) {
+			return newInferenceDisabledError(fmt.Errorf("failed to analyze segment with LLM: %w", err))
+		}
 		if openrouter.IsInsufficientCredits(err) {
 			return newInsufficientCreditsError(fmt.Errorf("failed to analyze segment with LLM: %w", err))
 		}

--- a/server/internal/background/activities/chat_resolutions/errors.go
+++ b/server/internal/background/activities/chat_resolutions/errors.go
@@ -70,6 +70,33 @@ func IsInsufficientCredits(err error) bool {
 	return false
 }
 
+// ErrTypeInferenceDisabled tags the non-retryable Temporal application error
+// emitted when an operator locked the organization's platform key down. It is
+// separate from ErrTypeInsufficientCredits so the workflow log says which of
+// the two happened.
+const ErrTypeInferenceDisabled = "ChatResolutionInferenceDisabled"
+
+func newInferenceDisabledError(cause error) error {
+	return temporal.NewNonRetryableApplicationError(
+		"organization inference is disabled",
+		ErrTypeInferenceDisabled,
+		cause,
+	)
+}
+
+// IsInferenceDisabled reports whether err is a locked-down-key failure, either
+// pre- or post-activity boundary.
+func IsInferenceDisabled(err error) bool {
+	if openrouter.IsPlatformKeyDisabled(err) {
+		return true
+	}
+	var appErr *temporal.ApplicationError
+	if errors.As(err, &appErr) {
+		return appErr.Type() == ErrTypeInferenceDisabled
+	}
+	return false
+}
+
 // loadMessagesAtPinnedGeneration verifies that the chat's current generation
 // still matches the pinned one and returns the messages at that generation. On
 // mismatch it returns a non-retryable Temporal error so the workflow can

--- a/server/internal/background/activities/chat_resolutions/errors.go
+++ b/server/internal/background/activities/chat_resolutions/errors.go
@@ -71,9 +71,7 @@ func IsInsufficientCredits(err error) bool {
 }
 
 // ErrTypeInferenceDisabled tags the non-retryable Temporal application error
-// emitted when an operator locked the organization's platform key down. It is
-// separate from ErrTypeInsufficientCredits so the workflow log says which of
-// the two happened.
+// emitted when an operator locked the organization's platform key down.
 const ErrTypeInferenceDisabled = "ChatResolutionInferenceDisabled"
 
 func newInferenceDisabledError(cause error) error {

--- a/server/internal/background/analyze_chat_resolutions.go
+++ b/server/internal/background/analyze_chat_resolutions.go
@@ -109,6 +109,15 @@ func AnalyzeChatResolutionsWorkflow(ctx workflow.Context, params AnalyzeChatReso
 				)
 				return workflow.NewContinueAsNewError(ctx, AnalyzeChatResolutionsWorkflow, params)
 			}
+			if activities.IsInferenceDisabled(err) {
+				workflow.GetLogger(ctx).Warn("skipping segment analysis: organization inference is disabled",
+					"chat_id", params.ChatID.String(),
+					"org_id", params.OrgID,
+					"start_index", segment.StartIndex,
+					"end_index", segment.EndIndex,
+				)
+				continue
+			}
 			if activities.IsInsufficientCredits(err) {
 				workflow.GetLogger(ctx).Warn("skipping segment analysis: organization has insufficient OpenRouter credits",
 					"chat_id", params.ChatID.String(),

--- a/server/internal/chat/completion_error_test.go
+++ b/server/internal/chat/completion_error_test.go
@@ -1,0 +1,40 @@
+package chat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+// A locked-down platform key must reach the user as its own code. Falling back
+// to a gateway error would tell an expired trial that Gram is broken.
+func TestClassifyCompletionError_InferenceDisabled(t *testing.T) {
+	t.Parallel()
+
+	svc := newServiceWithBilling(t, &fakeBillingRepo{})
+	err := svc.classifyCompletionError(t.Context(), "completion failed",
+		fmt.Errorf("resolve OpenRouter key: %w", openrouter.ErrPlatformKeyDisabled))
+
+	var se *oops.ShareableError
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeInferenceDisabled, se.Code)
+	require.Contains(t, se.Error(), "contact support")
+}
+
+// An exhausted balance keeps its own code: a top-up clears it, and a
+// reinstatement does not.
+func TestClassifyCompletionError_InsufficientCreditsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	svc := newServiceWithBilling(t, &fakeBillingRepo{})
+	err := svc.classifyCompletionError(t.Context(), "completion failed",
+		fmt.Errorf("openrouter 402: %w", openrouter.ErrInsufficientCredits))
+
+	var se *oops.ShareableError
+	require.ErrorAs(t, err, &se)
+	require.Equal(t, oops.CodeInsufficientCredits, se.Code)
+}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -1229,6 +1229,8 @@ func IsHistoryCorrupted(err error) bool {
 // (and through the runner to the assistant runtime).
 func (s *Service) classifyCompletionError(ctx context.Context, label string, err error) error {
 	switch {
+	case openrouter.IsPlatformKeyDisabled(err):
+		return oops.C(oops.CodeInferenceDisabled).LogError(ctx, s.logger)
 	case openrouter.IsInsufficientCredits(err):
 		return oops.C(oops.CodeInsufficientCredits).LogError(ctx, s.logger)
 	case openrouter.IsHistoryCorruptionCandidate(err):

--- a/server/internal/modelkeys/setup_test.go
+++ b/server/internal/modelkeys/setup_test.go
@@ -67,6 +67,10 @@ func (p *stubProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 	return 0, nil
 }
 
+func (p *stubProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType openrouter.KeyType) error {
+	return nil
+}
+
 func (p *stubProvisioner) GetCreditsUsed(ctx context.Context, orgID string, keyType openrouter.KeyType) (float64, int, error) {
 	return 0, 0, nil
 }

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -25,9 +25,8 @@ const (
 	CodeInsufficientCredits Code = "insufficient_credits"
 	CodeRateLimitExceeded   Code = "rate_limit_exceeded"
 	// CodeInferenceDisabled marks an organization whose platform inference key
-	// an operator locked down, such as an enterprise trial that expired without
-	// converting. No credit top-up clears it, which is what separates it from
-	// CodeInsufficientCredits: only a deliberate reinstatement does. Maps to 403.
+	// an operator locked down. No top-up clears it, which is what separates it
+	// from CodeInsufficientCredits: only a deliberate reinstatement does.
 	CodeInferenceDisabled Code = "inference_disabled"
 	// CodeCanceled represents a request whose client disconnected mid-flight,
 	// surfacing as a context.Canceled cause while the request context is itself

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -24,6 +24,11 @@ const (
 	CodeNotImplemented      Code = "not_implemented"
 	CodeInsufficientCredits Code = "insufficient_credits"
 	CodeRateLimitExceeded   Code = "rate_limit_exceeded"
+	// CodeInferenceDisabled marks an organization whose platform inference key
+	// an operator locked down, such as an enterprise trial that expired without
+	// converting. No credit top-up clears it, which is what separates it from
+	// CodeInsufficientCredits: only a deliberate reinstatement does. Maps to 403.
+	CodeInferenceDisabled Code = "inference_disabled"
 	// CodeCanceled represents a request whose client disconnected mid-flight,
 	// surfacing as a context.Canceled cause while the request context is itself
 	// canceled. It is not a server fault. It is never authored directly:
@@ -51,6 +56,7 @@ var StatusCodes = map[Code]int{
 	CodeNotImplemented:      http.StatusNotImplemented,
 	CodeInsufficientCredits: http.StatusPaymentRequired,
 	CodeRateLimitExceeded:   http.StatusTooManyRequests,
+	CodeInferenceDisabled:   http.StatusForbidden,
 	// 499 (client closed request) is non-standard but matches the convention
 	// already used by the request access log middleware.
 	CodeCanceled: 499,
@@ -80,6 +86,8 @@ func (c Code) UserMessage() string {
 		return "requested feature is not implemented"
 	case CodeInsufficientCredits:
 		return "token balance exhausted"
+	case CodeInferenceDisabled:
+		return "AI features are disabled for this organization, contact support to restore access"
 	case CodeRateLimitExceeded:
 		return "rate limit exceeded"
 	case CodeUnavailable:
@@ -104,7 +112,7 @@ func (c Code) MCPCode() MCPCode {
 	switch c {
 	case CodeUnauthorized:
 		return MCPCodeUnauthorized
-	case CodeForbidden:
+	case CodeForbidden, CodeInferenceDisabled:
 		return MCPCodeForbidden
 	case CodeBadRequest, CodeConflict, CodeUnsupportedMedia:
 		return MCPCodeInvalidRequest

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -22,6 +22,7 @@ type disableTestUpstream struct {
 	server  *httptest.Server
 	mu      sync.Mutex
 	patches []string
+	onPatch func()
 }
 
 // recorded returns the raw patch bodies. They stay raw because the field a
@@ -32,6 +33,15 @@ func (u *disableTestUpstream) recorded() []string {
 	defer u.mu.Unlock()
 
 	return append([]string(nil), u.patches...)
+}
+
+// interceptPatch runs fn while a patch is in flight, which is the window
+// between a refresh reading the key row and writing it back.
+func (u *disableTestUpstream) interceptPatch(fn func()) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.onPatch = fn
 }
 
 func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disableTestUpstream, *repo.Queries) {
@@ -51,7 +61,7 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 	})
 	require.NoError(t, err)
 
-	upstream := &disableTestUpstream{server: nil, mu: sync.Mutex{}, patches: nil}
+	upstream := &disableTestUpstream{server: nil, mu: sync.Mutex{}, patches: nil, onPatch: nil}
 	upstream.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -70,7 +80,12 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 
 			upstream.mu.Lock()
 			upstream.patches = append(upstream.patches, string(raw))
+			onPatch := upstream.onPatch
 			upstream.mu.Unlock()
+
+			if onPatch != nil {
+				onPatch()
+			}
 
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"limit": 100.0, "hash": "hash-1"},
@@ -226,4 +241,42 @@ func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 	patches = upstream.recorded()
 	require.Len(t, patches, 3)
 	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
+}
+
+// A refresh reads the key row, patches upstream, then writes the row back. A
+// lockdown that commits inside that window has to survive the write: the
+// refresh never sent disabled=false, so clearing the local flag would hand out
+// a key that OpenRouter refuses.
+func TestRefreshAPIKeyLimit_KeepsLockdownThatLandsMidRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+
+	locked := make(chan error, 1)
+	upstream.interceptPatch(func() {
+		locked <- queries.DisableOpenRouterAPIKey(ctx, repo.DisableOpenRouterAPIKeyParams{
+			OrganizationID: orgID,
+			KeyType:        string(KeyTypeInternal),
+		})
+	})
+
+	limit := 42
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+	require.NoError(t, <-locked)
+
+	require.Equal(t, []string{`{"limit":42,"limit_reset":"monthly"}`}, upstream.recorded())
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.True(t, row.Disabled, "a refresh must not clear a lockdown it never saw")
+	require.Equal(t, int64(42), row.MonthlyCredits)
 }

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -35,8 +35,7 @@ func (u *disableTestUpstream) recorded() []string {
 	return append([]string(nil), u.patches...)
 }
 
-// interceptPatch runs fn while a patch is in flight, which is the window
-// between a refresh reading the key row and writing it back.
+// interceptPatch runs fn while a patch is in flight.
 func (u *disableTestUpstream) interceptPatch(fn func()) {
 	u.mu.Lock()
 	defer u.mu.Unlock()

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -34,15 +34,6 @@ func (u *disableTestUpstream) recorded() []string {
 	return append([]string(nil), u.patches...)
 }
 
-func decodePatch(t *testing.T, body string) updateKeyRequest {
-	t.Helper()
-
-	var decoded updateKeyRequest
-	require.NoError(t, json.Unmarshal([]byte(body), &decoded))
-
-	return decoded
-}
-
 func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disableTestUpstream, *repo.Queries) {
 	t.Helper()
 
@@ -77,23 +68,12 @@ func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disabl
 				return
 			}
 
-			var body updateKeyRequest
-			if err := json.Unmarshal(raw, &body); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-
 			upstream.mu.Lock()
 			upstream.patches = append(upstream.patches, string(raw))
 			upstream.mu.Unlock()
 
-			limit := 100.0
-			if body.Limit != nil {
-				limit = *body.Limit
-			}
-
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{"limit": limit, "hash": "hash-1"},
+				"data": map[string]any{"limit": 100.0, "hash": "hash-1"},
 			})
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -120,18 +100,17 @@ func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
 	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
 	require.NoError(t, err)
 
+	before, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+
 	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
 
-	patches := upstream.recorded()
-	require.Len(t, patches, 1)
-
-	// Both halves ride in one patch. The zero ceiling keeps the upstream
-	// rejection a 402, which chat and resolution analysis both branch on.
-	lockdown := decodePatch(t, patches[0])
-	require.NotNil(t, lockdown.Disabled)
-	require.True(t, *lockdown.Disabled)
-	require.NotNil(t, lockdown.Limit)
-	require.Zero(t, *lockdown.Limit)
+	// The patch carries the off switch and nothing else. Touching the ceiling
+	// would lose the value a reinstatement restores.
+	require.Equal(t, []string{`{"disabled":true}`}, upstream.recorded())
 
 	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -139,7 +118,34 @@ func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, row.Disabled)
-	require.Equal(t, int64(0), row.MonthlyCredits)
+	require.Equal(t, before.MonthlyCredits, row.MonthlyCredits)
+}
+
+// The lockdown binds at key resolution, so a disabled key must never reach a
+// completion. This is what turns a demotion into an error Gram can explain.
+func TestProvisionAPIKey_RefusesDisabledKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, _ := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+
+	key, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.ErrorIs(t, err, ErrPlatformKeyDisabled)
+	require.Empty(t, key, "a refused resolution must not leak the key it refused")
+
+	// Reinstatement makes resolution work again without minting a new key.
+	limit := 42
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+
+	key, err = provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	require.Equal(t, "sk-or-disable-1", key)
 }
 
 // A retried demotion must not fail on a key it already turned off, so
@@ -200,17 +206,15 @@ func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
 
 	patches := upstream.recorded()
 	require.Len(t, patches, 2)
-
-	reinstate := decodePatch(t, patches[1])
-	require.NotNil(t, reinstate.Disabled)
-	require.False(t, *reinstate.Disabled, "a limit alone does not bring a disabled key back")
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly","disabled":false}`, patches[1],
+		"a limit alone does not bring a disabled key back")
 
 	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        string(KeyTypeInternal),
 	})
 	require.NoError(t, err)
-	require.False(t, row.Disabled, "a stale flag keeps the key out of credit-usage polling")
+	require.False(t, row.Disabled, "a stale flag keeps key resolution failing after reinstatement")
 	require.Equal(t, int64(42), row.MonthlyCredits)
 
 	// Refreshing an enabled key must send the body it sent before the disabled

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -1,0 +1,225 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+)
+
+type disableTestUpstream struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	patches []string
+}
+
+// recorded returns the raw patch bodies. They stay raw because the field a
+// limit-only patch must NOT carry cannot be told apart from a null one after
+// decoding.
+func (u *disableTestUpstream) recorded() []string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	return append([]string(nil), u.patches...)
+}
+
+func decodePatch(t *testing.T, body string) updateKeyRequest {
+	t.Helper()
+
+	var decoded updateKeyRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &decoded))
+
+	return decoded
+}
+
+func newDisableTestProvisioner(t *testing.T, orgID string) (*OpenRouter, *disableTestUpstream, *repo.Queries) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	conn, err := infra.CloneTestDatabase(t, "ordisablekey")
+	require.NoError(t, err)
+
+	_, err = orgRepo.New(conn).UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Disable Key Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{String: "", Valid: false},
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+
+	upstream := &disableTestUpstream{server: nil, mu: sync.Mutex{}, patches: nil}
+	upstream.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method {
+		case http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": 100.0, "hash": "hash-1"},
+				"key":  "sk-or-disable-1",
+			})
+		case http.MethodPatch:
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			var body updateKeyRequest
+			if err := json.Unmarshal(raw, &body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			upstream.mu.Lock()
+			upstream.patches = append(upstream.patches, string(raw))
+			upstream.mu.Unlock()
+
+			limit := 100.0
+			if body.Limit != nil {
+				limit = *body.Limit
+			}
+
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": limit, "hash": "hash-1"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(upstream.server.Close)
+
+	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+
+	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil)
+	provisioner.baseURL = upstream.server.URL
+
+	return provisioner, upstream, repo.New(conn)
+}
+
+func TestDisableAPIKey_DisablesKeyUpstream(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+
+	patches := upstream.recorded()
+	require.Len(t, patches, 1)
+
+	// Both halves ride in one patch. The zero ceiling keeps the upstream
+	// rejection a 402, which chat and resolution analysis both branch on.
+	lockdown := decodePatch(t, patches[0])
+	require.NotNil(t, lockdown.Disabled)
+	require.True(t, *lockdown.Disabled)
+	require.NotNil(t, lockdown.Limit)
+	require.Zero(t, *lockdown.Limit)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.True(t, row.Disabled)
+	require.Equal(t, int64(0), row.MonthlyCredits)
+}
+
+// A retried demotion must not fail on a key it already turned off, so
+// disabling twice has to stay safe.
+func TestDisableAPIKey_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+
+	require.Len(t, upstream.recorded(), 2)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.True(t, row.Disabled)
+}
+
+// An organization that never provisioned a key of this type has nothing to
+// lock down, and the sweeper must not fail on it.
+func TestDisableAPIKey_NoKeyIsNoop(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
+
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeChat))
+	require.Empty(t, upstream.recorded())
+}
+
+// Sales reinstate a demoted organization by raising its limit, so the refresh
+// path has to clear the flag on both sides.
+func TestRefreshAPIKeyLimit_ReinstatesDisabledKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
+
+	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
+	require.NoError(t, err)
+	require.NoError(t, provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal))
+
+	limit := 42
+	refreshed, err := provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+	require.Equal(t, 42, refreshed)
+
+	patches := upstream.recorded()
+	require.Len(t, patches, 2)
+
+	reinstate := decodePatch(t, patches[1])
+	require.NotNil(t, reinstate.Disabled)
+	require.False(t, *reinstate.Disabled, "a limit alone does not bring a disabled key back")
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+	})
+	require.NoError(t, err)
+	require.False(t, row.Disabled, "a stale flag keeps the key out of credit-usage polling")
+	require.Equal(t, int64(42), row.MonthlyCredits)
+
+	// Refreshing an enabled key must send the body it sent before the disabled
+	// field existed. Carrying disabled=false on every refresh would revive a
+	// key an operator turned off on the OpenRouter dashboard.
+	_, err = provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
+	require.NoError(t, err)
+
+	patches = upstream.recorded()
+	require.Len(t, patches, 3)
+	require.JSONEq(t, `{"limit":42,"limit_reset":"monthly"}`, patches[2])
+}

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -23,6 +23,19 @@ func IsInsufficientCredits(err error) bool {
 	return errors.Is(err, ErrInsufficientCredits)
 }
 
+// ErrPlatformKeyDisabled is returned when an organization's provisioned
+// platform key is locked down (see DisableAPIKey). Key resolution fails on it
+// before the request reaches OpenRouter, so the caller gets a reason it can
+// state to the user instead of an upstream status that means several things at
+// once. It clears on reinstatement only, never on a credit top-up.
+var ErrPlatformKeyDisabled = errors.New("openrouter: platform key disabled")
+
+// IsPlatformKeyDisabled reports whether err originated from a locked-down
+// platform key anywhere in the error chain.
+func IsPlatformKeyDisabled(err error) bool {
+	return errors.Is(err, ErrPlatformKeyDisabled)
+}
+
 // ErrHistoryCorruptionCandidate signals OpenRouter (or the upstream provider
 // it proxies for) rejected the request with a 4xx consistent with a
 // malformed or oversize transcript. Callers self-heal by trimming history

--- a/server/internal/thirdparty/openrouter/errors.go
+++ b/server/internal/thirdparty/openrouter/errors.go
@@ -25,9 +25,8 @@ func IsInsufficientCredits(err error) bool {
 
 // ErrPlatformKeyDisabled is returned when an organization's provisioned
 // platform key is locked down (see DisableAPIKey). Key resolution fails on it
-// before the request reaches OpenRouter, so the caller gets a reason it can
-// state to the user instead of an upstream status that means several things at
-// once. It clears on reinstatement only, never on a credit top-up.
+// before the request reaches OpenRouter, so the caller has a reason it can
+// state to the user rather than an ambiguous upstream status.
 var ErrPlatformKeyDisabled = errors.New("openrouter: platform key disabled")
 
 // IsPlatformKeyDisabled reports whether err originated from a locked-down

--- a/server/internal/thirdparty/openrouter/local.go
+++ b/server/internal/thirdparty/openrouter/local.go
@@ -22,6 +22,10 @@ func (o *Development) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyT
 	return 0, nil
 }
 
+func (o *Development) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
+	return nil
+}
+
 func (o *Development) GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error) {
 	return 12.5, 10, nil // arbitrary local numbers
 }

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -299,10 +299,9 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType 
 		}
 
 	default:
-		// This is where the lockdown binds. Every platform-key completion
-		// resolves through here, so refusing the key is what turns a demotion
-		// into an error the caller can explain, rather than an upstream
-		// rejection whose status also means "our provisioning key is broken".
+		// Every platform-key completion resolves through here, so this is where
+		// the lockdown binds. Refusing locally beats an upstream rejection
+		// whose status also means "our provisioning key is broken".
 		if key.Disabled {
 			return "", fmt.Errorf("resolve %s key: %w", keyType, ErrPlatformKeyDisabled)
 		}
@@ -433,9 +432,8 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	creditLimit := float64(keyLimit)
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
 	if key.Disabled {
-		// Setting a limit on a disabled key does not bring it back, so
-		// reinstatement has to clear the flag upstream too. UpdateOpenRouterKey
-		// clears the local one.
+		// Setting a limit on a disabled key does not bring it back upstream.
+		// UpdateOpenRouterKey clears the local flag.
 		enabled := false
 		patch.Disabled = &enabled
 	}
@@ -461,11 +459,8 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 
 // DisableAPIKey stops an organization from spending on its platform key. Gram
 // enforces the lockdown itself: ProvisionAPIKey refuses a disabled key and
-// returns ErrPlatformKeyDisabled, so each surface fails with a reason it can
-// state to the user. The upstream flag covers any spend that never passes
-// through key resolution, such as a key that leaked.
-//
-// The key survives, so RefreshAPIKeyLimit can reinstate it.
+// returns ErrPlatformKeyDisabled. The upstream flag covers any spend that never
+// passes through key resolution, such as a key that leaked.
 //
 // The upstream PATCH runs before the local write. The reverse order would
 // record a lockdown that a permanently failing PATCH never made.

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -447,7 +447,9 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 		MonthlyCredits: int64(keyLimit),
 		KeyHash:        keyResponse.Data.Hash,
 		Key:            key.Key,
-		Reinstate:      key.Disabled,
+		// Not an unconditional clear: that would drop a lockdown committed
+		// after the read above.
+		Reinstate: key.Disabled,
 	})
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -434,8 +434,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	if key.Disabled {
 		// Setting a limit on a disabled key does not bring it back upstream.
 		// UpdateOpenRouterKey clears the local flag.
-		enabled := false
-		patch.Disabled = &enabled
+		patch.Disabled = new(false)
 	}
 
 	keyResponse, err := o.patchOpenRouterAPIKey(ctx, key.KeyHash, patch)
@@ -482,11 +481,10 @@ func (o *OpenRouter) DisableAPIKey(ctx context.Context, orgID string, keyType Ke
 		return fmt.Errorf("get openrouter key to disable: %w", err)
 	}
 
-	disabled := true
 	if _, err := o.patchOpenRouterAPIKey(ctx, key.KeyHash, updateKeyRequest{
 		Limit:      nil,
 		LimitReset: "",
-		Disabled:   &disabled,
+		Disabled:   new(true),
 	}); err != nil {
 		return fmt.Errorf("disable upstream openrouter key: %w", err)
 	}

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -207,10 +207,10 @@ type Provisioner interface {
 	// enabled, upstream and locally.
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error)
 
-	// DisableAPIKey drops the org's upstream spending ceiling to zero, turns the
-	// key off, and mirrors both into the local DB. The key survives, so
-	// RefreshAPIKeyLimit can reinstate it. An org with no key of that type is a
-	// no-op.
+	// DisableAPIKey turns the org's key off upstream and records that locally,
+	// after which ProvisionAPIKey refuses it with ErrPlatformKeyDisabled. The
+	// key survives, so RefreshAPIKeyLimit can reinstate it. An org with no key
+	// of that type is a no-op.
 	DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error
 
 	GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error)
@@ -299,6 +299,13 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType 
 		}
 
 	default:
+		// This is where the lockdown binds. Every platform-key completion
+		// resolves through here, so refusing the key is what turns a demotion
+		// into an error the caller can explain, rather than an upstream
+		// rejection whose status also means "our provisioning key is broken".
+		if key.Disabled {
+			return "", fmt.Errorf("resolve %s key: %w", keyType, ErrPlatformKeyDisabled)
+		}
 		openrouterKey = key.Key
 	}
 
@@ -427,8 +434,8 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
 	if key.Disabled {
 		// Setting a limit on a disabled key does not bring it back, so
-		// reinstatement has to clear the flag on both sides. A stale local flag
-		// would keep the key out of credit-usage polling while it spends again.
+		// reinstatement has to clear the flag upstream too. UpdateOpenRouterKey
+		// clears the local one.
 		enabled := false
 		patch.Disabled = &enabled
 	}
@@ -449,33 +456,19 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)
 	}
 
-	if key.Disabled {
-		if err := o.repo.EnableOpenRouterAPIKey(ctx, repo.EnableOpenRouterAPIKeyParams{
-			OrganizationID: orgID,
-			KeyType:        string(keyType),
-		}); err != nil {
-			return 0, fmt.Errorf("clear openrouter key disabled flag: %w", err)
-		}
-	}
-
 	return keyLimit, nil
 }
 
-// DisableAPIKey stops an organization from spending on its platform key.
-// Upstream is the only place that binds every caller: key resolution never
-// reads the disabled column, and lockout leaves the dashboard session path and
-// platform-initiated background usage able to reach the key.
+// DisableAPIKey stops an organization from spending on its platform key. Gram
+// enforces the lockdown itself: ProvisionAPIKey refuses a disabled key and
+// returns ErrPlatformKeyDisabled, so each surface fails with a reason it can
+// state to the user. The upstream flag covers any spend that never passes
+// through key resolution, such as a key that leaked.
 //
-// The patch carries both halves of the lockdown. The zero ceiling is what
-// makes a completion fail with 402, which classifyHTTPError turns into
-// ErrInsufficientCredits: chat reports a distinct code and resolution analysis
-// skips the segment rather than logging a failure per segment. The disabled
-// flag is the unambiguous off switch, since OpenRouter does not document how a
-// key behaves at exactly zero usage against a zero ceiling.
+// The key survives, so RefreshAPIKeyLimit can reinstate it.
 //
-// The upstream PATCH runs before the local write. A failure then leaves a key
-// that still spends but is still polled for usage, which the next sweep
-// retries. The reverse order would hide a spending key from usage polling.
+// The upstream PATCH runs before the local write. The reverse order would
+// record a lockdown that a permanently failing PATCH never made.
 func (o *OpenRouter) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
 	keyType = keyType.OrDefault()
 	if err := keyType.Validate(); err != nil {
@@ -494,11 +487,10 @@ func (o *OpenRouter) DisableAPIKey(ctx context.Context, orgID string, keyType Ke
 		return fmt.Errorf("get openrouter key to disable: %w", err)
 	}
 
-	zero := float64(0)
 	disabled := true
 	if _, err := o.patchOpenRouterAPIKey(ctx, key.KeyHash, updateKeyRequest{
-		Limit:      &zero,
-		LimitReset: "monthly",
+		Limit:      nil,
+		LimitReset: "",
 		Disabled:   &disabled,
 	}); err != nil {
 		return fmt.Errorf("disable upstream openrouter key: %w", err)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -433,7 +433,6 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
 	if key.Disabled {
 		// Setting a limit on a disabled key does not bring it back upstream.
-		// UpdateOpenRouterKey clears the local flag.
 		patch.Disabled = new(false)
 	}
 
@@ -448,6 +447,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 		MonthlyCredits: int64(keyLimit),
 		KeyHash:        keyResponse.Data.Hash,
 		Key:            key.Key,
+		Reinstate:      key.Disabled,
 	})
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -202,8 +202,16 @@ type Provisioner interface {
 	ProvisionAPIKey(ctx context.Context, orgID string, keyType KeyType) (string, error)
 
 	// RefreshAPIKeyLimit mutates the upstream OpenRouter key limit (PATCH
-	// /v1/keys/:hash) and mirrors the new value into the local DB.
+	// /v1/keys/:hash) and mirrors the new value into the local DB. It is also
+	// the reinstatement path: a key that DisableAPIKey turned off comes back
+	// enabled, upstream and locally.
 	RefreshAPIKeyLimit(ctx context.Context, orgID string, keyType KeyType, limit *int) (int, error)
+
+	// DisableAPIKey drops the org's upstream spending ceiling to zero, turns the
+	// key off, and mirrors both into the local DB. The key survives, so
+	// RefreshAPIKeyLimit can reinstate it. An org with no key of that type is a
+	// no-op.
+	DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error
 
 	GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error)
 
@@ -415,7 +423,17 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 		keyLimit = o.getLimitForOrg(org)
 	}
 
-	keyResponse, err := o.updateOpenRouterAPIKeyLimit(ctx, key.KeyHash, keyLimit)
+	creditLimit := float64(keyLimit)
+	patch := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly", Disabled: nil}
+	if key.Disabled {
+		// Setting a limit on a disabled key does not bring it back, so
+		// reinstatement has to clear the flag on both sides. A stale local flag
+		// would keep the key out of credit-usage polling while it spends again.
+		enabled := false
+		patch.Disabled = &enabled
+	}
+
+	keyResponse, err := o.patchOpenRouterAPIKey(ctx, key.KeyHash, patch)
 	if err != nil {
 		return 0, err
 	}
@@ -431,7 +449,69 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)
 	}
 
+	if key.Disabled {
+		if err := o.repo.EnableOpenRouterAPIKey(ctx, repo.EnableOpenRouterAPIKeyParams{
+			OrganizationID: orgID,
+			KeyType:        string(keyType),
+		}); err != nil {
+			return 0, fmt.Errorf("clear openrouter key disabled flag: %w", err)
+		}
+	}
+
 	return keyLimit, nil
+}
+
+// DisableAPIKey stops an organization from spending on its platform key.
+// Upstream is the only place that binds every caller: key resolution never
+// reads the disabled column, and lockout leaves the dashboard session path and
+// platform-initiated background usage able to reach the key.
+//
+// The patch carries both halves of the lockdown. The zero ceiling is what
+// makes a completion fail with 402, which classifyHTTPError turns into
+// ErrInsufficientCredits: chat reports a distinct code and resolution analysis
+// skips the segment rather than logging a failure per segment. The disabled
+// flag is the unambiguous off switch, since OpenRouter does not document how a
+// key behaves at exactly zero usage against a zero ceiling.
+//
+// The upstream PATCH runs before the local write. A failure then leaves a key
+// that still spends but is still polled for usage, which the next sweep
+// retries. The reverse order would hide a spending key from usage polling.
+func (o *OpenRouter) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
+	keyType = keyType.OrDefault()
+	if err := keyType.Validate(); err != nil {
+		return fmt.Errorf("disable openrouter key: %w", err)
+	}
+
+	key, err := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// An organization that never ran a completion has no key of this type.
+		return nil
+	case err != nil:
+		return fmt.Errorf("get openrouter key to disable: %w", err)
+	}
+
+	zero := float64(0)
+	disabled := true
+	if _, err := o.patchOpenRouterAPIKey(ctx, key.KeyHash, updateKeyRequest{
+		Limit:      &zero,
+		LimitReset: "monthly",
+		Disabled:   &disabled,
+	}); err != nil {
+		return fmt.Errorf("disable upstream openrouter key: %w", err)
+	}
+
+	if err := o.repo.DisableOpenRouterAPIKey(ctx, repo.DisableOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(keyType),
+	}); err != nil {
+		return fmt.Errorf("mark openrouter key disabled: %w", err)
+	}
+
+	return nil
 }
 
 type keyUsageResponse struct {
@@ -577,6 +657,10 @@ type createKeyRequest struct {
 type updateKeyRequest struct {
 	Limit      *float64 `json:"limit,omitempty"`
 	LimitReset string   `json:"limit_reset,omitempty"`
+	// Disabled toggles the upstream key off and on. It is a pointer because
+	// omitting the field leaves the current state alone, which is what every
+	// limit-only patch wants.
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 type keyResponse struct {
@@ -640,10 +724,7 @@ func (o *OpenRouter) createOpenRouterAPIKey(ctx context.Context, orgID string, o
 	return &response, nil
 }
 
-func (o *OpenRouter) updateOpenRouterAPIKeyLimit(ctx context.Context, keyHash string, keyLimit int) (*keyResponse, error) {
-	creditLimit := float64(keyLimit)
-	requestBody := updateKeyRequest{Limit: &creditLimit, LimitReset: "monthly"}
-
+func (o *OpenRouter) patchOpenRouterAPIKey(ctx context.Context, keyHash string, requestBody updateKeyRequest) (*keyResponse, error) {
 	bodyBytes, err := json.Marshal(requestBody)
 	if err != nil {
 		o.logger.ErrorContext(ctx, "failed to marshal update openrouter key request body", attr.SlogError(err))

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -27,8 +27,10 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE;
 
 -- name: UpdateOpenRouterKey :one
+-- Also clears the disabled flag. This is the reinstatement write, and its only
+-- caller turns the upstream key back on in the same call.
 UPDATE openrouter_api_keys
-SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key
+SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key, disabled = FALSE
 WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE
@@ -36,22 +38,10 @@ RETURNING *;
 
 -- name: DisableOpenRouterAPIKey :exec
 -- Locks the key down without deleting it, so a reinstated organization keeps
--- the same upstream key. Mirrors both halves of the upstream lockdown: the
--- ceiling drops to 0 and the flag drops the key out of credit-usage polling.
+-- the same upstream key and its ceiling. ProvisionAPIKey reads this flag and
+-- refuses to hand the key to a completion.
 UPDATE openrouter_api_keys
 SET disabled = TRUE,
-    monthly_credits = 0,
-    updated_at = clock_timestamp()
-WHERE organization_id = @organization_id
-  AND key_type = @key_type
-  AND deleted IS FALSE;
-
--- name: EnableOpenRouterAPIKey :exec
--- Reverses DisableOpenRouterAPIKey. Reinstatement runs through
--- RefreshAPIKeyLimit, which sets a fresh ceiling in the same call, so this
--- only has to clear the flag.
-UPDATE openrouter_api_keys
-SET disabled = FALSE,
     updated_at = clock_timestamp()
 WHERE organization_id = @organization_id
   AND key_type = @key_type

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -27,9 +27,6 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE;
 
 -- name: UpdateOpenRouterKey :one
--- Clears the disabled flag only when the caller is reinstating, which it signals
--- with @reinstate. A routine refresh reads the row before it patches upstream, so
--- an unconditional clear here would revoke a lockdown that landed in between.
 UPDATE openrouter_api_keys
 SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key,
     disabled = disabled AND NOT @reinstate::boolean

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -27,10 +27,12 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE;
 
 -- name: UpdateOpenRouterKey :one
--- Also clears the disabled flag. This is the reinstatement write, and its only
--- caller turns the upstream key back on in the same call.
+-- Clears the disabled flag only when the caller is reinstating, which it signals
+-- with @reinstate. A routine refresh reads the row before it patches upstream, so
+-- an unconditional clear here would revoke a lockdown that landed in between.
 UPDATE openrouter_api_keys
-SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key, disabled = FALSE
+SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key,
+    disabled = disabled AND NOT @reinstate::boolean
 WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -34,6 +34,29 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE
 RETURNING *;
 
+-- name: DisableOpenRouterAPIKey :exec
+-- Locks the key down without deleting it, so a reinstated organization keeps
+-- the same upstream key. Mirrors both halves of the upstream lockdown: the
+-- ceiling drops to 0 and the flag drops the key out of credit-usage polling.
+UPDATE openrouter_api_keys
+SET disabled = TRUE,
+    monthly_credits = 0,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE;
+
+-- name: EnableOpenRouterAPIKey :exec
+-- Reverses DisableOpenRouterAPIKey. Reinstatement runs through
+-- RefreshAPIKeyLimit, which sets a fresh ceiling in the same call, so this
+-- only has to clear the flag.
+UPDATE openrouter_api_keys
+SET disabled = FALSE,
+    updated_at = clock_timestamp()
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND deleted IS FALSE;
+
 -- name: UpdateOpenRouterKeyMonthlyCredits :exec
 -- Updates only monthly_credits for the given organization. Used by the
 -- metrics-collection reconciliation path when the upstream OpenRouter limit

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -129,9 +129,10 @@ func (q *Queries) LockOpenRouterKeyProvisioning(ctx context.Context, arg LockOpe
 
 const updateOpenRouterKey = `-- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
-SET monthly_credits = $1, key_hash = $2, key = $3, disabled = FALSE
-WHERE organization_id = $4
-  AND key_type = $5
+SET monthly_credits = $1, key_hash = $2, key = $3,
+    disabled = disabled AND NOT $4::boolean
+WHERE organization_id = $5
+  AND key_type = $6
   AND deleted IS FALSE
 RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
@@ -140,17 +141,20 @@ type UpdateOpenRouterKeyParams struct {
 	MonthlyCredits int64
 	KeyHash        string
 	Key            string
+	Reinstate      bool
 	OrganizationID string
 	KeyType        string
 }
 
-// Also clears the disabled flag. This is the reinstatement write, and its only
-// caller turns the upstream key back on in the same call.
+// Clears the disabled flag only when the caller is reinstating, which it signals
+// with @reinstate. A routine refresh reads the row before it patches upstream, so
+// an unconditional clear here would revoke a lockdown that landed in between.
 func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterKeyParams) (OpenrouterApiKey, error) {
 	row := q.db.QueryRow(ctx, updateOpenRouterKey,
 		arg.MonthlyCredits,
 		arg.KeyHash,
 		arg.Key,
+		arg.Reinstate,
 		arg.OrganizationID,
 		arg.KeyType,
 	)

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -146,9 +146,6 @@ type UpdateOpenRouterKeyParams struct {
 	KeyType        string
 }
 
-// Clears the disabled flag only when the caller is reinstating, which it signals
-// with @reinstate. A routine refresh reads the row before it patches upstream, so
-// an unconditional clear here would revoke a lockdown that landed in between.
 func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterKeyParams) (OpenrouterApiKey, error) {
 	row := q.db.QueryRow(ctx, updateOpenRouterKey,
 		arg.MonthlyCredits,

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -58,6 +58,51 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 	return i, err
 }
 
+const disableOpenRouterAPIKey = `-- name: DisableOpenRouterAPIKey :exec
+UPDATE openrouter_api_keys
+SET disabled = TRUE,
+    monthly_credits = 0,
+    updated_at = clock_timestamp()
+WHERE organization_id = $1
+  AND key_type = $2
+  AND deleted IS FALSE
+`
+
+type DisableOpenRouterAPIKeyParams struct {
+	OrganizationID string
+	KeyType        string
+}
+
+// Locks the key down without deleting it, so a reinstated organization keeps
+// the same upstream key. Mirrors both halves of the upstream lockdown: the
+// ceiling drops to 0 and the flag drops the key out of credit-usage polling.
+func (q *Queries) DisableOpenRouterAPIKey(ctx context.Context, arg DisableOpenRouterAPIKeyParams) error {
+	_, err := q.db.Exec(ctx, disableOpenRouterAPIKey, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
+const enableOpenRouterAPIKey = `-- name: EnableOpenRouterAPIKey :exec
+UPDATE openrouter_api_keys
+SET disabled = FALSE,
+    updated_at = clock_timestamp()
+WHERE organization_id = $1
+  AND key_type = $2
+  AND deleted IS FALSE
+`
+
+type EnableOpenRouterAPIKeyParams struct {
+	OrganizationID string
+	KeyType        string
+}
+
+// Reverses DisableOpenRouterAPIKey. Reinstatement runs through
+// RefreshAPIKeyLimit, which sets a fresh ceiling in the same call, so this
+// only has to clear the flag.
+func (q *Queries) EnableOpenRouterAPIKey(ctx context.Context, arg EnableOpenRouterAPIKeyParams) error {
+	_, err := q.db.Exec(ctx, enableOpenRouterAPIKey, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
 const getOpenRouterAPIKey = `-- name: GetOpenRouterAPIKey :one
 SELECT organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 FROM openrouter_api_keys

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -61,7 +61,6 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 const disableOpenRouterAPIKey = `-- name: DisableOpenRouterAPIKey :exec
 UPDATE openrouter_api_keys
 SET disabled = TRUE,
-    monthly_credits = 0,
     updated_at = clock_timestamp()
 WHERE organization_id = $1
   AND key_type = $2
@@ -74,32 +73,10 @@ type DisableOpenRouterAPIKeyParams struct {
 }
 
 // Locks the key down without deleting it, so a reinstated organization keeps
-// the same upstream key. Mirrors both halves of the upstream lockdown: the
-// ceiling drops to 0 and the flag drops the key out of credit-usage polling.
+// the same upstream key and its ceiling. ProvisionAPIKey reads this flag and
+// refuses to hand the key to a completion.
 func (q *Queries) DisableOpenRouterAPIKey(ctx context.Context, arg DisableOpenRouterAPIKeyParams) error {
 	_, err := q.db.Exec(ctx, disableOpenRouterAPIKey, arg.OrganizationID, arg.KeyType)
-	return err
-}
-
-const enableOpenRouterAPIKey = `-- name: EnableOpenRouterAPIKey :exec
-UPDATE openrouter_api_keys
-SET disabled = FALSE,
-    updated_at = clock_timestamp()
-WHERE organization_id = $1
-  AND key_type = $2
-  AND deleted IS FALSE
-`
-
-type EnableOpenRouterAPIKeyParams struct {
-	OrganizationID string
-	KeyType        string
-}
-
-// Reverses DisableOpenRouterAPIKey. Reinstatement runs through
-// RefreshAPIKeyLimit, which sets a fresh ceiling in the same call, so this
-// only has to clear the flag.
-func (q *Queries) EnableOpenRouterAPIKey(ctx context.Context, arg EnableOpenRouterAPIKeyParams) error {
-	_, err := q.db.Exec(ctx, enableOpenRouterAPIKey, arg.OrganizationID, arg.KeyType)
 	return err
 }
 
@@ -152,7 +129,7 @@ func (q *Queries) LockOpenRouterKeyProvisioning(ctx context.Context, arg LockOpe
 
 const updateOpenRouterKey = `-- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
-SET monthly_credits = $1, key_hash = $2, key = $3
+SET monthly_credits = $1, key_hash = $2, key = $3, disabled = FALSE
 WHERE organization_id = $4
   AND key_type = $5
   AND deleted IS FALSE
@@ -167,6 +144,8 @@ type UpdateOpenRouterKeyParams struct {
 	KeyType        string
 }
 
+// Also clears the disabled flag. This is the reinstatement write, and its only
+// caller turns the upstream key back on in the same call.
 func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterKeyParams) (OpenrouterApiKey, error) {
 	row := q.db.QueryRow(ctx, updateOpenRouterKey,
 		arg.MonthlyCredits,

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -65,6 +65,10 @@ func (m *mockProvisioner) RefreshAPIKeyLimit(ctx context.Context, orgID string, 
 	return 0, nil
 }
 
+func (m *mockProvisioner) DisableAPIKey(ctx context.Context, orgID string, keyType KeyType) error {
+	return nil
+}
+
 func (m *mockProvisioner) GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error) {
 	return 0, 0, nil
 }


### PR DESCRIPTION
Adds `Provisioner.DisableAPIKey`, which stops an organization from spending on its platform OpenRouter key without deleting the key, and makes a limit refresh reinstate a locked-down key.

Split out of #4983 so the OpenRouter spend path can be reviewed on its own. The enterprise trial demotion sweeper is the first caller and stacks on top of this.

## Where the lockdown binds

Enforcement lives in Gram, not upstream. `ProvisionAPIKey` is the single funnel for every platform-key resolution: `PlatformKeyResolver.ResolveKey` calls it, and `modelkeys.Resolver` falls back to it whenever no customer-supplied key applies. It already reads the row, so it now refuses a disabled key with a new `ErrPlatformKeyDisabled` sentinel before any request reaches OpenRouter.

That choice decides the shape of the upstream patch. An earlier revision of this PR also dropped the spending ceiling to zero, so a completion would fail with 402 and land on the existing `ErrInsufficientCredits` path. Refusing the key locally is better on three counts:

- **It is unambiguous.** A disabled key returns 401, which is indistinguishable from our own provisioning key being broken. A zero ceiling returns 402, which is indistinguishable from a customer who genuinely ran out of credits. OpenRouter documents neither case.
- **It says something useful.** A local refusal carries a reason we authored, so the user learns that access ended and how to restore it.
- **It costs nothing upstream.** No HTTP request goes out for a key we already know is locked down.

The ceiling is therefore left alone. The lockdown patch carries `disabled: true` and nothing else, and the original ceiling survives for reinstatement. The upstream flag still covers any spend that never passes through key resolution, such as a key that leaked.

## Surfacing the failure

New `oops.CodeInferenceDisabled` (`inference_disabled`, 403). It is deliberately separate from `CodeInsufficientCredits`: no credit top-up clears it, only a deliberate reinstatement does. It maps to `MCPCodeForbidden` rather than falling through to internal error.

Three consumers branch on the sentinel:

- `server/internal/chat/impl.go` returns the new code. The dashboard renders the goa `message` verbatim, so the user sees "AI features are disabled for this organization, contact support to restore access" instead of a gateway error.
- `server/internal/background/analyze_chat_resolutions.go` skips the segment quietly, under its own non-retryable Temporal error type, so the workflow log names the real cause instead of reporting insufficient credits for a key we turned off.
- Everything else receives a wrapped sentinel instead of an unclassified 401.

## Reinstatement

`RefreshAPIKeyLimit` is the reinstatement path. Setting a limit on a disabled key does not bring it back, so the refresh clears the flag upstream as well. `UpdateOpenRouterKey` clears the local one in the write it already makes.

The local clear matters twice over: resolution keeps failing while the flag is set, and the credit-usage polling query in `server/internal/background/activities/queries.sql` joins on `k.disabled = FALSE`.

A routine refresh of an enabled key must not carry `disabled: false`, or it would revive a key an operator turned off on the OpenRouter dashboard. `TestRefreshAPIKeyLimit_ReinstatesDisabledKey` pins the exact wire format of both bodies.

Both callers of `RefreshAPIKeyLimit` are deliberate account-type transitions: a Polar subscription webhook, and the one-shot refresh workflow. Nothing runs it on a schedule, so a lockdown cannot lift itself.

## Ordering

The upstream PATCH runs before the local write. The reverse order would record a lockdown that a permanently failing PATCH never made.

## Notes for review

- `updateOpenRouterAPIKeyLimit` becomes `patchOpenRouterAPIKey` and takes the request body, so the limit patch and the lockdown patch share one HTTP path.
- `TestProvisionAPIKey_RefusesDisabledKey` pins the refusal and the round trip back through reinstatement. `TestDisableAPIKey_IsIdempotent` pins the `:exec` query choice, so a retried sweep cannot fail on a key it already turned off.
- No schema change. The `disabled` column already exists.
- No production caller in this PR.
