### PR TITLE
chore: relabel dev badge to "Internal Admin"

### DIFF
--- a/.changeset/internal-admin-badge-label.md
+++ b/.changeset/internal-admin-badge-label.md
@@ -1,0 +1,10 @@
+---
+"dashboard": patch
+---
+
+Relabel the amber badge that marks platform-admin-only UI from "Dev" to
+"Internal Admin". The badge appears on the platform admin toolbar and on
+admin-only fields of the device agent configuration page; "Dev" read as
+"development build" rather than "visible to Speakeasy staff only", which
+is what it actually means. Renamed the component to `InternalAdminBadge`
+to match.

--- a/client/dashboard/src/components/internal-admin-badge.tsx
+++ b/client/dashboard/src/components/internal-admin-badge.tsx
@@ -1,13 +1,13 @@
 import { Badge } from "@/components/ui/Badge";
 
-// Amber "DEV" pill marking UI that only Speakeasy platform admins (or local
-// dev builds) can see. Composes the design-system Badge — like
+// Amber "Internal Admin" pill marking UI that only Speakeasy platform admins
+// (or local dev builds) can see. Composes the design-system Badge — like
 // ReleaseStageBadge does — so the developer toolbar and dev-only form fields
 // render the marker from one source of truth.
-export function DevBadge(): JSX.Element {
+export function InternalAdminBadge(): JSX.Element {
   return (
     <Badge size="sm" variant="warning" background>
-      <Badge.Text>Dev</Badge.Text>
+      <Badge.Text>Internal Admin</Badge.Text>
     </Badge>
   );
 }

--- a/client/dashboard/src/components/platform-admin-toolbar.tsx
+++ b/client/dashboard/src/components/platform-admin-toolbar.tsx
@@ -10,7 +10,7 @@ import {
   PlatformAdminInfoPanel,
   PlatformAdminOnboardingPanel,
 } from "./platform-admin-panel";
-import { DevBadge } from "@/components/dev-badge";
+import { InternalAdminBadge } from "@/components/internal-admin-badge";
 import { Switch } from "@/components/ui/Switch";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -597,7 +597,7 @@ function PlatformAdminToolbarInner({ onHide }: { onHide: () => void }) {
             className="flex flex-1 cursor-grab items-center gap-2.5 active:cursor-grabbing"
           >
             <GripVertical className="text-muted-foreground/40 h-3.5 w-3.5 shrink-0" />
-            <DevBadge />
+            <InternalAdminBadge />
             <span className="text-muted-foreground text-xs font-semibold">
               Developer Toolkit
             </span>

--- a/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
+++ b/client/dashboard/src/pages/device-agent/device-agent-configuration.tsx
@@ -1,6 +1,6 @@
 import { RequireScope } from "@/components/require-scope";
 import { Heading } from "@/components/ui/Heading";
-import { DevBadge } from "@/components/dev-badge";
+import { InternalAdminBadge } from "@/components/internal-admin-badge";
 import { ErrorAlert } from "@/components/ui/Alert";
 import {
   Field,
@@ -398,7 +398,7 @@ function DeviceAgentConfigurationForm({
             <Field>
               <FieldLabel htmlFor="device-agent-update-channel">
                 Update channel
-                <DevBadge />
+                <InternalAdminBadge />
               </FieldLabel>
               <Input
                 id="device-agent-update-channel"
@@ -502,7 +502,7 @@ function DeviceAgentConfigurationForm({
           <Field>
             <FieldLabel htmlFor="device-agent-blocked-versions">
               Blocked versions
-              <DevBadge />
+              <InternalAdminBadge />
             </FieldLabel>
             <Input
               id="device-agent-blocked-versions"


### PR DESCRIPTION
Renames the amber badge that marks platform-admin-only UI from **"Dev"** to **"Internal Admin"**.

## Why

"Dev" read as "this is a development build" rather than what it actually
signals: _this UI is only visible to Speakeasy staff_. The new label says that
directly.

## What changed

- `Badge.Text` copy: `Dev` → `Internal Admin`
- Component renamed `DevBadge` → `InternalAdminBadge`, file renamed
  `dev-badge.tsx` → `internal-admin-badge.tsx` (moved with `git mv`, so blame
  history follows)
- Call sites updated: the platform admin toolbar, and both admin-only fields on
  the device agent configuration page

All three call sites render through the single shared component, so there is no
copy drift.

## Testing

`pnpm -F dashboard type-check` passes. No remaining references to `DevBadge` or
`dev-badge` anywhere in `client/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relabeled the amber badge marking platform-admin-only UI from “Dev” to “Internal Admin” to avoid confusion and clearly signal staff-only visibility.

- **Refactors**
  - Renamed `DevBadge` to `InternalAdminBadge` and file to `internal-admin-badge.tsx`.
  - Updated badge text: “Dev” → “Internal Admin”.
  - Switched call sites in the platform admin toolbar and device agent configuration fields to `InternalAdminBadge`.

<sup>Written for commit ea7ddd170125f0ac10b49c1957e14a673fe4040a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

