### PR TITLE
feat: move Access Requests onto the Shadow MCP page

### DIFF
--- a/client/dashboard/src/components/mcp-approvals/ApprovalQueue.tsx
+++ b/client/dashboard/src/components/mcp-approvals/ApprovalQueue.tsx
@@ -153,7 +153,7 @@ export function ApprovalQueue(): JSX.Element {
         data={requests}
         rowKey={(row) => row.id}
         onRowClick={(row) =>
-          void navigate(routes.mcp.approvalRequest.href(row.id))
+          void navigate(routes.shadowMCP.request.href(row.id))
         }
         noResultsMessage={<span>No matching requests.</span>}
       />

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -79,18 +79,17 @@ const breadcrumbSubstitutions = {
   "api-keys": "API Keys",
   "mdm-integrations": "MDM Integrations",
   rbac: "RBAC Override",
-  "mcp-approvals": "mcp-approvals",
   jamf: "Jamf Pro",
   slack: "Assistants",
 };
 
 // Segments that appear in crumb trails but are not routable pages themselves.
 // Their crumb links to the surface that owns them instead of a dead path —
-// e.g. MCP access requests render as a tab on the MCP page, so the
-// mcp-approvals segment (present only in request-detail URLs) points at that
-// tab rather than at a 404.
+// e.g. MCP access requests render as a tab on the Shadow MCP page, so the
+// requests segment (present only in request-detail URLs) points at that tab
+// rather than at a 404.
 const breadcrumbUrlSubstitutions: Record<string, string> = {
-  "/mcp/mcp-approvals": "/mcp?tab=requests",
+  "/shadow-mcp/requests": "/shadow-mcp?tab=requests",
 };
 
 // One rendered crumb. Pending crumbs (substitution key present, value not yet

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -5,15 +5,7 @@ import { MCPCard, MCPCardSkeleton } from "@/components/mcp/MCPCard";
 import { MCPServerCard } from "@/components/mcp/MCPServerCard";
 import { MCPServerTableRow } from "@/components/mcp/MCPServerTableRow";
 import { MCPTableRow, MCPTableRowSkeleton } from "@/components/mcp/MCPTableRow";
-import { ApprovalQueue } from "@/components/mcp-approvals/ApprovalQueue";
 import { Page } from "@/components/page-layout";
-import { ReleaseStageBadge } from "@/components/release-stage-badge";
-import {
-  PageTabsList,
-  PageTabsTrigger,
-  Tabs,
-  TabsContent,
-} from "@/components/ui/Tabs";
 import { DotTable } from "@/components/ui/DotTable";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { Text } from "@/components/ui/Text";
@@ -34,7 +26,7 @@ import { Button } from "@/components/ui/Button";
 import { Icon } from "@/components/ui/Icon";
 import { Plus } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Outlet, useSearchParams } from "react-router";
+import { Outlet } from "react-router";
 import { toast } from "sonner";
 import { useToolsets } from "../toolsets/useToolsets";
 import { MCPEmptyState } from "./MCPEmptyState";
@@ -87,77 +79,17 @@ export function MCPRoot(): JSX.Element {
   return <Outlet />;
 }
 
-const MCP_TAB_PARAM = "tab";
-
 export const MCPPage = (): JSX.Element => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const activeTab =
-    searchParams.get(MCP_TAB_PARAM) === "requests" ? "requests" : "servers";
-
-  const selectTab = (value: string) => {
-    setSearchParams(
-      (params) => {
-        if (value === "requests") {
-          params.set(MCP_TAB_PARAM, "requests");
-        } else {
-          params.delete(MCP_TAB_PARAM);
-        }
-        return params;
-      },
-      { replace: true },
-    );
-  };
-
   return (
     <Page>
       <Page.Header>
         <Page.Header.Breadcrumbs />
       </Page.Header>
-      {/* The tab views live in TabsContent inside the same Tabs root as the
-          triggers, so assistive tech gets the trigger→panel association. */}
-      <Tabs
-        value={activeTab}
-        onValueChange={selectTab}
-        className="flex min-h-0 flex-1 flex-col"
-      >
-        <div className="border-border shrink-0 border-b px-8">
-          <PageTabsList className="h-auto gap-6 bg-transparent p-0">
-            <PageTabsTrigger value="servers">Servers</PageTabsTrigger>
-            <PageTabsTrigger value="requests">
-              <span className="inline-flex items-center gap-2">
-                Access Requests
-                <ReleaseStageBadge stage="preview" noTooltip />
-              </span>
-            </PageTabsTrigger>
-          </PageTabsList>
-        </div>
-        <Page.Body>
-          <TabsContent value="servers">
-            <RequireScope scope={["mcp:read", "mcp:write"]} level="page">
-              <MCPOverview />
-            </RequireScope>
-          </TabsContent>
-          <TabsContent value="requests">
-            <RequireScope scope="mcp_approval:read" level="page">
-              <Page.Section>
-                {/* area="" — the MCP area eyebrow already sits over the page
-                    via the tab strip; repeating it under a secondary heading
-                    reads as a stutter. */}
-                <Page.Section.Title area="">
-                  MCP Access Requests
-                </Page.Section.Title>
-                <Page.Section.Description>
-                  Your team's requests to use MCP servers. Evidence is gathered
-                  for each request — the decision stays yours.
-                </Page.Section.Description>
-                <Page.Section.Body>
-                  <ApprovalQueue />
-                </Page.Section.Body>
-              </Page.Section>
-            </RequireScope>
-          </TabsContent>
-        </Page.Body>
-      </Tabs>
+      <Page.Body>
+        <RequireScope scope={["mcp:read", "mcp:write"]} level="page">
+          <MCPOverview />
+        </RequireScope>
+      </Page.Body>
     </Page>
   );
 };

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
@@ -1,4 +1,6 @@
+import { ApprovalQueue } from "@/components/mcp-approvals/ApprovalQueue";
 import { Page } from "@/components/page-layout";
