### PR TITLE
mig(risk): add attribution and reveal columns to risk_findings

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260805105902_risk-findings-app-team-attribution.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260805105902_risk-findings-app-team-attribution.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `risk_findings` DROP COLUMN `team`;
+ALTER TABLE `risk_findings` DROP COLUMN `chat_source`;

--- a/server/clickhouse/local/golang_migrate/20260805105902_risk-findings-app-team-attribution.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260805105902_risk-findings-app-team-attribution.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `risk_findings` ADD COLUMN `chat_source` LowCardinality(String) DEFAULT '' COMMENT 'Canonical product surface the scanned message came from (chat_messages.source canonicalized at ingest, e.g. codex, cursor, claude-code). Empty for rows written before the column existed or when attribution is unresolved.';
+ALTER TABLE `risk_findings` ADD COLUMN `team` LowCardinality(String) DEFAULT '' COMMENT 'WorkOS directory department_name of the resolved user at ingest. Empty when the user has no directory profile or attribution is unresolved.';

--- a/server/clickhouse/local/golang_migrate/20260805161427_risk-findings-user-email.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260805161427_risk-findings-user-email.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `risk_findings` DROP COLUMN `user_email`;

--- a/server/clickhouse/local/golang_migrate/20260805161427_risk-findings-user-email.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260805161427_risk-findings-user-email.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `risk_findings` ADD COLUMN `user_email` String DEFAULT '' COMMENT 'Email of the resolved internal user at ingest (users.email), letting the Watchdog display users without a Postgres lookup. Empty for external-only users or when attribution is unresolved.' CODEC(ZSTD(1));

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:p5bp8ea5cyXBS/5XawIHBxyaHeNkWP5malxe4hW9E7U=
+h1:hj82rT4GwY/8s91jOfOT+KS9d4CQmkCJz41dnsp/Nb8=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -84,3 +84,5 @@ h1:p5bp8ea5cyXBS/5XawIHBxyaHeNkWP5malxe4hW9E7U=
 20260803163755_surface-chatgpt-usage-in-summaries.up.sql h1:bAU93tpzoFDRdQdsw/VRkeGIDikck9Q/jVnGNSJ/ACo=
 20260803191817_event-urn-span-kind-comment.up.sql h1:IlqREavCQJhNLT4ZhOcLpcT4AaDbcNajPqg+qfuz844=
 20260803192750_litellm-usage-in-summaries.up.sql h1:7L9bzpMEUz/JyjSe0uh+tQ3fvOhH3Ahm9Xavtl3xgZo=
+20260805105902_risk-findings-app-team-attribution.up.sql h1:UmQaEOmnP7ormKmGnaolNXAq2ogrRNVqxGj7EhfkGQ4=
+20260805161427_risk-findings-user-email.up.sql h1:2m9vZDNhLAZ2w5mVIS4vNtJtbTULtrHn+qZUU6ww3dE=

--- a/server/clickhouse/migrations/20260805105857_risk-findings-app-team-attribution.sql
+++ b/server/clickhouse/migrations/20260805105857_risk-findings-app-team-attribution.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `risk_findings` ADD COLUMN `chat_source` LowCardinality(String) DEFAULT '' COMMENT 'Canonical product surface the scanned message came from (chat_messages.source canonicalized at ingest, e.g. codex, cursor, claude-code). Empty for rows written before the column existed or when attribution is unresolved.';
+ALTER TABLE `risk_findings` ADD COLUMN `team` LowCardinality(String) DEFAULT '' COMMENT 'WorkOS directory department_name of the resolved user at ingest. Empty when the user has no directory profile or attribution is unresolved.';

