### PR TITLE
fix(risk): stop reporting opaque ten-digit ids as UK NHS numbers

### DIFF
--- a/pystreams/src/pystreams/risk/presidiofp/__init__.py
+++ b/pystreams/src/pystreams/risk/presidiofp/__init__.py
@@ -1,9 +1,24 @@
 """Presidio false-positive classification.
 
 Classifies Presidio PII findings (reserved/placeholder IPs and emails, cloud/CDN
-ASN attribution) so the streaming scanner can drop the noise before publishing.
+ASN attribution, NHS number validity, retired recognizers) so the streaming
+scanner can drop the noise before publishing.
 """
 
-from .classify import reason, reason_by_rule_id, rule_ids
+from .classify import (
+    context_rule_ids,
+    reason,
+    reason_by_rule_id,
+    reason_by_rule_id_in_context,
+    reason_in_context,
+    rule_ids,
+)
 
-__all__ = ["reason", "reason_by_rule_id", "rule_ids"]
+__all__ = [
+    "context_rule_ids",
+    "reason",
+    "reason_by_rule_id",
+    "reason_by_rule_id_in_context",
+    "reason_in_context",
+    "rule_ids",
+]

--- a/pystreams/src/pystreams/risk/presidiofp/classify.py
+++ b/pystreams/src/pystreams/risk/presidiofp/classify.py
@@ -1,15 +1,19 @@
 """Classifies Presidio PII findings as false positives.
 
 Holds the per-entity false-positive catalogs (reserved/placeholder IPs and
-emails, cloud/CDN ASN attribution) and the dispatch over them.
+emails, cloud/CDN ASN attribution, NHS number validity, retired recognizers) and
+the dispatch over them.
 """
 
 from .email import non_pii_email_reason
 from .ip import non_pii_ip_reason
+from .nhs import nhs_context_reason, non_nhs_reason
+from .retired import RETIRED_RECOGNIZERS, retired_reason
 
 # Presidio's UPPER_SNAKE entity names that have a false-positive catalog.
 ENTITY_TYPE_EMAIL_ADDRESS = "EMAIL_ADDRESS"
 ENTITY_TYPE_IP_ADDRESS = "IP_ADDRESS"
+ENTITY_TYPE_UK_NHS = "UK_NHS"
 
 # The canonical rule_id prefix for Presidio PII findings. Mirrors
 # ``_canonical_rule_id`` in the handler ("pii." + lowercased entity); keep in sync.
@@ -18,13 +22,29 @@ _RULE_PREFIX = "pii."
 
 def reason(entity_type: str, match: str) -> str:
     """Return the catalog reason a Presidio match is treated as noise, or "" when
-    it is a real finding. Only IP_ADDRESS and EMAIL_ADDRESS have catalogs today;
-    other entity types always return "".
+    it is a real finding. Entity types without a catalog always return "".
+
+    This is the value-only view: it judges the matched text on its own. Callers
+    that hold the text the match was found in should prefer ``reason_in_context``,
+    which additionally applies the catalogs that need surrounding text.
     """
+    return reason_in_context(entity_type, match, "")
+
+
+def reason_in_context(entity_type: str, match: str, text: str) -> str:
+    """``reason`` with the payload the match was found in. Passing an empty
+    ``text`` is equivalent to calling ``reason``: no finding is ever suppressed
+    for missing context, only for context that is present and carries no signal.
+    """
+    retired = retired_reason(entity_type)
+    if retired:
+        return retired
     if entity_type == ENTITY_TYPE_IP_ADDRESS:
         return non_pii_ip_reason(match.strip())
     if entity_type == ENTITY_TYPE_EMAIL_ADDRESS:
         return non_pii_email_reason(match)
+    if entity_type == ENTITY_TYPE_UK_NHS:
+        return non_nhs_reason(match) or nhs_context_reason(text)
     return ""
 
 
@@ -36,14 +56,27 @@ def reason_by_rule_id(rule_id: str, match: str) -> str:
     return reason(_entity_type_for_rule_id(rule_id), match)
 
 
+def reason_by_rule_id_in_context(rule_id: str, match: str, text: str) -> str:
+    """``reason_in_context`` keyed by a stored finding's canonical rule_id."""
+    return reason_in_context(_entity_type_for_rule_id(rule_id), match, text)
+
+
 def rule_ids() -> list[str]:
     """Return the canonical rule ids whose entity types have a catalog. Keep in
-    sync with the dispatch in ``reason``.
+    sync with the dispatch in ``reason_in_context``.
     """
     return [
         _rule_id_for_entity(ENTITY_TYPE_IP_ADDRESS),
         _rule_id_for_entity(ENTITY_TYPE_EMAIL_ADDRESS),
-    ]
+        _rule_id_for_entity(ENTITY_TYPE_UK_NHS),
+    ] + [_rule_id_for_entity(entity) for entity in sorted(RETIRED_RECOGNIZERS)]
+
+
+def context_rule_ids() -> list[str]:
+    """Return the subset of ``rule_ids`` whose classification can change once the
+    surrounding text is supplied.
+    """
+    return [_rule_id_for_entity(ENTITY_TYPE_UK_NHS)]
 
 
 def _rule_id_for_entity(entity: str) -> str:

--- a/pystreams/src/pystreams/risk/presidiofp/nhs.py
+++ b/pystreams/src/pystreams/risk/presidiofp/nhs.py
@@ -1,0 +1,148 @@
+"""UK NHS number false-positive catalogs.
+
+Mirror of ``server/internal/risk/presidiofp/nhs.go``; see ``non_nhs_reason`` and
+``nhs_context_reason`` for the rationale behind each layer.
+"""
+
+
+def non_nhs_reason(match: str) -> str:
+    """Return why a UK_NHS match is noise, or "" when it could be a real NHS number.
+
+    This layer sees only the matched value, so it can rule out digit runs that
+    are not valid NHS numbers at all. The much larger noise class — a perfectly
+    valid-looking 10-digit run that is really a Confluence page id, a Unix
+    timestamp, or an order number — is indistinguishable by value alone and is
+    handled by ``nhs_context_reason`` instead.
+
+    Why the value-only layer matters: Presidio's ``NhsRecognizer`` matches
+    ``\\b(\\d{3})[- ]?(\\d{3})[- ]?(\\d{4})\\b`` and, when its mod-11 checksum
+    passes, ``PatternRecognizer`` raises the score to 1.0 with no context
+    requirement. Any 10-digit identifier therefore has a ~1-in-11 chance of being
+    reported as a UK National Health Service number at maximum confidence.
+
+    Three checks, in order:
+
+      1. Shape. Anything that is not exactly ten digits after separators are
+         stripped is left alone: it did not come from the NHS recognizer's own
+         grammar, so this catalog has nothing to say about it.
+      2. Check digit. NHS numbers carry a mod-11 check digit (the same
+         validation the recognizer runs). A run that fails it is not an NHS
+         number.
+      3. Allocation range. NHS/CHI/H&C/IHI numbers are only issued from the
+         ranges in ``NHS_ALLOCATED_RANGES``. A checksum-valid run outside them
+         was never issued to a patient.
+    """
+    digits = _nhs_digits(match)
+    if len(digits) != 10:
+        return ""
+    if not _nhs_check_digit_valid(digits):
+        return "fails the NHS number check digit"
+    if not _nhs_allocated(digits):
+        return "outside the allocated NHS number ranges"
+    return ""
+
+
+def nhs_context_reason(text: str) -> str:
+    """Report a UK_NHS match as noise when its text carries no NHS signal at all.
+
+    The recognizer already ships CONTEXT words ("nhs", "national health
+    service", ...) but Presidio only uses them to *raise* a score, never to gate
+    a match, and a passing checksum pins the score at 1.0 before any context is
+    consulted. This inverts that: a ten-digit run in a payload that never
+    mentions health care anywhere is treated as an opaque identifier rather than
+    a patient number.
+
+    ``text`` is the whole scanned payload, not a window around the match, so
+    that this agrees with the offline sweep, which re-locates a stored match
+    inside re-fetched message text and cannot rely on offsets. Scanning
+    everything only ever keeps more findings, which is the safe direction.
+
+    An empty ``text`` means "context unknown", and no finding is suppressed on
+    that basis.
+    """
+    if not text:
+        return ""
+    lower = text.lower()
+    if any(term in lower for term in NHS_CONTEXT_TERMS):
+        return ""
+    return "ten-digit identifier with no NHS context in the surrounding text"
+
+
+def _nhs_digits(match: str) -> str:
+    """Strip the separators the NHS recognizer's grammar allows (spaces and
+    hyphens, per its ``replacement_pairs``) and return the remaining characters
+    only when every one of them is a digit. Anything else returns "" so callers
+    treat the value as out of scope rather than mis-measuring it.
+    """
+    out: list[str] = []
+    for ch in match.strip():
+        if ch in " -":
+            continue
+        if not ch.isascii() or not ch.isdigit():
+            return ""
+        out.append(ch)
+    return "".join(out)
+
+
+def _nhs_check_digit_valid(digits: str) -> bool:
+    """Run the NHS Digital mod-11 check: each of the ten digits is weighted 10
+    down to 1 and the weighted sum must be divisible by 11. Same validation as
+    Presidio's ``NhsRecognizer``, reimplemented so a stored finding can be
+    re-checked offline without calling the analyzer.
+    """
+    total = sum(int(ch) * (10 - i) for i, ch in enumerate(digits))
+    return total % 11 == 0
+
+
+def _nhs_allocated(digits: str) -> bool:
+    """Report whether the run's leading nine digits fall in an issued range."""
+    prefix = int(digits[:9])
+    return any(low <= prefix <= high for low, high in NHS_ALLOCATED_RANGES)
+
+
+# Inclusive ranges over the first nine digits of an NHS number (the tenth is the
+# check digit) that identify a real person somewhere in the UK/Ireland numbering
+# scheme. Everything outside them has never been issued, so a checksum-valid run
+# there is an unrelated identifier that happens to validate.
+#
+# Sourced from the NHS Data Dictionary (HEALTH AND CARE NUMBER), NHS England's
+# NHS-number guidance and the UK FCI NHS number range table:
+#
+#   010 000 000 - 319 999 999  Scotland (CHI numbers, DDMMYY-prefixed)
+#   320 000 000 - 399 999 999  Northern Ireland (Health & Care numbers)
+#   400 000 000 - 499 999 999  England, Wales, Isle of Man
+#   600 000 000 - 799 999 999  England, Wales, Isle of Man
+#   800 000 000 - 859 999 999  Republic of Ireland (IHI)
+#
+# Two gaps are deliberate. 000 000 000 - 009 999 999 is unissued, and it is where
+# zero-padded internal ids land. 860 000 000 - 999 999 999 is unissued too; it
+# contains NHS England's 999-prefixed test range, which is valid by checksum but
+# reserved so it can never belong to a patient.
+NHS_ALLOCATED_RANGES: tuple[tuple[int, int], ...] = (
+    (10_000_000, 319_999_999),
+    (320_000_000, 399_999_999),
+    (400_000_000, 499_999_999),
+    (600_000_000, 799_999_999),
+    (800_000_000, 859_999_999),
+)
+
+# Lowercased substrings that count as NHS signal in the surrounding text. The
+# list starts from the recognizer's own CONTEXT words and adds the sibling
+# schemes that share the ten-digit format, so a Scottish CHI or Northern Irish
+# Health & Care number is not suppressed for lacking the letters "nhs".
+#
+# Substring matching is intentional: "nhs" also fires inside "nhsNumber" and
+# "NHS_NUMBER", the shapes these values take in JSON payloads and column names,
+# which a word-boundary match would miss.
+NHS_CONTEXT_TERMS: tuple[str, ...] = (
+    "nhs",
+    "national health service",
+    "health service",
+    "health authority",
+    "health and care number",
+    "health & care number",
+    "chi number",
+    "patient",
+    "medical record",
+    "hospital number",
+)

