### PR TITLE
feat: collapse project sidebar nav groups by default

### DIFF
--- a/.changeset/project-nav-collapsed-groups.md
+++ b/.changeset/project-nav-collapsed-groups.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The project sidebar now keeps nav groups collapsed by default: only the group containing the current page opens automatically, and a new chevron on each group header lets you pin other groups open without navigating. Vertical spacing between and within groups is tighter, so more of the nav fits on screen.

--- a/client/dashboard/src/components/app-sidebar.tsx
+++ b/client/dashboard/src/components/app-sidebar.tsx
@@ -171,16 +171,8 @@ export function AppSidebar({
     sidebarContent = <PluginDetailSidebarNav />;
   } else {
     sidebarContent = (
-      <NavGroupProvider
-        activeGroup={activeGroup}
-        defaultOpenGroups={
-          !activeGroup
-            ? ["Observe", "Secure", "Connect", "Distribute"]
-            : undefined
-        }
-        activeItem={activeItem}
-      >
-        <SidebarMenu className="gap-1 px-2 group-data-[collapsible=icon]:px-0">
+      <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
+        <SidebarMenu className="gap-0.5 px-2 group-data-[collapsible=icon]:px-0">
           {/* Home — top-level, no group */}
           <ScopeGatedTopLevelItem
             item={routes.home}
@@ -195,7 +187,7 @@ export function AppSidebar({
           />
 
           {/* Divider: sets Home + Chat apart from the grouped nav below */}
-          <li aria-hidden="true" className="my-3 px-1">
+          <li aria-hidden="true" className="my-2 px-1">
             <div className="border-border border-t" />
           </li>
 

--- a/client/dashboard/src/components/nav-menu.test.tsx
+++ b/client/dashboard/src/components/nav-menu.test.tsx
@@ -6,7 +6,14 @@ import {
   screen,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NAV_LOADING_DURATION_MS, NavButton } from "./nav-menu";
+import type { AppRoute } from "@/routes";
+import {
+  CollapsibleNavGroup,
+  CollapsibleNavItem,
+  NAV_LOADING_DURATION_MS,
+  NavButton,
+  NavGroupProvider,
+} from "./nav-menu";
 
 // Stub sidebar primitives to prevent real Radix/Tailwind sidebar from
 // loading. NavButton doesn't render these but nav-menu.tsx imports them.
@@ -130,5 +137,117 @@ describe("NavButton click loading state", () => {
 
     unmount();
     expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group expansion state
+// ---------------------------------------------------------------------------
+
+function makeRoute(title: string): AppRoute {
+  return {
+    title,
+    url: title.toLowerCase(),
+    href: () => `/${title.toLowerCase()}`,
+    active: false,
+  } as unknown as AppRoute;
+}
+
+function Groups({
+  activeGroup,
+  defaultOpenGroups,
+}: {
+  activeGroup?: string;
+  defaultOpenGroups?: string[];
+}) {
+  return (
+    <NavGroupProvider
+      activeGroup={activeGroup}
+      defaultOpenGroups={defaultOpenGroups}
+    >
+      <CollapsibleNavGroup label="Observe" Icon={TestIcon}>
+        <CollapsibleNavItem item={makeRoute("Costs")} />
+      </CollapsibleNavGroup>
+      <CollapsibleNavGroup label="Connect" Icon={TestIcon}>
+        <CollapsibleNavItem item={makeRoute("Sources")} />
+      </CollapsibleNavGroup>
+    </NavGroupProvider>
+  );
+}
+
+describe("NavGroupProvider group expansion", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders all groups collapsed when nothing is active and no defaults", () => {
+    render(<Groups />);
+
+    expect(screen.queryByText("Costs")).toBeNull();
+    expect(screen.queryByText("Sources")).toBeNull();
+    screen.getByRole("button", { name: "Expand Observe" });
+    screen.getByRole("button", { name: "Expand Connect" });
+  });
+
+  it("expands only the active group", () => {
+    render(<Groups activeGroup="Observe" />);
+
+    screen.getByText("Costs");
+    expect(screen.queryByText("Sources")).toBeNull();
+  });
+
+  it("collapses the previously active group when navigating to another group", () => {
+    const { rerender } = render(<Groups activeGroup="Observe" />);
+    screen.getByText("Costs");
+
+    rerender(<Groups activeGroup="Connect" />);
+
+    expect(screen.queryByText("Costs")).toBeNull();
+    screen.getByText("Sources");
+  });
+
+  it("keeps explicitly expanded groups open across navigation", () => {
+    const { rerender } = render(<Groups activeGroup="Observe" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Connect" }));
+    screen.getByText("Sources");
+
+    // Navigate to a top-level page: the active-only group collapses, the
+    // explicitly expanded one stays open.
+    rerender(<Groups />);
+
+    expect(screen.queryByText("Costs")).toBeNull();
+    screen.getByText("Sources");
+  });
+
+  it("collapses an open group via its chevron without navigating", () => {
+    render(<Groups activeGroup="Observe" />);
+    screen.getByText("Costs");
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse Observe" }));
+
+    expect(screen.queryByText("Costs")).toBeNull();
+  });
+
+  it("collapses a chevron-expanded group again on second chevron click", () => {
+    render(<Groups />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Connect" }));
+    screen.getByText("Sources");
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse Connect" }));
+    expect(screen.queryByText("Sources")).toBeNull();
+
+    // A group collapsed by hand is no longer "explicit": navigating into a
+    // different group must not resurrect it.
+    render(<Groups activeGroup="Observe" />);
+    expect(screen.queryByText("Sources")).toBeNull();
+  });
+
+  it("opens defaultOpenGroups initially (org sidebar behavior)", () => {
+    render(<Groups defaultOpenGroups={["Observe", "Connect"]} />);
+
+    screen.getByText("Costs");
+    screen.getByText("Sources");
   });
 });

--- a/client/dashboard/src/components/nav-menu.tsx
+++ b/client/dashboard/src/components/nav-menu.tsx
@@ -1,7 +1,12 @@
 import { SidebarMenuItem } from "@/components/ui/Sidebar";
-import { Collapsible, CollapsibleContent } from "@/components/ui/Collapsible";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/Collapsible";
 import { cn } from "@/lib/utils";
 import { AppRoute } from "@/routes";
+import { ChevronRightIcon } from "lucide-react";
 import { motion } from "motion/react";
 import React from "react";
 import { Link } from "react-router";
@@ -64,6 +69,10 @@ export function NavGroupProvider({
     if (activeGroup) initial.add(activeGroup);
     return initial;
   });
+  // Groups the user expanded via the chevron toggle. These survive navigation;
+  // a group that is open only because it holds the active route collapses as
+  // soon as the user navigates to a different group.
+  const explicitRef = React.useRef(new Set<string>());
   const [hoveredItem, setHoveredItem] = React.useState<string | null>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
   const itemRefs = React.useRef<Map<string, HTMLElement>>(new Map());
@@ -77,29 +86,36 @@ export function NavGroupProvider({
       const next = new Set(prev);
       if (next.has(group)) {
         next.delete(group);
+        explicitRef.current.delete(group);
       } else {
         // Opening a non-default group collapses defaults
         if (!defaultsRef.current.has(group)) {
-          for (const d of defaultsRef.current) next.delete(d);
+          for (const d of defaultsRef.current) {
+            if (!explicitRef.current.has(d)) next.delete(d);
+          }
         }
         next.add(group);
+        explicitRef.current.add(group);
       }
       return next;
     });
   }, []);
 
+  // Opens a group without marking it explicit — used when a closed group's
+  // header link is clicked, where the navigation is about to make the group
+  // active anyway.
   const openGroupFn = React.useCallback((group: string) => {
     suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
     _setOpenGroups((prev) => {
       if (prev.has(group)) return prev;
-      const next = new Set<string>();
+      const next = new Set(prev);
       // Opening a non-default group collapses defaults
       if (!defaultsRef.current.has(group)) {
-        next.add(group);
-      } else {
-        for (const g of prev) next.add(g);
-        next.add(group);
+        for (const d of defaultsRef.current) {
+          if (!explicitRef.current.has(d)) next.delete(d);
+        }
       }
+      next.add(group);
       return next;
     });
   }, []);
@@ -110,16 +126,21 @@ export function NavGroupProvider({
 
   React.useEffect(() => {
     suppressUntilRef.current = Date.now() + ACCORDION_DURATION;
-    if (activeGroup) {
-      _setOpenGroups((prev) => {
-        if (prev.has(activeGroup)) return prev;
-        const next = new Set(prev);
-        next.add(activeGroup);
-        return next;
-      });
-    } else if (defaultsRef.current.size > 0) {
-      _setOpenGroups(new Set(defaultsRef.current));
-    }
+    _setOpenGroups((prev) => {
+      if (!activeGroup && defaultsRef.current.size > 0) {
+        // Sidebars with a default-open set reset to it on top-level pages.
+        return new Set([...defaultsRef.current, ...explicitRef.current]);
+      }
+      // Only defaults and explicitly expanded groups stay open across
+      // navigation; the previously active group collapses.
+      const next = new Set(
+        [...prev].filter(
+          (g) => defaultsRef.current.has(g) || explicitRef.current.has(g),
+        ),
+      );
+      if (activeGroup) next.add(activeGroup);
+      return next;
+    });
   }, [activeGroup]);
 
   const resolvedActive = activeItem ?? activeGroup ?? null;
@@ -386,7 +407,7 @@ export function NavButton({
       target={target}
       onClick={handleClick}
       className={cn(
-        "relative z-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-sm transition-colors hover:no-underline",
+        "relative z-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors hover:no-underline",
         "group-data-[collapsible=icon]:min-w-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!",
         active
           ? "text-foreground font-semibold"
@@ -480,13 +501,13 @@ export function CollapsibleNavGroup({
           onMouseEnter={navItem.onMouseEnter}
           onMouseLeave={navItem.onMouseLeave}
           onMouseMove={navItem.onMouseMove}
-          className="group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:w-fit"
+          className="relative group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:w-fit"
         >
           <Link
             to={defaultHref ?? "#"}
             onClick={handleClick}
             className={cn(
-              "relative z-1 flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-sm transition-colors hover:no-underline",
+              "relative z-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 pr-7 text-left text-sm transition-colors hover:no-underline",
               "group-data-[collapsible=icon]:min-w-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2!",
               "cursor-pointer outline-hidden",
               isOpen
@@ -503,7 +524,7 @@ export function CollapsibleNavGroup({
             <span className="flex-1 truncate transition-[opacity,transform] duration-150 ease-out group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:-translate-x-2 group-data-[collapsible=icon]:opacity-0">
               {label}
             </span>
-            {stage && isOpen && (
+            {stage && (
               <ReleaseStageBadge
                 stage={stage}
                 noTooltip
@@ -511,12 +532,26 @@ export function CollapsibleNavGroup({
               />
             )}
           </Link>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              aria-label={isOpen ? `Collapse ${label}` : `Expand ${label}`}
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-1 z-1 flex size-5 -translate-y-1/2 cursor-pointer items-center justify-center rounded-sm transition-colors group-data-[collapsible=icon]:hidden"
+            >
+              <ChevronRightIcon
+                className={cn(
+                  "size-3.5 transition-transform duration-200",
+                  isOpen && "rotate-90",
+                )}
+              />
+            </button>
+          </CollapsibleTrigger>
         </div>
 
         <CollapsibleContent className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden">
-          <div className="border-border mt-1 ml-4 border-l pl-2 group-data-[collapsible=icon]:hidden">
+          <div className="border-border mt-0.5 ml-4 border-l pl-2 group-data-[collapsible=icon]:hidden">
             <motion.ul
-              className="flex flex-col gap-0.5 py-0.5"
+              className="flex flex-col py-0.5"
               initial={isOpen ? "open" : "closed"}
               animate={isOpen ? "open" : "closed"}
               variants={{
@@ -599,7 +634,7 @@ export function CollapsibleNavItem({
           to={item.href()}
           onClick={handleClick}
           className={cn(
-            "relative z-1 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:no-underline",
+            "relative z-1 flex items-center gap-2 rounded-md px-2 py-1 text-sm transition-colors hover:no-underline",
             item.active
               ? "text-foreground font-semibold"
               : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## What

Reworks how nav groups behave in the project sidebar:

- **Collapsed by default.** Groups (Observe, Secure, Connect, Distribute) no longer all open on top-level pages like Home. A group is expanded only when the current page belongs to it, or when the user has explicitly pinned it open.
- **Only the active group auto-expands.** Navigating from one group's page to another's collapses the previous group; explicitly expanded groups survive navigation.
- **Chevron toggle.** Each group header gains a chevron button so a group can be expanded or collapsed without navigating (clicking the header label still navigates to the group's first page). Explicit expansion is what pins a group open across navigation.
- **Tighter vertical rhythm.** Sub-item padding `py-1.5` → `py-1` with no inter-item gap, group header / top-level rows `py-2` → `py-1.5`, menu gap `gap-1` → `gap-0.5`.

The Secure group's `Beta` badge now shows while the group is collapsed too — previously it rendered only when open, which would have hidden it almost entirely under collapsed-by-default.

## How

`NavGroupProvider` now tracks chevron-expanded groups in an `explicitRef` set alongside the `openGroups` state. On `activeGroup` change, only defaults (org sidebar) and explicitly expanded groups persist; the newly active group is added. The org sidebar keeps its existing behavior via `defaultOpenGroups`, which still resets on top-level pages.

## Testing

- 7 new unit tests in `nav-menu.test.tsx` pin the expansion contract (collapsed default, active-only expansion, explicit pin surviving navigation, chevron collapse, org `defaultOpenGroups` behavior). Full dashboard suite passes (178 files / 1478 tests).
- `oxfmt` and `oxlint` clean on changed files.
- Local `tsc` baseline on main is broken (TS 7.0.2 preview, ~3.9k pre-existing errors); a differential check shows this PR introduces no new real errors.
- No demo GIF: the local dev stack wasn't available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7JpCTeN3U9fFccd7YD5XA


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed project sidebar nav groups by default to cut noise and make the nav easier to scan. Only the active group opens; others can be pinned open with a chevron.

- **New Features**
  - Active group opens; previous group closes when navigating.
  - Chevron on group headers to expand/collapse without navigating; pinned groups stay open across navigation.
  - Tighter vertical spacing so more items fit on screen.

- **Bug Fixes**
  - Secure group’s Beta badge now shows even when the group is collapsed.

<sup>Written for commit ae8bba53e5ba3afce95bb83abecdaf6348bbf8f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

