### PR TITLE
chore: add cmux config that delegates worktree creation to worktrunk

### DIFF
--- a/.cmux/cmux.json
+++ b/.cmux/cmux.json
@@ -1,0 +1,130 @@
+{
+  // cmux project config — worktree creation delegated to worktrunk.
+  //
+  // Requires worktrunk (`wt`) with its shell integration installed
+  // (https://worktrunk.dev/shell/), which the gram workflow already uses:
+  // the wrapper is what lets `wt switch` cd this shell into the new worktree.
+  // All project hooks in .config/wt.toml fire as usual: port remap
+  // (git:workinit), background stack boot (git:workboot).
+  //
+  // Layout per workspace: left pane creates/opens the worktree and stays as a
+  // shell inside it; right pane waits for the worktree path (state file),
+  // cds in, and starts Claude.
+  //
+  // cmux has NO teardown hook — closing a workspace does NOT remove the
+  // worktree or tear its stack down. Run `wt remove` from the worktree
+  // (the pre-remove nuke hook handles the compose stack).
+  "schemaVersion": 1,
+
+  "actions": {
+    "wt-new-branch": {
+      "type": "workspaceCommand",
+      "title": "New Branch (worktrunk)",
+      "subtitle": "wt switch --create: worktree + full stack boot",
+      "commandName": "New Branch",
+      "icon": { "type": "symbol", "name": "arrow.triangle.branch" }
+    },
+    "wt-open-branch": {
+      "type": "workspaceCommand",
+      "title": "Open Branch (worktrunk)",
+      "subtitle": "wt switch: existing branch's worktree",
+      "commandName": "Open Branch",
+      "icon": { "type": "symbol", "name": "folder.badge.gearshape" }
+    }
+  },
+
+  "ui": {
+    "newWorkspace": {
+      "action": "wt-new-branch",
+      "contextMenu": [
+        { "action": "wt-new-branch", "title": "New Branch (worktrunk)" },
+        { "action": "wt-open-branch", "title": "Open Branch (worktrunk)" },
+        { "type": "separator" },
+        { "action": "cmux.newTerminal", "title": "Plain Terminal" }
+      ]
+    }
+  },
+
+  "commands": [
+    {
+      "name": "New Branch",
+      "description": "Create branch + worktree via wt switch --create (hooks boot the stack), start Claude in it",
+      "workspace": {
+        "name": "wt: new",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "split": 0.45,
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  {
+                    "type": "terminal",
+                    "name": "Worktree",
+                    "focus": true,
+                    // Prompt for a branch name plus optional passthrough args.
+                    // --no-boot is consumed here (sets GRAM_WT_NO_BOOT=1, same
+                    // as the git:workboot hook expects); everything else goes
+                    // to `wt switch --create` (e.g. --base some-branch).
+                    "command": "exec \"${SHELL:-zsh}\" -ic 'state=\"${TMPDIR:-/tmp}/cmux-wt-${CMUX_WORKSPACE_ID:-manual}.dir\"; rm -f \"$state\"; printf \"branch name [args ok: --no-boot, --base <ref>]: \"; read -r line; eval \"set -- $line\"; rest=\"\"; for a in \"$@\"; do if [ \"$a\" = \"--no-boot\" ]; then export GRAM_WT_NO_BOOT=1; else rest=\"$rest $a\"; fi; done; eval \"wt switch --create $rest\" && { pwd > \"$state\"; port=$(sed -n \"s/^GRAM_SITE_PORT = .\\(.*\\)./\\1/p\" mise.local.toml 2>/dev/null); [ -n \"$port\" ] && echo \"Dashboard: https://localhost:$port\"; }; exec \"${SHELL:-zsh}\" -i'"
+                  }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  {
+                    "type": "terminal",
+                    "name": "Claude",
+                    "command": "state=\"${TMPDIR:-/tmp}/cmux-wt-${CMUX_WORKSPACE_ID:-manual}.dir\"; echo \"waiting for worktree...\"; while [ ! -s \"$state\" ]; do sleep 0.2; done; cd \"$(cat \"$state\")\" && exec \"${SHELL:-zsh}\" -ic claude"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Open Branch",
+      "description": "Switch to an existing branch's worktree via wt switch, start Claude in it",
+      "workspace": {
+        "name": "wt: open",
+        "cwd": ".",
+        "layout": {
+          "direction": "horizontal",
+          "split": 0.45,
+          "children": [
+            {
+              "pane": {
+                "surfaces": [
+                  {
+                    "type": "terminal",
+                    "name": "Worktree",
+                    "focus": true,
+                    // wt shortcuts pass through: ^ default branch, - previous,
+                    // pr:123 a PR. Empty input opens wt's interactive picker.
+                    "command": "exec \"${SHELL:-zsh}\" -ic 'state=\"${TMPDIR:-/tmp}/cmux-wt-${CMUX_WORKSPACE_ID:-manual}.dir\"; rm -f \"$state\"; printf \"branch [empty = picker, ^ = default, pr:123]: \"; read -r line; eval \"wt switch $line\" && pwd > \"$state\"; exec \"${SHELL:-zsh}\" -i'"
+                  }
+                ]
+              }
+            },
+            {
+              "pane": {
+                "surfaces": [
+                  {
+                    "type": "terminal",
+                    "name": "Claude",
+                    "command": "state=\"${TMPDIR:-/tmp}/cmux-wt-${CMUX_WORKSPACE_ID:-manual}.dir\"; echo \"waiting for worktree...\"; while [ ! -s \"$state\" ]; do sleep 0.2; done; cd \"$(cat \"$state\")\" && exec \"${SHELL:-zsh}\" -ic claude"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/.cmux/cmux.json
+++ b/.cmux/cmux.json
@@ -24,6 +24,14 @@
       "commandName": "New Branch",
       "icon": { "type": "symbol", "name": "arrow.triangle.branch" }
     },
+    "wt-import-worktrees": {
+      "type": "command",
+      "title": "Import Existing Worktrees",
+      "subtitle": "one workspace per git worktree, named by branch",
+      "target": "newTabInCurrentPane",
+      "command": "\"$(git rev-parse --show-toplevel)/.cmux/import-worktrees.sh\"; echo done — close this tab",
+      "icon": { "type": "symbol", "name": "square.stack.3d.up" }
+    },
     "wt-open-branch": {
       "type": "workspaceCommand",
       "title": "Open Branch (worktrunk)",

--- a/.cmux/import-worktrees.sh
+++ b/.cmux/import-worktrees.sh
@@ -9,14 +9,15 @@
 #       defaults write com.cmuxterm.app socketControlMode automation
 #     (default `cmuxOnly` rejects any process not started inside cmux)
 #   - the CLI ships inside the app bundle, not on PATH; resolved below
-#   - the socket lives under Application Support, not /tmp
+#   - cmux >= 0.64 required (the CLI auto-discovers the socket; override
+#     with CMUX_SOCKET_PATH if needed)
 set -euo pipefail
 
 cmux() {
   local bin
   bin=$(type -P cmux || true)
   [ -n "$bin" ] || bin="/Applications/cmux.app/Contents/Resources/bin/cmux"
-  CMUX_SOCKET_PATH="${CMUX_SOCKET_PATH:-$HOME/Library/Application Support/cmux/cmux.sock}" "$bin" "$@"
+  "$bin" "$@"
 }
 
 repo="${1:-$(git rev-parse --show-toplevel)}"

--- a/.cmux/import-worktrees.sh
+++ b/.cmux/import-worktrees.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Import existing git worktrees into cmux: one workspace per worktree, named
+# after its branch. Idempotent — worktrees that already have a workspace with
+# their cwd are skipped. cmux persists workspaces across restarts, so this is
+# a one-time (or occasional) sync, not a startup requirement.
+#
+# Run from any terminal while cmux is running (needs the cmux CLI on PATH and
+# its socket at the default /tmp/cmux.sock or $CMUX_SOCKET_PATH).
+set -euo pipefail
+
+repo="${1:-$(git rev-parse --show-toplevel)}"
+
+existing=$(cmux list-workspaces --json | python3 -c '
+import json, sys
+for ws in json.load(sys.stdin):
+    print(ws.get("cwd") or "")
+')
+
+git -C "$repo" worktree list --porcelain | awk '/^worktree /{print $2}' |
+while read -r wt; do
+  if printf "%s\n" "$existing" | grep -Fxq "$wt"; then
+    echo "skip (already open): $wt"
+    continue
+  fi
+  branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD)
+  cmux new-workspace --cwd "$wt"
+  id=$(cmux list-workspaces --json | python3 -c '
+import json, sys
+print(json.load(sys.stdin)[-1]["id"])
+')
+  cmux rename-workspace --workspace "$id" "$branch"
+  echo "imported: $branch ($wt)"
+done

--- a/.cmux/import-worktrees.sh
+++ b/.cmux/import-worktrees.sh
@@ -4,9 +4,20 @@
 # their cwd are skipped. cmux persists workspaces across restarts, so this is
 # a one-time (or occasional) sync, not a startup requirement.
 #
-# Run from any terminal while cmux is running (needs the cmux CLI on PATH and
-# its socket at the default /tmp/cmux.sock or $CMUX_SOCKET_PATH).
+# Run from any terminal while cmux is running. Requirements:
+#   - socket control mode must allow external clients:
+#       defaults write com.cmuxterm.app socketControlMode automation
+#     (default `cmuxOnly` rejects any process not started inside cmux)
+#   - the CLI ships inside the app bundle, not on PATH; resolved below
+#   - the socket lives under Application Support, not /tmp
 set -euo pipefail
+
+cmux() {
+  local bin
+  bin=$(type -P cmux || true)
+  [ -n "$bin" ] || bin="/Applications/cmux.app/Contents/Resources/bin/cmux"
+  CMUX_SOCKET_PATH="${CMUX_SOCKET_PATH:-$HOME/Library/Application Support/cmux/cmux.sock}" "$bin" "$@"
+}
 
 repo="${1:-$(git rev-parse --show-toplevel)}"
 


### PR DESCRIPTION
## What

Adds `.cmux/cmux.json`, a project config for [cmux](https://github.com/manaflow-ai/cmux) that plugs its workspace creation into our existing worktrunk flow instead of raw `git worktree add`.

Two workspace commands, wired to the "+" button and command palette:

- **New Branch (worktrunk)** — prompts for a branch name (plus optional `--no-boot` / `--base <ref>` passthrough), runs `wt switch --create`, so the `.config/wt.toml` hooks fire as usual: `git:workinit` port remap and the background `git:workboot` stack boot. Echoes the worktree's dashboard URL.
- **Open Branch (worktrunk)** — `wt switch` for an existing branch; supports wt shortcuts (`^`, `-`, `pr:123`) and the interactive picker on empty input.

Each workspace opens two panes: a shell left in the worktree, and a Claude agent pane that waits for the worktree path (via a state file keyed on `CMUX_WORKSPACE_ID`), cds in, and starts.

## Notes

- Requires worktrunk shell integration (https://worktrunk.dev/shell/), which the repo's worktree flow already assumes.
- `--no-boot` is translated to `GRAM_WT_NO_BOOT=1`, matching the `git:workboot` hook contract.
- cmux has no teardown hook: closing a workspace does not remove the worktree — `wt remove` still does that (and the `pre-remove` nuke hook tears the stack down).
- No-op for anyone not running cmux; the file is only read by the app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cmux` project config to create/open worktrees via `worktrunk` (`wt`), plus a palette action to import existing git worktrees. The import script resolves the bundled `cmux` CLI and relies on socket auto-discovery (>=0.64).

- **New Features**
  - Adds `.cmux/cmux.json` to route workspace creation/opening through `wt`.
  - Two commands: New Branch (`wt switch --create`, supports `--base`, `--no-boot`) and Open Branch (`wt switch`, supports `^`, `-`, `pr:123`, or picker); layout opens a terminal plus a `claude` pane that waits on `CMUX_WORKSPACE_ID`.
  - Import `.cmux/import-worktrees.sh`: one workspace per git worktree; resolves the bundled `cmux` CLI; socket auto-discovered (override with `CMUX_SOCKET_PATH`).
  - On create, `--no-boot` sets `GRAM_WT_NO_BOOT=1`; prints the dashboard URL if a port is found.

- **Migration**
  - Requires `worktrunk` shell integration.
  - For import, allow external CLI: `defaults write com.cmuxterm.app socketControlMode automation`.
  - Closing a `cmux` workspace does not remove the worktree; run `wt remove`.

<sup>Written for commit 6a8af9c4bc7972f73bc88ff5a660a6e98fd3fb57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

