### PR TITLE
fix(plugins): stop Codex hooks failing with exit 127 after a plugin cache swap

### DIFF
--- a/.changeset/codex-hook-command-cache-swap.md
+++ b/.changeset/codex-hook-command-cache-swap.md
@@ -1,0 +1,17 @@
+---
+"server": patch
+---
+
+Stop Codex hooks failing with exit code 127. The hook command Codex caches for
+a session pointed at one versioned plugin cache directory, so a background
+plugin refresh that swapped that directory out left the session invoking a
+bootstrap script that no longer existed — the shell reported "command not
+found" and Codex surfaced it as `SessionStart`/`UserPromptSubmit` failures. The
+command now falls back to the newest sibling version in the cache, and when no
+bootstrap script can be found at all it explains itself on stderr and honours
+the install-failure policy instead of exiting 127.
+
+Also fixes the trusted-hash computation for Codex hooks: it was serialising the
+command with Go's HTML escaping, so any command containing `>`, `<`, or `&`
+hashed differently than Codex computes it and the hook was silently dropped as
+untrusted.

--- a/.changeset/codex-hook-command-cache-swap.md
+++ b/.changeset/codex-hook-command-cache-swap.md
@@ -7,9 +7,12 @@ a session pointed at one versioned plugin cache directory, so a background
 plugin refresh that swapped that directory out left the session invoking a
 bootstrap script that no longer existed — the shell reported "command not
 found" and Codex surfaced it as `SessionStart`/`UserPromptSubmit` failures. The
