### PR TITLE
mig: expand assets to organization and platform tiers

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -271,9 +271,21 @@ CREATE TABLE IF NOT EXISTS deployment_logs (
   CONSTRAINT deployment_logs_project_id_fkey FOREIGN key (project_id) REFERENCES projects (id) ON DELETE SET NULL
 );
 
+-- Assets are uploaded blobs (OpenAPI documents, function bundles, chat
+-- attachments, images) tracked at one of three ownership tiers, mirroring the
+-- tiers remote_session_issuers and remote_session_clients already carry. The
+-- tier is derived from the two tenancy columns:
+--
+--   project      project_id IS NOT NULL
+--   organization project_id IS NULL AND organization_id IS NOT NULL
+--   platform     project_id IS NULL AND organization_id IS NULL
+--
+-- Tier validity is enforced in application code, not by a CHECK constraint, so
+-- adding a future tier does not require a migration.
 CREATE TABLE IF NOT EXISTS assets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
-  project_id uuid NOT NULL,
+  project_id uuid,
+  organization_id TEXT,
 
   name TEXT NOT NULL CHECK (name <> '' AND CHAR_LENGTH(name) <= 100),
   url TEXT NOT NULL,
@@ -288,8 +300,32 @@ CREATE TABLE IF NOT EXISTS assets (
   deleted boolean NOT NULL GENERATED ALWAYS AS (deleted_at IS NOT NULL) stored,
 
   CONSTRAINT assets_pkey PRIMARY KEY (id),
-  CONSTRAINT assets_project_id_sha256_key UNIQUE (project_id, sha256)
+  CONSTRAINT assets_project_id_sha256_key UNIQUE (project_id, sha256),
+  CONSTRAINT assets_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
+
+-- Content-addressed dedupe for the organization and platform tiers.
+--
+-- Deliberately NOT filtered on `deleted IS FALSE`, unlike the sibling
+-- remote_session_issuers indexes. assets_project_id_sha256_key spans
+-- soft-deleted rows too, and the CreateAsset upsert relies on colliding with a
+-- soft-deleted row to resurrect it (ON CONFLICT ... DO UPDATE SET deleted_at =
+-- NULL). Adding the filter here would diverge the tiers and break that path.
+--
+-- Any upsert targeting these indexes must repeat the predicate verbatim in its
+-- ON CONFLICT target, e.g.
+--   ON CONFLICT (organization_id, sha256)
+--     WHERE project_id IS NULL AND organization_id IS NOT NULL
+-- Postgres refuses to infer a partial index from a mismatched predicate, and a
+-- conflict raised against a non-arbiter index surfaces as an uncaught 23505 on
+-- the second upload of the same bytes rather than at deploy time.
+CREATE UNIQUE INDEX IF NOT EXISTS assets_organization_id_sha256_key
+ON assets (organization_id, sha256)
+WHERE project_id IS NULL AND organization_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS assets_platform_sha256_key
+ON assets (sha256)
+WHERE project_id IS NULL AND organization_id IS NULL;
 
 CREATE TABLE IF NOT EXISTS skills (
   id uuid NOT NULL DEFAULT generate_uuidv7(),

--- a/server/internal/assets/queries.sql
+++ b/server/internal/assets/queries.sql
@@ -10,7 +10,7 @@ INSERT INTO assets (
 ) VALUES (
     @name
   , @url
-  , @project_id
+  , @project_id::uuid
   , @sha256
   , @kind
   , @content_type
@@ -23,10 +23,10 @@ ON CONFLICT (project_id, sha256) DO UPDATE SET
 RETURNING *;
 
 -- name: GetProjectAsset :one
-SELECT * FROM assets WHERE project_id = @project_id AND id = @id;
+SELECT * FROM assets WHERE project_id = @project_id::uuid AND id = @id;
 
 -- name: GetProjectAssetBySHA256 :one
-SELECT * FROM assets WHERE project_id = @project_id AND sha256 = @sha256;
+SELECT * FROM assets WHERE project_id = @project_id::uuid AND sha256 = @sha256;
 
 -- name: GetImageAssetURL :one
 SELECT url, content_type, content_length, updated_at FROM assets WHERE id = @id AND kind = 'image';
@@ -36,29 +36,29 @@ SELECT url, content_type, content_length, updated_at
 FROM assets
 WHERE
   id = @id AND kind = 'openapiv3'
-  AND project_id = @project_id;
+  AND project_id = @project_id::uuid;
 
 -- name: GetFunctionAssetURL :one
 SELECT url, content_type, content_length, updated_at
 FROM assets
 WHERE
   id = @id AND kind = 'functions'
-  AND project_id = @project_id;
+  AND project_id = @project_id::uuid;
 
 -- name: GetChatAttachmentAssetURL :one
 SELECT url, content_type, content_length, updated_at
 FROM assets
 WHERE
   id = @id AND kind = 'chat_attachment'
-  AND project_id = @project_id
+  AND project_id = @project_id::uuid
   AND deleted = false;
 
 -- name: ListAssets :many
-SELECT * FROM assets WHERE project_id = @project_id;
+SELECT * FROM assets WHERE project_id = @project_id::uuid;
 
 -- name: GetAssetsByID :many
 SELECT id, url, sha256, content_type, content_length
 FROM assets
-WHERE project_id = @project_id
+WHERE project_id = @project_id::uuid
   AND id = ANY(@ids::uuid[])
   AND deleted IS FALSE;

--- a/server/internal/assets/repo/models.go
+++ b/server/internal/assets/repo/models.go
@@ -10,16 +10,17 @@ import (
 )
 
 type Asset struct {
-	ID            uuid.UUID
-	ProjectID     uuid.UUID
-	Name          string
-	Url           string
-	Kind          string
-	ContentType   string
-	ContentLength int64
-	Sha256        string
-	CreatedAt     pgtype.Timestamptz
-	UpdatedAt     pgtype.Timestamptz
-	DeletedAt     pgtype.Timestamptz
-	Deleted       bool
+	ID             uuid.UUID
+	ProjectID      uuid.NullUUID
+	OrganizationID pgtype.Text
+	Name           string
+	Url            string
+	Kind           string
+	ContentType    string
+	ContentLength  int64
+	Sha256         string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
 }

--- a/server/internal/assets/repo/queries.sql.go
+++ b/server/internal/assets/repo/queries.sql.go
@@ -24,7 +24,7 @@ INSERT INTO assets (
 ) VALUES (
     $1
   , $2
-  , $3
+  , $3::uuid
   , $4
   , $5
   , $6
@@ -34,7 +34,7 @@ ON CONFLICT (project_id, sha256) DO UPDATE SET
     deleted_at = NULL,
     url = $2,
     updated_at = clock_timestamp()
-RETURNING id, project_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateAssetParams struct {
@@ -61,6 +61,7 @@ func (q *Queries) CreateAsset(ctx context.Context, arg CreateAssetParams) (Asset
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Name,
 		&i.Url,
 		&i.Kind,
@@ -78,7 +79,7 @@ func (q *Queries) CreateAsset(ctx context.Context, arg CreateAssetParams) (Asset
 const getAssetsByID = `-- name: GetAssetsByID :many
 SELECT id, url, sha256, content_type, content_length
 FROM assets
-WHERE project_id = $1
+WHERE project_id = $1::uuid
   AND id = ANY($2::uuid[])
   AND deleted IS FALSE
 `
@@ -127,7 +128,7 @@ SELECT url, content_type, content_length, updated_at
 FROM assets
 WHERE
   id = $1 AND kind = 'chat_attachment'
-  AND project_id = $2
+  AND project_id = $2::uuid
   AND deleted = false
 `
 
@@ -160,7 +161,7 @@ SELECT url, content_type, content_length, updated_at
 FROM assets
 WHERE
   id = $1 AND kind = 'functions'
-  AND project_id = $2
+  AND project_id = $2::uuid
 `
 
 type GetFunctionAssetURLParams struct {
@@ -215,7 +216,7 @@ SELECT url, content_type, content_length, updated_at
 FROM assets
 WHERE
   id = $1 AND kind = 'openapiv3'
-  AND project_id = $2
+  AND project_id = $2::uuid
 `
 
 type GetOpenAPIv3AssetURLParams struct {
@@ -243,7 +244,7 @@ func (q *Queries) GetOpenAPIv3AssetURL(ctx context.Context, arg GetOpenAPIv3Asse
 }
 
 const getProjectAsset = `-- name: GetProjectAsset :one
-SELECT id, project_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted FROM assets WHERE project_id = $1 AND id = $2
+SELECT id, project_id, organization_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted FROM assets WHERE project_id = $1::uuid AND id = $2
 `
 
 type GetProjectAssetParams struct {
@@ -257,6 +258,7 @@ func (q *Queries) GetProjectAsset(ctx context.Context, arg GetProjectAssetParams
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Name,
 		&i.Url,
 		&i.Kind,
@@ -272,7 +274,7 @@ func (q *Queries) GetProjectAsset(ctx context.Context, arg GetProjectAssetParams
 }
 
 const getProjectAssetBySHA256 = `-- name: GetProjectAssetBySHA256 :one
-SELECT id, project_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted FROM assets WHERE project_id = $1 AND sha256 = $2
+SELECT id, project_id, organization_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted FROM assets WHERE project_id = $1::uuid AND sha256 = $2
 `
 
 type GetProjectAssetBySHA256Params struct {
@@ -286,6 +288,7 @@ func (q *Queries) GetProjectAssetBySHA256(ctx context.Context, arg GetProjectAss
 	err := row.Scan(
 		&i.ID,
 		&i.ProjectID,
+		&i.OrganizationID,
 		&i.Name,
 		&i.Url,
 		&i.Kind,
@@ -301,7 +304,7 @@ func (q *Queries) GetProjectAssetBySHA256(ctx context.Context, arg GetProjectAss
 }
 
 const listAssets = `-- name: ListAssets :many
-SELECT id, project_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted FROM assets WHERE project_id = $1
+SELECT id, project_id, organization_id, name, url, kind, content_type, content_length, sha256, created_at, updated_at, deleted_at, deleted FROM assets WHERE project_id = $1::uuid
 `
 
 func (q *Queries) ListAssets(ctx context.Context, projectID uuid.UUID) ([]Asset, error) {
@@ -316,6 +319,7 @@ func (q *Queries) ListAssets(ctx context.Context, projectID uuid.UUID) ([]Asset,
 		if err := rows.Scan(
 			&i.ID,
 			&i.ProjectID,
+			&i.OrganizationID,
 			&i.Name,
 			&i.Url,
 			&i.Kind,

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -1503,7 +1503,7 @@ WHERE project_id = @project_id
 -- project so a leaked asset id from another project cannot be attached.
 SELECT id, name, url, content_type, content_length
 FROM assets
-WHERE project_id = @project_id
+WHERE project_id = @project_id::uuid
   AND id = ANY(@ids::uuid[])
   AND kind = 'chat_attachment'
   AND deleted IS FALSE;

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1783,7 +1783,7 @@ func (q *Queries) ListAssistants(ctx context.Context, projectID uuid.UUID) ([]Li
 const listChatAttachmentAssets = `-- name: ListChatAttachmentAssets :many
 SELECT id, name, url, content_type, content_length
 FROM assets
-WHERE project_id = $1
+WHERE project_id = $1::uuid
   AND id = ANY($2::uuid[])
   AND kind = 'chat_attachment'
   AND deleted IS FALSE

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -85,18 +85,19 @@ type ApiKey struct {
 }
 
 type Asset struct {
-	ID            uuid.UUID
-	ProjectID     uuid.UUID
-	Name          string
-	Url           string
-	Kind          string
-	ContentType   string
-	ContentLength int64
-	Sha256        string
-	CreatedAt     pgtype.Timestamptz
-	UpdatedAt     pgtype.Timestamptz
-	DeletedAt     pgtype.Timestamptz
-	Deleted       bool
+	ID             uuid.UUID
+	ProjectID      uuid.NullUUID
+	OrganizationID pgtype.Text
+	Name           string
+	Url            string
+	Kind           string
+	ContentType    string
+	ContentLength  int64
+	Sha256         string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+	Deleted        bool
 }
 
 type Assistant struct {

--- a/server/internal/functions/queries.sql
+++ b/server/internal/functions/queries.sql
@@ -166,7 +166,7 @@ SELECT a.url
 FROM deployments_functions df
 INNER JOIN assets a ON df.asset_id = a.id
 WHERE
-  a.project_id = @project_id
+  a.project_id = @project_id::uuid
   AND df.deployment_id = @deployment_id
   AND df.id = @function_id
   AND a.id = @asset_id

--- a/server/internal/functions/repo/queries.sql.go
+++ b/server/internal/functions/repo/queries.sql.go
@@ -239,7 +239,7 @@ SELECT a.url
 FROM deployments_functions df
 INNER JOIN assets a ON df.asset_id = a.id
 WHERE
-  a.project_id = $1
+  a.project_id = $1::uuid
   AND df.deployment_id = $2
   AND df.id = $3
   AND a.id = $4

--- a/server/migrations/20260811225530_expand-assets-tiers.sql
+++ b/server/migrations/20260811225530_expand-assets-tiers.sql
@@ -1,0 +1,5 @@
+-- atlas:txmode none
+
+-- Modify "assets" table
+ALTER TABLE "assets" ALTER COLUMN "project_id" DROP NOT NULL, ADD COLUMN "organization_id" text NULL, ADD CONSTRAINT "assets_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE NOT VALID;
+ALTER TABLE "assets" VALIDATE CONSTRAINT "assets_organization_id_fkey";

--- a/server/migrations/20260811225943_assets-tier-dedupe-indexes.sql
+++ b/server/migrations/20260811225943_assets-tier-dedupe-indexes.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Create index "assets_organization_id_sha256_key" to table: "assets"
+CREATE UNIQUE INDEX CONCURRENTLY "assets_organization_id_sha256_key" ON "assets" ("organization_id", "sha256") WHERE ((project_id IS NULL) AND (organization_id IS NOT NULL));
+-- Create index "assets_platform_sha256_key" to table: "assets"
+CREATE UNIQUE INDEX CONCURRENTLY "assets_platform_sha256_key" ON "assets" ("sha256") WHERE ((project_id IS NULL) AND (organization_id IS NULL));

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fvlme0Jr7SMv7ve0BvCXaxoJa6w+Zicy0zWxB0E65Gg=
+h1:Bs0pT+vnoPML6h15n8czWE8J3jHtihvAmPMIhtTW1TQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -329,3 +329,5 @@ h1:fvlme0Jr7SMv7ve0BvCXaxoJa6w+Zicy0zWxB0E65Gg=
 20260811105106_publish-outbox-insert-path.sql h1:leS1M0XbzRMb45lo8LbQUeKhzhRdgGAnC6lTNLdIzQ0=
 20260811105118_publish-outbox-lz4-seq-cache.sql h1:WUBOsQMQ++yXODWc/pJ8oqr52ogxT0FnI2Ip5tz78IU=
 20260811183332_mcp-approval-workflow.sql h1:UwCSdC5Xh39xdlv47ACNaCw9VkOa/S1Gxsp0pIeFzeM=
+20260811225530_expand-assets-tiers.sql h1:K5IvMnYVFRA8qmUXXPvH5S0HtFWPUNYWbd7KCGlUFC4=
+20260811225943_assets-tier-dedupe-indexes.sql h1:thYfONo6SYry2Aew/GXLvIn/9WZtmZv82BfL7c5jp4A=


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIS-446/mig-expand-assets-to-organization-and-platform-tiers

Expand-only schema change so an `assets` row can be owned by a project (as today), an organization, or the platform. Organization and platform issuers have a null `project_id`, so neither had a legitimate project to own a logo blob, which is what AIS-118 deferred when it shipped `remote_session_issuers.logo_asset_id`. Tier is derived from the two tenancy columns and validated in application code, not by a CHECK constraint, so a future tier will not require a migration.

Schema and migration artifacts only: no application code, and the only query change is a mechanical cast. Relaxing `NOT NULL` would retype sqlc params, not just row structs, so every project-tier `@project_id` now carries an explicit `::uuid` cast to keep generated param structs and call sites unchanged. AIS-449 covers the application side and in turn unblocks AIS-445.

`assets_project_id_sha256_key` is what makes an upload of already-stored bytes reuse the existing row instead of writing a duplicate blob, and Postgres treats NULLs as distinct in a unique index, so it does not constrain rows where `project_id IS NULL`. Two partial unique indexes extend dedupe to the tiers it cannot reach, on `(organization_id, sha256)` and `(sha256)`. Neither filters on `deleted IS FALSE`, unlike the sibling `remote_session_issuers` indexes, because `assets_project_id_sha256_key` spans soft-deleted rows too and the `CreateAsset` upsert relies on colliding with one to resurrect it.

The foreign key is added as `NOT VALID` followed by `VALIDATE CONSTRAINT` so the validation scan does not hold `ACCESS EXCLUSIVE`. At 3010 production rows the plain form would also have been fine, and AIS-220 used it, but the split costs nothing and suppresses the PG306 warning. `ON DELETE CASCADE` matches the sibling `remote_session_issuers_organization_id_fkey`; `ON DELETE SET NULL` would silently promote a deleted organization's asset into a platform-tier asset, which is served to everyone.

Two migration files, so the concurrent index builds stay isolated per the `lint:migrations` rule. Both are Atlas output, with the sanctioned `NOT VALID` edit applied to the first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand assets to support organization and platform tiers so org/global identity providers can store logos. Schema-only change for AIS-446; project behavior is unchanged and this unblocks AIS-445.

- **Migration**
  - Make `assets.project_id` nullable and add `organization_id` with FK to `organization_metadata` (`ON DELETE CASCADE`; added `NOT VALID` then `VALIDATE` to avoid exclusive locks).
  - Add partial unique indexes for dedupe: `(organization_id, sha256)` and platform `(sha256)`; keep existing `(project_id, sha256)`; include soft-deleted rows to preserve upsert resurrection.
  - No application changes; `sqlc` queries now cast `@project_id::uuid` to keep params stable; generated models update `Asset.ProjectID` to nullable and add `OrganizationID`.
  - Two migrations: one for schema, one for concurrent index builds.

<sup>Written for commit 95bc62c508110866c2518b8ce99f26d4886fbf87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

