### PR TITLE
chore: pin Speakeasy CLI version and document Go comment conventions

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -28,6 +28,42 @@ This codebases uses features from Go 1.25 and above.
 - Always run linters as part of finalizing your code changes. Use `mise lint:server` to run the linters on the server codebase.
 - The `exhaustruct` linter requires all struct fields to be explicitly set in struct literals. When adding new fields to a type, update ALL call sites — including places that construct the struct with zero values (e.g., `MyStruct{}` → `MyStruct{NewField: nil}`).
 
+## Comments
+
+- Write comments that describe current intent and behavior. Do NOT leave "intermediate" comments narrating the edit you just made (e.g. "previously this returned X, now it returns Y", "renamed from Foo"). That commentary, when appropriate, belongs in the commit message or pull request body, where it stays attached to the change instead of aging in the source. Markers that state current status are not narration and stay: `Deprecated: use X instead` on a symbol kept for compatibility (as its own trailing paragraph, which is the form `gopls` and pkg.go.dev surface to callers), build tags, `//go:` directives, and `TODO(TICKET-123)` notes. Write the rest of a deprecated symbol's doc in the present tense, describing what it still does today.
+- Do NOT write "see X" comments that point at a comment somewhere else (e.g. "see the note on `Foo` above", "see `handler.go` for details"). The target moves or gets rewritten and the pointer silently goes stale. The test is what the comment does with the name it mentions: stating the fact where the reader needs it is fine ("callers must hold `Registry.mu`"), sending the reader elsewhere to go find it is not ("see `Registry` for locking rules"). Referencing a symbol, package, ticket, or external spec that the comment is actually about is fine. Repeating a sentence or two to keep an explanation local is fine; when the full explanation is too long to restate, document it on the type or package that owns the invariant and give each use site the one-line consequence it needs.
+- Document struct fields one per field, at least on exported types. A comment placed above only the first field of a group documents just that field: `go doc <Type>.<Field>` and editor hovers show nothing for the rest. Grouped `const` and `var` blocks and interface methods follow the same attachment rule, and a comment above the `const (` line documents the block rather than any spec in it. Put a blank line between the previous field and the next field's comment: attachment survives without it, but the blank line keeps the boundary obvious. Never leave a blank line between a comment and the field it documents, which silently detaches it. The first field in a block needs no blank line before its comment, and `gofmt` flags none of these mistakes.
+
+<bad-example>
+
+```go
+type Config struct {
+    // Timeouts applied to outbound requests. Previously these were a single
+    // Timeout field. See the note on Client above for retry interactions.
+    ReadTimeout  time.Duration
+    WriteTimeout time.Duration
+}
+```
+
+Three problems in four lines: the comment narrates a past refactor, it defers to a comment that can move or disappear, and `WriteTimeout` ends up with no documentation at all.
+
+</bad-example>
+
+<good-example>
+
+```go
+type Config struct {
+    // ReadTimeout bounds how long the client waits for response headers.
+    // Retries each get a fresh budget, so a request can exceed this in total.
+    ReadTimeout time.Duration
+
+    // WriteTimeout bounds how long the client spends sending the request body.
+    WriteTimeout time.Duration
+}
+```
+
+</good-example>
+
 ## Updating the API
 
 We use Goa to design our API and generate server code. All Goa code lives in `server/design`. The Goa DSL is documented in `https://pkg.go.dev/goa.design/goa/v3/dsl`.

--- a/.mise-tasks/gen/sdk.sh
+++ b/.mise-tasks/gen/sdk.sh
@@ -8,17 +8,10 @@ set -e
 
 # The Speakeasy CLI version is baked into every generated artifact (gen.lock,
 # workflow.lock, the SDK_METADATA userAgent), so generating with anything other
-# than the version pinned in mise.toml produces churn CI rejects. A system-wide
-# install (Homebrew, `go install`) can sit ahead of the mise shim on PATH, so
-# resolve the pinned binary explicitly rather than trusting a bare `speakeasy`.
-speakeasy() {
-  local bin
-  # Resolve in its own statement: inside a command substitution used as an
-  # argument, a failure would expand to "" and silently run the wrong thing.
-  bin=$(mise which speakeasy)
-  mise exec -- "$bin" "$@"
-}
-
+# than the pinned version produces churn CI rejects. `speakeasy run` re-execs
+# into the version named by speakeasyVersion in .speakeasy/workflow.yaml, so a
+# system-wide install (Homebrew, `go install`) ahead of the mise shim on PATH
+# still generates with the pinned version.
 generate() {
   # Speakeasy's TypeScript target compiles the generated SDK by invoking pnpm
   # directly in client/dashboard/src/sdk. Without CI=true, pnpm prompts to purge

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -7,7 +7,7 @@ targets:
         source: Hooks-Ingest
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: pinned
+    speakeasyVersion: 1.791.1
     sources:
         Gram-Internal:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: pinned
+speakeasyVersion: 1.791.1
 sources:
     Gram-Internal:
         inputs:

--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,8 @@ pin = true
 [tools]
 "aqua:ariga/atlas" = "1.0.0"
 "github:speakeasy-api/openapi" = "1.24.0"
+# Keep in sync with speakeasyVersion in .speakeasy/workflow.yaml, otherwise the
+# installed version and the version generation runs on can mismatch.
 "github:speakeasy-api/speakeasy" = "1.791.1"
 "github:FiloSottile/mkcert" = "1.4.4"
 apko = "1.2.31"


### PR DESCRIPTION
## Speakeasy CLI version pin

`.speakeasy/workflow.yaml` used `speakeasyVersion: pinned`, which means the CLI generates with whichever `speakeasy` binary `PATH` resolves first. A system-wide install (Homebrew, `go install`) can sit ahead of the mise shim, so generation silently runs on a different version than the one `mise.toml` pins. That surfaces in CI as `workflow.lock` version churn, or worse, actually changed SDK files.

An explicit version makes the CLI re-exec into it regardless of which binary is invoked. Verified locally with a newer Homebrew binary, which now reports `Downloading Speakeasy version v1.791.1` before running the workflow. A full `mise run gen:sdk` produced no SDK churn, only the two `speakeasyVersion` lines.

Two notes for reviewers:

- `.mise-tasks/gen/sdk.sh` loses its `mise which speakeasy` wrapper, which existed only to defend against the PATH shadowing that the explicit version now handles. The one remaining bare call, `speakeasy overlay apply` on the `--check` path, does not meaningfully depend on the CLI version.
- The version now lives in both `mise.toml` and `.speakeasy/workflow.yaml`, so `mise.toml` gets a comment noting that they move together.

## Go comment conventions

New `## Comments` section in the `golang` skill, covering three cleanups that recur in review:

- Comments narrating the change being made ("previously this did X, now it does Y") rather than current behavior. That commentary belongs in the commit message or PR body.
- "see X" comments pointing at a comment elsewhere, which go stale as the code evolves.
- Field-grouped struct doc comments that only document the first field.

The struct field rule has a mechanical failure mode, verified against `go doc` and the parsed AST rather than asserted:

- A comment placed above only the first field of a group leaves every later field with no doc at all. Grouped `const` and `var` blocks and interface methods follow the same attachment rule.
- A comment above the `const (` line documents the block rather than any spec inside it.
- A blank line between a comment and the field below it silently detaches the doc.
- `gofmt`, `go vet`, and `staticcheck` report none of these.

The section went through fresh-context subagent eval rounds per the `writing-skills` skill, finishing at a ship-as-is verdict.
