### PR TITLE
feat(assistants): serve Platform MCP read tools to the project assistant behind a PostHog flag

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -964,6 +964,7 @@ func newStartCommand() *cli.Command {
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)
 			assistantsCore.SetChatMessageWriter(chatWriter)
+			assistantsCore.SetFeatureProvider(featureFlags)
 			assistantsSvc := assistants.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv}, ratelimit.NewRedisStore(redisClient))
 			triggerApp.RegisterDispatcher(assistantsSvc)
 
@@ -1435,6 +1436,7 @@ func newStartCommand() *cli.Command {
 				AssistantSkillTools:           skillTools,
 				AssistantTriggerTools:         triggerTools,
 				ManagedAssistantInsightsTools: managedInsightsTools,
+				PlatformMCPReadTools:          platformtoolsruntime.PlatformMCPReadTools(platformmcp.NewPostgresReader(db)),
 			}))
 
 			srv := &http.Server{

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -910,7 +910,7 @@ func newStartCommand() *cli.Command {
 				chatSessionsManager,
 				env,
 				posthogClient,
-				posthogClient,
+				featureFlags,
 				serverURL,
 				siteURL,
 				encryptionClient,

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -786,6 +786,7 @@ func newWorkerCommand() *cli.Command {
 			assistantsCore.SetWakeCanceller(triggerApp)
 			assistantsCore.SetDashboardIngestor(triggerApp)
 			assistantsCore.SetChatMessageWriter(chatWriter)
+			assistantsCore.SetFeatureProvider(featureFlags)
 			assistantsSvc := assistants.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, assistantsCore, &background.AssistantWorkflowSignaler{TemporalEnv: temporalEnv}, ratelimit.NewRedisStore(redisClient))
 			triggerApp.RegisterDispatcher(assistantsSvc)
 

--- a/server/internal/assistants/platform_slugs_test.go
+++ b/server/internal/assistants/platform_slugs_test.go
@@ -1,0 +1,110 @@
+package assistants
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/assistants"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+)
+
+// platformSlugsFixture provisions the managed assistant plus a sibling and
+// returns records shaped for assistantPlatformSlugs.
+func platformSlugsFixture(t *testing.T) (*Service, assistantRecord, assistantRecord) {
+	t.Helper()
+
+	svc, ctx, projectID, conn := newRBACServiceWithConn(t, "assistants_platform_slugs")
+	ensureAssistantTestOrganization(t, conn)
+	ctx = authztest.WithExactGrants(t, ctx, projectWriteGrant(projectID))
+
+	managed, err := svc.EnsureManagedAssistant(ctx, &gen.EnsureManagedAssistantPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+	})
+	require.NoError(t, err)
+	managedID, err := uuid.Parse(managed.ID)
+	require.NoError(t, err)
+
+	other, err := svc.CreateAssistant(ctx, &gen.CreateAssistantPayload{
+		SessionToken:     nil,
+		ProjectSlugInput: nil,
+		Name:             "Sibling",
+		Model:            "openai/gpt-4o-mini",
+		Instructions:     "",
+		Toolsets:         nil,
+		McpServers:       nil,
+		WarmTTLSeconds:   nil,
+		MaxConcurrency:   nil,
+		Status:           nil,
+	})
+	require.NoError(t, err)
+	otherID, err := uuid.Parse(other.ID)
+	require.NoError(t, err)
+
+	managedRecord := assistantRecord{ID: managedID, ProjectID: projectID}
+	otherRecord := assistantRecord{ID: otherID, ProjectID: projectID}
+	return svc, managedRecord, otherRecord
+}
+
+func TestAssistantPlatformSlugsManagedWithFlagOnGetsPlatformToolset(t *testing.T) {
+	t.Parallel()
+
+	svc, managedRecord, _ := platformSlugsFixture(t)
+
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagAssistantPlatformMCP, "org-test", true)
+	svc.core.SetFeatureProvider(flags)
+
+	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		platformtools.AssistantsPlatformToolsetSlug,
+		platformtools.ManagedAssistantPlatformToolsetSlug,
+		platformtools.PlatformMCPReadToolsetSlug,
+	}, slugs)
+}
+
+func TestAssistantPlatformSlugsManagedWithFlagOffUnchanged(t *testing.T) {
+	t.Parallel()
+
+	svc, managedRecord, _ := platformSlugsFixture(t)
+	svc.core.SetFeatureProvider(&feature.InMemory{})
+
+	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		platformtools.AssistantsPlatformToolsetSlug,
+		platformtools.ManagedAssistantPlatformToolsetSlug,
+	}, slugs)
+}
+
+func TestAssistantPlatformSlugsNilProviderFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	svc, managedRecord, _ := platformSlugsFixture(t)
+
+	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), managedRecord)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		platformtools.AssistantsPlatformToolsetSlug,
+		platformtools.ManagedAssistantPlatformToolsetSlug,
+	}, slugs)
+}
+
+func TestAssistantPlatformSlugsNonManagedNeverGetsPlatformToolset(t *testing.T) {
+	t.Parallel()
+
+	svc, _, otherRecord := platformSlugsFixture(t)
+
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagAssistantPlatformMCP, "org-test", true)
+	svc.core.SetFeatureProvider(flags)
+
+	slugs, err := svc.core.assistantPlatformSlugs(t.Context(), otherRecord)
+	require.NoError(t, err)
+	require.Equal(t, []string{platformtools.AssistantsPlatformToolsetSlug}, slugs)
+}

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -31,10 +31,12 @@ import (
 	chatrepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers/visibility"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	slackclient "github.com/speakeasy-api/gram/server/internal/thirdparty/slack/client"
@@ -394,6 +396,7 @@ type ServiceCore struct {
 	wakeCanceller     WakeCanceller
 	chatWriter        *chat.ChatMessageWriter
 	dashboardIngestor DashboardIngestor
+	featureFlags      feature.Provider
 	turnClassified    metric.Int64Counter
 }
 
@@ -438,6 +441,7 @@ func NewServiceCore(
 		wakeCanceller:     nil,
 		chatWriter:        nil,
 		dashboardIngestor: nil,
+		featureFlags:      nil,
 		turnClassified:    turnClassified,
 	}
 }
