### PR TITLE
fix: correlate LiteLLM prompts with native agent turns

### DIFF
--- a/client/dashboard/src/pages/org/litellm-config.test.ts
+++ b/client/dashboard/src/pages/org/litellm-config.test.ts
@@ -21,7 +21,13 @@ describe("LiteLLM configuration", () => {
         - x-claude-code-session-id
         - session-id
         - thread-id
-        - x-session-id`);
+        - x-session-id
+        - x-gram-agent-provider
+        - x-gram-agent-session-id
+        - x-gram-agent-turn-id
+        - x-codex-turn-metadata
+        - x-opencode-session
+        - x-opencode-request`);
     expect(config).toContain("streaming_end_of_stream_only: true");
     expect(config).toContain("unreachable_fallback: fail_closed");
   });

--- a/client/dashboard/src/pages/org/litellm-config.ts
+++ b/client/dashboard/src/pages/org/litellm-config.ts
@@ -34,6 +34,12 @@ export function buildLiteLLMGuardrailConfig(
         - session-id
         - thread-id
         - x-session-id
+        - x-gram-agent-provider
+        - x-gram-agent-session-id
+        - x-gram-agent-turn-id
+        - x-codex-turn-metadata
+        - x-opencode-session
+        - x-opencode-request
       default_on: true
       streaming_end_of_stream_only: true
       fail_on_error: true

--- a/hooks/relay/envelope.go
+++ b/hooks/relay/envelope.go
@@ -11,7 +11,10 @@ import (
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
 
-const schemaVersion = "hook.ingest.v1"
+const (
+	schemaVersion   = "hook.ingest.v1"
+	agentTurnPrefix = "agent-turn:v1:"
+)
 
 // adapterSlug maps an agenthooks provider onto the stable Gram adapter slug the
 // backend expects (it keys its provider-style telemetry vocabulary on these).
@@ -320,9 +323,22 @@ func applyModelResponse(data *components.HookIngestData, base *agenthooks.Event)
 }
 
 func sessionOf(base *agenthooks.Event) *components.HookIngestSession {
+	turnID := base.Session.TurnID
+	if turnID == "" && base.Provider == agenthooks.ProviderOpenCode && base.Kind == agenthooks.KindPromptSubmitted {
+		for _, path := range []string{"output.message.id", "input.messageID"} {
+			var messageID string
+			if raw := base.RawField(path); len(raw) > 0 && json.Unmarshal(raw, &messageID) == nil && strings.TrimSpace(messageID) != "" {
+				turnID = strings.TrimSpace(messageID)
+				break
+			}
+		}
+	}
+	if turnID != "" {
+		turnID = agentTurnPrefix + adapterSlug(base.Provider) + ":" + turnID
+	}
 	s := &components.HookIngestSession{
 		ID:     optStr(base.Session.ID),
-		TurnID: optStr(base.Session.TurnID),
+		TurnID: optStr(turnID),
 		Cwd:    optStr(base.Session.CWD),
 		Model:  optStr(base.Session.Model),
 	}

--- a/hooks/relay/envelope.go
+++ b/hooks/relay/envelope.go
@@ -333,7 +333,7 @@ func sessionOf(base *agenthooks.Event) *components.HookIngestSession {
 			}
 		}
 	}
