### PR TITLE
fix: proxy compressed Git upload-pack requests

### DIFF
--- a/.changeset/forward-git-content-encoding.md
+++ b/.changeset/forward-git-content-encoding.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Support compressed Git upload-pack requests through marketplace URLs.

--- a/server/internal/marketplace/handler.go
+++ b/server/internal/marketplace/handler.go
@@ -184,6 +184,9 @@ func (s *Server) proxyToGitHub(
 	if ct := r.Header.Get("Content-Type"); ct != "" {
 		upstreamReq.Header.Set("Content-Type", ct)
 	}
+	if ce := r.Header.Get("Content-Encoding"); ce != "" {
+		upstreamReq.Header.Set("Content-Encoding", ce)
+	}
 	// Forward git-protocol negotiation hints. Git advertises protocol v2 via
 	// this header; without it GitHub falls back to v0/v1 and clients may see
 	// degraded behavior.

--- a/server/internal/marketplace/handler_test.go
+++ b/server/internal/marketplace/handler_test.go
@@ -84,6 +84,7 @@ func TestUploadPackRequestIsReplayable(t *testing.T) {
 			gotBody, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
 			require.Equal(t, wantBody, gotBody)
+			require.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
 			require.NotNil(t, req.GetBody)
 
 			replayedBody, err := req.GetBody()
@@ -122,6 +123,7 @@ func TestUploadPackRequestIsReplayable(t *testing.T) {
 		"/marketplace/"+strings.Repeat("a", 43)+".git/git-upload-pack",
 		bytes.NewReader(wantBody),
 	)
+	req.Header.Set("Content-Encoding", "gzip")
 	// Incoming server requests do not provide GetBody.
 	req.GetBody = nil
 	rec := httptest.NewRecorder()

--- a/server/internal/marketplace/handler_test.go
+++ b/server/internal/marketplace/handler_test.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"io"
 	"net/http"
@@ -79,12 +80,25 @@ func TestUploadPackRequestIsReplayable(t *testing.T) {
 	t.Parallel()
 
 	wantBody := []byte("0032want 0123456789012345678901234567890123456789\n0000")
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	_, err := zw.Write(wantBody)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	wantCompressedBody := compressed.Bytes()
+
 	client := &http.Client{
 		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 			gotBody, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
-			require.Equal(t, wantBody, gotBody)
+			require.Equal(t, wantCompressedBody, gotBody)
 			require.Equal(t, "gzip", req.Header.Get("Content-Encoding"))
+			zr, err := gzip.NewReader(bytes.NewReader(gotBody))
+			require.NoError(t, err)
+			decompressedBody, err := io.ReadAll(zr)
+			require.NoError(t, err)
+			require.NoError(t, zr.Close())
+			require.Equal(t, wantBody, decompressedBody)
 			require.NotNil(t, req.GetBody)
 
 			replayedBody, err := req.GetBody()
@@ -92,7 +106,7 @@ func TestUploadPackRequestIsReplayable(t *testing.T) {
 			defer func() { require.NoError(t, replayedBody.Close()) }()
 			gotReplayedBody, err := io.ReadAll(replayedBody)
 			require.NoError(t, err)
-			require.Equal(t, wantBody, gotReplayedBody)
+			require.Equal(t, wantCompressedBody, gotReplayedBody)
 			_, markedIdempotent := req.Header["Idempotency-Key"]
 			require.True(t, markedIdempotent)
 
@@ -121,7 +135,7 @@ func TestUploadPackRequestIsReplayable(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/marketplace/"+strings.Repeat("a", 43)+".git/git-upload-pack",
-		bytes.NewReader(wantBody),
+		bytes.NewReader(wantCompressedBody),
 	)
 	req.Header.Set("Content-Encoding", "gzip")
 	// Incoming server requests do not provide GetBody.


### PR DESCRIPTION
## Summary

- preserve `Content-Encoding` when proxying Git upload-pack requests to GitHub
- support Cursor Agent partial clones, which gzip the promisor fetch body
- cover compressed request forwarding in the existing upload-pack replay test

Refs DNO-792.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward Content-Encoding for marketplace Git upload-pack requests so gzipped bodies reach GitHub. This enables gzipped promisor fetches for partial clones (e.g., Cursor Agent) and includes tests that send and replay a compressed body, addressing DNO-792.

<sup>Written for commit a34193ebaa328ca8dc253bad49e4c9a9514516b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