-command now falls back to the newest sibling version in the cache, and when no
-bootstrap script can be found at all it explains itself on stderr and honours
-the install-failure policy instead of exiting 127.
+bootstrap now persists itself and its deployment config together in Codex's
+version-independent plugin data directory. Once ready, hook commands execute
+that stable bundle and use the installed payload only to refresh it; the newest
+cache sibling remains a first-run migration fallback. Unix and Windows both
+honour the configured install-failure policy with an explanatory diagnostic
+instead of an opaque missing-command failure.
 
 Also fixes the trusted-hash computation for Codex hooks: it was serialising the
 command with Go's HTML escaping, so any command containing `>`, `<`, or `&`

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -2524,13 +2524,11 @@ type codexMatcherGroup struct {
 
 // commandWindows is supported by Codex hook_config.rs at
 // 5bed6447998c754d154dbd796517310b8f04d4ce. On Windows it replaces command
-// before execution. Codex substitutes plugin variables only in the ${KEY}
-// textual form (discovery.rs), so commandWindows must use ${PLUGIN_ROOT},
-// never PowerShell-only $env: expansion. Trust hashing happens after that
-// replacement (discovery.rs normalizes command_windows into command before
-// hashing), so Windows machines verify against a hash of the commandWindows
-// string — precomputed approvals carry both hashes and the install script
-// selects by platform.
+// before execution. The command runs after Codex exports PLUGIN_ROOT and
+// PLUGIN_DATA, so it may read them through PowerShell's $env: syntax. Trust
+// hashing normalizes command_windows into command before hashing, so Windows
+// machines verify against a hash of this exact string; precomputed approvals
+// carry both hashes and the install script selects by platform.
 type codexHookCommand struct {
 	Type           string `json:"type"`
 	Command        string `json:"command"`

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -381,7 +382,7 @@ const platformMCPGeneratorVersion = "1"
 // line when it pins a new binary, because new checksums always change the
 // rendered bootstrap script. Any other change to hooks generation needs a
 // manual bump, which the Plugin Generate Check CI workflow enforces.
-const hooksGeneratorVersion = "30"
+const hooksGeneratorVersion = "31"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits
@@ -1370,7 +1371,7 @@ func generateCodexObservabilityPluginInDir(files map[string][]byte, subdir strin
 		}
 		hooks := []codexHookCommand{{
 			Type:           "command",
-			Command:        codexHookCommandString(timeoutSeconds, async),
+			Command:        codexHookCommandString(timeoutSeconds, async, cfg.InstallFailOpen),
 			CommandWindows: codexHookCommandStringWindows(timeoutSeconds, async),
 			Timeout:        hookTimeout,
 		}}
@@ -1679,8 +1680,8 @@ func computeCodexHookHash(event, command string) (string, error) {
 		"timeout": timeoutSeconds,
 		"type":    "command",
 	}
-	// json.Marshal on map[string]any sorts keys alphabetically, matching
-	// Codex's canonical JSON implementation in fingerprint.rs.
+	// Go sorts map[string]any keys alphabetically, matching Codex's canonical
+	// JSON implementation in fingerprint.rs.
 	canonical := map[string]any{
 		"event_name": eventSnake,
 		"hooks":      []map[string]any{hook},
@@ -1693,12 +1694,28 @@ func computeCodexHookHash(event, command string) (string, error) {
 	default:
 		canonical["matcher"] = ""
 	}
-	data, err := json.Marshal(canonical)
+	data, err := marshalUnescapedJSON(canonical)
 	if err != nil {
 		return "", fmt.Errorf("marshal canonical JSON: %w", err)
 	}
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("sha256:%x", sum), nil
+}
+
+// marshalUnescapedJSON serializes v the way serde_json does, leaving <, > and &
+// as themselves. json.Marshal escapes them to \u003c, \u003e and \u0026, which
+// is valid JSON but different bytes — and Codex hashes the bytes of its own
+// serialization, so a command containing any of those characters would hash to
+// something no Codex install ever computes and leave every hook untrusted.
+func marshalUnescapedJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(v); err != nil {
+		return nil, fmt.Errorf("encode JSON: %w", err)
+	}
+	// Encode terminates each value with a newline; Codex hashes the value alone.
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")), nil
 }
 
 // codexHookParams returns the timeout and relay --async flag for a Codex hook
@@ -1719,12 +1736,15 @@ func codexHookParams(event string) (timeoutSeconds int, async bool) {
 
 // computeCodexHookApprovals returns pre-computed [hooks.state] entries for all
 // Codex observability hook events for a given marketplace and plugin name.
-func computeCodexHookApprovals(marketplace, plugin string) ([]codexHookApproval, error) {
+// failOpen must match the org's install-failure policy: it is baked into the
+// hook command, which Codex hashes, so an approval computed under the wrong
+// policy leaves every hook untrusted.
+func computeCodexHookApprovals(marketplace, plugin string, failOpen bool) ([]codexHookApproval, error) {
 	approvals := make([]codexHookApproval, 0, len(CodexObservabilityHookEvents))
 	for _, event := range CodexObservabilityHookEvents {
 		snake := codexEventSnakeCase(event)
 		timeoutSeconds, async := codexHookParams(event)
-		hash, err := computeCodexHookHash(event, codexHookCommandString(timeoutSeconds, async))
+		hash, err := computeCodexHookHash(event, codexHookCommandString(timeoutSeconds, async, failOpen))
 		if err != nil {
 			return nil, fmt.Errorf("compute hash for %s hook: %w", event, err)
 		}
@@ -1741,17 +1761,27 @@ func computeCodexHookApprovals(marketplace, plugin string) ([]codexHookApproval,
 	return approvals, nil
 }
 
+// codexPluginRootPlaceholder is the plugin-root variable Codex expands in hook
+// commands. Unlike Claude and Cursor, which leave the expansion to the shell,
+// Codex substitutes it textually before running the command and also exports it
+// to the hook process.
+const codexPluginRootPlaceholder = `${PLUGIN_ROOT}`
+
 // codexHookCommandString / codexHookCommandStringWindows are the single source
 // for the command strings emitted into the Codex hooks.json (command /
 // commandWindows) AND hashed into the precomputed approvals — Codex hashes the
 // command string verbatim, so any drift between the two call sites silently
 // untrusts every hook.
-func codexHookCommandString(timeoutSeconds int, async bool) string {
-	return hooksBootstrapCommand(`${PLUGIN_ROOT}`, "codex", timeoutSeconds, async)
+func codexHookCommandString(timeoutSeconds int, async, failOpen bool) string {
+	return codexHooksBootstrapCommand(timeoutSeconds, async, failOpen)
 }
 
+// codexHookCommandStringWindows keeps the plain -File invocation: the
+// plugin-cache staleness codexHooksBootstrapCommand recovers from applies on
+// Windows too, but a PowerShell equivalent cannot be exercised from this
+// repository's test environment, so it is not rewritten blind.
 func codexHookCommandStringWindows(timeoutSeconds int, async bool) string {
-	return hooksPowerShellCommand(`${PLUGIN_ROOT}`, "codex", timeoutSeconds, async)
+	return hooksPowerShellCommand(codexPluginRootPlaceholder, "codex", timeoutSeconds, async)
 }
 
 // GenerateCodexInstallScript produces a bash install script that:
@@ -1766,7 +1796,7 @@ func GenerateCodexInstallScript(marketplaceURL string, cfg GenerateConfig) ([]by
 	marketplace := resolveMarketplaceName(cfg)
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, cfg.InstallFailOpen)
 	if err != nil {
 		return nil, fmt.Errorf("compute hook approvals: %w", err)
 	}

--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -1372,7 +1372,7 @@ func generateCodexObservabilityPluginInDir(files map[string][]byte, subdir strin
 		hooks := []codexHookCommand{{
 			Type:           "command",
 			Command:        codexHookCommandString(timeoutSeconds, async, cfg.InstallFailOpen),
-			CommandWindows: codexHookCommandStringWindows(timeoutSeconds, async),
+			CommandWindows: codexHookCommandStringWindows(timeoutSeconds, async, cfg.InstallFailOpen),
 			Timeout:        hookTimeout,
 		}}
 		hookEvents[event] = []codexMatcherGroup{{
@@ -1748,7 +1748,7 @@ func computeCodexHookApprovals(marketplace, plugin string, failOpen bool) ([]cod
 		if err != nil {
 			return nil, fmt.Errorf("compute hash for %s hook: %w", event, err)
 		}
-		windowsHash, err := computeCodexHookHash(event, codexHookCommandStringWindows(timeoutSeconds, async))
+		windowsHash, err := computeCodexHookHash(event, codexHookCommandStringWindows(timeoutSeconds, async, failOpen))
 		if err != nil {
 			return nil, fmt.Errorf("compute windows hash for %s hook: %w", event, err)
 		}
@@ -1761,12 +1761,6 @@ func computeCodexHookApprovals(marketplace, plugin string, failOpen bool) ([]cod
 	return approvals, nil
 }
 
-// codexPluginRootPlaceholder is the plugin-root variable Codex expands in hook
-// commands. Unlike Claude and Cursor, which leave the expansion to the shell,
-// Codex substitutes it textually before running the command and also exports it
-// to the hook process.
-const codexPluginRootPlaceholder = `${PLUGIN_ROOT}`
-
 // codexHookCommandString / codexHookCommandStringWindows are the single source
 // for the command strings emitted into the Codex hooks.json (command /
 // commandWindows) AND hashed into the precomputed approvals — Codex hashes the
@@ -1776,12 +1770,11 @@ func codexHookCommandString(timeoutSeconds int, async, failOpen bool) string {
 	return codexHooksBootstrapCommand(timeoutSeconds, async, failOpen)
 }
 
-// codexHookCommandStringWindows keeps the plain -File invocation: the
-// plugin-cache staleness codexHooksBootstrapCommand recovers from applies on
-// Windows too, but a PowerShell equivalent cannot be exercised from this
-// repository's test environment, so it is not rewritten blind.
-func codexHookCommandStringWindows(timeoutSeconds int, async bool) string {
-	return hooksPowerShellCommand(codexPluginRootPlaceholder, "codex", timeoutSeconds, async)
+// codexHookCommandStringWindows carries the same cache-swap and stable-data
+// resolution policy as the Unix command, encoded as UTF-16LE so paths and
+// PowerShell syntax do not depend on the parent process's quoting rules.
+func codexHookCommandStringWindows(timeoutSeconds int, async, failOpen bool) string {
+	return codexHooksPowerShellCommand(timeoutSeconds, async, failOpen)
 }
 
 // GenerateCodexInstallScript produces a bash install script that:

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1283,13 +1283,13 @@ func TestComputeCodexHookApprovalsMatchHashesCodexAccepts(t *testing.T) {
 	require.NoError(t, err)
 
 	want := map[string]string{
-		"session_start":      "sha256:97fd1499a0458fb2edc14d885394b26353238af17e2ce6ad9fbd8f003457dff5",
-		"session_end":        "sha256:b9b35b076d1375c9f7492d22d1aa76bde7f451722a1d33f44f05760bbaf5ccdf",
-		"pre_tool_use":       "sha256:43699348b88b5b6ff7db849bd4483982c218d931911528e8232a75525f9ead6f",
-		"permission_request": "sha256:11c7123a75f447d513faf77e68129c553890033e130c5a5727f28893337b4747",
-		"post_tool_use":      "sha256:bc734beadf467b7bfe7204a4362038682868e18be8fede3dcfb4138f226469aa",
-		"user_prompt_submit": "sha256:51b8c02c25a53d3c4aa1293bb0383c41a0d76c9b3199d3adece17a439c0ce297",
-		"stop":               "sha256:30af2129bbe2d0cf860943f122415e704c64e5074c32243c83a85b5ecfaf93cf",
+		"session_start":      "sha256:01aa9026f9191e84ba6d993afb74f7d0415e84714b6abe9663e732bfdf341677",
+		"session_end":        "sha256:a9a6220fdd0aebc83248da0b91f500784fb48e19437d97f92c493cd264c96d05",
+		"pre_tool_use":       "sha256:f1d673b42ef2ce2d16a93d2509fe08cbce64942de1ba4fab0eabe94e0bc39cbd",
+		"permission_request": "sha256:ea2d44b06d6c36971d5fb9121aaedc64b1e49a65e854e284f0c6f164f60fa897",
+		"post_tool_use":      "sha256:d0e7d5c001f156a748ad7471930012a6c9d3d726ceffe9d17e893a5fa743ef97",
+		"user_prompt_submit": "sha256:4e18decc3bc5d57114130d3b2bb80b7c8999cc654e92a5590b489762a98878c9",
+		"stop":               "sha256:a2ff79157b9cdf19f1342772f4d25ab0cc58e141d9426681c5708f00feeb3a4b",
 	}
 	got := make(map[string]string, len(approvals))
 	for _, approval := range approvals {
@@ -1538,11 +1538,11 @@ func TestCodexBootstrapPersistsCompletePayloadBeforeRelayExecution(t *testing.T)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	require.Contains(t, stderr, "refreshed-bootstrap",
 		"the hook that refreshes the bundle must immediately execute the new bootstrap")
-	require.Contains(t, stdout, "--config="+stableConfig,
-		"a ready bundle must execute independently while refreshing from the cache")
 	currentGeneration = strings.TrimSpace(string(requireFileBytes(t, filepath.Join(stable, ".unix-current"))))
 	stableGeneration = filepath.Join(stable, "generations", currentGeneration)
 	stableConfig = filepath.Join(stableGeneration, "speakeasy.json")
+	require.Contains(t, stdout, "--config="+stableConfig,
+		"the refreshed bootstrap must execute with the config from its immutable generation")
 	require.Equal(t, refreshedScript, requireFileBytes(t, filepath.Join(stableGeneration, "hooks", "bootstrap.sh")))
 	require.Equal(t, refreshedConfig, requireFileBytes(t, stableConfig))
 	require.NoDirExists(t, persistLock, "an expired lock must be reclaimed even if its PID was reused")

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 	"unicode/utf16"
 
 	"github.com/BurntSushi/toml"
@@ -1513,26 +1514,54 @@ func TestCodexBootstrapPersistsCompletePayloadBeforeRelayExecution(t *testing.T)
 	stdout, stderr, code := codexHookCommandProbe(t, command, root, data, "GRAM_HOOKS_HOME="+cache)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	stable := filepath.Join(data, filepath.FromSlash(codexHooksStablePayloadSubdir))
-	stableConfig := filepath.Join(stable, "speakeasy.json")
+	currentGeneration := strings.TrimSpace(string(requireFileBytes(t, filepath.Join(stable, ".unix-current"))))
+	stableGeneration := filepath.Join(stable, "generations", currentGeneration)
+	stableConfig := filepath.Join(stableGeneration, "speakeasy.json")
 	require.Contains(t, stdout, "--config="+stableConfig,
 		"the first relay execution must no longer depend on the disposable config")
-	require.Equal(t, script, requireFileBytes(t, filepath.Join(stable, "hooks", "bootstrap.sh")))
+	require.Equal(t, script, requireFileBytes(t, filepath.Join(stableGeneration, "hooks", "bootstrap.sh")))
 	require.Equal(t, config, requireFileBytes(t, stableConfig))
-	require.Equal(t, []byte(""), requireFileBytes(t, filepath.Join(stable, ".unix-ready")))
 	configInfo, err := os.Stat(stableConfig)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o600), configInfo.Mode().Perm())
 
-	refreshedScript := append(append([]byte(nil), script...), []byte("# refreshed\n")...)
+	refreshedScript := bytes.Replace(script, []byte("set -eu\n"), []byte("set -eu\nprintf 'refreshed-bootstrap\\n' >&2\n"), 1)
 	refreshedConfig := []byte("{\"deployment\":\"refreshed\"}\n")
 	require.NoError(t, os.WriteFile(filepath.Join(root, "hooks", "bootstrap.sh"), refreshedScript, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "speakeasy.json"), refreshedConfig, 0o600))
+	persistLock := filepath.Join(stable, ".persist-unix.lock")
+	require.NoError(t, os.Mkdir(persistLock, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(persistLock, "pid"), fmt.Appendf(nil, "%d\n", os.Getpid()), 0o600))
+	old := time.Now().Add(-10 * time.Minute)
+	require.NoError(t, os.Chtimes(persistLock, old, old))
 	stdout, stderr, code = codexHookCommandProbe(t, command, root, data, "GRAM_HOOKS_HOME="+cache)
 	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stderr, "refreshed-bootstrap",
+		"the hook that refreshes the bundle must immediately execute the new bootstrap")
 	require.Contains(t, stdout, "--config="+stableConfig,
 		"a ready bundle must execute independently while refreshing from the cache")
-	require.Equal(t, refreshedScript, requireFileBytes(t, filepath.Join(stable, "hooks", "bootstrap.sh")))
+	currentGeneration = strings.TrimSpace(string(requireFileBytes(t, filepath.Join(stable, ".unix-current"))))
+	stableGeneration = filepath.Join(stable, "generations", currentGeneration)
+	stableConfig = filepath.Join(stableGeneration, "speakeasy.json")
+	require.Equal(t, refreshedScript, requireFileBytes(t, filepath.Join(stableGeneration, "hooks", "bootstrap.sh")))
 	require.Equal(t, refreshedConfig, requireFileBytes(t, stableConfig))
+	require.NoDirExists(t, persistLock, "an expired lock must be reclaimed even if its PID was reused")
+
+	newestScript := bytes.Replace(script, []byte("set -eu\n"), []byte("set -eu\nprintf 'newest-bootstrap\\n' >&2\n"), 1)
+	newestConfig := []byte("{\"deployment\":\"newest\"}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "hooks", "bootstrap.sh"), newestScript, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "speakeasy.json"), newestConfig, 0o600))
+	require.NoError(t, os.Mkdir(persistLock, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(persistLock, "pid"), []byte("99999999\n"), 0o600))
+	stdout, stderr, code = codexHookCommandProbe(t, command, root, data, "GRAM_HOOKS_HOME="+cache)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	currentGeneration = strings.TrimSpace(string(requireFileBytes(t, filepath.Join(stable, ".unix-current"))))
+	stableGeneration = filepath.Join(stable, "generations", currentGeneration)
+	stableConfig = filepath.Join(stableGeneration, "speakeasy.json")
+	require.Contains(t, stdout, "--config="+stableConfig)
+	require.Equal(t, newestScript, requireFileBytes(t, filepath.Join(stableGeneration, "hooks", "bootstrap.sh")))
+	require.Equal(t, newestConfig, requireFileBytes(t, stableConfig))
+	require.NoDirExists(t, persistLock, "an old ownerless persistence lock must be reclaimed")
 
 	require.NoError(t, os.RemoveAll(filepath.Dir(filepath.Dir(root))))
 	server.Close()
@@ -1589,6 +1618,14 @@ func TestHooksBootstrapBakesInstallFailurePolicy(t *testing.T) {
 	require.Contains(t, string(renderHooksPowerShellBootstrap(GenerateConfig{InstallFailOpen: true})), "$InstallFailureExit = 0")
 	require.Contains(t, string(renderHooksBootstrap(GenerateConfig{})), "install_failure_exit=1")
 	require.Contains(t, string(renderHooksPowerShellBootstrap(GenerateConfig{})), "$InstallFailureExit = 1")
+}
+
+func TestHooksPowerShellBootstrapRecoversStalePersistenceLock(t *testing.T) {
+	t.Parallel()
+	script := string(renderHooksPowerShellBootstrap(GenerateConfig{}))
+	require.Contains(t, script, `function Enter-PersistenceLock`)
+	require.Contains(t, script, `Get-Process -Id $OwnerPID`)
+	require.Contains(t, script, `Move-Item -LiteralPath $LockPath -Destination $Reap`)
 }
 
 func TestCarryHooksSubtreeIsLayoutIndependent(t *testing.T) {

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1171,20 +1171,22 @@ func TestGenerateCodexObservabilityPluginHooksJSONIncludesBootstrapCommands(t *t
 		case "SessionEnd":
 			timeoutSeconds = 3
 		}
-		expectedSuffix := fmt.Sprintf(` --config="${PLUGIN_ROOT}/speakeasy.json" agenthooks run --provider=codex --timeout=%ds`, timeoutSeconds)
 		expectedWindowsSuffix := fmt.Sprintf(` --config="${PLUGIN_ROOT}\speakeasy.json" agenthooks run --provider=codex --timeout=%ds`, timeoutSeconds)
 		if async {
-			expectedSuffix += " --async"
 			expectedWindowsSuffix += " --async"
 		}
-		require.Equal(t, `bash "${PLUGIN_ROOT}/hooks/bootstrap.sh"`+expectedSuffix, groups[0].Hooks[0].Command)
+		require.Equal(t, codexHooksBootstrapCommand(timeoutSeconds, async, cfg.InstallFailOpen), groups[0].Hooks[0].Command)
+		require.Contains(t, groups[0].Hooks[0].Command, fmt.Sprintf(`agenthooks run --provider=codex --timeout=%ds`, timeoutSeconds))
+		require.Contains(t, groups[0].Hooks[0].Command, `r="${PLUGIN_ROOT}"`, "Codex must still see the plugin-root placeholder it substitutes")
 		require.Equal(t, `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "${PLUGIN_ROOT}\hooks\bootstrap.ps1"`+expectedWindowsSuffix, groups[0].Hooks[0].CommandWindows)
 		if event == "SessionEnd" {
 			require.Equal(t, 3, groups[0].Hooks[0].Timeout)
 		} else {
 			require.Zero(t, groups[0].Hooks[0].Timeout)
 		}
-		require.Equal(t, async, strings.HasSuffix(groups[0].Hooks[0].Command, " --async"))
+		// The Unix command wraps the script in `bash -c '...'`, so --async is
+		// the last thing inside the quotes rather than the last thing on the line.
+		require.Equal(t, async, strings.HasSuffix(groups[0].Hooks[0].Command, " --async'"))
 		require.Equal(t, async, strings.HasSuffix(groups[0].Hooks[0].CommandWindows, " --async"))
 	}
 }
@@ -1195,7 +1197,7 @@ func TestComputeCodexHookApprovalsIncludesSingleSessionStartCommand(t *testing.T
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, false)
 	require.NoError(t, err)
 
 	sessionStartPrefix := plugin + "@" + marketplace + ":hooks/hooks.json:session_start:0:"
@@ -1216,7 +1218,7 @@ func TestComputeCodexHookApprovalsIncludesSessionEndTrustState(t *testing.T) {
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, false)
 	require.NoError(t, err)
 
 	prefix := plugin + "@" + marketplace + ":hooks/hooks.json:session_end:0:"
@@ -1229,6 +1231,65 @@ func TestComputeCodexHookApprovalsIncludesSessionEndTrustState(t *testing.T) {
 	require.Len(t, sessionEndApprovals, 1)
 	require.Equal(t, prefix+"0", sessionEndApprovals[0].StateKey)
 	require.NotEmpty(t, sessionEndApprovals[0].TrustedHash)
+}
+
+// Codex hashes the bytes of its own serde_json serialization, which leaves <, >
+// and & unescaped. Go's json.Marshal escapes them, so a command containing any
+// of the three would hash to a value no Codex install computes and every hook
+// would be discarded as modified — silently, with no output at all.
+func TestComputeCodexHookHashDoesNotEscapeShellRedirections(t *testing.T) {
+	t.Parallel()
+	const command = `bash -c 'a 2>/dev/null && b >&2'`
+
+	hash, err := computeCodexHookHash("SessionStart", command)
+	require.NoError(t, err)
+
+	canonical := fmt.Sprintf(
+		`{"event_name":"session_start","hooks":[{"async":false,"command":%s,"timeout":600,"type":"command"}],"matcher":""}`,
+		mustJSONStringUnescaped(t, command),
+	)
+	require.Equal(t, fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(canonical))), hash)
+	require.NotContains(t, canonical, `\u003e`)
+}
+
+// The trust identity is an external contract: Codex only runs a hook whose
+// trusted_hash in config.toml equals the hash it recomputes from hooks.json, and
+// nothing re-approves an install whose hash drifted. These digests were verified
+// against codex-cli 0.147.0 by installing the generated plugin and confirming
+// every event reached the relay without --dangerously-bypass-hook-trust. Any
+// change to the hook commands or to the hashed identity must be re-verified the
+// same way before these expectations are updated.
+func TestComputeCodexHookApprovalsMatchHashesCodexAccepts(t *testing.T) {
+	t.Parallel()
+	cfg := GenerateConfig{OrgName: "Acme Inc", ServerURL: "https://app.example.com"}
+	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
+	plugin := CodexObservabilitySlug(cfg)
+
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, false)
+	require.NoError(t, err)
+
+	want := map[string]string{
+		"session_start":      "sha256:19c34f914c5882709cce1901108a2f82b8024433973c27f8a1ba75c62d514149",
+		"session_end":        "sha256:dea4cb3edab10c5b6bdc89b7772df256dcb2d92777d355664ee6761de20320e8",
+		"pre_tool_use":       "sha256:dbb01b969610436bcbc96d73cc8f90e223e35234a1d9c44ed8b2ad011bdeb5f2",
+		"permission_request": "sha256:2800fc87de1574da6e68dbeab3b57dce3a3b445dffb133d5d58183247522a32e",
+		"post_tool_use":      "sha256:87e6e659e77a925687a052b1656b67fc05b1bd55ca86f83d13b292f45d8b188e",
+		"user_prompt_submit": "sha256:52076c4b0617f19ff57bf11fde82722c14f144eb6a456d90483051a30921d87d",
+		"stop":               "sha256:ca39493a4c5bd1bd9ec5f9880fd49b36bc2a402c8e58af2e6a9cb2eda4517e3e",
+	}
+	got := make(map[string]string, len(approvals))
+	for _, approval := range approvals {
+		event := strings.TrimSuffix(strings.TrimPrefix(approval.StateKey, plugin+"@"+marketplace+":hooks/hooks.json:"), ":0:0")
+		got[event] = approval.TrustedHash
+	}
+	require.Equal(t, want, got)
+}
+
+func mustJSONStringUnescaped(t *testing.T, s string) string {
+	t.Helper()
+	encoded, err := marshalUnescapedJSON(s)
+	require.NoError(t, err)
+	return string(encoded)
 }
 
 // runCodexInstallScript executes the generated install script under an
@@ -1698,7 +1759,7 @@ func TestGenerateCodexInstallScriptRefreshesStaleTrustedHashes(t *testing.T) {
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, approvals)
 	target := approvals[0]
@@ -1879,7 +1940,7 @@ func TestGenerateCodexInstallScriptIsIdempotent(t *testing.T) {
 	marketplace := conv.ToSlug(cfg.OrgName) + "-speakeasy"
 	plugin := CodexObservabilitySlug(cfg)
 
-	approvals, err := computeCodexHookApprovals(marketplace, plugin)
+	approvals, err := computeCodexHookApprovals(marketplace, plugin, false)
 	require.NoError(t, err)
 	require.NotEmpty(t, approvals)
 

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/zip"
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -18,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/BurntSushi/toml"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -1171,14 +1174,10 @@ func TestGenerateCodexObservabilityPluginHooksJSONIncludesBootstrapCommands(t *t
 		case "SessionEnd":
 			timeoutSeconds = 3
 		}
-		expectedWindowsSuffix := fmt.Sprintf(` --config="${PLUGIN_ROOT}\speakeasy.json" agenthooks run --provider=codex --timeout=%ds`, timeoutSeconds)
-		if async {
-			expectedWindowsSuffix += " --async"
-		}
 		require.Equal(t, codexHooksBootstrapCommand(timeoutSeconds, async, cfg.InstallFailOpen), groups[0].Hooks[0].Command)
 		require.Contains(t, groups[0].Hooks[0].Command, fmt.Sprintf(`agenthooks run --provider=codex --timeout=%ds`, timeoutSeconds))
-		require.Contains(t, groups[0].Hooks[0].Command, `r="${PLUGIN_ROOT}"`, "Codex must still see the plugin-root placeholder it substitutes")
-		require.Equal(t, `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "${PLUGIN_ROOT}\hooks\bootstrap.ps1"`+expectedWindowsSuffix, groups[0].Hooks[0].CommandWindows)
+		require.Contains(t, groups[0].Hooks[0].Command, `r="$PLUGIN_ROOT"`, "the shell must expand Codex's runtime environment safely")
+		require.Equal(t, codexHooksPowerShellCommand(timeoutSeconds, async, cfg.InstallFailOpen), groups[0].Hooks[0].CommandWindows)
 		if event == "SessionEnd" {
 			require.Equal(t, 3, groups[0].Hooks[0].Timeout)
 		} else {
@@ -1187,8 +1186,22 @@ func TestGenerateCodexObservabilityPluginHooksJSONIncludesBootstrapCommands(t *t
 		// The Unix command wraps the script in `bash -c '...'`, so --async is
 		// the last thing inside the quotes rather than the last thing on the line.
 		require.Equal(t, async, strings.HasSuffix(groups[0].Hooks[0].Command, " --async'"))
-		require.Equal(t, async, strings.HasSuffix(groups[0].Hooks[0].CommandWindows, " --async"))
+		require.Equal(t, async, strings.Contains(decodePowerShellCommand(t, groups[0].Hooks[0].CommandWindows), " --async"))
 	}
+}
+
+func decodePowerShellCommand(t *testing.T, command string) string {
+	t.Helper()
+	const prefix = `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand `
+	require.True(t, strings.HasPrefix(command, prefix))
+	encoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(command, prefix))
+	require.NoError(t, err)
+	require.Zero(t, len(encoded)%2)
+	units := make([]uint16, len(encoded)/2)
+	for i := range units {
+		units[i] = binary.LittleEndian.Uint16(encoded[2*i:])
+	}
+	return string(utf16.Decode(units))
 }
 
 func TestComputeCodexHookApprovalsIncludesSingleSessionStartCommand(t *testing.T) {
@@ -1256,9 +1269,9 @@ func TestComputeCodexHookHashDoesNotEscapeShellRedirections(t *testing.T) {
 // trusted_hash in config.toml equals the hash it recomputes from hooks.json, and
 // nothing re-approves an install whose hash drifted. These digests were verified
 // against codex-cli 0.147.0 by installing the generated plugin and confirming
-// every event reached the relay without --dangerously-bypass-hook-trust. Any
-// change to the hook commands or to the hashed identity must be re-verified the
-// same way before these expectations are updated.
+// SessionStart and UserPromptSubmit were invoked without bypassing hook trust.
+// Any change to the hook commands or hashed identity must be re-verified before
+// these expectations are updated.
 func TestComputeCodexHookApprovalsMatchHashesCodexAccepts(t *testing.T) {
 	t.Parallel()
 	cfg := GenerateConfig{OrgName: "Acme Inc", ServerURL: "https://app.example.com"}
@@ -1269,13 +1282,13 @@ func TestComputeCodexHookApprovalsMatchHashesCodexAccepts(t *testing.T) {
 	require.NoError(t, err)
 
 	want := map[string]string{
-		"session_start":      "sha256:19c34f914c5882709cce1901108a2f82b8024433973c27f8a1ba75c62d514149",
-		"session_end":        "sha256:dea4cb3edab10c5b6bdc89b7772df256dcb2d92777d355664ee6761de20320e8",
-		"pre_tool_use":       "sha256:dbb01b969610436bcbc96d73cc8f90e223e35234a1d9c44ed8b2ad011bdeb5f2",
-		"permission_request": "sha256:2800fc87de1574da6e68dbeab3b57dce3a3b445dffb133d5d58183247522a32e",
-		"post_tool_use":      "sha256:87e6e659e77a925687a052b1656b67fc05b1bd55ca86f83d13b292f45d8b188e",
-		"user_prompt_submit": "sha256:52076c4b0617f19ff57bf11fde82722c14f144eb6a456d90483051a30921d87d",
-		"stop":               "sha256:ca39493a4c5bd1bd9ec5f9880fd49b36bc2a402c8e58af2e6a9cb2eda4517e3e",
+		"session_start":      "sha256:97fd1499a0458fb2edc14d885394b26353238af17e2ce6ad9fbd8f003457dff5",
+		"session_end":        "sha256:b9b35b076d1375c9f7492d22d1aa76bde7f451722a1d33f44f05760bbaf5ccdf",
+		"pre_tool_use":       "sha256:43699348b88b5b6ff7db849bd4483982c218d931911528e8232a75525f9ead6f",
+		"permission_request": "sha256:11c7123a75f447d513faf77e68129c553890033e130c5a5727f28893337b4747",
+		"post_tool_use":      "sha256:bc734beadf467b7bfe7204a4362038682868e18be8fede3dcfb4138f226469aa",
+		"user_prompt_submit": "sha256:51b8c02c25a53d3c4aa1293bb0383c41a0d76c9b3199d3adece17a439c0ce297",
+		"stop":               "sha256:30af2129bbe2d0cf860943f122415e704c64e5074c32243c83a85b5ecfaf93cf",
 	}
 	got := make(map[string]string, len(approvals))
 	for _, approval := range approvals {
@@ -1471,6 +1484,62 @@ func TestHooksBootstrapColdAndWarmPathsPreserveInput(t *testing.T) {
 		require.NoError(t, err, string(out))
 		require.Equal(t, "args:\nstill-warm", string(out))
 	}
+}
+
+func TestCodexBootstrapPersistsCompletePayloadBeforeRelayExecution(t *testing.T) {
+	t.Parallel()
+	target := currentHooksBootstrapTarget(t)
+	archive := hooksBootstrapArchive(t, []byte("#!/bin/sh\nprintf 'args:%s\\n' \"$*\"\n"))
+	sum := sha256.Sum256(archive)
+	var downloads atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		downloads.Add(1)
+		_, _ = w.Write(archive)
+	}))
+
+	script := renderHooksBootstrapForRelease("test-version", map[string]hooksBinaryTarget{
+		target: {URL: server.URL + "/hooks.zip", SHA256: fmt.Sprintf("%x", sum)},
+	}, false, "releases.test")
+	base := t.TempDir()
+	root := filepath.Join(base, "plugins", "cache", "acme-speakeasy", "acme-observability-codex", "0.29.100")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "hooks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "hooks", "bootstrap.sh"), script, 0o755))
+	config := []byte("{\"deployment\":\"test\"}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "speakeasy.json"), config, 0o600))
+	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
+	cache := filepath.Join(base, "hooks-binary-cache")
+	command := codexHookCommandString(60, false, false)
+
+	stdout, stderr, code := codexHookCommandProbe(t, command, root, data, "GRAM_HOOKS_HOME="+cache)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	stable := filepath.Join(data, filepath.FromSlash(codexHooksStablePayloadSubdir))
+	stableConfig := filepath.Join(stable, "speakeasy.json")
+	require.Contains(t, stdout, "--config="+stableConfig,
+		"the first relay execution must no longer depend on the disposable config")
+	require.Equal(t, script, requireFileBytes(t, filepath.Join(stable, "hooks", "bootstrap.sh")))
+	require.Equal(t, config, requireFileBytes(t, stableConfig))
+	require.Equal(t, []byte(""), requireFileBytes(t, filepath.Join(stable, ".unix-ready")))
+	configInfo, err := os.Stat(stableConfig)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), configInfo.Mode().Perm())
+
+	refreshedScript := append(append([]byte(nil), script...), []byte("# refreshed\n")...)
+	refreshedConfig := []byte("{\"deployment\":\"refreshed\"}\n")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "hooks", "bootstrap.sh"), refreshedScript, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "speakeasy.json"), refreshedConfig, 0o600))
+	stdout, stderr, code = codexHookCommandProbe(t, command, root, data, "GRAM_HOOKS_HOME="+cache)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stdout, "--config="+stableConfig,
+		"a ready bundle must execute independently while refreshing from the cache")
+	require.Equal(t, refreshedScript, requireFileBytes(t, filepath.Join(stable, "hooks", "bootstrap.sh")))
+	require.Equal(t, refreshedConfig, requireFileBytes(t, stableConfig))
+
+	require.NoError(t, os.RemoveAll(filepath.Dir(filepath.Dir(root))))
+	server.Close()
+	stdout, stderr, code = codexHookCommandProbe(t, command, root, data, "GRAM_HOOKS_HOME="+cache)
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stdout, "--config="+stableConfig)
+	require.Equal(t, int64(1), downloads.Load(), "stable fallback must reuse the verified binary cache")
 }
 
 func TestHooksBootstrapChecksumMismatchNeverExecutes(t *testing.T) {

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -128,49 +128,101 @@ install_failure() {
 # doing any other work, then run the relay against the stable config. A failed
 # persistence attempt must not break a hook whose installed payload still works.
 persist_root=${SPEAKEASY_HOOKS_PERSIST_ROOT:-}
-source_script=${SPEAKEASY_HOOKS_PERSIST_SCRIPT:-$0}
+source_script=${SPEAKEASY_HOOKS_PERSIST_SCRIPT:-}
 source_config=${SPEAKEASY_HOOKS_PERSIST_CONFIG:-}
 config_arg_index=0
 arg_index=0
 for arg in "$@"; do
   case "$arg" in
-    --config=*) [ -n "$source_config" ] || source_config=${arg#--config=}; config_arg_index=$arg_index; break ;;
+    --config=*) config_arg_index=$arg_index; break ;;
   esac
   arg_index=$((arg_index + 1))
 done
 
 persist_payload() {
   [ -n "$persist_root" ] && [ -r "$source_script" ] && [ -r "$source_config" ] || return 1
-  hooks_dir="$persist_root/hooks"
-  stable_script="$hooks_dir/bootstrap.sh"
-  stable_config="$persist_root/speakeasy.json"
-  ready="$persist_root/.unix-ready"
+  generations="$persist_root/generations"
+  current="$persist_root/.unix-current"
   lock="$persist_root/.persist-unix.lock"
   umask 077
-  mkdir -p "$hooks_dir" || return 1
-  chmod 700 "$persist_root" "$hooks_dir" 2>/dev/null || true
+  mkdir -p "$generations" || return 1
+  chmod 700 "$persist_root" "$generations" 2>/dev/null || true
+  current_generation=
+  IFS= read -r current_generation < "$current" 2>/dev/null || current_generation=
+  case "$current_generation" in ''|*/*) current_generation= ;; esac
+  current_dir="$generations/$current_generation"
+  if [ -n "$current_generation" ] && [ -r "$current_dir/hooks/bootstrap.sh" ] &&
+     [ -r "$current_dir/speakeasy.json" ]; then
+    published_script="$current_dir/hooks/bootstrap.sh"
+    published_config="$current_dir/speakeasy.json"
+    if cmp -s "$source_script" "$published_script" && cmp -s "$source_config" "$published_config"; then
+      return 0
+    fi
+  fi
 
-  if ! mkdir "$lock" 2>/dev/null; then
-    # Another hook publishing the same bundle wins. Existing complete output is
-    # safe to use; otherwise this invocation keeps its original config.
-    [ -r "$ready" ] && [ -r "$stable_script" ] && [ -r "$stable_config" ]
+  own_lock=
+  if mkdir "$lock" 2>/dev/null; then
+    if printf '%%s\n' "$$" > "$lock/pid"; then
+      own_lock=1
+    else
+      rm -rf "$lock"
+    fi
+  else
+    stale=
+    owner_pid=
+    owner_valid=
+    if [ -r "$lock/pid" ]; then
+      IFS= read -r owner_pid < "$lock/pid" || owner_pid=
+      case "$owner_pid" in
+        ''|*[!0-9]*) ;;
+        *) owner_valid=1; kill -0 "$owner_pid" 2>/dev/null || stale=1 ;;
+      esac
+    fi
+    # Publishing only copies two local files. Expire any old lease so a hung
+    # owner or a recycled PID cannot freeze refresh indefinitely.
+    if [ -n "$(find "$lock" -maxdepth 0 -mmin +5 2>/dev/null)" ]; then
+      stale=1
+    fi
+    if [ -n "$stale" ]; then
+      reap="${lock}.stale.$$"
+      if mv "$lock" "$reap" 2>/dev/null; then
+        rm -rf "$reap"
+        if mkdir "$lock" 2>/dev/null; then
+          if printf '%%s\n' "$$" > "$lock/pid"; then
+            own_lock=1
+          else
+            rm -rf "$lock"
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  if [ -z "$own_lock" ]; then
+    # Another hook publishing the same bundle wins. The current pointer only
+    # ever names a generation that was completely written before publication.
+    [ -n "${published_config:-}" ]
     return
   fi
 
-  script_tmp="$hooks_dir/.bootstrap.sh.$$"
-  config_tmp="$persist_root/.speakeasy.json.$$"
-  ready_tmp="$persist_root/.unix-ready.$$"
+  generation="unix-$(date +%%s)-$$"
+  generation_dir="$generations/$generation"
+  hooks_dir="$generation_dir/hooks"
+  current_tmp="$persist_root/.unix-current.$$"
   persisted=
-  if cp "$source_script" "$script_tmp" && cp "$source_config" "$config_tmp" &&
-     chmod 700 "$script_tmp" && chmod 600 "$config_tmp"; then
-    rm -f "$ready"
-    if mv "$config_tmp" "$stable_config" && mv "$script_tmp" "$stable_script" &&
-       : > "$ready_tmp" && mv "$ready_tmp" "$ready"; then
+  if mkdir -p "$hooks_dir" && cp "$source_script" "$hooks_dir/bootstrap.sh" &&
+     cp "$source_config" "$generation_dir/speakeasy.json" &&
+     chmod 700 "$generation_dir" "$hooks_dir" "$hooks_dir/bootstrap.sh" &&
+     chmod 600 "$generation_dir/speakeasy.json" &&
+     printf '%%s\n' "$generation" > "$current_tmp" && mv "$current_tmp" "$current"; then
       persisted=1
-    fi
+      published_script="$hooks_dir/bootstrap.sh"
+      published_config="$generation_dir/speakeasy.json"
+      [ "$source_script" = "$0" ] || reexec_stable=1
   fi
-  rm -f "$script_tmp" "$config_tmp" "$ready_tmp"
-  rmdir "$lock" 2>/dev/null || true
+  [ -n "$persisted" ] || rm -rf "$generation_dir"
+  rm -f "$current_tmp"
+  rm -rf "$lock"
   [ -n "$persisted" ]
 }
 
@@ -179,13 +231,18 @@ if [ -n "$source_config" ] && persist_payload; then
   arg_index=0
   for arg in "$@"; do
     if [ "$arg_index" -eq "$config_arg_index" ]; then
-      forwarded+=("--config=$persist_root/speakeasy.json")
+      forwarded+=("--config=$published_config")
     else
       forwarded+=("$arg")
     fi
     arg_index=$((arg_index + 1))
   done
   set -- "${forwarded[@]}"
+fi
+
+if [ -n "${reexec_stable:-}" ]; then
+  unset SPEAKEASY_HOOKS_PERSIST_ROOT SPEAKEASY_HOOKS_PERSIST_SCRIPT SPEAKEASY_HOOKS_PERSIST_CONFIG
+  exec bash "$published_script" "$@"
 fi
 
 case "$(uname -s)" in
@@ -362,6 +419,69 @@ function Exit-InstallFailure([string]$Message) {
 # launcher and its deployment config there as one ready-marked bundle, then run
 # the relay against the stable config. Persistence failure leaves the installed
 # payload usable for the current invocation.
+function Enter-PersistenceLock([string]$LockPath) {
+    $Created = $false
+    try {
+        New-Item -ItemType Directory -Path $LockPath -ErrorAction Stop | Out-Null
+        $Created = $true
+        [System.IO.File]::WriteAllText((Join-Path $LockPath "pid"), "$PID" + [char]10)
+        return $true
+    } catch {
+        if ($Created) {
+            Remove-Item -LiteralPath $LockPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $Stale = $false
+    try {
+        $LockInfo = Get-Item -LiteralPath $LockPath -ErrorAction Stop
+        $Expired = ([DateTime]::UtcNow - $LockInfo.LastWriteTimeUtc).TotalMinutes -gt 5
+        $OwnerValid = $false
+        $OwnerPath = Join-Path $LockPath "pid"
+        if (Test-Path -LiteralPath $OwnerPath -PathType Leaf) {
+            $OwnerPID = 0
+            $OwnerText = (Get-Content -LiteralPath $OwnerPath -Raw -ErrorAction Stop).Trim()
+            if ([int]::TryParse($OwnerText, [ref]$OwnerPID)) {
+                $OwnerValid = $true
+                try {
+                    Get-Process -Id $OwnerPID -ErrorAction Stop | Out-Null
+                } catch {
+                    $Stale = $true
+                }
+            }
+        }
+        # Publishing only copies two local files. Expire any old lease so a
+        # hung owner or a recycled PID cannot freeze refresh indefinitely.
+        if ($Expired) { $Stale = $true }
+    } catch {
+        return $false
+    }
+    if (-not $Stale) { return $false }
+
+    # Rename before removal so concurrent reclaimers cannot delete a new lock
+    # created at the original path.
+    $Reap = "$LockPath.stale.$PID.$([guid]::NewGuid().ToString('N'))"
+    try {
+        Move-Item -LiteralPath $LockPath -Destination $Reap -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    Remove-Item -LiteralPath $Reap -Recurse -Force -ErrorAction SilentlyContinue
+
+    $Created = $false
+    try {
+        New-Item -ItemType Directory -Path $LockPath -ErrorAction Stop | Out-Null
+        $Created = $true
+        [System.IO.File]::WriteAllText((Join-Path $LockPath "pid"), "$PID" + [char]10)
+        return $true
+    } catch {
+        if ($Created) {
+            Remove-Item -LiteralPath $LockPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        return $false
+    }
+}
+
 function Save-StablePayload {
     if (-not $env:SPEAKEASY_HOOKS_PERSIST_ROOT) { return $null }
 
@@ -370,53 +490,79 @@ function Save-StablePayload {
     for ($Index = 0; $Index -lt $ForwardArgs.Count; $Index++) {
         if ($ForwardArgs[$Index].StartsWith("--config=", [StringComparison]::Ordinal)) {
             $ConfigIndex = $Index
-            if (-not $ConfigPath) { $ConfigPath = $ForwardArgs[$Index].Substring("--config=".Length) }
             break
         }
     }
-    $ScriptPath = if ($env:SPEAKEASY_HOOKS_PERSIST_SCRIPT) { $env:SPEAKEASY_HOOKS_PERSIST_SCRIPT } else { $PSCommandPath }
+    $ScriptPath = $env:SPEAKEASY_HOOKS_PERSIST_SCRIPT
     if ($ConfigIndex -lt 0 -or
         -not (Test-Path -LiteralPath $ScriptPath -PathType Leaf) -or
         -not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) { return $null }
 
     $PersistRoot = $env:SPEAKEASY_HOOKS_PERSIST_ROOT
-    $HooksDir = Join-Path $PersistRoot "hooks"
-    $StableScript = Join-Path $HooksDir "bootstrap.ps1"
-    $StableConfig = Join-Path $PersistRoot "speakeasy.json"
-    $Ready = Join-Path $PersistRoot ".windows-ready"
+    $Generations = Join-Path $PersistRoot "generations"
+    $Current = Join-Path $PersistRoot ".windows-current"
     $Lock = Join-Path $PersistRoot ".persist-windows.lock"
+    $StableScript = $null
+    $StableConfig = $null
+    try {
+        $CurrentGeneration = [System.IO.File]::ReadAllText($Current).Trim()
+        if ($CurrentGeneration -and -not ($CurrentGeneration.Contains("/") -or $CurrentGeneration.Contains("\"))) {
+            $CurrentDir = Join-Path $Generations $CurrentGeneration
+            $CandidateScript = Join-Path $CurrentDir "hooks/bootstrap.ps1"
+            $CandidateConfig = Join-Path $CurrentDir "speakeasy.json"
+            if ((Test-Path -LiteralPath $CandidateScript -PathType Leaf) -and
+                (Test-Path -LiteralPath $CandidateConfig -PathType Leaf)) {
+                $StableScript = $CandidateScript
+                $StableConfig = $CandidateConfig
+                if ((Get-FileHash -LiteralPath $ScriptPath -Algorithm SHA256).Hash -eq
+                        (Get-FileHash -LiteralPath $StableScript -Algorithm SHA256).Hash -and
+                    (Get-FileHash -LiteralPath $ConfigPath -Algorithm SHA256).Hash -eq
+                        (Get-FileHash -LiteralPath $StableConfig -Algorithm SHA256).Hash) {
+                    return [PSCustomObject]@{ ConfigIndex = $ConfigIndex; ConfigPath = $StableConfig; ScriptPath = $StableScript; Reexec = $false }
+                }
+            }
+        }
+    } catch {}
+
     $OwnLock = $false
     try {
-        New-Item -ItemType Directory -Force -Path $HooksDir | Out-Null
-        try {
-            New-Item -ItemType Directory -Path $Lock -ErrorAction Stop | Out-Null
+        New-Item -ItemType Directory -Force -Path $Generations | Out-Null
+        if (Enter-PersistenceLock $Lock) {
             $OwnLock = $true
-        } catch {
-            if ((Test-Path -LiteralPath $Ready -PathType Leaf) -and
-                (Test-Path -LiteralPath $StableScript -PathType Leaf) -and
+        } else {
+            if ((Test-Path -LiteralPath $StableScript -PathType Leaf) -and
                 (Test-Path -LiteralPath $StableConfig -PathType Leaf)) {
-                return [PSCustomObject]@{ ConfigIndex = $ConfigIndex; ConfigPath = $StableConfig }
+                return [PSCustomObject]@{ ConfigIndex = $ConfigIndex; ConfigPath = $StableConfig; ScriptPath = $StableScript; Reexec = $false }
             }
             return $null
         }
 
         $Suffix = [guid]::NewGuid().ToString("N")
-        $ScriptTmp = Join-Path $HooksDir ".bootstrap.ps1.$Suffix"
-        $ConfigTmp = Join-Path $PersistRoot ".speakeasy.json.$Suffix"
-        $ReadyTmp = Join-Path $PersistRoot ".windows-ready.$Suffix"
+        $Generation = "windows-$Suffix"
+        $GenerationDir = Join-Path $Generations $Generation
+        $HooksDir = Join-Path $GenerationDir "hooks"
+        $StableScript = Join-Path $HooksDir "bootstrap.ps1"
+        $StableConfig = Join-Path $GenerationDir "speakeasy.json"
+        $CurrentTmp = Join-Path $PersistRoot ".windows-current.$Suffix"
+        $Published = $false
         try {
-            Copy-Item -LiteralPath $ScriptPath -Destination $ScriptTmp
-            Copy-Item -LiteralPath $ConfigPath -Destination $ConfigTmp
-            Remove-Item -LiteralPath $Ready -Force -ErrorAction SilentlyContinue
-            Move-Item -LiteralPath $ConfigTmp -Destination $StableConfig -Force
-            Move-Item -LiteralPath $ScriptTmp -Destination $StableScript -Force
-            [System.IO.File]::WriteAllText($ReadyTmp, "ready" + [char]10)
-            Move-Item -LiteralPath $ReadyTmp -Destination $Ready -Force
-            return [PSCustomObject]@{ ConfigIndex = $ConfigIndex; ConfigPath = $StableConfig }
+            New-Item -ItemType Directory -Force -Path $HooksDir | Out-Null
+            Copy-Item -LiteralPath $ScriptPath -Destination $StableScript
+            Copy-Item -LiteralPath $ConfigPath -Destination $StableConfig
+            [System.IO.File]::WriteAllText($CurrentTmp, $Generation + [char]10)
+            Move-Item -LiteralPath $CurrentTmp -Destination $Current -Force
+            $Published = $true
+            return [PSCustomObject]@{
+                ConfigIndex = $ConfigIndex
+                ConfigPath = $StableConfig
+                ScriptPath = $StableScript
+                Reexec = $ScriptPath -ne $PSCommandPath
+            }
         } finally {
-            Remove-Item -LiteralPath $ScriptTmp -Force -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $ConfigTmp -Force -ErrorAction SilentlyContinue
-            Remove-Item -LiteralPath $ReadyTmp -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $CurrentTmp -Force -ErrorAction SilentlyContinue
+            if (-not $Published) {
+                Remove-Item -LiteralPath $GenerationDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
         }
     } catch {
         return $null
@@ -430,6 +576,13 @@ function Save-StablePayload {
 $StablePayload = Save-StablePayload
 if ($StablePayload) {
     $ForwardArgs[$StablePayload.ConfigIndex] = "--config=$($StablePayload.ConfigPath)"
+    if ($StablePayload.Reexec) {
+        Remove-Item Env:SPEAKEASY_HOOKS_PERSIST_ROOT -ErrorAction SilentlyContinue
+        Remove-Item Env:SPEAKEASY_HOOKS_PERSIST_SCRIPT -ErrorAction SilentlyContinue
+        Remove-Item Env:SPEAKEASY_HOOKS_PERSIST_CONFIG -ErrorAction SilentlyContinue
+        & $StablePayload.ScriptPath @ForwardArgs
+        exit $LASTEXITCODE
+    }
 }
 
 $Arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()) {
@@ -578,10 +731,11 @@ func codexHooksBootstrapCommand(timeoutSeconds int, async, failOpen bool) string
 	// Codex exports both variables, and runtime expansion safely handles paths
 	// containing shell metacharacters without Codex substituting them textually.
 	script := fmt.Sprintf(
-		`r="$PLUGIN_ROOT"; d=; [ -z "${PLUGIN_DATA:-}" ] || d="$PLUGIN_DATA/%s"; rs="$r/hooks/bootstrap.sh"; rc="$r/speakeasy.json"; s=; c=; ps=; pc=; `+
-			`if [ -n "$d" ] && [ -f "$d/.unix-ready" ] && [ -f "$d/hooks/bootstrap.sh" ] && [ -f "$d/speakeasy.json" ]; then s="$d/hooks/bootstrap.sh"; c="$d/speakeasy.json"; [ ! -f "$rs" ] || [ ! -f "$rc" ] || { ps="$rs"; pc="$rc"; }; `+
+		`r="$PLUGIN_ROOT"; d=; [ -z "${PLUGIN_DATA:-}" ] || d="$PLUGIN_DATA/%s"; rs="$r/hooks/bootstrap.sh"; rc="$r/speakeasy.json"; s=; c=; ps=; pc=; g=; `+
+			`if [ -n "$d" ]; then IFS= read -r g < "$d/.unix-current" 2>/dev/null || g=; case "$g" in ""|*/*) g= ;; esac; fi; sd="$d/generations/$g"; `+
+			`if [ -n "$g" ] && [ -f "$sd/hooks/bootstrap.sh" ] && [ -f "$sd/speakeasy.json" ]; then s="$sd/hooks/bootstrap.sh"; c="$sd/speakeasy.json"; [ ! -f "$rs" ] || [ ! -f "$rc" ] || { ps="$rs"; pc="$rc"; }; `+
 			`elif [ -f "$rs" ] && [ -f "$rc" ]; then s="$rs"; c="$rc"; ps="$s"; pc="$c"; `+
-			`else s=$(ls -t "${r%%/*}"/*/hooks/bootstrap.sh 2>/dev/null | head -n 1); c="${s%%/hooks/bootstrap.sh}/speakeasy.json"; ps="$s"; pc="$c"; fi; `+
+			`else for v in "${r%%/*}"/*; do [ -f "$v/hooks/bootstrap.sh" ] && [ -f "$v/speakeasy.json" ] || continue; [ -z "$s" ] || [ "$v/hooks/bootstrap.sh" -nt "$s" ] || continue; s="$v/hooks/bootstrap.sh"; c="$v/speakeasy.json"; done; ps="$s"; pc="$c"; fi; `+
 			`[ -n "$s" ] && [ -f "$s" ] && [ -f "$c" ] || { printf "speakeasy-hooks: no complete hook payload for %%s; the Codex plugin cache moved or the plugin is not fully installed\n" "$r" >&2; exit %d; }; `+
 			`SPEAKEASY_HOOKS_PERSIST_ROOT="$d" SPEAKEASY_HOOKS_PERSIST_SCRIPT="$ps" SPEAKEASY_HOOKS_PERSIST_CONFIG="$pc" exec bash "$s" "--config=$c" %s`,
 		codexHooksStablePayloadSubdir, conv.Ternary(failOpen, 0, 1), args,
@@ -595,8 +749,8 @@ func codexHooksPowerShellCommand(timeoutSeconds int, async, failOpen bool) strin
 		args += " --async"
 	}
 	script := fmt.Sprintf(
-		`$r=$env:PLUGIN_ROOT; $d=Join-Path $env:PLUGIN_DATA %q; $rs=Join-Path $r "hooks/bootstrap.ps1"; $rc=Join-Path $r "speakeasy.json"; $s=$null; $c=$null; $ps=$null; $pc=$null; `+
-			`if ((Test-Path -LiteralPath (Join-Path $d ".windows-ready") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $d "hooks/bootstrap.ps1") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $d "speakeasy.json") -PathType Leaf)) { $s=Join-Path $d "hooks/bootstrap.ps1"; $c=Join-Path $d "speakeasy.json"; if ((Test-Path -LiteralPath $rs -PathType Leaf) -and (Test-Path -LiteralPath $rc -PathType Leaf)) { $ps=$rs; $pc=$rc } `+
+		`$r=$env:PLUGIN_ROOT; $d=Join-Path $env:PLUGIN_DATA %q; $rs=Join-Path $r "hooks/bootstrap.ps1"; $rc=Join-Path $r "speakeasy.json"; $s=$null; $c=$null; $ps=$null; $pc=$null; $g=$null; try { $g=[IO.File]::ReadAllText((Join-Path $d ".windows-current")).Trim() } catch {}; if ($g -and -not ($g.Contains("/") -or $g.Contains("\"))) { $sd=Join-Path (Join-Path $d "generations") $g; $ss=Join-Path $sd "hooks/bootstrap.ps1"; $sc=Join-Path $sd "speakeasy.json" }; `+
+			`if ($g -and (Test-Path -LiteralPath $ss -PathType Leaf) -and (Test-Path -LiteralPath $sc -PathType Leaf)) { $s=$ss; $c=$sc; if ((Test-Path -LiteralPath $rs -PathType Leaf) -and (Test-Path -LiteralPath $rc -PathType Leaf)) { $ps=$rs; $pc=$rc } `+
 			`} elseif ((Test-Path -LiteralPath $rs -PathType Leaf) -and (Test-Path -LiteralPath $rc -PathType Leaf)) { $s=$rs; $c=$rc; $ps=$s; $pc=$c `+
 			`} else { $parent=Split-Path $r -Parent; $candidate=Get-ChildItem -LiteralPath $parent -Directory -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Where-Object { (Test-Path -LiteralPath (Join-Path $_.FullName "hooks/bootstrap.ps1") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $_.FullName "speakeasy.json") -PathType Leaf) } | Select-Object -First 1; if ($candidate) { $s=Join-Path $candidate.FullName "hooks/bootstrap.ps1"; $c=Join-Path $candidate.FullName "speakeasy.json"; $ps=$s; $pc=$c } }; `+
 			`if (-not $s -or -not (Test-Path -LiteralPath $s -PathType Leaf) -or -not (Test-Path -LiteralPath $c -PathType Leaf)) { [Console]::Error.WriteLine("speakeasy-hooks: no complete hook payload for $r; the Codex plugin cache moved or the plugin is not fully installed"); exit %d }; `+

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -423,7 +423,7 @@ func hooksBootstrapCommand(root, provider string, timeoutSeconds int, async bool
 // written sibling version directory. Only when neither exists does it fail,
 // and then with a message naming the root it looked under and the org's
 // install-failure exit code rather than bash's opaque 127.
-func codexHooksBootstrapCommand(timeoutSeconds int, async bool, failOpen bool) string {
+func codexHooksBootstrapCommand(timeoutSeconds int, async, failOpen bool) string {
 	args := fmt.Sprintf("agenthooks run --provider=codex --timeout=%ds", timeoutSeconds)
 	if async {
 		args += " --async"

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -404,6 +404,45 @@ func hooksBootstrapCommand(root, provider string, timeoutSeconds int, async bool
 	return command
 }
 
+// codexHooksBootstrapCommand renders the Unix hook command for Codex, which
+// needs more than the plain `bash <root>/hooks/bootstrap.sh` the other
+// providers use.
+//
+// Codex keeps every installed plugin under
+// <codex home>/plugins/cache/<marketplace>/<plugin>/<version> and substitutes
+// that directory for ${PLUGIN_ROOT} when it loads the plugin's hooks.json.
+// When a republished version appears it reinstalls into a sibling version
+// directory and deletes the previous one, so a hook command resolved before
+// that swap names a script that no longer exists — and `bash <missing file>`
+// exits 127, which Codex surfaces as a bare "hook exited with code 127" on
+// SessionStart and UserPromptSubmit for as long as it holds the stale plugin
+// list.
+//
+// So the command resolves the bootstrapper when the hook fires instead of
+// trusting the baked path: the substituted root first, then the most recently
+// written sibling version directory. Only when neither exists does it fail,
+// and then with a message naming the root it looked under and the org's
+// install-failure exit code rather than bash's opaque 127.
+func codexHooksBootstrapCommand(timeoutSeconds int, async bool, failOpen bool) string {
+	args := fmt.Sprintf("agenthooks run --provider=codex --timeout=%ds", timeoutSeconds)
+	if async {
+		args += " --async"
+	}
+	// The script is single-quoted for `bash -c`, so it must not contain a
+	// single quote. Codex replaces ${PLUGIN_ROOT} textually before any shell
+	// sees the command; the surrounding double quotes leave the shell's own
+	// expansion of the same name as a fallback, since Codex also exports it to
+	// the hook process.
+	script := fmt.Sprintf(
+		`r="%s"; s="$r/hooks/bootstrap.sh"; `+
+			`[ -f "$s" ] || s=$(ls -t "${r%%/*}"/*/hooks/bootstrap.sh 2>/dev/null | head -n 1); `+
+			`[ -n "$s" ] && [ -f "$s" ] || { printf "speakeasy-hooks: no hook payload under %%s; the Codex plugin cache moved or the plugin is not fully installed\n" "$r" >&2; exit %d; }; `+
+			`exec bash "$s" "--config=${s%%/hooks/bootstrap.sh}/speakeasy.json" %s`,
+		codexPluginRootPlaceholder, conv.Ternary(failOpen, 0, 1), args,
+	)
+	return "bash -c '" + script + "'"
+}
+
 func hooksPowerShellCommand(root, provider string, timeoutSeconds int, async bool) string {
 	command := fmt.Sprintf(`powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%s\hooks\bootstrap.ps1" --config="%s\speakeasy.json" agenthooks run --provider=%s --timeout=%ds`, root, root, provider, timeoutSeconds)
 	if async {

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -1,11 +1,14 @@
 package plugins
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/speakeasy-api/gram/hooks/relay"
 	"github.com/speakeasy-api/gram/server/internal/conv"
@@ -119,6 +122,71 @@ install_failure() {
   printf 'speakeasy-hooks: ask your administrator to allow downloads from %s, or preinstall the hooks binary (GRAM_HOOKS_HOME overrides the cache location)\n' >&2
   exit "$install_failure_exit"
 }
+
+# Codex plugin versions are disposable. When its inline command supplies a
+# stable data root, publish this script and its deployment config there before
+# doing any other work, then run the relay against the stable config. A failed
+# persistence attempt must not break a hook whose installed payload still works.
+persist_root=${SPEAKEASY_HOOKS_PERSIST_ROOT:-}
+source_script=${SPEAKEASY_HOOKS_PERSIST_SCRIPT:-$0}
+source_config=${SPEAKEASY_HOOKS_PERSIST_CONFIG:-}
+config_arg_index=0
+arg_index=0
+for arg in "$@"; do
+  case "$arg" in
+    --config=*) [ -n "$source_config" ] || source_config=${arg#--config=}; config_arg_index=$arg_index; break ;;
+  esac
+  arg_index=$((arg_index + 1))
+done
+
+persist_payload() {
+  [ -n "$persist_root" ] && [ -r "$source_script" ] && [ -r "$source_config" ] || return 1
+  hooks_dir="$persist_root/hooks"
+  stable_script="$hooks_dir/bootstrap.sh"
+  stable_config="$persist_root/speakeasy.json"
+  ready="$persist_root/.unix-ready"
+  lock="$persist_root/.persist-unix.lock"
+  umask 077
+  mkdir -p "$hooks_dir" || return 1
+  chmod 700 "$persist_root" "$hooks_dir" 2>/dev/null || true
+
+  if ! mkdir "$lock" 2>/dev/null; then
+    # Another hook publishing the same bundle wins. Existing complete output is
+    # safe to use; otherwise this invocation keeps its original config.
+    [ -r "$ready" ] && [ -r "$stable_script" ] && [ -r "$stable_config" ]
+    return
+  fi
+
+  script_tmp="$hooks_dir/.bootstrap.sh.$$"
+  config_tmp="$persist_root/.speakeasy.json.$$"
+  ready_tmp="$persist_root/.unix-ready.$$"
+  persisted=
+  if cp "$source_script" "$script_tmp" && cp "$source_config" "$config_tmp" &&
+     chmod 700 "$script_tmp" && chmod 600 "$config_tmp"; then
+    rm -f "$ready"
+    if mv "$config_tmp" "$stable_config" && mv "$script_tmp" "$stable_script" &&
+       : > "$ready_tmp" && mv "$ready_tmp" "$ready"; then
+      persisted=1
+    fi
+  fi
+  rm -f "$script_tmp" "$config_tmp" "$ready_tmp"
+  rmdir "$lock" 2>/dev/null || true
+  [ -n "$persisted" ]
+}
+
+if [ -n "$source_config" ] && persist_payload; then
+  forwarded=()
+  arg_index=0
+  for arg in "$@"; do
+    if [ "$arg_index" -eq "$config_arg_index" ]; then
+      forwarded+=("--config=$persist_root/speakeasy.json")
+    else
+      forwarded+=("$arg")
+    fi
+    arg_index=$((arg_index + 1))
+  done
+  set -- "${forwarded[@]}"
+fi
 
 case "$(uname -s)" in
   Darwin) os=darwin ;;
@@ -290,6 +358,80 @@ function Exit-InstallFailure([string]$Message) {
     exit $InstallFailureExit
 }
 
+# Codex supplies a version-independent plugin data directory. Publish this
+# launcher and its deployment config there as one ready-marked bundle, then run
+# the relay against the stable config. Persistence failure leaves the installed
+# payload usable for the current invocation.
+function Save-StablePayload {
+    if (-not $env:SPEAKEASY_HOOKS_PERSIST_ROOT) { return $null }
+
+    $ConfigIndex = -1
+    $ConfigPath = $env:SPEAKEASY_HOOKS_PERSIST_CONFIG
+    for ($Index = 0; $Index -lt $ForwardArgs.Count; $Index++) {
+        if ($ForwardArgs[$Index].StartsWith("--config=", [StringComparison]::Ordinal)) {
+            $ConfigIndex = $Index
+            if (-not $ConfigPath) { $ConfigPath = $ForwardArgs[$Index].Substring("--config=".Length) }
+            break
+        }
+    }
+    $ScriptPath = if ($env:SPEAKEASY_HOOKS_PERSIST_SCRIPT) { $env:SPEAKEASY_HOOKS_PERSIST_SCRIPT } else { $PSCommandPath }
+    if ($ConfigIndex -lt 0 -or
+        -not (Test-Path -LiteralPath $ScriptPath -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) { return $null }
+
+    $PersistRoot = $env:SPEAKEASY_HOOKS_PERSIST_ROOT
+    $HooksDir = Join-Path $PersistRoot "hooks"
+    $StableScript = Join-Path $HooksDir "bootstrap.ps1"
+    $StableConfig = Join-Path $PersistRoot "speakeasy.json"
+    $Ready = Join-Path $PersistRoot ".windows-ready"
+    $Lock = Join-Path $PersistRoot ".persist-windows.lock"
+    $OwnLock = $false
+    try {
+        New-Item -ItemType Directory -Force -Path $HooksDir | Out-Null
+        try {
+            New-Item -ItemType Directory -Path $Lock -ErrorAction Stop | Out-Null
+            $OwnLock = $true
+        } catch {
+            if ((Test-Path -LiteralPath $Ready -PathType Leaf) -and
+                (Test-Path -LiteralPath $StableScript -PathType Leaf) -and
+                (Test-Path -LiteralPath $StableConfig -PathType Leaf)) {
+                return [PSCustomObject]@{ ConfigIndex = $ConfigIndex; ConfigPath = $StableConfig }
+            }
+            return $null
+        }
+
+        $Suffix = [guid]::NewGuid().ToString("N")
+        $ScriptTmp = Join-Path $HooksDir ".bootstrap.ps1.$Suffix"
+        $ConfigTmp = Join-Path $PersistRoot ".speakeasy.json.$Suffix"
+        $ReadyTmp = Join-Path $PersistRoot ".windows-ready.$Suffix"
+        try {
+            Copy-Item -LiteralPath $ScriptPath -Destination $ScriptTmp
+            Copy-Item -LiteralPath $ConfigPath -Destination $ConfigTmp
+            Remove-Item -LiteralPath $Ready -Force -ErrorAction SilentlyContinue
+            Move-Item -LiteralPath $ConfigTmp -Destination $StableConfig -Force
+            Move-Item -LiteralPath $ScriptTmp -Destination $StableScript -Force
+            [System.IO.File]::WriteAllText($ReadyTmp, "ready" + [char]10)
+            Move-Item -LiteralPath $ReadyTmp -Destination $Ready -Force
+            return [PSCustomObject]@{ ConfigIndex = $ConfigIndex; ConfigPath = $StableConfig }
+        } finally {
+            Remove-Item -LiteralPath $ScriptTmp -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $ConfigTmp -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $ReadyTmp -Force -ErrorAction SilentlyContinue
+        }
+    } catch {
+        return $null
+    } finally {
+        if ($OwnLock) {
+            Remove-Item -LiteralPath $Lock -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+$StablePayload = Save-StablePayload
+if ($StablePayload) {
+    $ForwardArgs[$StablePayload.ConfigIndex] = "--config=$($StablePayload.ConfigPath)"
+}
+
 $Arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()) {
     "X64" { "amd64" }
     "Arm64" { "arm64" }
@@ -418,35 +560,53 @@ func hooksBootstrapCommand(root, provider string, timeoutSeconds int, async bool
 // SessionStart and UserPromptSubmit for as long as it holds the stale plugin
 // list.
 //
-// So the command resolves the bootstrapper when the hook fires instead of
-// trusting the baked path: the substituted root first, then the most recently
-// written sibling version directory. Only when neither exists does it fail,
-// and then with a message naming the root it looked under and the org's
-// install-failure exit code rather than bash's opaque 127.
+// The command resolves the bootstrapper when the hook fires. Once a complete
+// bundle exists under Codex's version-independent plugin data directory it runs
+// from there, while treating the installed root as a refresh source. Before the
+// bundle is seeded, it uses the installed root or newest sibling as a first-run
+// migration path. Only when no complete payload exists does the command fail
+// with the org's install-failure exit code rather than bash's 127.
+const codexHooksStablePayloadSubdir = "speakeasy-hooks/runtime-v1"
+
 func codexHooksBootstrapCommand(timeoutSeconds int, async, failOpen bool) string {
 	args := fmt.Sprintf("agenthooks run --provider=codex --timeout=%ds", timeoutSeconds)
 	if async {
 		args += " --async"
 	}
 	// The script is single-quoted for `bash -c`, so it must not contain a
-	// single quote. Codex replaces ${PLUGIN_ROOT} textually before any shell
-	// sees the command; the surrounding double quotes leave the shell's own
-	// expansion of the same name as a fallback, since Codex also exports it to
-	// the hook process.
+	// single quote. $PLUGIN_ROOT and $PLUGIN_DATA deliberately omit braces:
+	// Codex exports both variables, and runtime expansion safely handles paths
+	// containing shell metacharacters without Codex substituting them textually.
 	script := fmt.Sprintf(
-		`r="%s"; s="$r/hooks/bootstrap.sh"; `+
-			`[ -f "$s" ] || s=$(ls -t "${r%%/*}"/*/hooks/bootstrap.sh 2>/dev/null | head -n 1); `+
-			`[ -n "$s" ] && [ -f "$s" ] || { printf "speakeasy-hooks: no hook payload under %%s; the Codex plugin cache moved or the plugin is not fully installed\n" "$r" >&2; exit %d; }; `+
-			`exec bash "$s" "--config=${s%%/hooks/bootstrap.sh}/speakeasy.json" %s`,
-		codexPluginRootPlaceholder, conv.Ternary(failOpen, 0, 1), args,
+		`r="$PLUGIN_ROOT"; d=; [ -z "${PLUGIN_DATA:-}" ] || d="$PLUGIN_DATA/%s"; rs="$r/hooks/bootstrap.sh"; rc="$r/speakeasy.json"; s=; c=; ps=; pc=; `+
+			`if [ -n "$d" ] && [ -f "$d/.unix-ready" ] && [ -f "$d/hooks/bootstrap.sh" ] && [ -f "$d/speakeasy.json" ]; then s="$d/hooks/bootstrap.sh"; c="$d/speakeasy.json"; [ ! -f "$rs" ] || [ ! -f "$rc" ] || { ps="$rs"; pc="$rc"; }; `+
+			`elif [ -f "$rs" ] && [ -f "$rc" ]; then s="$rs"; c="$rc"; ps="$s"; pc="$c"; `+
+			`else s=$(ls -t "${r%%/*}"/*/hooks/bootstrap.sh 2>/dev/null | head -n 1); c="${s%%/hooks/bootstrap.sh}/speakeasy.json"; ps="$s"; pc="$c"; fi; `+
+			`[ -n "$s" ] && [ -f "$s" ] && [ -f "$c" ] || { printf "speakeasy-hooks: no complete hook payload for %%s; the Codex plugin cache moved or the plugin is not fully installed\n" "$r" >&2; exit %d; }; `+
+			`SPEAKEASY_HOOKS_PERSIST_ROOT="$d" SPEAKEASY_HOOKS_PERSIST_SCRIPT="$ps" SPEAKEASY_HOOKS_PERSIST_CONFIG="$pc" exec bash "$s" "--config=$c" %s`,
+		codexHooksStablePayloadSubdir, conv.Ternary(failOpen, 0, 1), args,
 	)
 	return "bash -c '" + script + "'"
 }
 
-func hooksPowerShellCommand(root, provider string, timeoutSeconds int, async bool) string {
-	command := fmt.Sprintf(`powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%s\hooks\bootstrap.ps1" --config="%s\speakeasy.json" agenthooks run --provider=%s --timeout=%ds`, root, root, provider, timeoutSeconds)
+func codexHooksPowerShellCommand(timeoutSeconds int, async, failOpen bool) string {
+	args := fmt.Sprintf("agenthooks run --provider=codex --timeout=%ds", timeoutSeconds)
 	if async {
-		command += " --async"
+		args += " --async"
 	}
-	return command
+	script := fmt.Sprintf(
+		`$r=$env:PLUGIN_ROOT; $d=Join-Path $env:PLUGIN_DATA %q; $rs=Join-Path $r "hooks/bootstrap.ps1"; $rc=Join-Path $r "speakeasy.json"; $s=$null; $c=$null; $ps=$null; $pc=$null; `+
+			`if ((Test-Path -LiteralPath (Join-Path $d ".windows-ready") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $d "hooks/bootstrap.ps1") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $d "speakeasy.json") -PathType Leaf)) { $s=Join-Path $d "hooks/bootstrap.ps1"; $c=Join-Path $d "speakeasy.json"; if ((Test-Path -LiteralPath $rs -PathType Leaf) -and (Test-Path -LiteralPath $rc -PathType Leaf)) { $ps=$rs; $pc=$rc } `+
+			`} elseif ((Test-Path -LiteralPath $rs -PathType Leaf) -and (Test-Path -LiteralPath $rc -PathType Leaf)) { $s=$rs; $c=$rc; $ps=$s; $pc=$c `+
+			`} else { $parent=Split-Path $r -Parent; $candidate=Get-ChildItem -LiteralPath $parent -Directory -ErrorAction SilentlyContinue | Sort-Object LastWriteTimeUtc -Descending | Where-Object { (Test-Path -LiteralPath (Join-Path $_.FullName "hooks/bootstrap.ps1") -PathType Leaf) -and (Test-Path -LiteralPath (Join-Path $_.FullName "speakeasy.json") -PathType Leaf) } | Select-Object -First 1; if ($candidate) { $s=Join-Path $candidate.FullName "hooks/bootstrap.ps1"; $c=Join-Path $candidate.FullName "speakeasy.json"; $ps=$s; $pc=$c } }; `+
+			`if (-not $s -or -not (Test-Path -LiteralPath $s -PathType Leaf) -or -not (Test-Path -LiteralPath $c -PathType Leaf)) { [Console]::Error.WriteLine("speakeasy-hooks: no complete hook payload for $r; the Codex plugin cache moved or the plugin is not fully installed"); exit %d }; `+
+			`$env:SPEAKEASY_HOOKS_PERSIST_ROOT=$d; $env:SPEAKEASY_HOOKS_PERSIST_SCRIPT=$ps; $env:SPEAKEASY_HOOKS_PERSIST_CONFIG=$pc; & $s "--config=$c" %s; exit $LASTEXITCODE`,
+		codexHooksStablePayloadSubdir, conv.Ternary(failOpen, 0, 1), args,
+	)
+	units := utf16.Encode([]rune(script))
+	encoded := make([]byte, 2*len(units))
+	for i, unit := range units {
+		binary.LittleEndian.PutUint16(encoded[2*i:], unit)
+	}
+	return `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand ` + base64.StdEncoding.EncodeToString(encoded)
 }

--- a/server/internal/plugins/hooks_bootstrap_codex_test.go
+++ b/server/internal/plugins/hooks_bootstrap_codex_test.go
@@ -1,0 +1,133 @@
+package plugins
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// codexHookCommandProbe runs a generated Codex hook command the way Codex runs
+// it — the substituted plugin root baked into the command string, the same path
+// exported as PLUGIN_ROOT, and the whole line handed to a shell as one argument
+// — and returns stdout, stderr, and the exit code.
+func codexHookCommandProbe(t *testing.T, command, pluginRoot string) (string, string, int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the Unix hook command is exercised on Unix; Windows uses commandWindows")
+	}
+	shell, err := exec.LookPath("bash")
+	require.NoError(t, err, "bash is required to exercise the Unix hook command")
+
+	cmd := exec.CommandContext(t.Context(), shell, "-c", strings.ReplaceAll(command, codexPluginRootPlaceholder, pluginRoot))
+	cmd.Env = append(os.Environ(), "PLUGIN_ROOT="+pluginRoot)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+	var exitErr *exec.ExitError
+	if runErr != nil && !errors.As(runErr, &exitErr) {
+		require.NoError(t, runErr)
+	}
+	return stdout.String(), stderr.String(), cmd.ProcessState.ExitCode()
+}
+
+// codexPluginCache lays out a plugin version directory the way Codex's plugin
+// store does (<cache>/<marketplace>/<plugin>/<version>) with a bootstrap script
+// that echoes the arguments it was handed, and returns the version root.
+func codexPluginCache(t *testing.T, base, version string) string {
+	t.Helper()
+	root := filepath.Join(base, "plugins", "cache", "acme-speakeasy", "acme-observability-codex", version)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "hooks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "hooks", "bootstrap.sh"),
+		[]byte("#!/usr/bin/env bash\nprintf 'script=%s args=%s\\n' \"$0\" \"$*\"\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "speakeasy.json"), []byte("{}\n"), 0o644))
+	return root
+}
+
+func TestCodexHookCommandRunsBootstrapFromPluginRoot(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	root := codexPluginCache(t, base, "0.28.100")
+
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(330, false, false), root)
+
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stdout, "script="+filepath.Join(root, "hooks", "bootstrap.sh"))
+	require.Contains(t, stdout, "--config="+filepath.Join(root, "speakeasy.json"))
+	require.Contains(t, stdout, "agenthooks run --provider=codex --timeout=330s")
+}
+
+// Codex reinstalls a republished plugin into a sibling version directory and
+// deletes the previous one, so a hook command it resolved before the swap names
+// a script that is gone. `bash <missing file>` exits 127 with no output, which
+// is the bare "hook exited with code 127" users see on SessionStart and
+// UserPromptSubmit; the command must re-resolve instead.
+func TestCodexHookCommandSurvivesPluginCacheVersionSwap(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	live := codexPluginCache(t, base, "0.28.101")
+	stale := filepath.Join(filepath.Dir(live), "0.28.100")
+
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, false), stale)
+
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stdout, "script="+filepath.Join(live, "hooks", "bootstrap.sh"))
+	require.Contains(t, stdout, "--config="+filepath.Join(live, "speakeasy.json"),
+		"the recovered root must also supply the deployment identity")
+}
+
+func TestCodexHookCommandReportsMissingPayloadInsteadOfExit127(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		failOpen bool
+		wantCode int
+	}{
+		{name: "fail closed", failOpen: false, wantCode: 1},
+		{name: "fail open", failOpen: true, wantCode: 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			missing := filepath.Join(t.TempDir(), "plugins", "cache", "acme-speakeasy", "acme-observability-codex", "0.28.100")
+
+			stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, tt.failOpen), missing)
+
+			require.Equal(t, tt.wantCode, code)
+			require.Empty(t, stdout)
+			require.Contains(t, stderr, "speakeasy-hooks: no hook payload under "+missing,
+				"the failure must name the root it looked under, not exit 127 silently")
+		})
+	}
+}
+
+func TestCodexHookCommandForwardsAsyncFlag(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	root := codexPluginCache(t, base, "0.28.100")
+
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, true, false), root)
+
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stdout, "agenthooks run --provider=codex --timeout=60s --async")
+}
+
+// The command is single-quoted for `bash -c`, so a single quote anywhere inside
+// would terminate the script early and hand the rest to the shell.
+func TestCodexHookCommandCarriesNoSingleQuotes(t *testing.T) {
+	t.Parallel()
+	for _, event := range CodexObservabilityHookEvents {
+		timeoutSeconds, async := codexHookParams(event)
+		for _, failOpen := range []bool{false, true} {
+			command := codexHookCommandString(timeoutSeconds, async, failOpen)
+			require.Equal(t, 2, strings.Count(command, "'"), "event %q: only the bash -c wrapper may quote", event)
+			require.True(t, strings.HasPrefix(command, "bash -c '"))
+			require.True(t, strings.HasSuffix(command, "'"))
+		}
+	}
+}

