### PR TITLE
fix(auth): reject org names that slugify to nothing server-side

### DIFF
--- a/.changeset/reject-empty-slug-org-names.md
+++ b/.changeset/reject-empty-slug-org-names.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Reject organization names that contain fewer than two letters or numbers. A name made up entirely of punctuation, such as `-----` or `___`, previously passed validation and produced an organization whose URL slug was empty. The rule is enforced by the shared name check, so it covers both the sign-up parameter on login and the register endpoint, including requests that skip the sign-up form. Existing organizations are unaffected.

--- a/server/internal/auth/login_test.go
+++ b/server/internal/auth/login_test.go
@@ -313,6 +313,19 @@ func TestService_Login(t *testing.T) {
 	})
 }
 
+func TestService_LoginRejectsOrgNameWithShortSlug(t *testing.T) {
+	t.Parallel()
+
+	userInfo := defaultMockUserInfo()
+	ctx, instance := newTestAuthService(t, userInfo)
+
+	orgName := "-----"
+	result, err := instance.service.Login(ctx, &gen.LoginPayload{OrgName: &orgName})
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "organization name must contain at least 2 letters or numbers")
+}
+
 // nonceFromLocation pulls the nonce out of the state param on an authorization
 // URL returned by Login.
 func nonceFromLocation(t *testing.T, location string) string {

--- a/server/internal/auth/org_name.go
+++ b/server/internal/auth/org_name.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/speakeasy-api/gram/server/internal/auth/orgslug"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
@@ -93,6 +94,14 @@ var validOrgNameRegex = regexp.MustCompile(`^[a-zA-Z0-9 _-]+$`)
 // an unauthenticated endpoint that writes it to Redis.
 const maxOrgNameLength = 100
 
+// minOrgNameSlugChars is the floor on what survives slugification, mirroring
+// MIN_ORG_NAME_SLUG_CHARS in the sign-up form. Two rather than one: a single
+// alphanumeric such as "A-" still yields the one-character slug "a".
+const minOrgNameSlugChars = 2
+
+// shortOrgNameFormat mirrors SHORT_ORG_NAME_MESSAGE in the sign-up form.
+const shortOrgNameFormat = "organization name must contain at least %d letters or numbers"
+
 // validateOrgName is the single org-name rule, shared by the authenticated
 // register endpoint and the unauthenticated signup parameter on login.
 func validateOrgName(name string) error {
@@ -106,6 +115,19 @@ func validateOrgName(name string) error {
 
 	if !validOrgNameRegex.MatchString(name) {
 		return oops.E(oops.CodeInvalid, errors.New("organization name contains invalid characters"), "organization name contains invalid characters")
+	}
+
+	// Measured on Slugify's own output rather than restating its character rule,
+	// so the two cannot drift. The character set above admits names made only of
+	// punctuation ("-----", "___", "- _ -"), which slugify to nothing and would
+	// otherwise create an org reachable at app.getgram.ai//.
+	if len(orgslug.Slugify(name)) < minOrgNameSlugChars {
+		return oops.E(
+			oops.CodeInvalid,
+			fmt.Errorf(shortOrgNameFormat, minOrgNameSlugChars),
+			shortOrgNameFormat,
+			minOrgNameSlugChars,
+		)
 	}
 
 	return nil

--- a/server/internal/auth/org_name.go
+++ b/server/internal/auth/org_name.go
@@ -99,7 +99,9 @@ const maxOrgNameLength = 100
 // alphanumeric such as "A-" still yields the one-character slug "a".
 const minOrgNameSlugChars = 2
 
-// shortOrgNameFormat mirrors SHORT_ORG_NAME_MESSAGE in the sign-up form.
+// shortOrgNameFormat matches the sign-up form's constraint and keeps the
+// server's established "organization name" terminology; the form calls it a
+// "Company name".
 const shortOrgNameFormat = "organization name must contain at least %d letters or numbers"
 
 // validateOrgName is the single org-name rule, shared by the authenticated

--- a/server/internal/auth/org_name_test.go
+++ b/server/internal/auth/org_name_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -28,8 +29,19 @@ func TestGenerateLegibleOrgName_Distribution(t *testing.T) {
 	require.Greater(t, len(seen), 100, "expected diverse names, got %d unique of 200", len(seen))
 }
 
+func TestGenerateLegibleOrgName_PassesValidation(t *testing.T) {
+	t.Parallel()
+
+	for range 200 {
+		name := generateLegibleOrgName()
+		require.NoError(t, validateOrgName(name), "generated name %q must pass validateOrgName", name)
+	}
+}
+
 func TestValidateOrgName(t *testing.T) {
 	t.Parallel()
+
+	shortOrgName := fmt.Sprintf(shortOrgNameFormat, minOrgNameSlugChars)
 
 	tests := []struct {
 		name    string
@@ -43,6 +55,14 @@ func TestValidateOrgName(t *testing.T) {
 		{name: "whitespace only", input: "   ", wantErr: "org name is required"},
 		{name: "apostrophe", input: "Bob's Bakery", wantErr: "organization name contains invalid characters"},
 		{name: "over the length limit", input: strings.Repeat("a", 101), wantErr: "organization name is too long"},
+		{name: "two slug chars", input: "ab", wantErr: ""},
+		{name: "two slug chars separated", input: "a-b", wantErr: ""},
+		{name: "only hyphens", input: "-----", wantErr: shortOrgName},
+		{name: "only underscores", input: "___", wantErr: shortOrgName},
+		{name: "punctuation with spaces", input: "- _ -", wantErr: shortOrgName},
+		{name: "one slug char", input: "a", wantErr: shortOrgName},
+		{name: "one slug char with hyphen", input: "A-", wantErr: shortOrgName},
+		{name: "one slug char with punctuation", input: "A _ -", wantErr: shortOrgName},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/auth/register_test.go
+++ b/server/internal/auth/register_test.go
@@ -206,6 +206,68 @@ func TestService_Register(t *testing.T) {
 		}
 	})
 
+	t.Run("register fails when org name slugifies to nothing", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.Organizations = []MockOrganizationEntry{} // User has no organizations
+		ctx, instance := newTestAuthService(t, userInfo)
+
+		session := sessions.Session{
+			SessionID:            t.Name(),
+			UserID:               userInfo.UserID,
+			ActiveOrganizationID: "", // No active organization
+			WorkOSSessionID:      "",
+		}
+		err := instance.sessionManager.StoreSession(ctx, session)
+		require.NoError(t, err)
+
+		authCtx := &contextvalues.AuthContext{
+			SessionID:            &session.SessionID,
+			UserID:               session.UserID,
+			ActiveOrganizationID: session.ActiveOrganizationID,
+			ProjectID:            nil,
+			OrganizationSlug:     "",
+			Email:                &userInfo.Email,
+			AccountType:          "test",
+			ProjectSlug:          nil,
+			APIKeyScopes:         nil,
+		}
+		ctx = contextvalues.SetAuthContext(ctx, authCtx)
+
+		// Names built entirely from the punctuation the character rule allows
+		// (or with a single surviving alphanumeric) slugify to an empty or
+		// one-character slug and must be rejected server-side.
+		testCases := []struct {
+			name    string
+			orgName string
+		}{
+			{"only hyphens", "-----"},
+			{"only underscores", "___"},
+			{"mixed punctuation", "- _ -"},
+			{"single alphanumeric", "A-"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				payload := &gen.RegisterPayload{
+					OrgName:      tc.orgName,
+					SessionToken: nil,
+				}
+
+				err := instance.service.Register(ctx, payload)
+				require.Error(t, err)
+
+				var oopsErr *oops.ShareableError
+				require.ErrorAs(t, err, &oopsErr)
+				require.Equal(t, oops.CodeInvalid, oopsErr.Code)
+				require.Contains(t, err.Error(), "organization name must contain at least 2 letters or numbers")
+			})
+		}
+	})
+
 	t.Run("register allows valid characters in org name", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`validateOrgName` checks the character set (`^[a-zA-Z0-9 _-]+$`) and a length cap, but nothing requires the name to contain anything that survives slugification. `orgslug.Slugify` lowercases, replaces every run of non-`[a-z0-9]` with a hyphen, then trims hyphens from both ends — so a name built entirely from the punctuation the character rule allows (`-----`, `___`, `- _ -`) passes validation and slugifies to the empty string. `orgslug.FindUnique` then finds no org with an empty slug and returns it, and the org is created reachable at `app.getgram.ai//`.

The `MIN_ORG_NAME_SLUG_CHARS` guard in `signup-panel.tsx` is a UX guard, not a control: the signup parameter on `auth.login` is unauthenticated, so a direct request carrying `org_name=-----` still reaches `provisionOrgForUser`.

## Changes

One rule added to `validateOrgName`, which is already the single org-name rule shared by the authenticated `Register` endpoint and the unauthenticated signup parameter on login — so both surfaces are covered without touching either call site:

- `minOrgNameSlugChars = 2`, matching `MIN_ORG_NAME_SLUG_CHARS`. Two rather than one because a single alphanumeric such as `A-` still yields the one-character slug `a`.
- The check is measured on `orgslug.Slugify`'s own output (`len(orgslug.Slugify(name)) < minOrgNameSlugChars`) rather than restating its character rule, so the two cannot drift. At this threshold it is equivalent to the client's "count surviving alphanumerics": a name with one alphanumeric slugifies to exactly one character, and one with two or more always yields a slug of at least two.
- The message is built from a shared format constant and the same minimum, so the number in the error cannot drift from the constant. The server intentionally retains its established "organization name" wording while the form labels the field "Company name".

## Existing orgs (issue item 3)

The new rule only runs in `validateOrgName`, which is reached solely from the two paths that provision an org from a caller-supplied name. The WorkOS-sync `UpsertOrganizationMetadata` paths (`Login`, `SwitchScopes`, backfill) do **not** call it, so any organization that already has an empty or one-character slug keeps working and is never re-validated. Worth a spot-check of production slugs before assuming none exist, but this change cannot break them.

## Tests

- `TestValidateOrgName`: covers empty-slug and one-char-slug names (`-----`, `___`, `- _ -`, `a`, `A-`, `A _ -`) and the accepted boundary (`ab`, `a-b`).
- `TestGenerateLegibleOrgName_PassesValidation`: guards that auto-provisioned legible names satisfy the tightened rule.
- `TestService_Register/register_fails_when_org_name_slugifies_to_nothing`: verifies rejection through `Register`.
- `TestService_LoginRejectsOrgNameWithShortSlug`: verifies the unauthenticated Login surface rejects a punctuation-only name before producing an authorization result.

`go build`, `go vet`, the full `./server/internal/auth/...` suite, and `mise run lint:server` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3126](https://linear.app/speakeasy/issue/AGE-3126/reject-org-names-that-slugify-to-nothing-server-side)

<div><a href="https://cursor.com/agents/bc-206c1e89-7f4e-4eb1-b8b6-b4dbbd7b82ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-206c1e89-7f4e-4eb1-b8b6-b4dbbd7b82ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Server now rejects organization names that slugify to empty or a single character, preventing empty-slug org URLs (e.g., app.getgram.ai//). Addresses AGE-3126 and aligns server validation with the dashboard guard.

- **Bug Fixes**
  - Tightened `validateOrgName`: non-empty, allowed chars, and an `orgslug` slug with at least 2 chars; mirrors the signup form’s constant and error text.
  - Applies to both `Register` and the login sign-up path; existing orgs are not revalidated.
  - Tests cover the validator and end-to-end rejection in `Register` and `Login` for punctuation-only and single-char cases.
  - Added a changeset to publish a patch for `server`.

<sup>Written for commit d346f8e4e5c61296360a8dbbcb789febffd777ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

