### PR TITLE
fix: deflake full-page skill efficacy sweep test under parallel load

### DIFF
--- a/server/internal/background/skill_efficacy_test.go
+++ b/server/internal/background/skill_efficacy_test.go
@@ -581,6 +581,10 @@ func TestSkillEfficacySweepWorkflowContinuesAsNewPastAFullPage(t *testing.T) {
 	t.Parallel()
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	// Ten full pages mean over a thousand sequential mock activities; the test
+	// env's default 3s stall detector trips on scheduler gaps under parallel
+	// test load.
+	env.SetTestTimeout(time.Minute)
 
 	full := make([]efficacy.PendingWorkProject, efficacy.MaxSweepProjectPage)
 	for i := range full {


### PR DESCRIPTION
## What

Raises the Temporal test environment's idle timeout to one minute in `TestSkillEfficacySweepWorkflowContinuesAsNewPastAFullPage`.

## Why

The test flakes intermittently under parallel test load (fails ~2 in 3 full-suite runs on clean main). The SDK test env panics with `test timeout: 3s` whenever its event loop goes 3 seconds without a callback — `SetTestTimeout`'s parameter is literally named `idleTimeout`, so this is a stall detector, not a run budget. This test drives 10 full pages × 100 projects ≈ 1010 sequential mock activities, each a real goroutine hop, giving ~1010 windows for a >3s scheduler stall when the whole suite runs in parallel. No other test in the file has that exposure.

The timeout resets on every activity callback, so a healthy run still completes in ~40ms; the minute is only consumed when the workflow is genuinely stuck, which is a deterministic failure `go test`'s package timeout still backstops.

No production code changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the Temporal test environment idle timeout to 1 minute in TestSkillEfficacySweepWorkflowContinuesAsNewPastAFullPage to deflake under parallel load. Prevents the 3s stall detector from tripping during the 10-page sweep (~1000 sequential mock activities); no production code changed.

<sup>Written for commit 2bb4a93bc5c1f1dfff1e2ceb738dc4664c152ce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

