### PR TITLE
fix: flatten nested skill insight panels

### DIFF
--- a/client/dashboard/src/pages/skills/SkillActivitySections.tsx
+++ b/client/dashboard/src/pages/skills/SkillActivitySections.tsx
@@ -131,10 +131,7 @@ export function SkillActivitySections({
         </SettingsSection.Header>
         <div className="space-y-3">
           <dl className="grid gap-px overflow-hidden rounded-lg border sm:grid-cols-2 lg:grid-cols-4">
-            <Metric
-              label="Versions"
-              value={metricValue(skill.versionCount)}
-            />
+            <Metric label="Versions" value={metricValue(skill.versionCount)} />
             <Metric
               label="Active machines"
               value={metricValue(adoption.distinctHostnames)}

--- a/client/dashboard/src/pages/skills/SkillActivitySections.tsx
+++ b/client/dashboard/src/pages/skills/SkillActivitySections.tsx
@@ -129,64 +129,58 @@ export function SkillActivitySections({
             Activation coverage and version convergence over the last 30 days.
           </SettingsSection.Description>
         </SettingsSection.Header>
-        <SettingsSection.Panel>
-          <SettingsSection.Body>
-            <dl className="grid gap-px overflow-hidden rounded-lg border sm:grid-cols-2 lg:grid-cols-4">
-              <Metric
-                label="Versions"
-                value={metricValue(skill.versionCount)}
-              />
-              <Metric
-                label="Active machines"
-                value={metricValue(adoption.distinctHostnames)}
-              />
-              <Metric
-                label="30-day activations"
-                value={metricValue(adoption.activationsInWindow)}
-              />
-              <Metric
-                label="Drifted"
-                value={metricValue(drift.driftedMachines)}
-              />
-            </dl>
+        <div className="space-y-3">
+          <dl className="grid gap-px overflow-hidden rounded-lg border sm:grid-cols-2 lg:grid-cols-4">
+            <Metric
+              label="Versions"
+              value={metricValue(skill.versionCount)}
+            />
+            <Metric
+              label="Active machines"
+              value={metricValue(adoption.distinctHostnames)}
+            />
+            <Metric
+              label="30-day activations"
+              value={metricValue(adoption.activationsInWindow)}
+            />
+            <Metric
+              label="Drifted"
+              value={metricValue(drift.driftedMachines)}
+            />
+          </dl>
+          <Text small muted>
+            {drift.targetState === "single" && (
+              <>
+                {metricValue(drift.onTargetMachines)}{" "}
+                {machineLabel(drift.onTargetMachines)}{" "}
+                {drift.onTargetMachines === 1 ? "is" : "are"} on the distributed
+                version. {metricValue(drift.indeterminateMachines)}{" "}
+                {machineLabel(drift.indeterminateMachines)}{" "}
+                {drift.indeterminateMachines === 1 ? "has" : "have"} an unknown
+                version.
+              </>
+            )}
+            {drift.targetState === "not_distributed" &&
+              "No plugin distribution target is configured, so drift is indeterminate."}
+            {drift.targetState === "ambiguous" &&
+              "Multiple plugin distribution targets are configured, so drift is indeterminate."}
+          </Text>
+          {(skill.firstSeenAt || skill.lastSeenAt) && (
             <Text small muted>
-              {drift.targetState === "single" && (
+              {skill.firstSeenAt && (
                 <>
-                  {metricValue(drift.onTargetMachines)}{" "}
-                  {machineLabel(drift.onTargetMachines)}{" "}
-                  {drift.onTargetMachines === 1 ? "is" : "are"} on the
-                  distributed version.{" "}
-                  {metricValue(drift.indeterminateMachines)}{" "}
-                  {machineLabel(drift.indeterminateMachines)}{" "}
-                  {drift.indeterminateMachines === 1 ? "has" : "have"} an
-                  unknown version.
+                  First activated <HumanizeDateTime date={skill.firstSeenAt} />
                 </>
               )}
-              {drift.targetState === "not_distributed" &&
-                "No plugin distribution target is configured, so drift is indeterminate."}
-              {drift.targetState === "ambiguous" &&
-                "Multiple plugin distribution targets are configured, so drift is indeterminate."}
+              {skill.firstSeenAt && skill.lastSeenAt && " · "}
+              {skill.lastSeenAt && (
+                <>
+                  Last activated <HumanizeDateTime date={skill.lastSeenAt} />
+                </>
+              )}
             </Text>
-          </SettingsSection.Body>
-          {(skill.firstSeenAt || skill.lastSeenAt) && (
-            <SettingsSection.Footer>
-              <SettingsSection.FooterHint>
-                {skill.firstSeenAt && (
-                  <>
-                    First activated{" "}
-                    <HumanizeDateTime date={skill.firstSeenAt} />
-                  </>
-                )}
-                {skill.firstSeenAt && skill.lastSeenAt && " · "}
-                {skill.lastSeenAt && (
-                  <>
-                    Last activated <HumanizeDateTime date={skill.lastSeenAt} />
-                  </>
-                )}
-              </SettingsSection.FooterHint>
-            </SettingsSection.Footer>
           )}
-        </SettingsSection.Panel>
+        </div>
       </SettingsSection>
 
       <SettingsSection id={SKILL_TIMELINE_SECTION_ID}>
@@ -196,39 +190,35 @@ export function SkillActivitySections({
             Daily activation volume for the rolling 30-day window.
           </SettingsSection.Description>
         </SettingsSection.Header>
-        <SettingsSection.Panel>
-          <SettingsSection.Body>
-            <ChartCard
-              title="Activations by version"
-              chartId="skill-activation-timeline"
-              expandedChart={null}
-              onExpand={() => undefined}
-              expandable={false}
-              hasData={sightingTimeline.length > 0}
-              loading={versionsLoading}
-            >
-              {sightingTimeline.length === 0 ? (
-                <div className="flex h-56 items-center justify-center">
-                  <Text small muted>
-                    No activations captured in the last 30 days.
-                  </Text>
-                </div>
-              ) : (
-                <div className="h-64">
-                  <Line
-                    data={{
-                      labels: buckets.map((bucket) =>
-                        utcMonthDayFormatter.format(bucket),
-                      ),
-                      datasets,
-                    }}
-                    options={chartOptions}
-                  />
-                </div>
-              )}
-            </ChartCard>
-          </SettingsSection.Body>
-        </SettingsSection.Panel>
+        <ChartCard
+          title="Activations by version"
+          chartId="skill-activation-timeline"
+          expandedChart={null}
+          onExpand={() => undefined}
+          expandable={false}
+          hasData={sightingTimeline.length > 0}
+          loading={versionsLoading}
+        >
+          {sightingTimeline.length === 0 ? (
+            <div className="flex h-56 items-center justify-center">
+              <Text small muted>
+                No activations captured in the last 30 days.
+              </Text>
+            </div>
+          ) : (
+            <div className="h-64">
+              <Line
+                data={{
+                  labels: buckets.map((bucket) =>
+                    utcMonthDayFormatter.format(bucket),
+                  ),
+                  datasets,
+                }}
+                options={chartOptions}
+              />
+            </div>
+          )}
+        </ChartCard>
       </SettingsSection>
     </>
   );

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -552,8 +552,8 @@ function VersionHistory({
   });
 
   return (
-    <SettingsSection.Panel>
-      <SettingsSection.Body>
+    <>
+      <div className="space-y-4">
         {comparable && (
           <Text small muted>
             Select one version to compare it with current, or select any two
@@ -591,14 +591,14 @@ function VersionHistory({
           </Button>
         )}
         <VersionDiff versions={diffVersions} />
-      </SettingsSection.Body>
+      </div>
       <RestoreSkillVersionDialog
         skillId={skillId}
         version={restoreTarget?.version ?? null}
         direction={restoreTarget?.direction ?? null}
         onClose={() => setRestoreTarget(null)}
       />
-    </SettingsSection.Panel>
+    </>
   );
 }
 

--- a/client/dashboard/src/pages/skills/SkillInsightsSection.tsx
+++ b/client/dashboard/src/pages/skills/SkillInsightsSection.tsx
@@ -138,40 +138,31 @@ export function SkillInsightsSection({
           estimated time saved over the last 30 days.
         </SettingsSection.Description>
       </SettingsSection.Header>
-      <SettingsSection.Panel>
-        <SettingsSection.Body>
-          {query.error && !query.data && (
-            <ErrorAlert
-              title="Unable to load skill insights"
-              error={query.error}
-            />
-          )}
-          {versionsError && (
-            <ErrorAlert
-              title="Unable to load skill versions"
-              error={versionsError}
-            />
-          )}
-          {(query.isPending || (query.data && versionsLoading)) && (
-            <InsightsLoading />
-          )}
-          {query.data && !versionsLoading && !versionsError && (
-            <InsightsContent
-              insight={query.data.result.insights[0]}
-              skillId={data.skill.id}
-              canReadChats={canReadChats}
-              versionLabels={versionLabels}
-            />
-          )}
-        </SettingsSection.Body>
-        <SettingsSection.Footer>
-          <SettingsSection.FooterHint>
-            Efficacy and estimated savings cover sampled scored sessions.
-            Session cost is attributed in full to each activated skill version,
-            so totals are not additive.
-          </SettingsSection.FooterHint>
-        </SettingsSection.Footer>
-      </SettingsSection.Panel>
+      {query.error && !query.data && (
+        <ErrorAlert title="Unable to load skill insights" error={query.error} />
+      )}
+      {versionsError && (
+        <ErrorAlert
+          title="Unable to load skill versions"
+          error={versionsError}
+        />
+      )}
+      {(query.isPending || (query.data && versionsLoading)) && (
+        <InsightsLoading />
+      )}
+      {query.data && !versionsLoading && !versionsError && (
+        <InsightsContent
+          insight={query.data.result.insights[0]}
+          skillId={data.skill.id}
+          canReadChats={canReadChats}
+          versionLabels={versionLabels}
+        />
+      )}
+      <Text small muted>
+        Efficacy and estimated savings cover sampled scored sessions. Session
+        cost is attributed in full to each activated skill version, so totals
+        are not additive.
+      </Text>
     </SettingsSection>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove redundant outer panels from skill adoption, timeline, and insights sections
- flatten the version history panel so the table is the single surface
- preserve each metric group and chart as the single visual surface
- keep explanatory and activation metadata as lightweight supporting text

## Testing
- `pnpm -F dashboard lint`
- `pnpm -F dashboard type-check`
- `pnpm -F dashboard test -- SkillDetail.test.tsx` (178 files, 1,478 tests passed)
- manually created a valid local skill and verified Adoption and drift, Activation timeline, Insights, and Version history in the running dashboard
- modified sections rendered without new console errors; existing Table no-results DOM warnings are unrelated to this change

## Screenshot
Full skill detail page after flattening — each metric group, chart, and the version history table is now a single surface instead of a card nested inside a panel.

![Full skill detail page showing flattened Adoption and drift, Activation timeline, Insights, and Version history sections](https://cursor.com/artifacts/c/art-e4784bea-2204-41be-840b-1f102f773f9a)

Linear: DNO-724
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-724](https://linear.app/speakeasy/issue/DNO-724/bug-fix-box-within-box)

<div><a href="https://cursor.com/agents/bc-fbe56ac0-b714-439f-90b9-2751f39a1363?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbe56ac0-b714-439f-90b9-2751f39a1363&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed extra panels in the skill Activity, Insights, and Version History pages to fix the box-within-box UI. Charts, metrics, and diffs are now the single visual surface with lightweight helper text, aligning with Linear DNO-724 and without changing datasets, chart options, or calculations.

- **Bug Fixes**
  - SkillActivitySections: flatten panels; render metrics grid directly; move drift/activation timestamps to muted inline text; show activation timeline `ChartCard` at section root.
  - SkillInsightsSection: flatten; render error/loading/content directly; replace footer hint with muted inline text.
  - VersionHistory: remove outer panel; keep selection/actions and `VersionDiff` in a simple container.

<sup>Written for commit 2ab99eaade62c2ff2f11e417ba72a4e360e2e50e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

