### PR TITLE
feat: attribute Cursor usage events to sessions

### DIFF
--- a/.changeset/attribute-cursor-sessions.md
+++ b/.changeset/attribute-cursor-sessions.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Attribute Cursor usage events to sessions by decoding conversationId into the standard GenAI conversation attribute.

--- a/server/internal/aiintegrations/cursor_usage_polling.go
+++ b/server/internal/aiintegrations/cursor_usage_polling.go
@@ -168,6 +168,26 @@ func (src *cursorUsageSource) RetryAfter(err error) (time.Duration, bool) {
 
 func buildCursorUsageEvent(cfg Config, event cursorapi.UsageEvent) telemetry.LogParams {
 	userEmail := conv.NormalizeEmail(event.UserEmail)
+	attributes := map[attr.Key]any{
+		attr.EventSourceKey:                        string(telemetry.EventSourceAPI),
+		attr.LogBodyKey:                            "Cursor usage metrics",
+		attr.ProjectIDKey:                          cfg.ProjectID.String(),
+		attr.OrganizationIDKey:                     cfg.OrganizationID,
+		attr.ResourceURNKey:                        cursorUsageMetricsURN,
+		attr.HookSourceKey:                         "cursor",
+		attr.AIIntegrationConfigIDKey:              cfg.ID.String(),
+		attr.GenAIUsageInputTokensKey:              event.TokenUsage.InputTokens,
+		attr.GenAIUsageOutputTokensKey:             event.TokenUsage.OutputTokens,
+		attr.GenAIUsageCacheReadInputTokensKey:     event.TokenUsage.CacheReadTokens,
+		attr.GenAIUsageCacheCreationInputTokensKey: event.TokenUsage.CacheWriteTokens,
+		attr.GenAIUsageCostKey:                     event.TokenUsage.TotalCents / 100,
+		attr.GenAIResponseModelKey:                 event.Model,
+		attr.CursorUsageEventHashKey:               generateCursorUsageEventHash(event),
+		attr.CursorChargedCentsKey:                 event.ChargedCents,
+	}
+	if event.ConversationID != "" {
+		attributes[attr.GenAIConversationIDKey] = event.ConversationID
+	}
 
 	return telemetry.LogParams{
 		Timestamp: event.Timestamp,
@@ -180,24 +200,8 @@ func buildCursorUsageEvent(cfg Config, event cursorapi.UsageEvent) telemetry.Log
 			DeploymentID:   "",
 			FunctionID:     nil,
 		},
-		UserInfo: telemetry.UserInfoByEmail(userEmail),
-		Attributes: map[attr.Key]any{
-			attr.EventSourceKey:                        string(telemetry.EventSourceAPI),
-			attr.LogBodyKey:                            "Cursor usage metrics",
-			attr.ProjectIDKey:                          cfg.ProjectID.String(),
-			attr.OrganizationIDKey:                     cfg.OrganizationID,
-			attr.ResourceURNKey:                        cursorUsageMetricsURN,
-			attr.HookSourceKey:                         "cursor",
-			attr.AIIntegrationConfigIDKey:              cfg.ID.String(),
-			attr.GenAIUsageInputTokensKey:              event.TokenUsage.InputTokens,
-			attr.GenAIUsageOutputTokensKey:             event.TokenUsage.OutputTokens,
-			attr.GenAIUsageCacheReadInputTokensKey:     event.TokenUsage.CacheReadTokens,
-			attr.GenAIUsageCacheCreationInputTokensKey: event.TokenUsage.CacheWriteTokens,
-			attr.GenAIUsageCostKey:                     event.TokenUsage.TotalCents / 100,
-			attr.GenAIResponseModelKey:                 event.Model,
-			attr.CursorUsageEventHashKey:               generateCursorUsageEventHash(event),
-			attr.CursorChargedCentsKey:                 event.ChargedCents,
-		},
+		UserInfo:   telemetry.UserInfoByEmail(userEmail),
+		Attributes: attributes,
 	}
 }
 

