### PR TITLE
feat: add trial lifecycle emails

### DIFF
--- a/.changeset/trial-lifecycle-emails.md
+++ b/.changeset/trial-lifecycle-emails.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Send lifecycle emails to organization admins when Enterprise trials start and approach expiration through the Loops workflow integration.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -133,6 +133,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	"github.com/speakeasy-api/gram/server/internal/triggers"
 	"github.com/speakeasy-api/gram/server/internal/unproxiedmcp"
 
@@ -678,6 +679,8 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("failed to parse site url: %w", err)
 			}
+			loopsWorkflowClient := loops.NewWorkflowClient(ctx, logger, guardianPolicy, c.String("loops-api-key"))
+			trialEmailsService := trialemails.NewService(db, loopsWorkflowClient, logger, siteURL.String())
 
 			tigrisStore, shutdown, err := newTigrisStore(ctx, c, logger)
 			if err != nil {
@@ -1230,8 +1233,9 @@ func newStartCommand() *cli.Command {
 				authzProvisioner,
 				productfeatures.SeedEnterpriseTrialBundleTx,
 				auditLogger,
+				trialEmailsService,
 			))
-			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, serverURL.String(), siteURL.String(), auditLogger, svixClient)
+			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailsService, serverURL.String(), siteURL.String(), auditLogger, svixClient)
 			organizations.Attach(mux, organizationsService)
 			pluginsGitHub, err := plugins.NewGitHubConfig(plugins.GitHubConfigInput{
 				Client:         ghClient,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -679,6 +679,7 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("failed to parse site url: %w", err)
 			}
+			trialEmailNotifier := &background.TemporalTrialEmailNotifier{TemporalEnv: temporalEnv}
 			loopsWorkflowClient := loops.NewWorkflowClient(ctx, logger, guardianPolicy, c.String("loops-api-key"))
 			trialEmailsService := trialemails.NewService(db, loopsWorkflowClient, logger, siteURL.String())
 
@@ -1233,9 +1234,9 @@ func newStartCommand() *cli.Command {
 				authzProvisioner,
 				productfeatures.SeedEnterpriseTrialBundleTx,
 				auditLogger,
-				trialEmailsService,
+				trialEmailNotifier,
 			))
-			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailsService, serverURL.String(), siteURL.String(), auditLogger, svixClient)
+			organizationsService := organizations.NewService(logger, tracerProvider, db, sessionManager, workosClient, identityResolver, productFeatures, telemetryrepo.New(chDB), authzEngine, emailService, trialEmailNotifier, serverURL.String(), siteURL.String(), auditLogger, svixClient)
 			organizations.Attach(mux, organizationsService)
 			pluginsGitHub, err := plugins.NewGitHubConfig(plugins.GitHubConfigInput{
 				Client:         ghClient,
@@ -1518,6 +1519,7 @@ func newStartCommand() *cli.Command {
 						ProductFeatures:     productFeatures,
 						PluginPublisher:     pluginPublisher,
 						Publishers:          publishers,
+						TrialEmailsService:  trialEmailsService,
 					})
 					if err := temporalWorker.Run(workerInterruptCh); err != nil {
 						logger.ErrorContext(ctx, "temporal worker failed", attr.SlogError(err))

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -72,6 +72,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/pylon"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	userRepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions"
 	"github.com/speakeasy-api/gram/tunnel/route"
@@ -816,6 +817,8 @@ func newWorkerCommand() *cli.Command {
 					return fmt.Errorf("failed to parse site url: %w", err)
 				}
 			}
+			loopsWorkflowClient := loops.NewWorkflowClient(ctx, logger, guardianPolicy, c.String("loops-api-key"))
+			trialEmailsService := trialemails.NewService(db, loopsWorkflowClient, logger, c.String("site-url"))
 
 			temporalWorker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, &background.WorkerOptions{
 				GuardianPolicy:      guardianPolicy,
@@ -857,6 +860,7 @@ func newWorkerCommand() *cli.Command {
 				ProductFeatures:     productFeatures,
 				PluginPublisher:     pluginPublisher,
 				Publishers:          publishers,
+				TrialEmailsService:  trialEmailsService,
 			})
 
 			// Flush the throttle's queued trailing risk signals before this Action

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -1269,13 +1269,13 @@ func (s *Service) RequestAccess(ctx context.Context, payload *gen.RequestAccessP
 		return nil, oops.E(oops.CodeUnexpected, err, "get organization info").LogError(ctx, logger)
 	}
 
-	// Get list of org admin emails
-	adminEmails, err := repo.New(s.db).ListOrgAdminEmails(ctx, ac.ActiveOrganizationID)
+	// Get active organization administrators.
+	admins, err := repo.New(s.db).ListActiveOrganizationAdmins(ctx, ac.ActiveOrganizationID)
 	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list org admin emails").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "list organization administrators").LogError(ctx, logger)
 	}
 
