### PR TITLE
fix: deprovision deactivated directory users in WorkOS backfill

### DIFF
--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -316,7 +316,7 @@ func NewActivities(
 		signalAssistantCoordinator:      activities.NewSignalAssistantCoordinator(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		signalAssistantThread:           activities.NewSignalAssistantThread(&AssistantWorkflowSignaler{TemporalEnv: temporalEnv}),
 		listWorkOSOrganizations:         activities.NewListWorkOSOrganizations(logger, workosClient),
-		backfillWorkOSOrganization:      activities.NewBackfillWorkOSOrganization(logger, db, workosClient),
+		backfillWorkOSOrganization:      activities.NewBackfillWorkOSOrganization(logger, db, workosClient, cacheAdapter),
 		backfillWorkOSGlobalRoles:       activities.NewBackfillWorkOSGlobalRoles(logger, db, workosClient),
 		processWorkOSOrganizationEvents: activities.NewProcessWorkOSOrganizationEvents(logger, db, workosClient, cacheAdapter),
 		processWorkOSGlobalRoleEvents:   activities.NewProcessWorkOSGlobalRoleEvents(logger, db, workosClient),

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -111,6 +111,10 @@ func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWork
 		parsedMembers = append(parsedMembers, backfillWorkOSMember{member: member, updatedAt: updatedAt})
 	}
 
+	// Captured before the directory fetch: any relationship state stamped
+	// after this instant was written by an event the snapshot cannot have
+	// seen, and must win over the snapshot.
+	snapshotAt := time.Now().UTC()
 	directories, err := b.workos.ListDirectories(ctx, params.WorkOSOrganizationID)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "list WorkOS directories").LogError(ctx, logger)
@@ -168,7 +172,7 @@ func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWork
 
 	var effects []postCommitEffects
 	for _, directoryUser := range directoryUsers {
-		userEffects, err := backfillDirectoryUser(ctx, logger, tx, org.ID, directoryUser)
+		userEffects, err := backfillDirectoryUser(ctx, logger, tx, org.ID, directoryUser, snapshotAt)
 		if err != nil {
 			return err
 		}
@@ -197,7 +201,7 @@ func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWork
 // rows this backfill exists to repair. The snapshot is a fresh read of
 // current WorkOS state, so the staleness that cursors defend against does not
 // apply.
-func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser) (postCommitEffects, error) {
+func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser, snapshotAt time.Time) (postCommitEffects, error) {
 	var none postCommitEffects
 	repo := workosrepo.New(dbtx)
 
@@ -210,7 +214,7 @@ func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx databa
 	}
 
 	if rec.user.State != "" && rec.user.State != string(directorysync.Active) {
-		return backfillDeactivatedDirectoryUser(ctx, logger, dbtx, organizationID, rec, existing.UserID)
+		return backfillDeactivatedDirectoryUser(ctx, logger, dbtx, organizationID, rec, existing.UserID, snapshotAt)
 	}
 
 	var userID pgtype.Text
@@ -258,7 +262,7 @@ func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx databa
 // relationship, mirroring deactivateDirectoryUser. Directory state is
 // authoritative for access here, so only an already-deleted relationship
 // short-circuits the deprovision.
-func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser, storedUserID pgtype.Text) (postCommitEffects, error) {
+func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser, storedUserID pgtype.Text, snapshotAt time.Time) (postCommitEffects, error) {
 	var none postCommitEffects
 	repo := workosrepo.New(dbtx)
 
@@ -310,6 +314,14 @@ func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, 
 		return none, fmt.Errorf("get organization relationship for directory user: %w", err)
 	}
 	if rel.Deleted {
+		return none, nil
+	}
+	// Relationship state written after the snapshot was fetched comes from a
+	// concurrent event (e.g. a re-add) the snapshot cannot have observed —
+	// that state is newer truth and must not be revoked. Older relationship
+	// timestamps do NOT block the deprovision: directory state wins over
+	// membership state for anything the snapshot did see.
+	if rel.WorkosUpdatedAt.Valid && rel.WorkosUpdatedAt.Time.After(snapshotAt) {
 		return none, nil
 	}
 

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -10,15 +10,20 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/workos/workos-go/v6/pkg/directorysync"
 	"github.com/workos/workos-go/v6/pkg/events"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/database"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
@@ -30,6 +35,8 @@ type WorkOSClient interface {
 	ListOrgMemberships(ctx context.Context, orgID string) ([]workos.Member, error)
 	ListGlobalRoles(ctx context.Context) ([]workos.Role, error)
 	ListEvents(ctx context.Context, opts events.ListEventsOpts) (events.ListEventsResponse, error)
+	ListDirectories(ctx context.Context, organizationID string) ([]workos.Directory, error)
+	ListDirectoryUsers(ctx context.Context, directoryID string) ([]workos.DirectoryUser, error)
 	UpdateUserExternalID(ctx context.Context, workosUserID, externalID string) error
 	UpdateOrganizationExternalID(ctx context.Context, workosOrgID, externalID string) error
 }
