### PR TITLE
test: guard archive skill hover contrast

### DIFF
--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -454,12 +454,12 @@ describe("SkillDetail", () => {
     ).toBeTruthy();
   });
 
-  it("keeps the archive action legible on hover and archives the skill", async () => {
+  it("uses the destructive primary archive action and archives the skill", async () => {
     testState.archive.mutateAsync.mockResolvedValue(undefined);
     render(<SkillDetail />);
     const archiveButton = screen.getByRole("button", { name: "Archive" });
     expect(archiveButton.getAttribute("data-variant")).toBe(
-      "destructive-secondary",
+      "destructive-primary",
     );
 
     fireEvent.click(archiveButton);

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -452,10 +452,18 @@ describe("SkillDetail", () => {
     ).toBeTruthy();
   });
 
-  it("archives with the exact wrapper, navigates back, and invalidates all skill caches", async () => {
+  it("keeps the archive action legible on hover and archives the skill", async () => {
     testState.archive.mutateAsync.mockResolvedValue(undefined);
     render(<SkillDetail />);
-    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    const archiveButton = screen.getByRole("button", { name: "Archive" });
+    expect(archiveButton).toHaveClass(
+      "bg-transparent",
+      "text-btn-destructive-secondary",
+      "hover:text-btn-destructive-secondary-hover",
+    );
+    expect(archiveButton).not.toHaveClass("hover:bg-btn-destructive-hover");
+
+    fireEvent.click(archiveButton);
     fireEvent.click(screen.getByRole("button", { name: "Archive skill" }));
 
     await waitFor(() => {

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -456,12 +456,16 @@ describe("SkillDetail", () => {
     testState.archive.mutateAsync.mockResolvedValue(undefined);
     render(<SkillDetail />);
     const archiveButton = screen.getByRole("button", { name: "Archive" });
-    expect(archiveButton).toHaveClass(
-      "bg-transparent",
+    expect(archiveButton.className).toContain("bg-transparent");
+    expect(archiveButton.className).toContain(
       "text-btn-destructive-secondary",
+    );
+    expect(archiveButton.className).toContain(
       "hover:text-btn-destructive-secondary-hover",
     );
-    expect(archiveButton).not.toHaveClass("hover:bg-btn-destructive-hover");
+    expect(archiveButton.className).not.toContain(
+      "hover:bg-btn-destructive-hover",
+    );
 
     fireEvent.click(archiveButton);
     fireEvent.click(screen.getByRole("button", { name: "Archive skill" }));

--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -235,12 +235,14 @@ vi.mock("@/components/ui/Button", () => {
     children,
     onClick,
     disabled,
+    variant,
   }: {
     children: ReactNode;
     onClick?: () => void;
     disabled?: boolean;
+    variant?: string;
   }) => (
-    <button onClick={onClick} disabled={disabled}>
+    <button onClick={onClick} disabled={disabled} data-variant={variant}>
       {children}
     </button>
   );
@@ -456,15 +458,8 @@ describe("SkillDetail", () => {
     testState.archive.mutateAsync.mockResolvedValue(undefined);
     render(<SkillDetail />);
     const archiveButton = screen.getByRole("button", { name: "Archive" });
-    expect(archiveButton.className).toContain("bg-transparent");
-    expect(archiveButton.className).toContain(
-      "text-btn-destructive-secondary",
-    );
-    expect(archiveButton.className).toContain(
-      "hover:text-btn-destructive-secondary-hover",
-    );
-    expect(archiveButton.className).not.toContain(
-      "hover:bg-btn-destructive-hover",
+    expect(archiveButton.getAttribute("data-variant")).toBe(
+      "destructive-secondary",
     );
 
     fireEvent.click(archiveButton);

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -414,8 +414,8 @@ function SkillDetailSections({
           <DangerSettingsSection.Title>Danger zone</DangerSettingsSection.Title>
         </DangerSettingsSection.Header>
         <DangerSettingsSection.Panel>
-          <DangerSettingsSection.Body className="flex flex-wrap items-center justify-between gap-4">
-            <div className="space-y-1">
+          <DangerSettingsSection.Body className="flex flex-wrap items-center justify-between gap-2">
+            <div className="space-y-1 m-0">
               <Text className="text-sm font-semibold">Archive this skill</Text>
               <Text small muted className="max-w-xl">
                 Archiving removes the skill from this project's catalog and
@@ -428,7 +428,7 @@ function SkillDetailSections({
               level="component"
             >
               <Button
-                variant="destructive-secondary"
+                variant="destructive-primary"
                 onClick={() =>
                   setArchiveTarget({
                     id: skill.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- document that the legacy black-on-red archive hover state is already removed on main
- add focused regression coverage that the archive skill action uses the transparent `destructive-secondary` treatment
- keep the existing archive mutation and cache invalidation coverage

## Validation
- `pnpm -F dashboard test -- SkillDetail.test.tsx` — 178 files / 1,478 tests passed
- `pnpm -F dashboard type-check` — passed
- manually created a synthetic local skill and verified the Archive action in its Danger zone: default red text remains legible over the subtle light hover surface; no archive action was triggered

## Demo
<a href="https://cursor.com/agents/bc-6147001d-ad4c-4e76-a668-10431c82bb51/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farchive_skill_hover_contrast.mp4"><img src="https://cursor.com/artifacts/c/art-7263d192-b3e6-40b7-81e2-225d145a5769" alt="archive_skill_hover_contrast.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-730](https://linear.app/speakeasy/issue/DNO-730/bug-fix-hover-state-for-archive-skill-button)

<div><a href="https://cursor.com/agents/bc-6147001d-ad4c-4e76-a668-10431c82bb51?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6147001d-ad4c-4e76-a668-10431c82bb51&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Archive action in `SkillDetail.tsx` to `destructive-primary` and tighten spacing, fixing the hover legibility issue and aligning with Linear DNO-730. Update `SkillDetail.test.tsx` to assert `data-variant="destructive-primary"` and verify the action still archives the skill.

<sup>Written for commit 30c239b4a33e16506039a3de27b45d421cb4f722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

