### PR TITLE
fix: reclassify expected Slack refusals off error severity in MCP tool calls

### DIFF
--- a/.changeset/slack-tool-caller-fault-severity.md
+++ b/.changeset/slack-tool-caller-fault-severity.md
@@ -1,0 +1,21 @@
+---
+"server": patch
+---
+
+Slack tool calls that a caller has to fix are no longer reported as server
+errors. The Slack Web API answers HTTP 200 with `ok: false` for essentially
+every argument, permission, and state problem, so a thread timestamp that names
+no thread, a channel the bot was never invited to, a token missing a scope, or
+blocks that fail validation all arrived as untyped failures and were logged at
+error level by the MCP tool layer. A single misconfigured client emitting a few
+hundred of those an hour was enough to hold the component's error-log anomaly
+monitor at its threshold for a whole alert window, masking any genuine
+regression behind it.
+
+Slack refusals now carry the envelope error code, and the MCP tool boundary
+answers a caller-attributed failure with a 400 logged at warn — still recorded
+with the upstream code and the tool name, and no longer marking the request span
+as errored — while Slack's own failures (`internal_error`, `ratelimited`,
+5xx responses) keep error severity. `platform_slack_add_reaction` also treats
+`already_reacted` as the successful no-op it is, since the reaction the caller
+asked for is already on the message.

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -172,7 +172,7 @@ func (tp *ToolProxy) Do(
 		attr.ToolCallSource(string(tp.source)),
 	))
 	defer func() {
-		if err != nil {
+		if err != nil && !oops.IsClientFault(err) {
 			span.SetStatus(codes.Error, err.Error())
 		}
 		span.End()

--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/functions"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	tm "github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
@@ -51,6 +52,14 @@ func (m *mockPlatformExecutor) ExecuteTool(_ context.Context, _ *ToolCallPlan, _
 		Body:        []byte(`{"ok":true}`),
 	}, nil
 }
+
+// stubCallerFaultError stands in for a typed upstream API error that attributes
+// an outcome to the caller, e.g. Slack answering ok=false with thread_not_found.
+type stubCallerFaultError struct{}
+
+func (e *stubCallerFaultError) Error() string { return "upstream refused: thread_not_found" }
+
+func (e *stubCallerFaultError) ClientFault() bool { return true }
 
 func newTestToolDescriptor() *ToolDescriptor {
 	return &ToolDescriptor{
@@ -1720,6 +1729,49 @@ func TestToolProxy_Do_PlatformTool_PreservesRawBodyFieldPayload(t *testing.T) {
 
 	require.JSONEq(t, string(bodyBytes), string(platformExecutor.requestBody))
 	require.Equal(t, http.StatusOK, recorder.Code)
+}
+
+// A platform tool failure the caller has to fix must still be recognizable as
+// one after the proxy wraps it, so the MCP boundary can answer it as a bad
+// request logged at warn rather than as a server fault.
+func TestToolProxy_Do_PlatformTool_PreservesCallerFaultAttribution(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tracerProvider := testenv.NewTracerProvider(t)
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	require.NoError(t, err)
+
+	descriptor := newTestToolDescriptor()
+	descriptor.URN = urn.NewTool(urn.ToolKindPlatform, "slack", "read_thread_messages")
+
+	toolCallPlan := NewPlatformToolCallPlan(descriptor, &PlatformToolCallPlan{
+		SourceSlug:  "slack",
+		InputSchema: []byte(`{"type":"object","additionalProperties":true}`),
+	})
+
+	platformExecutor := &mockPlatformExecutor{
+		err: fmt.Errorf("execute platform tool %s: %w", descriptor.URN, &stubCallerFaultError{}),
+	}
+
+	proxy := NewToolProxy(
+		testenv.NewLogger(t),
+		tracerProvider,
+		testenv.NewMeterProvider(t),
+		ToolCallSourceDirect,
+		testenv.NewEncryptionClient(t),
+		nil,
+		policy,
+		funcs,
+		platformExecutor,
+	)
+
+	err = proxy.Do(ctx, httptest.NewRecorder(), bytes.NewReader([]byte(`{}`)), toolconfig.ToolCallEnv{
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+	}, toolCallPlan, tm.HTTPLogAttributes{})
+	require.Error(t, err)
+	require.True(t, oops.IsClientFault(err))
 }
 
 func TestToolProxy_Do_HTTPTool_UserConfigVariablesSent(t *testing.T) {

--- a/server/internal/gateway/proxy_test.go
+++ b/server/internal/gateway/proxy_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 var funcs functions.ToolCaller
@@ -1738,7 +1741,9 @@ func TestToolProxy_Do_PlatformTool_PreservesCallerFaultAttribution(t *testing.T)
 	t.Parallel()
 
 	ctx := context.Background()
-	tracerProvider := testenv.NewTracerProvider(t)
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, tracerProvider.Shutdown(context.Background())) })
 	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
@@ -1772,6 +1777,9 @@ func TestToolProxy_Do_PlatformTool_PreservesCallerFaultAttribution(t *testing.T)
 	}, toolCallPlan, tm.HTTPLogAttributes{})
 	require.Error(t, err)
 	require.True(t, oops.IsClientFault(err))
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "caller faults must not mark gateway spans as errors")
 }
 
 func TestToolProxy_Do_HTTPTool_UserConfigVariablesSent(t *testing.T) {

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -402,9 +402,12 @@ func handleToolsCall(
 	err = toolProxy.Do(ctx, rw, bytes.NewBuffer(params.Arguments), toolCallEnv, plan, logAttrs)
 	if err != nil {
 		if rejected, ok := toolCallRejection(ctx, logger, err, attr.SlogToolName(params.Name)); ok {
+			recordToolCallErrorStatus(ctx, rw, rejected)
 			return nil, rejected
 		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
+		failure := oops.E(oops.CodeUnexpected, err, "failed to execute tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
+		recordToolCallErrorStatus(ctx, rw, failure)
+		return nil, failure
 	}
 
 	outputBytes = int64(rw.body.Len())
@@ -481,6 +484,17 @@ func toolCallRejection(ctx context.Context, logger *slog.Logger, err error, args
 	}
 
 	return oops.E(oops.CodeBadRequest, err, "tool call was rejected as invalid or not permitted").LogWarn(ctx, logger, args...), true
+}
+
+// recordToolCallErrorStatus keeps deferred billing and telemetry metadata in
+// sync with the status represented by an error returned from the MCP boundary.
+// The response writer starts at 200 because successful tool implementations may
+// write only a body, so failures that occur before WriteHeader must update it.
+func recordToolCallErrorStatus(ctx context.Context, rw *toolCallResponseWriter, err error) {
+	var shareableErr *oops.ShareableError
+	if errors.As(err, &shareableErr) {
+		rw.statusCode = shareableErr.HTTPStatus(ctx)
+	}
 }
 
 func resolveUserConfiguration(

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -401,7 +401,10 @@ func handleToolsCall(
 
 	err = toolProxy.Do(ctx, rw, bytes.NewBuffer(params.Arguments), toolCallEnv, plan, logAttrs)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute tool call").LogError(ctx, logger)
+		if rejected, ok := toolCallRejection(ctx, logger, err, attr.SlogToolName(params.Name)); ok {
+			return nil, rejected
+		}
+		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
 	}
 
 	outputBytes = int64(rw.body.Len())
@@ -459,6 +462,25 @@ func handleToolsCall(
 	}
 
 	return bs, nil
+}
+
+// toolCallRejection answers a failed tool execution that the caller has to fix
+// — arguments naming a resource that does not exist, a payload an upstream
+// rejected as malformed, a scope the configured credential never had — with a
+// bad request logged at warn, and reports true. It reports false for a failure
+// that Gram or an upstream is answerable for, which the caller then reports as
+// the server fault it is.
+//
+// Caller mistakes are ordinary and arrive in volume: a single misconfigured
+// client can emit hundreds an hour, enough at error level to hold this
+// component's error-rate monitors at their threshold and mask a genuine
+// regression for a whole alert window.
+func toolCallRejection(ctx context.Context, logger *slog.Logger, err error, args ...slog.Attr) (*oops.ShareableError, bool) {
+	if !oops.IsClientFault(err) {
+		return nil, false
+	}
+
+	return oops.E(oops.CodeBadRequest, err, "tool call was rejected as invalid or not permitted").LogWarn(ctx, logger, args...), true
 }
 
 func resolveUserConfiguration(

--- a/server/internal/mcp/rpc_tools_call_internal_test.go
+++ b/server/internal/mcp/rpc_tools_call_internal_test.go
@@ -119,3 +119,24 @@ func TestPlatformToolCallError_ShareableClientFaultIsRejected(t *testing.T) {
 	entry := decodeLogEntry(t, buf)
 	require.Equal(t, "WARN", entry["level"], "caller faults must use the same warning path when already shareable")
 }
+
+func TestRecordToolCallErrorStatus_UsesShareableHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	rw := &toolCallResponseWriter{statusCode: http.StatusOK}
+	err := fmt.Errorf("execute platform tool: %w", oops.E(oops.CodeBadRequest, nil, "invalid tool call"))
+
+	recordToolCallErrorStatus(t.Context(), rw, err)
+
+	require.Equal(t, http.StatusBadRequest, rw.statusCode)
+}
+
+func TestRecordToolCallErrorStatus_IgnoresUnclassifiedErrors(t *testing.T) {
+	t.Parallel()
+
+	rw := &toolCallResponseWriter{statusCode: http.StatusOK}
+
+	recordToolCallErrorStatus(t.Context(), rw, errors.New("connection reset by peer"))
+
+	require.Equal(t, http.StatusOK, rw.statusCode)
+}

--- a/server/internal/mcp/rpc_tools_call_internal_test.go
+++ b/server/internal/mcp/rpc_tools_call_internal_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// upstreamRefusalError stands in for a typed upstream API error that attributes
+// an outcome to the caller, e.g. Slack answering ok=false with thread_not_found.
+type upstreamRefusalError struct {
+	code   string
+	caller bool
+}
+
+func (e *upstreamRefusalError) Error() string { return "upstream refused: " + e.code }
+
+func (e *upstreamRefusalError) ClientFault() bool { return e.caller }
+
+func recordedToolCallLogger(t *testing.T) (context.Context, *slog.Logger, *bytes.Buffer, *tracetest.SpanRecorder) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		AddSource:   false,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: nil,
+	}))
+
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	ctx, span := provider.Tracer("mcp-test").Start(t.Context(), "tools/call")
+	t.Cleanup(func() { span.End() })
+
+	return ctx, logger, &buf, recorder
+}
+
+func decodeLogEntry(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry), "log output: %s", buf.String())
+	return entry
+}
+
+func TestToolCallRejection_CallerFaultLogsAtWarn(t *testing.T) {
+	t.Parallel()
+
+	ctx, logger, buf, recorder := recordedToolCallLogger(t)
+
+	// The chain a Slack refusal arrives in: the tool returns the API error, and
+	// the platform runtime and the gateway each wrap it on the way out.
+	cause := fmt.Errorf("execute platform tool: %w",
+		fmt.Errorf("execute platform tool tools:platform/slack/add_reaction: %w",
+			&upstreamRefusalError{code: "thread_not_found", caller: true}))
+
+	rejected, ok := toolCallRejection(ctx, logger, cause)
+	require.True(t, ok)
+	require.Equal(t, oops.CodeBadRequest, rejected.Code)
+	require.Equal(t, http.StatusBadRequest, rejected.HTTPStatus(ctx))
+
+	entry := decodeLogEntry(t, buf)
+	require.Equal(t, "WARN", entry["level"], "caller mistakes must not drive the component error rate")
+	require.Contains(t, entry["error.message"], "thread_not_found", "the refusal must stay queryable")
+
+	spans := recorder.Started()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code, "a caller mistake must not mark the span as errored")
+	require.Empty(t, spans[0].Events())
+}
+
+func TestToolCallRejection_UnclassifiedFailureIsNotARejection(t *testing.T) {
+	t.Parallel()
+
+	ctx, logger, buf, _ := recordedToolCallLogger(t)
+
+	rejected, ok := toolCallRejection(ctx, logger, errors.New("connection reset by peer"))
+	require.False(t, ok)
+	require.Nil(t, rejected)
+	require.Empty(t, buf.String(), "the caller reports the server fault, so nothing is logged here")
+}
+
+func TestToolCallRejection_UpstreamServerRefusalIsNotARejection(t *testing.T) {
+	t.Parallel()
+
+	ctx, logger, _, _ := recordedToolCallLogger(t)
+
+	cause := fmt.Errorf("execute platform tool: %w", &upstreamRefusalError{code: "internal_error", caller: false})
+	rejected, ok := toolCallRejection(ctx, logger, cause)
+	require.False(t, ok)
+	require.Nil(t, rejected)
+}

