### PR TITLE
fix: sync skill sidebar active section as user scrolls

### DIFF
--- a/.changeset/skill-sidebar-scrollspy.md
+++ b/.changeset/skill-sidebar-scrollspy.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Highlight the skill detail sidebar section the reader is viewing as they scroll, and keep a section highlighted after its link is clicked until they scroll again.

--- a/client/dashboard/src/components/skill-detail-sidebar-nav.tsx
+++ b/client/dashboard/src/components/skill-detail-sidebar-nav.tsx
@@ -4,6 +4,7 @@ import {
   type McpSidebarNavItem,
 } from "@/components/mcp-sidebar-nav-shell";
 import { Text } from "@/components/ui/Text";
+import { useActiveSectionOnScroll } from "@/hooks/useActiveSectionOnScroll";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { HumanizeDateTime } from "@/lib/dates";
 import {
@@ -55,20 +56,41 @@ export function SkillDetailSidebarNav(): React.JSX.Element | null {
   // Drained so the count reflects every distribution, not the first page.
   useDrainInfiniteQuery(distributionsQuery, !!skillId);
 
-  if (!skillId) return null;
-
   const skill = skillQuery.data?.skill;
   const latestVersion = skillQuery.data?.latestVersion;
-  const distributionCount =
-    distributionsQuery.data?.pages.flatMap((page) => page.result.distributions)
-      .length ?? 0;
   const hasFrontmatter =
     Object.keys(latestVersion?.frontmatter ?? {}).filter(
       (key) => key !== "name" && key !== "description",
     ).length > 0;
 
+  // Kept in document order so the scrollspy can pick the topmost visible
+  // section; mirrors the sections rendered by SkillDetail.
+  const sectionIds = React.useMemo(() => {
+    const ids = [
+      SKILL_ADOPTION_SECTION_ID,
+      SKILL_TIMELINE_SECTION_ID,
+      SKILL_INSIGHTS_SECTION_ID,
+      SKILL_MANIFEST_SECTION_ID,
+    ];
+    if (hasFrontmatter) ids.push(SKILL_FRONTMATTER_SECTION_ID);
+    if (latestVersion) {
+      ids.push(SKILL_DISTRIBUTIONS_SECTION_ID, SKILL_VERSIONS_SECTION_ID);
+    }
+    return ids;
+  }, [hasFrontmatter, latestVersion]);
+
+  const scrolledSectionId = useActiveSectionOnScroll(sectionIds);
+
+  if (!skillId) return null;
+
+  const distributionCount =
+    distributionsQuery.data?.pages.flatMap((page) => page.result.distributions)
+      .length ?? 0;
+
   const detailHref = routes.skills.detail.href(skillId);
-  const activeSectionId = location.hash.replace("#", "");
+  // As the reader scrolls, the section in view drives the highlight; the hash
+  // only seeds it before the first scroll (e.g. deep-linking to a section).
+  const activeSectionId = scrolledSectionId ?? location.hash.replace("#", "");
   const sectionItem = (
     sectionId: string,
     title: string,

--- a/client/dashboard/src/components/skill-detail-sidebar-nav.tsx
+++ b/client/dashboard/src/components/skill-detail-sidebar-nav.tsx
@@ -79,7 +79,13 @@ export function SkillDetailSidebarNav(): React.JSX.Element | null {
     return ids;
   }, [hasFrontmatter, latestVersion]);
 
-  const scrolledSectionId = useActiveSectionOnScroll(sectionIds);
+  const hashSectionId = location.hash.replace("#", "");
+  // location.key changes on every navigation, so clicking the section already
+  // in the hash re-pins it instead of being treated as no change.
+  const trackedSectionId = useActiveSectionOnScroll(sectionIds, {
+    requestedSectionId: hashSectionId,
+    requestKey: location.key,
+  });
 
   if (!skillId) return null;
 
@@ -88,9 +94,9 @@ export function SkillDetailSidebarNav(): React.JSX.Element | null {
       .length ?? 0;
 
   const detailHref = routes.skills.detail.href(skillId);
-  // As the reader scrolls, the section in view drives the highlight; the hash
-  // only seeds it before the first scroll (e.g. deep-linking to a section).
-  const activeSectionId = scrolledSectionId ?? location.hash.replace("#", "");
+  // A clicked section stays highlighted until the reader scrolls; after that
+  // the section in view drives the highlight.
+  const activeSectionId = trackedSectionId ?? hashSectionId;
   const sectionItem = (
     sectionId: string,
     title: string,

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useActiveSectionOnScroll } from "./useActiveSectionOnScroll";
+
+type ObserverCallback = (entries: unknown[]) => void;
+
+const observerCallbacks: ObserverCallback[] = [];
+
+class MockIntersectionObserver {
+  callback: ObserverCallback;
+  constructor(callback: ObserverCallback) {
+    this.callback = callback;
+    observerCallbacks.push(callback);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// Drives every live observer so a simulated scroll triggers a recompute, the
+// same signal a real IntersectionObserver delivers when a section crosses the
+// activation line.
+function fireObservers() {
+  for (const callback of observerCallbacks) {
+    callback([]);
+  }
+}
+
+const TOP_OFFSET = 120;
+
+// Each section's top edge in viewport coordinates; adjusting these simulates
+// the page scrolling under a fixed activation line.
+const sectionTops = new Map<string, number>();
+
+function setSectionTops(tops: Record<string, number>) {
+  sectionTops.clear();
+  for (const [id, top] of Object.entries(tops)) {
+    sectionTops.set(id, top);
+  }
+}
+
+function createSection(id: string) {
+  const el = document.createElement("section");
+  el.id = id;
+  Object.defineProperty(el, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ top: sectionTops.get(id) ?? 0 }) as DOMRect,
+  });
+  document.body.appendChild(el);
+}
+
+// The hook batches recomputes on an animation frame. Queue them so the handle
+// is returned before the callback runs (matching a real async rAF), then flush
+// on demand inside act().
+let frameQueue: FrameRequestCallback[] = [];
+let nextFrameHandle = 1;
+
+function flushFrames() {
+  const pending = frameQueue;
+  frameQueue = [];
+  for (const cb of pending) {
+    cb(0);
+  }
+}
+
+beforeEach(() => {
+  observerCallbacks.length = 0;
+  frameQueue = [];
+  nextFrameHandle = 1;
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    frameQueue.push(cb);
+    return nextFrameHandle++;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  sectionTops.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("useActiveSectionOnScroll", () => {
+  it("activates the first section while the page is scrolled to the top", () => {
+    createSection("a");
+    createSection("b");
+    createSection("c");
+    // Every section starts below the activation line.
+    setSectionTops({ a: TOP_OFFSET + 40, b: 600, c: 1200 });
+
+    const { result } = renderHook(() =>
+      useActiveSectionOnScroll(["a", "b", "c"], TOP_OFFSET),
+    );
+    act(() => flushFrames());
+
+    expect(result.current).toBe("a");
+  });
+
+  it("advances the active section as later sections cross the activation line", () => {
+    createSection("a");
+    createSection("b");
+    createSection("c");
+    setSectionTops({ a: -400, b: TOP_OFFSET - 5, c: 800 });
+
+    const { result } = renderHook(() =>
+      useActiveSectionOnScroll(["a", "b", "c"], TOP_OFFSET),
+    );
+    act(() => flushFrames());
+
+    // "b" has scrolled just above the line; "c" is still below it.
+    expect(result.current).toBe("b");
+
+    // Scroll further so "c" crosses the line too.
+    act(() => {
+      setSectionTops({ a: -1200, b: -400, c: TOP_OFFSET - 5 });
+      fireObservers();
+      flushFrames();
+    });
+
+    expect(result.current).toBe("c");
+  });
+
+  it("re-subscribes when the set of sections changes", () => {
+    createSection("a");
+    createSection("b");
+    setSectionTops({ a: -400, b: -10 });
+
+    const { result, rerender } = renderHook(
+      ({ ids }: { ids: string[] }) => useActiveSectionOnScroll(ids, TOP_OFFSET),
+      { initialProps: { ids: ["a", "b"] } },
+    );
+    act(() => flushFrames());
+
+    expect(result.current).toBe("b");
+
+    // A new trailing section appears above the line after more content loads.
+    createSection("c");
+    setSectionTops({ a: -1200, b: -400, c: TOP_OFFSET - 5 });
+    // Re-run the effect first so it re-subscribes, then flush its queued frame.
+    act(() => rerender({ ids: ["a", "b", "c"] }));
+    act(() => flushFrames());
+
+    expect(result.current).toBe("c");
+  });
+});

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
@@ -90,7 +90,7 @@ describe("useActiveSectionOnScroll", () => {
     setSectionTops({ a: TOP_OFFSET + 40, b: 600, c: 1200 });
 
     const { result } = renderHook(() =>
-      useActiveSectionOnScroll(["a", "b", "c"], TOP_OFFSET),
+      useActiveSectionOnScroll(["a", "b", "c"], { topOffset: TOP_OFFSET }),
     );
     act(() => flushFrames());
 
@@ -104,7 +104,7 @@ describe("useActiveSectionOnScroll", () => {
     setSectionTops({ a: -400, b: TOP_OFFSET - 5, c: 800 });
 
     const { result } = renderHook(() =>
-      useActiveSectionOnScroll(["a", "b", "c"], TOP_OFFSET),
+      useActiveSectionOnScroll(["a", "b", "c"], { topOffset: TOP_OFFSET }),
     );
     act(() => flushFrames());
 
@@ -127,7 +127,8 @@ describe("useActiveSectionOnScroll", () => {
     setSectionTops({ a: -400, b: -10 });
 
     const { result, rerender } = renderHook(
-      ({ ids }: { ids: string[] }) => useActiveSectionOnScroll(ids, TOP_OFFSET),
+      ({ ids }: { ids: string[] }) =>
+        useActiveSectionOnScroll(ids, { topOffset: TOP_OFFSET }),
       { initialProps: { ids: ["a", "b"] } },
     );
     act(() => flushFrames());
@@ -149,7 +150,7 @@ describe("useActiveSectionOnScroll", () => {
   // the highlight on the first section forever.
   it("starts tracking sections that mount after the hook runs", async () => {
     const { result } = renderHook(() =>
-      useActiveSectionOnScroll(["a", "b", "c"], TOP_OFFSET),
+      useActiveSectionOnScroll(["a", "b", "c"], { topOffset: TOP_OFFSET }),
     );
     act(() => flushFrames());
 
@@ -168,6 +169,86 @@ describe("useActiveSectionOnScroll", () => {
     });
 
     expect(observerCallbacks.length).toBeGreaterThan(0);
+    expect(result.current).toBe("b");
+  });
+
+  // The trailing sections share the last screenful, so scrolling can never
+  // bring them to the activation line — without the pin the highlight springs
+  // back to whichever earlier section sits on the line.
+  it("keeps a requested section active when scrolling cannot reach it", () => {
+    createSection("a");
+    createSection("b");
+    createSection("c");
+    // Only "a" is above the line; "b" and "c" can never get there.
+    setSectionTops({ a: -10, b: 500, c: 700 });
+
+    const { result } = renderHook(() =>
+      useActiveSectionOnScroll(["a", "b", "c"], {
+        topOffset: TOP_OFFSET,
+        requestedSectionId: "c",
+        requestKey: "nav-1",
+      }),
+    );
+    act(() => flushFrames());
+
+    expect(result.current).toBe("c");
+  });
+
+  it("releases the requested section once the reader scrolls", () => {
+    createSection("a");
+    createSection("b");
+    createSection("c");
+    setSectionTops({ a: -10, b: 500, c: 700 });
+
+    const { result } = renderHook(() =>
+      useActiveSectionOnScroll(["a", "b", "c"], {
+        topOffset: TOP_OFFSET,
+        requestedSectionId: "c",
+        requestKey: "nav-1",
+      }),
+    );
+    act(() => flushFrames());
+    expect(result.current).toBe("c");
+
+    // Typing is not scrolling, so the pin survives it.
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "k" }));
+    });
+    expect(result.current).toBe("c");
+
+    act(() => {
+      window.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
+    });
+
+    // Scroll tracking takes over again.
+    expect(result.current).toBe("a");
+  });
+
+  it("re-pins the same section when its link is clicked again", () => {
+    createSection("a");
+    createSection("b");
+    setSectionTops({ a: -10, b: 500 });
+
+    const { result, rerender } = renderHook(
+      ({ requestKey }: { requestKey: string }) =>
+        useActiveSectionOnScroll(["a", "b"], {
+          topOffset: TOP_OFFSET,
+          requestedSectionId: "b",
+          requestKey,
+        }),
+      { initialProps: { requestKey: "nav-1" } },
+    );
+    act(() => flushFrames());
+    expect(result.current).toBe("b");
+
+    act(() => {
+      window.dispatchEvent(new WheelEvent("wheel", { deltaY: 40 }));
+    });
+    expect(result.current).toBe("a");
+
+    // Same hash, new navigation — the section should be pinned again.
+    act(() => rerender({ requestKey: "nav-2" }));
+
     expect(result.current).toBe("b");
   });
 });

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
@@ -285,6 +285,47 @@ describe("useActiveSectionOnScroll", () => {
     expect(result.current).toBe("a");
   });
 
+  // Dragging the scrollbar emits neither wheel nor touch events, only scroll
+  // events while the button is held.
+  it("releases the requested section when the reader drags the scrollbar", () => {
+    createSection("a");
+    createSection("b");
+    createSection("c");
+    setSectionTops({ a: -10, b: 500, c: 700 });
+
+    const { result } = renderHook(() =>
+      useActiveSectionOnScroll(["a", "b", "c"], {
+        topOffset: TOP_OFFSET,
+        requestedSectionId: "c",
+        requestKey: "nav-1",
+      }),
+    );
+    act(() => flushFrames());
+    expect(result.current).toBe("c");
+
+    // The smooth scroll the click itself triggers has no button held, so it
+    // must not release the pin.
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current).toBe("c");
+
+    // A click that scrolls nothing must not release it either.
+    act(() => {
+      window.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current).toBe("c");
+
+    // Button held while the page scrolls: a scrollbar drag.
+    act(() => {
+      window.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      window.dispatchEvent(new Event("scroll"));
+    });
+    expect(result.current).toBe("a");
+  });
+
   it("re-pins the same section when its link is clicked again", () => {
     createSection("a");
     createSection("b");

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
@@ -143,4 +143,31 @@ describe("useActiveSectionOnScroll", () => {
 
     expect(result.current).toBe("c");
   });
+
+  // The sidebar that calls this hook mounts before the page content that owns
+  // the sections, so observing only what exists on the first pass would freeze
+  // the highlight on the first section forever.
+  it("starts tracking sections that mount after the hook runs", async () => {
+    const { result } = renderHook(() =>
+      useActiveSectionOnScroll(["a", "b", "c"], TOP_OFFSET),
+    );
+    act(() => flushFrames());
+
+    // No sections in the DOM yet.
+    expect(observerCallbacks.length).toBe(0);
+
+    createSection("a");
+    createSection("b");
+    createSection("c");
+    setSectionTops({ a: -400, b: TOP_OFFSET - 5, c: 800 });
+
+    // MutationObserver callbacks are delivered as a microtask.
+    await act(async () => {
+      await Promise.resolve();
+      flushFrames();
+    });
+
+    expect(observerCallbacks.length).toBeGreaterThan(0);
+    expect(result.current).toBe("b");
+  });
 });

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.test.ts
@@ -4,15 +4,23 @@ import { useActiveSectionOnScroll } from "./useActiveSectionOnScroll";
 
 type ObserverCallback = (entries: unknown[]) => void;
 
-const observerCallbacks: ObserverCallback[] = [];
+type ObserverRecord = {
+  callback: ObserverCallback;
+  options: IntersectionObserverInit | undefined;
+  observed: Element[];
+};
+
+const observers: ObserverRecord[] = [];
 
 class MockIntersectionObserver {
-  callback: ObserverCallback;
-  constructor(callback: ObserverCallback) {
-    this.callback = callback;
-    observerCallbacks.push(callback);
+  record: ObserverRecord;
+  constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+    this.record = { callback, options, observed: [] };
+    observers.push(this.record);
   }
-  observe() {}
+  observe(el: Element) {
+    this.record.observed.push(el);
+  }
   unobserve() {}
   disconnect() {}
 }
@@ -21,7 +29,7 @@ class MockIntersectionObserver {
 // same signal a real IntersectionObserver delivers when a section crosses the
 // activation line.
 function fireObservers() {
-  for (const callback of observerCallbacks) {
+  for (const { callback } of observers) {
     callback([]);
   }
 }
@@ -39,14 +47,27 @@ function setSectionTops(tops: Record<string, number>) {
   }
 }
 
-function createSection(id: string) {
+function createSection(id: string, parent: HTMLElement = document.body) {
   const el = document.createElement("section");
   el.id = id;
   Object.defineProperty(el, "getBoundingClientRect", {
     configurable: true,
     value: () => ({ top: sectionTops.get(id) ?? 0 }) as DOMRect,
   });
+  parent.appendChild(el);
+}
+
+// Stands in for the app shell's scrolling container, which is what the observer
+// must use as its root rather than the viewport.
+function createScrollContainer() {
+  const el = document.createElement("div");
+  el.style.overflowY = "auto";
+  Object.defineProperty(el, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({ top: 0 }) as DOMRect,
+  });
   document.body.appendChild(el);
+  return el;
 }
 
 // The hook batches recomputes on an animation frame. Queue them so the handle
@@ -64,7 +85,7 @@ function flushFrames() {
 }
 
 beforeEach(() => {
-  observerCallbacks.length = 0;
+  observers.length = 0;
   frameQueue = [];
   nextFrameHandle = 1;
   vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
@@ -95,6 +116,45 @@ describe("useActiveSectionOnScroll", () => {
     act(() => flushFrames());
 
     expect(result.current).toBe("a");
+  });
+
+  // The app shell scrolls an inner container, so observing against the viewport
+  // would place the activation line a header's height off.
+  it("observes the sections' scroll container with the activation line offset", () => {
+    const container = createScrollContainer();
+    createSection("a", container);
+    createSection("b", container);
+    setSectionTops({ a: -10, b: 500 });
+
+    renderHook(() =>
+      useActiveSectionOnScroll(["a", "b"], { topOffset: TOP_OFFSET }),
+    );
+    act(() => flushFrames());
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.options?.root).toBe(container);
+    expect(observers[0]?.options?.rootMargin).toBe(
+      `-${TOP_OFFSET}px 0px 0px 0px`,
+    );
+    expect(observers[0]?.observed).toEqual([
+      document.getElementById("a"),
+      document.getElementById("b"),
+    ]);
+  });
+
+  it("observes against the viewport when no ancestor scrolls", () => {
+    createSection("a");
+    setSectionTops({ a: -10 });
+
+    renderHook(() =>
+      useActiveSectionOnScroll(["a"], { topOffset: TOP_OFFSET }),
+    );
+    act(() => flushFrames());
+
+    expect(observers[0]?.options?.root).toBe(null);
+    expect(observers[0]?.options?.rootMargin).toBe(
+      `-${TOP_OFFSET}px 0px 0px 0px`,
+    );
   });
 
   it("advances the active section as later sections cross the activation line", () => {
@@ -155,7 +215,7 @@ describe("useActiveSectionOnScroll", () => {
     act(() => flushFrames());
 
     // No sections in the DOM yet.
-    expect(observerCallbacks.length).toBe(0);
+    expect(observers).toHaveLength(0);
 
     createSection("a");
     createSection("b");
@@ -168,7 +228,8 @@ describe("useActiveSectionOnScroll", () => {
       flushFrames();
     });
 
-    expect(observerCallbacks.length).toBeGreaterThan(0);
+    expect(observers.length).toBeGreaterThan(0);
+    expect(observers.at(-1)?.observed).toHaveLength(3);
     expect(result.current).toBe("b");
   });
 

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
@@ -14,6 +14,35 @@ function findVerticalScrollParent(el: HTMLElement | null): HTMLElement | null {
   return node;
 }
 
+// Keys that scroll the page. Releasing the pin on any keystroke would drop it
+// on unrelated input (search shortcuts, typing in a dialog).
+const SCROLL_KEYS = new Set([
+  "ArrowUp",
+  "ArrowDown",
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  " ",
+]);
+
+export type ActiveSectionOptions = {
+  /**
+   * The section the reader explicitly asked for, e.g. the URL hash after
+   * clicking a sidebar link. It stays active until the reader scrolls again,
+   * so the highlight doesn't spring back when the page can't scroll far enough
+   * to bring that section to the activation line (the trailing sections that
+   * share the last screenful).
+   */
+  requestedSectionId?: string | null;
+  /**
+   * Changes on every navigation, so asking for the section that is already in
+   * the hash (clicking the same link twice) pins it again.
+   */
+  requestKey?: string;
+  topOffset?: number;
+};
+
 /**
  * Tracks which of the given page sections the reader is currently looking at
  * and returns its id, so a sidebar can keep its active item in sync as the
@@ -27,12 +56,45 @@ function findVerticalScrollParent(el: HTMLElement | null): HTMLElement | null {
  */
 export function useActiveSectionOnScroll(
   sectionIds: readonly string[],
-  topOffset = 120,
+  {
+    requestedSectionId = null,
+    requestKey = "",
+    topOffset = 120,
+  }: ActiveSectionOptions = {},
 ): string | null {
   const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [pinnedId, setPinnedId] = React.useState<string | null>(null);
   // Collapse the array into a primitive so the effect only re-subscribes when
   // the set of sections actually changes, not on every new array identity.
   const idsKey = sectionIds.join("\n");
+
+  // Keyed on the request alone: re-pinning whenever the section list changes
+  // would resurrect a pin the reader already scrolled away from.
+  React.useEffect(() => {
+    setPinnedId(requestedSectionId === "" ? null : requestedSectionId);
+  }, [requestedSectionId, requestKey]);
+
+  // Only real input gestures release the pin. A plain `scroll` listener would
+  // fire on the smooth scroll the click itself triggers and release it
+  // immediately.
+  React.useEffect(() => {
+    if (pinnedId === null || typeof window === "undefined") return;
+
+    const release = () => setPinnedId(null);
+    const releaseOnScrollKey = (event: KeyboardEvent) => {
+      if (SCROLL_KEYS.has(event.key)) setPinnedId(null);
+    };
+    const options = { passive: true, capture: true } as const;
+
+    window.addEventListener("wheel", release, options);
+    window.addEventListener("touchmove", release, options);
+    window.addEventListener("keydown", releaseOnScrollKey, options);
+    return () => {
+      window.removeEventListener("wheel", release, options);
+      window.removeEventListener("touchmove", release, options);
+      window.removeEventListener("keydown", releaseOnScrollKey, options);
+    };
+  }, [pinnedId]);
 
   React.useEffect(() => {
     if (
@@ -131,5 +193,9 @@ export function useActiveSectionOnScroll(
     };
   }, [idsKey, topOffset]);
 
+  // Validated during render rather than when pinning, so a section list that
+  // grows later (frontmatter, versions) can honor an existing pin without the
+  // pin effect having to re-run.
+  if (pinnedId !== null && sectionIds.includes(pinnedId)) return pinnedId;
   return activeId;
 }

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+// The app shell scrolls an inner container rather than the window, so the
+// observer must resolve the real scroll ancestor of the sections to place its
+// activation line correctly. Falls back to the viewport when nothing scrolls.
+function findVerticalScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node: HTMLElement | null = el?.parentElement ?? null;
+  while (
+    node &&
+    !/auto|scroll|overlay/.test(getComputedStyle(node).overflowY)
+  ) {
+    node = node.parentElement;
+  }
+  return node;
+}
+
+/**
+ * Tracks which of the given page sections the reader is currently looking at
+ * and returns its id, so a sidebar can keep its active item in sync as the
+ * user scrolls. `sectionIds` must be listed in document order; the topmost
+ * section whose start has scrolled past the activation line wins, and the
+ * first section stays active until the reader scrolls past it.
+ *
+ * Returns `null` until the observed sections have been measured (e.g. before
+ * the page content mounts or in environments without IntersectionObserver),
+ * letting callers fall back to their existing active-state logic.
+ */
+export function useActiveSectionOnScroll(
+  sectionIds: readonly string[],
+  topOffset = 120,
+): string | null {
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  // Collapse the array into a primitive so the effect only re-subscribes when
+  // the set of sections actually changes, not on every new array identity.
+  const idsKey = sectionIds.join("\n");
+
+  React.useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+
+    const ids = idsKey.length > 0 ? idsKey.split("\n") : [];
+    if (ids.length === 0) {
+      setActiveId(null);
+      return;
+    }
+
+    const root = findVerticalScrollParent(document.getElementById(ids[0]!));
+
+    const recompute = () => {
+      const lineTop = (root ? root.getBoundingClientRect().top : 0) + topOffset;
+      let current: string | null = null;
+      for (const id of ids) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        // Once a section starts below the activation line, every later section
+        // is below it too, so the last one above the line is the active one.
+        if (el.getBoundingClientRect().top <= lineTop + 1) {
+          current = id;
+        } else {
+          break;
+        }
+      }
+      // Before the first section reaches the line, keep the first one active.
+      setActiveId(current ?? ids[0] ?? null);
+    };
+
+    let frame = 0;
+    const scheduleRecompute = () => {
+      if (frame !== 0) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        recompute();
+      });
+    };
+
+    // Shifting the root's top edge down to the activation line makes the
+    // observer fire exactly when a section boundary crosses it, which is the
+    // only moment the active section can change.
+    const observer = new IntersectionObserver(scheduleRecompute, {
+      root: root ?? null,
+      rootMargin: `-${topOffset}px 0px 0px 0px`,
+      threshold: 0,
+    });
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    }
+
+    // Seed the initial value once the observed elements are in the DOM.
+    scheduleRecompute();
+
+    return () => {
+      if (frame !== 0) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [idsKey, topOffset]);
+
+  return activeId;
+}

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
@@ -48,10 +48,14 @@ export function useActiveSectionOnScroll(
       return;
     }
 
-    const root = findVerticalScrollParent(document.getElementById(ids[0]!));
+    let scrollRoot: HTMLElement | null = null;
+    let intersectionObserver: IntersectionObserver | null = null;
+    let observedCount = 0;
+    let frame = 0;
 
     const recompute = () => {
-      const lineTop = (root ? root.getBoundingClientRect().top : 0) + topOffset;
+      const lineTop =
+        (scrollRoot ? scrollRoot.getBoundingClientRect().top : 0) + topOffset;
       let current: string | null = null;
       for (const id of ids) {
         const el = document.getElementById(id);
@@ -68,7 +72,6 @@ export function useActiveSectionOnScroll(
       setActiveId(current ?? ids[0] ?? null);
     };
 
-    let frame = 0;
     const scheduleRecompute = () => {
       if (frame !== 0) return;
       frame = window.requestAnimationFrame(() => {
@@ -77,25 +80,54 @@ export function useActiveSectionOnScroll(
       });
     };
 
-    // Shifting the root's top edge down to the activation line makes the
-    // observer fire exactly when a section boundary crosses it, which is the
-    // only moment the active section can change.
-    const observer = new IntersectionObserver(scheduleRecompute, {
-      root: root ?? null,
-      rootMargin: `-${topOffset}px 0px 0px 0px`,
-      threshold: 0,
-    });
-    for (const id of ids) {
-      const el = document.getElementById(id);
-      if (el) observer.observe(el);
-    }
+    // Returns true once every section is being observed.
+    const attach = (): boolean => {
+      const elements: HTMLElement[] = [];
+      for (const id of ids) {
+        const el = document.getElementById(id);
+        if (el) elements.push(el);
+      }
+      // Nothing new to observe; skip rebuilding the observer.
+      if (elements.length === observedCount)
+        return elements.length === ids.length;
 
-    // Seed the initial value once the observed elements are in the DOM.
-    scheduleRecompute();
+      observedCount = elements.length;
+      scrollRoot = findVerticalScrollParent(elements[0]!);
+      intersectionObserver?.disconnect();
+      // Shifting the root's top edge down to the activation line makes the
+      // observer fire exactly when a section boundary crosses it, which is the
+      // only moment the active section can change.
+      intersectionObserver = new IntersectionObserver(scheduleRecompute, {
+        root: scrollRoot ?? null,
+        rootMargin: `-${topOffset}px 0px 0px 0px`,
+        threshold: 0,
+      });
+      for (const el of elements) intersectionObserver.observe(el);
+      scheduleRecompute();
+      return elements.length === ids.length;
+    };
+
+    // This hook runs from the sidebar, which mounts before the page content
+    // that owns the sections — observing nothing here would freeze the
+    // highlight on the first section. Watch for them until all are observed.
+    let mutationObserver: MutationObserver | null = null;
+    if (!attach() && typeof MutationObserver !== "undefined") {
+      mutationObserver = new MutationObserver(() => {
+        if (attach()) {
+          mutationObserver?.disconnect();
+          mutationObserver = null;
+        }
+      });
+      mutationObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    }
 
     return () => {
       if (frame !== 0) window.cancelAnimationFrame(frame);
-      observer.disconnect();
+      intersectionObserver?.disconnect();
+      mutationObserver?.disconnect();
     };
   }, [idsKey, topOffset]);
 

--- a/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
+++ b/client/dashboard/src/hooks/useActiveSectionOnScroll.ts
@@ -74,8 +74,8 @@ export function useActiveSectionOnScroll(
     setPinnedId(requestedSectionId === "" ? null : requestedSectionId);
   }, [requestedSectionId, requestKey]);
 
-  // Only real input gestures release the pin. A plain `scroll` listener would
-  // fire on the smooth scroll the click itself triggers and release it
+  // Only real input gestures release the pin. Releasing on `scroll` alone would
+  // fire on the smooth scroll the click itself triggers and drop the pin
   // immediately.
   React.useEffect(() => {
     if (pinnedId === null || typeof window === "undefined") return;
@@ -84,15 +84,38 @@ export function useActiveSectionOnScroll(
     const releaseOnScrollKey = (event: KeyboardEvent) => {
       if (SCROLL_KEYS.has(event.key)) setPinnedId(null);
     };
+
+    // Dragging the scrollbar emits neither wheel nor touch events, and its
+    // gutter can't be located by geometry when the platform draws overlay
+    // scrollbars (no width to measure). What distinguishes it is scrolling
+    // while the button is held — a plain click scrolls nothing.
+    let buttonHeld = false;
+    const holdButton = () => {
+      buttonHeld = true;
+    };
+    const releaseButton = () => {
+      buttonHeld = false;
+    };
+    const releaseOnDragScroll = () => {
+      if (buttonHeld) setPinnedId(null);
+    };
+
+    // Capture, because scroll events from the scrolling container don't bubble.
     const options = { passive: true, capture: true } as const;
 
     window.addEventListener("wheel", release, options);
     window.addEventListener("touchmove", release, options);
     window.addEventListener("keydown", releaseOnScrollKey, options);
+    window.addEventListener("mousedown", holdButton, options);
+    window.addEventListener("mouseup", releaseButton, options);
+    window.addEventListener("scroll", releaseOnDragScroll, options);
     return () => {
       window.removeEventListener("wheel", release, options);
       window.removeEventListener("touchmove", release, options);
       window.removeEventListener("keydown", releaseOnScrollKey, options);
+      window.removeEventListener("mousedown", holdButton, options);
+      window.removeEventListener("mouseup", releaseButton, options);
+      window.removeEventListener("scroll", releaseOnDragScroll, options);
     };
   }, [pinnedId]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

On the skill detail page, the sidebar's "Sections" nav highlighted the active item only from the URL hash. The hash changes when you click a nav item, but it never updates as you scroll, so the highlight went stale and no longer reflected the section the reader was actually looking at (DNO-727).

## Demo

Scrolling advances the highlight through the sections; at the bottom it rests on "Plugin distributions" (the last section that can reach the activation line), and clicking "Version history" pins it there instead of letting it snap back:

<a href="https://cursor.com/agents/bc-a6fcbe83-5687-471d-af4a-bc301b133e00/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskill_sidebar_scrollspy_demo.mp4"><img src="https://cursor.com/artifacts/c/art-3d54e229-3e3a-4e6f-ab63-1457417e0796" alt="skill_sidebar_scrollspy_demo.mp4" /></a>

## Changes

**1. Scrollspy (`useActiveSectionOnScroll`)** — `client/dashboard/src/hooks/useActiveSectionOnScroll.ts`

Given an ordered list of section ids, it observes those sections with an `IntersectionObserver` whose top edge is shifted down to an activation line near the top of the scroll container, and returns the id of the topmost section that has scrolled past the line. It resolves the real vertical scroll ancestor, since the app shell scrolls an inner container rather than the window.

`skill-detail-sidebar-nav.tsx` builds the section-id list in document order (mirroring what `SkillDetail` renders, including the conditional frontmatter/versions sections) and drives the highlight from it.

**2. Attach once the sections exist**

The sidebar mounts before the page content that owns the sections, so `getElementById` returned `null` for every section, the observer watched nothing, and the highlight froze on the first section permanently. The observer now attaches when the sections appear, using a `MutationObserver` that disconnects once all of them are observed, and the scroll root is resolved from a real element instead of a missing one.

**3. A clicked section stays highlighted**

The trailing sections share the last screenful, so scrolling can never bring them to the activation line. Clicking the last one highlighted it only until the smooth scroll settled, then the highlight sprang back to whichever section held the line. The requested section is now pinned, keyed on `location.key` so clicking the same link again re-pins it.

**4. Releasing the pin covers scrollbar dragging**

The pin is released by the next scroll gesture. A plain `scroll` listener won't do, because the click's own smooth scroll would drop the pin instantly, so releases come from `wheel`, `touchmove`, and scroll keys — plus a `scroll` that happens while a mouse button is held, which is what a scrollbar drag looks like and what a plain click never produces. Locating the scrollbar gutter by geometry was rejected: this container draws overlay scrollbars (`offsetWidth - clientWidth === 0`), so there is no width to measure.

## Testing

`useActiveSectionOnScroll.test.ts` covers: the first section active at the top; the observer's `root`, `rootMargin`, and observed elements (both with a scrolling ancestor and with the viewport fallback); the active section advancing as later sections cross the line; re-subscribing when the section list changes; sections that mount after the hook runs; a requested section surviving when scrolling cannot reach it; the pin releasing on a scroll gesture but not on unrelated typing; a scrollbar drag releasing it while a non-scrolling click and the click's own smooth scroll do not; and re-pinning on a repeat click.

Each new test was confirmed to fail against the unfixed code — including the observer-config assertions, checked by pointing the root at the viewport and dropping the margin.

`pnpm -F dashboard test` (147 tests across the hooks and skills suites), `pnpm -F dashboard type-check`, and `pnpm -F dashboard lint` all pass.

Manually verified against a seeded skill in the local dashboard (the demo above), including: a real click that scrolls nothing keeps the pin, and holding the button while the container scrolls releases it.

The plugin detail sidebar is intentionally untouched: its sections are separate routes (pathname-driven), not scroll sections on one page, so scrollspy does not apply there.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-727](https://linear.app/speakeasy/issue/DNO-727/bug-fix-active-section-should-update-in-sidebar-as-user-scrolls)

<div><a href="https://cursor.com/agents/bc-a6fcbe83-5687-471d-af4a-bc301b133e00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6fcbe83-5687-471d-af4a-bc301b133e00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the Skill detail sidebar highlight with scroll position so the active section updates as you read. Also pins a clicked section until you scroll, and preserves deep-link behavior (Linear DNO-727).

- **Bug Fixes**
  - Added `useActiveSectionOnScroll` (IntersectionObserver with an activation line on the real scroll container) and a `MutationObserver` to start tracking sections that mount after the sidebar; returns `null` until measured.
  - Sidebar now uses the hook for the active state, seeds from the URL hash, and pins a clicked section until a scroll gesture; clicking the same link re-pins it; also releases the pin when dragging the scrollbar (scroll while mouse button is held).
  - Tests cover initial-at-top, advancing across the line, tracking sections that mount later, re-subscribing when the section list changes, pin/release/re-pin including scrollbar drag, and assert the observer’s root and activation-line margin.
  - Plugin detail sidebar unchanged.
  - Added changeset for a `dashboard` patch release.

<sup>Written for commit ebe0bafa7bfadc4ad06bfacdd6edec1e7f3b2bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

