### PR TITLE
feat(server): encrypt platform OpenRouter keys

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -655,6 +655,7 @@ func newStartCommand() *cli.Command {
 					&background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv},
 					productFeatures,
 					billingTracker,
+					encryptionClient,
 				)
 			}
 

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -645,7 +645,7 @@ func newStartCommand() *cli.Command {
 			if c.String("environment") == "local" {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
-				openRouter = openrouter.New(
+				openRouterClient := openrouter.New(
 					logger,
 					tracerProvider,
 					guardianPolicy,
@@ -657,6 +657,10 @@ func newStartCommand() *cli.Command {
 					billingTracker,
 					encryptionClient,
 				)
+				if err := openRouterClient.BackfillAPIKeyEncryption(ctx); err != nil {
+					return fmt.Errorf("backfill openrouter API key encryption: %w", err)
+				}
+				openRouter = openRouterClient
 			}
 
 			serverURL, err := url.Parse(c.String("server-url"))

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -297,7 +297,11 @@ func newStreamsCommand() *cli.Command {
 			if c.String("environment") == "local" {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
-				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), nil, productFeatures, billingTracker, encryptionClient)
+				openRouterClient := openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), nil, productFeatures, billingTracker, encryptionClient)
+				if err := openRouterClient.BackfillAPIKeyEncryption(ctx); err != nil {
+					return fmt.Errorf("backfill openrouter API key encryption: %w", err)
+				}
+				openRouter = openRouterClient
 			}
 
 			completionsClient := openrouter.NewUnifiedClient(

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -297,7 +297,7 @@ func newStreamsCommand() *cli.Command {
 			if c.String("environment") == "local" {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
-				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), nil, productFeatures, billingTracker)
+				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), nil, productFeatures, billingTracker, encryptionClient)
 			}
 
 			completionsClient := openrouter.NewUnifiedClient(

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -504,7 +504,11 @@ func newWorkerCommand() *cli.Command {
 			if c.String("environment") == "local" {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
-				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker, encryptionClient)
+				openRouterClient := openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker, encryptionClient)
+				if err := openRouterClient.BackfillAPIKeyEncryption(ctx); err != nil {
+					return fmt.Errorf("backfill openrouter API key encryption: %w", err)
+				}
+				openRouter = openRouterClient
 			}
 
 			svixClient, shutdown, err := newSvixClient(c, logger, guardianPolicy)

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -504,7 +504,7 @@ func newWorkerCommand() *cli.Command {
 			if c.String("environment") == "local" {
 				openRouter = openrouter.NewDevelopment(c.String("openrouter-dev-key"))
 			} else {
-				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker)
+				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), &background.OpenRouterKeyRefresher{TemporalEnv: temporalEnv}, productFeatures, billingTracker, encryptionClient)
 			}
 
 			svixClient, shutdown, err := newSvixClient(c, logger, guardianPolicy)

