### PR TITLE
feat: add OpenCode to device agent managed tools

### DIFF
--- a/.changeset/device-agent-opencode-tool.md
+++ b/.changeset/device-agent-opencode-tool.md
@@ -1,0 +1,7 @@
+---
+"dashboard": minor
+---
+
+Add opencode to the managed tools list on the device agent fleet
+configuration page, with the same off/user/managed enforcement layer
+selection as the other supported tools.

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
@@ -55,8 +55,8 @@ const PLATFORMS = [
   },
   {
     key: "opencode",
-    label: "opencode",
-    description: "Configure opencode plugins and MCP settings.",
+    label: "OpenCode",
+    description: "Configure OpenCode plugins and MCP settings.",
     defaultLayer: "off",
   },
 ] as const satisfies ReadonlyArray<{

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
@@ -53,6 +53,12 @@ const PLATFORMS = [
     description: "Configure Cursor plugins and MCP settings.",
     defaultLayer: "off",
   },
+  {
+    key: "opencode",
+    label: "OpenCode",
+    description: "Configure OpenCode plugins and MCP settings.",
+    defaultLayer: "off",
+  },
 ] as const satisfies ReadonlyArray<{
   key: string;
   label: string;

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
@@ -55,8 +55,8 @@ const PLATFORMS = [
   },
   {
     key: "opencode",
-    label: "OpenCode",
-    description: "Configure OpenCode plugins and MCP settings.",
+    label: "opencode",
+    description: "Configure opencode plugins and MCP settings.",
     defaultLayer: "off",
   },
 ] as const satisfies ReadonlyArray<{


### PR DESCRIPTION
## Summary

Adds OpenCode to the Managed tools list on the device agent Fleet configuration page. It gets the same Off / User / Managed enforcement dropdown as the other tools, defaulting to Off like Codex and Cursor.

The config key is `opencode`, matching the tool id the device agent daemon registers for its OpenCode syncer and looks up in the remote `platforms` map, so no backend or agent changes are needed.

## Testing

- `pnpm -F dashboard type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added OpenCode to the device agent Fleet Managed Tools with the standard Off/User/Managed control (default Off). Uses lowercase config key `opencode`; no backend or agent changes needed, and a changeset is included.

<sup>Written for commit 53fb706ce763c6e281b64d47ba42636a8b819182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