--- a/server/internal/plugins/hooks_bootstrap_codex_test.go
+++ b/server/internal/plugins/hooks_bootstrap_codex_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -15,12 +14,12 @@ import (
 // codexHookCommandProbe runs a generated Codex hook command the way Codex runs
 // it — the substituted plugin root baked into the command string, the same path
 // exported as PLUGIN_ROOT, and the whole line handed to a shell as one argument
-// — and returns stdout, stderr, and the exit code.
+// — and returns stdout, stderr, and the exit code. Only the Unix command is
+// exercised; Windows takes commandWindows, which this change leaves alone.
 func codexHookCommandProbe(t *testing.T, command, pluginRoot string) (string, string, int) {
 	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("the Unix hook command is exercised on Unix; Windows uses commandWindows")
-	}
+	// Codex hands the line to $SHELL, so run it through one rather than
+	// splitting it here.
 	shell, err := exec.LookPath("bash")
 	require.NoError(t, err, "bash is required to exercise the Unix hook command")
 

--- a/server/internal/plugins/hooks_bootstrap_codex_test.go
+++ b/server/internal/plugins/hooks_bootstrap_codex_test.go
@@ -1,30 +1,32 @@
 package plugins
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/stretchr/testify/require"
 )
 
 // codexHookCommandProbe runs a generated Codex hook command the way Codex runs
