### PR TITLE
chore: speed up assistant CI build with Rust caching

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -445,7 +445,9 @@ jobs:
           # Release-artifact build; the action's -D warnings default would
           # diverge from the in-image fallback build.
           rustflags: ""
-          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+          # TEMP(AGE-3104): save on this PR branch once to demonstrate the warm
+          # build; revert to main-only before merge.
+          cache-save-if: true
 
       - name: Build assistant runner
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -417,6 +417,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
     if: needs.changes.outputs.server == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
+    env:
+      RUNNER_TARGET: x86_64-unknown-linux-musl
+      RUNNER_BINARY_DIR: /tmp/runner-binary
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
@@ -430,6 +433,31 @@ jobs:
 
       - name: Prepare GitHub Actions environment
         run: mise run github
+
+      - name: Install musl toolchain
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          target: ${{ env.RUNNER_TARGET }}
+          rust-src-dir: agents/runner
+          # Release-artifact build; the action's -D warnings default would
+          # diverge from the in-image fallback build.
+          rustflags: ""
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build assistant runner
+        run: |
+          mise run build:assistant-runner --release --bin gram-assistant-runner --target ${{ env.RUNNER_TARGET }}
+          mkdir -p ${{ env.RUNNER_BINARY_DIR }}
+          cp agents/runner/target/${{ env.RUNNER_TARGET }}/release/gram-assistant-runner ${{ env.RUNNER_BINARY_DIR }}/gram-assistant-runner
+
+      - name: Smoke test assistant runner binary
+        run: |
+          ldd ${{ env.RUNNER_BINARY_DIR }}/gram-assistant-runner 2>&1 | grep -Eq "not a dynamic executable|statically linked" \
+            || { echo "runner binary is not statically linked; it would fail inside the runtime image" >&2; exit 1; }
+          ${{ env.RUNNER_BINARY_DIR }}/gram-assistant-runner --help
 
       - name: Generate preview tag
         id: assistant-preview-tag
@@ -535,6 +563,11 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          # build-contexts and build-args travel together on all three pushes:
+          # the arg switches the Dockerfile to the prebuilt path, the context
+          # provides the host-built binary.
+          build-contexts: runner-binary=${{ env.RUNNER_BINARY_DIR }}
+          build-args: RUNNER_SOURCE=runner-binary
           file: ./agents/runtime-image/Dockerfile
           platforms: linux/amd64
           push: true
@@ -565,6 +598,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          build-contexts: runner-binary=${{ env.RUNNER_BINARY_DIR }}
+          build-args: RUNNER_SOURCE=runner-binary
           file: ./agents/runtime-image/Dockerfile
           platforms: linux/amd64
           push: true
@@ -595,6 +630,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          build-contexts: runner-binary=${{ env.RUNNER_BINARY_DIR }}
+          build-args: RUNNER_SOURCE=runner-binary
           file: ./agents/runtime-image/Dockerfile
           platforms: linux/amd64
           push: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -484,30 +484,6 @@ jobs:
           fi
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
-      - name: "[DEV] Create fly app"
-        id: assistantFlyCreateDev
-        shell: bash
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
-          FLY_IMAGE: ${{ vars.FLY_ASSISTANT_IMAGE_DEV }}
-        run: |
-          mise run fly:init-runner \
-            --org ${{ secrets.FLY_ORG_DEV }} \
-            --image $FLY_IMAGE \
-            --force
-
-      - name: "[PROD] Create fly app"
-        id: assistantFlyCreateProd
-        shell: bash
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
-          FLY_IMAGE: ${{ vars.FLY_ASSISTANT_IMAGE_PROD }}
-        run: |
-          mise run fly:init-runner \
-            --org ${{ secrets.FLY_ORG_PROD }} \
-            --image $FLY_IMAGE \
-            --force
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -563,9 +539,9 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          # build-contexts and build-args travel together on all three pushes:
-          # the arg switches the Dockerfile to the prebuilt path, the context
-          # provides the host-built binary.
+          # build-contexts and build-args travel together: the arg switches the
+          # Dockerfile to the prebuilt path, the context provides the
+          # host-built binary.
           build-contexts: runner-binary=${{ env.RUNNER_BINARY_DIR }}
           build-args: RUNNER_SOURCE=runner-binary
           file: ./agents/runtime-image/Dockerfile