@@ -461,6 +465,14 @@ func (s *ServiceCore) SetDashboardIngestor(i DashboardIngestor) {
 // site. Self-heal is skipped if the writer was never set.
 func (s *ServiceCore) SetChatMessageWriter(w *chat.ChatMessageWriter) {
 	s.chatWriter = w
+}
+
+// SetFeatureProvider wires PostHog flag evaluation. Set after construction
+// to match the existing post-construction injection pattern and avoid
+// churning every test call site. A nil provider leaves every flag-gated
+// grant off (fail closed).
+func (s *ServiceCore) SetFeatureProvider(p feature.Provider) {
+	s.featureFlags = p
 }
 
 // resolveAssistantContextWindow returns the smallest context_length the gram
@@ -2743,6 +2755,9 @@ func (s *ServiceCore) assistantPlatformSlugs(ctx context.Context, assistant assi
 	case mErr == nil:
 		if managed.ID == assistant.ID {
 			platformSlugs = append(platformSlugs, platformtools.ManagedAssistantPlatformToolsetSlug)
+			if s.platformMCPReadEnabled(ctx, assistant.ProjectID) {
+				platformSlugs = append(platformSlugs, platformtools.PlatformMCPReadToolsetSlug)
+			}
 		}
 	case errors.Is(mErr, pgx.ErrNoRows):
 		// Project has no managed assistant; managed-only tools stay ungranted.
@@ -2750,6 +2765,29 @@ func (s *ServiceCore) assistantPlatformSlugs(ctx context.Context, assistant assi
 		return nil, fmt.Errorf("resolve managed assistant: %w", mErr)
 	}
 	return platformSlugs, nil
+}
+
+// platformMCPReadEnabled reports whether the organization owning projectID is
+// cleared for the Platform MCP read toolset rollout. Evaluation mirrors the
+// Platform MCP organization gate: distinct ID is the org ID with the org-slug
+// PostHog group. Errors fail closed but never abort the turn — a flag-provider
+// outage must not take down bootstrap or reconcile, so the toolset is simply
+// withheld until evaluation recovers.
+func (s *ServiceCore) platformMCPReadEnabled(ctx context.Context, projectID uuid.UUID) bool {
+	if s.featureFlags == nil {
+		return false
+	}
+	project, err := projectsrepo.New(s.db).GetProjectWithOrganizationMetadata(ctx, projectID)
+	if err != nil {
+		s.logger.WarnContext(ctx, "resolve organization for platform mcp read toolset", attr.SlogError(err))
+		return false
+	}
+	enabled, err := s.featureFlags.IsFlagEnabled(ctx, feature.FlagAssistantPlatformMCP, project.ID, feature.OrgProjectGroups(project.Slug, ""))
+	if err != nil {
+		s.logger.WarnContext(ctx, "evaluate assistant platform mcp flag", attr.SlogError(err))
+		return false
+	}
+	return enabled
 }
 
 // turnUserID returns the Gram user whose identity a turn should act under.

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -46,6 +46,13 @@ const (
 	// FlagPlatformMCPRollout gates the organization-targeted Platform MCP rollout.
 	// It is evaluated in addition to the durable Platform MCP product capability.
 	FlagPlatformMCPRollout Flag = "platform-mcp-rollout"
+	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
+	// assistant the Platform MCP read toolset — the "platform" platform
+	// toolset re-serving the Platform MCP read tools over the assistant
+	// runtime channel. Targeted by PostHog organization group (org slug),
+	// like FlagBudgets. Evaluated server-side only; removed once the toolset
+	// is GA.
+	FlagAssistantPlatformMCP Flag = "assistant-platform-mcp"
 	// FlagRiskOverviewFromClickHouse serves the risk overview endpoint from
 	// ClickHouse risk_findings instead of Postgres risk_results. Per-org
 	// rollout gate; removed once the ClickHouse read path is GA.

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -19,6 +19,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -131,7 +132,9 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 // project is rejected as if the toolset did not exist, rather than relying on
 // downstream tools to refuse the call.
 func (s *Service) authorizePlatformToolset(ctx context.Context, slug string, authCtx *contextvalues.AuthContext) error {
-	if slug != platformtools.ManagedAssistantPlatformToolsetSlug {
+	switch slug {
+	case platformtools.ManagedAssistantPlatformToolsetSlug, platformtools.PlatformMCPReadToolsetSlug:
+	default:
 		return nil
 	}
 
@@ -150,6 +153,23 @@ func (s *Service) authorizePlatformToolset(ctx context.Context, slug string, aut
 
 	if managed.ID != principal.AssistantID {
 		return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
+	}
+
+	// The Platform MCP read toolset is rollout-gated per organization. The
+	// attachment decision in the assistants service uses the same flag, but
+	// the assistant token lives inside the runner VM, so the serve path
+	// re-checks rather than trusting attachment. Fail closed on evaluation
+	// errors.
+	if slug == platformtools.PlatformMCPReadToolsetSlug {
+		enabled, err := s.features.IsFlagEnabled(ctx, feature.FlagAssistantPlatformMCP,
+			authCtx.ActiveOrganizationID, feature.OrgProjectGroups(authCtx.OrganizationSlug, ""))
+		if err != nil {
+			s.logger.WarnContext(ctx, "evaluate assistant platform mcp flag", attr.SlogError(err))
+			return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
+		}
+		if !enabled {
+			return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
+		}
 	}
 
 	return nil

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -161,6 +161,9 @@ func (s *Service) authorizePlatformToolset(ctx context.Context, slug string, aut
 	// re-checks rather than trusting attachment. Fail closed on evaluation
 	// errors.
 	if slug == platformtools.PlatformMCPReadToolsetSlug {
+		if s.features == nil {
+			return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
+		}
 		enabled, err := s.features.IsFlagEnabled(ctx, feature.FlagAssistantPlatformMCP,
 			authCtx.ActiveOrganizationID, feature.OrgProjectGroups(authCtx.OrganizationSlug, ""))
 		if err != nil {

--- a/server/internal/mcp/serve_platform_test.go
+++ b/server/internal/mcp/serve_platform_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/auth/assistanttokens"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 )
 
@@ -256,4 +257,122 @@ func servePlatformHTTP(t *testing.T, ti *testInstance, slug string, body []byte,
 		return w, fmt.Errorf("serve platform toolset: %w", err)
 	}
 	return w, nil
+}
+
+// The Platform MCP read toolset is rollout-gated: the managed assistant
+// reaches it only when the assistant-platform-mcp flag is on for the org.
+func TestServePlatformToolset_PlatformMCPReadFlagOnListsTools(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	managedID := createAssistant(t, ti, authCtx, "Managed")
+	err := assistantsrepo.New(ti.conn).CreateProjectManagedAssistant(t.Context(), assistantsrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   *authCtx.ProjectID,
+		AssistantID: managedID,
+	})
+	require.NoError(t, err)
+
+	ti.features.SetFlag(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, true)
+
+	token := mintAssistantToken(t, ti, authCtx, managedID)
+	w, err := servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, toolsListBody(), token)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "managed assistant must reach the platform toolset when the flag is on: %s", w.Body.String())
+	body := w.Body.String()
+	require.Contains(t, body, platformtools.ToolNameGetPlatformContext)
+	require.Contains(t, body, platformtools.ToolNameListProjects)
+	require.Contains(t, body, platformtools.ToolNameListProjectMCPs)
+	require.Contains(t, body, platformtools.ToolNameGetMCP)
+}
+
+func TestServePlatformToolset_PlatformMCPReadFlagOffRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	managedID := createAssistant(t, ti, authCtx, "Managed")
+	err := assistantsrepo.New(ti.conn).CreateProjectManagedAssistant(t.Context(), assistantsrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   *authCtx.ProjectID,
+		AssistantID: managedID,
+	})
+	require.NoError(t, err)
+
+	token := mintAssistantToken(t, ti, authCtx, managedID)
+	_, err = servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, toolsListBody(), token)
+	require.Error(t, err, "the platform toolset must stay hidden while the flag is off")
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestServePlatformToolset_PlatformMCPReadNonManagedAssistantRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	managedID := createAssistant(t, ti, authCtx, "Managed")
+	err := assistantsrepo.New(ti.conn).CreateProjectManagedAssistant(t.Context(), assistantsrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   *authCtx.ProjectID,
+		AssistantID: managedID,
+	})
+	require.NoError(t, err)
+
+	ti.features.SetFlag(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, true)
+
+	otherID := createAssistant(t, ti, authCtx, "Other")
+	token := mintAssistantToken(t, ti, authCtx, otherID)
+
+	_, err = servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, toolsListBody(), token)
+	require.Error(t, err, "a non-managed assistant must not reach the platform toolset even with the flag on")
+	require.Contains(t, err.Error(), "not found")
+}
+
+// tools/call must round-trip through the re-served reader against the seeded
+// org: list_projects returns the project the auth context lives in.
+func TestServePlatformToolset_PlatformMCPReadListProjectsCall(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	managedID := createAssistant(t, ti, authCtx, "Managed")
+	err := assistantsrepo.New(ti.conn).CreateProjectManagedAssistant(t.Context(), assistantsrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   *authCtx.ProjectID,
+		AssistantID: managedID,
+	})
+	require.NoError(t, err)
+
+	ti.features.SetFlag(feature.FlagAssistantPlatformMCP, authCtx.ActiveOrganizationID, true)
+
+	token := mintAssistantToken(t, ti, authCtx, managedID)
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      platformtools.ToolNameListProjects,
+			"arguments": map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+
+	w, err := servePlatformHTTP(t, ti, platformtools.PlatformMCPReadToolsetSlug, body, token)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code, "list_projects call must succeed: %s", w.Body.String())
+	require.Contains(t, w.Body.String(), authCtx.ProjectID.String(), "the caller's project must appear in the listing")
 }

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	mcpmetadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/oauth"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
@@ -240,6 +241,7 @@ func newTestMCPServiceWithTunnelPublicConfig(t *testing.T, identityResolver mcp.
 		AssistantSkillTools:           assistantSkillTools,
 		AssistantTriggerTools:         nil,
 		ManagedAssistantInsightsTools: managedLogsTools,
+		PlatformMCPReadTools:          platformtoolsruntime.PlatformMCPReadTools(platformmcp.NewPostgresReader(conn)),
 	})
 	tunnelRoutes := route.NewRouteTable()
 	features := &feature.InMemory{}