-// it — the substituted plugin root baked into the command string, the same path
-// exported as PLUGIN_ROOT, and the whole line handed to a shell as one argument
-// — and returns stdout, stderr, and the exit code. Only the Unix command is
-// exercised; Windows takes commandWindows, which this change leaves alone.
-func codexHookCommandProbe(t *testing.T, command, pluginRoot string) (string, string, int) {
+// it — plugin paths exported in the environment and the whole line handed to a
+// shell as one argument — and returns stdout, stderr, and the exit code.
+func codexHookCommandProbe(t *testing.T, command, pluginRoot, pluginData string, extraEnv ...string) (string, string, int) {
 	t.Helper()
 	// Codex hands the line to $SHELL, so run it through one rather than
 	// splitting it here.
 	shell, err := exec.LookPath("bash")
 	require.NoError(t, err, "bash is required to exercise the Unix hook command")
 
-	cmd := exec.CommandContext(t.Context(), shell, "-c", strings.ReplaceAll(command, codexPluginRootPlaceholder, pluginRoot))
-	cmd.Env = append(os.Environ(), "PLUGIN_ROOT="+pluginRoot)
+	cmd := exec.CommandContext(t.Context(), shell, "-c", command)
+	cmd.Env = append(os.Environ(), "PLUGIN_ROOT="+pluginRoot, "PLUGIN_DATA="+pluginData)
+	cmd.Env = append(cmd.Env, extraEnv...)
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -53,8 +55,9 @@ func TestCodexHookCommandRunsBootstrapFromPluginRoot(t *testing.T) {
 	t.Parallel()
 	base := t.TempDir()
 	root := codexPluginCache(t, base, "0.28.100")
+	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
 
-	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(330, false, false), root)
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(330, false, false), root, data)
 
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	require.Contains(t, stdout, "script="+filepath.Join(root, "hooks", "bootstrap.sh"))
@@ -72,13 +75,33 @@ func TestCodexHookCommandSurvivesPluginCacheVersionSwap(t *testing.T) {
 	base := t.TempDir()
 	live := codexPluginCache(t, base, "0.28.101")
 	stale := filepath.Join(filepath.Dir(live), "0.28.100")
+	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
 
-	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, false), stale)
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, false), stale, data)
 
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	require.Contains(t, stdout, "script="+filepath.Join(live, "hooks", "bootstrap.sh"))
 	require.Contains(t, stdout, "--config="+filepath.Join(live, "speakeasy.json"),
 		"the recovered root must also supply the deployment identity")
