### PR TITLE
refactor(hooks): consume normalized skill activations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/samber/slog-multi v1.8.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
-	github.com/speakeasy-api/agenthooks v0.5.0
+	github.com/speakeasy-api/agenthooks v0.5.1-0.20260808153144-97096140abd0
 	github.com/speakeasy-api/mcp-setup-docs/go v0.3.0
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/samber/slog-multi v1.8.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
-	github.com/speakeasy-api/agenthooks v0.5.1-0.20260808153144-97096140abd0
+	github.com/speakeasy-api/agenthooks v0.6.0
 	github.com/speakeasy-api/mcp-setup-docs/go v0.3.0
 	github.com/speakeasy-api/openapi v1.24.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.0-20250711233419-a173a6c0125c

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/sorairolake/lzip-go v0.3.5 h1:ms5Xri9o1JBIWvOFAorYtUNik6HI3HgBTkISiqu
 github.com/sorairolake/lzip-go v0.3.5/go.mod h1:N0KYq5iWrMXI0ZEXKXaS9hCyOjZUQdBDEIbXfoUwbdk=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/speakeasy-api/agenthooks v0.5.0 h1:wKN2cqv0Vi/Nzn/wz3+Xv7IETF+K2b0tPLzws8be1Jw=
-github.com/speakeasy-api/agenthooks v0.5.0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
+github.com/speakeasy-api/agenthooks v0.5.1-0.20260808153144-97096140abd0 h1:aUqlI9tHHPpe5/17vuVLokBE9Gj6HH1cXrVrrhcbeX8=
+github.com/speakeasy-api/agenthooks v0.5.1-0.20260808153144-97096140abd0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/speakeasy-api/mcp-setup-docs/go v0.3.0 h1:y6/KsyZErJegJJR4P9l1PFXU+jyBWKKhnLmzl96ikgc=

--- a/go.sum
+++ b/go.sum
@@ -690,8 +690,8 @@ github.com/sorairolake/lzip-go v0.3.5 h1:ms5Xri9o1JBIWvOFAorYtUNik6HI3HgBTkISiqu
 github.com/sorairolake/lzip-go v0.3.5/go.mod h1:N0KYq5iWrMXI0ZEXKXaS9hCyOjZUQdBDEIbXfoUwbdk=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/speakeasy-api/agenthooks v0.5.1-0.20260808153144-97096140abd0 h1:aUqlI9tHHPpe5/17vuVLokBE9Gj6HH1cXrVrrhcbeX8=
-github.com/speakeasy-api/agenthooks v0.5.1-0.20260808153144-97096140abd0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
+github.com/speakeasy-api/agenthooks v0.6.0 h1:277cBJqcPO4ESBGi7X5M0VroY7/mvxJKkybu0hgyy+c=
+github.com/speakeasy-api/agenthooks v0.6.0/go.mod h1:AQgUKnaUl6icJT5IPp0tDinkEiwohfb1R2QWEwdNgBs=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/speakeasy-api/mcp-setup-docs/go v0.3.0 h1:y6/KsyZErJegJJR4P9l1PFXU+jyBWKKhnLmzl96ikgc=

--- a/hooks/cmd/speakeasy-hooks/main.go
+++ b/hooks/cmd/speakeasy-hooks/main.go
@@ -47,8 +47,6 @@ func main() {
 			// successful send, and by the device agent when its downtime
 			// detector sees the control plane recover.
 			os.Exit(relay.RunDrain(context.Background(), os.Stdout))
-		case "upload-skill":
-			os.Exit(relay.RunSkillUpload(context.Background(), os.Args[2:], os.Stdin))
 		case "skill-feedback":
 			// Serves the speakeasy-skill-feedback MCP server over stdio.
 			// Generated plugin .mcp.json entries invoke this through the

--- a/hooks/relay/client.go
+++ b/hooks/relay/client.go
@@ -27,7 +27,11 @@ const perAttemptTime = 10 * time.Second
 // verdict.
 const sendBudget = 45 * time.Second
 
-const skillUploadBudget = 30 * time.Second
+// skillUploadBudget bounds the content upload that runs inline after a
+// delivered event. The upload is best-effort — the server re-requests the
+// content on the skill's next activation — so it gets a budget that keeps
+// sendBudget plus this stall under the provider's 60s hook timeout.
+const skillUploadBudget = 10 * time.Second
 
 // retryMaxElapsedMS caps the SDK's backoff budget for retryable statuses
 // (429/5xx). A var rather than a const so tests that script 5xx responses can

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -190,17 +190,25 @@ func drainSpool(ctx context.Context, dir string) DrainSummary {
 }
 
 func replayedSkill(entry spoolEntry) *resolvedSkill {
-	if entry.SkillSourceRoot == "" || entry.Envelope.Data == nil || entry.Envelope.Data.Skill == nil ||
-		entry.Envelope.Data.Skill.SourcePath == nil || entry.Envelope.Data.Skill.RawSha256 == nil {
+	if entry.Envelope.Data == nil || entry.Envelope.Data.Skill == nil || entry.Envelope.Data.Skill.RawSha256 == nil || entry.Envelope.Data.ToolCall == nil {
+		return nil
+	}
+	var content string
+	switch output := entry.Envelope.Data.ToolCall.Output.(type) {
+	case string:
+		content = output
+	case json.RawMessage:
+		if json.Unmarshal(output, &content) != nil {
+			return nil
+		}
+	default:
 		return nil
 	}
 	return &resolvedSkill{
-		content:      "",
+		content:      content,
 		rawSHA256:    *entry.Envelope.Data.Skill.RawSha256,
-		sourcePath:   *entry.Envelope.Data.Skill.SourcePath,
-		sourceLevel:  "",
-		root:         entry.SkillSourceRoot,
 		captureReady: true,
+		name:         entry.Envelope.Data.Skill.Name,
 	}
 }
 
@@ -392,10 +400,10 @@ func (r *Relay) maybeSpawnDrain() {
 // finishExchange runs the spool bookkeeping for a final exchange result: an
 // unsent payload is kept for replay; a healthy exchange flushes any backlog
 // via a detached drain.
-func (r *Relay) finishExchange(idemKey string, payload components.IngestRequestBody, res ingestResult, skill *resolvedSkill) {
+func (r *Relay) finishExchange(idemKey string, payload components.IngestRequestBody, res ingestResult) {
 	switch {
 	case res.unsent():
-		r.spoolUnsent(idemKey, payload, skill)
+		r.spoolUnsent(idemKey, payload)
 	case res.accepted():
 		r.maybeSpawnDrain()
 	}

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -249,6 +249,13 @@ func readSpooledSkillSource(path string) (string, bool) {
 	if !filepath.IsAbs(path) {
 		return "", false
 	}
+	// Lstat + regular-file check keeps the drain from blocking on a FIFO and
+	// from following symlinks; a non-regular source drains content-less like
+	// any other mismatch.
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", false
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return "", false

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -251,13 +251,20 @@ func readSpooledSkillSource(path string) (string, bool) {
 	}
 	// Lstat + regular-file check keeps the drain from blocking on a FIFO and
 	// from following symlinks; a non-regular source drains content-less like
-	// any other mismatch.
+	// any other mismatch. The SameFile comparison pins the opened descriptor
+	// to the inode Lstat classified, so a path swapped in between the two
+	// calls is rejected rather than read.
 	info, err := os.Lstat(path)
 	if err != nil || !info.Mode().IsRegular() {
 		return "", false
 	}
 	file, err := os.Open(path)
 	if err != nil {
+		return "", false
+	}
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(info, opened) {
+		_ = file.Close()
 		return "", false
 	}
 	content, readErr := io.ReadAll(io.LimitReader(file, maxSkillContentBytes+1))

--- a/hooks/relay/drain.go
+++ b/hooks/relay/drain.go
@@ -2,6 +2,8 @@ package relay
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
@@ -190,8 +193,43 @@ func drainSpool(ctx context.Context, dir string) DrainSummary {
 }
 
 func replayedSkill(entry spoolEntry) *resolvedSkill {
-	if entry.Envelope.Data == nil || entry.Envelope.Data.Skill == nil || entry.Envelope.Data.Skill.RawSha256 == nil || entry.Envelope.Data.ToolCall == nil {
+	if entry.Envelope.Data == nil || entry.Envelope.Data.Skill == nil || entry.Envelope.Data.Skill.RawSha256 == nil {
 		return nil
+	}
+	skill := entry.Envelope.Data.Skill
+	if content, ok := spooledSkillOutput(entry); ok {
+		return &resolvedSkill{
+			content:      content,
+			rawSHA256:    *skill.RawSha256,
+			captureReady: true,
+			name:         skill.Name,
+		}
+	}
+	// Legacy v1 entries recorded where the manifest was read from instead of
+	// carrying its content in the tool output. Re-read that path, gated on the
+	// stored hash: matching content is byte-identical to what the server
+	// recorded at capture time, and anything else (edited, replaced) drains
+	// without a content upload like any other content-less entry.
+	if skill.SourcePath != nil {
+		content, ok := readSpooledSkillSource(*skill.SourcePath)
+		if ok {
+			digest := sha256.Sum256([]byte(content))
+			if hex.EncodeToString(digest[:]) == *skill.RawSha256 {
+				return &resolvedSkill{
+					content:      content,
+					rawSHA256:    *skill.RawSha256,
+					captureReady: true,
+					name:         skill.Name,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func spooledSkillOutput(entry spoolEntry) (string, bool) {
+	if entry.Envelope.Data.ToolCall == nil {
+		return "", false
 	}
 	var content string
 	switch output := entry.Envelope.Data.ToolCall.Output.(type) {
@@ -199,17 +237,28 @@ func replayedSkill(entry spoolEntry) *resolvedSkill {
 		content = output
 	case json.RawMessage:
 		if json.Unmarshal(output, &content) != nil {
-			return nil
+			return "", false
 		}
 	default:
-		return nil
+		return "", false
 	}
-	return &resolvedSkill{
-		content:      content,
-		rawSHA256:    *entry.Envelope.Data.Skill.RawSha256,
-		captureReady: true,
-		name:         entry.Envelope.Data.Skill.Name,
+	return content, true
+}
+
+func readSpooledSkillSource(path string) (string, bool) {
+	if !filepath.IsAbs(path) {
+		return "", false
 	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	content, readErr := io.ReadAll(io.LimitReader(file, maxSkillContentBytes+1))
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil || len(content) > maxSkillContentBytes || !utf8.Valid(content) {
+		return "", false
+	}
+	return string(content), true
 }
 
 // decodeSpoolEntry unmarshals an entry, restoring every any-typed envelope

--- a/hooks/relay/drain_test.go
+++ b/hooks/relay/drain_test.go
@@ -90,12 +90,10 @@ func TestDrainReplaysOldestFirstWithStoredKeys(t *testing.T) {
 	}
 }
 
-func TestDrainReplaysEnrichedSkillMetadataAndUploadsContent(t *testing.T) {
+func TestDrainReplaysSkillContent(t *testing.T) {
 	drainEnv(t)
 	content := []byte("# Offline skill\n")
 	rawSHA256 := sha256Hex(content)
-	root := filepath.Join(t.TempDir(), ".claude", "skills")
-	path := filepath.Join(root, "offline", "SKILL.md")
 	originalUpload := executeSkillUpload
 	t.Cleanup(func() { executeSkillUpload = originalUpload })
 	var capturedTasks []skillUploadTask
@@ -117,10 +115,8 @@ func TestDrainReplaysEnrichedSkillMetadataAndUploadsContent(t *testing.T) {
 	entry, err := decodeSpoolEntry(data)
 	require.NoError(t, err)
 	entry.Envelope.Data = activatedSkillPayload("offline").Data
-	entry.Envelope.Data.Skill.SourceLevel = new("project")
-	entry.Envelope.Data.Skill.SourcePath = new(path)
 	entry.Envelope.Data.Skill.RawSha256 = new(rawSHA256)
-	entry.SkillSourceRoot = root
+	entry.Envelope.Data.ToolCall = &components.HookToolCallData{Output: json.RawMessage(strconv.Quote(string(content)))}
 	data, err = json.Marshal(entry)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(spoolPath, data, 0o600))
@@ -137,15 +133,15 @@ func TestDrainReplaysEnrichedSkillMetadataAndUploadsContent(t *testing.T) {
 	require.Empty(t, spoolFiles(t), "a successful upload must remove the replayed entry")
 	require.Equal(t, []skillUploadTask{{
 		ServerURL: fs.URL, Project: "default", APIKey: "drain-key", RawSHA256: rawSHA256,
-		SourcePath: path, SourceRoot: root,
+		Content: string(content),
 	}, {
 		ServerURL: fs.URL, Project: "default", APIKey: "drain-key", RawSHA256: rawSHA256,
-		SourcePath: path, SourceRoot: root,
+		Content: string(content),
 	}}, capturedTasks)
 	replayed := fs.last().Data.Skill
 	require.Equal(t, "offline", replayed.Name)
-	require.Equal(t, "project", *replayed.SourceLevel)
-	require.Equal(t, path, *replayed.SourcePath)
+	require.Nil(t, replayed.SourceLevel)
+	require.Nil(t, replayed.SourcePath)
 	require.Equal(t, rawSHA256, *replayed.RawSha256)
 }
 

--- a/hooks/relay/drain_test.go
+++ b/hooks/relay/drain_test.go
@@ -447,3 +447,59 @@ func TestDecodeSpoolEntryPreservesLargeIntegers(t *testing.T) {
 	require.Equal(t, 4, bytes.Count(remarshaled, []byte(bigID)),
 		"raw, input, output, and error must all round-trip the integer exactly; a float64 detour rounds it")
 }
+
+// TestDrainReplaysLegacySkillSourcePath pins the upgrade path for v1 entries
+// spooled by a binary that recorded the manifest's source path instead of its
+// content: the drain re-reads the path and uploads only content that still
+// hashes to the value recorded at capture time.
+func TestDrainReplaysLegacySkillSourcePath(t *testing.T) {
+	drainEnv(t)
+	content := []byte("# Offline skill\n")
+	rawSHA256 := sha256Hex(content)
+	manifest := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(manifest, content, 0o600))
+	originalUpload := executeSkillUpload
+	t.Cleanup(func() { executeSkillUpload = originalUpload })
+	var capturedTasks []skillUploadTask
+	executeSkillUpload = func(_ context.Context, task skillUploadTask) error {
+		capturedTasks = append(capturedTasks, task)
+		return nil
+	}
+	fs := newFakeServer(t, nil)
+	fs.effects = requestedSkillCaptureEffects(true)
+	seedSpoolEntry(t, fs.URL, time.Hour, "sess-legacy")
+
+	spoolPath := filepath.Join(os.Getenv("XDG_STATE_HOME"), "gram", "hooks", "spool", spoolFiles(t)[0])
+	data, err := os.ReadFile(spoolPath)
+	require.NoError(t, err)
+	entry, err := decodeSpoolEntry(data)
+	require.NoError(t, err)
+	entry.Envelope.Data = activatedSkillPayload("legacy").Data
+	entry.Envelope.Data.Skill.RawSha256 = new(rawSHA256)
+	entry.Envelope.Data.Skill.SourcePath = new(manifest)
+	entry.Envelope.Data.ToolCall = nil
+	data, err = json.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(spoolPath, data, 0o600))
+
+	summary := Drain(t.Context())
+
+	require.Equal(t, 1, summary.Replayed)
+	require.Empty(t, spoolFiles(t))
+	require.Equal(t, []skillUploadTask{{
+		ServerURL: fs.URL, Project: "default", APIKey: "drain-key", RawSHA256: rawSHA256,
+		Content: string(content),
+	}}, capturedTasks)
+}
+
+func TestReplayedSkillRejectsMismatchedLegacySource(t *testing.T) {
+	manifest := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(manifest, []byte("edited since capture\n"), 0o600))
+	rawSHA256 := sha256Hex([]byte("# original\n"))
+	entry := spoolEntry{}
+	entry.Envelope.Data = &components.HookIngestData{Skill: &components.HookSkillData{
+		Name: "legacy", RawSha256: new(rawSHA256), SourcePath: new(manifest),
+	}}
+
+	require.Nil(t, replayedSkill(entry), "content that no longer matches the recorded hash must not upload")
+}

--- a/hooks/relay/drain_test.go
+++ b/hooks/relay/drain_test.go
@@ -503,3 +503,18 @@ func TestReplayedSkillRejectsMismatchedLegacySource(t *testing.T) {
 
 	require.Nil(t, replayedSkill(entry), "content that no longer matches the recorded hash must not upload")
 }
+
+func TestReplayedSkillRejectsNonRegularLegacySource(t *testing.T) {
+	content := []byte("# original\n")
+	target := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.WriteFile(target, content, 0o600))
+	link := filepath.Join(t.TempDir(), "SKILL.md")
+	require.NoError(t, os.Symlink(target, link))
+	rawSHA256 := sha256Hex(content)
+	entry := spoolEntry{}
+	entry.Envelope.Data = &components.HookIngestData{Skill: &components.HookSkillData{
+		Name: "legacy", RawSha256: new(rawSHA256), SourcePath: new(link),
+	}}
+
+	require.Nil(t, replayedSkill(entry), "a source path that is not a regular file must drain content-less")
+}

--- a/hooks/relay/envelope.go
+++ b/hooks/relay/envelope.go
@@ -140,6 +140,12 @@ func buildEnvelope(typed any, hostname string) components.IngestRequestBody {
 	case *agenthooks.ModelEvent:
 		applyModelResponse(data, base)
 	}
+	if activation := agenthooks.SkillActivationOf(typed); activation != nil && (base.Kind != agenthooks.KindToolPost || activation.Explicit) {
+		data.Skill = &components.HookSkillData{Name: activation.Name, Source: nil}
+		if activation.Explicit {
+			eventType = components.TypeSkillActivated
+		}
+	}
 
 	payload := components.IngestRequestBody{
 		SchemaVersion: schemaVersion,
@@ -264,25 +270,6 @@ func applyToolCall(data *components.HookIngestData, base *agenthooks.Event, tool
 		data.Mcp = m
 	}
 
-	if base.Provider == agenthooks.ProviderClaudeCode && strings.EqualFold(tool.Name, "Skill") {
-		if name := skillNameOf(tool.Input); name != "" {
-			data.Skill = &components.HookSkillData{Name: name, Source: nil}
-			return components.TypeSkillActivated
-		}
-	}
-	// Codex and Cursor skill activations are inferred from ordinary tool
-	// payloads, so the event keeps its true type: only pre-tool events count
-	// (completions must not re-report, permission previews may be denied).
-	if base.Provider == agenthooks.ProviderCodex && base.Kind == agenthooks.KindToolPre {
-		if name := codexToolSkillName(tool); name != "" {
-			data.Skill = &components.HookSkillData{Name: name, Source: nil}
-		}
-	}
-	if base.Provider == agenthooks.ProviderCursor && base.Kind == agenthooks.KindToolPre {
-		if name := cursorToolSkillName(tool, base.Session.CWD, base.Session.WorkspaceRoots); name != "" {
-			data.Skill = &components.HookSkillData{Name: name, Source: nil}
-		}
-	}
 	return eventType
 }
 
@@ -400,20 +387,6 @@ func toolErrorPayload(ev *agenthooks.ToolPostEvent) json.RawMessage {
 		}
 	}
 	return nil
-}
-
-func skillNameOf(input json.RawMessage) string {
-	var obj struct {
-		Skill string `json:"skill"`
-		Name  string `json:"name"`
-	}
-	if json.Unmarshal(input, &obj) == nil {
-		if obj.Skill != "" {
-			return obj.Skill
-		}
-		return obj.Name
-	}
-	return ""
 }
 
 func isEmptyData(d *components.HookIngestData) bool {

--- a/hooks/relay/envelope.go
+++ b/hooks/relay/envelope.go
@@ -140,7 +140,12 @@ func buildEnvelope(typed any, hostname string) components.IngestRequestBody {
 	case *agenthooks.ModelEvent:
 		applyModelResponse(data, base)
 	}
-	if activation := agenthooks.SkillActivationOf(typed); activation != nil && (base.Kind != agenthooks.KindToolPost || activation.Explicit) {
+	// The server records an activation for every event carrying data.skill, so
+	// an implicit (inferred) activation is attached only to the completed
+	// event: its tool output carries the manifest the content registry hashes,
+	// and marking the pre event too would double-count. Explicit Skill tool
+	// calls keep the provider's own event classification on both sides.
+	if activation := agenthooks.SkillActivationOf(typed); activation != nil && (activation.Explicit || base.Kind == agenthooks.KindToolPost) {
 		data.Skill = &components.HookSkillData{Name: activation.Name, Source: nil}
 		if activation.Explicit {
 			eventType = components.TypeSkillActivated

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -949,7 +949,7 @@ func TestEnvelopeCursorSkillInference(t *testing.T) {
 	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{}))))
 	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": "SKILL.md"}))))
 	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "not-a-skill", "SKILL.md")}))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "skills", "example", "SKILL.md")}))))
+	require.Equal(t, "example", skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "skills", "example", "SKILL.md")}))))
 	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "plugin", "skills", "SKILL.md")}))))
 }
 