--- a/server/internal/platformtools/platform/tool_get_mcp.go
+++ b/server/internal/platformtools/platform/tool_get_mcp.go
@@ -1,0 +1,61 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type GetMCP struct {
+	reader platformmcp.Reader
+}
+
+func NewGetMCPTool(reader platformmcp.Reader) *GetMCP {
+	return &GetMCP{reader: reader}
+}
+
+func (t *GetMCP) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  platformtools.SourcePlatform,
+		HandlerName: "get_mcp",
+		Name:        platformtools.ToolNameGetMCP,
+		Description: "Get an allowlisted summary of one configured MCP in an explicit project.",
+		InputSchema: core.BuildInputSchema[platformmcp.GetMCPInput](),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *GetMCP) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.reader == nil {
+		return fmt.Errorf("platform reader not configured")
+	}
+
+	input := platformmcp.GetMCPInput{ProjectID: "", MCPID: ""}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.ProjectID == "" || input.MCPID == "" {
+		return fmt.Errorf("project_id and mcp_id are required")
+	}
+
+	principal, err := principalFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	output, err := t.reader.GetMCP(ctx, principal, input)
+	if err != nil {
+		return fmt.Errorf("get configured mcp: %w", err)
+	}
+
+	return core.EncodeResult(wr, output)
+}