--- a/server/internal/aiintegrations/cursor_usage_polling_test.go
+++ b/server/internal/aiintegrations/cursor_usage_polling_test.go
@@ -38,6 +38,7 @@ func TestBuildCursorUsageEventIncludesIntegrationConfigID(t *testing.T) {
 	}
 	event := cursorapi.UsageEvent{
 		Timestamp:        time.Date(2026, 5, 20, 12, 30, 0, 0, time.UTC),
+		ConversationID:   "33333333-3333-4333-8333-333333333333",
 		Model:            "claude-4",
 		Kind:             "usage",
 		ChargedCents:     0,
@@ -58,5 +59,6 @@ func TestBuildCursorUsageEventIncludesIntegrationConfigID(t *testing.T) {
 
 	require.Equal(t, configID.String(), logParam.Attributes[attr.AIIntegrationConfigIDKey])
 	require.Equal(t, "cursor", logParam.Attributes[attr.HookSourceKey])
+	require.Equal(t, event.ConversationID, logParam.Attributes[attr.GenAIConversationIDKey])
 	require.Equal(t, "user@example.com", logParam.UserInfo.Email())
 }

--- a/server/internal/aiintegrations/event_key_test.go
+++ b/server/internal/aiintegrations/event_key_test.go
@@ -20,6 +20,7 @@ func TestCursorUsageEventKeyGolden(t *testing.T) {
 
 	event := cursorapi.UsageEvent{
 		Timestamp:        time.Date(2026, 7, 16, 10, 30, 0, 0, time.UTC),
+		ConversationID:   "11111111-2222-4333-8444-555555555555",
 		Model:            "claude-4.5-opus",
 		Kind:             "Included in Business",
 		ChargedCents:     12.5,
@@ -38,6 +39,8 @@ func TestCursorUsageEventKeyGolden(t *testing.T) {
 		UserEmail: "User@Example.com ",
 	}
 
+	// Conversation IDs are attribution metadata, not part of the stable event
+	// identity, so events ingested before Cursor exposed the field still dedupe.
 	require.Equal(t,
 		"aeeb699366765bfb9dc8db4c957dbc2beb5150032851feb3c66d7387ca9eb9b6",
 		generateCursorUsageEventHash(event))

--- a/server/internal/thirdparty/cursor/client.go
+++ b/server/internal/thirdparty/cursor/client.go
@@ -78,6 +78,7 @@ func New(guardianPolicy *guardian.Policy, opts ...Option) *Client {
 
 type UsageEvent struct {
 	Timestamp        time.Time  `json:"timestamp"`
+	ConversationID   string     `json:"conversationId"`
 	Model            string     `json:"model"`
 	Kind             string     `json:"kind"`
 	ChargedCents     float64    `json:"chargedCents"`

--- a/server/internal/thirdparty/cursor/client_test.go
+++ b/server/internal/thirdparty/cursor/client_test.go
@@ -198,6 +198,7 @@ func TestUsageEventUnmarshalsTimestamp(t *testing.T) {
 	var event UsageEvent
 	err := json.Unmarshal([]byte(`{
 		"timestamp": "1710720000123",
+		"conversationId": "11111111-2222-4333-8444-555555555555",
 		"model": "claude",
 		"kind": "Usage-based",
 		"chargedCents": 0,
@@ -215,6 +216,7 @@ func TestUsageEventUnmarshalsTimestamp(t *testing.T) {
 	}`), &event)
 	require.NoError(t, err)
 	require.Equal(t, int64(1710720000123), event.Timestamp.UnixMilli())
+	require.Equal(t, "11111111-2222-4333-8444-555555555555", event.ConversationID)
 }
 
 func TestFilteredUsageEventsResponseUnmarshalsDocsShape(t *testing.T) {
@@ -234,6 +236,7 @@ func TestFilteredUsageEventsResponseUnmarshalsDocsShape(t *testing.T) {
 			{
 				"timestamp": "1750979225854",
 				"userEmail": "developer@company.com",
+				"conversationId": "11111111-2222-4333-8444-555555555555",
 				"model": "claude-4.5-sonnet",
 				"kind": "Usage-based",
 				"maxMode": true,
@@ -277,6 +280,7 @@ func TestFilteredUsageEventsResponseUnmarshalsDocsShape(t *testing.T) {
 	require.True(t, resp.Pagination.HasNextPage)
 	require.Len(t, resp.UsageEvents, 2)
 	require.Equal(t, "developer@company.com", resp.UsageEvents[0].UserEmail)
+	require.Equal(t, "11111111-2222-4333-8444-555555555555", resp.UsageEvents[0].ConversationID)
 	require.Equal(t, int64(1750979225854), resp.UsageEvents[0].Timestamp.UnixMilli())
 	require.InDelta(t, float64(21.36232), resp.UsageEvents[0].ChargedCents, 0.000001)
 	require.Equal(t, int64(126), resp.UsageEvents[0].TokenUsage.InputTokens)
@@ -296,6 +300,7 @@ func testGuardianPolicy(t *testing.T) *guardian.Policy {
 func testUsageEvent(chargedCents float64) UsageEvent {
 	return UsageEvent{
 		Timestamp:        time.UnixMilli(1710720000123).UTC(),
+		ConversationID:   "11111111-2222-4333-8444-555555555555",
 		Model:            "claude",
 		Kind:             "Usage-based",
 		ChargedCents:     chargedCents,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- decode `conversationId` from Cursor usage events
- write it as the standard GenAI conversation attribute so session analytics include Cursor token usage and cost
- preserve the existing event hash for deduplication continuity

## Test plan
- [x] targeted Cursor client and integration polling tests
- [x] server lint
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-766](https://linear.app/speakeasy/issue/DNO-766/feat-attribute-cursor-usage-events-to-sessions)

<div><a href="https://cursor.com/agents/bc-3347c380-c193-4344-a888-76ee6b81d732?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3347c380-c193-4344-a888-76ee6b81d732&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes Cursor usage events to sessions by decoding `conversationId` and setting the standard GenAI conversation attribute. Aligns with Linear DNO-766 so session analytics include Cursor token usage and cost.

- **New Features**
  - Decode `conversationId` from `cursor` usage events and set `attr.GenAIConversationIDKey` when present.
  - Preserve the existing event hash (excludes `conversationId`) to keep deduplication stable.
  - Extend the `cursor` client `UsageEvent` to include `conversationId`; add tests for JSON unmarshal, attribution, and hashing; include a patch changeset.

<sup>Written for commit cc4a5ef34edae108bfa4e7e7b6b09ea746bd8bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

