### PR TITLE
chore: re-enable infra proto lint and gate server CI on infra changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -5,6 +5,7 @@ server:
   - "agents/**"
   - "ci/**"
   - "server/**"
+  - "infra/**"
   - ".mise-tasks/test/ci.sh"
   - ".mise-tasks/test/server.sh"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1140,15 +1140,15 @@ jobs:
             ${{ env.GH_CACHE_UV_KEY_PARTIAL }}
           path: ${{ env.UV_CACHE_DIR }}
 
-      # TODO: re-enable once buf.yaml + infra/proto exist on main. The breaking
-      # check compares against origin/main, which has no protos until this
-      # scaffolding lands, so `buf breaking` fails with "no .proto files" on the
-      # bootstrap PR. Uncomment both steps in a follow-up after the initial merge.
-      # - name: Fetch main branch
-      #   run: git fetch --depth=1 origin main
-      #
-      # - name: Lint proto files
-      #   run: mise run lint:infra --against ".git#ref=origin/main"
+      - name: Fetch main branch
+        run: git fetch --depth=1 origin main
+
+      # buf breaking against main is what catches a wire-incompatible proto
+      # change (field renumbering, type change) that would corrupt already
+      # published messages — including outbox rows, which store marshaled bytes
+      # and republish them verbatim after a deploy.
+      - name: Lint proto files
+        run: mise run lint:infra --against ".git#ref=origin/main"
 
       - name: Install uv dependencies
         run: mise run install:uv --all-packages --locked


### PR DESCRIPTION
Two CI gaps around the `infra/` tree, found while working on the Pub/Sub outbox publishing path.

## Re-enable the infra proto lint step

The `Lint proto files` step in `infra-build-lint` was commented out when `buf.yaml` and `infra/proto` had not yet landed on `main` — `buf breaking` against a main with no protos fails outright. That bootstrap merged long ago, but the step was never turned back on, so `buf lint`, `buf breaking --against origin/main`, and `ruff check infra` have all been silently skipped.

This matters most for wire compatibility: topics carry messages that outlive a deploy — the publish outbox stores marshaled bytes and republishes them verbatim — so a field renumbering or type change that decodes yesterday's bytes incorrectly needs to fail CI, not be discovered at replay time.

Verified locally: `mise run lint:infra --against ".git#ref=origin/main"` passes on this branch, and correctly reports breakage when the workspace and `origin/main` genuinely differ.

## Trigger server CI on infra changes

Server binaries compile the infra Go packages (generated proto bindings, the `infra/pkg` publisher library), but the `server` path filter did not include `infra/**`. An infra-only PR could therefore change code the server compiles — and behavior the server depends on — while every server build/test job was skipped. Added `infra/**` to the `server` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2226" height="480" alt="CleanShot 2026-08-06 at 11 15 40@2x" src="https://github.com/user-attachments/assets/576f7b2c-1a4b-4f79-87b6-e5bd33503d16" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled proto lint and breaking checks for `infra/` in CI and made server CI run on infra changes. This catches wire-incompatible proto changes and ensures server builds/tests run for infra-only PRs.

- **Bug Fixes**
  - Fetch `origin/main` and run `mise run lint:infra --against ".git#ref=origin/main"` to enforce `buf lint` and `buf breaking`.
  - Added `infra/**` to the server path filter so server build/test jobs trigger on infra-only changes.

<sup>Written for commit 5a674c62a5192f2a0b3bf51a96447336c5b036ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/4999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



