### PR TITLE
feat: forward requestable-block metadata to the device-agent socket

### DIFF
--- a/.changeset/agent-block-notify.md
+++ b/.changeset/agent-block-notify.md
@@ -1,0 +1,12 @@
+---
+"hooks": minor
+---
+
+Forward requestable-block metadata to the device-agent socket. When the server
+denies a tool call against an unapproved (shadow) MCP server, the relay now
+posts the structured block effect — request token, server, policy, expiry — to
+the local Speakeasy device agent (best-effort, 300ms budget, never on the
+allow path), so the agent can surface a native "request access" flow instead
+of the user fishing the bypass link out of the deny prose. Machines without
+the agent, or with an older agent, are unaffected: the notify swallows every
+failure and the deny is unchanged.

--- a/hooks/relay/agent_block_notify.go
+++ b/hooks/relay/agent_block_notify.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"strings"
@@ -124,39 +125,68 @@ func (r *Relay) notifyAgentBlock(ctx context.Context, effect *wire.BlockEffect, 
 // into map[string]any, so an unmarshal into the struct would need a marshal
 // round-trip). The keys are pinned to wire.BlockEffect's JSON tags by
 // TestDecodeBlockEffectMatchesWireContract. Returns nil for anything that
-// isn't the object shape this version understands — a non-object, or a
-// non-numeric "v" (the version gates the consumer's guard, so a garbled one
-// must not decode to a trusted zero). Other mistyped fields degrade to their
-// zero values, which the consumer's requestable/token guards already reject.
+// isn't the object shape this version understands: a non-object, or any
+// present field of the wrong type (including a fractional "v") — a garbled
+// effect suppresses the notify entirely rather than posting a degraded
+// report, matching what an unmarshal into the struct would do. Absent fields
+// are fine; they decode to zero values the consumer's guards treat as absent.
 func decodeBlockEffect(raw any) *wire.BlockEffect {
-	object, ok := raw.(map[string]any)
-	if !ok {
+	object, isObject := raw.(map[string]any)
+	if !isObject {
 		return nil
 	}
-	version := 0
-	if v, present := object["v"]; present {
-		f, ok := v.(float64) // JSON numbers decode as float64
-		if !ok {
-			return nil
+	valid := true
+	intField := func(key string) int {
+		value, present := object[key]
+		if !present {
+			return 0
 		}
-		version = int(f)
+		f, ok := value.(float64) // JSON numbers decode as float64
+		if !ok || f != math.Trunc(f) {
+			valid = false
+			return 0
+		}
+		return int(f)
 	}
-	str := func(key string) string {
-		s, _ := object[key].(string)
+	boolField := func(key string) bool {
+		value, present := object[key]
+		if !present {
+			return false
+		}
+		b, ok := value.(bool)
+		if !ok {
+			valid = false
+			return false
+		}
+		return b
+	}
+	strField := func(key string) string {
+		value, present := object[key]
+		if !present {
+			return ""
+		}
+		s, ok := value.(string)
+		if !ok {
+			valid = false
+			return ""
+		}
 		return s
 	}
-	requestable, _ := object["requestable"].(bool)
-	return &wire.BlockEffect{
-		V:                version,
-		Category:         str("category"),
-		Requestable:      requestable,
-		RequestToken:     str("request_token"),
-		RequestURL:       str("request_url"),
-		RequestExpiresAt: str("request_expires_at"),
-		ServerName:       str("server_name"),
-		ServerURL:        str("server_url"),
-		PolicyName:       str("policy_name"),
-		ToolName:         str("tool_name"),
-		BlockURL:         str("block_url"),
+	effect := wire.BlockEffect{
+		V:                intField("v"),
+		Category:         strField("category"),
+		Requestable:      boolField("requestable"),
+		RequestToken:     strField("request_token"),
+		RequestURL:       strField("request_url"),
+		RequestExpiresAt: strField("request_expires_at"),
+		ServerName:       strField("server_name"),
+		ServerURL:        strField("server_url"),
+		PolicyName:       strField("policy_name"),
+		ToolName:         strField("tool_name"),
+		BlockURL:         strField("block_url"),
 	}
+	if !valid {
+		return nil
+	}
+	return &effect
 }

--- a/hooks/relay/agent_block_notify.go
+++ b/hooks/relay/agent_block_notify.go
@@ -1,0 +1,129 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/speakeasy-api/agenthooks"
+)
+
+// agentBlockNotifyTimeout bounds the whole best-effort notify. It runs only
+// after a deny — the user's call is already blocked and already paid a WAN
+// round trip, so 300ms is imperceptible — and only a *hung* daemon ever pays
+// it: a missing socket fails the dial instantly (same reasoning as
+// socketAgentTimeout).
+const agentBlockNotifyTimeout = 300 * time.Millisecond
+
+const agentBlockReportPath = "/v1/blocks/report"
+
+// agentBlockReport is the hook→daemon contract for POST /v1/blocks/report
+// (the device agent's api.BlockReportRequest, BlocksContractVersion 1 — keep
+// in sync). The daemon answers 202 when recorded; 404 means it predates the
+// contract; every response is ignored either way.
+type agentBlockReport struct {
+	V                int    `json:"v"`
+	Category         string `json:"category"`
+	Requestable      bool   `json:"requestable"`
+	RequestToken     string `json:"request_token"`
+	RequestURL       string `json:"request_url,omitempty"`
+	RequestExpiresAt string `json:"request_expires_at,omitempty"`
+	ServerName       string `json:"server_name,omitempty"`
+	ServerURL        string `json:"server_url,omitempty"`
+	PolicyName       string `json:"policy_name,omitempty"`
+	ToolName         string `json:"tool_name,omitempty"`
+	BlockURL         string `json:"block_url,omitempty"`
+	Provider         string `json:"provider,omitempty"`
+	SessionID        string `json:"session_id,omitempty"`
+	BlockedAt        string `json:"blocked_at"`
+}
+
+// notifyAgentBlock best-effort forwards a requestable deny to the device
+// agent's socket so it can surface a native "request access" notification.
+// Synchronous on purpose: hook processes are one-shot, so a detached goroutine
+// would die at process exit before the write lands. Strictly off the allow
+// path, never a new failure mode — all errors are swallowed, and machines
+// without the agent fail the dial instantly. Spooled/drained replays never
+// reach the gating handlers that call this, so a stale deny cannot re-notify.
+func (r *Relay) notifyAgentBlock(ctx context.Context, effect *blockEffect, typed any) {
+	if effect == nil || !effect.Requestable || effect.V > 1 || strings.TrimSpace(effect.RequestToken) == "" {
+		return
+	}
+	socket := agentSocketPath()
+	if socket == "" {
+		return
+	}
+	base := agenthooks.EventOf(typed)
+	report := agentBlockReport{
+		V:                1,
+		Category:         effect.Category,
+		Requestable:      true,
+		RequestToken:     effect.RequestToken,
+		RequestURL:       effect.RequestURL,
+		RequestExpiresAt: effect.RequestExpiresAt,
+		ServerName:       effect.ServerName,
+		ServerURL:        effect.ServerURL,
+		PolicyName:       effect.PolicyName,
+		ToolName:         effect.ToolName,
+		BlockURL:         effect.BlockURL,
+		Provider:         string(base.Provider),
+		SessionID:        base.Session.ID,
+		BlockedAt:        time.Now().UTC().Format(time.RFC3339),
+	}
+	body, err := json.Marshal(report)
+	if err != nil {
+		return
+	}
+	// Detached from the event's context: the deny is already resolved, and a
+	// gating budget exhausted by the server exchange must not starve the
+	// notify of its own 300ms.
+	requestCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), agentBlockNotifyTimeout)
+	defer cancel()
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+			return dialAgentSocket(dialCtx, socket)
+		},
+		// One-shot client, same as socketIdentityEmail: without this the
+		// transport pools the socket connection for the process lifetime.
+		DisableKeepAlives: true,
+	}}
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, "http://speakeasy-agent"+agentBlockReportPath, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		r.debugf("agent block notify skipped: %v", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<10))
+	if resp.StatusCode != http.StatusAccepted {
+		r.debugf("agent block notify status=%d", resp.StatusCode)
+	}
+}
+
+// decodeBlockEffect reads the response's "block" effect into its typed form.
+// Returns nil for anything that isn't the object shape this version
+// understands; field-level validation stays with the consumer.
+func decodeBlockEffect(raw any) *blockEffect {
+	object, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	encoded, err := json.Marshal(object)
+	if err != nil {
+		return nil
+	}
+	var effect blockEffect
+	if err := json.Unmarshal(encoded, &effect); err != nil {
+		return nil
+	}
+	return &effect
+}