@@ -42,6 +49,11 @@ type BackfillWorkOSOrganization struct {
 	logger *slog.Logger
 	db     *pgxpool.Pool
 	workos WorkOSClient
+	// userInfoCache mirrors the identity resolver's cached user info (same
+	// key shape and suffix as the resolver wiring in cmd/gram) so that
+	// snapshot-driven deprovisioning can invalidate a user's cached org
+	// memberships instead of waiting out the cache TTL.
+	userInfoCache cache.TypedCacheObject[sessions.CachedUserInfo]
 }
 
 type backfillWorkOSMember struct {
@@ -49,11 +61,19 @@ type backfillWorkOSMember struct {
 	updatedAt time.Time
 }
 
-func NewBackfillWorkOSOrganization(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient) *BackfillWorkOSOrganization {
+// backfillWorkOSDirectoryUser pairs a directory user snapshot with its parsed
+// updated_at timestamp.
+type backfillWorkOSDirectoryUser struct {
+	user      workos.DirectoryUser
+	updatedAt time.Time
+}
+
+func NewBackfillWorkOSOrganization(logger *slog.Logger, db *pgxpool.Pool, workosClient WorkOSClient, cacheAdapter cache.Cache) *BackfillWorkOSOrganization {
 	return &BackfillWorkOSOrganization{
-		logger: logger.With(attr.SlogComponent("backfill_workos_organization")),
-		db:     db,
-		workos: workosClient,
+		logger:        logger.With(attr.SlogComponent("backfill_workos_organization")),
+		db:            db,
+		workos:        workosClient,
+		userInfoCache: cache.NewTypedObjectCache[sessions.CachedUserInfo](logger.With(attr.SlogCacheNamespace("user_info")), cacheAdapter, cache.SuffixNone),
 	}
 }
 
@@ -91,6 +111,29 @@ func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWork
 		parsedMembers = append(parsedMembers, backfillWorkOSMember{member: member, updatedAt: updatedAt})
 	}
 
+	directories, err := b.workos.ListDirectories(ctx, params.WorkOSOrganizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list WorkOS directories").LogError(ctx, logger)
+	}
+	var directoryUsers []backfillWorkOSDirectoryUser
+	for _, directory := range directories {
+		users, err := b.workos.ListDirectoryUsers(ctx, directory.ID)
+		if err != nil {
+			return oops.E(oops.CodeUnexpected, err, "list WorkOS directory users").LogError(ctx, logger)
+		}
+		for _, user := range users {
+			updatedAt, err := parseWorkOSTime(user.UpdatedAt)
+			if err != nil {
+				logger.WarnContext(ctx, "skipping WorkOS directory user with invalid updated_at",
+					attr.SlogWorkOSDirectoryUserID(user.ID),
+					attr.SlogError(err),
+				)
+				continue
+			}
+			directoryUsers = append(directoryUsers, backfillWorkOSDirectoryUser{user: user, updatedAt: updatedAt})
+		}
+	}
+
 	tx, err := b.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -123,11 +166,176 @@ func (b *BackfillWorkOSOrganization) Do(ctx context.Context, params BackfillWork
 		}
 	}
 
+	var effects []postCommitEffects
+	for _, directoryUser := range directoryUsers {
+		userEffects, err := backfillDirectoryUser(ctx, logger, tx, org.ID, directoryUser)
+		if err != nil {
+			return err
+		}
+		effects = append(effects, userEffects)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit transaction: %w", err)
 	}
 
+	for _, userEffects := range effects {
+		runPostCommitEffects(ctx, logger, b.workos, b.userInfoCache, userEffects)
+	}
+
 	return nil
+}
+
+// backfillDirectoryUser reconciles one directory user snapshot, mirroring
+// what the dsync.user.* event handlers do: an active user upserts (and may
+// restore a soft-deleted row), a non-active user is soft-deleted and has any
+// live organization access deprovisioned.
+//
+// Unlike the event handlers, guards compare timestamps only and ignore
+// workos_last_event_id. The event path historically advanced the cursor while
+// ignoring the user's state, so a cursor-based guard would skip exactly the
+// rows this backfill exists to repair. The snapshot is a fresh read of
+// current WorkOS state, so the staleness that cursors defend against does not
+// apply.
+func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser) (postCommitEffects, error) {
+	var none postCommitEffects
+	repo := workosrepo.New(dbtx)
+
+	existing, err := repo.GetDirectoryUserSyncStateByWorkOSID(ctx, rec.user.ID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return none, fmt.Errorf("get directory user sync state for %q: %w", rec.user.ID, err)
+	}
+	if err == nil && existing.WorkosUpdatedAt.Valid && rec.updatedAt.Before(existing.WorkosUpdatedAt.Time) {
+		return none, nil
+	}
+
+	if rec.user.State != "" && rec.user.State != string(directorysync.Active) {
+		return backfillDeactivatedDirectoryUser(ctx, logger, dbtx, organizationID, rec)
+	}
+
+	var userID pgtype.Text
+	email := conv.NormalizeEmail(rec.user.Email)
+	if email != "" {
+		user, err := usersrepo.New(dbtx).GetUserByEmail(ctx, email)
+		switch {
+		case err == nil:
+			userID = conv.ToPGText(user.ID)
+		case errors.Is(err, pgx.ErrNoRows):
+		default:
+			return none, fmt.Errorf("get user by directory email: %w", err)
+		}
+	}
+
+	attributes := rec.user.CustomAttributes
+	if len(attributes) == 0 || string(attributes) == "null" {
+		attributes = []byte("{}")
+	}
+	createdAt, err := parseWorkOSTime(rec.user.CreatedAt)
+	if err != nil {
+		createdAt = rec.updatedAt
+	}
+	if _, err := repo.UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        organizationID,
+		UserID:                userID,
+		WorkosDirectoryUserID: rec.user.ID,
+		Email:                 conv.ToPGText(email),
+		Attributes:            attributes,
+		// Only an explicitly active snapshot state may resurrect a
+		// soft-deleted row, mirroring the event upsert path.
+		RestoreDeleted:    rec.user.State == string(directorysync.Active),
+		WorkosCreatedAt:   conv.ToPGTimestamptz(createdAt),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(rec.updatedAt),
+		WorkosLastEventID: conv.ToPGText(""),
+	}); err != nil {
+		return none, fmt.Errorf("upsert directory user %q from WorkOS snapshot: %w", rec.user.ID, err)
+	}
+
+	return none, nil
+}
+
+// backfillDeactivatedDirectoryUser applies a non-active snapshot state:
+// soft-delete the directory user row and deprovision any live organization
+// relationship, mirroring deactivateDirectoryUser. Directory state is
+// authoritative for access here, and a fresh snapshot cannot be stale, so
+// only an already-deleted relationship short-circuits the deprovision.
+func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser) (postCommitEffects, error) {
+	var none postCommitEffects
+	repo := workosrepo.New(dbtx)
+
+	// Resolve the linked Gram user before soft-deleting the directory row:
+	// email is the canonical linkage (mirroring the upsert path), with the
+	// stored user_id as a fallback for directory users whose email changed.
+	var gramUserID string
+	if email := conv.NormalizeEmail(rec.user.Email); email != "" {
+		user, err := usersrepo.New(dbtx).GetUserByEmail(ctx, email)
+		switch {
+		case err == nil:
+			gramUserID = user.ID
+		case errors.Is(err, pgx.ErrNoRows):
+		default:
+			return none, fmt.Errorf("get user by directory email: %w", err)
+		}
+	}
+	if gramUserID == "" {
+		directoryUser, err := repo.GetDirectoryUserByWorkOSID(ctx, rec.user.ID)
+		switch {
+		case err == nil && directoryUser.UserID.Valid:
+			gramUserID = directoryUser.UserID.String
+		case err != nil && !errors.Is(err, pgx.ErrNoRows):
+			return none, fmt.Errorf("get directory user by WorkOS ID: %w", err)
+		}
+	}
+
+	if _, err := repo.DeleteDirectoryUserByWorkOSID(ctx, workosrepo.DeleteDirectoryUserByWorkOSIDParams{
+		WorkosDeletedAt:       conv.ToPGTimestamptz(rec.updatedAt),
+		WorkosLastEventID:     conv.ToPGText(""),
+		WorkosDirectoryUserID: rec.user.ID,
+	}); err != nil {
+		return none, fmt.Errorf("deactivate directory user %q from WorkOS snapshot: %w", rec.user.ID, err)
+	}
+
+	if gramUserID == "" {
+		logger.WarnContext(ctx, "directory user deactivated but no linked Gram user found",
+			attr.SlogWorkOSDirectoryUserID(rec.user.ID),
+		)
+		return none, nil
+	}
+
+	rel, err := orgrepo.New(dbtx).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(gramUserID),
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return none, nil
+	case err != nil:
+		return none, fmt.Errorf("get organization relationship for directory user: %w", err)
+	}
+	if rel.Deleted {
+		return none, nil
+	}
+
+	// The deprovision is stamped with the snapshot time rather than the
+	// user's updated_at so older queued events cannot overwrite it, while
+	// genuinely newer events (e.g. a later re-add) still apply.
+	deprovisionedAt := time.Now().UTC()
+	effects, err := deprovisionOrganizationAccess(ctx, dbtx, deprovisionOrganizationAccessParams{
+		organizationID:     organizationID,
+		gramUserID:         gramUserID,
+		workosUserID:       rel.WorkosUserID.String,
+		workosMembershipID: rel.WorkosMembershipID.String,
+		eventID:            "",
+		eventUpdatedAt:     deprovisionedAt,
+	})
+	if err != nil {
+		return none, fmt.Errorf("deprovision organization access for directory user %q: %w", rec.user.ID, err)
+	}
+
+	logger.InfoContext(ctx, "deprovisioned organization access for deactivated directory user",
+		attr.SlogUserID(gramUserID),
+		attr.SlogWorkOSDirectoryUserID(rec.user.ID),
+	)
+	return effects, nil
 }
 
 func backfillOrganizationMetadata(ctx context.Context, repo *orgrepo.Queries, org orgrepo.OrganizationMetadatum, workosOrg workos.Organization, updatedAt time.Time) (orgrepo.OrganizationMetadatum, error) {

--- a/server/internal/background/activities/backfill_workos_organization.go
+++ b/server/internal/background/activities/backfill_workos_organization.go
@@ -210,7 +210,7 @@ func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx databa
 	}
 
 	if rec.user.State != "" && rec.user.State != string(directorysync.Active) {
-		return backfillDeactivatedDirectoryUser(ctx, logger, dbtx, organizationID, rec)
+		return backfillDeactivatedDirectoryUser(ctx, logger, dbtx, organizationID, rec, existing.UserID)
 	}
 
 	var userID pgtype.Text
