### PR TITLE
fix: preserve native Cursor and Codex plugin formats

### DIFF
--- a/.changeset/preserve-native-plugin-marketplaces.md
+++ b/.changeset/preserve-native-plugin-marketplaces.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Keep Cursor and Codex marketplace entries on their native package formats while publishing Agent Plugins packages additively.

--- a/docs/plugins/package-format.md
+++ b/docs/plugins/package-format.md
@@ -248,15 +248,6 @@ Directory: `<plugin-slug>-codex/`
 
 Codex always uses `bearer_token_env_var` (a reference to an env var) rather than embedding the key directly.
 
-### `plugin.json` (marketplace metadata)
-
-```json
-{
-  "name": "<plugin-slug>-codex",
-  "description": "Plugin description"
-}
-```
-
 ## Observability plugin
 
 The observability plugin is included in every publish (once per org per platform) and ships **before** any MCP server plugins in the marketplace.

--- a/docs/plugins/package-format.md
+++ b/docs/plugins/package-format.md
@@ -46,15 +46,25 @@ When plugins are published, all platform configs land in a single repo. The root
 │       ├── .cursor-plugin/plugin.json
 │       └── mcp.json
 │
-└── <plugin-slug>-codex/               # Codex plugin (one per plugin)
-    ├── .codex-plugin/plugin.json
-    ├── .mcp.json
-    └── plugin.json
+├── <plugin-slug>-codex/               # Codex plugin (one per plugin)
+│   ├── .codex-plugin/plugin.json
+│   └── .mcp.json
+│
+└── agent-plugins/<plugin-slug>/       # Portable Agent Plugins 1.0 package
+    ├── .cursor-plugin/plugin.json     # Native Cursor overlay
+    ├── .codex-plugin/plugin.json      # Native Codex overlay
+    ├── .mcp.json                      # Native Codex MCP config
+    ├── plugin.json
+    ├── mcp.json
+    └── skills/
 ```
 
 Cursor plugins are grouped under the `cursor-plugins/` subdirectory, declared via
 `metadata.pluginRoot` in the Cursor `marketplace.json`. Plugin `source` values are
 then resolved relative to that root (bare names, no `./` prefix).
+
+Compatible plugins are also published under `agent-plugins/` without changing the
+native Cursor or Codex marketplace entries.
 
 ## Marketplace manifests
 
@@ -339,6 +349,6 @@ The auto-generated `README.md` contains:
 
 ## Single-plugin ZIP download
 
-`downloadPluginPackage` returns a ZIP containing only the files for one plugin on one platform. The ZIP structure mirrors the subdirectory in the published repo (e.g. for Claude, it contains `<plugin-slug>/.claude-plugin/plugin.json` and `<plugin-slug>/.mcp.json`).
+`downloadPluginPackage` returns a ZIP containing only the files for one plugin on one platform. Native ZIPs mirror their platform package layout. The `agent-plugin` platform returns a credential-free Agent Plugins 1.0 package rooted at `plugin.json`.
 
 `downloadObservabilityPlugin` returns the observability ZIP for a single platform (Claude or Cursor), minting a fresh hooks-scoped API key each time.

--- a/server/internal/plugins/agent_plugins_test.go
+++ b/server/internal/plugins/agent_plugins_test.go
@@ -89,7 +89,7 @@ func TestCompileAgentPluginUsesPinnedSchemasAndKeylessMode(t *testing.T) {
 	}
 }
 
-func TestAgentPluginMarketplaceTransitionPreservesIdentity(t *testing.T) {
+func TestAgentPluginMarketplaceKeepsNativeSources(t *testing.T) {
 	t.Parallel()
 
 	cfg := GenerateConfig{OrgName: "Example", OrgEmail: "", OrgID: "", ServerURL: "https://app.getgram.ai", APIKey: "", HooksAPIKey: "", ProjectSlug: "default", IsDefaultProject: true, Version: "", PlatformMCPEnabled: false, MarketplaceName: "", BrowserLogin: false, HooksOrgName: "", InstallFailOpen: false}
@@ -107,14 +107,14 @@ func TestAgentPluginMarketplaceTransitionPreservesIdentity(t *testing.T) {
 	require.NoError(t, json.Unmarshal(sharedFiles[".cursor-plugin/marketplace.json"], &sharedCursor))
 	require.NoError(t, json.Unmarshal(legacyFiles[".cursor-plugin/marketplace.json"], &legacyCursor))
 	require.Equal(t, legacyCursor.Plugins[0].Name, sharedCursor.Plugins[0].Name)
-	require.Equal(t, "agent-plugins/tools", sharedCursor.Plugins[0].Source)
-	require.Equal(t, "cursor-plugins/tools-cursor", legacyCursor.Plugins[0].Source)
+	require.Equal(t, "tools-cursor", sharedCursor.Plugins[0].Source)
+	require.Equal(t, "tools-cursor", legacyCursor.Plugins[0].Source)
 
 	var sharedCodex, legacyCodex codexMarketplaceManifest
 	require.NoError(t, json.Unmarshal(sharedFiles[".agents/plugins/marketplace.json"], &sharedCodex))
 	require.NoError(t, json.Unmarshal(legacyFiles[".agents/plugins/marketplace.json"], &legacyCodex))
 	require.Equal(t, legacyCodex.Plugins[0].Name, sharedCodex.Plugins[0].Name)
-	require.Equal(t, "./agent-plugins/tools", sharedCodex.Plugins[0].Source.Path)
+	require.Equal(t, "./tools-codex", sharedCodex.Plugins[0].Source.Path)
 	require.Equal(t, "./tools-codex", legacyCodex.Plugins[0].Source.Path)
 
 	sharedFingerprint, err := MCPFingerprints([]PluginInfo{compatible}, cfg)
@@ -122,7 +122,7 @@ func TestAgentPluginMarketplaceTransitionPreservesIdentity(t *testing.T) {
 	legacyFingerprint, err := MCPFingerprints([]PluginInfo{incompatible}, cfg)
 	require.NoError(t, err)
 	require.NotEqual(t, sharedFingerprint["tools"], legacyFingerprint["tools"])
-	require.NotEqual(t, sharedFingerprint[mcpSharedFingerprintKey], legacyFingerprint[mcpSharedFingerprintKey])
+	require.Equal(t, sharedFingerprint[mcpSharedFingerprintKey], legacyFingerprint[mcpSharedFingerprintKey])
 }
 
 func TestAgentPluginZipIsDeterministicAndExecutable(t *testing.T) {

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -705,7 +705,7 @@ func generateSharedFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        cursorObservability,
 			DisplayName: "", // Cursor carries the display name in its own plugin.json.
-			Source:      path.Join(cursorPluginRoot, cursorObservability),
+			Source:      cursorObservability,
 			Description: "Required: Speakeasy observability hooks for " + cfg.OrgName + ".",
 		})
 		codexObservability := CodexObservabilitySlug(cfg)
@@ -732,30 +732,23 @@ func generateSharedFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][
 	}
 
 	for _, p := range plugins {
-		compatible := classifyAgentPlugin(p).Compatible
 		claudePlugins = append(claudePlugins, marketplaceEntry{
 			Name:        p.Slug,
 			DisplayName: p.Name,
 			Source:      "./" + p.Slug,
 			Description: p.Description,
 		})
-		cursorSource := path.Join(cursorPluginRoot, p.Slug+"-cursor")
-		codexSource := "./" + p.Slug + "-codex"
-		if compatible {
-			cursorSource = path.Join(agentPluginRoot, p.Slug)
-			codexSource = "./" + path.Join(agentPluginRoot, p.Slug)
-		}
 		cursorPlugins = append(cursorPlugins, marketplaceEntry{
 			Name:        p.Slug + "-cursor",
 			DisplayName: "", // Cursor carries the display name in its own plugin.json.
-			Source:      cursorSource,
+			Source:      p.Slug + "-cursor",
 			Description: p.Description,
 		})
 		codexPlugins = append(codexPlugins, codexMarketplaceEntry{
 			Name: p.Slug + "-codex",
 			Source: codexMarketplaceSource{
 				Source: "local",
-				Path:   codexSource,
+				Path:   "./" + p.Slug + "-codex",
 			},
 			Policy: codexMarketplacePolicy{
 				Installation:   "AVAILABLE",
@@ -781,7 +774,7 @@ func generateSharedFiles(plugins []PluginInfo, cfg GenerateConfig) (map[string][
 	cursorManifest, err := marshalJSON(marketplaceManifest{
 		Name:     marketplaceName,
 		Owner:    owner,
-		Metadata: nil,
+		Metadata: &marketplaceMetadata{PluginRoot: cursorPluginRoot},
 		Plugins:  cursorPlugins,
 	})
 	if err != nil {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -947,9 +947,9 @@ func TestGenerateMarketplaceManifest(t *testing.T) {
 
 	require.Equal(t, "acme-speakeasy", cursorManifest.Name)
 	require.Len(t, cursorManifest.Plugins, 2)
-	require.Nil(t, cursorManifest.Metadata)
-	require.Equal(t, "agent-plugins/a", cursorManifest.Plugins[0].Source)
-	require.Equal(t, "agent-plugins/b", cursorManifest.Plugins[1].Source)
+	require.Equal(t, &marketplaceMetadata{PluginRoot: cursorPluginRoot}, cursorManifest.Metadata)
+	require.Equal(t, "a-cursor", cursorManifest.Plugins[0].Source)
+	require.Equal(t, "b-cursor", cursorManifest.Plugins[1].Source)
 }
 
 func TestGenerateMarketplaceManifestUsesMarketplaceNameOverride(t *testing.T) {

--- a/server/internal/plugins/impl_test.go
+++ b/server/internal/plugins/impl_test.go
@@ -1056,19 +1056,19 @@ func TestPluginsService_PublishAgentPluginCompatibilityTransitions(t *testing.T)
 
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
-	assertSources("agent-plugins/portable-transition", "./agent-plugins/portable-transition", true)
+	assertSources("portable-transition-cursor", "./portable-transition-codex", true)
 
 	err = toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{McpIsPublic: false, ID: toolset.ID, ProjectID: toolset.ProjectID})
 	require.NoError(t, err)
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
-	assertSources("cursor-plugins/portable-transition-cursor", "./portable-transition-codex", false)
+	assertSources("portable-transition-cursor", "./portable-transition-codex", false)
 
 	err = toolsetsrepo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsetsrepo.SetToolsetMCPPublicByIDParams{McpIsPublic: true, ID: toolset.ID, ProjectID: toolset.ProjectID})
 	require.NoError(t, err)
 	_, err = ti.service.PublishPlugins(ctx, &gen.PublishPluginsPayload{})
 	require.NoError(t, err)
-	assertSources("agent-plugins/portable-transition", "./agent-plugins/portable-transition", true)
+	assertSources("portable-transition-cursor", "./portable-transition-codex", true)
 }
 
 func TestPluginsService_GetPublishStatus_NotConfigured(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep Cursor marketplace entries on native packages using `metadata.pluginRoot` and bare sources
- keep Codex marketplace entries on native `<slug>-codex` packages
- continue publishing compatible Agent Plugins 1.0 packages additively under `agent-plugins/`
- document and test the additive package boundary

Refs DNO-792.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves native Cursor and Codex marketplace formats and source paths while publishing Agent Plugins 1.0 packages additively under `agent-plugins/`. Addresses DNO-792 by keeping marketplace identity stable during the marketplace cutover.

- **Bug Fixes**
  - Cursor: set `metadata.pluginRoot` and use bare sources like `tools-cursor` (including observability).
  - Codex: keep sources at `./<slug>-codex`; do not route to `agent-plugins/`.
  - Continue publishing portable packages at `agent-plugins/<slug>`; native ZIPs mirror platform layout; `agent-plugin` ZIPs are credential‑free and rooted at `plugin.json`.
  - Docs/tests: removed stale Codex `plugin.json` docs; clarified the additive boundary and stable MCP fingerprints.

<sup>Written for commit 22bbae567d7f481869b07037cebdc5e4c811e0e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