--- a/pystreams/src/pystreams/risk/presidiofp/retired.py
+++ b/pystreams/src/pystreams/risk/presidiofp/retired.py
@@ -1,0 +1,35 @@
+"""Presidio recognizers whose every finding is treated as a false positive.
+
+Mirror of ``server/internal/risk/presidiofp/retired.go``.
+"""
+
+# Entity types whose recognizer produces noise at a rate that makes every one of
+# its findings untrustworthy, so the scanners drop them outright rather than
+# filtering value by value.
+#
+# The live scanners already refuse these before this module is consulted (see
+# ``_FINDING_LEVEL_DROP`` in ``pystreams.risk.scanner`` and
+# ``findingLevelDropEntities`` in the Go risk_analysis package). Listing them
+# here as well is what lets the offline sweep reconcile history with that
+# decision: findings stored before the live drop landed are still sitting in
+# risk_results, and a value-only catalog entry is what marks them as false
+# positives.
+RETIRED_RECOGNIZERS: dict[str, str] = {
+    # Its patterns match a leading letter followed by a run of digits — the
+    # shape of Figma file and node ids, short object ids, and countless other
+    # opaque identifiers — at a score that any nearby "id", "number", "card" or
+    # "lic" lemma (including the ones inside "public" and "duplicate") lifts
+    # over the reporting threshold. Upstream has known about it since 2023:
+    # microsoft/presidio#1063.
+    "US_DRIVER_LICENSE": (
+        "US driver license recognizer retired: matches arbitrary "
+        "letter-and-digit identifiers"
+    ),
+}
+
+
+def retired_reason(entity_type: str) -> str:
+    """Return the retirement reason for an entity type, or "" when the
+    recognizer is still trusted.
+    """
+    return RETIRED_RECOGNIZERS.get(entity_type, "")

--- a/pystreams/src/pystreams/risk/scanner.py
+++ b/pystreams/src/pystreams/risk/scanner.py
@@ -551,8 +551,9 @@ def _scan_to_detections(
     n = len(content)
     # Clamp each span to the content's bounds (guarding against an out-of-range
     # span) and drop catalog false positives (reserved/placeholder IPs and emails,
-    # cloud/CDN ASN attribution) before they ever reach the handler. This pass
-    # works in character offsets, so a discarded match never costs byte conversion.
+    # cloud/CDN ASN attribution, NHS numbers with no health-care context) before
+    # they ever reach the handler. This pass works in character offsets, so a
+    # discarded match never costs byte conversion.
     spans: list[tuple[Recognized, int, int, str]] = []
     for r in results:
         # Drop US_DRIVER_LICENSE regardless of how the scan was scoped: an
@@ -563,7 +564,12 @@ def _scan_to_detections(
         start = max(0, min(r.start, n))
         end = max(start, min(r.end, n))
         match = content[start:end]
-        if presidiofp.reason(r.entity_type, match):
+        # The whole payload goes in alongside the match: some catalogs need it.
+        # A ten-digit run only reads as a UK NHS number when the surrounding
+        # text talks about health care, because Presidio's recognizer pins any
+        # checksum-valid run at maximum confidence without consulting its own
+        # context words.
+        if presidiofp.reason_in_context(r.entity_type, match, content):
             continue
         spans.append((r, start, end, match))
     if not spans:

--- a/pystreams/tests/test_presidiofp.py
+++ b/pystreams/tests/test_presidiofp.py
@@ -2,14 +2,16 @@
 
 Mirrors the Go unit tests in
 ``server/internal/risk/presidiofp/classify_test.go``
-(``TestNonPIIIPExactKeysAreCanonical``, ``TestReason``, ``TestReasonByRuleID``)
-and adds broader table coverage of the IP and email catalogs.
+(``TestNonPIIIPExactKeysAreCanonical``, ``TestReason``, ``TestReasonByRuleID``),
+``nhs_test.go`` and ``retired_test.go``, and adds broader table coverage of the
+IP and email catalogs.
 
 (``fp_split_test.go`` is build-tagged dev tooling that regenerates testdata
 rather than a unit test, so it has no counterpart here.)
 """
 
 import ipaddress
+import random
 
 import pytest
 
@@ -18,9 +20,17 @@ from pystreams.risk.presidiofp import ip_asn
 from pystreams.risk.presidiofp.classify import (
     ENTITY_TYPE_EMAIL_ADDRESS,
     ENTITY_TYPE_IP_ADDRESS,
+    ENTITY_TYPE_UK_NHS,
     _entity_type_for_rule_id,
 )
 from pystreams.risk.presidiofp.ip import _NON_PII_IP_EXACT
+from pystreams.risk.presidiofp.nhs import (
+    NHS_ALLOCATED_RANGES,
+    _nhs_check_digit_valid,
+    nhs_context_reason,
+    non_nhs_reason,
+)
+from pystreams.risk.presidiofp.retired import RETIRED_RECOGNIZERS
 
 
 def test_non_pii_ip_exact_keys_are_canonical():
@@ -79,7 +89,13 @@ def test_reason_by_rule_id():
 
     # rule_ids advertises exactly the catalogued rule ids, and the grammar is
     # invertible.
-    assert presidiofp.rule_ids() == ["pii.ip_address", "pii.email_address"]
+    assert presidiofp.rule_ids() == [
+        "pii.ip_address",
+        "pii.email_address",
+        "pii.uk_nhs",
+        "pii.us_driver_license",
+    ]
+    assert presidiofp.context_rule_ids() == ["pii.uk_nhs"]
     assert _entity_type_for_rule_id("pii.ip_address") == "IP_ADDRESS"
     assert _entity_type_for_rule_id("pii.email_address") == "EMAIL_ADDRESS"
     assert _entity_type_for_rule_id("secret.aws_access_key") == ""
@@ -183,3 +199,138 @@ def test_email_trailing_digit_is_ascii_only():
     assert presidiofp.reason("EMAIL_ADDRESS", "pkg@v1") != ""
     # U+00B2 SUPERSCRIPT TWO is a Unicode digit but not ASCII; must not fire.
     assert presidiofp.reason("EMAIL_ADDRESS", "user@example²") == ""
+
+
+@pytest.mark.parametrize(
+    ("match", "expect_fp"),
+    [
+        # Issued ranges, valid check digit: this layer must let them through.
+        ("401 023 2137", False),
+        ("401-023-2137", False),
+        ("4010232137", False),
+        ("6543210982", False),  # Wales range
+        ("1706349017", False),  # Scotland CHI range
+        ("3201234567", False),  # Northern Ireland range
+        # Never issued to anyone.
+        ("9999999999", True),  # NHS England test range
+        ("9434765919", True),  # unallocated above 859
+        ("0000000000", True),  # zero-padded internal id
+        # Not an NHS number at all.
+        ("4010232138", True),  # check digit fails
+        # Out of this catalog's scope: the recognizer only ever emits ten-digit
+        # runs, so anything else is left for another lane.
+        ("40102321", False),
+        ("40102321370", False),
+        ("40102321AB", False),
+        ("", False),
+    ],
+)
+def test_non_nhs_reason(match: str, expect_fp: bool):
+    """Mirror of ``TestNonNHSReason``: the value-only layer, i.e. what a ten-digit
+    run says about itself before any surrounding text is consulted.
+    """
+    assert bool(non_nhs_reason(match)) is expect_fp
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Patient NHS number 401 023 2137",
+        '{"nhsNumber": "4010232137"}',
+        "NHS_NUMBER=4010232137",
+        "the national health service record shows 4010232137",
+        "CHI number 1706349017 for the Scottish record",
+        "hospital number on file, id 4010232137",
+        # Unknown context is not evidence of anything.
+        "",
+    ],
+)
+def test_nhs_context_reason_keeps(text: str):
+    """Mirror of ``TestNHSContextReason``'s kept half."""
+    assert nhs_context_reason(text) == ""
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://acme.atlassian.net/wiki/spaces/ENG/pages/4010232137/Runbook",
+        '{"ts": 1706349017, "level": "info"}',
+        "order 4010232137 shipped",
+        "figma node 4010232137",
+    ],
+)
+def test_nhs_context_reason_suppresses(text: str):
+    """Mirror of ``TestNHSContextReason``'s suppressed half."""
+    assert nhs_context_reason(text) != ""
+
+
+def test_nhs_check_digit_matches_presidio():
+    """Mirror of ``TestNHSCheckDigitMatchesPresidio``: lock the reimplemented
+    mod-11 check to the one Presidio's ``NhsRecognizer`` runs.
+    """
+    valid = ("4010232137", "9434765919", "1706349017", "2481160193", "9999999999")
+    for digits in valid:
+        assert _nhs_check_digit_valid(digits), f"{digits} should pass"
+    invalid = ("4010232138", "0001234567", "6543210989", "1234567890", "3201234561")
+    for digits in invalid:
+        assert not _nhs_check_digit_valid(digits), f"{digits} should fail"
+
+
+def test_nhs_allocated_ranges_are_ordered_and_disjoint():
+    """Mirror of ``TestNHSAllocatedRangesAreOrderedAndDisjoint``: a low above its
+    high, or a pair of overlapping ranges, means someone mistyped a boundary.
+    """
+    for i, (low, high) in enumerate(NHS_ALLOCATED_RANGES):
+        assert low <= high, f"range {i} is inverted"
+        if i == 0:
+            continue
+        assert low > NHS_ALLOCATED_RANGES[i - 1][1], (
+            f"range {i} overlaps or backtracks on its predecessor"
+        )
+
+
+def test_nhs_suppresses_opaque_identifiers():
+    """Mirror of ``TestNHSSuppressesOpaqueIdentifiers``, the regression this
+    catalog exists for (AIS-494). Presidio reports any checksum-valid ten-digit
+    run as a UK NHS number at maximum confidence, so roughly one in eleven
+    Confluence page ids, Unix timestamps and order numbers surfaces as a
+    government/health identifier. Every one must now be classified as noise.
+    """
+    # Deterministic corpus, seeded so a failure is reproducible.
+    rng = random.Random(1)
+
+    checked = 0
+    for _ in range(20000):
+        identifier = f"{rng.randrange(1_000_000_000, 10_000_000_000):010d}"
+        if not _nhs_check_digit_valid(identifier):
+            continue  # Presidio would not have reported it in the first place.
+        checked += 1
+        text = f"https://acme.atlassian.net/wiki/spaces/ENG/pages/{identifier}/Runbook"
+        assert presidiofp.reason_in_context(ENTITY_TYPE_UK_NHS, identifier, text), (
+            f"opaque identifier {identifier} must not read as an NHS number"
+        )
+    assert checked > 0, "corpus produced no checksum-valid ids"
+
+
+def test_retired_recognizers():
+    """Mirror of ``TestRetiredRecognizers``: every finding from a retired
+    recognizer is noise regardless of its value, which is what lets the offline
+    sweep clear the rows stored before the live scanners started dropping them.
+    """
+    # The shapes AIS-494 reported: Figma file and node ids read as a driver
+    # license number to the upstream recognizer.
+    for match in ("N1234567", "K9182736450", "X12345678", ""):
+        assert presidiofp.reason("US_DRIVER_LICENSE", match), (
+            f"every US_DRIVER_LICENSE finding is retired noise, including {match!r}"
+        )
+
+    # Retirement is keyed on the entity, not the value: the same string under a
+    # live recognizer is judged on its merits.
+    assert presidiofp.reason("US_DRIVER_LICENSE_OTHER", "N1234567") == ""
+    assert list(RETIRED_RECOGNIZERS) == ["US_DRIVER_LICENSE"]
+
+    # Context cannot rescue it either, and the rule_id entry point agrees.
+    assert presidiofp.reason_in_context(
+        "US_DRIVER_LICENSE", "D1234567", "driver license D1234567"
+    )
+    assert presidiofp.reason_by_rule_id("pii.us_driver_license", "D1234567")

