### PR TITLE
feat: reuse assistant MCP OAuth clients

### DIFF
--- a/server/internal/assistants/mcp_auth_handler.go
+++ b/server/internal/assistants/mcp_auth_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -35,6 +36,13 @@ const (
 	mcpAuthFlowMaxBodyBytes = 16 * 1024
 	mcpAuthFlowTTL          = 15 * time.Minute
 	mcpAuthEventKind        = "assistant_mcp_auth"
+	mcpOAuthIssuerMaxLength = 500
+	mcpOAuthRegistrationTTL = 45 * time.Second
+	mcpOAuthRegistrationMax = 30 * time.Second
+	mcpOAuthPersistenceMax  = 5 * time.Second
+	mcpOAuthCoordinationMax = mcpOAuthRegistrationTTL + mcpOAuthRegistrationMax + mcpOAuthPersistenceMax
+	mcpOAuthPollMin         = 100 * time.Millisecond
+	mcpOAuthPollMax         = time.Second
 
 	mcpAuthStatusSuccess = "success"
 	mcpAuthStatusFailed  = "failed"
@@ -61,8 +69,23 @@ type mcpAuthClientRegistrationRequest struct {
 }
 
 type mcpAuthClientRegistrationResponse struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
+	ClientID              string `json:"client_id"`
+	ClientSecret          string `json:"client_secret"`
+	ClientSecretExpiresAt int64  `json:"client_secret_expires_at"`
+}
+
+type mcpAuthClientCredentials struct {
+	ClientID              string
+	ClientSecretEncrypted string
+}
+
+type mcpOAuthTokenError struct {
+	Code       string
+	StatusCode int
+}
+
+func (e *mcpOAuthTokenError) Error() string {
+	return fmt.Sprintf("token request failed: status=%d error=%s", e.StatusCode, e.Code)
 }
 
 type mcpAuthEventPayload struct {
@@ -128,11 +151,11 @@ func (s *Service) handleCreateMCPAuthFlow(w http.ResponseWriter, r *http.Request
 		return oops.E(oops.CodeBadRequest, err, "mcp auth flow only supports hosted MCP URLs")
 	}
 
-	flowID := uuid.NewString()
+	attemptID := uuid.NewString()
 	if s.core.serverURL == nil {
 		return oops.E(oops.CodeUnexpected, nil, "assistant mcp auth callback base url not configured").LogError(ctx, s.logger)
 	}
-	redirectURI := s.core.serverURL.JoinPath("rpc", "assistantMcpAuth", flowID, "oauth", "callback").String()
+	redirectURI := s.core.serverURL.JoinPath("rpc", "assistantMcpAuth", principal.AssistantID.String(), "oauth", "callback").String()
 	codeVerifier, codeChallenge, err := newPKCEPair()
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "generate PKCE verifier").LogError(ctx, s.logger)
@@ -146,40 +169,48 @@ func (s *Service) handleCreateMCPAuthFlow(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "discover mcp authorization server metadata").LogError(ctx, s.logger)
 	}
-	if metadata.AuthorizationEndpoint == "" || metadata.TokenEndpoint == "" || metadata.RegistrationEndpoint == "" {
+	if metadata.Issuer == "" || metadata.AuthorizationEndpoint == "" || metadata.TokenEndpoint == "" || metadata.RegistrationEndpoint == "" {
 		return oops.E(oops.CodeUnexpected, nil, "mcp authorization server does not advertise RFC 8414 endpoints").LogError(ctx, s.logger)
 	}
-
-	registration, err := s.registerMCPAuthClient(ctx, metadata.RegistrationEndpoint, redirectURI)
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "register assistant mcp oauth client").LogError(ctx, s.logger)
+	if len(metadata.Issuer) > mcpOAuthIssuerMaxLength {
+		return oops.E(oops.CodeUnexpected, nil, "mcp authorization server issuer is too long").LogError(ctx, s.logger)
 	}
-	encryptedSecret, err := s.core.encryptionClient.Encrypt([]byte(registration.ClientSecret))
+
+	credentials, err := s.getOrRegisterMCPAuthClient(
+		ctx,
+		projectID,
+		principal.AssistantID,
+		metadata.Issuer,
+		metadata.RegistrationEndpoint,
+		redirectURI,
+	)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "encrypt mcp client secret").LogError(ctx, s.logger)
+		return oops.E(oops.CodeUnexpected, err, "resolve assistant mcp oauth client").LogError(ctx, s.logger)
 	}
 
 	state, err := s.core.assistantTokens.GenerateMCPAuthFlow(assistanttokens.MCPAuthFlowInput{
-		OrgID:         claims.OrgID,
-		ProjectID:     projectID,
-		UserID:        claims.UserID,
-		AssistantID:   principal.AssistantID,
-		ThreadID:      threadID,
-		FlowID:        flowID,
-		ServerID:      req.ServerID,
-		McpURL:        mcpURL.String(),
-		ClientID:      registration.ClientID,
-		ClientSecret:  encryptedSecret,
-		RedirectURI:   redirectURI,
-		CodeVerifier:  encryptedVerifier,
-		TokenEndpoint: metadata.TokenEndpoint,
-		TTL:           mcpAuthFlowTTL,
+		OrgID:             claims.OrgID,
+		ProjectID:         projectID,
+		UserID:            claims.UserID,
+		AssistantID:       principal.AssistantID,
+		ThreadID:          threadID,
+		AttemptID:         attemptID,
+		FlowID:            principal.AssistantID.String(),
+		ServerID:          req.ServerID,
+		McpURL:            mcpURL.String(),
+		ClientID:          credentials.ClientID,
+		ClientSecret:      credentials.ClientSecretEncrypted,
+		RedirectURI:       redirectURI,
+		CodeVerifier:      encryptedVerifier,
+		TokenEndpoint:     metadata.TokenEndpoint,
+		OAuthServerIssuer: metadata.Issuer,
+		TTL:               mcpAuthFlowTTL,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "sign mcp auth flow state").LogError(ctx, s.logger)
 	}
 
-	authURL, err := buildMCPAuthURL(metadata.AuthorizationEndpoint, registration.ClientID, redirectURI, state, codeChallenge)
+	authURL, err := buildMCPAuthURL(metadata.AuthorizationEndpoint, credentials.ClientID, redirectURI, state, codeChallenge)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build mcp auth url").LogError(ctx, s.logger)
 	}
