### PR TITLE
feat: emit structured block effect on shadow-MCP deny responses

### DIFF
--- a/server/internal/hooks/block_effects.go
+++ b/server/internal/hooks/block_effects.go
@@ -1,0 +1,97 @@
+package hooks
+
+import (
+	"context"
+	"time"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+)
+
+// blockEffectContractVersion is the version stamped into the "block" effect.
+// Consumers (the speakeasy-hooks binary, and through it the device agent)
+// ignore effects whose version they don't understand, so bump it only on a
+// breaking reshape of the payload.
+const blockEffectContractVersion = 1
+
+// blockEffect is the structured mirror of the "Request access" prose appended
+// to a requestable deny. It rides in IngestHookResult.Effects under the
+// "block" key so the hooks binary can hand the device agent something it can
+// act on without parsing prose. Absence of the effect means the deny is not
+// requestable (PII, secrets, spend, prompt policies carry nothing).
+type blockEffect struct {
+	Category         string
+	RequestToken     string
+	RequestURL       string
+	RequestExpiresAt time.Time
+	ServerName       string
+	ServerURL        string
+	PolicyName       string
+	ToolName         string
+	BlockURL         string
+}
+
+// blockEffectCollector carries an optional blockEffect from the deny branch
+// that minted a request link up to the transport response. A context collector
+// (same pattern as withRiskScanTracker) avoids threading a third return value
+// through every branch of evaluateCanonicalHook.
+type blockEffectCollector struct {
+	effect *blockEffect
+}
+
+type blockEffectCollectorKey struct{}
+
+func withBlockEffectCollector(ctx context.Context) (context.Context, *blockEffectCollector) {
+	collector := &blockEffectCollector{effect: nil}
+	return context.WithValue(ctx, blockEffectCollectorKey{}, collector), collector
+}
+
+// setBlockEffect records the requestable-deny metadata for the current event.
+// No-op when no collector is installed (legacy per-provider endpoints).
+func setBlockEffect(ctx context.Context, effect blockEffect) {
+	if collector, ok := ctx.Value(blockEffectCollectorKey{}).(*blockEffectCollector); ok {
+		collector.effect = &effect
+	}
+}
+
+// setBlockEffectBlockURL attaches the durable block-row URL to an already
+// recorded effect. Duplicate deliveries re-mint the request link but never a
+// second block row, so the effect can exist without a block URL.
+func setBlockEffectBlockURL(ctx context.Context, blockURL string) {
+	if collector, ok := ctx.Value(blockEffectCollectorKey{}).(*blockEffectCollector); ok && collector.effect != nil {
+		collector.effect.BlockURL = blockURL
+	}
+}
+
+// withBlockEffect attaches the collected effect, if any, to a deny result.
+func withBlockEffect(collector *blockEffectCollector, res *gen.IngestHookResult) *gen.IngestHookResult {
+	if collector == nil || collector.effect == nil {
+		return res
+	}
+	e := collector.effect
+	payload := map[string]any{
+		"v":             blockEffectContractVersion,
+		"category":      e.Category,
+		"requestable":   true,
+		"request_token": e.RequestToken,
+		"request_url":   e.RequestURL,
+	}
+	if !e.RequestExpiresAt.IsZero() {
+		payload["request_expires_at"] = e.RequestExpiresAt.UTC().Format(time.RFC3339)
+	}
+	for key, value := range map[string]string{
+		"server_name": e.ServerName,
+		"server_url":  e.ServerURL,
+		"policy_name": e.PolicyName,
+		"tool_name":   e.ToolName,
+		"block_url":   e.BlockURL,
+	} {
+		if value != "" {
+			payload[key] = value
+		}
+	}
+	if res.Effects == nil {
+		res.Effects = map[string]any{}
+	}
+	res.Effects["block"] = payload
+	return res
+}

