### PR TITLE
feat: serve public skill share pages on custom domains

### DIFF
--- a/.changeset/skill-share-custom-domain.md
+++ b/.changeset/skill-share-custom-domain.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Public skill share links now use your custom domain when one is verified and activated. The share page (and a raw SKILL.md download) is served at `https://<your-domain>/shared/skills/<token>`, scoped so a domain can only ever serve skills belonging to its own organization, and the dashboard copies links with the custom domain automatically.

--- a/client/dashboard/src/pages/skills/SkillSharingControl.tsx
+++ b/client/dashboard/src/pages/skills/SkillSharingControl.tsx
@@ -20,8 +20,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Check, ChevronDown, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { useCustomDomain } from "@/hooks/useToolsetUrl";
 import { invalidateSkillQueries } from "./invalidate-skill-queries";
-import { skillShareUrl } from "./share-link";
+import { skillShareDomain, skillShareUrl } from "./share-link";
 
 type SharingStatus = "private" | "public";
 
@@ -99,7 +100,12 @@ export function SkillSharingCardBlocks({
   );
 
   const pending = share.isPending || unshare.isPending;
-  const shareUrl = skill.shareToken ? skillShareUrl(skill.shareToken) : null;
+  // Public pages are served on the org's custom domain when one is live, so
+  // the copied link carries the customer's own branding.
+  const { domain: customDomain } = useCustomDomain(!!skill.shareToken);
+  const shareUrl = skill.shareToken
+    ? skillShareUrl(skill.shareToken, skillShareDomain(customDomain))
+    : null;
   const currentStatus: SharingStatus = shareUrl ? "public" : "private";
   const currentOption = STATUS_OPTIONS.find(
     (option) => option.value === currentStatus,

--- a/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.page.test.tsx
@@ -201,6 +201,13 @@ vi.mock("@gram/client/react-query/skillTags.js", () => ({
   }),
   invalidateAllSkillTags: vi.fn(),
 }));