--- a/hooks/relay/agent_block_notify.go
+++ b/hooks/relay/agent_block_notify.go
@@ -84,14 +84,21 @@ func (r *Relay) notifyAgentBlock(ctx context.Context, effect *blockEffect, typed
 	// notify of its own 300ms.
 	requestCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), agentBlockNotifyTimeout)
 	defer cancel()
-	client := &http.Client{Transport: &http.Transport{
-		DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
-			return dialAgentSocket(dialCtx, socket)
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(dialCtx context.Context, _, _ string) (net.Conn, error) {
+				return dialAgentSocket(dialCtx, socket)
+			},
+			// One-shot client, same as socketIdentityEmail: without this the
+			// transport pools the socket connection for the process lifetime.
+			DisableKeepAlives: true,
 		},
-		// One-shot client, same as socketIdentityEmail: without this the
-		// transport pools the socket connection for the process lifetime.
-		DisableKeepAlives: true,
-	}}
+		// One attempt means one request: a redirect answer is terminal, not a
+		// license to re-send the report at another path.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, "http://speakeasy-agent"+agentBlockReportPath, bytes.NewReader(body))
 	if err != nil {
 		return

--- a/hooks/relay/agent_block_notify.go
+++ b/hooks/relay/agent_block_notify.go
@@ -116,21 +116,42 @@ func (r *Relay) notifyAgentBlock(ctx context.Context, effect *blockEffect, typed
 	}
 }
 
