### PR TITLE
feat: brand rainbow edge treatment for project assistant card

### DIFF
--- a/client/dashboard/src/lib/brand-mesh.ts
+++ b/client/dashboard/src/lib/brand-mesh.ts
@@ -1,0 +1,20 @@
+/**
+ * Brand-rainbow edge affordance for the project home assistant card: the
+ * full tech-color rainbow (--gradient-brand-primary in base.css) run along a
+ * diagonal, then masked so it only breathes in from the top-right corner —
+ * an accent on the card's edge, not a background. The surface itself stays a
+ * neutral theme-following gradient.
+ */
+export const RAINBOW_EDGE_GRADIENT =
+  "linear-gradient(230deg, #99c2ff 0%, #2874d7 7%, #00143d 14%, #002414 21%, #59824f 28%, #d3dd92 35%, #fb8841 42%, #c83228 49%, #330f1f 56%, rgba(51,15,31,0) 70%)";
+
+/** Confines the rainbow to the top-right corner, dissolving inward. */
+export const RAINBOW_EDGE_MASK =
+  "radial-gradient(85% 120% at 100% 0%, #000 0%, rgba(0,0,0,0.6) 40%, transparent 72%)";
+
+/**
+ * Film grain laid over the mesh — an inline SVG turbulence tile, so no
+ * network request and no image asset. Blended and heavily faded; texture only.
+ */
+export const GRAIN_TEXTURE_URL =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E\")";

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -232,8 +232,9 @@ export function ChatLanding({
       <div className="flex flex-col gap-4">
         <h1
           className={cn(
-            "text-foreground font-display font-thin",
+            "font-display font-thin",
             compact ? "text-2xl" : "text-4xl",
+            "text-foreground",
           )}
         >
           {greetingLead}{" "}
@@ -252,7 +253,7 @@ export function ChatLanding({
               e.preventDefault();
               submit();
             }}
-            className="border-border bg-card focus-within:border-foreground/30 relative border px-4 py-3 transition-colors"
+            className="border-border bg-card focus-within:border-foreground relative border px-4 py-3 transition-colors"
           >
             <input
               value={value}
@@ -744,7 +745,7 @@ function RecentRow({
   // container (not a Link) so the pin button isn't nested inside an anchor; the
   // Link covers the icon + title, and the pin button is a sibling action.
   return (
-    <div className="group/row hover:bg-accent flex items-center gap-3 px-3 py-1.5 transition-colors">
+    <div className="group/row hover:border-foreground flex items-center gap-3 border border-transparent px-3 py-1.5 transition-colors">
       <Link
         to={routes.chat.conversation.href(chat.id)}
         className="flex min-w-0 flex-1 items-center gap-3"
@@ -843,7 +844,7 @@ function ChatHomeSuggestions({
               key={suggestion.title}
               type="button"
               onClick={(event) => launchChat(suggestion, event.currentTarget)}
-              className="border-border bg-card text-foreground hover:bg-accent hover:text-accent-foreground flex items-center gap-2 border px-3 py-2 text-sm transition-colors"
+              className="border-border bg-card text-foreground hover:border-foreground flex items-center gap-2 border px-3 py-2 text-sm transition-colors"
             >
               <SuggestionIcon className="size-4 shrink-0" />
               {suggestion.title}

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -2,6 +2,11 @@ import { useHideInsightsDock } from "@/components/insights-context";
 import { Page } from "@/components/page-layout";
 import { ProjectDashboard } from "@/components/project/ProjectDashboard";
 import { RequireScope } from "@/components/require-scope";
+import {
+  GRAIN_TEXTURE_URL,
+  RAINBOW_EDGE_GRADIENT,
+  RAINBOW_EDGE_MASK,
+} from "@/lib/brand-mesh";
 import { ChatLanding } from "@/pages/chat/Chat";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useRoutes } from "@/routes";
@@ -33,14 +38,31 @@ export default function Home(): JSX.Element {
               below (the /chat page centers it; the home page does not). The
               compact variant drops pinned/recents — history lives on /chat. */}
           <div className="w-full pt-2 pb-6">
-            {/* A surface one step off the page background, tinted by a faint
-                mesh and a whisper of grain — present, but low contrast. */}
+            {/* Neutral theme-following gradient surface with the brand
+                rainbow breathing in from the top-right corner as an edge
+                affordance, and film grain throughout. */}
             {/* No `overflow-hidden` here — it would clip the composer's slash
-                menu. The decorative layers round themselves instead. */}
+                menu. The decorative layers clip themselves instead. */}
             {/* `z-10` lifts the card's stacking context above the dashboard
                 below, so the slash menu overlays it instead of the other way
                 round. */}
-            <div className="bg-card border-border relative isolate z-10 border p-6">
+            <div className="border-border from-card to-background relative isolate z-10 border bg-gradient-to-br p-8">
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 -z-10 overflow-hidden opacity-60 saturate-[0.65]"
+                style={{
+                  background: RAINBOW_EDGE_GRADIENT,
+                  maskImage: RAINBOW_EDGE_MASK,
+                  WebkitMaskImage: RAINBOW_EDGE_MASK,
+                }}
+              />
+              <div
+                aria-hidden="true"
+                // Multiply beds the grain into a light surface; in dark mode
+                // multiply is a no-op on near-black, so switch to screen.
+                className="pointer-events-none absolute inset-0 -z-10 opacity-[0.45] mix-blend-multiply grayscale dark:opacity-[0.5] dark:mix-blend-screen"
+                style={{ backgroundImage: GRAIN_TEXTURE_URL }}
+              />
               <ChatLanding compact />
             </div>
           </div>


### PR DESCRIPTION
## What

Restyles the project home assistant card to fit the new editorial design language while bringing back a distinct, branded surface (the old gradient card was flattened to plain white in #5046).

- **Neutral theme-following surface**: subtle `card → background` diagonal gradient, so the card reads light in light mode and dark in dark mode with no extra CSS.
- **Brand rainbow edge affordance**: the full tech-color rainbow (same palette as `--gradient-brand-primary`) breathes in from the top-right corner and dissolves by mid-card, via a compressed linear gradient + radial mask (`client/dashboard/src/lib/brand-mesh.ts`).
- **Film grain**: inline SVG turbulence tile across the card; multiply-blended on light surfaces, screen-blended in dark mode (multiply is a no-op on near-black).
- **Control polish** (shared with the `/chat` landing): solid `bg-card` composer and suggestion chips, hover/focus states switch to a black border instead of a background change (chips, recent-chat rows, and composer focus).

## Why

The redesign left the assistant card indistinguishable from the rest of the page. This restores a branded focal point without reintroducing a heavy gradient block that fights the light editorial pages.
<img width="3682" height="3368" alt="CleanShot 2026-08-07 at 18 01 22@2x" src="https://github.com/user-attachments/assets/4d20925f-2dc8-4edf-a85c-28f1d32af1bd" />

## Testing

- `pnpm -F dashboard type-check`
- Verified in the browser in both light and dark mode (screenshots/GIF in PR comment).