+vi.mock("@/hooks/useToolsetUrl", () => ({
+  useCustomDomain: () => ({
+    domain: undefined,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+}));
 vi.mock("@gram/client/react-query/unknownSkillActivations.js", () => ({
   useUnknownSkillActivationsInfinite: () => ({
     data: {

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -8,6 +8,7 @@ import { CopyButton } from "@/components/ui/CopyButton";
 import { SkeletonTable } from "@/components/ui/Skeleton";
 import { Text } from "@/components/ui/Text";
 import { useProject } from "@/contexts/Auth";
+import { useCustomDomain } from "@/hooks/useToolsetUrl";
 import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
 import type { Skill } from "@gram/client/models/components/skill.js";
 import type {
@@ -30,7 +31,7 @@ import { useQueryState } from "nuqs";
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useNavigate } from "react-router";
 import { toast } from "sonner";
-import { skillShareUrl } from "./share-link";
+import { skillShareDomain, skillShareUrl } from "./share-link";
 import { SkillManifestDialog } from "./SkillManifestDialog";
 import {
   SKILL_CLASSIFICATION_OPTIONS,
@@ -208,6 +209,10 @@ export default function SkillsList(): JSX.Element {
     ? metricSkills
     : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
 
+  // Copied share links point at the org's custom domain when one is live.
+  const { domain: customDomain } = useCustomDomain();
+  const shareDomain = skillShareDomain(customDomain);
+
   const columns: Column<Skill>[] = [
     {
       key: "name",
@@ -351,7 +356,7 @@ export default function SkillsList(): JSX.Element {
         skill.shareToken ? (
           <CopyButton
             size="sm"
-            text={skillShareUrl(skill.shareToken)}
+            text={skillShareUrl(skill.shareToken, shareDomain)}
             tooltip="Copy public link"
             onCopy={() => {
               toast.success("Public link copied");

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -210,7 +210,10 @@ export default function SkillsList(): JSX.Element {
     : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
 
   // Copied share links point at the org's custom domain when one is live.
-  const { domain: customDomain } = useCustomDomain();
+  // Only pay for the domains request when a listed skill is actually shared.
+  const { domain: customDomain } = useCustomDomain(
+    skills.some((skill) => !!skill.shareToken),
+  );
   const shareDomain = skillShareDomain(customDomain);
 
   const columns: Column<Skill>[] = [

--- a/client/dashboard/src/pages/skills/share-link.ts
+++ b/client/dashboard/src/pages/skills/share-link.ts
@@ -1,10 +1,26 @@
+import type { CustomDomain } from "@gram/client/models/components/customdomain.js";
+
 /**
  * Base path of the public skill share page. Shared with the route
  * registration in App.tsx so the URL builder and router cannot drift.
  */
 export const SHARED_SKILL_BASE_PATH = "/shared/skills";
 
+/**
+ * Picks the host share links should use: the org's custom domain when it is
+ * verified and activated (the server renders /shared/skills/* on custom
+ * domains), otherwise undefined to fall back to the dashboard origin.
+ */
+export function skillShareDomain(
+  domain: CustomDomain | undefined,
+): string | undefined {
+  return domain?.verified && domain.activated ? domain.domain : undefined;
+}
+
 /** Builds the public URL for a skill share token. */
-export function skillShareUrl(token: string): string {
-  return `${window.location.origin}${SHARED_SKILL_BASE_PATH}/${token}`;
+export function skillShareUrl(token: string, customDomain?: string): string {
+  const origin = customDomain
+    ? `https://${customDomain}`
+    : window.location.origin;
+  return `${origin}${SHARED_SKILL_BASE_PATH}/${token}`;
 }

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1246,7 +1246,7 @@ func newStartCommand() *cli.Command {
 			chatanalysis.Attach(mux, chatanalysis.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger,
 				&background.TemporalChatAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger}))
 			skillsService := skills.NewService(logger, tracerProvider, db, sessionManager, authzEngine, productFeatures, auditLogger,
-				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0})
+				&background.TemporalSkillSuggestionSignaler{TemporalEnv: temporalEnv, Logger: logger, StartDelay: 0}, siteURL)
 			skills.Attach(mux, skillsService)
 			toolsetsSvc := toolsets.NewService(logger, tracerProvider, db, sessionManager, cache.NewRedisCacheAdapter(redisClient), authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil)
 			toolsets.Attach(mux, toolsetsSvc)

--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -60,6 +61,7 @@ type Service struct {
 	features *productfeatures.Client
 	audit    *audit.Logger
 	signaler ManualSuggestionSignaler
+	siteURL  *url.URL
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -74,6 +76,7 @@ func NewService(
 	features *productfeatures.Client,
 	auditLogger *audit.Logger,
 	signaler ManualSuggestionSignaler,
+	siteURL *url.URL,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("skills"))
 
@@ -86,6 +89,7 @@ func NewService(
 		features: features,
 		audit:    auditLogger,
 		signaler: signaler,
+		siteURL:  siteURL,
 	}
 }
 
@@ -97,6 +101,11 @@ func Attach(mux goahttp.Muxer, service *Service) {
 		mux,
 		srv.New(endpoints, mux, skillsRequestDecoder, goahttp.ResponseEncoder, nil, nil),
 	)
+	// Public share pages, served outside Goa like the MCP install pages so
+	// they resolve on custom domains (which point at this server, not at the
+	// dashboard host).
+	o11y.AttachHandler(mux, http.MethodGet, "/shared/skills/{token}", oops.ErrHandle(service.logger, service.ServeSharedSkillPage).ServeHTTP)
+	o11y.AttachHandler(mux, http.MethodGet, "/shared/skills/{token}/SKILL.md", oops.ErrHandle(service.logger, service.ServeSharedSkillMarkdown).ServeHTTP)
 }
 
 func skillsRequestDecoder(r *http.Request) goahttp.Decoder {

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -2674,6 +2674,35 @@ JOIN LATERAL (
 WHERE l.token = @token
   AND l.revoked_at IS NULL;
 
+-- name: GetSharedSkillByTokenForOrganization :one
+-- Custom-domain variant of GetSharedSkillByToken: the extra projects join pins
+-- the share link to the organization that owns the serving domain, so one
+-- tenant's skill can never be rendered under another tenant's custom domain.
+SELECT
+  s.name,
+  s.display_name,
+  s.summary,
+  latest.content,
+  latest.created_at AS version_created_at
+FROM skill_share_links l
+JOIN projects p
+  ON p.id = l.project_id
+  AND p.organization_id = @organization_id
+  AND NOT p.deleted
+JOIN skills s
+  ON s.project_id = l.project_id
+  AND s.id = l.skill_id
+  AND s.archived_at IS NULL
+JOIN LATERAL (
+  SELECT sv.content, COALESCE(sv.promoted_at, sv.created_at) AS created_at
+  FROM skill_versions sv
+  WHERE sv.skill_id = l.skill_id
+  ORDER BY COALESCE(sv.promoted_at, sv.created_at) DESC, sv.id DESC
+  LIMIT 1
+) latest ON TRUE
+WHERE l.token = @token
+  AND l.revoked_at IS NULL;
+
 -- name: ListSkillEditSuggestionFeedback :many
 SELECT feedback.*
 FROM skill_edit_suggestion_feedback link

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -1970,6 +1970,62 @@ func (q *Queries) GetSharedSkillByToken(ctx context.Context, token string) (GetS
 	return i, err
 }
 
+const getSharedSkillByTokenForOrganization = `-- name: GetSharedSkillByTokenForOrganization :one
+SELECT
+  s.name,
+  s.display_name,
+  s.summary,
+  latest.content,
+  latest.created_at AS version_created_at
+FROM skill_share_links l
+JOIN projects p
+  ON p.id = l.project_id
+  AND p.organization_id = $1
+  AND NOT p.deleted
+JOIN skills s
+  ON s.project_id = l.project_id
+  AND s.id = l.skill_id
+  AND s.archived_at IS NULL
+JOIN LATERAL (
+  SELECT sv.content, COALESCE(sv.promoted_at, sv.created_at) AS created_at
+  FROM skill_versions sv
+  WHERE sv.skill_id = l.skill_id
+  ORDER BY COALESCE(sv.promoted_at, sv.created_at) DESC, sv.id DESC
+  LIMIT 1
+) latest ON TRUE
+WHERE l.token = $2
+  AND l.revoked_at IS NULL
+`
+
+type GetSharedSkillByTokenForOrganizationParams struct {
+	OrganizationID string
+	Token          string
+}
+
+type GetSharedSkillByTokenForOrganizationRow struct {
+	Name             string
+	DisplayName      string
+	Summary          pgtype.Text
+	Content          string
+	VersionCreatedAt pgtype.Timestamptz
+}
+
+// Custom-domain variant of GetSharedSkillByToken: the extra projects join pins
+// the share link to the organization that owns the serving domain, so one
+// tenant's skill can never be rendered under another tenant's custom domain.
+func (q *Queries) GetSharedSkillByTokenForOrganization(ctx context.Context, arg GetSharedSkillByTokenForOrganizationParams) (GetSharedSkillByTokenForOrganizationRow, error) {
+	row := q.db.QueryRow(ctx, getSharedSkillByTokenForOrganization, arg.OrganizationID, arg.Token)
+	var i GetSharedSkillByTokenForOrganizationRow
+	err := row.Scan(
+		&i.Name,
+		&i.DisplayName,
+		&i.Summary,
+		&i.Content,
+		&i.VersionCreatedAt,
+	)
+	return i, err
+}
+
 const getSkill = `-- name: GetSkill :one
 SELECT id, project_id, name, display_name, summary, source_kind, classification, tags, first_seen_at, last_seen_at, seen_count, archived_at, created_at, updated_at
 FROM skills

--- a/server/internal/skills/setup_test.go
+++ b/server/internal/skills/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"sync"
 	"testing"
@@ -133,7 +134,9 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
 	features := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)
 	signaler := &captureSuggestionSignaler{signals: nil, err: nil}
-	service := skills.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), signaler)
+	siteURL, err := url.Parse("https://app.getgram.test")
+	require.NoError(t, err)
+	service := skills.NewService(logger, tracerProvider, conn, sessionManager, authzEngine, features, audit.NewLogger(), signaler, siteURL)
 
 	ti := &testInstance{
 		service:        service,

--- a/server/internal/skills/shared_skill_page.html.tmpl
+++ b/server/internal/skills/shared_skill_page.html.tmpl
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="referrer" content="no-referrer" />
+    <title>{{ if .Unavailable }}Skill unavailable{{ else }}{{ .DisplayName }}{{ end }}</title>
+    <style>
+      :root {
+        --bg: hsl(0, 0%, 99%);
+        --fg: hsl(0, 0%, 12%);
+        --muted: hsl(0, 0%, 45%);
+        --border: hsl(0, 0%, 90%);
+        --code-bg: hsl(0, 0%, 95%);
+        --link: hsl(215, 71%, 40%);
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: hsl(0, 0%, 9%);
+          --fg: hsl(0, 0%, 93%);
+          --muted: hsl(0, 0%, 60%);
+          --border: hsl(0, 0%, 22%);
+          --code-bg: hsl(0, 0%, 15%);
+          --link: hsl(215, 80%, 65%);
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+          Arial, sans-serif;
+        line-height: 1.6;
+      }
+      main {
+        max-width: 48rem;
+        margin: 0 auto;
+        padding: 3rem 1.5rem;
+      }
+      header h1 {
+        font-size: 1.875rem;
+        font-weight: 600;
+        margin: 0 0 0.5rem;
+        line-height: 1.25;
+      }
+      .summary {
+        color: var(--muted);
+        margin: 0 0 0.5rem;
+      }
+      .updated {
+        color: var(--muted);
+        font-size: 0.8125rem;
+        margin: 0 0 1rem;
+      }
+      .actions {
+        margin: 0 0 2rem;
+      }
+      .actions a {
+        display: inline-block;
+        border: 1px solid var(--border);
+        border-radius: 0.375rem;
+        padding: 0.375rem 0.75rem;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--fg);
+        text-decoration: none;
+      }
+      .actions a:hover {
+        background: var(--code-bg);
+      }
+      article {
+        border-top: 1px solid var(--border);
+        padding-top: 2rem;
+        overflow-wrap: break-word;
+      }
+      article h1,
+      article h2,
+      article h3,
+      article h4 {
+        line-height: 1.3;
+        margin: 1.75em 0 0.5em;
+      }
+      article h1:first-child,
+      article h2:first-child,
+      article h3:first-child {
+        margin-top: 0;
+      }
+      article a {
+        color: var(--link);
+      }
+      article pre {
+        background: var(--code-bg);
+        border-radius: 0.375rem;
+        padding: 0.875rem 1rem;
+        overflow-x: auto;
+        font-size: 0.8125rem;
+      }
+      article code {
+        background: var(--code-bg);
+        border-radius: 0.25rem;
+        padding: 0.125rem 0.25rem;
+        font-family:
+          SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+          "Courier New", monospace;
+        font-size: 0.875em;
+      }
+      article pre code {
+        background: none;
+        padding: 0;
+      }
+      article img {
+        max-width: 100%;
+      }
+      article table {
+        border-collapse: collapse;
+        display: block;
+        overflow-x: auto;
+      }
+      article th,
+      article td {
+        border: 1px solid var(--border);
+        padding: 0.375rem 0.75rem;
+        text-align: left;
+      }
+      article blockquote {
+        border-left: 3px solid var(--border);
+        margin: 1em 0;
+        padding: 0 0 0 1rem;
+        color: var(--muted);
+      }
+      .empty,
+      .unavailable {
+        color: var(--muted);
+        font-size: 0.875rem;
+      }
+      .unavailable {
+        text-align: center;
+        padding: 4rem 0;
+      }
+      .unavailable h1 {
+        color: var(--fg);
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 0 0 0.75rem;
+      }
+      footer {
+        text-align: center;
+        color: var(--muted);
+        font-size: 0.8125rem;
+        padding: 2rem 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      {{ if .Unavailable }}
+      <div class="unavailable">
+        <h1>This skill isn't available</h1>
+        <p>
+          The link may have been turned off by its owner, or the address might
+          not be quite right. Ask whoever shared it with you for a fresh link.
+        </p>
+      </div>
+      {{ else }}
+      <header>
+        <h1>{{ .DisplayName }}</h1>
+        {{ if .Summary }}
+        <p class="summary">{{ .Summary }}</p>
+        {{ end }}
+        {{ if .UpdatedAt }}
+        <p class="updated">Updated {{ .UpdatedAt }}</p>
+        {{ end }}
+        <p class="actions">
+          <a href="{{ .DownloadPath }}" download="SKILL.md">Download SKILL.md</a>
+        </p>
+      </header>
+      <article>
+        {{ if .ContentHTML }}{{ .ContentHTML }}{{ else }}
+        <p class="empty">This manifest has no Markdown body.</p>
+        {{ end }}
+      </article>
+      {{ end }}
+    </main>
+    <footer>Powered by Gram</footer>
+  </body>
+</html>

--- a/server/internal/skills/sharepage.go
+++ b/server/internal/skills/sharepage.go
@@ -1,0 +1,201 @@
+package skills
+
+import (
+	"bytes"
+	_ "embed"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/skills/repo"
+)
+
+//go:embed shared_skill_page.html.tmpl
+var sharedSkillPageTmplData string
+
+var sharedSkillPageTmpl = template.Must(template.New("shared_skill_page").Parse(sharedSkillPageTmplData))
+
+// Token bounds mirror the getShared design payload validation.
+const (
+	minShareTokenLength = 32
+	maxShareTokenLength = 128
+)
+
+type sharedSkillPageData struct {
+	Unavailable  bool
+	DisplayName  string
+	Summary      string
+	UpdatedAt    string
+	ContentHTML  template.HTML
+	DownloadPath string
+}
+
+// ServeSharedSkillPage renders the public share page for a skill at
+// GET /shared/skills/{token}. On a custom domain the lookup is pinned to the
+// domain's organization so one tenant's skill can never be served under
+// another tenant's domain. On the platform host the canonical page is the
+// dashboard SPA route, so the request is redirected there instead.
+func (s *Service) ServeSharedSkillPage(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	token := chi.URLParam(r, "token")
+
+	domainCtx := customdomains.FromContext(ctx)
+	if domainCtx == nil {
+		http.Redirect(w, r, s.siteURL.JoinPath("shared", "skills", token).String(), http.StatusFound)
+		return nil
+	}
+
+	if len(token) < minShareTokenLength || len(token) > maxShareTokenLength {
+		return renderSharedSkillPage(w, http.StatusNotFound, sharedSkillPageData{
+			Unavailable:  true,
+			DisplayName:  "",
+			Summary:      "",
+			UpdatedAt:    "",
+			ContentHTML:  "",
+			DownloadPath: "",
+		})
+	}
+
+	row, err := repo.New(s.db).GetSharedSkillByTokenForOrganization(ctx, repo.GetSharedSkillByTokenForOrganizationParams{
+		Token:          token,
+		OrganizationID: domainCtx.OrganizationID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return renderSharedSkillPage(w, http.StatusNotFound, sharedSkillPageData{
+			Unavailable:  true,
+			DisplayName:  "",
+			Summary:      "",
+			UpdatedAt:    "",
+			ContentHTML:  "",
+			DownloadPath: "",
+		})
+	}
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "get shared skill for domain").LogError(ctx, s.logger)
+	}
+
+	body := stripSkillFrontmatter(row.Content)
+	var contentHTML template.HTML
+	if strings.TrimSpace(body) != "" {
+		rendered, err := conv.MarkdownToHTML([]byte(body))
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "render shared skill markdown").LogError(ctx, s.logger)
+		}
+		contentHTML = template.HTML(rendered) // #nosec G203 // sanitized by bluemonday in conv.MarkdownToHTML
+	}
+
+	var updatedAt string
+	if row.VersionCreatedAt.Valid {
+		updatedAt = row.VersionCreatedAt.Time.UTC().Format("January 2, 2006")
+	}
+
+	return renderSharedSkillPage(w, http.StatusOK, sharedSkillPageData{
+		Unavailable:  false,
+		DisplayName:  row.DisplayName,
+		Summary:      conv.PtrValOr(conv.FromPGText[string](row.Summary), ""),
+		UpdatedAt:    updatedAt,
+		ContentHTML:  contentHTML,
+		DownloadPath: "/shared/skills/" + token + "/SKILL.md",
+	})
+}
+
+// ServeSharedSkillMarkdown serves the raw SKILL.md of a shared skill at
+// GET /shared/skills/{token}/SKILL.md with the same tenancy rules as
+// ServeSharedSkillPage.
+func (s *Service) ServeSharedSkillMarkdown(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	token := chi.URLParam(r, "token")
+
+	domainCtx := customdomains.FromContext(ctx)
+	if domainCtx == nil {
+		http.Redirect(w, r, s.siteURL.JoinPath("shared", "skills", token).String(), http.StatusFound)
+		return nil
+	}
+
+	if len(token) < minShareTokenLength || len(token) > maxShareTokenLength {
+		return oops.E(oops.CodeNotFound, nil, "link not found or no longer available")
+	}
+
+	row, err := repo.New(s.db).GetSharedSkillByTokenForOrganization(ctx, repo.GetSharedSkillByTokenForOrganizationParams{
+		Token:          token,
+		OrganizationID: domainCtx.OrganizationID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return oops.E(oops.CodeNotFound, nil, "link not found or no longer available")
+	}
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "get shared skill for domain").LogError(ctx, s.logger)
+	}
+
+	setSharedSkillResponseHeaders(w)
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="SKILL.md"`)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(row.Content)); err != nil {
+		return fmt.Errorf("write shared skill markdown: %w", err)
+	}
+
+	return nil
+}
+
+func renderSharedSkillPage(w http.ResponseWriter, status int, data sharedSkillPageData) error {
+	var buf bytes.Buffer
+	if err := sharedSkillPageTmpl.Execute(&buf, data); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "render shared skill page")
+	}
+
+	setSharedSkillResponseHeaders(w)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; img-src https: data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'")
+	w.WriteHeader(status)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("write shared skill page: %w", err)
+	}
+
+	return nil
+}
+
+// setSharedSkillResponseHeaders mirrors the header policy of the
+// /rpc/skills.getShared JSON endpoint: short-lived private caching, no search
+// indexing, and no referrer leakage of the capability URL.
+func setSharedSkillResponseHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "private, max-age=300")
+	w.Header().Set("X-Robots-Tag", "noindex, nofollow")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+}
+
+// stripSkillFrontmatter removes the leading YAML frontmatter block from a
+// SKILL.md manifest, mirroring the dashboard's stripSkillFrontmatter helper so
+// the public page shows only the Markdown body.
+func stripSkillFrontmatter(content string) string {
+	const utf8BOM = "\ufeff"
+	normalized := strings.TrimPrefix(content, utf8BOM)
+	normalized = strings.ReplaceAll(normalized, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	lines := strings.Split(normalized, "\n")
+
+	if strings.TrimRight(lines[0], " \t") != "---" {
+		return content
+	}
+
+	closing := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], " \t") == "---" {
+			closing = i
+			break
+		}
+	}
+	if closing < 0 {
+		return content
+	}
+
+	return strings.TrimPrefix(strings.Join(lines[closing+1:], "\n"), "\n")
+}

--- a/server/internal/skills/sharepage_test.go
+++ b/server/internal/skills/sharepage_test.go
@@ -1,0 +1,202 @@
+package skills_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/skills"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// serveSharedSkillRequest invokes one of the raw share-page handlers with the
+// chi route parameter and optional custom-domain context the middleware would
+// normally provide.
+func serveSharedSkillRequest(
+	t *testing.T,
+	ctx context.Context,
+	handler func(w http.ResponseWriter, r *http.Request) error,
+	token string,
+	domainCtx *customdomains.Context,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("token", token)
+	reqCtx := context.WithValue(ctx, chi.RouteCtxKey, rctx)
+	if domainCtx != nil {
+		reqCtx = customdomains.WithContext(reqCtx, domainCtx)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/shared/skills/"+token, nil).WithContext(reqCtx)
+	rr := httptest.NewRecorder()
+	return rr, handler(rr, req)
+}
+
+func TestServeSharedSkillPageOnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created, err := ti.service.Create(ctx, &gen.CreatePayload{
+		Content:          skillManifest("domain-shared", "Served on a custom domain.", "# Getting started\n\nUse `gram` to *begin*."),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+
+	rr, err := serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillPage, link.Token, &customdomains.Context{
+		OrganizationID: ti.authContext.ActiveOrganizationID,
+		Domain:         "mcp.customer.example",
+		DomainID:       uuid.New(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Header().Get("Content-Type"), "text/html")
+	require.Equal(t, "noindex, nofollow", rr.Header().Get("X-Robots-Tag"))
+	require.Equal(t, "no-referrer", rr.Header().Get("Referrer-Policy"))
+	require.Equal(t, "private, max-age=300", rr.Header().Get("Cache-Control"))
+	require.NotEmpty(t, rr.Header().Get("Content-Security-Policy"))
+
+	body := rr.Body.String()
+	require.Contains(t, body, created.Skill.DisplayName)
+	require.Contains(t, body, "Served on a custom domain.")
+	// The Markdown body renders as HTML with the frontmatter stripped.
+	require.Contains(t, body, "Getting started")
+	require.Contains(t, body, "<code>gram</code>")
+	require.NotContains(t, body, "name: domain-shared")
+	require.Contains(t, body, "/shared/skills/"+link.Token+"/SKILL.md")
+	require.Contains(t, body, "Powered by Gram")
+}
+
+func TestServeSharedSkillPageWrongOrganizationDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "cross-tenant-skill", "Must not leak across domains.")
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+
+	rr, err := serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillPage, link.Token, &customdomains.Context{
+		OrganizationID: "other-org-" + uuid.NewString(),
+		Domain:         "mcp.other.example",
+		DomainID:       uuid.New(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "This skill isn't available")
+	require.NotContains(t, rr.Body.String(), created.Skill.DisplayName)
+}
+
+func TestServeSharedSkillPageRevokedToken(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "revoked-share", "Shared then revoked.")
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+	require.NoError(t, ti.service.Unshare(ctx, &gen.UnsharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil}))
+
+	rr, err := serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillPage, link.Token, &customdomains.Context{
+		OrganizationID: ti.authContext.ActiveOrganizationID,
+		Domain:         "mcp.customer.example",
+		DomainID:       uuid.New(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "This skill isn't available")
+}
+
+func TestServeSharedSkillPagePlatformHostRedirects(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "platform-share", "Redirects to the dashboard.")
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+
+	rr, err := serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillPage, link.Token, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, rr.Code)
+	require.Equal(t, "https://app.getgram.test/shared/skills/"+link.Token, rr.Header().Get("Location"))
+}
+
+func TestServeSharedSkillPageSanitizesMarkdown(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created, err := ti.service.Create(ctx, &gen.CreatePayload{
+		Content:          skillManifest("hostile-markdown", "Sanitized output.", "# Safe title\n\n<script>alert(1)</script>\n\n[link](javascript:alert(2))"),
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+
+	rr, err := serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillPage, link.Token, &customdomains.Context{
+		OrganizationID: ti.authContext.ActiveOrganizationID,
+		Domain:         "mcp.customer.example",
+		DomainID:       uuid.New(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	body := rr.Body.String()
+	require.Contains(t, body, "Safe title")
+	require.NotContains(t, body, "<script>")
+	require.NotContains(t, body, "javascript:alert")
+}
+
+func TestServeSharedSkillMarkdownOnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	manifest := skillManifest("raw-download", "Raw SKILL.md download.", "# Raw body")
+	created, err := ti.service.Create(ctx, &gen.CreatePayload{
+		Content:          manifest,
+		SessionToken:     nil,
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+
+	rr, err := serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillMarkdown, link.Token, &customdomains.Context{
+		OrganizationID: ti.authContext.ActiveOrganizationID,
+		Domain:         "mcp.customer.example",
+		DomainID:       uuid.New(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Header().Get("Content-Type"), "text/markdown")
+	require.Equal(t, `attachment; filename="SKILL.md"`, rr.Header().Get("Content-Disposition"))
+	// The download carries the full manifest, frontmatter included.
+	require.Equal(t, manifest, rr.Body.String())
+}
+
+func TestServeSharedSkillMarkdownWrongOrganizationDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "raw-cross-tenant", "Raw download must not leak.")
+	link, err := ti.service.Share(ctx, &gen.SharePayload{SkillID: created.Skill.ID, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+	require.NoError(t, err)
+
+	_, err = serveSharedSkillRequest(t, ctx, ti.service.ServeSharedSkillMarkdown, link.Token, &customdomains.Context{
+		OrganizationID: "other-org-" + uuid.NewString(),
+		Domain:         "mcp.other.example",
+		DomainID:       uuid.New(),
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}


### PR DESCRIPTION
## Summary

Public skill share links now surface under a customer's custom domain when one exists. Previously a shared skill was only viewable at the Gram dashboard host (`app.getgram.ai/shared/skills/<token>`), even for orgs with a live custom domain.

### Server

- New unauthenticated routes on the API mux (which is where custom domains point):
  - `GET /shared/skills/{token}` — server-rendered HTML share page (embedded template, same pattern as the MCP install pages). Markdown is rendered with the existing `conv.MarkdownToHTML` (bluemonday-sanitized), frontmatter stripped to mirror the dashboard page.
  - `GET /shared/skills/{token}/SKILL.md` — raw manifest download.
- On a custom domain, the lookup uses a new `GetSharedSkillByTokenForOrganization` query that pins the share link to the domain's organization — one tenant's skill can never be rendered under another tenant's domain.
- On the platform host, both routes 302 to the canonical dashboard page (`skills.NewService` now takes `siteURL`).
- Response headers mirror `/rpc/skills.getShared`: `Cache-Control: private, max-age=300`, `X-Robots-Tag: noindex, nofollow`, `Referrer-Policy: no-referrer`, plus a strict CSP on the HTML page.

### Dashboard

- `skillShareUrl` accepts an optional custom domain; `SkillSharingControl` and the skills list copy button prefer the org's custom domain when it is **verified and activated** (via the existing `useCustomDomain()` hook). Users without domain read access gracefully fall back to the dashboard-origin link.
- Existing dashboard-host links keep working — the SPA route is untouched.

## Testing

- New `sharepage_test.go`: custom-domain happy path (rendering, headers, frontmatter stripping), cross-org domain 404, revoked token 404, platform-host redirect, markdown sanitization (`<script>`/`javascript:` stripped), raw SKILL.md download + cross-org denial.
- Full `server/internal/skills` suite passes; `mise lint:server` clean; server builds.
- Dashboard: 86 skills page tests pass (SkillsList harness gained a `useCustomDomain` mock), oxlint/oxfmt clean, knip clean, no new type errors vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJMDX91x4yiwU5PWyv6m6p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Public skill share links now resolve on a customer’s verified, activated custom domain with a server-rendered HTML page and a raw `SKILL.md` download. Tokens are scoped to the domain’s organization, and platform-host requests redirect to the canonical dashboard route.

- New Features
  - Server: Added GET /shared/skills/{token} and GET /shared/skills/{token}/SKILL.md on the API mux; lookups are pinned to the serving domain’s organization; the HTML page renders sanitized Markdown with frontmatter stripped; responses include private caching, X-Robots-Tag, Referrer-Policy, and a strict CSP; platform host 302s to the dashboard page.
  - Dashboard: Share links prefer the org’s custom domain when it’s verified and activated (via useCustomDomain()); fallback to the dashboard origin if not available; existing dashboard-host links continue to work.

- Bug Fixes
  - Dashboard: Only request the org’s custom domain when a shared skill is present (skills list and share control), avoiding unnecessary network calls.

<sup>Written for commit a7fcd7f3e3d264885057e37af21173087863d625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

