### PR TITLE
feat: allow device keys (agent_user) on risk.createPolicyBypassRequest

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -33332,6 +33332,13 @@ paths:
           schema:
             description: Session header
             type: string
+        - allowEmptyValue: true
+          description: API Key header
+          in: header
+          name: Gram-Key
+          schema:
+            description: API Key header
+            type: string
       requestBody:
         content:
           application/json:
@@ -33401,6 +33408,7 @@ paths:
           description: 'gateway_error: an unexpected error occurred'
       security:
         - session_header_Gram-Session: []
+        - apikey_header_Gram-Key: []
         - {}
       summary: createRiskPolicyBypassRequest risk
       tags:

--- a/client/dashboard/src/sdk/src/funcs/riskPolicyBypassRequestsCreate.ts
+++ b/client/dashboard/src/sdk/src/funcs/riskPolicyBypassRequestsCreate.ts
@@ -114,6 +114,10 @@ async function $do(
   const headers = new Headers(compactMap({
     "Content-Type": "application/json",
     Accept: "application/json",
+    "Gram-Key": encodeSimple("Gram-Key", payload["Gram-Key"], {
+      explode: false,
+      charEncoding: "none",
+    }),
     "Gram-Session": encodeSimple("Gram-Session", payload["Gram-Session"], {
       explode: false,
       charEncoding: "none",
@@ -126,6 +130,13 @@ async function $do(
         fieldName: "Gram-Session",
         type: "apiKey:header",
         value: security?.sessionHeaderGramSession,
+      },
+    ],
+    [
+      {
+        fieldName: "Gram-Key",
+        type: "apiKey:header",
+        value: security?.apikeyHeaderGramKey,
       },
     ],
   );

--- a/client/dashboard/src/sdk/src/models/operations/createriskpolicybypassrequest.ts
+++ b/client/dashboard/src/sdk/src/models/operations/createriskpolicybypassrequest.ts
@@ -12,6 +12,7 @@ import {
 
 export type CreateRiskPolicyBypassRequestSecurity = {
   sessionHeaderGramSession?: string | undefined;
+  apikeyHeaderGramKey?: string | undefined;
 };
 
 export type CreateRiskPolicyBypassRequestRequest = {
@@ -19,6 +20,10 @@ export type CreateRiskPolicyBypassRequestRequest = {
    * Session header
    */
   gramSession?: string | undefined;
+  /**
+   * API Key header
+   */
+  gramKey?: string | undefined;
   createRiskPolicyBypassRequestRequestBody:
     CreateRiskPolicyBypassRequestRequestBody;
 };
@@ -26,6 +31,7 @@ export type CreateRiskPolicyBypassRequestRequest = {
 /** @internal */
 export type CreateRiskPolicyBypassRequestSecurity$Outbound = {
   "session_header_Gram-Session"?: string | undefined;
+  "apikey_header_Gram-Key"?: string | undefined;
 };
 
 /** @internal */
@@ -36,10 +42,12 @@ export const CreateRiskPolicyBypassRequestSecurity$outboundSchema:
   > = z.pipe(
     z.object({
       sessionHeaderGramSession: z.optional(z.string()),
+      apikeyHeaderGramKey: z.optional(z.string()),
     }),
     z.transform((v) => {
       return remap$(v, {
         sessionHeaderGramSession: "session_header_Gram-Session",
+        apikeyHeaderGramKey: "apikey_header_Gram-Key",
       });
     }),
   );
@@ -57,6 +65,7 @@ export function createRiskPolicyBypassRequestSecurityToJSON(
 /** @internal */
 export type CreateRiskPolicyBypassRequestRequest$Outbound = {
   "Gram-Session"?: string | undefined;
+  "Gram-Key"?: string | undefined;
   CreateRiskPolicyBypassRequestRequestBody:
     CreateRiskPolicyBypassRequestRequestBody$Outbound;
 };
@@ -68,12 +77,14 @@ export const CreateRiskPolicyBypassRequestRequest$outboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     gramSession: z.optional(z.string()),
+    gramKey: z.optional(z.string()),
     createRiskPolicyBypassRequestRequestBody:
       CreateRiskPolicyBypassRequestRequestBody$outboundSchema,
   }),
   z.transform((v) => {
     return remap$(v, {
       gramSession: "Gram-Session",
+      gramKey: "Gram-Key",
       createRiskPolicyBypassRequestRequestBody:
         "CreateRiskPolicyBypassRequestRequestBody",
     });

--- a/server/design/risk/design.go
+++ b/server/design/risk/design.go
@@ -766,9 +766,18 @@ var _ = Service("risk", func() {
 	Method("createRiskPolicyBypassRequest", func() {
 		Description("Create or refresh a risk policy bypass request from a signed request URL token.")
 		Security(security.Session)
+		// The device agent files the request on the user's behalf with the
+		// per-user `agent_user` key minted by token-exchange. The key owner is
+		// the enrolled user, so the handler's requester binding applies
+		// unchanged. Deliberately no ProjectSlug scheme: the project resolves
+		// from the request token's claims.
+		Security(security.ByKey, func() {
+			Scope("agent_user")
+		})
 
 		Payload(func() {
 			security.SessionPayload()
+			security.ByKeyPayload()
 			Attribute("request_token", String, "Signed request token generated when a risk policy blocks an action.")
 			Required("request_token")
 		})
@@ -778,6 +787,7 @@ var _ = Service("risk", func() {
 		HTTP(func() {
 			POST("/rpc/risk.createPolicyBypassRequest")
 			security.SessionHeader()
+			security.ByKeyHeader()
 			Response(StatusCreated)
 		})
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -2210,6 +2210,7 @@ func ParseEndpoint(
 		riskCreateRiskPolicyBypassRequestFlags            = flag.NewFlagSet("create-risk-policy-bypass-request", flag.ExitOnError)
 		riskCreateRiskPolicyBypassRequestBodyFlag         = riskCreateRiskPolicyBypassRequestFlags.String("body", "REQUIRED", "")
 		riskCreateRiskPolicyBypassRequestSessionTokenFlag = riskCreateRiskPolicyBypassRequestFlags.String("session-token", "", "")
+		riskCreateRiskPolicyBypassRequestApikeyTokenFlag  = riskCreateRiskPolicyBypassRequestFlags.String("apikey-token", "", "")
 
 		riskAcknowledgeRiskPolicyChallengeFlags            = flag.NewFlagSet("acknowledge-risk-policy-challenge", flag.ExitOnError)
 		riskAcknowledgeRiskPolicyChallengeBodyFlag         = riskAcknowledgeRiskPolicyChallengeFlags.String("body", "REQUIRED", "")
@@ -7267,7 +7268,7 @@ func ParseEndpoint(
 				data, err = riskc.BuildGetRiskPolicyStatusPayload(*riskGetRiskPolicyStatusIDFlag, *riskGetRiskPolicyStatusApikeyTokenFlag, *riskGetRiskPolicyStatusSessionTokenFlag, *riskGetRiskPolicyStatusProjectSlugInputFlag)
 			case "create-risk-policy-bypass-request":
 				endpoint = c.CreateRiskPolicyBypassRequest()
-				data, err = riskc.BuildCreateRiskPolicyBypassRequestPayload(*riskCreateRiskPolicyBypassRequestBodyFlag, *riskCreateRiskPolicyBypassRequestSessionTokenFlag)
+				data, err = riskc.BuildCreateRiskPolicyBypassRequestPayload(*riskCreateRiskPolicyBypassRequestBodyFlag, *riskCreateRiskPolicyBypassRequestSessionTokenFlag, *riskCreateRiskPolicyBypassRequestApikeyTokenFlag)
 			case "acknowledge-risk-policy-challenge":
 				endpoint = c.AcknowledgeRiskPolicyChallenge()
 				data, err = riskc.BuildAcknowledgeRiskPolicyChallengePayload(*riskAcknowledgeRiskPolicyChallengeBodyFlag, *riskAcknowledgeRiskPolicyChallengeSessionTokenFlag)
@@ -16944,6 +16945,7 @@ func riskCreateRiskPolicyBypassRequestUsage() {
 	fmt.Fprintf(os.Stderr, "%s [flags] risk create-risk-policy-bypass-request", os.Args[0])
 	fmt.Fprint(os.Stderr, " -body JSON")
 	fmt.Fprint(os.Stderr, " -session-token STRING")
+	fmt.Fprint(os.Stderr, " -apikey-token STRING")
 	fmt.Fprintln(os.Stderr)
 
 	// Description
@@ -16953,10 +16955,11 @@ func riskCreateRiskPolicyBypassRequestUsage() {
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -body JSON: `)
 	fmt.Fprintln(os.Stderr, `    -session-token STRING: `)
+	fmt.Fprintln(os.Stderr, `    -apikey-token STRING: `)
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "risk create-risk-policy-bypass-request --body '{\n      \"request_token\": \"abc123\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "risk create-risk-policy-bypass-request --body '{\n      \"request_token\": \"abc123\"\n   }' --session-token \"abc123\" --apikey-token \"abc123\"")
 }
 
 func riskAcknowledgeRiskPolicyChallengeUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -33760,6 +33760,13 @@ paths:
                   schema:
                     description: Session header
                     type: string
+                - allowEmptyValue: true
+                  description: API Key header
+                  in: header
+                  name: Gram-Key
+                  schema:
+                    description: API Key header
+                    type: string
             requestBody:
                 content:
                     application/json:
@@ -33829,6 +33836,7 @@ paths:
                     description: 'gateway_error: an unexpected error occurred'
             security:
                 - session_header_Gram-Session: []
+                - apikey_header_Gram-Key: []
             summary: createRiskPolicyBypassRequest risk
             tags:
                 - risk

--- a/server/gen/http/risk/client/cli.go
+++ b/server/gen/http/risk/client/cli.go
@@ -1384,7 +1384,7 @@ func BuildGetRiskPolicyStatusPayload(riskGetRiskPolicyStatusID string, riskGetRi
 
 // BuildCreateRiskPolicyBypassRequestPayload builds the payload for the risk
 // createRiskPolicyBypassRequest endpoint from CLI flags.
-func BuildCreateRiskPolicyBypassRequestPayload(riskCreateRiskPolicyBypassRequestBody string, riskCreateRiskPolicyBypassRequestSessionToken string) (*risk.CreateRiskPolicyBypassRequestPayload, error) {
+func BuildCreateRiskPolicyBypassRequestPayload(riskCreateRiskPolicyBypassRequestBody string, riskCreateRiskPolicyBypassRequestSessionToken string, riskCreateRiskPolicyBypassRequestApikeyToken string) (*risk.CreateRiskPolicyBypassRequestPayload, error) {
 	var err error
 	var body CreateRiskPolicyBypassRequestRequestBody
 	{
@@ -1399,10 +1399,17 @@ func BuildCreateRiskPolicyBypassRequestPayload(riskCreateRiskPolicyBypassRequest
 			sessionToken = &riskCreateRiskPolicyBypassRequestSessionToken
 		}
 	}
+	var apikeyToken *string
+	{
+		if riskCreateRiskPolicyBypassRequestApikeyToken != "" {
+			apikeyToken = &riskCreateRiskPolicyBypassRequestApikeyToken
+		}
+	}
 	v := &risk.CreateRiskPolicyBypassRequestPayload{
 		RequestToken: body.RequestToken,
 	}
 	v.SessionToken = sessionToken
+	v.ApikeyToken = apikeyToken
 
 	return v, nil
 }

--- a/server/gen/http/risk/client/encode_decode.go
+++ b/server/gen/http/risk/client/encode_decode.go
@@ -4935,6 +4935,10 @@ func EncodeCreateRiskPolicyBypassRequestRequest(encoder func(*http.Request) goah
 			head := *p.SessionToken
 			req.Header.Set("Gram-Session", head)
 		}
+		if p.ApikeyToken != nil {
+			head := *p.ApikeyToken
+			req.Header.Set("Gram-Key", head)
+		}
 		body := NewCreateRiskPolicyBypassRequestRequestBody(p)
 		if err := encoder(req).Encode(&body); err != nil {
 			return goahttp.ErrEncodingError("risk", "createRiskPolicyBypassRequest", err)

--- a/server/gen/http/risk/server/encode_decode.go
+++ b/server/gen/http/risk/server/encode_decode.go
@@ -4902,17 +4902,29 @@ func DecodeCreateRiskPolicyBypassRequestRequest(mux goahttp.Muxer, decoder func(
 
 		var (
 			sessionToken *string
+			apikeyToken  *string
 		)
 		sessionTokenRaw := r.Header.Get("Gram-Session")
 		if sessionTokenRaw != "" {
 			sessionToken = &sessionTokenRaw
 		}
-		payload = NewCreateRiskPolicyBypassRequestPayload(&body, sessionToken)
+		apikeyTokenRaw := r.Header.Get("Gram-Key")
+		if apikeyTokenRaw != "" {
+			apikeyToken = &apikeyTokenRaw
+		}
+		payload = NewCreateRiskPolicyBypassRequestPayload(&body, sessionToken, apikeyToken)
 		if payload.SessionToken != nil {
 			if strings.Contains(*payload.SessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")
 				cred := strings.SplitN(*payload.SessionToken, " ", 2)[1]
 				payload.SessionToken = &cred
+			}
+		}
+		if payload.ApikeyToken != nil {
+			if strings.Contains(*payload.ApikeyToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.ApikeyToken, " ", 2)[1]
+				payload.ApikeyToken = &cred
 			}
 		}
 

--- a/server/gen/http/risk/server/types.go
+++ b/server/gen/http/risk/server/types.go
@@ -19157,11 +19157,12 @@ func NewGetRiskPolicyStatusPayload(id string, apikeyToken *string, sessionToken 
 
 // NewCreateRiskPolicyBypassRequestPayload builds a risk service
 // createRiskPolicyBypassRequest endpoint payload.
-func NewCreateRiskPolicyBypassRequestPayload(body *CreateRiskPolicyBypassRequestRequestBody, sessionToken *string) *risk.CreateRiskPolicyBypassRequestPayload {
+func NewCreateRiskPolicyBypassRequestPayload(body *CreateRiskPolicyBypassRequestRequestBody, sessionToken *string, apikeyToken *string) *risk.CreateRiskPolicyBypassRequestPayload {
 	v := &risk.CreateRiskPolicyBypassRequestPayload{
 		RequestToken: *body.RequestToken,
 	}
 	v.SessionToken = sessionToken
+	v.ApikeyToken = apikeyToken
 
 	return v
 }

--- a/server/gen/risk/endpoints.go
+++ b/server/gen/risk/endpoints.go
@@ -1368,6 +1368,18 @@ func NewCreateRiskPolicyBypassRequestEndpoint(s Service, authAPIKeyFn security.A
 		}
 		ctx, err = authAPIKeyFn(ctx, key, &sc)
 		if err != nil {
+			sc := security.APIKeyScheme{
+				Name:           "apikey",
+				Scopes:         []string{"consumer", "producer", "chat", "hooks", "agent", "agent_user"},
+				RequiredScopes: []string{"agent_user"},
+			}
+			var key string
+			if p.ApikeyToken != nil {
+				key = *p.ApikeyToken
+			}
+			ctx, err = authAPIKeyFn(ctx, key, &sc)
+		}
+		if err != nil {
 			return nil, err
 		}
 		return s.CreateRiskPolicyBypassRequest(ctx, p)

--- a/server/gen/risk/service.go
+++ b/server/gen/risk/service.go
@@ -303,6 +303,7 @@ type CreateRiskExclusionPayload struct {
 // createRiskPolicyBypassRequest method.
 type CreateRiskPolicyBypassRequestPayload struct {
 	SessionToken *string
+	ApikeyToken  *string
 	// Signed request token generated when a risk policy blocks an action.
 	RequestToken string
 }

--- a/server/internal/risk/policy_bypass_test.go
+++ b/server/internal/risk/policy_bypass_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"goa.design/goa/v3/security"
 
 	gen "github.com/speakeasy-api/gram/server/gen/risk"
 	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
@@ -1018,4 +1019,37 @@ func TestCreateRiskPolicyBypassRequest_OrgKeyAttributedTokenForbidden(t *testing
 		RequestToken: token,
 	})
 	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+// The `agent_user` scope gate lives in the generated security wiring — the
+// design's Security(ByKey, Scope("agent_user")) becomes the key scheme's
+// RequiredScopes in gen/risk — not in the handler, so the direct-call tests
+// above cannot see it. Drive the generated endpoint with a recording
+// authorizer to pin that boundary: key auth must demand agent_user, and an
+// authorization failure must short-circuit before the service method runs.
+func TestCreateRiskPolicyBypassRequest_EndpointKeyAuthDemandsAgentUserScope(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	var schemes []*security.APIKeyScheme
+	forbidden := oops.C(oops.CodeForbidden)
+	endpoint := gen.NewCreateRiskPolicyBypassRequestEndpoint(ti.service,
+		func(ctx context.Context, key string, scheme *security.APIKeyScheme) (context.Context, error) {
+			schemes = append(schemes, scheme)
+			return ctx, forbidden
+		})
+
+	_, err := endpoint(ctx, &gen.CreateRiskPolicyBypassRequestPayload{
+		SessionToken: nil,
+		ApikeyToken:  new("gram_test_key"),
+		RequestToken: "rpbr2.never-redeemed",
+	})
+	require.Equal(t, forbidden, err, "the authorizer's rejection must surface, not a handler error")
+
+	require.Len(t, schemes, 2, "session scheme tried first, then the key scheme")
+	require.Equal(t, "session", schemes[0].Name)
+	require.Empty(t, schemes[0].RequiredScopes)
+	require.Equal(t, "apikey", schemes[1].Name)
+	require.Equal(t, []string{"agent_user"}, schemes[1].RequiredScopes,
+		"key auth must demand agent_user; removing the design's Scope() regenerates this away and fails here")
 }

--- a/server/internal/risk/policy_bypass_test.go
+++ b/server/internal/risk/policy_bypass_test.go
@@ -1,6 +1,7 @@
 package risk_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	oops "github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
@@ -907,4 +909,113 @@ func TestDenyPolicyBypassRequest_AllowAllLeavesBlockedListUntouched(t *testing.T
 	assert.Equal(t, "denied", denied.Status)
 
 	require.Equal(t, []string{blockedURL}, shadowMCPPolicyBlockedURLs(t, ctx, ti.conn, policy.ID))
+}
+
+// withAgentKeyAuth rewrites the auth context to look like an API-key-
+// authenticated device agent: no session, the given key scopes, and the key
+// owner as the caller. Mirrors what internal/auth/key.go builds for a
+// Gram-Key request.
+func withAgentKeyAuth(t *testing.T, ctx context.Context, scopes []string, ownerUserID string) context.Context {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	clone := *authCtx
+	clone.APIKeyScopes = scopes
+	clone.SessionID = nil
+	clone.UserID = ownerUserID
+	return contextvalues.SetAuthContext(ctx, &clone)
+}
+
+// The device agent files the request with the per-user `agent_user` key. Its
+// owner is the enrolled user, so the token's requester binding passes and the
+// request is attributed to the key owner.
+func TestCreateRiskPolicyBypassRequest_AgentUserKeyCreatesForKeyOwner(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	adminCtx := withExactAccessGrants(t, ctx, ti.conn, authz.Grant{
+		Scope:    authz.ScopeOrgAdmin,
+		Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID),
+	})
+
+	policy, err := ti.service.CreateRiskPolicy(adminCtx, &gen.CreateRiskPolicyPayload{
+		Name: new("Agent Key Bypass Request"),
+	})
+	require.NoError(t, err)
+
+	fullURL := "https://mcp.example.com/agent-key"
+	token := riskPolicyBypassRequestToken(t, ti, authCtx, policy.ID, fullURL)
+
+	beforeAuditCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRiskPolicyBypassRequestCreate)
+	require.NoError(t, err)
+
+	keyCtx := withAgentKeyAuth(t, ctx, []string{"agent_user"}, authCtx.UserID)
+	request, err := ti.service.CreateRiskPolicyBypassRequest(keyCtx, &gen.CreateRiskPolicyBypassRequestPayload{
+		RequestToken: token,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, request)
+	assert.Equal(t, "requested", request.Status)
+	assert.Equal(t, authCtx.UserID, request.RequesterUserID)
+	require.NotNil(t, request.TargetKey)
+	assert.Equal(t, fullURL, *request.TargetKey)
+
+	afterAuditCount, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRiskPolicyBypassRequestCreate)
+	require.NoError(t, err)
+	require.Equal(t, beforeAuditCount+1, afterAuditCount, "key-auth create must audit like the session path")
+}
+
+// A key owned by anyone other than the token's requester must not redeem it —
+// the same binding that stops a leaked link stops a leaked or wrong key.
+func TestCreateRiskPolicyBypassRequest_OtherUsersKeyForbidden(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	adminCtx := withExactAccessGrants(t, ctx, ti.conn, authz.Grant{
+		Scope:    authz.ScopeOrgAdmin,
+		Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID),
+	})
+
+	policy, err := ti.service.CreateRiskPolicy(adminCtx, &gen.CreateRiskPolicyPayload{
+		Name: new("Agent Key Bypass Wrong Owner"),
+	})
+	require.NoError(t, err)
+
+	token := riskPolicyBypassRequestToken(t, ti, authCtx, policy.ID, "https://mcp.example.com/wrong-owner")
+
+	keyCtx := withAgentKeyAuth(t, ctx, []string{"agent_user"}, "user_someone_else")
+	_, err = ti.service.CreateRiskPolicyBypassRequest(keyCtx, &gen.CreateRiskPolicyBypassRequestPayload{
+		RequestToken: token,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
+}
+
+// The shared org install key (`agent` scope) is owned by the provisioning
+// admin, not the developer named in an attributed token — it must not be able
+// to file requests on that developer's behalf. The daemon only ever uses the
+// per-user key for this call; this pins the server-side backstop.
+func TestCreateRiskPolicyBypassRequest_OrgKeyAttributedTokenForbidden(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	adminCtx := withExactAccessGrants(t, ctx, ti.conn, authz.Grant{
+		Scope:    authz.ScopeOrgAdmin,
+		Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID),
+	})
+
+	policy, err := ti.service.CreateRiskPolicy(adminCtx, &gen.CreateRiskPolicyPayload{
+		Name: new("Agent Org Key Bypass Request"),
+	})
+	require.NoError(t, err)
+
+	token := riskPolicyBypassRequestToken(t, ti, authCtx, policy.ID, "https://mcp.example.com/org-key")
+
+	orgKeyCtx := withAgentKeyAuth(t, ctx, []string{"agent", "agent_user"}, "user_provisioning_admin")
+	_, err = ti.service.CreateRiskPolicyBypassRequest(orgKeyCtx, &gen.CreateRiskPolicyBypassRequestPayload{
+		RequestToken: token,
+	})
+	requireOopsCode(t, err, oops.CodeForbidden)
 }


### PR DESCRIPTION
Part 2 of [Request access for blocked AI tool calls](https://linear.app/speakeasy/project/request-access-for-blocked-ai-tool-calls-08c7538c7b77) (DNO-803). Stacked on #5081.

## Why

The device agent files bypass requests on the user's behalf with the per-user `agent_user` key minted by token-exchange, so `risk.createPolicyBypassRequest` needs to accept key auth alongside the dashboard session.

## What

- `Security(ByKey, agent_user)` added to the Goa design; session auth unchanged; codegen + TS SDK regenerated.
- **No handler changes.** Key auth resolves `authCtx.UserID` to the key owner — for an `agent_user` key that IS the enrolled user — so the existing org + requester binding applies unchanged.
- Deliberately no vouched-`email` param (unlike `agent.getPlugins`): this feeds an admin-approval workflow, and a leaked shared org install key must not be able to file requests as arbitrary users. An org key redeeming an attributed token 403s via the same requester binding.

## Test plan

- New key-auth matrix in `policy_bypass_test.go`: `agent_user` key of the requester succeeds (and audits); another user's key 403s; the org install key with an attributed token 403s.
- `go test ./internal/risk/` green; dashboard `tsc` clean against the regenerated SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqNdUoJxcz85saAAyPodoW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow per-user device keys to create policy bypass requests via `risk.createPolicyBypassRequest`. Adds `agent_user` API key auth with the `Gram-Key` header alongside session so the device agent can submit for the enrolled user (DNO-803).

- **New Features**
  - Added `Security(ByKey)` with `agent_user` scope; session path unchanged.
  - Accepts `Gram-Key` header; OpenAPI and server codegen regenerated; dashboard SDK adds `gramKey`; CLI adds `--apikey-token`.
  - Endpoint authenticates via session first, then `agent_user` key; server decoders strip auth scheme from `Gram-Key`.
  - No handler changes; requester binding enforces owner-only. Other users’ keys or org install keys 403; no vouched-`email` param. Tests cover key-owner success, forbidden cases, audit attribution, and an endpoint-level check that `agent_user` is required and auth failures short-circuit before the handler.

<sup>Written for commit 6e03ea6036147e219d6e3d9330a892d2e4c33b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