@@ -256,15 +256,19 @@ func backfillDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx databa
 // backfillDeactivatedDirectoryUser applies a non-active snapshot state:
 // soft-delete the directory user row and deprovision any live organization
 // relationship, mirroring deactivateDirectoryUser. Directory state is
-// authoritative for access here, and a fresh snapshot cannot be stale, so
-// only an already-deleted relationship short-circuits the deprovision.
-func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser) (postCommitEffects, error) {
+// authoritative for access here, so only an already-deleted relationship
+// short-circuits the deprovision.
+func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, dbtx database.DBTX, organizationID string, rec backfillWorkOSDirectoryUser, storedUserID pgtype.Text) (postCommitEffects, error) {
 	var none postCommitEffects
 	repo := workosrepo.New(dbtx)
 
 	// Resolve the linked Gram user before soft-deleting the directory row:
 	// email is the canonical linkage (mirroring the upsert path), with the
 	// stored user_id as a fallback for directory users whose email changed.
+	// The stored linkage comes from the sync-state row, which includes
+	// soft-deleted rows, so a previously deactivated row that never got
+	// deprovisioned (e.g. an email mismatch at event time) can still be
+	// repaired.
 	var gramUserID string
 	if email := conv.NormalizeEmail(rec.user.Email); email != "" {
 		user, err := usersrepo.New(dbtx).GetUserByEmail(ctx, email)
@@ -276,14 +280,8 @@ func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, 
 			return none, fmt.Errorf("get user by directory email: %w", err)
 		}
 	}