--- a/server/internal/hooks/block_effects_test.go
+++ b/server/internal/hooks/block_effects_test.go
@@ -24,7 +24,7 @@ type blockEffectShadowMCPScanner struct {
 }
 
 func (s blockEffectShadowMCPScanner) LookupShadowMCPBlockingPolicy(_ context.Context, _ string, _ uuid.UUID, userID string) (*risk.ShadowMCPPolicy, error) {
-	if userID != s.ingestUserScopedShadowMCPScanner.userID {
+	if userID != s.userID {
 		return nil, nil
 	}
 	return &risk.ShadowMCPPolicy{ID: s.policyID, Name: "shadow-mcp-block"}, nil
@@ -84,7 +84,9 @@ func TestIngest_ShadowMCPDenyCarriesBlockEffect(t *testing.T) {
 	require.NotNil(t, result.Message)
 	require.Contains(t, *result.Message, requestURL, "effect must mirror the link in the prose, not mint a second one")
 
-	expiresAt, err := time.Parse(time.RFC3339, effect["request_expires_at"].(string))
+	expiresAtRaw, ok := effect["request_expires_at"].(string)
+	require.True(t, ok)
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtRaw)
 	require.NoError(t, err)
 	require.WithinDuration(t, time.Now().Add(shadowMCPApprovalRequestTokenTTL), expiresAt, time.Minute)
 

--- a/server/internal/hooks/block_effects_test.go
+++ b/server/internal/hooks/block_effects_test.go
@@ -1,0 +1,192 @@
+package hooks
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/uuid"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/risk"
+)
+
+// blockEffectShadowMCPScanner is ingestUserScopedShadowMCPScanner with a real
+// policy UUID: request-link minting validates risk_policy_id as a UUID, and
+// these tests need the link (and therefore the effect) to actually mint.
+type blockEffectShadowMCPScanner struct {
+	ingestUserScopedShadowMCPScanner
+	policyID string
+}
+
+func (s blockEffectShadowMCPScanner) LookupShadowMCPBlockingPolicy(_ context.Context, _ string, _ uuid.UUID, userID string) (*risk.ShadowMCPPolicy, error) {
+	if userID != s.ingestUserScopedShadowMCPScanner.userID {
+		return nil, nil
+	}
+	return &risk.ShadowMCPPolicy{ID: s.policyID, Name: "shadow-mcp-block"}, nil
+}
+
+func shadowMCPDenyPayload(sessionID, toolCallID string) *gen.IngestPayload {
+	toolName := "mcp__local_server__search"
+	serverIdentity := "local-server"
+	payload := canonicalIngestPayload("custom-adapter", "tool.requested", sessionID)
+	payload.Data = &gen.HookIngestData{
+		ToolCall: &gen.HookToolCallData{
+			ID:    &toolCallID,
+			Name:  &toolName,
+			Input: map[string]any{"query": "secret"},
+		},
+		Mcp: &gen.HookMCPData{
+			ServerIdentity: &serverIdentity,
+		},
+	}
+	return payload
+}
+
+// A shadow-MCP deny that minted a request link must also carry the structured
+// "block" effect so the hooks binary can hand the device agent something it
+// can act on without parsing prose.
+func TestIngest_ShadowMCPDenyCarriesBlockEffect(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	ti.service.riskScanner = blockEffectShadowMCPScanner{
+		ingestUserScopedShadowMCPScanner: ingestUserScopedShadowMCPScanner{userID: authCtx.UserID},
+		policyID:                         uuid.NewString(),
+	}
+
+	result, err := ti.service.Ingest(ctx, shadowMCPDenyPayload("block-effect-shadow-deny", "call-effect-1"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision)
+
+	effect := requireEffectMap(t, result.Effects, "block")
+	require.Equal(t, blockEffectContractVersion, effect["v"])
+	require.Equal(t, "shadow_mcp", effect["category"])
+	require.Equal(t, true, effect["requestable"])
+
+	token, ok := effect["request_token"].(string)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(token, "rpbr2."), "token must be the short cache-backed format")
+
+	requestURL, ok := effect["request_url"].(string)
+	require.True(t, ok)
+	require.Contains(t, requestURL, "/risk-policy-bypass/request#request_token="+token,
+		"URL and token must reference the same request state")
+	require.NotNil(t, result.Message)
+	require.Contains(t, *result.Message, requestURL, "effect must mirror the link in the prose, not mint a second one")
+
+	expiresAt, err := time.Parse(time.RFC3339, effect["request_expires_at"].(string))
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().Add(shadowMCPApprovalRequestTokenTTL), expiresAt, time.Minute)
+
+	require.Equal(t, "shadow-mcp-block", effect["policy_name"])
+	require.Equal(t, "search", effect["tool_name"])
+	require.NotEmpty(t, effect["server_name"])
+	require.NotContains(t, effect, "server_url", "identity-only evidence carries no URL")
+
+	blockURL, ok := effect["block_url"].(string)
+	require.True(t, ok, "first delivery must carry the durable block-row URL")
+	require.Contains(t, *result.Message, blockURL)
+}
+
+// An allow must never carry the effect.
+func TestIngest_AllowCarriesNoBlockEffect(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+
+	result, err := ti.service.Ingest(ctx, canonicalIngestPayload("claude", "session.started", "block-effect-allow"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "allow", result.Decision)
+	require.NotContains(t, result.Effects, "block")
+}
+
+// A scan-based deny (PII, prompt policy, …) is not requestable in v1 and must
+// not carry the effect — its absence is the "not requestable" signal.
+func TestIngest_ScanDenyCarriesNoBlockEffect(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+
+	prompt := "scan deny prompt"
+	payload := canonicalIngestPayload("claude", "prompt.submitted", "block-effect-scan-deny")
+	payload.Data = &gen.HookIngestData{
+		Prompt: &gen.HookPromptData{Text: &prompt},
+	}
+	ti.service.riskScanner = &stubResultScanner{result: &risk.ScanResult{
+		Action:      "block",
+		PolicyID:    uuid.NewString(),
+		PolicyName:  "pii boundary policy",
+		Description: "blocked by deterministic test scanner",
+	}}
+
+	result, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision)
+	require.NotContains(t, result.Effects, "block")
+}
+
+// A shadow-MCP deny whose link minting is unavailable (no site URL) has
+// nothing for the user to request — deny stands, no effect.
+func TestIngest_ShadowMCPDenyWithoutLinkCarriesNoBlockEffect(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	ti.service.riskScanner = blockEffectShadowMCPScanner{
+		ingestUserScopedShadowMCPScanner: ingestUserScopedShadowMCPScanner{userID: authCtx.UserID},
+		policyID:                         uuid.NewString(),
+	}
+	ti.service.siteURL = nil
+
+	result, err := ti.service.Ingest(ctx, shadowMCPDenyPayload("block-effect-no-link", "call-effect-2"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "deny", result.Decision)
+	require.NotContains(t, result.Effects, "block")
+}
+
+// A duplicate delivery re-mints the request link (the prose re-sends it too)
+// but never a second block row, so the effect exists without block_url.
+func TestIngest_DuplicateDeliveryBlockEffectOmitsBlockURL(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestHooksService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	ti.service.riskScanner = blockEffectShadowMCPScanner{
+		ingestUserScopedShadowMCPScanner: ingestUserScopedShadowMCPScanner{userID: authCtx.UserID},
+		policyID:                         uuid.NewString(),
+	}
+
+	idempotencyKey := "block-effect-dup-" + uuid.NewString()
+	payload := shadowMCPDenyPayload("block-effect-dup", "call-effect-dup")
+	payload.IdempotencyKey = &idempotencyKey
+
+	first, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "deny", first.Decision)
+	require.Contains(t, requireEffectMap(t, first.Effects, "block"), "block_url")
+
+	retry, err := ti.service.Ingest(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, "deny", retry.Decision)
+	retryEffect := requireEffectMap(t, retry.Effects, "block")
+	require.NotContains(t, retryEffect, "block_url",
+		"a duplicate delivery must not reference a block row it never minted")
+	require.Contains(t, retryEffect["request_token"], "rpbr2.")
+}

