### PR TITLE
chore: use lightweight deletes in ClickHouse demo seed

### DIFF
--- a/server/internal/demoseed/clickhouse.sql
+++ b/server/internal/demoseed/clickhouse.sql
@@ -6,7 +6,7 @@
 -- seed/demo/postgres.sql).
 --
 -- The MVs (trace/metrics/attribute_metrics/chat_token/chat_session summaries,
--- attribute_keys, spend_rule_usage) fire on INSERT, and a DELETE mutation on
+-- attribute_keys, spend_rule_usage) fire on INSERT, and a DELETE on
 -- telemetry_logs never shrinks their targets — so each target is deleted
 -- explicitly below before the fresh insert repopulates it through the MVs.
 -- Rows are inserted with recent timestamps (trailing ~12 days), safely past
@@ -45,31 +45,38 @@
 --   Prod:  run daily by the infra cron AFTER demo.ensure_demo_org() on
 --          Postgres (ClickHouse has no procedural functions, hence a script).
 
-SET mutations_sync = 1;
+SET lightweight_deletes_sync = 1;
 
 -- Scoped deletes: telemetry source + every MV target + the org-keyed tables.
-ALTER TABLE telemetry_logs DELETE WHERE gram_project_id IN
+-- Lightweight DELETEs, not ALTER TABLE ... DELETE: a heavy mutation on
+-- telemetry_logs rewrites every column of every part that contains demo rows
+-- (~12 days of shared, all-tenant partitions — the partition key is time-only,
+-- so project id cannot prune), which previously starved merges in prod. A
+-- lightweight delete only writes the _row_exists mask for matching parts and
+-- hides the rows as soon as the statement returns; physical cleanup happens in
+-- background merges.
+DELETE FROM telemetry_logs WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE trace_summaries DELETE WHERE gram_project_id IN
+DELETE FROM trace_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE metrics_summaries DELETE WHERE gram_project_id IN
+DELETE FROM metrics_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE attribute_metrics_summaries DELETE WHERE gram_project_id IN
+DELETE FROM attribute_metrics_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE chat_token_summaries DELETE WHERE gram_project_id IN
+DELETE FROM chat_token_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE chat_session_summaries DELETE WHERE gram_project_id IN
+DELETE FROM chat_session_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE spend_rule_usage_summaries DELETE WHERE gram_project_id IN
+DELETE FROM spend_rule_usage_summaries WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE attribute_keys DELETE WHERE gram_project_id IN
+DELETE FROM attribute_keys WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE shadow_mcp_inventory_urls DELETE WHERE gram_project_id IN
+DELETE FROM shadow_mcp_inventory_urls WHERE gram_project_id IN
   (toUUID('dec0de00-0000-4000-a000-000000000001'));
-ALTER TABLE authz_challenges DELETE WHERE organization_id = 'org_gram_demo_workspace';
-ALTER TABLE risk_findings DELETE WHERE organization_id = 'org_gram_demo_workspace';
-ALTER TABLE skill_session_versions DELETE WHERE organization_id = 'org_gram_demo_workspace';
-ALTER TABLE skill_efficacy_scores DELETE WHERE organization_id = 'org_gram_demo_workspace';
+DELETE FROM authz_challenges WHERE organization_id = 'org_gram_demo_workspace';
+DELETE FROM risk_findings WHERE organization_id = 'org_gram_demo_workspace';
+DELETE FROM skill_session_versions WHERE organization_id = 'org_gram_demo_workspace';
+DELETE FROM skill_efficacy_scores WHERE organization_id = 'org_gram_demo_workspace';
 
 -- Tool-execution rows: 3-12 per chat (hash-picked, so busy chats and quick
 -- ones both exist). gram.toolset.slug makes the Insights CTE's direct branch

--- a/server/internal/demoseed/demoseed.go
+++ b/server/internal/demoseed/demoseed.go
@@ -105,13 +105,13 @@ func Run(ctx context.Context, logger *slog.Logger, db *pgxpool.Pool, ch driver.C
 	// script's SET line cannot carry across statements — the setting rides on
 	// the context instead. Statements are split on ';': the seed files keep
 	// semicolons out of string literals by convention (see seed/demo/PAGES.md).
-	// mutations_sync=2 waits for ALL replicas (prod ClickHouse Cloud is
-	// replicated; =1 would let the re-insert race a delete still running on
+	// lightweight_deletes_sync=2 waits for ALL replicas (prod ClickHouse Cloud
+	// is replicated; =1 would let the re-insert race a delete still running on
 	// another replica). The base client caps max_execution_time at 60s, which
-	// prod-sized telemetry_logs mutations can exceed — raise it here.
+	// prod-sized telemetry_logs deletes can exceed — raise it here.
 	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"mutations_sync":     2,
-		"max_execution_time": 600,
+		"lightweight_deletes_sync": 2,
+		"max_execution_time":       600,
 	}))
 	for _, stmt := range splitStatements(clickhouseSQL) {
 		if strings.HasPrefix(strings.ToUpper(stmt), "SET ") {


### PR DESCRIPTION
## What

Converts the demo-seed ClickHouse cleanup from heavy `ALTER TABLE … DELETE` mutations to lightweight `DELETE FROM … WHERE` statements, and switches the sync setting accordingly (`mutations_sync` → `lightweight_deletes_sync`, still `=2` in prod so the re-insert cannot race a delete on another replica).

## Why

`ALTER TABLE telemetry_logs DELETE` is a heavy mutation: every part that contains demo rows is fully rewritten (all columns). The demo data spans the trailing ~12 days and `telemetry_logs` partitions by time only, so the daily seed run rewrote ~12 days of shared all-tenant partitions on every run — competing with background merges and queueing behind/ahead of other mutations. This mutation pressure on `telemetry_logs` previously contributed to an incident.

A lightweight delete only writes the `_row_exists` mask for parts with matching rows (found via the primary index — `gram_project_id` is first in the sorting key), hides the rows as soon as the statement returns, and defers physical cleanup to normal background merges.

## Notes

- The explicit deletes of each MV target remain necessary and unchanged in structure: MVs fire on INSERT only, so no form of delete on the source shrinks them.
- Local `.mise-tasks/seed*.mts` scripts still use `ALTER TABLE … DELETE`; they are local-dev only and left untouched.

## Testing

- `go build ./internal/demoseed/`
- `go test -tags demoseed_safety -run TestDemoSeedSafety ./internal/demoseed/` — replays the full seed twice against a real ClickHouse instance, exercising the new delete syntax, reseed idempotency, and tenant isolation. Passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the ClickHouse demo seed cleanup to lightweight deletes to reduce partition rewrites and merge pressure. Keeps replica safety by waiting for all replicas during delete operations.

- **Refactors**
  - Replace heavy ALTER TABLE … DELETE with lightweight DELETE FROM … WHERE across the seed SQL.
  - Use `lightweight_deletes_sync` instead of `mutations_sync` (SQL sets `=1`; client context sets `=2` in prod and raises `max_execution_time` to 600s).
  - Keep explicit deletes for MV targets; local `.mise-tasks/seed*.mts` remain unchanged.

<sup>Written for commit f2f0f4483057a7e553f1fa06af243416e8765e6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

