### PR TITLE
fix: bound the unproxied MCP live tools probe to its own timeout

### DIFF
--- a/.changeset/unproxied-mcp-list-tools-timeout.md
+++ b/.changeset/unproxied-mcp-list-tools-timeout.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Fix a live tool-listing probe for unproxied MCP servers taking up to a minute or more against an unreachable vendor server instead of the intended ~10 second bound. Two independent retry layers (HTTP-transport retries and the MCP SDK's own reconnect retries) compounded on top of each other, and the SDK's own cleanup after a context deadline could itself run well past that deadline. The probe now disables both retry layers for this one-shot check and time-boxes the response to the caller independently of how long the SDK's internal cleanup takes.

--- a/server/internal/externalmcp/mcpclient.go
+++ b/server/internal/externalmcp/mcpclient.go
@@ -33,6 +33,14 @@ type ClientOptions struct {
 	// Headers contains additional HTTP headers to send with each request.
 	// Keys are header names, values are header values.
 	Headers map[string]string
+	// DisableRetries skips both the HTTP-transport retry layer and the MCP
+	// transport's own connection retries. The two compound (up to 4 HTTP
+	// attempts per MCP-level retry, each with its own backoff), which is
+	// fine for the resilient gateway proxy path but defeats a caller-imposed
+	// context deadline meant to bound a one-shot interactive probe — without
+	// this, an unreachable server can take minutes to report as such instead
+	// of the ~10s the probe intends.
+	DisableRetries bool
 }
 
 // Client represents an active connection to an external MCP server.
@@ -49,14 +57,20 @@ type Client struct {
 func NewClient(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, remoteURL string, transportType types.TransportType, opts *ClientOptions) (*Client, error) {
 	if opts == nil {
 		opts = &ClientOptions{
-			Authorization: "",
-			Headers:       nil,
+			Authorization:  "",
+			Headers:        nil,
+			DisableRetries: false,
 		}
 	}
 
 	logger.InfoContext(ctx, "connecting to external MCP server", attr.SlogURL(remoteURL))
 
-	httpClient := guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
+	var httpClient *guardian.HTTPClient
+	if opts.DisableRetries {
+		httpClient = guardianPolicy.PooledClient()
+	} else {
+		httpClient = guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
+	}
 	trasnport := httpClient.Transport
 	authRT := &authRoundTripper{
 		base:            trasnport,
@@ -76,13 +90,21 @@ func NewClient(ctx context.Context, logger *slog.Logger, guardianPolicy *guardia
 		Icons:      nil,
 	}, nil)
 
+	// mcp.StreamableClientTransport treats MaxRetries == 0 as "use the SDK's
+	// own default of 5" — a negative value is required to actually disable
+	// its reconnect-retry loop.
+	maxRetries := 3
+	if opts.DisableRetries {
+		maxRetries = -1
+	}
+
 	var transport mcp.Transport
 	switch transportType {
 	case types.TransportTypeStreamableHTTP:
 		transport = &mcp.StreamableClientTransport{
 			Endpoint:             remoteURL,
 			HTTPClient:           httpClient,
-			MaxRetries:           3,
+			MaxRetries:           maxRetries,
 			DisableStandaloneSSE: true,
 			OAuthHandler:         nil,
 		}

--- a/server/internal/externalmcp/proxytoolexecutor.go
+++ b/server/internal/externalmcp/proxytoolexecutor.go
@@ -154,8 +154,9 @@ func (e *ProxyToolExecutor) listToolsForEntry(
 	headers := BuildHeaders(systemEnv, userConfig, plan.HeaderDefinitions, tokenForHeaders)
 
 	client, err := NewClient(ctx, e.logger, e.guardianPolicy, plan.RemoteURL, plan.TransportType, &ClientOptions{
-		Authorization: "",
-		Headers:       headers,
+		Authorization:  "",
+		Headers:        headers,
+		DisableRetries: false,
 	})
 	if err != nil {
 		return nil, err

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -835,8 +835,9 @@ func (tp *ToolProxy) doExternalMCP(
 	// Build headers from environment variables
 	headers := externalmcp.BuildHeaders(env.SystemEnv, env.UserConfig, plan.HeaderDefinitions, oauthToken)
 	opts := &externalmcp.ClientOptions{
-		Authorization: "",
-		Headers:       headers,
+		Authorization:  "",
+		Headers:        headers,
+		DisableRetries: false,
 	}
 
 	// Connect to the external MCP server

--- a/server/internal/unproxiedmcp/impl.go
+++ b/server/internal/unproxiedmcp/impl.go
@@ -299,11 +299,20 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 	case result := <-resultCh:
 		return result, nil
 	case <-probeCtx.Done():
-		return &gen.ListUnproxiedMcpServerToolsResult{
-			Status:  "unreachable",
-			Tools:   []*gen.UnproxiedMcpServerTool{},
-			Message: conv.PtrEmpty("Could not connect to the server."),
-		}, nil
+		// select picks pseudo-randomly when both cases are ready, so a probe
+		// that finishes right at the deadline could otherwise lose the race
+		// and have its real result discarded here. Give resultCh one more
+		// non-blocking check before reporting a timeout.
+		select {
+		case result := <-resultCh:
+			return result, nil
+		default:
+			return &gen.ListUnproxiedMcpServerToolsResult{
+				Status:  "unreachable",
+				Tools:   []*gen.UnproxiedMcpServerTool{},
+				Message: conv.PtrEmpty("Could not connect to the server."),
+			}, nil
+		}
 	}
 }
 

--- a/server/internal/unproxiedmcp/impl.go
+++ b/server/internal/unproxiedmcp/impl.go
@@ -281,10 +281,45 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 		return nil, oops.E(oops.CodeUnexpected, err, "get unproxied mcp server").LogError(ctx, s.logger)
 	}
 
-	probeCtx, cancel := context.WithTimeout(ctx, listToolsTimeout)
-	defer cancel()
+	// Detached from ctx and raced against its own deadline below: the MCP
+	// SDK's Connect can spend well past listToolsTimeout on its own
+	// synchronous cleanup after a context deadline trips (e.g. trying to
+	// notify the now-unreachable server that the request was cancelled), so
+	// bounding the probe's own context isn't enough to bound *this call's*
+	// latency. The goroutine keeps running to let that cleanup finish
+	// naturally; only the response to the caller is time-boxed.
+	probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), listToolsTimeout) //nolint:gosec // cancel is deferred inside the goroutine below
+	resultCh := make(chan *gen.ListUnproxiedMcpServerToolsResult, 1)
+	go func() {
+		defer cancel()
+		resultCh <- s.probeListTools(probeCtx, server.Url)
+	}()
 
-	client, err := externalmcp.NewClient(probeCtx, s.logger, s.policy, server.Url, externalmcptypes.TransportTypeStreamableHTTP, nil)
+	select {
+	case result := <-resultCh:
+		return result, nil
+	case <-probeCtx.Done():
+		return &gen.ListUnproxiedMcpServerToolsResult{
+			Status:  "unreachable",
+			Tools:   []*gen.UnproxiedMcpServerTool{},
+			Message: conv.PtrEmpty("Could not connect to the server."),
+		}, nil
+	}
+}
+
+// probeListTools performs the live MCP handshake and tools/list round trip.
+// Always returns a populated result (auth_required/unreachable/error/success)
+// rather than an error, since ListTools reports live-probe failures as a
+// result status, not a request error.
+func (s *Service) probeListTools(probeCtx context.Context, serverURL string) *gen.ListUnproxiedMcpServerToolsResult {
+	// DisableRetries: this is a one-shot bounded probe, not a resilient
+	// long-lived connection — retries would let an unreachable server take
+	// minutes to report as such instead of ~10s.
+	client, err := externalmcp.NewClient(probeCtx, s.logger, s.policy, serverURL, externalmcptypes.TransportTypeStreamableHTTP, &externalmcp.ClientOptions{
+		Authorization:  "",
+		Headers:        nil,
+		DisableRetries: true,
+	})
 	if err != nil {
 		var authErr *externalmcp.AuthRejectedError
 		if errors.As(err, &authErr) {
@@ -292,13 +327,13 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 				Status:  "auth_required",
 				Tools:   []*gen.UnproxiedMcpServerTool{},
 				Message: conv.PtrEmpty("This server requires authentication Gram doesn't manage."),
-			}, nil
+			}
 		}
 		return &gen.ListUnproxiedMcpServerToolsResult{
 			Status:  "unreachable",
 			Tools:   []*gen.UnproxiedMcpServerTool{},
 			Message: conv.PtrEmpty("Could not connect to the server."),
-		}, nil
+		}
 	}
 	defer o11y.NoLogDefer(client.Close)
 