--- a/server/internal/platformtools/platform/tool_get_platform_context.go
+++ b/server/internal/platformtools/platform/tool_get_platform_context.go
@@ -1,0 +1,67 @@
+package platform
+
+import (
+	"context"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type GetPlatformContext struct{}
+
+type getPlatformContextInput struct{}
+
+// getPlatformContextResult is the assistant-channel variant of
+// platformmcp.PlatformContext: there is no OAuth connection to report, and the
+// calling assistant benefits from knowing its own project alongside the
+// organization.
+type getPlatformContextResult struct {
+	OrganizationID string `json:"organization_id"`
+	ProjectID      string `json:"project_id,omitempty"`
+	ReadOnly       bool   `json:"read_only"`
+}
+
+func NewGetPlatformContextTool() *GetPlatformContext {
+	return &GetPlatformContext{}
+}
+
+func (t *GetPlatformContext) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  platformtools.SourcePlatform,
+		HandlerName: "get_platform_context",
+		Name:        platformtools.ToolNameGetPlatformContext,
+		Description: "Show the organization and project bound to this session. All platform tools on this server are read-only.",
+		InputSchema: core.BuildInputSchema[getPlatformContextInput](),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *GetPlatformContext) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	input := getPlatformContextInput{}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+
+	principal, err := principalFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	projectID := ""
+	if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.ProjectID != nil {
+		projectID = authCtx.ProjectID.String()
+	}
+
+	return core.EncodeResult(wr, getPlatformContextResult{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      projectID,
+		ReadOnly:       true,
+	})
+}

--- a/server/internal/platformtools/platform/tool_list_project_mcps.go
+++ b/server/internal/platformtools/platform/tool_list_project_mcps.go
@@ -52,7 +52,6 @@ func (t *ListProjectMCPs) Call(ctx context.Context, _ toolconfig.ToolCallEnv, pa
 		return err
 	}
 
-	input.Limit = boundedLimit(input.Limit)
 	output, err := t.reader.ListProjectMCPs(ctx, principal, input)
 	if err != nil {
 		return fmt.Errorf("list project mcps: %w", err)

--- a/server/internal/platformtools/platform/tool_list_project_mcps.go
+++ b/server/internal/platformtools/platform/tool_list_project_mcps.go
@@ -1,0 +1,62 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListProjectMCPs struct {
+	reader platformmcp.Reader
+}
+
+func NewListProjectMCPsTool(reader platformmcp.Reader) *ListProjectMCPs {
+	return &ListProjectMCPs{reader: reader}
+}
+
+func (t *ListProjectMCPs) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  platformtools.SourcePlatform,
+		HandlerName: "list_project_mcps",
+		Name:        platformtools.ToolNameListProjectMCPs,
+		Description: "List the configured MCPs in an explicit project. Results contain allowlisted MCP summaries only.",
+		InputSchema: core.BuildInputSchema[platformmcp.ListProjectMCPsInput](),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *ListProjectMCPs) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.reader == nil {
+		return fmt.Errorf("platform reader not configured")
+	}
+
+	input := platformmcp.ListProjectMCPsInput{ProjectID: "", Limit: 0}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+	if input.ProjectID == "" {
+		return fmt.Errorf("project_id is required")
+	}
+
+	principal, err := principalFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	input.Limit = boundedLimit(input.Limit)
+	output, err := t.reader.ListProjectMCPs(ctx, principal, input)
+	if err != nil {
+		return fmt.Errorf("list project mcps: %w", err)
+	}
+
+	return core.EncodeResult(wr, output)
+}

--- a/server/internal/platformtools/platform/tool_list_projects.go
+++ b/server/internal/platformtools/platform/tool_list_projects.go
@@ -49,7 +49,6 @@ func (t *ListProjects) Call(ctx context.Context, _ toolconfig.ToolCallEnv, paylo
 		return err
 	}
 
-	input.Limit = boundedLimit(input.Limit)
 	output, err := t.reader.ListProjects(ctx, principal, input)
 	if err != nil {
 		return fmt.Errorf("list projects: %w", err)

--- a/server/internal/platformtools/platform/tool_list_projects.go
+++ b/server/internal/platformtools/platform/tool_list_projects.go
@@ -1,0 +1,59 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	"github.com/speakeasy-api/gram/server/internal/platformtools/core"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type ListProjects struct {
+	reader platformmcp.Reader
+}
+
+func NewListProjectsTool(reader platformmcp.Reader) *ListProjects {
+	return &ListProjects{reader: reader}
+}
+
+func (t *ListProjects) Descriptor() core.ToolDescriptor {
+	return core.ToolDescriptor{
+		SourceSlug:  platformtools.SourcePlatform,
+		HandlerName: "list_projects",
+		Name:        platformtools.ToolNameListProjects,
+		Description: "List projects in the current organization. Results contain only project identifiers, names, and slugs.",
+		InputSchema: core.BuildInputSchema[platformmcp.ListProjectsInput](),
+		Variables:   nil,
+		Annotations: core.ReadOnlyAnnotations(),
+		Managed:     true,
+		OwnerKind:   nil,
+		OwnerID:     nil,
+	}
+}
+
+func (t *ListProjects) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload io.Reader, wr io.Writer) error {
+	if t.reader == nil {
+		return fmt.Errorf("platform reader not configured")
+	}
+
+	input := platformmcp.ListProjectsInput{Limit: 0}
+	if err := core.DecodeInput(payload, &input); err != nil {
+		return err
+	}
+
+	principal, err := principalFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	input.Limit = boundedLimit(input.Limit)
+	output, err := t.reader.ListProjects(ctx, principal, input)
+	if err != nil {
+		return fmt.Errorf("list projects: %w", err)
+	}
+
+	return core.EncodeResult(wr, output)
+}