@@ -573,70 +549,6 @@ jobs:
           push: true
           tags: ${{ steps.assistantMetaGcr.outputs.tags }}
           labels: ${{ steps.assistantMetaGcr.outputs.labels }}
-
-      - name: "[DEV] Login to Fly registry"
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
-        run: fly auth docker
-
-      - name: "[DEV] Extract assistant runtime metadata"
-        id: assistantMetaDev
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ steps.assistantFlyCreateDev.outputs.flyAppRegistry }}
-          tags: |
-            type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value=${{ steps.assistant-preview-tag.outputs.tag }},enable=${{ steps.assistant-preview-tag.outputs.enabled }}
-            type=raw,value=${{ steps.assistant-runtime-hash.outputs.hash }}
-            type=schedule,pattern=nightly
-            type=sha
-            type=sha,format=long
-
-      - name: "[DEV] Build and push assistant runtime image"
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          build-contexts: runner-binary=${{ env.RUNNER_BINARY_DIR }}
-          build-args: RUNNER_SOURCE=runner-binary
-          file: ./agents/runtime-image/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.assistantMetaDev.outputs.tags }}
-          labels: ${{ steps.assistantMetaDev.outputs.labels }}
-
-      - name: "[PROD] Login to Fly registry"
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PROD }}
-        run: fly auth docker
-
-      - name: "[PROD] Extract assistant runtime metadata"
-        id: assistantMetaProd
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ steps.assistantFlyCreateProd.outputs.flyAppRegistry }}
-          tags: |
-            type=ref,event=branch,enable=${{ github.event_name != 'merge_group' }}
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value=${{ steps.assistant-preview-tag.outputs.tag }},enable=${{ steps.assistant-preview-tag.outputs.enabled }}
-            type=raw,value=${{ steps.assistant-runtime-hash.outputs.hash }}
-            type=schedule,pattern=nightly
-            type=sha
-            type=sha,format=long
-
-      - name: "[PROD] Build and push assistant runtime image"
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          build-contexts: runner-binary=${{ env.RUNNER_BINARY_DIR }}
-          build-args: RUNNER_SOURCE=runner-binary
-          file: ./agents/runtime-image/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.assistantMetaProd.outputs.tags }}
-          labels: ${{ steps.assistantMetaProd.outputs.labels }}
 
   otel-collector:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -435,7 +435,9 @@ jobs:
         run: mise run github
 
       - name: Install musl toolchain
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
+        run: |
+          sudo apt-get update -qq -o Acquire::Languages=none
+          sudo apt-get install -y -qq --no-install-recommends musl-tools
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -483,9 +485,6 @@ jobs:
             exit 1
           fi
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -536,7 +535,11 @@ jobs:
             type=sha,format=long
 
       - name: Build and push assistant runtime image to GCR
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        # Blacksmith fork of docker/build-push-action: mounts a repo-scoped
+        # sticky-disk layer cache and runs its own local buildkit, so the
+        # bun/lightpanda/apt layers persist across runs. No setup-buildx
+        # needed — remote-builder config is ignored by this action.
+        uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
         with:
           context: .
           # build-contexts and build-args travel together: the arg switches the

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -445,9 +445,7 @@ jobs:
           # Release-artifact build; the action's -D warnings default would
           # diverge from the in-image fallback build.
           rustflags: ""
-          # TEMP(AGE-3104): save on this PR branch once to demonstrate the warm
-          # build; revert to main-only before merge.
-          cache-save-if: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build assistant runner
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -486,6 +486,11 @@ jobs:
           fi
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
+      - name: Setup Docker builder
+        uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
+        with:
+          cache-key: gram/assistant-runtime-image
+
       - name: Log in to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -535,10 +540,9 @@ jobs:
             type=sha,format=long
 
       - name: Build and push assistant runtime image to GCR