--- a/server/internal/background/activities/openrouter_credits_metrics.go
+++ b/server/internal/background/activities/openrouter_credits_metrics.go
@@ -74,7 +74,17 @@ func (c *CollectOpenRouterCreditsMetrics) Do(ctx context.Context, args CollectOp
 	g.SetLimit(openRouterCreditsPollConcurrency)
 	for i, row := range rows {
 		g.Go(func() error {
-			used, upstreamLimit, err := c.openRouter.GetKeyUsage(gctx, row.ApiKey)
+			apiKey, err := c.openRouter.ProvisionAPIKey(gctx, row.OrganizationID, openrouter.KeyType(row.KeyType))
+			if err != nil {
+				c.logger.ErrorContext(gctx, "read openrouter key for usage polling",
+					attr.SlogOrganizationID(row.OrganizationID),
+					attr.SlogOrganizationSlug(row.OrganizationSlug),
+					attr.SlogError(err),
+				)
+				return nil
+			}
+
+			used, upstreamLimit, err := c.openRouter.GetKeyUsage(gctx, apiKey)
 			if err != nil {
 				// Skip on a per-org failure so one bad key does not blank the
 				// whole batch. The error is logged for diagnosis and swallowed

--- a/server/internal/background/activities/openrouter_credits_targets_test.go
+++ b/server/internal/background/activities/openrouter_credits_targets_test.go
@@ -38,6 +38,7 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 		OrganizationID: orgID,
 		KeyType:        "chat",
 		Key:            "sk-chat",
+		KeyEncrypted:   pgtype.Text{},
 		KeyHash:        "hash-chat",
 		MonthlyCredits: 100,
 	})
@@ -46,6 +47,7 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 		OrganizationID: orgID,
 		KeyType:        "internal",
 		Key:            "sk-internal",
+		KeyEncrypted:   pgtype.Text{},
 		KeyHash:        "hash-internal",
 		MonthlyCredits: 100,
 	})
@@ -54,17 +56,14 @@ func TestGetOpenRouterCreditsMonitoringTargets_OneRowPerKeyType(t *testing.T) {
 	rows, err := repo.New(conn).GetOpenRouterCreditsMonitoringTargets(ctx, []string{"free"})
 	require.NoError(t, err)
 
-	byKeyType := map[string]string{}
+	keyTypes := map[string]bool{}
 	for _, row := range rows {
 		if row.OrganizationID != orgID {
 			continue
 		}
-		byKeyType[row.KeyType] = row.ApiKey
+		keyTypes[row.KeyType] = true
 	}
-	require.Equal(t, map[string]string{
-		"chat":     "sk-chat",
-		"internal": "sk-internal",
-	}, byKeyType)
+	require.Equal(t, map[string]bool{"chat": true, "internal": true}, keyTypes)
 
 	// The single-key lookup discriminates by type: each read returns its own
 	// row, never the sibling's.

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -55,16 +55,13 @@ HAVING COUNT(toolsets.id) > 0;
 -- account-type allowlist so coverage can expand (e.g. add 'pro') without a
 -- code change. monthly_credits is the canonical limit last written by
 -- RefreshAPIKeyLimit and reflects any per-org overrides applied via the
--- OpenrouterKeyRefreshWorkflow. The api_key is included so the caller can
--- issue the upstream usage HTTP call in a single round-trip — keep it inside
--- the activity boundary and never return it to the workflow.
+-- OpenrouterKeyRefreshWorkflow.
 SELECT
     om.id AS organization_id,
     om.slug AS organization_slug,
     om.gram_account_type,
     k.key_type,
-    k.monthly_credits,
-    k.key AS api_key
+    k.monthly_credits
 FROM organization_metadata om
 JOIN openrouter_api_keys k ON k.organization_id = om.id
 WHERE om.disabled_at IS NULL

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -476,8 +476,7 @@ SELECT
     om.slug AS organization_slug,
     om.gram_account_type,
     k.key_type,
-    k.monthly_credits,
-    k.key AS api_key
+    k.monthly_credits
 FROM organization_metadata om
 JOIN openrouter_api_keys k ON k.organization_id = om.id
 WHERE om.disabled_at IS NULL
@@ -493,7 +492,6 @@ type GetOpenRouterCreditsMonitoringTargetsRow struct {
 	GramAccountType  string
 	KeyType          string
 	MonthlyCredits   int64
-	ApiKey           string
 }
 
 // Targets for periodic OpenRouter credit usage polling. Filters out disabled
@@ -501,9 +499,7 @@ type GetOpenRouterCreditsMonitoringTargetsRow struct {
 // account-type allowlist so coverage can expand (e.g. add 'pro') without a
 // code change. monthly_credits is the canonical limit last written by
 // RefreshAPIKeyLimit and reflects any per-org overrides applied via the
-// OpenrouterKeyRefreshWorkflow. The api_key is included so the caller can
-// issue the upstream usage HTTP call in a single round-trip — keep it inside
-// the activity boundary and never return it to the workflow.
+// OpenrouterKeyRefreshWorkflow.
 func (q *Queries) GetOpenRouterCreditsMonitoringTargets(ctx context.Context, accountTypes []string) ([]GetOpenRouterCreditsMonitoringTargetsRow, error) {
 	rows, err := q.db.Query(ctx, getOpenRouterCreditsMonitoringTargets, accountTypes)
 	if err != nil {
@@ -519,7 +515,6 @@ func (q *Queries) GetOpenRouterCreditsMonitoringTargets(ctx context.Context, acc
 			&i.GramAccountType,
 			&i.KeyType,
 			&i.MonthlyCredits,
-			&i.ApiKey,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1228,6 +1228,7 @@ type OpenrouterApiKey struct {
 	OrganizationID string
 	KeyType        string
 	Key            string
+	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
 	Disabled       bool

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -15,11 +15,13 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -243,13 +245,14 @@ type OpenRouter struct {
 	orClient        *guardian.HTTPClient
 	refresher       KeyRefresher
 	featureClient   *productfeatures.Client
+	encryption      *encryption.Client
 	// baseURL is OpenRouterBaseURL outside of tests.
 	baseURL string
 }
 
 var _ Provisioner = (*OpenRouter)(nil)
 
-func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, env string, provisioningKey string, refresher KeyRefresher, featureClient *productfeatures.Client, tracking billing.Tracker) *OpenRouter {
+func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolicy *guardian.Policy, db *pgxpool.Pool, env string, provisioningKey string, refresher KeyRefresher, featureClient *productfeatures.Client, tracking billing.Tracker, encryptionClient *encryption.Client) *OpenRouter {
 	orClient := guardianPolicy.PooledClient(guardian.WithDefaultRetryConfig())
 
 	return &OpenRouter{
@@ -262,8 +265,34 @@ func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolic
 		orClient:        orClient,
 		refresher:       refresher,
 		featureClient:   featureClient,
+		encryption:      encryptionClient,
 		baseURL:         OpenRouterBaseURL,
 	}
+}
+
+func (o *OpenRouter) decryptAPIKey(ctx context.Context, queries *repo.Queries, key repo.OpenrouterApiKey) (string, error) {
+	if key.KeyEncrypted.Valid {
+		plaintext, err := o.encryption.Decrypt(key.KeyEncrypted.String)
+		if err != nil {
+			return "", fmt.Errorf("decrypt openrouter API key: %w", err)
+		}
+
+		return plaintext, nil
+	}
+
+	encryptedKey, err := o.encryption.Encrypt([]byte(key.Key))
+	if err != nil {
+		return "", fmt.Errorf("encrypt openrouter API key: %w", err)
+	}
+	if err := queries.SetOpenRouterKeyEncryption(ctx, repo.SetOpenRouterKeyEncryptionParams{
+		OrganizationID: key.OrganizationID,
+		KeyType:        key.KeyType,
+		KeyEncrypted:   pgtype.Text{String: encryptedKey, Valid: true},
+	}); err != nil {
+		return "", fmt.Errorf("backfill openrouter API key encryption: %w", err)
+	}
+
+	return key.Key, nil
 }
 
 func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType KeyType) (string, error) {
@@ -284,14 +313,17 @@ func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType 
 	case err != nil && !errors.Is(err, pgx.ErrNoRows):
 		return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
 
-	case errors.Is(err, pgx.ErrNoRows), key.Key == "":
+	case errors.Is(err, pgx.ErrNoRows), key.Key == "" && !key.KeyEncrypted.Valid:
 		openrouterKey, err = o.createAndStoreAPIKey(ctx, orgID, keyType)
 		if err != nil {
 			return "", err
 		}
 
 	default:
-		openrouterKey = key.Key
+		openrouterKey, err = o.decryptAPIKey(ctx, o.repo, key)
+		if err != nil {
+			return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
+		}
 	}
 
 	if err := inv.Check("openrouter provisioning", "key is set", openrouterKey != ""); err != nil {
@@ -336,9 +368,13 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 	// ProvisionAPIKey.
 	case err != nil && !errors.Is(err, pgx.ErrNoRows):
 		return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
-	case errors.Is(err, pgx.ErrNoRows), key.Key == "":
+	case errors.Is(err, pgx.ErrNoRows), key.Key == "" && !key.KeyEncrypted.Valid:
 	default:
-		return key.Key, nil
+		plaintext, err := o.decryptAPIKey(ctx, txRepo, key)
+		if err != nil {
+			return "", oops.E(oops.CodeUnexpected, err, "error reading open router key data").LogError(ctx, o.logger)
+		}
+		return plaintext, nil
 	}
 
 	// Read through the transaction: this goroutine already holds a pool
@@ -362,10 +398,16 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 		return "", err
 	}
 
+	encryptedKey, err := o.encryption.Encrypt([]byte(*keyResponse.Key))
+	if err != nil {
+		return "", oops.E(oops.CodeUnexpected, err, "failed to encrypt openrouter key").LogError(ctx, o.logger)
+	}
+
 	_, err = txRepo.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        string(keyType),
 		Key:            *keyResponse.Key,
+		KeyEncrypted:   pgtype.Text{String: encryptedKey, Valid: true},
 		KeyHash:        keyResponse.Data.Hash,
 		MonthlyCredits: int64(creditAmount),
 	})
@@ -425,7 +467,6 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 		KeyType:        string(keyType),
 		MonthlyCredits: int64(keyLimit),
 		KeyHash:        keyResponse.Data.Hash,
-		Key:            key.Key,
 	})
 	if err != nil {
 		return 0, oops.E(oops.CodeUnexpected, err, "failed to update openrouter key").LogError(ctx, o.logger)
@@ -456,7 +497,11 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 		return 0, limit, nil // the key doesn't exist yet
 	}
 