-	if len(adminEmails) == 0 {
+	if len(admins) == 0 {
 		logger.WarnContext(ctx, "no org admins found to notify for access request")
 		return &gen.RequestAccessResult{SentToCount: 0}, nil
 	}
@@ -1303,15 +1303,15 @@ func (s *Service) RequestAccess(ctx context.Context, payload *gen.RequestAccessP
 
 	// Send emails to all admins
 	sentCount := 0
-	for _, adminEmail := range adminEmails {
-		if adminEmail == "" {
+	for _, admin := range admins {
+		if admin.Email == "" {
 			continue
 		}
-		if err := s.email.Send(ctx, adminEmail, tmpl); err != nil {
+		if err := s.email.Send(ctx, admin.Email, tmpl); err != nil {
 			// Log but don't fail the entire request if one email fails
 			logger.WarnContext(ctx, "failed to send access request email",
 				attr.SlogError(err),
-				attr.SlogAccessRequestRecipient(adminEmail),
+				attr.SlogAccessRequestRecipient(admin.Email),
 			)
 			continue
 		}
@@ -1324,7 +1324,7 @@ func (s *Service) RequestAccess(ctx context.Context, payload *gen.RequestAccessP
 
 	logger.InfoContext(ctx, "access request emails sent",
 		attr.SlogAccessRequestSentCount(sentCount),
-		attr.SlogAccessRequestAdminCount(len(adminEmails)),
+		attr.SlogAccessRequestAdminCount(len(admins)),
 		attr.SlogAccessRequestScope(payload.Scope),
 	)
 

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -569,6 +569,38 @@ WHERE our.organization_id = @organization_id
   AND users.email <> ''
 ORDER BY users.email, users.id;
 
+-- name: GetActiveOrganizationAdmin :one
+-- Returns one active organization administrator and their Loops contact fields.
+-- The role assignment is joined by WorkOS user ID because
+-- organization_role_assignments.user_id is nullable during the
+-- WorkOS-to-Gram backfill window.
+SELECT DISTINCT
+  users.id,
+  users.display_name,
+  users.email
+FROM organization_user_relationships AS our
+JOIN users
+  ON users.id = our.user_id
+JOIN organization_role_assignments AS ora
+  ON ora.organization_id = our.organization_id
+  AND ora.workos_user_id = users.workos_id
+  AND ora.deleted_at IS NULL
+LEFT JOIN organization_roles
+  ON ora.role_urn = 'role:organization:' || organization_roles.id::text
+  AND organization_roles.organization_id = ora.organization_id
+  AND organization_roles.deleted IS FALSE
+  AND organization_roles.workos_deleted IS FALSE
+LEFT JOIN global_roles
+  ON ora.role_urn = 'role:global:' || global_roles.id::text
+  AND global_roles.deleted IS FALSE
+  AND global_roles.workos_deleted IS FALSE
+WHERE our.organization_id = @organization_id
+  AND our.user_id = @user_id
+  AND our.deleted IS FALSE
+  AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) = 'admin'
+  AND users.deleted_at IS NULL
+  AND users.email <> '';
+
 -- name: ListMemberRolePrincipalsByWorkosUser :many
 SELECT
   COALESCE(organization_roles.workos_slug, global_roles.workos_slug)::text AS role_slug,

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -537,13 +537,14 @@ WHERE our.organization_id = @organization_id
   AND users.email <> ''
 ORDER BY users.email, users.id;
 
--- name: ListOrgAdminEmails :many
--- Returns email addresses of users with the admin role in the organization.
--- Used for sending access request notifications to org admins. Anchored on
--- organization_user_relationships so only active members are notified, and
--- joined on workos_user_id because organization_role_assignments.user_id is
--- nullable during the WorkOS-to-Gram backfill window.
+-- name: ListActiveOrganizationAdmins :many
+-- Returns active organization administrators and their Loops contact fields.
+-- The role assignment is joined by WorkOS user ID because
+-- organization_role_assignments.user_id is nullable during the
+-- WorkOS-to-Gram backfill window.
 SELECT DISTINCT
+  users.id,
+  users.display_name,
   users.email
 FROM organization_user_relationships AS our
 JOIN users
@@ -566,7 +567,7 @@ WHERE our.organization_id = @organization_id
   AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) = 'admin'
   AND users.deleted_at IS NULL
   AND users.email <> ''
-ORDER BY users.email;
+ORDER BY users.email, users.id;
 
 -- name: ListMemberRolePrincipalsByWorkosUser :many
 SELECT

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -539,8 +539,8 @@ ORDER BY users.email, users.id;
 
 -- name: ListActiveOrganizationAdmins :many
 -- Returns active organization administrators and their Loops contact fields.
--- Prefer the internal user ID when the assignment has been linked; fall back
--- to the WorkOS user ID for assignments that predate that backfill.
+-- Resolve roles only through the internal user ID. WorkOS role assignments
+-- are not treated as internal authorization state until they are linked.
 SELECT DISTINCT
   users.id,
   users.display_name,
@@ -550,10 +550,7 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND (
-    ora.user_id = users.id
-    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
-  )
+  AND ora.user_id = users.id
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text
@@ -573,8 +570,8 @@ ORDER BY users.email, users.id;
 
 -- name: GetActiveOrganizationAdmin :one
 -- Returns one active organization administrator and their Loops contact fields.
--- Prefer the internal user ID when the assignment has been linked; fall back
--- to the WorkOS user ID for assignments that predate that backfill.
+-- Resolve roles only through the internal user ID. WorkOS role assignments
+-- are not treated as internal authorization state until they are linked.
 SELECT DISTINCT
   users.id,
   users.display_name,
@@ -584,10 +581,7 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND (
-    ora.user_id = users.id
-    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
-  )
+  AND ora.user_id = users.id
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -539,9 +539,8 @@ ORDER BY users.email, users.id;
 
 -- name: ListActiveOrganizationAdmins :many
 -- Returns active organization administrators and their Loops contact fields.
--- The role assignment is joined by WorkOS user ID because
--- organization_role_assignments.user_id is nullable during the
--- WorkOS-to-Gram backfill window.
+-- Prefer the internal user ID when the assignment has been linked; fall back
+-- to the WorkOS user ID for assignments that predate that backfill.
 SELECT DISTINCT
   users.id,
   users.display_name,
@@ -551,7 +550,10 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND ora.workos_user_id = users.workos_id
+  AND (
+    ora.user_id = users.id
+    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
+  )
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text
@@ -571,9 +573,8 @@ ORDER BY users.email, users.id;
 
 -- name: GetActiveOrganizationAdmin :one
 -- Returns one active organization administrator and their Loops contact fields.
--- The role assignment is joined by WorkOS user ID because
--- organization_role_assignments.user_id is nullable during the
--- WorkOS-to-Gram backfill window.
+-- Prefer the internal user ID when the assignment has been linked; fall back
+-- to the WorkOS user ID for assignments that predate that backfill.
 SELECT DISTINCT
   users.id,
   users.display_name,
@@ -583,7 +584,10 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND ora.workos_user_id = users.workos_id
+  AND (
+    ora.user_id = users.id
+    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
+  )
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -538,7 +538,10 @@ WHERE our.organization_id = @organization_id
 ORDER BY users.email, users.id;
 
 -- name: ListActiveOrganizationAdmins :many
--- Returns active organization administrators and their Loops contact fields.
+-- Returns a best-effort notification audience of active organization
+-- administrators and their Loops contact fields. This is not an authorization
+-- decision or a delivery guarantee; callers use the admins available when the
+-- notification is sent.
 -- Resolve roles only through the internal user ID. WorkOS role assignments
 -- are not treated as internal authorization state until they are linked.
 SELECT DISTINCT

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -231,10 +231,7 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND (
-    ora.user_id = users.id
-    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
-  )
+  AND ora.user_id = users.id
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text
@@ -265,8 +262,8 @@ type GetActiveOrganizationAdminRow struct {
 }
 
 // Returns one active organization administrator and their Loops contact fields.
-// Prefer the internal user ID when the assignment has been linked; fall back
-// to the WorkOS user ID for assignments that predate that backfill.
+// Resolve roles only through the internal user ID. WorkOS role assignments
+// are not treated as internal authorization state until they are linked.
 func (q *Queries) GetActiveOrganizationAdmin(ctx context.Context, arg GetActiveOrganizationAdminParams) (GetActiveOrganizationAdminRow, error) {
 	row := q.db.QueryRow(ctx, getActiveOrganizationAdmin, arg.OrganizationID, arg.UserID)
 	var i GetActiveOrganizationAdminRow
@@ -791,10 +788,7 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND (
-    ora.user_id = users.id
-    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
-  )
+  AND ora.user_id = users.id
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text
@@ -820,8 +814,8 @@ type ListActiveOrganizationAdminsRow struct {
 }
 
 // Returns active organization administrators and their Loops contact fields.
-// Prefer the internal user ID when the assignment has been linked; fall back
-// to the WorkOS user ID for assignments that predate that backfill.
+// Resolve roles only through the internal user ID. WorkOS role assignments
+// are not treated as internal authorization state until they are linked.
 func (q *Queries) ListActiveOrganizationAdmins(ctx context.Context, organizationID string) ([]ListActiveOrganizationAdminsRow, error) {
 	rows, err := q.db.Query(ctx, listActiveOrganizationAdmins, organizationID)
 	if err != nil {

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -221,6 +221,57 @@ func (q *Queries) DeletePrincipalGrantsByTarget(ctx context.Context, arg DeleteP
 	return result.RowsAffected(), nil
 }
 
+const getActiveOrganizationAdmin = `-- name: GetActiveOrganizationAdmin :one
+SELECT DISTINCT
+  users.id,
+  users.display_name,
+  users.email
+FROM organization_user_relationships AS our
+JOIN users
+  ON users.id = our.user_id
+JOIN organization_role_assignments AS ora
+  ON ora.organization_id = our.organization_id
+  AND ora.workos_user_id = users.workos_id
+  AND ora.deleted_at IS NULL
+LEFT JOIN organization_roles
+  ON ora.role_urn = 'role:organization:' || organization_roles.id::text
+  AND organization_roles.organization_id = ora.organization_id
+  AND organization_roles.deleted IS FALSE
+  AND organization_roles.workos_deleted IS FALSE
+LEFT JOIN global_roles
+  ON ora.role_urn = 'role:global:' || global_roles.id::text
+  AND global_roles.deleted IS FALSE
+  AND global_roles.workos_deleted IS FALSE
+WHERE our.organization_id = $1
+  AND our.user_id = $2
+  AND our.deleted IS FALSE
+  AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) = 'admin'
+  AND users.deleted_at IS NULL
+  AND users.email <> ''
+`
+
+type GetActiveOrganizationAdminParams struct {
+	OrganizationID string
+	UserID         pgtype.Text
+}
+
+type GetActiveOrganizationAdminRow struct {
+	ID          string
+	DisplayName string
+	Email       string
+}
+
+// Returns one active organization administrator and their Loops contact fields.
+// The role assignment is joined by WorkOS user ID because
+// organization_role_assignments.user_id is nullable during the
+// WorkOS-to-Gram backfill window.
+func (q *Queries) GetActiveOrganizationAdmin(ctx context.Context, arg GetActiveOrganizationAdminParams) (GetActiveOrganizationAdminRow, error) {
+	row := q.db.QueryRow(ctx, getActiveOrganizationAdmin, arg.OrganizationID, arg.UserID)
+	var i GetActiveOrganizationAdminRow
+	err := row.Scan(&i.ID, &i.DisplayName, &i.Email)
+	return i, err
+}
+
 const getActiveOrganizationRoleBySlug = `-- name: GetActiveOrganizationRoleBySlug :one
 WITH active_roles AS (
   SELECT id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, 'global'::text AS role_kind

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -231,7 +231,10 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND ora.workos_user_id = users.workos_id
+  AND (
+    ora.user_id = users.id
+    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
+  )
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text
@@ -262,9 +265,8 @@ type GetActiveOrganizationAdminRow struct {
 }
 
 // Returns one active organization administrator and their Loops contact fields.
-// The role assignment is joined by WorkOS user ID because
-// organization_role_assignments.user_id is nullable during the
-// WorkOS-to-Gram backfill window.
+// Prefer the internal user ID when the assignment has been linked; fall back
+// to the WorkOS user ID for assignments that predate that backfill.
 func (q *Queries) GetActiveOrganizationAdmin(ctx context.Context, arg GetActiveOrganizationAdminParams) (GetActiveOrganizationAdminRow, error) {
 	row := q.db.QueryRow(ctx, getActiveOrganizationAdmin, arg.OrganizationID, arg.UserID)
 	var i GetActiveOrganizationAdminRow
@@ -789,7 +791,10 @@ JOIN users
   ON users.id = our.user_id
 JOIN organization_role_assignments AS ora
   ON ora.organization_id = our.organization_id
-  AND ora.workos_user_id = users.workos_id
+  AND (
+    ora.user_id = users.id
+    OR (ora.user_id IS NULL AND ora.workos_user_id = users.workos_id)
+  )
   AND ora.deleted_at IS NULL
 LEFT JOIN organization_roles
   ON ora.role_urn = 'role:organization:' || organization_roles.id::text
@@ -815,9 +820,8 @@ type ListActiveOrganizationAdminsRow struct {
 }
 
 // Returns active organization administrators and their Loops contact fields.
-// The role assignment is joined by WorkOS user ID because
-// organization_role_assignments.user_id is nullable during the
-// WorkOS-to-Gram backfill window.
+// Prefer the internal user ID when the assignment has been linked; fall back
+// to the WorkOS user ID for assignments that predate that backfill.
 func (q *Queries) ListActiveOrganizationAdmins(ctx context.Context, organizationID string) ([]ListActiveOrganizationAdminsRow, error) {
 	rows, err := q.db.Query(ctx, listActiveOrganizationAdmins, organizationID)
 	if err != nil {

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -813,7 +813,10 @@ type ListActiveOrganizationAdminsRow struct {
 	Email       string
 }
 
-// Returns active organization administrators and their Loops contact fields.
+// Returns a best-effort notification audience of active organization
+// administrators and their Loops contact fields. This is not an authorization
+// decision or a delivery guarantee; callers use the admins available when the
+// notification is sent.
 // Resolve roles only through the internal user ID. WorkOS role assignments
 // are not treated as internal authorization state until they are linked.
 func (q *Queries) ListActiveOrganizationAdmins(ctx context.Context, organizationID string) ([]ListActiveOrganizationAdminsRow, error) {

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -728,6 +728,65 @@ func (q *Queries) ListAccessNotificationUsers(ctx context.Context, organizationI
 	return items, nil
 }
 
+const listActiveOrganizationAdmins = `-- name: ListActiveOrganizationAdmins :many
+SELECT DISTINCT
+  users.id,
+  users.display_name,
+  users.email
+FROM organization_user_relationships AS our
+JOIN users
+  ON users.id = our.user_id
+JOIN organization_role_assignments AS ora
+  ON ora.organization_id = our.organization_id
+  AND ora.workos_user_id = users.workos_id
+  AND ora.deleted_at IS NULL
+LEFT JOIN organization_roles
+  ON ora.role_urn = 'role:organization:' || organization_roles.id::text
+  AND organization_roles.organization_id = ora.organization_id
+  AND organization_roles.deleted IS FALSE
+  AND organization_roles.workos_deleted IS FALSE
+LEFT JOIN global_roles
+  ON ora.role_urn = 'role:global:' || global_roles.id::text
+  AND global_roles.deleted IS FALSE
+  AND global_roles.workos_deleted IS FALSE
+WHERE our.organization_id = $1
+  AND our.deleted IS FALSE
+  AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) = 'admin'
+  AND users.deleted_at IS NULL
+  AND users.email <> ''
+ORDER BY users.email, users.id
+`
+
+type ListActiveOrganizationAdminsRow struct {
+	ID          string
+	DisplayName string
+	Email       string
+}
+
+// Returns active organization administrators and their Loops contact fields.
+// The role assignment is joined by WorkOS user ID because
+// organization_role_assignments.user_id is nullable during the
+// WorkOS-to-Gram backfill window.
+func (q *Queries) ListActiveOrganizationAdmins(ctx context.Context, organizationID string) ([]ListActiveOrganizationAdminsRow, error) {
+	rows, err := q.db.Query(ctx, listActiveOrganizationAdmins, organizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveOrganizationAdminsRow
+	for rows.Next() {
+		var i ListActiveOrganizationAdminsRow
+		if err := rows.Scan(&i.ID, &i.DisplayName, &i.Email); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listActiveOrganizationRoles = `-- name: ListActiveOrganizationRoles :many
 WITH active_roles AS (
   SELECT id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, 'global'::text AS role_kind
@@ -1028,58 +1087,6 @@ func (q *Queries) ListMemberRolePrincipalsByWorkosUser(ctx context.Context, arg 
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listOrgAdminEmails = `-- name: ListOrgAdminEmails :many
-SELECT DISTINCT
-  users.email
-FROM organization_user_relationships AS our
-JOIN users
-  ON users.id = our.user_id
-JOIN organization_role_assignments AS ora
-  ON ora.organization_id = our.organization_id
-  AND ora.workos_user_id = users.workos_id
-  AND ora.deleted_at IS NULL
-LEFT JOIN organization_roles
-  ON ora.role_urn = 'role:organization:' || organization_roles.id::text
-  AND organization_roles.organization_id = ora.organization_id
-  AND organization_roles.deleted IS FALSE
-  AND organization_roles.workos_deleted IS FALSE
-LEFT JOIN global_roles
-  ON ora.role_urn = 'role:global:' || global_roles.id::text
-  AND global_roles.deleted IS FALSE
-  AND global_roles.workos_deleted IS FALSE
-WHERE our.organization_id = $1
-  AND our.deleted IS FALSE
-  AND COALESCE(organization_roles.workos_slug, global_roles.workos_slug) = 'admin'
-  AND users.deleted_at IS NULL
-  AND users.email <> ''
-ORDER BY users.email
-`
-
-// Returns email addresses of users with the admin role in the organization.
-// Used for sending access request notifications to org admins. Anchored on
-// organization_user_relationships so only active members are notified, and
-// joined on workos_user_id because organization_role_assignments.user_id is
-// nullable during the WorkOS-to-Gram backfill window.
-func (q *Queries) ListOrgAdminEmails(ctx context.Context, organizationID string) ([]string, error) {
-	rows, err := q.db.Query(ctx, listOrgAdminEmails, organizationID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var email string
-		if err := rows.Scan(&email); err != nil {
-			return nil, err
-		}
-		items = append(items, email)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/server/internal/access/trial_admins_test.go
+++ b/server/internal/access/trial_admins_test.go
@@ -23,13 +23,15 @@ func TestListActiveOrganizationAdmins(t *testing.T) {
 	require.NotNil(t, authCtx)
 
 	const (
-		globalAdminUserID = "global-admin-user"
-		orgAdminUserID    = "org-admin-user"
-		memberUserID      = "member-user"
+		globalAdminUserID     = "global-admin-user"
+		orgAdminUserID        = "org-admin-user"
+		workosOnlyAdminUserID = "workos-only-admin-user"
+		memberUserID          = "member-user"
 	)
 
 	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, globalAdminUserID, "global-admin@example.test", "Global Admin", "workos-global-admin")
 	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, orgAdminUserID, "org-admin@example.test", "Organization Admin", "workos-org-admin")
+	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, workosOnlyAdminUserID, "workos-only-admin@example.test", "WorkOS Only Admin", "workos-only-admin")
 	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, memberUserID, "member@example.test", "Member", "workos-member")
 
 	now := time.Now().UTC()
@@ -66,6 +68,16 @@ func TestListActiveOrganizationAdmins(t *testing.T) {
 	_, err = queries.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
 		OrganizationID:     authCtx.ActiveOrganizationID,
 		WorkosUserID:       "workos-global-admin",
+		UserID:             conv.ToPGText(globalAdminUserID),
+		WorkosMembershipID: conv.ToPGTextEmpty(""),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(now),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     "admin",
+	})
+	require.NoError(t, err)
+	_, err = queries.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     authCtx.ActiveOrganizationID,
+		WorkosUserID:       "workos-only-admin",
 		UserID:             conv.PtrToPGText(nil),
 		WorkosMembershipID: conv.ToPGTextEmpty(""),
 		WorkosUpdatedAt:    conv.ToPGTimestamptz(now),
@@ -101,6 +113,12 @@ func TestListActiveOrganizationAdmins(t *testing.T) {
 	_, err = queries.GetActiveOrganizationAdmin(ctx, accessrepo.GetActiveOrganizationAdminParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		UserID:         conv.ToPGText(memberUserID),
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	_, err = queries.GetActiveOrganizationAdmin(ctx, accessrepo.GetActiveOrganizationAdminParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText(workosOnlyAdminUserID),
 	})
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 }

--- a/server/internal/access/trial_admins_test.go
+++ b/server/internal/access/trial_admins_test.go
@@ -1,0 +1,124 @@
+package access
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListActiveOrganizationAdmins(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+
+	const (
+		globalAdminUserID = "global-admin-user"
+		orgAdminUserID    = "org-admin-user"
+		memberUserID      = "member-user"
+	)
+
+	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, globalAdminUserID, "global-admin@example.test", "Global Admin", "workos-global-admin")
+	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, orgAdminUserID, "org-admin@example.test", "Organization Admin", "workos-org-admin")
+	seedAdminQueryUser(t, ctx, ti, authCtx.ActiveOrganizationID, memberUserID, "member@example.test", "Member", "workos-member")
+
+	now := time.Now().UTC()
+	queries := accessrepo.New(ti.conn)
+	require.NoError(t, queries.UpsertGlobalRole(ctx, accessrepo.UpsertGlobalRoleParams{
+		WorkosSlug:        "admin",
+		WorkosName:        "Admin",
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	}))
+	_, err := queries.UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    authCtx.ActiveOrganizationID,
+		WorkosSlug:        "admin",
+		WorkosName:        "Admin",
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+	_, err = queries.UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID:    authCtx.ActiveOrganizationID,
+		WorkosSlug:        "member",
+		WorkosName:        "Member",
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+
+	_, err = queries.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     authCtx.ActiveOrganizationID,
+		WorkosUserID:       "workos-global-admin",
+		UserID:             conv.PtrToPGText(nil),
+		WorkosMembershipID: conv.ToPGTextEmpty(""),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(now),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     "admin",
+	})
+	require.NoError(t, err)
+	seedAdminQueryRoleAssignment(t, ctx, queries, authCtx.ActiveOrganizationID, orgAdminUserID, "workos-org-admin", "admin", now)
+	seedAdminQueryRoleAssignment(t, ctx, queries, authCtx.ActiveOrganizationID, memberUserID, "workos-member", "member", now)
+
+	admins, err := queries.ListActiveOrganizationAdmins(ctx, authCtx.ActiveOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, []accessrepo.ListActiveOrganizationAdminsRow{
+		{ID: globalAdminUserID, Email: "global-admin@example.test", DisplayName: "Global Admin"},
+		{ID: orgAdminUserID, Email: "org-admin@example.test", DisplayName: "Organization Admin"},
+	}, admins)
+}
+
+func seedAdminQueryUser(t *testing.T, ctx context.Context, ti *testInstance, organizationID, userID, email, displayName, workosUserID string) {
+	t.Helper()
+
+	_, err := userrepo.New(ti.conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: displayName,
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	err = userrepo.New(ti.conn).OverwriteUserWorkosID(ctx, userrepo.OverwriteUserWorkosIDParams{
+		ID:       userID,
+		WorkosID: conv.ToPGText(workosUserID),
+	})
+	require.NoError(t, err)
+
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+}
+
+func seedAdminQueryRoleAssignment(t *testing.T, ctx context.Context, queries *accessrepo.Queries, organizationID, userID, workosUserID, roleSlug string, updatedAt time.Time) {
+	t.Helper()
+
+	_, err := queries.UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       workosUserID,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGTextEmpty(""),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(updatedAt),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+}

--- a/server/internal/access/trial_admins_test.go
+++ b/server/internal/access/trial_admins_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -81,6 +82,23 @@ func TestListActiveOrganizationAdmins(t *testing.T) {
 		{ID: globalAdminUserID, Email: "global-admin@example.test", DisplayName: "Global Admin"},
 		{ID: orgAdminUserID, Email: "org-admin@example.test", DisplayName: "Organization Admin"},
 	}, admins)
+
+	admin, err := queries.GetActiveOrganizationAdmin(ctx, accessrepo.GetActiveOrganizationAdminParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText(orgAdminUserID),
+	})
+	require.NoError(t, err)
+	require.Equal(t, accessrepo.GetActiveOrganizationAdminRow{
+		ID:          orgAdminUserID,
+		Email:       "org-admin@example.test",
+		DisplayName: "Organization Admin",
+	}, admin)
+
+	_, err = queries.GetActiveOrganizationAdmin(ctx, accessrepo.GetActiveOrganizationAdminParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         conv.ToPGText(memberUserID),
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows)
 }
 
 func seedAdminQueryUser(t *testing.T, ctx context.Context, ti *testInstance, organizationID, userID, email, displayName, workosUserID string) {

--- a/server/internal/access/trial_admins_test.go
+++ b/server/internal/access/trial_admins_test.go
@@ -75,6 +75,10 @@ func TestListActiveOrganizationAdmins(t *testing.T) {
 	require.NoError(t, err)
 	seedAdminQueryRoleAssignment(t, ctx, queries, authCtx.ActiveOrganizationID, orgAdminUserID, "workos-org-admin", "admin", now)
 	seedAdminQueryRoleAssignment(t, ctx, queries, authCtx.ActiveOrganizationID, memberUserID, "workos-member", "member", now)
+	require.NoError(t, userrepo.New(ti.conn).OverwriteUserWorkosID(ctx, userrepo.OverwriteUserWorkosIDParams{
+		WorkosID: conv.PtrToPGText(nil),
+		ID:       orgAdminUserID,
+	}))
 
 	admins, err := queries.ListActiveOrganizationAdmins(ctx, authCtx.ActiveOrganizationID)
 	require.NoError(t, err)

--- a/server/internal/auth/callback_test.go
+++ b/server/internal/auth/callback_test.go
@@ -3,6 +3,7 @@ package auth_test
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	redisCache "github.com/go-redis/cache/v9"
@@ -637,6 +638,7 @@ func TestService_Callback_SignupIntent(t *testing.T) {
 		session, err := instance.sessionManager.GetSession(ctx, result.SessionToken)
 		require.NoError(t, err)
 		require.NotEmpty(t, session.ActiveOrganizationID, "the signup org must be active on the session")
+		require.Equal(t, []string{session.ActiveOrganizationID}, instance.trialNotifier.trialStarted)
 
 		org, err := orgRepo.New(instance.conn).GetOrganizationMetadata(ctx, session.ActiveOrganizationID)
 		require.NoError(t, err)
@@ -647,6 +649,24 @@ func TestService_Callback_SignupIntent(t *testing.T) {
 		trial, err := trialsRepo.New(instance.conn).GetTrial(ctx, session.ActiveOrganizationID)
 		require.NoError(t, err)
 		require.Equal(t, "enterprise", trial.Tier)
+	})
+
+	t.Run("trial notifier failure does not fail signup", func(t *testing.T) {
+		t.Parallel()
+
+		userInfo := defaultMockUserInfo()
+		userInfo.Organizations = nil
+		ctx, instance := newTestAuthServiceForOrganizationProvisioning(t, userInfo)
+		instance.trialNotifier.trialStartedErr = errors.New("notify failed")
+
+		ctx, stateParam := instance.stateWithSignupIntent(ctx, t, "", "Acme Inc")
+		result, err := instance.service.Callback(ctx, &gen.CallbackPayload{
+			Code:  "mock_code",
+			State: &stateParam,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, result.SessionToken)
+		require.Len(t, instance.trialNotifier.trialStarted, 1)
 	})
 
 	t.Run("intent is consumed so it cannot be replayed", func(t *testing.T) {

--- a/server/internal/auth/e2e_test.go
+++ b/server/internal/auth/e2e_test.go
@@ -175,9 +175,11 @@ func newE2EAuthService(t *testing.T, userInfo *MockUserInfo, fetcher *mockWorkOS
 
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthogClient, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger())
+	trialNotifier := &fakeTrialNotifier{}
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthogClient, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
 
 	ti := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
+	ti.trialNotifier = trialNotifier
 	return ctx, &e2eInstance{testInstance: *ti, fetcher: fetcher}
 }
 

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -46,8 +46,8 @@ import (
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
-	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	"github.com/speakeasy-api/gram/server/internal/trialemails"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 const dispositionAssistants = "assistants"

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -47,6 +47,7 @@ import (
 	projectsRepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
 const dispositionAssistants = "assistants"
@@ -118,6 +119,7 @@ type Service struct {
 	authzProvisioner    *authz.Provisioner
 	trialBundleSeeder   EnterpriseTrialBundleSeeder
 	auditLogger         *audit.Logger
+	trialNotifier       trialemails.Notifier
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -137,8 +139,12 @@ func NewService(
 	authzProvisioner *authz.Provisioner,
 	trialBundleSeeder EnterpriseTrialBundleSeeder,
 	auditLogger *audit.Logger,
+	trialNotifier trialemails.Notifier,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("auth"))
+	if trialNotifier == nil {
+		trialNotifier = trialemails.NoopNotifier{}
+	}
 
 	return &Service{
 		tracer:              tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/auth"),
@@ -158,6 +164,7 @@ func NewService(
 		authzProvisioner:    authzProvisioner,
 		trialBundleSeeder:   trialBundleSeeder,
 		auditLogger:         auditLogger,
+		trialNotifier:       trialNotifier,
 	}
 }
 
@@ -335,6 +342,10 @@ func (s *Service) Callback(ctx context.Context, payload *gen.CallbackPayload) (r
 			session.ActiveOrganizationID = org.ID
 			if err := s.sessions.StoreSession(ctx, session); err != nil {
 				return s.redirectSignupError(ctx, err)
+			}
+
+			if err := s.trialNotifier.TrialStarted(ctx, org.ID); err != nil {
+				s.logger.ErrorContext(ctx, "failed to notify trial started", attr.SlogError(err), attr.SlogOrganizationID(org.ID), attr.SlogUserID(userID))
 			}
 
 			s.captureSignupTelemetry(ctx, userInfo.Email, intent.OrgName, org)

--- a/server/internal/auth/register_test.go
+++ b/server/internal/auth/register_test.go
@@ -54,6 +54,11 @@ func TestService_Register(t *testing.T) {
 
 		err = instance.service.Register(ctx, payload)
 		require.NoError(t, err)
+
+		storedSession, err := instance.sessionManager.GetSession(ctx, session.SessionID)
+		require.NoError(t, err)
+		require.NotEmpty(t, storedSession.ActiveOrganizationID)
+		require.Empty(t, instance.trialNotifier.trialStarted)
 	})
 
 	t.Run("register fails when user already has active organization", func(t *testing.T) {

--- a/server/internal/auth/setup_test.go
+++ b/server/internal/auth/setup_test.go
@@ -46,6 +46,27 @@ func (noopCancelScheduler) ScheduleCancelAssistantsSubscription(ctx context.Cont
 	return nil
 }
 
+type fakeTrialNotifier struct {
+	trialStartedErr error
+	trialStarted    []string
+}
+
+func (f *fakeTrialNotifier) TrialStarted(_ context.Context, organizationID string) error {
+	f.trialStarted = append(f.trialStarted, organizationID)
+	if f.trialStartedErr != nil {
+		return f.trialStartedErr
+	}
+	return nil
+}
+
+func (f *fakeTrialNotifier) AdminAdded(context.Context, string, string) error {
+	return nil
+}
+
+func (f *fakeTrialNotifier) TrialInactive(context.Context, string) error {
+	return nil
+}
+
 func TestMain(m *testing.M) {
 	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true})
 	if err != nil {
@@ -74,6 +95,7 @@ type testInstance struct {
 	mockAuthServer   *httptest.Server
 	authConfigs      auth.AuthConfigurations
 	nonceStore       cache.Cache
+	trialNotifier    *fakeTrialNotifier
 }
 
 // MockUserInfo represents the user info used by the mock OIDC server
@@ -171,9 +193,11 @@ func newTestAuthServiceWithWorkOSClient(t *testing.T, userInfo *MockUserInfo, wo
 
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger())
+	trialNotifier := &fakeTrialNotifier{}
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
 	result := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	result.authorizer = auth.New(logger, conn, sessionManager, authzEngine)
+	result.trialNotifier = trialNotifier
 
 	return ctx, result
 }
@@ -238,9 +262,11 @@ func newTestAuthServiceWithAuthz(t *testing.T, userInfo *MockUserInfo) (context.
 
 	nonceStore := cache.NewRedisCacheAdapter(redisClient)
 	authzEngine := authz.NewEngine(logger, conn, chConn, authztest.ChallengeLoggingAlwaysDisabled, workos.NewStubClient())
-	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger())
+	trialNotifier := &fakeTrialNotifier{}
+	svc := auth.NewService(logger, tracerProvider, conn, sessionManager, resolver, authConfigs, authzEngine, billingClient, noopCancelScheduler{}, posthog, nonceStore, authzProvisioner, productfeatures.SeedEnterpriseTrialBundleTx, audit.NewLogger(), trialNotifier)
 	result := newTestAuthServiceResult(t, svc, conn, sessionManager, resolver, mockServer, authConfigs, nonceStore)
 	result.authorizer = auth.New(logger, conn, sessionManager, authzEngine)
+	result.trialNotifier = trialNotifier
 
 	return ctx, result
 }
@@ -255,6 +281,7 @@ func newTestAuthServiceResult(_ *testing.T, svc *auth.Service, conn *pgxpool.Poo
 		mockAuthServer:   mockServer,
 		authConfigs:      authConfigs,
 		nonceStore:       nonceStore,
+		trialNotifier:    nil,
 	}
 }
 

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -66,6 +66,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
 type Publishers struct {
@@ -155,6 +156,7 @@ type Activities struct {
 	chatAnalysisScorer              *activities.ChatAnalysisScorer
 	remoteSessionRefresh            *activities.RemoteSessionRefresh
 	demoteExpiredTrials             *activities.DemoteExpiredTrials
+	trialEmails                     *trialemails.Service
 }
 
 func NewActivities(
@@ -201,6 +203,7 @@ func NewActivities(
 	celEng *celenv.Engine,
 	judgeRateLimiter *ratelimit.Limiter,
 	builtinPresets *presetlib.Library,
+	trialEmailsService *trialemails.Service,
 ) *Activities {
 	// Spend rule evaluation reads ClickHouse; workers without a ClickHouse
 	// connection get a nil repo and the activity fails loudly if scheduled.
@@ -352,6 +355,7 @@ func NewActivities(
 		),
 		skillSuggestionAnalyzer: skillSuggestionAnalyzer,
 		remoteSessionRefresh:    remoteSessionRefresh,
+		trialEmails:             trialEmailsService,
 		// The judges draw on the same per-(org, model) bucket and the same
 		// completion client as every other platform judge, so chat analysis
 		// cannot outspend the org's key behind their backs.
@@ -361,6 +365,32 @@ func NewActivities(
 			analysis.NewPublisher(logger, tracerProvider, db, telemetryRepo, telemetryLogger, chatAnalysisJudges),
 			&TemporalChatAnalysisSignaler{TemporalEnv: temporalEnv, Logger: logger},
 		),
+	}
+}
+
+func (a *Activities) SendTrialLifecycleEmail(ctx context.Context, input TrialLifecycleEmailInput) error {
+	if a.trialEmails == nil {
+		return fmt.Errorf("trial email service is not configured")
+	}
+
+	switch input.Kind {
+	case TrialStartedEmailKind:
+		if err := a.trialEmails.TrialStarted(ctx, input.OrganizationID); err != nil {
+			return fmt.Errorf("trial started: %w", err)
+		}
+		return nil
+	case AdminAddedEmailKind:
+		if err := a.trialEmails.AdminAdded(ctx, input.OrganizationID, input.UserID); err != nil {
+			return fmt.Errorf("admin added: %w", err)
+		}
+		return nil
+	case TrialInactiveEmailKind:
+		if err := a.trialEmails.TrialInactive(ctx, input.OrganizationID); err != nil {
+			return fmt.Errorf("trial inactive: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported trial lifecycle email kind %q", input.Kind)
 	}
 }
 

--- a/server/internal/background/trial_emails.go
+++ b/server/internal/background/trial_emails.go
@@ -1,0 +1,106 @@
+package background
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tenvironment "github.com/speakeasy-api/gram/server/internal/temporal"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	trialLifecycleEmailWorkflowIDPrefix = "v1:trial-lifecycle-email"
+	trialLifecycleEmailActivityTimeout  = 5 * time.Minute
+)
+
+type TrialLifecycleEmailKind string
+
+const (
+	TrialStartedEmailKind  TrialLifecycleEmailKind = "trial-started"
+	AdminAddedEmailKind    TrialLifecycleEmailKind = "admin-added"
+	TrialInactiveEmailKind TrialLifecycleEmailKind = "trial-inactive"
+)
+
+// TrialLifecycleEmailInput identifies the lifecycle change to process in the
+// worker. The worker re-reads current state before contacting Loops.
+type TrialLifecycleEmailInput struct {
+	Kind           TrialLifecycleEmailKind `json:"kind"`
+	OrganizationID string                  `json:"organization_id"`
+	UserID         string                  `json:"user_id,omitempty"`
+}
+
+// TemporalTrialEmailNotifier enqueues trial email work without performing the
+// database fan-out or calling Loops on the API request path.
+type TemporalTrialEmailNotifier struct {
+	TemporalEnv *tenvironment.Environment
+}
+
+var _ trialemails.Notifier = (*TemporalTrialEmailNotifier)(nil)
+
+func (n *TemporalTrialEmailNotifier) TrialStarted(ctx context.Context, organizationID string) error {
+	return n.enqueue(ctx, TrialLifecycleEmailInput{
+		Kind:           TrialStartedEmailKind,
+		OrganizationID: organizationID,
+		UserID:         "",
+	})
+}
+
+func (n *TemporalTrialEmailNotifier) AdminAdded(ctx context.Context, organizationID, userID string) error {
+	return n.enqueue(ctx, TrialLifecycleEmailInput{
+		Kind:           AdminAddedEmailKind,
+		OrganizationID: organizationID,
+		UserID:         userID,
+	})
+}
+
+func (n *TemporalTrialEmailNotifier) TrialInactive(ctx context.Context, organizationID string) error {
+	return n.enqueue(ctx, TrialLifecycleEmailInput{
+		Kind:           TrialInactiveEmailKind,
+		OrganizationID: organizationID,
+		UserID:         "",
+	})
+}
+
+func (n *TemporalTrialEmailNotifier) enqueue(ctx context.Context, input TrialLifecycleEmailInput) error {
+	if n == nil || n.TemporalEnv == nil {
+		return fmt.Errorf("temporal environment is not configured")
+	}
+
+	_, err := n.TemporalEnv.Client().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:                    trialLifecycleEmailWorkflowID(input),
+		TaskQueue:             string(n.TemporalEnv.Queue()),
+		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowRunTimeout:    10 * time.Minute,
+	}, TrialLifecycleEmailWorkflow, input)
+	if err != nil {
+		return fmt.Errorf("enqueue trial lifecycle email workflow: %w", err)
+	}
+	return nil
+}
+
+func trialLifecycleEmailWorkflowID(input TrialLifecycleEmailInput) string {
+	return fmt.Sprintf("%s:%s:%s:%s", trialLifecycleEmailWorkflowIDPrefix, input.Kind, input.OrganizationID, input.UserID)
+}
+
+func TrialLifecycleEmailWorkflow(ctx workflow.Context, input TrialLifecycleEmailInput) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    5 * time.Second,
+			MaximumInterval:    time.Minute,
+			BackoffCoefficient: 2,
+			MaximumAttempts:    5,
+		},
+	})
+
+	var a *Activities
+	if err := workflow.ExecuteActivity(ctx, a.SendTrialLifecycleEmail, input).Get(ctx, nil); err != nil {
+		return fmt.Errorf("send trial lifecycle email: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/trial_emails.go
+++ b/server/internal/background/trial_emails.go
@@ -18,25 +18,36 @@ const (
 	trialLifecycleEmailActivityTimeout  = 5 * time.Minute
 )
 
+// TrialLifecycleEmailKind identifies the trial lifecycle change that starts a
+// Loops workflow.
 type TrialLifecycleEmailKind string
 
 const (
-	TrialStartedEmailKind  TrialLifecycleEmailKind = "trial-started"
-	AdminAddedEmailKind    TrialLifecycleEmailKind = "admin-added"
+	// TrialStartedEmailKind starts the trial workflow for an organization.
+	TrialStartedEmailKind TrialLifecycleEmailKind = "trial-started"
+	// AdminAddedEmailKind starts the trial workflow for an added administrator.
+	AdminAddedEmailKind TrialLifecycleEmailKind = "admin-added"
+	// TrialInactiveEmailKind stops pending trial reminders for an organization.
 	TrialInactiveEmailKind TrialLifecycleEmailKind = "trial-inactive"
 )
 
 // TrialLifecycleEmailInput identifies the lifecycle change to process in the
 // worker. The worker re-reads current state before contacting Loops.
 type TrialLifecycleEmailInput struct {
-	Kind           TrialLifecycleEmailKind `json:"kind"`
-	OrganizationID string                  `json:"organization_id"`
-	UserID         string                  `json:"user_id,omitempty"`
+	// Kind identifies the lifecycle change to process.
+	Kind TrialLifecycleEmailKind `json:"kind"`
+
+	// OrganizationID identifies the organization whose trial changed.
+	OrganizationID string `json:"organization_id"`
+
+	// UserID identifies the administrator affected by an admin-added event.
+	UserID string `json:"user_id,omitempty"`
 }
 
 // TemporalTrialEmailNotifier enqueues trial email work without performing the
 // database fan-out or calling Loops on the API request path.
 type TemporalTrialEmailNotifier struct {
+	// TemporalEnv provides the client and task queue used to enqueue workflows.
 	TemporalEnv *tenvironment.Environment
 }
 

--- a/server/internal/background/trial_emails.go
+++ b/server/internal/background/trial_emails.go
@@ -14,10 +14,23 @@ import (
 )
 
 const (
-	trialLifecycleEmailWorkflowIDPrefix   = "v1:trial-lifecycle-email"
-	trialLifecycleEmailActivityTimeout    = 5 * time.Minute
-	trialLifecycleEmailWorkflowRunTimeout = 30 * time.Minute
+	trialLifecycleEmailWorkflowIDPrefix              = "v1:trial-lifecycle-email"
+	trialLifecycleEmailActivityTimeout               = 5 * time.Minute
+	trialLifecycleEmailWorkflowRunTimeout            = 30 * time.Minute
+	trialLifecycleEmailRetryInitialInterval          = 5 * time.Second
+	trialLifecycleEmailRetryMaximumInterval          = time.Minute
+	trialLifecycleEmailRetryBackoffCoefficient       = 2.0
+	trialLifecycleEmailRetryMaximumAttempts    int32 = 5
 )
+
+func trialLifecycleEmailRetryPolicy() *temporal.RetryPolicy {
+	return &temporal.RetryPolicy{
+		InitialInterval:    trialLifecycleEmailRetryInitialInterval,
+		MaximumInterval:    trialLifecycleEmailRetryMaximumInterval,
+		BackoffCoefficient: trialLifecycleEmailRetryBackoffCoefficient,
+		MaximumAttempts:    trialLifecycleEmailRetryMaximumAttempts,
+	}
+}
 
 // TrialLifecycleEmailKind identifies the trial lifecycle change that starts a
 // Loops workflow.
@@ -102,12 +115,7 @@ func trialLifecycleEmailWorkflowID(input TrialLifecycleEmailInput) string {
 func TrialLifecycleEmailWorkflow(ctx workflow.Context, input TrialLifecycleEmailInput) error {
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: trialLifecycleEmailActivityTimeout,
-		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval:    5 * time.Second,
-			MaximumInterval:    time.Minute,
-			BackoffCoefficient: 2,
-			MaximumAttempts:    5,
-		},
+		RetryPolicy:         trialLifecycleEmailRetryPolicy(),
 	})
 
 	var a *Activities

--- a/server/internal/background/trial_emails.go
+++ b/server/internal/background/trial_emails.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	trialLifecycleEmailWorkflowIDPrefix = "v1:trial-lifecycle-email"
-	trialLifecycleEmailActivityTimeout  = 5 * time.Minute
+	trialLifecycleEmailWorkflowIDPrefix   = "v1:trial-lifecycle-email"
+	trialLifecycleEmailActivityTimeout    = 5 * time.Minute
+	trialLifecycleEmailWorkflowRunTimeout = 30 * time.Minute
 )
 
 // TrialLifecycleEmailKind identifies the trial lifecycle change that starts a
@@ -86,7 +87,7 @@ func (n *TemporalTrialEmailNotifier) enqueue(ctx context.Context, input TrialLif
 		ID:                    trialLifecycleEmailWorkflowID(input),
 		TaskQueue:             string(n.TemporalEnv.Queue()),
 		WorkflowIDReusePolicy: enums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
-		WorkflowRunTimeout:    10 * time.Minute,
+		WorkflowRunTimeout:    trialLifecycleEmailWorkflowRunTimeout,
 	}, TrialLifecycleEmailWorkflow, input)
 	if err != nil {
 		return fmt.Errorf("enqueue trial lifecycle email workflow: %w", err)

--- a/server/internal/background/trial_emails_test.go
+++ b/server/internal/background/trial_emails_test.go
@@ -1,0 +1,64 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func TestTrialLifecycleEmailWorkflowDispatchesAdminAdded(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var received TrialLifecycleEmailInput
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, input TrialLifecycleEmailInput) error {
+			received = input
+			return nil
+		},
+		activity.RegisterOptions{Name: "SendTrialLifecycleEmail"},
+	)
+
+	input := TrialLifecycleEmailInput{
+		Kind:           AdminAddedEmailKind,
+		OrganizationID: "<ORGANIZATION_ID>",
+		UserID:         "<USER_ID>",
+	}
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, input)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, input, received)
+}
+
+func TestTrialLifecycleEmailWorkflowRetriesActivity(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var attempts atomic.Int32
+	env.RegisterActivityWithOptions(
+		func(context.Context, TrialLifecycleEmailInput) error {
+			if attempts.Add(1) < 3 {
+				return errors.New("temporary Loops failure")
+			}
+			return nil
+		},
+		activity.RegisterOptions{Name: "SendTrialLifecycleEmail"},
+	)
+
+	env.ExecuteWorkflow(TrialLifecycleEmailWorkflow, TrialLifecycleEmailInput{
+		Kind:           TrialStartedEmailKind,
+		OrganizationID: "<ORGANIZATION_ID>",
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, int32(3), attempts.Load())
+}

--- a/server/internal/background/trial_emails_test.go
+++ b/server/internal/background/trial_emails_test.go
@@ -12,10 +12,21 @@ import (
 	"go.temporal.io/sdk/testsuite"
 )
 
+func trialLifecycleEmailRetryBudget() time.Duration {
+	policy := trialLifecycleEmailRetryPolicy()
+	budget := trialLifecycleEmailActivityTimeout * time.Duration(policy.MaximumAttempts)
+	retryDelay := policy.InitialInterval
+	for attempt := int32(1); attempt < policy.MaximumAttempts; attempt++ {
+		budget += retryDelay
+		retryDelay = min(time.Duration(float64(retryDelay)*policy.BackoffCoefficient), policy.MaximumInterval)
+	}
+	return budget
+}
+
 func TestTrialLifecycleEmailWorkflowRunTimeoutCoversRetryBudget(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, 30*time.Minute, trialLifecycleEmailWorkflowRunTimeout)
+	require.GreaterOrEqual(t, trialLifecycleEmailWorkflowRunTimeout, trialLifecycleEmailRetryBudget())
 }
 
 func TestTrialLifecycleEmailWorkflowDispatchesAdminAdded(t *testing.T) {

--- a/server/internal/background/trial_emails_test.go
+++ b/server/internal/background/trial_emails_test.go
@@ -5,11 +5,18 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
 )
