### PR TITLE
chore(skills): update ClickHouse guidance

### DIFF
--- a/.agents/recommended-skills.json
+++ b/.agents/recommended-skills.json
@@ -1,6 +1,16 @@
 {
   "$comment": "Recommended external agent skills. Installed on opt-in by `mise run skills:recommended` (offered by ./zero); contents land in .agents/skills/<name>/ and are kept out of git via .git/info/exclude. Pin `ref` to a commit SHA.",
   "skills": {
+    "clickhouse-architecture-advisor": {
+      "repo": "https://github.com/ClickHouse/agent-skills",
+      "ref": "5aec3114379671f33b1c502a51d420a0729c8172",
+      "path": "skills/clickhouse-architecture-advisor"
+    },
+    "clickhouse-best-practices": {
+      "repo": "https://github.com/ClickHouse/agent-skills",
+      "ref": "5aec3114379671f33b1c502a51d420a0729c8172",
+      "path": "skills/clickhouse-best-practices"
+    },
     "worktrunk": {
       "repo": "https://github.com/max-sixty/worktrunk",
       "ref": "1eded279436736e432a467cb8a0bd5d4496d797a",

--- a/.agents/skills/clickhouse/SKILL.md
+++ b/.agents/skills/clickhouse/SKILL.md
@@ -1,14 +1,21 @@
 ---
 name: clickhouse
-description: Rules when working with ClickHouse database in Gram for analytics and telemetry features, including editing the ClickHouse schema (server/clickhouse/schema.sql) and creating or fixing ClickHouse migrations
+description: Use when changing or reviewing Gram ClickHouse schemas, migrations, queries, inserts, tests, or performance for analytics, telemetry, risk, authz, and spend features
 ---
+
+## Official ClickHouse guidance
+
+Gram conventions and the checked-in schema remain authoritative. Also use:
+
+- `clickhouse-best-practices` when reviewing or changing a ClickHouse schema, query, insert strategy, or configuration. Read its applicable rule files and cite the rules in review findings.
+- `clickhouse-architecture-advisor` when choosing between ingestion patterns, raw tables and materialized views, partitioning or retention strategies, joins or enrichment, or mutable-state models.
 
 ## Schema design and evolution
 
 The ClickHouse schema is defined in `server/clickhouse/schema.sql`. To change it, edit that file and generate a migration:
 
-```
-mise clickhouse:diff <migration-name>
+```sh
+mise run clickhouse:diff <migration-name>
 ```
 
 This produces migrations in **two flavors** that must always stay in sync:
@@ -16,23 +23,23 @@ This produces migrations in **two flavors** that must always stay in sync:
 - `server/clickhouse/migrations/` — **Atlas** format. This is the source of truth: only these migrations are carried forward and applied in production.
 - `server/clickhouse/local/golang_migrate/` — **golang-migrate** format (`.up.sql`/`.down.sql` pairs). Used only for local development, so contributors without an Atlas Pro login can still run migrations.
 
-`mise clickhouse:diff` generates both flavors together. If you ever hand-edit a migration (or the diff output), make the equivalent change in **both** directories, then run `mise clickhouse:hash` to regenerate `atlas.sum`. Apply pending migrations locally with `mise clickhouse:migrate`.
+`mise run clickhouse:diff` generates both flavors together. If you ever hand-edit a migration (or the diff output), make the equivalent change in **both** directories, then run `mise run clickhouse:hash` to regenerate `atlas.sum`. Apply pending migrations locally with `mise run clickhouse:migrate`.
 
 **No semicolons in `COMMENT '...'` strings.** golang-migrate splits statements naively, so a semicolon inside a column/table comment breaks its parser and the local migrations fail to replay. Rephrase the comment instead.
 
 Three CI checks guard this on every PR:
 
-- **atlas-lint** — runs the Atlas migration linter, plus a porcelain check that migrations were generated and are up to date with both the Postgres and ClickHouse schemas. If you edited `schema.sql` without running `mise clickhouse:diff`, this fails.
+- **atlas-lint** — runs the Atlas migration linter, plus a porcelain check that migrations were generated and are up to date with both the Postgres and ClickHouse schemas. If you edited `schema.sql` without running `mise run clickhouse:diff`, this fails.
 - **golang-migrate-clickhouse** — replays all golang-migrate migrations against a real ClickHouse instance to prove they're valid. If the two flavors drifted, this is where it shows up.
 - **migration-order** — fails if a newly added migration in either ClickHouse dir (`server/clickhouse/migrations` or `server/clickhouse/local/golang_migrate`) has a timestamp at or before the latest already on `main`. It also runs in the merge queue, so two PRs branched from the same head cannot both land and produce non-linear history (the INC-418 failure mode).
 
-**Out-of-order timestamps.** If `migration-order` reports a ClickHouse migration timestamp at or before the latest on `main`, do **not** rename the file or hand-edit `atlas.sum`. Delete the offending file in **both** flavor dirs (`server/clickhouse/migrations` and `server/clickhouse/local/golang_migrate`), rebase/merge `main`, then re-run `mise clickhouse:diff <name>`. That regenerates both flavors on top with fresh, ordered timestamps and keeps them in sync. Avoid `atlas migrate rebase`: it renames only one dir (drifting the two flavors apart) and, for golang-migrate, moves an already-applied migration to a higher version so `migrate up` silently skips it on teammates' local databases.
+**Out-of-order timestamps.** If `migration-order` reports a ClickHouse migration timestamp at or before the latest on `main`, do **not** rename files, hand-edit `atlas.sum`, or run `atlas migrate rebase`. Delete the generated Atlas migration and both matching golang-migrate `.up.sql`/`.down.sql` files, identified by migration name; update from `main`; then re-run `mise run clickhouse:diff <name>`. That regenerates both flavors on top with fresh, ordered timestamps and keeps them in sync. Avoid `atlas migrate rebase`: it renames only one dir (drifting the two flavors apart) and, for golang-migrate, moves an already-applied migration to a higher version so `migrate up` silently skips it on teammates' local databases.
 
 ## ClickHouse Queries (Telemetry Package)
 
-The `server/internal/telemetry` package uses ClickHouse for high-performance analytics queries. Unlike PostgreSQL queries, **ClickHouse queries are NOT auto-generated by SQLc** (SQLc doesn't support ClickHouse). We use the **squirrel** query builder for dynamic query construction.
+The `server/internal/telemetry` package uses ClickHouse for high-performance analytics queries. Unlike PostgreSQL queries, ClickHouse queries are not auto-generated by SQLc. The telemetry repository uses Squirrel for dynamic query construction.
 
-> **CRITICAL:** The squirrel query builder is ONLY permitted for ClickHouse queries in the telemetry package. **DO NOT use squirrel for PostgreSQL queries** - all PostgreSQL queries MUST use SQLc-generated code. This is the only acceptable exception to our "no query builders" policy.
+> **CRITICAL:** Squirrel is permitted for ClickHouse repository code, including packages outside telemetry. Never use it for PostgreSQL queries; PostgreSQL repositories must use SQLc-generated code. Follow the target ClickHouse package's neighboring query and scan patterns.
 
 ### Read from summary views, not raw `telemetry_logs`
 
@@ -97,9 +104,11 @@ When asked to add a new ClickHouse query to the telemetry package:
 
 ### Testing ClickHouse Queries
 
-- Use `testenv.Launch()` in `TestMain` for infrastructure setup
-- Add `time.Sleep(100 * time.Millisecond)` after inserts (ClickHouse eventual consistency)
-- Use table-driven tests with descriptive "it" prefix names
-- Create helper functions for test data insertion
+- Use the target package's existing ClickHouse fixture pattern (`testenv.Launch` or `testenv.NewTestClickhouse`) and a real ClickHouse container.
+- For `async_insert=0`, read directly after the insert.
+- For `async_insert=1, wait_for_async_insert=1`, read directly after the insert returns.
+- For `async_insert=1, wait_for_async_insert=0`, call `testenv.FlushClickHouseAsyncInserts(t, conn)` after the application issues the write and before reading. Synchronize any application goroutine first; do not use `time.Sleep` or polling to wait for the async queue.
+- Do not use `clickhouse.WithAsync(false)` to request synchronous insertion: it enables fire-and-forget async inserts. Omit async options or set `async_insert=0` explicitly.
+- Use table-driven tests with descriptive `it`-prefix names and helper functions for test data insertion.
 
 See `server/internal/telemetry/README.md` for comprehensive documentation.

--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -11,7 +11,7 @@ Skills are agent-facing reference docs in `.agents/skills/<name>/SKILL.md`, syml
 
 1. Baseline per the eval loop below, then author `.agents/skills/<name>/SKILL.md` — kebab-case, verb-first name (`writing-skills`, not `skill-creation`).
 2. Run `mise run skills:sync` — creates the symlinks in `.claude/skills/`, `.codex/skills/`, `.opencode/skills/`, `.cursor/skills/` and prunes stale ones. Never hand-create the links; you will miss a harness.
-3. Add a row to the skills table in `CLAUDE.md`.
+3. Do not add a manual skills table to `CLAUDE.md`; harnesses discover skills from the synced directories and each skill's frontmatter.
 4. Commit the skill and the symlinks together.
 
 ## Frontmatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,50 +113,10 @@ mise run start
 
 </important>
 
-## Skills
-
-Skills provide domain-specific rules and best practices.
-
-<important>
-
-Activate a skill when your task falls within its scope.
-
-</important>
-
-| Skill                             | When to activate                                                                |
-| --------------------------------- | ------------------------------------------------------------------------------- |
-| `golang`                          | Writing or editing Go code                                                      |
-| `postgresql`                      | Creating migrations, writing SQLc queries, or changing the database schema      |
-| `clickhouse`                      | Working with ClickHouse queries, schema, or migrations in the `server/` package |
-| `frontend`                        | Working on the React frontend in `client/`                                      |
-| `vercel-react-best-practices`     | Optimizing React performance, reviewing components for best practices           |
-| `gram-demo-seed`                  | Editing or extending the demo org seed SQL, or a demo-seed-safety CI failure    |
-| `gram-functions`                  | Understanding or modifying the Gram Functions serverless execution feature      |
-| `gram-management-api`             | Designing or modifying management API endpoints (Goa design, impl)              |
-| `gram-audit-logging`              | Recording or exposing audit events via the auditlogs management API             |
-| `gram-rbac`                       | Adding or enforcing authorization scopes, grants, or roles                      |
-| `gram-pubsub`                     | Declaring Pub/Sub topics/subscriptions via proto, or publishing/consuming       |
-| `gram-pubsub-python`              | Building or running Python (`pystreams/`) Pub/Sub subscribers, NLP/ML use cases |
-| `gram-telemetry-query-dimensions` | Adding telemetry query group/filter attributes                                  |
-| `feature-flag`                    | Deciding between `productfeatures` vs PostHog flags, or adding either           |
-| `glint`                           | Authoring or editing analyzers in the `glint/` go/analysis package              |
-| `mise-tasks`                      | Creating or editing mise task scripts in `.mise-tasks/`                         |
-| `jaeger`                          | Testing backend endpoints locally and inspecting traces via Jaeger API          |
-| `pitchfork`                       | Starting/stopping/restarting local dev services or querying their logs          |
-| `worktrunk`                       | `wt` worktrees: create/boot/remove stacks, hooks, config (via `./zero` opt-in)  |
-| `writing-skills`                  | Adding or editing an agent skill in `.agents/skills/` and validating it         |
-| `datadog`                         | Investigating errors, performance, incidents, or telemetry via Datadog          |
-| `datadog-insights`                | Running the full Gram production health digest and posting it to Slack          |
-| `spec`                            | Interviewing user in-depth to produce a detailed spec before building           |
-| `page-toolbar`                    | Dashboard list page search, filters, sort, or view controls                     |
-| `gram-playwright-cli`             | Browser automation, dashboard inspection, screenshots, and page interaction     |
-| `pr`                              | Creating a Pull Request for current changes                                     |
-| `pr-demo-gif`                     | Recording a demo GIF of a user-visible frontend change for a PR comment         |
-
 # Plan Mode
 
 - Make the plan extremely concise. Sacrifice grammar for the sake of concision.
-- Identify any of the skills above that are relevant to the task so you can activate when implementing.
+- Identify any available skills relevant to the task so you can activate them when implementing.
 - At the end of each plan, give me a list of unresolved questions to answer, if any.
 
 ## Cursor Cloud specific instructions


### PR DESCRIPTION
## Summary

- pin the official ClickHouse best-practices and architecture-advisor skills as recommended external skills
- add concise routing from Gram's existing ClickHouse skill while preserving its migration and telemetry guidance
- correct the Squirrel scope, mise command syntax, migration recovery details, and async-insert testing guidance
- remove the redundant manual skills table from `CLAUDE.md` and update `writing-skills` to rely on harness discovery

## Why

The official ClickHouse skills provide maintained review and architecture guidance, while Gram's local skill remains the source for repository-specific workflows. Skills are already discovered from the synced harness directories and each `SKILL.md` frontmatter, so duplicating the catalog in `CLAUDE.md` adds context and can drift.

## Validation

- `mise run skills:sync`
- `jq empty .agents/recommended-skills.json`
- `git diff --check origin/main...HEAD`
- ClickHouse skill evaluation: ship, 9.5/10, no confusions
- skill-catalog removal evaluation: ship, 10/10, no confusions
