### PR TITLE
fix: soften the shadow-MCP missing-snapshot fail mode

### DIFF
--- a/.changeset/relay-mcp-inventory-diagnostics.md
+++ b/.changeset/relay-mcp-inventory-diagnostics.md
@@ -1,0 +1,13 @@
+---
+"hooks": patch
+---
+
+Make Claude MCP inventory collection failures diagnosable. The relay's
+`claude mcp list` gather at SessionStart bailed silently when the CLI was not
+on PATH or the command failed — and a session whose gather fails carries no
+inventory for its whole life, which under a block-all shadow-MCP policy
+blocks every MCP call in the session (DNO-784). Each bail-out now writes the
+reason (including captured stderr) to the relay debug log, and
+`GRAM_HOOKS_CLAUDE_BIN` is honored as an explicit CLI location, matching the
+plugin bootstrap's documented override for machines where the CLI is not
+discoverable via PATH.

--- a/.changeset/shadow-mcp-missing-snapshot-fail-mode.md
+++ b/.changeset/shadow-mcp-missing-snapshot-fail-mode.md
@@ -1,0 +1,17 @@
+---
+"server": patch
+---
+
+Stop fail-closing allow-all shadow-MCP policies when a session has no MCP
+inventory snapshot. An allow-all policy denies only on a blocked-URL match,
+and a missing inventory yields no URL to match — the same reasoning that lets
+unresolvable evidence fall through to an allow in the canonical guard. Before
+this, one failed SessionStart gather (typically a GUI-launched hook process
+without the `claude` CLI on PATH) blocked every MCP call for the whole session
+even under a permit-by-default policy.
+
+Block-all policies still fail closed, but the denial now logs at WARN under
+`claude_hook_denied_no_mcp_list` so a monitor can catch sessions bricked in
+this state, and the user-facing message names the real cause (the hooks
+client never reported MCP configuration) and the real remediations instead of
+suggesting a retry or restart that cannot help when the outage is chronic.

