### PR TITLE
fix(dashboard): complete client session cleanup

### DIFF
--- a/client/dashboard/src/contexts/Auth.tsx
+++ b/client/dashboard/src/contexts/Auth.tsx
@@ -6,6 +6,7 @@ import { useSessionInfo } from "@gram/client/react-query/sessionInfo.js";
 import { createContext, useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { initializePylon, PYLON_APP_ID } from "@/lib/pylon";
+import { clearLegacyUserStorage } from "@/lib/logout-storage";
 import {
   initializeFermat,
   setFermatProperties,
@@ -200,6 +201,8 @@ export const useIsSpeakeasyStaff = (): boolean => {
 
 export function usePylonInAppChat(user: User | undefined): void {
   useEffect(() => {
+    clearLegacyUserStorage();
+
     if (!user || !import.meta.env.PROD) {
       return;
     }
@@ -223,10 +226,6 @@ export function usePylonInAppChat(user: User | undefined): void {
     // is idempotent; re-running it just refreshes chat_settings.
     initializePylon(chatSettings);
     window.Pylon?.("setNewIssueCustomFields", { gram: true });
-
-    // This is for the marketing site
-    localStorage.setItem("pylon_user_email", email);
-    localStorage.setItem("pylon_user_display_name", displayName);
   }, [user]);
 }
 

--- a/client/dashboard/src/lib/local-storage-keys.ts
+++ b/client/dashboard/src/lib/local-storage-keys.ts
@@ -1,6 +1,8 @@
 export const PREFERRED_THEME_STORAGE_KEY = "preferred-theme";
+// Org-scoped list of favorited project UUIDs. Opaque ids only, so it is
+// preserved across logout (shared-profile teammates share the list).
 export const PROJECT_FAVORITES_STORAGE_PREFIX = "gram:org-favorites:";
 // Command-palette "Recently Visited" pages. The key embeds the user id, but
-// the values still reveal one user's navigation to the next person on a shared
-// machine, so logout clears them along with favorites; only the theme survives.
+// the values (labels, slugs) still reveal one user's navigation to the next
+// person on a shared machine, so logout clears them; theme and favorites survive.
 export const RECENTS_STORAGE_PREFIX = "gram:recents:";

--- a/client/dashboard/src/lib/local-storage-keys.ts
+++ b/client/dashboard/src/lib/local-storage-keys.ts
@@ -1,5 +1,6 @@
 export const PREFERRED_THEME_STORAGE_KEY = "preferred-theme";
 export const PROJECT_FAVORITES_STORAGE_PREFIX = "gram:org-favorites:";
-// Command-palette "Recently Visited" pages. User-scoped, so safe to keep across
-// logout (a different user reads their own key); preserved like favorites.
+// Command-palette "Recently Visited" pages. The key embeds the user id, but
+// the values still reveal one user's navigation to the next person on a shared
+// machine, so logout clears them along with favorites; only the theme survives.
 export const RECENTS_STORAGE_PREFIX = "gram:recents:";

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -6,7 +6,10 @@ import {
   PREFERRED_THEME_STORAGE_KEY,
   PROJECT_FAVORITES_STORAGE_PREFIX,
 } from "./local-storage-keys";
-import { clearStorageForLogout } from "./logout-storage";
+import {
+  clearLegacyUserStorage,
+  clearStorageForLogout,
+} from "./logout-storage";
 
 function createStorage(): Storage {
   const items = new Map<string, string>();
@@ -48,6 +51,7 @@ describe("clearStorageForLogout", () => {
     window.localStorage.setItem(favoritesKey, '["project_123"]');
     window.localStorage.setItem("preferredProject", "project-slug");
     window.localStorage.setItem("pylon_user_email", "user@example.com");
+    window.localStorage.setItem("pylon_user_display_name", "Example User");
 
     clearStorageForLogout();
 
@@ -57,6 +61,9 @@ describe("clearStorageForLogout", () => {
     expect(window.localStorage.getItem(favoritesKey)).toBe('["project_123"]');
     expect(window.localStorage.getItem("preferredProject")).toBeNull();
     expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
+    expect(
+      window.localStorage.getItem("pylon_user_display_name"),
+    ).toBeNull();
   });
 
   it("clears session storage", () => {
@@ -65,5 +72,21 @@ describe("clearStorageForLogout", () => {
     clearStorageForLogout();
 
     expect(window.sessionStorage.getItem("temporary")).toBeNull();
+  });
+
+  it("removes legacy Pylon PII without clearing unrelated storage", () => {
+    window.localStorage.setItem("pylon_user_email", "user@example.com");
+    window.localStorage.setItem("pylon_user_display_name", "Example User");
+    window.localStorage.setItem("unrelated", "value");
+    window.sessionStorage.setItem("pylon_user_email", "user@example.com");
+
+    clearLegacyUserStorage();
+
+    expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
+    expect(
+      window.localStorage.getItem("pylon_user_display_name"),
+    ).toBeNull();
+    expect(window.sessionStorage.getItem("pylon_user_email")).toBeNull();
+    expect(window.localStorage.getItem("unrelated")).toBe("value");
   });
 });

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -2,10 +2,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 
-import {
-  PREFERRED_THEME_STORAGE_KEY,
-  PROJECT_FAVORITES_STORAGE_PREFIX,
-} from "./local-storage-keys";
+import { PREFERRED_THEME_STORAGE_KEY } from "./local-storage-keys";
 import {
   clearLegacyUserStorage,
   clearStorageForLogout,
@@ -44,11 +41,13 @@ describe("clearStorageForLogout", () => {
     window.sessionStorage.clear();
   });
 
-  it("preserves preferred theme and organization favorites while clearing other local storage", () => {
-    const favoritesKey = `${PROJECT_FAVORITES_STORAGE_PREFIX}org_123`;
-
+  it("preserves the theme while clearing user-scoped local storage", () => {
     window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
-    window.localStorage.setItem(favoritesKey, '["project_123"]');
+    window.localStorage.setItem(
+      "gram:org-favorites:<ORG_ID>",
+      '["<PROJECT_ID>"]',
+    );
+    window.localStorage.setItem("gram:recents:<USER_ID>", '["/recent-page"]');
     window.localStorage.setItem("preferredProject", "project-slug");
     window.localStorage.setItem("pylon_user_email", "user@example.com");
     window.localStorage.setItem("pylon_user_display_name", "Example User");
@@ -58,12 +57,13 @@ describe("clearStorageForLogout", () => {
     expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
       "light",
     );
-    expect(window.localStorage.getItem(favoritesKey)).toBe('["project_123"]');
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<ORG_ID>"),
+    ).toBeNull();
+    expect(window.localStorage.getItem("gram:recents:<USER_ID>")).toBeNull();
     expect(window.localStorage.getItem("preferredProject")).toBeNull();
     expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
-    expect(
-      window.localStorage.getItem("pylon_user_display_name"),
-    ).toBeNull();
+    expect(window.localStorage.getItem("pylon_user_display_name")).toBeNull();
   });
 
   it("clears session storage", () => {
@@ -83,9 +83,7 @@ describe("clearStorageForLogout", () => {
     clearLegacyUserStorage();
 
     expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
-    expect(
-      window.localStorage.getItem("pylon_user_display_name"),
-    ).toBeNull();
+    expect(window.localStorage.getItem("pylon_user_display_name")).toBeNull();
     expect(window.sessionStorage.getItem("pylon_user_email")).toBeNull();
     expect(window.localStorage.getItem("unrelated")).toBe("value");
   });

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -27,6 +27,17 @@ function createStorage(): Storage {
   };
 }
 
+function blockStorageAccess(): void {
+  for (const name of ["localStorage", "sessionStorage"] as const) {
+    Object.defineProperty(window, name, {
+      configurable: true,
+      get: () => {
+        throw new DOMException("Storage disabled", "SecurityError");
+      },
+    });
+  }
+}
+
 describe("clearStorageForLogout", () => {
   beforeEach(() => {
     Object.defineProperty(window, "localStorage", {
@@ -86,5 +97,12 @@ describe("clearStorageForLogout", () => {
     expect(window.localStorage.getItem("pylon_user_display_name")).toBeNull();
     expect(window.sessionStorage.getItem("pylon_user_email")).toBeNull();
     expect(window.localStorage.getItem("unrelated")).toBe("value");
+  });
+
+  it("degrades to a no-op when the browser blocks storage access", () => {
+    blockStorageAccess();
+
+    expect(() => clearStorageForLogout()).not.toThrow();
+    expect(() => clearLegacyUserStorage()).not.toThrow();
   });
 });

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -52,7 +52,7 @@ describe("clearStorageForLogout", () => {
     window.sessionStorage.clear();
   });
 
-  it("preserves the theme while clearing user-scoped local storage", () => {
+  it("preserves theme and favorites while clearing user-scoped local storage", () => {
     window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
     window.localStorage.setItem(
       "gram:org-favorites:<ORG_ID>",
@@ -68,9 +68,9 @@ describe("clearStorageForLogout", () => {
     expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
       "light",
     );
-    expect(
-      window.localStorage.getItem("gram:org-favorites:<ORG_ID>"),
-    ).toBeNull();
+    expect(window.localStorage.getItem("gram:org-favorites:<ORG_ID>")).toBe(
+      '["<PROJECT_ID>"]',
+    );
     expect(window.localStorage.getItem("gram:recents:<USER_ID>")).toBeNull();
     expect(window.localStorage.getItem("preferredProject")).toBeNull();
     expect(window.localStorage.getItem("pylon_user_email")).toBeNull();

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -10,11 +10,32 @@ const PRESERVED_LOCAL_STORAGE_PREFIXES = [
   RECENTS_STORAGE_PREFIX,
 ];
 
+const LEGACY_USER_STORAGE_KEYS = [
+  "pylon_user_email",
+  "pylon_user_display_name",
+];
+
 function shouldPreserveLocalStorageKey(key: string) {
   return (
     PRESERVED_LOCAL_STORAGE_KEYS.has(key) ||
     PRESERVED_LOCAL_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
   );
+}
+
+/**
+ * Removes user-identifying values written by older dashboard versions.
+ *
+ * This runs during auth initialization as well as session teardown so users
+ * who logged out before the cleanup shipped do not retain stale PII.
+ */
+export function clearLegacyUserStorage(): void {
+  if (typeof window === "undefined") return;
+
+  for (const storage of [window.localStorage, window.sessionStorage]) {
+    for (const key of LEGACY_USER_STORAGE_KEYS) {
+      storage.removeItem(key);
+    }
+  }
 }
 
 export function clearStorageForLogout(): void {

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -12,6 +12,19 @@ function shouldPreserveLocalStorageKey(key: string) {
 }
 
 /**
+ * Merely reading `window.localStorage` / `window.sessionStorage` throws a
+ * `SecurityError` when the browser blocks persistence (cookies/site data
+ * disabled, sandboxed frames). Both cleanup functions run on paths that must
+ * survive that — auth initialization and the 401 login redirect — and blocked
+ * storage means nothing was persisted anyway, so each storage degrades to a
+ * no-op independently.
+ */
+const STORAGE_ACCESSORS = [
+  () => window.localStorage,
+  () => window.sessionStorage,
+];
+
+/**
  * Removes user-identifying values written by older dashboard versions.
  *
  * This runs during auth initialization as well as session teardown so users
@@ -20,19 +33,23 @@ function shouldPreserveLocalStorageKey(key: string) {
 export function clearLegacyUserStorage(): void {
   if (typeof window === "undefined") return;
 
-  for (const storage of [window.localStorage, window.sessionStorage]) {
-    for (const key of LEGACY_USER_STORAGE_KEYS) {
-      storage.removeItem(key);
+  for (const getStorage of STORAGE_ACCESSORS) {
+    try {
+      const storage = getStorage();
+      for (const key of LEGACY_USER_STORAGE_KEYS) {
+        storage.removeItem(key);
+      }
+    } catch {
+      // Storage blocked — nothing persisted, nothing to remove.
     }
   }
 }
 
 export function clearStorageForLogout(): void {
-  const local = typeof window !== "undefined" ? window.localStorage : undefined;
-  const session =
-    typeof window !== "undefined" ? window.sessionStorage : undefined;
+  if (typeof window === "undefined") return;
 
-  if (local) {
+  try {
+    const local = window.localStorage;
     const preserved = new Map<string, string>();
 
     for (let i = 0; i < local.length; i++) {
@@ -50,7 +67,13 @@ export function clearStorageForLogout(): void {
     for (const [key, value] of preserved) {
       local.setItem(key, value);
     }
+  } catch {
+    // Storage blocked — nothing persisted, nothing to clear.
   }
 
-  session?.clear();
+  try {
+    window.sessionStorage.clear();
+  } catch {
+    // Storage blocked — nothing persisted, nothing to clear.
+  }
 }

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -1,6 +1,12 @@
-import { PREFERRED_THEME_STORAGE_KEY } from "@/lib/local-storage-keys";
+import {
+  PREFERRED_THEME_STORAGE_KEY,
+  PROJECT_FAVORITES_STORAGE_PREFIX,
+} from "@/lib/local-storage-keys";
 
 const PRESERVED_LOCAL_STORAGE_KEYS = new Set([PREFERRED_THEME_STORAGE_KEY]);
+// Favorites hold only opaque project UUIDs keyed by org id — nothing
+// dereferenceable without an authenticated session — so they survive logout.
+const PRESERVED_LOCAL_STORAGE_PREFIXES = [PROJECT_FAVORITES_STORAGE_PREFIX];
 
 const LEGACY_USER_STORAGE_KEYS = [
   "pylon_user_email",
@@ -8,7 +14,10 @@ const LEGACY_USER_STORAGE_KEYS = [
 ];
 
 function shouldPreserveLocalStorageKey(key: string) {
-  return PRESERVED_LOCAL_STORAGE_KEYS.has(key);
+  return (
+    PRESERVED_LOCAL_STORAGE_KEYS.has(key) ||
+    PRESERVED_LOCAL_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
 }
 
 /**

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -1,14 +1,6 @@
-import {
-  PREFERRED_THEME_STORAGE_KEY,
-  PROJECT_FAVORITES_STORAGE_PREFIX,
-  RECENTS_STORAGE_PREFIX,
-} from "@/lib/local-storage-keys";
+import { PREFERRED_THEME_STORAGE_KEY } from "@/lib/local-storage-keys";
 
 const PRESERVED_LOCAL_STORAGE_KEYS = new Set([PREFERRED_THEME_STORAGE_KEY]);
-const PRESERVED_LOCAL_STORAGE_PREFIXES = [
-  PROJECT_FAVORITES_STORAGE_PREFIX,
-  RECENTS_STORAGE_PREFIX,
-];
 
 const LEGACY_USER_STORAGE_KEYS = [
   "pylon_user_email",
@@ -16,10 +8,7 @@ const LEGACY_USER_STORAGE_KEYS = [
 ];
 
 function shouldPreserveLocalStorageKey(key: string) {
-  return (
-    PRESERVED_LOCAL_STORAGE_KEYS.has(key) ||
-    PRESERVED_LOCAL_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
-  );
+  return PRESERVED_LOCAL_STORAGE_KEYS.has(key);
 }
 
 /**

--- a/client/dashboard/src/lib/session-expired.test.ts
+++ b/client/dashboard/src/lib/session-expired.test.ts
@@ -3,11 +3,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 async function loadModule(pathname: string, search = "") {
   vi.resetModules();
   const assign = vi.fn();
+  const localStorage = {
+    clear: vi.fn(),
+    getItem: vi.fn(),
+    key: vi.fn(),
+    length: 0,
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+  };
+  const sessionStorage = {
+    ...localStorage,
+    clear: vi.fn(),
+  };
   vi.stubGlobal("window", {
+    localStorage,
     location: { origin: "https://app.example", pathname, search, assign },
+    sessionStorage,
   });
   const mod = await import("./session-expired");
-  return { assign, ...mod };
+  return { assign, localStorage, sessionStorage, ...mod };
 }
 
 describe("safeRedirectPath", () => {
@@ -45,13 +59,17 @@ describe("redirectToLoginOnUnauthorized", () => {
   });
 
   it("redirects to login and preserves the current location", async () => {
-    const { assign, redirectToLoginOnUnauthorized } = await loadModule(
-      "/acme/projects/default/insights",
-      "?range=7d",
-    );
+    const {
+      assign,
+      localStorage,
+      redirectToLoginOnUnauthorized,
+      sessionStorage,
+    } = await loadModule("/acme/projects/default/insights", "?range=7d");
 
     redirectToLoginOnUnauthorized();
 
+    expect(localStorage.clear).toHaveBeenCalledOnce();
+    expect(sessionStorage.clear).toHaveBeenCalledOnce();
     expect(assign).toHaveBeenCalledWith(
       `/login?redirect=${encodeURIComponent("/acme/projects/default/insights?range=7d")}`,
     );

--- a/client/dashboard/src/lib/session-expired.test.ts
+++ b/client/dashboard/src/lib/session-expired.test.ts
@@ -75,6 +75,25 @@ describe("redirectToLoginOnUnauthorized", () => {
     );
   });
 
+  it("still redirects when the browser blocks storage access", async () => {
+    const { assign, redirectToLoginOnUnauthorized } =
+      await loadModule("/acme/toolsets");
+    for (const name of ["localStorage", "sessionStorage"]) {
+      Object.defineProperty(window, name, {
+        configurable: true,
+        get: () => {
+          throw new DOMException("Storage disabled", "SecurityError");
+        },
+      });
+    }
+
+    redirectToLoginOnUnauthorized();
+
+    expect(assign).toHaveBeenCalledWith(
+      `/login?redirect=${encodeURIComponent("/acme/toolsets")}`,
+    );
+  });
+
   it("redirects once even when several queries fail together", async () => {
     const { assign, redirectToLoginOnUnauthorized } =
       await loadModule("/acme/toolsets");

--- a/client/dashboard/src/lib/session-expired.ts
+++ b/client/dashboard/src/lib/session-expired.ts
@@ -1,3 +1,5 @@
+import { clearStorageForLogout } from "@/lib/logout-storage";
+
 /**
  * Paths that render without a session. A 401 on these is expected (auth.info
  * always 401s when logged out), so it must not trigger a login redirect.
@@ -59,6 +61,7 @@ export function redirectToLoginOnUnauthorized(): void {
   if (UNAUTHENTICATED_PATHS.some((p) => pathname.startsWith(p))) return;
 
   redirecting = true;
+  clearStorageForLogout();
   const target = safeRedirectPath(pathname + search);
   if (!target) {
     window.location.assign("/login");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop persisting Pylon user email and display name in browser storage
- remove legacy PII keys during auth initialization
- clear local and session storage when an expired or revoked session redirects to login
- preserve only the non-identifying theme preference during teardown; remove workspace favorites, recent pages, and other user-scoped data

## Test plan
- `pnpm -F dashboard test src/lib/logout-storage.test.ts src/lib/session-expired.test.ts`
- `pnpm -F dashboard lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-759](https://linear.app/speakeasy/issue/DNO-759/security-incomplete-session-cleanup)

<div><a href="https://cursor.com/agents/bc-58896038-18e4-4a35-88de-b9e6c078aef1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58896038-18e4-4a35-88de-b9e6c078aef1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes client session cleanup to remove stale PII and clear user-scoped data on logout or 401 redirects. Preserves theme and org-scoped project favorites, and tolerates blocked Web Storage so redirects still work (DNO-759).

- **Bug Fixes**
  - Stop writing Pylon user email/display name.
  - Add `clearLegacyUserStorage()` to remove old PII; run at auth init and teardown.
  - Clear local/session storage before 401 redirects or logout, preserving theme and org-scoped project favorites; clear recents and other user data.
  - Degrade cleanup to a no-op when `localStorage`/`sessionStorage` are blocked.

<sup>Written for commit e3776ca0f8cd7111209959489bfc97517bd61a70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