--- a/server/internal/hooks/claude_hooks.go
+++ b/server/internal/hooks/claude_hooks.go
@@ -1138,6 +1138,7 @@ func (s *Service) handlePreToolUse(ctx context.Context, ev *hookevents.BeforeToo
 		ToolName:        mcpToolName,
 		ToolInput:       payload.ToolInput,
 		RiskPolicyID:    policy.ID,
+		PolicyName:      policy.Name,
 	})
 	matchedURL := ""
 	if matched != nil {

--- a/server/internal/hooks/codex_hooks.go
+++ b/server/internal/hooks/codex_hooks.go
@@ -208,6 +208,7 @@ func (s *Service) Codex(ctx context.Context, payload *gen.CodexPayload) (res *ge
 						ToolName:        toolName,
 						ToolInput:       ev.ToolInput,
 						RiskPolicyID:    policy.ID,
+						PolicyName:      policy.Name,
 					})
 					isToolCallBlock = true
 					blockToolName = toolName

--- a/server/internal/hooks/cursor_hooks.go
+++ b/server/internal/hooks/cursor_hooks.go
@@ -202,6 +202,7 @@ func (s *Service) Cursor(ctx context.Context, payload *gen.CursorPayload) (res *
 				ToolName:        toolName,
 				ToolInput:       ev.ToolInput,
 				RiskPolicyID:    policy.ID,
+				PolicyName:      policy.Name,
 			})
 			blockReason = auditReason
 			if bURL := s.recordToolCallBlockAsync(ctx, toolCallBlockParams{

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -157,6 +157,7 @@ func (s *Service) ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 	orgSlug := ""
 	outcome := hookMetricOutcomeAccepted
 	ctx, riskScanned := withRiskScanTracker(ctx)
+	ctx, blockEffects := withBlockEffectCollector(ctx)
 	defer func() {
 		if err != nil && outcome == hookMetricOutcomeAccepted {
 			outcome = hookMetricOutcomeFailure
@@ -270,7 +271,7 @@ func (s *Service) ingest(ctx context.Context, payload *gen.IngestPayload) (res *
 	s.captureMCPAttribution(context.WithoutCancel(ctx), payload, authCtx)
 	if blockReason != "" {
 		return &AuthenticatedIngestResult{
-			Result: s.withOrgSettings(ctx, authCtx.ActiveOrganizationID, canonicalDenyResult(userReason), skillCapture),
+			Result: withBlockEffect(blockEffects, s.withOrgSettings(ctx, authCtx.ActiveOrganizationID, canonicalDenyResult(userReason), skillCapture)),
 			Actor:  ResolvedActor(actor),
 		}, nil
 	}
@@ -774,6 +775,7 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 			ToolName:        toolName,
 			ToolInput:       toolInput,
 			RiskPolicyID:    policy.ID,
+			PolicyName:      policy.Name,
 		})
 		// Retried deliveries still get the deny decision, but must not mint
 		// another block row (and a second block URL) for the same call.
@@ -796,6 +798,7 @@ func (s *Service) evaluateCanonicalShadowMCP(ctx context.Context, authCtx *conte
 				ChatMessageID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 			}); bURL != "" {
 				userReason = appendBlockURL(userReason, bURL)
+				setBlockEffectBlockURL(ctx, bURL)
 			}
 		}
 		return auditReason, userReason

--- a/server/internal/hooks/shadow_mcp_request_link.go
+++ b/server/internal/hooks/shadow_mcp_request_link.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/risk"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 )
 
@@ -25,28 +27,52 @@ type shadowMCPRequestLinkParams struct {
 	ToolName        string
 	ToolInput       any
 	RiskPolicyID    string
+	// PolicyName feeds the structured "block" effect on the canonical ingest
+	// path; legacy per-provider handlers may leave it empty.
+	PolicyName string
+}
+
+// shadowMCPRequestLink is a minted approval-request link plus the fields the
+// structured "block" effect needs alongside it.
+type shadowMCPRequestLink struct {
+	URL        string
+	Token      string
+	ExpiresAt  time.Time
+	ServerName string
+	ServerURL  string
 }
 
 func (s *Service) renderShadowMCPUserBlockReason(ctx context.Context, params shadowMCPRequestLinkParams) string {
 	message := renderUserBlockReason(params.UserMessage, params.AuditReason)
-	requestURL, ok := s.shadowMCPApprovalRequestURL(ctx, params)
+	link, ok := s.shadowMCPApprovalRequestURL(ctx, params)
 	if !ok {
 		return message
 	}
-	return strings.TrimSpace(message) + "\n\nRequest access:\n" + requestURL + "\n\n" + shadowMCPApprovalRequestPrompt
+	setBlockEffect(ctx, blockEffect{
+		Category:         string(categories.CategoryShadowMCP),
+		RequestToken:     link.Token,
+		RequestURL:       link.URL,
+		RequestExpiresAt: link.ExpiresAt,
+		ServerName:       link.ServerName,
+		ServerURL:        link.ServerURL,
+		PolicyName:       params.PolicyName,
+		ToolName:         params.ToolName,
+		BlockURL:         "",
+	})
+	return strings.TrimSpace(message) + "\n\nRequest access:\n" + link.URL + "\n\n" + shadowMCPApprovalRequestPrompt
 }
 
-func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadowMCPRequestLinkParams) (string, bool) {
+func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadowMCPRequestLinkParams) (shadowMCPRequestLink, bool) {
 	if s.siteURL == nil || s.cache == nil || strings.TrimSpace(s.jwtSecret) == "" {
-		return "", false
+		return shadowMCPRequestLink{}, false
 	}
 
 	evidence := shadowmcp.NormalizeAccessEvidence(params.Evidence)
 	if evidence.FullURL == "" && evidence.URLHost == "" && evidence.ServerIdentity == "" {
-		return "", false
+		return shadowMCPRequestLink{}, false
 	}
 
-	requestURL, _, err := risk.GeneratePolicyBypassRequestURL(ctx, s.cache, s.siteURL, risk.PolicyBypassRequestTokenInput{
+	requestURL, token, expiry, err := risk.GeneratePolicyBypassRequestURL(ctx, s.cache, s.siteURL, risk.PolicyBypassRequestTokenInput{
 		OrganizationID:         params.OrganizationID,
 		ProjectID:              params.ProjectID,
 		RequesterUserID:        params.RequesterUserID,
@@ -66,10 +92,16 @@ func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadow
 			attr.SlogOrganizationID(params.OrganizationID),
 			attr.SlogProjectID(params.ProjectID),
 		)
-		return "", false
+		return shadowMCPRequestLink{}, false
 	}
 
-	return requestURL, true
+	return shadowMCPRequestLink{
+		URL:        requestURL,
+		Token:      token,
+		ExpiresAt:  expiry,
+		ServerName: conv.PtrValOr(shadowmcp.ObservedName(evidence, params.ToolName), ""),
+		ServerURL:  evidence.FullURL,
+	}, true
 }
 
 func stringPtrOrNil(value string) *string {

--- a/server/internal/hooks/shadow_mcp_request_link.go
+++ b/server/internal/hooks/shadow_mcp_request_link.go
@@ -64,12 +64,12 @@ func (s *Service) renderShadowMCPUserBlockReason(ctx context.Context, params sha
 
 func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadowMCPRequestLinkParams) (shadowMCPRequestLink, bool) {
 	if s.siteURL == nil || s.cache == nil || strings.TrimSpace(s.jwtSecret) == "" {
-		return shadowMCPRequestLink{}, false
+		return shadowMCPRequestLink{URL: "", Token: "", ExpiresAt: time.Time{}, ServerName: "", ServerURL: ""}, false
 	}
 
 	evidence := shadowmcp.NormalizeAccessEvidence(params.Evidence)
 	if evidence.FullURL == "" && evidence.URLHost == "" && evidence.ServerIdentity == "" {
-		return shadowMCPRequestLink{}, false
+		return shadowMCPRequestLink{URL: "", Token: "", ExpiresAt: time.Time{}, ServerName: "", ServerURL: ""}, false
 	}
 
 	requestURL, token, expiry, err := risk.GeneratePolicyBypassRequestURL(ctx, s.cache, s.siteURL, risk.PolicyBypassRequestTokenInput{
@@ -92,7 +92,7 @@ func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadow
 			attr.SlogOrganizationID(params.OrganizationID),
 			attr.SlogProjectID(params.ProjectID),
 		)
-		return shadowMCPRequestLink{}, false
+		return shadowMCPRequestLink{URL: "", Token: "", ExpiresAt: time.Time{}, ServerName: "", ServerURL: ""}, false
 	}
 
 	return shadowMCPRequestLink{

--- a/server/internal/hooks/shadow_mcp_request_link.go
+++ b/server/internal/hooks/shadow_mcp_request_link.go
@@ -100,8 +100,24 @@ func (s *Service) shadowMCPApprovalRequestURL(ctx context.Context, params shadow
 		Token:      token,
 		ExpiresAt:  expiry,
 		ServerName: conv.PtrValOr(shadowmcp.ObservedName(evidence, params.ToolName), ""),
-		ServerURL:  evidence.FullURL,
+		ServerURL:  redactedServerURL(evidence.FullURL),
 	}, true
+}
+
+// redactedServerURL reduces an observed server URL to the inventory
+// convention (scheme/host/path — no userinfo, query, or fragment) before it
+// rides the machine-readable block effect: NormalizeAccessEvidence keeps the
+// query string and any embedded credentials, and this channel must not
+// re-expose them.
+func redactedServerURL(fullURL string) string {
+	if fullURL == "" {
+		return ""
+	}
+	inventory, ok := shadowmcp.CanonicalizeInventoryURL(fullURL)
+	if !ok {
+		return ""
+	}
+	return inventory.CanonicalURL
 }
 
 func stringPtrOrNil(value string) *string {

--- a/server/internal/hooks/shadow_mcp_request_link_test.go
+++ b/server/internal/hooks/shadow_mcp_request_link_test.go
@@ -136,3 +136,37 @@ func TestObservedShadowMCPName_PrefersURLHostOverServerIdentity(t *testing.T) {
 	require.NotNil(t, name)
 	require.Equal(t, "mcp.calendly.com", *name)
 }
+
+// The machine-readable channel must not re-expose credentials or query
+// parameters the deny prose never carried: server_url follows the inventory
+// convention (scheme/host/path only).
+func TestShadowMCPApprovalRequestURLRedactsServerURL(t *testing.T) {
+	t.Parallel()
+
+	siteURL, err := url.Parse("https://app.example.test")
+	require.NoError(t, err)
+	service := &Service{
+		logger:    testenv.NewLogger(t),
+		siteURL:   siteURL,
+		jwtSecret: "test-jwt-secret",
+		cache:     cache.NoopCache,
+	}
+
+	link, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
+		OrganizationID:  "org_test",
+		ProjectID:       "00000000-0000-0000-0000-000000000001",
+		RequesterUserID: "user_test",
+		AuditReason:     "blocked",
+		Evidence: shadowmcp.AccessEvidence{
+			FullURL:        "https://user:hunter2@mcp.example.com/sse?api_key=sk-123#frag",
+			URLHost:        "",
+			ServerIdentity: "",
+		},
+		ToolName:     "search",
+		RiskPolicyID: "00000000-0000-0000-0000-000000000002",
+	})
+	require.True(t, ok)
+	require.Equal(t, "https://mcp.example.com/sse", link.ServerURL)
+	require.NotContains(t, link.ServerURL, "hunter2")
+	require.NotContains(t, link.ServerURL, "api_key")
+}

--- a/server/internal/hooks/shadow_mcp_request_link_test.go
+++ b/server/internal/hooks/shadow_mcp_request_link_test.go
@@ -24,7 +24,7 @@ func TestShadowMCPApprovalRequestURLUsesFragmentToken(t *testing.T) {
 		cache:     cache.NoopCache,
 	}
 
-	requestURL, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
+	link, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
 		OrganizationID:  "org_test",
 		ProjectID:       "00000000-0000-0000-0000-000000000001",
 		RequesterUserID: "user_test",
@@ -39,6 +39,7 @@ func TestShadowMCPApprovalRequestURLUsesFragmentToken(t *testing.T) {
 		RiskPolicyID: "00000000-0000-0000-0000-000000000002",
 	})
 	require.True(t, ok)
+	requestURL := link.URL
 
 	parsed, err := url.Parse(requestURL)
 	require.NoError(t, err)
@@ -52,6 +53,10 @@ func TestShadowMCPApprovalRequestURLUsesFragmentToken(t *testing.T) {
 	require.NotContains(t, requestURL, "?request_token=")
 	require.Contains(t, fragment.Get("request_token"), "rpbr2.")
 	require.Less(t, len(requestURL), 120, "approval link should be a short cache-backed id, not embedded state")
+	require.Equal(t, fragment.Get("request_token"), link.Token, "returned token must match the one embedded in the fragment")
+	require.False(t, link.ExpiresAt.IsZero())
+	require.Equal(t, "mcp.example.com", link.ServerName)
+	require.Equal(t, "https://mcp.example.com/sse", link.ServerURL)
 }
 
 func TestShadowMCPApprovalRequestURLRequiresEvidence(t *testing.T) {
@@ -89,7 +94,7 @@ func TestShadowMCPApprovalRequestURLAllowsServerIdentityEvidence(t *testing.T) {
 		cache:     cache.NoopCache,
 	}
 
-	requestURL, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
+	link, ok := service.shadowMCPApprovalRequestURL(t.Context(), shadowMCPRequestLinkParams{
 		OrganizationID:  "org_test",
 		ProjectID:       "00000000-0000-0000-0000-000000000001",
 		RequesterUserID: "user_test",
@@ -103,7 +108,7 @@ func TestShadowMCPApprovalRequestURLAllowsServerIdentityEvidence(t *testing.T) {
 		RiskPolicyID: "00000000-0000-0000-0000-000000000002",
 	})
 	require.True(t, ok)
-	require.Contains(t, requestURL, "/risk-policy-bypass/request#request_token=rpbr2.")
+	require.Contains(t, link.URL, "/risk-policy-bypass/request#request_token=rpbr2.")
 }
 
 func TestObservedShadowMCPName_HumanizesServerIdentity(t *testing.T) {

--- a/server/internal/risk/policy_bypass_token.go
+++ b/server/internal/risk/policy_bypass_token.go
@@ -114,13 +114,13 @@ func newPolicyBypassRequestID() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(raw), nil
 }
 
-func GeneratePolicyBypassRequestURL(ctx context.Context, c cache.Cache, siteURL *url.URL, input PolicyBypassRequestTokenInput, ttl time.Duration) (string, time.Time, error) {
+func GeneratePolicyBypassRequestURL(ctx context.Context, c cache.Cache, siteURL *url.URL, input PolicyBypassRequestTokenInput, ttl time.Duration) (string, string, time.Time, error) {
 	if siteURL == nil {
-		return "", time.Time{}, fmt.Errorf("site url is required")
+		return "", "", time.Time{}, fmt.Errorf("site url is required")
 	}
 	token, expiry, err := GeneratePolicyBypassRequestToken(ctx, c, input, ttl)
 	if err != nil {
-		return "", time.Time{}, err
+		return "", "", time.Time{}, err
 	}
 	requestURL := siteURL.JoinPath("risk-policy-bypass", "request")
 	query := url.Values{}
@@ -134,7 +134,7 @@ func GeneratePolicyBypassRequestURL(ctx context.Context, c cache.Cache, siteURL 
 	// token to an rpbr2 cache id (AIS-228) did not change this: a short id is
 	// no less a secret, so it still belongs in the fragment.
 	requestURL.Fragment = query.Encode()
-	return requestURL.String(), expiry, nil
+	return requestURL.String(), token, expiry, nil
 }
 
 // GeneratePolicyBypassRequestToken stores the request state in the cache and


### PR DESCRIPTION
Part 1 of [Request access for blocked AI tool calls](https://linear.app/speakeasy/project/request-access-for-blocked-ai-tool-calls-08c7538c7b77) (DNO-802).

## Why

When a shadow-MCP policy denies a tool call, the "Request access" link is buried as prose in the deny message the AI tool prints. The device agent wants to surface a native request flow, and it can't (and shouldn't) parse prose.

## What

- Shadow-MCP denies on the canonical ingest path now carry a structured `effects["block"]` entry mirroring the minted request link: category, `rpbr2.` token + URL + expiry, observed server, policy, tool, and the durable block-row URL.
- Absence of the key is the "not requestable" signal — scan denies (PII, secrets, spend, prompt policies) carry nothing.
- Duplicate deliveries re-mint the link (the prose re-sends it too) but omit `block_url`, matching the existing no-second-block-row rule.
- Collected via a context carrier (same pattern as `withRiskScanTracker`) so `evaluateCanonicalHook`'s ten deny branches keep their signature.

## Test plan

- New ingest-level tests: effect present on a shadow-MCP deny; absent on allow, scan deny, and mint-failure; duplicate-delivery shape.
- `go test ./internal/hooks/ ./internal/risk/` green; golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqNdUoJxcz85saAAyPodoW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured `effects["block"]` payload to shadow‑MCP deny responses on the canonical ingest path so device agents can start a native “Request access” flow without parsing prose. Part of DNO-802 (Request access for blocked AI tool calls).

- **New Features**
  - Emits `effects["block"]` with v=1, `category: "shadow_mcp"`, `requestable: true`, `request_token` (`rpbr2.*`), `request_url`, `request_expires_at`, plus `server_name`/redacted `server_url`, `policy_name`, `tool_name`, and `block_url` (first delivery only).
  - No effect on allow, scan-based denies (PII/secrets/spend/prompt), or when link minting fails. Duplicate deliveries re-mint the link but omit `block_url`.
  - Added `withBlockEffectCollector`/`withBlockEffect` and `setBlockEffect`/`setBlockEffectBlockURL`; wired into the canonical ingest deny path.
  - `shadow_mcp_request_link` now returns URL, token, expiry and sets the effect; `PolicyName` plumbed through canonical and per-provider handlers (`claude`/`codex`/`cursor`). `GeneratePolicyBypassRequestURL` now returns `(url, token, expiry, err)`.

- **Bug Fixes**
  - Redacts `server_url` in the block effect to the inventory convention (scheme/host/path only); strips credentials, query, and fragment.

<sup>Written for commit c403252df77895873b9e76fa1730edec8eb67398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