-	if gramUserID == "" {
-		directoryUser, err := repo.GetDirectoryUserByWorkOSID(ctx, rec.user.ID)
-		switch {
-		case err == nil && directoryUser.UserID.Valid:
-			gramUserID = directoryUser.UserID.String
-		case err != nil && !errors.Is(err, pgx.ErrNoRows):
-			return none, fmt.Errorf("get directory user by WorkOS ID: %w", err)
-		}
+	if gramUserID == "" && storedUserID.Valid {
+		gramUserID = storedUserID.String
 	}
 
 	if _, err := repo.DeleteDirectoryUserByWorkOSID(ctx, workosrepo.DeleteDirectoryUserByWorkOSIDParams{
@@ -315,17 +313,18 @@ func backfillDeactivatedDirectoryUser(ctx context.Context, logger *slog.Logger, 
 		return none, nil
 	}
 
-	// The deprovision is stamped with the snapshot time rather than the
-	// user's updated_at so older queued events cannot overwrite it, while
-	// genuinely newer events (e.g. a later re-add) still apply.
-	deprovisionedAt := time.Now().UTC()
+	// The deprovision is stamped with the directory user's updated_at, not
+	// wall-clock time: a membership event that lands between the snapshot
+	// fetch and this write (e.g. a re-add) carries a newer WorkOS timestamp
+	// and must still apply, while events older than the deactivation stay
+	// blocked.
 	effects, err := deprovisionOrganizationAccess(ctx, dbtx, deprovisionOrganizationAccessParams{
 		organizationID:     organizationID,
 		gramUserID:         gramUserID,
 		workosUserID:       rel.WorkosUserID.String,
 		workosMembershipID: rel.WorkosMembershipID.String,
 		eventID:            "",
-		eventUpdatedAt:     deprovisionedAt,
+		eventUpdatedAt:     rec.updatedAt,
 	})
 	if err != nil {
 		return none, fmt.Errorf("deprovision organization access for directory user %q: %w", rec.user.ID, err)

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -465,6 +465,9 @@ func TestBackfillWorkOSOrganization_InactiveDirectoryUserDeprovisionsAccess(t *t
 	})
 	require.NoError(t, err)
 	require.True(t, relationship.Deleted)
+	// The deprovision is stamped with the snapshot's updated_at so delayed
+	// membership events that are genuinely newer still apply.
+	require.Equal(t, time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC), relationship.WorkosUpdatedAt.Time.UTC())
 
 	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
 		OrganizationID: organizationID,
@@ -477,6 +480,101 @@ func TestBackfillWorkOSOrganization_InactiveDirectoryUserDeprovisionsAccess(t *t
 	deletedKeys := capturingCache.Deleted()
 	require.Len(t, deletedKeys, 1)
 	require.Contains(t, deletedKeys[0], sessions.UserInfoCacheKey(userID))
+}
+
+func TestBackfillWorkOSOrganization_SoftDeletedRowEmailMismatchStillDeprovisions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_directory_user_email_mismatch")
+	logger := testenv.NewLogger(t)
+
+	const (
+		organizationID  = "gram_org_backfill_dsync_mismatch"
+		workosOrgID     = "org_01JBACKFILLDSYNCMISM"
+		userID          = "user_backfill_dsync_mismatch"
+		workosUserID    = "user_01JBACKFILLDSYNCMISM"
+		membershipID    = "mem_01JBACKFILLDSYNCMISM"
+		directoryID     = "directory_01JBACKFILLMISM"
+		directoryUserID = "directory_user_backfill_mismatch"
+	)
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+
+	err := orgrepo.New(conn).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGText(userID),
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)),
+		WorkosLastEventID:  conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	// A directory row that was soft-deleted by an earlier deactivation whose
+	// deprovision was skipped (the directory email no longer matches the
+	// Gram user). The stored user_id is the only remaining linkage.
+	_, err = workosrepo.New(conn).UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        organizationID,
+		UserID:                conv.ToPGText(userID),
+		WorkosDirectoryUserID: directoryUserID,
+		Email:                 conv.ToPGText("old." + userID + "@example.com"),
+		Attributes:            []byte(`{}`),
+		RestoreDeleted:        false,
+		WorkosCreatedAt:       conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)),
+		WorkosUpdatedAt:       conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)),
+		WorkosLastEventID:     conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+	_, err = workosrepo.New(conn).DeleteDirectoryUserByWorkOSID(ctx, workosrepo.DeleteDirectoryUserByWorkOSIDParams{
+		WorkosDeletedAt:       conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 30, 0, 0, time.UTC)),
+		WorkosLastEventID:     conv.ToPGText("event_00SEED"),
+		WorkosDirectoryUserID: directoryUserID,
+	})
+	require.NoError(t, err)
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Directory Mismatch",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-12T11:00:00Z",
+			UpdatedAt:  "2026-05-12T11:00:00Z",
+		},
+		nil,
+		nil,
+	)
+	workosClient.SetDirectories(workosOrgID, workos.Directory{
+		ID:             directoryID,
+		OrganizationID: workosOrgID,
+		Type:           "okta scim v2.0",
+		Name:           "Okta",
+		State:          "linked",
+		CreatedAt:      "2026-05-12T11:00:00Z",
+		UpdatedAt:      "2026-05-12T11:00:00Z",
+	})
+	workosClient.SetDirectoryUsers(directoryID, workos.DirectoryUser{
+		ID:               directoryUserID,
+		DirectoryID:      directoryID,
+		OrganizationID:   workosOrgID,
+		Email:            "renamed." + userID + "@example.com",
+		State:            "inactive",
+		CustomAttributes: nil,
+		CreatedAt:        "2026-05-12T12:00:00Z",
+		UpdatedAt:        "2026-05-12T13:00:00Z",
+	})
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
+
+	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	require.True(t, relationship.Deleted)
 }
 
 func TestBackfillWorkOSOrganization_ActiveDirectoryUserUpserted(t *testing.T) {

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -500,6 +500,7 @@ func TestBackfillWorkOSOrganization_SoftDeletedRowEmailMismatchStillDeprovisions
 	)
 	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
 	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	seedOrganizationRole(t, ctx, conn, organizationID, "member")
 
 	err := orgrepo.New(conn).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
 		OrganizationID:     organizationID,
@@ -508,6 +509,16 @@ func TestBackfillWorkOSOrganization_SoftDeletedRowEmailMismatchStillDeprovisions
 		WorkosMembershipID: conv.ToPGText(membershipID),
 		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)),
 		WorkosLastEventID:  conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+	err = orgrepo.New(conn).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       workosUserID,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)),
+		WorkosLastEventID:  conv.ToPGText("event_00SEED"),
+		WorkosRoleSlugs:    []string{"member"},
 	})
 	require.NoError(t, err)
 
@@ -564,6 +575,100 @@ func TestBackfillWorkOSOrganization_SoftDeletedRowEmailMismatchStillDeprovisions
 		UpdatedAt:        "2026-05-12T13:00:00Z",
 	})
 
+	capturingCache := newCaptureCache()
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, capturingCache)
+
+	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	// The directory row stays soft-deleted.
+	_, err = workosrepo.New(conn).GetDirectoryUserByWorkOSID(ctx, directoryUserID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	require.True(t, relationship.Deleted)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.True(t, assignments[0].DeletedAt.Valid)
+
+	deletedKeys := capturingCache.Deleted()
+	require.Len(t, deletedKeys, 1)
+	require.Contains(t, deletedKeys[0], sessions.UserInfoCacheKey(userID))
+}
+
+func TestBackfillWorkOSOrganization_RelationshipNewerThanSnapshotNotDeprovisioned(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_directory_user_newer_rel")
+	logger := testenv.NewLogger(t)
+
+	const (
+		organizationID  = "gram_org_backfill_dsync_newer_rel"
+		workosOrgID     = "org_01JBACKFILLDSYNCNEWREL"
+		userID          = "user_backfill_dsync_newer_rel"
+		workosUserID    = "user_01JBACKFILLDSYNCNEWREL"
+		membershipID    = "mem_01JBACKFILLDSYNCNEWREL"
+		directoryID     = "directory_01JBACKFILLNEWREL"
+		directoryUserID = "directory_user_backfill_newer_rel"
+	)
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	email := userID + "@example.com"
+
+	// A relationship stamped after the snapshot fetch models a concurrent
+	// membership event (e.g. a re-add) the snapshot could not have seen —
+	// the backfill must leave it alone.
+	err := orgrepo.New(conn).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGText(userID),
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(time.Now().UTC().Add(time.Hour)),
+		WorkosLastEventID:  conv.ToPGText("event_99CONCURRENT"),
+	})
+	require.NoError(t, err)
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Directory Newer Rel",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-12T11:00:00Z",
+			UpdatedAt:  "2026-05-12T11:00:00Z",
+		},
+		nil,
+		nil,
+	)
+	workosClient.SetDirectories(workosOrgID, workos.Directory{
+		ID:             directoryID,
+		OrganizationID: workosOrgID,
+		Type:           "okta scim v2.0",
+		Name:           "Okta",
+		State:          "linked",
+		CreatedAt:      "2026-05-12T11:00:00Z",
+		UpdatedAt:      "2026-05-12T11:00:00Z",
+	})
+	workosClient.SetDirectoryUsers(directoryID, workos.DirectoryUser{
+		ID:               directoryUserID,
+		DirectoryID:      directoryID,
+		OrganizationID:   workosOrgID,
+		Email:            email,
+		State:            "inactive",
+		CustomAttributes: nil,
+		CreatedAt:        "2026-05-12T12:00:00Z",
+		UpdatedAt:        "2026-05-12T12:00:00Z",
+	})
+
 	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