@@ -310,13 +345,13 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 				Status:  "auth_required",
 				Tools:   []*gen.UnproxiedMcpServerTool{},
 				Message: conv.PtrEmpty("This server requires authentication Gram doesn't manage."),
-			}, nil
+			}
 		}
 		return &gen.ListUnproxiedMcpServerToolsResult{
 			Status:  "error",
 			Tools:   []*gen.UnproxiedMcpServerTool{},
 			Message: conv.PtrEmpty("The server didn't respond with a valid tool list."),
-		}, nil
+		}
 	}
 
 	tools := make([]*gen.UnproxiedMcpServerTool, 0, len(discovered))
@@ -331,7 +366,7 @@ func (s *Service) ListTools(ctx context.Context, payload *gen.ListToolsPayload) 
 		Status:  "success",
 		Tools:   tools,
 		Message: nil,
-	}, nil
+	}
 }
 
 func (s *Service) DeleteServer(ctx context.Context, payload *gen.DeleteServerPayload) error {

--- a/server/internal/unproxiedmcp/list_tools_test.go
+++ b/server/internal/unproxiedmcp/list_tools_test.go
@@ -23,6 +23,14 @@ func TestListTools_UnreachableServer(t *testing.T) {
 	// server's URL can stop resolving after creation, so ListTools must
 	// degrade gracefully even though CreateServer's own validation would now
 	// reject this URL up front.
+	//
+	// unresolvableTestHost fails at the mocked DNS lookup itself (see
+	// newUnproxiedMCPMockResolver), so the test is fast and deterministic
+	// everywhere. A real unroutable domain like vendor.invalid would instead
+	// fall through the mock resolver's default case to a real, uncontrolled
+	// public IP — an actual network operation whose failure timing varies by
+	// environment, which previously made this test take 80s+ locally and
+	// nearly 3 minutes in CI.
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	created, err := unproxiedmcprepo.New(ti.conn).CreateServer(ctx, unproxiedmcprepo.CreateServerParams{
@@ -30,7 +38,7 @@ func TestListTools_UnreachableServer(t *testing.T) {
 		ProjectID:   *authCtx.ProjectID,
 		Name:        pgtype.Text{String: "", Valid: false},
 		Slug:        pgtype.Text{String: "test-unreachable-" + uuid.NewString(), Valid: true},
-		Url:         "https://vendor.invalid/mcp",
+		Url:         "https://" + unresolvableTestHost + "/mcp",
 		Description: pgtype.Text{String: "", Valid: false},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Why

[Flagged in Slack](https://speakeasyapi.slack.com/archives/C08H55TP4HZ/p1785969655772449) that `server/internal/unproxiedmcp` tests take over 3 minutes in CI, erasing the perf gains from parallelizing server tests. `TestListTools_UnreachableServer` was the culprit: 80s+ locally, ~3 minutes in CI, out of a package that otherwise runs in a few seconds.

Root cause is a real production bug, not just a slow test — the live tools probe is supposed to bound its response to [`listToolsTimeout` (10s)](https://github.com/speakeasy-api/gram/blob/10c050c77/server/internal/unproxiedmcp/impl.go#L254-L256) so a genuinely unreachable vendor server reports back quickly, but two independent retry layers plus an SDK cleanup quirk defeated that:

- `guardian.WithDefaultRetryConfig()` retried the underlying HTTP transport up to 4 times with exponential backoff.
- `mcp.StreamableClientTransport` treats `MaxRetries: 0` as *"use the SDK's own default of 5"* — a negative value is required to actually disable it. The existing hardcoded `MaxRetries: 3` was never a real bound.
- Even with both retry layers removed, the SDK's `Connect` can spend well past a blown context deadline on its own synchronous cleanup (e.g. trying to notify the now-unreachable server that the request was cancelled) — so bounding the probe's own context isn't enough to bound *this call's* latency to whoever's waiting on it.

Scope check: nothing in the dashboard calls this today. The only UI trigger would be the "Inspect" tab, which has been hidden for unproxied servers since the PR that introduced them (#4886) because anonymous vendor probes aren't reliable, and `CreateServer`'s own validation is scheme/host checks only, no live handshake. `listTools` is a public `mcp:read` management-API/SDK RPC with no in-app consumer yet — right now only this test exercises it — but it's still a shipped, authenticated endpoint, so an unbounded response is a real bug independent of dashboard wiring.

## What changed

- Added `externalmcp.ClientOptions.DisableRetries`, used only by the unproxied-server live probe — the resilient gateway/proxy path (real customer MCP traffic) keeps its retries unchanged.
- Fixed the `MaxRetries` zero-value gotcha: `-1` for genuinely no retries, not `0`.
- Restructured `ListTools` to race the probe against its own `listToolsTimeout` in a goroutine, returning "unreachable" to the caller as soon as the deadline trips regardless of how long the SDK's internal cleanup takes to actually finish in the background.
- Swapped the test's real, unrouted `vendor.invalid` host for the package's existing `unresolvableTestHost` mock-DNS host (already built for exactly this, just unused here), so the test no longer depends on real network/DNS timing in any environment.

### Before / After

`TestListTools_UnreachableServer`: 80s+ locally, ~3 minutes in CI → ~12.5s (bounded by `listToolsTimeout` + normal per-test overhead), consistently, everywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the unproxied MCP live tools probe to a ~10s timeout and disabled compounding retries, so unreachable servers respond quickly. `TestListTools_UnreachableServer` now completes in ~12.5s instead of 80s–3m.

- **Bug Fixes**
  - Added `externalmcp.ClientOptions.DisableRetries` for the unproxied live probe; the gateway/proxy path keeps retries.
  - Set `mcp.StreamableClientTransport` `MaxRetries` to `-1` when retries are disabled to avoid the SDK’s default retry loop.
  - Raced the probe in a goroutine against its own timeout using `context.WithoutCancel`, and added a final non-blocking read to avoid dropping a result that arrives at the deadline; return “unreachable” while SDK cleanup finishes in the background.
  - Switched the test to use the `unresolvableTestHost` mock DNS host for deterministic, fast failure.

<sup>Written for commit 10c050c770bd4125ef7fe2ffdc6c200bae73cda3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