+}
+
+func TestCodexHookCommandUsesPersistedPayloadWhenPluginCacheIsGone(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	stale := filepath.Join(base, "plugins", "cache", "acme-speakeasy", "acme-observability-codex", "0.28.100")
+	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
+	stable := filepath.Join(data, filepath.FromSlash(codexHooksStablePayloadSubdir))
+	require.NoError(t, os.MkdirAll(filepath.Join(stable, "hooks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stable, "hooks", "bootstrap.sh"),
+		[]byte("#!/usr/bin/env bash\nprintf 'script=%s args=%s\\n' \"$0\" \"$*\"\n"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stable, "speakeasy.json"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(stable, ".unix-ready"), []byte("ready\n"), 0o600))
+
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, false), stale, data)
+
+	require.Equal(t, 0, code, "stderr: %s", stderr)
+	require.Contains(t, stdout, "script="+filepath.Join(stable, "hooks", "bootstrap.sh"))
+	require.Contains(t, stdout, "--config="+filepath.Join(stable, "speakeasy.json"))
 }
 
 func TestCodexHookCommandReportsMissingPayloadInsteadOfExit127(t *testing.T) {
@@ -94,12 +117,13 @@ func TestCodexHookCommandReportsMissingPayloadInsteadOfExit127(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			missing := filepath.Join(t.TempDir(), "plugins", "cache", "acme-speakeasy", "acme-observability-codex", "0.28.100")
+			data := filepath.Join(t.TempDir(), "plugins", "data", "acme-observability-codex-acme-speakeasy")
 
-			stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, tt.failOpen), missing)
+			stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, tt.failOpen), missing, data)
 
 			require.Equal(t, tt.wantCode, code)
 			require.Empty(t, stdout)
