### PR TITLE
fix: pluralized "All tagses" filter label on Skills tab

### DIFF
--- a/client/dashboard/src/pages/plugins/plugins-filter-schema.ts
+++ b/client/dashboard/src/pages/plugins/plugins-filter-schema.ts
@@ -13,7 +13,12 @@ import {
  * plugins under different row ids.
  */
 export const PLUGINS_FILTERS = defineFilters([
-  { id: "servers", label: "Including servers", kind: "multiselect" },
+  {
+    id: "servers",
+    label: "Including servers",
+    kind: "multiselect",
+    allLabel: "All servers",
+  },
 ]);
 
 function serverKey(server: PluginServer): string {

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -49,7 +49,13 @@ const SKILL_FILTERS = defineFilters([
     kind: "multiselect",
     pinned: true,
   },
-  { id: "tags", label: "Tags", kind: "multiselect", pinned: true },
+  {
+    id: "tags",
+    label: "Tags",
+    kind: "multiselect",
+    pinned: true,
+    allLabel: "All tags",
+  },
 ]);
 
 const FILTER_OPTIONS = {


### PR DESCRIPTION
The Skills tab filter chip reads "All tagses" — the naive pluralizer in `filter-schema.ts` appends `es` to any label already ending in `s`, so the already-plural "Tags" label comes out mangled.

Fixes this with the `allLabel` override the filter schema provides for exactly this case:

- Skills tab `tags` dimension → "All tags"
- Plugins `servers` dimension ("Including servers") → "All servers", which had the same latent bug in its empty-state label

The pluralizer itself is left alone: dropping the `es` rule for `s`-ending words would break genuinely singular labels like "Enrollment status" ("All enrollment statuses").


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect pluralization in filter labels to clean up UI text. The Skills tab chip now shows "All tags" instead of "All tagses", and the Plugins servers filter uses "All servers" when empty via the `allLabel` override; pluralizer unchanged.

<sup>Written for commit 1d503a619f4cdcaf28b86d00e224c3a8566dca3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