--- a/server/internal/mcp/rpc_tools_call_internal_test.go
+++ b/server/internal/mcp/rpc_tools_call_internal_test.go
@@ -10,13 +10,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-
-	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
 // upstreamRefusalError stands in for a typed upstream API error that attributes

--- a/server/internal/mcp/rpc_tools_call_internal_test.go
+++ b/server/internal/mcp/rpc_tools_call_internal_test.go
@@ -15,6 +15,8 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
 )
 
 // upstreamRefusalError stands in for a typed upstream API error that attributes
@@ -102,4 +104,19 @@ func TestToolCallRejection_UpstreamServerRefusalIsNotARejection(t *testing.T) {
 	rejected, ok := toolCallRejection(ctx, logger, cause)
 	require.False(t, ok)
 	require.Nil(t, rejected)
+}
+
+func TestPlatformToolCallError_ShareableClientFaultIsRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, logger, buf, _ := recordedToolCallLogger(t)
+	cause := oops.E(oops.CodeBadRequest, &upstreamRefusalError{code: "thread_not_found", caller: true}, "upstream refused")
+
+	err := platformToolCallError(ctx, logger, cause, attr.SlogToolName("platform_tool"))
+	var rejected *oops.ShareableError
+	require.ErrorAs(t, err, &rejected)
+	require.Equal(t, oops.CodeBadRequest, rejected.Code)
+
+	entry := decodeLogEntry(t, buf)
+	require.Equal(t, "WARN", entry["level"], "caller faults must use the same warning path when already shareable")
 }

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -435,7 +435,9 @@ func (s *Service) callPlatformToolsetTool(
 	}()
 
 	if err := s.toolProxy.Do(ctx, rw, bytes.NewReader(requestBodyBytes), toolCallEnv, plan, logAttrs); err != nil {
-		return nil, platformToolCallError(ctx, logger, err, attr.SlogToolName(params.Name))
+		failure := platformToolCallError(ctx, logger, err, attr.SlogToolName(params.Name))
+		recordToolCallErrorStatus(ctx, rw, failure)
+		return nil, failure
 	}
 	outputBytes = int64(rw.body.Len())
 

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -435,14 +435,7 @@ func (s *Service) callPlatformToolsetTool(
 	}()
 
 	if err := s.toolProxy.Do(ctx, rw, bytes.NewReader(requestBodyBytes), toolCallEnv, plan, logAttrs); err != nil {
-		var shareableErr *oops.ShareableError
-		if errors.As(err, &shareableErr) {
-			return nil, fmt.Errorf("execute platform tool: %w", err)
-		}
-		if rejected, ok := toolCallRejection(ctx, logger, err, attr.SlogToolName(params.Name)); ok {
-			return nil, rejected
-		}
-		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute platform tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
+		return nil, platformToolCallError(ctx, logger, err, attr.SlogToolName(params.Name))
 	}
 	outputBytes = int64(rw.body.Len())
 
