### PR TITLE
feat: cap enterprise trial credits at $50 per key

### DIFF
--- a/.changeset/trial-chat-credit-cap.md
+++ b/.changeset/trial-chat-credit-cap.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+An organization inside a Gram enterprise trial now receives $50 of chat credits instead of the full enterprise amount. The billing page also reports the credit ceiling recorded on your key, so an organization whose limit was raised sees the raised amount rather than the standard one for its plan.

--- a/.changeset/trial-chat-credit-cap.md
+++ b/.changeset/trial-chat-credit-cap.md
@@ -2,4 +2,6 @@
 "server": minor
 ---
 
-An organization inside a Gram enterprise trial now receives $50 of chat credits instead of the full enterprise amount. The billing page also reports the credit ceiling recorded on your key, so an organization whose limit was raised sees the raised amount rather than the standard one for its plan.
+An organization that starts a Gram trial now receives $50 of chat credits instead of the full enterprise amount. Gram applies the same $50 ceiling to the inference it runs on the organization's behalf, such as chat titles and risk analysis. A trial that is already in progress keeps the credits it has.
+
+The billing page now shows the credit ceiling that is set for your organization. An organization whose ceiling was raised sees that amount instead of the standard amount for its plan.

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -190,19 +190,13 @@ var creditsAccountTypeMap = map[string]int{
 	"":           5, // safety default
 }
 
-// trialCreditLimit caps each key an organization inside a trial holds. An
-// organization holds one key per KeyType, so its total trial exposure is this
-// amount multiplied by len(AllKeyTypes).
+// trialCreditLimit caps each key an organization inside a trial holds, so its
+// total trial exposure is this amount multiplied by len(AllKeyTypes). A trial
+// is armed without verified intent and the credit-balance gate hard-stops the
+// free tier only, so these key limits are its only spend ceiling.
 //