-	used, _, err := o.GetKeyUsage(ctx, key.Key)
+	apiKey, err := o.decryptAPIKey(ctx, o.repo, key)
+	if err != nil {
+		return 0, limit, err
+	}
+	used, _, err := o.GetKeyUsage(ctx, apiKey)
 	if err != nil {
 		return 0, limit, err
 	}
@@ -467,10 +512,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 // GetKeyUsage issues the upstream `/v1/key` call with the given API key and
 // returns the rounded monthly usage along with the upstream-configured monthly
 // limit already rounded to the int64 representation used by the DB. The
-// returned limit is nil when OpenRouter reports an unlimited key. Callers that
-// already have the key (e.g. the credits monitoring activity, which joins
-// openrouter_api_keys in a single SQL query) can skip the org/key DB lookups
-// in GetCreditsUsed.
+// returned limit is nil when OpenRouter reports an unlimited key.
 func (o *OpenRouter) GetKeyUsage(ctx context.Context, apiKey string) (float64, *int64, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", o.baseURL+"/v1/key", nil)
 	if err != nil {
@@ -717,6 +759,10 @@ func (o *OpenRouter) getGenerationDetails(ctx context.Context, generationID stri
 	if err != nil {
 		return nil, 0, oops.E(oops.CodeUnexpected, err, "failed to get openrouter API key").LogError(ctx, o.logger)
 	}
+	apiKey, err := o.decryptAPIKey(ctx, o.repo, key)
+	if err != nil {
+		return nil, 0, oops.E(oops.CodeUnexpected, err, "failed to decrypt openrouter API key").LogError(ctx, o.logger)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", o.baseURL+"/v1/generation", nil)
 	if err != nil {
@@ -727,7 +773,7 @@ func (o *OpenRouter) getGenerationDetails(ctx context.Context, generationID stri
 	q.Set("id", generationID)
 	req.URL.RawQuery = q.Encode()
 
-	req.Header.Set("Authorization", "Bearer "+key.Key)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := o.orClient.Do(req)

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -295,6 +295,22 @@ func (o *OpenRouter) decryptAPIKey(ctx context.Context, queries *repo.Queries, k
 	return key.Key, nil
 }
 
+// BackfillAPIKeyEncryption encrypts platform keys created before encrypted storage was available.
+func (o *OpenRouter) BackfillAPIKeyEncryption(ctx context.Context) error {
+	keys, err := o.repo.ListUnencryptedOpenRouterAPIKeys(ctx)
+	if err != nil {
+		return fmt.Errorf("list unencrypted openrouter API keys: %w", err)
+	}
+
+	for _, key := range keys {
+		if _, err := o.decryptAPIKey(ctx, o.repo, key); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (o *OpenRouter) ProvisionAPIKey(ctx context.Context, orgID string, keyType KeyType) (string, error) {
 	var openrouterKey string
 

--- a/server/internal/thirdparty/openrouter/provision_test.go
+++ b/server/internal/thirdparty/openrouter/provision_test.go
@@ -64,7 +64,8 @@ func TestProvisionAPIKey_ConcurrentFirstProvision(t *testing.T) {
 	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
 	require.NoError(t, err)
 
-	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil)
+	encryptionClient := testenv.NewEncryptionClient(t)
+	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil, encryptionClient)
 	provisioner.baseURL = upstream.URL
 
 	const workers = 8
@@ -93,5 +94,49 @@ func TestProvisionAPIKey_ConcurrentFirstProvision(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "sk-or-race-1", row.Key)
+	require.True(t, row.KeyEncrypted.Valid)
+	require.NotEqual(t, "sk-or-race-1", row.KeyEncrypted.String)
+	decryptedKey, err := encryptionClient.Decrypt(row.KeyEncrypted.String)
+	require.NoError(t, err)
+	require.Equal(t, "sk-or-race-1", decryptedKey)
 	require.Equal(t, "hash-1", row.KeyHash)
+}
+
+func TestProvisionAPIKey_BackfillsPlaintextKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "orprovisionbackfill")
+	require.NoError(t, err)
+
+	orgID := "org-" + uuid.NewString()[:8]
+	_, err = repo.New(conn).CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		Key:            "sk-or-legacy",
+		KeyEncrypted:   pgtype.Text{},
+		KeyHash:        "legacy-hash",
+		MonthlyCredits: 100,
+	})
+	require.NoError(t, err)
+
+	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	encryptionClient := testenv.NewEncryptionClient(t)
+	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil, encryptionClient)
+
+	apiKey, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	require.NoError(t, err)
+	require.Equal(t, "sk-or-legacy", apiKey)
+
+	row, err := repo.New(conn).GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+	})
+	require.NoError(t, err)
+	require.True(t, row.KeyEncrypted.Valid)
+	require.NotEqual(t, row.Key, row.KeyEncrypted.String)
+	decryptedKey, err := encryptionClient.Decrypt(row.KeyEncrypted.String)
+	require.NoError(t, err)
+	require.Equal(t, row.Key, decryptedKey)
 }