--- a/pystreams/tests/test_risk_scanner.py
+++ b/pystreams/tests/test_risk_scanner.py
@@ -7,6 +7,7 @@ import anyio
 import pytest
 
 from pystreams.risk import scanner as scanner_mod
+from pystreams.risk.presidiofp.retired import RETIRED_RECOGNIZERS
 from pystreams.risk.scanner import (
     Detection,
     ProcessPoolScanner,
@@ -178,6 +179,47 @@ async def test_us_driver_license_is_dropped():
     entity_types = {d.entity_type for d in detections}
     assert "US_DRIVER_LICENSE" not in entity_types
     assert entity_types == {"PERSON", "EMAIL_ADDRESS"}
+
+
+def test_retired_recognizers_match_scanner_drops():
+    """Keep the two halves of a retirement in agreement. The live scanner refuses
+    these entity types outright (``_FINDING_LEVEL_DROP``) while presidiofp
+    classifies their stored findings as false positives, which is what lets the
+    offline sweep clear the rows written before the live drop landed. A type in
+    one list and not the other means history and live behaviour have diverged.
+    """
+    assert set(RETIRED_RECOGNIZERS) == set(scanner_mod._FINDING_LEVEL_DROP)
+
+
+async def test_uk_nhs_needs_context():
+    """Regression for AIS-494. Presidio's ``NhsRecognizer`` validates a mod-11
+    check digit and, on success, reports the match at maximum confidence without
+    consulting its own context words — so roughly one in eleven Confluence page
+    ids, Unix timestamps and order numbers surfaced as a UK National Health
+    Service number. A ten-digit run now only survives when the payload carries a
+    health-care signal.
+    """
+    # A Confluence page id that happens to pass the check digit.
+    content = "see https://acme.atlassian.net/wiki/spaces/ENG/pages/4010232137/Runbook"
+    start = content.index("4010232137")
+    analyzer = FakeAnalyzer(
+        {content: [_Result("UK_NHS", start=start, end=start + 10, score=1.0)]}
+    )
+    assert await _scanner(analyzer).scan(content, None, 0.75) == [], (
+        "a ten-digit page id with no health-care context is not an NHS number"
+    )
+
+    # The same digits in a payload that talks about patients still report.
+    content = '{"patient": {"nhsNumber": "4010232137"}}'
+    start = content.index("4010232137")
+    analyzer = FakeAnalyzer(
+        {content: [_Result("UK_NHS", start=start, end=start + 10, score=1.0)]}
+    )
+    detections = await _scanner(analyzer).scan(content, None, 0.75)
+
+    assert len(detections) == 1, "an NHS number in health-care context still reports"
+    assert detections[0].entity_type == "UK_NHS"
+    assert detections[0].match == "4010232137"
 
 
 async def test_nothing_recognized_yields_no_detections():

--- a/server/cmd/tools/sweep_false_positives/main.go
+++ b/server/cmd/tools/sweep_false_positives/main.go
@@ -1,7 +1,16 @@
 // Command sweep_false_positives is an offline operator tool that re-evaluates
 // stored Presidio risk findings against the false-positive catalogs in the
 // internal/risk/presidiofp package and marks the noise (reserved IPs, placeholder emails,
-// ...) as false positives so the dashboard hides them.
+// retired recognizers, NHS numbers with no health-care context, ...) as false
+// positives so the dashboard hides them.
+//
+// Most catalogs judge the matched value alone, so a stored row carries
+// everything they need. The NHS catalog also has a context layer — a ten-digit
+// run is only an NHS number if the payload it came from mentions health care —
+// which the live scanners evaluate against the text they scan. To let history
+// reach the same verdict, the sweep re-reads the chat message a candidate row
+// was anchored to and hands that text to the same classifier. Pass
+// -message-context=false to skip the re-read and sweep on values alone.
 //
 // It is meant to be run rarely and by hand, against a production database
 // reached through a Cloud SQL Auth Proxy tunnel:
@@ -50,15 +59,16 @@ const (
 )
 
 type config struct {
-	dbURL     string
-	orgID     string
-	projectID uuid.UUID
-	policyID  uuid.NullUUID
-	from      time.Time
-	to        time.Time
-	cursor    uuid.UUID
-	batchSize int32
-	dryRun    bool
+	dbURL          string
+	orgID          string
+	projectID      uuid.UUID
+	policyID       uuid.NullUUID
+	from           time.Time
+	to             time.Time
+	cursor         uuid.UUID
+	batchSize      int32
+	dryRun         bool
+	messageContext bool
 }
 
 type report struct {
@@ -67,6 +77,12 @@ type report struct {
 	updated    int64
 	byReason   map[string]int64
 	lastCursor uuid.UUID
+
+	// contextRead counts rows the sweep re-read a message for; contextMissing
+	// counts rows a context rule could have judged but whose payload could not
+	// be recovered (content-part anchors, deleted messages).
+	contextRead    int64
+	contextMissing int64
 }
 
 func main() {
@@ -116,6 +132,7 @@ func parseFlags() (config, error) {
 		cursorStr = flag.String("cursor", "", "optional id to resume after (exclusive); overrides -from when set")
 		batchSize = flag.Int("batch-size", defaultBatchSize, "rows fetched and updated per page")
 		dryRun    = flag.Bool("dry-run", true, "when true (default) only report; pass -dry-run=false to write")
+		msgCtx    = flag.Bool("message-context", true, "re-read the anchoring chat message so catalogs that classify on surrounding text (NHS numbers) apply; pass -message-context=false for a value-only sweep")
 	)
 	flag.Parse()
 
@@ -123,6 +140,7 @@ func parseFlags() (config, error) {
 	cfg.dbURL = *dbURL
 	cfg.orgID = *orgID
 	cfg.dryRun = *dryRun
+	cfg.messageContext = *msgCtx
 
 	if cfg.dbURL == "" {
 		return cfg, errors.New("missing -db / $GRAM_DATABASE_URL")
@@ -180,8 +198,13 @@ func parseFlags() (config, error) {
 // selectPage walks risk_results in id order. It only fetches rows whose rule_id
 // has a false-positive catalog (presidiofp.RuleIDs) and that are still active
 // (found, not excluded, not already swept), within the id/time window.
+//
+// chat_message_id comes along for the context pass: rules like the NHS one need
+// the text the match was found in, which is re-read from the anchoring message
+// (see selectMessages). Rows anchored to a content part instead carry NULL and
+// simply never get a context verdict.
 const selectPage = `
-SELECT id, rule_id, match
+SELECT id, rule_id, match, chat_message_id
 FROM risk_results
 WHERE organization_id = $1
   AND project_id = $2
@@ -196,6 +219,26 @@ ORDER BY id
 LIMIT $7
 `
 
+// selectMessages re-reads the payload a finding was scanned in, for the
+// catalogs that classify on surrounding text rather than on the matched value.
+//
+// Both the message body and its tool calls are concatenated because a finding
+// can sit in either, and the context catalogs only ever suppress on the
+// *absence* of a signal — handing them more text can only keep more findings.
+// The per-column cap keeps a pathological message from dominating a page; the
+// prefix is far longer than any payload the scanner accepts.
+//
+// The project_id predicate is redundant — these ids came from risk_results rows
+// already scoped to the project — but it keeps the tool's "every read is tenant
+// scoped" property true of each statement on its own.
+const selectMessages = `
+SELECT id
+     , left(content, 262144) || ' ' || left(coalesce(tool_calls::text, ''), 262144)
+FROM chat_messages
+WHERE project_id = $1
+  AND id = ANY($2::uuid[])
+`
+
 // markBatch flags the accumulated false positives. The id/reason pairs arrive
 // as parallel arrays; the false_positive_at IS NULL recheck keeps it idempotent.
 const markBatch = `
@@ -207,12 +250,27 @@ WHERE r.id = t.id
   AND r.false_positive_at IS NULL
 `
 
+// candidate is a row that the value-only pass did not classify but whose rule
+// could still be resolved once the surrounding text is known.
+type candidate struct {
+	id        uuid.UUID
+	ruleID    string
+	match     string
+	messageID uuid.UUID
+}
+
 func sweep(ctx context.Context, pool *pgxpool.Pool, cfg config) (report, error) {
 	var rep report
 	rep.byReason = map[string]int64{}
 	rep.lastCursor = cfg.cursor
 
 	ruleIDs := presidiofp.RuleIDs()
+	contextRules := map[string]struct{}{}
+	if cfg.messageContext {
+		for _, id := range presidiofp.ContextRuleIDs() {
+			contextRules[id] = struct{}{}
+		}
+	}
 	upper := uuidv7.LowerBound(cfg.to)
 	cursor := cfg.cursor
 
@@ -233,17 +291,19 @@ func sweep(ctx context.Context, pool *pgxpool.Pool, cfg config) (report, error) 
 		}
 
 		var (
-			ids     []uuid.UUID
-			reasons []string
-			n       int
+			ids        []uuid.UUID
+			reasons    []string
+			candidates []candidate
+			n          int
 		)
 		for rows.Next() {
 			var (
-				id     uuid.UUID
-				ruleID string
-				match  *string
+				id        uuid.UUID
+				ruleID    string
+				match     *string
+				messageID uuid.NullUUID
 			)
-			if err := rows.Scan(&id, &ruleID, &match); err != nil {
+			if err := rows.Scan(&id, &ruleID, &match, &messageID); err != nil {
 				rows.Close()
 				return rep, fmt.Errorf("scan row: %w", err)
 			}
@@ -256,13 +316,52 @@ func sweep(ctx context.Context, pool *pgxpool.Pool, cfg config) (report, error) 
 				ids = append(ids, id)
 				reasons = append(reasons, reason)
 				rep.byReason[reason]++
+				continue
 			}
+			if _, needsContext := contextRules[ruleID]; !needsContext {
+				continue
+			}
+			if !messageID.Valid {
+				// Anchored to a content part, whose text lives in the asset
+				// store rather than a column. No context, no verdict.
+				rep.contextMissing++
+				continue
+			}
+			candidates = append(candidates, candidate{
+				id:        id,
+				ruleID:    ruleID,
+				match:     *match,
+				messageID: messageID.UUID,
+			})
 		}
 		if err := rows.Err(); err != nil {
 			rows.Close()
 			return rep, fmt.Errorf("iterate page: %w", err)
 		}
 		rows.Close()
+
+		if len(candidates) > 0 {
+			texts, err := loadMessageTexts(ctx, pool, cfg.projectID, candidates)
+			if err != nil {
+				return rep, fmt.Errorf("load message context for page ending at %s: %w", cursor, err)
+			}
+			for _, c := range candidates {
+				text, ok := texts[c.messageID]
+				if !ok {
+					// The message was deleted out from under the finding.
+					rep.contextMissing++
+					continue
+				}
+				rep.contextRead++
+				reason := presidiofp.ReasonByRuleIDInContext(c.ruleID, c.match, text)
+				if reason == "" {
+					continue
+				}
+				ids = append(ids, c.id)
+				reasons = append(reasons, reason)
+				rep.byReason[reason]++
+			}
+		}
 
 		rep.scanned += int64(n)
 		rep.flagged += int64(len(ids))
@@ -286,6 +385,44 @@ func sweep(ctx context.Context, pool *pgxpool.Pool, cfg config) (report, error) 
 	}
 }
 
+// loadMessageTexts re-reads the payloads the given candidates were scanned in,
+// keyed by message id. Several findings usually share one message, so the ids
+// are deduped before the query. A message that no longer exists is simply
+// absent from the result, and its candidates go unclassified.
+func loadMessageTexts(ctx context.Context, pool *pgxpool.Pool, projectID uuid.UUID, candidates []candidate) (map[uuid.UUID]string, error) {
+	seen := make(map[uuid.UUID]struct{}, len(candidates))
+	messageIDs := make([]uuid.UUID, 0, len(candidates))
+	for _, c := range candidates {
+		if _, dup := seen[c.messageID]; dup {
+			continue
+		}
+		seen[c.messageID] = struct{}{}
+		messageIDs = append(messageIDs, c.messageID)
+	}
+
+	rows, err := pool.Query(ctx, selectMessages, projectID, messageIDs)
+	if err != nil {
+		return nil, fmt.Errorf("select messages: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[uuid.UUID]string, len(messageIDs))
+	for rows.Next() {
+		var (
+			id   uuid.UUID
+			text string
+		)
+		if err := rows.Scan(&id, &text); err != nil {
+			return nil, fmt.Errorf("scan message: %w", err)
+		}
+		out[id] = text
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate messages: %w", err)
+	}
+	return out, nil
+}
+
 func printReport(cfg config, rep report) {
 	mode := "DRY RUN (no writes)"
 	if !cfg.dryRun {
@@ -302,9 +439,17 @@ func printReport(cfg config, rep report) {
 		fmt.Printf("  policy:      (all)\n")
 	}
 	fmt.Printf("  window:      %s .. %s\n", cfg.from.Format(time.RFC3339), cfg.to.Format(time.RFC3339))
+	if cfg.messageContext {
+		fmt.Printf("  context:     on (re-reads the anchoring message)\n")
+	} else {
+		fmt.Printf("  context:     off (value-only)\n")
+	}
 	fmt.Printf("  scanned:     %d\n", rep.scanned)
 	fmt.Printf("  flagged:     %d\n", rep.flagged)
 	fmt.Printf("  updated:     %d\n", rep.updated)
+	if rep.contextRead > 0 || rep.contextMissing > 0 {
+		fmt.Printf("  re-read:     %d judged with context, %d unrecoverable\n", rep.contextRead, rep.contextMissing)
+	}
 	fmt.Printf("  last cursor: %s\n", rep.lastCursor)
 
 	if len(rep.byReason) > 0 {

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -667,7 +667,7 @@ func convertPresidioFindings(text string, results []presidioResult) []scanners.F
 			continue
 		}
 
-		if isPresidioFalsePositive(r.EntityType, match) {
+		if isPresidioFalsePositive(r.EntityType, match, text) {
 			continue
 		}
 
@@ -699,9 +699,15 @@ func convertPresidioFindings(text string, results []presidioResult) []scanners.F
 // type is noise the policy author would not want surfaced. The catalogs and
 // dispatch live in the leaf package internal/risk/presidiofp so they can be
 // reused outside the scanner (e.g. the offline sweep that re-evaluates stored
-// findings); see presidiofp.Reason for the per-entity coverage.
-func isPresidioFalsePositive(entityType, match string) bool {
-	return presidiofp.Reason(entityType, match) != ""
+// findings); see presidiofp.ReasonInContext for the per-entity coverage.
+//
+// text is the payload the match came from. Most catalogs judge the match alone,
+// but some need it: a ten-digit run only reads as a UK NHS number when the
+// surrounding text talks about health care, because Presidio's recognizer pins
+// any checksum-valid run at maximum confidence without ever consulting its own
+// context words.
+func isPresidioFalsePositive(entityType, match, text string) bool {
+	return presidiofp.ReasonInContext(entityType, match, text) != ""
 }
 
 // computeRetryBackoff returns a full-jittered exponential backoff for the

--- a/server/internal/background/activities/risk_analysis/presidio_internal_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_internal_test.go
@@ -10,11 +10,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/speakeasy-api/gram/server/internal/risk/presidiofp"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,10 +82,67 @@ func TestIsFindingLevelDropped(t *testing.T) {
 	assert.False(t, isFindingLevelDropped(""))
 }
 
+// TestRetiredRecognizersMatchScannerDrops keeps the two halves of a retirement
+// in agreement. The live scanner refuses these entity types outright
+// (findingLevelDropEntities) while presidiofp classifies their stored findings
+// as false positives, which is what lets the offline sweep clear the rows
+// written before the live drop landed. A type in one list and not the other
+// means history and live behaviour have diverged.
+func TestRetiredRecognizersMatchScannerDrops(t *testing.T) {
+	t.Parallel()
+
+	retired := presidiofp.RetiredEntityTypes()
+	dropped := make([]string, 0, len(findingLevelDropEntities))
+	for entity := range findingLevelDropEntities {
+		dropped = append(dropped, entity)
+	}
+	sort.Strings(dropped)
+	assert.Equal(t, dropped, retired)
+}
+
+// TestConvertPresidioFindings_NHSNeedsContext is the regression test for
+// AIS-494. Presidio's NhsRecognizer validates a mod-11 check digit and, on
+// success, reports the match at maximum confidence without consulting its own
+// context words — so roughly one in eleven Confluence page ids, Unix timestamps
+// and order numbers surfaced as a UK National Health Service number. A
+// ten-digit run now only survives when the payload carries a health-care
+// signal.
+func TestConvertPresidioFindings_NHSNeedsContext(t *testing.T) {
+	t.Parallel()
+
+	nhsRuleID := scanners.GuardRuleID(prefixPII + "uk_nhs")
+
+	// A Confluence page id that happens to pass the check digit.
+	text := "see https://acme.atlassian.net/wiki/spaces/ENG/pages/4010232137/Runbook"
+	start := strings.Index(text, "4010232137")
+	findings := convertPresidioFindings(text, []presidioResult{
+		{EntityType: "UK_NHS", Start: start, End: start + 10, Score: 1},
+	})
+	assert.Empty(t, findings, "a ten-digit page id with no health-care context is not an NHS number")
+
+	// The same digits in a payload that talks about patients still report.
+	text = `{"patient": {"nhsNumber": "4010232137"}}`
+	start = strings.Index(text, "4010232137")
+	findings = convertPresidioFindings(text, []presidioResult{
+		{EntityType: "UK_NHS", Start: start, End: start + 10, Score: 1},
+	})
+	require.Len(t, findings, 1, "an NHS number in health-care context must still report")
+	assert.Equal(t, nhsRuleID, findings[0].RuleID)
+	assert.Equal(t, "4010232137", findings[0].Match)
+}
+
+// isValueFalsePositive is the value-only view of isPresidioFalsePositive, for
+// the catalogs below that judge a match on its own. Passing no context is
+// never grounds for suppression, so this only ever reports what the value
+// itself proves.
+func isValueFalsePositive(entityType, match string) bool {
+	return isPresidioFalsePositive(entityType, match, "")
+}
+
 // TestIsPresidioFalsePositive_CorpusAllFiltered is the canonical
 // positive-coverage gate: every IP in testdata/fp-ip.txt is an address
 // the catalog must drop. Each line is run through
-// isPresidioFalsePositive; any miss is a regression. The corpus is
+// isValueFalsePositive; any miss is a regression. The corpus is
 // hand-curated — extend it by adding IPs (one per line, sorted) that
 // surface as false positives during catalog tuning. Real residential
 // IPs (PII) are never added to the corpus or otherwise committed.
@@ -102,7 +161,7 @@ func TestIsPresidioFalsePositive_CorpusAllFiltered(t *testing.T) {
 		if ip == "" || strings.HasPrefix(ip, "#") {
 			continue
 		}
-		assert.True(t, isPresidioFalsePositive("IP_ADDRESS", ip),
+		assert.True(t, isValueFalsePositive("IP_ADDRESS", ip),
 			"corpus IP %q must be filtered", ip)
 		checked++
 	}
@@ -132,7 +191,7 @@ func TestIsPresidioFalsePositive_EmailCorpusAllFiltered(t *testing.T) {
 		if email == "" || strings.HasPrefix(email, "#") {
 			continue
 		}
-		assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", email),
+		assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", email),
 			"corpus email %q must be filtered", email)
 		checked++
 	}
@@ -149,21 +208,21 @@ func TestIsPresidioFalsePositive_NegativesAndEntityScope(t *testing.T) {
 	// Real addresses still flow through. Consumer ISP IPs identify an end
 	// user and are deliberately not in the infra ASN regex, so they are
 	// still treated as PII.
-	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "71.126.87.167"), "residential Verizon")
-	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "82.15.226.61"), "residential Virgin Media")
-	assert.False(t, isPresidioFalsePositive("IP_ADDRESS", "dead::beef"), "two-group IPv6 still real")
+	assert.False(t, isValueFalsePositive("IP_ADDRESS", "71.126.87.167"), "residential Verizon")
+	assert.False(t, isValueFalsePositive("IP_ADDRESS", "82.15.226.61"), "residential Virgin Media")
+	assert.False(t, isValueFalsePositive("IP_ADDRESS", "dead::beef"), "two-group IPv6 still real")
 
 	// Whitespace-trimming applies to the IP_ADDRESS path.
-	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "  ::  "), "trimmed unspecified")
+	assert.True(t, isValueFalsePositive("IP_ADDRESS", "  ::  "), "trimmed unspecified")
 
 	// IP-shaped inputs that happen to land in the EMAIL_ADDRESS lane
 	// fall through cleanly (neither shape matches an email rule).
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "::"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "8.8.8.8"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "::"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "8.8.8.8"))
 
 	// Unknown entity types are never filtered.
-	assert.False(t, isPresidioFalsePositive("PERSON", "ada@speakeasy.com"))
-	assert.False(t, isPresidioFalsePositive("", "8.8.8.8"))
+	assert.False(t, isValueFalsePositive("PERSON", "ada@speakeasy.com"))
+	assert.False(t, isValueFalsePositive("", "8.8.8.8"))
 }
 
 func TestIsPresidioFalsePositive_Email(t *testing.T) {
@@ -172,104 +231,104 @@ func TestIsPresidioFalsePositive_Email(t *testing.T) {
 	// Real-shape emails flow through, including the lower-confidence
 	// buckets we deliberately do NOT filter so we err on the side of
 	// over-reporting rather than missing PII.
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "adam@speakeasy.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "alice.brown@techstartup.io"), "generic Faker localpart on a real domain is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "chadrick_quigley52@yahoo.com"), "generic Faker localpart on a real domain is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "support@speakeasy.com"), "role alias is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "u003ealice@speakeasy.com"), "JSON-escape prefix is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "170madam@speakeasy.com"), "ANSI prefix is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "47043212+thierry-dang@users.noreply.github.com"), "github noreply is not filtered")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "git@github.com"), "ssh git pseudo-user is a known FP")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "GIT@github.com"), "case-insensitive")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "no-reply-0EWsEuUO0Gky10deUMh0Kg@mail.anthropic.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "private@privaterelay.appleid.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "BOT_TOKEN}@github.com"), "template placeholder without slash is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "npresidio|EMAIL_ADDRESS|1068|107331|walker@speakeasy.com"), "presidio log-row wrapper is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@acme.co.uk"), "placeholder SLD under an out-of-list TLD is not filtered")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@invalid.com"), "invalid.com is a real registered domain; only the .invalid TLD is RFC 6761 reserved")
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@localhost.com"), "localhost.com is a real registered domain; only the .localhost TLD is RFC 6761 reserved")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "adam@speakeasy.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "alice.brown@techstartup.io"), "generic Faker localpart on a real domain is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "chadrick_quigley52@yahoo.com"), "generic Faker localpart on a real domain is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "support@speakeasy.com"), "role alias is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "u003ealice@speakeasy.com"), "JSON-escape prefix is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "170madam@speakeasy.com"), "ANSI prefix is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "47043212+thierry-dang@users.noreply.github.com"), "github noreply is not filtered")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "git@github.com"), "ssh git pseudo-user is a known FP")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "GIT@github.com"), "case-insensitive")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "no-reply-0EWsEuUO0Gky10deUMh0Kg@mail.anthropic.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "private@privaterelay.appleid.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "BOT_TOKEN}@github.com"), "template placeholder without slash is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "npresidio|EMAIL_ADDRESS|1068|107331|walker@speakeasy.com"), "presidio log-row wrapper is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "user@acme.co.uk"), "placeholder SLD under an out-of-list TLD is not filtered")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "user@invalid.com"), "invalid.com is a real registered domain; only the .invalid TLD is RFC 6761 reserved")
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "user@localhost.com"), "localhost.com is a real registered domain; only the .localhost TLD is RFC 6761 reserved")
 
 	// Image file extensions mis-shaped as TLDs — Presidio sometimes
 	// extracts a bare asset filename when the leading URL prefix is
 	// stripped before the slash layer fires.
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "1f615@2x.png"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "icon@2x.SVG"), "case-insensitive")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "logo@retina.jpg"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "hero@2x.jpeg"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "spinner@2x.gif"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "1f615@2x.png"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "icon@2x.SVG"), "case-insensitive")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "logo@retina.jpg"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "hero@2x.jpeg"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "spinner@2x.gif"))
 
 	// RFC 6761 reserved special-use TLDs (.example, .invalid,
 	// .localhost, .test) are guaranteed not to resolve to a public
 	// mailbox, regardless of SLD or subdomain depth.
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@host.test"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@host.invalid"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@host.example"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@host.localhost"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "user@host.test"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "user@host.invalid"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "user@host.example"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "user@host.localhost"))
 
 	// Fixture / placeholder domains — the primary motivation for the
 	// filter. example.com / .org, asdf.com, fake.com, nowhere.com,
 	// yourorg.com, acme.com, acmecorp.com, etc., regardless of the
 	// local-part. Subdomain depth is irrelevant.
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "test@example.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "TEST@EXAMPLE.COM"), "case-insensitive")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@dev.example.com"), "subdomain depth doesn't matter")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "sibling-a135@test.example.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "SuperSecret123!@db.example.com"), "any local-part still filtered")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "asdf@asdf.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "fakey@fake.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "zzzunknown@nowhere.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "you@yourorg.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "alice@acme.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "alice@acme.io"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "john.smith@acmecorp.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "sarah.chen@acmestore.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user@test.com"), "test.com is technically real but every match in the production corpus is fixture noise")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "test@example.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "TEST@EXAMPLE.COM"), "case-insensitive")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "user@dev.example.com"), "subdomain depth doesn't matter")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "sibling-a135@test.example.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "SuperSecret123!@db.example.com"), "any local-part still filtered")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "asdf@asdf.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "fakey@fake.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "zzzunknown@nowhere.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "you@yourorg.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "alice@acme.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "alice@acme.io"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "john.smith@acmecorp.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "sarah.chen@acmestore.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "user@test.com"), "test.com is technically real but every match in the production corpus is fixture noise")
 
 	// KV / env / config wrappers are NOT filtered: they usually wrap
 	// real production emails, so dropping them would mask PII.
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "DB_USERNAME=adam@speakeasy.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "identity=adam@speakeasy.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "user=david@speakeasyapi.dev"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "smtp.mailfrom=mail@hgstrust.org"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "nCLAUDE_CODE_USER_EMAIL=ecorella@moonpay.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "DB_USERNAME=adam@speakeasy.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "identity=adam@speakeasy.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "user=david@speakeasyapi.dev"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "smtp.mailfrom=mail@hgstrust.org"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "nCLAUDE_CODE_USER_EMAIL=ecorella@moonpay.com"))
 
 	// GCP service accounts are NOT filtered: the `@…gserviceaccount.com`
 	// shape can carry IAM context worth flagging on first review, so we
 	// over-report rather than drop the bucket wholesale.
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "argocd-image-updater@moonpay-sre.iam.gserviceaccount.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "{project_number}@cloudbuild.gserviceaccount.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "argocd-image-updater@moonpay-sre.iam.gserviceaccount.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "{project_number}@cloudbuild.gserviceaccount.com"))
 
 	// Any '/' makes the string a URL or path, not an addr-spec.
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "medium.com/@abdelghani.alhijawi"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "mail.google.com/mail/u/adamjamesbull@googlemail.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "iam.googleapis.com/projects/-/serviceAccounts/privacy@moonpay-prod.iam.gserviceaccount.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "a.slack-edge.com/production-standard-emoji-assets/15.0/apple-medium/1f4a1@2x.png"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy@v1.37.6"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "honnef.co/go/tools/cmd/staticcheck@v0.7.0"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "cloud.google.com/go/storage@v1.62.1"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "deno.land/x/zod@v3.21.4"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "medium.com/@abdelghani.alhijawi"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "mail.google.com/mail/u/adamjamesbull@googlemail.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "iam.googleapis.com/projects/-/serviceAccounts/privacy@moonpay-prod.iam.gserviceaccount.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "a.slack-edge.com/production-standard-emoji-assets/15.0/apple-medium/1f4a1@2x.png"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy@v1.37.6"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "honnef.co/go/tools/cmd/staticcheck@v0.7.0"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "cloud.google.com/go/storage@v1.62.1"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "deno.land/x/zod@v3.21.4"))
 
 	// Domain ends in a digit → version suffix on a slashless path
 	// (TLDs are always letters per IANA).
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "go.opentelemetry.io/otel/sdk@v1.43.0"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "pkg@v1.2.3"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "react@18.3.1"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "go.opentelemetry.io/otel/sdk@v1.43.0"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "pkg@v1.2.3"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "react@18.3.1"))
 
 	// Template-style local-parts and universally automated aliases that
 	// can never identify a real person, even on real-shape domains.
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "first.last@company.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "First.Last@company.com"), "case-insensitive")
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "firstname.lastname@company.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "noreply@speakeasy.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "no-reply@speakeasy.com"))
-	assert.True(t, isPresidioFalsePositive("EMAIL_ADDRESS", "NoReply@somewhere.io"), "case-insensitive")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "first.last@company.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "First.Last@company.com"), "case-insensitive")
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "firstname.lastname@company.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "noreply@speakeasy.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "no-reply@speakeasy.com"))
+	assert.True(t, isValueFalsePositive("EMAIL_ADDRESS", "NoReply@somewhere.io"), "case-insensitive")
 
 	// Canonical placeholder person names are NOT filtered: real people
 	// share these names so we accept the corpus noise to avoid the
 	// over-filter risk.
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "john.doe@gmail.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "jane.doe@gmail.com"))
-	assert.False(t, isPresidioFalsePositive("EMAIL_ADDRESS", "joe.bloggs@somewhere.co.uk"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "john.doe@gmail.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "jane.doe@gmail.com"))
+	assert.False(t, isValueFalsePositive("EMAIL_ADDRESS", "joe.bloggs@somewhere.co.uk"))
 }
 
 // TestIsPresidioFalsePositive_EquivalentIPFormsMatch verifies that
@@ -281,12 +340,12 @@ func TestIsPresidioFalsePositive_EquivalentIPFormsMatch(t *testing.T) {
 	t.Parallel()
 
 	// Cloudflare 2606:4700:4700::1111 spelled with explicit zero groups.
-	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "2606:4700:4700:0:0:0:0:1111"), "compressed-zero variant")
-	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "2606:4700:4700:0000:0000:0000:0000:1111"), "fully-expanded variant")
+	assert.True(t, isValueFalsePositive("IP_ADDRESS", "2606:4700:4700:0:0:0:0:1111"), "compressed-zero variant")
+	assert.True(t, isValueFalsePositive("IP_ADDRESS", "2606:4700:4700:0000:0000:0000:0000:1111"), "fully-expanded variant")
 	// Google 2001:4860:4860::8888 with explicit zero groups.