-// A trial is armed without verified intent, and the chat credit-balance gate
-// hard-stops the free tier only, so these key limits are the only spend
-// ceiling a trial organization has. The account type cannot supply one: arming
-// a trial sets the enterprise tier, which makes a trial indistinguishable from
-// a paying enterprise customer.
-//
-// The limit binds when a key is minted. Nothing re-mints a key, so it does not
-// follow an organization across the end of its trial in either direction. See
-// AGE-3138 and AGE-3141.
+// The limit binds at mint time and nothing re-mints a key. AGE-3138 and
+// AGE-3141 cover the two lifecycle edges that leaves wrong.
 const trialCreditLimit = 50
 
 var specialLimitOrgs = []string{
@@ -264,7 +258,6 @@ type OpenRouter struct {
 	db              *pgxpool.Pool
 	repo            *repo.Queries
 	orgRepo         *orgRepo.Queries
-	trialsRepo      *trialsRepo.Queries
 	orClient        *guardian.HTTPClient
 	refresher       KeyRefresher
 	featureClient   *productfeatures.Client
@@ -284,7 +277,6 @@ func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolic
 		db:              db,
 		repo:            repo.New(db),
 		orgRepo:         orgRepo.New(db),
-		trialsRepo:      trialsRepo.New(db),
 		orClient:        orClient,
 		refresher:       refresher,
 		featureClient:   featureClient,
@@ -382,7 +374,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 		return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
 
-	creditAmount := o.defaultLimitForOrg(ctx, o.trialsRepo.WithTx(dbtx), org)
+	creditAmount := o.defaultLimitForOrg(ctx, dbtx, org)
 
 	// Cap the upstream call so guardian's retry backoff cannot stretch the
 	// advisory-lock hold to minutes during an OpenRouter outage; a burst of
@@ -444,7 +436,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	if limit != nil {
 		keyLimit = *limit
 	} else {
-		keyLimit = o.defaultLimitForOrg(ctx, o.trialsRepo, org)
+		keyLimit = o.defaultLimitForOrg(ctx, o.db, org)
 	}
 
 	creditLimit := float64(keyLimit)
@@ -531,7 +523,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 	if err != nil {
 		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
-	limit := o.defaultLimitForOrg(ctx, o.trialsRepo, org)
+	limit := o.defaultLimitForOrg(ctx, o.db, org)
 
 	key, err := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -640,14 +632,14 @@ func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, 
 }
 
 // defaultLimitForOrg resolves the monthly credit ceiling an organization is
-// entitled to by policy. It describes what a key would be minted at today, not
-// what any existing key carries: an operator raise or a manual refresh leaves
-// the key above this amount, and only the key row records that.
+// entitled to by policy. It answers what a key would be minted at today, not
+// what an existing key carries: an operator raise leaves the key above this
+// amount, and only the key row records that.
 //
-// The trials queries arrive from the caller because the provisioning path runs
-// inside a transaction that already holds an advisory lock and a pool
-// connection, so it must read through that same transaction.
-func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, trials *trialsRepo.Queries, org orgRepo.OrganizationMetadatum) int {
+// dbtx arrives from the caller because the provisioning path runs inside a
+// transaction that already holds an advisory lock and a pool connection, so it
+// must read through that same transaction.
+func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, dbtx trialsRepo.DBTX, org orgRepo.OrganizationMetadatum) int {
 	if slices.Contains(specialLimitOrgs, org.ID) {
 		return 500
 	}
@@ -656,7 +648,7 @@ func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, trials *trialsRepo.
 	// cannot tell a trial apart from a paying enterprise customer. A read
 	// failure falls through to the account type rather than capping a paying
 	// customer on a transient database error.
-	_, err := trials.GetActiveTrial(ctx, org.ID)
+	_, err := trialsRepo.New(dbtx).GetActiveTrial(ctx, org.ID)
 	switch {
 	case err == nil:
 		return trialCreditLimit

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -190,12 +190,20 @@ var creditsAccountTypeMap = map[string]int{
 	"":           5, // safety default
 }
 
-// enterpriseTrialCredits caps an organization that is inside a self-signup
-// enterprise trial, which the account type alone cannot distinguish from a
-// paying enterprise customer. A trial is armed without verified intent, and
-// the chat credit-balance gate only hard-stops the free tier, so this key
-// limit is the only spend ceiling a trial organization has.
-const enterpriseTrialCredits = 50
+// trialCreditLimit caps each key an organization inside a trial holds. An
+// organization holds one key per KeyType, so its total trial exposure is this
+// amount multiplied by len(AllKeyTypes).
+//
+// A trial is armed without verified intent, and the chat credit-balance gate
+// hard-stops the free tier only, so these key limits are the only spend
+// ceiling a trial organization has. The account type cannot supply one: arming
+// a trial sets the enterprise tier, which makes a trial indistinguishable from
+// a paying enterprise customer.
+//
+// The limit binds when a key is minted. Nothing re-mints a key, so it does not
+// follow an organization across the end of its trial in either direction. See
+// AGE-3138 and AGE-3141.
+const trialCreditLimit = 50
 
 var specialLimitOrgs = []string{
 	"5a25158b-24dc-4d49-b03d-e85acfbea59c", // speakeasy-team
@@ -651,7 +659,7 @@ func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, trials *trialsRepo.
 	_, err := trials.GetActiveTrial(ctx, org.ID)
 	switch {
 	case err == nil:
-		return enterpriseTrialCredits
+		return trialCreditLimit
 	case !errors.Is(err, pgx.ErrNoRows):
 		o.logger.WarnContext(ctx, "error reading active trial; using the account type credit limit",
 			attr.SlogError(err),

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -27,6 +27,7 @@ import (
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
 const OpenRouterBaseURL = "https://openrouter.ai/api"
@@ -189,6 +190,13 @@ var creditsAccountTypeMap = map[string]int{
 	"":           5, // safety default
 }
 
+// enterpriseTrialCredits caps an organization that is inside a self-signup
+// enterprise trial, which the account type alone cannot distinguish from a
+// paying enterprise customer. A trial is armed without verified intent, and
+// the chat credit-balance gate only hard-stops the free tier, so this key
+// limit is the only spend ceiling a trial organization has.
+const enterpriseTrialCredits = 50
+
 var specialLimitOrgs = []string{
 	"5a25158b-24dc-4d49-b03d-e85acfbea59c", // speakeasy-team
 }
@@ -248,6 +256,7 @@ type OpenRouter struct {
 	db              *pgxpool.Pool
 	repo            *repo.Queries
 	orgRepo         *orgRepo.Queries
+	trialsRepo      *trialsRepo.Queries
 	orClient        *guardian.HTTPClient
 	refresher       KeyRefresher
 	featureClient   *productfeatures.Client
@@ -267,6 +276,7 @@ func New(logger *slog.Logger, tracerProvider trace.TracerProvider, guardianPolic
 		db:              db,
 		repo:            repo.New(db),
 		orgRepo:         orgRepo.New(db),
+		trialsRepo:      trialsRepo.New(db),
 		orClient:        orClient,
 		refresher:       refresher,
 		featureClient:   featureClient,
@@ -364,7 +374,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 		return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
 
-	creditAmount := o.getLimitForOrg(org)
+	creditAmount := o.defaultLimitForOrg(ctx, o.trialsRepo.WithTx(dbtx), org)
 
 	// Cap the upstream call so guardian's retry backoff cannot stretch the
 	// advisory-lock hold to minutes during an OpenRouter outage; a burst of
@@ -426,7 +436,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	if limit != nil {
 		keyLimit = *limit
 	} else {
-		keyLimit = o.getLimitForOrg(org)
+		keyLimit = o.defaultLimitForOrg(ctx, o.trialsRepo, org)
 	}
 
 	creditLimit := float64(keyLimit)
@@ -513,7 +523,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 	if err != nil {
 		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
-	limit := o.getLimitForOrg(org)
+	limit := o.defaultLimitForOrg(ctx, o.trialsRepo, org)
 
 	key, err := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -521,6 +531,14 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 	})
 	if err != nil {
 		return 0, limit, nil // the key doesn't exist yet
+	}
+
+	// The key carries the ceiling the customer actually spends against, which a
+	// raise or a tier change can move away from the policy amount. Keys minted
+	// before the column existed hold zero, and those fall back to the policy
+	// amount rather than reporting a ceiling of nothing.
+	if key.MonthlyCredits > 0 {
+		limit = int(key.MonthlyCredits)
 	}
 
 	used, _, err := o.GetKeyUsage(ctx, key.Key)
@@ -613,9 +631,32 @@ func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, 
 	return newLimit, nil
 }
 
-func (o *OpenRouter) getLimitForOrg(org orgRepo.OrganizationMetadatum) int {
+// defaultLimitForOrg resolves the monthly credit ceiling an organization is
+// entitled to by policy. It describes what a key would be minted at today, not
+// what any existing key carries: an operator raise or a manual refresh leaves
+// the key above this amount, and only the key row records that.
+//
+// The trials queries arrive from the caller because the provisioning path runs
+// inside a transaction that already holds an advisory lock and a pool
+// connection, so it must read through that same transaction.
+func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, trials *trialsRepo.Queries, org orgRepo.OrganizationMetadatum) int {
 	if slices.Contains(specialLimitOrgs, org.ID) {
 		return 500
+	}
+
+	// A trial runs on the real enterprise tier, so the account type on its own
+	// cannot tell a trial apart from a paying enterprise customer. A read
+	// failure falls through to the account type rather than capping a paying
+	// customer on a transient database error.
+	_, err := trials.GetActiveTrial(ctx, org.ID)
+	switch {
+	case err == nil:
+		return enterpriseTrialCredits
+	case !errors.Is(err, pgx.ErrNoRows):
+		o.logger.WarnContext(ctx, "error reading active trial; using the account type credit limit",
+			attr.SlogError(err),
+			attr.SlogOrganizationID(org.ID),
+		)
 	}
 
 	return creditsAccountTypeMap[org.GramAccountType]

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -374,7 +374,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 		return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
 
-	creditAmount := o.defaultLimitForOrg(ctx, dbtx, org)
+	creditAmount := o.defaultLimitForAccountType(ctx, dbtx, org)
 
 	// Cap the upstream call so guardian's retry backoff cannot stretch the
 	// advisory-lock hold to minutes during an OpenRouter outage; a burst of
@@ -436,7 +436,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	if limit != nil {
 		keyLimit = *limit
 	} else {
-		keyLimit = o.defaultLimitForOrg(ctx, o.db, org)
+		keyLimit = o.defaultLimitForAccountType(ctx, o.db, org)
 	}
 
 	creditLimit := float64(keyLimit)
@@ -523,7 +523,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 	if err != nil {
 		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
-	limit := o.defaultLimitForOrg(ctx, o.db, org)
+	limit := o.defaultLimitForAccountType(ctx, o.db, org)
 
 	key, err := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -631,15 +631,15 @@ func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, 
 	return newLimit, nil
 }
 
-// defaultLimitForOrg resolves the monthly credit ceiling an organization is
-// entitled to by policy. It answers what a key would be minted at today, not
-// what an existing key carries: an operator raise leaves the key above this
-// amount, and only the key row records that.
+// Resolves the monthly credit ceiling an organization is entitled to by
+// policy. It answers what a key would be minted at today, not what an existing
+// key carries: an operator raise leaves the key above this amount, and only
+// the key row records that.
 //
 // dbtx arrives from the caller because the provisioning path runs inside a
 // transaction that already holds an advisory lock and a pool connection, so it
 // must read through that same transaction.
-func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, dbtx trialsRepo.DBTX, org orgRepo.OrganizationMetadatum) int {
+func (o *OpenRouter) defaultLimitForAccountType(ctx context.Context, dbtx trialsRepo.DBTX, org orgRepo.OrganizationMetadatum) int {
 	if slices.Contains(specialLimitOrgs, org.ID) {
 		return 500
 	}

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -374,7 +374,7 @@ func (o *OpenRouter) createAndStoreAPIKey(ctx context.Context, orgID string, key
 		return "", oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
 
-	creditAmount := o.defaultLimitForAccountType(ctx, dbtx, org)
+	creditAmount := o.defaultLimitForOrg(ctx, dbtx, org)
 
 	// Cap the upstream call so guardian's retry backoff cannot stretch the
 	// advisory-lock hold to minutes during an OpenRouter outage; a burst of
@@ -436,7 +436,7 @@ func (o *OpenRouter) RefreshAPIKeyLimit(ctx context.Context, orgID string, keyTy
 	if limit != nil {
 		keyLimit = *limit
 	} else {
-		keyLimit = o.defaultLimitForAccountType(ctx, o.db, org)
+		keyLimit = o.defaultLimitForOrg(ctx, o.db, org)
 	}
 
 	creditLimit := float64(keyLimit)
@@ -523,7 +523,7 @@ func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType K
 	if err != nil {
 		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
 	}
-	limit := o.defaultLimitForAccountType(ctx, o.db, org)
+	limit := o.defaultLimitForOrg(ctx, o.db, org)
 
 	key, err := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
@@ -631,15 +631,16 @@ func (o *OpenRouter) ReconcileMonthlyCredits(ctx context.Context, orgID string, 
 	return newLimit, nil
 }
 
-// Resolves the monthly credit ceiling an organization is entitled to by
-// policy. It answers what a key would be minted at today, not what an existing
-// key carries: an operator raise leaves the key above this amount, and only
-// the key row records that.
+// defaultLimitForOrg resolves the monthly credit ceiling an organization is
+// entitled to by policy. It answers what a key would be minted at today, not
+// what an existing key carries: an operator raise leaves the key above this
+// amount, and only the key row records that. The account type is the last
+// resort, after the special-org list and the trial row.
 //
 // dbtx arrives from the caller because the provisioning path runs inside a
 // transaction that already holds an advisory lock and a pool connection, so it
 // must read through that same transaction.
-func (o *OpenRouter) defaultLimitForAccountType(ctx context.Context, dbtx trialsRepo.DBTX, org orgRepo.OrganizationMetadatum) int {
+func (o *OpenRouter) defaultLimitForOrg(ctx context.Context, dbtx trialsRepo.DBTX, org orgRepo.OrganizationMetadatum) int {
 	if slices.Contains(specialLimitOrgs, org.ID) {
 		return 500
 	}

--- a/server/internal/thirdparty/openrouter/openrouter.go
+++ b/server/internal/thirdparty/openrouter/openrouter.go
@@ -519,26 +519,33 @@ type keyUsageResponse struct {
 }
 
 func (o *OpenRouter) GetCreditsUsed(ctx context.Context, orgID string, keyType KeyType) (float64, int, error) {
-	org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
-	if err != nil {
-		return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
-	}
-	limit := o.defaultLimitForOrg(ctx, o.db, org)
-
-	key, err := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
+	// The key carries the ceiling the customer actually spends against, which a
+	// raise or a tier change can move away from the policy amount. Read it
+	// first: resolving the policy amount costs two more queries, and only a key
+	// minted before the column existed needs them.
+	key, keyErr := o.repo.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
 		OrganizationID: orgID,
 		KeyType:        string(keyType.OrDefault()),
 	})
-	if err != nil {
-		return 0, limit, nil // the key doesn't exist yet
+
+	limit := 0
+	if keyErr == nil {
+		limit = int(key.MonthlyCredits)
 	}
 
-	// The key carries the ceiling the customer actually spends against, which a
-	// raise or a tier change can move away from the policy amount. Keys minted
-	// before the column existed hold zero, and those fall back to the policy
-	// amount rather than reporting a ceiling of nothing.
-	if key.MonthlyCredits > 0 {
-		limit = int(key.MonthlyCredits)
+	// A key with no recorded ceiling reports the policy amount rather than a
+	// ceiling of nothing.
+	if limit <= 0 {
+		org, err := o.orgRepo.GetOrganizationMetadata(ctx, orgID)
+		if err != nil {
+			return 0, 0, oops.E(oops.CodeUnexpected, err, "failed to get organization").LogError(ctx, o.logger)
+		}
+
+		limit = o.defaultLimitForOrg(ctx, o.db, org)
+	}
+
+	if keyErr != nil {
+		return 0, limit, nil // the key doesn't exist yet
 	}
 
 	used, _, err := o.GetKeyUsage(ctx, key.Key)

--- a/server/internal/thirdparty/openrouter/trial_credits_test.go
+++ b/server/internal/thirdparty/openrouter/trial_credits_test.go
@@ -1,0 +1,206 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+// trialCapFixture provisions against an upstream stub that records the credit
+// limit each create-key request asks for.
+type trialCapFixture struct {
+	// provisioner is wired to the stub upstream and the cloned database.
+	provisioner *OpenRouter
+
+	// conn is the cloned database the fixture seeded the organization into.
+	conn *pgxpool.Pool
+
+	// orgID names the seeded organization, which sits on the enterprise tier.
+	orgID string
+
+	mu sync.Mutex
+
+	// createLimits collects the limit from every create-key request, in order.
+	createLimits []float64
+}
+
+// recordedLimits returns the limit each create-key request carried.
+func (f *trialCapFixture) recordedLimits() []float64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]float64(nil), f.createLimits...)
+}
+
+// newTrialCapFixture seeds an enterprise-tier organization with no trial. A
+// caller that wants a trial inserts the row itself, so each test states the
+// lifecycle state it exercises.
+func newTrialCapFixture(t *testing.T, dbName string) *trialCapFixture {
+	t.Helper()
+
+	ctx := t.Context()
+
+	conn, err := infra.CloneTestDatabase(t, dbName)
+	require.NoError(t, err)
+
+	orgID := "org-" + uuid.NewString()[:8]
+	orgQueries := orgRepo.New(conn)
+	_, err = orgQueries.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Trial Cap Org",
+		Slug:        orgID,
+		WorkosID:    pgtype.Text{String: "", Valid: false},
+		Whitelisted: pgtype.Bool{Bool: false, Valid: false},
+	})
+	require.NoError(t, err)
+
+	// Arming a trial sets the enterprise tier, so a trial organization and a
+	// paying enterprise customer are indistinguishable by account type alone.
+	require.NoError(t, orgQueries.SetAccountType(ctx, orgRepo.SetAccountTypeParams{
+		ID:              orgID,
+		GramAccountType: string(billing.TierEnterprise),
+	}))
+
+	fixture := &trialCapFixture{
+		provisioner:  nil,
+		conn:         conn,
+		orgID:        orgID,
+		mu:           sync.Mutex{},
+		createLimits: nil,
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// GetCreditsUsed reads usage before it reports the ceiling, so the stub
+		// answers that call too.
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/key" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": 0.0, "usage_monthly": 0.0},
+			})
+			return
+		}
+
+		// A refresh patches the ceiling upstream before it writes the key row,
+		// which is how a limit that no longer matches the tier gets recorded.
+		if r.Method == http.MethodPatch {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": 0.0, "hash": "hash-1"},
+			})
+			return
+		}
+
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/keys" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		var body struct {
+			Limit *float64 `json:"limit"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Limit == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		fixture.mu.Lock()
+		fixture.createLimits = append(fixture.createLimits, *body.Limit)
+		fixture.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{"limit": *body.Limit, "hash": "hash-1"},
+			"key":  "sk-or-trial-cap-1",
+		})
+	}))
+	t.Cleanup(upstream.Close)
+
+	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+
+	fixture.provisioner = New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil)
+	fixture.provisioner.baseURL = upstream.URL
+
+	return fixture
+}
+
+// TestProvisionAPIKey_ActiveTrialTakesTrialCap pins the trial ceiling: an
+// organization inside a self-signup enterprise trial must mint its key at the
+// trial cap, not at the paid enterprise amount its account type resolves to.
+func TestProvisionAPIKey_ActiveTrialTakesTrialCap(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newTrialCapFixture(t, "ortrialcapactive")
+
+	now := time.Now().UTC()
+	require.NoError(t, trialsRepo.New(fixture.conn).InsertTrialFixture(ctx, trialsRepo.InsertTrialFixtureParams{
+		OrganizationID: fixture.orgID,
+		CreatedAt:      conv.ToPGTimestamptz(now),
+		EndsAt:         conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
+		ConvertedAt:    conv.PtrToPGTimestamptz(nil),
+		DemotedAt:      conv.PtrToPGTimestamptz(nil),
+	}))
+
+	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
+	require.NoError(t, err)
+
+	require.Equal(t, []float64{float64(enterpriseTrialCredits)}, fixture.recordedLimits())
+
+	_, limit, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
+	require.NoError(t, err)
+	require.Equal(t, enterpriseTrialCredits, limit, "the reported ceiling must match the minted key")
+}
+
+// TestProvisionAPIKey_PaidEnterpriseKeepsTierCap guards the other side of the
+// trial ceiling: an enterprise customer with no trial row keeps the full
+// account-type amount.
+func TestProvisionAPIKey_PaidEnterpriseKeepsTierCap(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newTrialCapFixture(t, "ortrialcappaid")
+
+	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
+	require.NoError(t, err)
+
+	require.Equal(t, []float64{float64(creditsAccountTypeMap[string(billing.TierEnterprise)])}, fixture.recordedLimits())
+}
+
+// TestGetCreditsUsed_ReportsKeyLimitOverTierDefault covers the organizations
+// whose ceiling was moved by hand. Recomputing the amount from the account type
+// would report the tier default and hide the raise the customer was given, so
+// the reported ceiling has to come from the key.
+func TestGetCreditsUsed_ReportsKeyLimitOverTierDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newTrialCapFixture(t, "orcreditskeylimit")
+
+	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
+	require.NoError(t, err)
+
+	raised := creditsAccountTypeMap[string(billing.TierEnterprise)] + 150
+	refreshed, err := fixture.provisioner.RefreshAPIKeyLimit(ctx, fixture.orgID, KeyTypeChat, &raised)
+	require.NoError(t, err)
+	require.Equal(t, raised, refreshed)
+
+	_, limit, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
+	require.NoError(t, err)
+	require.Equal(t, raised, limit, "the reported ceiling must follow the key, not the account type")
+}

--- a/server/internal/thirdparty/openrouter/trial_credits_test.go
+++ b/server/internal/thirdparty/openrouter/trial_credits_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -22,19 +23,16 @@ import (
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
-// The trial cap and the enterprise tier amount are written as literals here on
-// purpose. Asserting against the production constants would make these tests
-// pass for any value of them, and the value is what this suite exists to pin.
+// The trial cap and the enterprise tier amount are literals on purpose.
+// Asserting against the production constants would make these tests pass for
+// any value of them, and the value is what this suite exists to pin.
 const (
-	// wantTrialLimit is the amount a key minted during a trial must carry.
-	wantTrialLimit = 50
-
-	// wantEnterpriseLimit is the amount a paying enterprise key must carry.
+	wantTrialLimit      = 50
 	wantEnterpriseLimit = 100
 )
 
 // trialCapFixture provisions against an upstream stub that records the credit
-// limit each key request asks for.
+// limit each create-key request asks for.
 type trialCapFixture struct {
 	// provisioner is wired to the stub upstream and the cloned database.
 	provisioner *OpenRouter
@@ -50,15 +48,12 @@ type trialCapFixture struct {
 	recorder *limitRecorder
 }
 
-// limitRecorder collects the credit limit of every upstream key request.
+// limitRecorder collects the credit limit of every create-key request.
 type limitRecorder struct {
 	mu sync.Mutex
 
 	// created holds the limit from each create-key request, in order.
 	created []float64
-
-	// patched holds the limit from each update-key request, in order.
-	patched []float64
 }
 
 // createdLimits returns the limit each create-key request carried.
@@ -66,33 +61,31 @@ func (r *limitRecorder) createdLimits() []float64 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	return append([]float64(nil), r.created...)
-}
-
-// patchedLimits returns the limit each update-key request carried.
-func (r *limitRecorder) patchedLimits() []float64 {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	return append([]float64(nil), r.patched...)
+	return slices.Clone(r.created)
 }
 
 func (r *limitRecorder) handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		var body struct {
-			Limit *float64 `json:"limit"`
-		}
+		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		// GetCreditsUsed reads usage before it reports the ceiling, so the stub
-		// answers that call too.
+		// GetCreditsUsed reads usage before it reports the ceiling, and
+		// RefreshAPIKeyLimit patches the ceiling upstream. Neither carries a
+		// limit this suite asserts on, so both get a canned reply.
 		case req.Method == http.MethodGet && req.URL.Path == "/v1/key":
-			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"limit": 0.0, "usage_monthly": 0.0},
 			})
 
+		case req.Method == http.MethodPatch:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": 0.0, "hash": "hash-1"},
+			})
+
 		case req.Method == http.MethodPost && req.URL.Path == "/v1/keys":
+			var body struct {
+				Limit *float64 `json:"limit"`
+			}
 			if err := json.NewDecoder(req.Body).Decode(&body); err != nil || body.Limit == nil {
 				w.WriteHeader(http.StatusBadRequest)
 				return
@@ -102,25 +95,9 @@ func (r *limitRecorder) handler() http.HandlerFunc {
 			r.created = append(r.created, *body.Limit)
 			r.mu.Unlock()
 
-			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{"limit": *body.Limit, "hash": "hash-1"},
 				"key":  "sk-or-trial-cap-1",
-			})
-
-		case req.Method == http.MethodPatch:
-			if err := json.NewDecoder(req.Body).Decode(&body); err != nil || body.Limit == nil {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-
-			r.mu.Lock()
-			r.patched = append(r.patched, *body.Limit)
-			r.mu.Unlock()
-
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{"limit": *body.Limit, "hash": "hash-1"},
 			})
 
 		default:
@@ -138,7 +115,7 @@ func newTrialCapFixture(t *testing.T) *trialCapFixture {
 	conn, err := infra.CloneTestDatabase(t, "ortrialcap")
 	require.NoError(t, err)
 
-	recorder := &limitRecorder{mu: sync.Mutex{}, created: nil, patched: nil}
+	recorder := &limitRecorder{mu: sync.Mutex{}, created: nil}
 
 	upstream := httptest.NewServer(recorder.handler())
 	t.Cleanup(upstream.Close)
@@ -149,25 +126,22 @@ func newTrialCapFixture(t *testing.T) *trialCapFixture {
 	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil)
 	provisioner.baseURL = upstream.URL
 
-	fixture := &trialCapFixture{
+	return &trialCapFixture{
 		provisioner: provisioner,
 		conn:        conn,
-		orgID:       "",
+		orgID:       seedOrg(t, conn),
 		recorder:    recorder,
 	}
-	fixture.orgID = fixture.seedOrg(t)
-
-	return fixture
 }
 
-// seedOrg adds another enterprise-tier organization to the cloned database so
-// one fixture can cover several trial lifecycle states.
-func (f *trialCapFixture) seedOrg(t *testing.T) string {
+// seedOrg adds an enterprise-tier organization with no trial row. A test that
+// covers several lifecycle states calls it once per state.
+func seedOrg(t *testing.T, conn *pgxpool.Pool) string {
 	t.Helper()
 
 	ctx := t.Context()
 	orgID := "org-" + uuid.NewString()[:8]
-	queries := orgRepo.New(f.conn)
+	queries := orgRepo.New(conn)
 
 	_, err := queries.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
 		ID:          orgID,
@@ -189,10 +163,10 @@ func (f *trialCapFixture) seedOrg(t *testing.T) string {
 }
 
 // insertTrial adds a trial row in the lifecycle state the caller names.
-func (f *trialCapFixture) insertTrial(t *testing.T, orgID string, endsAt time.Time, convertedAt, demotedAt *time.Time) {
+func insertTrial(t *testing.T, conn *pgxpool.Pool, orgID string, endsAt time.Time, convertedAt, demotedAt *time.Time) {
 	t.Helper()
 
-	require.NoError(t, trialsRepo.New(f.conn).InsertTrialFixture(t.Context(), trialsRepo.InsertTrialFixtureParams{
+	require.NoError(t, trialsRepo.New(conn).InsertTrialFixture(t.Context(), trialsRepo.InsertTrialFixtureParams{
 		OrganizationID: orgID,
 		CreatedAt:      conv.ToPGTimestamptz(time.Now().UTC().Add(-24 * time.Hour)),
 		EndsAt:         conv.ToPGTimestamptz(endsAt),
@@ -201,42 +175,23 @@ func (f *trialCapFixture) insertTrial(t *testing.T, orgID string, endsAt time.Ti
 	}))
 }
 
-// TestProvisionAPIKey_ActiveTrialTakesTrialCap pins the trial ceiling: an
-// organization inside a self-signup trial must mint its key at the trial cap,
-// not at the paid amount its account type resolves to.
-func TestProvisionAPIKey_ActiveTrialTakesTrialCap(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	fixture := newTrialCapFixture(t)
-	fixture.insertTrial(t, fixture.orgID, time.Now().UTC().Add(14*24*time.Hour), nil, nil)
-
-	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
-	require.NoError(t, err)
-
-	require.Equal(t, []float64{wantTrialLimit}, fixture.recorder.createdLimits())
-}
-
-// TestProvisionAPIKey_ActiveTrialCapsEveryKeyType pins the blast radius of the
-// cap. An organization holds one key per type, so a cap that reached the chat
-// key alone would leave the rest of its spend at the paid amount.
+// TestProvisionAPIKey_ActiveTrialCapsEveryKeyType pins the trial ceiling and
+// its blast radius. An organization holds one key per type, so a cap that
+// reached the chat key alone would leave the rest of its spend at the paid
+// amount.
 func TestProvisionAPIKey_ActiveTrialCapsEveryKeyType(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	fixture := newTrialCapFixture(t)
-	fixture.insertTrial(t, fixture.orgID, time.Now().UTC().Add(14*24*time.Hour), nil, nil)
+	insertTrial(t, fixture.conn, fixture.orgID, time.Now().UTC().Add(14*24*time.Hour), nil, nil)
 
 	for _, keyType := range AllKeyTypes {
 		_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, keyType)
 		require.NoError(t, err, "provisioning a %s key", keyType)
 	}
 
-	want := make([]float64, len(AllKeyTypes))
-	for i := range want {
-		want[i] = wantTrialLimit
-	}
-	require.Equal(t, want, fixture.recorder.createdLimits(),
+	require.Equal(t, slices.Repeat([]float64{wantTrialLimit}, len(AllKeyTypes)), fixture.recorder.createdLimits(),
 		"every key type an organization can hold must carry the trial cap")
 }
 
@@ -266,26 +221,25 @@ func TestProvisionAPIKey_InactiveTrialKeepsTierCap(t *testing.T) {
 	fixture := newTrialCapFixture(t)
 
 	now := time.Now().UTC()
-	stamp := now.Add(-time.Hour)
-	future := now.Add(14 * 24 * time.Hour)
 	past := now.Add(-time.Hour)
+	future := now.Add(14 * 24 * time.Hour)
 
-	converted := fixture.seedOrg(t)
-	fixture.insertTrial(t, converted, future, &stamp, nil)
+	converted := seedOrg(t, fixture.conn)
+	insertTrial(t, fixture.conn, converted, future, &past, nil)
 
-	demoted := fixture.seedOrg(t)
-	fixture.insertTrial(t, demoted, future, nil, &stamp)
+	demoted := seedOrg(t, fixture.conn)
+	insertTrial(t, fixture.conn, demoted, future, nil, &past)
 
-	expired := fixture.seedOrg(t)
-	fixture.insertTrial(t, expired, past, nil, nil)
+	expired := seedOrg(t, fixture.conn)
+	insertTrial(t, fixture.conn, expired, past, nil, nil)
 
-	for _, orgID := range []string{converted, demoted, expired} {
+	orgIDs := []string{converted, demoted, expired}
+	for _, orgID := range orgIDs {
 		_, err := fixture.provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, []float64{wantEnterpriseLimit, wantEnterpriseLimit, wantEnterpriseLimit},
-		fixture.recorder.createdLimits(),
+	require.Equal(t, slices.Repeat([]float64{wantEnterpriseLimit}, len(orgIDs)), fixture.recorder.createdLimits(),
 		"a converted, demoted, or expired trial must not cap the key")
 }
 
@@ -307,8 +261,6 @@ func TestGetCreditsUsed_ReportsKeyLimitOverTierDefault(t *testing.T) {
 	refreshed, err := fixture.provisioner.RefreshAPIKeyLimit(ctx, fixture.orgID, KeyTypeChat, &limit)
 	require.NoError(t, err)
 	require.Equal(t, raised, refreshed)
-	require.Equal(t, []float64{raised}, fixture.recorder.patchedLimits(),
-		"the raise must reach OpenRouter before Gram records it")
 
 	_, reported, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
 	require.NoError(t, err)

--- a/server/internal/thirdparty/openrouter/trial_credits_test.go
+++ b/server/internal/thirdparty/openrouter/trial_credits_test.go
@@ -18,49 +18,158 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	trialsRepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
+// The trial cap and the enterprise tier amount are written as literals here on
+// purpose. Asserting against the production constants would make these tests
+// pass for any value of them, and the value is what this suite exists to pin.
+const (
+	// wantTrialLimit is the amount a key minted during a trial must carry.
+	wantTrialLimit = 50
+
+	// wantEnterpriseLimit is the amount a paying enterprise key must carry.
+	wantEnterpriseLimit = 100
+)
+
 // trialCapFixture provisions against an upstream stub that records the credit
-// limit each create-key request asks for.
+// limit each key request asks for.
 type trialCapFixture struct {
 	// provisioner is wired to the stub upstream and the cloned database.
 	provisioner *OpenRouter
 
-	// conn is the cloned database the fixture seeded the organization into.
+	// conn is the cloned database the fixture seeded its organizations into.
 	conn *pgxpool.Pool
 
-	// orgID names the seeded organization, which sits on the enterprise tier.
+	// orgID names the organization seeded at construction, which sits on the
+	// enterprise tier and holds no trial row.
 	orgID string
 
-	mu sync.Mutex
-
-	// createLimits collects the limit from every create-key request, in order.
-	createLimits []float64
+	// recorder collects the limits the stub upstream received.
+	recorder *limitRecorder
 }
 
-// recordedLimits returns the limit each create-key request carried.
-func (f *trialCapFixture) recordedLimits() []float64 {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+// limitRecorder collects the credit limit of every upstream key request.
+type limitRecorder struct {
+	mu sync.Mutex
 
-	return append([]float64(nil), f.createLimits...)
+	// created holds the limit from each create-key request, in order.
+	created []float64
+
+	// patched holds the limit from each update-key request, in order.
+	patched []float64
+}
+
+// createdLimits returns the limit each create-key request carried.
+func (r *limitRecorder) createdLimits() []float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]float64(nil), r.created...)
+}
+
+// patchedLimits returns the limit each update-key request carried.
+func (r *limitRecorder) patchedLimits() []float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]float64(nil), r.patched...)
+}
+
+func (r *limitRecorder) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var body struct {
+			Limit *float64 `json:"limit"`
+		}
+
+		switch {
+		// GetCreditsUsed reads usage before it reports the ceiling, so the stub
+		// answers that call too.
+		case req.Method == http.MethodGet && req.URL.Path == "/v1/key":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": 0.0, "usage_monthly": 0.0},
+			})
+
+		case req.Method == http.MethodPost && req.URL.Path == "/v1/keys":
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil || body.Limit == nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			r.mu.Lock()
+			r.created = append(r.created, *body.Limit)
+			r.mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": *body.Limit, "hash": "hash-1"},
+				"key":  "sk-or-trial-cap-1",
+			})
+
+		case req.Method == http.MethodPatch:
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil || body.Limit == nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			r.mu.Lock()
+			r.patched = append(r.patched, *body.Limit)
+			r.mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"limit": *body.Limit, "hash": "hash-1"},
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
 }
 
 // newTrialCapFixture seeds an enterprise-tier organization with no trial. A
 // caller that wants a trial inserts the row itself, so each test states the
 // lifecycle state it exercises.
-func newTrialCapFixture(t *testing.T, dbName string) *trialCapFixture {
+func newTrialCapFixture(t *testing.T) *trialCapFixture {
+	t.Helper()
+
+	conn, err := infra.CloneTestDatabase(t, "ortrialcap")
+	require.NoError(t, err)
+
+	recorder := &limitRecorder{mu: sync.Mutex{}, created: nil, patched: nil}
+
+	upstream := httptest.NewServer(recorder.handler())
+	t.Cleanup(upstream.Close)
+
+	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+
+	provisioner := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil)
+	provisioner.baseURL = upstream.URL
+
+	fixture := &trialCapFixture{
+		provisioner: provisioner,
+		conn:        conn,
+		orgID:       "",
+		recorder:    recorder,
+	}
+	fixture.orgID = fixture.seedOrg(t)
+
+	return fixture
+}
+
+// seedOrg adds another enterprise-tier organization to the cloned database so
+// one fixture can cover several trial lifecycle states.
+func (f *trialCapFixture) seedOrg(t *testing.T) string {
 	t.Helper()
 
 	ctx := t.Context()
-
-	conn, err := infra.CloneTestDatabase(t, dbName)
-	require.NoError(t, err)
-
 	orgID := "org-" + uuid.NewString()[:8]
-	orgQueries := orgRepo.New(conn)
-	_, err = orgQueries.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
+	queries := orgRepo.New(f.conn)
+
+	_, err := queries.UpsertOrganizationMetadata(ctx, orgRepo.UpsertOrganizationMetadataParams{
 		ID:          orgID,
 		Name:        "Trial Cap Org",
 		Slug:        orgID,
@@ -71,100 +180,64 @@ func newTrialCapFixture(t *testing.T, dbName string) *trialCapFixture {
 
 	// Arming a trial sets the enterprise tier, so a trial organization and a
 	// paying enterprise customer are indistinguishable by account type alone.
-	require.NoError(t, orgQueries.SetAccountType(ctx, orgRepo.SetAccountTypeParams{
+	require.NoError(t, queries.SetAccountType(ctx, orgRepo.SetAccountTypeParams{
 		ID:              orgID,
 		GramAccountType: string(billing.TierEnterprise),
 	}))
 
-	fixture := &trialCapFixture{
-		provisioner:  nil,
-		conn:         conn,
-		orgID:        orgID,
-		mu:           sync.Mutex{},
-		createLimits: nil,
-	}
+	return orgID
+}
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// GetCreditsUsed reads usage before it reports the ceiling, so the stub
-		// answers that call too.
-		if r.Method == http.MethodGet && r.URL.Path == "/v1/key" {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{"limit": 0.0, "usage_monthly": 0.0},
-			})
-			return
-		}
+// insertTrial adds a trial row in the lifecycle state the caller names.
+func (f *trialCapFixture) insertTrial(t *testing.T, orgID string, endsAt time.Time, convertedAt, demotedAt *time.Time) {
+	t.Helper()
 
-		// A refresh patches the ceiling upstream before it writes the key row,
-		// which is how a limit that no longer matches the tier gets recorded.
-		if r.Method == http.MethodPatch {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{"limit": 0.0, "hash": "hash-1"},
-			})
-			return
-		}
-
-		if r.Method != http.MethodPost || r.URL.Path != "/v1/keys" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-
-		var body struct {
-			Limit *float64 `json:"limit"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Limit == nil {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		fixture.mu.Lock()
-		fixture.createLimits = append(fixture.createLimits, *body.Limit)
-		fixture.mu.Unlock()
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": map[string]any{"limit": *body.Limit, "hash": "hash-1"},
-			"key":  "sk-or-trial-cap-1",
-		})
+	require.NoError(t, trialsRepo.New(f.conn).InsertTrialFixture(t.Context(), trialsRepo.InsertTrialFixtureParams{
+		OrganizationID: orgID,
+		CreatedAt:      conv.ToPGTimestamptz(time.Now().UTC().Add(-24 * time.Hour)),
+		EndsAt:         conv.ToPGTimestamptz(endsAt),
+		ConvertedAt:    conv.PtrToPGTimestamptz(convertedAt),
+		DemotedAt:      conv.PtrToPGTimestamptz(demotedAt),
 	}))
-	t.Cleanup(upstream.Close)
-
-	guardianPolicy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
-	require.NoError(t, err)
-
-	fixture.provisioner = New(testenv.NewLogger(t), testenv.NewTracerProvider(t), guardianPolicy, conn, "test", "provisioning-key", nil, nil, nil)
-	fixture.provisioner.baseURL = upstream.URL
-
-	return fixture
 }
 
 // TestProvisionAPIKey_ActiveTrialTakesTrialCap pins the trial ceiling: an
-// organization inside a self-signup enterprise trial must mint its key at the
-// trial cap, not at the paid enterprise amount its account type resolves to.
+// organization inside a self-signup trial must mint its key at the trial cap,
+// not at the paid amount its account type resolves to.
 func TestProvisionAPIKey_ActiveTrialTakesTrialCap(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	fixture := newTrialCapFixture(t, "ortrialcapactive")
-
-	now := time.Now().UTC()
-	require.NoError(t, trialsRepo.New(fixture.conn).InsertTrialFixture(ctx, trialsRepo.InsertTrialFixtureParams{
-		OrganizationID: fixture.orgID,
-		CreatedAt:      conv.ToPGTimestamptz(now),
-		EndsAt:         conv.ToPGTimestamptz(now.Add(14 * 24 * time.Hour)),
-		ConvertedAt:    conv.PtrToPGTimestamptz(nil),
-		DemotedAt:      conv.PtrToPGTimestamptz(nil),
-	}))
+	fixture := newTrialCapFixture(t)
+	fixture.insertTrial(t, fixture.orgID, time.Now().UTC().Add(14*24*time.Hour), nil, nil)
 
 	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
 	require.NoError(t, err)
 
-	require.Equal(t, []float64{float64(enterpriseTrialCredits)}, fixture.recordedLimits())
+	require.Equal(t, []float64{wantTrialLimit}, fixture.recorder.createdLimits())
+}
 
-	_, limit, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
-	require.NoError(t, err)
-	require.Equal(t, enterpriseTrialCredits, limit, "the reported ceiling must match the minted key")
+// TestProvisionAPIKey_ActiveTrialCapsEveryKeyType pins the blast radius of the
+// cap. An organization holds one key per type, so a cap that reached the chat
+// key alone would leave the rest of its spend at the paid amount.
+func TestProvisionAPIKey_ActiveTrialCapsEveryKeyType(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newTrialCapFixture(t)
+	fixture.insertTrial(t, fixture.orgID, time.Now().UTC().Add(14*24*time.Hour), nil, nil)
+
+	for _, keyType := range AllKeyTypes {
+		_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, keyType)
+		require.NoError(t, err, "provisioning a %s key", keyType)
+	}
+
+	want := make([]float64, len(AllKeyTypes))
+	for i := range want {
+		want[i] = wantTrialLimit
+	}
+	require.Equal(t, want, fixture.recorder.createdLimits(),
+		"every key type an organization can hold must carry the trial cap")
 }
 
 // TestProvisionAPIKey_PaidEnterpriseKeepsTierCap guards the other side of the
@@ -174,12 +247,46 @@ func TestProvisionAPIKey_PaidEnterpriseKeepsTierCap(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	fixture := newTrialCapFixture(t, "ortrialcappaid")
+	fixture := newTrialCapFixture(t)
 
 	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
 	require.NoError(t, err)
 
-	require.Equal(t, []float64{float64(creditsAccountTypeMap[string(billing.TierEnterprise)])}, fixture.recordedLimits())
+	require.Equal(t, []float64{wantEnterpriseLimit}, fixture.recorder.createdLimits())
+}
+
+// TestProvisionAPIKey_InactiveTrialKeepsTierCap pins the three lifecycle states
+// that end a trial. Each one must release the cap, because the organization has
+// either paid or lost the trial. A query that dropped any of these filters
+// would cap a paying customer forever.
+func TestProvisionAPIKey_InactiveTrialKeepsTierCap(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newTrialCapFixture(t)
+
+	now := time.Now().UTC()
+	stamp := now.Add(-time.Hour)
+	future := now.Add(14 * 24 * time.Hour)
+	past := now.Add(-time.Hour)
+
+	converted := fixture.seedOrg(t)
+	fixture.insertTrial(t, converted, future, &stamp, nil)
+
+	demoted := fixture.seedOrg(t)
+	fixture.insertTrial(t, demoted, future, nil, &stamp)
+
+	expired := fixture.seedOrg(t)
+	fixture.insertTrial(t, expired, past, nil, nil)
+
+	for _, orgID := range []string{converted, demoted, expired} {
+		_, err := fixture.provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, []float64{wantEnterpriseLimit, wantEnterpriseLimit, wantEnterpriseLimit},
+		fixture.recorder.createdLimits(),
+		"a converted, demoted, or expired trial must not cap the key")
 }
 
 // TestGetCreditsUsed_ReportsKeyLimitOverTierDefault covers the organizations
@@ -190,17 +297,44 @@ func TestGetCreditsUsed_ReportsKeyLimitOverTierDefault(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	fixture := newTrialCapFixture(t, "orcreditskeylimit")
+	fixture := newTrialCapFixture(t)
 
 	_, err := fixture.provisioner.ProvisionAPIKey(ctx, fixture.orgID, KeyTypeChat)
 	require.NoError(t, err)
 
-	raised := creditsAccountTypeMap[string(billing.TierEnterprise)] + 150
-	refreshed, err := fixture.provisioner.RefreshAPIKeyLimit(ctx, fixture.orgID, KeyTypeChat, &raised)
+	const raised = wantEnterpriseLimit + 150
+	limit := raised
+	refreshed, err := fixture.provisioner.RefreshAPIKeyLimit(ctx, fixture.orgID, KeyTypeChat, &limit)
 	require.NoError(t, err)
 	require.Equal(t, raised, refreshed)
+	require.Equal(t, []float64{raised}, fixture.recorder.patchedLimits(),
+		"the raise must reach OpenRouter before Gram records it")
 
-	_, limit, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
+	_, reported, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
 	require.NoError(t, err)
-	require.Equal(t, raised, limit, "the reported ceiling must follow the key, not the account type")
+	require.Equal(t, raised, reported, "the reported ceiling must follow the key, not the account type")
+}
+
+// TestGetCreditsUsed_ZeroKeyLimitFallsBackToPolicy covers the keys minted
+// before the monthly_credits column carried a value. Those rows hold zero, and
+// reporting it would tell the customer they have no credits at all.
+func TestGetCreditsUsed_ZeroKeyLimitFallsBackToPolicy(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	fixture := newTrialCapFixture(t)
+
+	_, err := repo.New(fixture.conn).CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: fixture.orgID,
+		KeyType:        string(KeyTypeChat),
+		Key:            "sk-or-legacy-zero",
+		KeyHash:        "hash-legacy",
+		MonthlyCredits: 0,
+	})
+	require.NoError(t, err)
+
+	_, reported, err := fixture.provisioner.GetCreditsUsed(ctx, fixture.orgID, KeyTypeChat)
+	require.NoError(t, err)
+	require.Equal(t, wantEnterpriseLimit, reported,
+		"a key with no recorded ceiling must report the account-type amount")
 }