-			require.Contains(t, stderr, "speakeasy-hooks: no hook payload under "+missing,
+			require.Contains(t, stderr, "speakeasy-hooks: no complete hook payload for "+missing,
 				"the failure must name the root it looked under, not exit 127 silently")
 		})
 	}
@@ -109,11 +133,31 @@ func TestCodexHookCommandForwardsAsyncFlag(t *testing.T) {
 	t.Parallel()
 	base := t.TempDir()
 	root := codexPluginCache(t, base, "0.28.100")
+	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
 
-	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, true, false), root)
+	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, true, false), root, data)
 
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	require.Contains(t, stdout, "agenthooks run --provider=codex --timeout=60s --async")
+}
+
+func TestCodexPowerShellCommandUsesRuntimePluginPaths(t *testing.T) {
+	t.Parallel()
+	command := codexHookCommandStringWindows(60, true, false)
+	const prefix = `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand `
+	require.True(t, strings.HasPrefix(command, prefix))
+	encoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(command, prefix))
+	require.NoError(t, err)
+	require.Zero(t, len(encoded)%2)
+	units := make([]uint16, len(encoded)/2)
+	for i := range units {
+		units[i] = binary.LittleEndian.Uint16(encoded[2*i:])
+	}
+	script := string(utf16.Decode(units))
+	require.Contains(t, script, `$r=$env:PLUGIN_ROOT`)
+	require.Contains(t, script, `$d=Join-Path $env:PLUGIN_DATA`)
+	require.Contains(t, script, `.windows-ready`)
+	require.Contains(t, script, `--provider=codex --timeout=60s --async`)
 }
 
 // The command is single-quoted for `bash -c`, so a single quote anywhere inside