+
+func TestTrialLifecycleEmailWorkflowRunTimeoutCoversRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 30*time.Minute, trialLifecycleEmailWorkflowRunTimeout)
+}
 
 func TestTrialLifecycleEmailWorkflowDispatchesAdminAdded(t *testing.T) {
 	t.Parallel()

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -57,6 +57,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
 	slack_client "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 )
 
 type WorkerOptions struct {
@@ -99,6 +100,7 @@ type WorkerOptions struct {
 	ProductFeatures     *productfeatures.Client
 	PluginPublisher     *plugins.Service
 	Publishers          *Publishers
+	TrialEmailsService  *trialemails.Service
 }
 
 func ForDeploymentProcessing(
@@ -160,6 +162,7 @@ func ForDeploymentProcessing(
 			TelemetryLogs:           gcp.NewNoopPublisher[*telemetryv1.LogRecord](),
 			Outbox:                  topics.NewNoopPublisher(),
 		},
+		TrialEmailsService: nil,
 	}
 }
 
@@ -210,6 +213,7 @@ func NewTemporalWorker(
 		ClickhouseConn:      nil,
 		PluginPublisher:     nil,
 		Publishers:          nil,
+		TrialEmailsService:  nil,
 	}
 
 	for _, o := range options {
@@ -253,6 +257,7 @@ func NewTemporalWorker(
 			ClickhouseConn:      conv.Default(o.ClickhouseConn, opts.ClickhouseConn),
 			PluginPublisher:     conv.Default(o.PluginPublisher, opts.PluginPublisher),
 			Publishers:          conv.Default(o.Publishers, opts.Publishers),
+			TrialEmailsService:  conv.Default(o.TrialEmailsService, opts.TrialEmailsService),
 		}
 	}
 
@@ -336,6 +341,7 @@ func NewTemporalWorker(
 		celEng,
 		judgeRateLimiter,
 		opts.BuiltinPresets,
+		opts.TrialEmailsService,
 	)
 
 	temporalWorker.RegisterActivity(activities.ProcessDeployment)
@@ -426,6 +432,7 @@ func NewTemporalWorker(
 	// Trial expiry activities
 	temporalWorker.RegisterActivity(activities.ListExpiredTrials)
 	temporalWorker.RegisterActivity(activities.DemoteExpiredTrial)
+	temporalWorker.RegisterActivity(activities.SendTrialLifecycleEmail)
 	// Skill efficacy activities — the database steps run on the main queue and
 	// only the judged publication goes to the dedicated worker.
 	temporalWorker.RegisterActivity(activities.skillEfficacyScorer.EnqueueSkillEfficacyPage)
@@ -537,6 +544,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(RemoteSessionRefreshWorkflow)
 	// Trial expiry workflows
 	temporalWorker.RegisterWorkflow(DemoteExpiredTrialsWorkflow)
+	temporalWorker.RegisterWorkflow(TrialLifecycleEmailWorkflow)
 	if err := AddPlatformUsageMetricsSchedule(context.Background(), env); err != nil {
 		if !errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
 			logger.ErrorContext(context.Background(), "failed to add platform usage metrics schedule", attr.SlogError(err))

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -100,7 +100,9 @@ type WorkerOptions struct {
 	ProductFeatures     *productfeatures.Client
 	PluginPublisher     *plugins.Service
 	Publishers          *Publishers
-	TrialEmailsService  *trialemails.Service
+
+	// TrialEmailsService synchronizes trial lifecycle changes with Loops.
+	TrialEmailsService *trialemails.Service
 }
 
 func ForDeploymentProcessing(

--- a/server/internal/organizations/impl.go
+++ b/server/internal/organizations/impl.go
@@ -47,6 +47,7 @@ import (
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	telemrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/trialemails"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	svix "github.com/svix/svix-webhooks/go"
@@ -102,6 +103,7 @@ type Service struct {
 	features  orgFeatureChecker
 	hooks     HookEventReader // optional; nil disables verifyOnboardingHooksSetup
 	email     *email.Service
+	trial     trialemails.Notifier
 	serverURL string // API server URL; used to build invite links
 	siteURL   string // frontend URL; used for post-callback browser redirects
 	audit     *audit.Logger
@@ -112,8 +114,11 @@ var _ gen.Service = (*Service)(nil)
 
 var _ gen.Auther = (*Service)(nil)
 
-func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, invite InviteIdentityProvider, features orgFeatureChecker, hooks HookEventReader, authzEngine *authz.Engine, emailService *email.Service, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
+func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pgxpool.Pool, sessionMgr *sessions.Manager, orgs OrganizationProvider, invite InviteIdentityProvider, features orgFeatureChecker, hooks HookEventReader, authzEngine *authz.Engine, emailService *email.Service, trialNotifier trialemails.Notifier, serverURL string, siteURL string, auditLogger *audit.Logger, svix *svix.Svix) *Service {
 	logger = logger.With(attr.SlogComponent("organizations"))
+	if trialNotifier == nil {
+		trialNotifier = trialemails.NoopNotifier{}
+	}
 
 	return &Service{
 		logger:    logger,
@@ -127,6 +132,7 @@ func NewService(logger *slog.Logger, tracerProvider trace.TracerProvider, db *pg
 		features:  features,
 		hooks:     hooks,
 		email:     emailService,
+		trial:     trialNotifier,
 		serverURL: serverURL,
 		siteURL:   siteURL,
 		audit:     auditLogger,
@@ -1506,6 +1512,17 @@ func (s *Service) handleInviteCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	span.AddEvent("invite.callback.invitation_accepted")
+
+	if invite.RoleSlug.Valid && invite.RoleSlug.String == authz.SystemRoleAdmin {
+		if err := s.trial.AdminAdded(ctx, invite.OrganizationID, gramUserID); err != nil {
+			s.logger.ErrorContext(ctx, "invite callback: failed to notify trial admin added",
+				attr.SlogError(err),
+				attr.SlogOrganizationID(invite.OrganizationID),
+				attr.SlogUserID(gramUserID),
+				attr.SlogOrganizationInviteID(invite.ID.String()),
+			)
+		}
+	}
 
 	// Create a Gram session directly. The invitee is already authenticated
 	// by Magic Auth, and the WorkOS session ID is stored for logout revocation.

--- a/server/internal/organizations/invitecallback_test.go
+++ b/server/internal/organizations/invitecallback_test.go
@@ -1,0 +1,152 @@
+package organizations_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/organizations"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+func TestInviteCallback_AdminInviteNotifiesTrialAdminAdded(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "admin-accepted", authCtx.ActiveOrganizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", authCtx.ActiveOrganizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	seedInviteeUser(t, ctx, ti)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	require.Equal(t, []adminAddedNotification{{
+		organizationID: authCtx.ActiveOrganizationID,
+		userID:         "user_01INVITEE",
+	}}, ti.trial.adminAdded)
+
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+}
+
+func TestInviteCallback_MemberInviteDoesNotNotifyTrialAdminAdded(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "member-accepted", authCtx.ActiveOrganizationID, authCtx.UserID, authz.SystemRoleMember)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", authCtx.ActiveOrganizationID, authz.SystemRoleMember).Return("membership_01INVITE", nil).Once()
+	seedInviteeUser(t, ctx, ti)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	require.Empty(t, ti.trial.adminAdded)
+
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+}
+
+func TestInviteCallback_TrialNotifierFailurePreservesInviteAcceptance(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "admin-notifier-failure", authCtx.ActiveOrganizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	ti.orgs.On("CreateOrganizationMembership", mock.Anything, "user_01INVITEE", authCtx.ActiveOrganizationID, authz.SystemRoleAdmin).Return("membership_01INVITE", nil).Once()
+	ti.trial.adminAddedErr = errors.New("notify failed")
+	seedInviteeUser(t, ctx, ti)
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	require.Equal(t, []adminAddedNotification{{
+		organizationID: authCtx.ActiveOrganizationID,
+		userID:         "user_01INVITEE",
+	}}, ti.trial.adminAdded)
+
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "accepted", storedInvite.State)
+}
+
+func TestInviteCallback_RevokedInviteDoesNotNotifyTrialAdminAdded(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx := requireAuthContext(t, ctx)
+	rawToken, invite := seedInviteCallbackInvite(t, ctx, ti, "admin-revoked", authCtx.ActiveOrganizationID, authCtx.UserID, authz.SystemRoleAdmin)
+	require.NoError(t, orgrepo.New(ti.conn).RevokeInvitation(ctx, invite.ID))
+
+	recorder := serveInviteCallback(t, ti, rawToken)
+	require.Equal(t, http.StatusTemporaryRedirect, recorder.Code)
+	require.Empty(t, ti.trial.adminAdded)
+
+	storedInvite, err := orgrepo.New(ti.conn).GetInvitationByID(ctx, invite.ID)
+	require.NoError(t, err)
+	require.Equal(t, "revoked", storedInvite.State)
+}
+
+func requireAuthContext(t *testing.T, ctx context.Context) *contextvalues.AuthContext {
+	t.Helper()
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx)
+	return authCtx
+}
+
+func seedInviteCallbackInvite(t *testing.T, ctx context.Context, ti *testInstance, name, organizationID, inviterUserID, roleSlug string) (string, orgrepo.OrganizationInvitation) {
+	t.Helper()
+
+	rawToken := "token-" + name
+	invite, err := orgrepo.New(ti.conn).CreateInvitation(ctx, orgrepo.CreateInvitationParams{
+		OrganizationID: organizationID,
+		Email:          "invitee@example.test",
+		TokenHash:      inviteTokenHash(rawToken),
+		InviterUserID:  conv.ToPGText(inviterUserID),
+		RoleSlug:       pgtype.Text{String: roleSlug, Valid: roleSlug != ""},
+		ExpiresInDays:  7,
+	})
+	require.NoError(t, err)
+	return rawToken, invite
+}
+
+func seedInviteeUser(t *testing.T, ctx context.Context, ti *testInstance) {
+	t.Helper()
+
+	require.NoError(t, testrepo.New(ti.conn).InsertUserFixture(ctx, testrepo.InsertUserFixtureParams{
+		ID:          "user_01INVITEE",
+		Email:       "invitee@example.test",
+		DisplayName: "Invitee",
+	}))
+}
+
+func serveInviteCallback(t *testing.T, ti *testInstance, rawToken string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	mux := goahttp.NewMuxer()
+	organizations.Attach(mux, ti.service)
+	req := httptest.NewRequest(http.MethodGet, "/rpc/organizations.inviteCallback?invite_token="+rawToken, nil)
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func inviteTokenHash(rawToken string) string {
+	sum := sha256.Sum256([]byte(rawToken))
+	return hex.EncodeToString(sum[:])
+}

--- a/server/internal/organizations/setup_test.go
+++ b/server/internal/organizations/setup_test.go
@@ -98,7 +98,31 @@ type testInstance struct {
 	conn    *pgxpool.Pool
 	orgs    *MockOrganizationProvider
 	loops   *MockLoopsClient
+	trial   *fakeTrialNotifier
 	svixSrv *svixtest.MockServer
+}
+
+type fakeTrialNotifier struct {
+	adminAddedErr error
+	adminAdded    []adminAddedNotification
+}
+
+type adminAddedNotification struct {
+	organizationID string
+	userID         string
+}
+
+func (f *fakeTrialNotifier) TrialStarted(context.Context, string) error {
+	return nil
+}
+
+func (f *fakeTrialNotifier) AdminAdded(_ context.Context, organizationID, userID string) error {
+	f.adminAdded = append(f.adminAdded, adminAddedNotification{organizationID: organizationID, userID: userID})
+	return f.adminAddedErr
+}
+
+func (f *fakeTrialNotifier) TrialInactive(context.Context, string) error {
+	return nil
 }
 
 func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) {
@@ -145,12 +169,14 @@ func newTestOrganizationsService(t *testing.T) (context.Context, *testInstance) 
 	svixClient, err := svix.New("test-token", &svix.SvixOptions{ServerUrl: svixSrv.URL()})
 	require.NoError(t, err)
 
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, nil, authzEngine, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	trialNotifier := &fakeTrialNotifier{}
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, nil, authzEngine, nil, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,
 		conn:    conn,
 		orgs:    orgs,
+		trial:   trialNotifier,
 		svixSrv: svixSrv,
 	}
 }
@@ -201,12 +227,14 @@ func newTestOrganizationsServiceRBAC(t *testing.T) (context.Context, *testInstan
 	svixClient, err := svix.New("test-token", &svix.SvixOptions{ServerUrl: svixSrv.URL()})
 	require.NoError(t, err)
 
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeaturesEnabled{}, nil, authzEngine, nil, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	trialNotifier := &fakeTrialNotifier{}
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeaturesEnabled{}, nil, authzEngine, nil, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,
 		conn:    conn,
 		orgs:    orgs,
+		trial:   trialNotifier,
 		svixSrv: svixSrv,
 	}
 }
@@ -256,13 +284,15 @@ func newTestOrganizationsServiceWithEmail(t *testing.T) (context.Context, *testI
 	require.NoError(t, err)
 
 	emailService := email.NewService(logger, loopsMock)
-	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, nil, authzEngine, emailService, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
+	trialNotifier := &fakeTrialNotifier{}
+	svc := organizations.NewService(logger, tracerProvider, conn, sessionManager, orgs, stubUserProvisioner{}, stubOrgFeatures{}, nil, authzEngine, emailService, trialNotifier, "http://localhost:35291", "http://localhost:5173", auditLogger, svixClient)
 
 	return ctx, &testInstance{
 		service: svc,
 		conn:    conn,
 		orgs:    orgs,
 		loops:   loopsMock,
+		trial:   trialNotifier,
 		svixSrv: svixSrv,
 	}
 }

--- a/server/internal/thirdparty/loops/client.go
+++ b/server/internal/thirdparty/loops/client.go
@@ -37,7 +37,9 @@ type WorkflowClient interface {
 	SendEvent(ctx context.Context, input SendEventInput) error
 }
 
-// FindContactInput identifies a Loops contact by email or user ID.
+var errInvalidFindContactInput = errors.New("find contact requires exactly one of email or user ID")
+
+// FindContactInput identifies a Loops contact by exactly one of email or user ID.
 type FindContactInput struct {
 	// Email is the contact's email address.
 	Email string
@@ -73,11 +75,17 @@ type SendEventInput struct {
 
 // Contact is the subset of Loops contact data needed by workflow callers.
 type Contact struct {
-	Email        string         `json:"email"`
-	FirstName    *string        `json:"firstName"`
-	UserID       *string        `json:"userId"`
-	Subscribed   bool           `json:"subscribed"`
-	CustomFields map[string]any `json:"-"`
+	// Email is the contact's email address.
+	Email string `json:"email"`
+
+	// FirstName is the contact's first name when configured in Loops.
+	FirstName *string `json:"firstName"`
+
+	// UserID is the contact's external user ID.
+	UserID *string `json:"userId"`
+
+	// Subscribed reports whether the contact can receive workflow emails.
+	Subscribed bool `json:"subscribed"`
 }
 
 // SendTransactionalInput is the boundary type for sending a transactional
@@ -220,6 +228,10 @@ type eventRequest struct {
 }
 
 func (c *httpClient) FindContact(ctx context.Context, input FindContactInput) (*Contact, error) {
+	if (input.Email == "") == (input.UserID == "") {
+		return nil, errInvalidFindContactInput
+	}
+
 	query := url.Values{}
 	if input.Email != "" {
 		query.Set("email", input.Email)
@@ -338,7 +350,10 @@ type noopClient struct {
 	logger *slog.Logger
 }
 
-func (c *noopClient) FindContact(context.Context, FindContactInput) (*Contact, error) {
+func (c *noopClient) FindContact(_ context.Context, input FindContactInput) (*Contact, error) {
+	if (input.Email == "") == (input.UserID == "") {
+		return nil, errInvalidFindContactInput
+	}
 	return nil, nil
 }
 

--- a/server/internal/thirdparty/loops/client.go
+++ b/server/internal/thirdparty/loops/client.go
@@ -10,10 +10,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
+	"net/url"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -25,6 +28,56 @@ const defaultBaseURL = "https://app.loops.so/api/v1"
 // Client sends transactional emails via Loops.
 type Client interface {
 	SendTransactional(ctx context.Context, input SendTransactionalInput) error
+}
+
+// WorkflowClient manages Loops contacts and sends events that trigger workflows.
+type WorkflowClient interface {
+	FindContact(ctx context.Context, input FindContactInput) (*Contact, error)
+	UpdateContact(ctx context.Context, input UpdateContactInput) error
+	SendEvent(ctx context.Context, input SendEventInput) error
+}
+
+// FindContactInput identifies a Loops contact by email or user ID.
+type FindContactInput struct {
+	// Email is the contact's email address.
+	Email string
+	// UserID is the contact's external user ID.
+	UserID string
+}
+
+// UpdateContactInput contains the contact fields to upsert in Loops.
+type UpdateContactInput struct {
+	// Email identifies the contact by email address.
+	Email string
+	// FirstName is the optional standard Loops first-name property.
+	FirstName *string
+	// UserID identifies the contact by external user ID when provided.
+	UserID string
+	// CustomProperties contains camelCase Loops contact property names and values.
+	CustomProperties map[string]any
+}
+
+// SendEventInput contains an event and its contact identity and properties.
+type SendEventInput struct {
+	// Email identifies the contact by email address.
+	Email string
+	// UserID identifies the contact by external user ID when provided.
+	UserID string
+	// EventName is the Loops workflow event name.
+	EventName string
+	// EventProperties contains values made available to the workflow email.
+	EventProperties map[string]any
+	// IdempotencyKey prevents duplicate lifecycle events.
+	IdempotencyKey string
+}
+
+// Contact is the subset of Loops contact data needed by workflow callers.
+type Contact struct {
+	Email        string         `json:"email"`
+	FirstName    *string        `json:"firstName"`
+	UserID       *string        `json:"userId"`
+	Subscribed   bool           `json:"subscribed"`
+	CustomFields map[string]any `json:"-"`
 }
 
 // SendTransactionalInput is the boundary type for sending a transactional
@@ -54,6 +107,26 @@ func New(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Poli
 
 	if apiKey == "" || apiKey == "unset" {
 		logger.InfoContext(ctx, "loops API key not configured, transactional emails will be dropped")
+		return &noopClient{logger: logger}
+	}
+
+	return &httpClient{
+		logger:     logger,
+		httpClient: guardianPolicy.PooledClient(),
+		baseURL:    defaultBaseURL,
+		apiKey:     apiKey,
+	}
+}
+
+// NewWorkflowClient returns a WorkflowClient that is always safe to call.
+//
+// When apiKey is empty or the placeholder value "unset", the returned client
+// is a no-op that logs at debug level and returns nil for every operation.
+func NewWorkflowClient(ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, apiKey string) WorkflowClient {
+	logger = logger.With(attr.SlogComponent("loops"))
+
+	if apiKey == "" || apiKey == "unset" {
+		logger.InfoContext(ctx, "loops API key not configured, workflow emails will be dropped")
 		return &noopClient{logger: logger}
 	}
 
@@ -139,8 +212,144 @@ func (c *httpClient) SendTransactional(ctx context.Context, input SendTransactio
 	return nil
 }
 
+type eventRequest struct {
+	Email           string         `json:"email,omitempty"`
+	UserID          string         `json:"userId,omitempty"`
+	EventName       string         `json:"eventName"`
+	EventProperties map[string]any `json:"eventProperties,omitempty"`
+}
+
+func (c *httpClient) FindContact(ctx context.Context, input FindContactInput) (*Contact, error) {
+	query := url.Values{}
+	if input.Email != "" {
+		query.Set("email", input.Email)
+	} else if input.UserID != "" {
+		query.Set("userId", input.UserID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/contacts/find?"+query.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build find contact request: %w", err)
+	}
+
+	respBody, err := c.doWorkflowRequestWithRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("find contact: %w", err)
+	}
+
+	var contacts []Contact
+	if err := json.Unmarshal(respBody, &contacts); err != nil {
+		return nil, fmt.Errorf("decode find contact response: %w", err)
+	}
+	if len(contacts) == 0 {
+		return nil, nil
+	}
+	return &contacts[0], nil
+}
+
+func (c *httpClient) UpdateContact(ctx context.Context, input UpdateContactInput) error {
+	payload := map[string]any{}
+	if input.Email != "" {
+		payload["email"] = input.Email
+	}
+	if input.FirstName != nil {
+		payload["firstName"] = *input.FirstName
+	}
+	if input.UserID != "" {
+		payload["userId"] = input.UserID
+	}
+	maps.Copy(payload, input.CustomProperties)
+
+	return c.sendWorkflowJSON(ctx, http.MethodPut, "/contacts/update", payload, "update contact", "")
+}
+
+func (c *httpClient) SendEvent(ctx context.Context, input SendEventInput) error {
+	payload, err := json.Marshal(eventRequest{
+		Email:           input.Email,
+		UserID:          input.UserID,
+		EventName:       input.EventName,
+		EventProperties: input.EventProperties,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal send event request: %w", err)
+	}
+	return c.sendWorkflowJSON(ctx, http.MethodPost, "/events/send", payload, "send event", input.IdempotencyKey)
+}
+
+func (c *httpClient) sendWorkflowJSON(ctx context.Context, method, path string, payload any, operation, idempotencyKey string) error {
+	var body io.Reader
+	if data, ok := payload.([]byte); ok {
+		body = bytes.NewReader(data)
+	} else {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal %s request: %w", operation, err)
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", operation, err)
+	}
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	if _, err := c.doWorkflowRequestWithRequest(req); err != nil {
+		var respErr *workflowResponseError
+		if errors.As(err, &respErr) && respErr.statusCode == http.StatusConflict && idempotencyKey != "" {
+			c.logger.DebugContext(ctx, "loops suppressed duplicate workflow event", attr.SlogName(idempotencyKey))
+			return nil
+		}
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+	return nil
+}
+
+func (c *httpClient) doWorkflowRequestWithRequest(req *http.Request) ([]byte, error) {
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if req.Body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute workflow request: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read workflow response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, &workflowResponseError{statusCode: resp.StatusCode, body: string(respBody)}
+	}
+	return respBody, nil
+}
+
+type workflowResponseError struct {
+	statusCode int
+	body       string
+}
+
+func (e *workflowResponseError) Error() string {
+	return fmt.Sprintf("loops API returned HTTP %d: %s", e.statusCode, e.body)
+}
+
 type noopClient struct {
 	logger *slog.Logger
+}
+
+func (c *noopClient) FindContact(context.Context, FindContactInput) (*Contact, error) {
+	return nil, nil
+}
+
+func (c *noopClient) UpdateContact(ctx context.Context, input UpdateContactInput) error {
+	c.logger.DebugContext(ctx, "loops disabled, dropping contact update", attr.SlogName(input.Email))
+	return nil
+}
+
+func (c *noopClient) SendEvent(ctx context.Context, input SendEventInput) error {
+	c.logger.DebugContext(ctx, "loops disabled, dropping workflow event", attr.SlogName(input.EventName))
+	return nil
 }
 
 func (c *noopClient) SendTransactional(ctx context.Context, input SendTransactionalInput) error {

--- a/server/internal/thirdparty/loops/client.go
+++ b/server/internal/thirdparty/loops/client.go
@@ -23,7 +23,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 )
 
-const defaultBaseURL = "https://app.loops.so/api/v1"
+const (
+	defaultBaseURL           = "https://app.loops.so/api/v1"
+	maxWorkflowResponseBytes = 64 << 10
+)
 
 // Client sends transactional emails via Loops.
 type Client interface {
@@ -327,9 +330,12 @@ func (c *httpClient) doWorkflowRequestWithRequest(req *http.Request) ([]byte, er
 		return nil, fmt.Errorf("execute workflow request: %w", err)
 	}
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxWorkflowResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read workflow response: %w", err)
+	}
+	if len(respBody) > maxWorkflowResponseBytes {
+		return nil, fmt.Errorf("workflow response body exceeded %d bytes", maxWorkflowResponseBytes)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, &workflowResponseError{statusCode: resp.StatusCode, body: string(respBody)}

--- a/server/internal/thirdparty/loops/client_test.go
+++ b/server/internal/thirdparty/loops/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -285,6 +286,18 @@ func TestHTTPClient_FindContact_ReturnsNilWhenNotFound(t *testing.T) {
 	contact, err := newTestHTTPClient(t, server.URL, "workflow-key").FindContact(t.Context(), FindContactInput{UserID: "<USER_ID>"})
 	require.NoError(t, err)
 	require.Nil(t, contact)
+}
+
+func TestHTTPClient_WorkflowResponseRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", maxWorkflowResponseBytes+1)))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := newTestHTTPClient(t, server.URL, "workflow-key").FindContact(t.Context(), FindContactInput{Email: "<EMAIL>@example.com"})
+	require.ErrorContains(t, err, "workflow response body exceeded")
 }
 
 func TestHTTPClient_FindContact_RejectsAmbiguousIdentity(t *testing.T) {

--- a/server/internal/thirdparty/loops/client_test.go
+++ b/server/internal/thirdparty/loops/client_test.go
@@ -287,6 +287,19 @@ func TestHTTPClient_FindContact_ReturnsNilWhenNotFound(t *testing.T) {
 	require.Nil(t, contact)
 }
 
+func TestHTTPClient_FindContact_RejectsAmbiguousIdentity(t *testing.T) {
+	t.Parallel()
+
+	client := newTestHTTPClient(t, "http://invalid", "workflow-key")
+	for _, input := range []FindContactInput{
+		{},
+		{Email: "<EMAIL>@example.com", UserID: "<USER_ID>"},
+	} {
+		_, err := client.FindContact(t.Context(), input)
+		require.ErrorContains(t, err, "find contact requires exactly one of email or user ID")
+	}
+}
+
 func TestHTTPClient_UpdateContact_SendsTypedCamelCaseProperties(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/loops/client_test.go
+++ b/server/internal/thirdparty/loops/client_test.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/guardian"
@@ -235,6 +236,150 @@ func TestHTTPClient_SendTransactional_OmitsEmptyVariables(t *testing.T) {
 	require.NoError(t, readErr)
 	require.NotContains(t, string(rawBody), "dataVariables")
 	require.NotContains(t, string(rawBody), "addToAudience")
+}
+
+func TestNewWorkflowClient_NoopWhenAPIKeyIsNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	for _, apiKey := range []string{"", "unset"} {
+		client := NewWorkflowClient(t.Context(), testenv.NewLogger(t), newTestPolicy(t), apiKey)
+		require.IsType(t, &noopClient{}, client)
+		require.NoError(t, client.UpdateContact(t.Context(), UpdateContactInput{Email: "<EMAIL>"}))
+		require.NoError(t, client.SendEvent(t.Context(), SendEventInput{Email: "<EMAIL>", EventName: "trial_started"}))
+		contact, err := client.FindContact(t.Context(), FindContactInput{Email: "<EMAIL>"})
+		require.NoError(t, err)
+		require.Nil(t, contact)
+	}
+}
+
+func TestHTTPClient_FindContact_SendsEncodedQueryAndDecodesContact(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "<EMAIL>@example.com", r.URL.Query().Get("email"))
+		assert.Empty(t, r.URL.Query().Get("userId"))
+		assert.Equal(t, "Bearer workflow-key", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`[{"email":"<EMAIL>@example.com","firstName":"Ada","userId":"<USER_ID>","subscribed":true}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "workflow-key")
+	contact, err := c.FindContact(t.Context(), FindContactInput{Email: "<EMAIL>@example.com"})
+	require.NoError(t, err)
+	require.NotNil(t, contact)
+	require.Equal(t, "<EMAIL>@example.com", contact.Email)
+	require.Equal(t, "Ada", *contact.FirstName)
+	require.Equal(t, "<USER_ID>", *contact.UserID)
+	require.True(t, contact.Subscribed)
+}
+
+func TestHTTPClient_FindContact_ReturnsNilWhenNotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	contact, err := newTestHTTPClient(t, server.URL, "workflow-key").FindContact(t.Context(), FindContactInput{UserID: "<USER_ID>"})
+	require.NoError(t, err)
+	require.Nil(t, contact)
+}
+
+func TestHTTPClient_UpdateContact_SendsTypedCamelCaseProperties(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/contacts/update", r.URL.Path)
+		assert.Equal(t, "Bearer workflow-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "<EMAIL>@example.com", body["email"])
+		assert.Equal(t, "<USER_ID>", body["userId"])
+		assert.Equal(t, "Ada", body["firstName"])
+		assert.Equal(t, "<ORG_NAME>", body["organizationName"])
+		assert.Equal(t, true, body["trialActive"])
+		assert.InDelta(t, float64(14), body["trialDays"], 0)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	firstName := "Ada"
+	err := newTestHTTPClient(t, server.URL, "workflow-key").UpdateContact(t.Context(), UpdateContactInput{
+		Email:     "<EMAIL>@example.com",
+		FirstName: &firstName,
+		UserID:    "<USER_ID>",
+		CustomProperties: map[string]any{
+			"organizationName": "<ORG_NAME>",
+			"trialActive":      true,
+			"trialDays":        14,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestHTTPClient_SendEvent_SendsPropertiesAuthAndIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/events/send", r.URL.Path)
+		assert.Equal(t, "Bearer workflow-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "event-key", r.Header.Get("Idempotency-Key"))
+		var body eventRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "<EMAIL>@example.com", body.Email)
+		assert.Equal(t, "<USER_ID>", body.UserID)
+		assert.Equal(t, "trial_started", body.EventName)
+		assert.Equal(t, map[string]any{"trialEndsAt": "<TRIAL_ENDS_AT>"}, body.EventProperties)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := newTestHTTPClient(t, server.URL, "workflow-key").SendEvent(t.Context(), SendEventInput{
+		Email:           "<EMAIL>@example.com",
+		UserID:          "<USER_ID>",
+		EventName:       "trial_started",
+		EventProperties: map[string]any{"trialEndsAt": "<TRIAL_ENDS_AT>"},
+		IdempotencyKey:  "event-key",
+	})
+	require.NoError(t, err)
+}
+
+func TestHTTPClient_SendEvent_TreatsDuplicateAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"message":"duplicate"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := newTestHTTPClient(t, server.URL, "workflow-key").SendEvent(t.Context(), SendEventInput{
+		Email:          "<EMAIL>@example.com",
+		EventName:      "trial_started",
+		IdempotencyKey: "event-key",
+	})
+	require.NoError(t, err)
+}
+
+func TestHTTPClient_WorkflowMethodsReturnAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"success":false,"message":"invalid property"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c := newTestHTTPClient(t, server.URL, "workflow-key")
+	err := c.UpdateContact(t.Context(), UpdateContactInput{Email: "<EMAIL>@example.com"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "HTTP 400")
+	require.Contains(t, err.Error(), "invalid property")
 }
 
 func newTestPolicy(t *testing.T) *guardian.Policy {

--- a/server/internal/trialemails/notifier.go
+++ b/server/internal/trialemails/notifier.go
@@ -1,0 +1,25 @@
+package trialemails
+
+import "context"
+
+// Notifier publishes lifecycle changes that affect enterprise trial email workflows.
+type Notifier interface {
+	TrialStarted(ctx context.Context, organizationID string) error
+	AdminAdded(ctx context.Context, organizationID, userID string) error
+	TrialInactive(ctx context.Context, organizationID string) error
+}
+
+// NoopNotifier drops lifecycle notifications.
+type NoopNotifier struct{}
+
+func (NoopNotifier) TrialStarted(context.Context, string) error {
+	return nil
+}
+
+func (NoopNotifier) AdminAdded(context.Context, string, string) error {
+	return nil
+}
+
+func (NoopNotifier) TrialInactive(context.Context, string) error {
+	return nil
+}

--- a/server/internal/trialemails/service.go
+++ b/server/internal/trialemails/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 const trialStartedEventName = "trial_started"
@@ -42,8 +43,7 @@ func NewService(db *pgxpool.Pool, workflows loops.WorkflowClient, logger *slog.L
 
 // TrialStarted enters every active organization administrator into the trial workflow.
 func (s *Service) TrialStarted(ctx context.Context, organizationID string) error {
-	queries := orgrepo.New(s.db)
-	trial, err := queries.GetActiveTrial(ctx, organizationID)
+	trial, err := trialsrepo.New(s.db).GetActiveTrial(ctx, organizationID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
 	}
@@ -51,6 +51,7 @@ func (s *Service) TrialStarted(ctx context.Context, organizationID string) error
 		return fmt.Errorf("get active trial: %w", err)
 	}
 
+	queries := orgrepo.New(s.db)
 	organization, err := queries.GetOrganizationMetadata(ctx, organizationID)
 	if err != nil {
 		return fmt.Errorf("get organization metadata: %w", err)
@@ -71,8 +72,7 @@ func (s *Service) TrialStarted(ctx context.Context, organizationID string) error
 
 // AdminAdded enters a newly added administrator into an active trial workflow.
 func (s *Service) AdminAdded(ctx context.Context, organizationID, userID string) error {
-	queries := orgrepo.New(s.db)
-	trial, err := queries.GetActiveTrial(ctx, organizationID)
+	trial, err := trialsrepo.New(s.db).GetActiveTrial(ctx, organizationID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
 	}
@@ -80,6 +80,7 @@ func (s *Service) AdminAdded(ctx context.Context, organizationID, userID string)
 		return fmt.Errorf("get active trial: %w", err)
 	}
 
+	queries := orgrepo.New(s.db)
 	organization, err := queries.GetOrganizationMetadata(ctx, organizationID)
 	if err != nil {
 		return fmt.Errorf("get organization metadata: %w", err)
@@ -170,15 +171,19 @@ func (s *Service) updateContact(ctx context.Context, admin accessrepo.ListActive
 
 func (s *Service) findContact(ctx context.Context, admin accessrepo.ListActiveOrganizationAdminsRow) (*loops.Contact, error) {
 	if admin.ID != "" {
-		contact, err := s.workflows.FindContact(ctx, loops.FindContactInput{UserID: admin.ID})
+		contact, err := s.workflows.FindContact(ctx, loops.FindContactInput{Email: "", UserID: admin.ID})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("find contact by user ID: %w", err)
 		}
 		if contact != nil {
 			return contact, nil
 		}
 	}
-	return s.workflows.FindContact(ctx, loops.FindContactInput{Email: admin.Email})
+	contact, err := s.workflows.FindContact(ctx, loops.FindContactInput{Email: admin.Email, UserID: ""})
+	if err != nil {
+		return nil, fmt.Errorf("find contact by email: %w", err)
+	}
+	return contact, nil
 }
 
 func trialStartedIdempotencyKey(organizationID, userID string, trialCreatedAt time.Time) string {

--- a/server/internal/trialemails/service.go
+++ b/server/internal/trialemails/service.go
@@ -28,6 +28,8 @@ type Service struct {
 	siteURL   string
 }
 
+var _ Notifier = (*Service)(nil)
+
 // NewService constructs a trial lifecycle email synchronizer.
 func NewService(db *pgxpool.Pool, workflows loops.WorkflowClient, logger *slog.Logger, siteURL string) *Service {
 	return &Service{

--- a/server/internal/trialemails/service.go
+++ b/server/internal/trialemails/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
@@ -85,24 +86,27 @@ func (s *Service) AdminAdded(ctx context.Context, organizationID, userID string)
 	if err != nil {
 		return fmt.Errorf("get organization metadata: %w", err)
 	}
-	admins, err := accessrepo.New(s.db).ListActiveOrganizationAdmins(ctx, organizationID)
+	admin, err := accessrepo.New(s.db).GetActiveOrganizationAdmin(ctx, accessrepo.GetActiveOrganizationAdminParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return errors.New("administrator not found in active organization administrators")
+	}
 	if err != nil {
-		return fmt.Errorf("list active organization administrators: %w", err)
+		return fmt.Errorf("get active organization administrator: %w", err)
 	}
 
-	for _, admin := range admins {
-		if admin.ID != userID {
-			continue
-		}
-		return s.syncTrialAdmins(ctx, organizationID, []accessrepo.ListActiveOrganizationAdminsRow{admin}, map[string]any{
-			"organizationName": organization.Name,
-			"dashboardUrl":     s.siteURL + "/" + organization.Slug,
-			"trialEndsAt":      trial.EndsAt.Time.UTC().Format(time.RFC3339),
-			"trialActive":      true,
-		}, trial.CreatedAt.Time)
-	}
-
-	return errors.New("administrator not found in active organization administrators")
+	return s.syncTrialAdmins(ctx, organizationID, []accessrepo.ListActiveOrganizationAdminsRow{{
+		ID:          admin.ID,
+		DisplayName: admin.DisplayName,
+		Email:       admin.Email,
+	}}, map[string]any{
+		"organizationName": organization.Name,
+		"dashboardUrl":     s.siteURL + "/" + organization.Slug,
+		"trialEndsAt":      trial.EndsAt.Time.UTC().Format(time.RFC3339),
+		"trialActive":      true,
+	}, trial.CreatedAt.Time)
 }
 
 // TrialInactive prevents active administrators from receiving pending trial reminders.

--- a/server/internal/trialemails/service.go
+++ b/server/internal/trialemails/service.go
@@ -1,0 +1,191 @@
+// Package trialemails synchronizes enterprise trial lifecycle state to Loops.
+package trialemails
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+)
+
+const trialStartedEventName = "trial_started"
+
+// Service synchronizes active trial administrators with Loops workflows.
+type Service struct {
+	db        *pgxpool.Pool
+	workflows loops.WorkflowClient
+	logger    *slog.Logger
+	siteURL   string
+}
+
+// NewService constructs a trial lifecycle email synchronizer.
+func NewService(db *pgxpool.Pool, workflows loops.WorkflowClient, logger *slog.Logger, siteURL string) *Service {
+	return &Service{
+		db:        db,
+		workflows: workflows,
+		logger:    logger,
+		siteURL:   strings.TrimRight(siteURL, "/"),
+	}
+}
+
+// TrialStarted enters every active organization administrator into the trial workflow.
+func (s *Service) TrialStarted(ctx context.Context, organizationID string) error {
+	queries := orgrepo.New(s.db)
+	trial, err := queries.GetActiveTrial(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get active trial: %w", err)
+	}
+
+	organization, err := queries.GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("get organization metadata: %w", err)
+	}
+	admins, err := accessrepo.New(s.db).ListActiveOrganizationAdmins(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("list active organization administrators: %w", err)
+	}
+
+	properties := map[string]any{
+		"organizationName": organization.Name,
+		"dashboardUrl":     s.siteURL + "/" + organization.Slug,
+		"trialEndsAt":      trial.EndsAt.Time.UTC().Format(time.RFC3339),
+		"trialActive":      true,
+	}
+	return s.syncTrialAdmins(ctx, organizationID, admins, properties, trial.CreatedAt.Time)
+}
+
+// AdminAdded enters a newly added administrator into an active trial workflow.
+func (s *Service) AdminAdded(ctx context.Context, organizationID, userID string) error {
+	queries := orgrepo.New(s.db)
+	trial, err := queries.GetActiveTrial(ctx, organizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get active trial: %w", err)
+	}
+
+	organization, err := queries.GetOrganizationMetadata(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("get organization metadata: %w", err)
+	}
+	admins, err := accessrepo.New(s.db).ListActiveOrganizationAdmins(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("list active organization administrators: %w", err)
+	}
+
+	for _, admin := range admins {
+		if admin.ID != userID {
+			continue
+		}
+		return s.syncTrialAdmins(ctx, organizationID, []accessrepo.ListActiveOrganizationAdminsRow{admin}, map[string]any{
+			"organizationName": organization.Name,
+			"dashboardUrl":     s.siteURL + "/" + organization.Slug,
+			"trialEndsAt":      trial.EndsAt.Time.UTC().Format(time.RFC3339),
+			"trialActive":      true,
+		}, trial.CreatedAt.Time)
+	}
+
+	return nil
+}
+
+// TrialInactive prevents active administrators from receiving pending trial reminders.
+func (s *Service) TrialInactive(ctx context.Context, organizationID string) error {
+	admins, err := accessrepo.New(s.db).ListActiveOrganizationAdmins(ctx, organizationID)
+	if err != nil {
+		return fmt.Errorf("list active organization administrators: %w", err)
+	}
+
+	var syncErrors []error
+	for _, admin := range admins {
+		if _, err := s.updateContact(ctx, admin, map[string]any{"trialActive": false}); err != nil {
+			s.logger.ErrorContext(ctx, "sync inactive trial contact", attr.SlogOrganizationID(organizationID), attr.SlogUserID(admin.ID), attr.SlogError(err))
+			syncErrors = append(syncErrors, err)
+		}
+	}
+	return errors.Join(syncErrors...)
+}
+
+func (s *Service) syncTrialAdmins(ctx context.Context, organizationID string, admins []accessrepo.ListActiveOrganizationAdminsRow, properties map[string]any, trialCreatedAt time.Time) error {
+	var syncErrors []error
+	for _, admin := range admins {
+		contact, err := s.updateContact(ctx, admin, properties)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "sync trial contact", attr.SlogOrganizationID(organizationID), attr.SlogUserID(admin.ID), attr.SlogError(err))
+			syncErrors = append(syncErrors, err)
+			continue
+		}
+		if contact != nil && !contact.Subscribed {
+			continue
+		}
+		if err := s.workflows.SendEvent(ctx, loops.SendEventInput{
+			Email:           admin.Email,
+			UserID:          admin.ID,
+			EventName:       trialStartedEventName,
+			EventProperties: properties,
+			IdempotencyKey:  trialStartedIdempotencyKey(organizationID, admin.ID, trialCreatedAt),
+		}); err != nil {
+			s.logger.ErrorContext(ctx, "send trial workflow event", attr.SlogOrganizationID(organizationID), attr.SlogUserID(admin.ID), attr.SlogError(err))
+			syncErrors = append(syncErrors, err)
+		}
+	}
+	return errors.Join(syncErrors...)
+}
+
+func (s *Service) updateContact(ctx context.Context, admin accessrepo.ListActiveOrganizationAdminsRow, properties map[string]any) (*loops.Contact, error) {
+	contact, err := s.findContact(ctx, admin)
+	if err != nil {
+		return nil, fmt.Errorf("find contact: %w", err)
+	}
+
+	var firstName *string
+	if fields := strings.Fields(admin.DisplayName); len(fields) > 0 {
+		firstName = &fields[0]
+	}
+	if err := s.workflows.UpdateContact(ctx, loops.UpdateContactInput{
+		Email:            admin.Email,
+		FirstName:        firstName,
+		UserID:           admin.ID,
+		CustomProperties: properties,
+	}); err != nil {
+		return nil, fmt.Errorf("update contact: %w", err)
+	}
+	return contact, nil
+}
+
+func (s *Service) findContact(ctx context.Context, admin accessrepo.ListActiveOrganizationAdminsRow) (*loops.Contact, error) {
+	if admin.ID != "" {
+		contact, err := s.workflows.FindContact(ctx, loops.FindContactInput{UserID: admin.ID})
+		if err != nil {
+			return nil, err
+		}
+		if contact != nil {
+			return contact, nil
+		}
+	}
+	return s.workflows.FindContact(ctx, loops.FindContactInput{Email: admin.Email})
+}
+
+func trialStartedIdempotencyKey(organizationID, userID string, trialCreatedAt time.Time) string {
+	input := strings.Join([]string{
+		trialStartedEventName,
+		organizationID,
+		userID,
+		trialCreatedAt.UTC().Format(time.RFC3339Nano),
+	}, ":")
+	checksum := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%s:%x", trialStartedEventName, checksum)
+}

--- a/server/internal/trialemails/service.go
+++ b/server/internal/trialemails/service.go
@@ -102,7 +102,7 @@ func (s *Service) AdminAdded(ctx context.Context, organizationID, userID string)
 		}, trial.CreatedAt.Time)
 	}
 
-	return nil
+	return errors.New("administrator not found in active organization administrators")
 }
 
 // TrialInactive prevents active administrators from receiving pending trial reminders.

--- a/server/internal/trialemails/service_test.go
+++ b/server/internal/trialemails/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	"github.com/stretchr/testify/require"
 )
@@ -226,7 +227,7 @@ func newTestServiceWithTrial(t *testing.T, active bool) (context.Context, *testI
 		FreeTrialEndsAt:    conv.ToPGTimestamptz(endsAt),
 		DisabledAt:         conv.PtrToPGTimestamptz(nil),
 	}))
-	require.NoError(t, testrepo.New(conn).InsertTrialFixture(ctx, testrepo.InsertTrialFixtureParams{
+	require.NoError(t, trialsrepo.New(conn).InsertTrialFixture(ctx, trialsrepo.InsertTrialFixtureParams{
 		OrganizationID: organizationID,
 		CreatedAt:      conv.ToPGTimestamptz(createdAt),
 		EndsAt:         conv.ToPGTimestamptz(endsAt),
@@ -324,11 +325,6 @@ func trialStartedEvent(ti *testInstance, admin testAdmin) loops.SendEventInput {
 		EventProperties: activeProperties(ti),
 		IdempotencyKey:  trialStartedIdempotencyKey(ti.organizationID, admin.id, ti.trialCreatedAt),
 	}
-}
-
-//go:fix inline
-func stringPtr(value string) *string {
-	return new(value)
 }
 
 type fakeWorkflowClient struct {

--- a/server/internal/trialemails/service_test.go
+++ b/server/internal/trialemails/service_test.go
@@ -1,0 +1,408 @@
+package trialemails
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/loops"
+	userrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+	"github.com/stretchr/testify/require"
+)
+
+var infra *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	if err != nil {
+		log.Fatalf("launch test infrastructure: %v", err)
+	}
+
+	infra = res
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		log.Printf("clean up test infrastructure: %v", err)
+	}
+
+	os.Exit(code)
+}
+
+func TestTrialStartedFansOutOnlyToActiveAdmins(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	firstAdmin := ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "Admin One")
+	secondAdmin := ti.seedAdmin(t, ctx, "<SECOND_ADMIN_USER_ID>", "<SECOND_ADMIN_EMAIL>@example.test", "Admin Two")
+	ti.seedMember(t, ctx, "<MEMBER_USER_ID>", "<MEMBER_EMAIL>@example.test", "Member")
+
+	err := ti.service.TrialStarted(ctx, ti.organizationID)
+	require.NoError(t, err)
+
+	require.Equal(t, []loops.FindContactInput{
+		{UserID: firstAdmin.id},
+		{Email: firstAdmin.email},
+		{UserID: secondAdmin.id},
+		{Email: secondAdmin.email},
+	}, ti.client.finds())
+	require.Equal(t, []loops.UpdateContactInput{
+		{Email: firstAdmin.email, FirstName: new("Admin"), UserID: firstAdmin.id, CustomProperties: activeProperties(ti)},
+		{Email: secondAdmin.email, FirstName: new("Admin"), UserID: secondAdmin.id, CustomProperties: activeProperties(ti)},
+	}, ti.client.updates())
+	require.Equal(t, []loops.SendEventInput{
+		trialStartedEvent(ti, firstAdmin),
+		trialStartedEvent(ti, secondAdmin),
+	}, ti.client.events())
+}
+
+func TestTrialStartedUsesLifecyclePropertiesAndStableIdempotency(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	admin := ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "Taylor Admin")
+
+	require.NoError(t, ti.service.TrialStarted(ctx, ti.organizationID))
+	require.NoError(t, ti.service.TrialStarted(ctx, ti.organizationID))
+
+	updates := ti.client.updates()
+	require.Len(t, updates, 2)
+	require.Equal(t, activeProperties(ti), updates[0].CustomProperties)
+	require.Equal(t, new("Taylor"), updates[0].FirstName)
+
+	events := ti.client.events()
+	require.Len(t, events, 2)
+	require.Equal(t, activeProperties(ti), events[0].EventProperties)
+	require.Equal(t, events[0].IdempotencyKey, events[1].IdempotencyKey)
+	require.Equal(t, trialStartedEvent(ti, admin).IdempotencyKey, events[0].IdempotencyKey)
+}
+
+func TestTrialStartedSkipsInactiveTrial(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestServiceWithTrial(t, false)
+	ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "Admin")
+
+	require.NoError(t, ti.service.TrialStarted(ctx, ti.organizationID))
+	require.Empty(t, ti.client.finds())
+	require.Empty(t, ti.client.updates())
+	require.Empty(t, ti.client.events())
+}
+
+func TestAdminAddedStartsSequenceForNewActiveAdmin(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	admin := ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "New Admin")
+	ti.seedMember(t, ctx, "<MEMBER_USER_ID>", "<MEMBER_EMAIL>@example.test", "Member")
+
+	require.NoError(t, ti.service.AdminAdded(ctx, ti.organizationID, admin.id))
+	require.Equal(t, []loops.SendEventInput{trialStartedEvent(ti, admin)}, ti.client.events())
+
+	require.NoError(t, ti.service.AdminAdded(ctx, ti.organizationID, "<MEMBER_USER_ID>"))
+	require.Len(t, ti.client.updates(), 1)
+	require.Len(t, ti.client.events(), 1)
+}
+
+func TestTrialStartedDoesNotSendToUnsubscribedContact(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	admin := ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "Admin")
+	ti.client.contactsByEmail[admin.email] = &loops.Contact{Email: admin.email, Subscribed: false}
+
+	require.NoError(t, ti.service.TrialStarted(ctx, ti.organizationID))
+	require.Equal(t, []loops.FindContactInput{
+		{UserID: admin.id},
+		{Email: admin.email},
+	}, ti.client.finds())
+	require.Equal(t, []loops.UpdateContactInput{{
+		Email:            admin.email,
+		FirstName:        new("Admin"),
+		UserID:           admin.id,
+		CustomProperties: activeProperties(ti),
+	}}, ti.client.updates())
+	require.Empty(t, ti.client.events())
+}
+
+func TestTrialStartedDoesNotSendToUnsubscribedContactFoundByUserID(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	admin := ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "Admin")
+	ti.client.contactsByUserID[admin.id] = &loops.Contact{Email: "<OLD_ADMIN_EMAIL>@example.test", UserID: &admin.id, Subscribed: false}
+
+	require.NoError(t, ti.service.TrialStarted(ctx, ti.organizationID))
+	require.Equal(t, []loops.FindContactInput{{UserID: admin.id}}, ti.client.finds())
+	require.Equal(t, []loops.UpdateContactInput{{
+		Email:            admin.email,
+		FirstName:        new("Admin"),
+		UserID:           admin.id,
+		CustomProperties: activeProperties(ti),
+	}}, ti.client.updates())
+	require.Empty(t, ti.client.events())
+}
+
+func TestTrialStartedContinuesAfterContactFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	failedAdmin := ti.seedAdmin(t, ctx, "<FAILED_ADMIN_USER_ID>", "<FAILED_ADMIN_EMAIL>@example.test", "Failed Admin")
+	remainingAdmin := ti.seedAdmin(t, ctx, "<REMAINING_ADMIN_USER_ID>", "<REMAINING_ADMIN_EMAIL>@example.test", "Remaining Admin")
+	ti.client.updateErrors[failedAdmin.id] = errors.New("update failed")
+
+	err := ti.service.TrialStarted(ctx, ti.organizationID)
+	require.Error(t, err)
+	require.Equal(t, []loops.SendEventInput{trialStartedEvent(ti, remainingAdmin)}, ti.client.events())
+}
+
+func TestTrialInactiveUpdatesOnlyActiveAdmins(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	firstAdmin := ti.seedAdmin(t, ctx, "<ADMIN_USER_ID>", "<ADMIN_EMAIL>@example.test", "Admin One")
+	secondAdmin := ti.seedAdmin(t, ctx, "<SECOND_ADMIN_USER_ID>", "<SECOND_ADMIN_EMAIL>@example.test", "Admin Two")
+	ti.seedMember(t, ctx, "<MEMBER_USER_ID>", "<MEMBER_EMAIL>@example.test", "Member")
+
+	require.NoError(t, ti.service.TrialInactive(ctx, ti.organizationID))
+	require.Equal(t, []loops.FindContactInput{
+		{UserID: firstAdmin.id},
+		{Email: firstAdmin.email},
+		{UserID: secondAdmin.id},
+		{Email: secondAdmin.email},
+	}, ti.client.finds())
+	require.Equal(t, []loops.UpdateContactInput{
+		{Email: firstAdmin.email, FirstName: new("Admin"), UserID: firstAdmin.id, CustomProperties: map[string]any{"trialActive": false}},
+		{Email: secondAdmin.email, FirstName: new("Admin"), UserID: secondAdmin.id, CustomProperties: map[string]any{"trialActive": false}},
+	}, ti.client.updates())
+	require.Empty(t, ti.client.events())
+}
+
+type testInstance struct {
+	service        *Service
+	client         *fakeWorkflowClient
+	conn           *pgxpool.Pool
+	organizationID string
+	trialCreatedAt time.Time
+	trialEndsAt    time.Time
+}
+
+func newTestService(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+	return newTestServiceWithTrial(t, true)
+}
+
+func newTestServiceWithTrial(t *testing.T, active bool) (context.Context, *testInstance) {
+	t.Helper()
+
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "trialemailstest")
+	require.NoError(t, err)
+
+	createdAt := time.Date(2099, time.August, 1, 12, 0, 0, 0, time.UTC)
+	endsAt := time.Date(2099, time.August, 15, 12, 0, 0, 0, time.UTC)
+	if !active {
+		endsAt = time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+		createdAt = endsAt.Add(-14 * 24 * time.Hour)
+	}
+	const organizationID = "<ORGANIZATION_ID>"
+	require.NoError(t, testrepo.New(conn).CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID:                 organizationID,
+		Name:               "<ORGANIZATION_NAME>",
+		Slug:               "<ORGANIZATION_SLUG>",
+		GramAccountType:    "enterprise",
+		WorkosID:           conv.PtrToPGText(nil),
+		Whitelisted:        true,
+		FreeTrialStartedAt: conv.ToPGTimestamptz(createdAt),
+		FreeTrialEndsAt:    conv.ToPGTimestamptz(endsAt),
+		DisabledAt:         conv.PtrToPGTimestamptz(nil),
+	}))
+	require.NoError(t, testrepo.New(conn).InsertTrialFixture(ctx, testrepo.InsertTrialFixtureParams{
+		OrganizationID: organizationID,
+		CreatedAt:      conv.ToPGTimestamptz(createdAt),
+		EndsAt:         conv.ToPGTimestamptz(endsAt),
+		ConvertedAt:    conv.PtrToPGTimestamptz(nil),
+		DemotedAt:      conv.PtrToPGTimestamptz(nil),
+	}))
+
+	client := newFakeWorkflowClient()
+	return ctx, &testInstance{
+		service:        NewService(conn, client, testenv.NewLogger(t), "https://app.example.test/"),
+		client:         client,
+		conn:           conn,
+		organizationID: organizationID,
+		trialCreatedAt: createdAt,
+		trialEndsAt:    endsAt,
+	}
+}
+
+type testAdmin struct {
+	id    string
+	email string
+}
+
+func (ti *testInstance) seedAdmin(t *testing.T, ctx context.Context, userID, email, displayName string) testAdmin {
+	t.Helper()
+	ti.seedUser(t, ctx, userID, email, displayName, "admin")
+	return testAdmin{id: userID, email: email}
+}
+
+func (ti *testInstance) seedMember(t *testing.T, ctx context.Context, userID, email, displayName string) {
+	t.Helper()
+	ti.seedUser(t, ctx, userID, email, displayName, "member")
+}
+
+func (ti *testInstance) seedUser(t *testing.T, ctx context.Context, userID, email, displayName, roleSlug string) {
+	t.Helper()
+
+	queries := repo.New(ti.conn)
+	now := time.Date(2099, time.July, 31, 12, 0, 0, 0, time.UTC)
+	_, err := queries.UpsertOrganizationRole(ctx, repo.UpsertOrganizationRoleParams{
+		OrganizationID:    ti.organizationID,
+		WorkosSlug:        roleSlug,
+		WorkosName:        roleSlug,
+		WorkosDescription: conv.ToPGTextEmpty(""),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(now),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(now),
+		WorkosLastEventID: conv.ToPGTextEmpty(""),
+	})
+	require.NoError(t, err)
+	_, err = userrepo.New(ti.conn).UpsertUser(ctx, userrepo.UpsertUserParams{
+		ID:          userID,
+		Email:       email,
+		DisplayName: displayName,
+		PhotoUrl:    conv.PtrToPGText(nil),
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	err = userrepo.New(ti.conn).OverwriteUserWorkosID(ctx, userrepo.OverwriteUserWorkosIDParams{
+		ID:       userID,
+		WorkosID: conv.ToPGText("workos-" + userID),
+	})
+	require.NoError(t, err)
+	_, err = orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{
+		OrganizationID: ti.organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	rows, err := queries.UpsertOrganizationRoleAssignment(ctx, repo.UpsertOrganizationRoleAssignmentParams{
+		OrganizationID:     ti.organizationID,
+		WorkosUserID:       "workos-" + userID,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGTextEmpty(""),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(now),
+		WorkosLastEventID:  conv.ToPGTextEmpty(""),
+		WorkosRoleSlug:     roleSlug,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), rows)
+}
+
+func activeProperties(ti *testInstance) map[string]any {
+	return map[string]any{
+		"organizationName": "<ORGANIZATION_NAME>",
+		"dashboardUrl":     "https://app.example.test/<ORGANIZATION_SLUG>",
+		"trialEndsAt":      ti.trialEndsAt.Format(time.RFC3339),
+		"trialActive":      true,
+	}
+}
+
+func trialStartedEvent(ti *testInstance, admin testAdmin) loops.SendEventInput {
+	return loops.SendEventInput{
+		Email:           admin.email,
+		UserID:          admin.id,
+		EventName:       "trial_started",
+		EventProperties: activeProperties(ti),
+		IdempotencyKey:  trialStartedIdempotencyKey(ti.organizationID, admin.id, ti.trialCreatedAt),
+	}
+}
+
+//go:fix inline
+func stringPtr(value string) *string {
+	return new(value)
+}
+
+type fakeWorkflowClient struct {
+	mu               sync.Mutex
+	contactsByEmail  map[string]*loops.Contact
+	contactsByUserID map[string]*loops.Contact
+	findErrors       map[string]error
+	updateErrors     map[string]error
+	eventErrors      map[string]error
+	findInputs       []loops.FindContactInput
+	updateInputs     []loops.UpdateContactInput
+	eventInputs      []loops.SendEventInput
+}
+
+func newFakeWorkflowClient() *fakeWorkflowClient {
+	return &fakeWorkflowClient{
+		contactsByEmail:  map[string]*loops.Contact{},
+		contactsByUserID: map[string]*loops.Contact{},
+		findErrors:       map[string]error{},
+		updateErrors:     map[string]error{},
+		eventErrors:      map[string]error{},
+	}
+}
+
+func (c *fakeWorkflowClient) FindContact(_ context.Context, input loops.FindContactInput) (*loops.Contact, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.findInputs = append(c.findInputs, input)
+	if err := c.findErrors[input.Email]; err != nil {
+		return nil, err
+	}
+	if input.UserID != "" {
+		return c.contactsByUserID[input.UserID], nil
+	}
+	return c.contactsByEmail[input.Email], nil
+}
+
+func (c *fakeWorkflowClient) UpdateContact(_ context.Context, input loops.UpdateContactInput) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.updateInputs = append(c.updateInputs, input)
+	if err := c.updateErrors[input.UserID]; err != nil {
+		return err
+	}
+	contact := &loops.Contact{Email: input.Email, Subscribed: true}
+	c.contactsByEmail[input.Email] = contact
+	if input.UserID != "" {
+		contact.UserID = &input.UserID
+		c.contactsByUserID[input.UserID] = contact
+	}
+	return nil
+}
+
+func (c *fakeWorkflowClient) SendEvent(_ context.Context, input loops.SendEventInput) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.eventInputs = append(c.eventInputs, input)
+	return c.eventErrors[input.UserID]
+}
+
+func (c *fakeWorkflowClient) finds() []loops.FindContactInput {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]loops.FindContactInput(nil), c.findInputs...)
+}
+
+func (c *fakeWorkflowClient) updates() []loops.UpdateContactInput {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]loops.UpdateContactInput(nil), c.updateInputs...)
+}
+
+func (c *fakeWorkflowClient) events() []loops.SendEventInput {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]loops.SendEventInput(nil), c.eventInputs...)
+}

--- a/server/internal/trialemails/service_test.go
+++ b/server/internal/trialemails/service_test.go
@@ -109,7 +109,8 @@ func TestAdminAddedStartsSequenceForNewActiveAdmin(t *testing.T) {
 	require.NoError(t, ti.service.AdminAdded(ctx, ti.organizationID, admin.id))
 	require.Equal(t, []loops.SendEventInput{trialStartedEvent(ti, admin)}, ti.client.events())
 
-	require.NoError(t, ti.service.AdminAdded(ctx, ti.organizationID, "<MEMBER_USER_ID>"))
+	err := ti.service.AdminAdded(ctx, ti.organizationID, "<MEMBER_USER_ID>")
+	require.ErrorContains(t, err, "not found in active organization administrators")
 	require.Len(t, ti.client.updates(), 1)
 	require.Len(t, ti.client.events(), 1)
 }


### PR DESCRIPTION
## Summary

- Add a separate Loops Workflow transport for trial lifecycle events without changing transactional email delivery. 
  - [Workflow](https://app.loops.so/workflows/cmsikbcg80yvq0jva2xm9gdeq?stepName=Builder)
  - [Welcome Email](https://app.loops.so/workflows/cmsikbcg80yvq0jva2xm9gdeq?stepName=Builder&nodeId=n3&showComposerPopup=true)
- Sync trial properties and active organization admins to Loops on trial start and admin invite acceptance.
- Add focused coverage for Loops transport, admin selection, signup, and invite notification behavior.
- Configure the corresponding Speakeasy Enterprise Trial Lifecycle Workflow and draft templates in Loops.

## Workflow

- `trial_started` trigger, one-time eligibility.
- Immediate welcome email, then 7-days-left and 1-day-left reminders with active-trial filters.
- Recipients are organization admins.
- Talk-to-sales CTA: https://www.speakeasy.com/talk-to-us.

## Dependencies and follow-up

- Trial creation wiring assumes PR #4881 lands.
- Trial demotion notification wiring remains deferred until PR #4983 lands, then this branch should be rebased.
- The Loops Workflow remains a draft until the upstream trial paths are available for end-to-end validation.

## Email example

<img width="598" height="1164" alt="Screenshot 2026-08-10 at 1 45 22 PM" src="https://github.com/user-attachments/assets/8fa66d1f-b056-4c97-8ee0-17bfd0a83b01" />

## Testing

- `go test ./server/internal/trialemails ./server/internal/thirdparty/loops ./server/internal/organizations ./server/internal/auth` passes.
- `go test ./...` reaches one unrelated existing failure in `gram/plog`: `TestPrettyPrint_TimestampFormats`, whose snapshot differs under the local timezone.

Fixes AGE-3042



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds enterprise trial lifecycle emails via Loops workflows, enqueued with Temporal so signup and admin-invite acceptance don’t block. Syncs active org admins to Loops, fires `trial_started` on signup/admin-add, and provides a stop hook when a trial ends (AGE-3042).

- **New Features**
  - Added `server/internal/thirdparty/loops` workflow client (`FindContact`, `UpdateContact`, `SendEvent`); treats HTTP 409 with an idempotency key as success, bounds responses to 64KB, requires exactly one of email or user ID, and no-ops when the API key is unset.
  - Introduced `server/internal/trialemails` service and `Notifier` to upsert contacts (org name, `dashboardUrl`, `trialEndsAt`, `trialActive`) and emit `trial_started` with stable keys derived from org ID, user ID, and trial start; prefers internal user ID and falls back to email; unsubscribed contacts are skipped; includes `TrialInactive` to stop reminders.
  - Implemented Temporal workflow/activity (`TrialLifecycleEmailWorkflow`, `Activities.SendTrialLifecycleEmail`) with retries/backoff, a 5-minute activity timeout, and a 30-minute workflow run timeout; `TemporalTrialEmailNotifier` enqueues trial-started/admin-added/trial-inactive; worker registers both workflow and activity.
  - Hooked into signup (`auth.Callback`) and admin invite acceptance (`organizations.inviteCallback`) to enqueue notifications when an admin is added; failures are logged and non-blocking.
  - Replaced the admin email query with `ListActiveOrganizationAdmins` and `GetActiveOrganizationAdmin`, resolving roles via internal user ID; used for best-effort, active-admin notifications (also applied in access request emails).

- **Migration**
  - Configure the Loops API key (e.g., via `--loops-api-key`); without it the workflow client is a no-op.
  - In Loops, create a workflow triggered by `trial_started` that sends: welcome (immediate), 7-days-left, and 1-day-left, each gated by `trialActive=true`. Recipients are organization admins.

<sup>Written for commit e01bea92a040f3715b9618685a7cec0b13b937cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