+import { ReleaseStageBadge } from "@/components/release-stage-badge";
 import { RequireScope } from "@/components/require-scope";
 import type { ShadowMCPPolicy } from "@/components/shadow-mcp/ShadowMCPInventoryActions";
 import { ShadowMCPInventoryTable } from "@/components/shadow-mcp/ShadowMCPInventoryTable";
@@ -9,12 +11,18 @@ import {
   shadowMCPPolicyState,
 } from "@/components/shadow-mcp/shadowMCPInventoryStatus";
 import { SkeletonTable } from "@/components/ui/Skeleton";
+import {
+  PageTabsList,
+  PageTabsTrigger,
+  Tabs,
+  TabsContent,
+} from "@/components/ui/Tabs";
 import { useProject } from "@/contexts/Auth";
 import { useRoutes } from "@/routes";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useRiskListPolicies } from "@gram/client/react-query/riskListPolicies.js";
 import { useRoles } from "@gram/client/react-query/roles.js";
-import { Outlet } from "react-router";
+import { Outlet, useSearchParams } from "react-router";
 
 export function ShadowMCPRoot(): JSX.Element {
   return <Outlet />;
@@ -32,8 +40,87 @@ function ShadowMCPLoadingState(): JSX.Element {
   );
 }
 
+const SHADOW_MCP_TAB_PARAM = "tab";
+
 export default function ShadowMCP(): JSX.Element {
   const pageTitle = "Shadow MCP";
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab =
+    searchParams.get(SHADOW_MCP_TAB_PARAM) === "requests"
+      ? "requests"
+      : "inventory";
+
+  const selectTab = (value: string) => {
+    setSearchParams(
+      (params) => {
+        if (value === "requests") {
+          params.set(SHADOW_MCP_TAB_PARAM, "requests");
+        } else {
+          params.delete(SHADOW_MCP_TAB_PARAM);
+        }
+        return params;
+      },
+      { replace: true },
+    );
+  };
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Breadcrumbs
+          substitutions={{ ["shadow-mcp"]: pageTitle }}
+        />
+      </Page.Header>
+      {/* The tab views live in TabsContent inside the same Tabs root as the
+          triggers, so assistive tech gets the trigger→panel association. */}
+      <Tabs
+        value={activeTab}
+        onValueChange={selectTab}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <div className="border-border shrink-0 border-b px-8">
+          <PageTabsList className="h-auto gap-6 bg-transparent p-0">
+            <PageTabsTrigger value="inventory">Inventory</PageTabsTrigger>
+            <PageTabsTrigger value="requests">
+              <span className="inline-flex items-center gap-2">
+                Access Requests
+                <ReleaseStageBadge stage="preview" noTooltip />
+              </span>
+            </PageTabsTrigger>
+          </PageTabsList>
+        </div>
+        <Page.Body fullHeight className="pb-8">
+          <TabsContent value="inventory">
+            <RequireScope scope="org:admin" level="page">
+              <ShadowMCPInventory pageTitle={pageTitle} />
+            </RequireScope>
+          </TabsContent>
+          <TabsContent value="requests">
+            <RequireScope scope="mcp_approval:read" level="page">
+              <Page.Section>
+                {/* area="" — the Secure area eyebrow already sits over the
+                    page via the tab strip; repeating it under a secondary
+                    heading reads as a stutter. */}
+                <Page.Section.Title area="">
+                  MCP Access Requests
+                </Page.Section.Title>
+                <Page.Section.Description>
+                  Your team's requests to use MCP servers. Evidence is gathered
+                  for each request — the decision stays yours.
+                </Page.Section.Description>
+                <Page.Section.Body>
+                  <ApprovalQueue />
+                </Page.Section.Body>
+              </Page.Section>
+            </RequireScope>
+          </TabsContent>
+        </Page.Body>
+      </Tabs>
+    </Page>
+  );
+}
+
+function ShadowMCPInventory({ pageTitle }: { pageTitle: string }): JSX.Element {
   const project = useProject();
   const routes = useRoutes();
   const policiesQuery = useRiskListPolicies();
@@ -51,49 +138,39 @@ export default function ShadowMCP(): JSX.Element {
   const disposition = shadowMCPBlockingPolicyDisposition(shadowMCPPolicies);
 
   return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs
-          substitutions={{ ["shadow-mcp"]: pageTitle }}
-        />
-      </Page.Header>
-      <Page.Body fullHeight className="pb-8">
-        <RequireScope scope="org:admin" level="page">
-          <Page.Section>
-            <Page.Section.Title stage="beta">{pageTitle}</Page.Section.Title>
-            <Page.Section.Description>
-              Manage the Shadow MCP server inventory, allow decisions, and
-              requests.
-            </Page.Section.Description>
-            {policyDataReady ? (
-              <Page.Section.CTA>
-                <ShadowMCPPolicyStatus
-                  disposition={disposition}
-                  policyState={policyState}
-                />
-              </Page.Section.CTA>
-            ) : null}
-            <Page.Section.Body>
-              {policyDataReady ? (
-                <div className="flex flex-col pb-8">
-                  <ShadowMCPInventoryTable
-                    members={membersQuery.data?.members ?? []}
-                    onOpenServer={(server) =>
-                      routes.shadowMCP.detail.goTo(server.serverSlug)
-                    }
-                    policyState={policyState}
-                    projectID={project.id}
-                    roles={rolesQuery.data?.roles ?? []}
-                    shadowMCPPolicies={shadowMCPPolicies}
-                  />
-                </div>
-              ) : (
-                <ShadowMCPLoadingState />
-              )}
-            </Page.Section.Body>
-          </Page.Section>
-        </RequireScope>
-      </Page.Body>
-    </Page>
+    <Page.Section>
+      <Page.Section.Title stage="beta" area="">
+        {pageTitle}
+      </Page.Section.Title>
+      <Page.Section.Description>
+        Manage the Shadow MCP server inventory, allow decisions, and requests.
+      </Page.Section.Description>
+      {policyDataReady ? (
+        <Page.Section.CTA>
+          <ShadowMCPPolicyStatus
+            disposition={disposition}
+            policyState={policyState}
+          />
+        </Page.Section.CTA>
+      ) : null}
+      <Page.Section.Body>
+        {policyDataReady ? (
+          <div className="flex flex-col pb-8">
+            <ShadowMCPInventoryTable
+              members={membersQuery.data?.members ?? []}
+              onOpenServer={(server) =>
+                routes.shadowMCP.detail.goTo(server.serverSlug)
+              }
+              policyState={policyState}
+              projectID={project.id}
+              roles={rolesQuery.data?.roles ?? []}
+              shadowMCPPolicies={shadowMCPPolicies}
+            />
+          </div>
+        ) : (
+          <ShadowMCPLoadingState />
+        )}
+      </Page.Section.Body>
+    </Page.Section>
   );
 }

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -394,11 +394,6 @@ const ROUTE_STRUCTURE = {
     component: MCPRoot,
     indexComponent: MCPPage,
     subPages: {
-      approvalRequest: {
-        title: "Access request",
-        url: "mcp-approvals/:requestId",
-        component: MCPApprovalDetail,
-      },
       builtIn: {
         title: "Built-in MCP",
         url: "built-in/:builtInSlug",
@@ -659,6 +654,11 @@ const ROUTE_STRUCTURE = {
     component: ShadowMCPRoot,
     indexComponent: ShadowMCP,
     subPages: {
+      request: {
+        title: "Access request",
+        url: "requests/:requestId",
+        component: MCPApprovalDetail,
+      },
       detail: {
         title: "Shadow MCP Server",
         url: ":serverSlug",


### PR DESCRIPTION
Moves the Access Requests queue onto the Shadow MCP page (AIS-521), replacing the tab that previously lived on the Distribute → MCP page.

## What changed

- **Shadow MCP** (Secure) now has two tabs: **Inventory** (the existing server inventory, `org:admin`-gated as before) and **Access Requests** (the approval queue, gated on `mcp_approval:read` so reviewers don't need org admin). Requests and inventory share the same canonical-URL identity, so the queue now sits next to the traffic it's derived from.
- The request detail moves to `shadow-mcp/requests/:requestId`; the `mcp/mcp-approvals/*` route and the MCP page's tab are removed — the MCP page returns to a plain servers listing.
- The "Requests" breadcrumb segment on detail pages links back to the tab rather than a dead path.

Everything stays project-scoped, matching the rest of the Shadow MCP surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the MCP Access Requests queue onto the Shadow MCP page to sit next to the inventory it’s derived from. This aligns with AIS-521 by replacing the old MCP tab, updating routes, and making the queue accessible with `mcp_approval:read`.

- New Features
  - Shadow MCP now has tabs: Inventory (`org:admin`) and Access Requests (`mcp_approval:read`).
  - Request detail route moved to `shadow-mcp/requests/:requestId`; removed `mcp/mcp-approvals/*`.
  - MCP page returns to a plain servers listing (no tabs).
  - Breadcrumb “requests” segment links to `shadow-mcp?tab=requests`.
  - Queue row navigation updated to `routes.shadowMCP.request.href(id)`.

- Migration
  - Update any bookmarks/links from `mcp/mcp-approvals/:requestId` to `shadow-mcp/requests/:requestId`.

<sup>Written for commit 9304b8aa9141ca8088b4e72cb18f05819fcdeaf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

