### PR TITLE
mig: index risk_results FK columns for cascade deletes

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4660,12 +4660,13 @@ CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx
 ON risk_results (excluded_exclusion_id)
 WHERE excluded_exclusion_id IS NOT NULL;
 
--- FK-cascade support: deleting chat_messages / chat_content_parts fires the
--- ON DELETE CASCADE trigger with `WHERE chat_message_id = $1` (no project_id),
--- which none of the project_id-leading composites above can serve — each
--- deleted parent row seq-scans the whole table. The daily demo-seed's project
--- cascade (~1k chat_messages) blew its 60s statement_timeout this way once
--- risk_results reached ~47M rows.
+-- FK-cascade support: deleting chat_messages (or chat_content_parts) fires
+-- the ON DELETE CASCADE trigger with `WHERE chat_message_id = $1` (resp.
+-- `chat_content_part_id = $1`) and no project_id, which none of the
+-- project_id-leading composites above can serve — each deleted parent row
+-- seq-scans the whole table. The daily demo-seed's project cascade (~1k
+-- chat_messages) blew its 60s statement_timeout this way once risk_results
+-- reached ~47M rows.
 CREATE INDEX IF NOT EXISTS risk_results_chat_message_idx
 ON risk_results (chat_message_id);
 

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4660,6 +4660,18 @@ CREATE INDEX IF NOT EXISTS risk_results_excluded_exclusion_idx
 ON risk_results (excluded_exclusion_id)
 WHERE excluded_exclusion_id IS NOT NULL;
 
+-- FK-cascade support: deleting chat_messages / chat_content_parts fires the
+-- ON DELETE CASCADE trigger with `WHERE chat_message_id = $1` (no project_id),
+-- which none of the project_id-leading composites above can serve — each
+-- deleted parent row seq-scans the whole table. The daily demo-seed's project
+-- cascade (~1k chat_messages) blew its 60s statement_timeout this way once
+-- risk_results reached ~47M rows.
+CREATE INDEX IF NOT EXISTS risk_results_chat_message_idx
+ON risk_results (chat_message_id);
+
+CREATE INDEX IF NOT EXISTS risk_results_chat_content_part_idx
+ON risk_results (chat_content_part_id);
+
 -- risk_policy_eval_reviews is the durable "regression set" for a prompt-based
 -- risk policy: a reviewer's ground-truth verdict on whether a given chat session
 -- should be flagged by the policy. The policy-eval workbench replays the

--- a/server/migrations/20260807090620_risk-results-fk-cascade-indexes.sql
+++ b/server/migrations/20260807090620_risk-results-fk-cascade-indexes.sql
@@ -1,0 +1,6 @@
+-- atlas:txmode none
+
+-- Create index "risk_results_chat_content_part_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_chat_content_part_idx" ON "risk_results" ("chat_content_part_id");
+-- Create index "risk_results_chat_message_idx" to table: "risk_results"
+CREATE INDEX CONCURRENTLY "risk_results_chat_message_idx" ON "risk_results" ("chat_message_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:j2PFyQABKLCGL5Bv1xIUGTyHDNkG4sffj2skUCX9l2Q=
+h1:4b0HRTmOMZCnJmZWzY2vHNDiUoOu1wfiIGBZHi/Vwgc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -320,3 +320,4 @@ h1:j2PFyQABKLCGL5Bv1xIUGTyHDNkG4sffj2skUCX9l2Q=
 20260805211101_enterprise-trials.sql h1:7NH6ss0phB6SS9BuHVEgy8fq7j3Ca0Sq10cgdDADW3A=
 20260805222807_publish-outbox-lease-token.sql h1:UkZ7i59bP6G3xZBSOQUlepqDLK4yjJMplJcUkBS3i5Y=
 20260806224308_trials-table-tier.sql h1:77p16W+Y+06uZULh/GZxFuIvSLmaMsSPp6uGlfmjfUI=
+20260807090620_risk-results-fk-cascade-indexes.sql h1:kViSEj0zhDuK1yw9ti+36gkApVeRf/E0TbK4b53C27c=


### PR DESCRIPTION
## Problem

Prod `gram-demo-seed` CronJob has failed since 2026-08-07 04:00 UTC with:

```
apply demo seed to postgres: ERROR: canceling statement due to statement timeout (SQLSTATE 57014)
```

The seed's `DELETE FROM projects` cascades projects → chats → chat_messages (~1,260 rows for the demo org). `risk_results` (47M rows / 22 GB in prod) references `chat_messages(id)` and `chat_content_parts(id)` with `ON DELETE CASCADE`, but every index on those columns leads with `project_id` — the FK trigger's `WHERE chat_message_id = $1` lookup can't use any of them. Each deleted parent row seq-scans the whole table, blowing the pool's 60s `statement_timeout`. Reproduced with a manual job run today; failed at exactly 60s both attempts.

## Fix

Plain indexes on the two FK columns so cascade lookups are index scans:

- `risk_results_chat_message_idx` on `(chat_message_id)`
- `risk_results_chat_content_part_idx` on `(chat_content_part_id)`

Migration builds them `CONCURRENTLY` (`atlas:txmode none`), so no write-blocking on this hot table.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add plain indexes on `risk_results` foreign keys so cascade deletes use index scans instead of full-table scans. This fixes the demo-seed timeout, makes project deletes fast again, and clarifies the schema comment.

- **Bug Fixes**
  - Added `risk_results_chat_message_idx` on `(chat_message_id)`.
  - Added `risk_results_chat_content_part_idx` on `(chat_content_part_id)`.
  - Built both indexes `CONCURRENTLY` (`atlas:txmode none`) to avoid write blocking on this hot table.

<sup>Written for commit 722ec66057e5ad34c6ad8ed80c5d72e25bfef42e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

