### PR TITLE
fix: reinstate system-role editability in roles tab

### DIFF
--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -294,7 +294,7 @@ export function RolesTab(): JSX.Element {
           <Badge
             variant="neutral"
             size="sm"
-            className="bg-background mt-0.5 w-16 shrink-0 justify-center"
+            className="bg-surface-primary-default mt-0.5 w-16 shrink-0 [&>span]:text-center"
           >
             Member
           </Badge>
@@ -308,7 +308,7 @@ export function RolesTab(): JSX.Element {
           <Badge
             variant="neutral"
             size="sm"
-            className="bg-background mt-0.5 w-16 shrink-0 justify-center"
+            className="bg-surface-primary-default mt-0.5 w-16 shrink-0 [&>span]:text-center"
           >
             Admin
           </Badge>

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -202,7 +202,9 @@ export function RolesTab(): JSX.Element {
     if (editRoleId && roles.length > 0) {
       const role = roles.find((r) => r.id === editRoleId);
       if (role) {
-        setEditingRole(role);
+        // Mirror the row/menu gate (org:admin) on the deep-link path too
+        // (still consume the param so it doesn't linger in the URL).
+        if (canManageRoles) setEditingRole(role);
         setSearchParams(
           (prev) => {
             prev.delete("editRole");
@@ -212,7 +214,7 @@ export function RolesTab(): JSX.Element {
         );
       }
     }
-  }, [searchParams, roles, setSearchParams]);
+  }, [searchParams, roles, setSearchParams, canManageRoles]);
 
   const defaultRole =
     roles.find((r) => r.isSystem && r.name === "Member") ?? null;

--- a/client/dashboard/src/pages/access/RolesTab.tsx
+++ b/client/dashboard/src/pages/access/RolesTab.tsx
@@ -35,16 +35,17 @@ import { cn } from "@/lib/utils";
 import { visiblePermissionCount } from "./roleDialogState";
 
 // Single source of truth for the per-role actions: the "⋯" dropdown and the
-// row's right-click context menu both render from this list. System roles are
-// fixed (their grants aren't editable), so they get no actions at all.
+// row's right-click context menu both render from this list. Edit always;
+// Delete only for non-system roles.
 function roleActions(
   role: Role,
   { onEdit, onDelete }: { onEdit: () => void; onDelete: () => void },
 ): Action[] {
-  if (role.isSystem) return [];
   return [
     { label: "Edit", onClick: onEdit },
-    { label: "Delete", destructive: true, onClick: onDelete },
+    ...(!role.isSystem
+      ? [{ label: "Delete", destructive: true, onClick: onDelete }]
+      : []),
   ];
 }
 
@@ -128,21 +129,20 @@ function RoleRow({
       photoUrl: m.photoUrl,
     }));
 
-  // Mirror the row-actions menu via the shared builder. Without org:admin —
-  // or for a fixed system role — the menu is empty and the row stays unwrapped.
+  // Mirror the row-actions menu via the shared builder. Without org:admin the
+  // menu is empty and the row stays unwrapped.
   const actions: Action[] = canManageRoles
     ? roleActions(role, { onEdit, onDelete })
     : [];
-  const canEdit = canManageRoles && !role.isSystem;
 
   return (
     <TableRowContextMenu actions={actions}>
       <div
-        role={canEdit ? "button" : undefined}
-        tabIndex={canEdit ? 0 : undefined}
-        onClick={canEdit ? onEdit : undefined}
+        role={canManageRoles ? "button" : undefined}
+        tabIndex={canManageRoles ? 0 : undefined}
+        onClick={canManageRoles ? onEdit : undefined}
         onKeyDown={
-          canEdit
+          canManageRoles
             ? (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
@@ -153,7 +153,7 @@ function RoleRow({
         }
         className={cn(
           "border-border col-span-full grid grid-cols-subgrid items-center gap-x-6 border-b px-4 py-3 last:border-b-0",
-          canEdit && "hover:bg-muted/50 cursor-pointer",
+          canManageRoles && "hover:bg-muted/50 cursor-pointer",
         )}
       >
         <div className="flex items-center gap-2">
@@ -169,19 +169,11 @@ function RoleRow({
         <Text variant="body" className="text-muted-foreground min-w-0 truncate">
           {role.description}
         </Text>
-        <Text variant="body">
-          {role.isSystem
-            ? role.name === "Admin"
-              ? "All"
-              : "System"
-            : visiblePermissionCount(role.grants)}
-        </Text>
+        <Text variant="body">{visiblePermissionCount(role.grants)}</Text>
         <MemberFacepile members={roleMembers} />
         <div aria-hidden />
         <div onClick={(e) => e.stopPropagation()} className="flex justify-end">
-          {!role.isSystem && (
-            <RoleActionsMenu role={role} onEdit={onEdit} onDelete={onDelete} />
-          )}
+          <RoleActionsMenu role={role} onEdit={onEdit} onDelete={onDelete} />
         </div>
       </div>
     </TableRowContextMenu>
@@ -210,9 +202,7 @@ export function RolesTab(): JSX.Element {
     if (editRoleId && roles.length > 0) {
       const role = roles.find((r) => r.id === editRoleId);
       if (role) {
-        // System roles are fixed — never deep-link them into the edit sheet
-        // (still consume the param so it doesn't linger in the URL).
-        if (!role.isSystem) setEditingRole(role);
+        setEditingRole(role);
         setSearchParams(
           (prev) => {
             prev.delete("editRole");


### PR DESCRIPTION
## What

Reinstates editing of system-role (Admin/Member) permissions in the Roles tab, which regressed in the dashboard restyle (#5046).

That PR unintentionally changed behavior in `RolesTab.tsx` alongside the styling work:

- `roleActions()` returned no actions for system roles, so the "⋯" menu and right-click context menu disappeared entirely
- the row click / keyboard handler was gated on `!role.isSystem`, so system-role permissions could no longer be viewed at all (the edit sheet doubles as the viewer)
- the Permissions column showed "All"/"System" placeholders instead of the real grant count
- `?editRole=` deep links were dropped for system roles

System-role grants are intentionally editable per-org since #3727 — the backend still supports it (name/description stay platform-managed, and the lockout guardrail keeps `org:admin` on the Admin role). This PR reverts the four behavior hunks while keeping all styling from the restyle.

## Changes

- Edit action restored for all roles; Delete remains custom-role-only
- Row click / Enter / Space and the "⋯" menu work on system roles again (still gated on `org:admin`)
- Permissions column shows `visiblePermissionCount(role.grants)` for every role
- System roles can be deep-linked into the edit sheet via `?editRole=` again

<img width="3682" height="3368" alt="CleanShot 2026-08-10 at 11 52 33@2x" src="https://github.com/user-attachments/assets/0ae4712c-bedb-4375-8d27-2d42f0543419" />


## Verification

- `pnpm -F dashboard type-check` green
- Access page tests pass (8 files, 172 tests)
- `CreateRoleDialog` untouched by the regression (its #5046 diff was styling-only), so the edit sheet itself was already fully functional



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores editing and viewing of system-role permissions in Roles after the dashboard restyle regression. Also fixes Admin/Member badge alignment and background.

- **Bug Fixes**
  - Enabled Edit for system roles; Delete stays custom-role only.
  - Restored row click/Enter/Space and the "⋯" menu for system roles when user has `org:admin`.
  - Permissions column now shows `visiblePermissionCount(role.grants)` for all roles.
  - Re-enabled `?editRole=` deep links, gated on `org:admin` to match row/menu behavior.

<sup>Written for commit 41d491103de3e025ee662e936d3a472840a473e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