--- a/server/clickhouse/migrations/20260805161421_risk-findings-user-email.sql
+++ b/server/clickhouse/migrations/20260805161421_risk-findings-user-email.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `risk_findings` ADD COLUMN `user_email` String DEFAULT '' COMMENT 'Email of the resolved internal user at ingest (users.email), letting the Watchdog display users without a Postgres lookup. Empty for external-only users or when attribution is unresolved.' CODEC(ZSTD(1));

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:xOHmeQgoQfuEfB8Y8n3SCuAuakSoIjShS0VuxcHJY48=
+h1:Mq76XAULFPC58+uB8wBu3kO3XpxMHdIqhHv/CX1zADg=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -89,3 +89,5 @@ h1:xOHmeQgoQfuEfB8Y8n3SCuAuakSoIjShS0VuxcHJY48=
 20260803163750_surface-chatgpt-usage-in-summaries.sql h1:Fn6K/rFMTsYYxWwyxBnwBvU1OCwi0MwPRp9uoelAMB8=
 20260803191705_event-urn-span-kind-comment.sql h1:7IFQs0jGu092U3E6e/piSkAQ3Zd5SqIDMVOf8yA8Bwk=
 20260803192745_litellm-usage-in-summaries.sql h1:dMsZ2uPJxHOq8HL/Y0Eb0acbiPscYc9DMRdBZgKVYTo=
+20260805105857_risk-findings-app-team-attribution.sql h1:vfAJnjNr6OCXRxKCft2zjU02TZ6MjdfSMGqcLWchAos=
+20260805161421_risk-findings-user-email.sql h1:vIbFrSbYl1wNZ+j1o3GKTsE7s5yIFAQEcHhnqB2yW9Q=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1315,6 +1315,9 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     -- traffic (scans follow messages within seconds).
     message_created_at DateTime64(9) DEFAULT created_at COMMENT 'Event time of the scanned chat message (chat_messages.created_at). Defaults to created_at (scan time) for rows written before the column existed or when attribution is unresolved.' CODEC(DoubleDelta, ZSTD),
     assistant_id String DEFAULT '' COMMENT 'Assistant linked to the finding chat via a live assistant_threads row at ingest. Empty when the chat has no assistant link or attribution is unresolved.' CODEC(ZSTD),
+    chat_source LowCardinality(String) DEFAULT '' COMMENT 'Canonical product surface the scanned message came from (chat_messages.source canonicalized at ingest, e.g. codex, cursor, claude-code). Empty for rows written before the column existed or when attribution is unresolved.',
+    team LowCardinality(String) DEFAULT '' COMMENT 'WorkOS directory department_name of the resolved user at ingest. Empty when the user has no directory profile or attribution is unresolved.',
+    user_email String DEFAULT '' COMMENT 'Email of the resolved internal user at ingest (users.email), letting the Watchdog display users without a Postgres lookup. Empty for external-only users or when attribution is unresolved.' CODEC(ZSTD),
 
     -- Reveal metadata. The raw match is reconstructed at reveal time by
     -- slicing the original chat data at start_pos and end_pos, then verified

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1315,9 +1315,6 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     -- traffic (scans follow messages within seconds).
     message_created_at DateTime64(9) DEFAULT created_at COMMENT 'Event time of the scanned chat message (chat_messages.created_at). Defaults to created_at (scan time) for rows written before the column existed or when attribution is unresolved.' CODEC(DoubleDelta, ZSTD),
     assistant_id String DEFAULT '' COMMENT 'Assistant linked to the finding chat via a live assistant_threads row at ingest. Empty when the chat has no assistant link or attribution is unresolved.' CODEC(ZSTD),
-    chat_source LowCardinality(String) DEFAULT '' COMMENT 'Canonical product surface the scanned message came from (chat_messages.source canonicalized at ingest, e.g. codex, cursor, claude-code). Empty for rows written before the column existed or when attribution is unresolved.',
-    team LowCardinality(String) DEFAULT '' COMMENT 'WorkOS directory department_name of the resolved user at ingest. Empty when the user has no directory profile or attribution is unresolved.',
-    user_email String DEFAULT '' COMMENT 'Email of the resolved internal user at ingest (users.email), letting the Watchdog display users without a Postgres lookup. Empty for external-only users or when attribution is unresolved.' CODEC(ZSTD),
 
     -- Reveal metadata. The raw match is reconstructed at reveal time by
     -- slicing the original chat data at start_pos and end_pos, then verified
