### PR TITLE
feat: make clickable table rows keyboard accessible

### DIFF
--- a/.changeset/table-row-keyboard-a11y.md
+++ b/.changeset/table-row-keyboard-a11y.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Make clickable table rows keyboard-focusable and activatable with Enter or Space.

--- a/client/dashboard/src/components/ui/Table/index.test.tsx
+++ b/client/dashboard/src/components/ui/Table/index.test.tsx
@@ -1,0 +1,134 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type Column, Table } from "@/components/ui/Table";
+
+afterEach(cleanup);
+
+type Row = {
+  id: string;
+  name: string;
+  clickable?: boolean;
+};
+
+const columns: Column<Row>[] = [
+  {
+    key: "name",
+    header: "Name",
+    render: (row) => row.name,
+  },
+];
+
+const data: Row[] = [
+  { id: "1", name: "Alpha", clickable: true },
+  { id: "2", name: "Beta", clickable: false },
+];
+
+function rowKey(row: Row): string {
+  return row.id;
+}
+
+describe("Table row keyboard accessibility (DNO-758)", () => {
+  it("makes clickable rows focusable and activates on Enter and Space", () => {
+    const onRowClick = vi.fn<(row: Row) => void>();
+
+    render(
+      <Table
+        columns={columns}
+        data={data}
+        rowKey={rowKey}
+        onRowClick={onRowClick}
+      />,
+    );
+
+    const alphaRow = screen.getByText("Alpha").closest("tr");
+    expect(alphaRow).not.toBeNull();
+    expect(alphaRow!.getAttribute("tabindex")).toBe("0");
+
+    alphaRow!.focus();
+    fireEvent.keyDown(alphaRow!, { key: "Enter" });
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "1", name: "Alpha" }),
+    );
+
+    fireEvent.keyDown(alphaRow!, { key: " " });
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps non-clickable rows non-focusable when isRowClickable returns false", () => {
+    const onRowClick = vi.fn<(row: Row) => void>();
+
+    render(
+      <Table columns={columns}>
+        <Table.Header columns={columns} />
+        <Table.Body
+          columns={columns}
+          data={data}
+          rowKey={rowKey}
+          onRowClick={onRowClick}
+          isRowClickable={(row) => row.clickable !== false}
+        />
+      </Table>,
+    );
+
+    const alphaRow = screen.getByText("Alpha").closest("tr");
+    const betaRow = screen.getByText("Beta").closest("tr");
+
+    expect(alphaRow!.getAttribute("tabindex")).toBe("0");
+    expect(betaRow!.getAttribute("tabindex")).toBeNull();
+
+    fireEvent.keyDown(betaRow!, { key: "Enter" });
+    fireEvent.click(betaRow!);
+    expect(onRowClick).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(alphaRow!, { key: "Enter" });
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not activate the row when Enter/Space originates from a nested control", () => {
+    const onRowClick = vi.fn<(row: Row) => void>();
+    const onButtonClick = vi.fn<() => void>();
+
+    const columnsWithAction: Column<Row>[] = [
+      {
+        key: "name",
+        header: "Name",
+        render: (row) => (
+          <span>
+            {row.name}
+            <button type="button" onClick={onButtonClick}>
+              Edit {row.name}
+            </button>
+          </span>
+        ),
+      },
+    ];
+
+    render(
+      <Table
+        columns={columnsWithAction}
+        data={[{ id: "1", name: "Alpha" }]}
+        rowKey={rowKey}
+        onRowClick={onRowClick}
+      />,
+    );
+
+    const row = screen.getByText("Alpha").closest("tr");
+    const button = screen.getByRole("button", { name: "Edit Alpha" });
+
+    button.focus();
+    fireEvent.keyDown(button, { key: "Enter" });
+    fireEvent.keyDown(button, { key: " " });
+
+    expect(onRowClick).not.toHaveBeenCalled();
+    expect(row!.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("does not make rows focusable when onRowClick is omitted", () => {
+    render(<Table columns={columns} data={data} rowKey={rowKey} />);
+
+    const alphaRow = screen.getByText("Alpha").closest("tr");
+    expect(alphaRow!.getAttribute("tabindex")).toBeNull();
+  });
+});