--- a/server/internal/platformtools/platform/tools.go
+++ b/server/internal/platformtools/platform/tools.go
@@ -1,0 +1,46 @@
+// Package platform re-serves the Platform MCP read tools
+// (server/internal/platformmcp) as platform tools on the assistant runtime
+// channel. The OAuth-facing Platform MCP surface authenticates org admins;
+// here the caller is an assistant runtime whose auth context already carries
+// the organization, so the tools reuse platformmcp.Reader with a principal
+// built from that context and never touch the Platform MCP OAuth state.
+package platform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+)
+
+// maxListLimit mirrors the clamp platformmcp applies inside its MCP SDK
+// handlers, which this channel bypasses by calling the Reader directly.
+const (
+	defaultListLimit = 50
+	maxListLimit     = 100
+)
+
+func boundedLimit(limit int) int {
+	if limit <= 0 {
+		return defaultListLimit
+	}
+	return min(limit, maxListLimit)
+}
+
+// principalFromContext derives the Reader principal from the assistant
+// runtime auth context. The Postgres reader scopes every query by
+// organization ID alone, so no connection identity is required.
+func principalFromContext(ctx context.Context) (platformmcp.Principal, error) {
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	if !ok || authCtx == nil || authCtx.ActiveOrganizationID == "" {
+		return platformmcp.Principal{}, fmt.Errorf("platform tools require organization auth context")
+	}
+	return platformmcp.Principal{
+		UserID:         "",
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ConnectionID:   "",
+		Generation:     "",
+		ClientID:       "",
+	}, nil
+}

--- a/server/internal/platformtools/platform/tools.go
+++ b/server/internal/platformtools/platform/tools.go
@@ -14,20 +14,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 )
 
-// maxListLimit mirrors the clamp platformmcp applies inside its MCP SDK
-// handlers, which this channel bypasses by calling the Reader directly.
-const (
-	defaultListLimit = 50
-	maxListLimit     = 100
-)
-
-func boundedLimit(limit int) int {
-	if limit <= 0 {
-		return defaultListLimit
-	}
-	return min(limit, maxListLimit)
-}
-
 // principalFromContext derives the Reader principal from the assistant
 // runtime auth context. The Postgres reader scopes every query by
 // organization ID alone, so no connection identity is required.

--- a/server/internal/platformtools/platform/tools_test.go
+++ b/server/internal/platformtools/platform/tools_test.go
@@ -60,7 +60,9 @@ func orgAuthContext(t *testing.T, orgID string, projectID *uuid.UUID) context.Co
 	})
 }
 
