### PR TITLE
fix: handle SIGTERM in the streams command so shutdown runs

### DIFF
--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"os/signal"
 	"runtime/debug"
+	"syscall"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -217,8 +220,11 @@ func newStreamsCommand() *cli.Command {
 				attr.SlogServiceEnv(serviceEnv),
 			)
 
-			ctx, cancel := context.WithCancel(c.Context)
-			defer cancel()
+			// Without a signal handler the runtime kills the process on SIGTERM,
+			// so the Action never returns and the After hook never runs the
+			// shutdownFuncs registered below.
+			ctx, stop := signal.NotifyContext(c.Context, os.Interrupt, syscall.SIGTERM)
+			defer stop()
 
 			shutdown, err := o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
 				ServiceName:    serviceName,
@@ -451,6 +457,8 @@ func newStreamsCommand() *cli.Command {
 			if err := group.Wait(); err != nil {
 				return fmt.Errorf("streaming error: %w", err)
 			}
+
+			logger.InfoContext(c.Context, "shutdown signal received, all receivers stopped")
 
 			return nil
 		},


### PR DESCRIPTION
`gram streams` was the only long-running command that never installed a signal handler. The root context is a plain `context.Background()` (`server/main.go` → `root.go`), and the streams Action derived a bare `context.WithCancel` from it before parking in `group.Wait()`. With no handler installed, Go's default disposition for SIGTERM terminates the process outright — so on every rollout, scale-down, node drain or eviction the Action never returned, the `After` hook never ran, and none of the registered `shutdownFuncs` executed.

For comparison, `gram start` uses `signal.NotifyContext` and `gram worker` gets one from the Temporal SDK's `worker.InterruptCh()`. Only `streams` was missing it.

## Evidence

Over 14 days, `kubernetes_state.container.status_report.count.terminated` for the `gram-streams` container reports **only `reason:error`** in both dev and prod. There is no `reason:completed` series — the container has never exited 0.

The logs agree. Of the 214 prod pods that logged `control server started`, 4 ever reached `all components shutdown`, and every one of those had already logged a fatal error (`streaming error: ...` or a startup DB connect failure). The shutdown path only ever ran on the exit-1 route, never on a signal.

A representative pod logged four lines at boot and then nothing at all. The co-located Cloud SQL proxy sidecar logged `SIGTERM signal received` 13 minutes later; the app container logged neither a shutdown line nor an error — the signature of an unhandled SIGTERM, where the runtime kills the process before anything can log.

## What was being skipped

`runShutdown` never ran, so on every restart: the OTel SDK flush, the ClickHouse connection, `findingsPub.Stop` plus the pubsub client close, the control server, and the Svix client were all skipped, along with the deferred `db.Close()` / `replicaDB.Close()`. In-flight Pub/Sub messages were left neither acked nor nacked until their ack deadline lapsed — worst case the `FindingCHWriter` batch receiver, which buffers up to 1000 messages / 10 MiB.

Notably, `infra/pkg/gcp/subscriber.go` already contains a cancellation-drain path that flushes the in-flight batch while `Receive` is still live so ack/nack reaches the iterator. It had never once executed in production, because no context was ever cancelled.

## The change

Everything downstream already returns cleanly on cancellation — `pubsub.Subscriber.Receive` returns nil on ctx cancel, and `ping.StartPublisher` returns nil on both `ctx.Done()` and a `context.Canceled` publish error. So `group.Wait()` returns nil, `After` runs `runShutdown`, and the process exits 0. Wrapping the context is the whole fix:

```go
ctx, stop := signal.NotifyContext(c.Context, os.Interrupt, syscall.SIGTERM)
defer stop()
```

Plus one log line on the clean-exit path, so a signal-driven rollout is distinguishable from the error-driven exit above it (previously the only difference was a missing log line).

## Deploy note

`runShutdown` budgets 30s. If the deployment leaves `terminationGracePeriodSeconds` at the default 30, the kubelet can SIGKILL mid-shutdown and we trade exit 143 for 137. The manifests live outside this repo — worth confirming the current value before/after this ships.

## Verification

- `go build ./server/cmd/gram/` passes.
- `go test -race ./server/cmd/gram/` passes.
- After deploy, `all components shutdown` should start appearing on ordinary rollouts, and the terminated-reason metric should show `completed`.

## Out of scope (surfaced during the investigation)

- Prod pods occasionally fail at boot with a connection-refused error against the Cloud SQL proxy — the app container beating the sidecar to readiness.
- Two stale preview `streams` deployments are crashlooping on `No help topic for 'streams'`, from images predating the subcommand. They should be reaped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle SIGTERM in `gram streams` so the command shuts down cleanly and runs all shutdown hooks. This prevents dropped telemetry and stuck Pub/Sub messages during rollouts and scale-downs.

- **Bug Fixes**
  - Use `signal.NotifyContext` to handle `os.Interrupt` and `SIGTERM`.
  - Let the Action return so `After`/`runShutdown` run and the process exits 0.
  - Add a log line for signal-driven clean shutdown.

- **Migration**
  - Ensure `terminationGracePeriodSeconds` covers the 30s shutdown budget to avoid SIGKILL.

<sup>Written for commit 122a1af1e8a36472bbc07c283ff97c19190f374b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