### PR DESCRIPTION
Closes AGE-3136.

## What

An organization inside a self-signup enterprise trial now mints each of its OpenRouter keys at $50 instead of the full enterprise amount. An organization holds one key per `KeyType`, so total trial exposure drops from $200 to $100.

Arming a trial sets `gram_account_type = "enterprise"`, so the account type alone cannot tell a trial apart from a paying enterprise customer. `defaultLimitForOrg` now reads the active trial row and returns the trial cap when one matches.

This matters because the key limit is the only spend ceiling a trial organization has. The chat credit-balance gate hard-stops the free tier only, and a trial is armed without verified intent.

## Why the key limit, not the tier map

Setting `creditsAccountTypeMap["enterprise"] = 50` would silently cap every new paying enterprise customer. The trial row is the only signal that separates the two.

The database handle arrives as a `DBTX` parameter rather than coming off the struct. The provisioning path runs inside a transaction that already holds an advisory lock and a pool connection, so it has to read through that same transaction. Reading through `o.db` there would ask the pool for a second connection while the first is still held, which deadlocks under provisioning contention. The neighbouring organization read already does the same thing for the same reason.

`DBTX` is satisfied by both `pgx.Tx` and `*pgxpool.Pool`, so the two non-transactional callers pass `o.db` directly.