--- a/hooks/relay/mcp_inventory.go
+++ b/hooks/relay/mcp_inventory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -28,11 +29,25 @@ type mcpInventoryEntry struct {
 // collectClaudeMCPInventory asks Claude for the effective server list so
 // plugin and claude.ai connector servers, which are absent from config files,
 // are included. Collection is best-effort: hooks must continue when the CLI
-// is unavailable, slow, or returns an unfamiliar format.
-func collectClaudeMCPInventory(ctx context.Context, cwd string) []mcpInventoryEntry {
-	bin, err := exec.LookPath("claude")
-	if err != nil {
-		return nil
+// is unavailable, slow, or returns an unfamiliar format. Every bail-out is
+// logged to the debug log — a session whose gather silently fails carries no
+// inventory for its whole life, and under a block-all shadow-MCP policy that
+// blocks every MCP call in the session (DNO-784), so the failure has to be
+// diagnosable.
+func (r *Relay) collectClaudeMCPInventory(ctx context.Context, cwd string) []mcpInventoryEntry {
+	bin := strings.TrimSpace(os.Getenv("GRAM_HOOKS_CLAUDE_BIN"))
+	if bin == "" {
+		found, err := exec.LookPath("claude")
+		if err != nil {
+			// GUI- and MDM-launched hook processes routinely receive a
+			// minimal PATH without the CLI. The plugin bootstrap repairs
+			// PATH from the documented install locations before exec'ing
+			// this binary; landing here means that repair found nothing
+			// either.
+			r.debugf("mcp-inventory: claude CLI not on PATH (set GRAM_HOOKS_CLAUDE_BIN to override): %v", err)
+			return nil
+		}
+		bin = found
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, claudeMCPInventoryTimeout)
@@ -41,11 +56,18 @@ func collectClaudeMCPInventory(ctx context.Context, cwd string) []mcpInventoryEn
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil && len(out) == 0 {
+		r.debugf("mcp-inventory: 'claude mcp list' produced no output (err: %v, stderr: %s)", err, strings.TrimSpace(stderr.String()))
 		return nil
 	}
-	return parseClaudeMCPInventory(string(out))
+	entries := parseClaudeMCPInventory(string(out))
+	if len(entries) == 0 {
+		r.debugf("mcp-inventory: 'claude mcp list' output had no parseable entries (err: %v, stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+	return entries
 }
 
 // parseClaudeMCPInventory parses `<name>: <target> (<transport>) - <status>`.

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -178,7 +178,7 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	ctx = withHarnessInfo(ctx, base)
 	if base.Provider == agenthooks.ProviderClaudeCode &&
 		(base.Kind == agenthooks.KindSessionStart || base.NativeName == "ConfigChange") {
-		attachMCPInventory(&payload, collectClaudeMCPInventory(ctx, base.Session.CWD))
+		attachMCPInventory(&payload, r.collectClaudeMCPInventory(ctx, base.Session.CWD))
 	}
 	// Codex needs the same snapshot for the shadow-MCP guard to prove where a
 	// tool call routes. Without it the guard has nothing to check the call

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -538,12 +538,15 @@ func (s *Service) cacheMCPListSnapshot(ctx context.Context, sessionID string, en
 
 // payloadInventoryIsFresh reports whether the hook payload's MCP inventory was
 // gathered live during this PreToolUse call (additional_data.mcp_inventory_fresh)
-// rather than replayed from the per-session inventory file. hook.sh sets the
-// flag only when it shells out to gather the inventory inline because the file
-// did not exist yet; a replay from the file leaves it unset. A live gather
-// reflects the agent's current MCP configuration and supersedes the cache; a
-// replayed snapshot may lag a ConfigChange the server already cached, so it is
-// only used to fill cache misses (see resolveMCPListForEnforcement).
+// rather than replayed from a per-session inventory file. Only the legacy bash
+// hook clients set this flag — they shell out to gather the inventory inline
+// when their session file does not exist yet, while a replay from the file
+// leaves it unset. The Go relay ships inventory only on SessionStart and
+// ConfigChange (via the ingest surface) and never populates these fields. A
+// live gather reflects the agent's current MCP configuration and supersedes
+// the cache; a replayed snapshot may lag a ConfigChange the server already
+// cached, so it is only used to fill cache misses (see
+// resolveMCPListForEnforcement).
 func payloadInventoryIsFresh(payload *gen.ClaudePayload) bool {
 	if payload.AdditionalData == nil {
 		return false
@@ -563,7 +566,9 @@ func payloadInventoryIsFresh(payload *gen.ClaudePayload) bool {
 //
 //  1. A payload inventory gathered live this call (fresh) is authoritative —
 //     it reflects the agent's current MCP configuration — so it supersedes any
-//     cached snapshot and is written back to heal the cache.
+//     cached snapshot and is written back to heal the cache. Only legacy bash
+//     hook clients ship payload inventories on PreToolUse; the Go relay does
+//     not, so for it the cached snapshot below is the only source.
 //  2. Otherwise the cached SessionStart/ConfigChange snapshot when present.
 //     ConfigChange refreshes the cache synchronously server-side, whereas the
 //     per-session file the payload replays is written asynchronously and can
@@ -575,7 +580,10 @@ func payloadInventoryIsFresh(payload *gen.ClaudePayload) bool {
 //     events. A cache transport error is NOT a miss: it fails closed rather
 //     than enforcing against a possibly-stale replay.
 //
-// Callers treat a returned error as fail-closed.
+// Callers treat a returned error as fail-closed for block-all policies. A
+// returned error can be chronic, not just the startup race: a client whose
+// single SessionStart gather failed never populates the cache for the whole
+// session.
 func (s *Service) resolveMCPListForEnforcement(ctx context.Context, payload *gen.ClaudePayload, sessionID string) ([]MCPServerEntry, error) {
 	entries, variant, ok := s.parseMCPInventoryFromPayload(ctx, payload)
 
@@ -1022,25 +1030,45 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 		return result, nil
 	}
 
-	// Resolve the `claude mcp list` inventory to enforce against. The hook
-	// script replays the SessionStart inventory file on every PreToolUse, so
-	// this normally comes straight from the request payload and is immune to
-	// the SessionStart-snapshot race (DNO-286); it falls back to the cached
-	// snapshot only when the payload carried none. If neither is available we
-	// can't enforce the policy — deny with a retry-or-restart message so the
-	// user knows the guard is fail-closed rather than silently allowing.
+	// Resolve the MCP inventory to enforce against: a payload-carried
+	// inventory when the client ships one (legacy bash hooks replay it on
+	// every PreToolUse and stamp inline gathers as fresh), otherwise the
+	// cached SessionStart/ConfigChange snapshot. Clients that gather only at
+	// SessionStart leave a session with no inventory for its whole life when
+	// that single gather fails (e.g. no `claude` CLI on a GUI hook PATH), so
+	// the missing-snapshot outcome below can be chronic, not just the
+	// DNO-286 startup race.
 	entries, cacheErr := s.resolveMCPListForEnforcement(ctx, payload, sessionID)
 	if cacheErr != nil {
-		auditReason := "missing MCP list snapshot for session"
-		userReason := "Speakeasy blocked this tool call: MCP server configuration is not available yet. Please retry in a moment, or restart Claude Code if the issue persists."
-		s.logger.With(
+		logger := s.logger.With(
 			attr.SlogHookSource("claude"),
 			attr.SlogHookEvent(payload.HookEventName),
 			attr.SlogOrganizationID(metadata.GramOrgID),
 			attr.SlogProjectID(metadata.ProjectID),
 			attr.SlogGenAIConversationID(sessionID),
 			attr.SlogToolName(rawToolName),
-		).InfoContext(ctx, "denying claude tool call: no cached MCP list",
+		)
+		// Permit-by-default policies deny only on a blocked-URL match, and a
+		// missing inventory yields no URL to match — the same reasoning that
+		// lets unresolvable evidence fall through to an allow in
+		// enforceShadowMCPToolAccess. Failing closed here would turn one
+		// failed SessionStart gather into a session-long outage of every MCP
+		// tool under a policy whose default posture is allow.
+		if policy.IsAllowAll() {
+			logger.InfoContext(ctx, "allowing claude tool call without MCP list: allow-all policy has no URL to match",
+				attr.SlogEvent("claude_hook_allowed_no_mcp_list"),
+				attr.SlogError(cacheErr),
+				attr.SlogRiskPolicyID(policy.ID),
+				attr.SlogRiskPolicyName(policy.Name),
+			)
+			if output != nil {
+				output.PermissionDecision = &allow
+			}
+			return result, nil
+		}
+		auditReason := "missing MCP list snapshot for session"
+		userReason := "Speakeasy blocked this tool call: this session's MCP server inventory was never received, so the shadow-MCP policy cannot verify the target. Retry in a moment; if every MCP call in this session stays blocked, the Speakeasy hooks client on this machine is not reporting MCP configuration (update the Speakeasy plugin and make sure the `claude` CLI is reachable from hook processes), or ask your Gram admin about the shadow-MCP policy."
+		logger.WarnContext(ctx, "denying claude tool call: no cached MCP list",
 			attr.SlogEvent("claude_hook_denied_no_mcp_list"),
 			attr.SlogError(cacheErr),
 			attr.SlogRiskPolicyID(policy.ID),

--- a/server/internal/hooks/claude_hooks_test.go
+++ b/server/internal/hooks/claude_hooks_test.go
@@ -42,6 +42,34 @@ func (stubBlockingShadowMCPScanner) HasAcknowledgedChallenge(_ context.Context, 
 func (stubBlockingShadowMCPScanner) RecordPolicyChallenge(_ context.Context, _ string, _ uuid.UUID, _, _, _, _, _, _, _ string) {
 }
 
+// stubAllowAllShadowMCPScanner reports an enabled shadow-MCP policy whose
+// disposition is allow_all (permit unless a blocked URL matches).
+type stubAllowAllShadowMCPScanner struct{}
+
+func (stubAllowAllShadowMCPScanner) ScanForEnforcement(_ context.Context, _ string, _ uuid.UUID, _ string, _ string, _ string, _ string) (*risk.ScanResult, error) {
+	return nil, nil
+}
+
+func (stubAllowAllShadowMCPScanner) LookupShadowMCPBlockingPolicy(_ context.Context, _ string, _ uuid.UUID, _ string) (*risk.ShadowMCPPolicy, error) {
+	return &risk.ShadowMCPPolicy{
+		ID:          "00000000-0000-0000-0000-000000000002",
+		Name:        "shadow-mcp-allow-all",
+		Disposition: risk.ShadowMCPDispositionAllowAll,
+		BlockedURLs: []string{"https://blocked.example.com/mcp"},
+	}, nil
+}
+
+func (stubAllowAllShadowMCPScanner) HasEnabledShadowMCPPolicy(_ context.Context, _ uuid.UUID) (bool, error) {
+	return true, nil
+}
+
+func (stubAllowAllShadowMCPScanner) HasAcknowledgedChallenge(_ context.Context, _ uuid.UUID, _, _, _, _ string) bool {
+	return false
+}
+
+func (stubAllowAllShadowMCPScanner) RecordPolicyChallenge(_ context.Context, _ string, _ uuid.UUID, _, _, _, _, _, _, _ string) {
+}
+
 type userScopedShadowMCPScanner struct {
 	userID string
 }
@@ -219,7 +247,7 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 	userEmail := "claude-authctx@example.com"
 
 	// No MCP list snapshot is cached for this session, so the guard must
-	// deny with the retry/restart message. Reaching that check at all proves
+	// deny with the missing-inventory message. Reaching that check at all proves
 	// the auth-context branch ran — before the fix, the empty Redis cache
 	// would have returned allow without consulting the policy.
 	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
@@ -242,7 +270,7 @@ func TestClaude_PreToolUse_UsesAuthContextWhenNoCachedMetadata(t *testing.T) {
 
 // When the MCP list snapshot is missing from the cache (SessionStart hasn't
 // finished yet, or the 12h inactivity TTL elapsed), the guard fails closed
-// and surfaces a retry/restart hint to the user. Failing open would let a
+// and tells the user the session's MCP inventory was never received. Failing open would let a
 // shadow MCP server slip past during the snapshot-population window.
 func TestClaude_PreToolUse_DeniesWhenMCPListNotCached(t *testing.T) {
 	t.Parallel()
@@ -271,8 +299,44 @@ func TestClaude_PreToolUse_DeniesWhenMCPListNotCached(t *testing.T) {
 	require.NotNil(t, output.PermissionDecision)
 	assert.Equal(t, "deny", *output.PermissionDecision)
 	require.NotNil(t, output.PermissionDecisionReason)
-	assert.Contains(t, *output.PermissionDecisionReason, "restart Claude Code",
-		"deny reason should tell the user to retry or restart so they aren't stuck guessing")
+	assert.Contains(t, *output.PermissionDecisionReason, "MCP server inventory was never received",
+		"deny reason should name the missing inventory as the cause")
+	assert.Contains(t, *output.PermissionDecisionReason, "hooks client",
+		"deny reason should point at the hooks client when the outage is chronic, not just suggest retrying")
+}
+
+// An allow-all policy denies only on a blocked-URL match, and a missing
+// inventory yields no URL to match — so the missing-snapshot fail-closed
+// branch must not apply. Before this behavior, one failed SessionStart gather
+// blocked every MCP call for the whole session even under a permit-by-default
+// policy.
+func TestClaude_PreToolUse_AllowsWhenMCPListNotCachedUnderAllowAllPolicy(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+	ti.service.riskScanner = stubAllowAllShadowMCPScanner{}
+
+	sessionID := uuid.NewString()
+	toolName := "mcp__gram__do_thing"
+	toolUseID := "toolu_no_mcp_list_allow_all"
+	userEmail := "claude-allow-all-no-mcp-list@example.com"
+
+	result, err := ti.service.Claude(ctx, &gen.ClaudePayload{
+		HookEventName: "PreToolUse",
+		SessionID:     &sessionID,
+		UserEmail:     &userEmail,
+		ToolName:      &toolName,
+		ToolUseID:     &toolUseID,
+		ToolInput:     map[string]any{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	output, ok := result.HookSpecificOutput.(*HookSpecificOutput)
+	require.True(t, ok, "HookSpecificOutput should be *HookSpecificOutput")
+	require.NotNil(t, output.PermissionDecision)
+	assert.Equal(t, "allow", *output.PermissionDecision,
+		"allow-all policy has no blocked URL to match without an inventory, so the call must not fail closed")
 }
 
 // Gram-hosted MCP servers are permitted by the shadow-MCP guard. A server
@@ -430,7 +494,7 @@ func TestClaude_PreToolUse_AllowsGramHostedServer(t *testing.T) {
 // file by hook.sh — not only the server-side cache. Here no snapshot is
 // cached, yet a payload-supplied inventory that resolves the tool's server to
 // a Gram-hosted URL must ALLOW, proving the payload path is consulted. Before
-// the fix this session would have denied with the retry/restart message
+// the fix this session would have denied with the missing-inventory message
 // because the cache races the async SessionStart snapshot.
 func TestClaude_PreToolUse_EnforcesFromPayloadInventoryWithoutCache(t *testing.T) {
 	t.Parallel()
@@ -474,7 +538,7 @@ func TestClaude_PreToolUse_EnforcesFromPayloadInventoryWithoutCache(t *testing.T
 
 // A payload-supplied inventory that resolves the server to a non-Gram URL must
 // block with the shadow-MCP policy decision — not the "snapshot unavailable"
-// retry/restart message — confirming the inventory was consumed for
+// missing-inventory message — confirming the inventory was consumed for
 // enforcement rather than triggering the fail-closed cache-miss branch.
 func TestClaude_PreToolUse_PayloadInventoryBlocksNonGramServer(t *testing.T) {
 	t.Parallel()
@@ -506,7 +570,7 @@ func TestClaude_PreToolUse_PayloadInventoryBlocksNonGramServer(t *testing.T) {
 	require.NotNil(t, output.PermissionDecision)
 	assert.Equal(t, "deny", *output.PermissionDecision)
 	require.NotNil(t, output.PermissionDecisionReason)
-	assert.NotContains(t, *output.PermissionDecisionReason, "restart Claude Code",
+	assert.NotContains(t, *output.PermissionDecisionReason, "MCP server inventory was never received",
 		"a payload inventory was supplied, so the block must come from the policy, not the cache-miss fail-closed path")
 }
 
@@ -633,7 +697,7 @@ func (c mcpGetErrorCache) Get(ctx context.Context, key string, value any) error 
 // payload carries a non-fresh replayed inventory. A genuine miss legitimately
 // falls back to the replay (DNO-286), but on a transport error we cannot
 // establish cache-authoritative ordering, so enforcing against a possibly-stale
-// replay is unsafe — deny with the retry/restart message instead.
+// replay is unsafe — deny with the missing-inventory message instead.
 func TestClaude_PreToolUse_CacheTransportErrorFailsClosedDespiteReplay(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestHooksService(t)
@@ -674,7 +738,7 @@ func TestClaude_PreToolUse_CacheTransportErrorFailsClosedDespiteReplay(t *testin
 	assert.Equal(t, "deny", *output.PermissionDecision,
 		"a cache transport error must fail closed, not fall back to a non-fresh replay")
 	require.NotNil(t, output.PermissionDecisionReason)
-	assert.Contains(t, *output.PermissionDecisionReason, "restart Claude Code",
+	assert.Contains(t, *output.PermissionDecisionReason, "MCP server inventory was never received",
 		"the block must be the cache-unavailable fail-closed message, not a policy decision")
 }
 


### PR DESCRIPTION
## What

Softens the Claude PreToolUse shadow-MCP guard's behavior when a session has no MCP inventory snapshot, and makes the relay's inventory-gather failures diagnosable. Fixes the incident in DNO-784, where every MCP call in affected sessions was denied with "MCP server configuration is not available yet" for hours across multiple restarts.

## Why

A session whose SessionStart `claude mcp list` gather fails (typically a GUI-launched hook process without the `claude` CLI on PATH) never populates its inventory snapshot, and the guard's missing-snapshot branch then fail-closes **every** MCP call for the session's whole life. That branch predates allow-all policies and applied to them too, which is wrong: a permit-by-default policy denies only on a blocked-URL match, and a missing inventory yields no URL to match — the guard already allows servers that are *absent from* a resolved inventory under allow-all, so a missing inventory should behave the same.

The deny was also hard to notice and harder to act on: it logged at INFO, and the user-facing message suggested retrying or restarting Claude Code, neither of which helps when the outage is chronic.

## Changes

**Server (`server/internal/hooks/claude_hooks.go`)**
- Allow-all policies no longer fail closed on a missing snapshot; the call is allowed with an `claude_hook_allowed_no_mcp_list` INFO log.
- Block-all policies still fail closed, but the denial logs at WARN (`claude_hook_denied_no_mcp_list`) so a monitor can catch sessions bricked in this state, and the deny message names the actual cause (the hooks client never reported MCP configuration) and remediations.
- Refreshes comments that still described the deleted bash hook clients' PreToolUse inventory replay as current behavior.

**Relay (`hooks/relay/mcp_inventory.go`)**
- `collectClaudeMCPInventory` bail-outs are logged to the relay debug log: CLI not on PATH, `claude mcp list` failure (with captured stderr), and unparseable output.
- Honors `GRAM_HOOKS_CLAUDE_BIN` as an explicit CLI location, matching the plugin bootstrap's documented override.

## Testing

- New test: allow-all policy + missing snapshot allows.
- Updated deny-path assertions for the new message; full `server/internal/hooks` and `hooks/relay` suites pass, plus `mise lint:server` and `build:hooks`/`test:hooks`.

## Notes for reviewers

- The originally planned "restore PreToolUse-time inventory fallback in the relay" is deliberately **not** here: agenthooks v0.4.0 already resolves each Claude MCP call's transport per-call and the relay ships it as `data.mcp`, so the canonical ingest guard doesn't depend on the SessionStart snapshot. The affected sessions were old bash-hook clients on the legacy endpoint (context in DNO-784).
- Complements `fix-hooks-claude-cli-path` (bootstrap PATH repair), which addresses why the gather fails on desktop/MDM machines in the first place.

Refs DNO-784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-784 by allowing MCP calls under allow-all policies when a session has no MCP inventory snapshot, and making block-all denials observable and actionable. Adds relay debug logs for `claude mcp list` failures and supports `GRAM_HOOKS_CLAUDE_BIN` for CLI lookup.

- **Bug Fixes**
  - Server: allow-all no longer fail-closes on a missing snapshot; block-all still denies but logs at WARN with a clear cause and remediation.
  - Relay: logs bail-outs for `claude mcp list` (CLI not on PATH, command error, unparseable output) with captured stderr; honors `GRAM_HOOKS_CLAUDE_BIN`.
  - Tests: added allow-all/missing-snapshot allow test; updated deny-path assertions.

<sup>Written for commit 64bd09bbef92c6c53ecfc45db48ad15387e2141d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