-func TestListProjectsToolPassesOrgPrincipalAndClampsLimit(t *testing.T) {
+// Limit clamping is the Reader's job (platformmcp.PostgresReader applies
+// boundedLimit internally); the adapter passes the caller's limit through.
+func TestListProjectsToolPassesOrgPrincipalAndInputThrough(t *testing.T) {
 	t.Parallel()
 
 	reader := &stubReader{
@@ -74,23 +76,12 @@ func TestListProjectsToolPassesOrgPrincipalAndClampsLimit(t *testing.T) {
 	var out bytes.Buffer
 	require.NoError(t, NewListProjectsTool(reader).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{"limit": 500}`), &out))
 	require.Equal(t, "org_123", reader.principal.OrganizationID)
-	require.Equal(t, 100, reader.projectsInput.Limit, "limit above the cap must be clamped")
+	require.Equal(t, 500, reader.projectsInput.Limit)
 
 	var result platformmcp.ListProjectsOutput
 	require.NoError(t, json.Unmarshal(out.Bytes(), &result))
 	require.Len(t, result.Projects, 1)
 	require.Equal(t, "one", result.Projects[0].Slug)
-}
-
-func TestListProjectsToolDefaultsLimit(t *testing.T) {
-	t.Parallel()
-
-	reader := &stubReader{}
-	ctx := orgAuthContext(t, "org_123", nil)
-
-	var out bytes.Buffer
-	require.NoError(t, NewListProjectsTool(reader).Call(ctx, testToolCallEnv(), nil, &out))
-	require.Equal(t, 50, reader.projectsInput.Limit)
 }
 
 func TestListProjectsToolRejectsMissingAuthContext(t *testing.T) {
@@ -126,7 +117,7 @@ func TestListProjectMCPsToolPassesInputThrough(t *testing.T) {
 	require.NoError(t, NewListProjectMCPsTool(reader).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{"project_id":"p1"}`), &out))
 	require.Equal(t, "org_123", reader.principal.OrganizationID)
 	require.Equal(t, "p1", reader.mcpsInput.ProjectID)
-	require.Equal(t, 50, reader.mcpsInput.Limit)
+	require.Equal(t, 0, reader.mcpsInput.Limit, "unset limit reaches the reader untouched; the reader owns clamping")
 }
 
 func TestGetMCPToolRequiresBothIDs(t *testing.T) {

--- a/server/internal/platformtools/platform/tools_test.go
+++ b/server/internal/platformtools/platform/tools_test.go
@@ -1,0 +1,203 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	"github.com/speakeasy-api/gram/server/internal/toolconfig"
+)
+
+type stubReader struct {
+	principal      platformmcp.Principal
+	projectsInput  platformmcp.ListProjectsInput
+	mcpsInput      platformmcp.ListProjectMCPsInput
+	getInput       platformmcp.GetMCPInput
+	projectsOutput platformmcp.ListProjectsOutput
+	mcpsOutput     platformmcp.ListProjectMCPsOutput
+	getOutput      platformmcp.MCP
+}
+
+func (s *stubReader) ListProjects(_ context.Context, principal platformmcp.Principal, input platformmcp.ListProjectsInput) (platformmcp.ListProjectsOutput, error) {
+	s.principal = principal
+	s.projectsInput = input
+	return s.projectsOutput, nil
+}
+
+func (s *stubReader) ListProjectMCPs(_ context.Context, principal platformmcp.Principal, input platformmcp.ListProjectMCPsInput) (platformmcp.ListProjectMCPsOutput, error) {
+	s.principal = principal
+	s.mcpsInput = input
+	return s.mcpsOutput, nil
+}
+
+func (s *stubReader) GetMCP(_ context.Context, principal platformmcp.Principal, input platformmcp.GetMCPInput) (platformmcp.MCP, error) {
+	s.principal = principal
+	s.getInput = input
+	return s.getOutput, nil
+}
+
+func testToolCallEnv() toolconfig.ToolCallEnv {
+	return toolconfig.ToolCallEnv{
+		UserConfig: toolconfig.NewCaseInsensitiveEnv(),
+		SystemEnv:  toolconfig.NewCaseInsensitiveEnv(),
+		OAuthToken: "",
+		GramEmail:  "",
+		GramChatID: "",
+	}
+}
+
+func orgAuthContext(t *testing.T, orgID string, projectID *uuid.UUID) context.Context {
+	t.Helper()
+	return contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: orgID,
+		ProjectID:            projectID,
+	})
+}
+
+func TestListProjectsToolPassesOrgPrincipalAndClampsLimit(t *testing.T) {
+	t.Parallel()
+
+	reader := &stubReader{
+		projectsOutput: platformmcp.ListProjectsOutput{
+			Projects:  []platformmcp.Project{{ID: "p1", Name: "One", Slug: "one"}},
+			Truncated: false,
+		},
+	}
+	ctx := orgAuthContext(t, "org_123", nil)
+
+	var out bytes.Buffer
+	require.NoError(t, NewListProjectsTool(reader).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{"limit": 500}`), &out))
+	require.Equal(t, "org_123", reader.principal.OrganizationID)
+	require.Equal(t, 100, reader.projectsInput.Limit, "limit above the cap must be clamped")
+
+	var result platformmcp.ListProjectsOutput
+	require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+	require.Len(t, result.Projects, 1)
+	require.Equal(t, "one", result.Projects[0].Slug)
+}
+
+func TestListProjectsToolDefaultsLimit(t *testing.T) {
+	t.Parallel()
+
+	reader := &stubReader{}
+	ctx := orgAuthContext(t, "org_123", nil)
+
+	var out bytes.Buffer
+	require.NoError(t, NewListProjectsTool(reader).Call(ctx, testToolCallEnv(), nil, &out))
+	require.Equal(t, 50, reader.projectsInput.Limit)
+}
+
+func TestListProjectsToolRejectsMissingAuthContext(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := NewListProjectsTool(&stubReader{}).Call(t.Context(), testToolCallEnv(), nil, &out)
+	require.ErrorContains(t, err, "organization auth context")
+}
+
+func TestListProjectMCPsToolRequiresProjectID(t *testing.T) {
+	t.Parallel()
+
+	ctx := orgAuthContext(t, "org_123", nil)
+
+	var out bytes.Buffer
+	err := NewListProjectMCPsTool(&stubReader{}).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{}`), &out)
+	require.ErrorContains(t, err, "project_id is required")
+}
+
+func TestListProjectMCPsToolPassesInputThrough(t *testing.T) {
+	t.Parallel()
+
+	reader := &stubReader{
+		mcpsOutput: platformmcp.ListProjectMCPsOutput{
+			MCPs:      []platformmcp.MCP{{ID: "m1", ProjectID: "p1", Visibility: "public"}},
+			Truncated: false,
+		},
+	}
+	ctx := orgAuthContext(t, "org_123", nil)
+
+	var out bytes.Buffer
+	require.NoError(t, NewListProjectMCPsTool(reader).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{"project_id":"p1"}`), &out))
+	require.Equal(t, "org_123", reader.principal.OrganizationID)
+	require.Equal(t, "p1", reader.mcpsInput.ProjectID)
+	require.Equal(t, 50, reader.mcpsInput.Limit)
+}
+
+func TestGetMCPToolRequiresBothIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := orgAuthContext(t, "org_123", nil)
+
+	var out bytes.Buffer
+	err := NewGetMCPTool(&stubReader{}).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{"project_id":"p1"}`), &out)
+	require.ErrorContains(t, err, "project_id and mcp_id are required")
+}
+
+func TestGetMCPToolReturnsReaderOutput(t *testing.T) {
+	t.Parallel()
+
+	reader := &stubReader{
+		getOutput: platformmcp.MCP{ID: "m1", ProjectID: "p1", Name: "My MCP", Slug: "my-mcp", Visibility: "public"},
+	}
+	ctx := orgAuthContext(t, "org_123", nil)
+
+	var out bytes.Buffer
+	require.NoError(t, NewGetMCPTool(reader).Call(ctx, testToolCallEnv(), bytes.NewBufferString(`{"project_id":"p1","mcp_id":"m1"}`), &out))
+	require.Equal(t, platformmcp.GetMCPInput{ProjectID: "p1", MCPID: "m1"}, reader.getInput)
+
+	var result platformmcp.MCP
+	require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+	require.Equal(t, "my-mcp", result.Slug)
+}
+
+func TestGetPlatformContextToolReportsOrgProjectAndReadOnly(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	ctx := orgAuthContext(t, "org_123", &projectID)
+
+	var out bytes.Buffer
+	require.NoError(t, NewGetPlatformContextTool().Call(ctx, testToolCallEnv(), nil, &out))
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &result))
+	require.Equal(t, "org_123", result["organization_id"])
+	require.Equal(t, projectID.String(), result["project_id"])
+	require.Equal(t, true, result["read_only"])
+	require.NotContains(t, result, "connection_id")
+}
+
+func TestToolDescriptorsCarrySchemasAndReadOnlyAnnotations(t *testing.T) {
+	t.Parallel()
+
+	reader := &stubReader{}
+	for name, descriptor := range map[string]func() ([]byte, *bool){
+		"get_platform_context": func() ([]byte, *bool) {
+			d := NewGetPlatformContextTool().Descriptor()
+			return d.InputSchema, d.Annotations.ReadOnlyHint
+		},
+		"list_projects": func() ([]byte, *bool) {
+			d := NewListProjectsTool(reader).Descriptor()
+			return d.InputSchema, d.Annotations.ReadOnlyHint
+		},
+		"list_project_mcps": func() ([]byte, *bool) {
+			d := NewListProjectMCPsTool(reader).Descriptor()
+			return d.InputSchema, d.Annotations.ReadOnlyHint
+		},
+		"get_mcp": func() ([]byte, *bool) {
+			d := NewGetMCPTool(reader).Descriptor()
+			return d.InputSchema, d.Annotations.ReadOnlyHint
+		},
+	} {
+		schema, readOnly := descriptor()
+		require.NotEmpty(t, schema, "%s must publish an input schema", name)
+		require.NotNil(t, readOnly, "%s must carry annotations", name)
+		require.True(t, *readOnly, "%s must be read-only", name)
+	}
+}

