### PR TITLE
chore: extend sticky-disk layer caching to remaining image builds

### DIFF
--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -34,6 +34,9 @@ inputs:
   git-auth-token:
     description: "The GitHub access token for accessing private repos"
     required: true
+  cache-key:
+    description: "Blacksmith sticky-disk cache key; use one key per image so builds share layers across runs"
+    required: true
 
 outputs:
   image-tag:
@@ -43,8 +46,10 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+    - name: Setup Docker builder
+      uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
+      with:
+        cache-key: ${{ inputs.cache-key }}
 
     - name: Log in to Docker Hub
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -143,7 +148,11 @@ runs:
       run: echo "GIT_SHA=$(echo $GITHUB_SHA)" >> $GITHUB_ENV
 
     - name: Build and push registry Docker image
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      # Blacksmith fork of docker/build-push-action, paired with the
+      # setup-docker-builder step above: buildkit state lives on a sticky disk
+      # keyed by inputs.cache-key, so layers persist across runs without the
+      # registry cache round-trip.
+      uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
@@ -155,8 +164,6 @@ runs:
           GIT_SHA=${{ env.GIT_SHA }}
         secrets: |
           git_auth_token=${{ inputs.git-auth-token }}
-        cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:latest
-        cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:latest,mode=max,enable=${{ github.event_name == 'merge_group' }}
 
     - name: Set output image tag
       id: set-tag

--- a/.github/workflows/composite/build-push/action.yaml
+++ b/.github/workflows/composite/build-push/action.yaml
@@ -47,6 +47,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup Docker builder
+      # Skip on fork PRs: untrusted code must not commit to the shared sticky
+      # disk. The build step below then falls back to the default builder and
+      # simply runs uncached.
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
       uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
       with:
         cache-key: ${{ inputs.cache-key }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -489,6 +489,10 @@ jobs:
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker builder
+        # Skip on fork PRs: untrusted code must not commit to the shared sticky
+        # disk. The build step below then falls back to the default builder and
+        # simply runs uncached.
+        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
         with:
           cache-key: gram/assistant-runtime-image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -348,6 +348,7 @@ jobs:
           context: ./server
           file: server/Dockerfile
           git-auth-token: ${{ secrets.BOT_REPO_TOKEN }}
+          cache-key: gram/server-image
           build-args: |
             GIT_USERNAME=speakeasybot
       - name: Pull and Run Image
@@ -406,6 +407,7 @@ jobs:
           context: .
           file: pystreams/Dockerfile.pystreams
           git-auth-token: ${{ secrets.BOT_REPO_TOKEN }}
+          cache-key: gram/pystreams-image
       - name: Pull and Run Image
         run: |
           echo "Pulling image: ${{ steps.build.outputs.image-tag }}"
@@ -1556,6 +1558,7 @@ jobs:
           context: ./client/dashboard
           file: client/dashboard/Dockerfile
           git-auth-token: ${{ secrets.BOT_REPO_TOKEN }}
+          cache-key: gram/dashboard-image
 
       - name: Prune PNPM store
         if: success()
@@ -2234,10 +2237,15 @@ jobs:
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Setup Docker builder
+        uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
+        with:
+          cache-key: gram/tunnel-agent-image
       - name: Build image (no push)
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        # Blacksmith fork of docker/build-push-action, paired with the
+        # setup-docker-builder step above: the go build/mod cache mounts in
+        # tunnel/Dockerfile persist on the sticky disk across runs.
+        uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
         with:
           context: .
           file: tunnel/Dockerfile

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2238,6 +2238,10 @@ jobs:
       - name: Checkout
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
       - name: Setup Docker builder
+        # Skip on fork PRs: untrusted code must not commit to the shared sticky
+        # disk. The build step below then falls back to the default builder and
+        # simply runs uncached.
+        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
         uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
         with:
           cache-key: gram/tunnel-agent-image

--- a/tunnel/Dockerfile
+++ b/tunnel/Dockerfile
@@ -3,7 +3,9 @@ WORKDIR /src
 COPY go.mod go.sum ./
 COPY tunnel ./tunnel
 ARG TARGETOS TARGETARCH VERSION=dev
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -trimpath -ldflags="-s -w" -o /out/tunnel-agent ./tunnel/cmd/tunnel-agent
 
 FROM alpine:3.22

--- a/tunnel/Dockerfile.dockerignore
+++ b/tunnel/Dockerfile.dockerignore
@@ -1,0 +1,7 @@
+# Build-scoped ignore for tunnel/Dockerfile (context = repo root). The image
+# only consumes the Go module files and tunnel/, so exclude everything else to
+# keep the build context small.
+*
+!go.mod
+!go.sum
+!tunnel/


### PR DESCRIPTION
## Summary

Follow-up to #4987, applying the same layer-caching lessons to the remaining docker image builds:

- **Composite `build-push` action** (covers `docker-build-server`, `docker-build-pystreams`, `docker-build-client`): provision a Blacksmith sticky-disk builder keyed per image (`cache-key` input) and swap to `useblacksmith/build-push-action`. This replaces the registry `cache-from`/`cache-to` round-trip — whose `mode=max` cache-to also targeted the `:latest` image tag itself, so a merge-group cache export could clobber the `:latest` manifest.
- **`tunnel-agent`**: same builder swap, plus `go` build/mod cache mounts in `tunnel/Dockerfile` and a build-scoped `Dockerfile.dockerignore` — previously the entire repo checkout (including `.git`) was sent as build context; now only `go.mod`, `go.sum`, and `tunnel/`.

Expected wins: pystreams uv-install layers and the tunnel Go compile (×2 arches, previously uncached every run) stop rebuilding from scratch; server/dashboard images are already thin (prebuilt artifacts copied in) so they mainly shed the registry cache pulls.

Explicitly out of scope, with reasons:
- `functions-image` builds with apko, not BuildKit — sticky-disk layer caching doesn't apply.
- `otel-collector` image is a single COPY on the upstream collector base — nothing to cache.
- `release.yaml` runs on GitHub-hosted runners where Blacksmith actions are unavailable; its tunnel build still benefits from the trimmed context and cache mounts (non-persistent).

Reminder from #4987: `useblacksmith/build-push-action` v2 does **not** provision the builder itself — without the `setup-docker-builder` step it silently falls back to the default builder and the cache never engages.

First run per image primes its sticky disk; subsequent runs (shared across PRs) hit it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend sticky-disk BuildKit caching to server, pystreams, dashboard, and tunnel images to speed up CI and avoid registry cache round-trips. First run per image primes the cache; subsequent runs reuse layers across PRs, while fork PRs skip the shared cache.

- **Refactors**
  - Composite `build-push` action: add `cache-key`, switch to `useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action`, and remove registry `cache-from/cache-to` to prevent `:latest` manifest clobbering.
  - PR workflow: set per-image `cache-key` for server (`gram/server-image`), pystreams (`gram/pystreams-image`), dashboard (`gram/dashboard-image`), and assistant runtime (`gram/assistant-runtime-image`); tunnel job uses the Blacksmith builder/action without push.
  - Tunnel image: add Go module/build cache mounts and a scoped `tunnel/Dockerfile.dockerignore` to send only `go.mod`, `go.sum`, and `tunnel/` as context.

- **Bug Fixes**
  - Skip sticky-disk builder on fork PRs across composite builds, tunnel, and assistant-runtime so untrusted builds run uncached and don’t write to the shared cache.

<sup>Written for commit 44711a1b94acc43304a395cea6f2925edfa63ad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

