### PR TITLE
feat(server): add encrypted OpenRouter key column

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1908,6 +1908,7 @@ CREATE TABLE IF NOT EXISTS openrouter_api_keys (
   key_type TEXT NOT NULL DEFAULT 'chat',
 
   key TEXT NOT NULL,
+  key_encrypted TEXT,
   key_hash TEXT NOT NULL,
   monthly_credits BIGINT NOT NULL DEFAULT 0,
   disabled BOOLEAN NOT NULL DEFAULT FALSE,

--- a/server/migrations/20260806165256_openrouter-api-key-encryption.sql
+++ b/server/migrations/20260806165256_openrouter-api-key-encryption.sql
@@ -1,0 +1,2 @@
+-- Modify "openrouter_api_keys" table
+ALTER TABLE "openrouter_api_keys" ADD COLUMN "key_encrypted" text NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GiiKbYRSXyAts/yCz2pYagAP2dH480W4GbWY3MebzXU=
+h1:qqzIVntB1akBemINRuePFzmoYPa8fvkkip45Za+6MFw=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -319,3 +319,4 @@ h1:GiiKbYRSXyAts/yCz2pYagAP2dH480W4GbWY3MebzXU=
 20260805191625_publish-outbox.sql h1:dqHs3CK4gTejbarFRGVwP1pqTPSXBkkuRnha8s2hrUY=
 20260805211101_enterprise-trials.sql h1:7NH6ss0phB6SS9BuHVEgy8fq7j3Ca0Sq10cgdDADW3A=
 20260805222807_publish-outbox-lease-token.sql h1:UkZ7i59bP6G3xZBSOQUlepqDLK4yjJMplJcUkBS3i5Y=
+20260806165256_openrouter-api-key-encryption.sql h1:VCi99ckP9tlYcpIV/3mweHyzP+Xp8G6iH7jr914Xpv0=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add nullable `key_encrypted` storage for platform OpenRouter credentials
- preserve the plaintext column for the expand phase so currently deployed application versions remain compatible

## Rollout
This is the schema-only first step of an expand-contract remediation for AIS-450. Application dual-write, backfill, and plaintext removal must ship separately after this migration is deployed.

## Testing
- reset the local Postgres schema and replayed all 321 migrations successfully
- `mise run lint:migrations`: one migration analyzed, no diagnostics found
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-450](https://linear.app/speakeasy/issue/AIS-450/triage-platform-openrouter-api-keys-are-stored-unencrypted-in-postgres)

<div><a href="https://cursor.com/agents/bc-2f5820c5-aab8-4916-b0e3-bf0f0b12af2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f5820c5-aab8-4916-b0e3-bf0f0b12af2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a nullable key_encrypted column to the openrouter_api_keys table to store encrypted OpenRouter API keys while keeping the existing plaintext key for compatibility. This prepares encrypted storage and starts the expand phase for AIS-450.

- **Migration**
  - Adds key_encrypted TEXT NULL via migration 20260806165256; no behavior change or backfill yet.
  - Next steps (separate PRs): app dual-write, backfill existing keys, then drop plaintext key to complete AIS-450.

<sup>Written for commit fda658df02a82369ff14dace5b05b6135376b899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