A trial read that fails for any reason other than "no row" falls through to the account type. A transient database error must not cap a paying customer.

## Also in this PR

**The billing meter now reports the ceiling on the key.** `GetCreditsUsed` used to recompute the amount from the account type and ignore the key row entirely, so any organization whose limit was moved by hand saw the standard amount for its plan rather than the amount it can actually spend.

Alerting and the credit metrics job already read `monthly_credits` directly. This makes the customer-facing number agree with them.

Keys minted before the column carried a value hold zero. Those fall back to the computed amount rather than reporting a ceiling of nothing.

**Rename** `getLimitForOrg` to `defaultLimitForOrg`, with a doc comment that states the distinction the old name blurred. The function answers "what would a key be minted at today", not "what does this key carry".

## Testing

Five tests in a new `trial_credits_test.go`, each against an upstream stub that records the limit every create-key request carries:

- an active trial caps every entry in `AllKeyTypes`, not the chat key alone
- an enterprise customer with no trial row keeps the full account-type amount
- a converted, demoted, or expired trial keeps the account-type amount
- an organization whose key was raised by hand reports the raised amount, not the plan default
- a key at zero credits falls back to the policy amount

The suite is mutation-tested. Changing the cap constant, dropping any one of the three predicates from `GetActiveTrial`, or loosening the zero-credit guard each turn a test red.

## Not in this PR

Existing trial keys minted at the old amount are not backfilled. A trial already running keeps the keys it has.

Four follow-ups are filed:

- AGE-3138: nothing refreshes the key when a trial converts or when a trial is armed. The refresh gates on a change of account type, and a trial is already `enterprise`, so the comparison never fires.
- AGE-3139: `RefreshAPIKeyLimit` refuses keys at zero credits, which makes the Polar tier-change webhook retry forever
- AGE-3140: credit reconciliation covers the enterprise tier only, so a manual raise below it stays invisible
- AGE-3141: the cap binds at mint time only, so it stops applying once the trial window ends

AGE-3138 and AGE-3140 overlap with the Phase 3 plan in AGE-2122 and are linked to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