-	if turnID != "" {
+	if turnID != "" && (base.Provider == agenthooks.ProviderCodex || base.Provider == agenthooks.ProviderOpenCode) {
 		turnID = agentTurnPrefix + adapterSlug(base.Provider) + ":" + turnID
 	}
 	s := &components.HookIngestSession{

--- a/hooks/relay/opencode_hooks_test.go
+++ b/hooks/relay/opencode_hooks_test.go
@@ -64,6 +64,23 @@ func TestOpenCodePromptSubmittedEnvelope(t *testing.T) {
 	require.Equal(t, "deploy to staging", *got.Data.Prompt.Text)
 }
 
+func TestOpenCodePromptSubmittedEnvelopeCarriesMessageID(t *testing.T) {
+	payload := buildEnvelope(&agenthooks.PromptEvent{
+		Event: agenthooks.Event{
+			Provider:   agenthooks.ProviderOpenCode,
+			Kind:       agenthooks.KindPromptSubmitted,
+			NativeName: "chat.message",
+			Session:    agenthooks.SessionInfo{ID: "oc-sess-1"},
+			Raw:        json.RawMessage(`{"hook":"chat.message","input":{"messageID":"msg-input"},"output":{"message":{"id":"msg-output"}}}`),
+		},
+		Prompt: "deploy to staging",
+	}, "test-host")
+
+	require.NotNil(t, payload.Session)
+	require.NotNil(t, payload.Session.TurnID)
+	require.Equal(t, "agent-turn:v1:opencode:msg-output", *payload.Session.TurnID)
+}
+
 func TestOpenCodeToolRequestedEnvelope(t *testing.T) {
 	got := opencodeEnvelope(t, "tool_execute_before.json")
 

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -1510,6 +1510,32 @@ func TestEnvelopeReportsBinaryVersion(t *testing.T) {
 	require.Equal(t, "9.9.9", *payload.Source.AdapterVersion)
 }
 
+func TestSessionOfNamespacesNativeTurnIDs(t *testing.T) {
+	claude := sessionOf(&agenthooks.Event{
+		Provider: agenthooks.ProviderClaudeCode,
+		Kind:     agenthooks.KindPromptSubmitted,
+		Session:  agenthooks.SessionInfo{ID: "claude-session", TurnID: "prompt-1"},
+	})
+	require.NotNil(t, claude.TurnID)
+	require.Equal(t, "agent-turn:v1:claude:prompt-1", *claude.TurnID)
+
+	codex := sessionOf(&agenthooks.Event{
+		Provider: agenthooks.ProviderCodex,
+		Kind:     agenthooks.KindPromptSubmitted,
+		Session:  agenthooks.SessionInfo{ID: "codex-session", TurnID: "turn-1"},
+	})
+	require.NotNil(t, codex.TurnID)
+	require.Equal(t, "agent-turn:v1:codex:turn-1", *codex.TurnID)
+
+	cursor := sessionOf(&agenthooks.Event{
+		Provider: agenthooks.ProviderCursor,
+		Kind:     agenthooks.KindPromptSubmitted,
+		Session:  agenthooks.SessionInfo{ID: "cursor-session", TurnID: "generation-1"},
+	})
+	require.NotNil(t, cursor.TurnID)
+	require.Equal(t, "agent-turn:v1:cursor:generation-1", *cursor.TurnID)
+}
+
 func TestMCPInventoryEnvelopeRedactsCredentials(t *testing.T) {
 	payload := buildEnvelope(&agenthooks.MCPInventoryEvent{
 		Event: agenthooks.Event{

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -1510,14 +1510,14 @@ func TestEnvelopeReportsBinaryVersion(t *testing.T) {
 	require.Equal(t, "9.9.9", *payload.Source.AdapterVersion)
 }
 
-func TestSessionOfNamespacesNativeTurnIDs(t *testing.T) {
+func TestSessionOfNamespacesSharedTurnIDs(t *testing.T) {
 	claude := sessionOf(&agenthooks.Event{
 		Provider: agenthooks.ProviderClaudeCode,
 		Kind:     agenthooks.KindPromptSubmitted,
 		Session:  agenthooks.SessionInfo{ID: "claude-session", TurnID: "prompt-1"},
 	})
 	require.NotNil(t, claude.TurnID)
-	require.Equal(t, "agent-turn:v1:claude:prompt-1", *claude.TurnID)
+	require.Equal(t, "prompt-1", *claude.TurnID)
 
 	codex := sessionOf(&agenthooks.Event{
 		Provider: agenthooks.ProviderCodex,
@@ -1533,7 +1533,7 @@ func TestSessionOfNamespacesNativeTurnIDs(t *testing.T) {
 		Session:  agenthooks.SessionInfo{ID: "cursor-session", TurnID: "generation-1"},
 	})
 	require.NotNil(t, cursor.TurnID)
-	require.Equal(t, "agent-turn:v1:cursor:generation-1", *cursor.TurnID)
+	require.Equal(t, "generation-1", *cursor.TurnID)
 }
 
 func TestMCPInventoryEnvelopeRedactsCredentials(t *testing.T) {

--- a/local/litellm/contract-fixtures/config.yaml
+++ b/local/litellm/contract-fixtures/config.yaml
@@ -48,3 +48,9 @@ guardrails:
         - session-id
         - thread-id
         - x-session-id
+        - x-gram-agent-provider
+        - x-gram-agent-session-id
+        - x-gram-agent-turn-id
+        - x-codex-turn-metadata
+        - x-opencode-session
+        - x-opencode-request

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -182,6 +182,10 @@ func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, para
 // WriteCorrelated atomically inserts a message or promotes an earlier LiteLLM
 // observation of the same turn to the authoritative native-hook source.
 func (w *ChatMessageWriter) WriteCorrelated(ctx context.Context, projectID uuid.UUID, param repo.CreateChatMessageParams, externalMessageID string) (int64, error) {
+	params := []repo.CreateChatMessageParams{param}
+	stampUnsetCreatedAt(params)
+	param = params[0]
+
 	n, err := repo.New(w.db).UpsertCorrelatedChatMessage(ctx, repo.UpsertCorrelatedChatMessageParams{
 		ChatID:            param.ChatID,
 		Role:              param.Role,

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -25,7 +25,7 @@ import (
 // ChatMessageWriter is the only sanctioned way to persist chat messages.
 // It wraps repo.CreateChatMessage and notifies observers after a successful
 // write that stored at least one message. External packages must use Write,
-// WriteTurn, or WriteWithAssets.
+// WriteCorrelated, WriteTurn, or WriteWithAssets.
 type ChatMessageWriter struct {
 	db           *pgxpool.Pool
 	logger       *slog.Logger
@@ -174,6 +174,46 @@ func (w *ChatMessageWriter) Write(ctx context.Context, projectID uuid.UUID, para
 	}
 	if n > 0 {
 		w.publishTurnFrames(ctx, nil, params)
+		w.notifyMessagesStored(ctx, projectID)
+	}
+	return n, nil
+}
+
+// WriteCorrelated atomically inserts a message or promotes an earlier LiteLLM
+// observation of the same turn to the authoritative native-hook source.
+func (w *ChatMessageWriter) WriteCorrelated(ctx context.Context, projectID uuid.UUID, param repo.CreateChatMessageParams, externalMessageID string) (int64, error) {
+	n, err := repo.New(w.db).UpsertCorrelatedChatMessage(ctx, repo.UpsertCorrelatedChatMessageParams{
+		ChatID:            param.ChatID,
+		Role:              param.Role,
+		ProjectID:         param.ProjectID,
+		Content:           param.Content,
+		ContentRaw:        param.ContentRaw,
+		ContentAssetUrl:   param.ContentAssetUrl,
+		StorageError:      param.StorageError,
+		Model:             param.Model,
+		MessageID:         param.MessageID,
+		ToolCallID:        param.ToolCallID,
+		UserID:            param.UserID,
+		ExternalUserID:    param.ExternalUserID,
+		ExternalMessageID: conv.ToPGText(externalMessageID),
+		FinishReason:      param.FinishReason,
+		ToolCalls:         param.ToolCalls,
+		PromptTokens:      param.PromptTokens,
+		CompletionTokens:  param.CompletionTokens,
+		TotalTokens:       param.TotalTokens,
+		Origin:            param.Origin,
+		UserAgent:         param.UserAgent,
+		IpAddress:         param.IpAddress,
+		Source:            param.Source,
+		ContentHash:       param.ContentHash,
+		Generation:        param.Generation,
+		Replayed:          param.Replayed,
+		CreatedAt:         param.CreatedAt,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("upsert correlated chat message: %w", err)
+	}
+	if n > 0 {
 		w.notifyMessagesStored(ctx, projectID)
 	}
 	return n, nil

--- a/server/internal/chat/message_store.go
+++ b/server/internal/chat/message_store.go
@@ -242,10 +242,10 @@ func (w *ChatMessageWriter) WriteExternal(ctx context.Context, projectID uuid.UU
 }
 
 // WriteInTx inserts messages via a caller-provided transaction. Observers are
-// NOT fired here — the caller must invoke NotifyStored after commit so observers
-// never see a write that ended up rolled back. Use when the write must be
-// atomic with surrounding DB operations (e.g. a row-level lock for generation
-// serialisation).
+// NOT fired here — the caller must invoke NotifyStored or NotifyStoredRows after
+// commit so observers never see a write that ended up rolled back. Use when the
+// write must be atomic with surrounding DB operations (e.g. a row-level lock
+// for generation serialisation).
 func (w *ChatMessageWriter) WriteInTx(ctx context.Context, tx repo.DBTX, params []repo.CreateChatMessageParams) (int64, error) {
 	return insertChatMessages(ctx, tx, params)
 }
@@ -253,6 +253,12 @@ func (w *ChatMessageWriter) WriteInTx(ctx context.Context, tx repo.DBTX, params 
 // NotifyStored fans out a stored-messages signal to registered observers.
 // Pair with WriteInTx: invoke after the surrounding transaction commits.
 func (w *ChatMessageWriter) NotifyStored(ctx context.Context, projectID uuid.UUID) {
+	w.notifyMessagesStored(ctx, projectID)
+}
+
+// NotifyStoredRows publishes rows inserted through WriteInTx after commit.
+func (w *ChatMessageWriter) NotifyStoredRows(ctx context.Context, projectID uuid.UUID, params []repo.CreateChatMessageParams) {
+	w.publishTurnFrames(ctx, nil, params)
 	w.notifyMessagesStored(ctx, projectID)
 }
 

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -289,6 +289,16 @@ WHERE chat_messages.project_id = EXCLUDED.project_id
   AND EXCLUDED.source IN ('claude', 'claude-code', 'claude-code-desktop', 'cowork', 'codex', 'cursor', 'opencode')
   AND chat_messages.source = 'litellm';
 
+-- name: HasNativeChatPrompt :one
+SELECT EXISTS (
+  SELECT 1
+  FROM chat_messages
+  WHERE chat_id = @chat_id
+    AND project_id = @project_id::uuid
+    AND role = 'user'
+    AND source = ANY(@sources::text[])
+);
+
 -- name: CreateChatContentPart :copyfrom
 INSERT INTO chat_content_parts (
     chat_id

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -219,6 +219,76 @@ VALUES (
   , @created_at
 );
 
+-- name: UpsertCorrelatedChatMessage :execrows
+INSERT INTO chat_messages (
+    chat_id
+  , role
+  , project_id
+  , content
+  , content_raw
+  , content_asset_url
+  , storage_error
+  , model
+  , message_id
+  , tool_call_id
+  , user_id
+  , external_user_id
+  , external_message_id
+  , finish_reason
+  , tool_calls
+  , prompt_tokens
+  , completion_tokens
+  , total_tokens
+  , origin
+  , user_agent
+  , ip_address
+  , source
+  , content_hash
+  , generation
+  , replayed
+  , created_at
+)
+VALUES (
+    @chat_id
+  , @role
+  , @project_id::uuid
+  , @content
+  , @content_raw
+  , @content_asset_url
+  , @storage_error
+  , @model
+  , @message_id
+  , @tool_call_id
+  , @user_id
+  , @external_user_id
+  , @external_message_id
+  , @finish_reason
+  , @tool_calls
+  , @prompt_tokens
+  , @completion_tokens
+  , @total_tokens
+  , @origin
+  , @user_agent
+  , @ip_address
+  , @source
+  , @content_hash
+  , @generation
+  , @replayed
+  , @created_at
+)
+ON CONFLICT (chat_id, external_message_id) WHERE external_message_id IS NOT NULL
+DO UPDATE SET
+    source = EXCLUDED.source
+  , user_id = COALESCE(EXCLUDED.user_id, chat_messages.user_id)
+  , external_user_id = COALESCE(EXCLUDED.external_user_id, chat_messages.external_user_id)
+  , model = COALESCE(EXCLUDED.model, chat_messages.model)
+  , replayed = chat_messages.replayed OR EXCLUDED.replayed
+  , created_at = EXCLUDED.created_at
+  , risk_analyzed_at = NULL
+WHERE chat_messages.project_id = EXCLUDED.project_id
+  AND EXCLUDED.source IN ('claude', 'claude-code', 'claude-code-desktop', 'cowork', 'codex', 'cursor', 'opencode')
+  AND chat_messages.source = 'litellm';
+
 -- name: CreateChatContentPart :copyfrom
 INSERT INTO chat_content_parts (
     chat_id

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -289,15 +289,37 @@ WHERE chat_messages.project_id = EXCLUDED.project_id
   AND EXCLUDED.source IN ('claude', 'claude-code', 'claude-code-desktop', 'cowork', 'codex', 'cursor', 'opencode')
   AND chat_messages.source = 'litellm';
 
--- name: HasNativeChatPrompt :one
-SELECT EXISTS (
-  SELECT 1
-  FROM chat_messages
-  WHERE chat_id = @chat_id
-    AND project_id = @project_id::uuid
-    AND role = 'user'
-    AND source = ANY(@sources::text[])
-);
+-- name: AcquireChatPromptCorrelationLock :exec
+SELECT pg_advisory_xact_lock(hashtextextended(
+  'chat-prompt-correlation:' || (@project_id::uuid)::text || ':' || (@chat_id::uuid)::text,
+  0
+));
+
+-- name: GetLatestChatUserPrompt :one
+-- The chat_id/created_at index serves this backward LIMIT 1 scan. Unlike a
+-- source-filtered EXISTS, a negative result does not walk the full transcript.
+SELECT id, content, source
+FROM chat_messages
+WHERE chat_id = @chat_id
+  AND project_id = @project_id::uuid
+  AND role = 'user'
+ORDER BY created_at DESC, seq DESC
+LIMIT 1;
+
+-- name: PromoteLiteLLMPrompt :execrows
+UPDATE chat_messages
+SET source = @source
+  , user_id = COALESCE(@user_id, user_id)
+  , external_user_id = COALESCE(@external_user_id, external_user_id)
+  , model = COALESCE(@model, model)
+  , replayed = replayed OR @replayed
+  , created_at = @created_at
+  , risk_analyzed_at = NULL
+WHERE id = @id
+  AND project_id = @project_id::uuid
+  AND role = 'user'
+  AND content = @content
+  AND source = 'litellm';
 
 -- name: CreateChatContentPart :copyfrom
 INSERT INTO chat_content_parts (

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -286,7 +286,7 @@ DO UPDATE SET
   , created_at = EXCLUDED.created_at
   , risk_analyzed_at = NULL
 WHERE chat_messages.project_id = EXCLUDED.project_id
-  AND EXCLUDED.source IN ('claude', 'claude-code', 'claude-code-desktop', 'cowork', 'codex', 'cursor', 'opencode')
+  AND EXCLUDED.source IN ('codex', 'opencode')
   AND chat_messages.source = 'litellm';
 
 -- name: AcquireChatPromptCorrelationLock :exec
@@ -295,31 +295,16 @@ SELECT pg_advisory_xact_lock(hashtextextended(
   0
 ));
 
--- name: GetLatestChatUserPrompt :one
+-- name: GetLatestChatUserPromptSource :one
 -- The chat_id/created_at index serves this backward LIMIT 1 scan. Unlike a
 -- source-filtered EXISTS, a negative result does not walk the full transcript.
-SELECT id, content, source
+SELECT source
 FROM chat_messages
 WHERE chat_id = @chat_id
   AND project_id = @project_id::uuid
   AND role = 'user'
 ORDER BY created_at DESC, seq DESC
 LIMIT 1;
-
--- name: PromoteLiteLLMPrompt :execrows
-UPDATE chat_messages
-SET source = @source
-  , user_id = COALESCE(@user_id, user_id)
-  , external_user_id = COALESCE(@external_user_id, external_user_id)
-  , model = COALESCE(@model, model)
-  , replayed = replayed OR @replayed
-  , created_at = @created_at
-  , risk_analyzed_at = NULL
-WHERE id = @id
-  AND project_id = @project_id::uuid
-  AND role = 'user'
-  AND content = @content
-  AND source = 'litellm';
 
 -- name: CreateChatContentPart :copyfrom
 INSERT INTO chat_content_parts (

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -982,8 +982,8 @@ func (q *Queries) GetLLMClientBreakdownByMessages(ctx context.Context, arg GetLL
 	return items, nil
 }
 
-const getLatestChatUserPrompt = `-- name: GetLatestChatUserPrompt :one
-SELECT id, content, source
+const getLatestChatUserPromptSource = `-- name: GetLatestChatUserPromptSource :one
+SELECT source
 FROM chat_messages
 WHERE chat_id = $1
   AND project_id = $2::uuid
@@ -992,24 +992,18 @@ ORDER BY created_at DESC, seq DESC
 LIMIT 1
 `
 
-type GetLatestChatUserPromptParams struct {
+type GetLatestChatUserPromptSourceParams struct {
 	ChatID    uuid.UUID
 	ProjectID uuid.UUID
 }
 
-type GetLatestChatUserPromptRow struct {
-	ID      uuid.UUID
-	Content string
-	Source  pgtype.Text
-}
-
 // The chat_id/created_at index serves this backward LIMIT 1 scan. Unlike a
 // source-filtered EXISTS, a negative result does not walk the full transcript.
-func (q *Queries) GetLatestChatUserPrompt(ctx context.Context, arg GetLatestChatUserPromptParams) (GetLatestChatUserPromptRow, error) {
-	row := q.db.QueryRow(ctx, getLatestChatUserPrompt, arg.ChatID, arg.ProjectID)
-	var i GetLatestChatUserPromptRow
-	err := row.Scan(&i.ID, &i.Content, &i.Source)
-	return i, err
+func (q *Queries) GetLatestChatUserPromptSource(ctx context.Context, arg GetLatestChatUserPromptSourceParams) (pgtype.Text, error) {
+	row := q.db.QueryRow(ctx, getLatestChatUserPromptSource, arg.ChatID, arg.ProjectID)
+	var source pgtype.Text
+	err := row.Scan(&source)
+	return source, err
 }
 
 const getMaxGenerationForChat = `-- name: GetMaxGenerationForChat :one
@@ -2713,52 +2707,6 @@ func (q *Queries) ListUserFeedbackForChat(ctx context.Context, chatID uuid.UUID)
 	return items, nil
 }
 
-const promoteLiteLLMPrompt = `-- name: PromoteLiteLLMPrompt :execrows
-UPDATE chat_messages
-SET source = $1
-  , user_id = COALESCE($2, user_id)
-  , external_user_id = COALESCE($3, external_user_id)
-  , model = COALESCE($4, model)
-  , replayed = replayed OR $5
-  , created_at = $6
-  , risk_analyzed_at = NULL
-WHERE id = $7
-  AND project_id = $8::uuid
-  AND role = 'user'
-  AND content = $9
-  AND source = 'litellm'
-`
-
-type PromoteLiteLLMPromptParams struct {
-	Source         pgtype.Text
-	UserID         pgtype.Text
-	ExternalUserID pgtype.Text
-	Model          pgtype.Text
-	Replayed       bool
-	CreatedAt      pgtype.Timestamptz
-	ID             uuid.UUID
-	ProjectID      uuid.UUID
-	Content        string
-}
-
-func (q *Queries) PromoteLiteLLMPrompt(ctx context.Context, arg PromoteLiteLLMPromptParams) (int64, error) {
-	result, err := q.db.Exec(ctx, promoteLiteLLMPrompt,
-		arg.Source,
-		arg.UserID,
-		arg.ExternalUserID,
-		arg.Model,
-		arg.Replayed,
-		arg.CreatedAt,
-		arg.ID,
-		arg.ProjectID,
-		arg.Content,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const renameChat = `-- name: RenameChat :exec
 UPDATE chats
 SET title = $1,
@@ -3414,7 +3362,7 @@ DO UPDATE SET
   , created_at = EXCLUDED.created_at
   , risk_analyzed_at = NULL
 WHERE chat_messages.project_id = EXCLUDED.project_id
-  AND EXCLUDED.source IN ('claude', 'claude-code', 'claude-code-desktop', 'cowork', 'codex', 'cursor', 'opencode')
+  AND EXCLUDED.source IN ('codex', 'opencode')
   AND chat_messages.source = 'litellm'
 `
 

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -1092,6 +1092,30 @@ func (q *Queries) GetTopUsersByMessages(ctx context.Context, arg GetTopUsersByMe
 	return items, nil
 }
 
+const hasNativeChatPrompt = `-- name: HasNativeChatPrompt :one
+SELECT EXISTS (
+  SELECT 1
+  FROM chat_messages
+  WHERE chat_id = $1
+    AND project_id = $2::uuid
+    AND role = 'user'
+    AND source = ANY($3::text[])
+)
+`
+
+type HasNativeChatPromptParams struct {
+	ChatID    uuid.UUID
+	ProjectID uuid.UUID
+	Sources   []string
+}
+
+func (q *Queries) HasNativeChatPrompt(ctx context.Context, arg HasNativeChatPromptParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasNativeChatPrompt, arg.ChatID, arg.ProjectID, arg.Sources)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const insertChatResolution = `-- name: InsertChatResolution :one
 INSERT INTO chat_resolutions (
     project_id,

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -3254,6 +3254,141 @@ func (q *Queries) UpsertChat(ctx context.Context, arg UpsertChatParams) (uuid.UU
 	return id, err
 }
 
+const upsertCorrelatedChatMessage = `-- name: UpsertCorrelatedChatMessage :execrows
+INSERT INTO chat_messages (
+    chat_id
+  , role
+  , project_id
+  , content
+  , content_raw
+  , content_asset_url
+  , storage_error
+  , model
+  , message_id
+  , tool_call_id
+  , user_id
+  , external_user_id
+  , external_message_id
+  , finish_reason
+  , tool_calls
+  , prompt_tokens
+  , completion_tokens
+  , total_tokens
+  , origin
+  , user_agent
+  , ip_address
+  , source
+  , content_hash
+  , generation
+  , replayed
+  , created_at
+)
+VALUES (
+    $1
+  , $2
+  , $3::uuid
+  , $4
+  , $5
+  , $6
+  , $7
+  , $8
+  , $9
+  , $10
+  , $11
+  , $12
+  , $13
+  , $14
+  , $15
+  , $16
+  , $17
+  , $18
+  , $19
+  , $20
+  , $21
+  , $22
+  , $23
+  , $24
+  , $25
+  , $26
+)
+ON CONFLICT (chat_id, external_message_id) WHERE external_message_id IS NOT NULL
+DO UPDATE SET
+    source = EXCLUDED.source
+  , user_id = COALESCE(EXCLUDED.user_id, chat_messages.user_id)
+  , external_user_id = COALESCE(EXCLUDED.external_user_id, chat_messages.external_user_id)
+  , model = COALESCE(EXCLUDED.model, chat_messages.model)
+  , replayed = chat_messages.replayed OR EXCLUDED.replayed
+  , created_at = EXCLUDED.created_at
+  , risk_analyzed_at = NULL
+WHERE chat_messages.project_id = EXCLUDED.project_id
+  AND EXCLUDED.source IN ('claude', 'claude-code', 'claude-code-desktop', 'cowork', 'codex', 'cursor', 'opencode')
+  AND chat_messages.source = 'litellm'
+`
+
+type UpsertCorrelatedChatMessageParams struct {
+	ChatID            uuid.UUID
+	Role              string
+	ProjectID         uuid.UUID
+	Content           string
+	ContentRaw        []byte
+	ContentAssetUrl   pgtype.Text
+	StorageError      pgtype.Text
+	Model             pgtype.Text
+	MessageID         pgtype.Text
+	ToolCallID        pgtype.Text
+	UserID            pgtype.Text
+	ExternalUserID    pgtype.Text
+	ExternalMessageID pgtype.Text
+	FinishReason      pgtype.Text
+	ToolCalls         []byte
+	PromptTokens      int64
+	CompletionTokens  int64
+	TotalTokens       int64
+	Origin            pgtype.Text
+	UserAgent         pgtype.Text
+	IpAddress         pgtype.Text
+	Source            pgtype.Text
+	ContentHash       []byte
+	Generation        int32
+	Replayed          bool
+	CreatedAt         pgtype.Timestamptz
+}
+
+func (q *Queries) UpsertCorrelatedChatMessage(ctx context.Context, arg UpsertCorrelatedChatMessageParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertCorrelatedChatMessage,
+		arg.ChatID,
+		arg.Role,
+		arg.ProjectID,
+		arg.Content,
+		arg.ContentRaw,
+		arg.ContentAssetUrl,
+		arg.StorageError,
+		arg.Model,
+		arg.MessageID,
+		arg.ToolCallID,
+		arg.UserID,
+		arg.ExternalUserID,
+		arg.ExternalMessageID,
+		arg.FinishReason,
+		arg.ToolCalls,
+		arg.PromptTokens,
+		arg.CompletionTokens,
+		arg.TotalTokens,
+		arg.Origin,
+		arg.UserAgent,
+		arg.IpAddress,
+		arg.Source,
+		arg.ContentHash,
+		arg.Generation,
+		arg.Replayed,
+		arg.CreatedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const upsertExternalChat = `-- name: UpsertExternalChat :one
 INSERT INTO chats (
     id

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -13,6 +13,23 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+const acquireChatPromptCorrelationLock = `-- name: AcquireChatPromptCorrelationLock :exec
+SELECT pg_advisory_xact_lock(hashtextextended(
+  'chat-prompt-correlation:' || ($1::uuid)::text || ':' || ($2::uuid)::text,
+  0
+))
+`
+
+type AcquireChatPromptCorrelationLockParams struct {
+	ProjectID uuid.UUID
+	ChatID    uuid.UUID
+}
+
+func (q *Queries) AcquireChatPromptCorrelationLock(ctx context.Context, arg AcquireChatPromptCorrelationLockParams) error {
+	_, err := q.db.Exec(ctx, acquireChatPromptCorrelationLock, arg.ProjectID, arg.ChatID)
+	return err
+}
+
 const addUserFeedbackChatResolution = `-- name: AddUserFeedbackChatResolution :exec
 UPDATE chat_user_feedback
 SET chat_resolution_id = $1
@@ -965,6 +982,36 @@ func (q *Queries) GetLLMClientBreakdownByMessages(ctx context.Context, arg GetLL
 	return items, nil
 }
 
+const getLatestChatUserPrompt = `-- name: GetLatestChatUserPrompt :one
+SELECT id, content, source
+FROM chat_messages
+WHERE chat_id = $1
+  AND project_id = $2::uuid
+  AND role = 'user'
+ORDER BY created_at DESC, seq DESC
+LIMIT 1
+`
+
+type GetLatestChatUserPromptParams struct {
+	ChatID    uuid.UUID
+	ProjectID uuid.UUID
+}
+
+type GetLatestChatUserPromptRow struct {
+	ID      uuid.UUID
+	Content string
+	Source  pgtype.Text
+}
+
+// The chat_id/created_at index serves this backward LIMIT 1 scan. Unlike a
+// source-filtered EXISTS, a negative result does not walk the full transcript.
+func (q *Queries) GetLatestChatUserPrompt(ctx context.Context, arg GetLatestChatUserPromptParams) (GetLatestChatUserPromptRow, error) {
+	row := q.db.QueryRow(ctx, getLatestChatUserPrompt, arg.ChatID, arg.ProjectID)
+	var i GetLatestChatUserPromptRow
+	err := row.Scan(&i.ID, &i.Content, &i.Source)
+	return i, err
+}
+
 const getMaxGenerationForChat = `-- name: GetMaxGenerationForChat :one
 SELECT COALESCE(MAX(generation), 0)::integer AS generation FROM chat_messages WHERE chat_id = $1
 `
@@ -1090,30 +1137,6 @@ func (q *Queries) GetTopUsersByMessages(ctx context.Context, arg GetTopUsersByMe
 		return nil, err
 	}
 	return items, nil
-}
-
-const hasNativeChatPrompt = `-- name: HasNativeChatPrompt :one
-SELECT EXISTS (
-  SELECT 1
-  FROM chat_messages
-  WHERE chat_id = $1
-    AND project_id = $2::uuid
-    AND role = 'user'
-    AND source = ANY($3::text[])
-)
-`
-
-type HasNativeChatPromptParams struct {
-	ChatID    uuid.UUID
-	ProjectID uuid.UUID
-	Sources   []string
-}
-
-func (q *Queries) HasNativeChatPrompt(ctx context.Context, arg HasNativeChatPromptParams) (bool, error) {
-	row := q.db.QueryRow(ctx, hasNativeChatPrompt, arg.ChatID, arg.ProjectID, arg.Sources)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
 }
 
 const insertChatResolution = `-- name: InsertChatResolution :one
@@ -2688,6 +2711,52 @@ func (q *Queries) ListUserFeedbackForChat(ctx context.Context, chatID uuid.UUID)
 		return nil, err
 	}
 	return items, nil
+}
+
+const promoteLiteLLMPrompt = `-- name: PromoteLiteLLMPrompt :execrows
+UPDATE chat_messages
+SET source = $1
+  , user_id = COALESCE($2, user_id)
+  , external_user_id = COALESCE($3, external_user_id)
+  , model = COALESCE($4, model)
+  , replayed = replayed OR $5
+  , created_at = $6
+  , risk_analyzed_at = NULL
+WHERE id = $7
+  AND project_id = $8::uuid
+  AND role = 'user'
+  AND content = $9
+  AND source = 'litellm'
+`
+
+type PromoteLiteLLMPromptParams struct {
+	Source         pgtype.Text
+	UserID         pgtype.Text
+	ExternalUserID pgtype.Text
+	Model          pgtype.Text
+	Replayed       bool
+	CreatedAt      pgtype.Timestamptz
+	ID             uuid.UUID
+	ProjectID      uuid.UUID
+	Content        string
+}
+
+func (q *Queries) PromoteLiteLLMPrompt(ctx context.Context, arg PromoteLiteLLMPromptParams) (int64, error) {
+	result, err := q.db.Exec(ctx, promoteLiteLLMPrompt,
+		arg.Source,
+		arg.UserID,
+		arg.ExternalUserID,
+		arg.Model,
+		arg.Replayed,
+		arg.CreatedAt,
+		arg.ID,
+		arg.ProjectID,
+		arg.Content,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const renameChat = `-- name: RenameChat :exec

--- a/server/internal/chat/transcript_order_test.go
+++ b/server/internal/chat/transcript_order_test.go
@@ -253,7 +253,7 @@ func TestChatMessageWriter_CorrelatedMessageStampsMissingCreatedAt(t *testing.T)
 		Model:      conv.ToPGTextEmpty(""),
 		MessageID:  conv.ToPGText("agent-prompt:v1:test"),
 		ToolCallID: conv.ToPGTextEmpty(""),
-		Source:     conv.ToPGText("claude"),
+		Source:     conv.ToPGText("codex"),
 		CreatedAt:  conv.ToPGTimestamptz(eventTime),
 	}, "agent-prompt:v1:test")
 	require.NoError(t, err)

--- a/server/internal/chat/transcript_order_test.go
+++ b/server/internal/chat/transcript_order_test.go
@@ -213,3 +213,56 @@ func TestChatMessageWriter_BatchKeepsInsertionOrder(t *testing.T) {
 		require.Equal(t, first, m.CreatedAt, "batch rows must share one created_at stamp")
 	}
 }
+
+func TestChatMessageWriter_CorrelatedMessageStampsMissingCreatedAt(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := initSessionCtx(t, ti)
+
+	chatID := seedChat(t, ctx, ti, "u", "", "correlated timestamp")
+	writer, shutdown := chat.NewChatMessageWriter(testenv.NewLogger(t), ti.conn, assetstest.NewTestBlobStore(t))
+	t.Cleanup(func() { _ = shutdown(context.WithoutCancel(t.Context())) })
+
+	_, err := writer.WriteCorrelated(ctx, ti.projectID, repo.CreateChatMessageParams{
+		ChatID:     chatID,
+		ProjectID:  ti.projectID,
+		Role:       "user",
+		Content:    "correlated prompt",
+		Model:      conv.ToPGTextEmpty(""),
+		MessageID:  conv.ToPGText("agent-prompt:v1:test"),
+		ToolCallID: conv.ToPGTextEmpty(""),
+		Source:     conv.ToPGText("litellm"),
+	}, "agent-prompt:v1:test")
+	require.NoError(t, err)
+
+	messages, err := repo.New(ti.conn).ListChatMessages(ctx, repo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: ti.projectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.True(t, messages[0].CreatedAt.Valid)
+	require.False(t, messages[0].CreatedAt.Time.IsZero())
+
+	eventTime := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	_, err = writer.WriteCorrelated(ctx, ti.projectID, repo.CreateChatMessageParams{
+		ChatID:     chatID,
+		ProjectID:  ti.projectID,
+		Role:       "user",
+		Content:    "correlated prompt",
+		Model:      conv.ToPGTextEmpty(""),
+		MessageID:  conv.ToPGText("agent-prompt:v1:test"),
+		ToolCallID: conv.ToPGTextEmpty(""),
+		Source:     conv.ToPGText("claude"),
+		CreatedAt:  conv.ToPGTimestamptz(eventTime),
+	}, "agent-prompt:v1:test")
+	require.NoError(t, err)
+
+	messages, err = repo.New(ti.conn).ListChatMessages(ctx, repo.ListChatMessagesParams{
+		ChatID:    chatID,
+		ProjectID: ti.projectID,
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.True(t, eventTime.Equal(messages[0].CreatedAt.Time))
+}

--- a/server/internal/hooks/cache.go
+++ b/server/internal/hooks/cache.go
@@ -11,6 +11,13 @@ func sessionCacheKey(sessionID string) string {
 	return fmt.Sprintf("session:metadata:%s", sessionID)
 }
 
+// sessionNativeHooksCacheKey records that a session has an authoritative
+// native hook stream, so model-proxy prompts can remain telemetry-only when no
+// shared turn identifier is available.
+func sessionNativeHooksCacheKey(projectID, sessionID string) string {
+	return fmt.Sprintf("session:native-hooks:%s:%s", projectID, sessionID)
+}
+
 // hookPendingCacheKey returns the Redis key for buffered hooks for a session
 func hookPendingCacheKey(sessionID string) string {
 	return fmt.Sprintf("hook:pending:%s", sessionID)

--- a/server/internal/hooks/cache.go
+++ b/server/internal/hooks/cache.go
@@ -11,11 +11,11 @@ func sessionCacheKey(sessionID string) string {
 	return fmt.Sprintf("session:metadata:%s", sessionID)
 }
 
-// sessionNativeHooksCacheKey records that a session has an authoritative
-// native hook stream, so model-proxy prompts can remain telemetry-only when no
-// shared turn identifier is available.
+// sessionNativeHooksCacheKey records that a session has a durably captured
+// native prompt, so model-proxy prompts can remain telemetry-only when no shared
+// turn identifier is available.
 func sessionNativeHooksCacheKey(projectID, sessionID string) string {
-	return fmt.Sprintf("session:native-hooks:%s:%s", projectID, sessionID)
+	return fmt.Sprintf("session:native-prompt:v1:%s:%s", projectID, sessionID)
 }
 
 // hookPendingCacheKey returns the Redis key for buffered hooks for a session

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"slices"
 	"strings"
 	"time"
 
@@ -34,8 +33,6 @@ const (
 	agentTurnPrefix              = "agent-turn:v1:"
 	agentPromptCorrelationPrefix = "agent-prompt:v1:"
 )
-
-var nativeTranscriptFallbackSources = []string{"claude", "claude-code", "claude-code-desktop", "cowork", "cursor"}
 
 type authenticatedIngestOptionsKey struct{}
 
@@ -1408,6 +1405,8 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 
 	var msg chatRepo.CreateChatMessageParams
 	var titleContent string
+	uncorrelatedPrompt := false
+	nativePrompt := false
 	switch strings.TrimSpace(payload.Event.Type) {
 	case "prompt.submitted":
 		content := canonicalPromptText(payload)
@@ -1417,25 +1416,9 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		msg = baseMsg("user", content)
 		if correlationID := agentPromptCorrelationID(payload, content); correlationID != "" {
 			msg.MessageID = conv.ToPGText(correlationID)
-		} else if strings.EqualFold(strings.TrimSpace(hookSource), "litellm") {
-			var nativeSource string
-			if err := s.cache.Get(ctx, sessionNativeHooksCacheKey(authCtx.ProjectID.String(), sessionID), &nativeSource); err == nil && strings.TrimSpace(nativeSource) != "" {
-				return false, nil
-			}
-			captured, err := chatRepo.New(s.db).HasNativeChatPrompt(ctx, chatRepo.HasNativeChatPromptParams{
-				ChatID:    msg.ChatID,
-				ProjectID: *authCtx.ProjectID,
-				Sources:   nativeTranscriptFallbackSources,
-			})
-			if err != nil {
-				s.logger.WarnContext(ctx, "failed to verify native prompt capture",
-					attr.SlogError(err),
-					attr.SlogGenAIConversationID(sessionID),
-				)
-			} else if captured {
-				s.markNativePromptSession(ctx, authCtx.ProjectID.String(), sessionID, "captured")
-				return false, nil
-			}
+		} else {
+			uncorrelatedPrompt = strings.EqualFold(strings.TrimSpace(hookSource), "litellm") || usesNativeTranscriptFallback(payload.Source.Adapter)
+			nativePrompt = usesNativeTranscriptFallback(payload.Source.Adapter)
 		}
 		titleContent = content
 	case "assistant.responded":
@@ -1487,13 +1470,21 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		return false, nil
 	}
 
-	stored, err := s.insertMessageWithFallbackUpsertResult(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, canonicalChatTitle(payload, titleContent))
+	title := canonicalChatTitle(payload, titleContent)
+	if uncorrelatedPrompt {
+		return s.insertUncorrelatedAgentPrompt(ctx, metadata, msg, title, nativePrompt)
+	}
+	stored, err := s.insertMessageWithFallbackUpsertResult(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, title)
 	return stored && msg.Role == "user", err
 }
 
 func usesNativeTranscriptFallback(adapter string) bool {
-	adapter = strings.ToLower(strings.TrimSpace(adapter))
-	return slices.Contains(nativeTranscriptFallbackSources, adapter)
+	switch strings.ToLower(strings.TrimSpace(adapter)) {
+	case "claude", "claude-code", "claude-code-desktop", "cowork", "cursor":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) markNativePromptSession(ctx context.Context, projectID, sessionID, source string) {

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -28,7 +28,11 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
 
-const hookIngestSchemaV1 = "hook.ingest.v1"
+const (
+	hookIngestSchemaV1           = "hook.ingest.v1"
+	agentTurnPrefix              = "agent-turn:v1:"
+	agentPromptCorrelationPrefix = "agent-prompt:v1:"
+)
 
 type authenticatedIngestOptionsKey struct{}
 
@@ -945,6 +949,18 @@ func canonicalShadowMCPEvidence(payload *gen.IngestPayload, rawToolName string) 
 }
 
 func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, actor canonicalActor, timestamp time.Time, blockReason string) {
+	adapter := strings.TrimSpace(payload.Source.Adapter)
+	if sessionID := canonicalSessionID(payload); sessionID != "" && usesNativeTranscriptFallback(adapter) {
+		cacheCtx, cancel := context.WithTimeout(ctx, canonicalSessionCacheWriteTimeout)
+		err := s.cache.Set(cacheCtx, sessionNativeHooksCacheKey(authCtx.ProjectID.String(), sessionID), adapter, 24*time.Hour)
+		cancel()
+		if err != nil {
+			s.logger.WarnContext(ctx, "failed to mark native hook session",
+				attr.SlogError(err),
+				attr.SlogGenAIConversationID(sessionID),
+			)
+		}
+	}
 	// Resolve the session identity once, before the telemetry write, so the
 	// hook row and the chat persistence below stamp the same AI-account
 	// attribution.
@@ -1404,20 +1420,15 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		if strings.TrimSpace(content) == "" {
 			return nil
 		}
-		if strings.EqualFold(strings.TrimSpace(hookSource), "litellm") {
-			matched, err := s.repo.LatestUserMessageMatchesOpenCode(ctx, repo.LatestUserMessageMatchesOpenCodeParams{
-				ProjectID: *authCtx.ProjectID,
-				ChatID:    sessionIDToUUID(sessionID),
-				Content:   content,
-			})
-			if err != nil {
-				return fmt.Errorf("match LiteLLM prompt to OpenCode message: %w", err)
-			}
-			if matched {
+		msg = baseMsg("user", content)
+		if correlationID := agentPromptCorrelationID(payload, content); correlationID != "" {
+			msg.MessageID = conv.ToPGText(correlationID)
+		} else if strings.EqualFold(strings.TrimSpace(hookSource), "litellm") {
+			var nativeSource string
+			if err := s.cache.Get(ctx, sessionNativeHooksCacheKey(authCtx.ProjectID.String(), sessionID), &nativeSource); err == nil && strings.TrimSpace(nativeSource) != "" {
 				return nil
 			}
 		}
-		msg = baseMsg("user", content)
 		titleContent = content
 	case "assistant.responded":
 		content := canonicalMessageText(payload)
@@ -1469,6 +1480,87 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 	}
 
 	return s.insertMessageWithFallbackUpsert(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, canonicalChatTitle(payload, titleContent))
+}
+
+func usesNativeTranscriptFallback(adapter string) bool {
+	switch strings.ToLower(strings.TrimSpace(adapter)) {
+	case "claude", "claude-code", "claude-code-desktop", "cowork", "cursor":
+		return true
+	default:
+		return false
+	}
+}
+
+func agentPromptCorrelationID(payload *gen.IngestPayload, content string) string {
+	turnID := canonicalAgentTurnID(payload)
+	if turnID == "" {
+		return ""
+	}
+	digest := sha256.Sum256([]byte(turnID + "\x00" + content))
+	return agentPromptCorrelationPrefix + hex.EncodeToString(digest[:])
+}
+
+func canonicalAgentTurnID(payload *gen.IngestPayload) string {
+	if payload == nil || payload.Source == nil {
+		return ""
+	}
+	adapter := strings.ToLower(strings.TrimSpace(payload.Source.Adapter))
+	provider := canonicalAgentProvider(adapter)
+	if payload.Session != nil && payload.Session.TurnID != nil {
+		turnID := strings.TrimSpace(*payload.Session.TurnID)
+		if encoded, ok := strings.CutPrefix(turnID, agentTurnPrefix); ok {
+			encodedProvider, nativeTurnID, found := strings.Cut(encoded, ":")
+			encodedProvider = canonicalAgentProvider(encodedProvider)
+			if found && encodedProvider != "" && strings.TrimSpace(nativeTurnID) != "" &&
+				(adapter == "litellm" || provider == encodedProvider) {
+				return encodedProvider + ":" + strings.TrimSpace(nativeTurnID)
+			}
+			return ""
+		}
+		if provider != "" && turnID != "" {
+			return provider + ":" + turnID
+		}
+	}
+	if provider != "opencode" || payload.Raw == nil {
+		return ""
+	}
+
+	raw, err := json.Marshal(payload.Raw)
+	if err != nil {
+		return ""
+	}
+	var event struct {
+		Input struct {
+			MessageID string `json:"messageID"`
+		} `json:"input"`
+		Output struct {
+			Message struct {
+				ID string `json:"id"`
+			} `json:"message"`
+		} `json:"output"`
+	}
+	if json.Unmarshal(raw, &event) != nil {
+		return ""
+	}
+	messageID := strings.TrimSpace(event.Output.Message.ID)
+	if messageID == "" {
+		messageID = strings.TrimSpace(event.Input.MessageID)
+	}
+	if messageID == "" {
+		return ""
+	}
+	return "opencode:" + messageID
+}
+
+func canonicalAgentProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "claude", "claude-code", "claude-code-desktop", "cowork":
+		return "claude"
+	case "codex", "cursor", "opencode":
+		return strings.ToLower(strings.TrimSpace(provider))
+	default:
+		return ""
+	}
 }
 
 func (s *Service) persistPromptAttachments(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, occurredAt time.Time) error {

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -1414,7 +1414,7 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 			return false, nil
 		}
 		msg = baseMsg("user", content)
-		if correlationID := agentPromptCorrelationID(payload, content); correlationID != "" {
+		if correlationID := agentPromptCorrelationID(payload); correlationID != "" {
 			msg.MessageID = conv.ToPGText(correlationID)
 		} else {
 			uncorrelatedPrompt = strings.EqualFold(strings.TrimSpace(hookSource), "litellm") || usesNativeTranscriptFallback(payload.Source.Adapter)
@@ -1502,12 +1502,12 @@ func (s *Service) markNativePromptSession(ctx context.Context, projectID, sessio
 	}
 }
 
-func agentPromptCorrelationID(payload *gen.IngestPayload, content string) string {
+func agentPromptCorrelationID(payload *gen.IngestPayload) string {
 	turnID := canonicalAgentTurnID(payload)
 	if turnID == "" {
 		return ""
 	}
-	digest := sha256.Sum256([]byte(turnID + "\x00" + content))
+	digest := sha256.Sum256([]byte(turnID))
 	return agentPromptCorrelationPrefix + hex.EncodeToString(digest[:])
 }
 
@@ -1516,23 +1516,25 @@ func canonicalAgentTurnID(payload *gen.IngestPayload) string {
 		return ""
 	}
 	adapter := strings.ToLower(strings.TrimSpace(payload.Source.Adapter))
-	provider := canonicalAgentProvider(adapter)
+	if adapter != "codex" && adapter != "opencode" && adapter != "litellm" {
+		return ""
+	}
 	if payload.Session != nil && payload.Session.TurnID != nil {
 		turnID := strings.TrimSpace(*payload.Session.TurnID)
 		if encoded, ok := strings.CutPrefix(turnID, agentTurnPrefix); ok {
 			encodedProvider, nativeTurnID, found := strings.Cut(encoded, ":")
-			encodedProvider = canonicalAgentProvider(encodedProvider)
-			if found && encodedProvider != "" && strings.TrimSpace(nativeTurnID) != "" &&
-				(adapter == "litellm" || provider == encodedProvider) {
+			encodedProvider = strings.ToLower(strings.TrimSpace(encodedProvider))
+			stableProvider := encodedProvider == "codex" || encodedProvider == "opencode"
+			if found && stableProvider && (adapter == "litellm" || adapter == encodedProvider) && strings.TrimSpace(nativeTurnID) != "" {
 				return encodedProvider + ":" + strings.TrimSpace(nativeTurnID)
 			}
 			return ""
 		}
-		if provider != "" && turnID != "" {
-			return provider + ":" + turnID
+		if adapter != "litellm" && turnID != "" {
+			return adapter + ":" + turnID
 		}
 	}
-	if provider != "opencode" || payload.Raw == nil {
+	if adapter != "opencode" || payload.Raw == nil {
 		return ""
 	}
 
@@ -1561,17 +1563,6 @@ func canonicalAgentTurnID(payload *gen.IngestPayload) string {
 		return ""
 	}
 	return "opencode:" + messageID
-}
-
-func canonicalAgentProvider(provider string) string {
-	switch strings.ToLower(strings.TrimSpace(provider)) {
-	case "claude", "claude-code", "claude-code-desktop", "cowork":
-		return "claude"
-	case "codex", "cursor", "opencode":
-		return strings.ToLower(strings.TrimSpace(provider))
-	default:
-		return ""
-	}
 }
 
 func (s *Service) persistPromptAttachments(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, occurredAt time.Time) error {

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -1404,6 +1404,19 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		if strings.TrimSpace(content) == "" {
 			return nil
 		}
+		if strings.EqualFold(strings.TrimSpace(hookSource), "litellm") {
+			matched, err := s.repo.LatestUserMessageMatchesOpenCode(ctx, repo.LatestUserMessageMatchesOpenCodeParams{
+				ProjectID: *authCtx.ProjectID,
+				ChatID:    sessionIDToUUID(sessionID),
+				Content:   content,
+			})
+			if err != nil {
+				return fmt.Errorf("match LiteLLM prompt to OpenCode message: %w", err)
+			}
+			if matched {
+				return nil
+			}
+		}
 		msg = baseMsg("user", content)
 		titleContent = content
 	case "assistant.responded":

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,6 +34,8 @@ const (
 	agentTurnPrefix              = "agent-turn:v1:"
 	agentPromptCorrelationPrefix = "agent-prompt:v1:"
 )
+
+var nativeTranscriptFallbackSources = []string{"claude", "claude-code", "claude-code-desktop", "cowork", "cursor"}
 
 type authenticatedIngestOptionsKey struct{}
 
@@ -949,18 +952,6 @@ func canonicalShadowMCPEvidence(payload *gen.IngestPayload, rawToolName string) 
 }
 
 func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, actor canonicalActor, timestamp time.Time, blockReason string) {
-	adapter := strings.TrimSpace(payload.Source.Adapter)
-	if sessionID := canonicalSessionID(payload); sessionID != "" && usesNativeTranscriptFallback(adapter) {
-		cacheCtx, cancel := context.WithTimeout(ctx, canonicalSessionCacheWriteTimeout)
-		err := s.cache.Set(cacheCtx, sessionNativeHooksCacheKey(authCtx.ProjectID.String(), sessionID), adapter, 24*time.Hour)
-		cancel()
-		if err != nil {
-			s.logger.WarnContext(ctx, "failed to mark native hook session",
-				attr.SlogError(err),
-				attr.SlogGenAIConversationID(sessionID),
-			)
-		}
-	}
 	// Resolve the session identity once, before the telemetry write, so the
 	// hook row and the chat persistence below stamp the same AI-account
 	// attribution.
@@ -991,7 +982,8 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 		}
 	}
 	s.writeCanonicalTelemetry(ctx, payload, authCtx, &metadata, hookSource, timestamp, blockReason)
-	if err := s.persistCanonicalConversationEvent(ctx, payload, authCtx, &metadata, hookSource, timestamp); err != nil {
+	promptCaptured, err := s.persistCanonicalConversationEvent(ctx, payload, authCtx, &metadata, hookSource, timestamp)
+	if err != nil {
 		s.logger.WarnContext(ctx, "failed to persist canonical hook conversation event",
 			attr.SlogEvent("hooks_ingest_chat_persist_failed"),
 			attr.SlogError(err),
@@ -1000,6 +992,8 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 			attr.SlogGenAIConversationID(canonicalSessionID(payload)),
 			attr.SlogProjectID(authCtx.ProjectID.String()),
 		)
+	} else if promptCaptured && usesNativeTranscriptFallback(payload.Source.Adapter) {
+		s.markNativePromptSession(ctx, authCtx.ProjectID.String(), canonicalSessionID(payload), payload.Source.Adapter)
 	}
 	if err := s.persistPromptAttachments(ctx, payload, authCtx, &metadata, timestamp); err != nil {
 		s.logger.WarnContext(ctx, "failed to persist prompt attachments",
@@ -1374,10 +1368,10 @@ func telemetryHookEventName(payload *gen.IngestPayload) string {
 // so the chat row, telemetry, and enforcement carry the exact same
 // server-resolved time for one event — a recomputed fallback or clamp would
 // drift by the handler's processing latency.
-func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, hookSource string, occurredAt time.Time) error {
+func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload *gen.IngestPayload, authCtx *contextvalues.AuthContext, metadata *SessionMetadata, hookSource string, occurredAt time.Time) (bool, error) {
 	sessionID := canonicalSessionID(payload)
 	if sessionID == "" || authCtx.ProjectID == nil {
-		return nil
+		return false, nil
 	}
 	baseMsg := func(role, content string) chatRepo.CreateChatMessageParams {
 		return chatRepo.CreateChatMessageParams{
@@ -1418,7 +1412,7 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 	case "prompt.submitted":
 		content := canonicalPromptText(payload)
 		if strings.TrimSpace(content) == "" {
-			return nil
+			return false, nil
 		}
 		msg = baseMsg("user", content)
 		if correlationID := agentPromptCorrelationID(payload, content); correlationID != "" {
@@ -1426,7 +1420,21 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		} else if strings.EqualFold(strings.TrimSpace(hookSource), "litellm") {
 			var nativeSource string
 			if err := s.cache.Get(ctx, sessionNativeHooksCacheKey(authCtx.ProjectID.String(), sessionID), &nativeSource); err == nil && strings.TrimSpace(nativeSource) != "" {
-				return nil
+				return false, nil
+			}
+			captured, err := chatRepo.New(s.db).HasNativeChatPrompt(ctx, chatRepo.HasNativeChatPromptParams{
+				ChatID:    msg.ChatID,
+				ProjectID: *authCtx.ProjectID,
+				Sources:   nativeTranscriptFallbackSources,
+			})
+			if err != nil {
+				s.logger.WarnContext(ctx, "failed to verify native prompt capture",
+					attr.SlogError(err),
+					attr.SlogGenAIConversationID(sessionID),
+				)
+			} else if captured {
+				s.markNativePromptSession(ctx, authCtx.ProjectID.String(), sessionID, "captured")
+				return false, nil
 			}
 		}
 		titleContent = content
@@ -1434,13 +1442,13 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		content := canonicalMessageText(payload)
 		outputToolCalls := authenticatedIngestOptions(ctx).OutputToolCalls
 		if strings.TrimSpace(content) == "" && len(outputToolCalls) == 0 {
-			return nil
+			return false, nil
 		}
 		msg = baseMsg("assistant", content)
 		if len(outputToolCalls) > 0 {
 			toolCallsJSON, err := json.Marshal(outputToolCalls)
 			if err != nil {
-				return fmt.Errorf("marshal output tool calls: %w", err)
+				return false, fmt.Errorf("marshal output tool calls: %w", err)
 			}
 			msg.FinishReason = conv.ToPGText("tool_calls")
 			msg.ToolCalls = toolCallsJSON
@@ -1453,15 +1461,15 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		// put phantom or duplicate tool_calls rows in the transcript.
 		if canonicalPermissionType(payload) != "" ||
 			strings.EqualFold(strings.TrimSpace(conv.PtrValOr(payload.Source.RawEventName, "")), "PermissionRequest") {
-			return nil
+			return false, nil
 		}
 		toolName := canonicalToolName(payload)
 		if strings.TrimSpace(toolName) == "" {
-			return nil
+			return false, nil
 		}
 		toolCallsJSON, err := canonicalToolCallsJSON(payload)
 		if err != nil {
-			return err
+			return false, err
 		}
 		msg = baseMsg("assistant", "")
 		msg.FinishReason = conv.ToPGText("tool_calls")
@@ -1470,24 +1478,36 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 	case "tool.completed", "tool.failed":
 		content := canonicalToolResultContent(payload)
 		if strings.TrimSpace(content) == "" {
-			return nil
+			return false, nil
 		}
 		msg = baseMsg("tool", content)
 		msg.ToolCallID = conv.ToPGTextEmpty(canonicalChatToolCallID(payload))
 		titleContent = content
 	default:
-		return nil
+		return false, nil
 	}
 
-	return s.insertMessageWithFallbackUpsert(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, canonicalChatTitle(payload, titleContent))
+	stored, err := s.insertMessageWithFallbackUpsertResult(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, canonicalChatTitle(payload, titleContent))
+	return stored && msg.Role == "user", err
 }
 
 func usesNativeTranscriptFallback(adapter string) bool {
-	switch strings.ToLower(strings.TrimSpace(adapter)) {
-	case "claude", "claude-code", "claude-code-desktop", "cowork", "cursor":
-		return true
-	default:
-		return false
+	adapter = strings.ToLower(strings.TrimSpace(adapter))
+	return slices.Contains(nativeTranscriptFallbackSources, adapter)
+}
+
+func (s *Service) markNativePromptSession(ctx context.Context, projectID, sessionID, source string) {
+	if sessionID == "" {
+		return
+	}
+	cacheCtx, cancel := context.WithTimeout(ctx, canonicalSessionCacheWriteTimeout)
+	err := s.cache.Set(cacheCtx, sessionNativeHooksCacheKey(projectID, sessionID), source, 24*time.Hour)
+	cancel()
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to mark native prompt session",
+			attr.SlogError(err),
+			attr.SlogGenAIConversationID(sessionID),
+		)
 	}
 }
 

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -48,11 +48,13 @@ type sessionCacheDeadlineRecorder struct {
 }
 
 func (r *sessionCacheDeadlineRecorder) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
-	deadline, ok := ctx.Deadline()
-	if ok {
-		r.remaining <- time.Until(deadline)
-	} else {
-		r.remaining <- 0
+	if strings.HasPrefix(key, "session:metadata:") {
+		deadline, ok := ctx.Deadline()
+		if ok {
+			r.remaining <- time.Until(deadline)
+		} else {
+			r.remaining <- 0
+		}
 	}
 	if err := r.Cache.Set(ctx, key, value, ttl); err != nil {
 		return fmt.Errorf("set cache: %w", err)
@@ -627,6 +629,30 @@ func TestCanonicalChatTitle_TruncatesByRunes(t *testing.T) {
 	title := canonicalChatTitle(payload, "")
 	require.True(t, utf8.ValidString(title))
 	require.Len(t, []rune(title), 80)
+}
+
+func TestCanonicalAgentTurnIDAcceptsLegacyCodexTurnID(t *testing.T) {
+	t.Parallel()
+
+	payload := canonicalIngestPayload("codex", "prompt.submitted", "codex-session")
+	payload.Session.TurnID = new("turn-1")
+	require.Equal(t, "codex:turn-1", canonicalAgentTurnID(payload))
+}
+
+func TestCanonicalAgentTurnIDExtractsLegacyOpenCodeMessageID(t *testing.T) {
+	t.Parallel()
+
+	payload := canonicalIngestPayload("opencode", "prompt.submitted", "opencode-session")
+	payload.Raw = json.RawMessage(`{"input":{"messageID":"msg-input"},"output":{"message":{"id":"msg-output"}}}`)
+	require.Equal(t, "opencode:msg-output", canonicalAgentTurnID(payload))
+}
+
+func TestCanonicalAgentTurnIDRejectsSpoofedProviderPrefix(t *testing.T) {
+	t.Parallel()
+
+	payload := canonicalIngestPayload("custom-adapter", "prompt.submitted", "custom-session")
+	payload.Session.TurnID = new("agent-turn:v1:opencode:msg-1")
+	require.Empty(t, canonicalAgentTurnID(payload))
 }
 
 func TestIngest_SkillActivationIsAcceptedAsFeatureEvent(t *testing.T) {

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -655,6 +655,14 @@ func TestCanonicalAgentTurnIDRejectsSpoofedProviderPrefix(t *testing.T) {
 	require.Empty(t, canonicalAgentTurnID(payload))
 }
 
+func TestCanonicalAgentTurnIDRejectsProviderWithoutSharedIdentity(t *testing.T) {
+	t.Parallel()
+
+	payload := canonicalIngestPayload("claude", "prompt.submitted", "claude-session")
+	payload.Session.TurnID = new("turn-1")
+	require.Empty(t, canonicalAgentTurnID(payload))
+}
+
 func TestIngest_SkillActivationIsAcceptedAsFeatureEvent(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -132,6 +132,17 @@ RETURNING id;
 -- name: UpdateClaudeCodeSessionTimestamp :exec
 UPDATE chats SET updated_at = NOW() WHERE id = @id AND project_id = @project_id;
 
+-- name: LatestUserMessageMatchesOpenCode :one
+SELECT COALESCE((
+  SELECT source = 'opencode' AND content = @content
+  FROM chat_messages
+  WHERE project_id = @project_id::uuid
+    AND chat_id = @chat_id
+    AND role = 'user'
+  ORDER BY created_at DESC, seq DESC
+  LIMIT 1
+), FALSE)::boolean;
+
 -- name: LinkChatUserAccount :execrows
 -- Backfills the chat -> user_accounts link for a session whose chat row was
 -- created before account attribution landed. A chat is created once, on the

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -132,17 +132,6 @@ RETURNING id;
 -- name: UpdateClaudeCodeSessionTimestamp :exec
 UPDATE chats SET updated_at = NOW() WHERE id = @id AND project_id = @project_id;
 
--- name: LatestUserMessageMatchesOpenCode :one
-SELECT COALESCE((
-  SELECT source = 'opencode' AND content = @content
-  FROM chat_messages
-  WHERE project_id = @project_id::uuid
-    AND chat_id = @chat_id
-    AND role = 'user'
-  ORDER BY created_at DESC, seq DESC
-  LIMIT 1
-), FALSE)::boolean;
-
 -- name: LinkChatUserAccount :execrows
 -- Backfills the chat -> user_accounts link for a session whose chat row was
 -- created before account attribution landed. A chat is created once, on the

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -466,6 +466,31 @@ func (q *Queries) InsertToolCallBlock(ctx context.Context, arg InsertToolCallBlo
 	return err
 }
 
+const latestUserMessageMatchesOpenCode = `-- name: LatestUserMessageMatchesOpenCode :one
+SELECT COALESCE((
+  SELECT source = 'opencode' AND content = $1
+  FROM chat_messages
+  WHERE project_id = $2::uuid
+    AND chat_id = $3
+    AND role = 'user'
+  ORDER BY created_at DESC, seq DESC
+  LIMIT 1
+), FALSE)::boolean
+`
+
+type LatestUserMessageMatchesOpenCodeParams struct {
+	Content   string
+	ProjectID uuid.UUID
+	ChatID    uuid.UUID
+}
+
+func (q *Queries) LatestUserMessageMatchesOpenCode(ctx context.Context, arg LatestUserMessageMatchesOpenCodeParams) (bool, error) {
+	row := q.db.QueryRow(ctx, latestUserMessageMatchesOpenCode, arg.Content, arg.ProjectID, arg.ChatID)
+	var column_1 bool
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const linkChatUserAccount = `-- name: LinkChatUserAccount :execrows
 UPDATE chats
 SET user_account_id = $1

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -466,31 +466,6 @@ func (q *Queries) InsertToolCallBlock(ctx context.Context, arg InsertToolCallBlo
 	return err
 }
 
-const latestUserMessageMatchesOpenCode = `-- name: LatestUserMessageMatchesOpenCode :one
-SELECT COALESCE((
-  SELECT source = 'opencode' AND content = $1
-  FROM chat_messages
-  WHERE project_id = $2::uuid
-    AND chat_id = $3
-    AND role = 'user'
-  ORDER BY created_at DESC, seq DESC
-  LIMIT 1
-), FALSE)::boolean
-`
-
-type LatestUserMessageMatchesOpenCodeParams struct {
-	Content   string
-	ProjectID uuid.UUID
-	ChatID    uuid.UUID
-}
-
-func (q *Queries) LatestUserMessageMatchesOpenCode(ctx context.Context, arg LatestUserMessageMatchesOpenCodeParams) (bool, error) {
-	row := q.db.QueryRow(ctx, latestUserMessageMatchesOpenCode, arg.Content, arg.ProjectID, arg.ChatID)
-	var column_1 bool
-	err := row.Scan(&column_1)
-	return column_1, err
-}
-
 const linkChatUserAccount = `-- name: LinkChatUserAccount :execrows
 UPDATE chats
 SET user_account_id = $1

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -336,14 +336,26 @@ func (s *Service) insertMessageWithFallbackUpsert(
 	msgParams chatRepo.CreateChatMessageParams,
 	defaultTitle string,
 ) error {
+	_, err := s.insertMessageWithFallbackUpsertResult(ctx, metadata, chatID, projectID, msgParams, defaultTitle)
+	return err
+}
+
+func (s *Service) insertMessageWithFallbackUpsertResult(
+	ctx context.Context,
+	metadata *SessionMetadata,
+	chatID uuid.UUID,
+	projectID uuid.UUID,
+	msgParams chatRepo.CreateChatMessageParams,
+	defaultTitle string,
+) (bool, error) {
 	if s.productFeatures == nil {
-		return nil
+		return false, nil
 	}
 
 	// Check if session capture is enabled for this org
 	enabled, err := s.productFeatures.IsFeatureEnabled(ctx, metadata.GramOrgID, productfeatures.FeatureSessionCapture)
 	if err != nil {
-		return fmt.Errorf("check session_capture feature flag: %w", err)
+		return false, fmt.Errorf("check session_capture feature flag: %w", err)
 	}
 	if !enabled {
 		s.logger.DebugContext(ctx, "session capture disabled; skipping Claude chat persistence",
@@ -352,31 +364,33 @@ func (s *Service) insertMessageWithFallbackUpsert(
 			attr.SlogProjectID(projectID.String()),
 			attr.SlogGenAIConversationID(metadata.SessionID),
 		)
-		return nil
+		return false, nil
 	}
 
-	writeMessage := func() error {
+	writeMessage := func() (int64, error) {
 		if msgParams.MessageID.Valid && strings.HasPrefix(msgParams.MessageID.String, agentPromptCorrelationPrefix) {
-			if _, writeErr := s.writer.WriteCorrelated(ctx, projectID, msgParams, msgParams.MessageID.String); writeErr != nil {
-				return fmt.Errorf("write correlated chat message: %w", writeErr)
+			n, writeErr := s.writer.WriteCorrelated(ctx, projectID, msgParams, msgParams.MessageID.String)
+			if writeErr != nil {
+				return 0, fmt.Errorf("write correlated chat message: %w", writeErr)
 			}
-			return nil
+			return n, nil
 		}
-		if _, writeErr := s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams}); writeErr != nil {
-			return fmt.Errorf("write chat message: %w", writeErr)
+		n, writeErr := s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams})
+		if writeErr != nil {
+			return 0, fmt.Errorf("write chat message: %w", writeErr)
 		}
-		return nil
+		return n, nil
 	}
 
 	// Try to insert the message (the writer handles notification on success).
-	err = writeMessage()
+	n, err := writeMessage()
 	if err == nil {
-		return nil
+		return n > 0, nil
 	}
 
 	// If this is not a foreign key violation (chat doesn't exist), fail.
 	if !isForeignKeyViolation(err) {
-		return fmt.Errorf("insert chat message: %w", err)
+		return false, fmt.Errorf("insert chat message: %w", err)
 	}
 
 	// Create the chat and retry.
@@ -390,13 +404,14 @@ func (s *Service) insertMessageWithFallbackUpsert(
 		Title:          conv.ToPGText(defaultTitle),
 	})
 	if upsertErr != nil {
-		return fmt.Errorf("upsert claude code session after FK violation: %w", upsertErr)
+		return false, fmt.Errorf("upsert claude code session after FK violation: %w", upsertErr)
 	}
 
-	if err = writeMessage(); err != nil {
-		return fmt.Errorf("insert chat message after creating chat: %w", err)
+	n, err = writeMessage()
+	if err != nil {
+		return false, fmt.Errorf("insert chat message after creating chat: %w", err)
 	}
-	return nil
+	return n > 0, nil
 }
 
 // persistConversationEvent writes a conversation event (user prompt or assistant response) to PostgreSQL.

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/hookevents"
 	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 )
 
@@ -348,23 +350,9 @@ func (s *Service) insertMessageWithFallbackUpsertResult(
 	msgParams chatRepo.CreateChatMessageParams,
 	defaultTitle string,
 ) (bool, error) {
-	if s.productFeatures == nil {
-		return false, nil
-	}
-
-	// Check if session capture is enabled for this org
-	enabled, err := s.productFeatures.IsFeatureEnabled(ctx, metadata.GramOrgID, productfeatures.FeatureSessionCapture)
-	if err != nil {
-		return false, fmt.Errorf("check session_capture feature flag: %w", err)
-	}
-	if !enabled {
-		s.logger.DebugContext(ctx, "session capture disabled; skipping Claude chat persistence",
-			attr.SlogEvent("claude_hook_session_capture_disabled"),
-			attr.SlogOrganizationID(metadata.GramOrgID),
-			attr.SlogProjectID(projectID.String()),
-			attr.SlogGenAIConversationID(metadata.SessionID),
-		)
-		return false, nil
+	enabled, err := s.sessionCaptureEnabled(ctx, metadata, projectID)
+	if err != nil || !enabled {
+		return false, err
 	}
 
 	writeMessage := func() (int64, error) {
@@ -410,6 +398,124 @@ func (s *Service) insertMessageWithFallbackUpsertResult(
 	n, err = writeMessage()
 	if err != nil {
 		return false, fmt.Errorf("insert chat message after creating chat: %w", err)
+	}
+	return n > 0, nil
+}
+
+func (s *Service) sessionCaptureEnabled(ctx context.Context, metadata *SessionMetadata, projectID uuid.UUID) (bool, error) {
+	if s.productFeatures == nil {
+		return false, nil
+	}
+
+	// Check if session capture is enabled for this org
+	enabled, err := s.productFeatures.IsFeatureEnabled(ctx, metadata.GramOrgID, productfeatures.FeatureSessionCapture)
+	if err != nil {
+		return false, fmt.Errorf("check session_capture feature flag: %w", err)
+	}
+	if !enabled {
+		s.logger.DebugContext(ctx, "session capture disabled; skipping Claude chat persistence",
+			attr.SlogEvent("claude_hook_session_capture_disabled"),
+			attr.SlogOrganizationID(metadata.GramOrgID),
+			attr.SlogProjectID(projectID.String()),
+			attr.SlogGenAIConversationID(metadata.SessionID),
+		)
+		return false, nil
+	}
+	return true, nil
+}
+
+func (s *Service) insertUncorrelatedAgentPrompt(
+	ctx context.Context,
+	metadata *SessionMetadata,
+	msgParams chatRepo.CreateChatMessageParams,
+	defaultTitle string,
+	native bool,
+) (bool, error) {
+	projectID := msgParams.ProjectID
+	enabled, err := s.sessionCaptureEnabled(ctx, metadata, projectID)
+	if err != nil || !enabled {
+		return false, err
+	}
+	if !native {
+		var nativeSource string
+		if cacheErr := s.cache.Get(ctx, sessionNativeHooksCacheKey(projectID.String(), metadata.SessionID), &nativeSource); cacheErr == nil && strings.TrimSpace(nativeSource) != "" {
+			return false, nil
+		}
+	}
+
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("begin prompt correlation transaction: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+	queries := chatRepo.New(tx)
+	lockParams := chatRepo.AcquireChatPromptCorrelationLockParams{ProjectID: projectID, ChatID: msgParams.ChatID}
+	if err := queries.AcquireChatPromptCorrelationLock(ctx, lockParams); err != nil {
+		return false, fmt.Errorf("lock prompt correlation: %w", err)
+	}
+
+	latest, latestErr := queries.GetLatestChatUserPrompt(ctx, chatRepo.GetLatestChatUserPromptParams{
+		ChatID:    msgParams.ChatID,
+		ProjectID: projectID,
+	})
+	if latestErr != nil && !errors.Is(latestErr, pgx.ErrNoRows) {
+		return false, fmt.Errorf("get latest chat user prompt: %w", latestErr)
+	}
+
+	if !native && latestErr == nil && latest.Source.Valid && usesNativeTranscriptFallback(latest.Source.String) {
+		s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, latest.Source.String)
+		return false, nil
+	}
+	if native && latestErr == nil && latest.Source.String == "litellm" && latest.Content == msgParams.Content {
+		n, promoteErr := queries.PromoteLiteLLMPrompt(ctx, chatRepo.PromoteLiteLLMPromptParams{
+			Source:         msgParams.Source,
+			UserID:         msgParams.UserID,
+			ExternalUserID: msgParams.ExternalUserID,
+			Model:          msgParams.Model,
+			Replayed:       msgParams.Replayed,
+			CreatedAt:      msgParams.CreatedAt,
+			ID:             latest.ID,
+			ProjectID:      projectID,
+			Content:        msgParams.Content,
+		})
+		if promoteErr != nil {
+			return false, fmt.Errorf("promote LiteLLM prompt: %w", promoteErr)
+		}
+		if n > 0 {
+			if err := tx.Commit(ctx); err != nil {
+				return false, fmt.Errorf("commit promoted LiteLLM prompt: %w", err)
+			}
+			s.writer.NotifyStored(ctx, projectID)
+			s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, msgParams.Source.String)
+			return true, nil
+		}
+	}
+
+	_, err = repo.New(tx).UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID:             msgParams.ChatID,
+		ProjectID:      projectID,
+		OrganizationID: metadata.GramOrgID,
+		UserID:         conv.ToPGTextEmpty(metadata.UserID),
+		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
+		UserAccountID:  conv.StringToNullUUID(metadata.UserAccountID),
+		Title:          conv.ToPGText(defaultTitle),
+	})
+	if err != nil {
+		return false, fmt.Errorf("upsert claude code session: %w", err)
+	}
+	params := []chatRepo.CreateChatMessageParams{msgParams}
+	n, err := s.writer.WriteInTx(ctx, tx, params)
+	if err != nil {
+		return false, fmt.Errorf("insert uncorrelated agent prompt: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("commit uncorrelated agent prompt: %w", err)
+	}
+	if n > 0 {
+		s.writer.NotifyStoredRows(ctx, projectID, params)
+	}
+	if native && n > 0 {
+		s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, msgParams.Source.String)
 	}
 	return n > 0, nil
 }

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -355,8 +355,21 @@ func (s *Service) insertMessageWithFallbackUpsert(
 		return nil
 	}
 
-	// Try to insert the message (Write handles notification on success).
-	_, err = s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams})
+	writeMessage := func() error {
+		if msgParams.MessageID.Valid && strings.HasPrefix(msgParams.MessageID.String, agentPromptCorrelationPrefix) {
+			if _, writeErr := s.writer.WriteCorrelated(ctx, projectID, msgParams, msgParams.MessageID.String); writeErr != nil {
+				return fmt.Errorf("write correlated chat message: %w", writeErr)
+			}
+			return nil
+		}
+		if _, writeErr := s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams}); writeErr != nil {
+			return fmt.Errorf("write chat message: %w", writeErr)
+		}
+		return nil
+	}
+
+	// Try to insert the message (the writer handles notification on success).
+	err = writeMessage()
 	if err == nil {
 		return nil
 	}
@@ -380,7 +393,7 @@ func (s *Service) insertMessageWithFallbackUpsert(
 		return fmt.Errorf("upsert claude code session after FK violation: %w", upsertErr)
 	}
 
-	if _, err = s.writer.Write(ctx, projectID, []chatRepo.CreateChatMessageParams{msgParams}); err != nil {
+	if err = writeMessage(); err != nil {
 		return fmt.Errorf("insert chat message after creating chat: %w", err)
 	}
 	return nil

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -454,42 +454,22 @@ func (s *Service) insertUncorrelatedAgentPrompt(
 		return false, fmt.Errorf("lock prompt correlation: %w", err)
 	}
 
-	latest, latestErr := queries.GetLatestChatUserPrompt(ctx, chatRepo.GetLatestChatUserPromptParams{
-		ChatID:    msgParams.ChatID,
-		ProjectID: projectID,
-	})
-	if latestErr != nil && !errors.Is(latestErr, pgx.ErrNoRows) {
-		return false, fmt.Errorf("get latest chat user prompt: %w", latestErr)
-	}
-
-	if !native && latestErr == nil && latest.Source.Valid && usesNativeTranscriptFallback(latest.Source.String) {
-		s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, latest.Source.String)
-		return false, nil
-	}
-	if native && latestErr == nil && latest.Source.String == "litellm" && latest.Content == msgParams.Content {
-		n, promoteErr := queries.PromoteLiteLLMPrompt(ctx, chatRepo.PromoteLiteLLMPromptParams{
-			Source:         msgParams.Source,
-			UserID:         msgParams.UserID,
-			ExternalUserID: msgParams.ExternalUserID,
-			Model:          msgParams.Model,
-			Replayed:       msgParams.Replayed,
-			CreatedAt:      msgParams.CreatedAt,
-			ID:             latest.ID,
-			ProjectID:      projectID,
-			Content:        msgParams.Content,
+	if !native {
+		latestSource, latestErr := queries.GetLatestChatUserPromptSource(ctx, chatRepo.GetLatestChatUserPromptSourceParams{
+			ChatID:    msgParams.ChatID,
+			ProjectID: projectID,
 		})
-		if promoteErr != nil {
-			return false, fmt.Errorf("promote LiteLLM prompt: %w", promoteErr)
+		if latestErr != nil && !errors.Is(latestErr, pgx.ErrNoRows) {
+			return false, fmt.Errorf("get latest chat user prompt source: %w", latestErr)
 		}
-		if n > 0 {
-			if err := tx.Commit(ctx); err != nil {
-				return false, fmt.Errorf("commit promoted LiteLLM prompt: %w", err)
-			}
-			s.writer.NotifyStored(ctx, projectID)
-			s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, msgParams.Source.String)
-			return true, nil
+		if latestErr == nil && latestSource.Valid && usesNativeTranscriptFallback(latestSource.String) {
+			s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, latestSource.String)
+			return false, nil
 		}
 	}
+	// Claude and Cursor have no turn ID shared with LiteLLM. If LiteLLM won the
+	// lock, keep both rows rather than guessing from prompt text and losing or
+	// misattributing a legitimate repeated native turn.
 
 	_, err = repo.New(tx).UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
 		ID:             msgParams.ChatID,
@@ -513,9 +493,6 @@ func (s *Service) insertUncorrelatedAgentPrompt(
 	}
 	if n > 0 {
 		s.writer.NotifyStoredRows(ctx, projectID, params)
-	}
-	if native && n > 0 {
-		s.markNativePromptSession(ctx, projectID.String(), metadata.SessionID, msgParams.Source.String)
 	}
 	return n > 0, nil
 }

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -454,7 +454,7 @@ func codexTurnMetadataFromHeaders(headers map[string]string) (codexTurnMetadata,
 func agentTurnFromHeaders(headers map[string]string) (string, string) {
 	provider := strings.ToLower(requestHeader(headers, "x-gram-agent-provider"))
 	turnID := requestHeader(headers, "x-gram-agent-turn-id")
-	if isCorrelatableAgentProvider(provider) && turnID != "" {
+	if (provider == "codex" || provider == "opencode") && turnID != "" {
 		return provider, turnID
 	}
 
@@ -466,15 +466,6 @@ func agentTurnFromHeaders(headers map[string]string) (string, string) {
 		return "opencode", turnID
 	}
 	return "", ""
-}
-
-func isCorrelatableAgentProvider(provider string) bool {
-	switch provider {
-	case "claude", "codex", "cursor", "opencode":
-		return true
-	default:
-		return false
-	}
 }
 
 func requestHeader(headers map[string]string, name string) string {

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -2,6 +2,7 @@ package litellm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -33,6 +34,7 @@ import (
 const (
 	genericBlockedReason = "Request blocked by policy."
 	callCacheTimeout     = time.Second
+	agentTurnPrefix      = "agent-turn:v1:"
 )
 
 type HookIngester interface {
@@ -163,6 +165,10 @@ func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload,
 	version := strings.TrimSpace(conv.PtrValOr(payload.LitellmVersion, ""))
 	email := conv.NormalizeEmail(conv.PtrValOr(payload.RequestData.UserAPIKeyUserEmail, ""))
 	idempotencyKey := "litellm:" + callID + ":request"
+	turnID := callID
+	if provider, agentTurnID := agentTurnFromHeaders(payload.RequestHeaders); agentTurnID != "" {
+		turnID = agentTurnPrefix + provider + ":" + agentTurnID
+	}
 
 	hookPayload := &hooksgen.IngestPayload{
 		ApikeyToken:      nil,
@@ -179,7 +185,7 @@ func (s *Service) ingestRequest(ctx context.Context, payload *gen.IngestPayload,
 		},
 		Session: &hooksgen.HookIngestSession{
 			ID:     &sessionID,
-			TurnID: &callID,
+			TurnID: &turnID,
 			Cwd:    nil,
 			Model:  conv.PtrEmpty(model),
 		},
@@ -410,20 +416,60 @@ func joinedTexts(texts []string) string {
 
 func sessionHeader(headers map[string]string) string {
 	for _, header := range []string{
+		"x-gram-agent-session-id",
 		"x-gram-session-id",
 		"x-claude-code-session-id",
 		"session-id",
 		"thread-id",
 		"x-session-id",
+		"x-opencode-session",
 	} {
-		for key, value := range headers {
-			if !strings.EqualFold(strings.TrimSpace(key), header) {
-				continue
-			}
-			value = strings.TrimSpace(value)
-			if value != "" && !strings.EqualFold(value, "[present]") {
-				return value
-			}
+		if value := requestHeader(headers, header); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func agentTurnFromHeaders(headers map[string]string) (string, string) {
+	provider := strings.ToLower(requestHeader(headers, "x-gram-agent-provider"))
+	turnID := requestHeader(headers, "x-gram-agent-turn-id")
+	if isCorrelatableAgentProvider(provider) && turnID != "" {
+		return provider, turnID
+	}
+
+	if encoded := requestHeader(headers, "x-codex-turn-metadata"); encoded != "" {
+		var metadata struct {
+			TurnID string `json:"turn_id"`
+		}
+		if json.Unmarshal([]byte(encoded), &metadata) == nil && strings.TrimSpace(metadata.TurnID) != "" {
+			return "codex", strings.TrimSpace(metadata.TurnID)
+		}
+	}
+
+	if turnID := requestHeader(headers, "x-opencode-request"); turnID != "" {
+		return "opencode", turnID
+	}
+	return "", ""
+}
+
+func isCorrelatableAgentProvider(provider string) bool {
+	switch provider {
+	case "claude", "codex", "cursor", "opencode":
+		return true
+	default:
+		return false
+	}
+}
+
+func requestHeader(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if !strings.EqualFold(strings.TrimSpace(key), name) {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value != "" && !strings.EqualFold(value, "[present]") {
+			return value
 		}
 	}
 	return ""

--- a/server/internal/litellm/impl.go
+++ b/server/internal/litellm/impl.go
@@ -428,7 +428,27 @@ func sessionHeader(headers map[string]string) string {
 			return value
 		}
 	}
+	if metadata, ok := codexTurnMetadataFromHeaders(headers); ok {
+		return strings.TrimSpace(metadata.SessionID)
+	}
 	return ""
+}
+
+type codexTurnMetadata struct {
+	SessionID string `json:"session_id"`
+	TurnID    string `json:"turn_id"`
+}
+
+func codexTurnMetadataFromHeaders(headers map[string]string) (codexTurnMetadata, bool) {
+	encoded := requestHeader(headers, "x-codex-turn-metadata")
+	if encoded == "" {
+		return codexTurnMetadata{SessionID: "", TurnID: ""}, false
+	}
+	var metadata codexTurnMetadata
+	if json.Unmarshal([]byte(encoded), &metadata) != nil {
+		return codexTurnMetadata{SessionID: "", TurnID: ""}, false
+	}
+	return metadata, true
 }
 
 func agentTurnFromHeaders(headers map[string]string) (string, string) {
@@ -438,13 +458,8 @@ func agentTurnFromHeaders(headers map[string]string) (string, string) {
 		return provider, turnID
 	}
 
-	if encoded := requestHeader(headers, "x-codex-turn-metadata"); encoded != "" {
-		var metadata struct {
-			TurnID string `json:"turn_id"`
-		}
-		if json.Unmarshal([]byte(encoded), &metadata) == nil && strings.TrimSpace(metadata.TurnID) != "" {
-			return "codex", strings.TrimSpace(metadata.TurnID)
-		}
+	if metadata, ok := codexTurnMetadataFromHeaders(headers); ok && strings.TrimSpace(metadata.TurnID) != "" {
+		return "codex", strings.TrimSpace(metadata.TurnID)
 	}
 
 	if turnID := requestHeader(headers, "x-opencode-request"); turnID != "" {

--- a/server/internal/litellm/ingest_test.go
+++ b/server/internal/litellm/ingest_test.go
@@ -323,6 +323,13 @@ func TestAgentTurnFromHeadersUsesCodexMetadataAndOpenCodeFallback(t *testing.T) 
 	provider, turnID = agentTurnFromHeaders(map[string]string{"X-OpenCode-Request": "message-1"})
 	require.Equal(t, "opencode", provider)
 	require.Equal(t, "message-1", turnID)
+
+	provider, turnID = agentTurnFromHeaders(map[string]string{
+		"X-Gram-Agent-Provider": "claude",
+		"X-Gram-Agent-Turn-ID":  "turn-1",
+	})
+	require.Empty(t, provider)
+	require.Empty(t, turnID)
 }
 
 func TestIngestResponseUsesCachedActorAndSession(t *testing.T) {

--- a/server/internal/litellm/ingest_test.go
+++ b/server/internal/litellm/ingest_test.go
@@ -183,7 +183,11 @@ func TestIngestTranslatesLatestStructuredUserMessage(t *testing.T) {
 	payload.Images = []string{"image"}
 	payload.Tools = []any{map[string]any{"name": "definition-only"}}
 	payload.ToolCalls = []any{map[string]any{"name": "historical-only"}}
-	payload.RequestHeaders = map[string]string{"X-Gram-Session-ID": "session-from-header"}
+	payload.RequestHeaders = map[string]string{
+		"X-Gram-Session-ID":     "session-from-header",
+		"X-Gram-Agent-Provider": "opencode",
+		"X-Gram-Agent-Turn-ID":  "message-1",
+	}
 	payload.LitellmTraceID = new("trace-1")
 	payload.LitellmVersion = new("1.94.0")
 	payload.Model = new("model-1")
@@ -206,7 +210,7 @@ func TestIngestTranslatesLatestStructuredUserMessage(t *testing.T) {
 	require.Equal(t, "1.94.0", *call.payload.Source.AdapterVersion)
 	require.Equal(t, "member@example.test", *call.payload.Source.UserEmail)
 	require.Equal(t, "session-from-header", *call.payload.Session.ID)
-	require.Equal(t, "call-1", *call.payload.Session.TurnID)
+	require.Equal(t, "agent-turn:v1:opencode:message-1", *call.payload.Session.TurnID)
 	require.Equal(t, "model-1", *call.payload.Session.Model)
 	require.Equal(t, "litellm:call-1:request", *call.payload.IdempotencyKey)
 	require.Empty(t, call.auth.UserID)
@@ -298,6 +302,25 @@ func TestSessionHeaderUsesNativeClientHeadersInPrecedenceOrder(t *testing.T) {
 
 	headers["X-Gram-Session-ID"] = "[present]"
 	require.Equal(t, "opencode-session", sessionHeader(headers))
+}
+
+func TestRequestHeaderIgnoresRedactedValues(t *testing.T) {
+	t.Parallel()
+	require.Empty(t, requestHeader(map[string]string{"X-Gram-Agent-Turn-ID": "[present]"}, "x-gram-agent-turn-id"))
+	require.Equal(t, "message-1", requestHeader(map[string]string{"X-Gram-Agent-Turn-ID": " message-1 "}, "x-gram-agent-turn-id"))
+}
+
+func TestAgentTurnFromHeadersUsesCodexMetadataAndOpenCodeFallback(t *testing.T) {
+	t.Parallel()
+	provider, turnID := agentTurnFromHeaders(map[string]string{
+		"X-Codex-Turn-Metadata": `{"session_id":"session-1","turn_id":"turn-1"}`,
+	})
+	require.Equal(t, "codex", provider)
+	require.Equal(t, "turn-1", turnID)
+
+	provider, turnID = agentTurnFromHeaders(map[string]string{"X-OpenCode-Request": "message-1"})
+	require.Equal(t, "opencode", provider)
+	require.Equal(t, "message-1", turnID)
 }
 
 func TestIngestResponseUsesCachedActorAndSession(t *testing.T) {

--- a/server/internal/litellm/ingest_test.go
+++ b/server/internal/litellm/ingest_test.go
@@ -312,9 +312,11 @@ func TestRequestHeaderIgnoresRedactedValues(t *testing.T) {
 
 func TestAgentTurnFromHeadersUsesCodexMetadataAndOpenCodeFallback(t *testing.T) {
 	t.Parallel()
-	provider, turnID := agentTurnFromHeaders(map[string]string{
+	headers := map[string]string{
 		"X-Codex-Turn-Metadata": `{"session_id":"session-1","turn_id":"turn-1"}`,
-	})
+	}
+	require.Equal(t, "session-1", sessionHeader(headers))
+	provider, turnID := agentTurnFromHeaders(headers)
 	require.Equal(t, "codex", provider)
 	require.Equal(t, "turn-1", turnID)
 
@@ -342,7 +344,11 @@ func TestIngestResponseUsesCachedActorAndSession(t *testing.T) {
 	payload.Texts = []string{" first segment ", "", "  second segment  "}
 	payload.StructuredMessages = []*gen.LiteLLMStructuredMessage{{Role: "user", Content: "request history must be ignored"}}
 	payload.ToolCalls = []any{map[string]any{"id": "tool-1", "type": "function"}}
-	payload.RequestHeaders = map[string]string{"x-gram-session-id": "conflicting-response-session"}
+	payload.RequestHeaders = map[string]string{
+		"x-gram-session-id":     "conflicting-response-session",
+		"x-gram-agent-provider": "opencode",
+		"x-gram-agent-turn-id":  "agent-turn-that-must-not-replace-call-id",
+	}
 	payload.LitellmTraceID = new("conflicting-response-trace")
 	payload.RequestData.UserAPIKeyUserEmail = new("conflicting@example.test")
 

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -353,56 +354,85 @@ func TestRealHooksCapturesResponseWithCachedActorAndDedupesRetry(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
-func TestRealHooksCoalescesLiteLLMPromptsWithOpenCodeMessages(t *testing.T) {
+func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newRealTestService(t, nil)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	sessionID := "ses_" + uuid.NewString()
 	prompt := "summarize this repository"
-	ingestOpenCodePrompt := func() {
+	ingestNativePrompt := func(adapter, sessionID, turn string) {
 		t.Helper()
+		turnID := "agent-turn:v1:" + adapter + ":" + turn
 		_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
 			ApikeyToken:      nil,
 			ProjectSlugInput: nil,
 			Replayed:         nil,
 			SchemaVersion:    "hook.ingest.v1",
-			IdempotencyKey:   new("opencode-" + uuid.NewString()),
+			IdempotencyKey:   new("native-" + uuid.NewString()),
 			Source: &hooksgen.HookIngestSource{
-				Adapter:        "opencode",
+				Adapter:        adapter,
 				AdapterVersion: nil,
 				RawEventName:   nil,
 				Hostname:       nil,
 				UserEmail:      nil,
 			},
-			Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: nil, Cwd: nil, Model: nil},
+			Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: &turnID, Cwd: nil, Model: nil},
 			Event:   &hooksgen.HookIngestEvent{Type: "prompt.submitted", OccurredAt: nil},
 			Data:    &hooksgen.HookIngestData{Prompt: &hooksgen.HookPromptData{Text: &prompt}},
 			Raw:     nil,
 		})
 		require.NoError(t, err)
 	}
-	ingestLiteLLMPrompt := func() {
+	ingestLiteLLMPrompt := func(sessionID string, extraHeaders map[string]string) {
 		t.Helper()
 		payload := testPayload()
 		payload.LitellmCallID = new("call-" + uuid.NewString())
 		payload.Texts = []string{prompt}
 		payload.RequestHeaders = map[string]string{"x-session-id": sessionID}
+		maps.Copy(payload.RequestHeaders, extraHeaders)
 		result, err := ti.service.Ingest(ctx, payload)
 		require.NoError(t, err)
 		require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
 	}
 
-	ingestOpenCodePrompt()
-	ingestLiteLLMPrompt()
-	ingestLiteLLMPrompt()
-	ingestOpenCodePrompt()
-	ingestLiteLLMPrompt()
+	openCodeFirstSession := "ses_" + uuid.NewString()
+	openCodeFirstMessage := "msg_" + uuid.NewString()
+	openCodeHeaders := map[string]string{
+		"x-gram-agent-provider": "opencode",
+		"x-gram-agent-turn-id":  openCodeFirstMessage,
+	}
+	ingestNativePrompt("opencode", openCodeFirstSession, openCodeFirstMessage)
+	ingestLiteLLMPrompt(openCodeFirstSession, openCodeHeaders)
+	ingestLiteLLMPrompt(openCodeFirstSession, openCodeHeaders)
 
 	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
-		ChatID:    chat.SessionIDToChatID(sessionID),
+		ChatID:    chat.SessionIDToChatID(openCodeFirstSession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "opencode", messages[0].Source.String)
+
+	liteLLMFirstSession := uuid.NewString()
+	liteLLMFirstTurn := uuid.NewString()
+	codexHeaders := map[string]string{
+		"x-codex-turn-metadata": fmt.Sprintf(`{"session_id":%q,"turn_id":%q}`, liteLLMFirstSession, liteLLMFirstTurn),
+	}
+	ingestLiteLLMPrompt(liteLLMFirstSession, codexHeaders)
+	ingestLiteLLMPrompt(liteLLMFirstSession, codexHeaders)
+	ingestNativePrompt("codex", liteLLMFirstSession, liteLLMFirstTurn)
+
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(liteLLMFirstSession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "codex", messages[0].Source.String)
+
+	repeatedSession := "ses_" + uuid.NewString()
+	ingestNativePrompt("opencode", repeatedSession, "msg_"+uuid.NewString())
+	ingestNativePrompt("opencode", repeatedSession, "msg_"+uuid.NewString())
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(repeatedSession),
 		ProjectID: *authCtx.ProjectID,
 	}, 2)
 	for _, msg := range messages {
@@ -410,6 +440,24 @@ func TestRealHooksCoalescesLiteLLMPromptsWithOpenCodeMessages(t *testing.T) {
 		require.Equal(t, prompt, msg.Content)
 		require.Equal(t, "opencode", msg.Source.String)
 	}
+
+	claudeSession := uuid.NewString()
+	ingestNativePrompt("claude", claudeSession, "prompt_"+uuid.NewString())
+	ingestLiteLLMPrompt(claudeSession, nil)
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(claudeSession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "claude", messages[0].Source.String)
+
+	cursorSession := uuid.NewString()
+	ingestNativePrompt("cursor", cursorSession, "generation_"+uuid.NewString())
+	ingestLiteLLMPrompt(cursorSession, nil)
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(cursorSession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "cursor", messages[0].Source.String)
 }
 
 func TestRealHooksPersistsToolCallOnlyResponse(t *testing.T) {

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -353,6 +353,65 @@ func TestRealHooksCapturesResponseWithCachedActorAndDedupesRetry(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 }
 
+func TestRealHooksCoalescesLiteLLMPromptsWithOpenCodeMessages(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	sessionID := "ses_" + uuid.NewString()
+	prompt := "summarize this repository"
+	ingestOpenCodePrompt := func() {
+		t.Helper()
+		_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
+			ApikeyToken:      nil,
+			ProjectSlugInput: nil,
+			Replayed:         nil,
+			SchemaVersion:    "hook.ingest.v1",
+			IdempotencyKey:   new("opencode-" + uuid.NewString()),
+			Source: &hooksgen.HookIngestSource{
+				Adapter:        "opencode",
+				AdapterVersion: nil,
+				RawEventName:   nil,
+				Hostname:       nil,
+				UserEmail:      nil,
+			},
+			Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: nil, Cwd: nil, Model: nil},
+			Event:   &hooksgen.HookIngestEvent{Type: "prompt.submitted", OccurredAt: nil},
+			Data:    &hooksgen.HookIngestData{Prompt: &hooksgen.HookPromptData{Text: &prompt}},
+			Raw:     nil,
+		})
+		require.NoError(t, err)
+	}
+	ingestLiteLLMPrompt := func() {
+		t.Helper()
+		payload := testPayload()
+		payload.LitellmCallID = new("call-" + uuid.NewString())
+		payload.Texts = []string{prompt}
+		payload.RequestHeaders = map[string]string{"x-session-id": sessionID}
+		result, err := ti.service.Ingest(ctx, payload)
+		require.NoError(t, err)
+		require.Equal(t, gen.LiteLLMGuardrailAction("NONE"), result.Action)
+	}
+
+	ingestOpenCodePrompt()
+	ingestLiteLLMPrompt()
+	ingestLiteLLMPrompt()
+	ingestOpenCodePrompt()
+	ingestLiteLLMPrompt()
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	}, 2)
+	for _, msg := range messages {
+		require.Equal(t, "user", msg.Role)
+		require.Equal(t, prompt, msg.Content)
+		require.Equal(t, "opencode", msg.Source.String)
+	}
+}
+
 func TestRealHooksPersistsToolCallOnlyResponse(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newRealTestService(t, nil)

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -364,7 +365,10 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 	prompt := "summarize this repository"
 	ingestNativePrompt := func(adapter, sessionID, turn string) {
 		t.Helper()
-		turnID := "agent-turn:v1:" + adapter + ":" + turn
+		var turnID *string
+		if turn != "" {
+			turnID = new("agent-turn:v1:" + adapter + ":" + turn)
+		}
 		_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
 			ApikeyToken:      nil,
 			ProjectSlugInput: nil,
@@ -378,7 +382,7 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 				Hostname:       nil,
 				UserEmail:      nil,
 			},
-			Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: &turnID, Cwd: nil, Model: nil},
+			Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: turnID, Cwd: nil, Model: nil},
 			Event:   &hooksgen.HookIngestEvent{Type: "prompt.submitted", OccurredAt: nil},
 			Data:    &hooksgen.HookIngestData{Prompt: &hooksgen.HookPromptData{Text: &prompt}},
 			Raw:     nil,
@@ -455,7 +459,7 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 	require.Equal(t, "claude", messages[0].Source.String)
 	var repairedMarker string
 	require.NoError(t, ti.cache.Get(ctx, fmt.Sprintf("session:native-prompt:v1:%s:%s", authCtx.ProjectID.String(), claudeSession), &repairedMarker))
-	require.Equal(t, "captured", repairedMarker)
+	require.Equal(t, "claude", repairedMarker)
 
 	cursorSession := uuid.NewString()
 	ingestNativePrompt("cursor", cursorSession, "generation_"+uuid.NewString())
@@ -465,6 +469,15 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 		ProjectID: *authCtx.ProjectID,
 	}, 1)
 	require.Equal(t, "cursor", messages[0].Source.String)
+
+	liteLLMFirstFallbackSession := uuid.NewString()
+	ingestLiteLLMPrompt(liteLLMFirstFallbackSession, nil)
+	ingestNativePrompt("claude", liteLLMFirstFallbackSession, "")
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(liteLLMFirstFallbackSession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "claude", messages[0].Source.String)
 
 	startedOnlySession := uuid.NewString()
 	_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
@@ -492,6 +505,99 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 		ProjectID: *authCtx.ProjectID,
 	}, 1)
 	require.Equal(t, "litellm", messages[0].Source.String)
+}
+
+func TestRealHooksConcurrentUncorrelatedPromptsConverge(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	const sessions = 16
+	start := make(chan struct{})
+	errs := make(chan error, sessions*2)
+	var wg sync.WaitGroup
+	sessionIDs := make([]string, sessions)
+	for i := range sessions {
+		sessionID := "concurrent-uncorrelated-" + uuid.NewString()
+		sessionIDs[i] = sessionID
+		prompt := fmt.Sprintf("concurrent prompt %d", i)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
+				ApikeyToken:      nil,
+				ProjectSlugInput: nil,
+				Replayed:         nil,
+				SchemaVersion:    "hook.ingest.v1",
+				IdempotencyKey:   new("native-concurrent-" + uuid.NewString()),
+				Source: &hooksgen.HookIngestSource{
+					Adapter:        "claude",
+					AdapterVersion: nil,
+					RawEventName:   nil,
+					Hostname:       nil,
+					UserEmail:      nil,
+				},
+				Session: &hooksgen.HookIngestSession{ID: &sessionID, TurnID: nil, Cwd: nil, Model: nil},
+				Event:   &hooksgen.HookIngestEvent{Type: "prompt.submitted", OccurredAt: nil},
+				Data:    &hooksgen.HookIngestData{Prompt: &hooksgen.HookPromptData{Text: &prompt}},
+				Raw:     nil,
+			})
+			errs <- err
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			payload := testPayload()
+			payload.LitellmCallID = new("litellm-concurrent-" + uuid.NewString())
+			payload.Texts = []string{prompt}
+			payload.RequestHeaders = map[string]string{"x-session-id": sessionID}
+			_, err := ti.service.Ingest(ctx, payload)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	for _, sessionID := range sessionIDs {
+		messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+			ChatID:    chat.SessionIDToChatID(sessionID),
+			ProjectID: *authCtx.ProjectID,
+		}, 1)
+		require.Equal(t, "claude", messages[0].Source.String)
+	}
+}
+
+func TestRealHooksLiteLLMOnlyLongSessionPersistsEveryPrompt(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newRealTestService(t, nil)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	const promptCount = 128
+	sessionID := "litellm-long-session-" + uuid.NewString()
+	for i := range promptCount {
+		payload := testPayload()
+		payload.LitellmCallID = new(fmt.Sprintf("long-session-call-%d-%s", i, uuid.NewString()))
+		payload.Texts = []string{fmt.Sprintf("long session prompt %d", i)}
+		payload.RequestHeaders = map[string]string{"x-session-id": sessionID}
+		_, err := ti.service.Ingest(ctx, payload)
+		require.NoError(t, err)
+	}
+
+	messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(sessionID),
+		ProjectID: *authCtx.ProjectID,
+	}, promptCount)
+	require.Equal(t, "long session prompt 0", messages[0].Content)
+	require.Equal(t, "long session prompt 127", messages[len(messages)-1].Content)
 }
 
 func TestRealHooksPersistsToolCallOnlyResponse(t *testing.T) {

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -390,7 +390,10 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 		payload := testPayload()
 		payload.LitellmCallID = new("call-" + uuid.NewString())
 		payload.Texts = []string{prompt}
-		payload.RequestHeaders = map[string]string{"x-session-id": sessionID}
+		payload.RequestHeaders = map[string]string{}
+		if sessionID != "" {
+			payload.RequestHeaders["x-session-id"] = sessionID
+		}
 		maps.Copy(payload.RequestHeaders, extraHeaders)
 		result, err := ti.service.Ingest(ctx, payload)
 		require.NoError(t, err)
@@ -418,8 +421,8 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 	codexHeaders := map[string]string{
 		"x-codex-turn-metadata": fmt.Sprintf(`{"session_id":%q,"turn_id":%q}`, liteLLMFirstSession, liteLLMFirstTurn),
 	}
-	ingestLiteLLMPrompt(liteLLMFirstSession, codexHeaders)
-	ingestLiteLLMPrompt(liteLLMFirstSession, codexHeaders)
+	ingestLiteLLMPrompt("", codexHeaders)
+	ingestLiteLLMPrompt("", codexHeaders)
 	ingestNativePrompt("codex", liteLLMFirstSession, liteLLMFirstTurn)
 
 	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
@@ -443,12 +446,16 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 
 	claudeSession := uuid.NewString()
 	ingestNativePrompt("claude", claudeSession, "prompt_"+uuid.NewString())
+	require.NoError(t, ti.cache.Delete(ctx, fmt.Sprintf("session:native-prompt:v1:%s:%s", authCtx.ProjectID.String(), claudeSession)))
 	ingestLiteLLMPrompt(claudeSession, nil)
 	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
 		ChatID:    chat.SessionIDToChatID(claudeSession),
 		ProjectID: *authCtx.ProjectID,
 	}, 1)
 	require.Equal(t, "claude", messages[0].Source.String)
+	var repairedMarker string
+	require.NoError(t, ti.cache.Get(ctx, fmt.Sprintf("session:native-prompt:v1:%s:%s", authCtx.ProjectID.String(), claudeSession), &repairedMarker))
+	require.Equal(t, "captured", repairedMarker)
 
 	cursorSession := uuid.NewString()
 	ingestNativePrompt("cursor", cursorSession, "generation_"+uuid.NewString())
@@ -458,6 +465,33 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 		ProjectID: *authCtx.ProjectID,
 	}, 1)
 	require.Equal(t, "cursor", messages[0].Source.String)
+
+	startedOnlySession := uuid.NewString()
+	_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
+		ApikeyToken:      nil,
+		ProjectSlugInput: nil,
+		Replayed:         nil,
+		SchemaVersion:    "hook.ingest.v1",
+		IdempotencyKey:   new("native-start-" + uuid.NewString()),
+		Source: &hooksgen.HookIngestSource{
+			Adapter:        "claude",
+			AdapterVersion: nil,
+			RawEventName:   nil,
+			Hostname:       nil,
+			UserEmail:      nil,
+		},
+		Session: &hooksgen.HookIngestSession{ID: &startedOnlySession, TurnID: nil, Cwd: nil, Model: nil},
+		Event:   &hooksgen.HookIngestEvent{Type: "session.started", OccurredAt: nil},
+		Data:    nil,
+		Raw:     nil,
+	})
+	require.NoError(t, err)
+	ingestLiteLLMPrompt(startedOnlySession, nil)
+	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		ChatID:    chat.SessionIDToChatID(startedOnlySession),
+		ProjectID: *authCtx.ProjectID,
+	}, 1)
+	require.Equal(t, "litellm", messages[0].Source.String)
 }
 
 func TestRealHooksPersistsToolCallOnlyResponse(t *testing.T) {

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -473,11 +473,16 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 	liteLLMFirstFallbackSession := uuid.NewString()
 	ingestLiteLLMPrompt(liteLLMFirstFallbackSession, nil)
 	ingestNativePrompt("claude", liteLLMFirstFallbackSession, "")
+	ingestNativePrompt("claude", liteLLMFirstFallbackSession, "")
 	messages = requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
 		ChatID:    chat.SessionIDToChatID(liteLLMFirstFallbackSession),
 		ProjectID: *authCtx.ProjectID,
-	}, 1)
-	require.Equal(t, "claude", messages[0].Source.String)
+	}, 3)
+	// Claude has no turn ID shared with LiteLLM. LiteLLM-first therefore keeps
+	// both observations, and repeated identical native prompts remain distinct.
+	require.Equal(t, "litellm", messages[0].Source.String)
+	require.Equal(t, "claude", messages[1].Source.String)
+	require.Equal(t, "claude", messages[2].Source.String)
 
 	startedOnlySession := uuid.NewString()
 	_, err := ti.hooks.IngestAuthenticated(ctx, authCtx, &hooksgen.IngestPayload{
@@ -507,7 +512,7 @@ func TestRealHooksCorrelatesAgentTurnsAcrossNativeHooksAndLiteLLM(t *testing.T) 
 	require.Equal(t, "litellm", messages[0].Source.String)
 }
 
-func TestRealHooksConcurrentUncorrelatedPromptsConverge(t *testing.T) {
+func TestRealHooksConcurrentUncorrelatedPromptsPreserveNative(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newRealTestService(t, nil)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -566,11 +571,26 @@ func TestRealHooksConcurrentUncorrelatedPromptsConverge(t *testing.T) {
 	}
 
 	for _, sessionID := range sessionIDs {
-		messages := requireChatMessages(t, ctx, ti.conn, chatrepo.ListChatMessagesParams{
+		messages, err := chatrepo.New(ti.conn).ListChatMessages(ctx, chatrepo.ListChatMessagesParams{
 			ChatID:    chat.SessionIDToChatID(sessionID),
 			ProjectID: *authCtx.ProjectID,
-		}, 1)
-		require.Equal(t, "claude", messages[0].Source.String)
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, messages)
+		require.LessOrEqual(t, len(messages), 2)
+		nativeCount := 0
+		liteLLMCount := 0
+		for _, message := range messages {
+			switch message.Source.String {
+			case "claude":
+				nativeCount++
+			case "litellm":
+				liteLLMCount++
+			}
+		}
+		require.Equal(t, 1, nativeCount)
+		require.LessOrEqual(t, liteLLMCount, 1)
+		require.Equal(t, len(messages), nativeCount+liteLLMCount)
 	}
 }
 

--- a/server/internal/litellm/setup_test.go
+++ b/server/internal/litellm/setup_test.go
@@ -59,6 +59,7 @@ func TestMain(m *testing.M) {
 type realTestInstance struct {
 	service   *Service
 	hooks     *hooks.Service
+	cache     cache.Cache
 	conn      *pgxpool.Pool
 	chConn    clickhouse.Conn
 	telemetry *telemetry.Logger
@@ -182,6 +183,7 @@ func newRealTestServiceWithScannerFactory(t *testing.T, scannerFactory func(*pgx
 	return ctx, &realTestInstance{
 		service:   service,
 		hooks:     hookService,
+		cache:     cacheAdapter,
 		conn:      conn,
 		chConn:    chConn,
 		telemetry: telemetryLogger,

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -379,7 +379,7 @@ const platformMCPGeneratorVersion = "1"
 // line when it pins a new binary, because new checksums always change the
 // rendered bootstrap script. Any other change to hooks generation needs a
 // manual bump, which the Plugin Generate Check CI workflow enforces.
-const hooksGeneratorVersion = "28"
+const hooksGeneratorVersion = "29"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits
@@ -1517,6 +1517,15 @@ export const SpeakeasyObservability = async (ctx: any) => {
   return {
     "chat.message": forward("chat.message"),
     "chat.params": forward("chat.params"),
+    "chat.headers": async (input: any, output: any) => {
+      const messageID = input?.message?.id
+      if (messageID) output.headers = {
+        ...output.headers,
+        "x-gram-agent-provider": "opencode",
+        "x-gram-agent-session-id": input.sessionID,
+        "x-gram-agent-turn-id": messageID,
+      }
+    },
     "tool.execute.before": forward("tool.execute.before"),
     "tool.execute.after": forward("tool.execute.after"),
     event: async ({ event }: any) => {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1678,6 +1678,8 @@ func TestGenerateOpenCodeObservabilityPluginPackage(t *testing.T) {
 	require.Contains(t, string(shim), "--provider=opencode")
 	require.Contains(t, string(shim), "speakeasy.json")
 	require.Contains(t, string(shim), "bootstrap.sh")
+	require.Contains(t, string(shim), `"x-gram-agent-provider": "opencode"`)
+	require.Contains(t, string(shim), `"x-gram-agent-turn-id": messageID`)
 
 	_, ok = files["speakeasy.json"]
 	require.True(t, ok, "opencode package must ship speakeasy.json alongside the shim")


### PR DESCRIPTION
## Summary
- correlate LiteLLM and native hook prompts using stable provider turn identities for OpenCode and Codex
- atomically promote LiteLLM rows to the authoritative native source regardless of arrival order
- suppress LiteLLM transcript prompts for Claude and Cursor sessions once their native hook stream is known
- forward agent identity headers in generated LiteLLM config and republish the OpenCode observability plugin
- remain compatible with the currently pinned hooks binary by normalizing legacy Codex turn IDs and extracting OpenCode message IDs from raw events

## Rollout Note
Existing customer-managed LiteLLM instances must apply the updated generated config so the new turn identity headers are forwarded to the Gram guardrail. The control plane cannot mutate external LiteLLM configuration.