--- a/server/internal/platformtools/registry_test.go
+++ b/server/internal/platformtools/registry_test.go
@@ -98,3 +98,31 @@ func BenchmarkFindToolEntriesWithHTTPTools(b *testing.B) {
 		}
 	}
 }
+
+// BuildToolsets must expose the Platform MCP read toolset under its reserved
+// slug so the serve path and attachment logic agree on where the tools live.
+func TestBuildToolsetsIncludesPlatformMCPReadToolset(t *testing.T) {
+	t.Parallel()
+
+	tool := ExternalTool{
+		Executor: &fixedDescriptorExecutor{descriptor: ToolDescriptor{
+			SourceSlug:  SourcePlatform,
+			HandlerName: "list_projects",
+			Name:        ToolNameListProjects,
+		}},
+		RequiredFeature: "",
+	}
+
+	toolsets := BuildToolsets(ToolsetDependencies{
+		AssistantMemoryTools:          nil,
+		AssistantSkillTools:           nil,
+		AssistantTriggerTools:         nil,
+		ManagedAssistantInsightsTools: nil,
+		PlatformMCPReadTools:          []ExternalTool{tool},
+	})
+
+	ts, ok := toolsets[PlatformMCPReadToolsetSlug]
+	require.True(t, ok, "platform toolset must be registered")
+	require.Len(t, ts.Tools, 1)
+	require.Equal(t, ToolNameListProjects, ts.Tools[0].Executor.Descriptor().Name)
+}

--- a/server/internal/platformtools/runtime/service.go
+++ b/server/internal/platformtools/runtime/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/memory"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	platformchangelog "github.com/speakeasy-api/gram/server/internal/platformtools/changelog"
 	platformchats "github.com/speakeasy-api/gram/server/internal/platformtools/chats"
@@ -24,6 +25,7 @@ import (
 	platformdocs "github.com/speakeasy-api/gram/server/internal/platformtools/docs"
 	platformlogs "github.com/speakeasy-api/gram/server/internal/platformtools/logs"
 	platformmemory "github.com/speakeasy-api/gram/server/internal/platformtools/memory"
+	platformplatform "github.com/speakeasy-api/gram/server/internal/platformtools/platform"
 	platformplugins "github.com/speakeasy-api/gram/server/internal/platformtools/plugins"
 	platformrisk "github.com/speakeasy-api/gram/server/internal/platformtools/risk"
 	platformskills "github.com/speakeasy-api/gram/server/internal/platformtools/skills"
@@ -239,6 +241,19 @@ func ManagedAssistantSkillsTools(skillsSvc platformskills.SkillsService, insight
 		{Executor: platformskills.NewDistributeTool(skillsSvc), RequiredFeature: "skills"},
 		{Executor: platformskills.NewUndistributeTool(skillsSvc), RequiredFeature: "skills"},
 		{Executor: platformskills.NewInsightsTool(skillsSvc, insights), RequiredFeature: "skills"},
+	}
+}
+
+// PlatformMCPReadTools returns the Platform MCP read tools re-served to the
+// project's managed assistant over the assistant runtime channel. The reader
+// is the same Postgres reader backing the OAuth-facing Platform MCP surface,
+// so both channels return identical data.
+func PlatformMCPReadTools(reader platformmcp.Reader) []platformtools.ExternalTool {
+	return []platformtools.ExternalTool{
+		{Executor: platformplatform.NewGetPlatformContextTool(), RequiredFeature: ""},
+		{Executor: platformplatform.NewListProjectsTool(reader), RequiredFeature: ""},
+		{Executor: platformplatform.NewListProjectMCPsTool(reader), RequiredFeature: ""},
+		{Executor: platformplatform.NewGetMCPTool(reader), RequiredFeature: ""},
 	}
 }
 

--- a/server/internal/platformtools/toolsets.go
+++ b/server/internal/platformtools/toolsets.go
@@ -12,6 +12,12 @@ const AssistantsPlatformToolsetSlug = "assistants"
 // other assistant.
 const ManagedAssistantPlatformToolsetSlug = "managed-assistant"
 
+// PlatformMCPReadToolsetSlug is the reserved slug for the platform toolset
+// re-serving the Platform MCP read tools to a project's managed assistant.
+// Granted only when the assistant-platform-mcp rollout flag is on for the
+// organization.
+const PlatformMCPReadToolsetSlug = "platform"
+
 // Toolset is a virtual collection of platform tools exposed at runtime via a
 // dedicated MCP endpoint. Platform toolsets are not persisted; the slug is
 // hardcoded per consumer and wired in code at process startup.
@@ -28,6 +34,7 @@ type ToolsetDependencies struct {
 	AssistantSkillTools           []ExternalTool
 	AssistantTriggerTools         []ExternalTool
 	ManagedAssistantInsightsTools []ExternalTool
+	PlatformMCPReadTools          []ExternalTool
 }
 
 type toolsetBuilder func(deps ToolsetDependencies) Toolset
