### PR TITLE
fix: route /shared/skills through custom domain ingress

### DIFF
--- a/.changeset/shared-skills-ingress-path.md
+++ b/.changeset/shared-skills-ingress-path.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Custom domain ingresses now route /shared/skills to the Gram server, so public skill share pages resolve on custom domains instead of returning an edge 404. Existing domains pick up the new route on their next ingress re-apply (e.g. saving domain settings).

--- a/server/internal/k8s/ingress_provisioner.go
+++ b/server/internal/k8s/ingress_provisioner.go
@@ -204,6 +204,18 @@ func (p *IngressProvisioner) buildIngress(domain string, ipAllowlist []string) (
 									},
 								},
 								{
+									// Public skill share pages (/shared/skills/{token})
+									// are served by the app on custom domains.
+									Path:     "/shared/skills",
+									PathType: &pathTypePrefix,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: p.backendService,
+											Port: networkingv1.ServiceBackendPort{Number: 80},
+										},
+									},
+								},
+								{
 									Path:     "/.well-known/openai-apps-challenge",
 									PathType: &pathTypeExact,
 									Backend: networkingv1.IngressBackend{

--- a/server/internal/k8s/ingress_provisioner_test.go
+++ b/server/internal/k8s/ingress_provisioner_test.go
@@ -66,6 +66,18 @@ func TestIngressProvisioner_Setup_CreateNew(t *testing.T) {
 			Resource: nil,
 		},
 	})
+	pathTypePrefix := networkingv1.PathTypePrefix
+	require.Contains(t, ingress.Spec.Rules[0].HTTP.Paths, networkingv1.HTTPIngressPath{
+		Path:     "/shared/skills",
+		PathType: &pathTypePrefix,
+		Backend: networkingv1.IngressBackend{
+			Service: &networkingv1.IngressServiceBackend{
+				Name: "gram-server",
+				Port: networkingv1.ServiceBackendPort{Number: 80},
+			},
+			Resource: nil,
+		},
+	})
 }
 
 func TestIngressProvisioner_Setup_WithAllowlist_SetsAnnotation(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up fix for #5023: shared skill pages on custom domains returned a bare nginx 404 (e.g. `https://chat.speakeasy.com/shared/skills/<token>`).

**Root cause:** the app route existed, but the custom-domain Kubernetes Ingress (`server/internal/k8s/ingress_provisioner.go`) only forwards an allowlist of paths to the Gram server — `/mcp`, `/oauth`, and specific `/.well-known/*` entries. `/shared/skills/*` was never routed, so requests died at the edge before reaching the handler.

**Fix:** add `/shared/skills` (PathType Prefix, same backend service) to the main custom-domain ingress spec, mirroring `/mcp`.

## Rollout note

Existing domains keep their old Ingress object until the next re-apply — there is no reconcile-all on deploy. After this deploys, trigger a re-apply per affected domain via the domain edit flow (saving domain settings runs `CustomDomainUpdateWorkflow` → `ReconcileCustomDomain` → `provisioner.Apply` with the new spec).

## Testing

- Added a path assertion to `ingress_provisioner_test.go`; `go test ./server/internal/k8s/` passes.
- `mise lint:server` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJMDX91x4yiwU5PWyv6m6p


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `/shared/skills` through the custom-domain Kubernetes Ingress so public skill share pages work on custom domains instead of returning an NGINX 404.

- **Bug Fixes**
  - Added `/shared/skills` (PathType Prefix) to the custom-domain ingress to forward to the Gram server.
  - Added a path assertion test in `server/internal/k8s/ingress_provisioner_test.go`.

- **Migration**
  - Existing custom domains need an ingress re-apply. Save domain settings to trigger `CustomDomainUpdateWorkflow` → `ReconcileCustomDomain`.

<sup>Written for commit bfb78abb59464b25e40be1d6d6c3c7c2e4e7cd1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

