### PR TITLE
fix: pin assistant-cloud so @assistant-ui/core resolves to a single instance

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ overrides:
   glob@>=10.0 <10.5.0: 10.5.0
   fast-uri@<3.1.5: 3.1.5
   '@radix-ui/react-dismissable-layer': 1.1.13
+  assistant-cloud: 0.1.37
 
 patchedDependencies:
   svix@1.92.2: 77208f035e49ee60ffce4534d12d46b62e1da64bc4c49ff97afb18a6ffc42791
@@ -587,7 +588,7 @@ packages:
       '@assistant-ui/store': ^0.3.0
       '@assistant-ui/tap': ^0.9.0
       '@types/react': '*'
-      assistant-cloud: ^0.1.31
+      assistant-cloud: 0.1.37
       react: ^18 || ^19
       zustand: ^5.0.11
     peerDependenciesMeta:
@@ -4808,9 +4809,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  assistant-cloud@0.1.35:
-    resolution: {integrity: sha512-SiMvAXalCwM9GcnyIiJfQTZda00E2VE/jZWqSdX4WPxQyHeVNK7uBzw3AaFpBQT1vXbS1UYdKVlZdUJ3vRftCg==}
-
   assistant-cloud@0.1.37:
     resolution: {integrity: sha512-cofr0dM/mRyHZKwIDhMxX8xvZNWd078PM77eBdxbuuzxTa6aXYm5E+rq6q92RZF10CAMn+Ruir3vhjsVg7kZ0w==}
 
@@ -8235,21 +8233,6 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
-  '@assistant-ui/core@0.3.0(@assistant-ui/store@0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8))(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35)(react@19.2.8)(zustand@5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))':
-    dependencies:
-      '@assistant-ui/store': 0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8)
-      '@assistant-ui/tap': 0.9.7(@types/react@19.2.17)(react@19.2.8)
-      assistant-stream: 0.3.29
-      nanoid: 6.0.0
-    optionalDependencies:
-      '@types/react': 19.2.17
-      assistant-cloud: 0.1.35
-      react: 19.2.8
-      zustand: 5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
-    transitivePeerDependencies:
-      - ioredis
-      - redis
-
   '@assistant-ui/core@0.3.0(@assistant-ui/store@0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8))(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.37)(react@19.2.8)(zustand@5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))':
     dependencies:
       '@assistant-ui/store': 0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8)
@@ -8269,10 +8252,10 @@ snapshots:
     dependencies:
       '@ai-sdk/mcp': 2.0.17(zod@4.4.3)
       '@ai-sdk/react': 4.0.41(react@19.2.8)(zod@4.4.3)
-      '@assistant-ui/core': 0.3.0(@assistant-ui/store@0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8))(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.35)(react@19.2.8)(zustand@5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
+      '@assistant-ui/core': 0.3.0(@assistant-ui/store@0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8))(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(assistant-cloud@0.1.37)(react@19.2.8)(zustand@5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)))
       '@assistant-ui/store': 0.3.0(@assistant-ui/tap@0.9.7(@types/react@19.2.17)(react@19.2.8))(@types/react@19.2.17)(react@19.2.8)
       ai: 7.0.38(zod@4.4.3)
-      assistant-cloud: 0.1.35
+      assistant-cloud: 0.1.37
       assistant-stream: 0.3.29
       react: 19.2.8
     optionalDependencies:
@@ -12462,13 +12445,6 @@ snapshots:
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
-
-  assistant-cloud@0.1.35:
-    dependencies:
-      assistant-stream: 0.3.29
-    transitivePeerDependencies:
-      - ioredis
-      - redis
 
   assistant-cloud@0.1.37:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,13 @@ overrides:
   # layers then can't see each other (e.g. the filter sheet closing when dismissing a
   # dropdown inside it, DNO-393/AIS-168). Force one copy so all primitives share a stack.
   "@radix-ui/react-dismissable-layer": 1.1.13
+  # @assistant-ui/core must resolve to a single instance: its React contexts
+  # (e.g. RuntimeAdapterProvider) are shared between @assistant-ui/react and
+  # @assistant-ui/react-ai-sdk, and pnpm mints a separate core instance per
+  # distinct peer set — splitting the context and silently breaking chat
+  # history loading (AGE-2977). assistant-cloud is core's only unpinned
+  # optional peer, so forcing one assistant-cloud version forces one core.
+  assistant-cloud: 0.1.37
 
 peerDependencyRules:
   allowedVersions:


### PR DESCRIPTION
## Summary

Restores the `assistant-cloud` override in `pnpm-workspace.yaml` (removed in #4906) so `@assistant-ui/core` resolves to a single instance. Fixes a production regression where opening any saved Project Assistant chat (direct URL, refresh, or new session) rendered an empty welcome screen instead of the transcript.

## Root cause

- `assistant-cloud` is an optional peer of `@assistant-ui/core`. After #4906 dropped the override, `@assistant-ui/react` resolved `assistant-cloud@0.1.37` while `@assistant-ui/react-ai-sdk` (range `*`) kept a stale `0.1.35` lockfile entry.
- pnpm mints a separate package instance per distinct peer-resolution set, so two `assistant-cloud` versions produced **two** `@assistant-ui/core@0.3.0` instances — and two copies of core's React contexts.
- The Elements glue mounts `RuntimeAdapterProvider` (carrying the chat history adapter) into one copy's context; `useExternalHistory` inside `react-ai-sdk` reads the other copy's context, finds no adapter, and silently skips history loading — `/rpc/chat.load` never fires.
- New chats and same-session re-opens were unaffected (messages served from the in-memory runtime), which is why the regression passed local testing and review.

Same failure class as the pre-existing `@radix-ui/react-dismissable-layer` override (AGE-2977 for the original assistant-cloud instance of it).

## Changes

- `pnpm-workspace.yaml`: re-add `assistant-cloud: 0.1.37` override with a comment explaining the single-instance requirement.
- `pnpm-lock.yaml`: all `assistant-cloud@0.1.35` entries collapse to `0.1.37`; `react-ai-sdk` now links the same `@assistant-ui/core` instance as `@assistant-ui/react`.

## Validation

- Reproduced pre-fix locally: cold load of `/chat/<id>` shows the chat title but an empty body, with zero `chat.load` requests.
- Post-fix: same cold load renders the full transcript; `node_modules/.pnpm` contains a single `@assistant-ui/core` directory.
- `pnpm install --frozen-lockfile` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `assistant-cloud` to 0.1.37 so `@assistant-ui/core` resolves to a single instance. Fixes a production issue where saved Project Assistant chats opened to an empty screen instead of the transcript.

- **Bug Fixes**
  - Stopped split React contexts from two `@assistant-ui/core` instances caused by mixed `assistant-cloud` versions, which blocked chat history loading (`/rpc/chat.load`). Related to Linear AGE-2977.

- **Dependencies**
  - Re-added `assistant-cloud: 0.1.37` override in `pnpm-workspace.yaml` and updated `pnpm-lock.yaml` to unify `@assistant-ui/react` and `@assistant-ui/react-ai-sdk` on the same `@assistant-ui/core` instance.

<sup>Written for commit 62e110aa46049762a4e065467cc6a628efdb5abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