@@ -200,13 +231,13 @@ func (s *Service) handleCreateMCPAuthFlow(w http.ResponseWriter, r *http.Request
 
 func (s *Service) handleMCPAuthCallback(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
-	flowID := chi.URLParam(r, "id")
+	callbackID := chi.URLParam(r, "id")
 	state := r.URL.Query().Get("state")
 	claims, err := s.core.assistantTokens.ValidateMCPAuthFlow(state)
 	if err != nil {
 		return oops.E(oops.CodeBadRequest, err, "invalid mcp auth callback state").LogError(ctx, s.logger)
 	}
-	if claims.FlowID != flowID {
+	if claims.FlowID != callbackID {
 		return oops.E(oops.CodeBadRequest, nil, "mcp auth callback flow mismatch").LogError(ctx, s.logger)
 	}
 
@@ -252,6 +283,10 @@ func (s *Service) handleMCPAuthCallback(w http.ResponseWriter, r *http.Request) 
 		payload.ErrorDescription = "authorization code missing from callback"
 	default:
 		if err := s.consumeMCPAuthGrant(ctx, claims, code); err != nil {
+			var tokenErr *mcpOAuthTokenError
+			if errors.As(err, &tokenErr) && tokenErr.Code == "invalid_client" {
+				s.invalidateMCPAuthClient(ctx, projectID, assistantID, claims.OAuthServerIssuer, claims.ClientID)
+			}
 			payload.Status = mcpAuthStatusFailed
 			payload.Error = "invalid_grant"
 			payload.ErrorDescription = "failed to consume authorization grant"
@@ -363,9 +398,220 @@ func decodeMCPAuthTurn(ctx context.Context, logger *slog.Logger, event assistant
 	return b.String(), true
 }
 
-func (s *Service) registerMCPAuthClient(ctx context.Context, endpoint, redirectURI string) (mcpAuthClientRegistrationResponse, error) {
+func (s *Service) getOrRegisterMCPAuthClient(
+	ctx context.Context,
+	projectID uuid.UUID,
+	assistantID uuid.UUID,
+	oauthServerIssuer string,
+	registrationEndpoint string,
+	redirectURI string,
+) (mcpAuthClientCredentials, error) {
+	queries := assistantrepo.New(s.core.db)
+	coordinationCtx, cancel := context.WithTimeout(ctx, mcpOAuthCoordinationMax)
+	defer cancel()
+	pollDelay := mcpOAuthPollMin
+	claimLease := pgtype.Interval{
+		Microseconds: mcpOAuthRegistrationTTL.Microseconds(),
+		Days:         0,
+		Months:       0,
+		Valid:        true,
+	}
+
+	for {
+		now := time.Now()
+		usableAfter := pgtype.Timestamptz{
+			Time:             now.Add(mcpAuthFlowTTL),
+			InfinityModifier: pgtype.Finite,
+			Valid:            true,
+		}
+		existing, err := queries.GetAssistantMCPOAuthClient(coordinationCtx, assistantrepo.GetAssistantMCPOAuthClientParams{
+			ProjectID:         projectID,
+			AssistantID:       assistantID,
+			OauthServerIssuer: oauthServerIssuer,
+			RedirectUri:       redirectURI,
+			UsableAfter:       usableAfter,
+			ClaimLease:        claimLease,
+		})
+		if err == nil && existing.Usable.Bool {
+			return mcpAuthClientCredentials{
+				ClientID:              existing.ClientID.String,
+				ClientSecretEncrypted: existing.ClientSecretEncrypted.String,
+			}, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			if err != nil {
+				return mcpAuthClientCredentials{}, fmt.Errorf("get assistant mcp oauth client: %w", err)
+			}
+		}
+
+		if errors.Is(err, pgx.ErrNoRows) || existing.Claimable.Bool {
+			registrationOwner := uuid.New()
+			claimed, err := queries.ClaimAssistantMCPOAuthClientRegistration(coordinationCtx, assistantrepo.ClaimAssistantMCPOAuthClientRegistrationParams{
+				ProjectID:         projectID,
+				AssistantID:       assistantID,
+				OauthServerIssuer: oauthServerIssuer,
+				RedirectUri:       redirectURI,
+				RegistrationOwner: uuid.NullUUID{UUID: registrationOwner, Valid: true},
+				ClaimLease:        claimLease,
+				UsableAfter:       usableAfter,
+			})
+			if err != nil {
+				return mcpAuthClientCredentials{}, fmt.Errorf("claim assistant mcp oauth client registration: %w", err)
+			}
+			if claimed == 1 {
+				return s.completeMCPAuthClientRegistration(
+					coordinationCtx,
+					queries,
+					projectID,
+					assistantID,
+					oauthServerIssuer,
+					registrationOwner,
+					registrationEndpoint,
+					redirectURI,
+				)
+			}
+		}
+
+		poll := time.NewTimer(mcpOAuthPollDelay(pollDelay))
+		select {
+		case <-coordinationCtx.Done():
+			if !poll.Stop() {
+				select {
+				case <-poll.C:
+				default:
+				}
+			}
+			return mcpAuthClientCredentials{}, fmt.Errorf("wait for assistant mcp oauth client registration: %w", coordinationCtx.Err())
+		case <-poll.C:
+		}
+		pollDelay = min(pollDelay*2, mcpOAuthPollMax)
+	}
+}
+
+func mcpOAuthPollDelay(base time.Duration) time.Duration {
+	var randomByte [1]byte
+	if _, err := rand.Read(randomByte[:]); err != nil {
+		return base
+	}
+	return base/2 + time.Duration(randomByte[0])*base/(2*255)
+}
+
+func (s *Service) completeMCPAuthClientRegistration(
+	ctx context.Context,
+	queries *assistantrepo.Queries,
+	projectID uuid.UUID,
+	assistantID uuid.UUID,
+	oauthServerIssuer string,
+	registrationOwner uuid.UUID,
+	registrationEndpoint string,
+	redirectURI string,
+) (mcpAuthClientCredentials, error) {
+	registrationCtx, cancel := context.WithTimeout(ctx, mcpOAuthRegistrationMax)
+	registration, err := s.registerMCPAuthClient(
+		registrationCtx,
+		registrationEndpoint,
+		redirectURI,
+		"Gram Assistant "+assistantID.String(),
+	)
+	cancel()
+	if err != nil {
+		s.abandonMCPAuthClientRegistration(ctx, queries, projectID, assistantID, oauthServerIssuer, registrationOwner)
+		return mcpAuthClientCredentials{}, err
+	}
+	if registration.ClientSecretExpiresAt < 0 {
+		s.abandonMCPAuthClientRegistration(ctx, queries, projectID, assistantID, oauthServerIssuer, registrationOwner)
+		return mcpAuthClientCredentials{}, fmt.Errorf("registration response has invalid client_secret_expires_at")
+	}
+	if registration.ClientSecretExpiresAt > 0 && !time.Unix(registration.ClientSecretExpiresAt, 0).After(time.Now().Add(mcpAuthFlowTTL)) {
+		s.abandonMCPAuthClientRegistration(ctx, queries, projectID, assistantID, oauthServerIssuer, registrationOwner)
+		return mcpAuthClientCredentials{}, fmt.Errorf("registration response client secret expires before the authorization flow")
+	}
+
+	clientSecretEncrypted, err := s.core.encryptionClient.Encrypt([]byte(registration.ClientSecret))
+	if err != nil {
+		s.abandonMCPAuthClientRegistration(ctx, queries, projectID, assistantID, oauthServerIssuer, registrationOwner)
+		return mcpAuthClientCredentials{}, fmt.Errorf("encrypt mcp client secret: %w", err)
+	}
+	clientSecretExpiresAt := pgtype.Timestamptz{
+		Time:             time.Time{},
+		InfinityModifier: pgtype.Finite,
+		Valid:            false,
+	}
+	if registration.ClientSecretExpiresAt > 0 {
+		clientSecretExpiresAt = pgtype.Timestamptz{
+			Time:             time.Unix(registration.ClientSecretExpiresAt, 0),
+			InfinityModifier: pgtype.Finite,
+			Valid:            true,
+		}
+	}
+	persistenceCtx, persistenceCancel := context.WithTimeout(context.WithoutCancel(ctx), mcpOAuthPersistenceMax)
+	defer persistenceCancel()
+	completed, err := queries.CompleteAssistantMCPOAuthClientRegistration(persistenceCtx, assistantrepo.CompleteAssistantMCPOAuthClientRegistrationParams{
+		ClientID:              pgtype.Text{String: registration.ClientID, Valid: true},
+		ClientSecretEncrypted: pgtype.Text{String: clientSecretEncrypted, Valid: true},
+		ClientSecretExpiresAt: clientSecretExpiresAt,
+		ProjectID:             projectID,
+		AssistantID:           assistantID,
+		OauthServerIssuer:     oauthServerIssuer,
+		RegistrationOwner:     uuid.NullUUID{UUID: registrationOwner, Valid: true},
+	})
+	if err != nil {
+		s.abandonMCPAuthClientRegistration(ctx, queries, projectID, assistantID, oauthServerIssuer, registrationOwner)
+		return mcpAuthClientCredentials{}, fmt.Errorf("complete assistant mcp oauth client registration: %w", err)
+	}
+	if completed != 1 {
+		return mcpAuthClientCredentials{}, fmt.Errorf("assistant mcp oauth client registration lease was lost")
+	}
+
+	return mcpAuthClientCredentials{
+		ClientID:              registration.ClientID,
+		ClientSecretEncrypted: clientSecretEncrypted,
+	}, nil
+}
+
+func (s *Service) abandonMCPAuthClientRegistration(
+	ctx context.Context,
+	queries *assistantrepo.Queries,
+	projectID uuid.UUID,
+	assistantID uuid.UUID,
+	oauthServerIssuer string,
+	registrationOwner uuid.UUID,
+) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer cancel()
+
+	err := queries.AbandonAssistantMCPOAuthClientRegistration(cleanupCtx, assistantrepo.AbandonAssistantMCPOAuthClientRegistrationParams{
+		ProjectID:         projectID,
+		AssistantID:       assistantID,
+		OauthServerIssuer: oauthServerIssuer,
+		RegistrationOwner: uuid.NullUUID{UUID: registrationOwner, Valid: true},
+	})
+	if err != nil {
+		s.logger.WarnContext(cleanupCtx, "failed to release assistant mcp oauth client registration claim", attr.SlogError(err))
+	}
+}
+
+func (s *Service) invalidateMCPAuthClient(ctx context.Context, projectID, assistantID uuid.UUID, oauthServerIssuer, clientID string) {
+	if oauthServerIssuer == "" || clientID == "" {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), mcpOAuthPersistenceMax)
+	defer cancel()
+
+	err := assistantrepo.New(s.core.db).InvalidateAssistantMCPOAuthClient(cleanupCtx, assistantrepo.InvalidateAssistantMCPOAuthClientParams{
+		ProjectID:         projectID,
+		AssistantID:       assistantID,
+		OauthServerIssuer: oauthServerIssuer,
+		ClientID:          pgtype.Text{String: clientID, Valid: true},
+	})
+	if err != nil {
+		s.logger.WarnContext(cleanupCtx, "failed to invalidate assistant mcp oauth client", attr.SlogError(err))
+	}
+}
+
+func (s *Service) registerMCPAuthClient(ctx context.Context, endpoint, redirectURI, clientName string) (mcpAuthClientRegistrationResponse, error) {
 	payload := mcpAuthClientRegistrationRequest{
-		ClientName:              "Gram Assistant MCP Auth",
+		ClientName:              clientName,
 		RedirectURIs:            []string{redirectURI},
 		GrantTypes:              []string{"authorization_code"},
 		ResponseTypes:           []string{"code"},
@@ -380,7 +626,7 @@ func (s *Service) registerMCPAuthClient(ctx context.Context, endpoint, redirectU
 		return mcpAuthClientRegistrationResponse{}, fmt.Errorf("build registration request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := s.core.guardianPolicy.Client(guardian.WithDefaultRetryConfig()).Do(req)
+	resp, err := s.core.guardianPolicy.Client().Do(req)
 	if err != nil {
 		return mcpAuthClientRegistrationResponse{}, fmt.Errorf("send registration request: %w", err)
 	}
@@ -445,6 +691,12 @@ func (s *Service) consumeMCPAuthGrant(ctx context.Context, claims *assistanttoke
 		return fmt.Errorf("read token response: %w", err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var tokenError struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &tokenError) == nil && tokenError.Error != "" {
+			return &mcpOAuthTokenError{Code: tokenError.Error, StatusCode: resp.StatusCode}
+		}
 		return fmt.Errorf("token request failed: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil

--- a/server/internal/assistants/mcp_auth_handler_test.go
+++ b/server/internal/assistants/mcp_auth_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -100,11 +102,20 @@ func TestGetOrRegisterMCPAuthClientReusesRegistration(t *testing.T) {
 	require.Equal(t, "Gram Assistant "+assistantID.String(), request.ClientName)
 	require.Equal(t, []string{redirectURI}, request.RedirectURIs)
 
-	err = assistantrepo.New(conn).DeleteAssistant(t.Context(), assistantrepo.DeleteAssistantParams{
+	deleteTx, err := conn.Begin(t.Context())
+	require.NoError(t, err)
+	deleteQueries := assistantrepo.New(deleteTx)
+	err = deleteQueries.DeleteAssistant(t.Context(), assistantrepo.DeleteAssistantParams{
 		AssistantID: assistantID,
 		ProjectID:   projectID,
 	})
 	require.NoError(t, err)
+	err = deleteQueries.RetireAssistantMCPOAuthClients(t.Context(), assistantrepo.RetireAssistantMCPOAuthClientsParams{
+		AssistantID: assistantID,
+		ProjectID:   projectID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, deleteTx.Commit(t.Context()))
 	var registrationDeleted bool
 	err = conn.QueryRow(t.Context(), `
 		SELECT deleted
@@ -240,4 +251,63 @@ func TestGetOrRegisterMCPAuthClientSerializesFirstRegistration(t *testing.T) {
 	first := <-results
 	second := <-results
 	require.Equal(t, first, second)
+}
+
+func TestAssistantDeletionSerializesWithOAuthRegistrationClaim(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_mcp_oauth_client_delete_race")
+	require.NoError(t, err)
+	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
+
+	deleteTx, err := conn.Begin(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = deleteTx.Rollback(t.Context()) })
+	deleteQueries := assistantrepo.New(deleteTx)
+	require.NoError(t, deleteQueries.DeleteAssistant(t.Context(), assistantrepo.DeleteAssistantParams{
+		AssistantID: assistantID,
+		ProjectID:   projectID,
+	}))
+
+	type claimResult struct {
+		rows int64
+		err  error
+	}
+	claimDone := make(chan claimResult, 1)
+	go func() {
+		rows, claimErr := assistantrepo.New(conn).ClaimAssistantMCPOAuthClientRegistration(
+			t.Context(),
+			assistantrepo.ClaimAssistantMCPOAuthClientRegistrationParams{
+				ProjectID:         projectID,
+				AssistantID:       assistantID,
+				OauthServerIssuer: "https://auth.example.com",
+				RedirectUri:       "https://gram.example.com/oauth/callback",
+				RegistrationOwner: uuid.NullUUID{UUID: uuid.New(), Valid: true},
+				ClaimLease: pgtype.Interval{
+					Microseconds: time.Minute.Microseconds(),
+					Days:         0,
+					Months:       0,
+					Valid:        true,
+				},
+				UsableAfter: pgtype.Timestamptz{
+					Time:             time.Now().Add(mcpAuthFlowTTL),
+					InfinityModifier: pgtype.Finite,
+					Valid:            true,
+				},
+			},
+		)
+		claimDone <- claimResult{rows: rows, err: claimErr}
+	}()
+
+	require.Never(t, func() bool { return len(claimDone) > 0 }, 250*time.Millisecond, 25*time.Millisecond,
+		"registration claim did not wait for assistant deletion")
+	require.NoError(t, deleteQueries.RetireAssistantMCPOAuthClients(
+		t.Context(),
+		assistantrepo.RetireAssistantMCPOAuthClientsParams{AssistantID: assistantID, ProjectID: projectID},
+	))
+	require.NoError(t, deleteTx.Commit(t.Context()))
+
+	result := <-claimDone
+	require.NoError(t, result.err)
+	require.Zero(t, result.rows)
 }

--- a/server/internal/assistants/mcp_auth_handler_test.go
+++ b/server/internal/assistants/mcp_auth_handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	assistantrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -98,6 +99,20 @@ func TestGetOrRegisterMCPAuthClientReusesRegistration(t *testing.T) {
 	request := <-requests
 	require.Equal(t, "Gram Assistant "+assistantID.String(), request.ClientName)
 	require.Equal(t, []string{redirectURI}, request.RedirectURIs)
+
+	err = assistantrepo.New(conn).DeleteAssistant(t.Context(), assistantrepo.DeleteAssistantParams{
+		AssistantID: assistantID,
+		ProjectID:   projectID,
+	})
+	require.NoError(t, err)
+	var registrationDeleted bool
+	err = conn.QueryRow(t.Context(), `
+		SELECT deleted
+		FROM assistant_mcp_oauth_clients
+		WHERE project_id = $1 AND assistant_id = $2
+	`, projectID, assistantID).Scan(&registrationDeleted)
+	require.NoError(t, err)
+	require.True(t, registrationDeleted)
 }
 
 func TestInvalidateMCPAuthClientForcesRegistration(t *testing.T) {

--- a/server/internal/assistants/mcp_auth_handler_test.go
+++ b/server/internal/assistants/mcp_auth_handler_test.go
@@ -1,0 +1,228 @@
+package assistants
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func newMCPAuthTestService(t *testing.T, conn *pgxpool.Pool) *Service {
+	t.Helper()
+
+	logger := testenv.NewLogger(t)
+	tracerProvider := testenv.NewTracerProvider(t)
+	meterProvider := testenv.NewMeterProvider(t)
+	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, nil)
+	require.NoError(t, err)
+	core := NewServiceCore(
+		logger,
+		tracerProvider,
+		meterProvider,
+		conn,
+		guardianPolicy,
+		testenv.NewEncryptionClient(t),
+		testRuntimeBackend{backend: runtimeBackendFlyIO},
+		nil,
+		nil,
+		nil,
+		telemetry.NewStub(logger),
+		nil,
+		newTestAuditLogger(),
+	)
+	return &Service{
+		tracer:           tracerProvider.Tracer("test"),
+		logger:           logger,
+		auth:             nil,
+		authz:            nil,
+		core:             core,
+		signaler:         nil,
+		bootstrapLimiter: nil,
+	}
+}
+
+func TestGetOrRegisterMCPAuthClientReusesRegistration(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_mcp_oauth_client_reuse")
+	require.NoError(t, err)
+	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
+
+	var registrations atomic.Int32
+	requests := make(chan mcpAuthClientRegistrationRequest, 2)
+	registrationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		registrations.Add(1)
+		var request mcpAuthClientRegistrationRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requests <- request
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcpAuthClientRegistrationResponse{
+			ClientID:              "stable-client",
+			ClientSecret:          "stable-secret",
+			ClientSecretExpiresAt: 0,
+		})
+	}))
+	t.Cleanup(registrationServer.Close)
+
+	service := newMCPAuthTestService(t, conn)
+	redirectURI := "https://gram.example.com/rpc/assistantMcpAuth/" + assistantID.String() + "/oauth/callback"
+	first, err := service.getOrRegisterMCPAuthClient(
+		t.Context(), projectID, assistantID, registrationServer.URL, registrationServer.URL, redirectURI,
+	)
+	require.NoError(t, err)
+	second, err := service.getOrRegisterMCPAuthClient(
+		t.Context(), projectID, assistantID, registrationServer.URL, registrationServer.URL, redirectURI,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), registrations.Load())
+	require.Equal(t, first, second)
+	require.Equal(t, "stable-client", first.ClientID)
+	secret, err := service.core.encryptionClient.Decrypt(first.ClientSecretEncrypted)
+	require.NoError(t, err)
+	require.Equal(t, "stable-secret", secret)
+	request := <-requests
+	require.Equal(t, "Gram Assistant "+assistantID.String(), request.ClientName)
+	require.Equal(t, []string{redirectURI}, request.RedirectURIs)
+}
+
+func TestInvalidateMCPAuthClientForcesRegistration(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_mcp_oauth_client_invalidation")
+	require.NoError(t, err)
+	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
+
+	var registrations atomic.Int32
+	registrationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		registrationNumber := registrations.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcpAuthClientRegistrationResponse{
+			ClientID:              "client-" + fmt.Sprint(registrationNumber),
+			ClientSecret:          "secret",
+			ClientSecretExpiresAt: 0,
+		})
+	}))
+	t.Cleanup(registrationServer.Close)
+
+	service := newMCPAuthTestService(t, conn)
+	redirectURI := "https://gram.example.com/rpc/assistantMcpAuth/" + assistantID.String() + "/oauth/callback"
+	first, err := service.getOrRegisterMCPAuthClient(
+		t.Context(), projectID, assistantID, registrationServer.URL, registrationServer.URL, redirectURI,
+	)
+	require.NoError(t, err)
+	service.invalidateMCPAuthClient(t.Context(), projectID, assistantID, registrationServer.URL, first.ClientID)
+	second, err := service.getOrRegisterMCPAuthClient(
+		t.Context(), projectID, assistantID, registrationServer.URL, registrationServer.URL, redirectURI,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(2), registrations.Load())
+	require.NotEqual(t, first.ClientID, second.ClientID)
+}
+
+func TestGetOrRegisterMCPAuthClientRejectsSoonExpiringRegistration(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_mcp_oauth_client_expiry")
+	require.NoError(t, err)
+	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
+
+	var registrations atomic.Int32
+	registrationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		registrationNumber := registrations.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcpAuthClientRegistrationResponse{
+			ClientID:              "client-" + fmt.Sprint(registrationNumber),
+			ClientSecret:          "secret",
+			ClientSecretExpiresAt: time.Now().Add(5 * time.Minute).Unix(),
+		})
+	}))
+	t.Cleanup(registrationServer.Close)
+
+	service := newMCPAuthTestService(t, conn)
+	redirectURI := "https://gram.example.com/rpc/assistantMcpAuth/" + assistantID.String() + "/oauth/callback"
+	_, err = service.getOrRegisterMCPAuthClient(
+		t.Context(), projectID, assistantID, registrationServer.URL, registrationServer.URL, redirectURI,
+	)
+	require.ErrorContains(t, err, "client secret expires before the authorization flow")
+	require.Equal(t, int32(1), registrations.Load())
+}
+
+func TestGetOrRegisterMCPAuthClientSerializesFirstRegistration(t *testing.T) {
+	t.Parallel()
+
+	conn, err := assistantsInfra.CloneTestDatabase(t, "assistants_mcp_oauth_client_concurrent")
+	require.NoError(t, err)
+	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
+
+	var registrations atomic.Int32
+	registrationStarted := make(chan struct{}, 1)
+	finishRegistration := make(chan struct{})
+	var finishRegistrationOnce sync.Once
+	finish := func() { finishRegistrationOnce.Do(func() { close(finishRegistration) }) }
+	registrationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		registrations.Add(1)
+		registrationStarted <- struct{}{}
+		<-finishRegistration
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(mcpAuthClientRegistrationResponse{
+			ClientID:              "concurrent-client",
+			ClientSecret:          "concurrent-secret",
+			ClientSecretExpiresAt: 0,
+		})
+	}))
+	t.Cleanup(registrationServer.Close)
+	t.Cleanup(finish)
+
+	service := newMCPAuthTestService(t, conn)
+	redirectURI := "https://gram.example.com/rpc/assistantMcpAuth/" + assistantID.String() + "/oauth/callback"
+	results := make(chan mcpAuthClientCredentials, 2)
+	errs := make(chan error, 2)
+	var completed atomic.Int32
+	register := func() {
+		result, err := service.getOrRegisterMCPAuthClient(
+			t.Context(), projectID, assistantID, registrationServer.URL, registrationServer.URL, redirectURI,
+		)
+		results <- result
+		errs <- err
+		completed.Add(1)
+	}
+
+	go register()
+	require.Eventually(t, func() bool { return len(registrationStarted) > 0 }, 30*time.Second, 25*time.Millisecond,
+		"first dynamic registration did not start")
+	<-registrationStarted
+	secondStarted := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		register()
+	}()
+	<-secondStarted
+	require.Never(t, func() bool { return registrations.Load() > 1 }, 500*time.Millisecond, 25*time.Millisecond,
+		"a second dynamic registration started while the first claim was active")
+	finish()
+	require.Eventually(t, func() bool { return completed.Load() == 2 }, 30*time.Second, 25*time.Millisecond,
+		"both registration callers did not complete")
+
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	require.Equal(t, int32(1), registrations.Load())
+	first := <-results
+	second := <-results
+	require.Equal(t, first, second)
+}

--- a/server/internal/assistants/mcp_auth_handler_test.go
+++ b/server/internal/assistants/mcp_auth_handler_test.go
@@ -102,8 +102,7 @@ func TestGetOrRegisterMCPAuthClientReusesRegistration(t *testing.T) {
 	require.Equal(t, "Gram Assistant "+assistantID.String(), request.ClientName)
 	require.Equal(t, []string{redirectURI}, request.RedirectURIs)
 
-	deleteTx, err := conn.Begin(t.Context())
-	require.NoError(t, err)
+	deleteTx := testenv.BeginTx(t, t.Context(), conn)
 	deleteQueries := assistantrepo.New(deleteTx)
 	err = deleteQueries.DeleteAssistant(t.Context(), assistantrepo.DeleteAssistantParams{
 		AssistantID: assistantID,
@@ -116,12 +115,14 @@ func TestGetOrRegisterMCPAuthClientReusesRegistration(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, deleteTx.Commit(t.Context()))
-	var registrationDeleted bool
-	err = conn.QueryRow(t.Context(), `
-		SELECT deleted
-		FROM assistant_mcp_oauth_clients
-		WHERE project_id = $1 AND assistant_id = $2
-	`, projectID, assistantID).Scan(&registrationDeleted)
+	registrationDeleted, err := assistantrepo.New(conn).GetAssistantMCPOAuthClientDeleted(
+		t.Context(),
+		assistantrepo.GetAssistantMCPOAuthClientDeletedParams{
+			ProjectID:         projectID,
+			AssistantID:       assistantID,
+			OauthServerIssuer: registrationServer.URL,
+		},
+	)
 	require.NoError(t, err)
 	require.True(t, registrationDeleted)
 }
@@ -260,9 +261,7 @@ func TestAssistantDeletionSerializesWithOAuthRegistrationClaim(t *testing.T) {
 	require.NoError(t, err)
 	projectID, assistantID, _, _ := insertAssistantFixture(t, conn)
 
-	deleteTx, err := conn.Begin(t.Context())
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = deleteTx.Rollback(t.Context()) })
+	deleteTx := testenv.BeginTx(t, t.Context(), conn)
 	deleteQueries := assistantrepo.New(deleteTx)
 	require.NoError(t, deleteQueries.DeleteAssistant(t.Context(), assistantrepo.DeleteAssistantParams{
 		AssistantID: assistantID,

--- a/server/internal/assistants/provisioning.go
+++ b/server/internal/assistants/provisioning.go
@@ -171,6 +171,12 @@ func (s *ServiceCore) DisableManagedAssistant(ctx context.Context, projectID uui
 	}); err != nil {
 		return fmt.Errorf("soft-delete managed assistant: %w", err)
 	}
+	if err := queries.RetireAssistantMCPOAuthClients(ctx, assistantrepo.RetireAssistantMCPOAuthClientsParams{
+		AssistantID: row.ID,
+		ProjectID:   projectID,
+	}); err != nil {
+		return fmt.Errorf("retire managed assistant mcp oauth clients: %w", err)
+	}
 	if err := s.revokeAssistantSkillDistributions(ctx, tx, projectID, row.ID, actor, actorDisplayName); err != nil {
 		return err
 	}

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -494,20 +494,18 @@ WHERE id = @assistant_id
 RETURNING id, project_id, organization_id, created_by_user_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status, created_at, updated_at, deleted_at;
 
 -- name: DeleteAssistant :exec
-WITH deleted_assistant AS (
-  UPDATE assistants target
-  SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
-  WHERE target.id = @assistant_id
-    AND target.project_id = @project_id
-    AND target.deleted IS FALSE
-  RETURNING target.id, target.project_id
-)
-UPDATE assistant_mcp_oauth_clients clients
+UPDATE assistants
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
-FROM deleted_assistant assistant
-WHERE clients.assistant_id = assistant.id
-  AND clients.project_id = assistant.project_id
-  AND clients.deleted IS FALSE;
+WHERE id = @assistant_id
+  AND project_id = @project_id
+  AND deleted IS FALSE;
+
+-- name: RetireAssistantMCPOAuthClients :exec
+UPDATE assistant_mcp_oauth_clients
+SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+WHERE assistant_id = @assistant_id
+  AND project_id = @project_id
+  AND deleted IS FALSE;
 
 -- name: RevokeSkillDistributionsByAssistant :many
 -- Returns pre-revocation state and skill identity for per-edge audit events.
@@ -1387,11 +1385,18 @@ SELECT
     )
     OR (client_id IS NOT NULL AND redirect_uri <> @redirect_uri)
   ) AS claimable
-FROM assistant_mcp_oauth_clients
-WHERE project_id = @project_id
-  AND assistant_id = @assistant_id
-  AND oauth_server_issuer = @oauth_server_issuer
-  AND deleted IS FALSE;
+FROM assistant_mcp_oauth_clients clients
+WHERE clients.project_id = @project_id
+  AND clients.assistant_id = @assistant_id
+  AND clients.oauth_server_issuer = @oauth_server_issuer
+  AND EXISTS (
+    SELECT 1
+    FROM assistants owner
+    WHERE owner.id = @assistant_id
+      AND owner.project_id = @project_id
+      AND owner.deleted IS FALSE
+  )
+  AND clients.deleted IS FALSE;
 
 -- name: ClaimAssistantMCPOAuthClientRegistration :execrows
 INSERT INTO assistant_mcp_oauth_clients AS clients (
@@ -1401,14 +1406,18 @@ INSERT INTO assistant_mcp_oauth_clients AS clients (
   redirect_uri,
   registration_owner,
   registration_started_at
-) VALUES (
+) SELECT
   @project_id,
   @assistant_id,
   @oauth_server_issuer,
   @redirect_uri,
   @registration_owner,
   clock_timestamp()
-)
+FROM assistants owner
+WHERE owner.id = @assistant_id
+  AND owner.project_id = @project_id
+  AND owner.deleted IS FALSE
+FOR UPDATE
 ON CONFLICT (project_id, assistant_id, oauth_server_issuer) WHERE deleted IS FALSE
 DO UPDATE SET
   client_id = NULL,
@@ -1435,7 +1444,7 @@ WHERE
   );
 
 -- name: CompleteAssistantMCPOAuthClientRegistration :execrows
-UPDATE assistant_mcp_oauth_clients
+UPDATE assistant_mcp_oauth_clients AS clients
 SET
   client_id = @client_id,
   client_secret_encrypted = @client_secret_encrypted,
@@ -1443,12 +1452,19 @@ SET
   registration_owner = NULL,
   registration_started_at = NULL,
   updated_at = clock_timestamp()
-WHERE project_id = @project_id
-  AND assistant_id = @assistant_id
-  AND oauth_server_issuer = @oauth_server_issuer
-  AND registration_owner = @registration_owner
-  AND client_id IS NULL
-  AND deleted IS FALSE;
+WHERE clients.project_id = @project_id
+  AND clients.assistant_id = @assistant_id
+  AND clients.oauth_server_issuer = @oauth_server_issuer
+  AND clients.registration_owner = @registration_owner
+  AND clients.client_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM assistants owner
+    WHERE owner.id = @assistant_id
+      AND owner.project_id = @project_id
+      AND owner.deleted IS FALSE
+  )
+  AND clients.deleted IS FALSE;
 
 -- name: AbandonAssistantMCPOAuthClientRegistration :exec
 UPDATE assistant_mcp_oauth_clients

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -1354,3 +1354,110 @@ WHERE assistant_thread_id = @assistant_thread_id
   AND project_id = @project_id
 ORDER BY created_at DESC
 LIMIT 1;
+
+-- name: GetAssistantMCPOAuthClient :one
+SELECT
+  client_id,
+  client_secret_encrypted,
+  (
+    client_id IS NOT NULL
+    AND client_secret_encrypted IS NOT NULL
+    AND redirect_uri = @redirect_uri
+    AND (client_secret_expires_at IS NULL OR client_secret_expires_at > @usable_after)
+  ) AS usable,
+  (
+    (
+      client_id IS NULL
+      AND registration_started_at < clock_timestamp() - @claim_lease::interval
+    )
+    OR
+    (
+      client_id IS NOT NULL
+      AND client_secret_expires_at IS NOT NULL
+      AND client_secret_expires_at <= @usable_after
+    )
+    OR redirect_uri <> @redirect_uri
+  ) AS claimable
+FROM assistant_mcp_oauth_clients
+WHERE project_id = @project_id
+  AND assistant_id = @assistant_id
+  AND oauth_server_issuer = @oauth_server_issuer
+  AND deleted IS FALSE;
+
+-- name: ClaimAssistantMCPOAuthClientRegistration :execrows
+INSERT INTO assistant_mcp_oauth_clients AS clients (
+  project_id,
+  assistant_id,
+  oauth_server_issuer,
+  redirect_uri,
+  registration_owner,
+  registration_started_at
+) VALUES (
+  @project_id,
+  @assistant_id,
+  @oauth_server_issuer,
+  @redirect_uri,
+  @registration_owner,
+  clock_timestamp()
+)
+ON CONFLICT (project_id, assistant_id, oauth_server_issuer) WHERE deleted IS FALSE
+DO UPDATE SET
+  client_id = NULL,
+  client_secret_encrypted = NULL,
+  client_secret_expires_at = NULL,
+  redirect_uri = EXCLUDED.redirect_uri,
+  registration_owner = EXCLUDED.registration_owner,
+  registration_started_at = EXCLUDED.registration_started_at,
+  updated_at = clock_timestamp()
+WHERE
+  (
+    clients.client_id IS NULL
+    AND clients.registration_started_at < clock_timestamp() - @claim_lease::interval
+  )
+  OR
+  (
+    clients.client_id IS NOT NULL
+    AND clients.client_secret_expires_at IS NOT NULL
+    AND clients.client_secret_expires_at <= @usable_after
+  )
+  OR clients.redirect_uri <> EXCLUDED.redirect_uri;
+
+-- name: CompleteAssistantMCPOAuthClientRegistration :execrows
+UPDATE assistant_mcp_oauth_clients
+SET
+  client_id = @client_id,
+  client_secret_encrypted = @client_secret_encrypted,
+  client_secret_expires_at = @client_secret_expires_at,
+  registration_owner = NULL,
+  registration_started_at = NULL,
+  updated_at = clock_timestamp()
+WHERE project_id = @project_id
+  AND assistant_id = @assistant_id
+  AND oauth_server_issuer = @oauth_server_issuer
+  AND registration_owner = @registration_owner
+  AND client_id IS NULL
+  AND deleted IS FALSE;
+
+-- name: AbandonAssistantMCPOAuthClientRegistration :exec
+UPDATE assistant_mcp_oauth_clients
+SET
+  registration_started_at = to_timestamp(0),
+  updated_at = clock_timestamp()
+WHERE project_id = @project_id
+  AND assistant_id = @assistant_id
+  AND oauth_server_issuer = @oauth_server_issuer
+  AND registration_owner = @registration_owner
+  AND client_id IS NULL
+  AND deleted IS FALSE;
+
+-- name: InvalidateAssistantMCPOAuthClient :exec
+UPDATE assistant_mcp_oauth_clients
+SET
+  client_secret_expires_at = to_timestamp(0),
+  updated_at = clock_timestamp()
+WHERE project_id = @project_id
+  AND assistant_id = @assistant_id
+  AND oauth_server_issuer = @oauth_server_issuer
+  AND client_id = @client_id
+  AND client_id IS NOT NULL
+  AND deleted IS FALSE;

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -1376,7 +1376,7 @@ SELECT
       AND client_secret_expires_at IS NOT NULL
       AND client_secret_expires_at <= @usable_after
     )
-    OR redirect_uri <> @redirect_uri
+    OR (client_id IS NOT NULL AND redirect_uri <> @redirect_uri)
   ) AS claimable
 FROM assistant_mcp_oauth_clients
 WHERE project_id = @project_id
@@ -1420,7 +1420,10 @@ WHERE
     AND clients.client_secret_expires_at IS NOT NULL
     AND clients.client_secret_expires_at <= @usable_after
   )
-  OR clients.redirect_uri <> EXCLUDED.redirect_uri;
+  OR (
+    clients.client_id IS NOT NULL
+    AND clients.redirect_uri <> EXCLUDED.redirect_uri
+  );
 
 -- name: CompleteAssistantMCPOAuthClientRegistration :execrows
 UPDATE assistant_mcp_oauth_clients

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -494,11 +494,20 @@ WHERE id = @assistant_id
 RETURNING id, project_id, organization_id, created_by_user_id, name, model, instructions, warm_ttl_seconds, max_concurrency, status, created_at, updated_at, deleted_at;
 
 -- name: DeleteAssistant :exec
-UPDATE assistants
+WITH deleted_assistant AS (
+  UPDATE assistants target
+  SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+  WHERE target.id = @assistant_id
+    AND target.project_id = @project_id
+    AND target.deleted IS FALSE
+  RETURNING target.id, target.project_id
+)
+UPDATE assistant_mcp_oauth_clients clients
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
-WHERE id = @assistant_id
-  AND project_id = @project_id
-  AND deleted IS FALSE;
+FROM deleted_assistant assistant
+WHERE clients.assistant_id = assistant.id
+  AND clients.project_id = assistant.project_id
+  AND clients.deleted IS FALSE;
 
 -- name: RevokeSkillDistributionsByAssistant :many
 -- Returns pre-revocation state and skill identity for per-edge audit events.

--- a/server/internal/assistants/queries.sql
+++ b/server/internal/assistants/queries.sql
@@ -1489,3 +1489,11 @@ WHERE project_id = @project_id
   AND client_id = @client_id
   AND client_id IS NOT NULL
   AND deleted IS FALSE;
+
+-- name: GetAssistantMCPOAuthClientDeleted :one
+-- Test-only helper for verifying credential retirement on assistant deletion.
+SELECT deleted
+FROM assistant_mcp_oauth_clients
+WHERE project_id = @project_id
+  AND assistant_id = @assistant_id
+  AND oauth_server_issuer = @oauth_server_issuer;

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -766,11 +766,20 @@ func (q *Queries) CreateProjectManagedAssistant(ctx context.Context, arg CreateP
 }
 
 const deleteAssistant = `-- name: DeleteAssistant :exec
-UPDATE assistants
+WITH deleted_assistant AS (
+  UPDATE assistants target
+  SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+  WHERE target.id = $1
+    AND target.project_id = $2
+    AND target.deleted IS FALSE
+  RETURNING target.id, target.project_id
+)
+UPDATE assistant_mcp_oauth_clients clients
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
-WHERE id = $1
-  AND project_id = $2
-  AND deleted IS FALSE
+FROM deleted_assistant assistant
+WHERE clients.assistant_id = assistant.id
+  AND clients.project_id = assistant.project_id
+  AND clients.deleted IS FALSE
 `
 
 type DeleteAssistantParams struct {

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -205,14 +205,18 @@ INSERT INTO assistant_mcp_oauth_clients AS clients (
   redirect_uri,
   registration_owner,
   registration_started_at
-) VALUES (
+) SELECT
   $1,
   $2,
   $3,
   $4,
   $5,
   clock_timestamp()
-)
+FROM assistants owner
+WHERE owner.id = $2
+  AND owner.project_id = $1
+  AND owner.deleted IS FALSE
+FOR UPDATE
 ON CONFLICT (project_id, assistant_id, oauth_server_issuer) WHERE deleted IS FALSE
 DO UPDATE SET
   client_id = NULL,
@@ -376,7 +380,7 @@ func (q *Queries) ClearAssistantToolsets(ctx context.Context, arg ClearAssistant
 }
 
 const completeAssistantMCPOAuthClientRegistration = `-- name: CompleteAssistantMCPOAuthClientRegistration :execrows
-UPDATE assistant_mcp_oauth_clients
+UPDATE assistant_mcp_oauth_clients AS clients
 SET
   client_id = $1,
   client_secret_encrypted = $2,
@@ -384,12 +388,19 @@ SET
   registration_owner = NULL,
   registration_started_at = NULL,
   updated_at = clock_timestamp()
-WHERE project_id = $4
-  AND assistant_id = $5
-  AND oauth_server_issuer = $6
-  AND registration_owner = $7
-  AND client_id IS NULL
-  AND deleted IS FALSE
+WHERE clients.project_id = $4
+  AND clients.assistant_id = $5
+  AND clients.oauth_server_issuer = $6
+  AND clients.registration_owner = $7
+  AND clients.client_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM assistants owner
+    WHERE owner.id = $5
+      AND owner.project_id = $4
+      AND owner.deleted IS FALSE
+  )
+  AND clients.deleted IS FALSE
 `
 
 type CompleteAssistantMCPOAuthClientRegistrationParams struct {
@@ -766,20 +777,11 @@ func (q *Queries) CreateProjectManagedAssistant(ctx context.Context, arg CreateP
 }
 
 const deleteAssistant = `-- name: DeleteAssistant :exec
-WITH deleted_assistant AS (
-  UPDATE assistants target
-  SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
-  WHERE target.id = $1
-    AND target.project_id = $2
-    AND target.deleted IS FALSE
-  RETURNING target.id, target.project_id
-)
-UPDATE assistant_mcp_oauth_clients clients
+UPDATE assistants
 SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
-FROM deleted_assistant assistant
-WHERE clients.assistant_id = assistant.id
-  AND clients.project_id = assistant.project_id
-  AND clients.deleted IS FALSE
+WHERE id = $1
+  AND project_id = $2
+  AND deleted IS FALSE
 `
 
 type DeleteAssistantParams struct {
@@ -1062,11 +1064,18 @@ SELECT
     )
     OR (client_id IS NOT NULL AND redirect_uri <> $1)
   ) AS claimable
-FROM assistant_mcp_oauth_clients
-WHERE project_id = $4
-  AND assistant_id = $5
-  AND oauth_server_issuer = $6
-  AND deleted IS FALSE
+FROM assistant_mcp_oauth_clients clients
+WHERE clients.project_id = $4
+  AND clients.assistant_id = $5
+  AND clients.oauth_server_issuer = $6
+  AND EXISTS (
+    SELECT 1
+    FROM assistants owner
+    WHERE owner.id = $5
+      AND owner.project_id = $4
+      AND owner.deleted IS FALSE
+  )
+  AND clients.deleted IS FALSE
 `
 
 type GetAssistantMCPOAuthClientParams struct {
@@ -3339,6 +3348,24 @@ func (q *Queries) ResolveToolsetsForWrite(ctx context.Context, arg ResolveToolse
 		return nil, err
 	}
 	return items, nil
+}
+
+const retireAssistantMCPOAuthClients = `-- name: RetireAssistantMCPOAuthClients :exec
+UPDATE assistant_mcp_oauth_clients
+SET deleted_at = clock_timestamp(), updated_at = clock_timestamp()
+WHERE assistant_id = $1
+  AND project_id = $2
+  AND deleted IS FALSE
+`
+
+type RetireAssistantMCPOAuthClientsParams struct {
+	AssistantID uuid.UUID
+	ProjectID   uuid.UUID
+}
+
+func (q *Queries) RetireAssistantMCPOAuthClients(ctx context.Context, arg RetireAssistantMCPOAuthClientsParams) error {
+	_, err := q.db.Exec(ctx, retireAssistantMCPOAuthClients, arg.AssistantID, arg.ProjectID)
+	return err
 }
 
 const revertExpireAssistantRuntimeToActive = `-- name: RevertExpireAssistantRuntimeToActive :exec

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -1113,6 +1113,28 @@ func (q *Queries) GetAssistantMCPOAuthClient(ctx context.Context, arg GetAssista
 	return i, err
 }
 
+const getAssistantMCPOAuthClientDeleted = `-- name: GetAssistantMCPOAuthClientDeleted :one
+SELECT deleted
+FROM assistant_mcp_oauth_clients
+WHERE project_id = $1
+  AND assistant_id = $2
+  AND oauth_server_issuer = $3
+`
+
+type GetAssistantMCPOAuthClientDeletedParams struct {
+	ProjectID         uuid.UUID
+	AssistantID       uuid.UUID
+	OauthServerIssuer string
+}
+
+// Test-only helper for verifying credential retirement on assistant deletion.
+func (q *Queries) GetAssistantMCPOAuthClientDeleted(ctx context.Context, arg GetAssistantMCPOAuthClientDeletedParams) (bool, error) {
+	row := q.db.QueryRow(ctx, getAssistantMCPOAuthClientDeleted, arg.ProjectID, arg.AssistantID, arg.OauthServerIssuer)
+	var deleted bool
+	err := row.Scan(&deleted)
+	return deleted, err
+}
+
 const getAssistantRuntime = `-- name: GetAssistantRuntime :one
 SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, runtime_version, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
 WHERE id = $1

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -233,7 +233,10 @@ WHERE
     AND clients.client_secret_expires_at IS NOT NULL
     AND clients.client_secret_expires_at <= $7
   )
-  OR clients.redirect_uri <> EXCLUDED.redirect_uri
+  OR (
+    clients.client_id IS NOT NULL
+    AND clients.redirect_uri <> EXCLUDED.redirect_uri
+  )
 `
 
 type ClaimAssistantMCPOAuthClientRegistrationParams struct {
@@ -1048,7 +1051,7 @@ SELECT
       AND client_secret_expires_at IS NOT NULL
       AND client_secret_expires_at <= $2
     )
-    OR redirect_uri <> $1
+    OR (client_id IS NOT NULL AND redirect_uri <> $1)
   ) AS claimable
 FROM assistant_mcp_oauth_clients
 WHERE project_id = $4

--- a/server/internal/assistants/repo/queries.sql.go
+++ b/server/internal/assistants/repo/queries.sql.go
@@ -12,6 +12,36 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const abandonAssistantMCPOAuthClientRegistration = `-- name: AbandonAssistantMCPOAuthClientRegistration :exec
+UPDATE assistant_mcp_oauth_clients
+SET
+  registration_started_at = to_timestamp(0),
+  updated_at = clock_timestamp()
+WHERE project_id = $1
+  AND assistant_id = $2
+  AND oauth_server_issuer = $3
+  AND registration_owner = $4
+  AND client_id IS NULL
+  AND deleted IS FALSE
+`
+
+type AbandonAssistantMCPOAuthClientRegistrationParams struct {
+	ProjectID         uuid.UUID
+	AssistantID       uuid.UUID
+	OauthServerIssuer string
+	RegistrationOwner uuid.NullUUID
+}
+
+func (q *Queries) AbandonAssistantMCPOAuthClientRegistration(ctx context.Context, arg AbandonAssistantMCPOAuthClientRegistrationParams) error {
+	_, err := q.db.Exec(ctx, abandonAssistantMCPOAuthClientRegistration,
+		arg.ProjectID,
+		arg.AssistantID,
+		arg.OauthServerIssuer,
+		arg.RegistrationOwner,
+	)
+	return err
+}
+
 const acquireAssistantAdvisoryLock = `-- name: AcquireAssistantAdvisoryLock :exec
 SELECT pg_advisory_xact_lock(hashtext('asst:' || $1::text))
 `
@@ -167,6 +197,71 @@ func (q *Queries) CallerOwnsDashboardChat(ctx context.Context, arg CallerOwnsDas
 	return ok, err
 }
 
+const claimAssistantMCPOAuthClientRegistration = `-- name: ClaimAssistantMCPOAuthClientRegistration :execrows
+INSERT INTO assistant_mcp_oauth_clients AS clients (
+  project_id,
+  assistant_id,
+  oauth_server_issuer,
+  redirect_uri,
+  registration_owner,
+  registration_started_at
+) VALUES (
+  $1,
+  $2,
+  $3,
+  $4,
+  $5,
+  clock_timestamp()
+)
+ON CONFLICT (project_id, assistant_id, oauth_server_issuer) WHERE deleted IS FALSE
+DO UPDATE SET
+  client_id = NULL,
+  client_secret_encrypted = NULL,
+  client_secret_expires_at = NULL,
+  redirect_uri = EXCLUDED.redirect_uri,
+  registration_owner = EXCLUDED.registration_owner,
+  registration_started_at = EXCLUDED.registration_started_at,
+  updated_at = clock_timestamp()
+WHERE
+  (
+    clients.client_id IS NULL
+    AND clients.registration_started_at < clock_timestamp() - $6::interval
+  )
+  OR
+  (
+    clients.client_id IS NOT NULL
+    AND clients.client_secret_expires_at IS NOT NULL
+    AND clients.client_secret_expires_at <= $7
+  )
+  OR clients.redirect_uri <> EXCLUDED.redirect_uri
+`
+
+type ClaimAssistantMCPOAuthClientRegistrationParams struct {
+	ProjectID         uuid.UUID
+	AssistantID       uuid.UUID
+	OauthServerIssuer string
+	RedirectUri       string
+	RegistrationOwner uuid.NullUUID
+	ClaimLease        pgtype.Interval
+	UsableAfter       pgtype.Timestamptz
+}
+
+func (q *Queries) ClaimAssistantMCPOAuthClientRegistration(ctx context.Context, arg ClaimAssistantMCPOAuthClientRegistrationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimAssistantMCPOAuthClientRegistration,
+		arg.ProjectID,
+		arg.AssistantID,
+		arg.OauthServerIssuer,
+		arg.RedirectUri,
+		arg.RegistrationOwner,
+		arg.ClaimLease,
+		arg.UsableAfter,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const claimNextPendingEvent = `-- name: ClaimNextPendingEvent :one
 WITH next_event AS (
   SELECT e.id, t.skill_set_snapshot
@@ -275,6 +370,49 @@ type ClearAssistantToolsetsParams struct {
 func (q *Queries) ClearAssistantToolsets(ctx context.Context, arg ClearAssistantToolsetsParams) error {
 	_, err := q.db.Exec(ctx, clearAssistantToolsets, arg.AssistantID, arg.ProjectID)
 	return err
+}
+
+const completeAssistantMCPOAuthClientRegistration = `-- name: CompleteAssistantMCPOAuthClientRegistration :execrows
+UPDATE assistant_mcp_oauth_clients
+SET
+  client_id = $1,
+  client_secret_encrypted = $2,
+  client_secret_expires_at = $3,
+  registration_owner = NULL,
+  registration_started_at = NULL,
+  updated_at = clock_timestamp()
+WHERE project_id = $4
+  AND assistant_id = $5
+  AND oauth_server_issuer = $6
+  AND registration_owner = $7
+  AND client_id IS NULL
+  AND deleted IS FALSE
+`
+
+type CompleteAssistantMCPOAuthClientRegistrationParams struct {
+	ClientID              pgtype.Text
+	ClientSecretEncrypted pgtype.Text
+	ClientSecretExpiresAt pgtype.Timestamptz
+	ProjectID             uuid.UUID
+	AssistantID           uuid.UUID
+	OauthServerIssuer     string
+	RegistrationOwner     uuid.NullUUID
+}
+
+func (q *Queries) CompleteAssistantMCPOAuthClientRegistration(ctx context.Context, arg CompleteAssistantMCPOAuthClientRegistrationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, completeAssistantMCPOAuthClientRegistration,
+		arg.ClientID,
+		arg.ClientSecretEncrypted,
+		arg.ClientSecretExpiresAt,
+		arg.ProjectID,
+		arg.AssistantID,
+		arg.OauthServerIssuer,
+		arg.RegistrationOwner,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const completeAssistantThreadEventAndAdvanceSkillSnapshot = `-- name: CompleteAssistantThreadEventAndAdvanceSkillSnapshot :one
@@ -889,6 +1027,71 @@ func (q *Queries) GetAssistantIgnoringDeleted(ctx context.Context, arg GetAssist
 	return i, err
 }
 
+const getAssistantMCPOAuthClient = `-- name: GetAssistantMCPOAuthClient :one
+SELECT
+  client_id,
+  client_secret_encrypted,
+  (
+    client_id IS NOT NULL
+    AND client_secret_encrypted IS NOT NULL
+    AND redirect_uri = $1
+    AND (client_secret_expires_at IS NULL OR client_secret_expires_at > $2)
+  ) AS usable,
+  (
+    (
+      client_id IS NULL
+      AND registration_started_at < clock_timestamp() - $3::interval
+    )
+    OR
+    (
+      client_id IS NOT NULL
+      AND client_secret_expires_at IS NOT NULL
+      AND client_secret_expires_at <= $2
+    )
+    OR redirect_uri <> $1
+  ) AS claimable
+FROM assistant_mcp_oauth_clients
+WHERE project_id = $4
+  AND assistant_id = $5
+  AND oauth_server_issuer = $6
+  AND deleted IS FALSE
+`
+
+type GetAssistantMCPOAuthClientParams struct {
+	RedirectUri       string
+	UsableAfter       pgtype.Timestamptz
+	ClaimLease        pgtype.Interval
+	ProjectID         uuid.UUID
+	AssistantID       uuid.UUID
+	OauthServerIssuer string
+}
+
+type GetAssistantMCPOAuthClientRow struct {
+	ClientID              pgtype.Text
+	ClientSecretEncrypted pgtype.Text
+	Usable                pgtype.Bool
+	Claimable             pgtype.Bool
+}
+
+func (q *Queries) GetAssistantMCPOAuthClient(ctx context.Context, arg GetAssistantMCPOAuthClientParams) (GetAssistantMCPOAuthClientRow, error) {
+	row := q.db.QueryRow(ctx, getAssistantMCPOAuthClient,
+		arg.RedirectUri,
+		arg.UsableAfter,
+		arg.ClaimLease,
+		arg.ProjectID,
+		arg.AssistantID,
+		arg.OauthServerIssuer,
+	)
+	var i GetAssistantMCPOAuthClientRow
+	err := row.Scan(
+		&i.ClientID,
+		&i.ClientSecretEncrypted,
+		&i.Usable,
+		&i.Claimable,
+	)
+	return i, err
+}
+
 const getAssistantRuntime = `-- name: GetAssistantRuntime :one
 SELECT id, assistant_thread_id, assistant_id, project_id, backend, state, warm_until, lease_owner, last_heartbeat_at, backend_metadata_json, ended_at, runtime_version, created_at, updated_at, deleted_at, deleted, ended FROM assistant_runtimes
 WHERE id = $1
@@ -1265,6 +1468,36 @@ func (q *Queries) InsertAssistantThreadEvent(ctx context.Context, arg InsertAssi
 	var id uuid.UUID
 	err := row.Scan(&id)
 	return id, err
+}
+
+const invalidateAssistantMCPOAuthClient = `-- name: InvalidateAssistantMCPOAuthClient :exec
+UPDATE assistant_mcp_oauth_clients
+SET
+  client_secret_expires_at = to_timestamp(0),
+  updated_at = clock_timestamp()
+WHERE project_id = $1
+  AND assistant_id = $2
+  AND oauth_server_issuer = $3
+  AND client_id = $4
+  AND client_id IS NOT NULL
+  AND deleted IS FALSE
+`
+
+type InvalidateAssistantMCPOAuthClientParams struct {
+	ProjectID         uuid.UUID
+	AssistantID       uuid.UUID
+	OauthServerIssuer string
+	ClientID          pgtype.Text
+}
+
+func (q *Queries) InvalidateAssistantMCPOAuthClient(ctx context.Context, arg InvalidateAssistantMCPOAuthClientParams) error {
+	_, err := q.db.Exec(ctx, invalidateAssistantMCPOAuthClient,
+		arg.ProjectID,
+		arg.AssistantID,
+		arg.OauthServerIssuer,
+		arg.ClientID,
+	)
+	return err
 }
 
 const listActiveAssistantRuntimes = `-- name: ListActiveAssistantRuntimes :many

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1431,6 +1431,12 @@ func (s *ServiceCore) DeleteAssistant(ctx context.Context, projectID uuid.UUID, 
 	if err != nil {
 		return fmt.Errorf("delete assistant: %w", err)
 	}
+	if err := queries.RetireAssistantMCPOAuthClients(ctx, assistantrepo.RetireAssistantMCPOAuthClientsParams{
+		AssistantID: assistantID,
+		ProjectID:   projectID,
+	}); err != nil {
+		return fmt.Errorf("retire assistant mcp oauth clients: %w", err)
+	}
 	if err := s.revokeAssistantSkillDistributions(ctx, tx, projectID, assistantID, actor, actorDisplayName); err != nil {
 		return err
 	}

--- a/server/internal/auth/assistanttokens/manager.go
+++ b/server/internal/auth/assistanttokens/manager.go
@@ -49,36 +49,41 @@ type Claims struct {
 const mcpAuthFlowIssuer = "gram-assistants-mcp-auth-flow"
 
 type MCPAuthFlowInput struct {
-	OrgID         string
-	ProjectID     uuid.UUID
-	UserID        string
-	AssistantID   uuid.UUID
-	ThreadID      uuid.UUID
-	FlowID        string
-	ServerID      string
-	McpURL        string
-	ClientID      string
-	ClientSecret  string
-	RedirectURI   string
-	CodeVerifier  string
-	TokenEndpoint string
-	TTL           time.Duration
+	OrgID       string
+	ProjectID   uuid.UUID
+	UserID      string
+	AssistantID uuid.UUID
+	ThreadID    uuid.UUID
+	// AttemptID uniquely identifies one authorization attempt.
+	AttemptID string
+	// FlowID binds the token to the stable callback path.
+	FlowID            string
+	ServerID          string
+	McpURL            string
+	ClientID          string
+	ClientSecret      string
+	RedirectURI       string
+	CodeVerifier      string
+	TokenEndpoint     string
+	OAuthServerIssuer string
+	TTL               time.Duration
 }
 
 type MCPAuthFlowClaims struct {
-	OrgID         string `json:"org_id"`
-	ProjectID     string `json:"project_id"`
-	UserID        string `json:"user_id"`
-	AssistantID   string `json:"assistant_id"`
-	ThreadID      string `json:"thread_id"`
-	FlowID        string `json:"flow_id"`
-	ServerID      string `json:"server_id"`
-	McpURL        string `json:"mcp_url"`
-	ClientID      string `json:"client_id"`
-	ClientSecret  string `json:"client_secret,omitempty"`
-	RedirectURI   string `json:"redirect_uri"`
-	CodeVerifier  string `json:"code_verifier"`
-	TokenEndpoint string `json:"token_endpoint"`
+	OrgID             string `json:"org_id"`
+	ProjectID         string `json:"project_id"`
+	UserID            string `json:"user_id"`
+	AssistantID       string `json:"assistant_id"`
+	ThreadID          string `json:"thread_id"`
+	FlowID            string `json:"flow_id"`
+	ServerID          string `json:"server_id"`
+	McpURL            string `json:"mcp_url"`
+	ClientID          string `json:"client_id"`
+	ClientSecret      string `json:"client_secret,omitempty"`
+	RedirectURI       string `json:"redirect_uri"`
+	CodeVerifier      string `json:"code_verifier"`
+	TokenEndpoint     string `json:"token_endpoint"`
+	OAuthServerIssuer string `json:"oauth_server_issuer,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -157,20 +162,25 @@ func (m *Manager) GenerateMCPAuthFlow(input MCPAuthFlowInput) (string, error) {
 		ttl = 15 * time.Minute
 	}
 
+	attemptID := input.AttemptID
+	if attemptID == "" {
+		attemptID = input.FlowID
+	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, MCPAuthFlowClaims{
-		OrgID:         input.OrgID,
-		ProjectID:     input.ProjectID.String(),
-		UserID:        input.UserID,
-		AssistantID:   input.AssistantID.String(),
-		ThreadID:      input.ThreadID.String(),
-		FlowID:        input.FlowID,
-		ServerID:      input.ServerID,
-		McpURL:        input.McpURL,
-		ClientID:      input.ClientID,
-		ClientSecret:  input.ClientSecret,
-		RedirectURI:   input.RedirectURI,
-		CodeVerifier:  input.CodeVerifier,
-		TokenEndpoint: input.TokenEndpoint,
+		OrgID:             input.OrgID,
+		ProjectID:         input.ProjectID.String(),
+		UserID:            input.UserID,
+		AssistantID:       input.AssistantID.String(),
+		ThreadID:          input.ThreadID.String(),
+		FlowID:            input.FlowID,
+		ServerID:          input.ServerID,
+		McpURL:            input.McpURL,
+		ClientID:          input.ClientID,
+		ClientSecret:      input.ClientSecret,
+		RedirectURI:       input.RedirectURI,
+		CodeVerifier:      input.CodeVerifier,
+		TokenEndpoint:     input.TokenEndpoint,
+		OAuthServerIssuer: input.OAuthServerIssuer,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    mcpAuthFlowIssuer,
 			Subject:   input.AssistantID.String(),
@@ -178,7 +188,7 @@ func (m *Manager) GenerateMCPAuthFlow(input MCPAuthFlowInput) (string, error) {
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 			NotBefore: nil,
 			IssuedAt:  jwt.NewNumericDate(now),
-			ID:        input.FlowID,
+			ID:        attemptID,
 		},
 	})
 
@@ -196,19 +206,20 @@ func (m *Manager) ValidateMCPAuthFlow(tokenString string) (*MCPAuthFlowClaims, e
 	}
 
 	token, err := jwt.ParseWithClaims(tokenString, &MCPAuthFlowClaims{
-		OrgID:         "",
-		ProjectID:     "",
-		UserID:        "",
-		AssistantID:   "",
-		ThreadID:      "",
-		FlowID:        "",
-		ServerID:      "",
-		McpURL:        "",
-		ClientID:      "",
-		ClientSecret:  "",
-		RedirectURI:   "",
-		CodeVerifier:  "",
-		TokenEndpoint: "",
+		OrgID:             "",
+		ProjectID:         "",
+		UserID:            "",
+		AssistantID:       "",
+		ThreadID:          "",
+		FlowID:            "",
+		ServerID:          "",
+		McpURL:            "",
+		ClientID:          "",
+		ClientSecret:      "",
+		RedirectURI:       "",
+		CodeVerifier:      "",
+		TokenEndpoint:     "",
+		OAuthServerIssuer: "",
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    "",
 			Subject:   "",

--- a/server/internal/auth/assistanttokens/manager_test.go
+++ b/server/internal/auth/assistanttokens/manager_test.go
@@ -179,6 +179,70 @@ func TestCheckRevocation_assistantScoped(t *testing.T) {
 	require.NoError(t, m.checkRevocation(t.Context(), f.projectID, f.assistantID, uuid.Nil))
 }
 
+func TestMCPAuthFlowSeparatesStableCallbackFromAttempt(t *testing.T) {
+	t.Parallel()
+
+	manager := New("test-secret", nil, nil)
+	assistantID := uuid.New()
+	attemptID := uuid.NewString()
+	token, err := manager.GenerateMCPAuthFlow(MCPAuthFlowInput{
+		OrgID:             "org-test",
+		ProjectID:         uuid.New(),
+		UserID:            "user-test",
+		AssistantID:       assistantID,
+		ThreadID:          uuid.New(),
+		AttemptID:         attemptID,
+		FlowID:            assistantID.String(),
+		ServerID:          "server-test",
+		McpURL:            "https://mcp.example.com/mcp/test",
+		ClientID:          "client-test",
+		ClientSecret:      "encrypted-secret",
+		RedirectURI:       "https://gram.example.com/rpc/assistantMcpAuth/" + assistantID.String() + "/oauth/callback",
+		CodeVerifier:      "encrypted-verifier",
+		TokenEndpoint:     "https://auth.example.com/token",
+		OAuthServerIssuer: "https://auth.example.com",
+		TTL:               time.Minute,
+	})
+	require.NoError(t, err)
+
+	claims, err := manager.ValidateMCPAuthFlow(token)
+	require.NoError(t, err)
+	require.Equal(t, assistantID.String(), claims.FlowID)
+	require.Equal(t, attemptID, claims.ID)
+	require.Equal(t, "https://auth.example.com", claims.OAuthServerIssuer)
+}
+
+func TestMCPAuthFlowDefaultsAttemptToLegacyFlowID(t *testing.T) {
+	t.Parallel()
+
+	manager := New("test-secret", nil, nil)
+	flowID := uuid.NewString()
+	token, err := manager.GenerateMCPAuthFlow(MCPAuthFlowInput{
+		OrgID:             "org-test",
+		ProjectID:         uuid.New(),
+		UserID:            "user-test",
+		AssistantID:       uuid.New(),
+		ThreadID:          uuid.New(),
+		AttemptID:         "",
+		FlowID:            flowID,
+		ServerID:          "server-test",
+		McpURL:            "https://mcp.example.com/mcp/test",
+		ClientID:          "client-test",
+		ClientSecret:      "encrypted-secret",
+		RedirectURI:       "https://gram.example.com/rpc/assistantMcpAuth/" + flowID + "/oauth/callback",
+		CodeVerifier:      "encrypted-verifier",
+		TokenEndpoint:     "https://auth.example.com/token",
+		OAuthServerIssuer: "",
+		TTL:               time.Minute,
+	})
+	require.NoError(t, err)
+
+	claims, err := manager.ValidateMCPAuthFlow(token)
+	require.NoError(t, err)
+	require.Equal(t, flowID, claims.FlowID)
+	require.Equal(t, flowID, claims.ID)
+}
+
 func TestCheckRevocation_assistantScoped_assistantPaused(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -3,6 +3,7 @@ package externalmcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -127,9 +128,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 			resourceMeta = meta
 			// Follow the chain to get AS metadata
 			if len(meta.AuthorizationServers) > 0 {
-				expectedIssuer := meta.AuthorizationServers[0]
-				asURL := buildWellKnownURL(expectedIssuer)
-				asMeta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, expectedIssuer)
+				asMeta, err := fetchAdvertisedAuthServerMetadata(ctx, logger, guardianPolicy, meta.AuthorizationServers)
 				if err != nil {
 					return nil, fmt.Errorf("fetch protected resource authorization server metadata: %w", err)
 				}
@@ -147,9 +146,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 			resourceMeta = meta
 			// Follow the chain
 			if len(meta.AuthorizationServers) > 0 {
-				expectedIssuer := meta.AuthorizationServers[0]
-				asURL := buildWellKnownURL(expectedIssuer)
-				asMeta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, expectedIssuer)
+				asMeta, err := fetchAdvertisedAuthServerMetadata(ctx, logger, guardianPolicy, meta.AuthorizationServers)
 				if err != nil {
 					return nil, fmt.Errorf("fetch discovered authorization server metadata: %w", err)
 				}
@@ -179,9 +176,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 			if err == nil && meta != nil {
 				resourceMeta = meta
 				if len(meta.AuthorizationServers) > 0 {
-					expectedIssuer := meta.AuthorizationServers[0]
-					asURL := buildWellKnownURL(expectedIssuer)
-					asMeta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, expectedIssuer)
+					asMeta, err := fetchAdvertisedAuthServerMetadata(ctx, logger, guardianPolicy, meta.AuthorizationServers)
 					if err != nil {
 						return nil, fmt.Errorf("fetch origin authorization server metadata: %w", err)
 					}
@@ -364,6 +359,24 @@ func fetchAuthServerMetadata(
 		return nil, fmt.Errorf("authorization server metadata issuer mismatch")
 	}
 	return metadata, nil
+}
+
+func fetchAdvertisedAuthServerMetadata(
+	ctx context.Context,
+	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
+	issuers []string,
+) (*authServerMetadata, error) {
+	var errs []error
+	for _, issuer := range issuers {
+		metadata, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, buildWellKnownURL(issuer), issuer)
+		if err == nil {
+			return metadata, nil
+		}
+		errs = append(errs, fmt.Errorf("issuer %q: %w", issuer, err))
+	}
+
+	return nil, fmt.Errorf("no advertised authorization server metadata was usable: %w", errors.Join(errs...))
 }
 
 func validateOAuthIssuer(rawURL string) error {

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -27,6 +28,7 @@ const (
 // OAuthDiscoveryResult contains the OAuth metadata discovered for an external MCP server.
 type OAuthDiscoveryResult struct {
 	Version               string // "2.1", "2.0", or "none"
+	Issuer                string // Authorization server issuer from RFC 8414 metadata.
 	AuthorizationEndpoint string
 	TokenEndpoint         string
 	RegistrationEndpoint  string
@@ -111,10 +113,11 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 
 	// Strategy 1: Check for auth_server_metadata in header (direct AS metadata URL)
 	if asURL, ok := params["auth_server_metadata"]; ok && asURL != "" {
-		meta, err := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
-		if err == nil && meta != nil {
-			authServerMeta = meta
+		meta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, "")
+		if err != nil {
+			return nil, fmt.Errorf("fetch advertised authorization server metadata: %w", err)
 		}
+		authServerMeta = meta
 	}
 
 	// Strategy 2: Check for resource_metadata in header (Protected Resource metadata)
@@ -124,11 +127,13 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 			resourceMeta = meta
 			// Follow the chain to get AS metadata
 			if len(meta.AuthorizationServers) > 0 {
-				asURL := buildWellKnownURL(meta.AuthorizationServers[0])
-				asMeta, err := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
-				if err == nil && asMeta != nil {
-					authServerMeta = asMeta
+				expectedIssuer := meta.AuthorizationServers[0]
+				asURL := buildWellKnownURL(expectedIssuer)
+				asMeta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, expectedIssuer)
+				if err != nil {
+					return nil, fmt.Errorf("fetch protected resource authorization server metadata: %w", err)
 				}
+				authServerMeta = asMeta
 			}
 		}
 	}
@@ -142,18 +147,20 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 			resourceMeta = meta
 			// Follow the chain
 			if len(meta.AuthorizationServers) > 0 {
-				asURL := buildWellKnownURL(meta.AuthorizationServers[0])
-				asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
-				if asMeta != nil {
-					authServerMeta = asMeta
+				expectedIssuer := meta.AuthorizationServers[0]
+				asURL := buildWellKnownURL(expectedIssuer)
+				asMeta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, expectedIssuer)
+				if err != nil {
+					return nil, fmt.Errorf("fetch discovered authorization server metadata: %w", err)
 				}
+				authServerMeta = asMeta
 			}
 		}
 
 		// Try OAuth Authorization Server metadata directly
 		if authServerMeta == nil {
 			asURL := buildWellKnownURL(remoteURL)
-			asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
+			asMeta, _ := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, issuerFromWellKnownBase(remoteURL))
 			if asMeta != nil {
 				authServerMeta = asMeta
 			}
@@ -172,17 +179,19 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 			if err == nil && meta != nil {
 				resourceMeta = meta
 				if len(meta.AuthorizationServers) > 0 {
-					asURL := buildWellKnownURL(meta.AuthorizationServers[0])
-					asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
-					if asMeta != nil {
-						authServerMeta = asMeta
+					expectedIssuer := meta.AuthorizationServers[0]
+					asURL := buildWellKnownURL(expectedIssuer)
+					asMeta, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, expectedIssuer)
+					if err != nil {
+						return nil, fmt.Errorf("fetch origin authorization server metadata: %w", err)
 					}
+					authServerMeta = asMeta
 				}
 			}
 
 			if authServerMeta == nil {
 				asURL := buildWellKnownURL(rootURL)
-				asMeta, _ := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, asURL)
+				asMeta, _ := fetchAuthServerMetadata(ctx, logger, guardianPolicy, asURL, rootURL)
 				if asMeta != nil {
 					authServerMeta = asMeta
 				}
@@ -193,6 +202,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 	// Determine the OAuth version based on what we found
 	result := &OAuthDiscoveryResult{
 		Version:               OAuthVersionNone,
+		Issuer:                "",
 		AuthorizationEndpoint: "",
 		TokenEndpoint:         "",
 		RegistrationEndpoint:  "",
@@ -200,6 +210,7 @@ func DiscoverOAuthMetadata(ctx context.Context, logger *slog.Logger, guardianPol
 	}
 
 	if authServerMeta != nil {
+		result.Issuer = authServerMeta.Issuer
 		result.AuthorizationEndpoint = authServerMeta.AuthorizationEndpoint
 		result.TokenEndpoint = authServerMeta.TokenEndpoint
 		result.RegistrationEndpoint = authServerMeta.RegistrationEndpoint
@@ -261,6 +272,14 @@ func buildWellKnownURL(baseURL string) string {
 	return buildWellKnownSuffixURL(baseURL, "oauth-authorization-server")
 }
 
+func issuerFromWellKnownBase(baseURL string) string {
+	u, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path)
+}
+
 // buildWellKnownResourceURL constructs the well-known OAuth Protected Resource metadata URL.
 // Per RFC 9728, the well-known suffix is inserted between the host and the path.
 // e.g. https://example.com/path → https://example.com/.well-known/oauth-protected-resource/path
@@ -305,4 +324,81 @@ func fetchJSON[T any](ctx context.Context, logger *slog.Logger, guardianPolicy *
 	}
 
 	return &result, nil
+}
+
+func fetchAuthServerMetadata(
+	ctx context.Context,
+	logger *slog.Logger,
+	guardianPolicy *guardian.Policy,
+	metadataURL string,
+	expectedIssuer string,
+) (*authServerMetadata, error) {
+	metadata, err := fetchJSON[authServerMetadata](ctx, logger, guardianPolicy, metadataURL)
+	if err != nil {
+		return nil, err
+	}
+	if metadata.Issuer == "" {
+		return nil, fmt.Errorf("authorization server metadata missing issuer")
+	}
+	if err := validateOAuthIssuer(metadata.Issuer); err != nil {
+		return nil, fmt.Errorf("invalid authorization server issuer: %w", err)
+	}
+	for name, endpoint := range map[string]string{
+		"authorization_endpoint": metadata.AuthorizationEndpoint,
+		"token_endpoint":         metadata.TokenEndpoint,
+		"registration_endpoint":  metadata.RegistrationEndpoint,
+	} {
+		if endpoint != "" {
+			if err := validateOAuthEndpoint(endpoint); err != nil {
+				return nil, fmt.Errorf("invalid %s: %w", name, err)
+			}
+		}
+	}
+	if expectedIssuer == "" {
+		if buildWellKnownURL(metadata.Issuer) != metadataURL {
+			return nil, fmt.Errorf("authorization server metadata issuer does not match metadata URL")
+		}
+		return metadata, nil
+	}
+	if metadata.Issuer != expectedIssuer {
+		return nil, fmt.Errorf("authorization server metadata issuer mismatch")
+	}
+	return metadata, nil
+}
+
+func validateOAuthIssuer(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse issuer URL: %w", err)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("must not contain a query or fragment")
+	}
+	return validateSecureOAuthURL(u)
+}
+
+func validateOAuthEndpoint(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse endpoint URL: %w", err)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("must not contain a fragment")
+	}
+	return validateSecureOAuthURL(u)
+}
+
+func validateSecureOAuthURL(u *url.URL) error {
+	if u.Host == "" || u.User != nil {
+		return fmt.Errorf("must be an absolute URL without userinfo")
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	host := u.Hostname()
+	ip := net.ParseIP(host)
+	if u.Scheme == "http" && (host == "localhost" || ip != nil && ip.IsLoopback()) {
+		return nil
+	}
+	return fmt.Errorf("must use HTTPS")
 }

--- a/server/internal/externalmcp/oauthdiscovery.go
+++ b/server/internal/externalmcp/oauthdiscovery.go
@@ -292,17 +292,30 @@ func buildWellKnownSuffixURL(baseURL, suffix string) string {
 }
 
 // fetchJSON fetches JSON from a URL and decodes it into the target.
-func fetchJSON[T any](ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, url string) (*T, error) {
+func fetchJSON[T any](ctx context.Context, logger *slog.Logger, guardianPolicy *guardian.Policy, rawURL string) (*T, error) {
+	if err := validateOAuthEndpoint(rawURL); err != nil {
+		return nil, fmt.Errorf("invalid metadata URL: %w", err)
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
 
-	client := guardianPolicy.Client(guardian.WithDefaultRetryConfig())
+	client := guardianPolicy.Client()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		if err := validateOAuthEndpoint(req.URL.String()); err != nil {
+			return fmt.Errorf("invalid metadata redirect URL: %w", err)
+		}
+		return nil
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch: %w", err)
@@ -367,8 +380,14 @@ func fetchAdvertisedAuthServerMetadata(
 	guardianPolicy *guardian.Policy,
 	issuers []string,
 ) (*authServerMetadata, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	var errs []error
 	for _, issuer := range issuers {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("authorization server metadata discovery deadline: %w", errors.Join(append(errs, err)...))
+		}
 		metadata, err := fetchAuthServerMetadata(ctx, logger, guardianPolicy, buildWellKnownURL(issuer), issuer)
 		if err == nil {
 			return metadata, nil

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -99,5 +99,55 @@ func TestDiscoverOAuthMetadata_PreservesProtectedResourceScopes(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, OAuthVersion21, result.Version)
+	require.Equal(t, server.URL, result.Issuer)
 	require.Equal(t, []string{"resource.read", "resource.write"}, result.ScopesSupported)
+}
+
+func TestDiscoverOAuthMetadataRejectsIssuerMismatch(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/resource-metadata":
+			_ = json.NewEncoder(w).Encode(protectedResourceMetadata{
+				Resource:             server.URL + "/mcp",
+				AuthorizationServers: []string{server.URL + "/expected"},
+				ScopesSupported:      nil,
+			})
+		case "/.well-known/oauth-authorization-server/expected":
+			_ = json.NewEncoder(w).Encode(authServerMetadata{
+				Issuer:                server.URL + "/different",
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+				RegistrationEndpoint:  server.URL + "/register",
+				ScopesSupported:       nil,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	result, err := DiscoverOAuthMetadata(
+		t.Context(),
+		testenv.NewLogger(t),
+		policy,
+		`Bearer resource_metadata="`+server.URL+`/resource-metadata"`,
+		server.URL+"/mcp",
+	)
+	require.ErrorContains(t, err, "issuer mismatch")
+	require.Nil(t, result)
+}
+
+func TestValidateOAuthIssuerRequiresHTTPS(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorContains(t, validateOAuthIssuer("http://auth.example.com"), "HTTPS")
+	require.ErrorContains(t, validateOAuthIssuer("https://auth.example.com?tenant=test"), "query or fragment")
+	require.NoError(t, validateOAuthIssuer("https://auth.example.com/tenant"))
 }

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -144,6 +144,59 @@ func TestDiscoverOAuthMetadataRejectsIssuerMismatch(t *testing.T) {
 	require.Nil(t, result)
 }
 
+func TestDiscoverOAuthMetadataUsesLaterAdvertisedAuthorizationServer(t *testing.T) {
+	t.Parallel()
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/resource-metadata":
+			_ = json.NewEncoder(w).Encode(protectedResourceMetadata{
+				Resource: server.URL + "/mcp",
+				AuthorizationServers: []string{
+					server.URL + "/unavailable",
+					server.URL + "/mismatched",
+					server.URL + "/valid",
+				},
+				ScopesSupported: []string{"resource.read"},
+			})
+		case "/.well-known/oauth-authorization-server/mismatched":
+			_ = json.NewEncoder(w).Encode(authServerMetadata{
+				Issuer:                server.URL + "/different",
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+				RegistrationEndpoint:  server.URL + "/register",
+			})
+		case "/.well-known/oauth-authorization-server/valid":
+			_ = json.NewEncoder(w).Encode(authServerMetadata{
+				Issuer:                server.URL + "/valid",
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+				RegistrationEndpoint:  server.URL + "/register",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	result, err := DiscoverOAuthMetadata(
+		t.Context(),
+		testenv.NewLogger(t),
+		policy,
+		`Bearer resource_metadata="`+server.URL+`/resource-metadata"`,
+		server.URL+"/mcp",
+	)
+	require.NoError(t, err)
+	require.Equal(t, OAuthVersion21, result.Version)
+	require.Equal(t, server.URL+"/valid", result.Issuer)
+	require.Equal(t, []string{"resource.read"}, result.ScopesSupported)
+}
+
 func TestValidateOAuthIssuerRequiresHTTPS(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/externalmcp/oauthdiscovery_test.go
+++ b/server/internal/externalmcp/oauthdiscovery_test.go
@@ -1,6 +1,7 @@
 package externalmcp
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -195,6 +196,47 @@ func TestDiscoverOAuthMetadataUsesLaterAdvertisedAuthorizationServer(t *testing.
 	require.Equal(t, OAuthVersion21, result.Version)
 	require.Equal(t, server.URL+"/valid", result.Issuer)
 	require.Equal(t, []string{"resource.read"}, result.ScopesSupported)
+}
+
+func TestDiscoverOAuthMetadataRejectsInsecureMetadataURL(t *testing.T) {
+	t.Parallel()
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := DiscoverOAuthMetadata(
+		ctx,
+		testenv.NewLogger(t),
+		policy,
+		`Bearer auth_server_metadata="http://auth.example.com/.well-known/oauth-authorization-server"`,
+		"https://mcp.example.com",
+	)
+	require.ErrorContains(t, err, "must use HTTPS")
+	require.Nil(t, result)
+}
+
+func TestDiscoverOAuthMetadataRejectsInsecureMetadataRedirect(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://auth.example.com/.well-known/oauth-authorization-server", http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+
+	result, err := DiscoverOAuthMetadata(
+		t.Context(),
+		testenv.NewLogger(t),
+		policy,
+		`Bearer auth_server_metadata="`+server.URL+`"`,
+		"https://mcp.example.com",
+	)
+	require.ErrorContains(t, err, "must use HTTPS")
+	require.Nil(t, result)
 }
 
 func TestValidateOAuthIssuerRequiresHTTPS(t *testing.T) {


### PR DESCRIPTION
## Summary

- reuse one dynamic OAuth client per project, assistant, and RFC 8414 issuer
- register a stable assistant callback URI while preserving a unique event ID for every authorization attempt
- coordinate first registration with a bounded, database-clock lease and exponential jittered polling; no database transaction or connection spans the remote DCR request
- persist encrypted client secrets and expiry, replace registrations when the redirect URI changes or the secret can no longer outlive a flow, and invalidate registrations after `invalid_client`
- validate issuer identity and HTTPS metadata endpoints, fail closed on issuer mismatch, and disable automatic retries for non-idempotent DCR
- retire credentials in the same deletion transaction and serialize short claim statements against assistant deletion

## Stack

Foundation #5085 is merged. This PR is now runtime-only and based on `main`.

## Rollout and cleanup

#5085 deployed the callback consumer compatibility first. This PR can now switch to stable assistant callback paths without mixed-version callback rejection or event deduplication.

After this change has been deployed for longer than the 15-minute in-flight flow TTL, administrators can remove legacy dynamic registrations named `Gram Assistant MCP Auth` whose redirect path ends in a per-flow UUID. New registrations are named `Gram Assistant <assistant-uuid>` and use the stable assistant callback path.

## Verification

- `mise exec -- go test ./server/internal/assistants ./server/internal/externalmcp ./server/internal/auth/assistanttokens`
- focused two-connection assistant-delete/registration-claim serialization regression
- `mise lint:server`
- `git diff --check`

Linear: DNO-799