@@ -574,7 +679,8 @@ func TestBackfillWorkOSOrganization_SoftDeletedRowEmailMismatchStillDeprovisions
 		UserID:         conv.ToPGText(userID),
 	})
 	require.NoError(t, err)
-	require.True(t, relationship.Deleted)
+	require.False(t, relationship.Deleted)
+	require.Equal(t, "event_99CONCURRENT", relationship.WorkosLastEventID.String)
 }
 
 func TestBackfillWorkOSOrganization_ActiveDirectoryUserUpserted(t *testing.T) {

--- a/server/internal/background/activities/backfill_workos_test.go
+++ b/server/internal/background/activities/backfill_workos_test.go
@@ -12,11 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	workosrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/workos/repo"
 )
 
 func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t *testing.T) {
@@ -40,7 +43,7 @@ func TestBackfillWorkOSOrganization_CreatesUnlinkedOrganizationWithExternalID(t 
 		nil,
 		nil,
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -78,7 +81,7 @@ func TestBackfillWorkOSOrganization_ExternalIDChangeDoesNotChangeOrganizationID(
 		nil,
 		nil,
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -120,7 +123,7 @@ func TestBackfillWorkOSOrganization_DoesNotClearDisabled(t *testing.T) {
 		nil,
 		nil,
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -174,7 +177,7 @@ func TestBackfillWorkOSOrganization_UnknownUserSyncsSingleRoleAssignment(t *test
 			UpdatedAt:      "2026-05-07T11:05:00Z",
 		}},
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -256,7 +259,7 @@ func TestBackfillWorkOSOrganization_MembershipWithNewerEventSkipsRoleSnapshot(t 
 			UpdatedAt:      "2026-05-07T11:00:00Z",
 		}},
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -303,7 +306,7 @@ func TestBackfillWorkOSOrganization_RoleWithLastEventIDSkipsSnapshot(t *testing.
 		}},
 		nil,
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -342,7 +345,7 @@ func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
 		nil,
 		nil,
 	)
-	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient)
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
 
 	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
 	require.NoError(t, err)
