### PR TITLE
fix: handle organization-less login sessions

### DIFF
--- a/.agents/skills/golang/SKILL.md
+++ b/.agents/skills/golang/SKILL.md
@@ -153,10 +153,11 @@ This keeps the service dependency simple and avoids baking `repo.Queries` into t
 
 ## Auth context assumptions
 
-- When reading `authctx`, assume `ActiveOrganisationID` is present.
-- Do NOT add defensive empty checks for `ActiveOrganisationID` unless there is a concrete code path proving otherwise.
+- In organization-scoped handlers, assume `ActiveOrganizationID` is present.
+- Session authentication can briefly produce an org-less context during login. The auth middleware handles that boundary by installing zero RBAC grants; do not spread empty-org checks into handlers.
+- Do NOT add defensive empty checks for `ActiveOrganizationID` outside that boundary unless there is another concrete code path proving otherwise.
 
-Avoid patterns that treat `ActiveOrganisationID` as optional when reading `authctx`. That adds defensive code around an invariant that should already hold.
+Avoid patterns that treat `ActiveOrganizationID` as optional when reading `authctx`. That adds defensive code around an invariant that should already hold.
 
 ## Third-party clients
 

--- a/.agents/skills/gram-rbac/SKILL.md
+++ b/.agents/skills/gram-rbac/SKILL.md
@@ -37,7 +37,7 @@ Gram's RBAC is a scope-and-selector model. The server ships with a fixed set of 
 
 **Enforcement.** Inside a handler, authorization is an explicit one-line check: the handler names the scope (and resource, if project-scoped) it needs, and the RBAC engine either allows the call or returns a forbidden error.
 
-**Auth context invariant.** By the time a handler runs, the auth context's `ActiveOrganizationID` is always populated — RBAC does not defensively check for an empty org id.
+**Auth context invariant.** Organization-scoped handlers can assume `ActiveOrganizationID` is populated. During login, session authentication can briefly produce an org-less context; `Engine.PrepareContext` handles that middleware boundary by installing zero grants instead of trying organization-scoped principal resolution. Endpoints already exposed during login keep their explicit org-less behavior: for example, `access.ListGrants` returns no grants, `productfeatures.GetProductFeatures` returns unauthorized, and `auth.Info` continues the login flow. Do not spread defensive empty-org checks into other handlers.
 
 ## Server
 

--- a/.changeset/orgless-session-authz.md
+++ b/.changeset/orgless-session-authz.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Prevent organization-less login sessions from failing RBAC grant preparation.

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -360,6 +360,9 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 	if err != nil {
 		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
+	if acPre.ActiveOrganizationID == "" {
+		return &gen.ListUserGrantsResult{Grants: nil}, nil
+	}
 	// Sessions in the shared demo org have no membership rows. Return the
 	// full user-visible scope set so every dashboard page is browsable in the
 	// demo (page gates like Costs require org:admin). This is display-only:

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -360,6 +360,10 @@ func (s *Service) ListGrants(ctx context.Context, _ *gen.ListGrantsPayload) (*ge
 	if err != nil {
 		return nil, oops.E(oops.CodeUnauthorized, err, "missing auth context").LogError(ctx, s.logger)
 	}
+	// A session can exist before organization selection during login. Unlike
+	// sessionless or API-key requests, RBAC still applies and PrepareContext
+	// installs zero grants. Mirror that effective set so dashboard gates remain
+	// closed until registration or organization selection completes.
 	if acPre.ActiveOrganizationID == "" {
 		return &gen.ListUserGrantsResult{Grants: nil}, nil
 	}

--- a/server/internal/access/listusergrants_test.go
+++ b/server/internal/access/listusergrants_test.go
@@ -130,6 +130,21 @@ func TestService_ListGrants_InvalidUserPrincipal(t *testing.T) {
 	require.ErrorIs(t, err, authz.ErrPrincipalInvalid)
 }
 
+func TestService_ListGrants_WithoutActiveOrganizationReturnsNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	authCtx.ActiveOrganizationID = ""
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	result, err := ti.service.ListGrants(ctx, &gen.ListGrantsPayload{})
+	require.NoError(t, err)
+	require.Empty(t, result.Grants)
+}
+
 func TestService_ListGrants_AdminImpersonatingReturnsFullAccess(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -423,6 +423,38 @@ func TestService_Info(t *testing.T) {
 	})
 }
 
+func TestService_Info_OrganizationlessSessionContinuesLogin(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	userInfo.UserID = "organizationless-info-user"
+	userInfo.Email = "organizationless-info@example.com"
+	userInfo.Organizations = nil
+	ctx, instance := newTestAuthService(t, userInfo)
+	require.NoError(t, instance.createTestUser(ctx, userInfo))
+
+	session := sessions.Session{
+		SessionID:            t.Name(),
+		UserID:               userInfo.UserID,
+		ActiveOrganizationID: "",
+		WorkOSSessionID:      "",
+	}
+	require.NoError(t, instance.sessionManager.StoreSession(ctx, session))
+
+	authedCtx, err := instance.authorizer.Authorize(t.Context(), session.SessionID, sessionScheme)
+	require.NoError(t, err)
+	grants, ok := authz.GrantsFromContext(authedCtx)
+	require.True(t, ok)
+	require.Empty(t, grants)
+
+	result, err := instance.service.Info(authedCtx, &gen.InfoPayload{})
+	require.NoError(t, err)
+	require.Equal(t, session.SessionID, result.SessionToken)
+	require.Empty(t, result.ActiveOrganizationID)
+	require.Equal(t, userInfo.UserID, result.UserID)
+	require.Empty(t, result.Organizations)
+}
+
 func TestService_Info_ProjectFiltering(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/authz/context_test.go
+++ b/server/internal/authz/context_test.go
@@ -84,6 +84,28 @@ func TestPrepareContext_skipsNonSessionAuth(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestPrepareContext_sessionWithoutActiveOrganizationGetsNoGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx := enterpriseTestCtx(t.Context())
+	conn := newTestDB(t)
+	chConn, err := newClickhouseClient(t)
+	require.NoError(t, err)
+	engine := NewEngine(testenv.NewLogger(t), conn, chConn, challengeLoggingAlwaysEnabled, workos.NewStubClient())
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	authCtx.ActiveOrganizationID = ""
+	ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+	ctx, err = engine.PrepareContext(ctx)
+	require.NoError(t, err)
+
+	grants, ok := GrantsFromContext(ctx)
+	require.True(t, ok)
+	require.Empty(t, grants)
+}
+
 func TestPrepareContext_loadsAssistantPrincipalGrants(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/authz/engine.go
+++ b/server/internal/authz/engine.go
@@ -93,6 +93,9 @@ func (e *Engine) PrepareContext(ctx context.Context) (context.Context, error) {
 	if authCtx.SessionID == nil && !isAssistant {
 		return ctx, nil
 	}
+	if authCtx.ActiveOrganizationID == "" {
+		return GrantsToContext(ctx, nil), nil
+	}
 
 	// Sessions in the shared demo org (which has no membership rows) get a
 	// fixed read-only grant set. This must precede scope and admin overrides so


### PR DESCRIPTION
Organization-less sessions can exist briefly during login, but RBAC grant preparation attempted organization-scoped principal resolution and returned a 500 before handlers ran.

This handles the transient state by preparing an empty grant set. The grants endpoint also returns an empty list until an organization is active, while the existing login and unauthorized endpoint behavior remains unchanged.