--- a/hooks/relay/relay_test.go
+++ b/hooks/relay/relay_test.go
@@ -775,10 +775,12 @@ func TestNudgeEmittedOncePerSession(t *testing.T) {
 }
 
 // TestEnvelopeCodexSkillInference mirrors the bash senders' best-effort Codex
-// skill detection: a reader tool opening skills/<name>/SKILL.md and an
-// explicit $skill-name prompt mention (validated against the skill roots on
-// disk) both attach data.skill while the event keeps its true type on the
-// wire — a reclassified event would skip the server's tool/prompt policy scan.
+// skill detection: a reader tool opening skills/<name>/SKILL.md attaches
+// data.skill to the completed read (whose output carries the manifest the
+// content registry hashes), an explicit $skill-name prompt mention (validated
+// against the skill roots on disk) attaches it to the prompt event, and both
+// keep the event's true type on the wire — a reclassified event would skip
+// the server's tool/prompt policy scan.
 func TestEnvelopeCodexSkillInference(t *testing.T) {
 	t.Setenv("TMPDIR", t.TempDir())
 	dir := t.TempDir()
@@ -830,11 +832,11 @@ func TestEnvelopeCodexSkillInference(t *testing.T) {
 
 	got := envelope(`{"hook_event_name":"PreToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"sed -n 1,240p ` + repo + `/.agents/skills/repo-skill/SKILL.md"},"tool_use_id":"call_1"}`)
 	require.Equal(t, components.TypeToolRequested, got.Event.Type, "a detected skill read must keep its true event type")
-	require.Equal(t, "repo-skill", skillOf(got), "a SKILL.md path in a reader tool input must resolve the skill name")
+	require.Empty(t, skillOf(got), "the requested read has no content yet and must not count as the activation")
 
 	got = envelope(`{"hook_event_name":"PostToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"sed -n 1,240p ` + repo + `/.agents/skills/repo-skill/SKILL.md"},"tool_response":{"output":"ok"},"tool_use_id":"call_1"}`)
-	require.Equal(t, components.TypeToolCompleted, got.Event.Type)
-	require.Empty(t, skillOf(got), "completions must not re-report the activation")
+	require.Equal(t, components.TypeToolCompleted, got.Event.Type, "a detected skill read must keep its true event type")
+	require.Equal(t, "repo-skill", skillOf(got), "the completed read reports the activation exactly once")
 
 	got = envelope(`{"hook_event_name":"PermissionRequest","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"cat ` + repo + `/.agents/skills/repo-skill/SKILL.md"},"permission_type":"exec"}`)
 	require.Equal(t, components.TypeToolRequested, got.Event.Type)
@@ -862,8 +864,8 @@ func TestEnvelopeCodexSkillInference(t *testing.T) {
 	got = envelope(`{"hook_event_name":"UserPromptSubmit","session_id":"sess-skill","prompt":"use $sys-skill","cwd":"` + cwd + `"}`)
 	require.Equal(t, "sys-skill", skillOf(got), "bundled skills under a .system subdirectory must resolve by bare name")
 
-	got = envelope(`{"hook_event_name":"PreToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"cat /opt/codex/skills/.system/imagegen/SKILL.md"},"tool_use_id":"call_3"}`)
-	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	got = envelope(`{"hook_event_name":"PostToolUse","session_id":"sess-skill","tool_name":"Bash","tool_input":{"command":"cat /opt/codex/skills/.system/imagegen/SKILL.md"},"tool_response":{"output":"ok"},"tool_use_id":"call_3"}`)
+	require.Equal(t, components.TypeToolCompleted, got.Event.Type)
 	require.Equal(t, "imagegen", skillOf(got), "reads of .system skill paths must infer the bare skill name")
 }
 
@@ -919,19 +921,19 @@ func TestEnvelopeCursorSkillInference(t *testing.T) {
 	}
 
 	workspacePath := filepath.Join(home, ".cursor", "skills", "workspace-skill", "SKILL.md")
-	got := envelope(payload("preToolUse", "Read", map[string]any{"file_path": workspacePath}))
-	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	got := envelope(payload("postToolUse", "Read", map[string]any{"file_path": workspacePath}))
+	require.Equal(t, components.TypeToolCompleted, got.Event.Type)
 	require.Equal(t, "workspace-skill", skillOf(got))
 
 	pluginRoot := filepath.Join(t.TempDir(), "arbitrary", "plugin")
 	pluginPath := filepath.Join(pluginRoot, "skills", "plugin-skill", "SKILL.md")
 	require.NoError(t, os.MkdirAll(filepath.Join(pluginRoot, ".cursor-plugin"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(pluginRoot, ".cursor-plugin", "plugin.json"), []byte(`{}`), 0o644))
-	got = envelope(payload("preToolUse", "Read", map[string]any{"file_path": pluginPath}))
-	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	got = envelope(payload("postToolUse", "Read", map[string]any{"file_path": pluginPath}))
+	require.Equal(t, components.TypeToolCompleted, got.Event.Type)
 	require.Equal(t, "plugin-skill", skillOf(got))
 
-	got = envelope(payload("preToolUse", "Read", map[string]any{"path": workspacePath}))
+	got = envelope(payload("postToolUse", "Read", map[string]any{"path": workspacePath}))
 	require.Equal(t, "workspace-skill", skillOf(got), "legacy Cursor payloads use path instead of file_path")
 
 	got = envelope(payload("beforeReadFile", "", workspacePath))
@@ -939,18 +941,18 @@ func TestEnvelopeCursorSkillInference(t *testing.T) {
 	require.Equal(t, "ReadFile", *got.Data.ToolCall.Name)
 	require.Empty(t, skillOf(got), "the duplicate beforeReadFile is normalized to ReadFile")
 
-	got = envelope(payload("postToolUse", "Read", map[string]any{"file_path": workspacePath}))
-	require.Equal(t, components.TypeToolCompleted, got.Event.Type)
-	require.Empty(t, skillOf(got), "completions must not re-report the activation")
+	got = envelope(payload("preToolUse", "Read", map[string]any{"file_path": workspacePath}))
+	require.Equal(t, components.TypeToolRequested, got.Event.Type)
+	require.Empty(t, skillOf(got), "the requested read has no content yet and must not count as the activation")
 
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Bash", map[string]any{"file_path": workspacePath}))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(filepath.Dir(workspacePath), "README.md")}))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", "{"))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{}))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": "SKILL.md"}))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "not-a-skill", "SKILL.md")}))))
-	require.Equal(t, "example", skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "skills", "example", "SKILL.md")}))))
-	require.Empty(t, skillOf(envelope(payload("preToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "plugin", "skills", "SKILL.md")}))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Bash", map[string]any{"file_path": workspacePath}))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Read", map[string]any{"file_path": filepath.Join(filepath.Dir(workspacePath), "README.md")}))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Read", "{"))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Read", map[string]any{}))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Read", map[string]any{"file_path": "SKILL.md"}))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "not-a-skill", "SKILL.md")}))))
+	require.Equal(t, "example", skillOf(envelope(payload("postToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "docs", "skills", "example", "SKILL.md")}))))
+	require.Empty(t, skillOf(envelope(payload("postToolUse", "Read", map[string]any{"file_path": filepath.Join(t.TempDir(), "plugin", "skills", "SKILL.md")}))))
 }
 
 // TestRedactCommandMasksSeparatedHeaderValue pins the tokenized-header shape:

--- a/hooks/relay/runner.go
+++ b/hooks/relay/runner.go
@@ -165,12 +165,6 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	payload := buildEnvelope(typed, hostname())
 	resolvedSkill := resolveActivatedSkill(typed, &payload)
 	if resolvedSkill != nil {
-		if resolvedSkill.sourceLevel != "" {
-			payload.Data.Skill.SourceLevel = new(resolvedSkill.sourceLevel)
-		}
-		if resolvedSkill.sourcePath != "" {
-			payload.Data.Skill.SourcePath = new(resolvedSkill.sourcePath)
-		}
 		if resolvedSkill.rawSHA256 != "" {
 			payload.Data.Skill.RawSha256 = new(resolvedSkill.rawSHA256)
 		}
@@ -235,11 +229,11 @@ func (r *Relay) deliver(ctx context.Context, typed any) (ingestResult, authState
 	// kept for replay, a healthy exchange flushes any backlog, and a
 	// definitive 4xx does neither — the server answered, and would reject a
 	// replay identically.
-	r.finishExchange(idemKey, payload, res, resolvedSkill)
+	r.finishExchange(idemKey, payload, res)
 	if res.accepted() || res.unsent() {
 		commitPromptAttachmentHighWater(promptAttachmentAdvance)
 	}
-	if err := startSkillContentUpload(finalCreds, res, resolvedSkill); err != nil {
+	if err := uploadSkillContent(ctx, finalCreds, res, resolvedSkill); err != nil {
 		r.debugf("skill upload: %v", err)
 	}
 	return res, state

--- a/hooks/relay/skillcapture_test.go
+++ b/hooks/relay/skillcapture_test.go
@@ -1,6 +1,8 @@
 package relay
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -57,17 +59,19 @@ func TestRelayEnrichesSkillAndCreatesRequestedUploadTask(t *testing.T) {
 	require.True(t, delivery.result.accepted())
 	require.NotNil(t, delivery.payload.Data)
 	require.NotNil(t, delivery.payload.Data.Skill)
-	require.Equal(t, "project", *delivery.payload.Data.Skill.SourceLevel)
-	require.Equal(t, delivery.path, *delivery.payload.Data.Skill.SourcePath)
+	require.Nil(t, delivery.payload.Data.Skill.SourceLevel)
+	require.Nil(t, delivery.payload.Data.Skill.SourcePath)
 	require.Equal(t, delivery.rawSHA256, *delivery.payload.Data.Skill.RawSha256)
 	require.Nil(t, delivery.payload.Data.Skill.Source)
+	output, ok := delivery.payload.Data.ToolCall.Output.(string)
+	require.True(t, ok)
+	require.Equal(t, "# Captured skill\n", output)
 	require.Equal(t, []skillUploadTask{{
-		ServerURL:  delivery.serverURL,
-		Project:    "default",
-		APIKey:     "test-hooks-key",
-		RawSHA256:  delivery.rawSHA256,
-		SourcePath: delivery.path,
-		SourceRoot: filepath.Dir(filepath.Dir(delivery.path)),
+		ServerURL: delivery.serverURL,
+		Project:   "default",
+		APIKey:    "test-hooks-key",
+		RawSHA256: delivery.rawSHA256,
+		Content:   "# Captured skill\n",
 	}}, delivery.tasks)
 }
 
@@ -110,7 +114,7 @@ func TestRelayDeniedAcceptedSkillCreatesRequestedUploadTask(t *testing.T) {
 
 func TestRelayCacheRejectionUsesFinalOrgCredentialsForUploadTask(t *testing.T) {
 	capturedTasks := captureSkillUploadTasks(t)
-	event, _, _ := relaySkillEvent(t, []byte("fallback"))
+	event, _ := relaySkillEvent(t, []byte("fallback"))
 	var requests atomic.Int32
 	fs := newFakeServer(t, func(components.IngestRequestBody) (int, decision) {
 		if requests.Add(1) == 1 {
@@ -142,7 +146,7 @@ func TestRelayCacheRejectionUsesFinalOrgCredentialsForUploadTask(t *testing.T) {
 
 func TestRelaySpoolsEnrichedUnsentSkillPayload(t *testing.T) {
 	setSpoolStateHome(t)
-	event, path, rawSHA256 := relaySkillEvent(t, []byte("offline content"))
+	event, rawSHA256 := relaySkillEvent(t, []byte("offline content"))
 	cfg := authedConfig(t, closedPortURL(t))
 
 	result, _ := NewRelay(cfg).deliver(t.Context(), event)
@@ -153,10 +157,10 @@ func TestRelaySpoolsEnrichedUnsentSkillPayload(t *testing.T) {
 	entry := readSpoolEntry(t, names[0])
 	skill := entry.Envelope.Data.Skill
 	require.NotNil(t, skill)
-	require.Equal(t, "project", *skill.SourceLevel)
-	require.Equal(t, path, *skill.SourcePath)
+	require.Nil(t, skill.SourceLevel)
+	require.Nil(t, skill.SourcePath)
 	require.Equal(t, rawSHA256, *skill.RawSha256)
-	require.Equal(t, filepath.Dir(filepath.Dir(path)), entry.SkillSourceRoot)
+	require.Equal(t, "offline content", entry.Envelope.Data.ToolCall.Output)
 }
 
 func TestIngestRedirectDoesNotForwardKeyAndFailsClosedWithoutSpool(t *testing.T) {
@@ -213,7 +217,6 @@ func ingestSkillCaptureEffect(t *testing.T, effect any) *skillCapture {
 
 type skillDelivery struct {
 	serverURL string
-	path      string
 	rawSHA256 string
 	payload   components.IngestRequestBody
 	result    ingestResult
@@ -234,11 +237,10 @@ func deliverSkillForTest(
 	})
 	fs.effects = effects
 	cfg := authedConfig(t, fs.URL)
-	event, path, rawSHA256 := relaySkillEvent(t, content)
+	event, rawSHA256 := relaySkillEvent(t, content)
 	result, _ := NewRelay(cfg).deliver(t.Context(), event)
 	return skillDelivery{
 		serverURL: fs.URL,
-		path:      path,
 		rawSHA256: rawSHA256,
 		payload:   fs.last(),
 		result:    result,
@@ -257,21 +259,27 @@ func requestedSkillCaptureEffects(contentRequired bool) func(components.IngestRe
 
 func captureSkillUploadTasks(t *testing.T) func() []skillUploadTask {
 	t.Helper()
-	original := startSkillUploadProcess
-	t.Cleanup(func() { startSkillUploadProcess = original })
+	original := executeSkillUpload
+	t.Cleanup(func() { executeSkillUpload = original })
 	var tasks []skillUploadTask
-	startSkillUploadProcess = func(task skillUploadTask) error {
+	executeSkillUpload = func(_ context.Context, task skillUploadTask) error {
 		tasks = append(tasks, task)
 		return nil
 	}
 	return func() []skillUploadTask { return tasks }
 }
 
-func relaySkillEvent(t *testing.T, content []byte) (*agenthooks.ToolPreEvent, string, string) {
+func relaySkillEvent(t *testing.T, content []byte) (*agenthooks.ToolPostEvent, string) {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
 	cwd := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(cwd, ".claude", "skills", "dno-441-relay-capture"), content)
-	return claudeSkillEvent(cwd, "dno-441-relay-capture"), path, sha256Hex(content)
+	output, err := json.Marshal(string(content))
+	require.NoError(t, err)
+	input, err := json.Marshal(map[string]string{"skill": "dno-441-relay-capture"})
+	require.NoError(t, err)
+	return &agenthooks.ToolPostEvent{
+		Event:  agenthooks.Event{Provider: agenthooks.ProviderClaudeCode, Kind: agenthooks.KindToolPost, Session: agenthooks.SessionInfo{CWD: cwd}},
+		Tool:   agenthooks.ToolCall{Name: "Skill", Input: input},
+		Output: output,
+		Failed: false,
+	}, sha256Hex(content)
 }

--- a/hooks/relay/skills.go
+++ b/hooks/relay/skills.go
@@ -3,12 +3,9 @@ package relay
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -18,218 +15,38 @@ import (
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
 
-const (
-	maxSkillContentBytes        = 65_536
-	maxClaudePluginRegistrySize = 1 << 20
-)
+const maxSkillContentBytes = 65_536
 
 var skillTokenRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
-var claudeManagedSkillsRoot = platformClaudeManagedSkillsRoot
-
 type resolvedSkill struct {
 	name         string
-	sourceLevel  string
-	sourcePath   string
 	rawSHA256    string
 	content      string
 	captureReady bool
-	root         string
 }
 
-type skillAuthorization uint8
-
-const (
-	skillAuthorizationExact skillAuthorization = iota
-	skillAuthorizationProject
-	skillAuthorizationPersonal
-)
-
-type skillLocation struct {
-	path          string
-	level         string
-	root          string
-	authorization skillAuthorization
-	owner         string
-}
-
-// resolveActivatedSkill resolves and captures the manifest for a skill already
-// detected in the ingest payload. Resolution failures deliberately preserve the
-// activation name without guessing at a different source.
 func resolveActivatedSkill(typed any, payload *components.IngestRequestBody) *resolvedSkill {
 	if payload == nil || payload.Data == nil || payload.Data.Skill == nil {
 		return nil
 	}
 
 	result := &resolvedSkill{name: payload.Data.Skill.Name}
-	base := agenthooks.EventOf(typed)
-	if base == nil {
+	activation := agenthooks.SkillActivationOf(typed)
+	if activation == nil || !activation.ContentAvailable || len(activation.Content) > maxSkillContentBytes || !utf8.ValidString(activation.Content) {
 		return result
 	}
-
-	var location skillLocation
-	switch base.Provider {
-	case agenthooks.ProviderClaudeCode:
-		location = resolveClaudeSkill(result.name, base.Session.CWD)
-	case agenthooks.ProviderCodex:
-		switch event := typed.(type) {
-		case *agenthooks.ToolPreEvent:
-			location = resolveCodexToolSkill(&event.Tool, base.Session.CWD)
-		case *agenthooks.PromptEvent:
-			_, location = codexPromptSkill(event.Prompt, base.Session.CWD)
-		}
-	case agenthooks.ProviderCursor:
-		if event, ok := typed.(*agenthooks.ToolPreEvent); ok {
-			location = resolveCursorToolSkill(&event.Tool, base.Session.CWD, base.Session.WorkspaceRoots)
-		}
-	}
-	if location.path == "" {
-		return result
-	}
-	return captureResolvedSkill(result, location)
-}
-
-func captureResolvedSkill(result *resolvedSkill, location skillLocation) *resolvedSkill {
-	file, authorizedRoot, ok := openValidatedSkill(location)
-	if !ok {
-		return result
-	}
-	hasher := sha256.New()
-	content, readErr := io.ReadAll(io.LimitReader(io.TeeReader(file, hasher), maxSkillContentBytes+1))
-	if readErr == nil {
-		// Capture stays bounded, but metadata requires the exact full-file hash.
-		_, readErr = io.Copy(io.Discard, io.TeeReader(file, hasher))
-	}
-	closeErr := file.Close()
-	if readErr != nil || closeErr != nil {
-		return result
-	}
-
-	result.sourceLevel = location.level
-	result.sourcePath = filepath.Clean(location.path)
-	result.rawSHA256 = hex.EncodeToString(hasher.Sum(nil))
-	result.root = authorizedRoot
-	if len(content) > maxSkillContentBytes || !utf8.Valid(content) {
-		return result
-	}
-
-	result.content = string(content)
+	digest := sha256.Sum256([]byte(activation.Content))
+	result.rawSHA256 = hex.EncodeToString(digest[:])
+	result.content = activation.Content
 	result.captureReady = true
 	return result
 }
 
-// Codex has no structured skill signal: implicit activations surface as a
-// reader tool opening a skills/<name>/SKILL.md path, and explicit $skill-name
-// prompt mentions are expanded internally without any tool call.
-
-// codexToolSkillName infers an implicit activation from a reader tool opening
-// a SKILL.md path. Callers gate on the pre-tool kind.
-func codexToolSkillName(tool *agenthooks.ToolCall) string {
-	_, name := codexToolSkillPath(tool, "")
-	return name
-}
-
-func codexToolSkillPath(tool *agenthooks.ToolCall, cwd string) (string, string) {
-	switch tool.Name {
-	case "Read":
-		path := readToolPath(tool.Input)
-		name := skillNameFromManifestPath(path, true)
-		if name == "" {
-			return "", ""
-		}
-		return absoluteSessionPath(path, cwd), name
-	case "Bash", "shell":
-		var input struct {
-			Command string `json:"command"`
-		}
-		if json.Unmarshal(tool.Input, &input) != nil {
-			return "", ""
-		}
-		var path, name string
-		for _, token := range shellTokens(input.Command) {
-			if candidate := skillNameFromManifestPath(token, true); candidate != "" {
-				path, name = token, candidate
-			}
-		}
-		return absoluteSessionPath(path, cwd), name
-	default:
-		return "", ""
-	}
-}
-
-func resolveCodexToolSkill(tool *agenthooks.ToolCall, cwd string) skillLocation {
-	path, _ := codexToolSkillPath(tool, cwd)
-	if path == "" {
-		return skillLocation{}
-	}
-	return classifyCodexSkill(path, cwd)
-}
-
-func cursorToolSkillName(tool *agenthooks.ToolCall, cwd string, workspaceRoots []string) string {
-	location := resolveCursorToolSkill(tool, cwd, workspaceRoots)
-	return skillNameFromManifestPath(location.path, false)
-}
-
-func cursorToolSkillPath(tool *agenthooks.ToolCall, cwd string) (string, string) {
-	if tool.Name != "Read" {
-		return "", ""
-	}
-	path := readToolPath(tool.Input)
-	name := skillNameFromManifestPath(path, false)
-	if name == "" {
-		return "", ""
-	}
-	return absoluteSessionPath(path, cwd), name
-}
-
-func readToolPath(input json.RawMessage) string {
-	var paths struct {
-		FilePath string `json:"file_path"`
-		Path     string `json:"path"`
-	}
-	if json.Unmarshal(input, &paths) != nil {
-		return ""
-	}
-	if paths.FilePath != "" {
-		return paths.FilePath
-	}
-	return paths.Path
-}
-
-func resolveCursorToolSkill(tool *agenthooks.ToolCall, cwd string, workspaceRoots []string) skillLocation {
-	path, _ := cursorToolSkillPath(tool, cwd)
-	if path == "" {
-		return skillLocation{}
-	}
-	return classifyCursorSkill(path, workspaceRoots)
-}
-
-func skillNameFromManifestPath(path string, allowSystem bool) string {
-	slashed := strings.ReplaceAll(path, `\`, "/")
-	parts := strings.Split(slashed, "/")
-	if len(parts) < 3 || parts[len(parts)-1] != "SKILL.md" {
-		return ""
-	}
-	nameIndex := len(parts) - 2
-	skillsIndex := nameIndex - 1
-	if allowSystem && parts[skillsIndex] == ".system" {
-		skillsIndex--
-	}
-	if skillsIndex < 0 || parts[skillsIndex] != "skills" || !skillTokenRE.MatchString(parts[nameIndex]) {
-		return ""
-	}
-	return parts[nameIndex]
-}
-
-// codexPromptSkillName preserves the existing sorted-name inference behavior.
+// Codex has no structured signal for explicit $skill-name prompt activations.
 func codexPromptSkillName(prompt, cwd string) string {
-	name, _ := codexPromptSkill(prompt, cwd)
-	return name
-}
-
-func codexPromptSkill(prompt, cwd string) (string, skillLocation) {
 	if !strings.Contains(prompt, "$") {
-		return "", skillLocation{}
+		return ""
 	}
 	fields := strings.FieldsFunc(prompt, func(r rune) bool {
 		switch {
@@ -249,327 +66,52 @@ func codexPromptSkill(prompt, cwd string) (string, skillLocation) {
 			continue
 		}
 		name = strings.TrimRight(name, ".")
-		if seen[name] {
-			continue
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
 		}
-		seen[name] = true
-		names = append(names, name)
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		locations := codexSkillLocations(name, cwd)
-		if len(locations) > 0 {
-			if len(locations) == 1 {
-				return name, locations[0]
-			}
-			return name, skillLocation{}
+		if codexSkillExists(name, cwd) {
+			return name
 		}
 	}
-	return "", skillLocation{}
+	return ""
 }
 
 func codexSkillExists(name, cwd string) bool {
-	return len(codexSkillLocations(name, cwd)) > 0
-}
-
-func codexSkillLocations(name, cwd string) []skillLocation {
 	if name == "" || strings.ContainsAny(name, `/\`) || strings.HasPrefix(name, ".") {
-		return nil
-	}
-	var locations []skillLocation
-	seen := map[string]bool{}
-	add := func(location skillLocation) {
-		if location.path == "" {
-			return
-		}
-		clean := filepath.Clean(location.path)
-		if seen[clean] || !readableRegularFile(clean) {
-			return
-		}
-		seen[clean] = true
-		location.path = clean
-		locations = append(locations, location)
+		return false
 	}
 	home, _ := os.UserHomeDir()
+	roots := []string{"/etc/codex/skills", "/opt/codex/skills"}
 	if home != "" {
-		root := filepath.Join(home, ".agents", "skills")
-		add(personalSkillLocation(existingSkillManifest(filepath.Join(root, name)), "personal", root, home))
+		roots = append(roots, filepath.Join(home, ".agents", "skills"))
 	}
 	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 	if codexHome == "" && home != "" {
 		codexHome = filepath.Join(home, ".codex")
-	}
-	roots := []skillLocation{
-		exactSkillLocation("", "admin", "/etc/codex/skills"),
-		exactSkillLocation("", "system", "/opt/codex/skills"),
 	}
 	if codexHome != "" {
-		root := filepath.Join(codexHome, "skills")
-		if home != "" && filepath.Clean(codexHome) == filepath.Join(filepath.Clean(home), ".codex") {
-			roots = append(roots, personalSkillLocation("", "personal", root, home))
-		} else {
-			roots = append(roots, exactSkillLocation("", "personal", root))
-		}
+		roots = append(roots, filepath.Join(codexHome, "skills"), filepath.Join(codexHome, "skills", ".system"))
 	}
 	for _, root := range roots {
-		root.path = existingSkillManifest(filepath.Join(root.root, name))
-		add(root)
-		level := root.level
-		if codexHome != "" && root.root == filepath.Join(codexHome, "skills") {
-			level = "system"
-		}
-		systemRoot := filepath.Join(root.root, ".system")
-		add(exactSkillLocation(existingSkillManifest(filepath.Join(systemRoot, name)), level, systemRoot))
-	}
-	if filepath.IsAbs(cwd) {
-		for dir := cwd; ; dir = filepath.Dir(dir) {
-			root := filepath.Join(dir, ".agents", "skills")
-			add(projectSkillLocation(existingSkillManifest(filepath.Join(root, name)), "project", root, dir))
-			if pathExists(filepath.Join(dir, ".git")) {
-				break
-			}
-			if parent := filepath.Dir(dir); parent == dir {
-				break
-			}
-		}
-	}
-	return locations
-}
-
-func resolveClaudeSkill(name, cwd string) skillLocation {
-	if plugin, skill, ok := strings.Cut(name, ":"); ok {
-		if !skillTokenRE.MatchString(plugin) || !skillTokenRE.MatchString(skill) || strings.Contains(skill, ":") {
-			return skillLocation{}
-		}
-		return resolveClaudePluginSkill(plugin, skill, cwd)
-	}
-	if !skillTokenRE.MatchString(name) {
-		return skillLocation{}
-	}
-	if root := claudeManagedSkillsRoot(); root != "" {
-		path := filepath.Join(root, name, "SKILL.md")
-		info, err := os.Stat(path)
-		switch {
-		case err == nil && info.Mode().IsRegular():
-			if readableRegularFile(path) {
-				return exactSkillLocation(path, "admin", root)
-			}
-			return skillLocation{}
-		case err != nil && !os.IsNotExist(err):
-			return skillLocation{}
-		}
-	}
-
-	home, _ := os.UserHomeDir()
-	configRoot := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
-	if configRoot == "" && home != "" {
-		configRoot = filepath.Join(home, ".claude")
-	}
-	if configRoot != "" {
-		root := filepath.Join(configRoot, "skills")
-		if path := existingSkillManifest(filepath.Join(root, name)); path != "" {
-			if home != "" && filepath.Clean(configRoot) == filepath.Join(filepath.Clean(home), ".claude") {
-				return personalSkillLocation(path, "personal", root, home)
-			}
-			return exactSkillLocation(path, "personal", root)
+		if readableRegularFile(filepath.Join(root, name, "SKILL.md")) {
+			return true
 		}
 	}
 	if filepath.IsAbs(cwd) {
 		for dir := cwd; ; dir = filepath.Dir(dir) {
-			root := filepath.Join(dir, ".claude", "skills")
-			if path := existingSkillManifest(filepath.Join(root, name)); path != "" {
-				return projectSkillLocation(path, "project", root, dir)
+			if readableRegularFile(filepath.Join(dir, ".agents", "skills", name, "SKILL.md")) {
+				return true
 			}
-			if pathExists(filepath.Join(dir, ".git")) {
-				break
-			}
-			if parent := filepath.Dir(dir); parent == dir {
+			if pathExists(filepath.Join(dir, ".git")) || filepath.Dir(dir) == dir {
 				break
 			}
 		}
 	}
-	return skillLocation{}
-}
-
-func platformClaudeManagedSkillsRoot() string {
-	switch runtime.GOOS {
-	case "darwin":
-		return "/Library/Application Support/ClaudeCode/.claude/skills"
-	case "linux":
-		return "/etc/claude-code/.claude/skills"
-	case "windows":
-		return `C:\Program Files\ClaudeCode\.claude\skills`
-	default:
-		return ""
-	}
-}
-
-func resolveClaudePluginSkill(plugin, skill, cwd string) skillLocation {
-	home, _ := os.UserHomeDir()
-	configRoot := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
-	if configRoot == "" && home != "" {
-		configRoot = filepath.Join(home, ".claude")
-	}
-	if configRoot == "" {
-		return skillLocation{}
-	}
-	registryFile, err := os.Open(filepath.Join(configRoot, "plugins", "installed_plugins.json"))
-	if err != nil {
-		return skillLocation{}
-	}
-	data, readErr := io.ReadAll(io.LimitReader(registryFile, maxClaudePluginRegistrySize+1))
-	closeErr := registryFile.Close()
-	if readErr != nil || closeErr != nil || len(data) > maxClaudePluginRegistrySize {
-		return skillLocation{}
-	}
-	var registry struct {
-		Version int `json:"version"`
-		Plugins map[string][]struct {
-			Scope       string `json:"scope"`
-			ProjectPath string `json:"projectPath"`
-			InstallPath string `json:"installPath"`
-		} `json:"plugins"`
-	}
-	if json.Unmarshal(data, &registry) != nil || registry.Version != 2 {
-		return skillLocation{}
-	}
-
-	type candidate struct {
-		installPath string
-		projectPath string
-	}
-	var projectCandidates, userCandidates []candidate
-	for key, records := range registry.Plugins {
-		prefix, _, _ := strings.Cut(key, "@")
-		if prefix != plugin {
-			continue
-		}
-		for _, record := range records {
-			switch record.Scope {
-			case "project", "local":
-				if record.InstallPath != "" && pathWithin(cwd, record.ProjectPath) {
-					projectCandidates = append(projectCandidates, candidate{installPath: record.InstallPath, projectPath: record.ProjectPath})
-				}
-			case "user":
-				if record.InstallPath != "" {
-					userCandidates = append(userCandidates, candidate{installPath: record.InstallPath})
-				}
-			}
-		}
-	}
-
-	candidates := userCandidates
-	if len(projectCandidates) > 0 {
-		longest := 0
-		for _, candidate := range projectCandidates {
-			if len(filepath.Clean(candidate.projectPath)) > longest {
-				longest = len(filepath.Clean(candidate.projectPath))
-			}
-		}
-		candidates = nil
-		for _, candidate := range projectCandidates {
-			if len(filepath.Clean(candidate.projectPath)) == longest {
-				candidates = append(candidates, candidate)
-			}
-		}
-	}
-	if len(candidates) != 1 {
-		return skillLocation{}
-	}
-	for _, dir := range []string{filepath.Join(candidates[0].installPath, "skills", skill), candidates[0].installPath} {
-		if path := existingSkillManifest(dir); path != "" {
-			return exactSkillLocation(path, "plugin", candidates[0].installPath)
-		}
-	}
-	return skillLocation{}
-}
-
-func classifyCursorSkill(path string, workspaceRoots []string) skillLocation {
-	home, _ := os.UserHomeDir()
-	for _, dir := range []string{".cursor", ".agents", ".claude", ".codex"} {
-		root := filepath.Join(home, dir, "skills")
-		if home != "" && pathWithin(path, root) {
-			return personalSkillLocation(path, "personal", root, home)
-		}
-	}
-	if root := pluginManifestAncestor(path, ".cursor-plugin", containingWorkspaceRoot(path, workspaceRoots)); root != "" {
-		return exactSkillLocation(path, "plugin", root)
-	}
-	for _, workspaceRoot := range workspaceRoots {
-		if skillRoot, owner := providerSkillRoot(path, workspaceRoot); skillRoot != "" {
-			return projectSkillLocation(path, "project", skillRoot, owner)
-		}
-	}
-	return skillLocation{}
-}
-
-func classifyCodexSkill(path, cwd string) skillLocation {
-	home, _ := os.UserHomeDir()
-	root := filepath.Join(home, ".agents", "skills")
-	if home != "" && pathWithin(path, root) {
-		return personalSkillLocation(path, "personal", root, home)
-	}
-	if root = "/etc/codex/skills"; pathWithin(path, root) {
-		return exactSkillLocation(path, "admin", root)
-	}
-	if root = "/opt/codex/skills"; pathWithin(path, root) {
-		return exactSkillLocation(path, "system", root)
-	}
-	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
-	if codexHome == "" && home != "" {
-		codexHome = filepath.Join(home, ".codex")
-	}
-	root = filepath.Join(codexHome, "skills")
-	if codexHome != "" && pathWithin(path, filepath.Join(root, ".system")) {
-		systemRoot := filepath.Join(root, ".system")
-		return exactSkillLocation(path, "system", systemRoot)
-	}
-	if filepath.IsAbs(cwd) {
-		for dir := cwd; ; dir = filepath.Dir(dir) {
-			root = filepath.Join(dir, ".agents", "skills")
-			if pathWithin(path, root) {
-				return projectSkillLocation(path, "project", root, dir)
-			}
-			if pathExists(filepath.Join(dir, ".git")) {
-				break
-			}
-			if parent := filepath.Dir(dir); parent == dir {
-				break
-			}
-		}
-	}
-	root = filepath.Join(codexHome, "skills")
-	if codexHome != "" && pathWithin(path, root) {
-		if home != "" && filepath.Clean(codexHome) == filepath.Join(filepath.Clean(home), ".codex") {
-			return personalSkillLocation(path, "personal", root, home)
-		}
-		return exactSkillLocation(path, "personal", root)
-	}
-	if root = pluginManifestAncestor(path, ".codex-plugin", ""); root != "" {
-		return exactSkillLocation(path, "plugin", root)
-	}
-	return skillLocation{}
-}
-
-func exactSkillLocation(path, level, root string) skillLocation {
-	return skillLocation{path: path, level: level, root: root, authorization: skillAuthorizationExact}
-}
-
-func projectSkillLocation(path, level, root, owner string) skillLocation {
-	return skillLocation{path: path, level: level, root: root, authorization: skillAuthorizationProject, owner: owner}
-}
-
-func personalSkillLocation(path, level, root, owner string) skillLocation {
-	return skillLocation{path: path, level: level, root: root, authorization: skillAuthorizationPersonal, owner: owner}
-}
-
-func existingSkillManifest(dir string) string {
-	path := filepath.Join(dir, "SKILL.md")
-	info, err := os.Stat(path)
-	if err == nil && info.Mode().IsRegular() {
-		return path
-	}
-	return ""
+	return false
 }
 
 func readableRegularFile(path string) bool {
@@ -586,114 +128,9 @@ func readableRegularFile(path string) bool {
 	return statErr == nil && openedInfo.Mode().IsRegular() && closeErr == nil
 }
 
-func openValidatedSkill(location skillLocation) (*os.File, string, bool) {
-	if !filepath.IsAbs(location.path) || !filepath.IsAbs(location.root) {
-		return nil, "", false
-	}
-	// Skill trees commonly use symlinks — a linked skill directory
-	// (.claude/skills/<name> -> ../../.agents/skills/<name>) or a linked
-	// manifest (SKILL.md -> ../shared/guide.md). Agents follow both when
-	// loading the manifest into context, so capture follows them too.
-	resolved, err := filepath.EvalSymlinks(location.path)
-	if err != nil {
-		return nil, "", false
-	}
-	resolvedRoot, err := filepath.EvalSymlinks(location.root)
-	if err != nil {
-		return nil, "", false
-	}
-	authorizedRoot, ok := authorizedSkillRoot(location, resolvedRoot, resolved)
-	if !ok {
-		return nil, "", false
-	}
-	rootDir, err := os.OpenRoot(filepath.Dir(resolved))
-	if err != nil {
-		return nil, "", false
-	}
-	name := filepath.Base(resolved)
-	info, err := rootDir.Stat(name)
-	if err != nil || !info.Mode().IsRegular() {
-		_ = rootDir.Close()
-		return nil, "", false
-	}
-	file, err := rootDir.Open(name)
-	closeRootErr := rootDir.Close()
-	if err != nil || closeRootErr != nil {
-		if file != nil {
-			_ = file.Close()
-		}
-		return nil, "", false
-	}
-	openedInfo, err := file.Stat()
-	if err != nil || !openedInfo.Mode().IsRegular() {
-		_ = file.Close()
-		return nil, "", false
-	}
-	return file, authorizedRoot, true
-}
-
-// authorizedSkillRoot applies the boundary selected by the resolver. Project
-// and standard personal skills may link between known provider skill trees
-// under the same owner. Configured, managed, and plugin locations stay within
-// their exact resolved tree and its resolver-selected parent.
-func authorizedSkillRoot(location skillLocation, resolvedRoot, resolvedPath string) (string, bool) {
-	switch location.authorization {
-	case skillAuthorizationProject, skillAuthorizationPersonal:
-		if !filepath.IsAbs(location.owner) {
-			return "", false
-		}
-		// The owner is selected from the unresolved provider location so a
-		// linked provider root cannot change which project or home owns it.
-		resolvedOwner, err := filepath.EvalSymlinks(location.owner)
-		if err != nil {
-			return "", false
-		}
-		allowedRoots := providerSkillRoots(resolvedOwner)
-		if !pathWithinAny(resolvedRoot, allowedRoots) {
-			return "", false
-		}
-		sourceRoots := providerSkillRoots(location.owner)
-		for i, root := range allowedRoots {
-			if pathWithin(resolvedPath, root) {
-				return filepath.Clean(sourceRoots[i]), true
-			}
-		}
-		return "", false
-	case skillAuthorizationExact:
-		// Resolve the parent independently so a symlink at the exact root cannot
-		// redefine its confinement boundary outside the resolver-selected tree.
-		resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(location.root))
-		if err == nil && pathWithin(resolvedRoot, resolvedParent) && pathWithin(resolvedPath, resolvedRoot) {
-			return filepath.Clean(location.root), true
-		}
-		return "", false
-	default:
-		return "", false
-	}
-}
-
-func providerSkillRoots(owner string) []string {
-	roots := make([]string, 0, 4)
-	for _, provider := range []string{".agents", ".claude", ".codex", ".cursor"} {
-		roots = append(roots, filepath.Join(owner, provider, "skills"))
-	}
-	return roots
-}
-
-func pathWithinAny(path string, roots []string) bool {
-	for _, root := range roots {
-		if pathWithin(path, root) {
-			return true
-		}
-	}
-	return false
-}
-
-func absoluteSessionPath(path, cwd string) string {
-	if path == "" || filepath.IsAbs(path) || cwd == "" {
-		return path
-	}
-	return filepath.Join(cwd, path)
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func pathWithin(path, root string) bool {
@@ -710,107 +147,4 @@ func pathWithin(path, root string) bool {
 	}
 	rel, err := filepath.Rel(rootAbs, pathAbs)
 	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func containingWorkspaceRoot(path string, workspaceRoots []string) string {
-	var result string
-	for _, root := range workspaceRoots {
-		rootAbs, err := filepath.Abs(root)
-		if err == nil && pathWithin(path, rootAbs) && (result == "" || len(rootAbs) > len(result)) {
-			result = rootAbs
-		}
-	}
-	return result
-}
-
-func providerSkillRoot(path, workspaceRoot string) (string, string) {
-	pathAbs, err := filepath.Abs(path)
-	if err != nil {
-		return "", ""
-	}
-	rootAbs, err := filepath.Abs(workspaceRoot)
-	if err != nil {
-		return "", ""
-	}
-	rel, err := filepath.Rel(rootAbs, pathAbs)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", ""
-	}
-	parts := strings.Split(rel, string(filepath.Separator))
-	for i := 0; i+2 < len(parts); i++ {
-		switch parts[i] {
-		case ".cursor", ".agents", ".claude", ".codex":
-			if parts[i+1] == "skills" {
-				owner := filepath.Join(append([]string{rootAbs}, parts[:i]...)...)
-				return filepath.Join(owner, parts[i], "skills"), owner
-			}
-		}
-	}
-	return "", ""
-}
-
-func pluginManifestAncestor(path, markerDir, stop string) string {
-	stop = filepath.Clean(stop)
-	for dir := filepath.Dir(path); ; dir = filepath.Dir(dir) {
-		if readableRegularFile(filepath.Join(dir, markerDir, "plugin.json")) {
-			return dir
-		}
-		if stop != "." && filepath.Clean(dir) == stop {
-			return ""
-		}
-		if parent := filepath.Dir(dir); parent == dir {
-			return ""
-		}
-	}
-}
-
-func pathExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
-
-func shellTokens(command string) []string {
-	var tokens []string
-	var token strings.Builder
-	var quote rune
-	escaped := false
-	flush := func() {
-		if token.Len() > 0 {
-			tokens = append(tokens, token.String())
-			token.Reset()
-		}
-	}
-	for _, char := range command {
-		if escaped {
-			token.WriteRune(char)
-			escaped = false
-			continue
-		}
-		if char == '\\' && quote != '\'' && runtime.GOOS != "windows" {
-			escaped = true
-			continue
-		}
-		if quote != 0 {
-			if char == quote {
-				quote = 0
-			} else {
-				token.WriteRune(char)
-			}
-			continue
-		}
-		if char == '\'' || char == '"' {
-			quote = char
-			continue
-		}
-		if strings.ContainsRune(" \t\r\n;|&()<>", char) {
-			flush()
-			continue
-		}
-		token.WriteRune(char)
-	}
-	if escaped {
-		token.WriteRune('\\')
-	}
-	flush()
-	return tokens
 }

--- a/hooks/relay/skills.go
+++ b/hooks/relay/skills.go
@@ -85,9 +85,13 @@ func codexSkillExists(name, cwd string) bool {
 		return false
 	}
 	home, _ := os.UserHomeDir()
-	roots := []string{"/etc/codex/skills", "/opt/codex/skills"}
+	roots := []string{
+		"/etc/codex/skills", filepath.Join("/etc/codex/skills", ".system"),
+		"/opt/codex/skills", filepath.Join("/opt/codex/skills", ".system"),
+	}
 	if home != "" {
-		roots = append(roots, filepath.Join(home, ".agents", "skills"))
+		personal := filepath.Join(home, ".agents", "skills")
+		roots = append(roots, personal, filepath.Join(personal, ".system"))
 	}
 	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 	if codexHome == "" && home != "" {

--- a/hooks/relay/skills_test.go
+++ b/hooks/relay/skills_test.go
@@ -4,8 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -15,680 +13,47 @@ import (
 	"github.com/speakeasy-api/gram/hooks/sdk/models/components"
 )
 
-func TestResolveActivatedSkillPreservesExactRawContent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := filepath.Join(t.TempDir(), "workspace")
-	path := writeSkillManifest(t, filepath.Join(workspace, ".cursor", "skills", "raw-skill"), []byte("---\r\nname: raw-skill\r\n---\r\nbody\r\n"))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
+func TestResolveActivatedSkillUsesNormalizedEventContent(t *testing.T) {
+	content := "---\r\nname: review\r\n---\r\nbody\r\n"
+	event := completedClaudeSkillEvent(t, "review", content)
 
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("raw-skill"))
+	resolved := resolveActivatedSkill(event, activatedSkillPayload("review"))
 
-	require.NotNil(t, resolved)
-	require.Equal(t, "raw-skill", resolved.name)
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "---\r\nname: raw-skill\r\n---\r\nbody\r\n", resolved.content)
-	require.Equal(t, sha256Hex([]byte(resolved.content)), resolved.rawSHA256)
+	require.Equal(t, "review", resolved.name)
+	require.Equal(t, content, resolved.content)
+	require.Equal(t, sha256Hex([]byte(content)), resolved.rawSHA256)
 	require.True(t, resolved.captureReady)
 }
 
-func TestResolveActivatedSkillCapturesEmptyManifest(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(workspace, ".cursor", "skills", "empty"), nil)
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("empty"))
+func TestResolveActivatedSkillCapturesEmptyNormalizedContent(t *testing.T) {
+	resolved := resolveActivatedSkill(completedClaudeSkillEvent(t, "empty", ""), activatedSkillPayload("empty"))
 
 	require.True(t, resolved.captureReady)
 	require.Empty(t, resolved.content)
 	require.Equal(t, sha256Hex(nil), resolved.rawSHA256)
 }
 
-func TestResolveActivatedSkillAcceptsMaximumManifestSize(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	content := []byte(strings.Repeat("a", maxSkillContentBytes))
-	path := writeSkillManifest(t, filepath.Join(workspace, ".cursor", "skills", "maximum"), content)
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("maximum"))
-
-	require.True(t, resolved.captureReady)
-	require.Len(t, resolved.content, maxSkillContentBytes)
-	require.Equal(t, sha256Hex(content), resolved.rawSHA256)
-}
-
-func TestResolveActivatedSkillHashesEntireOversizedManifestButDoesNotCaptureContent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	content := []byte(strings.Repeat("a", maxSkillContentBytes+8192) + "full-file-tail")
-	path := writeSkillManifest(t, filepath.Join(workspace, ".cursor", "skills", "oversized"), content)
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("oversized"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, sha256Hex(content), resolved.rawSHA256)
-	require.Empty(t, resolved.content)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillHashesInvalidUTF8ButDoesNotCaptureContent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	content := []byte{0xff, 0xfe, 0x00, 0x61}
-	path := writeSkillManifest(t, filepath.Join(workspace, ".cursor", "skills", "invalid"), content)
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("invalid"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, sha256Hex(content), resolved.rawSHA256)
-	require.Empty(t, resolved.content)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillClaudePersonalBeatsProject(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	repo := filepath.Join(t.TempDir(), "repo")
-	cwd := filepath.Join(repo, "nested")
-	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
-	personalPath := writeSkillManifest(t, filepath.Join(home, ".claude", "skills", "shared"), []byte("personal"))
-	writeSkillManifest(t, filepath.Join(repo, ".claude", "skills", "shared"), []byte("project"))
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(cwd, "shared"), activatedSkillPayload("shared"))
-
-	require.Equal(t, "personal", resolved.sourceLevel)
-	require.Equal(t, personalPath, resolved.sourcePath)
-	require.Equal(t, "personal", resolved.content)
-}
-
-func TestResolveActivatedSkillClaudeManagedBeatsPersonalAndProject(t *testing.T) {
-	managedRoot := filepath.Join(t.TempDir(), "managed", "skills")
-	original := claudeManagedSkillsRoot
-	claudeManagedSkillsRoot = func() string { return managedRoot }
-	t.Cleanup(func() { claudeManagedSkillsRoot = original })
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	repo := filepath.Join(t.TempDir(), "repo")
-	cwd := filepath.Join(repo, "nested")
-	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
-	managedPath := writeSkillManifest(t, filepath.Join(managedRoot, "shared"), []byte("managed"))
-	writeSkillManifest(t, filepath.Join(home, ".claude", "skills", "shared"), []byte("personal"))
-	writeSkillManifest(t, filepath.Join(repo, ".claude", "skills", "shared"), []byte("project"))
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(cwd, "shared"), activatedSkillPayload("shared"))
-
-	require.Equal(t, "admin", resolved.sourceLevel)
-	require.Equal(t, managedPath, resolved.sourcePath)
-	require.Equal(t, "managed", resolved.content)
-}
-
-func TestResolveActivatedSkillClaudeManagedStatErrorIsNameOnly(t *testing.T) {
-	managedRoot := filepath.Join(t.TempDir(), "managed", "skills")
-	original := claudeManagedSkillsRoot
-	claudeManagedSkillsRoot = func() string { return managedRoot }
-	t.Cleanup(func() { claudeManagedSkillsRoot = original })
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	managedSkill := filepath.Join(managedRoot, "indeterminate")
-	require.NoError(t, os.MkdirAll(managedSkill, 0o755))
-	require.NoError(t, os.Symlink("SKILL.md", filepath.Join(managedSkill, "SKILL.md")))
-	writeSkillManifest(t, filepath.Join(home, ".claude", "skills", "indeterminate"), []byte("personal"))
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(t.TempDir(), "indeterminate"), activatedSkillPayload("indeterminate"))
-
-	require.Equal(t, "indeterminate", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillClaudeFindsProjectAtGitRoot(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	repo := filepath.Join(t.TempDir(), "repo")
-	cwd := filepath.Join(repo, "nested", "deeper")
-	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
-	path := writeSkillManifest(t, filepath.Join(repo, ".claude", "skills", "project-skill"), []byte("project"))
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(cwd, "project-skill"), activatedSkillPayload("project-skill"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-}
-
-func TestResolveActivatedSkillClaudeFollowsSymlinkedProjectSkill(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	repo := filepath.Join(t.TempDir(), "repo")
-	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
-	targetDir := filepath.Join(repo, ".agents", "skills", "linked-skill")
-	writeSkillManifest(t, targetDir, []byte("agents skill body"))
-	skillsRoot := filepath.Join(repo, ".claude", "skills")
-	require.NoError(t, os.MkdirAll(skillsRoot, 0o755))
-	require.NoError(t, os.Symlink(filepath.Join("..", "..", ".agents", "skills", "linked-skill"), filepath.Join(skillsRoot, "linked-skill")))
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(repo, "linked-skill"), activatedSkillPayload("linked-skill"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, filepath.Join(skillsRoot, "linked-skill", "SKILL.md"), resolved.sourcePath)
-	require.Equal(t, "agents skill body", resolved.content)
-	require.Equal(t, sha256Hex([]byte("agents skill body")), resolved.rawSHA256)
-	require.True(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillClaudeUsesConfigDirectory(t *testing.T) {
-	home := t.TempDir()
-	configRoot := filepath.Join(t.TempDir(), "custom-claude")
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", configRoot)
-	path := writeSkillManifest(t, filepath.Join(configRoot, "skills", "configured"), []byte("configured"))
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(t.TempDir(), "configured"), activatedSkillPayload("configured"))
-
-	require.Equal(t, "personal", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-}
-
-func TestResolveActivatedSkillClaudeFollowsConfiguredRootSymlinkWithinConfigTree(t *testing.T) {
-	home := t.TempDir()
-	configRoot := filepath.Join(t.TempDir(), "custom-claude")
-	sharedRoot := filepath.Join(configRoot, "shared-skills")
-	targetPath := writeSkillManifest(t, filepath.Join(sharedRoot, "configured"), []byte("configured"))
-	require.NoError(t, os.Symlink(sharedRoot, filepath.Join(configRoot, "skills")))
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", configRoot)
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(t.TempDir(), "configured"), activatedSkillPayload("configured"))
-
-	require.Equal(t, "personal", resolved.sourceLevel)
-	require.Equal(t, filepath.Join(configRoot, "skills", "configured", "SKILL.md"), resolved.sourcePath)
-	require.Equal(t, "configured", resolved.content)
-	require.Equal(t, sha256Hex([]byte("configured")), resolved.rawSHA256)
-	require.True(t, resolved.captureReady)
-	require.Equal(t, filepath.Join(configRoot, "skills"), resolved.root)
-	resolvedPath, err := filepath.EvalSymlinks(resolved.sourcePath)
+func TestResolveActivatedSkillPreEventIsNameOnly(t *testing.T) {
+	input, err := json.Marshal(map[string]string{"skill": "review"})
 	require.NoError(t, err)
-	targetPath, err = filepath.EvalSymlinks(targetPath)
-	require.NoError(t, err)
-	require.Equal(t, targetPath, resolvedPath)
-}
-
-func TestResolveActivatedSkillClaudeRejectsConfiguredRootSymlinkOutsideConfigTree(t *testing.T) {
-	home := t.TempDir()
-	sandbox := t.TempDir()
-	configRoot := filepath.Join(sandbox, "custom-claude")
-	externalRoot := filepath.Join(sandbox, "external-skills")
-	writeSkillManifest(t, filepath.Join(externalRoot, "configured"), []byte("outside configured tree"))
-	require.NoError(t, os.MkdirAll(configRoot, 0o755))
-	require.NoError(t, os.Symlink(externalRoot, filepath.Join(configRoot, "skills")))
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", configRoot)
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(t.TempDir(), "configured"), activatedSkillPayload("configured"))
-
-	require.Equal(t, "configured", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillClaudeUsesApplicablePluginRecord(t *testing.T) {
-	home := t.TempDir()
-	configRoot := filepath.Join(t.TempDir(), "claude")
-	repo := filepath.Join(t.TempDir(), "repo")
-	cwd := filepath.Join(repo, "nested")
-	projectInstall := filepath.Join(t.TempDir(), "project-plugin")
-	userInstall := filepath.Join(t.TempDir(), "user-plugin")
-	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_CONFIG_DIR", configRoot)
-	path := writeSkillManifest(t, filepath.Join(projectInstall, "skills", "review"), []byte("project plugin"))
-	writeSkillManifest(t, filepath.Join(userInstall, "skills", "review"), []byte("user plugin"))
-	registry := map[string]any{
-		"version": 2,
-		"plugins": map[string]any{
-			"quality@marketplace": []map[string]string{
-				{"scope": "user", "installPath": userInstall},
-				{"scope": "project", "projectPath": repo, "installPath": projectInstall},
-			},
-		},
+	event := &agenthooks.ToolPreEvent{
+		Event: agenthooks.Event{Provider: agenthooks.ProviderClaudeCode, Kind: agenthooks.KindToolPre},
+		Tool:  agenthooks.ToolCall{Name: "Skill", Input: input},
 	}
-	writeJSONFile(t, filepath.Join(configRoot, "plugins", "installed_plugins.json"), registry)
-
-	resolved := resolveActivatedSkill(claudeSkillEvent(cwd, "quality:review"), activatedSkillPayload("quality:review"))
-
-	require.Equal(t, "quality:review", resolved.name)
-	require.Equal(t, "plugin", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "project plugin", resolved.content)
-}
-
-func TestResolveActivatedSkillCodexAbsoluteReadPath(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	repo := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(repo, ".agents", "skills", "absolute"), []byte("absolute"))
-	event := codexToolEvent(t, repo, "Read", map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("absolute"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "absolute", resolved.content)
-}
-
-func TestResolveActivatedSkillCodexRelativeShellPath(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	repo := t.TempDir()
-	relative := filepath.Join(".agents", "skills", "relative", "SKILL.md")
-	path := writeSkillManifest(t, filepath.Dir(filepath.Join(repo, relative)), []byte("relative"))
-	event := codexToolEvent(t, repo, "Bash", map[string]string{"command": "cat " + relative})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("relative"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "relative", resolved.content)
-}
-
-func TestResolveActivatedSkillCodexPromptReturnsWinningRootPath(t *testing.T) {
-	home := t.TempDir()
-	codexHome := filepath.Join(t.TempDir(), "codex")
-	t.Setenv("HOME", home)
-	t.Setenv("CODEX_HOME", codexHome)
-	path := writeSkillManifest(t, filepath.Join(codexHome, "skills", ".system", "bundled"), []byte("bundled"))
-	event := &agenthooks.PromptEvent{
-		Event:  agenthooks.Event{Provider: agenthooks.ProviderCodex, Kind: agenthooks.KindPromptSubmitted, Session: agenthooks.SessionInfo{CWD: t.TempDir()}},
-		Prompt: "use $bundled",
-	}
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("bundled"))
-
-	require.Equal(t, "system", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "bundled", resolved.content)
-}
-
-func TestResolveActivatedSkillCursorProjectCurrentKey(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(workspace, ".cursor", "skills", "current"), []byte("current"))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("current"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-}
-
-func TestResolveActivatedSkillFollowsSymlinkedSkillDir(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	sharedDir := filepath.Join(workspace, ".agents", "skills", "shared")
-	writeSkillManifest(t, sharedDir, []byte("shared skill body"))
-	root := filepath.Join(workspace, ".cursor", "skills")
-	require.NoError(t, os.MkdirAll(root, 0o755))
-	linkedDir := filepath.Join(root, "linked")
-	require.NoError(t, os.Symlink(sharedDir, linkedDir))
-	linkedPath := filepath.Join(linkedDir, "SKILL.md")
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": linkedPath})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("linked"))
-
-	require.Equal(t, "linked", resolved.name)
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, linkedPath, resolved.sourcePath)
-	require.Equal(t, "shared skill body", resolved.content)
-	require.Equal(t, sha256Hex([]byte("shared skill body")), resolved.rawSHA256)
-	require.True(t, resolved.captureReady)
-
-	reopened := captureResolvedSkill(&resolvedSkill{}, skillLocation{path: resolved.sourcePath, root: resolved.root})
-	require.Equal(t, "shared skill body", reopened.content)
-	require.Equal(t, resolved.rawSHA256, reopened.rawSHA256)
-	require.True(t, reopened.captureReady)
-}
-
-func TestResolveActivatedSkillFollowsProviderRootLinkedToSiblingSkillTree(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	targetDir := filepath.Join(workspace, ".agents", "skills", "root-linked")
-	writeSkillManifest(t, targetDir, []byte("root-linked skill body"))
-	cursorRoot := filepath.Join(workspace, ".cursor")
-	require.NoError(t, os.MkdirAll(cursorRoot, 0o755))
-	require.NoError(t, os.Symlink(filepath.Join("..", ".agents", "skills"), filepath.Join(cursorRoot, "skills")))
-	path := filepath.Join(cursorRoot, "skills", "root-linked", "SKILL.md")
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("root-linked"))
-
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "root-linked skill body", resolved.content)
-	require.Equal(t, sha256Hex([]byte("root-linked skill body")), resolved.rawSHA256)
-	require.True(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillFollowsManifestSymlink(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	shared := filepath.Join(workspace, ".cursor", "skills", "shared", "guide.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(shared), 0o755))
-	require.NoError(t, os.WriteFile(shared, []byte("shared guide body"), 0o644))
-	path := filepath.Join(workspace, ".cursor", "skills", "linked", "SKILL.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.Symlink(shared, path))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("linked"))
-
-	require.Equal(t, "linked", resolved.name)
-	require.Equal(t, "project", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-	require.Equal(t, "shared guide body", resolved.content)
-	require.Equal(t, sha256Hex([]byte("shared guide body")), resolved.rawSHA256)
-	require.True(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillRejectsWorkspaceFileOutsideSkillTrees(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	target := filepath.Join(workspace, ".env")
-	require.NoError(t, os.WriteFile(target, []byte("workspace configuration"), 0o600))
-	path := filepath.Join(workspace, ".cursor", "skills", "workspace-file", "SKILL.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.Symlink(target, path))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("workspace-file"))
-
-	require.Equal(t, "workspace-file", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillRejectsProviderRootOutsideSkillTrees(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	shared := filepath.Join(workspace, ".agents", "skills", "shared", "guide.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(shared), 0o755))
-	require.NoError(t, os.WriteFile(shared, []byte("shared guide"), 0o644))
-	redirectedRoot := filepath.Join(workspace, "configuration")
-	pathWithinRedirectedRoot := filepath.Join(redirectedRoot, "root-target", "SKILL.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(pathWithinRedirectedRoot), 0o755))
-	require.NoError(t, os.Symlink(shared, pathWithinRedirectedRoot))
-	cursorRoot := filepath.Join(workspace, ".cursor")
-	require.NoError(t, os.MkdirAll(cursorRoot, 0o755))
-	require.NoError(t, os.Symlink(redirectedRoot, filepath.Join(cursorRoot, "skills")))
-	path := filepath.Join(cursorRoot, "skills", "root-target", "SKILL.md")
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("root-target"))
-
-	require.Equal(t, "root-target", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillRejectsWorkspaceDirectoryTargetOutsideSkillTrees(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	gitDir := filepath.Join(workspace, ".git")
-	require.NoError(t, os.MkdirAll(gitDir, 0o755))
-	configPath := filepath.Join(gitDir, "config")
-	require.NoError(t, os.WriteFile(configPath, []byte("repository configuration"), 0o600))
-	require.NoError(t, os.Symlink("config", filepath.Join(gitDir, "SKILL.md")))
-	skillsRoot := filepath.Join(workspace, ".cursor", "skills")
-	require.NoError(t, os.MkdirAll(skillsRoot, 0o755))
-	linkedDir := filepath.Join(skillsRoot, "repository-config")
-	require.NoError(t, os.Symlink(gitDir, linkedDir))
-	path := filepath.Join(linkedDir, "SKILL.md")
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("repository-config"))
-
-	require.Equal(t, "repository-config", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillRejectsPersonalFileOutsideSkillTrees(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CODEX_HOME", "")
-	target := filepath.Join(home, "auth.json")
-	require.NoError(t, os.WriteFile(target, []byte("personal configuration"), 0o600))
-	path := filepath.Join(home, ".codex", "skills", "personal-file", "SKILL.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.Symlink(target, path))
-	event := codexToolEvent(t, t.TempDir(), "Read", map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("personal-file"))
-
-	require.Equal(t, "personal-file", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillPluginRootNamedSkillsRemainsExact(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	tree := t.TempDir()
-	plugin := filepath.Join(tree, "skills")
-	writeJSONFile(t, filepath.Join(plugin, ".cursor-plugin", "plugin.json"), map[string]string{"name": "quality"})
-	target := filepath.Join(tree, "shared.md")
-	require.NoError(t, os.WriteFile(target, []byte("shared content"), 0o600))
-	path := filepath.Join(plugin, "skills", "review", "SKILL.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.Symlink(target, path))
-	workspace := t.TempDir()
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
 
 	resolved := resolveActivatedSkill(event, activatedSkillPayload("review"))
 
 	require.Equal(t, "review", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
+	require.False(t, resolved.captureReady)
 	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
 }
 
-func TestResolveActivatedSkillRejectsSymlinkEscape(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	external := filepath.Join(t.TempDir(), "secret")
-	require.NoError(t, os.WriteFile(external, []byte("private key material"), 0o600))
-	path := filepath.Join(workspace, ".cursor", "skills", "escape", "SKILL.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.Symlink(external, path))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
+func TestResolveActivatedSkillRejectsOversizedNormalizedContent(t *testing.T) {
+	content := strings.Repeat("x", maxSkillContentBytes+1)
+	resolved := resolveActivatedSkill(completedClaudeSkillEvent(t, "large", content), activatedSkillPayload("large"))
 
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("escape"))
-
-	require.NotNil(t, resolved)
 	require.False(t, resolved.captureReady)
-	require.Empty(t, resolved.content)
 	require.Empty(t, resolved.rawSHA256)
-	require.Empty(t, resolved.sourcePath)
-}
-
-func TestResolveActivatedSkillCursorPluginLegacyKey(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	plugin := filepath.Join(t.TempDir(), "plugin")
-	path := writeSkillManifest(t, filepath.Join(plugin, "skills", "legacy"), []byte("plugin"))
-	require.NoError(t, os.MkdirAll(filepath.Join(plugin, ".cursor-plugin"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(plugin, ".cursor-plugin", "plugin.json"), []byte(`{"name":"plugin"}`), 0o644))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("legacy"))
-
-	require.Equal(t, "plugin", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-}
-
-func TestResolveActivatedSkillCursorPluginInsideWorkspace(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	plugin := filepath.Join(workspace, "plugins", "quality")
-	path := writeSkillManifest(t, filepath.Join(plugin, "skills", "review"), []byte("plugin"))
-	writeJSONFile(t, filepath.Join(plugin, ".cursor-plugin", "plugin.json"), map[string]string{"name": "quality"})
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("review"))
-
-	require.Equal(t, "plugin", resolved.sourceLevel)
-	require.Equal(t, path, resolved.sourcePath)
-}
-
-func TestContainingWorkspaceRootChoosesLongestNestedRoot(t *testing.T) {
-	outer := t.TempDir()
-	inner := filepath.Join(outer, "nested", "workspace")
-	path := filepath.Join(inner, ".cursor", "skills", "nested", "SKILL.md")
-
-	require.Equal(t, inner, containingWorkspaceRoot(path, []string{outer, inner}))
-}
-
-func TestResolveActivatedSkillCursorDocsSkillsIsNameOnly(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(workspace, "docs", "skills", "example"), []byte("documentation"))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("example"))
-
-	require.Equal(t, "example", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillCursorUnknownExternalPathIsNameOnly(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	external := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(external, "skills", "unknown"), []byte("external"))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("unknown"))
-
-	require.Equal(t, "unknown", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillCodexUnknownExternalPathIsNameOnly(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("CODEX_HOME", t.TempDir())
-	repo := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
-	external := t.TempDir()
-	path := writeSkillManifest(t, filepath.Join(external, "skills", "unknown"), []byte("external"))
-	event := codexToolEvent(t, repo, "Read", map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("unknown"))
-
-	require.Equal(t, "unknown", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillCodexPromptDuplicateCandidatesIsNameOnly(t *testing.T) {
-	home := t.TempDir()
-	codexHome := filepath.Join(t.TempDir(), "codex")
-	t.Setenv("HOME", home)
-	t.Setenv("CODEX_HOME", codexHome)
-	writeSkillManifest(t, filepath.Join(home, ".agents", "skills", "duplicate"), []byte("agents"))
-	writeSkillManifest(t, filepath.Join(codexHome, "skills", "duplicate"), []byte("codex"))
-	event := &agenthooks.PromptEvent{
-		Event:  agenthooks.Event{Provider: agenthooks.ProviderCodex, Kind: agenthooks.KindPromptSubmitted, Session: agenthooks.SessionInfo{CWD: t.TempDir()}},
-		Prompt: "use $duplicate",
-	}
-	payload := buildEnvelope(event, "host")
-
-	resolved := resolveActivatedSkill(event, &payload)
-
-	require.NotNil(t, payload.Data.Skill)
-	require.Equal(t, "duplicate", payload.Data.Skill.Name)
-	require.Equal(t, "duplicate", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.False(t, resolved.captureReady)
-}
-
-func TestCodexProjectSearchStopsAfterGitRoot(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
-	outer := t.TempDir()
-	repo := filepath.Join(outer, "repo")
-	cwd := filepath.Join(repo, "nested")
-	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
-	writeSkillManifest(t, filepath.Join(outer, ".agents", "skills", "outside"), []byte("outside"))
-
-	require.False(t, codexSkillExists("outside", cwd))
-	require.Empty(t, codexPromptSkillName("use $outside", cwd))
-}
-
-func TestResolveActivatedSkillRejectsNonRegularManifest(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	workspace := t.TempDir()
-	path := filepath.Join(workspace, ".cursor", "skills", "directory", "SKILL.md")
-	require.NoError(t, os.MkdirAll(path, 0o755))
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("directory"))
-
-	require.Equal(t, "directory", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.False(t, resolved.captureReady)
-}
-
-func TestResolveActivatedSkillMissingManifestDegradesToNameOnly(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	workspace := t.TempDir()
-	path := filepath.Join(workspace, ".cursor", "skills", "missing", "SKILL.md")
-	event := cursorReadEvent(t, workspace, []string{workspace}, map[string]string{"file_path": path})
-
-	resolved := resolveActivatedSkill(event, activatedSkillPayload("missing"))
-
-	require.Equal(t, "missing", resolved.name)
-	require.Empty(t, resolved.sourceLevel)
-	require.Empty(t, resolved.sourcePath)
-	require.Empty(t, resolved.rawSHA256)
-	require.Empty(t, resolved.content)
-	require.False(t, resolved.captureReady)
 }
 
 func TestResolveActivatedSkillWithoutSkillReturnsNil(t *testing.T) {
@@ -697,19 +62,17 @@ func TestResolveActivatedSkillWithoutSkillReturnsNil(t *testing.T) {
 	require.Nil(t, resolveActivatedSkill(nil, &components.IngestRequestBody{Data: &components.HookIngestData{}}))
 }
 
-func activatedSkillPayload(name string) *components.IngestRequestBody {
-	return &components.IngestRequestBody{
-		Data: &components.HookIngestData{
-			Skill: &components.HookSkillData{Name: name},
-		},
-	}
-}
-
-func claudeSkillEvent(cwd, name string) *agenthooks.ToolPreEvent {
-	input, _ := json.Marshal(map[string]string{"skill": name})
-	return &agenthooks.ToolPreEvent{
-		Event: agenthooks.Event{Provider: agenthooks.ProviderClaudeCode, Kind: agenthooks.KindToolPre, Session: agenthooks.SessionInfo{CWD: cwd}},
-		Tool:  agenthooks.ToolCall{Name: "Skill", Input: input},
+func completedClaudeSkillEvent(t *testing.T, name, content string) *agenthooks.ToolPostEvent {
+	t.Helper()
+	input, err := json.Marshal(map[string]string{"skill": name})
+	require.NoError(t, err)
+	output, err := json.Marshal(content)
+	require.NoError(t, err)
+	return &agenthooks.ToolPostEvent{
+		Event:  agenthooks.Event{Provider: agenthooks.ProviderClaudeCode, Kind: agenthooks.KindToolPost},
+		Tool:   agenthooks.ToolCall{Name: "Skill", Input: input},
+		Output: output,
+		Failed: false,
 	}
 }
 
@@ -719,37 +82,15 @@ func codexToolEvent(t *testing.T, cwd, name string, input any) *agenthooks.ToolP
 	require.NoError(t, err)
 	return &agenthooks.ToolPreEvent{
 		Event: agenthooks.Event{Provider: agenthooks.ProviderCodex, Kind: agenthooks.KindToolPre, Session: agenthooks.SessionInfo{CWD: cwd}},
-		Tool:  agenthooks.ToolCall{Name: name, Input: encoded},
+		Tool:  agenthooks.ToolCall{Name: name, Canonical: agenthooks.CanonicalToolFor(name), Input: encoded},
 	}
 }
 
-func cursorReadEvent(t *testing.T, cwd string, workspaceRoots []string, input any) *agenthooks.ToolPreEvent {
-	t.Helper()
-	encoded, err := json.Marshal(input)
-	require.NoError(t, err)
-	return &agenthooks.ToolPreEvent{
-		Event: agenthooks.Event{Provider: agenthooks.ProviderCursor, Kind: agenthooks.KindToolPre, Session: agenthooks.SessionInfo{CWD: cwd, WorkspaceRoots: workspaceRoots}},
-		Tool:  agenthooks.ToolCall{Name: "Read", Input: encoded},
-	}
-}
-
-func writeSkillManifest(t *testing.T, dir string, content []byte) string {
-	t.Helper()
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	path := filepath.Join(dir, "SKILL.md")
-	require.NoError(t, os.WriteFile(path, content, 0o644))
-	return path
-}
-
-func writeJSONFile(t *testing.T, path string, value any) {
-	t.Helper()
-	data, err := json.Marshal(value)
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	require.NoError(t, os.WriteFile(path, data, 0o644))
+func activatedSkillPayload(name string) *components.IngestRequestBody {
+	return &components.IngestRequestBody{Data: &components.HookIngestData{Skill: &components.HookSkillData{Name: name, Source: nil}}}
 }
 
 func sha256Hex(content []byte) string {
-	sum := sha256.Sum256(content)
-	return hex.EncodeToString(sum[:])
+	digest := sha256.Sum256(content)
+	return hex.EncodeToString(digest[:])
 }

--- a/hooks/relay/skillupload.go
+++ b/hooks/relay/skillupload.go
@@ -2,75 +2,22 @@ package relay
 
 import (
 	"context"
-	"flag"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"io"
 	"net/url"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
+	"unicode/utf8"
 )
 
 const maxSkillUploadAPIKeyBytes = 256
 
-// skillUploadTask identifies content the detached worker must reopen. Only the
-// credential is private; content never crosses the process boundary.
 type skillUploadTask struct {
-	ServerURL  string
-	Project    string
-	APIKey     string
-	RawSHA256  string
-	SourcePath string
-	SourceRoot string
-}
-
-var newSkillUploadCommand = func(task skillUploadTask) (*exec.Cmd, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		return nil, fmt.Errorf("resolve executable: %w", err)
-	}
-	cmd := exec.Command(exe, "upload-skill",
-		"--server-url="+task.ServerURL,
-		"--project="+task.Project,
-		"--raw-sha256="+task.RawSHA256,
-		"--source-path="+task.SourcePath,
-		"--source-root="+task.SourceRoot,
-	)
-	cmd.Env = envWithoutCredential(os.Environ(), task.APIKey)
-	return cmd, nil
-}
-
-// startSkillUploadProcess starts a detached child without copying content. The
-// child reopens and verifies the manifest, leaving only process creation on the
-// gating path. agenthooks.Main calls os.Exit as soon as the handler returns, so
-// cmd.Start cannot safely move to a goroutine. The bounded credential is
-// prefilled into an anonymous pipe so it remains available after this process
-// exits without appearing in argv, the environment, or a file.
-var startSkillUploadProcess = func(task skillUploadTask) error {
-	cmd, err := newSkillUploadCommand(task)
-	if err != nil {
-		return err
-	}
-	credential, err := prefilledSkillUploadCredential(task.APIKey)
-	if err != nil {
-		return err
-	}
-	cmd.Stdin = credential
-	cmd.SysProcAttr = drainSysProcAttr()
-	if err := cmd.Start(); err != nil {
-		_ = credential.Close()
-		return fmt.Errorf("start skill upload: %w", err)
-	}
-	closeErr := credential.Close()
-	releaseErr := cmd.Process.Release()
-	if closeErr != nil {
-		return fmt.Errorf("close skill upload credential pipe: %w", closeErr)
-	}
-	if releaseErr != nil {
-		return fmt.Errorf("release skill upload process: %w", releaseErr)
-	}
-	return nil
+	ServerURL string
+	Project   string
+	APIKey    string
+	RawSHA256 string
+	Content   string
 }
 
 func requestedSkillUploadTask(c creds, res ingestResult, skill *resolvedSkill) (skillUploadTask, bool, error) {
@@ -79,12 +26,11 @@ func requestedSkillUploadTask(c creds, res ingestResult, skill *resolvedSkill) (
 		return skillUploadTask{}, false, nil
 	}
 	task := skillUploadTask{
-		ServerURL:  c.ServerURL,
-		Project:    c.Project,
-		APIKey:     c.APIKey,
-		RawSHA256:  skill.rawSHA256,
-		SourcePath: skill.sourcePath,
-		SourceRoot: skill.root,
+		ServerURL: c.ServerURL,
+		Project:   c.Project,
+		APIKey:    c.APIKey,
+		RawSHA256: skill.rawSHA256,
+		Content:   skill.content,
 	}
 	if !validSkillUploadTask(task) {
 		return skillUploadTask{}, false, fmt.Errorf("invalid skill upload task")
@@ -92,18 +38,6 @@ func requestedSkillUploadTask(c creds, res ingestResult, skill *resolvedSkill) (
 	return task, true, nil
 }
 
-// startSkillContentUpload hands live traffic to a detached process so content
-// upload never extends the hook's gating path.
-func startSkillContentUpload(c creds, res ingestResult, skill *resolvedSkill) error {
-	task, requested, err := requestedSkillUploadTask(c, res, skill)
-	if err != nil || !requested {
-		return err
-	}
-	return startSkillUploadProcess(task)
-}
-
-// uploadSkillContent completes replay uploads before their spool entry is
-// removed, keeping the task retryable when verification or upload fails.
 func uploadSkillContent(ctx context.Context, c creds, res ingestResult, skill *resolvedSkill) error {
 	task, requested, err := requestedSkillUploadTask(c, res, skill)
 	if err != nil || !requested {
@@ -113,49 +47,16 @@ func uploadSkillContent(ctx context.Context, c creds, res ingestResult, skill *r
 }
 
 var executeSkillUpload = func(ctx context.Context, task skillUploadTask) error {
-	skill := captureResolvedSkill(&resolvedSkill{}, skillLocation{path: task.SourcePath, level: "", root: task.SourceRoot})
-	if !skill.captureReady || skill.rawSHA256 != task.RawSHA256 {
-		return fmt.Errorf("skill manifest no longer matches captured content")
-	}
 	c := creds{ServerURL: task.ServerURL, APIKey: task.APIKey, Project: task.Project, Email: "", Org: "", Source: credEnv}
-	return newClient(task.ServerURL).uploadSkillContent(ctx, c, task.RawSHA256, skill.content)
-}
-
-// RunSkillUpload reads one bounded credential, reopens one manifest from a
-// trusted parent-supplied root, and uploads it only if its full raw hash still
-// matches the accepted activation.
-func RunSkillUpload(ctx context.Context, args []string, credential io.Reader) int {
-	fs := flag.NewFlagSet("upload-skill", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	task := skillUploadTask{}
-	fs.StringVar(&task.ServerURL, "server-url", "", "")
-	fs.StringVar(&task.Project, "project", "", "")
-	fs.StringVar(&task.RawSHA256, "raw-sha256", "", "")
-	fs.StringVar(&task.SourcePath, "source-path", "", "")
-	fs.StringVar(&task.SourceRoot, "source-root", "", "")
-	if fs.Parse(args) != nil || fs.NArg() != 0 {
-		return 1
-	}
-	key, ok := readSkillUploadCredential(credential)
-	if !ok {
-		return 1
-	}
-	task.APIKey = key
-	if !validSkillUploadTask(task) {
-		return 1
-	}
-	if err := executeSkillUpload(ctx, task); err != nil {
-		return 1
-	}
-	return 0
+	return newClient(task.ServerURL).uploadSkillContent(ctx, c, task.RawSHA256, task.Content)
 }
 
 func validSkillUploadTask(task skillUploadTask) bool {
 	if task.APIKey == "" || len(task.APIKey) > maxSkillUploadAPIKeyBytes || strings.ContainsAny(task.APIKey+task.Project, "\r\n") ||
-		len(task.RawSHA256) != 64 || !filepath.IsAbs(task.SourcePath) || !filepath.IsAbs(task.SourceRoot) {
+		len(task.RawSHA256) != 64 || len(task.Content) > maxSkillContentBytes || !utf8.ValidString(task.Content) {
 		return false
 	}
-	for _, arg := range []string{task.ServerURL, task.Project, task.RawSHA256, task.SourcePath, task.SourceRoot} {
+	for _, arg := range []string{task.ServerURL, task.Project, task.RawSHA256} {
 		if strings.Contains(arg, task.APIKey) {
 			return false
 		}
@@ -163,50 +64,10 @@ func validSkillUploadTask(task skillUploadTask) bool {
 	if !validRawSHA256(task.RawSHA256) {
 		return false
 	}
-	u, err := url.Parse(task.ServerURL)
-	if err != nil || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || insecureServerURL(task.ServerURL) {
+	digest := sha256.Sum256([]byte(task.Content))
+	if hex.EncodeToString(digest[:]) != task.RawSHA256 {
 		return false
 	}
-	return true
-}
-
-func prefilledSkillUploadCredential(key string) (*os.File, error) {
-	if key == "" || len(key) > maxSkillUploadAPIKeyBytes || strings.ContainsAny(key, "\r\n") {
-		return nil, fmt.Errorf("invalid skill upload credential")
-	}
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		return nil, fmt.Errorf("open skill upload credential pipe: %w", err)
-	}
-	if _, err := io.WriteString(writer, key); err != nil {
-		_ = reader.Close()
-		_ = writer.Close()
-		return nil, fmt.Errorf("prefill skill upload credential pipe: %w", err)
-	}
-	if err := writer.Close(); err != nil {
-		_ = reader.Close()
-		return nil, fmt.Errorf("close skill upload credential writer: %w", err)
-	}
-	return reader, nil
-}
-
-func readSkillUploadCredential(input io.Reader) (string, bool) {
-	if input == nil {
-		return "", false
-	}
-	key, err := io.ReadAll(io.LimitReader(input, maxSkillUploadAPIKeyBytes+1))
-	if err != nil || len(key) == 0 || len(key) > maxSkillUploadAPIKeyBytes || strings.ContainsAny(string(key), "\r\n") {
-		return "", false
-	}
-	return string(key), true
-}
-
-func envWithoutCredential(env []string, credential string) []string {
-	result := make([]string, 0, len(env))
-	for _, value := range env {
-		if credential == "" || !strings.Contains(value, credential) {
-			result = append(result, value)
-		}
-	}
-	return result
+	u, err := url.Parse(task.ServerURL)
+	return err == nil && u.Host != "" && u.User == nil && u.RawQuery == "" && u.Fragment == "" && !insecureServerURL(task.ServerURL)
 }

--- a/hooks/relay/skillupload_test.go
+++ b/hooks/relay/skillupload_test.go
@@ -1,300 +1,64 @@
 package relay
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestMaybeUploadSkillContentHandsOffExactLocation(t *testing.T) {
-	task := skillUploadTaskForTest(t, "https://example.com", "project", "secret-key", "# Exact skill\n")
-	capturedTasks := captureSkillUploadTasks(t)
-	skill := &resolvedSkill{
-		name:         "skill",
-		sourceLevel:  "project",
-		sourcePath:   task.SourcePath,
-		rawSHA256:    task.RawSHA256,
-		content:      "# Exact skill\n",
-		captureReady: true,
-		root:         task.SourceRoot,
-	}
-
-	require.NoError(t, startSkillContentUpload(creds{ServerURL: task.ServerURL, APIKey: task.APIKey, Project: task.Project, Email: "", Org: "", Source: credCache}, acceptedSkillUploadResult(task.RawSHA256, true), skill))
-	require.Equal(t, []skillUploadTask{task}, capturedTasks())
-
-	skill.captureReady = false
-	require.NoError(t, startSkillContentUpload(creds{ServerURL: task.ServerURL, APIKey: task.APIKey, Project: task.Project, Email: "", Org: "", Source: credCache}, acceptedSkillUploadResult(task.RawSHA256, true), skill))
-	require.Len(t, capturedTasks(), 1)
-}
-
-func TestRunSkillUploadReopensAndUploadsExactContent(t *testing.T) {
+func TestUploadSkillContentUsesNormalizedContent(t *testing.T) {
 	content := "# Skill\n\nExact content.\n"
 	type observedRequest struct {
-		Method   string
-		Path     string
-		GramKeys []string
-		Projects []string
-		Body     map[string]any
+		GramKey string
+		Project string
+		Body    map[string]any
 	}
 	observed := make(chan observedRequest, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var body map[string]any
-		_ = json.NewDecoder(req.Body).Decode(&body)
-		observed <- observedRequest{Method: req.Method, Path: req.URL.Path, GramKeys: req.Header.Values("Gram-Key"), Projects: req.Header.Values("Gram-Project"), Body: body}
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		observed <- observedRequest{GramKey: req.Header.Get("Gram-Key"), Project: req.Header.Get("Gram-Project"), Body: body}
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
-	task := skillUploadTaskForTest(t, server.URL, "project", "key", content)
+	task := skillUploadTaskForTest(server.URL, "project", "key", content)
+	skill := &resolvedSkill{name: "skill", rawSHA256: task.RawSHA256, content: content, captureReady: true}
 
-	require.Equal(t, 0, runSkillUploadTask(t, task))
+	require.NoError(t, uploadSkillContent(t.Context(), creds{ServerURL: task.ServerURL, APIKey: task.APIKey, Project: task.Project, Email: "", Org: "", Source: credCache}, acceptedSkillUploadResult(task.RawSHA256, true), skill))
 	request := <-observed
-	require.Equal(t, http.MethodPost, request.Method)
-	require.Equal(t, "/rpc/hooks.uploadSkillContent", request.Path)
-	require.Equal(t, []string{"key"}, request.GramKeys)
-	require.Equal(t, []string{"project"}, request.Projects)
+	require.Equal(t, "key", request.GramKey)
+	require.Equal(t, "project", request.Project)
 	require.Equal(t, map[string]any{"content": content, "raw_sha256": task.RawSHA256, "schema_version": "hook.skill-content.v1"}, request.Body)
 }
 
-func TestRunSkillUploadRejectsChangedManifestWithoutNetwork(t *testing.T) {
+func TestUploadSkillContentRejectsMismatchedContentWithoutNetwork(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		requests.Add(1)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(server.Close)
-	task := skillUploadTaskForTest(t, server.URL, "project", "key", "original")
-	require.NoError(t, os.WriteFile(task.SourcePath, []byte("changed"), 0o600))
+	task := skillUploadTaskForTest(server.URL, "project", "key", "original")
+	skill := &resolvedSkill{name: "skill", rawSHA256: task.RawSHA256, content: "changed", captureReady: true}
 
-	require.NotZero(t, runSkillUploadTask(t, task))
+	require.Error(t, uploadSkillContent(t.Context(), creds{ServerURL: task.ServerURL, APIKey: task.APIKey, Project: task.Project, Email: "", Org: "", Source: credCache}, acceptedSkillUploadResult(task.RawSHA256, true), skill))
 	require.Zero(t, requests.Load())
 }
 
-func TestRunSkillUploadRejectsInvalidArgumentsWithoutNetwork(t *testing.T) {
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests.Add(1)
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-	task := skillUploadTaskForTest(t, server.URL, "project", "key", "content")
+func TestUploadSkillContentSkipsUnrequestedContent(t *testing.T) {
+	task := skillUploadTaskForTest("https://example.com", "project", "key", "content")
+	skill := &resolvedSkill{name: "skill", rawSHA256: task.RawSHA256, content: task.Content, captureReady: true}
 
-	require.NotZero(t, RunSkillUpload(t.Context(), nil, strings.NewReader(task.APIKey)))
-	require.NotZero(t, RunSkillUpload(t.Context(), append(skillUploadArgs(task), "extra"), strings.NewReader(task.APIKey)))
-	badHash := task
-	badHash.RawSHA256 = strings.Repeat("A", 64)
-	require.NotZero(t, RunSkillUpload(t.Context(), skillUploadArgs(badHash), strings.NewReader(task.APIKey)))
-	require.NotZero(t, RunSkillUpload(t.Context(), skillUploadArgs(task), strings.NewReader(strings.Repeat("x", maxSkillUploadAPIKeyBytes+1))))
-	require.Zero(t, requests.Load())
+	require.NoError(t, uploadSkillContent(t.Context(), creds{ServerURL: task.ServerURL, APIKey: task.APIKey, Project: task.Project, Email: "", Org: "", Source: credCache}, acceptedSkillUploadResult(task.RawSHA256, false), skill))
 }
 
-func TestRunSkillUploadOmitsEmptyProjectHeader(t *testing.T) {
-	var keys, projects []string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		keys = req.Header.Values("Gram-Key")
-		projects = req.Header.Values("Gram-Project")
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-	task := skillUploadTaskForTest(t, server.URL, "", "key", "content")
-
-	require.Equal(t, 0, runSkillUploadTask(t, task))
-	require.Equal(t, []string{"key"}, keys)
-	require.Empty(t, projects)
-}
-
-func TestRunSkillUploadDoesNotFollowRedirect(t *testing.T) {
-	var targetRequests atomic.Int32
-	var targetKey, sourceKey atomic.Value
-	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		targetRequests.Add(1)
-		targetKey.Store(req.Header.Get("Gram-Key"))
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(target.Close)
-	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		sourceKey.Store(req.Header.Get("Gram-Key"))
-		w.Header().Set("Location", target.URL)
-		w.WriteHeader(http.StatusFound)
-	}))
-	t.Cleanup(redirect.Close)
-	task := skillUploadTaskForTest(t, redirect.URL, "project", "secret", "content")
-
-	require.NotZero(t, runSkillUploadTask(t, task))
-	require.Equal(t, "secret", sourceKey.Load())
-	require.Zero(t, targetRequests.Load())
-	require.Nil(t, targetKey.Load())
-}
-
-func TestNewSkillUploadCommandKeepsCredentialOutOfArgsAndEnvironment(t *testing.T) {
-	task := skillUploadTaskForTest(t, "https://example.com", "project", "exact-secret-key-for-child-handoff", "private content")
-	t.Setenv("GRAM_HOOKS_API_KEY", task.APIKey)
-	t.Setenv("GRAM_HOOKS_ORG_KEY", task.APIKey)
-	cmd, err := newSkillUploadCommand(task)
-	require.NoError(t, err)
-
-	args := strings.Join(cmd.Args, "\x00")
-	require.NotContains(t, args, task.APIKey)
-	require.NotContains(t, args, "private content")
-	require.Contains(t, args, task.SourcePath)
-	require.NotContains(t, strings.Join(cmd.Env, "\x00"), task.APIKey)
-}
-
-func TestRunSkillUploadRetriesTransientServerError(t *testing.T) {
-	original := retryMaxElapsedMS
-	retryMaxElapsedMS = 2_500
-	t.Cleanup(func() { retryMaxElapsedMS = original })
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if requests.Add(1) == 1 {
-			http.Error(w, "unavailable", http.StatusServiceUnavailable)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	require.Zero(t, runSkillUploadTask(t, skillUploadTaskForTest(t, server.URL, "project", "key", "retry content")))
-	require.Equal(t, int32(2), requests.Load())
-}
-
-func TestRunSkillUploadRetriesDroppedConnection(t *testing.T) {
-	var requests atomic.Int32
-	var successfulKey, successfulProject atomic.Value
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if requests.Add(1) == 1 {
-			hijacker, ok := w.(http.Hijacker)
-			require.True(t, ok)
-			conn, _, err := hijacker.Hijack()
-			require.NoError(t, err)
-			require.NoError(t, conn.Close())
-			return
-		}
-		successfulKey.Store(req.Header.Get("Gram-Key"))
-		successfulProject.Store(req.Header.Get("Gram-Project"))
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	require.Zero(t, runSkillUploadTask(t, skillUploadTaskForTest(t, server.URL, "project", "key", "retry-safe content")))
-	require.Equal(t, int32(2), requests.Load())
-	require.Equal(t, "key", successfulKey.Load())
-	require.Equal(t, "project", successfulProject.Load())
-}
-
-func TestRunSkillUploadDoesNotRetryDefinitiveClientError(t *testing.T) {
-	var requests atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests.Add(1)
-		http.Error(w, "bad request", http.StatusBadRequest)
-	}))
-	t.Cleanup(server.Close)
-
-	require.NotZero(t, runSkillUploadTask(t, skillUploadTaskForTest(t, server.URL, "project", "key", "content")))
-	require.Equal(t, int32(1), requests.Load())
-}
-
-func TestStartSkillUploadProcessHandsOffExactCredentialAndMaximumContent(t *testing.T) {
-	originalCommand := newSkillUploadCommand
-	t.Cleanup(func() { newSkillUploadCommand = originalCommand })
-	newSkillUploadCommand = skillUploadHelperCommand
-
-	content := strings.Repeat("x", maxSkillContentBytes)
-	type upload struct {
-		key     string
-		content string
-	}
-	observed := make(chan upload, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		var body struct {
-			Content string `json:"content"`
-		}
-		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
-		observed <- upload{key: req.Header.Get("Gram-Key"), content: body.Content}
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-	task := skillUploadTaskForTest(t, server.URL, "project", "exact-pipe-key_123", content)
-
-	require.NoError(t, startSkillUploadProcess(task))
-	select {
-	case got := <-observed:
-		require.Equal(t, task.APIKey, got.key)
-		require.Equal(t, content, got.content)
-	case <-time.After(5 * time.Second):
-		t.Fatal("detached upload did not arrive")
-	}
-}
-
-func TestStartSkillUploadProcessReturnsWithoutWaitingForWorker(t *testing.T) {
-	originalCommand := newSkillUploadCommand
-	t.Cleanup(func() { newSkillUploadCommand = originalCommand })
-	newSkillUploadCommand = func(task skillUploadTask) (*exec.Cmd, error) {
-		cmd := exec.Command(os.Args[0], "-test.run=^TestSkillUploadHelperProcess$")
-		cmd.Env = append(envWithoutCredential(os.Environ(), task.APIKey), "GO_SKILL_UPLOAD_HELPER=delay")
-		return cmd, nil
-	}
-	task := skillUploadTaskForTest(t, "https://example.com", "project", "key", "content")
-
-	started := time.Now()
-	require.NoError(t, startSkillUploadProcess(task))
-
-	require.Less(t, time.Since(started), time.Second)
-}
-
-func TestSkillUploadHelperProcess(t *testing.T) {
-	switch os.Getenv("GO_SKILL_UPLOAD_HELPER") {
-	case "delay":
-		<-time.After(2 * time.Second)
-		os.Exit(0)
-	case "1":
-	default:
-		return
-	}
-	separator := slices.Index(os.Args, "--")
-	if separator < 0 {
-		os.Exit(2)
-	}
-	os.Exit(RunSkillUpload(context.Background(), os.Args[separator+1:], os.Stdin))
-}
-
-func skillUploadHelperCommand(task skillUploadTask) (*exec.Cmd, error) {
-	args := append([]string{"-test.run=^TestSkillUploadHelperProcess$", "--"}, skillUploadArgs(task)...)
-	cmd := exec.Command(os.Args[0], args...)
-	cmd.Env = append(envWithoutCredential(os.Environ(), task.APIKey), "GO_SKILL_UPLOAD_HELPER=1")
-	return cmd, nil
-}
-
-func skillUploadTaskForTest(t *testing.T, serverURL, project, key, content string) skillUploadTask {
-	t.Helper()
-	root := filepath.Join(t.TempDir(), "skills")
-	path := writeSkillManifest(t, filepath.Join(root, "test"), []byte(content))
-	return skillUploadTask{ServerURL: serverURL, Project: project, APIKey: key, RawSHA256: sha256Hex([]byte(content)), SourcePath: path, SourceRoot: root}
-}
-
-func runSkillUploadTask(t *testing.T, task skillUploadTask) int {
-	t.Helper()
-	return RunSkillUpload(t.Context(), skillUploadArgs(task), strings.NewReader(task.APIKey))
-}
-
-func skillUploadArgs(task skillUploadTask) []string {
-	return []string{
-		"--server-url=" + task.ServerURL,
-		"--project=" + task.Project,
-		"--raw-sha256=" + task.RawSHA256,
-		"--source-path=" + task.SourcePath,
-		"--source-root=" + task.SourceRoot,
-	}
+func skillUploadTaskForTest(serverURL, project, key, content string) skillUploadTask {
+	return skillUploadTask{ServerURL: serverURL, Project: project, APIKey: key, RawSHA256: sha256Hex([]byte(content)), Content: content}
 }
 
 func acceptedSkillUploadResult(rawSHA256 string, contentRequired bool) ingestResult {
@@ -305,4 +69,12 @@ func acceptedSkillUploadResult(rawSHA256 string, contentRequired bool) ingestRes
 		failOpen:     nil,
 		skillCapture: &skillCapture{rawSHA256: rawSHA256, contentRequired: contentRequired},
 	}
+}
+
+func TestValidSkillUploadTaskRejectsInvalidValues(t *testing.T) {
+	task := skillUploadTaskForTest("https://example.com", "project", "key", "content")
+	require.True(t, validSkillUploadTask(task))
+
+	task.RawSHA256 = strings.Repeat("A", 64)
+	require.False(t, validSkillUploadTask(task))
 }

--- a/hooks/relay/spool.go
+++ b/hooks/relay/spool.go
@@ -63,15 +63,14 @@ var (
 // came from. The envelope itself already contains the event's occurred_at,
 // so replay preserves original timestamps.
 type spoolEntry struct {
-	V               int                          `json:"v"`
-	IdempotencyKey  string                       `json:"idempotency_key"`
-	ServerURL       string                       `json:"server_url"`
-	OrgID           string                       `json:"org_id,omitempty"`
-	ProjectSlug     string                       `json:"project_slug,omitempty"`
-	ConfigPath      string                       `json:"config_path,omitempty"`
-	SkillSourceRoot string                       `json:"skill_source_root,omitempty"`
-	SpooledAt       time.Time                    `json:"spooled_at"`
-	Envelope        components.IngestRequestBody `json:"envelope"`
+	V              int                          `json:"v"`
+	IdempotencyKey string                       `json:"idempotency_key"`
+	ServerURL      string                       `json:"server_url"`
+	OrgID          string                       `json:"org_id,omitempty"`
+	ProjectSlug    string                       `json:"project_slug,omitempty"`
+	ConfigPath     string                       `json:"config_path,omitempty"`
+	SpooledAt      time.Time                    `json:"spooled_at"`
+	Envelope       components.IngestRequestBody `json:"envelope"`
 }
 
 // maxSpoolEntryBytes caps one entry on disk. A single entry must never
@@ -85,7 +84,7 @@ const maxSpoolEntryBytes = 8 << 20
 // control plane. Best-effort by design: a spool failure only logs — the
 // event's gating outcome was already decided, and buffering must never
 // affect the user's session.
-func (r *Relay) spoolUnsent(idemKey string, payload components.IngestRequestBody, skill *resolvedSkill) {
+func (r *Relay) spoolUnsent(idemKey string, payload components.IngestRequestBody) {
 	dir := spoolDir()
 	if dir == "" {
 		r.debugf("spool: no writable state dir; entry dropped")
@@ -100,9 +99,6 @@ func (r *Relay) spoolUnsent(idemKey string, payload components.IngestRequestBody
 		ConfigPath:     r.cfg.ConfigPath,
 		SpooledAt:      time.Now().UTC(),
 		Envelope:       payload,
-	}
-	if skill != nil && skill.captureReady {
-		entry.SkillSourceRoot = skill.root
 	}
 	data, err := json.Marshal(entry)
 	if err != nil {

--- a/hooks/relay/spool_test.go
+++ b/hooks/relay/spool_test.go
@@ -271,7 +271,7 @@ func TestSpoolOversizeEntryShedsRawNotBacklog(t *testing.T) {
 		Raw:           json.RawMessage(`{"blob":"` + string(big) + `"}`),
 	}
 	NewRelay(Config{ServerURL: "https://gram.test", ProjectSlug: "default", OrgID: "", HooksAPIKey: "", BrowserLogin: false, Nonblocking: false, DebugLog: "", ConfigPath: "", ConfigError: ""}).
-		spoolUnsent(newIdempotencyToken(), payload, nil)
+		spoolUnsent(newIdempotencyToken(), payload)
 
 	names := spoolFiles(t)
 	require.Len(t, names, 2, "the oversize entry must be stored (raw stripped) and the backlog preserved")


### PR DESCRIPTION
Uses [agenthooks v0.6.0](https://github.com/speakeasy-api/agenthooks/releases/tag/v0.6.0), released from speakeasy-api/agenthooks#13.

Consume `agenthooks.SkillActivationOf` as the single projection for tool-based skill activations. The normalized tool output continues through ordinary hook ingestion, and the same event content supplies the hash and payload used by the skill-content registry and offline replay.

Delete Gram’s Claude/Codex/Cursor manifest readers, path classification, symlink authorization, detached file-reopen uploader, and internal `upload-skill` command. Keep only the separate Codex `$skill-name` prompt fallback because it has no tool event.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consume normalized skill activations via `agenthooks.SkillActivationOf`, attach implicit activations only to the completed read, route tool output through standard hook ingestion, and restore detection of `.system` Codex skill roots. Live skill uploads are bounded to 10s to fit provider hook timeouts.

- **Refactors**
  - Set `data.skill` from `agenthooks.SkillActivationOf`; emit `skill.activated` only when explicit, and attach implicit activations on the completed tool read.
  - Derive skill content from `tool_call.output`; compute `rawSHA256` from it. `SourcePath` and `SourceLevel` are unset.
  - Replay reads content from stored tool output and can replay legacy spooled manifests; require a regular file for legacy skill source replay and pin the legacy read to the lstat-checked inode.
  - Remove Claude/Codex/Cursor manifest readers, path classification, symlink checks, detached uploader, and the `upload-skill` command.
  - Keep Codex `$skill-name` prompt fallback.
  - Update tests and internal APIs (e.g., `finishExchange`, `spoolUnsent`) to the new flow.
  - Bump `github.com/speakeasy-api/agenthooks` to `v0.6.0`.

- **Migration**
  - Remove any `upload-skill` CLI usage; uploads use captured tool output.
  - Do not rely on `SourcePath`/`SourceLevel` in payloads; ensure downstream consumers accept this.

<sup>Written for commit 933f15b88e5850b74013c30128884a5c2dc7e2ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

