### PR TITLE
feat(risk): pick a ready-made exclusion rule instead of writing DSL

### DIFF
--- a/client/dashboard/src/components/ui/bulk-action-bar.tsx
+++ b/client/dashboard/src/components/ui/bulk-action-bar.tsx
@@ -43,7 +43,6 @@ export interface BulkAction {
 export function BulkActionBar({
   selectedCount,
   actions,
-  loading,
   leftOffsetPx,
   heightPx,
 }: {
@@ -51,10 +50,6 @@ export function BulkActionBar({
   /** One or two actions (e.g. "Mark as false positive" and "Setup exclusion
    * rule"), listed in the "Bulk actions" dropdown in the order given. */
   actions: BulkAction[];
-  /** An action is running asynchronously (e.g. an AI suggestion) — shows a
-   * spinner on the "Bulk actions" trigger itself, since the action that
-   * triggered it is inside a menu that isn't necessarily open right now. */
-  loading?: boolean;
   /** Width of the header row's own select-all checkbox column in pixels —
    * the bar starts immediately after it, leaving that checkbox uncovered
    * and clickable. */
@@ -108,7 +103,6 @@ export function BulkActionBar({
       </span>
       <MoreActions
         triggerLabel="Bulk actions"
-        triggerLoading={loading}
         triggerStyle={{ transitionProperty: "none" }}
         actions={actions.map(
           (a): Action => ({

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -76,7 +76,7 @@ import {
 import { useChatTranscript } from "./useChatTranscript";
 import { useWindowedTranscript } from "./useWindowedTranscript";
 import { CreateExclusionContext } from "./exclusionContext";
-import { findingToExclusionState, riskResultAnchorId } from "./chatHelpers";
+import { riskResultAnchorId } from "./chatHelpers";
 import {
   ChatTranscript,
   type RowContext,
@@ -1409,7 +1409,7 @@ function ChatDetailPanel({
   // "Setup exclusion rule" swaps the transcript for the exclusion editor
   // in-place (with a back button) rather than stacking a second sheet on top.
   const openExclusion = useCallback((result: RiskResult) => {
-    setExclusionState(findingToExclusionState(result));
+    setExclusionState({ mode: "create", results: [result] });
     setPendingExclusionKey(findingKey(result));
     setView("exclusion");
   }, []);

--- a/client/dashboard/src/pages/chatLogs/chatHelpers.tsx
+++ b/client/dashboard/src/pages/chatLogs/chatHelpers.tsx
@@ -2,11 +2,6 @@ import { type ReactNode, useEffect, useRef, useState } from "react";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import { cn } from "@/lib/utils";
 import { ruleIdCategoryLabel } from "@/pages/security/rule-ids";
-import { serializeExclusionExpression } from "@/pages/security/exclusion-expression";
-import {
-  type ExclusionSheetState,
-  GLOBAL_SCOPE,
-} from "@/pages/security/exclusion-sheet";
 import {
   getCategoryCodeForFinding,
   getRuleTitleFallback,
@@ -316,31 +311,4 @@ export function highlightMatches(
   });
   if (pos < text.length) nodes.push(text.slice(pos));
   return nodes;
-}
-
-export function findingToExclusionState(
-  result: RiskResult,
-): ExclusionSheetState {
-  let expression: string;
-  if (result.match) {
-    expression = serializeExclusionExpression({
-      matchType: "exact",
-      matchValue: result.match,
-    });
-  } else if (result.ruleId) {
-    expression = serializeExclusionExpression({
-      matchType: "rule_id",
-      matchValue: result.ruleId,
-    });
-  } else {
-    expression = serializeExclusionExpression({
-      matchType: "source",
-      matchValue: result.source,
-    });
-  }
-  return {
-    mode: "create",
-    initialExpression: expression,
-    initialScope: result.policyId ?? GLOBAL_SCOPE,
-  };
 }

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -342,12 +342,8 @@ export default function RiskEvents(): JSX.Element {
   const handleSetupExclusionSelected = useCallback(() => {
     const selected = selection.selectedItems;
     if (selected.length === 0) return;
-    // Deliberately doesn't clear the selection (unlike handleDismissSelected):
-    // a batch AI suggestion takes a few seconds, and clearing here would
-    // collapse the bulk bar mid-request, hiding the spinner on "Setup
-    // exclusion rule" with no visible feedback until the sheet opens. Leaving
-    // the selection also means Clear/retry still works if the sheet is
-    // cancelled.
+    // Deliberately doesn't clear the selection (unlike handleDismissSelected)
+    // so retrying still works if the sheet is canceled.
     exclusionRule.open(selected);
   }, [selection, exclusionRule]);
 
@@ -425,7 +421,6 @@ export default function RiskEvents(): JSX.Element {
                   onClick: handleSetupExclusionSelected,
                 },
               ]}
-              loading={exclusionRule.isSuggesting}
               leftOffsetPx={28}
               heightPx={headerMeasure.height}
             />

--- a/client/dashboard/src/pages/security/RiskOverviewCategoryDetail.tsx
+++ b/client/dashboard/src/pages/security/RiskOverviewCategoryDetail.tsx
@@ -184,12 +184,8 @@ function RiskOverviewCategoryDetailContent() {
   const handleSetupExclusionSelected = useCallback(() => {
     const selected = selection.selectedItems;
     if (selected.length === 0) return;
-    // Deliberately doesn't clear the selection (unlike handleDismissSelected):
-    // a batch AI suggestion takes a few seconds, and clearing here would
-    // collapse the bulk bar mid-request, hiding the spinner on "Setup
-    // exclusion rule" with no visible feedback until the sheet opens. Leaving
-    // the selection also means Clear/retry still works if the sheet is
-    // cancelled.
+    // Deliberately doesn't clear the selection (unlike handleDismissSelected)
+    // so retrying still works if the sheet is canceled.
     exclusionRule.open(selected);
   }, [selection, exclusionRule]);
 
@@ -287,7 +283,6 @@ function RiskOverviewCategoryDetailContent() {
                     onClick: handleSetupExclusionSelected,
                   },
                 ]}
-                loading={exclusionRule.isSuggesting}
                 leftOffsetPx={32}
                 heightPx={headerMeasure.height}
               />

--- a/client/dashboard/src/pages/security/exclusion-options.test.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.test.ts
@@ -1,6 +1,6 @@
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import { describe, expect, it } from "vitest";
-import { exclusionOptions } from "./exclusion-options";
+import { exactCandidate, exclusionOptions } from "./exclusion-options";
 
 function result(overrides: Partial<RiskResult> = {}): RiskResult {
   return {
@@ -14,8 +14,8 @@ function result(overrides: Partial<RiskResult> = {}): RiskResult {
   };
 }
 
-const values = (results: RiskResult[], revealed?: string) =>
-  exclusionOptions(results, revealed).map((o) => o.value);
+const values = (results: RiskResult[]) =>
+  exclusionOptions(results).map((o) => o.value);
 
 describe("exclusionOptions", () => {
   it("offers only custom for an empty selection", () => {
@@ -40,11 +40,23 @@ describe("exclusionOptions", () => {
   });
 
   it("offers exact from a revealed value on a masked finding", () => {
-    const options = exclusionOptions([result()], "jane@acme.com");
+    const options = exclusionOptions([result()], {
+      value: "jane@acme.com",
+      label: "jane@acme.com",
+    });
     expect(options[0]).toMatchObject({
       value: "exact",
       fields: { matchType: "exact", matchValue: "jane@acme.com" },
     });
+  });
+
+  it("labels a pending reveal but leaves it unsavable", () => {
+    const options = exclusionOptions([result()], {
+      label: "<redacted len=13 sha=ab12>",
+    });
+    expect(options[0]?.value).toBe("exact");
+    expect(options[0]?.title).toContain("<redacted len=13 sha=ab12>");
+    expect(options[0]?.fields).toBeUndefined();
   });
 
   it("offers rule and source but never exact for a shared-rule batch", () => {
@@ -70,5 +82,34 @@ describe("exclusionOptions", () => {
         result({ id: "b", source: "gitleaks", ruleId: "generic-api-key" }),
       ]),
     ).toEqual(["custom"]);
+  });
+});
+
+describe("exactCandidate", () => {
+  const masked = result({ matchRedacted: "<redacted len=13 sha=ab12>" });
+
+  it("prefers a match the finding already carries", () => {
+    expect(
+      exactCandidate(result({ match: "jane@acme.com" }), null, true),
+    ).toEqual({ value: "jane@acme.com", label: "jane@acme.com" });
+  });
+
+  it("labels the redaction while the reveal is unfired", () => {
+    expect(exactCandidate(masked, null, true)).toEqual({
+      label: "<redacted len=13 sha=ab12>",
+    });
+  });
+
+  it("takes the plaintext once the reveal resolves", () => {
+    expect(exactCandidate(masked, "jane@acme.com", true)).toEqual({
+      value: "jane@acme.com",
+      label: "jane@acme.com",
+    });
+  });
+
+  it("offers nothing without the reveal scope, or with nothing to reveal", () => {
+    expect(exactCandidate(masked, null, false)).toBeUndefined();
+    expect(exactCandidate(result(), null, true)).toBeUndefined();
+    expect(exactCandidate(undefined, null, true)).toBeUndefined();
   });
 });

--- a/client/dashboard/src/pages/security/exclusion-options.test.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.test.ts
@@ -1,0 +1,74 @@
+import type { RiskResult } from "@gram/client/models/components/riskresult.js";
+import { describe, expect, it } from "vitest";
+import { exclusionOptions } from "./exclusion-options";
+
+function result(overrides: Partial<RiskResult> = {}): RiskResult {
+  return {
+    id: "r1",
+    policyId: "p1",
+    policyVersion: 1,
+    source: "presidio",
+    ruleId: "pii.email_address",
+    createdAt: new Date(0),
+    ...overrides,
+  };
+}
+
+const values = (results: RiskResult[], revealed?: string) =>
+  exclusionOptions(results, revealed).map((o) => o.value);
+
+describe("exclusionOptions", () => {
+  it("offers only custom for an empty selection", () => {
+    expect(values([])).toEqual(["custom"]);
+  });
+
+  it("offers exact first when a single finding holds its match", () => {
+    const options = exclusionOptions([result({ match: "jane@acme.com" })]);
+    expect(options.map((o) => o.value)).toEqual([
+      "exact",
+      "rule",
+      "source",
+      "custom",
+    ]);
+    expect(options[0]?.fields).toEqual({
+      matchType: "exact",
+      matchValue: "jane@acme.com",
+      ruleIdFilter: "",
+      sourceFilter: "",
+    });
+    expect(options[0]?.title).toContain("jane@acme.com");
+  });
+
+  it("offers exact from a revealed value on a masked finding", () => {
+    const options = exclusionOptions([result()], "jane@acme.com");
+    expect(options[0]).toMatchObject({
+      value: "exact",
+      fields: { matchType: "exact", matchValue: "jane@acme.com" },
+    });
+  });
+
+  it("offers rule and source but never exact for a shared-rule batch", () => {
+    const options = exclusionOptions([
+      result({ id: "a", match: "one@acme.com" }),
+      result({ id: "b", match: "two@acme.com" }),
+    ]);
+    expect(options.map((o) => o.value)).toEqual(["rule", "source", "custom"]);
+    expect(options[0]?.fields).toMatchObject({
+      matchType: "rule_id",
+      matchValue: "pii.email_address",
+    });
+    expect(options[1]?.fields).toMatchObject({
+      matchType: "source",
+      matchValue: "presidio",
+    });
+  });
+
+  it("offers only custom when rows share neither rule nor source", () => {
+    expect(
+      values([
+        result({ id: "a" }),
+        result({ id: "b", source: "gitleaks", ruleId: "generic-api-key" }),
+      ]),
+    ).toEqual(["custom"]);
+  });
+});

--- a/client/dashboard/src/pages/security/exclusion-options.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.ts
@@ -1,0 +1,79 @@
+import type { RiskResult } from "@gram/client/models/components/riskresult.js";
+import type { ExclusionFields } from "./exclusion-expression";
+import { getRuleTitleFallback } from "./risk-utils";
+
+// The ready-made rules offered for a finding-originated exclusion. Each option
+// is a complete, savable rule: `fields` goes straight to the mutation, skipping
+// the expression serialize -> parse round trip. Only "custom" has no fields —
+// it reveals the DSL textarea instead.
+export interface ExclusionOption {
+  value: "exact" | "rule" | "source" | "custom";
+  title: string;
+  hint: string;
+  fields?: ExclusionFields;
+}
+
+const CUSTOM_OPTION: ExclusionOption = {
+  value: "custom",
+  title: "Write it myself",
+  hint: "Regex, entity types, and rule/source filters.",
+};
+
+function fields(
+  matchType: ExclusionFields["matchType"],
+  matchValue: string,
+): ExclusionFields {
+  return { matchType, matchValue, ruleIdFilter: "", sourceFilter: "" };
+}
+
+function shared<K extends "ruleId" | "source">(
+  results: RiskResult[],
+  key: K,
+): string | undefined {
+  const value = results[0]?.[key];
+  return value && results.every((r) => r[key] === value) ? value : undefined;
+}
+
+// Builds the options valid for a selection. An exact-value rule needs a single
+// finding whose plaintext we actually hold — `revealed` covers the masked list
+// pages, where the raw match never reaches the browser until it is unmasked.
+// Rule and source rules need every selected row to agree on that field.
+export function exclusionOptions(
+  results: RiskResult[],
+  revealed?: string,
+): ExclusionOption[] {
+  const options: ExclusionOption[] = [];
+
+  const match = results.length === 1 ? (revealed ?? results[0]?.match) : "";
+  if (match) {
+    options.push({
+      value: "exact",
+      title: `Just this value — ${match}`,
+      hint: "Only this exact value stops being flagged.",
+      fields: fields("exact", match),
+    });
+  }
+
+  const ruleId = shared(results, "ruleId");
+  if (ruleId) {
+    options.push({
+      value: "rule",
+      title: `Any ${getRuleTitleFallback(ruleId)} finding`,
+      hint: "Every finding from this detection rule stops being flagged.",
+      fields: fields("rule_id", ruleId),
+    });
+  }
+
+  const source = shared(results, "source");
+  if (source) {
+    options.push({
+      value: "source",
+      title: `Anything detected by ${source}`,
+      hint: "Every finding from this detector stops being flagged.",
+      fields: fields("source", source),
+    });
+  }
+
+  options.push(CUSTOM_OPTION);
+  return options;
+}

--- a/client/dashboard/src/pages/security/exclusion-options.ts
+++ b/client/dashboard/src/pages/security/exclusion-options.ts
@@ -3,14 +3,42 @@ import type { ExclusionFields } from "./exclusion-expression";
 import { getRuleTitleFallback } from "./risk-utils";
 
 // The ready-made rules offered for a finding-originated exclusion. Each option
-// is a complete, savable rule: `fields` goes straight to the mutation, skipping
-// the expression serialize -> parse round trip. Only "custom" has no fields —
-// it reveals the DSL textarea instead.
+// carries a complete rule in `fields`, which goes straight to the mutation,
+// skipping the expression serialize -> parse round trip. Two options have no
+// fields and so cannot be saved as-is: "custom", which reveals the DSL textarea
+// instead, and an "exact" whose plaintext is still behind an unfired reveal.
 export interface ExclusionOption {
   value: "exact" | "rule" | "source" | "custom";
   title: string;
   hint: string;
   fields?: ExclusionFields;
+}
+
+/** The value an exact-match rule would be written against. The masked list
+ * pages hold only `label` (the redacted placeholder) until the operator
+ * selects the option and the audited reveal resolves into `value`. */
+export interface ExactCandidate {
+  value?: string;
+  label: string;
+}
+
+// Where the plaintext for an exact rule comes from, in order: the finding
+// itself (the chat surfaces carry it), a resolved reveal, or — on the masked
+// list pages — nothing yet, in which case the redacted placeholder labels an
+// option that exists only to be selected. `undefined` means no exact rule is
+// on offer at all: a multi-row selection, or `canReveal` false because the
+// caller lacks `chat:read` or the finding has no match behind it (a judge
+// verdict), in which case the option must not appear as a dead affordance.
+export function exactCandidate(
+  single: RiskResult | undefined,
+  revealed: string | null,
+  canReveal: boolean,
+): ExactCandidate | undefined {
+  if (!single) return undefined;
+  if (single.match) return { value: single.match, label: single.match };
+  if (revealed) return { value: revealed, label: revealed };
+  if (canReveal && single.matchRedacted) return { label: single.matchRedacted };
+  return undefined;
 }
 
 const CUSTOM_OPTION: ExclusionOption = {
@@ -35,22 +63,29 @@ function shared<K extends "ruleId" | "source">(
 }
 
 // Builds the options valid for a selection. An exact-value rule needs a single
-// finding whose plaintext we actually hold — `revealed` covers the masked list
-// pages, where the raw match never reaches the browser until it is unmasked.
-// Rule and source rules need every selected row to agree on that field.
+// finding — its plaintext comes from the finding itself on the chat surfaces,
+// or from `exact` on the masked list pages, where the raw match never reaches
+// the browser until it is unmasked. Rule and source rules need every selected
+// row to agree on that field.
 export function exclusionOptions(
   results: RiskResult[],
-  revealed?: string,
+  exact?: ExactCandidate,
 ): ExclusionOption[] {
   const options: ExclusionOption[] = [];
 
-  const match = results.length === 1 ? (revealed ?? results[0]?.match) : "";
-  if (match) {
+  const own = results.length === 1 ? results[0]?.match : undefined;
+  const match = exact?.value ?? own;
+  const label = exact?.label ?? own;
+  if (label) {
     options.push({
       value: "exact",
-      title: `Just this value — ${match}`,
-      hint: "Only this exact value stops being flagged.",
-      fields: fields("exact", match),
+      title: `Just this value — ${label}`,
+      hint: match
+        ? "Only this exact value stops being flagged."
+        : "Select to reveal the value — this is recorded in the audit log.",
+      // Absent while a reveal is still pending: the option renders and can be
+      // selected (that is what fires the reveal), but cannot yet be saved.
+      fields: match ? fields("exact", match) : undefined,
     });
   }
 

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -239,7 +239,8 @@ function ExclusionForm({
   const exact = exactCandidate(
     single,
     reveals.value,
-    hasScope(REVEAL_SCOPE, single?.chatId) && hasRevealableEvent(single?.matchRedacted),
+    hasScope(REVEAL_SCOPE, single?.chatId) &&
+      hasRevealableEvent(single?.matchRedacted),
   );
 
   // Ready-made rules for the selection. Always at least ["custom"], so an

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -53,8 +53,6 @@ export type ExclusionSheetState =
        * picker; absent for the Exclusions tab / Policy Center buttons, which
        * have no finding and open straight onto the criteria box. */
       results?: RiskResult[];
-      initialExpression?: string;
-      initialScope?: string;
     }
   | { mode: "edit"; exclusion: RiskExclusion };
 
@@ -122,7 +120,7 @@ export function ExclusionEditor({
   const formKey =
     state.mode === "edit"
       ? `edit-${state.exclusion.id}`
-      : `create-${(state.results ?? []).map((r) => r.id).join(",")}-${state.initialExpression ?? ""}-${state.initialScope ?? ""}`;
+      : `create-${(state.results ?? []).map((r) => r.id).join(",")}`;
 
   return (
     <ExclusionForm
@@ -215,20 +213,6 @@ interface ExclusionFormProps {
   }) => void;
 }
 
-function initialExpressionFor(state: ExclusionSheetState): string {
-  if (state.mode === "edit") {
-    return serializeExclusionExpression(state.exclusion);
-  }
-  return state.initialExpression ?? "";
-}
-
-function initialScopeFor(state: ExclusionSheetState): string {
-  if (state.mode === "edit") {
-    return state.exclusion.riskPolicyId ?? GLOBAL_SCOPE;
-  }
-  return state.initialScope ?? GLOBAL_SCOPE;
-}
-
 function ExclusionForm({
   policies,
   state,
@@ -236,17 +220,20 @@ function ExclusionForm({
   onSubmit,
 }: ExclusionFormProps) {
   const editing = state.mode === "edit" ? state.exclusion : null;
+  const results = state.mode === "create" ? (state.results ?? []) : [];
   // Ready-made rules for the selection. Always at least ["custom"], so an
   // edit or a no-finding create renders no picker and opens on the DSL box.
-  const options = exclusionOptions(
-    state.mode === "create" ? (state.results ?? []) : [],
-  );
+  const options = exclusionOptions(results);
   const [choice, setChoice] = useState<ExclusionOption["value"]>(
     options[0]?.value ?? "custom",
   );
-  const [scope, setScope] = useState<string>(initialScopeFor(state));
+  // A finding-originated create is always global: "stop flagging this" means
+  // everywhere, and the Scope select is there to narrow it.
+  const [scope, setScope] = useState<string>(
+    editing?.riskPolicyId ?? GLOBAL_SCOPE,
+  );
   const [expression, setExpression] = useState<string>(
-    initialExpressionFor(state),
+    editing ? serializeExclusionExpression(editing) : "",
   );
   const [enabled, setEnabled] = useState<boolean>(editing?.enabled ?? true);
   const [error, setError] = useState<string | null>(null);
@@ -278,6 +265,13 @@ function ExclusionForm({
     },
   });
 
+  // A batch the picker can't cover (no shared rule or source) is exactly what
+  // the server generalizes well, so hand it the selection alongside the
+  // prompt. Single findings gain nothing — their local options are complete —
+  // and the endpoint caps the list at 50 ids.
+  const findingIds =
+    results.length > 1 ? results.slice(0, 50).map((r) => r.id) : [];
+
   const handleSuggest = () => {
     const prompt = askPrompt.trim();
     if (prompt.length < 3) {
@@ -288,6 +282,7 @@ function ExclusionForm({
       request: {
         suggestExclusionRequestBody: {
           prompt,
+          findingIds: findingIds.length > 0 ? findingIds : undefined,
           knownRuleIds: BUILTIN_RULE_ID_LIST,
         },
       },
@@ -378,8 +373,10 @@ function ExclusionForm({
               />
               <div className="flex items-center justify-between gap-3">
                 <Text className="text-muted-foreground" small>
-                  Describe what to stop flagging. We'll write the criteria
-                  expression, you tweak before saving.
+                  {"Describe what to stop flagging. We'll write the criteria expression, you tweak before saving." +
+                    (findingIds.length > 0
+                      ? ` Your ${findingIds.length} selected findings go along as context.`
+                      : "")}
                 </Text>
                 <Button
                   variant="secondary"

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -50,7 +50,7 @@ import {
 import { hasRevealableEvent, REVEAL_SCOPE, useUnmaskedMatch } from "./unmask";
 import { useRBAC } from "@/hooks/useRBAC";
 
-export const GLOBAL_SCOPE = "__global__";
+const GLOBAL_SCOPE = "__global__";
 
 export type ExclusionSheetState =
   | {

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -29,6 +29,8 @@ import { invalidateAllRiskOverview } from "@gram/client/react-query/riskOverview
 import { useRiskSuggestExclusionMutation } from "@gram/client/react-query/riskSuggestExclusion.js";
 import { useRiskUpdateExclusionMutation } from "@gram/client/react-query/riskUpdateExclusion.js";
 import type { RiskExclusion } from "@gram/client/models/components/riskexclusion.js";
+import type { RiskResult } from "@gram/client/models/components/riskresult.js";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/RadioGroup";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2, Sparkles } from "lucide-react";
 import type { JSX } from "react";
@@ -40,11 +42,20 @@ import {
   parseExclusionExpression,
   serializeExclusionExpression,
 } from "./exclusion-expression";
+import { exclusionOptions, type ExclusionOption } from "./exclusion-options";
 
 export const GLOBAL_SCOPE = "__global__";
 
 export type ExclusionSheetState =
-  | { mode: "create"; initialExpression?: string; initialScope?: string }
+  | {
+      mode: "create";
+      /** Findings the create was started from. Drives the ready-made rule
+       * picker; absent for the Exclusions tab / Policy Center buttons, which
+       * have no finding and open straight onto the criteria box. */
+      results?: RiskResult[];
+      initialExpression?: string;
+      initialScope?: string;
+    }
   | { mode: "edit"; exclusion: RiskExclusion };
 
 /**
@@ -111,7 +122,7 @@ export function ExclusionEditor({
   const formKey =
     state.mode === "edit"
       ? `edit-${state.exclusion.id}`
-      : `create-${state.initialExpression ?? ""}-${state.initialScope ?? ""}`;
+      : `create-${(state.results ?? []).map((r) => r.id).join(",")}-${state.initialExpression ?? ""}-${state.initialScope ?? ""}`;
 
   return (
     <ExclusionForm
@@ -225,6 +236,14 @@ function ExclusionForm({
   onSubmit,
 }: ExclusionFormProps) {
   const editing = state.mode === "edit" ? state.exclusion : null;
+  // Ready-made rules for the selection. Always at least ["custom"], so an
+  // edit or a no-finding create renders no picker and opens on the DSL box.
+  const options = exclusionOptions(
+    state.mode === "create" ? (state.results ?? []) : [],
+  );
+  const [choice, setChoice] = useState<ExclusionOption["value"]>(
+    options[0]?.value ?? "custom",
+  );
   const [scope, setScope] = useState<string>(initialScopeFor(state));
   const [expression, setExpression] = useState<string>(
     initialExpressionFor(state),
@@ -276,6 +295,15 @@ function ExclusionForm({
   };
 
   const handleSave = () => {
+    // A picked option is already a complete rule, so it skips the
+    // serialize -> parse round trip; only "custom" carries no fields.
+    const picked = options.find((o) => o.value === choice);
+    if (picked?.fields) {
+      setError(null);
+      onSubmit({ fields: picked.fields, scope, enabled });
+      return;
+    }
+
     const parsed = parseExclusionExpression(expression);
     if (!parsed.ok) {
       setError(parsed.error);
@@ -287,7 +315,38 @@ function ExclusionForm({
 
   return (
     <>
-      <div className="flex-1 space-y-5 overflow-y-auto px-6">
+      <div className="flex-1 space-y-5 overflow-y-auto px-6 py-2">
+        {options.length > 1 && (
+          <div className="space-y-2">
+            <Label>What should we stop flagging?</Label>
+            <RadioGroup
+              value={choice}
+              onValueChange={(v) => setChoice(v as ExclusionOption["value"])}
+              className="gap-2"
+            >
+              {options.map((option) => (
+                <label
+                  key={option.value}
+                  htmlFor={`exclusion-${option.value}`}
+                  className="hover:bg-muted/40 flex cursor-pointer items-start gap-3 border px-3 py-2.5"
+                >
+                  <RadioGroupItem
+                    id={`exclusion-${option.value}`}
+                    value={option.value}
+                    className="mt-0.5"
+                  />
+                  <div className="min-w-0">
+                    <div className="text-sm break-all">{option.title}</div>
+                    <div className="text-muted-foreground text-xs">
+                      {option.hint}
+                    </div>
+                  </div>
+                </label>
+              ))}
+            </RadioGroup>
+          </div>
+        )}
+
         <div className="space-y-2">
           <Label>Scope</Label>
           <Select value={scope} onValueChange={setScope}>
@@ -307,51 +366,57 @@ function ExclusionForm({
           </Select>
         </div>
 
-        <div className="space-y-2">
-          <Label>Suggest with AI</Label>
-          <TextArea
-            rows={2}
-            value={askPrompt}
-            onChange={setAskPrompt}
-            placeholder="e.g. stop flagging our shared test account jane.doe@acme.com in email findings"
-          />
-          <div className="flex items-center justify-between gap-3">
-            <Text className="text-muted-foreground" small>
-              Describe what to stop flagging. We'll write the criteria
-              expression, you tweak before saving.
-            </Text>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={
-                askPrompt.trim().length < 3 || suggestMutation.isPending
-              }
-              onClick={handleSuggest}
-            >
-              <Button.LeftIcon>
-                {suggestMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Sparkles className="h-4 w-4" />
-                )}
-              </Button.LeftIcon>
-              <Button.Text>Suggest with AI</Button.Text>
-            </Button>
-          </div>
-        </div>
+        {choice === "custom" && (
+          <>
+            <div className="space-y-2">
+              <Label>Suggest with AI</Label>
+              <TextArea
+                rows={2}
+                value={askPrompt}
+                onChange={setAskPrompt}
+                placeholder="e.g. stop flagging our shared test account jane.doe@acme.com in email findings"
+              />
+              <div className="flex items-center justify-between gap-3">
+                <Text className="text-muted-foreground" small>
+                  Describe what to stop flagging. We'll write the criteria
+                  expression, you tweak before saving.
+                </Text>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={
+                    askPrompt.trim().length < 3 || suggestMutation.isPending
+                  }
+                  onClick={handleSuggest}
+                >
+                  <Button.LeftIcon>
+                    {suggestMutation.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Sparkles className="h-4 w-4" />
+                    )}
+                  </Button.LeftIcon>
+                  <Button.Text>Suggest with AI</Button.Text>
+                </Button>
+              </div>
+            </div>
 
-        <div className="space-y-2">
-          <Label>Exclusion criteria</Label>
-          <TextArea
-            rows={4}
-            value={expression}
-            onChange={setExpression}
-            placeholder={'e.g. match == "jane.doe@acme.com"'}
-            className="font-mono text-sm"
-          />
-          {error && <Text className="text-destructive text-sm">{error}</Text>}
-          <ExclusionExamples />
-        </div>
+            <div className="space-y-2">
+              <Label>Exclusion criteria</Label>
+              <TextArea
+                rows={4}
+                value={expression}
+                onChange={setExpression}
+                placeholder={'e.g. match == "jane.doe@acme.com"'}
+                className="font-mono text-sm"
+              />
+              {error && (
+                <Text className="text-destructive text-sm">{error}</Text>
+              )}
+              <ExclusionExamples />
+            </div>
+          </>
+        )}
 
         {editing && (
           <div className="flex items-center justify-between">

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -42,7 +42,13 @@ import {
   parseExclusionExpression,
   serializeExclusionExpression,
 } from "./exclusion-expression";
-import { exclusionOptions, type ExclusionOption } from "./exclusion-options";
+import {
+  exactCandidate,
+  exclusionOptions,
+  type ExclusionOption,
+} from "./exclusion-options";
+import { hasRevealableEvent, REVEAL_SCOPE, useUnmaskedMatch } from "./unmask";
+import { useRBAC } from "@/hooks/useRBAC";
 
 export const GLOBAL_SCOPE = "__global__";
 
@@ -221,12 +227,31 @@ function ExclusionForm({
 }: ExclusionFormProps) {
   const editing = state.mode === "edit" ? state.exclusion : null;
   const results = state.mode === "create" ? (state.results ?? []) : [];
+  const single = results.length === 1 ? results[0] : undefined;
+
+  // Risk Events and Risk Overview null the raw match at the API boundary, so
+  // an exact rule there needs the same audited, chat:read-gated reveal the row
+  // itself offers. Fired on selecting the option rather than on open: an
+  // operator who picks "any finding from this rule" should not leave an audit
+  // entry for a value they never looked at.
+  const { hasScope } = useRBAC();
+  const reveals = useUnmaskedMatch(single?.id ?? "");
+  const exact = exactCandidate(
+    single,
+    reveals.value,
+    hasScope(REVEAL_SCOPE) && hasRevealableEvent(single?.matchRedacted),
+  );
+
   // Ready-made rules for the selection. Always at least ["custom"], so an
   // edit or a no-finding create renders no picker and opens on the DSL box.
-  const options = exclusionOptions(results);
+  const options = exclusionOptions(results, exact);
   const [choice, setChoice] = useState<ExclusionOption["value"]>(
-    options[0]?.value ?? "custom",
+    // A pending exact option is not savable yet, so never open on it —
+    // selecting it is the gesture that fires the reveal.
+    () =>
+      options.find((o) => o.value !== "exact" || o.fields)?.value ?? "custom",
   );
+  const picked = options.find((o) => o.value === choice);
   // A finding-originated create is always global: "stop flagging this" means
   // everywhere, and the Scope select is there to narrow it.
   const [scope, setScope] = useState<string>(
@@ -292,7 +317,6 @@ function ExclusionForm({
   const handleSave = () => {
     // A picked option is already a complete rule, so it skips the
     // serialize -> parse round trip; only "custom" carries no fields.
-    const picked = options.find((o) => o.value === choice);
     if (picked?.fields) {
       setError(null);
       onSubmit({ fields: picked.fields, scope, enabled });
@@ -316,7 +340,10 @@ function ExclusionForm({
             <Label>What should we stop flagging?</Label>
             <RadioGroup
               value={choice}
-              onValueChange={(v) => setChoice(v as ExclusionOption["value"])}
+              onValueChange={(v) => {
+                setChoice(v as ExclusionOption["value"]);
+                if (v === "exact") reveals.reveal();
+              }}
               className="gap-2"
             >
               {options.map((option) => (
@@ -424,8 +451,13 @@ function ExclusionForm({
       </div>
 
       <SheetFooter className="px-6 pb-6">
-        <Button onClick={handleSave} disabled={submitting}>
-          {submitting && (
+        {/* An exact rule stays unsavable until the reveal resolves — there is
+            no client-side stand-in for the plaintext to write it against. */}
+        <Button
+          onClick={handleSave}
+          disabled={submitting || (choice === "exact" && !picked?.fields)}
+        >
+          {(submitting || reveals.isLoading) && (
             <Button.LeftIcon>
               <Loader2 className="h-4 w-4 animate-spin" />
             </Button.LeftIcon>

--- a/client/dashboard/src/pages/security/exclusion-sheet.tsx
+++ b/client/dashboard/src/pages/security/exclusion-sheet.tsx
@@ -239,7 +239,7 @@ function ExclusionForm({
   const exact = exactCandidate(
     single,
     reveals.value,
-    hasScope(REVEAL_SCOPE) && hasRevealableEvent(single?.matchRedacted),
+    hasScope(REVEAL_SCOPE, single?.chatId) && hasRevealableEvent(single?.matchRedacted),
   );
 
   // Ready-made rules for the selection. Always at least ["custom"], so an
@@ -342,7 +342,7 @@ function ExclusionForm({
               value={choice}
               onValueChange={(v) => {
                 setChoice(v as ExclusionOption["value"]);
-                if (v === "exact") reveals.reveal();
+                if (v === "exact" && !single?.match) reveals.reveal();
               }}
               className="gap-2"
             >

--- a/client/dashboard/src/pages/security/risk-ui.tsx
+++ b/client/dashboard/src/pages/security/risk-ui.tsx
@@ -7,7 +7,6 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useRiskUnmaskResultMutation } from "@gram/client/react-query/riskUnmaskResult.js";
 import { CodeBlock } from "@/components/code";
 import { Dialog } from "@/components/ui/Dialog";
 import { RULE_CATEGORY_META } from "./policy-data";
@@ -27,15 +26,12 @@ import {
   type RevealAllContextValue,
 } from "./reveal-all-context";
 import { useRBAC } from "@/hooks/useRBAC";
-import type { Scope } from "@gram/client/models/components/rolegrant.js";
-
-// Revealing a flagged secret exposes the raw value captured from agent/chat
-// traffic, so it is gated behind the same `chat:read` scope that grants access
-// to other members' session transcripts. hasScope short-circuits to true when
-// RBAC is disabled, preserving existing behavior for non-RBAC orgs.
-const REVEAL_SCOPE: Scope = "chat:read";
-const REVEAL_DENIED_REASON =
-  "You need the chat:read scope to reveal flagged values.";
+import {
+  hasRevealableEvent,
+  REVEAL_DENIED_REASON,
+  REVEAL_SCOPE,
+  useUnmaskedMatch,
+} from "./unmask";
 
 export function CategoryLabel({
   source,
@@ -174,28 +170,6 @@ export function RevealAllToggle({
   );
 }
 
-// useUnmaskedMatch backs a single MaskedMatch row: it calls risk.unmaskResult
-// on reveal and caches the plaintext locally so re-toggling visibility (or a
-// second "reveal all" pass) never re-fetches or re-audits an already-seen
-// value. Each reveal is a real, audited server call — there is no client-side
-// stand-in for the plaintext until this resolves.
-function useUnmaskedMatch(resultId: string): {
-  value: string | null;
-  isLoading: boolean;
-  reveal: () => void;
-} {
-  const { mutate, isPending } = useRiskUnmaskResultMutation();
-  const [value, setValue] = useState<string | null>(null);
-  const reveal = useCallback(() => {
-    if (value !== null || isPending) return;
-    mutate(
-      { request: { riskIDRequestBody: { id: resultId } } },
-      { onSuccess: (res) => setValue(res.match) },
-    );
-  }, [mutate, resultId, value, isPending]);
-  return { value, isLoading: isPending, reveal };
-}
-
 export function MaskedMatch({
   resultId,
   matchRedacted,
@@ -301,16 +275,6 @@ function RationaleText({ text }: { text: string }): JSX.Element {
       {text}
     </span>
   );
-}
-
-// The server redacts an absent match to this exact sentinel (no sha segment,
-// unlike a real fingerprint). A prompt-based policy finding records the judge's
-// verdict rather than a span of the message, so it lands here: there is no
-// event behind the reveal, and offering one opens an empty dialog.
-const NO_MATCH_FINGERPRINT = "<redacted len=0>";
-
-function hasRevealableEvent(matchRedacted: string | undefined): boolean {
-  return Boolean(matchRedacted) && matchRedacted !== NO_MATCH_FINGERPRINT;
 }
 
 // EventMatchDialog is the evidence cell for llm_judge / prompt_injection

--- a/client/dashboard/src/pages/security/unmask.ts
+++ b/client/dashboard/src/pages/security/unmask.ts
@@ -1,0 +1,44 @@
+import { useRiskUnmaskResultMutation } from "@gram/client/react-query/riskUnmaskResult.js";
+import type { Scope } from "@gram/client/models/components/rolegrant.js";
+import { useCallback, useState } from "react";
+
+// Revealing a flagged secret exposes the raw value captured from agent/chat
+// traffic, so it is gated behind the same `chat:read` scope that grants access
+// to other members' session transcripts. hasScope short-circuits to true when
+// RBAC is disabled, preserving existing behavior for non-RBAC orgs.
+export const REVEAL_SCOPE: Scope = "chat:read";
+export const REVEAL_DENIED_REASON =
+  "You need the chat:read scope to reveal flagged values.";
+
+// The server redacts an absent match to this exact sentinel (no sha segment,
+// unlike a real fingerprint). A prompt-based policy finding records the judge's
+// verdict rather than a span of the message, so it lands here: there is no
+// event behind the reveal, and offering one opens an empty dialog.
+const NO_MATCH_FINGERPRINT = "<redacted len=0>";
+
+export function hasRevealableEvent(matchRedacted: string | undefined): boolean {
+  return Boolean(matchRedacted) && matchRedacted !== NO_MATCH_FINGERPRINT;
+}
+
+// useUnmaskedMatch backs a single revealable value — a MaskedMatch row, or the
+// exact-value option in the exclusion picker. It calls risk.unmaskResult on
+// reveal and caches the plaintext locally so re-toggling visibility (or a
+// second "reveal all" pass) never re-fetches or re-audits an already-seen
+// value. Each reveal is a real, audited server call — there is no client-side
+// stand-in for the plaintext until this resolves.
+export function useUnmaskedMatch(resultId: string): {
+  value: string | null;
+  isLoading: boolean;
+  reveal: () => void;
+} {
+  const { mutate, isPending } = useRiskUnmaskResultMutation();
+  const [value, setValue] = useState<string | null>(null);
+  const reveal = useCallback(() => {
+    if (value !== null || isPending) return;
+    mutate(
+      { request: { riskIDRequestBody: { id: resultId } } },
+      { onSuccess: (res) => setValue(res.match) },
+    );
+  }, [mutate, resultId, value, isPending]);
+  return { value, isLoading: isPending, reveal };
+}

--- a/client/dashboard/src/pages/security/useSetupExclusionRule.tsx
+++ b/client/dashboard/src/pages/security/useSetupExclusionRule.tsx
@@ -1,19 +1,6 @@
-import { useCallback, useRef, useState, type JSX } from "react";
-import { toast } from "sonner";
+import { useCallback, useState, type JSX } from "react";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
-import { useRiskSuggestExclusionMutation } from "@gram/client/react-query/riskSuggestExclusion.js";
-import { BUILTIN_RULE_ID_LIST } from "./detection-rules-data";
-import { serializeExclusionExpression } from "./exclusion-expression";
-import {
-  ExclusionSheet,
-  GLOBAL_SCOPE,
-  type ExclusionSheetState,
-} from "./exclusion-sheet";
-
-// A batch AI-suggestion attempt gets this long to resolve before the sheet
-// opens unprefilled — long enough for a real completion, short enough that
-// selecting a batch and asking for an exclusion never feels stuck.
-const SUGGEST_TIMEOUT_MS = 6000;
+import { ExclusionSheet, type ExclusionSheetState } from "./exclusion-sheet";
 
 /** Opens the "Setup exclusion rule" sheet from a selection of one or more
  * findings — shared by every surface that offers both "Mark as false
@@ -21,96 +8,25 @@ const SUGGEST_TIMEOUT_MS = 6000;
  * Category Detail; the chat transcript wires its own single-finding case
  * directly via CreateExclusionContext instead, since it predates this hook).
  *
- * A single finding hands the sheet the finding itself, so it opens on the
- * ready-made rule picker (the chat transcript does the same). Two
- * or more triggers an AI-suggested pattern derived from the batch — the
- * caller should show `isSuggesting` as a spinner on its trigger button. The
- * sheet still opens (unprefilled, so the operator can finish manually)
- * rather than dead-ending on a timeout or a failed/empty suggestion. */
+ * The sheet opens immediately on ready-made rules computed from the selection
+ * itself (see `exclusionOptions`), single or batch alike. Nothing is fetched
+ * here; the AI suggestion lives inside the sheet's "Write it myself" branch,
+ * where the operator asks for it. */
 export function useSetupExclusionRule(): {
   open: (results: RiskResult[]) => void;
-  isSuggesting: boolean;
   sheet: JSX.Element;
 } {
   const [sheetState, setSheetState] = useState<ExclusionSheetState | null>(
     null,
   );
-  const [isSuggesting, setIsSuggesting] = useState(false);
-  const suggestMutation = useRiskSuggestExclusionMutation();
-  // Bumped on every open() call. Promise.race doesn't cancel the losing
-  // request — after a timeout falls back to the manual sheet, the actual
-  // mutation keeps running in the background and eventually still resolves.
-  // Without this token, that late resolution (or a second open() call for a
-  // different selection made in the meantime) would clobber whatever sheet
-  // state the operator is looking at by then and leave the spinner on past
-  // the fallback.
-  const requestIdRef = useRef(0);
 
-  const open = useCallback(
-    (results: RiskResult[]) => {
-      if (results.length === 0) return;
-
-      const requestId = ++requestIdRef.current;
-
-      if (results.length === 1) {
-        setIsSuggesting(false);
-        setSheetState({ mode: "create", results });
-        return;
-      }
-
-      setIsSuggesting(true);
-
-      const timedOut = new Promise<"timeout">((resolve) => {
-        setTimeout(() => resolve("timeout"), SUGGEST_TIMEOUT_MS);
-      });
-      void Promise.race([
-        suggestMutation.mutateAsync({
-          request: {
-            suggestExclusionRequestBody: {
-              findingIds: results.map((r) => r.id),
-              knownRuleIds: BUILTIN_RULE_ID_LIST,
-            },
-          },
-        }),
-        timedOut,
-      ])
-        .then((result) => {
-          if (requestId !== requestIdRef.current) return;
-          setIsSuggesting(false);
-          if (result === "timeout") {
-            toast.error("AI suggestion took too long. Setting up manually.");
-            setSheetState({ mode: "create", initialScope: GLOBAL_SCOPE });
-            return;
-          }
-          if (!result.matchType || !result.matchValue) {
-            toast.error("No suggestion came back. Setting up manually.");
-            setSheetState({ mode: "create", initialScope: GLOBAL_SCOPE });
-            return;
-          }
-          setSheetState({
-            mode: "create",
-            initialExpression: serializeExclusionExpression({
-              matchType: result.matchType,
-              matchValue: result.matchValue,
-              ruleIdFilter: result.ruleIdFilter ?? "",
-              sourceFilter: result.sourceFilter ?? "",
-            }),
-            initialScope: GLOBAL_SCOPE,
-          });
-        })
-        .catch(() => {
-          if (requestId !== requestIdRef.current) return;
-          setIsSuggesting(false);
-          toast.error("AI suggestion failed. Setting up manually.");
-          setSheetState({ mode: "create", initialScope: GLOBAL_SCOPE });
-        });
-    },
-    [suggestMutation],
-  );
+  const open = useCallback((results: RiskResult[]) => {
+    if (results.length === 0) return;
+    setSheetState({ mode: "create", results });
+  }, []);
 
   return {
     open,
-    isSuggesting,
     sheet: (
       <ExclusionSheet
         state={sheetState}

--- a/client/dashboard/src/pages/security/useSetupExclusionRule.tsx
+++ b/client/dashboard/src/pages/security/useSetupExclusionRule.tsx
@@ -2,7 +2,6 @@ import { useCallback, useRef, useState, type JSX } from "react";
 import { toast } from "sonner";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import { useRiskSuggestExclusionMutation } from "@gram/client/react-query/riskSuggestExclusion.js";
-import { findingToExclusionState } from "@/pages/chatLogs/chatHelpers";
 import { BUILTIN_RULE_ID_LIST } from "./detection-rules-data";
 import { serializeExclusionExpression } from "./exclusion-expression";
 import {
@@ -22,8 +21,8 @@ const SUGGEST_TIMEOUT_MS = 6000;
  * Category Detail; the chat transcript wires its own single-finding case
  * directly via CreateExclusionContext instead, since it predates this hook).
  *
- * A single finding prefills the expression directly, mirroring the chat
- * transcript's per-finding flow (same `findingToExclusionState` helper). Two
+ * A single finding hands the sheet the finding itself, so it opens on the
+ * ready-made rule picker (the chat transcript does the same). Two
  * or more triggers an AI-suggested pattern derived from the batch — the
  * caller should show `isSuggesting` as a spinner on its trigger button. The
  * sheet still opens (unprefilled, so the operator can finish manually)
@@ -55,7 +54,7 @@ export function useSetupExclusionRule(): {
 
       if (results.length === 1) {
         setIsSuggesting(false);
-        setSheetState(findingToExclusionState(results[0]!));
+        setSheetState({ mode: "create", results });
         return;
       }
 


### PR DESCRIPTION
Setting up an exclusion rule from a finding used to open on a monospace textarea expecting DSL, with an AI prompt box sitting right above it — two inputs, no indication that filling one meant skipping the other. Batch selections additionally blocked on a 6-second race against `risk.suggestExclusion` before the sheet would open at all.

The sheet now opens instantly on a radio list of ready-made rules stated as sentences. Every option is already a complete, savable rule; no code is visible unless you ask for it.

### Demo

![demo](https://gist.githubusercontent.com/svadrutk/c14f697b83262883c949bbbb310da5ba/raw/demo.gif)

Single finding in a transcript → the picker opens preselected on the exact value → "Write it myself" is what reveals the DSL → back to the exact value → Create, and the session drops from 2 risks to 1.

### What changed

**A picker instead of a code box.** `exclusionOptions()` (new, `exclusion-options.ts`) takes the selection and returns only the rules that are valid for it:

| Option | Offered when |
|---|---|
| `Just this value — <match>` | one finding, and we hold its plaintext — or can reveal it |
| `Any <rule title> finding` | every selected row shares a `ruleId` |
| `Anything detected by <source>` | every selected row shares a `source` |
| `Write it myself` | always, last |

Each option carries its own `ExclusionFields`, so saving one skips the serialize → parse round trip entirely — `handleSave` hands the mutation the same shape it already produced. Only `custom` has no fields.

<img src="https://gist.githubusercontent.com/svadrutk/c14f697b83262883c949bbbb310da5ba/raw/batch-picker.png" width="820" />

**The two text inputs can no longer co-occur.** The criteria textarea and the "Suggest with AI" box are both behind `choice === "custom"`. They are removed from the tree rather than hidden, so the picker never leaves a stale expression behind it.

<img src="https://gist.githubusercontent.com/svadrutk/c14f697b83262883c949bbbb310da5ba/raw/write-it-myself.png" width="820" />

**The blocking AI race is gone.** `SUGGEST_TIMEOUT_MS`, the `Promise.race`, the `requestIdRef` token, `isSuggesting`, the spinner on the bulk-actions trigger, and three fallback toasts that all dead-ended on an empty code box — deleted. The options are computed locally, so none of that has an output to produce any more. `useSetupExclusionRule` goes 124 → 32 lines.

The suggestion endpoint survives inside "Write it myself", where it now carries the selected `findingIds` (capped at 50). That covers the one case local computation can't: a batch sharing neither rule nor source, which is exactly what the server generalizes well. On demand now, rather than on a blocking race.

**Scope defaults to global for any finding-originated create.** Previously the chat transcript defaulted to the finding's `policyId` while the batch path defaulted to global — an undisclosed split. "Stop flagging this" means everywhere; the Scope select is there to narrow it.

**The exact-value option reaches the masked list pages too.** Risk Events and Risk Overview null the raw `match` at the API boundary, so without this the entry point silently changed what the default rule meant. The option now appears there behind the same audited, `chat:read`-gated `risk.unmaskResult` reveal the row itself uses.

The reveal fires on **selecting** the option, not on opening the sheet — an operator who picks "any finding from this rule" should not leave an audit entry for a value they never looked at. Until it resolves the option is labelled with the redaction, is never preselected, and Create stays disabled; there is no client-side stand-in for the plaintext. Re-selecting after switching away reuses the cached value, so one reveal is one audit entry.

<img src="https://gist.githubusercontent.com/svadrutk/c14f697b83262883c949bbbb310da5ba/raw/masked-reveal.png" width="820" />

`useUnmaskedMatch` and `hasRevealableEvent` move out of `risk-ui.tsx` into a new `unmask.ts` — exporting non-components from a component module trips `react/only-export-components`. No behaviour change to `MaskedMatch` or `EventMatchDialog`.

### Unchanged

Edit mode and the no-finding create paths (Exclusions tab, Policy Center) render exactly as before — `exclusionOptions([])` returns just `custom`, so no picker appears and the form opens straight onto the criteria box. The expression parser and all 12 of its error strings are untouched.

### Not in this PR

No "this will suppress N findings" preview; `entity_type`, regex, and combined rule+source filters stay DSL-only. The Exclusions tab and Policy Center still open on a code box — there is no finding there to build options from, and the picker simply never appears.

### Testing

- `exclusion-options.test.ts` (new, pure, no mocks) covers the selection shapes — empty, single-with-match, single-with-revealed-value, pending reveal, shared-rule batch, batch sharing nothing — plus `exactCandidate`'s precedence and its scope gate.
- `pnpm -F dashboard type-check`, `build`, `lint`, and `vitest run src/pages/security/` (14 files, 105 tests) all green.
- Manually walked the transcript, Risk Events bulk, Risk Overview category bulk, Exclusions tab, Policy Center, and edit paths against the local seed. Confirmed on Risk Events that selecting the exact option fires exactly one `risk.unmaskResult`, that switching away and back fires no second one, and that no request goes out when the operator picks rule/source instead.