@@ -355,6 +358,264 @@ func TestBackfillWorkOSOrganization_MissingRoleSoftDeleted(t *testing.T) {
 	require.True(t, role.Deleted)
 	require.True(t, role.WorkosDeleted)
 	require.Empty(t, role.WorkosLastEventID.String)
+}
+
+func TestBackfillWorkOSOrganization_InactiveDirectoryUserDeprovisionsAccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_directory_user_inactive")
+	logger := testenv.NewLogger(t)
+
+	const (
+		organizationID  = "gram_org_backfill_dsync_inactive"
+		workosOrgID     = "org_01JBACKFILLDSYNCINACT"
+		userID          = "user_backfill_dsync_inactive"
+		workosUserID    = "user_01JBACKFILLDSYNCINACT"
+		membershipID    = "mem_01JBACKFILLDSYNCINACT"
+		directoryID     = "directory_01JBACKFILLINACT"
+		directoryUserID = "directory_user_backfill_inactive"
+	)
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	seedOrganizationRole(t, ctx, conn, organizationID, "member")
+	email := userID + "@example.com"
+
+	// Seed the state the pre-state-check event handlers left behind: a live
+	// relationship, role assignments, and a directory user row whose cursor
+	// was advanced by an event that ignored state=inactive.
+	relationshipUpdatedAt := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	err := orgrepo.New(conn).UpsertWorkOSMembership(ctx, orgrepo.UpsertWorkOSMembershipParams{
+		OrganizationID:     organizationID,
+		UserID:             conv.ToPGText(userID),
+		WorkosUserID:       conv.ToPGText(workosUserID),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(relationshipUpdatedAt),
+		WorkosLastEventID:  conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+	err = orgrepo.New(conn).SyncUserOrganizationRoleAssignments(ctx, orgrepo.SyncUserOrganizationRoleAssignmentsParams{
+		OrganizationID:     organizationID,
+		WorkosUserID:       workosUserID,
+		UserID:             conv.ToPGText(userID),
+		WorkosMembershipID: conv.ToPGText(membershipID),
+		WorkosUpdatedAt:    conv.ToPGTimestamptz(relationshipUpdatedAt),
+		WorkosLastEventID:  conv.ToPGText("event_00SEED"),
+		WorkosRoleSlugs:    []string{"member"},
+	})
+	require.NoError(t, err)
+	_, err = workosrepo.New(conn).UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        organizationID,
+		UserID:                conv.ToPGText(userID),
+		WorkosDirectoryUserID: directoryUserID,
+		Email:                 conv.ToPGText(email),
+		Attributes:            []byte(`{}`),
+		RestoreDeleted:        false,
+		WorkosCreatedAt:       conv.ToPGTimestamptz(relationshipUpdatedAt),
+		WorkosUpdatedAt:       conv.ToPGTimestamptz(relationshipUpdatedAt),
+		WorkosLastEventID:     conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Directory Inactive",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-12T11:00:00Z",
+			UpdatedAt:  "2026-05-12T11:00:00Z",
+		},
+		nil,
+		nil,
+	)
+	workosClient.SetDirectories(workosOrgID, workos.Directory{
+		ID:             directoryID,
+		OrganizationID: workosOrgID,
+		Type:           "okta scim v2.0",
+		Name:           "Okta",
+		State:          "linked",
+		CreatedAt:      "2026-05-12T11:00:00Z",
+		UpdatedAt:      "2026-05-12T11:00:00Z",
+	})
+	workosClient.SetDirectoryUsers(directoryID, workos.DirectoryUser{
+		ID:               directoryUserID,
+		DirectoryID:      directoryID,
+		OrganizationID:   workosOrgID,
+		Email:            email,
+		State:            "inactive",
+		CustomAttributes: nil,
+		CreatedAt:        "2026-05-12T12:00:00Z",
+		UpdatedAt:        "2026-05-12T12:00:00Z",
+	})
+
+	capturingCache := newCaptureCache()
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, capturingCache)
+
+	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	// The directory user row is soft-deleted despite its advanced event
+	// cursor — the snapshot repair guard is timestamp-only.
+	_, err = workosrepo.New(conn).GetDirectoryUserByWorkOSID(ctx, directoryUserID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	relationship, err := orgrepo.New(conn).GetOrganizationRelationshipForUser(ctx, orgrepo.GetOrganizationRelationshipForUserParams{
+		OrganizationID: organizationID,
+		UserID:         conv.ToPGText(userID),
+	})
+	require.NoError(t, err)
+	require.True(t, relationship.Deleted)
+
+	assignments, err := orgrepo.New(conn).ListOrganizationRoleAssignmentsByWorkOSUser(ctx, orgrepo.ListOrganizationRoleAssignmentsByWorkOSUserParams{
+		OrganizationID: organizationID,
+		WorkosUserID:   workosUserID,
+	})
+	require.NoError(t, err)
+	require.Len(t, assignments, 1)
+	require.True(t, assignments[0].DeletedAt.Valid)
+
+	deletedKeys := capturingCache.Deleted()
+	require.Len(t, deletedKeys, 1)
+	require.Contains(t, deletedKeys[0], sessions.UserInfoCacheKey(userID))
+}
+
+func TestBackfillWorkOSOrganization_ActiveDirectoryUserUpserted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_directory_user_active")
+	logger := testenv.NewLogger(t)
+
+	const (
+		organizationID  = "gram_org_backfill_dsync_active"
+		workosOrgID     = "org_01JBACKFILLDSYNCACT"
+		userID          = "user_backfill_dsync_active"
+		workosUserID    = "user_01JBACKFILLDSYNCACT"
+		directoryID     = "directory_01JBACKFILLACT"
+		directoryUserID = "directory_user_backfill_active"
+	)
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	email := userID + "@example.com"
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Directory Active",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-12T11:00:00Z",
+			UpdatedAt:  "2026-05-12T11:00:00Z",
+		},
+		nil,
+		nil,
+	)
+	workosClient.SetDirectories(workosOrgID, workos.Directory{
+		ID:             directoryID,
+		OrganizationID: workosOrgID,
+		Type:           "okta scim v2.0",
+		Name:           "Okta",
+		State:          "linked",
+		CreatedAt:      "2026-05-12T11:00:00Z",
+		UpdatedAt:      "2026-05-12T11:00:00Z",
+	})
+	workosClient.SetDirectoryUsers(directoryID, workos.DirectoryUser{
+		ID:               directoryUserID,
+		DirectoryID:      directoryID,
+		OrganizationID:   workosOrgID,
+		Email:            email,
+		State:            "active",
+		CustomAttributes: []byte(`{"department":"Engineering"}`),
+		CreatedAt:        "2026-05-12T12:00:00Z",
+		UpdatedAt:        "2026-05-12T12:00:00Z",
+	})
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
+
+	err := activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	directoryUser, err := workosrepo.New(conn).GetDirectoryUserByWorkOSID(ctx, directoryUserID)
+	require.NoError(t, err)
+	require.False(t, directoryUser.Deleted)
+	require.Equal(t, userID, directoryUser.UserID.String)
+	require.JSONEq(t, `{"department":"Engineering"}`, string(directoryUser.Attributes))
+	require.Empty(t, directoryUser.WorkosLastEventID.String)
+}
+
+func TestBackfillWorkOSOrganization_StaleDirectoryUserSnapshotSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newOrgEventsTestConn(t, "workos_backfill_directory_user_stale")
+	logger := testenv.NewLogger(t)
+
+	const (
+		organizationID  = "gram_org_backfill_dsync_stale"
+		workosOrgID     = "org_01JBACKFILLDSYNCSTALE"
+		userID          = "user_backfill_dsync_stale"
+		workosUserID    = "user_01JBACKFILLDSYNCSTALE"
+		directoryID     = "directory_01JBACKFILLSTALE"
+		directoryUserID = "directory_user_backfill_stale"
+	)
+	seedLinkedWorkOSOrganization(t, ctx, conn, organizationID, workosOrgID)
+	seedWorkOSUser(t, ctx, conn, userID, workosUserID)
+	email := userID + "@example.com"
+
+	// The local row is newer than the snapshot, so the backfill must not
+	// touch it.
+	_, err := workosrepo.New(conn).UpsertDirectoryUser(ctx, workosrepo.UpsertDirectoryUserParams{
+		OrganizationID:        organizationID,
+		UserID:                conv.ToPGText(userID),
+		WorkosDirectoryUserID: directoryUserID,
+		Email:                 conv.ToPGText(email),
+		Attributes:            []byte(`{}`),
+		RestoreDeleted:        false,
+		WorkosCreatedAt:       conv.ToPGTimestamptz(time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)),
+		WorkosUpdatedAt:       conv.ToPGTimestamptz(time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)),
+		WorkosLastEventID:     conv.ToPGText("event_00SEED"),
+	})
+	require.NoError(t, err)
+
+	workosClient := newWorkOSSnapshotClient(t, ctx,
+		workos.Organization{
+			ID:         workosOrgID,
+			Name:       "Backfill Directory Stale",
+			ExternalID: organizationID,
+			CreatedAt:  "2026-05-12T11:00:00Z",
+			UpdatedAt:  "2026-05-12T11:00:00Z",
+		},
+		nil,
+		nil,
+	)
+	workosClient.SetDirectories(workosOrgID, workos.Directory{
+		ID:             directoryID,
+		OrganizationID: workosOrgID,
+		Type:           "okta scim v2.0",
+		Name:           "Okta",
+		State:          "linked",
+		CreatedAt:      "2026-05-12T11:00:00Z",
+		UpdatedAt:      "2026-05-12T11:00:00Z",
+	})
+	workosClient.SetDirectoryUsers(directoryID, workos.DirectoryUser{
+		ID:               directoryUserID,
+		DirectoryID:      directoryID,
+		OrganizationID:   workosOrgID,
+		Email:            email,
+		State:            "inactive",
+		CustomAttributes: nil,
+		CreatedAt:        "2026-05-12T12:00:00Z",
+		UpdatedAt:        "2026-05-12T13:00:00Z",
+	})
+
+	activity := activities.NewBackfillWorkOSOrganization(logger, conn, workosClient, cache.NoopCache)
+
+	err = activity.Do(ctx, activities.BackfillWorkOSOrganizationParams{WorkOSOrganizationID: workosOrgID})
+	require.NoError(t, err)
+
+	directoryUser, err := workosrepo.New(conn).GetDirectoryUserByWorkOSID(ctx, directoryUserID)
+	require.NoError(t, err)
+	require.False(t, directoryUser.Deleted)
+	require.Equal(t, "event_00SEED", directoryUser.WorkosLastEventID.String)
 }
 
 func newWorkOSSnapshotClient(t *testing.T, ctx context.Context, org workos.Organization, roles []workos.Role, members []workos.Member) *workos.StubClient {

--- a/server/internal/background/activities/process_workos_org_events.go
+++ b/server/internal/background/activities/process_workos_org_events.go
@@ -165,15 +165,15 @@ type postCommitEffects struct {
 	invalidateUserInfoCacheUserID string
 }
 
-func (p *ProcessWorkOSOrganizationEvents) runPostCommitEffects(ctx context.Context, logger *slog.Logger, effects postCommitEffects) {
+func runPostCommitEffects(ctx context.Context, logger *slog.Logger, workosClient WorkOSClient, userInfoCache cache.TypedCacheObject[sessions.CachedUserInfo], effects postCommitEffects) {
 	if update := effects.updateWorkOSExternalID; update != nil {
-		if err := p.workosClient.UpdateOrganizationExternalID(ctx, update.workosOrgID, update.externalID); err != nil {
+		if err := workosClient.UpdateOrganizationExternalID(ctx, update.workosOrgID, update.externalID); err != nil {
 			logger.WarnContext(ctx, "failed to update WorkOS organization external ID", attr.SlogError(err))
 		}
 	}
 
 	if userID := effects.invalidateUserInfoCacheUserID; userID != "" {
-		if err := p.userInfoCache.Delete(ctx, sessions.CachedUserInfo{
+		if err := userInfoCache.Delete(ctx, sessions.CachedUserInfo{
 			UserID:             userID,
 			Admin:              false,
 			Email:              "",
@@ -246,7 +246,7 @@ func (p *ProcessWorkOSOrganizationEvents) handleEvent(ctx context.Context, logge
 		return "", fmt.Errorf("commit transaction: %w", err)
 	}
 
-	p.runPostCommitEffects(ctx, logger, effects)
+	runPostCommitEffects(ctx, logger, p.workosClient, p.userInfoCache, effects)
 
 	return event.ID, nil
 }

--- a/server/internal/thirdparty/workos/connection.go
+++ b/server/internal/thirdparty/workos/connection.go
@@ -2,6 +2,7 @@ package workos
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/workos/workos-go/v6/pkg/directorysync"
 	"github.com/workos/workos-go/v6/pkg/sso"
@@ -88,6 +89,59 @@ func (wc *Client) ListDirectories(ctx context.Context, organizationID string) ([
 		})
 	}
 	return out, nil
+}
+
+// DirectoryUser represents a WorkOS Directory Sync user.
+type DirectoryUser struct {
+	ID               string
+	DirectoryID      string
+	OrganizationID   string
+	Email            string
+	State            string // "active", "inactive"
+	CustomAttributes json.RawMessage
+	CreatedAt        string
+	UpdatedAt        string
+}
+
+// ListDirectoryUsers fetches all provisioned users for a directory from WorkOS.
+// https://workos.com/docs/reference/directory-sync/directory-user/list
+func (wc *Client) ListDirectoryUsers(ctx context.Context, directoryID string) ([]DirectoryUser, error) {
+	var all []DirectoryUser
+	after := ""
+
+	for {
+		resp, err := wc.dsync.ListUsers(ctx, directorysync.ListUsersOpts{
+			Directory: directoryID,
+			Group:     "",
+			Limit:     100,
+			Order:     "",
+			Before:    "",
+			After:     after,
+		})
+		if err != nil {
+			return nil, wrapSDKError(err, "list directory users")
+		}
+
+		for _, u := range resp.Data {
+			all = append(all, DirectoryUser{
+				ID:               u.ID,
+				DirectoryID:      u.DirectoryID,
+				OrganizationID:   u.OrganizationID,
+				Email:            u.Email,
+				State:            string(u.State),
+				CustomAttributes: u.CustomAttributes,
+				CreatedAt:        u.CreatedAt,
+				UpdatedAt:        u.UpdatedAt,
+			})
+		}
+
+		if resp.ListMetadata.After == "" {
+			break
+		}
+		after = resp.ListMetadata.After
+	}
+
+	return all, nil
 }
 
 // HasActiveConnection returns true if the organization has at least one active SSO connection.

--- a/server/internal/thirdparty/workos/queries.sql
+++ b/server/internal/thirdparty/workos/queries.sql
@@ -130,7 +130,9 @@ ON CONFLICT (workos_directory_user_id) DO UPDATE SET
 RETURNING id;
 
 -- name: GetDirectoryUserSyncStateByWorkOSID :one
-SELECT workos_updated_at, workos_last_event_id
+-- Includes soft-deleted rows so snapshot reconciliation can read the cursor
+-- and stored user linkage even after a deactivation soft-deleted the row.
+SELECT user_id, workos_updated_at, workos_last_event_id
 FROM directory_users
 WHERE workos_directory_user_id = @workos_directory_user_id;
 

--- a/server/internal/thirdparty/workos/repo/queries.sql.go
+++ b/server/internal/thirdparty/workos/repo/queries.sql.go
@@ -284,20 +284,23 @@ func (q *Queries) GetDirectoryUserIDByWorkOSID(ctx context.Context, workosDirect
 }
 
 const getDirectoryUserSyncStateByWorkOSID = `-- name: GetDirectoryUserSyncStateByWorkOSID :one
-SELECT workos_updated_at, workos_last_event_id
+SELECT user_id, workos_updated_at, workos_last_event_id
 FROM directory_users
 WHERE workos_directory_user_id = $1
 `
 
 type GetDirectoryUserSyncStateByWorkOSIDRow struct {
+	UserID            pgtype.Text
 	WorkosUpdatedAt   pgtype.Timestamptz
 	WorkosLastEventID pgtype.Text
 }
 
+// Includes soft-deleted rows so snapshot reconciliation can read the cursor
+// and stored user linkage even after a deactivation soft-deleted the row.
 func (q *Queries) GetDirectoryUserSyncStateByWorkOSID(ctx context.Context, workosDirectoryUserID string) (GetDirectoryUserSyncStateByWorkOSIDRow, error) {
 	row := q.db.QueryRow(ctx, getDirectoryUserSyncStateByWorkOSID, workosDirectoryUserID)
 	var i GetDirectoryUserSyncStateByWorkOSIDRow
-	err := row.Scan(&i.WorkosUpdatedAt, &i.WorkosLastEventID)
+	err := row.Scan(&i.UserID, &i.WorkosUpdatedAt, &i.WorkosLastEventID)
 	return i, err
 }
 

--- a/server/internal/thirdparty/workos/stub.go
+++ b/server/internal/thirdparty/workos/stub.go
@@ -21,6 +21,8 @@ type StubClient struct {
 	eventCalls            []events.ListEventsOpts
 	userExternalIDUpdates []UserExternalIDUpdate
 	orgExternalIDUpdates  []OrgExternalIDUpdate
+	directories           map[string][]Directory
+	directoryUsers        map[string][]DirectoryUser
 	next                  int
 	nowFn                 func() time.Time
 }
@@ -56,6 +58,8 @@ func NewStubClient() *StubClient {
 		eventCalls:            make([]events.ListEventsOpts, 0),
 		userExternalIDUpdates: make([]UserExternalIDUpdate, 0),
 		orgExternalIDUpdates:  make([]OrgExternalIDUpdate, 0),
+		directories:           make(map[string][]Directory),
+		directoryUsers:        make(map[string][]DirectoryUser),
 		next:                  1,
 		nowFn:                 time.Now,
 	}
@@ -326,8 +330,32 @@ func (s *StubClient) ListConnections(_ context.Context, _ string) ([]Connection,
 	return nil, nil
 }
 
-func (s *StubClient) ListDirectories(_ context.Context, _ string) ([]Directory, error) {
-	return nil, nil
+func (s *StubClient) ListDirectories(_ context.Context, organizationID string) ([]Directory, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	return append([]Directory(nil), s.directories[organizationID]...), nil
+}
+
+func (s *StubClient) SetDirectories(organizationID string, directories ...Directory) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	s.directories[organizationID] = append([]Directory(nil), directories...)
+}
+
+func (s *StubClient) ListDirectoryUsers(_ context.Context, directoryID string) ([]DirectoryUser, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	return append([]DirectoryUser(nil), s.directoryUsers[directoryID]...), nil
+}
+
+func (s *StubClient) SetDirectoryUsers(directoryID string, users ...DirectoryUser) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
+	s.directoryUsers[directoryID] = append([]DirectoryUser(nil), users...)
 }
 
 func (s *StubClient) EnsureOrgExternalID(_ context.Context, workosOrgID, gramOrgID string) error {


### PR DESCRIPTION
## Why

Production orgs retain members who have left the company. The `dsync.user.created` / `dsync.user.updated` handlers ignored the `state` property until #4283, so SCIM deactivations (which WorkOS emits as updates with `state=inactive`, not deletes) were consumed as plain upserts. The per-org event cursor advanced past those events, and the WorkOS Events API only retains ~30 days, so the fixed handlers can never replay them. The result is orphaned org relationships and role assignments for deactivated directory users.

## What

Extends the existing snapshot-driven `BackfillWorkOSOrganization` activity (run via the manually triggered `BackfillWorkOSWorkflow`) to reconcile directory users:

- New `ListDirectoryUsers` wrapper on the WorkOS client (paginated, boundary type, no vendor leakage), plus `ListDirectories`/`ListDirectoryUsers` on the `WorkOSClient` interface and stub.
- For each directory user in the snapshot:
  - `state=active` → upsert the directory user row (restoring soft-deleted rows), linking by normalized email.
  - non-active state → soft-delete the row and run `deprovisionOrganizationAccess` (relationship tombstone, role-assignment revocation, user-info cache invalidation), mirroring what the fixed event handler does.
- `runPostCommitEffects` converted from a method to a shared free function so the backfill reuses the same post-commit cache invalidation as event processing.

### Guard semantics (the important bit)

Directory-user reconciliation guards are **timestamp-only** and deliberately ignore `workos_last_event_id`. The pre-#4283 handlers advanced the event cursor on exactly the rows this backfill exists to repair, so `ShouldProcessEvent`'s cursor branch would skip all of them. A fresh snapshot cannot be stale, so timestamps arbitrate instead. Deprovision writes are stamped with the reconcile time so older queued events cannot resurrect access while genuinely newer events still apply.

## Rollout

Trigger `BackfillWorkOSWorkflow` from Temporal (scoped to the affected org first via `workos_organization_id`, then org-wide). Idempotent and safe to run alongside the live event stream.

## Tests

- Inactive snapshot user deprovisions access despite an advanced event cursor (directory row soft-deleted, relationship + assignments tombstoned, user-info cache invalidated).
- Active snapshot user upserts and links to the Gram user by email.
- Snapshot older than local row is skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprovisions deactivated WorkOS Directory Sync users during backfill to remove lingering org access. Also skips deprovision when a relationship was updated after the snapshot to avoid rolling back newer changes.

- **Bug Fixes**
  - Extend `BackfillWorkOSOrganization` to reconcile directory users from WorkOS snapshots.
  - Inactive users: soft-delete directory user, run `deprovisionOrganizationAccess`, invalidate the user-info cache, and stamp deprovision with the snapshot `updated_at`. Recover the linked Gram user from stored `user_id` when the directory email changed. Skip deprovision if the membership’s `workos_updated_at` is newer than the snapshot.
  - Active users: upsert/restore directory user and link to the Gram user by normalized email.
  - Guards compare timestamps only and ignore `workos_last_event_id` to repair cases where cursors advanced past deactivations.
  - Share post-commit effects via a new `runPostCommitEffects` function; `NewBackfillWorkOSOrganization` now takes a cache adapter.
  - Add WorkOS client methods `ListDirectories` and `ListDirectoryUsers` (plus stub support) to fetch directory snapshots.

<sup>Written for commit ad09d74498bd0c5410be8503ce3ceff352e6ab96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

