### PR TITLE
fix: deflake bounded concurrent recovery sweep test

### DIFF
--- a/server/internal/skills/efficacy/reserve_test.go
+++ b/server/internal/skills/efficacy/reserve_test.go
@@ -762,6 +762,17 @@ func TestRecoverStaleReservationsBoundsConcurrentBatches(t *testing.T) {
 	require.Len(t, fixture.pendingEvaluations(t), 2)
 	require.Len(t, fixture.reservedEvaluations(t, 3), 1, "one bounded row remains")
 
+	// reservedEvaluations claims through the recovery query, which stamps
+	// updated_at = clock_timestamp() on the remaining row. On a fast runner the
+	// concurrent sweeps below can start inside the millisecond lease and find
+	// nothing stale, so age the row again.
+	aged, err = repo.New(fixture.db).BackdateReservedSkillEfficacyEvaluationsFixture(ctx, repo.BackdateReservedSkillEfficacyEvaluationsFixtureParams{
+		BackdateBy: pgtype.Interval{Microseconds: time.Hour.Microseconds(), Days: 0, Months: 0, Valid: true},
+		ProjectID:  fixture.projectID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, aged)
+
 	var group sync.WaitGroup
 	results := make([]RecoveryResult, 2)
 	errs := make([]error, 2)


### PR DESCRIPTION
## Summary

Fixes the flake in `TestRecoverStaleReservationsBoundsConcurrentBatches` seen on `main` ([example run](https://github.com/speakeasy-api/gram/actions/runs/31106394060/job/92632690027)), where the concurrent-sweep phase failed with `expected: 1, actual: 0`.

## Root cause

After the first bounded sweep, the test asserts "one bounded row remains" via `fixture.reservedEvaluations(t, 3)`. That helper is not a read: it goes through `LoadReservedSkillEfficacyEvaluations`, the crash-recovery claim query, which is an `UPDATE` that stamps `updated_at = clock_timestamp()` on the row it returns.

The two concurrent sweeps that follow use a 1ms staleness cutoff (`updated_at < now() - 1ms`). On a fast runner, both sweep statements can begin within 1ms of that fresh stamp, so neither sees the row as stale and both report `Recovered: 0` — failing the assertion that exactly one of them recovers it.

## Fix

Backdate the remaining reserved row again after the claim, before spawning the concurrent sweeps — the same "backdate rather than depend on timing" pattern the test already uses ahead of the first sweep. The recovery query itself is unchanged; its `FOR UPDATE SKIP LOCKED` + ownership fences behave correctly.

## Verification

`go test ./server/internal/skills/efficacy/ -run TestRecoverStaleReservationsBoundsConcurrentBatches -race -count=50` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flake in `TestRecoverStaleReservationsBoundsConcurrentBatches` by backdating the remaining reserved row after the claim so concurrent sweeps reliably see it as stale and exactly one recovers it. Prevents the timing issue where the claim refreshes `updated_at` and both sweeps report 0 recovered.

<sup>Written for commit 4ceb98cbf2e77c7daf5ec04ddc9bd806a58dc26b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