--- a/client/dashboard/src/components/ui/Table/index.tsx
+++ b/client/dashboard/src/components/ui/Table/index.tsx
@@ -584,17 +584,42 @@ type RowContainerProps = {
   >;
 
 const RowContainer = forwardRef<HTMLTableRowElement, RowContainerProps>(
-  function RowContainer({ className, children, onClick, ...rest }, ref) {
+  function RowContainer(
+    { className, children, onClick, onKeyDown, tabIndex, ...rest },
+    ref,
+  ) {
+    const isClickable = Boolean(onClick);
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented || !onClick) {
+        return;
+      }
+      // Only the row itself activates on Enter/Space. Key events from a focused
+      // nested control (button, link, input, …) must reach that control instead.
+      if (event.target !== event.currentTarget) {
+        return;
+      }
+      if (event.key !== "Enter" && event.key !== " ") {
+        return;
+      }
+      event.preventDefault();
+      onClick();
+    };
+
     return (
       <tr
         ref={ref}
+        {...rest}
         className={cn(
           "-z-0 [grid-column:1/-1] grid max-w-full [grid-template-columns:subgrid] border-b transition-colors last:border-none hover:bg-muted/50 data-[state=selected]:bg-muted",
-          onClick && "cursor-pointer",
+          isClickable &&
+            "cursor-pointer focus-visible:bg-muted/50 focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:outline-none",
           className,
         )}
         onClick={onClick}
-        {...rest}
+        onKeyDown={isClickable ? handleKeyDown : onKeyDown}
+        tabIndex={isClickable ? 0 : tabIndex}
       >
         {children}
       </tr>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clickable dashboard table rows only worked with a mouse. Keyboard users couldn't focus them or activate `onRowClick` with Enter/Space, which broke accessibility for every `Table` consumer that uses row actions (including Costs navigation from shadow MCP servers).

This PR makes actionable rows focusable and keyboard-activatable in the shared `Table` component, without changing consumer layouts or wrapping rows in invalid link markup.

- Clickable rows get `tabIndex={0}` and a visible `focus-visible` ring
- Enter/Space run the existing row click handler
- Key events from nested controls (buttons, links, inputs) are ignored so those controls keep their own behavior
- Rows without `onRowClick`, or where `isRowClickable` returns `false`, stay non-focusable

Fixes [DNO-758](https://linear.app/speakeasy/issue/DNO-758/feat-make-clickable-table-rows-keyboard-accessible).

### Demo

Tabbing into the Risk Policies table focuses the first row (blue focus ring), and Enter opens the policy editor — the same action a mouse click performs:

<img alt="Tab focuses a clickable table row with a visible focus ring, Enter opens the policy editor" src="https://cursor.com/artifacts/c/art-56ef5799-e1f4-4ec8-8148-748ddb179ef4" width="900" />

## Test plan

- [x] Unit tests cover Enter/Space activation, conditional `isRowClickable`, nested-control key events, and non-clickable rows
- [x] `pnpm -F dashboard type-check`
- [x] `pnpm -F dashboard exec vitest run src/components/ui/Table/index.test.tsx`
- [x] Dashboard patch changeset added
- [x] Manual keyboard pass on the Risk Policies table (Tab reaches the row, Enter activates it)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-758](https://linear.app/speakeasy/issue/DNO-758/feat-make-clickable-table-rows-keyboard-accessible)

<div><a href="https://cursor.com/agents/bc-6ca9b12f-61ee-46f1-bf9d-60254135755f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ca9b12f-61ee-46f1-bf9d-60254135755f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make clickable rows in the dashboard table keyboard accessible to satisfy Linear DNO-758, and add a changeset to publish a `dashboard` patch. Non-clickable rows remain out of the tab order.

- **New Features**
  - Clickable rows get `tabIndex=0` and a visible `focus-visible` ring.
  - Enter and Space activate the existing row action.
  - Key events from nested controls (buttons, links, inputs) are ignored.
  - Supports `isRowClickable` so rows can opt out of focus and activation.

<sup>Written for commit 19d0cdaa64bac809494094bb6b014393b69196a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

