### PR TITLE
chore: restyle login page to square editorial design

### DIFF
--- a/.agents/skills/frontend/SKILL.md
+++ b/.agents/skills/frontend/SKILL.md
@@ -483,7 +483,7 @@ A page that renders its own `<h1>` instead of this pattern is a defect; if a cus
 
 The dashboard follows an editorial, print-like design language. The load-bearing rules:
 
-- **Square corners.** The Tailwind radius scale is wiped (`--radius-*: initial` in `App.css`), so `rounded-sm/md/lg/...` generate nothing — never write them. `rounded-full` is reserved for true circles (avatars, status dots, spinners); pills on wide elements are off-style. The login/marketing surfaces keep documented pill styling — do not "fix" them.
+- **Square corners.** The Tailwind radius scale is wiped (`--radius-*: initial` in `App.css`), so `rounded-sm/md/lg/...` generate nothing — never write them. `rounded-full` is reserved for true circles (avatars, status dots, spinners); pills on wide elements are off-style.
 - **Flat.** No `shadow-*` on in-flow surfaces (cards, buttons, inputs, tiles, sticky bars). Shadows are allowed only on floating overlays (menus, dialogs, tooltips, sheets). No gradients, no colored tint washes (`bg-blue-500/10`, `bg-amber-100`, `bg-*-softest` panels) — express semantics with colored text, borders, or a small dot on a neutral surface.
 - **Hairline borders** via the default border token; the content area is a white `bg-card` sheet on the gray page gutter. Beware: `bg-background` is the page-gray token, NOT white — use `bg-card` for white surfaces.
 - **Page pattern**: every page shows an area micro-label + thin serif title. `Page.Section.Title` renders both automatically (`area` prop overrides, `""` suppresses); custom headers render `<PageEyebrow />` from `@/components/page-eyebrow` above an `h1` with `text-display-sm font-thin`. The area derives from the URL via `useNavArea()` — one source shared with the sidebar highlight.

--- a/client/dashboard/src/pages/login/components/agent-session-showcase.tsx
+++ b/client/dashboard/src/pages/login/components/agent-session-showcase.tsx
@@ -141,7 +141,7 @@ const DecisionRow = memo(function DecisionRow({
         <span className="text-[14px]">{step.label}</span>
         <span
           className={cn(
-            "auth-mono rounded-full px-2.5 py-[3px] text-[10px] transition-opacity duration-400",
+            "auth-mono px-2.5 py-[3px] text-[10px] transition-opacity duration-400",
             step.chipClassName,
           )}
           style={{ opacity: reveal }}

--- a/client/dashboard/src/pages/login/components/auth-constants.ts
+++ b/client/dashboard/src/pages/login/components/auth-constants.ts
@@ -2,7 +2,8 @@
 // demo-gate AuthLayout so the messaging can't fork between auth surfaces.
 export const AUTH_PILLARS = ["Observe", "Secure", "Connect", "Distribute"];
 
-// Primary CTA styling shared by the login and register panels: the
-// marketing-site pill button (mono uppercase, inset bevel highlight).
+// Primary CTA styling shared by the login and register panels: square,
+// flat solid-ink button (mono uppercase) matching the dashboard's editorial
+// design language.
 export const AUTH_BUTTON_CLASSES =
-  "auth-mono-text inline-flex h-10 items-center justify-center rounded-full bg-[var(--cta)] text-[15px] leading-[1.6] tracking-[0.01em] text-white uppercase shadow-[inset_0_2px_1px_0_#414141,inset_0_-2px_1px_0_rgba(0,0,0,0.05)] transition-colors hover:bg-[var(--cta-hover)]";
+  "auth-mono-text inline-flex h-10 items-center justify-center bg-[var(--cta)] text-[15px] leading-[1.6] tracking-[0.01em] text-white uppercase transition-colors hover:bg-[var(--cta-hover)]";

--- a/client/dashboard/src/pages/login/components/login-panel.tsx
+++ b/client/dashboard/src/pages/login/components/login-panel.tsx
@@ -26,7 +26,7 @@ export function LoginPanel({
         {AUTH_PILLARS.map((label) => (
           <span
             key={label}
-            className="auth-mono rounded-full border border-[var(--edge)] px-[11px] py-[5px] text-[11px]"
+            className="auth-mono border border-[var(--edge)] px-[11px] py-[5px] text-[11px]"
           >
             {label}
           </span>

--- a/client/dashboard/src/pages/login/components/register-panel.tsx
+++ b/client/dashboard/src/pages/login/components/register-panel.tsx
@@ -140,9 +140,9 @@ export function RegisterPanel(): JSX.Element {
           }
           className={cn(
             AUTH_BUTTON_CLASSES,
-            // Deliberate disabled treatment: muted fill and text, no bevel,
-            // instead of dimming the solid-ink CTA with opacity.
-            "w-full disabled:cursor-not-allowed disabled:bg-[var(--edge)] disabled:text-[var(--muted)] disabled:shadow-none disabled:hover:bg-[var(--edge)]",
+            // Deliberate disabled treatment: muted fill and text instead of
+            // dimming the solid-ink CTA with opacity.
+            "w-full disabled:cursor-not-allowed disabled:bg-[var(--edge)] disabled:text-[var(--muted)] disabled:hover:bg-[var(--edge)]",
           )}
         >
           Create organization

--- a/client/dashboard/src/pages/login/components/signup-panel.tsx
+++ b/client/dashboard/src/pages/login/components/signup-panel.tsx
@@ -116,7 +116,7 @@ export function SignUpPanel(): JSX.Element {
         {AUTH_PILLARS.map((label) => (
           <span
             key={label}
-            className="auth-mono rounded-full border border-(--edge) px-[11px] py-[5px] text-[11px]"
+            className="auth-mono border border-(--edge) px-[11px] py-[5px] text-[11px]"
           >
             {label}
           </span>


### PR DESCRIPTION
Brings the login/auth surfaces in line with the dashboard's square editorial design language.

## Changes

- **Primary CTA** (`AUTH_BUTTON_CLASSES`, shared by Log in / Create organization / sign-up): drops the `rounded-full` pill shape and the inset bevel shadow — now a square, flat, solid-ink button.
- **Pillar chips** (Observe / Secure / Connect / Distribute on the login and sign-up panels): pill → square hairline border.
- **Agent session showcase**: step status chips squared; the live-pulse dot and avatar circle keep `rounded-full` (true circles, allowed by the style rules).
- **Register panel**: removes the now-dead `disabled:shadow-none` and the stale "no bevel" comment.
- **`frontend` skill doc**: deletes the "login/marketing surfaces keep documented pill styling — do not fix them" carve-out, which this PR makes untrue.

No layout or copy changes; the auth shell's cards, inputs, and hairline borders were already square.

## Verification

- `pnpm -F dashboard type-check` ✅
- `pnpm -F dashboard lint` ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyled login and auth pages to match the dashboard’s square editorial design: square CTAs and chips, flat surfaces, and updated docs to reflect the change. No layout or copy changes.

- **Refactors**
  - Primary CTA: removed `rounded-full` and bevel shadow; now a square, flat solid-ink button.
  - Pillar chips: pill → square with hairline border.
  - Agent session showcase: step chips squared; live-pulse dot and avatar remain true circles.
  - Register panel: simplified disabled styles; removed stale comment.
  - `frontend` skill doc: removed carve-out that preserved pill styling on auth/marketing surfaces.

<sup>Written for commit c3797590bddad3f6db32612cbe9665ead5570d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