--- a/server/internal/thirdparty/openrouter/provision_test.go
+++ b/server/internal/thirdparty/openrouter/provision_test.go
@@ -125,6 +125,7 @@ func TestProvisionAPIKey_BackfillsPlaintextKey(t *testing.T) {
 	encryptionClient := testenv.NewEncryptionClient(t)
 	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil, encryptionClient)
 
+	require.NoError(t, provisioner.BackfillAPIKeyEncryption(ctx))
 	apiKey, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
 	require.NoError(t, err)
 	require.Equal(t, "sk-or-legacy", apiKey)

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -28,6 +28,12 @@ WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE;
 
+-- name: ListUnencryptedOpenRouterAPIKeys :many
+SELECT *
+FROM openrouter_api_keys
+WHERE key_encrypted IS NULL
+  AND deleted IS FALSE;
+
 -- name: SetOpenRouterKeyEncryption :exec
 UPDATE openrouter_api_keys
 SET key_encrypted = @key_encrypted

--- a/server/internal/thirdparty/openrouter/queries.sql
+++ b/server/internal/thirdparty/openrouter/queries.sql
@@ -8,12 +8,14 @@ INSERT INTO openrouter_api_keys (
     organization_id
   , key_type
   , key
+  , key_encrypted
   , key_hash
   , monthly_credits
 ) VALUES (
     @organization_id
   , @key_type
   , @key
+  , @key_encrypted
   , @key_hash
   , @monthly_credits
 )
