### PR TITLE
feat: publish shared Agent Plugins packages

### DIFF
--- a/.changeset/shared-agent-plugin-packages.md
+++ b/.changeset/shared-agent-plugin-packages.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Publish compatible Cursor and Codex plugins from a shared Agent Plugins 1.0 package and expose compatibility on plugin responses.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -27043,6 +27043,7 @@ paths:
               - claude
               - cursor
               - codex
+              - agent-plugin
             type: string
         - allowEmptyValue: true
           description: Session header
@@ -27103,6 +27104,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: 'conflict: resource already exists'
+        "412":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: 'failed_precondition: resource is not in a valid state for this operation'
         "415":
           content:
             application/json:
@@ -64406,6 +64413,9 @@ components:
     Plugin:
       type: object
       properties:
+        agent_plugins_v1_compatible:
+          type: boolean
+          description: Whether the plugin's complete current intended state can be published as an Agent Plugins 1.0 package.
         assignment_count:
           type: integer
           description: Number of role/user assignments.
@@ -64454,6 +64464,7 @@ components:
         - id
         - name
         - slug
+        - agent_plugins_v1_compatible
         - created_at
         - updated_at
     PluginAssignment:

--- a/client/dashboard/src/sdk/.speakeasy/gen.lock
+++ b/client/dashboard/src/sdk/.speakeasy/gen.lock
@@ -3321,7 +3321,7 @@ examples:
         application/json: {"name": "<value>"}
       responses:
         "201":
-          application/json: {"created_at": "2024-03-14T08:34:14.314Z", "id": "48e343e0-be10-4d97-b8ea-83f4c4424dd1", "name": "<value>", "slug": "<value>", "updated_at": "2024-04-03T03:53:36.214Z"}
+          application/json: {"agent_plugins_v1_compatible": true, "created_at": "2024-03-14T08:34:14.314Z", "id": "48e343e0-be10-4d97-b8ea-83f4c4424dd1", "name": "<value>", "slug": "<value>", "updated_at": "2024-04-03T03:53:36.214Z"}
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": true}
         "500":
@@ -4833,7 +4833,7 @@ examples:
           id: "2c3fdec1-236d-49ee-a524-9bb3bf5bbcec"
       responses:
         "200":
-          application/json: {"created_at": "2025-09-14T20:16:24.036Z", "id": "f243a7e5-70a1-4090-8cb1-acae8dbc689f", "name": "<value>", "slug": "<value>", "updated_at": "2026-11-14T18:06:48.573Z"}
+          application/json: {"agent_plugins_v1_compatible": true, "created_at": "2025-09-14T20:16:24.036Z", "id": "f243a7e5-70a1-4090-8cb1-acae8dbc689f", "name": "<value>", "slug": "<value>", "updated_at": "2026-11-14T18:06:48.573Z"}
         "400":
           application/json: {"fault": true, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": true, "timeout": true}
         "500":
@@ -8063,7 +8063,7 @@ examples:
         application/json: {"id": "1c0290eb-9c44-4e10-bcbb-55a9ea8ae57f", "name": "<value>", "slug": "<value>"}
       responses:
         "200":
-          application/json: {"created_at": "2024-07-31T05:16:06.164Z", "id": "e86c4107-85e9-41a5-97b4-77624099c31d", "name": "<value>", "slug": "<value>", "updated_at": "2026-12-30T01:18:18.622Z"}
+          application/json: {"agent_plugins_v1_compatible": true, "created_at": "2024-07-31T05:16:06.164Z", "id": "e86c4107-85e9-41a5-97b4-77624099c31d", "name": "<value>", "slug": "<value>", "updated_at": "2026-12-30T01:18:18.622Z"}
         "400":
           application/json: {"fault": false, "id": "123abc", "message": "parameter 'p' must be an integer", "name": "bad_request", "temporary": false, "timeout": true}
         "500":

--- a/client/dashboard/src/sdk/src/funcs/pluginsDownloadPluginPackage.ts
+++ b/client/dashboard/src/sdk/src/funcs/pluginsDownloadPluginPackage.ts
@@ -200,7 +200,10 @@ async function $do(
       hdrs: true,
       key: "Result",
     }),
-    M.jsonErr([400, 401, 403, 404, 409, 415, 422], ServiceError$inboundSchema),
+    M.jsonErr(
+      [400, 401, 403, 404, 409, 412, 415, 422],
+      ServiceError$inboundSchema,
+    ),
     M.jsonErr([500, 502], ServiceError$inboundSchema),
     M.fail("4XX"),
     M.fail("5XX"),