-	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "2001:4860:4860:0:0:0:0:8888"), "Google DNS expanded")
+	assert.True(t, isValueFalsePositive("IP_ADDRESS", "2001:4860:4860:0:0:0:0:8888"), "Google DNS expanded")
 	// AdGuard 2a10:50c0::bad1:ff in uppercase hex.
-	assert.True(t, isPresidioFalsePositive("IP_ADDRESS", "2A10:50C0::BAD1:FF"), "uppercase hex variant")
+	assert.True(t, isValueFalsePositive("IP_ADDRESS", "2A10:50C0::BAD1:FF"), "uppercase hex variant")
 }
 
 func TestStubPIIScannerReturnsEmptyResults(t *testing.T) {

--- a/server/internal/risk/presidiofp/classify.go
+++ b/server/internal/risk/presidiofp/classify.go
@@ -1,9 +1,9 @@
 // Package presidiofp classifies Presidio PII findings as false positives. It
 // holds the per-entity false-positive catalogs (reserved/placeholder IPs and
-// emails, cloud/CDN ASN attribution) and the dispatch over them. It is a leaf
-// domain package with no Temporal or activity dependencies, so it can be reused
-// from the scanner, from offline tools, or anywhere a stored finding needs to
-// be re-evaluated.
+// emails, cloud/CDN ASN attribution, NHS number validity, retired recognizers)
+// and the dispatch over them. It is a leaf domain package with no Temporal or
+// activity dependencies, so it can be reused from the scanner, from offline
+// tools, or anywhere a stored finding needs to be re-evaluated.
 package presidiofp
 
 import "strings"
@@ -12,8 +12,10 @@ import "strings"
 type EntityType = string
 
 const (
-	EntityTypeEmailAddress EntityType = "EMAIL_ADDRESS"
-	EntityTypeIPAddress    EntityType = "IP_ADDRESS"
+	EntityTypeEmailAddress    EntityType = "EMAIL_ADDRESS"
+	EntityTypeIPAddress       EntityType = "IP_ADDRESS"
+	EntityTypeUKNHS           EntityType = "UK_NHS"
+	EntityTypeUSDriverLicense EntityType = "US_DRIVER_LICENSE"
 )
 
 // rulePrefix is the canonical rule_id prefix for Presidio PII findings. It
@@ -22,14 +24,33 @@ const (
 const rulePrefix = "pii."
 
 // Reason returns the catalog reason a Presidio match of the given entity type
-// is treated as noise, or "" when it is a real finding. Only IP_ADDRESS and
-// EMAIL_ADDRESS have catalogs today; other entity types always return "".
+// is treated as noise, or "" when it is a real finding. Entity types without a
+// catalog always return "".
+//
+// This is the value-only view: it judges the matched text on its own. Callers
+// that hold the text the match was found in should prefer ReasonInContext,
+// which additionally applies the catalogs that need surrounding text.
 func Reason(entityType, match string) string {
+	return ReasonInContext(entityType, match, "")
+}
+
+// ReasonInContext is Reason with the payload the match was found in. Passing an
+// empty text is equivalent to calling Reason: no finding is ever suppressed for
+// missing context, only for context that is present and carries no signal.
+func ReasonInContext(entityType, match, text string) string {
+	if reason := retiredReason(entityType); reason != "" {
+		return reason
+	}
 	switch entityType {
 	case EntityTypeIPAddress:
 		return nonPIIIPReason(strings.TrimSpace(match))
 	case EntityTypeEmailAddress:
 		return nonPIIEmailReason(match)
+	case EntityTypeUKNHS:
+		if reason := nonNHSReason(match); reason != "" {
+			return reason
+		}
+		return nhsContextReason(text)
 	default:
 		return ""
 	}
@@ -42,14 +63,33 @@ func ReasonByRuleID(ruleID, match string) string {
 	return Reason(entityTypeForRuleID(ruleID), match)
 }
 
+// ReasonByRuleIDInContext is ReasonInContext keyed by a stored finding's
+// canonical rule_id, for the offline sweep that re-reads the message a finding
+// was anchored to.
+func ReasonByRuleIDInContext(ruleID, match, text string) string {
+	return ReasonInContext(entityTypeForRuleID(ruleID), match, text)
+}
+
 // RuleIDs returns the canonical rule ids whose entity types have a catalog.
 // Callers re-scanning stored findings can use it to read only rows that could
-// possibly be reclassified. Keep in sync with the switch in Reason.
+// possibly be reclassified. Keep in sync with the switch in ReasonInContext.
 func RuleIDs() []string {
-	return []string{
+	ids := []string{
 		ruleIDForEntity(EntityTypeIPAddress),
 		ruleIDForEntity(EntityTypeEmailAddress),
+		ruleIDForEntity(EntityTypeUKNHS),
 	}
+	for _, entity := range RetiredEntityTypes() {
+		ids = append(ids, ruleIDForEntity(entity))
+	}
+	return ids
+}
+
+// ContextRuleIDs returns the subset of RuleIDs whose classification can change
+// once the surrounding text is supplied. The sweep uses it to decide which rows
+// are worth re-reading a message for.
+func ContextRuleIDs() []string {
+	return []string{ruleIDForEntity(EntityTypeUKNHS)}
 }
 
 // ruleIDForEntity maps a Presidio entity type to its canonical rule_id.

--- a/server/internal/risk/presidiofp/classify_test.go
+++ b/server/internal/risk/presidiofp/classify_test.go
@@ -30,14 +30,42 @@ func TestReason(t *testing.T) {
 	assert.NotEmpty(t, Reason(EntityTypeIPAddress, "10.0.0.1"), "RFC1918 IP")
 	assert.NotEmpty(t, Reason(EntityTypeIPAddress, "  ::  "), "trimmed unspecified IP")
 	assert.NotEmpty(t, Reason(EntityTypeEmailAddress, "noreply@example.com"), "placeholder email")
+	assert.NotEmpty(t, Reason(EntityTypeUKNHS, "9434765919"), "NHS number outside the issued ranges")
+	assert.NotEmpty(t, Reason(EntityTypeUSDriverLicense, "N1234567"), "retired recognizer")
 
 	assert.Empty(t, Reason(EntityTypeIPAddress, "71.126.87.167"), "residential IP")
 	assert.Empty(t, Reason(EntityTypeEmailAddress, "ada@speakeasy.com"), "real email")
+	assert.Empty(t, Reason(EntityTypeUKNHS, "401 023 2137"), "issued NHS number, no context supplied")
 
 	// Uncatalogued entity types never fire, even on a match another lane would
 	// flag.
 	assert.Empty(t, Reason("PERSON", "10.0.0.1"))
 	assert.Empty(t, Reason("", "10.0.0.1"))
+}
+
+// TestReasonInContext covers the layer that needs the payload a match came
+// from: an NHS-shaped run only survives when the text talks about health care,
+// and supplying context never resurrects a value the value-only layer rejected.
+func TestReasonInContext(t *testing.T) {
+	t.Parallel()
+
+	const nhs = "401 023 2137"
+
+	assert.Empty(t, ReasonInContext(EntityTypeUKNHS, nhs, "Patient NHS number "+nhs),
+		"issued number in health-care context")
+	assert.NotEmpty(t, ReasonInContext(EntityTypeUKNHS, nhs, "invoice reference "+nhs),
+		"issued number with no health-care signal")
+	assert.Empty(t, ReasonInContext(EntityTypeUKNHS, nhs, ""),
+		"empty text means context unknown, never suppress on it")
+
+	// The value-only verdict still wins: context cannot rescue a run that was
+	// never an NHS number.
+	assert.NotEmpty(t, ReasonInContext(EntityTypeUKNHS, "9434765919", "NHS number 9434765919"),
+		"unissued range, even in context")
+
+	// Catalogs that ignore context behave identically either way.
+	assert.NotEmpty(t, ReasonInContext(EntityTypeIPAddress, "10.0.0.1", "ping 10.0.0.1"))
+	assert.Empty(t, ReasonInContext(EntityTypeEmailAddress, "ada@speakeasy.com", "mail ada@speakeasy.com"))
 }
 
 // TestReasonByRuleID covers the rule_id-keyed entry point used to re-evaluate
@@ -47,8 +75,14 @@ func TestReasonByRuleID(t *testing.T) {
 
 	assert.NotEmpty(t, ReasonByRuleID("pii.ip_address", "10.0.0.1"), "RFC1918 IP")
 	assert.NotEmpty(t, ReasonByRuleID("pii.email_address", "noreply@example.com"), "placeholder email")
+	assert.NotEmpty(t, ReasonByRuleID("pii.us_driver_license", "N1234567"), "retired recognizer")
 
 	assert.Empty(t, ReasonByRuleID("pii.ip_address", "71.126.87.167"), "residential IP")
+
+	// The context-keyed entry point is what a sweep uses once it has re-read the
+	// message a stored finding was anchored to.
+	assert.NotEmpty(t, ReasonByRuleIDInContext("pii.uk_nhs", "4010232137", "confluence page 4010232137"))
+	assert.Empty(t, ReasonByRuleIDInContext("pii.uk_nhs", "4010232137", "NHS number 4010232137"))
 
 	// Rule ids without a catalog never fire, even when the match would match
 	// another lane's catalog.
@@ -58,7 +92,14 @@ func TestReasonByRuleID(t *testing.T) {
 
 	// RuleIDs advertises exactly the catalogued rule ids, and the grammar is
 	// invertible.
-	assert.Equal(t, []string{"pii.ip_address", "pii.email_address"}, RuleIDs())
+	assert.Equal(t, []string{
+		"pii.ip_address",
+		"pii.email_address",
+		"pii.uk_nhs",
+		"pii.us_driver_license",
+	}, RuleIDs())
+	assert.Equal(t, []string{"pii.uk_nhs"}, ContextRuleIDs())
+	assert.Subset(t, RuleIDs(), ContextRuleIDs(), "a context rule must also be scanned for")
 	assert.Equal(t, "IP_ADDRESS", entityTypeForRuleID("pii.ip_address"))
 	assert.Equal(t, "EMAIL_ADDRESS", entityTypeForRuleID("pii.email_address"))
 	assert.Empty(t, entityTypeForRuleID("secret.aws_access_key"))

--- a/server/internal/risk/presidiofp/nhs.go
+++ b/server/internal/risk/presidiofp/nhs.go
@@ -1,0 +1,180 @@
+package presidiofp
+
+import "strings"
+
+// nonNHSReason returns a short, human-readable reason why a UK_NHS match is a
+// false positive, or "" when the value could be a real NHS number.
+//
+// This layer sees only the matched value, so it can rule out digit runs that
+// are not valid NHS numbers at all. The much larger noise class — a perfectly
+// valid-looking 10-digit run that is really a Confluence page id, a Unix
+// timestamp, or an order number — is indistinguishable by value alone and is
+// handled by nhsContextReason instead.
+//
+// Why the value-only layer matters: Presidio's NhsRecognizer matches
+// `\b(\d{3})[- ]?(\d{3})[- ]?(\d{4})\b` and, when its mod-11 checksum passes,
+// PatternRecognizer raises the score to 1.0 with no context requirement. Any
+// 10-digit identifier therefore has a ~1-in-11 chance of being reported as a
+// UK National Health Service number at maximum confidence.
+//
+// Three checks, in order:
+//
+//  1. Shape. Anything that is not exactly ten digits after separators are
+//     stripped is left alone: it did not come from the NHS recognizer's own
+//     grammar, so this catalog has nothing to say about it.
+//  2. Check digit. NHS numbers carry a mod-11 check digit (the same validation
+//     the recognizer runs). A run that fails it is not an NHS number.
+//  3. Allocation range. NHS/CHI/H&C/IHI numbers are only issued from the
+//     ranges recorded in nhsAllocatedRanges. A checksum-valid run outside them
+//     was never issued to a patient.
+//
+// Deliberately NOT filtered here: repeated or sequential digit runs
+// (0000000000, 1234567890). They are placeholder-shaped, but they also fail
+// the check digit in almost every case, so a dedicated rule would be dead
+// weight, and the ones that do pass are cleared by the context layer.
+func nonNHSReason(match string) string {
+	digits := nhsDigits(match)
+	if len(digits) != 10 {
+		return ""
+	}
+	if !nhsCheckDigitValid(digits) {
+		return "fails the NHS number check digit"
+	}
+	if !nhsAllocated(digits) {
+		return "outside the allocated NHS number ranges"
+	}
+	return ""
+}
+
+// nhsContextReason reports a UK_NHS match as noise when the text it was found
+// in carries no NHS signal at all.
+//
+// The recognizer already ships CONTEXT words ("nhs", "national health
+// service", ...) but Presidio only uses them to *raise* a score, never to gate
+// a match, and a passing checksum pins the score at 1.0 before any context is
+// consulted. This inverts that: a ten-digit run in a payload that never
+// mentions health care anywhere is treated as an opaque identifier rather than
+// a patient number.
+//
+// text is the whole scanned payload (or, for the offline sweep, the whole
+// message the finding was anchored to), not a window around the match. A
+// window would be tighter, but the two callers cannot agree on offsets — the
+// sweep re-locates a stored match inside re-fetched text — and scanning
+// everything only ever keeps more findings, which is the safe direction.
+//
+// An empty text means "context unknown", and no finding is suppressed on that
+// basis.
+func nhsContextReason(text string) string {
+	if text == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	for _, term := range nhsContextTerms {
+		if strings.Contains(lower, term) {
+			return ""
+		}
+	}
+	return "ten-digit identifier with no NHS context in the surrounding text"
+}
+
+// nhsDigits strips the separators the NHS recognizer's own grammar allows
+// (spaces and hyphens, per its replacement_pairs) and returns the remaining
+// characters only when every one of them is a digit. Anything else returns ""
+// so callers treat the value as out of scope rather than mis-measuring it.
+func nhsDigits(match string) string {
+	var b strings.Builder
+	b.Grow(len(match))
+	for _, r := range strings.TrimSpace(match) {
+		switch {
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '-':
+			continue
+		default:
+			return ""
+		}
+	}
+	return b.String()
+}
+
+// nhsCheckDigitValid runs the NHS Digital mod-11 check: each of the ten digits
+// is weighted 10 down to 1 and the weighted sum must be divisible by 11. This
+// is the same validation Presidio's NhsRecognizer applies, reimplemented here
+// so a stored finding can be re-checked offline without calling the analyzer.
+func nhsCheckDigitValid(digits string) bool {
+	total := 0
+	for i, r := range digits {
+		total += int(r-'0') * (10 - i)
+	}
+	return total%11 == 0
+}
+
+// nhsRange is an inclusive range over the first nine digits of an NHS number
+// (the tenth is the check digit).
+type nhsRange struct {
+	low  int
+	high int
+}
+
+// nhsAllocatedRanges is the set of nine-digit prefixes that identify a real
+// person somewhere in the UK/Ireland numbering scheme. Everything outside them
+// has never been issued, so a checksum-valid run there is an unrelated
+// identifier that happens to validate.
+//
+// Sourced from the NHS Data Dictionary (HEALTH AND CARE NUMBER), NHS England's
+// NHS-number guidance and the UK FCI NHS number range table:
+//
+//	010 000 000 - 319 999 999  Scotland (CHI numbers, DDMMYY-prefixed)
+//	320 000 000 - 399 999 999  Northern Ireland (Health & Care numbers)
+//	400 000 000 - 499 999 999  England, Wales, Isle of Man
+//	600 000 000 - 799 999 999  England, Wales, Isle of Man
+//	800 000 000 - 859 999 999  Republic of Ireland (IHI)
+//
+// Two gaps are deliberate. 000 000 000 - 009 999 999 is unissued, and it is
+// where zero-padded internal ids land. 860 000 000 - 999 999 999 is unissued
+// too; it contains NHS England's 999-prefixed test range, which is valid by
+// checksum but reserved so it can never belong to a patient.
+var nhsAllocatedRanges = []nhsRange{
+	{low: 10000000, high: 319999999},
+	{low: 320000000, high: 399999999},
+	{low: 400000000, high: 499999999},
+	{low: 600000000, high: 799999999},
+	{low: 800000000, high: 859999999},
+}
+
+// nhsAllocated reports whether the ten-digit run's leading nine digits fall in
+// an issued range.
+func nhsAllocated(digits string) bool {
+	prefix := 0
+	for _, r := range digits[:9] {
+		prefix = prefix*10 + int(r-'0')
+	}
+	for _, rng := range nhsAllocatedRanges {
+		if prefix >= rng.low && prefix <= rng.high {
+			return true
+		}
+	}
+	return false
+}
+
+// nhsContextTerms are the lowercased substrings that count as NHS signal in the
+// surrounding text. The list starts from the recognizer's own CONTEXT words and
+// adds the sibling schemes that share the ten-digit format, so a Scottish CHI
+// or Northern Irish Health & Care number is not suppressed for lacking the
+// letters "nhs".
+//
+// Substring matching is intentional: "nhs" also fires inside "nhsNumber" and
+// "NHS_NUMBER", the shapes these values take in JSON payloads and column names,
+// which a word-boundary match would miss.
+var nhsContextTerms = []string{
+	"nhs",
+	"national health service",
+	"health service",
+	"health authority",
+	"health and care number",
+	"health & care number",
+	"chi number",
+	"patient",
+	"medical record",
+	"hospital number",
+}

--- a/server/internal/risk/presidiofp/nhs_test.go
+++ b/server/internal/risk/presidiofp/nhs_test.go
@@ -1,0 +1,147 @@
+package presidiofp
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNonNHSReason covers the value-only layer: what a ten-digit run says about
+// itself, before any surrounding text is consulted.
+func TestNonNHSReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		match  string
+		expect bool // true when the value alone proves it is not an NHS number
+	}{
+		// Issued ranges, valid check digit: this layer must let them through.
+		{name: "england separated", match: "401 023 2137", expect: false},
+		{name: "england hyphenated", match: "401-023-2137", expect: false},
+		{name: "england bare", match: "4010232137", expect: false},
+		{name: "wales range", match: "6543210982", expect: false},
+		{name: "scotland chi range", match: "1706349017", expect: false},
+		{name: "northern ireland range", match: "3201234567", expect: false},
+
+		// Never issued to anyone.
+		{name: "nhs england test range", match: "9999999999", expect: true},
+		{name: "unallocated above 859", match: "9434765919", expect: true},
+		{name: "zero padded internal id", match: "0000000000", expect: true},
+
+		// Not an NHS number at all.
+		{name: "check digit fails", match: "4010232138", expect: true},
+
+		// Out of this catalog's scope: the recognizer only ever emits
+		// ten-digit runs, so anything else is left for another lane.
+		{name: "too short", match: "40102321", expect: false},
+		{name: "too long", match: "40102321370", expect: false},
+		{name: "not digits", match: "40102321AB", expect: false},
+		{name: "empty", match: "", expect: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			reason := nonNHSReason(tt.match)
+			if tt.expect {
+				assert.NotEmpty(t, reason)
+				return
+			}
+			assert.Empty(t, reason)
+		})
+	}
+}
+
+// TestNHSContextReason covers the layer that reads the payload the match came
+// from. Presidio's recognizer ships these context words but only lets them
+// raise a score, so this is where they become a requirement.
+func TestNHSContextReason(t *testing.T) {
+	t.Parallel()
+
+	kept := []string{
+		"Patient NHS number 401 023 2137",
+		`{"nhsNumber": "4010232137"}`,
+		"NHS_NUMBER=4010232137",
+		"the national health service record shows 4010232137",
+		"CHI number 1706349017 for the Scottish record",
+		"hospital number on file, id 4010232137",
+	}
+	for _, text := range kept {
+		assert.Emptyf(t, nhsContextReason(text), "should keep: %q", text)
+	}
+
+	suppressed := []string{
+		"https://acme.atlassian.net/wiki/spaces/ENG/pages/4010232137/Runbook",
+		`{"ts": 1706349017, "level": "info"}`,
+		"order 4010232137 shipped",
+		"figma node 4010232137",
+	}
+	for _, text := range suppressed {
+		assert.NotEmptyf(t, nhsContextReason(text), "should suppress: %q", text)
+	}
+
+	// Unknown context is not evidence of anything.
+	assert.Empty(t, nhsContextReason(""))
+}
+
+// TestNHSCheckDigitMatchesPresidio locks our reimplementation of the mod-11
+// check to the one Presidio's NhsRecognizer runs (weights ten down to one, sum
+// divisible by eleven). Vectors are the ones exercised elsewhere in this
+// package, verified against the analyzer itself.
+func TestNHSCheckDigitMatchesPresidio(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"4010232137", "9434765919", "1706349017", "2481160193", "9999999999"}
+	for _, digits := range valid {
+		assert.Truef(t, nhsCheckDigitValid(digits), "%s should pass", digits)
+	}
+	invalid := []string{"4010232138", "0001234567", "6543210989", "1234567890", "3201234561"}
+	for _, digits := range invalid {
+		assert.Falsef(t, nhsCheckDigitValid(digits), "%s should fail", digits)
+	}
+}
+
+// TestNHSAllocatedRangesAreOrderedAndDisjoint keeps the range table honest: a
+// low above its high, or a pair of overlapping ranges, would mean someone
+// mistyped a boundary while editing it.
+func TestNHSAllocatedRangesAreOrderedAndDisjoint(t *testing.T) {
+	t.Parallel()
+
+	for i, rng := range nhsAllocatedRanges {
+		require.LessOrEqualf(t, rng.low, rng.high, "range %d is inverted", i)
+		if i == 0 {
+			continue
+		}
+		assert.Greaterf(t, rng.low, nhsAllocatedRanges[i-1].high,
+			"range %d overlaps or backtracks on its predecessor", i)
+	}
+}
+
+// TestNHSSuppressesOpaqueIdentifiers is the regression this catalog exists for
+// (AIS-494). Presidio reports any checksum-valid ten-digit run as a UK NHS
+// number at maximum confidence, so roughly one in eleven Confluence page ids,
+// Unix timestamps and order numbers surfaces as a government/health identifier.
+// Every one of them must now be classified as noise.
+func TestNHSSuppressesOpaqueIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	// Deterministic corpus, seeded so a failure is reproducible.
+	rng := rand.New(rand.NewPCG(1, 2))
+
+	var checked int
+	for range 20000 {
+		id := fmt.Sprintf("%010d", rng.IntN(9_000_000_000)+1_000_000_000)
+		if !nhsCheckDigitValid(id) {
+			continue // Presidio would not have reported it in the first place.
+		}
+		checked++
+		text := "https://acme.atlassian.net/wiki/spaces/ENG/pages/" + id + "/Runbook"
+		assert.NotEmptyf(t, ReasonInContext(EntityTypeUKNHS, id, text),
+			"opaque identifier %s must not read as an NHS number", id)
+	}
+	require.Positive(t, checked, "corpus produced no checksum-valid ids")
+}

--- a/server/internal/risk/presidiofp/retired.go
+++ b/server/internal/risk/presidiofp/retired.go
@@ -1,0 +1,44 @@
+package presidiofp
+
+import "slices"
+
+// retiredRecognizers are Presidio entity types whose recognizer produces noise
+// at a rate that makes every one of its findings untrustworthy, so the scanners
+// drop them outright rather than filtering value by value.
+//
+// The live scanners already refuse these before this package is consulted (see
+// findingLevelDropEntities in the risk_analysis package and _FINDING_LEVEL_DROP
+// in the pystreams scanner). Listing them here as well is what lets the offline
+// sweep reconcile history with that decision: findings stored before the live
+// drop landed are still sitting in risk_results, and a value-only catalog entry
+// is what marks them as false positives.
+//
+// TestRetiredRecognizersMatchScannerDrops in the risk_analysis package keeps
+// this map and the live drop set in agreement.
+var retiredRecognizers = map[EntityType]string{
+	// Its patterns match a leading letter followed by a run of digits — the
+	// shape of Figma file and node ids, short object ids, and countless other
+	// opaque identifiers — at a score that any nearby "id", "number", "card"
+	// or "lic" lemma (including the ones inside "public" and "duplicate")
+	// lifts over the reporting threshold. Upstream has known about it since
+	// 2023: microsoft/presidio#1063.
+	EntityTypeUSDriverLicense: "US driver license recognizer retired: matches arbitrary letter-and-digit identifiers",
+}
+
+// retiredReason returns the retirement reason for an entity type, or "" when
+// the recognizer is still trusted.
+func retiredReason(entityType EntityType) string {
+	return retiredRecognizers[entityType]
+}
+
+// RetiredEntityTypes returns, in a stable order, the entity types whose
+// findings are always classified as false positives. Exported for the
+// cross-package test that locks this set to the scanners' own drop list.
+func RetiredEntityTypes() []EntityType {
+	out := make([]EntityType, 0, len(retiredRecognizers))
+	for entity := range retiredRecognizers {
+		out = append(out, entity)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/server/internal/risk/presidiofp/retired_test.go
+++ b/server/internal/risk/presidiofp/retired_test.go
@@ -1,0 +1,27 @@
+package presidiofp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRetiredRecognizers covers the blanket classification: every finding from
+// a retired recognizer is noise regardless of its value, which is what lets the
+// offline sweep clear the rows stored before the live scanners started dropping
+// them.
+func TestRetiredRecognizers(t *testing.T) {
+	t.Parallel()
+
+	// The shapes AIS-494 reported: Figma file and node ids read as a driver
+	// license number to the upstream recognizer.
+	for _, match := range []string{"N1234567", "K9182736450", "X12345678", ""} {
+		assert.NotEmptyf(t, Reason(EntityTypeUSDriverLicense, match),
+			"every US_DRIVER_LICENSE finding is retired noise, including %q", match)
+	}
+
+	// Retirement is keyed on the entity, not the value: the same string under a
+	// live recognizer is judged on its merits.
+	assert.Empty(t, Reason(EntityTypeUSDriverLicense+"_OTHER", "N1234567"))
+	assert.Equal(t, []EntityType{EntityTypeUSDriverLicense}, RetiredEntityTypes())
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A customer reports the government-identifiers and HIPAA policies firing on Figma file ids and Confluence doc ids, which is keeping them in flag-only mode. I reproduced both against the analyzer we actually run and found two distinct causes.

**UK NHS numbers (the Confluence doc ids).** Presidio's `NhsRecognizer` matches `\b(\d{3})[- ]?(\d{3})[- ]?(\d{4})\b` and, when its mod-11 checksum passes, `PatternRecognizer` sets the score to `MAX_SCORE` **before any context enhancement runs**. Any ten-digit identifier therefore has a ~1-in-11 chance of being reported as a UK National Health Service number at maximum confidence. Confluence page ids, Unix timestamps and order numbers are all ten digits.

Reproduced against the running analyzer:

```
$ curl -s localhost:5050/analyze -d '{"text":"see https://acme.atlassian.net/wiki/spaces/ENG/pages/4010232137/Runbook","language":"en"}'
[{"entity_type": "UK_NHS", "score": 1.0, "start": 53, "end": 63}, ...]
```

**Figma file ids.** These were `US_DRIVER_LICENSE`, whose recognizer matches a leading letter followed by a run of digits (upstream microsoft/presidio#1063). The live scanners already drop it (AIS-158), so this is no longer a live problem — but the findings written before that drop are still in `risk_results`, which is why the customer still sees them.

### On the "outdated version" hypothesis

The issue suggests we may be running an outdated detector and that NHS numbers are already excluded upstream. Neither holds. We run `presidio-analyzer` 2.2.362; the latest is 2.2.364, and I diffed the recognizer out of the 2.2.364 wheel — the pattern, the context words and the checksum-only `validate_result` are **byte-identical**. Upstream does ship `CONTEXT` words for `UK_NHS`, but Presidio only ever uses context to *raise* a score, never to gate a match, and the checksum has already saturated the score before context is consulted. Upgrading would not have fixed this.

## What changed

A `UK_NHS` catalog in `internal/risk/presidiofp` with two layers:

- **Value-only** — rules out runs that are not NHS numbers at all: a failing check digit, or a nine-digit prefix outside the ranges the UK/Ireland schemes actually issue from. That covers zero-padded internal ids and NHS England's reserved `999` test range.
- **Context** — requires the payload to carry a health-care signal. A checksum-valid run is genuinely indistinguishable from a Confluence page id by value alone, so this layer does the heavy lifting. Terms cover the sibling schemes too (Scottish CHI, Northern Irish Health & Care), and an *absent* payload never suppresses anything.

Both live scanner paths (Go `risk_analysis`, Python `pystreams`) now hand the classifier the text they scanned, and `US_DRIVER_LICENSE` is recorded as a retired recognizer so its stored findings are classifiable.

For the backfill, `sweep_false_positives` re-reads the chat message a candidate row was anchored to and runs the same classifier, so history reaches the same verdict as everything scanned from now on. Rows anchored to a content part, or whose message has since been deleted, are reported as unrecoverable rather than guessed at.

## Testing

Unit and lint:

- `go test ./server/internal/risk/... ./server/internal/background/activities/risk_analysis/... ./server/internal/scanners/...` — all pass
- `mise run test:pystreams` (154 passed), `mise run lint:pystreams`, `mise run lint:server`
- A 20k-identifier randomized corpus asserts every checksum-valid ten-digit run in a Confluence-URL payload is classified as noise, in both Go and Python.
- A cross-package invariant test keeps the live scanner's drop list and the retired-recognizer catalog from drifting apart.

End-to-end against the real analyzer — a corpus of realistic payloads through Presidio, then through the catalogs:

```
SAMPLE                    ENTITY               SCORE  VERDICT   REASON
confluence page url       UK_NHS               1.00   filtered  ten-digit identifier with no NHS context in the surrounding text
figma node id             UK_NHS               1.00   filtered  ten-digit identifier with no NHS context in the surrounding text
unix timestamp json       UK_NHS               1.00   filtered  ten-digit identifier with no NHS context in the surrounding text
order number              UK_NHS               1.00   filtered  ten-digit identifier with no NHS context in the surrounding text
zero padded internal id   UK_NHS               1.00   filtered  outside the allocated NHS number ranges
figma id near license     US_DRIVER_LICENSE    0.65   filtered  US driver license recognizer retired: ...
nhs number labelled       UK_NHS               1.00   REPORTS
nhs number json           UK_NHS               1.00   REPORTS
scottish chi              UK_NHS               1.00   REPORTS
us ssn                    US_SSN               0.85   REPORTS

false positives from the analyzer: 9 -> 0 after filtering
real identifiers from the analyzer: 5 -> 5 after filtering
```

End-to-end backfill against a local database, seeded with the reported shapes plus real identifiers as a control. Dry run and apply both flag exactly the 7 false positives; a re-run flags 0 (idempotent); clearing the two columns restores all rows (reversible); `-message-context=false` falls back to the 2 the value alone proves.

Before — every one of these is a Confluence page id, Figma id, timestamp or order number reported under **Government Identifiers**:

![Risk Events before the sweep, showing government-identifier findings on opaque ids](https://cursor.com/artifacts/c/art-c20f07a7-d863-4c2c-ada7-29d96213bd85)

After — 615 to 608 findings, and the only government identifiers left are the three genuine ones (a real SSN, a real NHS number in patient context, and a Scottish CHI number):

![Risk Events after the sweep, with only genuine identifiers remaining](https://cursor.com/artifacts/c/art-25bb9e5b-584b-4016-b4aa-60fb44724f77)

The swept rows are hidden, not deleted — they remain auditable and reversible on the False Positives tab:

![False Positives tab listing the seven swept findings](https://cursor.com/artifacts/c/art-92af53b3-9633-4a95-be96-b519d12a0be9)

Refs AIS-494
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-494](https://linear.app/speakeasy/issue/AIS-494/investigate-government-identifiers-detector-false-positives-and)

<div><a href="https://cursor.com/agents/bc-3e797e37-dfb4-4f90-b9e8-7164e3262d4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e797e37-dfb4-4f90-b9e8-7164e3262d4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UK NHS false positives by requiring health-care context and valid allocation ranges, and retires noisy `US_DRIVER_LICENSE`. This reduces false alarms in government-identifiers and HIPAA policies so teams can move off flag-only mode. Addresses AIS-494.

- Bug Fixes
  - Add `UK_NHS` catalog with two layers: value checks (mod-11 digit, issued ranges) and context checks (must mention health care).
  - Pass the full scanned text to the classifier in Go (`risk_analysis`) and Python (`pystreams`) so context rules apply.
  - Retire `US_DRIVER_LICENSE`: scanners drop it; stored findings are classified as false positives; tests keep drop lists in sync.
  - Add context-aware APIs (`ReasonInContext`/`reason_in_context`, `ContextRuleIDs`) and parity tests; randomized corpus proves Confluence-like IDs are suppressed.

- Migration
  - Run `sweep_false_positives` (default `-message-context=true`) to re-read anchoring messages and reclassify history; rows without recoverable context are reported, not guessed.
  - No app changes needed; live scanners already apply the new rules.

<sup>Written for commit 1afc17709215e7ebeb8ae9c9ea01be891be11700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