@@ -44,6 +51,11 @@ var toolsetRegistry = []toolsetBuilder{
 		tools := make([]ExternalTool, 0, len(deps.ManagedAssistantInsightsTools))
 		tools = append(tools, deps.ManagedAssistantInsightsTools...)
 		return NewManagedAssistantToolset(tools...)
+	},
+	func(deps ToolsetDependencies) Toolset {
+		tools := make([]ExternalTool, 0, len(deps.PlatformMCPReadTools))
+		tools = append(tools, deps.PlatformMCPReadTools...)
+		return NewPlatformMCPReadToolset(tools...)
 	},
 }
 
@@ -78,6 +90,13 @@ func NewAssistantsToolset(tools ...ExternalTool) Toolset {
 // production wiring goes through BuildToolsets.
 func NewManagedAssistantToolset(tools ...ExternalTool) Toolset {
 	return Toolset{Slug: ManagedAssistantPlatformToolsetSlug, Tools: tools}
+}
+
+// NewPlatformMCPReadToolset returns the platform toolset re-serving the
+// Platform MCP read tools to a project's managed assistant. Exposed for tests
+// and direct callers; production wiring goes through BuildToolsets.
+func NewPlatformMCPReadToolset(tools ...ExternalTool) Toolset {
+	return Toolset{Slug: PlatformMCPReadToolsetSlug, Tools: tools}
 }
 
 // PlatformToolsetURL builds the URL where a runtime reaches the named

--- a/server/internal/platformtools/types.go
+++ b/server/internal/platformtools/types.go
@@ -15,6 +15,7 @@ import (
 const (
 	SourceLogs                     = "logs"
 	SourceMemory                   = "memory"
+	SourcePlatform                 = "platform"
 	SourceSlack                    = "slack"
 	SourceTriggers                 = "triggers"
 	ToolNameSearchLogs             = "platform_search_logs"
@@ -38,6 +39,10 @@ const (
 	ToolNameListEmoji              = "platform_slack_list_emoji"
 	ToolNameListUserSessions       = "platform_list_user_sessions"
 	ToolNameGetUserSession         = "platform_get_user_session"
+	ToolNameGetPlatformContext     = "platform_get_platform_context"
+	ToolNameListProjects           = "platform_list_projects"
+	ToolNameListProjectMCPs        = "platform_list_project_mcps"
+	ToolNameGetMCP                 = "platform_get_mcp"
 )
 
 // Skill tool names are externally specified by the skills RFC.


### PR DESCRIPTION
## Why

The Platform MCP (#4885, #4943) ships a read-only tool catalog on the OAuth-gated `/platform-mcp` endpoint. The in-dashboard project assistant (the managed assistant) should start exercising those same tools so we can dogfood the Platform MCP surface from the assistant, without waiting on OAuth/token bridging into the assistant runtime.

## What changed

- New platform toolset `platform` re-serves the Platform MCP read tools — `platform_get_platform_context`, `platform_list_projects`, `platform_list_project_mcps`, `platform_get_mcp` — over the existing assistant-token channel (`/mcp/platform/mcp/{slug}`). The adapters (`server/internal/platformtools/platform/`) reuse `platformmcp.Reader`, so both channels return identical data; the Platform MCP OAuth path is untouched.
- Attachment is gated by a new PostHog flag `assistant-platform-mcp` (org-slug group targeted, like `gram-budgets`) and restricted to the project's managed assistant. Flag off ⇒ exactly today's behavior; flipping it off is the kill switch (takes effect on the next reconcile, and the serve path re-checks the flag per request to close the window).
- `assistants.ServiceCore` gains a `feature.Provider` via post-construction setter, wired in both `start.go` and `worker.go` so bootstrap and worker reconcile agree on the toolset set.
- The 8 not-yet-available Platform MCP stub tools are intentionally not re-served.

## Rollout

- Create the `assistant-platform-mcp` flag in the PostHog console with organization-group (org slug) release conditions before dogfooding. Unknown flag / provider error fails closed.
- No productfeatures entitlement and no org-admin requirement on this channel: the tools are read-only, org-scoped, and reachable only by the managed assistant under the engineering-controlled rollout flag.

## Testing

- `mise lint:server`, `mise exec -- go build ./...`
- New unit tests for the four adapters and toolset registration (`internal/platformtools/...`)
- Serve-path tests: flag on lists all four tools; flag off 404s; non-managed assistant 404s even with the flag on; `tools/call platform_list_projects` round-trips against the seeded org (`internal/mcp`)
- Attachment tests: managed assistant + flag on → `assistants, managed-assistant, platform`; flag off / nil provider / non-managed unchanged (`internal/assistants`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes the Platform MCP read tools to the project’s managed assistant via a new `platform` toolset, gated by the PostHog flag `assistant-platform-mcp`. Returns the same data as the OAuth `/platform-mcp` surface and now safely fails closed if the feature provider is nil.

- **New Features**
  - New `platform` toolset serves: `platform_get_platform_context`, `platform_list_projects`, `platform_list_project_mcps`, `platform_get_mcp` (read-only, backed by `platformmcp.Reader`).
  - Managed-assistant only; others 404. The serve path re-checks `assistant-platform-mcp` per request using server `featureFlags`, guards a nil provider, and fails closed on errors.
  - `assistants.ServiceCore` now accepts a `feature.Provider`; wired in `server/cmd/gram/start.go` and `server/cmd/gram/worker.go`. Toolset registered in `platformtools`; runtime exposes `PlatformMCPReadTools(...)`. Limits are passed through; clamping is handled by `platformmcp.Reader`. Write/stub tools are not re-served.

- **Migration**
  - Create the PostHog flag `assistant-platform-mcp` (target by org-slug group).
  - No entitlements or org-admin required; tools are org-scoped and read-only. Toggle acts as a kill switch; changes apply on next reconcile.

<sup>Written for commit 18677e51c72ab847a96106214d699319e90af4ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