@@ -26,9 +28,17 @@ WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE;
 
+-- name: SetOpenRouterKeyEncryption :exec
+UPDATE openrouter_api_keys
+SET key_encrypted = @key_encrypted
+WHERE organization_id = @organization_id
+  AND key_type = @key_type
+  AND key_encrypted IS NULL
+  AND deleted IS FALSE;
+
 -- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
-SET monthly_credits = @monthly_credits, key_hash = @key_hash, key = @key
+SET monthly_credits = @monthly_credits, key_hash = @key_hash
 WHERE organization_id = @organization_id
   AND key_type = @key_type
   AND deleted IS FALSE

--- a/server/internal/thirdparty/openrouter/repo/models.go
+++ b/server/internal/thirdparty/openrouter/repo/models.go
@@ -12,6 +12,7 @@ type OpenrouterApiKey struct {
 	OrganizationID string
 	KeyType        string
 	Key            string
+	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
 	Disabled       bool

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -7,6 +7,8 @@ package repo
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const createOpenRouterAPIKey = `-- name: CreateOpenRouterAPIKey :one
@@ -14,6 +16,7 @@ INSERT INTO openrouter_api_keys (
     organization_id
   , key_type
   , key
+  , key_encrypted
   , key_hash
   , monthly_credits
 ) VALUES (
@@ -22,14 +25,16 @@ INSERT INTO openrouter_api_keys (
   , $3
   , $4
   , $5
+  , $6
 )
-RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateOpenRouterAPIKeyParams struct {
 	OrganizationID string
 	KeyType        string
 	Key            string
+	KeyEncrypted   pgtype.Text
 	KeyHash        string
 	MonthlyCredits int64
 }
@@ -39,6 +44,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 		arg.OrganizationID,
 		arg.KeyType,
 		arg.Key,
+		arg.KeyEncrypted,
 		arg.KeyHash,
 		arg.MonthlyCredits,
 	)
@@ -47,6 +53,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 		&i.OrganizationID,
 		&i.KeyType,
 		&i.Key,
+		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
 		&i.Disabled,
@@ -59,7 +66,7 @@ func (q *Queries) CreateOpenRouterAPIKey(ctx context.Context, arg CreateOpenRout
 }
 
 const getOpenRouterAPIKey = `-- name: GetOpenRouterAPIKey :one
-SELECT organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+SELECT organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 FROM openrouter_api_keys
 WHERE organization_id = $1
   AND key_type = $2
@@ -78,6 +85,7 @@ func (q *Queries) GetOpenRouterAPIKey(ctx context.Context, arg GetOpenRouterAPIK
 		&i.OrganizationID,
 		&i.KeyType,
 		&i.Key,
+		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
 		&i.Disabled,
@@ -105,19 +113,38 @@ func (q *Queries) LockOpenRouterKeyProvisioning(ctx context.Context, arg LockOpe
 	return err
 }
 
+const setOpenRouterKeyEncryption = `-- name: SetOpenRouterKeyEncryption :exec
+UPDATE openrouter_api_keys
+SET key_encrypted = $1
+WHERE organization_id = $2
+  AND key_type = $3
+  AND key_encrypted IS NULL
+  AND deleted IS FALSE
+`
+
+type SetOpenRouterKeyEncryptionParams struct {
+	KeyEncrypted   pgtype.Text
+	OrganizationID string
+	KeyType        string
+}
+
+func (q *Queries) SetOpenRouterKeyEncryption(ctx context.Context, arg SetOpenRouterKeyEncryptionParams) error {
+	_, err := q.db.Exec(ctx, setOpenRouterKeyEncryption, arg.KeyEncrypted, arg.OrganizationID, arg.KeyType)
+	return err
+}
+
 const updateOpenRouterKey = `-- name: UpdateOpenRouterKey :one
 UPDATE openrouter_api_keys
-SET monthly_credits = $1, key_hash = $2, key = $3
-WHERE organization_id = $4
-  AND key_type = $5
+SET monthly_credits = $1, key_hash = $2
+WHERE organization_id = $3
+  AND key_type = $4
   AND deleted IS FALSE
-RETURNING organization_id, key_type, key, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+RETURNING organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateOpenRouterKeyParams struct {
 	MonthlyCredits int64
 	KeyHash        string
-	Key            string
 	OrganizationID string
 	KeyType        string
 }
@@ -126,7 +153,6 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 	row := q.db.QueryRow(ctx, updateOpenRouterKey,
 		arg.MonthlyCredits,
 		arg.KeyHash,
-		arg.Key,
 		arg.OrganizationID,
 		arg.KeyType,
 	)
@@ -135,6 +161,7 @@ func (q *Queries) UpdateOpenRouterKey(ctx context.Context, arg UpdateOpenRouterK
 		&i.OrganizationID,
 		&i.KeyType,
 		&i.Key,
+		&i.KeyEncrypted,
 		&i.KeyHash,
 		&i.MonthlyCredits,
 		&i.Disabled,

--- a/server/internal/thirdparty/openrouter/repo/queries.sql.go
+++ b/server/internal/thirdparty/openrouter/repo/queries.sql.go
@@ -97,6 +97,45 @@ func (q *Queries) GetOpenRouterAPIKey(ctx context.Context, arg GetOpenRouterAPIK
 	return i, err
 }
 
+const listUnencryptedOpenRouterAPIKeys = `-- name: ListUnencryptedOpenRouterAPIKeys :many
+SELECT organization_id, key_type, key, key_encrypted, key_hash, monthly_credits, disabled, created_at, updated_at, deleted_at, deleted
+FROM openrouter_api_keys
+WHERE key_encrypted IS NULL
+  AND deleted IS FALSE
+`
+
+func (q *Queries) ListUnencryptedOpenRouterAPIKeys(ctx context.Context) ([]OpenrouterApiKey, error) {
+	rows, err := q.db.Query(ctx, listUnencryptedOpenRouterAPIKeys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OpenrouterApiKey
+	for rows.Next() {
+		var i OpenrouterApiKey
+		if err := rows.Scan(
+			&i.OrganizationID,
+			&i.KeyType,
+			&i.Key,
+			&i.KeyEncrypted,
+			&i.KeyHash,
+			&i.MonthlyCredits,
+			&i.Disabled,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const lockOpenRouterKeyProvisioning = `-- name: LockOpenRouterKeyProvisioning :exec
 SELECT pg_advisory_xact_lock(hashtext('openrouter_key:' || $1::text || ':' || $2::text))
 `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- inject the shared encryption client into the OpenRouter provisioner
- encrypt newly created platform keys while dual-writing plaintext for rollout compatibility
- backfill every legacy plaintext row on non-local process startup
- prefer encrypted values on reads and lazily repair any remaining plaintext row
- stop selecting plaintext credentials in the periodic credits-monitoring query
- preserve plaintext fallback until a later contract rollout can safely clear the legacy column

## Dependency
Stacked on the schema expansion in #5016. Merge and deploy that migration before this application change.

## Testing
- `go test` passed for OpenRouter, background activities, and model-key packages
- provisioning tests verify ciphertext differs from plaintext, decrypts correctly, and legacy rows are backfilled
- `mise lint:server` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-450](https://linear.app/speakeasy/issue/AIS-450/triage-platform-openrouter-api-keys-are-stored-unencrypted-in-postgres)

<div><a href="https://cursor.com/agents/bc-2f5820c5-aab8-4916-b0e3-bf0f0b12af2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f5820c5-aab8-4916-b0e3-bf0f0b12af2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypt platform OpenRouter API keys at rest and add a startup backfill to encrypt legacy rows, with encrypted reads preferred throughout. Addresses Linear AIS-450 by storing encrypted keys in Postgres and resolving keys at usage time to avoid plaintext exposure.

- **New Features**
  - Injected the shared encryption client into `openrouter` and gram commands; run `BackfillAPIKeyEncryption` at startup in `start`, `streams`, and `worker`.
  - Encrypt new keys on create (`key_encrypted`); prefer encrypted reads and lazily backfill legacy plaintext via `SetOpenRouterKeyEncryption`.
  - Credits monitoring resolves keys per org via `ProvisionAPIKey`; the metrics query no longer returns plaintext keys.
  - Removed plaintext key updates in limit refresh; added tests for concurrency and legacy backfill.

- **Migration**
  - Requires the schema expansion from #5016 to be deployed before this app change.

<sup>Written for commit d4324abf0985feb7106ffa16b25a9a87a3655785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