-// decodeBlockEffect reads the response's "block" effect into its typed form.
-// Returns nil for anything that isn't the object shape this version
-// understands; field-level validation stays with the consumer.
+// decodeBlockEffect reads the response's "block" effect into its typed form,
+// asserting fields straight off the decoded map like the org_settings /
+// skill_capture readers in client.go. Returns nil for anything that isn't the
+// object shape this version understands — a non-object, or a non-numeric "v"
+// (the version gates the consumer's guard, so a garbled one must not decode
+// to a trusted zero). Other mistyped fields degrade to their zero values,
+// which the consumer's requestable/token guards already reject.
 func decodeBlockEffect(raw any) *blockEffect {
 	object, ok := raw.(map[string]any)
 	if !ok {
 		return nil
 	}
-	encoded, err := json.Marshal(object)
-	if err != nil {
-		return nil
+	version := 0
+	if v, present := object["v"]; present {
+		f, ok := v.(float64) // JSON numbers decode as float64
+		if !ok {
+			return nil
+		}
+		version = int(f)
 	}
-	var effect blockEffect
-	if err := json.Unmarshal(encoded, &effect); err != nil {
-		return nil
+	str := func(key string) string {
+		s, _ := object[key].(string)
+		return s
 	}
-	return &effect
+	requestable, _ := object["requestable"].(bool)
+	return &blockEffect{
+		V:                version,
+		Category:         str("category"),
+		Requestable:      requestable,
+		RequestToken:     str("request_token"),
+		RequestURL:       str("request_url"),
+		RequestExpiresAt: str("request_expires_at"),
+		ServerName:       str("server_name"),
+		ServerURL:        str("server_url"),
+		PolicyName:       str("policy_name"),
+		ToolName:         str("tool_name"),
+		BlockURL:         str("block_url"),
+	}
 }

--- a/hooks/relay/agent_block_notify.go
+++ b/hooks/relay/agent_block_notify.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/agenthooks"
+
+	"github.com/speakeasy-api/gram/hooks/wire"
 )
 
 // agentBlockNotifyTimeout bounds the whole best-effort notify. It runs only
@@ -50,8 +52,8 @@ type agentBlockReport struct {
 // path, never a new failure mode — all errors are swallowed, and machines
 // without the agent fail the dial instantly. Spooled/drained replays never
 // reach the gating handlers that call this, so a stale deny cannot re-notify.
-func (r *Relay) notifyAgentBlock(ctx context.Context, effect *blockEffect, typed any) {
-	if effect == nil || !effect.Requestable || effect.V > 1 || strings.TrimSpace(effect.RequestToken) == "" {
+func (r *Relay) notifyAgentBlock(ctx context.Context, effect *wire.BlockEffect, typed any) {
+	if effect == nil || !effect.Requestable || effect.V > wire.BlockEffectVersion || strings.TrimSpace(effect.RequestToken) == "" {
 		return
 	}
 	socket := agentSocketPath()
@@ -116,14 +118,17 @@ func (r *Relay) notifyAgentBlock(ctx context.Context, effect *blockEffect, typed
 	}
 }
 
-// decodeBlockEffect reads the response's "block" effect into its typed form,
+// decodeBlockEffect reads the response's "block" effect into its wire type,
 // asserting fields straight off the decoded map like the org_settings /
-// skill_capture readers in client.go. Returns nil for anything that isn't the
-// object shape this version understands — a non-object, or a non-numeric "v"
-// (the version gates the consumer's guard, so a garbled one must not decode
-// to a trusted zero). Other mistyped fields degrade to their zero values,
-// which the consumer's requestable/token guards already reject.
-func decodeBlockEffect(raw any) *blockEffect {
+// skill_capture readers in client.go (the SDK has already decoded Effects
+// into map[string]any, so an unmarshal into the struct would need a marshal
+// round-trip). The keys are pinned to wire.BlockEffect's JSON tags by
+// TestDecodeBlockEffectMatchesWireContract. Returns nil for anything that
+// isn't the object shape this version understands — a non-object, or a
+// non-numeric "v" (the version gates the consumer's guard, so a garbled one
+// must not decode to a trusted zero). Other mistyped fields degrade to their
+// zero values, which the consumer's requestable/token guards already reject.
+func decodeBlockEffect(raw any) *wire.BlockEffect {
 	object, ok := raw.(map[string]any)
 	if !ok {
 		return nil
@@ -141,7 +146,7 @@ func decodeBlockEffect(raw any) *blockEffect {
 		return s
 	}
 	requestable, _ := object["requestable"].(bool)
-	return &blockEffect{
+	return &wire.BlockEffect{
 		V:                version,
 		Category:         str("category"),
 		Requestable:      requestable,

--- a/hooks/relay/agent_block_notify_test.go
+++ b/hooks/relay/agent_block_notify_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
+	"github.com/speakeasy-api/gram/hooks/wire"
 )
 
 // blockReportCapture records what the fake agent socket received.
@@ -248,4 +249,33 @@ func TestDecodeBlockEffectRejectsNonObjects(t *testing.T) {
 	require.Nil(t, decodeBlockEffect("string"))
 	require.Nil(t, decodeBlockEffect([]any{"list"}))
 	require.Nil(t, decodeBlockEffect(map[string]any{"v": "not-a-number"}))
+}
+
+// decodeBlockEffect reads keys off the map by hand (the SDK pre-decodes
+// Effects, so there are no raw bytes to unmarshal); this pins those keys to
+// wire.BlockEffect's JSON tags so the reader and the shared type cannot
+// drift. exhaustruct keeps both literals below naming every field, so a field
+// added to the wire type without a matching read fails here, and a renamed
+// tag fails the round trip.
+func TestDecodeBlockEffectMatchesWireContract(t *testing.T) {
+	want := wire.BlockEffect{
+		V:                wire.BlockEffectVersion,
+		Category:         "shadow_mcp",
+		Requestable:      true,
+		RequestToken:     "rpbr2.contract",
+		RequestURL:       "https://app.example.test/risk-policy-bypass/request#request_token=rpbr2.contract",
+		RequestExpiresAt: "2026-08-14T12:00:00Z",
+		ServerName:       "mcp.example.com",
+		ServerURL:        "https://mcp.example.com/sse",
+		PolicyName:       "Shadow MCP policy",
+		ToolName:         "search",
+		BlockURL:         "https://app.example.test/blocks/0000",
+	}
+	raw, err := json.Marshal(want)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	got := decodeBlockEffect(decoded)
+	require.NotNil(t, got)
+	require.Equal(t, want, *got)
 }

--- a/hooks/relay/agent_block_notify_test.go
+++ b/hooks/relay/agent_block_notify_test.go
@@ -251,6 +251,21 @@ func TestDecodeBlockEffectRejectsNonObjects(t *testing.T) {
 	require.Nil(t, decodeBlockEffect(map[string]any{"v": "not-a-number"}))
 }
 
+// Any present-but-mistyped field rejects the whole effect — a garbled payload
+// must suppress the notify, not POST a degraded report — while absent fields
+// stay acceptable (older servers omit optional ones).
+func TestDecodeBlockEffectRejectsMistypedFields(t *testing.T) {
+	require.Nil(t, decodeBlockEffect(map[string]any{"v": 1.5}),
+		"a fractional version must not truncate past the version guard")
+	require.Nil(t, decodeBlockEffect(map[string]any{"requestable": "yes"}))
+	require.Nil(t, decodeBlockEffect(map[string]any{"server_name": 42.0}))
+	require.Nil(t, decodeBlockEffect(map[string]any{"request_token": true}))
+
+	got := decodeBlockEffect(map[string]any{"v": 1.0, "requestable": true, "request_token": "rpbr2.min"})
+	require.NotNil(t, got, "absent optional fields must not reject the effect")
+	require.Equal(t, "rpbr2.min", got.RequestToken)
+}
+
 // decodeBlockEffect reads keys off the map by hand (the SDK pre-decodes
 // Effects, so there are no raw bytes to unmarshal); this pins those keys to
 // wire.BlockEffect's JSON tags so the reader and the shared type cannot

--- a/hooks/relay/agent_block_notify_test.go
+++ b/hooks/relay/agent_block_notify_test.go
@@ -230,7 +230,9 @@ func TestDenyNotifyBoundedByHungAgent(t *testing.T) {
 	res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
 	elapsed := time.Since(start)
 	require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
-	require.Less(t, elapsed, 3*time.Second, "a hung agent must cost at most the notify budget, elapsed=%s", elapsed)
+	// Bound = the 300ms budget plus slack for the local ingest exchange and
+	// runner overhead — tight enough that a budget regression to even 1s fails.
+	require.Less(t, elapsed, 1300*time.Millisecond, "a hung agent must cost at most the notify budget, elapsed=%s", elapsed)
 }
 
 func TestDecodeBlockEffectRejectsNonObjects(t *testing.T) {

--- a/hooks/relay/agent_block_notify_test.go
+++ b/hooks/relay/agent_block_notify_test.go
@@ -100,7 +100,15 @@ func requestableBlockEffects(components.IngestRequestBody) map[string]any {
 
 func denyWithEffects(t *testing.T, effects func(components.IngestRequestBody) map[string]any) *fakeServer {
 	t.Helper()
-	fs := newFakeServer(t, func(components.IngestRequestBody) (int, decision) {
+	fs := newFakeServer(t, func(p components.IngestRequestBody) (int, decision) {
+		// agenthooks ≥0.6 backfills a synthetic prompt.submitted before the
+		// first real event of a session. Only the tool call carries the policy
+		// deny — as on the real server, where shadow-MCP enforcement gates
+		// tool.pre — so the deny reaches onToolPre instead of short-circuiting
+		// at the backfilled prompt.
+		if p.Event.Type != components.TypeToolRequested {
+			return http.StatusOK, decision{Decision: "allow", Reason: "", Message: ""}
+		}
 		return http.StatusOK, decision{Decision: "deny", Reason: "policy_denied", Message: "blocked by policy X"}
 	})
 	fs.effects = effects

--- a/hooks/relay/agent_block_notify_test.go
+++ b/hooks/relay/agent_block_notify_test.go
@@ -1,0 +1,241 @@
+package relay
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/speakeasy-api/agenthooks"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
+)
+
+// blockReportCapture records what the fake agent socket received.
+type blockReportCapture struct {
+	mu      sync.Mutex
+	reports []agentBlockReport
+	status  int
+	delay   time.Duration
+}
+
+func (c *blockReportCapture) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.reports)
+}
+
+func (c *blockReportCapture) last() agentBlockReport {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reports[len(c.reports)-1]
+}
+
+// startBlockReportSocket serves POST /v1/blocks/report on a unix socket,
+// capturing payloads. Mirrors startIdentitySocket's tempdir handling.
+func startBlockReportSocket(t *testing.T, status int, delay time.Duration) (string, *blockReportCapture) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket fixture is POSIX-only")
+	}
+	capture := &blockReportCapture{mu: sync.Mutex{}, reports: nil, status: status, delay: delay}
+	// Not t.TempDir(): it embeds the test name and can blow the ~104-byte
+	// sockaddr_un path limit on macOS.
+	dir, err := os.MkdirTemp("", "sk")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "agent.sock")
+	ln, err := net.Listen("unix", socket)
+	require.NoError(t, err)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture.delay > 0 {
+			time.Sleep(capture.delay)
+		}
+		if r.URL.Path != agentBlockReportPath || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %q", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var report agentBlockReport
+		if err := json.Unmarshal(body, &report); err != nil {
+			t.Errorf("undecodable block report: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		capture.mu.Lock()
+		capture.reports = append(capture.reports, report)
+		capture.mu.Unlock()
+		w.WriteHeader(capture.status)
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return socket, capture
+}
+
+func requestableBlockEffects(components.IngestRequestBody) map[string]any {
+	return map[string]any{
+		"block": map[string]any{
+			"v":                  1,
+			"category":           "shadow_mcp",
+			"requestable":        true,
+			"request_token":      "rpbr2.test-token",
+			"request_url":        "https://app.example.test/risk-policy-bypass/request#request_token=rpbr2.test-token",
+			"request_expires_at": "2026-08-14T12:00:00Z",
+			"server_name":        "mcp.example.com",
+			"server_url":         "https://mcp.example.com/sse",
+			"policy_name":        "Shadow MCP policy",
+			"tool_name":          "search",
+			"block_url":          "https://app.example.test/blocks/0000",
+		},
+	}
+}
+
+func denyWithEffects(t *testing.T, effects func(components.IngestRequestBody) map[string]any) *fakeServer {
+	t.Helper()
+	fs := newFakeServer(t, func(components.IngestRequestBody) (int, decision) {
+		return http.StatusOK, decision{Decision: "deny", Reason: "policy_denied", Message: "blocked by policy X"}
+	})
+	fs.effects = effects
+	return fs
+}
+
+// A requestable deny reaches the agent socket with the effect's fields plus
+// event attribution, and the deny itself is unchanged.
+func TestDenyWithBlockEffectNotifiesAgent(t *testing.T) {
+	fs := denyWithEffects(t, requestableBlockEffects)
+	socket, capture := startBlockReportSocket(t, http.StatusAccepted, 0)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+
+	cfg := authedConfig(t, fs.URL)
+	cfg.DebugLog = filepath.Join(t.TempDir(), "debug.log")
+	res := invoke(t, cfg, agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+
+	if capture.count() == 0 {
+		b, _ := os.ReadFile(cfg.DebugLog)
+		t.Logf("debug log: %s", b)
+	}
+	require.Equal(t, 1, capture.count(), "exactly one report per denied call")
+	report := capture.last()
+	require.Equal(t, 1, report.V)
+	require.Equal(t, "shadow_mcp", report.Category)
+	require.True(t, report.Requestable)
+	require.Equal(t, "rpbr2.test-token", report.RequestToken)
+	require.Contains(t, report.RequestURL, "#request_token=rpbr2.test-token")
+	require.Equal(t, "2026-08-14T12:00:00Z", report.RequestExpiresAt)
+	require.Equal(t, "mcp.example.com", report.ServerName)
+	require.Equal(t, "https://mcp.example.com/sse", report.ServerURL)
+	require.Equal(t, "Shadow MCP policy", report.PolicyName)
+	require.Equal(t, "search", report.ToolName)
+	require.Equal(t, "https://app.example.test/blocks/0000", report.BlockURL)
+	require.Equal(t, "claude-code", report.Provider)
+	require.Equal(t, "sess-claude-1", report.SessionID)
+	_, err := time.Parse(time.RFC3339, report.BlockedAt)
+	require.NoError(t, err)
+}
+
+// A deny without a block effect — the overwhelmingly common case — must not
+// touch the agent socket at all.
+func TestDenyWithoutBlockEffectDoesNotDial(t *testing.T) {
+	fs := denyWithEffects(t, nil)
+	socket, capture := startBlockReportSocket(t, http.StatusAccepted, 0)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+
+	res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+	require.Equal(t, 0, capture.count())
+}
+
+// Effects the notifier doesn't understand or can't act on are dropped before
+// the dial: not requestable, a newer contract version, or a missing token.
+func TestDenyWithUnusableBlockEffectDoesNotDial(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{"not requestable", func(effect map[string]any) { effect["requestable"] = false }},
+		{"version too new", func(effect map[string]any) { effect["v"] = 2 }},
+		{"missing token", func(effect map[string]any) { effect["request_token"] = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := denyWithEffects(t, func(body components.IngestRequestBody) map[string]any {
+				effects := requestableBlockEffects(body)
+				tc.mutate(effects["block"].(map[string]any))
+				return effects
+			})
+			socket, capture := startBlockReportSocket(t, http.StatusAccepted, 0)
+			t.Setenv("SPEAKEASY_SOCKET", socket)
+
+			res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+			require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+			require.Equal(t, 0, capture.count())
+		})
+	}
+}
+
+// An allow with a (misconfigured) block effect must never notify — the effect
+// only rides denies, but the guard is on our side too.
+func TestAllowNeverNotifies(t *testing.T) {
+	fs := newFakeServer(t, nil) // scripted allow
+	fs.effects = requestableBlockEffects
+	socket, capture := startBlockReportSocket(t, http.StatusAccepted, 0)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+
+	res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	require.NotContains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+	require.Equal(t, 0, capture.count())
+}
+
+// The daemon answering 404 (a build that predates the contract) changes
+// nothing about the deny.
+func TestDenyNotifySwallowsOldDaemon404(t *testing.T) {
+	fs := denyWithEffects(t, requestableBlockEffects)
+	socket, _ := startBlockReportSocket(t, http.StatusNotFound, 0)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+
+	res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+}
+
+// A machine with no agent at all: the dial fails instantly and the deny is
+// unchanged.
+func TestDenyNotifySwallowsAbsentSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket fixture is POSIX-only")
+	}
+	fs := denyWithEffects(t, requestableBlockEffects)
+	t.Setenv("SPEAKEASY_SOCKET", filepath.Join(t.TempDir(), "nope.sock"))
+
+	res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+}
+
+// A hung daemon costs at most the notify budget, never the provider's
+// patience.
+func TestDenyNotifyBoundedByHungAgent(t *testing.T) {
+	fs := denyWithEffects(t, requestableBlockEffects)
+	socket, _ := startBlockReportSocket(t, http.StatusAccepted, 5*time.Second)
+	t.Setenv("SPEAKEASY_SOCKET", socket)
+
+	start := time.Now()
+	res := invoke(t, authedConfig(t, fs.URL), agenthooks.ProviderClaudeCode, "claude/pre_tool_use.json")
+	elapsed := time.Since(start)
+	require.Contains(t, string(res.Stdout), `"permissionDecision":"deny"`)
+	require.Less(t, elapsed, 3*time.Second, "a hung agent must cost at most the notify budget, elapsed=%s", elapsed)
+}
+
+func TestDecodeBlockEffectRejectsNonObjects(t *testing.T) {
+	require.Nil(t, decodeBlockEffect(nil))
+	require.Nil(t, decodeBlockEffect("string"))
+	require.Nil(t, decodeBlockEffect([]any{"list"}))
+	require.Nil(t, decodeBlockEffect(map[string]any{"v": "not-a-number"}))
+}

--- a/hooks/relay/client.go
+++ b/hooks/relay/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 	"github.com/speakeasy-api/gram/hooks/sdk/models/operations"
 	"github.com/speakeasy-api/gram/hooks/sdk/retry"
+	"github.com/speakeasy-api/gram/hooks/wire"
 )
 
 const perAttemptTime = 10 * time.Second
@@ -52,24 +53,6 @@ type skillCapture struct {
 	contentRequired bool
 }
 
-// blockEffect is the structured mirror of a requestable deny, decoded from the
-// response's "block" effect. It exists so the device agent can offer a native
-// "request access" flow without parsing the deny prose. Absence means the deny
-// is not requestable.
-type blockEffect struct {
-	V                int    `json:"v"`
-	Category         string `json:"category"`
-	Requestable      bool   `json:"requestable"`
-	RequestToken     string `json:"request_token"`
-	RequestURL       string `json:"request_url"`
-	RequestExpiresAt string `json:"request_expires_at"`
-	ServerName       string `json:"server_name"`
-	ServerURL        string `json:"server_url"`
-	PolicyName       string `json:"policy_name"`
-	ToolName         string `json:"tool_name"`
-	BlockURL         string `json:"block_url"`
-}
-
 // ingestResult reports the outcome of an ingest attempt.
 type ingestResult struct {
 	// statusCode is the final HTTP status, or 0 if the server was never
@@ -84,7 +67,7 @@ type ingestResult struct {
 	skillCapture *skillCapture
 	// blockEffect carries the structured requestable-block metadata from the
 	// response's "block" effects; nil when the server sent none.
-	blockEffect *blockEffect
+	blockEffect *wire.BlockEffect
 }
 
 // accepted reports a definitive 2xx exchange — the server stored (or

--- a/hooks/relay/client.go
+++ b/hooks/relay/client.go
@@ -52,6 +52,24 @@ type skillCapture struct {
 	contentRequired bool
 }
 
+// blockEffect is the structured mirror of a requestable deny, decoded from the
+// response's "block" effect. It exists so the device agent can offer a native
+// "request access" flow without parsing the deny prose. Absence means the deny
+// is not requestable.
+type blockEffect struct {
+	V                int    `json:"v"`
+	Category         string `json:"category"`
+	Requestable      bool   `json:"requestable"`
+	RequestToken     string `json:"request_token"`
+	RequestURL       string `json:"request_url"`
+	RequestExpiresAt string `json:"request_expires_at"`
+	ServerName       string `json:"server_name"`
+	ServerURL        string `json:"server_url"`
+	PolicyName       string `json:"policy_name"`
+	ToolName         string `json:"tool_name"`
+	BlockURL         string `json:"block_url"`
+}
+
 // ingestResult reports the outcome of an ingest attempt.
 type ingestResult struct {
 	// statusCode is the final HTTP status, or 0 if the server was never
@@ -64,6 +82,9 @@ type ingestResult struct {
 	// org_settings effects; nil when the server sent none.
 	failOpen     *bool
 	skillCapture *skillCapture
+	// blockEffect carries the structured requestable-block metadata from the
+	// response's "block" effects; nil when the server sent none.
+	blockEffect *blockEffect
 }
 
 // accepted reports a definitive 2xx exchange — the server stored (or
@@ -217,7 +238,7 @@ func (cl *client) send(ctx context.Context, c creds, body components.IngestReque
 		}
 	}
 
-	out := ingestResult{statusCode: res.StatusCode, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil}
+	out := ingestResult{statusCode: res.StatusCode, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}
 	if res.IngestHookResult != nil {
 		out.decision = decision{
 			Decision: string(res.IngestHookResult.Decision),
@@ -236,6 +257,7 @@ func (cl *client) send(ctx context.Context, c creds, body components.IngestReque
 				out.skillCapture = &skillCapture{rawSHA256: rawSHA256, contentRequired: contentRequired}
 			}
 		}
+		out.blockEffect = decodeBlockEffect(res.IngestHookResult.Effects["block"])
 	}
 	return out
 }
@@ -253,6 +275,7 @@ func interpretError(err error) ingestResult {
 			authRejected: status == http.StatusUnauthorized || status == http.StatusForbidden,
 			failOpen:     nil,
 			skillCapture: nil,
+			blockEffect:  nil,
 		}
 	}
 	var apiErr *apierrors.APIError
@@ -269,6 +292,7 @@ func interpretError(err error) ingestResult {
 				authRejected: false,
 				failOpen:     nil,
 				skillCapture: nil,
+				blockEffect:  nil,
 			}
 		}
 		return ingestResult{
@@ -277,9 +301,10 @@ func interpretError(err error) ingestResult {
 			authRejected: apiErr.StatusCode == http.StatusUnauthorized || apiErr.StatusCode == http.StatusForbidden,
 			failOpen:     nil,
 			skillCapture: nil,
+			blockEffect:  nil,
 		}
 	}
-	return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil}
+	return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: ""}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}
 }
 
 func validRawSHA256(value string) bool {

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -111,6 +111,9 @@ type verdict struct {
 	// nudge marks a never-authenticated Claude prompt that should offer the
 	// user an interactive sign-in.
 	nudge bool
+	// blockEffect carries the server's structured requestable-block metadata
+	// for a denied gating event; nil otherwise.
+	blockEffect *blockEffect
 }
 
 const brokenAuthMessage = "Speakeasy hooks are configured for this workspace but this machine's credentials are missing or invalid. Run the Speakeasy hooks login command to reconnect."
@@ -131,9 +134,9 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		r.debugf("event=%s config-error path=%s err=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ConfigPath, r.cfg.ConfigError)
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks cannot read the plugin config at %q. Reinstall the Speakeasy hooks plugin.", r.cfg.ConfigPath)
-			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateBroken
 		}
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateNeverAuthed
 	}
 
 	// Refuse to send credentials over plaintext HTTP before resolving them,