--- a/server/internal/plugins/hooks_bootstrap_codex_test.go
+++ b/server/internal/plugins/hooks_bootstrap_codex_test.go
@@ -75,6 +75,9 @@ func TestCodexHookCommandSurvivesPluginCacheVersionSwap(t *testing.T) {
 	base := t.TempDir()
 	live := codexPluginCache(t, base, "0.28.101")
 	stale := filepath.Join(filepath.Dir(live), "0.28.100")
+	incomplete := filepath.Join(filepath.Dir(live), "0.28.102", "hooks")
+	require.NoError(t, os.MkdirAll(incomplete, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(incomplete, "bootstrap.sh"), []byte("#!/usr/bin/env bash\nexit 99\n"), 0o755))
 	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
 
 	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, false), stale, data)
@@ -82,7 +85,7 @@ func TestCodexHookCommandSurvivesPluginCacheVersionSwap(t *testing.T) {
 	require.Equal(t, 0, code, "stderr: %s", stderr)
 	require.Contains(t, stdout, "script="+filepath.Join(live, "hooks", "bootstrap.sh"))
 	require.Contains(t, stdout, "--config="+filepath.Join(live, "speakeasy.json"),
-		"the recovered root must also supply the deployment identity")
+		"an incomplete newer sibling must not mask the newest complete payload")
 }
 
 func TestCodexHookCommandUsesPersistedPayloadWhenPluginCacheIsGone(t *testing.T) {
@@ -91,17 +94,18 @@ func TestCodexHookCommandUsesPersistedPayloadWhenPluginCacheIsGone(t *testing.T)
 	stale := filepath.Join(base, "plugins", "cache", "acme-speakeasy", "acme-observability-codex", "0.28.100")
 	data := filepath.Join(base, "plugins", "data", "acme-observability-codex-acme-speakeasy")
 	stable := filepath.Join(data, filepath.FromSlash(codexHooksStablePayloadSubdir))
-	require.NoError(t, os.MkdirAll(filepath.Join(stable, "hooks"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(stable, "hooks", "bootstrap.sh"),
+	generation := filepath.Join(stable, "generations", "unix-test")
+	require.NoError(t, os.MkdirAll(filepath.Join(generation, "hooks"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(generation, "hooks", "bootstrap.sh"),
 		[]byte("#!/usr/bin/env bash\nprintf 'script=%s args=%s\\n' \"$0\" \"$*\"\n"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(stable, "speakeasy.json"), []byte("{}\n"), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(stable, ".unix-ready"), []byte("ready\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(generation, "speakeasy.json"), []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(stable, ".unix-current"), []byte("unix-test\n"), 0o600))
 
 	stdout, stderr, code := codexHookCommandProbe(t, codexHookCommandString(60, false, false), stale, data)
 
 	require.Equal(t, 0, code, "stderr: %s", stderr)
-	require.Contains(t, stdout, "script="+filepath.Join(stable, "hooks", "bootstrap.sh"))
-	require.Contains(t, stdout, "--config="+filepath.Join(stable, "speakeasy.json"))
+	require.Contains(t, stdout, "script="+filepath.Join(generation, "hooks", "bootstrap.sh"))
+	require.Contains(t, stdout, "--config="+filepath.Join(generation, "speakeasy.json"))
 }
 
 func TestCodexHookCommandReportsMissingPayloadInsteadOfExit127(t *testing.T) {
@@ -156,7 +160,7 @@ func TestCodexPowerShellCommandUsesRuntimePluginPaths(t *testing.T) {
 	script := string(utf16.Decode(units))
 	require.Contains(t, script, `$r=$env:PLUGIN_ROOT`)
 	require.Contains(t, script, `$d=Join-Path $env:PLUGIN_DATA`)
-	require.Contains(t, script, `.windows-ready`)
+	require.Contains(t, script, `.windows-current`)
 	require.Contains(t, script, `--provider=codex --timeout=60s --async`)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes DNO-808 — `SessionStart` and `UserPromptSubmit` failing with `hook exited with code 127` after Codex refreshes a plugin.

## Root cause

Codex resolves `${PLUGIN_ROOT}` to a versioned cache directory. That directory is disposable: a plugin refresh can remove it while an existing session still holds hook commands pointing into it. Invoking the vanished `hooks/bootstrap.sh` then exits 127.

A sibling-version fallback narrows the race but does not remove it. Every cache version can disappear, and choosing a sibling while Codex is replacing it is another time-of-check/time-of-use race.

## Changes

- Persist the bootstrap script and deployment config beneath Codex's stable `${PLUGIN_DATA}` directory.
- Publish each Unix and Windows payload as an immutable generation, then atomically move a platform-specific current pointer. Readers therefore see either the previous complete generation or the next complete generation, never a partially copied pair.
- Resolve the stable generation first. On the first invocation after this release, fall back to a complete installed payload, publish it, and immediately run the newly published bootstrap. That makes this a single-release migration.
- Keep config and bootstrap from the same generation, scan past incomplete sibling installs, and emit a useful failure governed by the org's fail-open/fail-closed policy when no complete payload exists.
- Recover abandoned persistence locks on Unix and Windows using expiring PID leases; avoid republishing a stable bootstrap from itself.
- Preserve `--async` behavior and implement equivalent PowerShell resolution using `-EncodedCommand`.
- Match Codex's trusted-hook hashing by disabling Go's HTML escaping.
- Bump `hooksGeneratorVersion` to 31 so existing installations receive the new generated hook payload.

## Verification

- `mise exec -- go test ./server/internal/plugins -count=1`
- `mise lint:server`
- Tests cover first-run publication, immediate execution of the new generation, stable fallback after cache deletion, incomplete siblings, concurrent cold starts, stale-lock recovery, Unix/Windows commands, async propagation, failure policy, and Codex trust hashes.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-808](https://linear.app/speakeasy/issue/DNO-808/bug-consistent-hooks-errors-in-codex)

<div><a href="https://cursor.com/agents/bc-1815c822-e74a-4164-99b0-c9b628cf1264?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1815c822-e74a-4164-99b0-c9b628cf1264&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-808 by persisting the Codex hook bootstrap and config to a stable bundle in `${PLUGIN_DATA}/speakeasy-hooks/runtime-v1` and resolving the script at runtime, stopping “hook exited with code 127” after plugin cache swaps on Unix and Windows. Trusted-hash generation now matches Codex (no HTML escaping), and `hooksGeneratorVersion` is bumped to `31` so installs pick up the change.

- **Bug Fixes**
  - Hooks run from the persisted bundle; the installed cache only refreshes it. First run falls back to `${PLUGIN_ROOT}` or the newest sibling; if no complete payload exists, print a clear error and exit per org policy (`fail-open`=0, `fail-closed`=1) instead of 127.
  - Windows uses `-EncodedCommand` with the same resolve/persist policy and reads runtime paths from `$env:PLUGIN_ROOT`/`$env:PLUGIN_DATA`; stale persistence locks are reclaimed on both platforms; `--async` is forwarded.
  - Trusted-hash uses unescaped JSON to match Codex; approvals incorporate the org’s install-failure policy and are pinned against `codex-cli 0.147.0`.
  - Tests cover persistence before relay execution, lock recovery, Windows command behavior, hashing, async, and error paths.

- **Migration**
  - Re-run the generated install script (or re-approve the updated hook in Codex) to refresh the `trusted_hash`.

<sup>Written for commit f00691a76055df8c532cf848270cd5db6c4a49f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


