### PR TITLE
mig: replace enterprise_trials with trials

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -75,12 +75,18 @@ CREATE TABLE IF NOT EXISTS organization_metadata (
 CREATE UNIQUE INDEX IF NOT EXISTS organization_metadata_workos_id_key
 ON organization_metadata (workos_id);
 
--- One row per organization provisioned by the enterprise trial signup flow.
--- Only that transaction inserts a row; a trial is never attached to an
--- organization that already exists, which is what lets expiry hardcode its
--- demotion. Unrelated to organization_metadata.free_trial_*, another concept.
-CREATE TABLE IF NOT EXISTS enterprise_trials (
+-- One row per organization provisioned by the trial signup flow. Only that
+-- transaction inserts a row; a trial is never attached to an organization that
+-- already exists, which is what lets expiry hardcode its demotion. Unrelated to
+-- organization_metadata.free_trial_*, another concept.
+CREATE TABLE IF NOT EXISTS trials (
   organization_id TEXT NOT NULL,
+
+  -- 'enterprise' is the only value the application writes today. Allowed values
+  -- live in application code rather than a CHECK, so a new tier needs no
+  -- migration.
+  tier TEXT NOT NULL,
+
   ends_at timestamptz NOT NULL,
 
   -- The sweeper acts on ends_at only while both are null: a conversion stamped
@@ -92,8 +98,8 @@ CREATE TABLE IF NOT EXISTS enterprise_trials (
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
 
-  CONSTRAINT enterprise_trials_pkey PRIMARY KEY (organization_id),
-  CONSTRAINT enterprise_trials_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+  CONSTRAINT trials_pkey PRIMARY KEY (organization_id),
+  CONSTRAINT trials_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
 
 -- Billing contract metadata for an organization. Currently holds the

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -694,15 +694,6 @@ type DirectoryUserGroupMembership struct {
 	WorkosCreatedAt        pgtype.Timestamptz
 }
 
-type EnterpriseTrial struct {
-	OrganizationID string
-	EndsAt         pgtype.Timestamptz
-	ConvertedAt    pgtype.Timestamptz
-	DemotedAt      pgtype.Timestamptz
-	CreatedAt      pgtype.Timestamptz
-	UpdatedAt      pgtype.Timestamptz
-}
-
 type Environment struct {
 	ID             uuid.UUID
 	OrganizationID string
@@ -2347,6 +2338,16 @@ type ToolsetVersion struct {
 	UpdatedAt     pgtype.Timestamptz
 	DeletedAt     pgtype.Timestamptz
 	Deleted       bool
+}
+
+type Trial struct {
+	OrganizationID string
+	Tier           string
+	EndsAt         pgtype.Timestamptz
+	ConvertedAt    pgtype.Timestamptz
+	DemotedAt      pgtype.Timestamptz
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
 }
 
 type TriggerInstance struct {

--- a/server/migrations/20260806224308_trials-table-tier.sql
+++ b/server/migrations/20260806224308_trials-table-tier.sql
@@ -1,0 +1,16 @@
+-- atlas:nolint DS102
+
+-- Create "trials" table
+CREATE TABLE "trials" (
+  "organization_id" text NOT NULL,
+  "tier" text NOT NULL,
+  "ends_at" timestamptz NOT NULL,
+  "converted_at" timestamptz NULL,
+  "demoted_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("organization_id"),
+  CONSTRAINT "trials_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Drop "enterprise_trials" table
+DROP TABLE "enterprise_trials";

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GiiKbYRSXyAts/yCz2pYagAP2dH480W4GbWY3MebzXU=
+h1:j2PFyQABKLCGL5Bv1xIUGTyHDNkG4sffj2skUCX9l2Q=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -319,3 +319,4 @@ h1:GiiKbYRSXyAts/yCz2pYagAP2dH480W4GbWY3MebzXU=
 20260805191625_publish-outbox.sql h1:dqHs3CK4gTejbarFRGVwP1pqTPSXBkkuRnha8s2hrUY=
 20260805211101_enterprise-trials.sql h1:7NH6ss0phB6SS9BuHVEgy8fq7j3Ca0Sq10cgdDADW3A=
 20260805222807_publish-outbox-lease-token.sql h1:UkZ7i59bP6G3xZBSOQUlepqDLK4yjJMplJcUkBS3i5Y=
+20260806224308_trials-table-tier.sql h1:77p16W+Y+06uZULh/GZxFuIvSLmaMsSPp6uGlfmjfUI=


### PR DESCRIPTION
Renames `enterprise_trials` to `trials` and adds a `tier` column (`text`, `NOT NULL`). `enterprise` is the only value the application writes today.

## Why one migration and not expand-contract

Atlas does not detect renames, so the generated file creates `trials` and drops `enterprise_trials`. That is a destructive change in the same migration as an additive one, which the repo normally forbids. It is safe here for two reasons, both verifiable:

- **No deployed code touches the table.** #4982 shipped it as schema only. `grep -ri enterprise_trials` on `main` returns the schema, the migration, and the generated `EnterpriseTrial` struct. Nothing else.
- **The table is empty.** Only the signup transaction ever inserts a row, and that insert lives in #4881, which has not merged. There is no data to carry over, so the migration needs no backfill.

Expand-contract protects a running server from a schema its deployed code cannot handle. There is no such consumer, so the two-step form would only add a second deploy.

## Why `tier` has no CHECK constraint

Per the `postgresql` skill, enumerations are validated in application code. A new tier then needs no migration. `tier` also takes no default, so every insert states the tier it grants.

## Downstream

Three open PRs read `enterprise_trials` and need to move to `trials` when they rebase:

| PR | what it does with the table |
| --- | --- |
| #4881 | inserts the row at signup |
| #4983 | the demotion sweeper: `internal/enterprisetrials/` package, queries, repo, activity, workflow |
| #4994 | dashboard trial status: `organizations/queries.sql`, testenv, auth impl |

Each also needs to supply `tier` on insert, and #4983 should rename its package to match.

`client/dashboard/src/lib/featureFlags.ts` keeps the `enterprise-trials` PostHog flag key. That is a flag name, not the table, so it is unchanged.

## Notes for review

- `server/internal/database/models.go` is a sqlc regen. The `server-build-lint` "Check for dirty files" job requires it, and it is the only `server/internal/**` file in the diff.
- `-- atlas:nolint DS102` suppresses the destructive-change diagnostic on the drop. Same pattern as `20260429103554_drop_mcp_frontends_and_slugs.sql`. `atlas.sum` was re-hashed with `mise run db:hash`.
- New table, so the foreign key is declared inside `CREATE TABLE` and triggers no PG305/PG306 full-table-scan lint.
- AGE-3123 (the missing partial index on the sweeper predicate) is still open, now against `trials`. This PR mirrors the existing shape and does not add it.

## Verified locally

- `mise run lint:migrations` — ordering check passes.
- `atlas migrate lint` against a clean scratch database — no diagnostics, exit 0.
- `mise run db:migrate` — applies cleanly.
- `mise run db:diff` afterwards — "migration directory is synced with the desired state".
- `go build ./...` and `mise run lint:server` — both clean.

[skip migration check]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `enterprise_trials` to `trials` and added a required `tier` column to support tiered trials. Done in a single migration because the table is unused and empty; regenerated database models.

- **Migration**
  - Update any branches using `enterprise_trials` to `trials`.
  - Set `tier` on insert (current value: `enterprise`).
  - No data migration needed; FK to `organization_metadata` remains the same.

<sup>Written for commit c88310f57941235b44c84db716e65929c33a986d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