@@ -463,6 +456,19 @@ func (s *Service) callPlatformToolsetTool(
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to serialize tools/call result").LogError(ctx, logger, attr.SlogToolName(params.Name))
 	}
 	return bs, nil
+}
+
+func platformToolCallError(ctx context.Context, logger *slog.Logger, err error, args ...slog.Attr) error {
+	if rejected, ok := toolCallRejection(ctx, logger, err, args...); ok {
+		return rejected
+	}
+
+	var shareableErr *oops.ShareableError
+	if errors.As(err, &shareableErr) {
+		return fmt.Errorf("execute platform tool: %w", err)
+	}
+
+	return oops.E(oops.CodeUnexpected, err, "failed to execute platform tool call").LogError(ctx, logger, args...)
 }
 
 // platformToolFeatureAvailable reports whether a platform tool gated on

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -439,6 +439,9 @@ func (s *Service) callPlatformToolsetTool(
 		if errors.As(err, &shareableErr) {
 			return nil, fmt.Errorf("execute platform tool: %w", err)
 		}
+		if rejected, ok := toolCallRejection(ctx, logger, err, attr.SlogToolName(params.Name)); ok {
+			return nil, rejected
+		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to execute platform tool call").LogError(ctx, logger, attr.SlogToolName(params.Name))
 	}
 	outputBytes = int64(rw.body.Len())

--- a/server/internal/oops/clientfault.go
+++ b/server/internal/oops/clientfault.go
@@ -28,7 +28,11 @@ func IsClientFault(err error) bool {
 		return false
 	}
 
-	if faulter, ok := err.(ClientFaulter); ok && faulter.ClientFault() {
+	// Preserve standard errors.As behavior, including custom As(any) hooks. Do
+	// not return false when the first match is not a client fault: a later node
+	// or sibling branch can still contain one.
+	var faulter ClientFaulter
+	if errors.As(err, &faulter) && faulter.ClientFault() {
 		return true
 	}
 
@@ -36,9 +40,8 @@ func IsClientFault(err error) bool {
 		return IsClientFault(wrapped)
 	}
 
-	// The standard errors package has no helper for errors that unwrap to
-	// multiple children (for example errors.Join), so inspect that shape after
-	// using errors.Unwrap for the ordinary single-error chain.
+	// errors.Unwrap only follows a single child. Inspect the []error shape
+	// directly for multi-child error trees such as errors.Join.
 	if wrapped, ok := any(err).(interface{ Unwrap() []error }); ok {
 		for _, child := range wrapped.Unwrap() {
 			if IsClientFault(child) {

--- a/server/internal/oops/clientfault.go
+++ b/server/internal/oops/clientfault.go
@@ -1,0 +1,32 @@
+package oops
+
+import "errors"
+
+// ClientFaulter is implemented by error types that can attribute themselves to
+// the caller rather than to Gram or an upstream service: arguments naming a
+// resource that does not exist, a payload an upstream rejected as malformed, or
+// a credential whose scopes were never granted. Such an outcome is the expected
+// answer to the request that was made, not a fault to page on.
+//
+// Error boundaries consult it through IsClientFault to pick a severity: a
+// caller fault is answered with a 4xx and logged at warn, keeping error-level
+// logs and errored spans — the signals error-rate monitors and SLOs key on —
+// for failures Gram or an upstream is responsible for. High-volume caller
+// mistakes would otherwise mask genuine regressions in the same component.
+type ClientFaulter interface {
+	// ClientFault reports whether this particular error value is the caller's
+	// to fix. Implementations that carry an upstream status or error code
+	// typically answer per code, so one type can cover both attributions.
+	ClientFault() bool
+}
+
+// IsClientFault reports whether err, or any error it wraps, attributes itself
+// to the caller. Errors that do not implement ClientFaulter are treated as
+// server faults, so an unclassified failure keeps full error severity.
+func IsClientFault(err error) bool {
+	var faulter ClientFaulter
+	if !errors.As(err, &faulter) {
+		return false
+	}
+	return faulter.ClientFault()
+}

--- a/server/internal/oops/clientfault.go
+++ b/server/internal/oops/clientfault.go
@@ -24,9 +24,28 @@ type ClientFaulter interface {
 // to the caller. Errors that do not implement ClientFaulter are treated as
 // server faults, so an unclassified failure keeps full error severity.
 func IsClientFault(err error) bool {
-	var faulter ClientFaulter
-	if !errors.As(err, &faulter) {
+	if err == nil {
 		return false
 	}
-	return faulter.ClientFault()
+
+	if faulter, ok := err.(ClientFaulter); ok && faulter.ClientFault() {
+		return true
+	}
+
+	if wrapped := errors.Unwrap(err); wrapped != nil {
+		return IsClientFault(wrapped)
+	}
+
+	// The standard errors package has no helper for errors that unwrap to
+	// multiple children (for example errors.Join), so inspect that shape after
+	// using errors.Unwrap for the ordinary single-error chain.
+	if wrapped, ok := any(err).(interface{ Unwrap() []error }); ok {
+		for _, child := range wrapped.Unwrap() {
+			if IsClientFault(child) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/server/internal/oops/clientfault_test.go
+++ b/server/internal/oops/clientfault_test.go
@@ -16,6 +16,17 @@ func (e *stubFaultError) Error() string { return "stub fault" }
 
 func (e *stubFaultError) ClientFault() bool { return e.client }
 
+type wrappingStubFaultError struct {
+	client bool
+	cause  error
+}
+
+func (e *wrappingStubFaultError) Error() string { return "wrapping stub fault" }
+
+func (e *wrappingStubFaultError) Unwrap() error { return e.cause }
+
+func (e *wrappingStubFaultError) ClientFault() bool { return e.client }
+
 func TestIsClientFault_MatchesSelfAttributingError(t *testing.T) {
 	t.Parallel()
 
@@ -28,6 +39,26 @@ func TestIsClientFault_TraversesWrappedErrors(t *testing.T) {
 
 	wrapped := fmt.Errorf("execute platform tool: %w", fmt.Errorf("call upstream: %w", &stubFaultError{client: true}))
 	require.True(t, IsClientFault(wrapped))
+}
+
+func TestIsClientFault_TraversesPastNonClientFaulter(t *testing.T) {
+	t.Parallel()
+
+	wrapped := &wrappingStubFaultError{
+		client: false,
+		cause:  &stubFaultError{client: true},
+	}
+	require.True(t, IsClientFault(wrapped), "an outer faulter must not hide a caller fault deeper in the chain")
+}
+
+func TestIsClientFault_TraversesJoinedErrors(t *testing.T) {
+	t.Parallel()
+
+	joined := errors.Join(
+		&stubFaultError{client: false},
+		fmt.Errorf("call upstream: %w", &stubFaultError{client: true}),
+	)
+	require.True(t, IsClientFault(joined))
 }
 
 func TestIsClientFault_TreatsUnclassifiedErrorsAsServerFaults(t *testing.T) {

--- a/server/internal/oops/clientfault_test.go
+++ b/server/internal/oops/clientfault_test.go
@@ -27,6 +27,22 @@ func (e *wrappingStubFaultError) Unwrap() error { return e.cause }
 
 func (e *wrappingStubFaultError) ClientFault() bool { return e.client }
 
+type asStubFaultError struct {
+	faulter ClientFaulter
+}
+
+func (e *asStubFaultError) Error() string { return "as stub fault" }
+
+func (e *asStubFaultError) As(target any) bool {
+	faulter, ok := target.(*ClientFaulter)
+	if !ok {
+		return false
+	}
+
+	*faulter = e.faulter
+	return true
+}
+
 func TestIsClientFault_MatchesSelfAttributingError(t *testing.T) {
 	t.Parallel()
 
@@ -59,6 +75,13 @@ func TestIsClientFault_TraversesJoinedErrors(t *testing.T) {
 		fmt.Errorf("call upstream: %w", &stubFaultError{client: true}),
 	)
 	require.True(t, IsClientFault(joined))
+}
+
+func TestIsClientFault_HonorsCustomAs(t *testing.T) {
+	t.Parallel()
+
+	err := &asStubFaultError{faulter: &stubFaultError{client: true}}
+	require.True(t, IsClientFault(err))
 }
 
 func TestIsClientFault_TreatsUnclassifiedErrorsAsServerFaults(t *testing.T) {

--- a/server/internal/oops/clientfault_test.go
+++ b/server/internal/oops/clientfault_test.go
@@ -1,0 +1,45 @@
+package oops
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubFaultError struct {
+	client bool
+}
+
+func (e *stubFaultError) Error() string { return "stub fault" }
+
+func (e *stubFaultError) ClientFault() bool { return e.client }
+
+func TestIsClientFault_MatchesSelfAttributingError(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsClientFault(&stubFaultError{client: true}))
+	require.False(t, IsClientFault(&stubFaultError{client: false}))
+}
+
+func TestIsClientFault_TraversesWrappedErrors(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("execute platform tool: %w", fmt.Errorf("call upstream: %w", &stubFaultError{client: true}))
+	require.True(t, IsClientFault(wrapped))
+}
+
+func TestIsClientFault_TreatsUnclassifiedErrorsAsServerFaults(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsClientFault(nil))
+	require.False(t, IsClientFault(errors.New("connection reset by peer")))
+}
+
+func TestIsClientFault_MatchesShareableErrorCause(t *testing.T) {
+	t.Parallel()
+
+	err := E(CodeBadRequest, &stubFaultError{client: true}, "tool call was rejected")
+	require.True(t, IsClientFault(err), "a ShareableError must expose its cause's attribution")
+}

--- a/server/internal/platformtools/runtime/service_test.go
+++ b/server/internal/platformtools/runtime/service_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -14,7 +17,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	platformslack "github.com/speakeasy-api/gram/server/internal/platformtools/slack"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -312,4 +317,62 @@ func TestService_ExecuteTool_PlanExecutorOverrideSurfacesError(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "boom")
 	require.True(t, exec.called)
+}
+
+// slackRedirectTransport sends a Slack tool's outbound call to a local test
+// server, since the tools pin the real slack.com base URL.
+type slackRedirectTransport struct {
+	host string
+}
+
+func (t *slackRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rewritten := req.Clone(req.Context())
+	rewritten.URL.Scheme = "http"
+	rewritten.URL.Host = t.host
+
+	resp, err := http.DefaultTransport.RoundTrip(rewritten)
+	if err != nil {
+		return nil, fmt.Errorf("roundtrip to test slack: %w", err)
+	}
+	return resp, nil
+}
+
+// Slack answers a thread timestamp that names no thread with HTTP 200 and an
+// ok=false envelope. That refusal must remain attributable to the caller after
+// the runtime wraps it, so the MCP boundary logs it at warn instead of driving
+// the component's error rate with an ordinary caller mistake.
+func TestService_ExecuteTool_KeepsSlackRefusalAttributedToCaller(t *testing.T) {
+	t.Parallel()
+
+	slack := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer slack.Close()
+
+	slackURL, err := url.Parse(slack.URL)
+	require.NoError(t, err)
+
+	svc := NewService(testenv.NewLogger(t), nil, nil, audit.NewLogger())
+	projectID := uuid.New()
+	ctx := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "org-1",
+		ProjectID:            &projectID,
+	})
+
+	tool := platformslack.NewReadThreadMessagesTool(&http.Client{
+		Transport: &slackRedirectTransport{host: slackURL.Host},
+	})
+
+	env := toolconfig.ToolCallEnv{
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+	}
+	env.SystemEnv.Set("SLACK_BOT_TOKEN", "xoxb-test")
+
+	_, err = svc.ExecuteTool(ctx, overridePlan(projectID, tool), env, strings.NewReader(`{"channel_id":"C1","thread_ts":"1.2"}`))
+	require.ErrorContains(t, err, "thread_not_found")
+	require.True(t, oops.IsClientFault(err), "a thread the caller named that does not exist is the caller's to fix")
 }

--- a/server/internal/platformtools/slack/client.go
+++ b/server/internal/platformtools/slack/client.go
@@ -29,6 +29,7 @@ const (
 type (
 	apiClient             = slackapi.Client
 	slackResponseEnvelope = slackapi.ResponseEnvelope
+	slackAPIError         = slackapi.Error
 )
 
 const (

--- a/server/internal/platformtools/slack/tool_add_reaction.go
+++ b/server/internal/platformtools/slack/tool_add_reaction.go
@@ -2,11 +2,13 @@ package slack
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	slackapi "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/api"
 	"github.com/speakeasy-api/gram/server/internal/toolconfig"
 )
 
@@ -29,7 +31,7 @@ func NewAddReactionTool(httpClient *guardian.HTTPClient) core.PlatformToolExecut
 			SourceSlug:  sourceSlack,
 			HandlerName: "add_reaction",
 			Name:        toolNameAddReaction,
-			Description: "Add an emoji reaction to a Slack message using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN.",
+			Description: "Add an emoji reaction to a Slack message using the server's Slack token from SLACK_BOT_TOKEN or SLACK_TOKEN. Adding a reaction that is already on the message succeeds and reports already_reacted.",
 			InputSchema: core.BuildInputSchema[addReactionInput](),
 			Variables:   nil,
 			Annotations: slackToolAnnotations(readOnly, destructive, idempotent, openWorld),
@@ -70,6 +72,14 @@ func callAddReaction(ctx context.Context, client *apiClient, env toolconfig.Tool
 
 	body, err := client.Call(ctx, "reactions.add", request, tokenPreferBot, env)
 	if err != nil {
+		// Slack refuses a repeat reaction with already_reacted, but the end
+		// state the caller asked for already holds, so report it as the
+		// successful no-op it is rather than sending a caller that cannot tell
+		// the difference off to reconcile a failure.
+		var apiErr *slackAPIError
+		if errors.As(err, &apiErr) && apiErr.Code == slackapi.ErrCodeAlreadyReacted {
+			return writeResponse(wr, []byte(`{"ok":true,"already_reacted":true}`))
+		}
 		return err
 	}
 	return writeResponse(wr, body)

--- a/server/internal/platformtools/slack/tool_add_reaction_test.go
+++ b/server/internal/platformtools/slack/tool_add_reaction_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +47,61 @@ func TestAddReactionTool_PostsToReactionsAdd(t *testing.T) {
 	require.Equal(t, "123.456", requestPayload.Get("timestamp"))
 	require.Equal(t, "thumbsup", requestPayload.Get("name"))
 	require.JSONEq(t, `{"ok":true}`, out.String())
+}
+
+func TestAddReactionTool_TreatsAlreadyReactedAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":false,"error":"already_reacted"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewAddReactionTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callAddReaction,
+	}
+
+	var out bytes.Buffer
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"timestamp":"123.456",
+		"name":"thumbsup"
+	}`), &out)
+	require.NoError(t, err, "the reaction the caller asked for is already present")
+	require.JSONEq(t, `{"ok":true,"already_reacted":true}`, out.String())
+}
+
+func TestAddReactionTool_SurfacesOtherSlackRefusals(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ok":false,"error":"message_not_found"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	tool := &slackTool{
+		descriptor: NewAddReactionTool(nil).Descriptor(),
+		client:     newAPIClient(server.URL, server.Client()),
+		callFn:     callAddReaction,
+	}
+
+	err := tool.Call(t.Context(), testSlackEnv(), bytes.NewBufferString(`{
+		"channel_id":"C123",
+		"timestamp":"123.456",
+		"name":"thumbsup"
+	}`), &bytes.Buffer{})
+	require.ErrorContains(t, err, "message_not_found")
+	require.True(t, oops.IsClientFault(err), "a message the caller named that does not exist is the caller's to fix")
 }
 
 func TestAddReactionTool_RequiresFields(t *testing.T) {

--- a/server/internal/thirdparty/slack/api/client.go
+++ b/server/internal/thirdparty/slack/api/client.go
@@ -87,7 +87,8 @@ func (c *Client) BaseURL() string {
 
 // Call invokes a Slack Web API method with a form-encoded payload, resolving
 // the token from env according to kind, and returns the raw response body once
-// the Slack envelope reports ok=true.
+// the Slack envelope reports ok=true. A refusal by Slack — a non-200 status or
+// an ok=false envelope — is returned as an *Error carrying the envelope code.
 func (c *Client) Call(ctx context.Context, method string, payload map[string]any, kind TokenKind, env toolconfig.ToolCallEnv) ([]byte, error) {
 	token, err := c.Token(kind, env)
 	if err != nil {
@@ -130,7 +131,7 @@ func (c *Client) CallWithToken(ctx context.Context, method string, payload map[s
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("slack %s returned %d: %s", method, resp.StatusCode, string(bodyBytes))
+		return nil, newStatusError(method, resp.StatusCode, bodyBytes)
 	}
 
 	var envelope ResponseEnvelope
@@ -138,7 +139,7 @@ func (c *Client) CallWithToken(ctx context.Context, method string, payload map[s
 		return nil, fmt.Errorf("decode slack response for %s: %w", method, err)
 	}
 	if !envelope.Ok {
-		return nil, fmt.Errorf("slack %s: %s", method, errorDetails(envelope))
+		return nil, newEnvelopeError(method, resp.StatusCode, envelope)
 	}
 
 	return bodyBytes, nil

--- a/server/internal/thirdparty/slack/api/errors.go
+++ b/server/internal/thirdparty/slack/api/errors.go
@@ -45,6 +45,7 @@ var slackFaultCodes = map[string]struct{}{
 	"fatal_error":         {},
 	"service_unavailable": {},
 	"request_timeout":     {},
+	"team_added_to_org":   {},
 	// Slack spells the throttling code both ways depending on the method.
 	"ratelimited":  {},
 	"rate_limited": {},

--- a/server/internal/thirdparty/slack/api/errors.go
+++ b/server/internal/thirdparty/slack/api/errors.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ErrCodeAlreadyReacted is the envelope error reactions.add answers with when
+// the emoji the caller asked for is already on the message. The requested end
+// state already holds, so callers generally treat it as success rather than as
+// a failed call.
+const ErrCodeAlreadyReacted = "already_reacted"
+
+// Error is returned when a Slack Web API call completed but Slack refused it:
+// either the HTTP response was not 200, or the response envelope reported
+// ok=false. It carries the machine-readable envelope code so callers can branch
+// on specific outcomes and so error boundaries can tell an expected caller
+// mistake apart from a Slack-side failure.
+type Error struct {
+	// Method is the Slack Web API method that was called, e.g. "reactions.add".
+	Method string
+
+	// Code is the envelope's `error` value, e.g. "thread_not_found". It is empty
+	// when Slack answered with a non-200 status instead of an envelope, or when
+	// the envelope reported ok=false without naming an error.
+	Code string
+
+	// StatusCode is the HTTP status Slack answered with. Envelope failures carry
+	// 200, since Slack reports most refusals in the body of a 200 response.
+	StatusCode int
+
+	// message is the rendered error text, fixed at construction so the two
+	// refusal shapes (non-200 status, ok=false envelope) each keep their own
+	// wording.
+	message string
+}
+
+// slackFaultCodes are the envelope error codes that report a failure on Slack's
+// side rather than in the request: its own internal errors and throttling.
+// Everything else an envelope can report — an unknown channel, a thread ts that
+// is not a parent, blocks that fail validation, a scope the token never had —
+// is something the caller or the app's Slack configuration has to change.
+var slackFaultCodes = map[string]struct{}{
+	"internal_error":      {},
+	"fatal_error":         {},
+	"service_unavailable": {},
+	"request_timeout":     {},
+	// Slack spells the throttling code both ways depending on the method.
+	"ratelimited":  {},
+	"rate_limited": {},
+}
+
+func newStatusError(method string, statusCode int, body []byte) *Error {
+	return &Error{
+		Method:     method,
+		Code:       "",
+		StatusCode: statusCode,
+		message:    fmt.Sprintf("slack %s returned %d: %s", method, statusCode, string(body)),
+	}
+}
+
+func newEnvelopeError(method string, statusCode int, envelope ResponseEnvelope) *Error {
+	return &Error{
+		Method:     method,
+		Code:       envelope.Error,
+		StatusCode: statusCode,
+		message:    fmt.Sprintf("slack %s: %s", method, errorDetails(envelope)),
+	}
+}
+
+func (e *Error) Error() string {
+	return e.message
+}
+
+// ClientFault implements oops.ClientFaulter, reporting whether this refusal is
+// the caller's to fix.
+//
+// The Slack Web API answers HTTP 200 with `ok: false` for essentially every
+// argument, permission, and state problem, reserving a small set of codes for
+// its own failures, so an envelope error is a caller fault unless its code names
+// a Slack-side failure. A non-200 status follows the usual HTTP split, except
+// that 429 stays a Slack-side fault: a throttled call is worth retrying, not
+// worth reporting back as bad input.
+func (e *Error) ClientFault() bool {
+	if e.StatusCode != http.StatusOK {
+		return e.StatusCode >= 400 && e.StatusCode < 500 && e.StatusCode != http.StatusTooManyRequests
+	}
+
+	if e.Code == "" {
+		return false
+	}
+
+	_, slackFault := slackFaultCodes[e.Code]
+	return !slackFault
+}

--- a/server/internal/thirdparty/slack/api/errors.go
+++ b/server/internal/thirdparty/slack/api/errors.go
@@ -46,6 +46,7 @@ var slackFaultCodes = map[string]struct{}{
 	"service_unavailable": {},
 	"request_timeout":     {},
 	"team_added_to_org":   {},
+	"org_login_required":  {},
 	// Slack spells the throttling code both ways depending on the method.
 	"ratelimited":  {},
 	"rate_limited": {},

--- a/server/internal/thirdparty/slack/api/errors_test.go
+++ b/server/internal/thirdparty/slack/api/errors_test.go
@@ -44,6 +44,7 @@ func TestError_SlackSideEnvelopeCodesStayServerFaults(t *testing.T) {
 		"fatal_error",
 		"service_unavailable",
 		"request_timeout",
+		"org_login_required",
 		"ratelimited",
 		"rate_limited",
 	}

--- a/server/internal/thirdparty/slack/api/errors_test.go
+++ b/server/internal/thirdparty/slack/api/errors_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/stretchr/testify/require"
+)
+
+func TestError_EnvelopeCodesAreClientFaults(t *testing.T) {
+	t.Parallel()
+
+	// Every one of these was observed being logged at error level, drowning out
+	// genuine faults in the MCP component's error rate.
+	codes := []string{
+		"thread_not_found",
+		"already_reacted",
+		"not_in_channel",
+		"missing_scope",
+		"invalid_blocks",
+		"channel_not_found",
+		"invalid_auth",
+	}
+
+	for _, code := range codes {
+		err := newEnvelopeError("chat.postMessage", http.StatusOK, ResponseEnvelope{
+			Ok:               false,
+			Error:            code,
+			Warning:          "",
+			ResponseMetadata: nil,
+		})
+		require.True(t, err.ClientFault(), "%s is the caller's to fix", code)
+		require.True(t, oops.IsClientFault(err), "%s must be visible to error boundaries", code)
+	}
+}
+
+func TestError_SlackSideEnvelopeCodesStayServerFaults(t *testing.T) {
+	t.Parallel()
+
+	codes := []string{
+		"internal_error",
+		"fatal_error",
+		"service_unavailable",
+		"request_timeout",
+		"ratelimited",
+		"rate_limited",
+	}
+
+	for _, code := range codes {
+		err := newEnvelopeError("conversations.replies", http.StatusOK, ResponseEnvelope{
+			Ok:               false,
+			Error:            code,
+			Warning:          "",
+			ResponseMetadata: nil,
+		})
+		require.False(t, err.ClientFault(), "%s is a Slack-side failure", code)
+		require.False(t, oops.IsClientFault(err))
+	}
+}
+
+func TestError_UnnamedEnvelopeFailureStaysServerFault(t *testing.T) {
+	t.Parallel()
+
+	err := newEnvelopeError("reactions.add", http.StatusOK, ResponseEnvelope{
+		Ok:               false,
+		Error:            "",
+		Warning:          "",
+		ResponseMetadata: nil,
+	})
+	require.False(t, err.ClientFault(), "an unclassifiable refusal must keep error severity")
+	require.Equal(t, "slack reactions.add: request failed", err.Error())
+}
+
+func TestError_StatusCodesFollowTheHTTPSplit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status      int
+		clientFault bool
+	}{
+		{http.StatusBadRequest, true},
+		{http.StatusForbidden, true},
+		{http.StatusNotFound, true},
+		{http.StatusTooManyRequests, false},
+		{http.StatusBadGateway, false},
+		{http.StatusServiceUnavailable, false},
+	}
+
+	for _, tc := range cases {
+		err := newStatusError("users.list", tc.status, []byte("upstream said no"))
+		require.Equal(t, tc.clientFault, err.ClientFault(), "status %d", tc.status)
+	}
+}
+
+func TestError_MessagesKeepTheirRefusalShape(t *testing.T) {
+	t.Parallel()
+
+	envelopeErr := newEnvelopeError("conversations.replies", http.StatusOK, ResponseEnvelope{
+		Ok:      false,
+		Error:   "thread_not_found",
+		Warning: "",
+		ResponseMetadata: &struct {
+			Messages []string `json:"messages,omitempty"`
+		}{Messages: []string{"no such thread"}},
+	})
+	require.Equal(t, "slack conversations.replies: thread_not_found | no such thread", envelopeErr.Error())
+
+	statusErr := newStatusError("users.list", http.StatusBadGateway, []byte("bad gateway"))
+	require.Equal(t, "slack users.list returned 502: bad gateway", statusErr.Error())
+}
+
+func TestClient_CallReturnsTypedEnvelopeError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, server.Client())
+	_, err := client.CallWithToken(t.Context(), "conversations.replies", map[string]any{"channel": "C1"}, "xoxb-test")
+
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, "thread_not_found", apiErr.Code)
+	require.Equal(t, "conversations.replies", apiErr.Method)
+	require.Equal(t, http.StatusOK, apiErr.StatusCode)
+	require.True(t, oops.IsClientFault(err))
+}
+
+func TestClient_CallReturnsTypedStatusError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, server.Client())
+	_, err := client.CallWithToken(t.Context(), "users.list", nil, "xoxb-test")
+
+	var apiErr *Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusServiceUnavailable, apiErr.StatusCode)
+	require.Empty(t, apiErr.Code)
+	require.False(t, oops.IsClientFault(err), "a Slack outage must keep error severity")
+}

--- a/server/internal/thirdparty/slack/api/errors_test.go
+++ b/server/internal/thirdparty/slack/api/errors_test.go
@@ -60,6 +60,18 @@ func TestError_SlackSideEnvelopeCodesStayServerFaults(t *testing.T) {
 	}
 }
 
+func TestError_SlackMigrationEnvelopeCodeStaysServerFault(t *testing.T) {
+	t.Parallel()
+
+	err := newEnvelopeError("team.info", http.StatusOK, ResponseEnvelope{
+		Ok:    false,
+		Error: "team_added_to_org",
+	})
+
+	require.False(t, err.ClientFault(), "a workspace migration is a Slack-side outage")
+	require.False(t, oops.IsClientFault(err))
+}
+
 func TestError_UnnamedEnvelopeFailureStaysServerFault(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DNO-743.

## Problem

The Slack Web API answers HTTP 200 with `ok: false` for essentially every argument, permission, and state problem. Those refusals reached the MCP tool boundary as untyped `error` values and were reported as server faults, so `thread_not_found`, `not_in_channel`, `missing_scope`, `invalid_blocks`, and even the idempotent `already_reacted` were indistinguishable from real faults in `gram.component.log_count{status:error}`.

On 2026-08-03 one misconfigured Slack assistant produced ~190 `thread_not_found` errors in an hour, which was enough to hold the `mcp` component's error-log anomaly monitor at 100% anomalous for a full alert window — any genuine regression in that hour would have been masked.

## Change

**A generic attribution contract (`server/internal/oops/clientfault.go`).** `oops.ClientFaulter` lets an error type say whether an outcome is the caller's to fix; `oops.IsClientFault` walks the wrap chain to ask. Errors that do not implement it stay server faults, so nothing becomes quieter by accident.

**Typed Slack refusals (`server/internal/thirdparty/slack/api/errors.go`).** The shared client now returns `*api.Error` carrying the method, HTTP status, and the envelope `error` code. Because Slack reserves only a small set of codes for its own failures, an envelope error is a caller fault unless the code names a Slack-side failure (`internal_error`, `fatal_error`, `service_unavailable`, `request_timeout`, `ratelimited`/`rate_limited`); a non-200 status follows the usual HTTP split, with 429 kept on Slack's side because a throttled call is worth retrying rather than reporting back as bad input. Both message shapes are byte-for-byte what they were, so existing callers and assertions are unaffected. All 68 Slack platform tools route through this client, so the classification covers every one of them rather than only the methods named in the issue.

**Severity at the MCP tool boundary (`rpc_tools_call.go`, `serve_platform.go`).** A caller-attributed failure is answered as a bad request logged at warn, tagged with `gram.tool.name` and the upstream message, and does not mark the request span as errored. Everything else keeps the 500 and error severity under its existing message. Both MCP paths already answer HTTP 200 with a JSON-RPC error body, so the only client-visible change is the JSON-RPC code (`-32603` internal error → `-32600` invalid request) and a message that says the call was rejected rather than that Gram failed.

**`already_reacted` is success (`platform_slack_add_reaction`).** The reaction the caller asked for is already on the message, so the tool returns `{"ok":true,"already_reacted":true}` instead of a failure the caller cannot tell apart from one worth reconciling. The tool description now says so.

The issue's optional fourth suggestion — a separate counter for caller-input failures — is not included: the warn-level log carries the tool name and the upstream error code, which is the queryable per-client, per-code breakdown a counter would provide, without adding a metric dimension.

## Testing

New tests, all passing alongside the existing suites for `internal/oops`, `internal/thirdparty/slack/...`, `internal/platformtools/...`, `internal/gateway`, and `internal/mcp/...`:

- `internal/thirdparty/slack/api/errors_test.go` — every code from the issue's table classifies as a caller fault; Slack-side codes and 429/5xx do not; an `ok: false` envelope with no named error stays a server fault; both message shapes are unchanged; the client returns the typed error end to end.
- `internal/oops/clientfault_test.go` — attribution survives `fmt.Errorf` wrapping and `ShareableError` causes; unclassified errors stay server faults.
- `internal/mcp/rpc_tools_call_internal_test.go` — a refusal wrapped the way the platform runtime and gateway wrap it logs at WARN with a 400 and an unerrored span, keeps the upstream code in `error.message`, and unclassified or Slack-side failures are not treated as rejections.
- `internal/platformtools/runtime/service_test.go` — a real Slack tool pointed at a stub answering `{"ok":false,"error":"thread_not_found"}` is still a caller fault after the platform runtime wraps it.
- `internal/gateway/proxy_test.go` — a caller-attributed platform tool failure is still recognizable as one after the proxy wraps it. The severity split only holds if attribution survives both of these layers.
- `internal/platformtools/slack/tool_add_reaction_test.go` — `already_reacted` returns success; another refusal still fails and is attributed to the caller.

```
ok  github.com/speakeasy-api/gram/server/internal/oops
ok  github.com/speakeasy-api/gram/server/internal/thirdparty/slack/api
ok  github.com/speakeasy-api/gram/server/internal/platformtools/runtime
ok  github.com/speakeasy-api/gram/server/internal/platformtools/slack
ok  github.com/speakeasy-api/gram/server/internal/gateway
ok  github.com/speakeasy-api/gram/server/internal/mcp        36.611s
```

`mise lint:server` and `gofmt` are clean.

### Observed severity, end to end

Driving the real `platform_slack_read_thread_messages` tool through the gateway proxy and the platform runtime against a stub Slack returning each envelope code, then handling the error exactly as the MCP boundary does, produces the log lines below. Every code from the issue's table drops to WARN while keeping the Slack code queryable in `error.message`, and Slack's own failures keep ERROR.

```json
{"level":"WARN","msg":"tool call was rejected as invalid or not permitted","gram.component":"mcp","gram.tool.name":"platform_slack_read_thread_messages","error.message":"tool call was rejected as invalid or not permitted: execute platform tool: execute platform tool tools:platform:slack:read_thread_messages: slack conversations.replies: thread_not_found"}
{"level":"WARN","msg":"tool call was rejected as invalid or not permitted","gram.component":"mcp","gram.tool.name":"platform_slack_read_thread_messages","error.message":"... slack conversations.replies: not_in_channel"}
{"level":"WARN","msg":"tool call was rejected as invalid or not permitted","gram.component":"mcp","gram.tool.name":"platform_slack_read_thread_messages","error.message":"... slack conversations.replies: missing_scope"}
{"level":"WARN","msg":"tool call was rejected as invalid or not permitted","gram.component":"mcp","gram.tool.name":"platform_slack_read_thread_messages","error.message":"... slack conversations.replies: invalid_blocks"}
{"level":"ERROR","msg":"failed to execute tool call","gram.component":"mcp","gram.tool.name":"platform_slack_read_thread_messages","error.message":"failed to execute tool call: ... slack conversations.replies: internal_error"}
{"level":"ERROR","msg":"failed to execute tool call","gram.component":"mcp","gram.tool.name":"platform_slack_read_thread_messages","error.message":"failed to execute tool call: ... slack conversations.replies: ratelimited"}
```

The scaffolding that produced this was a scratch harness and is not part of the diff; the committed tests assert the same behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-743](https://linear.app/speakeasy/issue/DNO-743/reclassify-expected-slack-client-errors-off-error-in-mcp-platform)

<div><a href="https://cursor.com/agents/bc-8e9f6c32-f5f1-4df4-9ef3-8f330f157f00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e9f6c32-f5f1-4df4-9ef3-8f330f157f00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclassifies expected Slack Web API refusals as caller faults at the MCP and gateway tool boundaries, returning 400/JSON-RPC -32600 with warn logs, no error spans, and the correct HTTP status on the response. Addresses Linear DNO-743 by preventing misconfigured Slack clients from inflating the `mcp` error rate.

- **New Features**
  - Added `oops.ClientFaulter` and `oops.IsClientFault`; Slack client now returns typed `internal/thirdparty/slack/api.Error` (method, status, envelope code).
  - Classification: envelope errors are caller faults except Slack-side codes (`internal_error`, `fatal_error`, `service_unavailable`, `request_timeout`, `ratelimited`/`rate_limited`, `team_added_to_org`, `org_login_required`); non-200 statuses treat 4xx as caller faults (429 stays server-side), 5xx remain server faults.
  - Caller faults now return 400 with JSON-RPC `-32600`, log at warn with the tool name and upstream message, and do not mark spans as errored in `gateway/proxy`, `mcp/tools.call`, or `serve_platform`.

- **Bug Fixes**
  - `platform_slack_add_reaction`: treat `already_reacted` as success and return `{"ok":true,"already_reacted":true}`.
  - Preserve caller-fault attribution across wrapping, `errors.Join`, and custom `errors.As` projections; rejected tool calls set HTTP 400 so billing/telemetry reflect the correct status.

<sup>Written for commit 6890bd4c60b2ec5aca3d24270fe050d79d88de0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

