### PR TITLE
fix: keep shadow MCP risk descriptions generic

### DIFF
--- a/.changeset/generic-shadow-mcp-description.md
+++ b/.changeset/generic-shadow-mcp-description.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Keep shadow MCP risk finding descriptions generic instead of naming the tool that was called.

--- a/server/internal/scanners/shadowmcpscan/scanner.go
+++ b/server/internal/scanners/shadowmcpscan/scanner.go
@@ -25,7 +25,6 @@ package shadowmcpscan
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -360,15 +359,16 @@ func resolvedAccessEvidence(prov telemetryrepo.MCPProvenance, match string) shad
 	}
 }
 
+// finding builds a shadow_mcp finding. The description stays a fixed sentence
+// rather than naming the tool: the finding already carries the offending server
+// identity as its match and the recorded call id, so interpolating the tool
+// name would only spread the caller's tool inventory into a field rendered
+// wherever findings are listed.
 func (s *Scanner) finding(call ToolCall, match string) scanners.Finding {
-	description := "Detected an unverified MCP tool call."
-	if call.Name != "" {
-		description = fmt.Sprintf("Detected an unverified MCP tool call to %q.", call.Name)
-	}
 	return scanners.Finding{
 		Source:      Source,
 		RuleID:      scanners.GuardRuleID(Rule),
-		Description: description,
+		Description: "Detected an unverified MCP tool call.",
 		Match:       match,
 		StartPos:    0,
 		EndPos:      0,

--- a/server/internal/scanners/shadowmcpscan/scanner_test.go
+++ b/server/internal/scanners/shadowmcpscan/scanner_test.go
@@ -172,7 +172,7 @@ func TestScanner_ThirdPartyURLProvenanceIsFlagged(t *testing.T) {
 	require.Equal(t, Rule, f.RuleID)
 	require.Equal(t, "https://evil.example/mcp", f.Match)
 	require.Equal(t, "call-1", f.McpLookupToolCallID)
-	require.Contains(t, f.Description, "mcp__db__delete")
+	require.NotContains(t, f.Description, "mcp__db__delete", "the description stays generic and must not name the tool")
 	require.Empty(t, validator.orgIDs, "a resolved verdict must not consult the signature validator")
 	require.Equal(t, []recordedResolution{{hookSource: "claude", resolution: ResolutionShadow}}, coverage.got)
 }
@@ -594,12 +594,13 @@ func TestFinding_UsesCanonicalRuleIDAndLeaksNoInternals(t *testing.T) {
 	f := s.finding(ToolCall{ID: "call-1", Name: "mcp__db__delete", Arguments: "", CreatedAt: time.Time{}}, "db")
 	require.Equal(t, Rule, f.RuleID)
 	require.NoError(t, scanners.ValidateRuleID(f.RuleID))
-	require.Contains(t, f.Description, "mcp__db__delete")
+	require.Equal(t, "Detected an unverified MCP tool call.", f.Description)
+	require.NotContains(t, f.Description, "mcp__db__delete", "the description must not name the tool")
 	require.NotContains(t, f.Description, "x-gram-toolset-id", "must not leak validator internals")
 
 	nameless := s.finding(ToolCall{ID: "call-2", Name: "", Arguments: "", CreatedAt: time.Time{}}, "db")
 	require.Equal(t, Rule, nameless.RuleID)
-	require.NotEmpty(t, nameless.Description)
+	require.Equal(t, f.Description, nameless.Description, "the description does not vary with the call")
 }
 
 func TestResolvedServerIdentity(t *testing.T) {


### PR DESCRIPTION
## What

`shadow_mcp` findings interpolated the offending tool name into their description:

```
Detected an unverified MCP tool call to "mcp__some__tool".
```

They now always read:

```
Detected an unverified MCP tool call.
```

## Why

Every other risk category describes the class of problem rather than the artifact that triggered it, and the description is rendered wherever findings are listed — a wider surface than the finding's own detail view. Naming the tool spread a piece of the caller's tool inventory across all of it.

Nothing is lost for triage: the finding still carries the offending server identity as its `match` and still links the originating call via `mcp_lookup_tool_call_id`.

## Changes

- `server/internal/scanners/shadowmcpscan/scanner.go` — `finding` returns a fixed description; dropped the now-unused `fmt` import.
- `scanner_test.go` — the two assertions that required the tool name now require its absence, plus an exact-string check and a check that a nameless call gets the same sentence.
- Changeset (`server`, patch).

## Testing

`go test -race ./server/internal/scanners/shadowmcpscan/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `shadow_mcp` risk descriptions generic by removing the tool name from finding descriptions. Prevents leaking tool inventory in lists while keeping triage context via `match` and `mcp_lookup_tool_call_id`.

<sup>Written for commit edc580363706b2fd01086dc80344108af2676e4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