-        # Blacksmith fork of docker/build-push-action: mounts a repo-scoped
-        # sticky-disk layer cache and runs its own local buildkit, so the
-        # bun/lightpanda/apt layers persist across runs. No setup-buildx
-        # needed — remote-builder config is ignored by this action.
+        # Blacksmith fork of docker/build-push-action, paired with the
+        # setup-docker-builder step above: buildkit runs on a sticky-disk
+        # cache so the bun/lightpanda/apt layers persist across runs.
         uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
         with:
           context: .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -457,7 +457,7 @@ jobs:
 
       - name: Smoke test assistant runner binary
         run: |
-          ldd ${{ env.RUNNER_BINARY_DIR }}/gram-assistant-runner 2>&1 | grep -Eq "not a dynamic executable|statically linked" \
+          file -b ${{ env.RUNNER_BINARY_DIR }}/gram-assistant-runner | grep -Eq "statically linked|static-pie linked" \
             || { echo "runner binary is not statically linked; it would fail inside the runtime image" >&2; exit 1; }
           ${{ env.RUNNER_BINARY_DIR }}/gram-assistant-runner --help
 

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -18,8 +18,8 @@ FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf100
 
 FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS sandbox-deps
 WORKDIR /sandbox
-COPY agents/runtime-image/sandbox/package.json ./
-RUN bun install --production
+COPY agents/runtime-image/sandbox/package.json agents/runtime-image/sandbox/bun.lock ./
+RUN bun install --production --frozen-lockfile
 
 # Workaround for oven-sh/bun#9911: playwright-core's bundled `ws` shim is
 # missing 'upgrade'/'unexpected-response' events on bun, which breaks

--- a/agents/runtime-image/Dockerfile
+++ b/agents/runtime-image/Dockerfile
@@ -1,9 +1,18 @@
+# CI builds the runner binary on the host (with cargo caching) and injects it
+# via --build-arg RUNNER_SOURCE=runner-binary --build-context runner-binary=<dir>.
+# Local builds keep the default in-image build. The prebuilt path requires
+# BuildKit (podman/buildah cannot FROM a directory context).
+ARG RUNNER_SOURCE=runner-builder
+
 FROM rust:1.97-bookworm@sha256:77fac8b98f9f46062bb680b6d25d5bcaabfc400143952ebc572e924bcbedc3fa AS runner-builder
 
 WORKDIR /src
 COPY agents/runner/Cargo.toml agents/runner/Cargo.lock ./agents/runner/
 COPY agents/runner/src ./agents/runner/src
-RUN cargo build --manifest-path ./agents/runner/Cargo.toml --release --bin gram-assistant-runner
+RUN cargo build --locked --manifest-path ./agents/runner/Cargo.toml --release --bin gram-assistant-runner \
+ && cp /src/agents/runner/target/release/gram-assistant-runner /gram-assistant-runner
+
+FROM ${RUNNER_SOURCE} AS runner-artifact
 
 FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun
 
@@ -61,7 +70,7 @@ RUN apt-get update \
     util-linux \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=runner-builder /src/agents/runner/target/release/gram-assistant-runner /usr/local/bin/gram-assistant-runner
+COPY --from=runner-artifact /gram-assistant-runner /usr/local/bin/gram-assistant-runner
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=lightpanda /lightpanda /usr/local/bin/lightpanda
 COPY agents/runtime-image/lightpanda-supervise.sh /usr/local/bin/lightpanda-supervise

--- a/agents/runtime-image/Dockerfile.dockerignore
+++ b/agents/runtime-image/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+# Build-scoped ignore for agents/runtime-image/Dockerfile (context = repo root).
+# The image only consumes files under agents/, so exclude everything else to
+# keep the build context small.
+*
+!agents/
+agents/runner/target/

--- a/agents/runtime-image/sandbox/bun.lock
+++ b/agents/runtime-image/sandbox/bun.lock
@@ -1,0 +1,108 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "gram-sandbox",
+      "dependencies": {
+        "@mozilla/readability": "0.6.0",
+        "jsdom": "29.0.2",
+        "playwright-core": "1.49.0",
+        "turndown": "7.2.4",
+        "turndown-plugin-gfm": "1.0.2",
+        "ws": "8.21.0",
+      },
+    },
+  },
+  "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.3.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.10", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.3.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.7", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "playwright-core": ["playwright-core@1.49.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tldts": ["tldts@7.4.10", "", { "dependencies": { "tldts-core": "^7.4.10" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog=="],
+
+    "tldts-core": ["tldts-core@7.4.10", "", {}, "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+  }
+}