@@ -1327,7 +1324,18 @@ CREATE TABLE IF NOT EXISTS risk_findings (
     surface LowCardinality(String) DEFAULT '' COMMENT 'Which text start_pos and end_pos index: content, scan_surface, tool_args, json_path, derived, legacy_presidio or none. Empty for rows written before this column existed, where reveal falls back to a verified candidate cascade.',
     field LowCardinality(String) DEFAULT '' COMMENT 'Scanner field the finding was detected in, e.g. content or tool.args, copied from the scanner span. Empty when unknown.',
     path String DEFAULT '' COMMENT 'JSON path of the extracted value within the field for json_path surfaces, gjson syntax. Empty otherwise.' CODEC(ZSTD),
-    tool_call_id String DEFAULT '' COMMENT 'Recorded tool call id anchoring the finding when the scanned text belongs to a tool call. Empty when not applicable or unknown.' CODEC(ZSTD)
+    tool_call_id String DEFAULT '' COMMENT 'Recorded tool call id anchoring the finding when the scanned text belongs to a tool call. Empty when not applicable or unknown.' CODEC(ZSTD),
+
+    -- Watchdog attribution, resolved from Postgres at ingest alongside the
+    -- chat/user ids above. Declared last on purpose: the migrations add these
+    -- with a bare ADD COLUMN (appended at the table end) and the Atlas
+    -- ClickHouse driver does not track column position, so listing them
+    -- mid-table would silently give schema.sql-built databases (the test
+    -- container inits from this file) a different physical order than
+    -- migration-built ones.
+    chat_source LowCardinality(String) DEFAULT '' COMMENT 'Canonical product surface the scanned message came from (chat_messages.source canonicalized at ingest, e.g. codex, cursor, claude-code). Empty for rows written before the column existed or when attribution is unresolved.',
+    team LowCardinality(String) DEFAULT '' COMMENT 'WorkOS directory department_name of the resolved user at ingest. Empty when the user has no directory profile or attribution is unresolved.',
+    user_email String DEFAULT '' COMMENT 'Email of the resolved internal user at ingest (users.email), letting the Watchdog display users without a Postgres lookup. Empty for external-only users or when attribution is unresolved.' CODEC(ZSTD)
 ) ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(created_at)
 ORDER BY (organization_id, project_id, created_at, id)


### PR DESCRIPTION
## What

Migration-only PR: adds three ingest-denormalized columns to the ClickHouse `risk_findings` table, in both migration flavors (Atlas + golang-migrate) plus the schema file.

| Column        | Type                                | Purpose                                                                                                                                    |
| ------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
| `chat_source` | `LowCardinality(String) DEFAULT ''` | Canonical product surface of the scanned message (e.g. `codex`, `cursor`, `claude-code`), stamped at ingest from the chat message's source |
| `team`        | `LowCardinality(String) DEFAULT ''` | WorkOS directory `department_name` of the resolved user at ingest                                                                          |
| `user_email`  | `String DEFAULT ''`                 | Resolved internal user's email at ingest                                                                                                   |

## Why

The upcoming Watchdog page clusters findings into ranked signals served entirely from ClickHouse. These columns let it attribute exposure to source apps, teams, and users without any Postgres lookup on the read path. Ingest enrichment and the read paths land in a follow-up feature PR.

## Compatibility

- Pure `ADD COLUMN` with `DEFAULT ''` — no rewrites, no backfill required; rows written before the migration read as unattributed.
- No changes to existing columns, indexes, or the table engine/TTL.
- Both flavors generated together via `mise clickhouse:diff`; applied and exercised locally (migrations replayed clean, ingest + reads tested against the new columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three attribution columns to the ClickHouse `risk_findings` table to power Watchdog signals without Postgres joins. Backward compatible: ADD COLUMNs with empty-string defaults; columns are declared last in `schema.sql` to match migration append order.

- **Migration**
  - Added `chat_source` LowCardinality(String) DEFAULT '' — canonical source app (e.g., codex, cursor, claude-code).
  - Added `team` LowCardinality(String) DEFAULT '' — WorkOS department name at ingest.
  - Added `user_email` String DEFAULT '' CODEC(ZSTD(1)) — resolved internal user email at ingest.
  - Shipped in both Atlas and `golang-migrate`, with columns declared last to keep schema- and migration-built DBs in the same column order.

<sup>Written for commit b0c10b4b6dae82c1f6548821257507bde48a8702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