@@ -143,23 +146,23 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 		r.debugf("event=%s insecure-server-url server=%s", agenthooks.EventOf(typed).NativeName, r.cfg.ServerURL)
 		if authEstablished() {
 			msg := fmt.Sprintf("Speakeasy hooks refused insecure Gram server URL %q; use https:// (or an http://localhost dev server).", r.cfg.ServerURL)
-			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{Decision: "", Reason: "", Message: msg}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateBroken
 		}
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateNeverAuthed
 	}
 
 	c, ok := resolveAuth(r.cfg)
 	if !ok {
 		if reauthNeeded() {
 			r.debugf("event=%s no-creds state=reauth-needed authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateReauthNeeded
+			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateReauthNeeded
 		}
 		if authEstablished() {
 			r.debugf("event=%s no-creds state=broken authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateBroken
+			return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateBroken
 		}
 		r.debugf("event=%s no-creds state=never-authed authfile=%s", agenthooks.EventOf(typed).NativeName, authFilePath())
-		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil}, stateNeverAuthed
+		return ingestResult{statusCode: 0, decision: decision{}, authRejected: false, failOpen: nil, skillCapture: nil, blockEffect: nil}, stateNeverAuthed
 	}
 
 	payload := buildEnvelope(typed, hostname())
@@ -259,13 +262,13 @@ func (r *Relay) evaluate(ctx context.Context, typed any) verdict {
 	case stateNeverAuthed:
 		// A broken config suppresses the nudge: sign-in cannot recover an
 		// unknown deployment identity, only a reinstall can.
-		return verdict{block: false, message: "", nudge: r.cfg.ConfigError == ""}
+		return verdict{block: false, message: "", nudge: r.cfg.ConfigError == "", blockEffect: nil}
 	case stateBroken:
 		msg := res.decision.Message
 		if msg == "" {
 			msg = brokenAuthMessage
 		}
-		return verdict{block: true, message: msg, nudge: false}
+		return verdict{block: true, message: msg, nudge: false, blockEffect: nil}
 	case stateReauthNeeded:
 		// Tool events fail closed on the rejection (or its memory); prompt
 		// handlers honor nudge and fail open instead.
@@ -273,15 +276,15 @@ func (r *Relay) evaluate(ctx context.Context, typed any) verdict {
 		if res.statusCode != 0 {
 			msg = httpMessage(res)
 		}
-		return verdict{block: true, message: msg, nudge: true}
+		return verdict{block: true, message: msg, nudge: true, blockEffect: nil}
 	}
 
 	if res.accepted() {
 		switch {
 		case strings.EqualFold(res.decision.Decision, "allow"):
-			return verdict{block: false, message: "", nudge: false}
+			return verdict{block: false, message: "", nudge: false, blockEffect: nil}
 		case res.decision.denied():
-			return verdict{block: true, message: res.decision.Message, nudge: false}
+			return verdict{block: true, message: res.decision.Message, nudge: false, blockEffect: res.blockEffect}
 		default:
 			// A 2xx whose body carries no explicit verdict (an intermediary's
 			// JSON, a skewed server) is not an allow.
@@ -289,7 +292,7 @@ func (r *Relay) evaluate(ctx context.Context, typed any) verdict {
 			if msg == "" {
 				msg = "Speakeasy hooks could not read the server's verdict."
 			}
-			return verdict{block: true, message: msg, nudge: false}
+			return verdict{block: true, message: msg, nudge: false, blockEffect: nil}
 		}
 	}
 	// Non-2xx or unreachable: the server could not confirm the action is
@@ -304,9 +307,9 @@ func (r *Relay) evaluate(ctx context.Context, typed any) verdict {
 	// a broken credential into an enforcement bypass.
 	if (res.statusCode == 0 || res.statusCode >= 500) && failOpenAllowed(r.cfg) {
 		r.debugf("event=%s fail-open engaged status=%d", agenthooks.EventOf(typed).NativeName, res.statusCode)
-		return verdict{block: false, message: "", nudge: false}
+		return verdict{block: false, message: "", nudge: false, blockEffect: nil}
 	}
-	return verdict{block: true, message: httpMessage(res), nudge: false}
+	return verdict{block: true, message: httpMessage(res), nudge: false, blockEffect: nil}
 }
 
 func (r *Relay) onPrompt(ctx context.Context, e *agenthooks.PromptEvent) (agenthooks.PromptDecision, error) {
@@ -352,6 +355,7 @@ func (r *Relay) onToolPre(ctx context.Context, e *agenthooks.ToolPreEvent) (agen
 	}
 	v := r.evaluate(ctx, e)
 	if v.block {
+		r.notifyAgentBlock(ctx, v.blockEffect, e)
 		// The system message mirrors the deny reason so the block text (and
 		// any access-request URL in it) reaches the user verbatim, not only
 		// the model.
@@ -368,6 +372,7 @@ func (r *Relay) onPermission(ctx context.Context, e *agenthooks.PermissionEvent)
 	}
 	v := r.evaluate(ctx, e)
 	if v.block {
+		r.notifyAgentBlock(ctx, v.blockEffect, e)
 		return agenthooks.Deny(v.message).WithSystemMessage(v.message), nil
 	}
 	return agenthooks.NoDecision(), nil

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/speakeasy-api/agenthooks"
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
+	"github.com/speakeasy-api/gram/hooks/wire"
 )
 
 // authState classifies the machine's credential posture for the ratchet.
@@ -113,7 +114,7 @@ type verdict struct {
 	nudge bool
 	// blockEffect carries the server's structured requestable-block metadata
 	// for a denied gating event; nil otherwise.
-	blockEffect *blockEffect
+	blockEffect *wire.BlockEffect
 }
 
 const brokenAuthMessage = "Speakeasy hooks are configured for this workspace but this machine's credentials are missing or invalid. Run the Speakeasy hooks login command to reconnect."

--- a/hooks/wire/blockeffect.go
+++ b/hooks/wire/blockeffect.go
@@ -1,0 +1,44 @@
+package wire
+
+// BlockEffectKey is the IngestHookResult.Effects key the structured
+// requestable-block payload rides under.
+const BlockEffectKey = "block"
+
+// BlockEffectVersion is the current contract version stamped into V.
+// Consumers ignore effects whose version they don't understand, so bump it
+// only on a breaking reshape of the payload.
+const BlockEffectVersion = 1
+
+// BlockEffect is the structured mirror of the "Request access" prose the
+// server appends to a requestable deny (today: a shadow-MCP block that minted
+// a bypass-request link). It exists so the speakeasy-hooks binary — and
+// through it the local device agent — can offer a native "request access"
+// flow without parsing prose. Absence of the effect means the deny is not
+// requestable (PII, secrets, spend, prompt policies carry nothing).
+//
+// The server emitter (server/internal/hooks) and the relay decoder
+// (hooks/relay) both import this so the vocabulary cannot drift within the
+// repo; deployed relays still lag the server, so each side validates
+// independently (the relay guards on V, Requestable, and RequestToken).
+type BlockEffect struct {
+	V           int    `json:"v"`
+	Category    string `json:"category"`
+	Requestable bool   `json:"requestable"`
+	// RequestToken is the control plane's opaque bypass-request token
+	// (rpbr2.…) the device agent later spends on
+	// risk.createPolicyBypassRequest.
+	RequestToken string `json:"request_token"`
+	// RequestURL is the browser fallback carrying the same token in its
+	// fragment; it mirrors the link in the deny prose.
+	RequestURL string `json:"request_url"`
+	// RequestExpiresAt is RFC3339; empty when the token TTL is unknown.
+	RequestExpiresAt string `json:"request_expires_at,omitempty"`
+	ServerName       string `json:"server_name,omitempty"`
+	ServerURL        string `json:"server_url,omitempty"`
+	PolicyName       string `json:"policy_name,omitempty"`
+	ToolName         string `json:"tool_name,omitempty"`
+	// BlockURL is the dashboard's durable block-row page. Duplicate
+	// deliveries re-mint the request link but never a second block row, so
+	// the effect can exist without it.
+	BlockURL string `json:"block_url,omitempty"`
+}

--- a/server/internal/hooks/block_effects.go
+++ b/server/internal/hooks/block_effects.go
@@ -2,40 +2,20 @@ package hooks
 
 import (
 	"context"
-	"time"
 
+	"github.com/speakeasy-api/gram/hooks/wire"
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 )
 
-// blockEffectContractVersion is the version stamped into the "block" effect.
-// Consumers (the speakeasy-hooks binary, and through it the device agent)
-// ignore effects whose version they don't understand, so bump it only on a
-// breaking reshape of the payload.
-const blockEffectContractVersion = 1
+// The "block" effect payload is wire.BlockEffect — shared with the relay
+// decoder in hooks/relay so the vocabulary cannot drift within the repo.
 
-// blockEffect is the structured mirror of the "Request access" prose appended
-// to a requestable deny. It rides in IngestHookResult.Effects under the
-// "block" key so the hooks binary can hand the device agent something it can
-// act on without parsing prose. Absence of the effect means the deny is not
-// requestable (PII, secrets, spend, prompt policies carry nothing).
-type blockEffect struct {
-	Category         string
-	RequestToken     string
-	RequestURL       string
-	RequestExpiresAt time.Time
-	ServerName       string
-	ServerURL        string
-	PolicyName       string
-	ToolName         string
-	BlockURL         string
-}
-
-// blockEffectCollector carries an optional blockEffect from the deny branch
-// that minted a request link up to the transport response. A context collector
+// blockEffectCollector carries an optional effect from the deny branch that
+// minted a request link up to the transport response. A context collector
 // (same pattern as withRiskScanTracker) avoids threading a third return value
 // through every branch of evaluateCanonicalHook.
 type blockEffectCollector struct {
-	effect *blockEffect
+	effect *wire.BlockEffect
 }
 
 type blockEffectCollectorKey struct{}
@@ -47,7 +27,7 @@ func withBlockEffectCollector(ctx context.Context) (context.Context, *blockEffec
 
 // setBlockEffect records the requestable-deny metadata for the current event.
 // No-op when no collector is installed (legacy per-provider endpoints).
-func setBlockEffect(ctx context.Context, effect blockEffect) {
+func setBlockEffect(ctx context.Context, effect wire.BlockEffect) {
 	if collector, ok := ctx.Value(blockEffectCollectorKey{}).(*blockEffectCollector); ok {
 		collector.effect = &effect
 	}
@@ -67,31 +47,9 @@ func withBlockEffect(collector *blockEffectCollector, res *gen.IngestHookResult)
 	if collector == nil || collector.effect == nil {
 		return res
 	}
-	e := collector.effect
-	payload := map[string]any{
-		"v":             blockEffectContractVersion,
-		"category":      e.Category,
-		"requestable":   true,
-		"request_token": e.RequestToken,
-		"request_url":   e.RequestURL,
-	}
-	if !e.RequestExpiresAt.IsZero() {
-		payload["request_expires_at"] = e.RequestExpiresAt.UTC().Format(time.RFC3339)
-	}
-	for key, value := range map[string]string{
-		"server_name": e.ServerName,
-		"server_url":  e.ServerURL,
-		"policy_name": e.PolicyName,
-		"tool_name":   e.ToolName,
-		"block_url":   e.BlockURL,
-	} {
-		if value != "" {
-			payload[key] = value
-		}
-	}
 	if res.Effects == nil {
 		res.Effects = map[string]any{}
 	}
-	res.Effects["block"] = payload
+	res.Effects[wire.BlockEffectKey] = *collector.effect
 	return res
 }

--- a/server/internal/hooks/block_effects_test.go
+++ b/server/internal/hooks/block_effects_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -10,10 +11,27 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/speakeasy-api/gram/hooks/wire"
 	gen "github.com/speakeasy-api/gram/server/gen/hooks"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 )
+
+// requireWireBlockEffect returns the "block" effect as the JSON object a
+// client sees. The server stores the shared wire.BlockEffect struct in
+// Effects, so asserting on wire shape (keys present and omitted) means
+// round-tripping it through encoding/json exactly as the response encoder
+// will.
+func requireWireBlockEffect(t *testing.T, effects map[string]any) map[string]any {
+	t.Helper()
+	value, ok := effects[wire.BlockEffectKey]
+	require.True(t, ok)
+	raw, err := json.Marshal(value)
+	require.NoError(t, err)
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(raw, &object))
+	return object
+}
 
 // blockEffectShadowMCPScanner is ingestUserScopedShadowMCPScanner with a real
 // policy UUID: request-link minting validates risk_policy_id as a UUID, and
@@ -68,8 +86,8 @@ func TestIngest_ShadowMCPDenyCarriesBlockEffect(t *testing.T) {
 	require.NotNil(t, result)
 	require.Equal(t, "deny", result.Decision)
 
-	effect := requireEffectMap(t, result.Effects, "block")
-	require.Equal(t, blockEffectContractVersion, effect["v"])
+	effect := requireWireBlockEffect(t, result.Effects)
+	require.EqualValues(t, wire.BlockEffectVersion, effect["v"])
 	require.Equal(t, "shadow_mcp", effect["category"])
 	require.Equal(t, true, effect["requestable"])
 
@@ -182,12 +200,12 @@ func TestIngest_DuplicateDeliveryBlockEffectOmitsBlockURL(t *testing.T) {
 	first, err := ti.service.Ingest(ctx, payload)
 	require.NoError(t, err)
 	require.Equal(t, "deny", first.Decision)
-	require.Contains(t, requireEffectMap(t, first.Effects, "block"), "block_url")
+	require.Contains(t, requireWireBlockEffect(t, first.Effects), "block_url")
 
 	retry, err := ti.service.Ingest(ctx, payload)
 	require.NoError(t, err)
 	require.Equal(t, "deny", retry.Decision)
-	retryEffect := requireEffectMap(t, retry.Effects, "block")
+	retryEffect := requireWireBlockEffect(t, retry.Effects)
 	require.NotContains(t, retryEffect, "block_url",
 		"a duplicate delivery must not reference a block row it never minted")
 	require.Contains(t, retryEffect["request_token"], "rpbr2.")

--- a/server/internal/hooks/shadow_mcp_request_link.go
+++ b/server/internal/hooks/shadow_mcp_request_link.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/speakeasy-api/gram/hooks/wire"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/risk"
@@ -48,11 +49,17 @@ func (s *Service) renderShadowMCPUserBlockReason(ctx context.Context, params sha
 	if !ok {
 		return message
 	}
-	setBlockEffect(ctx, blockEffect{
+	expiresAt := ""
+	if !link.ExpiresAt.IsZero() {
+		expiresAt = link.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	setBlockEffect(ctx, wire.BlockEffect{
+		V:                wire.BlockEffectVersion,
 		Category:         string(categories.CategoryShadowMCP),
+		Requestable:      true,
 		RequestToken:     link.Token,
 		RequestURL:       link.URL,
-		RequestExpiresAt: link.ExpiresAt,
+		RequestExpiresAt: expiresAt,
 		ServerName:       link.ServerName,
 		ServerURL:        link.ServerURL,
 		PolicyName:       params.PolicyName,


### PR DESCRIPTION
Part 3 of [Request access for blocked AI tool calls](https://linear.app/speakeasy/project/request-access-for-blocked-ai-tool-calls-08c7538c7b77) (DNO-804). Stacked on #5082.

## Why

The device agent can only offer a native "request access" notification if it learns about requestable denies. The hooks binary is the process holding that verdict at the moment it happens.

## What

- Decode the ingest response's `block` effect and thread it onto the deny verdict (tool-pre / permission gating events only).
- New best-effort notify: a synchronous fire-and-forget `POST /v1/blocks/report` to the device agent's socket, hard 300 ms budget, one attempt, all errors swallowed. Reuses the identity socket's path + build-tagged dial pair, so Windows named-pipe parity comes free.
- Guards: never on the allow path; only requestable effects with a token and a known contract version; spooled/drained replays never reach the gating handlers, so stale denies can't re-notify. A 404 means the daemon predates the contract and is ignored.

The deny itself is byte-for-byte unchanged in every case — machines without the agent fail the dial instantly.

## Test plan

- New relay tests with a fake agent socket: payload contents; a hung daemon costs ≤ the notify budget; 404 / absent socket / unusable effects never change the deny; allow never dials.
- `go test ./...` in `hooks/` green (two pre-existing MCP-inventory test failures reproduce on pristine main and are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqNdUoJxcz85saAAyPodoW

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward requestable-block metadata to the device agent so it can show a native “Request access” notification on blocked AI tool calls (DNO-804). Deny behavior is unchanged; notify is best-effort with a strict 300 ms budget.

- **New Features**
  - Decode ingest `block` effect into a structured `wire.BlockEffect`; reject garbled effects (any mistyped field or non‑integral `v`) to suppress notify.
  - On deny for tool-pre and permission events, synchronously POST to the device agent at `/v1/blocks/report` over the identity socket; payload includes effect fields plus `provider`, `session_id`, and `blocked_at`.
  - Transport: hard 300 ms timeout; one attempt; redirects are terminal; `DisableKeepAlives`; all errors swallowed. `404` means an older daemon and is ignored. Guards: only when requestable, `v <= 1`, and token present; never on allow; replayed events never trigger.

- **Refactors**
  - Share `wire.BlockEffect` and `wire.BlockEffectKey` between server and relay. Server now stores the struct in `Effects` under `wire.BlockEffectKey`; relay reads the effects map directly with a contract test pinning keys to struct tags.

<sup>Written for commit 28dc00f0bbe607c5ac3e2829fe4a81786d6db2d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