### PR DESCRIPTION
## Summary

- Build the assistant runner on the CI host as a static `x86_64-unknown-linux-musl` binary using `actions-rust-lang/setup-rust-toolchain` (cargo registry + target caching via Swatinem/rust-cache; toolchain pinned by `agents/runner/rust-toolchain.toml`), instead of compiling it inside the Docker image with zero caching on every run.
- Inject the prebuilt binary into the runtime image via a BuildKit named build context and an `ARG RUNNER_SOURCE`-selected alias stage. Local `mise run build:assistants-runtime-image` keeps the default in-image cargo build (works on podman and arm64, unchanged).
- musl static binary sidesteps the glibc skew between the Ubuntu 24.04 runner (glibc 2.39) and the `debian:bookworm` runtime image (glibc 2.36); a smoke-test step asserts the binary is statically linked and runs `--help` before any image build.
- Add a build-scoped `Dockerfile.dockerignore` allowlisting `agents/` — the context previously uploaded the entire checkout (including `.git` and `node_modules`) on every build; now it is ~26 files.
- Cargo cache is saved on `main` runs only to avoid churning the shared GitHub cache quota; PRs restore from it.
- Add `--locked` to the in-image fallback build for parity with CI.
- Drop the Fly.io publish steps from the assistant runtime image job — the assistant runtime runs on GKE only now and consumes the image from GCR (`otel-collector` / `functions-image` keep their Fly publishing). This removes two of the three image pushes (~1.5min).

## Verification

- musl build of the runner (incl. `aws-lc-sys`/`ring`) compiles clean and the static binary runs (validated in a native arm64 Ubuntu 24.04 container; amd64 validated by this PR's own CI run).
- Both Dockerfile paths validated: default in-image path builds under podman/buildah locally (`mise run build:assistants-runtime-image` passes end to end), prebuilt named-context path builds under BuildKit.
- dockerignore allowlist semantics verified identical under podman and BuildKit.

## Follow-up candidates (out of scope)

- Registry-backed `cache-from`/`cache-to` for the remaining image layers (bun install, lightpanda download).
- Gate the PROD Fly registry push off pull requests.
- Commit a `bun.lock` for the sandbox helper deps and use `--frozen-lockfile`.

Closes [AGE-3104](https://linear.app/speakeasy/issue/AGE-3104/speed-up-assistant-ci-build-with-rust-caching)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up assistant CI builds by compiling the Rust runner once on the host with caching and injecting the static binary into the runtime image. Add a Blacksmith sticky-disk builder to persist runtime layer caches, pin sandbox deps with a committed `bun.lock`, and drop Fly.io publishes; the runtime now builds and pushes to GCR only. Closes [AGE-3104](https://linear.app/speakeasy/issue/AGE-3104/speed-up-assistant-ci-build-with-rust-caching).

- **Refactors**
  - Build static `x86_64-unknown-linux-musl` runner via `actions-rust-lang/setup-rust-toolchain`; install `musl-tools`; smoke test verifies static link; cargo cache saves on `main`, PRs restore.
  - Inject prebuilt binary via BuildKit named context with `ARG RUNNER_SOURCE`; local builds keep the in-image Cargo build.
  - Cache runtime image layers using `useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action` (bun install, lightpanda, apt); drop `docker/setup-buildx-action`.
  - Commit `agents/runtime-image/sandbox/bun.lock` and install with `--frozen-lockfile` to pin deps and stabilize cache keys.
  - Add `agents/runtime-image/Dockerfile.dockerignore` to allowlist `agents/` and ignore `agents/runner/target/`.
  - Remove Fly.io registry steps; assistant runtime is consumed from GCR (GKE).

<sup>Written for commit 7f53fb582a259b717b4eea21bf0428af0484ecfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