--- a/client/dashboard/src/sdk/src/models/components/plugin.ts
+++ b/client/dashboard/src/sdk/src/models/components/plugin.ts
@@ -15,6 +15,10 @@ import { PluginServer, PluginServer$inboundSchema } from "./pluginserver.js";
 
 export type Plugin = {
   /**
+   * Whether the plugin's complete current intended state can be published as an Agent Plugins 1.0 package.
+   */
+  agentPluginsV1Compatible: boolean;
+  /**
    * Number of role/user assignments.
    */
   assignmentCount?: number | undefined;
@@ -61,6 +65,7 @@ export type Plugin = {
 /** @internal */
 export const Plugin$inboundSchema: z.ZodMiniType<Plugin, unknown> = z.pipe(
   z.object({
+    agent_plugins_v1_compatible: z.boolean(),
     assignment_count: z.optional(z.int()),
     assignments: z.optional(z.array(PluginAssignment$inboundSchema)),
     created_at: z.pipe(
@@ -82,6 +87,7 @@ export const Plugin$inboundSchema: z.ZodMiniType<Plugin, unknown> = z.pipe(
   }),
   z.transform((v) => {
     return remap$(v, {
+      "agent_plugins_v1_compatible": "agentPluginsV1Compatible",
       "assignment_count": "assignmentCount",
       "created_at": "createdAt",
       "is_default": "isDefault",

--- a/client/dashboard/src/sdk/src/models/operations/downloadpluginpackage.ts
+++ b/client/dashboard/src/sdk/src/models/operations/downloadpluginpackage.ts
@@ -21,6 +21,7 @@ export const QueryParamPlatform = {
   Claude: "claude",
   Cursor: "cursor",
   Codex: "codex",
+  AgentPlugin: "agent-plugin",
 } as const;
 /**
  * Target platform to download plugins for.

--- a/server/design/plugins/design.go
+++ b/server/design/plugins/design.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/design/security"
 	"github.com/speakeasy-api/gram/server/design/shared"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 // --- Service ---
@@ -238,6 +239,7 @@ var _ = Service("plugins", func() {
 
 	Method("downloadPluginPackage", func() {
 		Description("Download a ZIP of a single plugin package for direct installation.")
+		Error(string(oops.CodeFailedPrecondition), func() { Description(oops.CodeFailedPrecondition.UserMessage()) })
 
 		Payload(func() {
 			Attribute("plugin_id", String, func() {
@@ -246,7 +248,7 @@ var _ = Service("plugins", func() {
 			})
 			Attribute("platform", String, func() {
 				Description("Target platform to download plugins for.")
-				Enum("claude", "cursor", "codex")
+				Enum("claude", "cursor", "codex", "agent-plugin")
 			})
 			Required("plugin_id", "platform")
 			security.SessionPayload()
@@ -269,6 +271,9 @@ var _ = Service("plugins", func() {
 				ContentType("application/zip")
 				Header("content_type:Content-Type")
 				Header("content_disposition:Content-Disposition")
+			})
+			Response(string(oops.CodeFailedPrecondition), StatusPreconditionFailed, func() {
+				ContentType("application/json")
 			})
 			SkipResponseBodyEncodeDecode()
 		})
@@ -481,7 +486,7 @@ var PluginAssignmentModel = Type("PluginAssignment", func() {
 
 // PluginModel is the full plugin representation.
 var PluginModel = Type("Plugin", func() {
-	Required("id", "name", "slug", "created_at", "updated_at")
+	Required("id", "name", "slug", "agent_plugins_v1_compatible", "created_at", "updated_at")
 
 	Attribute("id", String, func() {
 		Description("Unique plugin identifier.")
@@ -494,6 +499,7 @@ var PluginModel = Type("Plugin", func() {
 	Attribute("server_count", Int64, "Number of active servers in this plugin.")
 	Attribute("skill_count", Int64, "Number of active skills in this plugin.")
 	Attribute("assignment_count", Int64, "Number of role/user assignments.")
+	Attribute("agent_plugins_v1_compatible", Boolean, "Whether the plugin's complete current intended state can be published as an Agent Plugins 1.0 package.")
 	Attribute("servers", ArrayOf(PluginServerModel), "Servers included in this plugin.")
 	Attribute("assignments", ArrayOf(PluginAssignmentModel), "Role/user assignments.")
 	Attribute("created_at", String, func() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -27532,6 +27532,7 @@ paths:
                         - claude
                         - cursor
                         - codex
+                        - agent-plugin
                     type: string
                 - allowEmptyValue: true
                   description: Session header
@@ -27592,6 +27593,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/Error'
                     description: 'conflict: resource already exists'
+                "412":
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                    description: 'failed_precondition: resource is not in a valid state for this operation'
                 "415":
                     content:
                         application/json:
@@ -64652,6 +64659,9 @@ components:
         Plugin:
             type: object
             properties:
+                agent_plugins_v1_compatible:
+                    type: boolean
+                    description: Whether the plugin's complete current intended state can be published as an Agent Plugins 1.0 package.
                 assignment_count:
                     type: integer
                     description: Number of role/user assignments.
@@ -64700,6 +64710,7 @@ components:
                 - id
                 - name
                 - slug
+                - agent_plugins_v1_compatible
                 - created_at
                 - updated_at
         PluginAssignment:

--- a/server/gen/http/plugins/client/cli.go
+++ b/server/gen/http/plugins/client/cli.go
@@ -395,8 +395,8 @@ func BuildDownloadPluginPackagePayload(pluginsDownloadPluginPackagePluginID stri
 	var platform string
 	{
 		platform = pluginsDownloadPluginPackagePlatform
-		if !(platform == "claude" || platform == "cursor" || platform == "codex") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("platform", platform, []any{"claude", "cursor", "codex"}))
+		if !(platform == "claude" || platform == "cursor" || platform == "codex" || platform == "agent-plugin") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("platform", platform, []any{"claude", "cursor", "codex", "agent-plugin"}))
 		}
 		if err != nil {
 			return nil, err

--- a/server/gen/http/plugins/client/encode_decode.go
+++ b/server/gen/http/plugins/client/encode_decode.go
@@ -2176,6 +2176,7 @@ func EncodeDownloadPluginPackageRequest(encoder func(*http.Request) goahttp.Enco
 // by the plugins downloadPluginPackage endpoint. restoreBody controls whether
 // the response body should be restored after having been read.
 // DecodeDownloadPluginPackageResponse may return the following errors:
+//   - "failed_precondition" (type *goa.ServiceError): http.StatusPreconditionFailed
 //   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
 //   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
 //   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
@@ -2221,6 +2222,20 @@ func DecodeDownloadPluginPackageResponse(decoder func(*http.Response) goahttp.De
 			}
 			res := NewDownloadPluginPackageResultOK(contentType, contentDisposition)
 			return res, nil
+		case http.StatusPreconditionFailed:
+			var (
+				body DownloadPluginPackageFailedPreconditionResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("plugins", "downloadPluginPackage", err)
+			}
+			err = ValidateDownloadPluginPackageFailedPreconditionResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("plugins", "downloadPluginPackage", err)
+			}
+			return nil, NewDownloadPluginPackageFailedPrecondition(&body)
 		case http.StatusUnauthorized:
 			var (
 				body DownloadPluginPackageUnauthorizedResponseBody
@@ -3806,16 +3821,17 @@ func DecodeUpdateMarketplaceSettingsResponse(decoder func(*http.Response) goahtt
 // *plugins.Plugin from a value of type *PluginResponseBody.
 func unmarshalPluginResponseBodyToPluginsPlugin(v *PluginResponseBody) *plugins.Plugin {
 	res := &plugins.Plugin{
-		ID:              *v.ID,
-		Name:            *v.Name,
-		Slug:            *v.Slug,
-		Description:     v.Description,
-		IsDefault:       v.IsDefault,
-		ServerCount:     v.ServerCount,
-		SkillCount:      v.SkillCount,
-		AssignmentCount: v.AssignmentCount,
-		CreatedAt:       *v.CreatedAt,
-		UpdatedAt:       *v.UpdatedAt,
+		ID:                       *v.ID,
+		Name:                     *v.Name,
+		Slug:                     *v.Slug,
+		Description:              v.Description,
+		IsDefault:                v.IsDefault,
+		ServerCount:              v.ServerCount,
+		SkillCount:               v.SkillCount,
+		AssignmentCount:          v.AssignmentCount,
+		AgentPluginsV1Compatible: *v.AgentPluginsV1Compatible,
+		CreatedAt:                *v.CreatedAt,
+		UpdatedAt:                *v.UpdatedAt,
 	}
 	if v.Servers != nil {
 		res.Servers = make([]*plugins.PluginServer, len(v.Servers))

--- a/server/gen/http/plugins/client/types.go
+++ b/server/gen/http/plugins/client/types.go
@@ -112,6 +112,9 @@ type GetPluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible *bool `form:"agent_plugins_v1_compatible,omitempty" json:"agent_plugins_v1_compatible,omitempty" xml:"agent_plugins_v1_compatible,omitempty"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -139,6 +142,9 @@ type CreatePluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible *bool `form:"agent_plugins_v1_compatible,omitempty" json:"agent_plugins_v1_compatible,omitempty" xml:"agent_plugins_v1_compatible,omitempty"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -166,6 +172,9 @@ type UpdatePluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible *bool `form:"agent_plugins_v1_compatible,omitempty" json:"agent_plugins_v1_compatible,omitempty" xml:"agent_plugins_v1_compatible,omitempty"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -1948,6 +1957,25 @@ type SetPluginAssignmentsGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// DownloadPluginPackageFailedPreconditionResponseBody is the type of the
+// "plugins" service "downloadPluginPackage" endpoint HTTP response body for
+// the "failed_precondition" error.
+type DownloadPluginPackageFailedPreconditionResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // DownloadPluginPackageUnauthorizedResponseBody is the type of the "plugins"
 // service "downloadPluginPackage" endpoint HTTP response body for the
 // "unauthorized" error.
@@ -3282,6 +3310,9 @@ type PluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible *bool `form:"agent_plugins_v1_compatible,omitempty" json:"agent_plugins_v1_compatible,omitempty" xml:"agent_plugins_v1_compatible,omitempty"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -3615,16 +3646,17 @@ func NewListPluginsGatewayError(body *ListPluginsGatewayErrorResponseBody) *goa.
 // from a HTTP "OK" response.
 func NewGetPluginPluginOK(body *GetPluginResponseBody) *plugins.Plugin {
 	v := &plugins.Plugin{
-		ID:              *body.ID,
-		Name:            *body.Name,
-		Slug:            *body.Slug,
-		Description:     body.Description,
-		IsDefault:       body.IsDefault,
-		ServerCount:     body.ServerCount,
-		SkillCount:      body.SkillCount,
-		AssignmentCount: body.AssignmentCount,
-		CreatedAt:       *body.CreatedAt,
-		UpdatedAt:       *body.UpdatedAt,
+		ID:                       *body.ID,
+		Name:                     *body.Name,
+		Slug:                     *body.Slug,
+		Description:              body.Description,
+		IsDefault:                body.IsDefault,
+		ServerCount:              body.ServerCount,
+		SkillCount:               body.SkillCount,
+		AssignmentCount:          body.AssignmentCount,
+		AgentPluginsV1Compatible: *body.AgentPluginsV1Compatible,
+		CreatedAt:                *body.CreatedAt,
+		UpdatedAt:                *body.UpdatedAt,
 	}
 	if body.Servers != nil {
 		v.Servers = make([]*plugins.PluginServer, len(body.Servers))
@@ -3804,16 +3836,17 @@ func NewGetPluginGatewayError(body *GetPluginGatewayErrorResponseBody) *goa.Serv
 // endpoint result from a HTTP "Created" response.
 func NewCreatePluginPluginCreated(body *CreatePluginResponseBody) *plugins.Plugin {
 	v := &plugins.Plugin{
-		ID:              *body.ID,
-		Name:            *body.Name,
-		Slug:            *body.Slug,
-		Description:     body.Description,
-		IsDefault:       body.IsDefault,
-		ServerCount:     body.ServerCount,
-		SkillCount:      body.SkillCount,
-		AssignmentCount: body.AssignmentCount,
-		CreatedAt:       *body.CreatedAt,
-		UpdatedAt:       *body.UpdatedAt,
+		ID:                       *body.ID,
+		Name:                     *body.Name,
+		Slug:                     *body.Slug,
+		Description:              body.Description,
+		IsDefault:                body.IsDefault,
+		ServerCount:              body.ServerCount,
+		SkillCount:               body.SkillCount,
+		AssignmentCount:          body.AssignmentCount,
+		AgentPluginsV1Compatible: *body.AgentPluginsV1Compatible,
+		CreatedAt:                *body.CreatedAt,
+		UpdatedAt:                *body.UpdatedAt,
 	}
 	if body.Servers != nil {
 		v.Servers = make([]*plugins.PluginServer, len(body.Servers))
@@ -3993,16 +4026,17 @@ func NewCreatePluginGatewayError(body *CreatePluginGatewayErrorResponseBody) *go
 // result from a HTTP "OK" response.
 func NewUpdatePluginPluginOK(body *UpdatePluginResponseBody) *plugins.Plugin {
 	v := &plugins.Plugin{
-		ID:              *body.ID,
-		Name:            *body.Name,
-		Slug:            *body.Slug,
-		Description:     body.Description,
-		IsDefault:       body.IsDefault,
-		ServerCount:     body.ServerCount,
-		SkillCount:      body.SkillCount,
-		AssignmentCount: body.AssignmentCount,
-		CreatedAt:       *body.CreatedAt,
-		UpdatedAt:       *body.UpdatedAt,
+		ID:                       *body.ID,
+		Name:                     *body.Name,
+		Slug:                     *body.Slug,
+		Description:              body.Description,
+		IsDefault:                body.IsDefault,
+		ServerCount:              body.ServerCount,
+		SkillCount:               body.SkillCount,
+		AssignmentCount:          body.AssignmentCount,
+		AgentPluginsV1Compatible: *body.AgentPluginsV1Compatible,
+		CreatedAt:                *body.CreatedAt,
+		UpdatedAt:                *body.UpdatedAt,
 	}
 	if body.Servers != nil {
 		v.Servers = make([]*plugins.PluginServer, len(body.Servers))
@@ -4982,6 +5016,21 @@ func NewDownloadPluginPackageResultOK(contentType string, contentDisposition str
 	v := &plugins.DownloadPluginPackageResult{}
 	v.ContentType = contentType
 	v.ContentDisposition = contentDisposition
+
+	return v
+}
+
+// NewDownloadPluginPackageFailedPrecondition builds a plugins service
+// downloadPluginPackage endpoint failed_precondition error.
+func NewDownloadPluginPackageFailedPrecondition(body *DownloadPluginPackageFailedPreconditionResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
 
 	return v
 }
@@ -6139,6 +6188,9 @@ func ValidateGetPluginResponseBody(body *GetPluginResponseBody) (err error) {
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
 	}
+	if body.AgentPluginsV1Compatible == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("agent_plugins_v1_compatible", "body"))
+	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
@@ -6183,6 +6235,9 @@ func ValidateCreatePluginResponseBody(body *CreatePluginResponseBody) (err error
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
 	}
+	if body.AgentPluginsV1Compatible == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("agent_plugins_v1_compatible", "body"))
+	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
 	}
@@ -6226,6 +6281,9 @@ func ValidateUpdatePluginResponseBody(body *UpdatePluginResponseBody) (err error
 	}
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AgentPluginsV1Compatible == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("agent_plugins_v1_compatible", "body"))
 	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))
@@ -8564,6 +8622,31 @@ func ValidateSetPluginAssignmentsGatewayErrorResponseBody(body *SetPluginAssignm
 	return
 }
 
+// ValidateDownloadPluginPackageFailedPreconditionResponseBody runs the
+// validations defined on
+// downloadPluginPackage_failed_precondition_response_body
+func ValidateDownloadPluginPackageFailedPreconditionResponseBody(body *DownloadPluginPackageFailedPreconditionResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
 // ValidateDownloadPluginPackageUnauthorizedResponseBody runs the validations
 // defined on downloadPluginPackage_unauthorized_response_body
 func ValidateDownloadPluginPackageUnauthorizedResponseBody(body *DownloadPluginPackageUnauthorizedResponseBody) (err error) {
@@ -10263,6 +10346,9 @@ func ValidatePluginResponseBody(body *PluginResponseBody) (err error) {
 	}
 	if body.Slug == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AgentPluginsV1Compatible == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("agent_plugins_v1_compatible", "body"))
 	}
 	if body.CreatedAt == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("created_at", "body"))

--- a/server/gen/http/plugins/server/encode_decode.go
+++ b/server/gen/http/plugins/server/encode_decode.go
@@ -2030,8 +2030,8 @@ func DecodeDownloadPluginPackageRequest(mux goahttp.Muxer, decoder func(*http.Re
 		if platform == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("platform", "query string"))
 		}
-		if !(platform == "claude" || platform == "cursor" || platform == "codex") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("platform", platform, []any{"claude", "cursor", "codex"}))
+		if !(platform == "claude" || platform == "cursor" || platform == "codex" || platform == "agent-plugin") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("platform", platform, []any{"claude", "cursor", "codex", "agent-plugin"}))
 		}
 		sessionTokenRaw := r.Header.Get("Gram-Session")
 		if sessionTokenRaw != "" {
@@ -2074,6 +2074,20 @@ func EncodeDownloadPluginPackageError(encoder func(context.Context, http.Respons
 			return encodeError(ctx, w, v)
 		}
 		switch en.GoaErrorName() {
+		case "failed_precondition":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewDownloadPluginPackageFailedPreconditionResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return enc.Encode(body)
 		case "unauthorized":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -3500,16 +3514,17 @@ func EncodeUpdateMarketplaceSettingsError(encoder func(context.Context, http.Res
 // *PluginResponseBody from a value of type *plugins.Plugin.
 func marshalPluginsPluginToPluginResponseBody(v *plugins.Plugin) *PluginResponseBody {
 	res := &PluginResponseBody{
-		ID:              v.ID,
-		Name:            v.Name,
-		Slug:            v.Slug,
-		Description:     v.Description,
-		IsDefault:       v.IsDefault,
-		ServerCount:     v.ServerCount,
-		SkillCount:      v.SkillCount,
-		AssignmentCount: v.AssignmentCount,
-		CreatedAt:       v.CreatedAt,
-		UpdatedAt:       v.UpdatedAt,
+		ID:                       v.ID,
+		Name:                     v.Name,
+		Slug:                     v.Slug,
+		Description:              v.Description,
+		IsDefault:                v.IsDefault,
+		ServerCount:              v.ServerCount,
+		SkillCount:               v.SkillCount,
+		AssignmentCount:          v.AssignmentCount,
+		AgentPluginsV1Compatible: v.AgentPluginsV1Compatible,
+		CreatedAt:                v.CreatedAt,
+		UpdatedAt:                v.UpdatedAt,
 	}
 	if v.Servers != nil {
 		res.Servers = make([]*PluginServerResponseBody, len(v.Servers))

--- a/server/gen/http/plugins/server/types.go
+++ b/server/gen/http/plugins/server/types.go
@@ -112,6 +112,9 @@ type GetPluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible bool `form:"agent_plugins_v1_compatible" json:"agent_plugins_v1_compatible" xml:"agent_plugins_v1_compatible"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -139,6 +142,9 @@ type CreatePluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible bool `form:"agent_plugins_v1_compatible" json:"agent_plugins_v1_compatible" xml:"agent_plugins_v1_compatible"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -166,6 +172,9 @@ type UpdatePluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible bool `form:"agent_plugins_v1_compatible" json:"agent_plugins_v1_compatible" xml:"agent_plugins_v1_compatible"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -1948,6 +1957,25 @@ type SetPluginAssignmentsGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// DownloadPluginPackageFailedPreconditionResponseBody is the type of the
+// "plugins" service "downloadPluginPackage" endpoint HTTP response body for
+// the "failed_precondition" error.
+type DownloadPluginPackageFailedPreconditionResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // DownloadPluginPackageUnauthorizedResponseBody is the type of the "plugins"
 // service "downloadPluginPackage" endpoint HTTP response body for the
 // "unauthorized" error.
@@ -3282,6 +3310,9 @@ type PluginResponseBody struct {
 	SkillCount *int64 `form:"skill_count,omitempty" json:"skill_count,omitempty" xml:"skill_count,omitempty"`
 	// Number of role/user assignments.
 	AssignmentCount *int64 `form:"assignment_count,omitempty" json:"assignment_count,omitempty" xml:"assignment_count,omitempty"`
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible bool `form:"agent_plugins_v1_compatible" json:"agent_plugins_v1_compatible" xml:"agent_plugins_v1_compatible"`
 	// Servers included in this plugin.
 	Servers []*PluginServerResponseBody `form:"servers,omitempty" json:"servers,omitempty" xml:"servers,omitempty"`
 	// Role/user assignments.
@@ -3354,16 +3385,17 @@ func NewListPluginsResponseBody(res *plugins.ListPluginsResult) *ListPluginsResp
 // the "getPlugin" endpoint of the "plugins" service.
 func NewGetPluginResponseBody(res *plugins.Plugin) *GetPluginResponseBody {
 	body := &GetPluginResponseBody{
-		ID:              res.ID,
-		Name:            res.Name,
-		Slug:            res.Slug,
-		Description:     res.Description,
-		IsDefault:       res.IsDefault,
-		ServerCount:     res.ServerCount,
-		SkillCount:      res.SkillCount,
-		AssignmentCount: res.AssignmentCount,
-		CreatedAt:       res.CreatedAt,
-		UpdatedAt:       res.UpdatedAt,
+		ID:                       res.ID,
+		Name:                     res.Name,
+		Slug:                     res.Slug,
+		Description:              res.Description,
+		IsDefault:                res.IsDefault,
+		ServerCount:              res.ServerCount,
+		SkillCount:               res.SkillCount,
+		AssignmentCount:          res.AssignmentCount,
+		AgentPluginsV1Compatible: res.AgentPluginsV1Compatible,
+		CreatedAt:                res.CreatedAt,
+		UpdatedAt:                res.UpdatedAt,
 	}
 	if res.Servers != nil {
 		body.Servers = make([]*PluginServerResponseBody, len(res.Servers))
@@ -3392,16 +3424,17 @@ func NewGetPluginResponseBody(res *plugins.Plugin) *GetPluginResponseBody {
 // the "createPlugin" endpoint of the "plugins" service.
 func NewCreatePluginResponseBody(res *plugins.Plugin) *CreatePluginResponseBody {
 	body := &CreatePluginResponseBody{
-		ID:              res.ID,
-		Name:            res.Name,
-		Slug:            res.Slug,
-		Description:     res.Description,
-		IsDefault:       res.IsDefault,
-		ServerCount:     res.ServerCount,
-		SkillCount:      res.SkillCount,
-		AssignmentCount: res.AssignmentCount,
-		CreatedAt:       res.CreatedAt,
-		UpdatedAt:       res.UpdatedAt,
+		ID:                       res.ID,
+		Name:                     res.Name,
+		Slug:                     res.Slug,
+		Description:              res.Description,
+		IsDefault:                res.IsDefault,
+		ServerCount:              res.ServerCount,
+		SkillCount:               res.SkillCount,
+		AssignmentCount:          res.AssignmentCount,
+		AgentPluginsV1Compatible: res.AgentPluginsV1Compatible,
+		CreatedAt:                res.CreatedAt,
+		UpdatedAt:                res.UpdatedAt,
 	}
 	if res.Servers != nil {
 		body.Servers = make([]*PluginServerResponseBody, len(res.Servers))
@@ -3430,16 +3463,17 @@ func NewCreatePluginResponseBody(res *plugins.Plugin) *CreatePluginResponseBody 
 // the "updatePlugin" endpoint of the "plugins" service.
 func NewUpdatePluginResponseBody(res *plugins.Plugin) *UpdatePluginResponseBody {
 	body := &UpdatePluginResponseBody{
-		ID:              res.ID,
-		Name:            res.Name,
-		Slug:            res.Slug,
-		Description:     res.Description,
-		IsDefault:       res.IsDefault,
-		ServerCount:     res.ServerCount,
-		SkillCount:      res.SkillCount,
-		AssignmentCount: res.AssignmentCount,
-		CreatedAt:       res.CreatedAt,
-		UpdatedAt:       res.UpdatedAt,
+		ID:                       res.ID,
+		Name:                     res.Name,
+		Slug:                     res.Slug,
+		Description:              res.Description,
+		IsDefault:                res.IsDefault,
+		ServerCount:              res.ServerCount,
+		SkillCount:               res.SkillCount,
+		AssignmentCount:          res.AssignmentCount,
+		AgentPluginsV1Compatible: res.AgentPluginsV1Compatible,
+		CreatedAt:                res.CreatedAt,
+		UpdatedAt:                res.UpdatedAt,
 	}
 	if res.Servers != nil {
 		body.Servers = make([]*PluginServerResponseBody, len(res.Servers))
@@ -4842,6 +4876,21 @@ func NewSetPluginAssignmentsUnexpectedResponseBody(res *goa.ServiceError) *SetPl
 // service.
 func NewSetPluginAssignmentsGatewayErrorResponseBody(res *goa.ServiceError) *SetPluginAssignmentsGatewayErrorResponseBody {
 	body := &SetPluginAssignmentsGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewDownloadPluginPackageFailedPreconditionResponseBody builds the HTTP
+// response body from the result of the "downloadPluginPackage" endpoint of the
+// "plugins" service.
+func NewDownloadPluginPackageFailedPreconditionResponseBody(res *goa.ServiceError) *DownloadPluginPackageFailedPreconditionResponseBody {
+	body := &DownloadPluginPackageFailedPreconditionResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
 		Message:   res.Message,

--- a/server/gen/plugins/client.go
+++ b/server/gen/plugins/client.go
@@ -253,6 +253,7 @@ func (c *Client) SetPluginAssignments(ctx context.Context, p *SetPluginAssignmen
 // DownloadPluginPackage calls the "downloadPluginPackage" endpoint of the
 // "plugins" service.
 // DownloadPluginPackage may return the following errors:
+//   - "failed_precondition" (type *goa.ServiceError): resource is not in a valid state for this operation
 //   - "unauthorized" (type *goa.ServiceError): unauthorized access
 //   - "forbidden" (type *goa.ServiceError): permission denied
 //   - "bad_request" (type *goa.ServiceError): request is invalid

--- a/server/gen/plugins/service.go
+++ b/server/gen/plugins/service.go
@@ -246,6 +246,9 @@ type Plugin struct {
 	SkillCount *int64
 	// Number of role/user assignments.
 	AssignmentCount *int64
+	// Whether the plugin's complete current intended state can be published as an
+	// Agent Plugins 1.0 package.
+	AgentPluginsV1Compatible bool
 	// Servers included in this plugin.
 	Servers []*PluginServer
 	// Role/user assignments.
@@ -467,4 +470,9 @@ func MakeUnexpected(err error) *goa.ServiceError {
 // MakeGatewayError builds a goa.ServiceError from an error.
 func MakeGatewayError(err error) *goa.ServiceError {
 	return goa.NewServiceError(err, "gateway_error", false, false, true)
+}
+
+// MakeFailedPrecondition builds a goa.ServiceError from an error.
+func MakeFailedPrecondition(err error) *goa.ServiceError {
+	return goa.NewServiceError(err, "failed_precondition", false, false, false)
 }

--- a/server/internal/mcpservers/updatemcpserver_test.go
+++ b/server/internal/mcpservers/updatemcpserver_test.go
@@ -479,7 +479,7 @@ func TestUpdateMcpServer_RenameUpdatesPublishedPluginName(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	publishRows, err := pluginsQueries.ListPluginsWithMcpServersForProject(ctx, *authCtx.ProjectID)
+	publishRows, err := pluginsQueries.ListPluginsWithMcpServersForProject(ctx, pluginsrepo.ListPluginsWithMcpServersForProjectParams{ProjectID: *authCtx.ProjectID, PluginIds: nil})
 	require.NoError(t, err)
 	require.Len(t, publishRows, 1)
 	require.Equal(t, "Original Server Name", publishRows[0].ServerDisplayName)
@@ -498,7 +498,7 @@ func TestUpdateMcpServer_RenameUpdatesPublishedPluginName(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	publishRows, err = pluginsQueries.ListPluginsWithMcpServersForProject(ctx, *authCtx.ProjectID)
+	publishRows, err = pluginsQueries.ListPluginsWithMcpServersForProject(ctx, pluginsrepo.ListPluginsWithMcpServersForProjectParams{ProjectID: *authCtx.ProjectID, PluginIds: nil})
 	require.NoError(t, err)
 	require.Len(t, publishRows, 1)
 	require.Equal(t, renamed, publishRows[0].ServerDisplayName)
@@ -563,7 +563,7 @@ func TestUpdateMcpServer_RenamePreservesCustomizedPluginName(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	publishRows, err := pluginsQueries.ListPluginsWithMcpServersForProject(ctx, *authCtx.ProjectID)
+	publishRows, err := pluginsQueries.ListPluginsWithMcpServersForProject(ctx, pluginsrepo.ListPluginsWithMcpServersForProjectParams{ProjectID: *authCtx.ProjectID, PluginIds: nil})
 	require.NoError(t, err)
 	require.Len(t, publishRows, 1)
 	require.Equal(t, customName, publishRows[0].ServerDisplayName)

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -10,6 +10,7 @@ const (
 	CodeBadRequest         Code = "bad_request"
 	CodeNotFound           Code = "not_found"
 	CodeConflict           Code = "conflict"
+	CodeFailedPrecondition Code = "failed_precondition"
 	CodeUnsupportedMedia   Code = "unsupported_media"
 	CodeMethodNotAllowed   Code = "method_not_allowed"
 	CodeRequestTooLarge    Code = "request_too_large"
@@ -44,6 +45,7 @@ var StatusCodes = map[Code]int{
 	CodeBadRequest:          http.StatusBadRequest,
 	CodeNotFound:            http.StatusNotFound,
 	CodeConflict:            http.StatusConflict,
+	CodeFailedPrecondition:  http.StatusPreconditionFailed,
 	CodeUnsupportedMedia:    http.StatusUnsupportedMediaType,
 	CodeMethodNotAllowed:    http.StatusMethodNotAllowed,
 	CodeRequestTooLarge:     http.StatusRequestEntityTooLarge,
@@ -75,6 +77,8 @@ func (c Code) UserMessage() string {
 		return "resource not found"
 	case CodeConflict:
 		return "resource already exists"
+	case CodeFailedPrecondition:
+		return "resource is not in a valid state for this operation"
 	case CodeUnsupportedMedia:
 		return "unsupported media type"
 	case CodeRequestTooLarge:
@@ -113,7 +117,7 @@ func (c Code) MCPCode() MCPCode {
 		return MCPCodeUnauthorized
 	case CodeForbidden, CodeInferenceDisabled:
 		return MCPCodeForbidden
-	case CodeBadRequest, CodeConflict, CodeUnsupportedMedia:
+	case CodeBadRequest, CodeConflict, CodeFailedPrecondition, CodeUnsupportedMedia:
 		return MCPCodeInvalidRequest
 	case CodeMethodNotAllowed:
 		return MCPCodeServerError

--- a/server/internal/oops/http_test.go
+++ b/server/internal/oops/http_test.go
@@ -158,6 +158,18 @@ func TestErrHandle_WrappedShareableError(t *testing.T) {
 	require.Empty(t, logBuf.String(), "ShareableError should not log even when wrapped")
 }
 
+func TestErrHandle_FailedPrecondition(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+	handler := ErrHandle(logger, func(http.ResponseWriter, *http.Request) error {
+		return E(CodeFailedPrecondition, nil, "operation cannot be completed")
+	})
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusPreconditionFailed, rec.Code)
+}
+
 type contextKey string
 
 func TestErrHandle_ContextPropagation(t *testing.T) {

--- a/server/internal/plugins/agent_plugins.go
+++ b/server/internal/plugins/agent_plugins.go
@@ -1,0 +1,290 @@
+package plugins
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+
+	domainskills "github.com/speakeasy-api/gram/server/internal/skills"
+)
+
+const (
+	agentPluginSchemaID = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+	agentMCPSchemaID    = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+	agentPluginRoot     = "agent-plugins"
+)
+
+//go:embed agent_plugins_schema/plugin.schema.json
+var agentPluginSchemaJSON []byte
+
+//go:embed agent_plugins_schema/mcp.schema.json
+var agentMCPSchemaJSON []byte
+
+var ErrAgentPluginsV1Incompatible = errors.New("plugin is not compatible with Agent Plugins 1.0")
+
+type agentPluginCredentialMode uint8
+
+const (
+	agentPluginCredentialsPackage agentPluginCredentialMode = iota
+	agentPluginCredentialsKeyless
+)
+
+type agentPluginCompatibility struct {
+	Compatible bool
+	Reasons    []string
+}
+
+type agentPluginManifest struct {
+	Schema      string            `json:"$schema"`
+	Name        string            `json:"name"`
+	Version     string            `json:"version,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Author      agentPluginAuthor `json:"author"`
+	Homepage    string            `json:"homepage,omitempty"`
+}
+
+type agentPluginAuthor struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+type agentMCPConfig struct {
+	Schema     string                    `json:"$schema"`
+	MCPServers map[string]agentMCPServer `json:"mcpServers"`
+}
+
+type agentMCPServer struct {
+	Type    string            `json:"type"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	CWD     string            `json:"cwd,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+var (
+	agentSchemasOnce sync.Once
+	agentSchemas     map[string]*jsonschema.Schema
+	errAgentSchemas  error
+)
+
+const agentPluginNamePattern = `^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$`
+
+type agentSchemaRegexp struct {
+	pattern string
+	re      *regexp.Regexp
+	name    bool
+}
+
+func (r *agentSchemaRegexp) MatchString(value string) bool {
+	if r.name && (strings.Contains(value, "--") || strings.Contains(value, "..")) {
+		return false
+	}
+	return r.re.MatchString(value)
+}
+
+func (r *agentSchemaRegexp) String() string { return r.pattern }
+
+func loadAgentPluginSchemas() (map[string]*jsonschema.Schema, error) {
+	agentSchemasOnce.Do(func() {
+		compiler := jsonschema.NewCompiler()
+		compiler.UseRegexpEngine(func(pattern string) (jsonschema.Regexp, error) {
+			if pattern == agentPluginNamePattern {
+				return &agentSchemaRegexp{pattern: pattern, re: regexp.MustCompile(`^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$`), name: true}, nil
+			}
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("compile schema regexp: %w", err)
+			}
+			return &agentSchemaRegexp{pattern: pattern, re: re, name: false}, nil
+		})
+		for id, schemaBytes := range map[string][]byte{
+			agentPluginSchemaID: agentPluginSchemaJSON,
+			agentMCPSchemaID:    agentMCPSchemaJSON,
+		} {
+			raw, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaBytes))
+			if err != nil {
+				errAgentSchemas = fmt.Errorf("parse vendored schema %s: %w", id, err)
+				return
+			}
+			if err := compiler.AddResource(id, raw); err != nil {
+				errAgentSchemas = fmt.Errorf("add vendored schema %s: %w", id, err)
+				return
+			}
+		}
+		agentSchemas = make(map[string]*jsonschema.Schema, 2)
+		for _, id := range []string{agentPluginSchemaID, agentMCPSchemaID} {
+			schema, err := compiler.Compile(id)
+			if err != nil {
+				errAgentSchemas = fmt.Errorf("compile vendored schema %s: %w", id, err)
+				return
+			}
+			agentSchemas[id] = schema
+		}
+	})
+	return agentSchemas, errAgentSchemas
+}
+
+func classifyAgentPlugin(p PluginInfo) agentPluginCompatibility {
+	reasons := append([]string(nil), p.AgentPluginsV1Issues...)
+	seenServers := make(map[string]struct{}, len(p.Servers))
+	for _, server := range p.Servers {
+		if _, exists := seenServers[server.DisplayName]; exists {
+			reasons = append(reasons, "duplicate server name")
+		}
+		seenServers[server.DisplayName] = struct{}{}
+		if !server.IsUnproxied && !server.IsPublic && !server.IsOAuth {
+			reasons = append(reasons, "server requires a Gram credential")
+		}
+		if len(server.EnvConfigs) > 0 {
+			reasons = append(reasons, "server requires environment-backed headers")
+		}
+		if err := validateAgentPluginRemoteURL(server.MCPURL); err != nil {
+			reasons = append(reasons, "server URL is not portable")
+		}
+	}
+	for _, skill := range p.Skills {
+		if !domainskills.ValidSpecName(skill.Name) {
+			reasons = append(reasons, "skill name is invalid")
+		}
+	}
+
+	manifest := agentPluginManifest{Schema: agentPluginSchemaID, Name: p.Slug, Version: "0.1.0", Description: p.Description, Author: agentPluginAuthor{Name: "", URL: ""}, Homepage: ""}
+	if err := validateAgentPluginDocument(agentPluginSchemaID, manifest); err != nil {
+		reasons = append(reasons, "plugin manifest is invalid: "+err.Error())
+	}
+	return agentPluginCompatibility{Compatible: len(reasons) == 0, Reasons: reasons}
+}
+
+func validateAgentPluginRemoteURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" || u.User != nil || u.Fragment != "" {
+		return errors.New("url must be absolute and must not contain user information or a fragment")
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme != "http" {
+		return errors.New("url scheme must be HTTP or HTTPS")
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return errors.New("non-loopback HTTP URL")
+	}
+	return nil
+}
+
+func validateAgentPluginDocument(schemaID string, document any) error {
+	schemas, err := loadAgentPluginSchemas()
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		return fmt.Errorf("marshal Agent Plugins document: %w", err)
+	}
+	value, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("parse Agent Plugins document: %w", err)
+	}
+	if err := schemas[schemaID].Validate(value); err != nil {
+		return fmt.Errorf("validate Agent Plugins document: %w", err)
+	}
+	return nil
+}
+
+func compileAgentPlugin(p PluginInfo, cfg GenerateConfig, mode agentPluginCredentialMode) (map[string][]byte, error) {
+	if compatibility := classifyAgentPlugin(p); !compatibility.Compatible {
+		return nil, fmt.Errorf("%w: %s", ErrAgentPluginsV1Incompatible, strings.Join(compatibility.Reasons, ", "))
+	}
+	if mode == agentPluginCredentialsKeyless {
+		cfg.APIKey = ""
+		cfg.HooksAPIKey = ""
+	}
+
+	files := make(map[string][]byte)
+	manifest := agentPluginManifest{
+		Schema:      agentPluginSchemaID,
+		Name:        p.Slug,
+		Version:     pluginManifestVersion(cfg),
+		Description: p.Description,
+		Author:      agentPluginAuthor{Name: cfg.OrgName, URL: "https://www.speakeasy.com/"},
+		Homepage:    "https://www.speakeasy.com/product/gram",
+	}
+	manifestJSON, err := marshalJSON(manifest)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Agent Plugins plugin.json: %w", err)
+	}
+	files["plugin.json"] = manifestJSON
+
+	mcpServers := make(map[string]agentMCPServer, len(p.Servers)+1)
+	for _, server := range p.Servers {
+		mcpServers[server.DisplayName] = agentMCPServer{Type: "streamable-http", Command: "", Args: nil, Env: nil, CWD: "", URL: server.MCPURL, Headers: nil}
+	}
+	if bundleSkillFeedbackMCP(p) {
+		mcpServers[skillFeedbackMCPServerName] = agentMCPServer{
+			Type:    "stdio",
+			Command: "bash",
+			Args: []string{
+				"-c",
+				`exec "${PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT}}/hooks/bootstrap.sh" skill-feedback "--config=${PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT}}/speakeasy.json"`,
+			},
+			Env:     nil,
+			CWD:     "",
+			URL:     "",
+			Headers: nil,
+		}
+		if err := writeHooksRuntimeFiles(files, "", cfg); err != nil {
+			return nil, err
+		}
+	}
+	mcpConfig := agentMCPConfig{Schema: agentMCPSchemaID, MCPServers: mcpServers}
+	mcpJSON, err := marshalJSON(mcpConfig)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Agent Plugins mcp.json: %w", err)
+	}
+	files["mcp.json"] = mcpJSON
+	emitPluginSkills(files, "", p)
+
+	if mode == agentPluginCredentialsPackage {
+		cursorJSON, err := marshalJSON(cursorPluginMeta{Name: p.Slug + "-cursor", DisplayName: p.Name + " (Cursor)", Description: p.Description, Version: pluginManifestVersion(cfg), Author: cursorAuthor{Name: cfg.OrgName, Email: ""}, Homepage: "https://getgram.ai"})
+		if err != nil {
+			return nil, fmt.Errorf("marshal shared Cursor plugin.json: %w", err)
+		}
+		files[".cursor-plugin/plugin.json"] = cursorJSON
+
+		legacyCodexFiles := make(map[string][]byte)
+		if err := generateCodexPluginInDir(legacyCodexFiles, "", p.Slug+"-codex", p, cfg); err != nil {
+			return nil, fmt.Errorf("generate shared Codex legacy overlay: %w", err)
+		}
+		files[".codex-plugin/plugin.json"] = legacyCodexFiles[".codex-plugin/plugin.json"]
+		files[".mcp.json"] = legacyCodexFiles[".mcp.json"]
+	}
+
+	if err := validateAgentPluginDocument(agentPluginSchemaID, manifest); err != nil {
+		return nil, err
+	}
+	if err := validateAgentPluginDocument(agentMCPSchemaID, mcpConfig); err != nil {
+		return nil, err
+	}
+	for filePath := range files {
+		if strings.HasPrefix(filePath, "/") || strings.HasPrefix(filePath, "../") || strings.Contains(filePath, "/../") {
+			return nil, fmt.Errorf("agent plugins package path escapes root: %s", filePath)
+		}
+	}
+	return files, nil
+}

--- a/server/internal/plugins/agent_plugins.go
+++ b/server/internal/plugins/agent_plugins.go
@@ -211,10 +211,8 @@ func compileAgentPlugin(p PluginInfo, cfg GenerateConfig, mode agentPluginCreden
 	if compatibility := classifyAgentPlugin(p); !compatibility.Compatible {
 		return nil, fmt.Errorf("%w: %s", ErrAgentPluginsV1Incompatible, strings.Join(compatibility.Reasons, ", "))
 	}
-	if mode == agentPluginCredentialsKeyless {
-		cfg.APIKey = ""
-		cfg.HooksAPIKey = ""
-	}
+	cfg.APIKey = ""
+	cfg.HooksAPIKey = ""
 
 	files := make(map[string][]byte)
 	manifest := agentPluginManifest{

--- a/server/internal/plugins/agent_plugins_schema/LICENSE.apache-2.0.txt
+++ b/server/internal/plugins/agent_plugins_schema/LICENSE.apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/server/internal/plugins/agent_plugins_schema/NOTICE.md
+++ b/server/internal/plugins/agent_plugins_schema/NOTICE.md
@@ -1,0 +1,10 @@
+# Agent Plugins 1.0 schemas
+
+`plugin.schema.json` and `mcp.schema.json` are exact copies from
+[`agentplugins/agent-plugins-spec`](https://github.com/agentplugins/agent-plugins-spec)
+at commit `bd383552095128f6effe895b9257cfd580a6d179`.
+
+The upstream project licenses schemas and other software material under the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). The upstream
+licensing notice is available at
+[`LICENSE.md`](https://github.com/agentplugins/agent-plugins-spec/blob/bd383552095128f6effe895b9257cfd580a6d179/LICENSE.md).

--- a/server/internal/plugins/agent_plugins_schema/mcp.schema.json
+++ b/server/internal/plugins/agent_plugins_schema/mcp.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "title": "Agent Plugins MCP Configuration",
+  "description": "Machine-readable schema for mcp.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      "description": "Canonical identifier of the MCP configuration schema for the Agent Plugins version targeted by this document."
+    },
+    "mcpServers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/server"
+      }
+    }
+  },
+  "required": ["$schema", "mcpServers"],
+  "additionalProperties": false,
+  "$defs": {
+    "server": {
+      "title": "MCP server",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/stdioServer"
+        },
+        {
+          "$ref": "#/$defs/streamableHttpServer"
+        },
+        {
+          "$ref": "#/$defs/sseServer"
+        }
+      ]
+    },
+    "stdioServer": {
+      "title": "stdio MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "stdio"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Executable token. Resolution rules are defined by the Agent Plugins specification."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "enum": ["PLUGIN_ROOT", "PLUGIN_DATA"]
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "type": "string",
+          "pattern": "^(?:\\./|\\$\\{PLUGIN_ROOT\\}(?:/|$)|\\$\\{PLUGIN_DATA\\}(?:/|$))",
+          "description": "Plugin-relative, PLUGIN_ROOT-rooted, or PLUGIN_DATA-rooted working directory. Filesystem containment is validated separately."
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    },
+    "streamableHttpServer": {
+      "title": "Streamable HTTP MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "streamable-http"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "sseServer": {
+      "title": "Legacy HTTP+SSE MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "sse"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "headers": {
+      "title": "HTTP headers",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/server/internal/plugins/agent_plugins_schema/plugin.schema.json
+++ b/server/internal/plugins/agent_plugins_schema/plugin.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "title": "Agent Plugins Manifest",
+  "description": "Machine-readable schema for plugin.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      "description": "Canonical identifier of the plugin manifest schema for the Agent Plugins version targeted by this document."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^(?!.*(?:--|\\.\\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$",
+      "description": "Human-readable plugin name."
+    },
+    "version": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "homepage": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Client-specific manifest data keyed by reverse-domain extension namespace. Agent Plugins assigns no semantics to namespace object contents.",
+      "additionalProperties": {
+        "type": "object"
+      }
+    }
+  },
+  "required": ["$schema", "name"],
+  "additionalProperties": false
+}

--- a/server/internal/plugins/agent_plugins_test.go
+++ b/server/internal/plugins/agent_plugins_test.go
@@ -83,6 +83,10 @@ func TestCompileAgentPluginUsesPinnedSchemasAndKeylessMode(t *testing.T) {
 	require.Contains(t, published, ".cursor-plugin/plugin.json")
 	require.Contains(t, published, ".codex-plugin/plugin.json")
 	require.Contains(t, published, ".mcp.json")
+	for path, content := range published {
+		require.NotContains(t, string(content), cfg.APIKey, path)
+		require.NotContains(t, string(content), cfg.HooksAPIKey, path)
+	}
 }
 
 func TestAgentPluginMarketplaceTransitionPreservesIdentity(t *testing.T) {

--- a/server/internal/plugins/agent_plugins_test.go
+++ b/server/internal/plugins/agent_plugins_test.go
@@ -1,0 +1,152 @@
+package plugins
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentPluginClassifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		plugin     PluginInfo
+		compatible bool
+	}{
+		{name: "empty", plugin: PluginInfo{Name: "Empty", Slug: "empty", Description: "", Servers: nil, Skills: nil, AgentPluginsV1Issues: nil}, compatible: true},
+		{name: "skills only", plugin: PluginInfo{Name: "Skills", Slug: "skills", Description: "", Servers: nil, Skills: []PluginSkillInfo{{Name: "review", Content: "content"}}, AgentPluginsV1Issues: nil}, compatible: true},
+		{name: "public remote", plugin: PluginInfo{Name: "Public", Slug: "public", Description: "", Servers: []PluginServerInfo{{DisplayName: "public", Policy: "required", MCPURL: "https://example.com/mcp", IsPublic: true, IsOAuth: false, IsUnproxied: false, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: true},
+		{name: "oauth remote", plugin: PluginInfo{Name: "OAuth", Slug: "oauth", Description: "", Servers: []PluginServerInfo{{DisplayName: "oauth", Policy: "required", MCPURL: "https://example.com/mcp", IsPublic: false, IsOAuth: true, IsUnproxied: false, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: true},
+		{name: "loopback http", plugin: PluginInfo{Name: "Local", Slug: "local", Description: "", Servers: []PluginServerInfo{{DisplayName: "local", Policy: "required", MCPURL: "http://127.0.0.1:8080/mcp", IsPublic: true, IsOAuth: false, IsUnproxied: false, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: true},
+		{name: "unproxied https", plugin: PluginInfo{Name: "External", Slug: "external", Description: "", Servers: []PluginServerInfo{{DisplayName: "external", Policy: "required", MCPURL: "https://example.com/Authorization", IsPublic: false, IsOAuth: false, IsUnproxied: true, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: true},
+		{name: "private remote", plugin: PluginInfo{Name: "Private", Slug: "private", Description: "", Servers: []PluginServerInfo{{DisplayName: "private", Policy: "required", MCPURL: "https://example.com/mcp", IsPublic: false, IsOAuth: false, IsUnproxied: false, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: false},
+		{name: "environment header", plugin: PluginInfo{Name: "Header", Slug: "header", Description: "", Servers: []PluginServerInfo{{DisplayName: "header", Policy: "required", MCPURL: "https://example.com/mcp", IsPublic: true, IsOAuth: false, IsUnproxied: false, EnvConfigs: []ServerEnvConfig{{VariableName: "TOKEN", DisplayName: "X-Token"}}}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: false},
+		{name: "non portable url", plugin: PluginInfo{Name: "HTTP", Slug: "http", Description: "", Servers: []PluginServerInfo{{DisplayName: "http", Policy: "required", MCPURL: "http://example.com/mcp", IsPublic: true, IsOAuth: false, IsUnproxied: false, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}, compatible: false},
+		{name: "unresolved attachment", plugin: PluginInfo{Name: "Broken", Slug: "broken", Description: "", Servers: nil, Skills: nil, AgentPluginsV1Issues: []string{"mcp_server_disabled"}}, compatible: false},
+	}
+
+	for _, test := range tests {
+		require.Equal(t, test.compatible, classifyAgentPlugin(test.plugin).Compatible, test.name)
+	}
+}
+
+func TestCompileAgentPluginUsesPinnedSchemasAndKeylessMode(t *testing.T) {
+	t.Parallel()
+
+	pluginSchemaHash := sha256.Sum256(agentPluginSchemaJSON)
+	mcpSchemaHash := sha256.Sum256(agentMCPSchemaJSON)
+	require.Equal(t, "0a4aad95ce337878ad38802ebf0daa3fde76abe3f65400c86bcbb1ec0b3ab883", hex.EncodeToString(pluginSchemaHash[:]))
+	require.Equal(t, "6539175bfcdf43085855183e86da40ea94b166547a72b47ae9a0a390516d3acb", hex.EncodeToString(mcpSchemaHash[:]))
+
+	plugin := PluginInfo{
+		Name:                 "Review Tools",
+		Slug:                 "review-tools",
+		Description:          "Review code",
+		Servers:              []PluginServerInfo{{DisplayName: "reviews", Policy: "required", MCPURL: "https://example.com/mcp", IsPublic: true, IsOAuth: false, IsUnproxied: false, EnvConfigs: nil}},
+		Skills:               []PluginSkillInfo{{Name: "review", Content: "---\nname: review\ndescription: Review code.\n---\n"}},
+		AgentPluginsV1Issues: nil,
+	}
+	cfg := GenerateConfig{OrgName: "Example", OrgEmail: "", OrgID: "org-example", ServerURL: "https://app.getgram.ai", APIKey: "consumer-secret", HooksAPIKey: "hooks-secret", ProjectSlug: "default", IsDefaultProject: true, Version: "1", PlatformMCPEnabled: false, MarketplaceName: "", BrowserLogin: false, HooksOrgName: "", InstallFailOpen: false}
+
+	files, err := compileAgentPlugin(plugin, cfg, agentPluginCredentialsKeyless)
+	require.NoError(t, err)
+	require.Contains(t, files, "plugin.json")
+	require.Contains(t, files, "mcp.json")
+	require.NotContains(t, files, ".cursor-plugin/plugin.json")
+	require.NotContains(t, files, ".codex-plugin/plugin.json")
+	require.NotContains(t, files, ".mcp.json")
+	require.Contains(t, files, "skills/review/SKILL.md")
+	require.Contains(t, files, "hooks/bootstrap.sh")
+	require.Contains(t, files, "speakeasy.json")
+	require.NotContains(t, string(files["speakeasy.json"]), "hooks-secret")
+
+	var mcp agentMCPConfig
+	require.NoError(t, json.Unmarshal(files["mcp.json"], &mcp))
+	require.NoError(t, validateAgentPluginDocument(agentMCPSchemaID, mcp))
+	require.Empty(t, mcp.MCPServers["reviews"].Headers)
+	for _, forbidden := range []string{"consumer-secret", "hooks-secret", "Authorization", "${env:", "bearer_token_env_var", "env_http_headers"} {
+		require.NotContains(t, string(files["mcp.json"]), forbidden)
+	}
+	feedback := mcp.MCPServers[skillFeedbackMCPServerName]
+	require.Equal(t, "bash", feedback.Command)
+	require.Contains(t, feedback.Args[1], `${PLUGIN_ROOT:-${CURSOR_PLUGIN_ROOT}}`)
+
+	published, err := compileAgentPlugin(plugin, cfg, agentPluginCredentialsPackage)
+	require.NoError(t, err)
+	require.Contains(t, published, ".cursor-plugin/plugin.json")
+	require.Contains(t, published, ".codex-plugin/plugin.json")
+	require.Contains(t, published, ".mcp.json")
+}
+
+func TestAgentPluginMarketplaceTransitionPreservesIdentity(t *testing.T) {
+	t.Parallel()
+
+	cfg := GenerateConfig{OrgName: "Example", OrgEmail: "", OrgID: "", ServerURL: "https://app.getgram.ai", APIKey: "", HooksAPIKey: "", ProjectSlug: "default", IsDefaultProject: true, Version: "", PlatformMCPEnabled: false, MarketplaceName: "", BrowserLogin: false, HooksOrgName: "", InstallFailOpen: false}
+	compatible := PluginInfo{Name: "Tools", Slug: "tools", Description: "", Servers: []PluginServerInfo{{DisplayName: "tools", Policy: "required", MCPURL: "https://example.com/mcp", IsPublic: true, IsOAuth: false, IsUnproxied: false, EnvConfigs: nil}}, Skills: nil, AgentPluginsV1Issues: nil}
+	incompatible := compatible
+	incompatible.Servers = append([]PluginServerInfo(nil), compatible.Servers...)
+	incompatible.Servers[0].IsPublic = false
+
+	sharedFiles, err := generateSharedFiles([]PluginInfo{compatible}, cfg)
+	require.NoError(t, err)
+	legacyFiles, err := generateSharedFiles([]PluginInfo{incompatible}, cfg)
+	require.NoError(t, err)
+
+	var sharedCursor, legacyCursor marketplaceManifest
+	require.NoError(t, json.Unmarshal(sharedFiles[".cursor-plugin/marketplace.json"], &sharedCursor))
+	require.NoError(t, json.Unmarshal(legacyFiles[".cursor-plugin/marketplace.json"], &legacyCursor))
+	require.Equal(t, legacyCursor.Plugins[0].Name, sharedCursor.Plugins[0].Name)
+	require.Equal(t, "agent-plugins/tools", sharedCursor.Plugins[0].Source)
+	require.Equal(t, "cursor-plugins/tools-cursor", legacyCursor.Plugins[0].Source)
+
+	var sharedCodex, legacyCodex codexMarketplaceManifest
+	require.NoError(t, json.Unmarshal(sharedFiles[".agents/plugins/marketplace.json"], &sharedCodex))
+	require.NoError(t, json.Unmarshal(legacyFiles[".agents/plugins/marketplace.json"], &legacyCodex))
+	require.Equal(t, legacyCodex.Plugins[0].Name, sharedCodex.Plugins[0].Name)
+	require.Equal(t, "./agent-plugins/tools", sharedCodex.Plugins[0].Source.Path)
+	require.Equal(t, "./tools-codex", legacyCodex.Plugins[0].Source.Path)
+
+	sharedFingerprint, err := MCPFingerprints([]PluginInfo{compatible}, cfg)
+	require.NoError(t, err)
+	legacyFingerprint, err := MCPFingerprints([]PluginInfo{incompatible}, cfg)
+	require.NoError(t, err)
+	require.NotEqual(t, sharedFingerprint["tools"], legacyFingerprint["tools"])
+	require.NotEqual(t, sharedFingerprint[mcpSharedFingerprintKey], legacyFingerprint[mcpSharedFingerprintKey])
+}
+
+func TestAgentPluginZipIsDeterministicAndExecutable(t *testing.T) {
+	t.Parallel()
+
+	files := map[string][]byte{"z.txt": []byte("z"), "hooks/bootstrap.sh": []byte("#!/bin/sh\n"), "a.txt": []byte("a")}
+	var first, second bytes.Buffer
+	require.NoError(t, writePluginZip(&first, files))
+	require.NoError(t, writePluginZip(&second, files))
+	require.Equal(t, first.Bytes(), second.Bytes())
+
+	zr, err := zip.NewReader(bytes.NewReader(first.Bytes()), int64(first.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.txt", "hooks/bootstrap.sh", "z.txt"}, []string{zr.File[0].Name, zr.File[1].Name, zr.File[2].Name})
+	require.Equal(t, "-rwxr-xr-x", zr.File[1].Mode().String())
+	rc, err := zr.File[1].Open()
+	require.NoError(t, err)
+	_, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+}
+
+func TestCompileAgentPluginFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, err := compileAgentPlugin(PluginInfo{Name: "Broken", Slug: "broken", Description: "", Servers: nil, Skills: nil, AgentPluginsV1Issues: []string{"backing unresolved"}}, GenerateConfig{}, agentPluginCredentialsKeyless)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAgentPluginsV1Incompatible)
+	require.Contains(t, err.Error(), "backing unresolved")
+	require.NotContains(t, err.Error(), "secret")
+}

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/url"
@@ -62,7 +63,8 @@ type PluginInfo struct {
 	Description string
 	Servers     []PluginServerInfo
 	// Skills are emitted into each platform plugin's skills/ directory.
-	Skills []PluginSkillInfo
+	Skills               []PluginSkillInfo
+	AgentPluginsV1Issues []string
 }
 
 // GenerateConfig holds org-level configuration for package generation.
@@ -361,7 +363,7 @@ func storedHooksConfigHash(stored []byte) string {
 // MCP plugins on the next run, even when a project's generated MCP output is
 // byte-identical — for generator changes that alter MCP behaviour in ways the
 // placeholder fingerprint pass can't observe.
-const mcpGeneratorVersion = "10"
+const mcpGeneratorVersion = "11"
 
 // platformMCPGeneratorVersion is independent from mcpGeneratorVersion so adding
 // or changing the first-party Platform MCP never triggers a fleet-wide customer
@@ -664,6 +666,16 @@ func generateMCPFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][]by
 		if err := generateOpenCodePlugin(files, p, cfg); err != nil {
 			return nil, fmt.Errorf("generate opencode plugin %s: %w", p.Slug, err)
 		}
+		agentFiles, err := compileAgentPlugin(p, cfg, agentPluginCredentialsPackage)
+		if err != nil {
+			if errors.Is(err, ErrAgentPluginsV1Incompatible) {
+				continue
+			}
+			return nil, fmt.Errorf("generate Agent Plugins package %s: %w", p.Slug, err)
+		}
+		for filePath, content := range agentFiles {
+			files[path.Join(agentPluginRoot, p.Slug, filePath)] = content
+		}
 	}
 	return files, nil
 }
@@ -693,7 +705,7 @@ func generateSharedFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        cursorObservability,
 			DisplayName: "", // Cursor carries the display name in its own plugin.json.
-			Source:      cursorObservability,
+			Source:      path.Join(cursorPluginRoot, cursorObservability),
 			Description: "Required: Speakeasy observability hooks for " + cfg.OrgName + ".",
 		})
 		codexObservability := CodexObservabilitySlug(cfg)
@@ -720,23 +732,30 @@ func generateSharedFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][
 	}
 
 	for _, p := range plugins {
+		compatible := classifyAgentPlugin(p).Compatible
 		claudePlugins = append(claudePlugins, marketplaceEntry{
 			Name:        p.Slug,
 			DisplayName: p.Name,
 			Source:      "./" + p.Slug,
 			Description: p.Description,
 		})
+		cursorSource := path.Join(cursorPluginRoot, p.Slug+"-cursor")
+		codexSource := "./" + p.Slug + "-codex"
+		if compatible {
+			cursorSource = path.Join(agentPluginRoot, p.Slug)
+			codexSource = "./" + path.Join(agentPluginRoot, p.Slug)
+		}
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        p.Slug + "-cursor",
 			DisplayName: "", // Cursor carries the display name in its own plugin.json.
-			Source:      p.Slug + "-cursor",
+			Source:      cursorSource,
 			Description: p.Description,
 		})
 		codexPlugins = append(codexPlugins, codexMarketplaceEntry{
 			Name: p.Slug + "-codex",
 			Source: codexMarketplaceSource{
 				Source: "local",
-				Path:   "./" + p.Slug + "-codex",
+				Path:   codexSource,
 			},
 			Policy: codexMarketplacePolicy{
 				Installation:   "AVAILABLE",
@@ -762,7 +781,7 @@ func generateSharedFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][
 	cursorManifest, err := marshalJSON(marketplaceManifest{
 		Name:     marketplaceName,
 		Owner:    owner,
-		Metadata: &marketplaceMetadata{PluginRoot: cursorPluginRoot},
+		Metadata: nil,
 		Plugins:  cursorPlugins,
 	})
 	if err != nil {
@@ -893,6 +912,8 @@ func GenerateSinglePluginPackage(plugin PluginInfo, cfg GenerateConfig, platform
 		if err := generateCodexPluginFlat(files, plugin, cfg); err != nil {
 			return nil, fmt.Errorf("generate codex plugin: %w", err)
 		}
+	case "agent-plugin":
+		return compileAgentPlugin(plugin, cfg, agentPluginCredentialsKeyless)
 	// ponytail: no "opencode" case — the downloadPluginPackage enum is
 	// claude|cursor|codex, so a flat per-plugin opencode package is unreachable.
 	// OpenCode ships via downloadObservabilityPlugin only; add here if per-plugin

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -947,10 +947,9 @@ func TestGenerateMarketplaceManifest(t *testing.T) {
 
 	require.Equal(t, "acme-speakeasy", cursorManifest.Name)
 	require.Len(t, cursorManifest.Plugins, 2)
-	require.NotNil(t, cursorManifest.Metadata)
-	require.Equal(t, "cursor-plugins", cursorManifest.Metadata.PluginRoot)
-	require.Equal(t, "a-cursor", cursorManifest.Plugins[0].Source)
-	require.Equal(t, "b-cursor", cursorManifest.Plugins[1].Source)
+	require.Nil(t, cursorManifest.Metadata)
+	require.Equal(t, "agent-plugins/a", cursorManifest.Plugins[0].Source)
+	require.Equal(t, "agent-plugins/b", cursorManifest.Plugins[1].Source)
 }
 
 func TestGenerateMarketplaceManifestUsesMarketplaceNameOverride(t *testing.T) {

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -44,7 +44,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/marketplace"
-	mcpmetarepo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers/visibility"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -300,6 +299,10 @@ func (s *Service) ListPlugins(ctx context.Context, payload *gen.ListPluginsPaylo
 	for _, srv := range allServers {
 		serversByPlugin[srv.PluginID] = append(serversByPlugin[srv.PluginID], srv)
 	}
+	compatibility, err := s.resolveAgentPluginCompatibility(ctx, *ac.ProjectID, pluginIDs...)
+	if err != nil {
+		return nil, err
+	}
 
 	plugins := make([]*gen.Plugin, 0, len(rows))
 	for _, r := range rows {
@@ -310,18 +313,19 @@ func (s *Service) ListPlugins(ctx context.Context, payload *gen.ListPluginsPaylo
 		}
 
 		plugins = append(plugins, &gen.Plugin{
-			ID:              r.ID.String(),
-			Name:            r.Name,
-			Slug:            r.Slug,
-			Description:     conv.FromPGText[string](r.Description),
-			IsDefault:       conv.FromPGBool[bool](r.IsDefault),
-			ServerCount:     &r.ServerCount,
-			SkillCount:      &r.SkillCount,
-			AssignmentCount: &r.AssignmentCount,
-			Servers:         genServers,
-			Assignments:     nil,
-			CreatedAt:       formatTime(r.CreatedAt),
-			UpdatedAt:       formatTime(r.UpdatedAt),
+			ID:                       r.ID.String(),
+			Name:                     r.Name,
+			Slug:                     r.Slug,
+			Description:              conv.FromPGText[string](r.Description),
+			IsDefault:                conv.FromPGBool[bool](r.IsDefault),
+			ServerCount:              &r.ServerCount,
+			SkillCount:               &r.SkillCount,
+			AssignmentCount:          &r.AssignmentCount,
+			AgentPluginsV1Compatible: compatibility[r.Slug],
+			Servers:                  genServers,
+			Assignments:              nil,
+			CreatedAt:                formatTime(r.CreatedAt),
+			UpdatedAt:                formatTime(r.UpdatedAt),
 		})
 	}
 
@@ -409,7 +413,11 @@ func (s *Service) GetPlugin(ctx context.Context, payload *gen.GetPluginPayload) 
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").LogError(ctx, s.logger)
 	}
 
-	return pluginToGen(plugin, servers, assignments), nil
+	compatibility, err := s.resolveAgentPluginCompatibility(ctx, *ac.ProjectID, pluginID)
+	if err != nil {
+		return nil, err
+	}
+	return pluginToGen(plugin, servers, assignments, compatibility[plugin.Slug]), nil
 }
 
 func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPayload) (*gen.Plugin, error) {
@@ -497,7 +505,9 @@ func (s *Service) CreatePlugin(ctx context.Context, payload *gen.CreatePluginPay
 		return nil, oops.E(oops.CodeUnexpected, err, "commit transaction").LogError(ctx, s.logger)
 	}
 
-	return pluginToGen(plugin, nil, nil), nil
+	return pluginToGen(plugin, nil, nil, classifyAgentPlugin(PluginInfo{
+		Name: plugin.Name, Slug: plugin.Slug, Description: conv.FromPGTextOrEmpty[string](plugin.Description), Servers: nil, Skills: nil, AgentPluginsV1Issues: nil,
+	}).Compatible), nil
 }
 
 func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPayload) (*gen.Plugin, error) {
@@ -596,7 +606,11 @@ func (s *Service) UpdatePlugin(ctx context.Context, payload *gen.UpdatePluginPay
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin assignments").LogError(ctx, s.logger)
 	}
 
-	return pluginToGen(plugin, servers, assignments), nil
+	compatibility, err := s.resolveAgentPluginCompatibility(ctx, *ac.ProjectID, pluginID)
+	if err != nil {
+		return nil, err
+	}
+	return pluginToGen(plugin, servers, assignments, compatibility[plugin.Slug]), nil
 }
 
 func (s *Service) DeletePlugin(ctx context.Context, payload *gen.DeletePluginPayload) error {
@@ -1173,7 +1187,7 @@ func (s *Service) DownloadPluginPackage(ctx context.Context, payload *gen.Downlo
 	}
 
 	// Resolve all plugin infos and find the matching one.
-	allInfos, err := s.resolvePluginInfos(ctx, *ac.ProjectID)
+	allInfos, err := s.resolvePluginInfos(ctx, *ac.ProjectID, pluginID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1186,14 +1200,7 @@ func (s *Service) DownloadPluginPackage(ctx context.Context, payload *gen.Downlo
 		}
 	}
 	if pluginInfo == nil {
-		// Plugin exists but has no servers — generate an empty plugin.
-		pluginInfo = &PluginInfo{
-			Name:        dbPlugin.Name,
-			Slug:        dbPlugin.Slug,
-			Description: conv.FromPGTextOrEmpty[string](dbPlugin.Description),
-			Servers:     nil,
-			Skills:      nil,
-		}
+		return nil, nil, oops.E(oops.CodeUnexpected, nil, "resolve plugin package").LogError(ctx, s.logger)
 	}
 
 	projectSlug := ""
@@ -1204,6 +1211,9 @@ func (s *Service) DownloadPluginPackage(ctx context.Context, payload *gen.Downlo
 
 	files, err := GenerateSinglePluginPackage(*pluginInfo, cfg, payload.Platform)
 	if err != nil {
+		if payload.Platform == "agent-plugin" && errors.Is(err, ErrAgentPluginsV1Incompatible) {
+			return nil, nil, oops.E(oops.CodeFailedPrecondition, err, "plugin is not compatible with Agent Plugins 1.0")
+		}
 		return nil, nil, oops.E(oops.CodeUnexpected, err, "generate plugin package").LogError(ctx, s.logger)
 	}
 
@@ -1342,7 +1352,7 @@ func writePluginZip(w io.Writer, files map[string][]byte) error {
 			ReaderVersion:      0,
 			Flags:              0,
 			Method:             zip.Deflate,
-			Modified:           time.Now(),
+			Modified:           time.Date(1980, time.January, 1, 0, 0, 0, 0, time.UTC),
 			ModifiedTime:       0,
 			ModifiedDate:       0,
 			CRC32:              0,
@@ -2754,8 +2764,12 @@ func (s *Service) persistPluginAPIKeys(
 
 // --- Internal helpers ---
 
-func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) ([]PluginInfo, error) {
-	rows, err := s.repo.ListPluginsWithServersForProject(ctx, projectID)
+func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID, pluginIDs ...uuid.UUID) ([]PluginInfo, error) {
+	plugins, err := s.repo.ListActivePluginsForProject(ctx, repo.ListActivePluginsForProjectParams{ProjectID: projectID, PluginIds: pluginIDs})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list active plugins").LogError(ctx, s.logger)
+	}
+	rows, err := s.repo.ListPluginsWithServersForProject(ctx, repo.ListPluginsWithServersForProjectParams{ProjectID: projectID, PluginIds: pluginIDs})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugins with servers").LogError(ctx, s.logger)
 	}
@@ -2763,14 +2777,22 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 	// Remote MCP-backed (mcp_server) plugin servers are resolved by a separate
 	// query and merged in below. Both backends are supported simultaneously
 	// until the AGE-1902 cutover.
-	mcpRows, err := s.repo.ListPluginsWithMcpServersForProject(ctx, projectID)
+	mcpRows, err := s.repo.ListPluginsWithMcpServersForProject(ctx, repo.ListPluginsWithMcpServersForProjectParams{ProjectID: projectID, PluginIds: pluginIDs})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugins with mcp servers").LogError(ctx, s.logger)
 	}
 
-	skillRows, err := s.repo.ListPluginSkillsForProject(ctx, projectID)
+	skillRows, err := s.repo.ListPluginSkillsForProject(ctx, repo.ListPluginSkillsForProjectParams{ProjectID: projectID, PluginIds: pluginIDs})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "list plugin skills").LogError(ctx, s.logger)
+	}
+	envRows, err := s.repo.ListPluginEnvironmentConfigsForProject(ctx, repo.ListPluginEnvironmentConfigsForProjectParams{ProjectID: projectID, PluginIds: pluginIDs})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list plugin environment configs").LogError(ctx, s.logger)
+	}
+	compatibilityIssues, err := s.repo.ListAgentPluginCompatibilityIssuesForProject(ctx, repo.ListAgentPluginCompatibilityIssuesForProjectParams{ProjectID: projectID, PluginIds: pluginIDs})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list Agent Plugins compatibility issues").LogError(ctx, s.logger)
 	}
 
 	// serverBuild carries the row's sort_order so the merged toolset- and
@@ -2784,25 +2806,38 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 		info    PluginInfo
 		servers []serverBuild
 	}
-	pluginMap := make(map[uuid.UUID]*pluginBuild)
-	mcpMeta := mcpmetarepo.New(s.db)
+	pluginMap := make(map[uuid.UUID]*pluginBuild, len(plugins))
 
 	ensurePlugin := func(id uuid.UUID, name, slug string, description pgtype.Text) *pluginBuild {
 		pb, ok := pluginMap[id]
 		if !ok {
 			pb = &pluginBuild{
 				info: PluginInfo{
-					Name:        name,
-					Slug:        slug,
-					Description: conv.FromPGTextOrEmpty[string](description),
-					Servers:     nil,
-					Skills:      nil,
+					Name:                 name,
+					Slug:                 slug,
+					Description:          conv.FromPGTextOrEmpty[string](description),
+					Servers:              nil,
+					Skills:               nil,
+					AgentPluginsV1Issues: nil,
 				},
 				servers: nil,
 			}
 			pluginMap[id] = pb
 		}
 		return pb
+	}
+	for _, plugin := range plugins {
+		ensurePlugin(plugin.ID, plugin.Name, plugin.Slug, plugin.Description)
+	}
+
+	envConfigs := make(map[uuid.UUID][]ServerEnvConfig)
+	invalidEnvConfig := make(map[uuid.UUID]bool)
+	for _, env := range envRows {
+		if !env.HeaderDisplayName.Valid {
+			invalidEnvConfig[env.ToolsetID] = true
+			continue
+		}
+		envConfigs[env.ToolsetID] = append(envConfigs[env.ToolsetID], ServerEnvConfig{VariableName: env.VariableName, DisplayName: env.HeaderDisplayName.String})
 	}
 
 	for _, r := range rows {
@@ -2823,43 +2858,10 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				EnvConfigs:  nil,
 			}
 
-			// For public servers, load user-facing environment configs. A public
-			// toolset without an mcp_metadata row simply has no user-provided
-			// env vars — UpsertMetadata is explicit, not auto-created on publish.
 			if r.ToolsetIsPublic {
-				metadata, metaErr := mcpMeta.GetMetadataForToolset(ctx, r.ToolsetID)
-				switch {
-				case errors.Is(metaErr, pgx.ErrNoRows):
-					// No metadata configured → no env configs to surface.
-				case metaErr != nil:
-					return nil, oops.E(oops.CodeUnexpected, metaErr, "load mcp metadata for toolset").LogError(ctx, s.logger)
-				default:
-					envConfigs, envErr := mcpMeta.ListEnvironmentConfigs(ctx, metadata.ID)
-					if envErr != nil {
-						return nil, oops.E(oops.CodeUnexpected, envErr, "load environment configs for toolset").LogError(ctx, s.logger)
-					}
-					for _, ec := range envConfigs {
-						if ec.ProvidedBy != "user" {
-							continue
-						}
-						// DisplayName ends up as both the HTTP header name and
-						// the userConfig description in generated configs. The
-						// env variable name is not a valid header substitute,
-						// so skip configs with no HeaderDisplayName rather than
-						// emit a broken header.
-						headerName := conv.FromPGText[string](ec.HeaderDisplayName)
-						if headerName == nil {
-							s.logger.WarnContext(ctx, "skipping user env config with no header name",
-								attr.SlogToolsetID(r.ToolsetID.UUID.String()),
-								attr.SlogEnvVarName(ec.VariableName),
-							)
-							continue
-						}
-						serverInfo.EnvConfigs = append(serverInfo.EnvConfigs, ServerEnvConfig{
-							VariableName: ec.VariableName,
-							DisplayName:  *headerName,
-						})
-					}
+				serverInfo.EnvConfigs = append(serverInfo.EnvConfigs, envConfigs[r.ToolsetID.UUID]...)
+				if invalidEnvConfig[r.ToolsetID.UUID] {
+					pb.info.AgentPluginsV1Issues = append(pb.info.AgentPluginsV1Issues, "environment header is unresolved")
 				}
 			}
 
@@ -2879,7 +2881,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 		// An unproxied-backed server's URL always wins so it's never routed
 		// through a Gram endpoint it can't actually be served from.
 		mcpURL := ""
-		isOAuth := false
+		isOAuth := m.McpServerIsOauth
 		isUnproxied := false
 		switch {
 		case m.UnproxiedUrl.Valid:
@@ -2894,10 +2896,6 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				mcpBase = fmt.Sprintf("https://%s", *cd)
 			}
 			mcpURL = fmt.Sprintf("%s/mcp/%s", mcpBase, m.EndpointSlug)
-			// Remote MCP-backed servers authenticate via their user session
-			// issuer (OAuth), so the generated config carries no static
-			// Authorization header (IsOAuth).
-			isOAuth = true
 		}
 
 		// Environments are not yet wired to mcp_servers, so there are no
@@ -2907,7 +2905,7 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 				DisplayName: m.ServerDisplayName,
 				Policy:      m.ServerPolicy,
 				MCPURL:      mcpURL,
-				IsPublic:    false,
+				IsPublic:    m.McpServerIsPublic,
 				IsOAuth:     isOAuth,
 				IsUnproxied: isUnproxied,
 				EnvConfigs:  nil,
@@ -2925,6 +2923,11 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 			Name:    sk.SkillName,
 			Content: sk.SkillContent,
 		})
+	}
+	for _, issue := range compatibilityIssues {
+		if pb := pluginMap[issue.PluginID]; pb != nil {
+			pb.info.AgentPluginsV1Issues = append(pb.info.AgentPluginsV1Issues, issue.Reason)
+		}
 	}
 
 	pluginInfos := make([]PluginInfo, 0, len(pluginMap))
@@ -2949,6 +2952,18 @@ func (s *Service) resolvePluginInfos(ctx context.Context, projectID uuid.UUID) (
 		return pluginInfos[i].Slug < pluginInfos[j].Slug
 	})
 	return pluginInfos, nil
+}
+
+func (s *Service) resolveAgentPluginCompatibility(ctx context.Context, projectID uuid.UUID, pluginIDs ...uuid.UUID) (map[string]bool, error) {
+	plugins, err := s.resolvePluginInfos(ctx, projectID, pluginIDs...)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]bool, len(plugins))
+	for _, plugin := range plugins {
+		result[plugin.Slug] = classifyAgentPlugin(plugin).Compatible
+	}
+	return result, nil
 }
 
 func (s *Service) generateConfig(ctx context.Context, orgID, orgSlug, projectSlug string, projectID uuid.UUID) GenerateConfig {
@@ -3056,20 +3071,21 @@ func (s *Service) authContext(ctx context.Context) (*contextvalues.AuthContext, 
 
 // --- Conversion helpers ---
 
-func pluginToGen(p repo.Plugin, servers []repo.PluginServer, assignments []repo.PluginAssignment) *gen.Plugin {
+func pluginToGen(p repo.Plugin, servers []repo.PluginServer, assignments []repo.PluginAssignment, agentPluginsV1Compatible bool) *gen.Plugin {
 	result := &gen.Plugin{
-		ID:              p.ID.String(),
-		Name:            p.Name,
-		Slug:            p.Slug,
-		Description:     conv.FromPGText[string](p.Description),
-		IsDefault:       conv.FromPGBool[bool](p.IsDefault),
-		ServerCount:     nil,
-		SkillCount:      nil,
-		AssignmentCount: nil,
-		Servers:         nil,
-		Assignments:     nil,
-		CreatedAt:       formatTime(p.CreatedAt),
-		UpdatedAt:       formatTime(p.UpdatedAt),
+		ID:                       p.ID.String(),
+		Name:                     p.Name,
+		Slug:                     p.Slug,
+		Description:              conv.FromPGText[string](p.Description),
+		IsDefault:                conv.FromPGBool[bool](p.IsDefault),
+		ServerCount:              nil,
+		SkillCount:               nil,
+		AssignmentCount:          nil,
+		AgentPluginsV1Compatible: agentPluginsV1Compatible,
+		Servers:                  nil,
+		Assignments:              nil,
+		CreatedAt:                formatTime(p.CreatedAt),
+		UpdatedAt:                formatTime(p.UpdatedAt),
 	}
 
 	if servers != nil {

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -893,12 +893,65 @@ func TestPluginsService_DownloadAgentPluginIsFlatAndKeyless(t *testing.T) {
 	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
 	require.NoError(t, err)
 	paths := make([]string, 0, len(zr.File))
+	var contents bytes.Buffer
 	for _, file := range zr.File {
 		paths = append(paths, file.Name)
+		entry, err := file.Open()
+		require.NoError(t, err)
+		_, err = io.Copy(&contents, entry)
+		require.NoError(t, err)
+		require.NoError(t, entry.Close())
 	}
 	require.Equal(t, []string{"mcp.json", "plugin.json"}, paths)
-	require.NotContains(t, string(archive), "Authorization")
-	require.NotContains(t, string(archive), "hooks_api_key")
+	require.NotContains(t, contents.String(), "Authorization")
+	require.NotContains(t, contents.String(), "hooks_api_key")
+}
+
+func TestPluginsService_DirectToolsetUserConfigFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "User Config"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "user-config")
+	require.NoError(t, toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{
+		McpIsPublic: true,
+		ID:          toolset.ID,
+		ProjectID:   toolset.ProjectID,
+	}))
+
+	metadata, err := mcpmetarepo.New(ti.conn).UpsertMetadata(ctx, mcpmetarepo.UpsertMetadataParams{
+		ToolsetID:                 uuid.NullUUID{UUID: toolset.ID, Valid: true},
+		ProjectID:                 *authCtx.ProjectID,
+		ExternalDocumentationUrl:  pgtype.Text{},
+		ExternalDocumentationText: pgtype.Text{},
+		LogoID:                    uuid.NullUUID{},
+		Instructions:              pgtype.Text{},
+		DefaultEnvironmentID:      uuid.NullUUID{},
+		InstallationOverrideUrl:   pgtype.Text{},
+	})
+	require.NoError(t, err)
+	_, err = mcpmetarepo.New(ti.conn).UpsertEnvironmentConfig(ctx, mcpmetarepo.UpsertEnvironmentConfigParams{
+		ProjectID:         *authCtx.ProjectID,
+		McpMetadataID:     metadata.ID,
+		VariableName:      "USER_TOKEN",
+		HeaderDisplayName: pgtype.Text{},
+		ProvidedBy:        "user",
+	})
+	require.NoError(t, err)
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
+		PluginID:  plugin.ID,
+		ToolsetID: conv.PtrEmpty(toolset.ID.String()),
+		Policy:    "required",
+		SortOrder: 0,
+	})
+	require.NoError(t, err)
+
+	plugin, err = ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: plugin.ID})
+	require.NoError(t, err)
+	require.False(t, plugin.AgentPluginsV1Compatible)
 }
 
 func TestPluginsService_TombstonedAttachmentIsNotIntended(t *testing.T) {

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -1,9 +1,12 @@
 package plugins_test
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"maps"
 	"strings"
 	"testing"
@@ -822,6 +825,199 @@ func TestPluginsService_DownloadPluginPackage(t *testing.T) {
 	require.NoError(t, body.Close())
 }
 
+func TestPluginsService_AgentPluginCompatibilityIsConsistent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+	created, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Portable Empty"})
+	require.NoError(t, err)
+	require.True(t, created.AgentPluginsV1Compatible)
+
+	fetched, err := ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: created.ID})
+	require.NoError(t, err)
+	require.True(t, fetched.AgentPluginsV1Compatible)
+
+	updated, err := ti.service.UpdatePlugin(ctx, &gen.UpdatePluginPayload{ID: created.ID, Name: "Portable Empty", Slug: created.Slug})
+	require.NoError(t, err)
+	require.True(t, updated.AgentPluginsV1Compatible)
+
+	listed, err := ti.service.ListPlugins(ctx, &gen.ListPluginsPayload{})
+	require.NoError(t, err)
+	for _, plugin := range listed.Plugins {
+		if plugin.ID == created.ID {
+			require.True(t, plugin.AgentPluginsV1Compatible)
+			return
+		}
+	}
+	require.Fail(t, "created plugin missing from list")
+}
+
+func TestPluginsService_DownloadAgentPluginFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Private Download"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "private-download")
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{PluginID: plugin.ID, ToolsetID: conv.PtrEmpty(toolset.ID.String()), Policy: "required", SortOrder: 0})
+	require.NoError(t, err)
+
+	result, body, err := ti.service.DownloadPluginPackage(ctx, &gen.DownloadPluginPackagePayload{PluginID: plugin.ID, Platform: "agent-plugin"})
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Nil(t, body)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeFailedPrecondition, oopsErr.Code)
+	require.Equal(t, "plugin is not compatible with Agent Plugins 1.0", oopsErr.Error())
+}
+
+func TestPluginsService_DownloadAgentPluginIsFlatAndKeyless(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	keysBefore := countPluginHooksKeys(t, ctx, ti.conn, authCtx.ActiveOrganizationID)
+
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Portable Download"})
+	require.NoError(t, err)
+	result, body, err := ti.service.DownloadPluginPackage(ctx, &gen.DownloadPluginPackagePayload{PluginID: plugin.ID, Platform: "agent-plugin"})
+	require.NoError(t, err)
+	require.Equal(t, "application/zip", result.ContentType)
+	archive, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.NoError(t, body.Close())
+	require.Equal(t, keysBefore, countPluginHooksKeys(t, ctx, ti.conn, authCtx.ActiveOrganizationID))
+
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	require.NoError(t, err)
+	paths := make([]string, 0, len(zr.File))
+	for _, file := range zr.File {
+		paths = append(paths, file.Name)
+	}
+	require.Equal(t, []string{"mcp.json", "plugin.json"}, paths)
+	require.NotContains(t, string(archive), "Authorization")
+	require.NotContains(t, string(archive), "hooks_api_key")
+}
+
+func TestPluginsService_TombstonedAttachmentIsNotIntended(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Removed Private Server"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "removed-private-server")
+	server, err := ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{PluginID: plugin.ID, ToolsetID: conv.PtrEmpty(toolset.ID.String()), Policy: "required", SortOrder: 0})
+	require.NoError(t, err)
+
+	fetched, err := ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: plugin.ID})
+	require.NoError(t, err)
+	require.False(t, fetched.AgentPluginsV1Compatible)
+
+	require.NoError(t, ti.service.RemovePluginServer(ctx, &gen.RemovePluginServerPayload{ID: server.ID, PluginID: plugin.ID}))
+	fetched, err = ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: plugin.ID})
+	require.NoError(t, err)
+	require.True(t, fetched.AgentPluginsV1Compatible)
+}
+
+func TestPluginsService_McpServerCompatibilityFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	privatePlugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Private MCP Server"})
+	require.NoError(t, err)
+	privateServer := createTestMcpServer(t, ctx, ti.conn, "Private MCP Server", mcpservers.VisibilityPrivate)
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{PluginID: privatePlugin.ID, McpServerID: conv.PtrEmpty(privateServer.idStr), Policy: "required", SortOrder: 0})
+	require.NoError(t, err)
+	privatePlugin, err = ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: privatePlugin.ID})
+	require.NoError(t, err)
+	require.False(t, privatePlugin.AgentPluginsV1Compatible)
+
+	brokenPlugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Broken MCP Backing"})
+	require.NoError(t, err)
+	brokenServer := createTestMcpServer(t, ctx, ti.conn, "Broken MCP Backing", mcpservers.VisibilityPublic)
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{PluginID: brokenPlugin.ID, McpServerID: conv.PtrEmpty(brokenServer.idStr), Policy: "required", SortOrder: 0})
+	require.NoError(t, err)
+	brokenPlugin, err = ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: brokenPlugin.ID})
+	require.NoError(t, err)
+	require.True(t, brokenPlugin.AgentPluginsV1Compatible)
+
+	_, err = toolsetsrepo.New(ti.conn).DeleteToolset(ctx, toolsetsrepo.DeleteToolsetParams{Slug: brokenServer.backingToolsetSlug, ProjectID: *authCtx.ProjectID})
+	require.NoError(t, err)
+	brokenPlugin, err = ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: brokenPlugin.ID})
+	require.NoError(t, err)
+	require.False(t, brokenPlugin.AgentPluginsV1Compatible)
+}
+
+func TestPluginsService_PublishAgentPluginCompatibilityTransitions(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockGitHubPublisher{}
+	ctx, ti := newTestPluginsServiceWithGitHub(t, mock)
+	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Portable Transition"})
+	require.NoError(t, err)
+	toolset := createTestToolset(t, ctx, ti.conn, "portable-transition")
+	err = toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{McpIsPublic: true, ID: toolset.ID, ProjectID: toolset.ProjectID})
+	require.NoError(t, err)
+	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{PluginID: plugin.ID, ToolsetID: conv.PtrEmpty(toolset.ID.String()), Policy: "required", SortOrder: 0})
+	require.NoError(t, err)
+
+	assertSources := func(cursorSource, codexSource string, sharedPackage bool) {
+		t.Helper()
+		var cursor struct {
+			Plugins []struct {
+				Name   string `json:"name"`
+				Source string `json:"source"`
+			} `json:"plugins"`
+		}
+		require.NoError(t, json.Unmarshal(mock.lastPushedFiles[".cursor-plugin/marketplace.json"], &cursor))
+		var codex struct {
+			Plugins []struct {
+				Name   string `json:"name"`
+				Source struct {
+					Path string `json:"path"`
+				} `json:"source"`
+			} `json:"plugins"`
+		}
+		require.NoError(t, json.Unmarshal(mock.lastPushedFiles[".agents/plugins/marketplace.json"], &codex))
+		var actualCursorSource, actualCodexSource string
+		for _, entry := range cursor.Plugins {
+			if entry.Name == "portable-transition-cursor" {
+				actualCursorSource = entry.Source
+			}
+		}
+		for _, entry := range codex.Plugins {
+			if entry.Name == "portable-transition-codex" {
+				actualCodexSource = entry.Source.Path
+			}
+		}
+		require.Equal(t, cursorSource, actualCursorSource)
+		require.Equal(t, codexSource, actualCodexSource)
+		require.Equal(t, sharedPackage, len(filesWithPrefix(mock.lastPushedFiles, "agent-plugins/portable-transition/")) > 0)
+	}
+
+	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
+	require.NoError(t, err)
+	assertSources("agent-plugins/portable-transition", "./agent-plugins/portable-transition", true)
+
+	err = toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{McpIsPublic: false, ID: toolset.ID, ProjectID: toolset.ProjectID})
+	require.NoError(t, err)
+	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
+	require.NoError(t, err)
+	assertSources("cursor-plugins/portable-transition-cursor", "./portable-transition-codex", false)
+
+	err = toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{McpIsPublic: true, ID: toolset.ID, ProjectID: toolset.ProjectID})
+	require.NoError(t, err)
+	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
+	require.NoError(t, err)
+	assertSources("agent-plugins/portable-transition", "./agent-plugins/portable-transition", true)
+}
+
 func TestPluginsService_GetPublishStatus_NotConfigured(t *testing.T) {
 	t.Parallel()
 
@@ -1588,6 +1784,10 @@ func TestPluginsService_PublishPlugins_SkipsDisabledMCPToolsets(t *testing.T) {
 
 	require.Contains(t, cursorConfig.MCPServers, "Server enabled-toolset", "enabled toolset should appear in published config")
 	require.NotContains(t, cursorConfig.MCPServers, "Server disabled-toolset", "disabled toolset must be filtered out by ListPluginsWithServersForProject")
+	fetched, err := ti.service.GetPlugin(ctx, &gen.GetPluginPayload{ID: plugin.ID})
+	require.NoError(t, err)
+	require.False(t, fetched.AgentPluginsV1Compatible, "an active attachment whose backing was disabled must fail closed")
+	require.NotContains(t, mock.lastPushedFiles, "agent-plugins/mixed/plugin.json")
 }
 
 // A public toolset with no mcp_metadata row should publish cleanly. The
@@ -2252,6 +2452,16 @@ func hooksFilesOf(files map[string][]byte) map[string]string {
 	return out
 }
 
+func filesWithPrefix(files map[string][]byte, prefix string) map[string]string {
+	out := make(map[string]string)
+	for p, content := range files {
+		if strings.HasPrefix(p, prefix) {
+			out[p] = string(content)
+		}
+	}
+	return out
+}
+
 // observabilityManifestVersion extracts the version stamped into the pushed
 // Claude observability plugin.json — the value platform marketplaces compare
 // to decide whether installed copies refresh.
@@ -2513,6 +2723,8 @@ func TestPluginsService_PublishProject_RegeneratesHooksOnBrowserLoginFlip(t *tes
 
 	plugin, err := ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Flip Hooks"})
 	require.NoError(t, err)
+	_, err = ti.service.CreatePlugin(ctx, &gen.CreatePluginPayload{Name: "Carry Agent Plugin"})
+	require.NoError(t, err)
 
 	toolset := createTestToolset(t, ctx, ti.conn, "flip-toolset")
 	_, err = ti.service.AddPluginServer(ctx, &gen.AddPluginServerPayload{
@@ -2536,6 +2748,8 @@ func TestPluginsService_PublishProject_RegeneratesHooksOnBrowserLoginFlip(t *tes
 	require.False(t, first.Skipped)
 	hooksBefore := hooksFilesOf(mock.lastPushedFiles)
 	require.NotEmpty(t, hooksBefore)
+	agentPluginBefore := filesWithPrefix(mock.lastPushedFiles, "agent-plugins/carry-agent-plugin/")
+	require.NotEmpty(t, agentPluginBefore)
 	versionBefore := observabilityManifestVersion(t, mock.lastPushedFiles)
 
 	_, pfErr := productfeaturesrepo.New(ti.conn).EnableFeature(ctx, productfeaturesrepo.EnableFeatureParams{
@@ -2552,6 +2766,8 @@ func TestPluginsService_PublishProject_RegeneratesHooksOnBrowserLoginFlip(t *tes
 		"hooks subtree must be regenerated, not carried, after a settings flip")
 	require.NotEqual(t, versionBefore, observabilityManifestVersion(t, mock.lastPushedFiles),
 		"the observability plugin.json version must move on a settings flip, or installed copies never refresh")
+	require.Equal(t, agentPluginBefore, filesWithPrefix(mock.lastPushedFiles, "agent-plugins/carry-agent-plugin/"),
+		"a hooks-only publish must carry the shared feature package byte-for-byte")
 
 	// The regenerated config is persisted, so the next unchanged rollout skips.
 	third, err := ti.service.PublishProject(ctx, input)

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -429,6 +429,12 @@ WITH intended AS (
       WHEN ps.toolset_id IS NOT NULL AND t.project_id <> p.project_id THEN 'toolset_wrong_project'
       WHEN ps.toolset_id IS NOT NULL AND t.deleted IS TRUE THEN 'toolset_deleted'
       WHEN ps.toolset_id IS NOT NULL AND (t.mcp_enabled IS FALSE OR t.mcp_slug IS NULL) THEN 'toolset_disabled_or_unresolved'
+	  WHEN ps.toolset_id IS NOT NULL AND EXISTS (
+		SELECT 1
+		FROM mcp_metadata md
+		JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+		WHERE md.toolset_id = t.id AND md.project_id = p.project_id AND ec.provided_by = 'user'
+	  ) THEN 'toolset_requires_user_header'
       WHEN ps.mcp_server_id IS NOT NULL AND s.id IS NULL THEN 'mcp_server_missing'
       WHEN ps.mcp_server_id IS NOT NULL AND s.project_id <> p.project_id THEN 'mcp_server_wrong_project'
       WHEN ps.mcp_server_id IS NOT NULL AND s.deleted IS TRUE THEN 'mcp_server_deleted'
@@ -494,7 +500,7 @@ WITH intended AS (
 ), unresolved_skills AS (
   SELECT p.id AS plugin_id, sd.id AS server_id, 'skill_distribution_unresolved'::text AS reason
   FROM plugins p
-  JOIN skill_distributions sd ON sd.plugin_id = p.id
+  JOIN skill_distributions sd ON sd.plugin_id = p.id AND sd.project_id = p.project_id
   LEFT JOIN skills sk ON sk.id = sd.skill_id AND sk.project_id = p.project_id AND sk.archived_at IS NULL
   WHERE p.project_id = @project_id
     AND p.deleted IS FALSE

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -95,6 +95,16 @@ WHERE p.organization_id = @organization_id
   AND p.deleted IS FALSE
 ORDER BY p.created_at DESC;
 
+-- name: ListActivePluginsForProject :many
+-- Seeds package resolution with every active plugin so empty plugins are not
+-- omitted merely because they have no server or skill rows.
+SELECT *
+FROM plugins
+WHERE project_id = @project_id
+  AND deleted IS FALSE
+  AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR id = ANY(@plugin_ids::uuid[]))
+ORDER BY slug ASC;
+
 -- name: UpdatePlugin :one
 UPDATE plugins
 SET name = @name,
@@ -313,11 +323,31 @@ SELECT
   cd.domain AS toolset_custom_domain
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
-JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
-LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE AND cd.deleted IS FALSE
+JOIN toolsets t ON t.id = ps.toolset_id AND t.project_id = p.project_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.organization_id = p.organization_id AND cd.activated IS TRUE AND cd.verified IS TRUE AND cd.deleted IS FALSE
 WHERE p.project_id = @project_id
   AND p.deleted IS FALSE
+  AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR p.id = ANY(@plugin_ids::uuid[]))
 ORDER BY p.slug, ps.sort_order ASC;
+
+-- name: ListPluginEnvironmentConfigsForProject :many
+-- Batch companion to ListPluginsWithServersForProject. Keeping environment
+-- config resolution in one query avoids one metadata/config round trip per
+-- public toolset while preserving the same user-provided-header semantics.
+SELECT DISTINCT
+  t.id AS toolset_id,
+  ec.variable_name,
+  ec.header_display_name
+FROM plugin_servers ps
+JOIN plugins p ON p.id = ps.plugin_id AND p.deleted IS FALSE
+JOIN toolsets t ON t.id = ps.toolset_id AND t.project_id = p.project_id AND t.deleted IS FALSE
+JOIN mcp_metadata md ON md.toolset_id = t.id AND md.project_id = p.project_id
+JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+WHERE p.project_id = @project_id
+  AND ps.deleted IS FALSE
+  AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR p.id = ANY(@plugin_ids::uuid[]))
+  AND ec.provided_by = 'user'
+ORDER BY t.id, ec.variable_name ASC;
 
 -- name: ListPluginsWithMcpServersForProject :many
 -- Plugin-generation companion to ListPluginsWithServersForProject covering
@@ -343,6 +373,8 @@ SELECT
   ps.policy AS server_policy,
   ps.sort_order AS server_sort_order,
   ps.mcp_server_id,
+	(s.visibility = 'public')::bool AS mcp_server_is_public,
+	(s.user_session_issuer_id IS NOT NULL)::bool AS mcp_server_is_oauth,
   COALESCE(ep.slug, '') AS endpoint_slug,
   ep.custom_domain AS endpoint_custom_domain,
   ump.url AS unproxied_url
@@ -354,20 +386,138 @@ LEFT JOIN LATERAL (
   FROM mcp_endpoints e
   LEFT JOIN custom_domains cd
     ON cd.id = e.custom_domain_id
+	AND cd.organization_id = p.organization_id
     AND cd.activated IS TRUE
     AND cd.verified IS TRUE
     AND cd.deleted IS FALSE
   WHERE e.mcp_server_id = s.id
+	AND e.project_id = p.project_id
     AND e.deleted IS FALSE
     AND (e.custom_domain_id IS NULL OR cd.id IS NOT NULL)
   ORDER BY (e.custom_domain_id IS NULL) ASC, e.created_at ASC
   LIMIT 1
 ) ep ON TRUE
 LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE
+LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse')
+LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
+LEFT JOIN toolsets mts ON mts.id = s.toolset_id AND mts.project_id = p.project_id AND mts.deleted IS FALSE AND mts.mcp_enabled IS TRUE
 WHERE p.project_id = @project_id
   AND p.deleted IS FALSE
   AND (ep.slug IS NOT NULL OR ump.url IS NOT NULL)
+  AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR p.id = ANY(@plugin_ids::uuid[]))
+  AND (
+    (s.remote_mcp_server_id IS NOT NULL AND rms.id IS NOT NULL)
+    OR (s.tunneled_mcp_server_id IS NOT NULL AND tms.id IS NOT NULL)
+    OR (s.toolset_id IS NOT NULL AND mts.id IS NOT NULL)
+    OR (s.unproxied_mcp_server_id IS NOT NULL AND ump.id IS NOT NULL)
+  )
 ORDER BY p.slug, ps.sort_order ASC;
+
+-- name: ListAgentPluginCompatibilityIssuesForProject :many
+-- Classifies every active intended attachment, including broken references that
+-- the package-resolution queries intentionally omit. A tombstoned attachment
+-- is not intended and is excluded. Any returned row makes its plugin fail
+-- closed for the shared Agent Plugins package while legacy packages continue to
+-- render from the subset that resolves.
+WITH intended AS (
+  SELECT
+    p.id AS plugin_id,
+    ps.id AS server_id,
+    CASE
+      WHEN ps.toolset_id IS NULL AND ps.mcp_server_id IS NULL THEN 'missing_backend'
+      WHEN ps.toolset_id IS NOT NULL AND t.id IS NULL THEN 'toolset_missing'
+      WHEN ps.toolset_id IS NOT NULL AND t.project_id <> p.project_id THEN 'toolset_wrong_project'
+      WHEN ps.toolset_id IS NOT NULL AND t.deleted IS TRUE THEN 'toolset_deleted'
+      WHEN ps.toolset_id IS NOT NULL AND (t.mcp_enabled IS FALSE OR t.mcp_slug IS NULL) THEN 'toolset_disabled_or_unresolved'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.id IS NULL THEN 'mcp_server_missing'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.project_id <> p.project_id THEN 'mcp_server_wrong_project'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.deleted IS TRUE THEN 'mcp_server_deleted'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'disabled' THEN 'mcp_server_disabled'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND (rms.id IS NULL OR rms.project_id <> p.project_id OR rms.deleted IS TRUE) THEN 'remote_backing_unresolved'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND rms.transport_type NOT IN ('streamable-http', 'sse') THEN 'remote_transport_unsupported'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND EXISTS (
+		SELECT 1 FROM remote_mcp_server_headers rmh
+		WHERE rmh.remote_mcp_server_id = rms.id AND rmh.deleted IS FALSE AND rmh.value_from_request_header IS NOT NULL
+	  ) THEN 'remote_backing_requires_user_header'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.tunneled_mcp_server_id IS NOT NULL AND (tms.id IS NULL OR tms.project_id <> p.project_id OR tms.deleted IS TRUE OR tms.status = 'revoked') THEN 'tunneled_backing_unresolved'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.tunneled_mcp_server_id IS NOT NULL AND s.visibility = 'public' AND tms.allow_public IS FALSE THEN 'tunneled_public_consent_missing'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.tunneled_mcp_server_id IS NOT NULL AND EXISTS (
+		SELECT 1 FROM tunneled_mcp_server_headers tmh
+		WHERE tmh.tunneled_mcp_server_id = tms.id AND tmh.deleted IS FALSE AND tmh.value_from_request_header IS NOT NULL
+	  ) THEN 'tunneled_backing_requires_user_header'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.toolset_id IS NOT NULL AND (mts.id IS NULL OR mts.project_id <> p.project_id OR mts.deleted IS TRUE OR mts.mcp_enabled IS FALSE) THEN 'toolset_backing_unresolved'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.toolset_id IS NOT NULL AND s.visibility = 'public' AND mts.mcp_is_public IS FALSE THEN 'toolset_backing_auth_mismatch'
+	  WHEN ps.mcp_server_id IS NOT NULL AND EXISTS (
+		SELECT 1
+		FROM mcp_metadata md
+		JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+		WHERE md.mcp_server_id = s.id AND md.project_id = p.project_id AND ec.provided_by = 'user'
+	  ) THEN 'mcp_server_requires_user_header'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.toolset_id IS NOT NULL AND EXISTS (
+		SELECT 1
+		FROM mcp_metadata md
+		JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+		WHERE md.toolset_id = mts.id AND md.project_id = p.project_id AND ec.provided_by = 'user'
+	  ) THEN 'toolset_backing_requires_user_header'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.unproxied_mcp_server_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM unproxied_mcp_servers ump
+        WHERE ump.id = s.unproxied_mcp_server_id
+          AND ump.project_id = p.project_id
+          AND ump.deleted IS FALSE
+      ) THEN 'unproxied_backing_unresolved'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.unproxied_mcp_server_id IS NULL AND NOT EXISTS (
+        SELECT 1
+        FROM mcp_endpoints e
+        LEFT JOIN custom_domains cd
+          ON cd.id = e.custom_domain_id
+		  AND cd.organization_id = p.organization_id
+          AND cd.activated IS TRUE
+          AND cd.verified IS TRUE
+          AND cd.deleted IS FALSE
+        WHERE e.mcp_server_id = s.id
+		  AND e.project_id = p.project_id
+          AND e.deleted IS FALSE
+          AND (e.custom_domain_id IS NULL OR cd.id IS NOT NULL)
+      ) THEN 'mcp_server_endpoint_unresolved'
+    END::text AS reason
+  FROM plugins p
+  JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
+  LEFT JOIN toolsets t ON t.id = ps.toolset_id
+  LEFT JOIN mcp_servers s ON s.id = ps.mcp_server_id
+  LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id
+  LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id
+  LEFT JOIN toolsets mts ON mts.id = s.toolset_id
+  WHERE p.project_id = @project_id
+    AND p.deleted IS FALSE
+	AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR p.id = ANY(@plugin_ids::uuid[]))
+), unresolved_skills AS (
+  SELECT p.id AS plugin_id, sd.id AS server_id, 'skill_distribution_unresolved'::text AS reason
+  FROM plugins p
+  JOIN skill_distributions sd ON sd.plugin_id = p.id
+  LEFT JOIN skills sk ON sk.id = sd.skill_id AND sk.project_id = p.project_id AND sk.archived_at IS NULL
+  WHERE p.project_id = @project_id
+    AND p.deleted IS FALSE
+    AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR p.id = ANY(@plugin_ids::uuid[]))
+    AND sd.channel = 'plugin'
+    AND sd.assistant_id IS NULL
+    AND sd.revoked_at IS NULL
+    AND (
+      sk.id IS NULL
+      OR NOT EXISTS (
+        SELECT 1 FROM skill_versions sv
+        WHERE sv.skill_id = sd.skill_id
+          AND sv.spec_valid IS TRUE
+          AND (sd.pinned_version_id IS NULL OR sv.id = sd.pinned_version_id)
+      )
+    )
+)
+SELECT plugin_id, server_id, reason
+FROM intended
+WHERE reason IS NOT NULL
+UNION ALL
+SELECT plugin_id, server_id, reason FROM unresolved_skills
+ORDER BY plugin_id, server_id;
 
 -- name: GetOrganizationName :one
 SELECT name FROM organization_metadata WHERE id = @id;
@@ -607,6 +757,7 @@ JOIN LATERAL (
   LIMIT 1
 ) resolved ON TRUE
 WHERE sd.project_id = @project_id
+	AND (COALESCE(cardinality(@plugin_ids::uuid[]), 0) = 0 OR p.id = ANY(@plugin_ids::uuid[]))
   AND sd.channel = 'plugin'
   AND sd.plugin_id IS NOT NULL
   AND sd.assistant_id IS NULL

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -570,6 +570,192 @@ func (q *Queries) IsOrganizationFeatureEnabled(ctx context.Context, arg IsOrgani
 	return enabled, err
 }
 
+const listActivePluginsForProject = `-- name: ListActivePluginsForProject :many
+SELECT id, organization_id, project_id, name, slug, description, is_default, created_at, updated_at, deleted_at, deleted
+FROM plugins
+WHERE project_id = $1
+  AND deleted IS FALSE
+  AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR id = ANY($2::uuid[]))
+ORDER BY slug ASC
+`
+
+type ListActivePluginsForProjectParams struct {
+	ProjectID uuid.UUID
+	PluginIds []uuid.UUID
+}
+
+// Seeds package resolution with every active plugin so empty plugins are not
+// omitted merely because they have no server or skill rows.
+func (q *Queries) ListActivePluginsForProject(ctx context.Context, arg ListActivePluginsForProjectParams) ([]Plugin, error) {
+	rows, err := q.db.Query(ctx, listActivePluginsForProject, arg.ProjectID, arg.PluginIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Plugin
+	for rows.Next() {
+		var i Plugin
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.ProjectID,
+			&i.Name,
+			&i.Slug,
+			&i.Description,
+			&i.IsDefault,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAgentPluginCompatibilityIssuesForProject = `-- name: ListAgentPluginCompatibilityIssuesForProject :many
+WITH intended AS (
+  SELECT
+    p.id AS plugin_id,
+    ps.id AS server_id,
+    CASE
+      WHEN ps.toolset_id IS NULL AND ps.mcp_server_id IS NULL THEN 'missing_backend'
+      WHEN ps.toolset_id IS NOT NULL AND t.id IS NULL THEN 'toolset_missing'
+      WHEN ps.toolset_id IS NOT NULL AND t.project_id <> p.project_id THEN 'toolset_wrong_project'
+      WHEN ps.toolset_id IS NOT NULL AND t.deleted IS TRUE THEN 'toolset_deleted'
+      WHEN ps.toolset_id IS NOT NULL AND (t.mcp_enabled IS FALSE OR t.mcp_slug IS NULL) THEN 'toolset_disabled_or_unresolved'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.id IS NULL THEN 'mcp_server_missing'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.project_id <> p.project_id THEN 'mcp_server_wrong_project'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.deleted IS TRUE THEN 'mcp_server_deleted'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.visibility = 'disabled' THEN 'mcp_server_disabled'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND (rms.id IS NULL OR rms.project_id <> p.project_id OR rms.deleted IS TRUE) THEN 'remote_backing_unresolved'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND rms.transport_type NOT IN ('streamable-http', 'sse') THEN 'remote_transport_unsupported'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.remote_mcp_server_id IS NOT NULL AND EXISTS (
+		SELECT 1 FROM remote_mcp_server_headers rmh
+		WHERE rmh.remote_mcp_server_id = rms.id AND rmh.deleted IS FALSE AND rmh.value_from_request_header IS NOT NULL
+	  ) THEN 'remote_backing_requires_user_header'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.tunneled_mcp_server_id IS NOT NULL AND (tms.id IS NULL OR tms.project_id <> p.project_id OR tms.deleted IS TRUE OR tms.status = 'revoked') THEN 'tunneled_backing_unresolved'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.tunneled_mcp_server_id IS NOT NULL AND s.visibility = 'public' AND tms.allow_public IS FALSE THEN 'tunneled_public_consent_missing'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.tunneled_mcp_server_id IS NOT NULL AND EXISTS (
+		SELECT 1 FROM tunneled_mcp_server_headers tmh
+		WHERE tmh.tunneled_mcp_server_id = tms.id AND tmh.deleted IS FALSE AND tmh.value_from_request_header IS NOT NULL
+	  ) THEN 'tunneled_backing_requires_user_header'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.toolset_id IS NOT NULL AND (mts.id IS NULL OR mts.project_id <> p.project_id OR mts.deleted IS TRUE OR mts.mcp_enabled IS FALSE) THEN 'toolset_backing_unresolved'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.toolset_id IS NOT NULL AND s.visibility = 'public' AND mts.mcp_is_public IS FALSE THEN 'toolset_backing_auth_mismatch'
+	  WHEN ps.mcp_server_id IS NOT NULL AND EXISTS (
+		SELECT 1
+		FROM mcp_metadata md
+		JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+		WHERE md.mcp_server_id = s.id AND md.project_id = p.project_id AND ec.provided_by = 'user'
+	  ) THEN 'mcp_server_requires_user_header'
+	  WHEN ps.mcp_server_id IS NOT NULL AND s.toolset_id IS NOT NULL AND EXISTS (
+		SELECT 1
+		FROM mcp_metadata md
+		JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+		WHERE md.toolset_id = mts.id AND md.project_id = p.project_id AND ec.provided_by = 'user'
+	  ) THEN 'toolset_backing_requires_user_header'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.unproxied_mcp_server_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM unproxied_mcp_servers ump
+        WHERE ump.id = s.unproxied_mcp_server_id
+          AND ump.project_id = p.project_id
+          AND ump.deleted IS FALSE
+      ) THEN 'unproxied_backing_unresolved'
+      WHEN ps.mcp_server_id IS NOT NULL AND s.unproxied_mcp_server_id IS NULL AND NOT EXISTS (
+        SELECT 1
+        FROM mcp_endpoints e
+        LEFT JOIN custom_domains cd
+          ON cd.id = e.custom_domain_id
+		  AND cd.organization_id = p.organization_id
+          AND cd.activated IS TRUE
+          AND cd.verified IS TRUE
+          AND cd.deleted IS FALSE
+        WHERE e.mcp_server_id = s.id
+		  AND e.project_id = p.project_id
+          AND e.deleted IS FALSE
+          AND (e.custom_domain_id IS NULL OR cd.id IS NOT NULL)
+      ) THEN 'mcp_server_endpoint_unresolved'
+    END::text AS reason
+  FROM plugins p
+  JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
+  LEFT JOIN toolsets t ON t.id = ps.toolset_id
+  LEFT JOIN mcp_servers s ON s.id = ps.mcp_server_id
+  LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id
+  LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id
+  LEFT JOIN toolsets mts ON mts.id = s.toolset_id
+  WHERE p.project_id = $1
+    AND p.deleted IS FALSE
+	AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR p.id = ANY($2::uuid[]))
+), unresolved_skills AS (
+  SELECT p.id AS plugin_id, sd.id AS server_id, 'skill_distribution_unresolved'::text AS reason
+  FROM plugins p
+  JOIN skill_distributions sd ON sd.plugin_id = p.id
+  LEFT JOIN skills sk ON sk.id = sd.skill_id AND sk.project_id = p.project_id AND sk.archived_at IS NULL
+  WHERE p.project_id = $1
+    AND p.deleted IS FALSE
+    AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR p.id = ANY($2::uuid[]))
+    AND sd.channel = 'plugin'
+    AND sd.assistant_id IS NULL
+    AND sd.revoked_at IS NULL
+    AND (
+      sk.id IS NULL
+      OR NOT EXISTS (
+        SELECT 1 FROM skill_versions sv
+        WHERE sv.skill_id = sd.skill_id
+          AND sv.spec_valid IS TRUE
+          AND (sd.pinned_version_id IS NULL OR sv.id = sd.pinned_version_id)
+      )
+    )
+)
+SELECT plugin_id, server_id, reason
+FROM intended
+WHERE reason IS NOT NULL
+UNION ALL
+SELECT plugin_id, server_id, reason FROM unresolved_skills
+ORDER BY plugin_id, server_id
+`
+
+type ListAgentPluginCompatibilityIssuesForProjectParams struct {
+	ProjectID uuid.UUID
+	PluginIds []uuid.UUID
+}
+
+type ListAgentPluginCompatibilityIssuesForProjectRow struct {
+	PluginID uuid.UUID
+	ServerID uuid.UUID
+	Reason   string
+}
+
+// Classifies every active intended attachment, including broken references that
+// the package-resolution queries intentionally omit. A tombstoned attachment
+// is not intended and is excluded. Any returned row makes its plugin fail
+// closed for the shared Agent Plugins package while legacy packages continue to
+// render from the subset that resolves.
+func (q *Queries) ListAgentPluginCompatibilityIssuesForProject(ctx context.Context, arg ListAgentPluginCompatibilityIssuesForProjectParams) ([]ListAgentPluginCompatibilityIssuesForProjectRow, error) {
+	rows, err := q.db.Query(ctx, listAgentPluginCompatibilityIssuesForProject, arg.ProjectID, arg.PluginIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAgentPluginCompatibilityIssuesForProjectRow
+	for rows.Next() {
+		var i ListAgentPluginCompatibilityIssuesForProjectRow
+		if err := rows.Scan(&i.PluginID, &i.ServerID, &i.Reason); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listOrgPluginPublishTargets = `-- name: ListOrgPluginPublishTargets :many
 SELECT
   c.project_id,
@@ -643,6 +829,57 @@ func (q *Queries) ListPluginAssignments(ctx context.Context, pluginID uuid.UUID)
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPluginEnvironmentConfigsForProject = `-- name: ListPluginEnvironmentConfigsForProject :many
+SELECT DISTINCT
+  t.id AS toolset_id,
+  ec.variable_name,
+  ec.header_display_name
+FROM plugin_servers ps
+JOIN plugins p ON p.id = ps.plugin_id AND p.deleted IS FALSE
+JOIN toolsets t ON t.id = ps.toolset_id AND t.project_id = p.project_id AND t.deleted IS FALSE
+JOIN mcp_metadata md ON md.toolset_id = t.id AND md.project_id = p.project_id
+JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+WHERE p.project_id = $1
+  AND ps.deleted IS FALSE
+  AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR p.id = ANY($2::uuid[]))
+  AND ec.provided_by = 'user'
+ORDER BY t.id, ec.variable_name ASC
+`
+
+type ListPluginEnvironmentConfigsForProjectParams struct {
+	ProjectID uuid.UUID
+	PluginIds []uuid.UUID
+}
+
+type ListPluginEnvironmentConfigsForProjectRow struct {
+	ToolsetID         uuid.UUID
+	VariableName      string
+	HeaderDisplayName pgtype.Text
+}
+
+// Batch companion to ListPluginsWithServersForProject. Keeping environment
+// config resolution in one query avoids one metadata/config round trip per
+// public toolset while preserving the same user-provided-header semantics.
+func (q *Queries) ListPluginEnvironmentConfigsForProject(ctx context.Context, arg ListPluginEnvironmentConfigsForProjectParams) ([]ListPluginEnvironmentConfigsForProjectRow, error) {
+	rows, err := q.db.Query(ctx, listPluginEnvironmentConfigsForProject, arg.ProjectID, arg.PluginIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPluginEnvironmentConfigsForProjectRow
+	for rows.Next() {
+		var i ListPluginEnvironmentConfigsForProjectRow
+		if err := rows.Scan(&i.ToolsetID, &i.VariableName, &i.HeaderDisplayName); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -846,12 +1083,18 @@ JOIN LATERAL (
   LIMIT 1
 ) resolved ON TRUE
 WHERE sd.project_id = $1
+	AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR p.id = ANY($2::uuid[]))
   AND sd.channel = 'plugin'
   AND sd.plugin_id IS NOT NULL
   AND sd.assistant_id IS NULL
   AND sd.revoked_at IS NULL
 ORDER BY p.slug ASC, s.name ASC
 `
+
+type ListPluginSkillsForProjectParams struct {
+	ProjectID uuid.UUID
+	PluginIds []uuid.UUID
+}
 
 type ListPluginSkillsForProjectRow struct {
 	PluginID          uuid.UUID
@@ -868,8 +1111,8 @@ type ListPluginSkillsForProjectRow struct {
 // latest valid version). Distributions with no valid resolvable version are
 // dropped — packages only ever carry valid manifests. Plugin identity is
 // selected here so a skills-only plugin (no servers) still generates a package.
-func (q *Queries) ListPluginSkillsForProject(ctx context.Context, projectID uuid.UUID) ([]ListPluginSkillsForProjectRow, error) {
-	rows, err := q.db.Query(ctx, listPluginSkillsForProject, projectID)
+func (q *Queries) ListPluginSkillsForProject(ctx context.Context, arg ListPluginSkillsForProjectParams) ([]ListPluginSkillsForProjectRow, error) {
+	rows, err := q.db.Query(ctx, listPluginSkillsForProject, arg.ProjectID, arg.PluginIds)
 	if err != nil {
 		return nil, err
 	}
@@ -995,6 +1238,8 @@ SELECT
   ps.policy AS server_policy,
   ps.sort_order AS server_sort_order,
   ps.mcp_server_id,
+	(s.visibility = 'public')::bool AS mcp_server_is_public,
+	(s.user_session_issuer_id IS NOT NULL)::bool AS mcp_server_is_oauth,
   COALESCE(ep.slug, '') AS endpoint_slug,
   ep.custom_domain AS endpoint_custom_domain,
   ump.url AS unproxied_url
@@ -1006,21 +1251,38 @@ LEFT JOIN LATERAL (
   FROM mcp_endpoints e
   LEFT JOIN custom_domains cd
     ON cd.id = e.custom_domain_id
+	AND cd.organization_id = p.organization_id
     AND cd.activated IS TRUE
     AND cd.verified IS TRUE
     AND cd.deleted IS FALSE
   WHERE e.mcp_server_id = s.id
+	AND e.project_id = p.project_id
     AND e.deleted IS FALSE
     AND (e.custom_domain_id IS NULL OR cd.id IS NOT NULL)
   ORDER BY (e.custom_domain_id IS NULL) ASC, e.created_at ASC
   LIMIT 1
 ) ep ON TRUE
 LEFT JOIN unproxied_mcp_servers ump ON ump.id = s.unproxied_mcp_server_id AND ump.project_id = p.project_id AND ump.deleted IS FALSE
+LEFT JOIN remote_mcp_servers rms ON rms.id = s.remote_mcp_server_id AND rms.project_id = p.project_id AND rms.deleted IS FALSE AND rms.transport_type IN ('streamable-http', 'sse')
+LEFT JOIN tunneled_mcp_servers tms ON tms.id = s.tunneled_mcp_server_id AND tms.project_id = p.project_id AND tms.deleted IS FALSE AND tms.status <> 'revoked' AND (s.visibility <> 'public' OR tms.allow_public IS TRUE)
+LEFT JOIN toolsets mts ON mts.id = s.toolset_id AND mts.project_id = p.project_id AND mts.deleted IS FALSE AND mts.mcp_enabled IS TRUE
 WHERE p.project_id = $1
   AND p.deleted IS FALSE
   AND (ep.slug IS NOT NULL OR ump.url IS NOT NULL)
+  AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR p.id = ANY($2::uuid[]))
+  AND (
+    (s.remote_mcp_server_id IS NOT NULL AND rms.id IS NOT NULL)
+    OR (s.tunneled_mcp_server_id IS NOT NULL AND tms.id IS NOT NULL)
+    OR (s.toolset_id IS NOT NULL AND mts.id IS NOT NULL)
+    OR (s.unproxied_mcp_server_id IS NOT NULL AND ump.id IS NOT NULL)
+  )
 ORDER BY p.slug, ps.sort_order ASC
 `
+
+type ListPluginsWithMcpServersForProjectParams struct {
+	ProjectID uuid.UUID
+	PluginIds []uuid.UUID
+}
 
 type ListPluginsWithMcpServersForProjectRow struct {
 	PluginID             uuid.UUID
@@ -1032,6 +1294,8 @@ type ListPluginsWithMcpServersForProjectRow struct {
 	ServerPolicy         string
 	ServerSortOrder      int32
 	McpServerID          uuid.NullUUID
+	McpServerIsPublic    bool
+	McpServerIsOauth     bool
 	EndpointSlug         string
 	EndpointCustomDomain pgtype.Text
 	UnproxiedUrl         pgtype.Text
@@ -1050,8 +1314,8 @@ type ListPluginsWithMcpServersForProjectRow struct {
 // usable endpoint nor an unproxied backing are dropped.
 // Scoped to project_id; the mcp_server must live in the same project as the
 // plugin, and disabled servers are excluded.
-func (q *Queries) ListPluginsWithMcpServersForProject(ctx context.Context, projectID uuid.UUID) ([]ListPluginsWithMcpServersForProjectRow, error) {
-	rows, err := q.db.Query(ctx, listPluginsWithMcpServersForProject, projectID)
+func (q *Queries) ListPluginsWithMcpServersForProject(ctx context.Context, arg ListPluginsWithMcpServersForProjectParams) ([]ListPluginsWithMcpServersForProjectRow, error) {
+	rows, err := q.db.Query(ctx, listPluginsWithMcpServersForProject, arg.ProjectID, arg.PluginIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,6 +1333,8 @@ func (q *Queries) ListPluginsWithMcpServersForProject(ctx context.Context, proje
 			&i.ServerPolicy,
 			&i.ServerSortOrder,
 			&i.McpServerID,
+			&i.McpServerIsPublic,
+			&i.McpServerIsOauth,
 			&i.EndpointSlug,
 			&i.EndpointCustomDomain,
 			&i.UnproxiedUrl,
@@ -1100,12 +1366,18 @@ SELECT
   cd.domain AS toolset_custom_domain
 FROM plugins p
 JOIN plugin_servers ps ON ps.plugin_id = p.id AND ps.deleted IS FALSE
-JOIN toolsets t ON t.id = ps.toolset_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
-LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.activated IS TRUE AND cd.verified IS TRUE AND cd.deleted IS FALSE
+JOIN toolsets t ON t.id = ps.toolset_id AND t.project_id = p.project_id AND t.deleted IS FALSE AND t.mcp_enabled IS TRUE
+LEFT JOIN custom_domains cd ON cd.id = t.custom_domain_id AND cd.organization_id = p.organization_id AND cd.activated IS TRUE AND cd.verified IS TRUE AND cd.deleted IS FALSE
 WHERE p.project_id = $1
   AND p.deleted IS FALSE
+  AND (COALESCE(cardinality($2::uuid[]), 0) = 0 OR p.id = ANY($2::uuid[]))
 ORDER BY p.slug, ps.sort_order ASC
 `
+
+type ListPluginsWithServersForProjectParams struct {
+	ProjectID uuid.UUID
+	PluginIds []uuid.UUID
+}
 
 type ListPluginsWithServersForProjectRow struct {
 	PluginID            uuid.UUID
@@ -1125,8 +1397,8 @@ type ListPluginsWithServersForProjectRow struct {
 
 // Used during plugin generation: returns all active plugin servers joined with
 // their parent plugin and toolset mcp_slug for URL construction.
-func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, projectID uuid.UUID) ([]ListPluginsWithServersForProjectRow, error) {
-	rows, err := q.db.Query(ctx, listPluginsWithServersForProject, projectID)
+func (q *Queries) ListPluginsWithServersForProject(ctx context.Context, arg ListPluginsWithServersForProjectParams) ([]ListPluginsWithServersForProjectRow, error) {
+	rows, err := q.db.Query(ctx, listPluginsWithServersForProject, arg.ProjectID, arg.PluginIds)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -629,6 +629,12 @@ WITH intended AS (
       WHEN ps.toolset_id IS NOT NULL AND t.project_id <> p.project_id THEN 'toolset_wrong_project'
       WHEN ps.toolset_id IS NOT NULL AND t.deleted IS TRUE THEN 'toolset_deleted'
       WHEN ps.toolset_id IS NOT NULL AND (t.mcp_enabled IS FALSE OR t.mcp_slug IS NULL) THEN 'toolset_disabled_or_unresolved'
+	  WHEN ps.toolset_id IS NOT NULL AND EXISTS (
+		SELECT 1
+		FROM mcp_metadata md
+		JOIN mcp_environment_configs ec ON ec.mcp_metadata_id = md.id AND ec.project_id = p.project_id
+		WHERE md.toolset_id = t.id AND md.project_id = p.project_id AND ec.provided_by = 'user'
+	  ) THEN 'toolset_requires_user_header'
       WHEN ps.mcp_server_id IS NOT NULL AND s.id IS NULL THEN 'mcp_server_missing'
       WHEN ps.mcp_server_id IS NOT NULL AND s.project_id <> p.project_id THEN 'mcp_server_wrong_project'
       WHEN ps.mcp_server_id IS NOT NULL AND s.deleted IS TRUE THEN 'mcp_server_deleted'
@@ -694,7 +700,7 @@ WITH intended AS (
 ), unresolved_skills AS (
   SELECT p.id AS plugin_id, sd.id AS server_id, 'skill_distribution_unresolved'::text AS reason
   FROM plugins p
-  JOIN skill_distributions sd ON sd.plugin_id = p.id
+  JOIN skill_distributions sd ON sd.plugin_id = p.id AND sd.project_id = p.project_id
   LEFT JOIN skills sk ON sk.id = sd.skill_id AND sk.project_id = p.project_id AND sk.archived_at IS NULL
   WHERE p.project_id = $1
     AND p.deleted IS FALSE

--- a/server/internal/plugins/setup_test.go
+++ b/server/internal/plugins/setup_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
@@ -316,11 +317,12 @@ func createTestToolset(t *testing.T, ctx context.Context, conn *pgxpool.Pool, na
 // server stands in for a Remote MCP-backed one without the remote_mcp_server /
 // user_session_issuer fixture weight.
 type mcpServerFixture struct {
-	id           uuid.UUID
-	idStr        string
-	name         string
-	slug         string
-	endpointSlug string
+	id                 uuid.UUID
+	idStr              string
+	name               string
+	slug               string
+	endpointSlug       string
+	backingToolsetSlug string
 }
 
 // createTestMcpServer creates an mcp_server in the active project with a single
@@ -340,6 +342,10 @@ func createTestMcpServerWithEndpoint(t *testing.T, ctx context.Context, conn *pg
 	// Back the mcp_server with a toolset to satisfy the backend-exclusivity
 	// check; the plugin path does not distinguish remote- vs toolset-backed.
 	backing := createTestToolset(t, ctx, conn, name+"-backing")
+	if visibility == mcpservers.VisibilityPublic {
+		err := toolsetsrepo.New(conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{McpIsPublic: true, ID: backing.ID, ProjectID: backing.ProjectID})
+		require.NoError(t, err)
+	}
 
 	slug := fmt.Sprintf("mcp-%s-%s", name, uuid.New().String()[:8])
 	serverID := uuid.New()
@@ -354,7 +360,7 @@ func createTestMcpServerWithEndpoint(t *testing.T, ctx context.Context, conn *pg
 	})
 	require.NoError(t, err)
 
-	fixture := mcpServerFixture{id: serverID, idStr: serverID.String(), name: name, slug: slug}
+	fixture := mcpServerFixture{id: serverID, idStr: serverID.String(), name: name, slug: slug, backingToolsetSlug: backing.Slug}
 
 	if withEndpoint {
 		endpointSlug := slug + "-endpoint"

--- a/server/internal/plugins/skill_distributions_test.go
+++ b/server/internal/plugins/skill_distributions_test.go
@@ -163,7 +163,7 @@ func TestListPluginSkillsForProjectResolvesContent(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	rows, err := pluginsrepo.New(ti.conn).ListPluginSkillsForProject(ctx, projectID)
+	rows, err := pluginsrepo.New(ti.conn).ListPluginSkillsForProject(ctx, pluginsrepo.ListPluginSkillsForProjectParams{ProjectID: projectID, PluginIds: nil})
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	require.Equal(t, "pinned", rows[0].SkillName)

--- a/server/internal/skills/restore_version_test.go
+++ b/server/internal/skills/restore_version_test.go
@@ -96,7 +96,7 @@ func TestRestoreSkillVersionUpdatesCurrentResolversWithoutMovingPins(t *testing.
 	}
 	require.Equal(t, first.Version.ID, resolvedByPlugin[trackedPlugin.ID.String()])
 	require.Equal(t, third.Version.ID, resolvedByPlugin[pinnedPlugin.ID.String()])
-	pluginSkills, err := pluginsrepo.New(ti.conn).ListPluginSkillsForProject(ctx, ti.projectID)
+	pluginSkills, err := pluginsrepo.New(ti.conn).ListPluginSkillsForProject(ctx, pluginsrepo.ListPluginSkillsForProjectParams{ProjectID: ti.projectID, PluginIds: nil})
 	require.NoError(t, err)
 	contentByPlugin := map[uuid.UUID]string{}
 	for _, row := range pluginSkills {
@@ -246,7 +246,7 @@ func TestRestoreSkillVersionPromotesCurrentCapturedTargetToManual(t *testing.T) 
 	runtimeVersionID, err = ti.repo.GetLatestValidSkillVersion(ctx, repo.GetLatestValidSkillVersionParams{ProjectID: ti.projectID, SkillID: captured.SkillID})
 	require.NoError(t, err)
 	require.Equal(t, captured.SkillVersionID, runtimeVersionID)
-	pluginSkills, err := pluginsrepo.New(ti.conn).ListPluginSkillsForProject(ctx, ti.projectID)
+	pluginSkills, err := pluginsrepo.New(ti.conn).ListPluginSkillsForProject(ctx, pluginsrepo.ListPluginSkillsForProjectParams{ProjectID: ti.projectID, PluginIds: nil})
 	require.NoError(t, err)
 	require.Len(t, pluginSkills, 1)
 	require.Equal(t, capturedManifest("restore-current-captured", "Captured.", "captured"), pluginSkills[0].SkillContent)


### PR DESCRIPTION
## Summary

- publish compatible Cursor and Codex plugins from one Agent Plugins 1.0 hybrid package while retaining native fallbacks
- compute fail-closed compatibility from complete plugin state and expose it through plugin APIs
- add credential-free portable ZIP downloads with pinned schema validation and a stable failed-precondition response

Closes [DNO-790](https://linear.app/speakeasy/issue/DNO-790/feat-publish-shared-agent-plugins-10-packages-for-cursor-and-codex)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a single Agent Plugins 1.0 package per plugin that works in both Cursor and Codex while keeping native fallbacks. Adds fail-closed compatibility with 412 handling, exposes it on plugin APIs, and tightens portability checks. Implements DNO-790.

- **New Features**
  - Generate one shared hybrid package with minimal Cursor/Codex overlays; marketplace entries stay stable.
  - Compute compatibility from full plugin state; use the same result for list/get, publishing, and downloads.
  - Expose `agent_plugins_v1_compatible` on plugin list/get responses.
  - Add direct download support for `platform=agent-plugin`; returns a flat ZIP on success or `failed_precondition (412)` when incompatible.
  - Validate manifests against pinned Agent Plugins 1.0 schemas and enforce stricter portability rules for URLs, transports, headers, and credentials; OpenAPI/SDK updated (includes 412 handling).

- **Migration**
  - No user action for existing Cursor/Codex installs; entries keep the same identity.
  - API consumers should read `agent_plugins_v1_compatible` and handle `failed_precondition (412)` for downloads.
  - Use `platform=agent-plugin` to fetch the portable ZIP.

<sup>Written for commit f1a00dabdbf2f37ca538ba71ecc89384026cb258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

