### PR TITLE
feat: add an upgrade gate for ended enterprise trials

### DIFF
--- a/.changeset/expired-trial-upgrade-gate.md
+++ b/.changeset/expired-trial-upgrade-gate.md
@@ -1,0 +1,6 @@
+---
+"dashboard": minor
+"server": minor
+---
+
+An organization whose enterprise trial has ended now lands on a page that says so and books an upgrade call, instead of the generic book-a-demo screen a company that had never heard of Gram sees. Anyone still inside a trial can reach the same page from the sidebar countdown to upgrade early.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -40,6 +40,7 @@ import { BlockPage } from "./pages/blocks/BlockDetail";
 import { SHARED_SKILL_BASE_PATH } from "./pages/skills/share-link";
 import { SharedSkillPage } from "./pages/skills/SharedSkillPage";
 import SwitchOrg from "./pages/demo/SwitchOrg";
+import TalkToUs from "./pages/demo/TalkToUs";
 import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
 
 export default function App(): JSX.Element {
@@ -335,6 +336,12 @@ const RouteProvider = () => {
         {routesWithSubroutes(unauthenticatedRoutes)}
         <Route path="/switch-org" element={<LoginCheck />}>
           <Route index element={<SwitchOrg />} />
+        </Route>
+        {/* Outside the app layout because it is a full-page gate, but behind
+            LoginCheck: an expired trial still has a session, and a logged-out
+            visitor has no trial to talk about. */}
+        <Route path="/talk-to-us" element={<LoginCheck />}>
+          <Route index element={<TalkToUs />} />
         </Route>
         <Route
           path="/shadow-mcp/request"

--- a/client/dashboard/src/components/trial-status-card.test.tsx
+++ b/client/dashboard/src/components/trial-status-card.test.tsx
@@ -1,4 +1,10 @@
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render as rtlRender,
+  screen,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { emptySession } from "@/contexts/Auth";
 
@@ -15,6 +21,10 @@ vi.mock("@/contexts/Auth", async (importOriginal) => {
 });
 
 import { TrialStatusCard } from "./trial-status-card";
+
+// The card links to the in-app upgrade gate, so Link needs router context.
+const render = (ui: React.ReactElement) =>
+  rtlRender(ui, { wrapper: MemoryRouter });
 
 const activeTrial = {
   startedAt: new Date("2026-08-05T00:00:00.000Z"),
@@ -187,14 +197,13 @@ describe("TrialStatusCard", () => {
     ).toBe(true);
   });
 
-  it("opens the Sales conversation safely in a new tab", () => {
+  it("sends the Sales conversation to the in-app upgrade gate", () => {
     render(<TrialStatusCard />);
 
+    // In-app rather than the marketing site: the gate prefills the booking
+    // form from the session, so it stays in the same tab.
     const salesLink = screen.getByRole("link", { name: "Talk to sales" });
-    expect(salesLink.getAttribute("href")).toBe(
-      "https://www.speakeasy.com/talk-to-us",
-    );
-    expect(salesLink.getAttribute("target")).toBe("_blank");
-    expect(salesLink.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(salesLink.getAttribute("href")).toBe("/talk-to-us");
+    expect(salesLink.getAttribute("target")).toBeNull();
   });
 });

--- a/client/dashboard/src/components/trial-status-card.test.tsx
+++ b/client/dashboard/src/components/trial-status-card.test.tsx
@@ -163,10 +163,10 @@ describe("TrialStatusCard", () => {
 
   it("changes the brand color as the trial progresses", () => {
     const colorByDay = [
-      [1, "bg-[var(--color-base-black)]"],
-      [5, "bg-[var(--color-brand-c)]"],
-      [9, "bg-[var(--color-brand-ruby)]"],
-      [13, "bg-[var(--color-brand-swift)]"],
+      [1, "bg-(--color-base-black)"],
+      [5, "bg-(--color-brand-c)"],
+      [9, "bg-(--color-brand-ruby)"],
+      [13, "bg-(--color-brand-swift)"],
     ] as const;
 
     for (const [day, colorClass] of colorByDay) {

--- a/client/dashboard/src/components/trial-status-card.tsx
+++ b/client/dashboard/src/components/trial-status-card.tsx
@@ -13,10 +13,10 @@ import { Link } from "react-router";
 // The marketing site's /talk-to-us cannot.
 const SALES_PATH = "/talk-to-us";
 
-const BLACK_PROGRESS_CLASS = "bg-[var(--color-base-black)]";
-const DEEP_GREEN_PROGRESS_CLASS = "bg-[var(--color-brand-c)]";
-const ORANGE_PROGRESS_CLASS = "bg-[var(--color-brand-ruby)]";
-const RED_PROGRESS_CLASS = "bg-[var(--color-brand-swift)]";
+const BLACK_PROGRESS_CLASS = "bg-(--color-base-black)";
+const DEEP_GREEN_PROGRESS_CLASS = "bg-(--color-brand-c)";
+const ORANGE_PROGRESS_CLASS = "bg-(--color-brand-ruby)";
+const RED_PROGRESS_CLASS = "bg-(--color-brand-swift)";
 
 function getTrialProgressColorClass(
   dayNumber: number,

--- a/client/dashboard/src/components/trial-status-card.tsx
+++ b/client/dashboard/src/components/trial-status-card.tsx
@@ -1,7 +1,11 @@
 import { Icon } from "@/components/ui/Icon";
 import { Text } from "@/components/ui/Text";
 import { useSession } from "@/contexts/Auth";
-import { getTrialStatus, MILLISECONDS_PER_DAY } from "@/lib/trial-status";
+import {
+  getTrialStatusFromDates,
+  isValidDate,
+  MILLISECONDS_PER_DAY,
+} from "@/lib/trial-status";
 import { useEffect, useState } from "react";
 
 const SALES_URL = "https://www.speakeasy.com/talk-to-us";
@@ -10,32 +14,6 @@ const BLACK_PROGRESS_CLASS = "bg-[var(--color-base-black)]";
 const DEEP_GREEN_PROGRESS_CLASS = "bg-[var(--color-brand-c)]";
 const ORANGE_PROGRESS_CLASS = "bg-[var(--color-brand-ruby)]";
 const RED_PROGRESS_CLASS = "bg-[var(--color-brand-swift)]";
-
-function isValidDate(value: unknown): value is Date {
-  return value instanceof Date && Number.isFinite(value.getTime());
-}
-
-function getTrialStatusFromDates(
-  trial: { startedAt: Date; endsAt: Date } | null | undefined,
-  now: Date,
-) {
-  if (
-    trial === null ||
-    trial === undefined ||
-    !isValidDate(trial.startedAt) ||
-    !isValidDate(trial.endsAt)
-  ) {
-    return null;
-  }
-
-  return getTrialStatus(
-    {
-      startedAt: trial.startedAt.toISOString(),
-      endsAt: trial.endsAt.toISOString(),
-    },
-    now,
-  );
-}
 
 function getTrialProgressColorClass(
   dayNumber: number,

--- a/client/dashboard/src/components/trial-status-card.tsx
+++ b/client/dashboard/src/components/trial-status-card.tsx
@@ -7,8 +7,11 @@ import {
   MILLISECONDS_PER_DAY,
 } from "@/lib/trial-status";
 import { useEffect, useState } from "react";
+import { Link } from "react-router";
 
-const SALES_URL = "https://www.speakeasy.com/talk-to-us";
+// The in-app upgrade gate, which prefills the booking form from the session.
+// The marketing site's /talk-to-us cannot.
+const SALES_PATH = "/talk-to-us";
 
 const BLACK_PROGRESS_CLASS = "bg-[var(--color-base-black)]";
 const DEEP_GREEN_PROGRESS_CLASS = "bg-[var(--color-brand-c)]";
@@ -123,15 +126,13 @@ export function TrialStatusCard(): React.ReactNode {
             />
           </div>
         </div>
-        <a
-          href={SALES_URL}
-          target="_blank"
-          rel="noopener noreferrer"
+        <Link
+          to={SALES_PATH}
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
           Talk to sales
           <Icon name="arrow-right" className="size-3" aria-hidden="true" />
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -13,6 +13,8 @@ import {
 import { Skeleton } from "@/components/ui/Skeleton";
 import BookDemo from "@/pages/demo/BookDemo";
 import SwitchOrg from "@/pages/demo/SwitchOrg";
+import TrialEnded from "@/pages/demo/TrialEnded";
+import { getTrialLifecycleFromDates } from "@/lib/trial-status";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useIsPlatformAdminRef } from "@/contexts/Sdk";
@@ -126,6 +128,11 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   ) {
     if (session.organizations.length > 1) {
       return <SwitchOrg gate />;
+    }
+    // An org demoted after its trial ran out gets told so; an org that never
+    // trialed (or is still mid-trial) falls through to the cold-signup gate.
+    if (getTrialLifecycleFromDates(session.trial, new Date()) === "expired") {
+      return <TrialEnded />;
     }
     return <BookDemo />;
   }

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -13,7 +13,6 @@ import {
 import { Skeleton } from "@/components/ui/Skeleton";
 import BookDemo from "@/pages/demo/BookDemo";
 import SwitchOrg from "@/pages/demo/SwitchOrg";
-import TrialEnded from "@/pages/demo/TrialEnded";
 import { getTrialLifecycleFromDates } from "@/lib/trial-status";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
@@ -52,12 +51,17 @@ const PREFERRED_PROJECT_KEY = "preferredProject";
 const SLUG_EXEMPT_PATHS = [
   "/switch-org",
   "/explore-demo",
+  "/talk-to-us",
   "/shadow-mcp/request",
   "/risk-policy-bypass/request",
   "/risk-policy-challenge/acknowledge",
   "/blocks",
   "/shared",
 ];
+
+// Paths the non-whitelisted gate lets through: the cold-signup gate's escape
+// hatch into the demo org, and the expired-trial gate's own route.
+const GATE_EXEMPT_PATHS = ["/explore-demo", "/talk-to-us"];
 
 export const AuthProvider = ({
   children,
@@ -117,22 +121,25 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   // Show book demo page if organization is not whitelisted
   // Check this before the no-org fallback so non-whitelisted orgs are blocked before reaching the normal app flow
   // /explore-demo stays reachable: it's the gate page's own escape hatch into
-  // the shared demo org (which is whitelisted). Exact match only — a prefix
-  // match would let deeper paths (e.g. /explore-demo/projects/x) through the
-  // gate.
+  // the shared demo org (which is whitelisted). /talk-to-us has to be reachable
+  // too or the redirect below loops. Exact match only — a prefix match would
+  // let deeper paths (e.g. /explore-demo/projects/x) through the gate.
+  const isGateExemptPath = GATE_EXEMPT_PATHS.some(
+    (p) => location.pathname === p || location.pathname === `${p}/`,
+  );
+
   if (
     session.activeOrganizationId &&
     !session.whitelisted &&
-    location.pathname !== "/explore-demo" &&
-    location.pathname !== "/explore-demo/"
+    !isGateExemptPath
   ) {
     if (session.organizations.length > 1) {
       return <SwitchOrg gate />;
     }
-    // An org demoted after its trial ran out gets told so; an org that never
-    // trialed (or is still mid-trial) falls through to the cold-signup gate.
+    // An org that never trialed (or is still mid-trial) falls through to the
+    // cold-signup gate.
     if (getTrialLifecycleFromDates(session.trial, new Date()) === "expired") {
-      return <TrialEnded />;
+      return <Navigate to="/talk-to-us" replace />;
     }
     return <BookDemo />;
   }

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -59,9 +59,11 @@ const SLUG_EXEMPT_PATHS = [
   "/shared",
 ];
 
-// Paths the non-whitelisted gate lets through: the cold-signup gate's escape
-// hatch into the demo org, and the expired-trial gate's own route.
-const GATE_EXEMPT_PATHS = ["/explore-demo", "/talk-to-us"];
+// Exact match, with or without the trailing slash. A prefix match would let
+// deeper paths (e.g. /explore-demo/projects/x) through the gate.
+function isPath(pathname: string, path: string): boolean {
+  return pathname === path || pathname === `${path}/`;
+}
 
 export const AuthProvider = ({
   children,
@@ -121,27 +123,28 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   // Show book demo page if organization is not whitelisted
   // Check this before the no-org fallback so non-whitelisted orgs are blocked before reaching the normal app flow
   // /explore-demo stays reachable: it's the gate page's own escape hatch into
-  // the shared demo org (which is whitelisted). /talk-to-us has to be reachable
-  // too or the redirect below loops. Exact match only — a prefix match would
-  // let deeper paths (e.g. /explore-demo/projects/x) through the gate.
-  const isGateExemptPath = GATE_EXEMPT_PATHS.some(
-    (p) => location.pathname === p || location.pathname === `${p}/`,
-  );
-
+  // the shared demo org (which is whitelisted).
   if (
     session.activeOrganizationId &&
     !session.whitelisted &&
-    !isGateExemptPath
+    !isPath(location.pathname, "/explore-demo")
   ) {
+    // The switcher wins even on the upgrade gate's own route. Someone with a
+    // second organization has somewhere to go, and that page offers no way to
+    // reach it — landing there would strand them.
     if (session.organizations.length > 1) {
       return <SwitchOrg gate />;
     }
-    // An org that never trialed (or is still mid-trial) falls through to the
-    // cold-signup gate.
-    if (getTrialLifecycleFromDates(session.trial, new Date()) === "expired") {
-      return <Navigate to="/talk-to-us" replace />;
+    // Past this point the upgrade gate has to render, or the redirect below
+    // sends the user to a route that bounces them straight back to it.
+    if (!isPath(location.pathname, "/talk-to-us")) {
+      // An org that never trialed (or is still mid-trial) falls through to the
+      // cold-signup gate.
+      if (getTrialLifecycleFromDates(session.trial, new Date()) === "expired") {
+        return <Navigate to="/talk-to-us" replace />;
+      }
+      return <BookDemo />;
     }
-    return <BookDemo />;
   }
 
   if (!session.activeOrganizationId) {

--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 import type { User } from "./Auth";
+import type { TrialLifecycle } from "@/lib/trial-status";
 
 export type Telemetry = Pick<
   PostHog,
@@ -224,30 +225,43 @@ export function useCaptureEnterpriseGateViewed({
 }
 
 // Kept separate from `enterprise_gate_viewed` so that event keeps meaning "cold
-// org that never trialed" and the two funnels stay separable.
-export function useCaptureTrialExpiredGateViewed({
+// org that never trialed" and the two funnels stay separable. The upgrade page
+// serves both ended and running trials, so the lifecycle rides along as a
+// property rather than splitting the event again — a walled org and one
+// upgrading early are the same funnel at different stages.
+export function useCaptureUpgradeGateViewed({
   email,
   organizationId,
   organizationName,
   organizationSlug,
+  trialLifecycle,
 }: {
   email: string;
   organizationId: string;
   organizationName: string;
   organizationSlug: string;
+  trialLifecycle: TrialLifecycle;
 }): void {
   const telemetry = useTelemetry();
 
   useEffect(() => {
     if (!email) return;
     if (!organizationId) return;
-    telemetry.capture("trial_expired_gate_viewed", {
+    telemetry.capture("upgrade_gate_viewed", {
       email,
       organization_id: organizationId,
       organization_name: organizationName,
       organization_slug: organizationSlug,
+      trial_lifecycle: trialLifecycle,
     });
-  }, [email, organizationId, organizationName, organizationSlug, telemetry]);
+  }, [
+    email,
+    organizationId,
+    organizationName,
+    organizationSlug,
+    trialLifecycle,
+    telemetry,
+  ]);
 }
 
 export function useRegisterChatTelemetry({

--- a/client/dashboard/src/contexts/Telemetry.tsx
+++ b/client/dashboard/src/contexts/Telemetry.tsx
@@ -223,6 +223,33 @@ export function useCaptureEnterpriseGateViewed({
   }, [email, organizationId, organizationName, organizationSlug, telemetry]);
 }
 
+// Kept separate from `enterprise_gate_viewed` so that event keeps meaning "cold
+// org that never trialed" and the two funnels stay separable.
+export function useCaptureTrialExpiredGateViewed({
+  email,
+  organizationId,
+  organizationName,
+  organizationSlug,
+}: {
+  email: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+}): void {
+  const telemetry = useTelemetry();
+
+  useEffect(() => {
+    if (!email) return;
+    if (!organizationId) return;
+    telemetry.capture("trial_expired_gate_viewed", {
+      email,
+      organization_id: organizationId,
+      organization_name: organizationName,
+      organization_slug: organizationSlug,
+    });
+  }, [email, organizationId, organizationName, organizationSlug, telemetry]);
+}
+
 export function useRegisterChatTelemetry({
   chatId,
   chatUrl,

--- a/client/dashboard/src/lib/trial-status.test.ts
+++ b/client/dashboard/src/lib/trial-status.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { getTrialStatus } from "./trial-status";
+import {
+  getTrialLifecycle,
+  getTrialLifecycleFromDates,
+  getTrialStatus,
+  getTrialStatusFromDates,
+} from "./trial-status";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const trial = (startedAt: string, endsAt: string) => ({
   startedAt,
   endsAt,
+});
+
+const dateTrial = (startedAt: string, endsAt: string) => ({
+  startedAt: new Date(startedAt),
+  endsAt: new Date(endsAt),
 });
 
 describe("getTrialStatus", () => {
@@ -117,5 +127,128 @@ describe("getTrialStatus", () => {
     ],
   ])("returns null for invalid trial input: %j", (invalidTrial, now) => {
     expect(getTrialStatus(invalidTrial, now)).toBeNull();
+  });
+});
+
+describe("getTrialLifecycle", () => {
+  it("reports an in-progress trial as active", () => {
+    expect(
+      getTrialLifecycle(
+        trial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date("2026-08-07T12:00:00.000Z"),
+      ),
+    ).toBe("active");
+  });
+
+  it("reports a trial that has not started yet as active", () => {
+    expect(
+      getTrialLifecycle(
+        trial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date("2026-07-31T00:00:00.000Z"),
+      ),
+    ).toBe("active");
+  });
+
+  it("stays active in the final instant before expiry", () => {
+    expect(
+      getTrialLifecycle(
+        trial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date("2026-08-14T23:59:59.999Z"),
+      ),
+    ).toBe("active");
+  });
+
+  it("reports expired at exact expiry", () => {
+    expect(
+      getTrialLifecycle(
+        trial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date("2026-08-15T00:00:00.000Z"),
+      ),
+    ).toBe("expired");
+  });
+
+  it("reports a long-finished trial as expired", () => {
+    expect(
+      getTrialLifecycle(
+        trial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date("2026-09-30T00:00:00.000Z"),
+      ),
+    ).toBe("expired");
+  });
+
+  it.each([
+    [undefined, new Date("2026-08-01T00:00:00.000Z")],
+    [null, new Date("2026-08-01T00:00:00.000Z")],
+    [trial("not-a-date", "2026-08-15T00:00:00.000Z"), new Date()],
+    [trial("2026-08-01T00:00:00.000Z", "not-a-date"), new Date()],
+    [
+      trial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+      new Date(Number.NaN),
+    ],
+    [
+      trial("2026-08-15T00:00:00.000Z", "2026-08-01T00:00:00.000Z"),
+      new Date("2026-08-01T00:00:00.000Z"),
+    ],
+    [
+      trial("2026-08-01T00:00:00.000Z", "2026-08-01T00:00:00.000Z"),
+      new Date("2026-08-01T00:00:00.000Z"),
+    ],
+  ])("returns none for unusable trial input: %j", (invalidTrial, now) => {
+    expect(getTrialLifecycle(invalidTrial, now)).toBe("none");
+  });
+});
+
+describe("getTrialStatusFromDates", () => {
+  it("derives the status from Date-shaped trial fields", () => {
+    expect(
+      getTrialStatusFromDates(
+        dateTrial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date("2026-08-07T12:00:00.000Z"),
+      ),
+    ).toEqual({
+      dayNumber: 7,
+      totalDays: 14,
+      remainingDays: 8,
+      progress: 13 / 28,
+    });
+  });
+
+  it.each([
+    [undefined],
+    [null],
+    [{ startedAt: new Date(Number.NaN), endsAt: new Date() }],
+    [{ startedAt: new Date(), endsAt: new Date(Number.NaN) }],
+  ])("returns null for unusable trial input: %j", (invalidTrial) => {
+    expect(
+      getTrialStatusFromDates(invalidTrial, new Date("2026-08-07T12:00:00Z")),
+    ).toBeNull();
+  });
+});
+
+describe("getTrialLifecycleFromDates", () => {
+  it.each([
+    ["2026-08-07T12:00:00.000Z", "active"],
+    ["2026-08-15T00:00:00.000Z", "expired"],
+  ])("classifies a Date-shaped trial at %s as %s", (now, expected) => {
+    expect(
+      getTrialLifecycleFromDates(
+        dateTrial("2026-08-01T00:00:00.000Z", "2026-08-15T00:00:00.000Z"),
+        new Date(now),
+      ),
+    ).toBe(expected);
+  });
+
+  it.each([
+    [undefined],
+    [null],
+    [{ startedAt: new Date(Number.NaN), endsAt: new Date() }],
+    [{ startedAt: new Date(), endsAt: new Date(Number.NaN) }],
+  ])("returns none for unusable trial input: %j", (invalidTrial) => {
+    expect(
+      getTrialLifecycleFromDates(
+        invalidTrial,
+        new Date("2026-08-07T12:00:00Z"),
+      ),
+    ).toBe("none");
   });
 });

--- a/client/dashboard/src/lib/trial-status.ts
+++ b/client/dashboard/src/lib/trial-status.ts
@@ -7,10 +7,25 @@ export type TrialStatus = {
   progress: number;
 };
 
-export function getTrialStatus(
+/** Where a trial sits relative to `now`, including after it has ended. */
+export type TrialLifecycle = "none" | "active" | "expired";
+
+type ParsedTrial = {
+  startedAt: number;
+  endsAt: number;
+  nowTime: number;
+  duration: number;
+};
+
+/**
+ * Normalizes a trial and reference time into timestamps, returning null when
+ * either date is unparseable, `now` is invalid, or the trial has no positive
+ * duration. Shared so every trial derivation rejects the same inputs.
+ */
+function parseTrial(
   trial: { startedAt: string; endsAt: string } | null | undefined,
   now: Date,
-): TrialStatus | null {
+): ParsedTrial | null {
   if (trial === null || trial === undefined) {
     return null;
   }
@@ -28,7 +43,28 @@ export function getTrialStatus(
   }
 
   const duration = endsAt - startedAt;
-  if (duration <= 0 || nowTime >= endsAt) {
+  if (duration <= 0) {
+    return null;
+  }
+
+  return { startedAt, endsAt, nowTime, duration };
+}
+
+export function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+export function getTrialStatus(
+  trial: { startedAt: string; endsAt: string } | null | undefined,
+  now: Date,
+): TrialStatus | null {
+  const parsed = parseTrial(trial, now);
+  if (parsed === null) {
+    return null;
+  }
+
+  const { startedAt, endsAt, nowTime, duration } = parsed;
+  if (nowTime >= endsAt) {
     return null;
   }
 
@@ -42,4 +78,54 @@ export function getTrialStatus(
     remainingDays: Math.ceil((endsAt - effectiveNow) / MILLISECONDS_PER_DAY),
     progress: Math.min(1, Math.max(0, elapsed / duration)),
   };
+}
+
+/**
+ * Classifies a trial so callers can distinguish an organization whose trial
+ * ended from one that never trialed. Unusable input reads as "none".
+ */
+export function getTrialLifecycle(
+  trial: { startedAt: string; endsAt: string } | null | undefined,
+  now: Date,
+): TrialLifecycle {
+  const parsed = parseTrial(trial, now);
+  if (parsed === null) {
+    return "none";
+  }
+
+  return parsed.nowTime >= parsed.endsAt ? "expired" : "active";
+}
+
+function toStringTrial(
+  trial: { startedAt: Date; endsAt: Date } | null | undefined,
+): { startedAt: string; endsAt: string } | null {
+  if (
+    trial === null ||
+    trial === undefined ||
+    !isValidDate(trial.startedAt) ||
+    !isValidDate(trial.endsAt)
+  ) {
+    return null;
+  }
+
+  return {
+    startedAt: trial.startedAt.toISOString(),
+    endsAt: trial.endsAt.toISOString(),
+  };
+}
+
+/** `getTrialStatus` for the `Date`-shaped trial carried on the session. */
+export function getTrialStatusFromDates(
+  trial: { startedAt: Date; endsAt: Date } | null | undefined,
+  now: Date,
+): TrialStatus | null {
+  return getTrialStatus(toStringTrial(trial), now);
+}
+
+/** `getTrialLifecycle` for the `Date`-shaped trial carried on the session. */
+export function getTrialLifecycleFromDates(
+  trial: { startedAt: Date; endsAt: Date } | null | undefined,
+  now: Date,
+): TrialLifecycle {
+  return getTrialLifecycle(toStringTrial(trial), now);
 }

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -31,7 +31,7 @@ export default function BookDemo(): JSX.Element {
         <button
           type="button"
           onClick={() => void handleLogout()}
-          className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
+          className="auth-mono text-[13px] leading-none text-(--muted) transition-colors hover:text-black"
         >
           Log out
         </button>
@@ -41,7 +41,7 @@ export default function BookDemo(): JSX.Element {
       <div className="mt-6 text-center">
         <Link
           to="/explore-demo"
-          className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
+          className="auth-mono text-xs text-(--muted) underline underline-offset-4 transition-colors hover:text-black"
         >
           Or explore a live demo org →
         </Link>

--- a/client/dashboard/src/pages/demo/BookDemo.tsx
+++ b/client/dashboard/src/pages/demo/BookDemo.tsx
@@ -31,7 +31,7 @@ export default function BookDemo(): JSX.Element {
         <button
           type="button"
           onClick={() => void handleLogout()}
-          className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+          className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
         >
           Log out
         </button>

--- a/client/dashboard/src/pages/demo/SwitchOrg.tsx
+++ b/client/dashboard/src/pages/demo/SwitchOrg.tsx
@@ -41,31 +41,31 @@ function OrgRow({
       className={cn(
         "flex w-full items-center gap-3 border px-3.5 py-3 text-left transition-colors",
         current
-          ? "cursor-default border-[var(--edge)] bg-[var(--surface)]"
+          ? "cursor-default border-(--edge) bg-(--surface)"
           : selected
-            ? "border-[var(--cta)] bg-[hsl(0,0%,97%)]"
-            : "border-[var(--edge)] bg-[var(--card)] hover:border-[hsl(0,0%,60%)]",
+            ? "border-(--cta) bg-[hsl(0,0%,97%)]"
+            : "border-(--edge) bg-(--card) hover:border-[hsl(0,0%,60%)]",
       )}
     >
       <span
         className={cn(
-          "auth-mono-text flex h-7 w-7 flex-none items-center justify-center text-[12px]",
+          "auth-mono-text flex h-7 w-7 flex-none items-center justify-center text-xs",
           current || selected
-            ? "bg-[var(--cta)] text-white"
-            : "bg-[var(--edge-soft)] text-[var(--muted-strong)]",
+            ? "bg-(--cta) text-white"
+            : "bg-(--edge-soft) text-(--muted-strong)",
         )}
       >
         {displayName.charAt(0).toUpperCase()}
       </span>
       <span className="flex flex-1 flex-col gap-px">
         <span className="text-[15px]">{displayName}</span>
-        <span className="auth-mono-text text-[11px] text-[var(--muted)]">
+        <span className="auth-mono-text text-[11px] text-(--muted)">
           {org.slug} · {projectCount}{" "}
           {projectCount === 1 ? "project" : "projects"}
         </span>
       </span>
       {current && (
-        <span className="auth-mono rounded-full bg-[var(--moss)] px-2.5 py-[3px] text-[10px] text-white">
+        <span className="auth-mono rounded-full bg-(--moss) px-2.5 py-[3px] text-[10px] text-white">
           Current
         </span>
       )}
@@ -124,7 +124,7 @@ export default function SwitchOrg({
         <button
           type="button"
           onClick={() => void handleLogout()}
-          className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
+          className="auth-mono text-[13px] leading-none text-(--muted) transition-colors hover:text-black"
         >
           Log out
         </button>
@@ -136,7 +136,7 @@ export default function SwitchOrg({
             ? `${currentOrgName} doesn't have platform access.`
             : "Switch organization."}
         </p>
-        <p className="mt-1.5 text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
+        <p className="mt-1.5 text-sm tracking-[0.0025em] text-(--muted-strong)">
           {gate
             ? "Switch to another organization to continue, or contact your admin."
             : "Select which organization you'd like to work in."}
@@ -144,11 +144,11 @@ export default function SwitchOrg({
       </div>
 
       {gate && (
-        <div className="flex w-full items-center gap-2.5 border border-[var(--ember)] bg-[hsl(23,96%,97%)] px-3.5 py-2.5">
-          <span className="auth-mono flex-none rounded-full bg-[var(--ember)] px-2.5 py-[3px] text-[10px] text-black">
+        <div className="flex w-full items-center gap-2.5 border border-(--ember) bg-[hsl(23,96%,97%)] px-3.5 py-2.5">
+          <span className="auth-mono flex-none rounded-full bg-(--ember) px-2.5 py-[3px] text-[10px] text-black">
             No access
           </span>
-          <span className="auth-mono-text text-[12px] text-[var(--muted-strong)]">
+          <span className="auth-mono-text text-xs text-(--muted-strong)">
             {currentOrg?.slug ?? "this organization"} · MCP platform not enabled
           </span>
         </div>

--- a/client/dashboard/src/pages/demo/SwitchOrg.tsx
+++ b/client/dashboard/src/pages/demo/SwitchOrg.tsx
@@ -124,7 +124,7 @@ export default function SwitchOrg({
         <button
           type="button"
           onClick={() => void handleLogout()}
-          className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+          className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
         >
           Log out
         </button>

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -3,14 +3,66 @@ import { useSdkClient } from "@/contexts/Sdk";
 import { useCaptureTrialExpiredGateViewed } from "@/contexts/Telemetry";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
-import { isValidDate } from "@/lib/trial-status";
+import {
+  getTrialLifecycleFromDates,
+  getTrialStatusFromDates,
+  isValidDate,
+} from "@/lib/trial-status";
 import { format } from "date-fns";
 
 const SALES_EMAIL = "sales@speakeasy.com";
 
-// The gate an organization lands on once its enterprise trial has ended and the
-// sweep has demoted it.
-export default function TrialEnded(): JSX.Element {
+const SHARED_BODY =
+  "Book 30 minutes and we'll find the plan that fits your organization.";
+
+type GateCopy = {
+  /** Colour of the status dot. Static — the pulse is for live sessions. */
+  dotClassName: string;
+  status: string;
+  body: string;
+  detail: string;
+};
+
+// The page serves two audiences: an org walled after its trial ran out, and an
+// org still inside its trial that wants to upgrade early. Only the header copy
+// differs; the booking card below is the same either way. A trial that has
+// ended is the exception, so the running trial is the default — a session with
+// no readable trial gets that wording rather than a third variant.
+function getGateCopy(
+  trial: { startedAt: Date; endsAt: Date } | null | undefined,
+  now: Date,
+): GateCopy {
+  const endsAt = trial?.endsAt;
+
+  if (getTrialLifecycleFromDates(trial, now) === "expired") {
+    return {
+      dotClassName: "bg-[var(--vermilion)]",
+      status: isValidDate(endsAt)
+        ? `Trial ended ${format(endsAt, "MMM do, yyyy")}`
+        : "Trial ended",
+      body: `Trials run 14 days. ${SHARED_BODY}`,
+      detail:
+        "Your MCP servers, observability data, and policies are still here when you upgrade.",
+    };
+  }
+
+  const remainingDays = getTrialStatusFromDates(trial, now)?.remainingDays;
+  return {
+    dotClassName: "bg-[var(--moss)]",
+    status:
+      remainingDays === undefined
+        ? "Trial in progress"
+        : `Trial · ${remainingDays} day${remainingDays === 1 ? "" : "s"} left`,
+    body: `Upgrade before your trial ends and nothing pauses. ${SHARED_BODY}`,
+    detail:
+      "Your MCP servers, observability data, and policies carry over unchanged.",
+  };
+}
+
+// Reached two ways: the gate redirects an organization here once its trial has
+// ended and the sweep has demoted it, or a user on a running trial navigates
+// here to upgrade early.
+export default function TalkToUs(): JSX.Element {
   const client = useSdkClient();
   const { session } = useSessionData();
 
@@ -26,12 +78,7 @@ export default function TrialEnded(): JSX.Element {
     window.location.href = "/login";
   };
 
-  // A session can reach this page without a parseable end date; naming the day
-  // is a nicety, so drop it rather than rendering "Invalid Date".
-  const endsAt = session?.trial?.endsAt;
-  const statusLabel = isValidDate(endsAt)
-    ? `Trial ended ${format(endsAt, "MMM do")}`
-    : "Trial ended";
+  const copy = getGateCopy(session?.trial, new Date());
 
   return (
     <AuthShell
@@ -55,26 +102,22 @@ export default function TrialEnded(): JSX.Element {
           <div className="grid w-full grid-cols-1 items-start gap-10 md:grid-cols-2">
             <div className="flex flex-col gap-2.5">
               <span className="auth-mono flex items-center gap-2.5 text-[12px] text-[var(--muted)]">
-                {/* Static, unlike the showcase's live-session dot: the pulse
-                    reads as "happening now", which is the opposite of this. */}
                 <i
                   aria-hidden="true"
-                  className="size-[7px] rounded-full bg-[var(--vermilion)]"
+                  className={`size-[7px] rounded-full ${copy.dotClassName}`}
                 />
-                {statusLabel}
+                {copy.status}
               </span>
-              <p className="text-[40px] leading-[1.05] font-thin tracking-[-0.035em] [font-family:var(--f-display)]">
+              <h1 className="text-[40px] leading-[1.05] font-thin tracking-[-0.035em] [font-family:var(--f-display)]">
                 Book a call to upgrade.
-              </p>
+              </h1>
             </div>
             <div className="flex flex-col gap-2 md:border-l md:border-[var(--edge-soft)] md:pl-10">
               <p className="text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
-                Trials run 14 days. Book 30 minutes and we&rsquo;ll find the
-                plan that fits your organization.
+                {copy.body}
               </p>
               <p className="auth-mono-text text-[12px] text-[var(--muted)]">
-                MCP servers, observability data, and policies retained for 30
-                days.
+                {copy.detail}
               </p>
             </div>
           </div>

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -71,14 +71,14 @@ function UpgradeGate({
           <button
             type="button"
             onClick={() => void handleLogout()}
-            className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
+            className="auth-mono text-[13px] leading-none text-(--muted) transition-colors hover:text-black"
           >
             Log out
           </button>
         ) : (
           <Link
             to="/"
-            className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
+            className="auth-mono text-[13px] leading-none text-(--muted) transition-colors hover:text-black"
           >
             Back to dashboard
           </Link>
@@ -90,22 +90,20 @@ function UpgradeGate({
         intro={
           <div className="grid w-full grid-cols-1 items-start gap-4 md:grid-cols-[2fr_2.25fr]">
             <div className="flex flex-col gap-2">
-              <span className="auth-mono flex items-center gap-2.5 text-[12px] text-[var(--muted)]">
+              <span className="auth-mono flex items-center gap-2.5 text-xs text-(--muted)">
                 <i
                   aria-hidden="true"
                   className={`size-[7px] rounded-full ${copy.dotClassName}`}
                 />
                 {copy.status}
               </span>
-              <h1 className="text-[40px] leading-[1.05] font-thin tracking-tight [font-family:var(--f-display)]">
+              <h1 className="text-[40px] leading-[1.05] font-thin tracking-tight font-(family-name:--f-display)">
                 Book a call to upgrade.
               </h1>
             </div>
-            <div className="flex flex-col gap-2 md:border-l md:border-[var(--edge-soft)] md:pl-6">
-              <p className="text-[14px] text-[var(--muted-strong)]">
-                {copy.body}
-              </p>
-              <p className="auth-mono-text text-[12px] text-[var(--muted)]">
+            <div className="flex flex-col gap-2 md:border-l md:border-(--edge-soft) md:pl-6">
+              <p className="text-sm text-(--muted-strong)">{copy.body}</p>
+              <p className="auth-mono-text text-xs text-(--muted)">
                 {copy.detail}
               </p>
             </div>
@@ -115,14 +113,14 @@ function UpgradeGate({
       <div className="flex items-center justify-center gap-4">
         <Link
           to="/explore-demo"
-          className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
+          className="auth-mono text-xs text-(--muted) underline underline-offset-4 transition-colors hover:text-black"
         >
           Explore demo
         </Link>
-        <span aria-hidden="true" className="h-3 w-px bg-[var(--edge)]" />
+        <span aria-hidden="true" className="h-3 w-px bg-(--edge)" />
         <a
           href={`mailto:${SALES_EMAIL}`}
-          className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
+          className="auth-mono text-xs text-(--muted) underline underline-offset-4 transition-colors hover:text-black"
         >
           Email {SALES_EMAIL} →
         </a>

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -1,63 +1,16 @@
 import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
-import { useCaptureTrialExpiredGateViewed } from "@/contexts/Telemetry";
+import { useCaptureUpgradeGateViewed } from "@/contexts/Telemetry";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
 import {
   getTrialLifecycleFromDates,
-  getTrialStatusFromDates,
-  isValidDate,
+  type TrialLifecycle,
 } from "@/lib/trial-status";
-import { format } from "date-fns";
+import { getGateCopy } from "@/pages/demo/upgrade-gate-copy";
+import { Link } from "react-router";
 
 const SALES_EMAIL = "sales@speakeasy.com";
-
-const SHARED_BODY =
-  "Book 30 minutes and we'll find the plan that fits your organization.";
-
-type GateCopy = {
-  /** Colour of the status dot. Static — the pulse is for live sessions. */
-  dotClassName: string;
-  status: string;
-  body: string;
-  detail: string;
-};
-
-// The page serves two audiences: an org walled after its trial ran out, and an
-// org still inside its trial that wants to upgrade early. Only the header copy
-// differs; the booking card below is the same either way. A trial that has
-// ended is the exception, so the running trial is the default — a session with
-// no readable trial gets that wording rather than a third variant.
-function getGateCopy(
-  trial: { startedAt: Date; endsAt: Date } | null | undefined,
-  now: Date,
-): GateCopy {
-  const endsAt = trial?.endsAt;
-
-  if (getTrialLifecycleFromDates(trial, now) === "expired") {
-    return {
-      dotClassName: "bg-[var(--vermilion)]",
-      status: isValidDate(endsAt)
-        ? `Trial ended ${format(endsAt, "MMM do, yyyy")}`
-        : "Trial ended",
-      body: `Trials run 14 days. ${SHARED_BODY}`,
-      detail:
-        "Your MCP servers, observability data, and policies are still here when you upgrade.",
-    };
-  }
-
-  const remainingDays = getTrialStatusFromDates(trial, now)?.remainingDays;
-  return {
-    dotClassName: "bg-[var(--moss)]",
-    status:
-      remainingDays === undefined
-        ? "Trial in progress"
-        : `Trial · ${remainingDays} day${remainingDays === 1 ? "" : "s"} left`,
-    body: `Upgrade before your trial ends and nothing pauses. ${SHARED_BODY}`,
-    detail:
-      "Your MCP servers, observability data, and policies carry over unchanged.",
-  };
-}
 
 // Reached two ways: the gate redirects an organization here once its trial has
 // ended and the sweep has demoted it, or a user on a running trial navigates
@@ -65,12 +18,18 @@ function getGateCopy(
 export default function TalkToUs(): JSX.Element {
   const client = useSdkClient();
   const { session } = useSessionData();
+  const now = new Date();
+  const lifecycle: TrialLifecycle = getTrialLifecycleFromDates(
+    session?.trial,
+    now,
+  );
 
-  useCaptureTrialExpiredGateViewed({
+  useCaptureUpgradeGateViewed({
     email: session?.user.email ?? "",
     organizationId: session?.organization?.id ?? "",
     organizationName: session?.organization?.name ?? "",
     organizationSlug: session?.organization?.slug ?? "",
+    trialLifecycle: lifecycle,
   });
 
   const handleLogout = async () => {
@@ -78,7 +37,7 @@ export default function TalkToUs(): JSX.Element {
     window.location.href = "/login";
   };
 
-  const copy = getGateCopy(session?.trial, new Date());
+  const copy = getGateCopy(session?.trial, now);
 
   return (
     <AuthShell
@@ -87,13 +46,24 @@ export default function TalkToUs(): JSX.Element {
       // The card carries its own prefill footnote instead ("2E Book a demo").
       showTerms={false}
       headerAction={
-        <button
-          type="button"
-          onClick={() => void handleLogout()}
-          className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
-        >
-          Log out
-        </button>
+        // A walled org has nothing to go back to, so logging out is the only
+        // exit. Anyone else still has a dashboard and arrived here by choice.
+        lifecycle === "expired" ? (
+          <button
+            type="button"
+            onClick={() => void handleLogout()}
+            className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+          >
+            Log out
+          </button>
+        ) : (
+          <Link
+            to="/"
+            className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+          >
+            Back to dashboard
+          </Link>
+        )
       }
     >
       <DemoBookingFlow

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -87,6 +87,7 @@ function UpgradeGate({
     >
       <DemoBookingFlow
         eventLabel="Upgrade Trial — 30 min"
+        formDefaults={{ source: copy.source, notes: copy.notes }}
         intro={
           <div className="grid w-full grid-cols-1 items-start gap-4 md:grid-cols-[2fr_2.25fr]">
             <div className="flex flex-col gap-2">

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -88,8 +88,8 @@ function UpgradeGate({
       <DemoBookingFlow
         eventLabel="Upgrade Trial — 30 min"
         intro={
-          <div className="grid w-full grid-cols-1 items-start gap-10 md:grid-cols-2">
-            <div className="flex flex-col gap-2.5">
+          <div className="grid w-full grid-cols-1 items-start gap-4 md:grid-cols-[2fr_2.25fr]">
+            <div className="flex flex-col gap-2">
               <span className="auth-mono flex items-center gap-2.5 text-[12px] text-[var(--muted)]">
                 <i
                   aria-hidden="true"
@@ -97,12 +97,12 @@ function UpgradeGate({
                 />
                 {copy.status}
               </span>
-              <h1 className="text-[40px] leading-[1.05] font-thin tracking-[-0.035em] [font-family:var(--f-display)]">
+              <h1 className="text-[40px] leading-[1.05] font-thin tracking-tight [font-family:var(--f-display)]">
                 Book a call to upgrade.
               </h1>
             </div>
-            <div className="flex flex-col gap-2 md:border-l md:border-[var(--edge-soft)] md:pl-10">
-              <p className="text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
+            <div className="flex flex-col gap-2 md:border-l md:border-[var(--edge-soft)] md:pl-6">
+              <p className="text-[14px] text-[var(--muted-strong)]">
                 {copy.body}
               </p>
               <p className="auth-mono-text text-[12px] text-[var(--muted)]">

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -112,12 +112,19 @@ function UpgradeGate({
           </div>
         }
       />
-      <div className="text-center">
+      <div className="flex items-center justify-center gap-4">
+        <Link
+          to="/explore-demo"
+          className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
+        >
+          Explore demo
+        </Link>
+        <span aria-hidden="true" className="h-3 w-px bg-[var(--edge)]" />
         <a
           href={`mailto:${SALES_EMAIL}`}
           className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
         >
-          Or email {SALES_EMAIL} →
+          Email {SALES_EMAIL} →
         </a>
       </div>
     </AuthShell>

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -71,14 +71,14 @@ function UpgradeGate({
           <button
             type="button"
             onClick={() => void handleLogout()}
-            className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+            className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
           >
             Log out
           </button>
         ) : (
           <Link
             to="/"
-            className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+            className="auth-mono text-[13px] leading-none text-[var(--muted)] transition-colors hover:text-black"
           >
             Back to dashboard
           </Link>

--- a/client/dashboard/src/pages/demo/TalkToUs.tsx
+++ b/client/dashboard/src/pages/demo/TalkToUs.tsx
@@ -8,7 +8,7 @@ import {
   type TrialLifecycle,
 } from "@/lib/trial-status";
 import { getGateCopy } from "@/pages/demo/upgrade-gate-copy";
-import { Link } from "react-router";
+import { Link, Navigate } from "react-router";
 
 const SALES_EMAIL = "sales@speakeasy.com";
 
@@ -16,13 +16,32 @@ const SALES_EMAIL = "sales@speakeasy.com";
 // ended and the sweep has demoted it, or a user on a running trial navigates
 // here to upgrade early.
 export default function TalkToUs(): JSX.Element {
-  const client = useSdkClient();
   const { session } = useSessionData();
   const now = new Date();
   const lifecycle: TrialLifecycle = getTrialLifecycleFromDates(
     session?.trial,
     now,
   );
+
+  // No trial on the session means a converted customer or an org that never
+  // trialed. Neither has a trial to talk about, and the gate never sends them
+  // here, so bounce rather than describe a trial they do not have.
+  if (lifecycle === "none") {
+    return <Navigate to="/" replace />;
+  }
+
+  return <UpgradeGate lifecycle={lifecycle} now={now} />;
+}
+
+function UpgradeGate({
+  lifecycle,
+  now,
+}: {
+  lifecycle: TrialLifecycle;
+  now: Date;
+}): JSX.Element {
+  const client = useSdkClient();
+  const { session } = useSessionData();
 
   useCaptureUpgradeGateViewed({
     email: session?.user.email ?? "",

--- a/client/dashboard/src/pages/demo/TrialEnded.tsx
+++ b/client/dashboard/src/pages/demo/TrialEnded.tsx
@@ -1,0 +1,65 @@
+import { useSessionData } from "@/contexts/Auth";
+import { useSdkClient } from "@/contexts/Sdk";
+import { Link } from "react-router";
+import { useCaptureTrialExpiredGateViewed } from "@/contexts/Telemetry";
+import { AuthShell } from "@/pages/login/components/auth-shell";
+import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
+import { isValidDate } from "@/lib/trial-status";
+import { format } from "date-fns";
+
+const DATELESS_TITLE = "Your 14-day trial has ended.";
+
+export default function TrialEnded(): JSX.Element {
+  const client = useSdkClient();
+  const { session } = useSessionData();
+
+  useCaptureTrialExpiredGateViewed({
+    email: session?.user.email ?? "",
+    organizationId: session?.organization?.id ?? "",
+    organizationName: session?.organization?.name ?? "",
+    organizationSlug: session?.organization?.slug ?? "",
+  });
+
+  const handleLogout = async () => {
+    await client.auth.logout();
+    window.location.href = "/login";
+  };
+
+  // A session can reach this page without a parseable end date; naming the day
+  // is a nicety, so drop it rather than rendering "Invalid Date".
+  const endsAt = session?.trial?.endsAt;
+  const title = isValidDate(endsAt)
+    ? `Your 14-day trial ended on ${format(endsAt, "MMMM d, yyyy")}.`
+    : DATELESS_TITLE;
+
+  return (
+    <AuthShell
+      page="Trial ended"
+      contentClassName="max-w-[560px]"
+      // The card carries its own prefill footnote instead ("2E Book a demo").
+      showTerms={false}
+      headerAction={
+        <button
+          type="button"
+          onClick={() => void handleLogout()}
+          className="auth-mono text-[12px] text-[var(--muted)] transition-colors hover:text-black"
+        >
+          Log out
+        </button>
+      }
+    >
+      <DemoBookingFlow
+        title={title}
+        subtitle="Your projects, MCP servers, and toolsets are still here. Book time with our team to move to a paid plan."
+      />
+      <div className="mt-6 text-center">
+        <Link
+          to="/explore-demo"
+          className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
+        >
+          Or explore a live demo org →
+        </Link>
+      </div>
+    </AuthShell>
+  );
+}

--- a/client/dashboard/src/pages/demo/TrialEnded.tsx
+++ b/client/dashboard/src/pages/demo/TrialEnded.tsx
@@ -1,13 +1,12 @@
 import { useSessionData } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
-import { Link } from "react-router";
 import { useCaptureTrialExpiredGateViewed } from "@/contexts/Telemetry";
 import { AuthShell } from "@/pages/login/components/auth-shell";
 import { DemoBookingFlow } from "@/pages/demo/components/DemoBookingFlow";
 import { isValidDate } from "@/lib/trial-status";
 import { format } from "date-fns";
 
-const DATELESS_TITLE = "Your 14-day trial has ended.";
+const SALES_EMAIL = "sales@speakeasy.com";
 
 // The gate an organization lands on once its enterprise trial has ended and the
 // sweep has demoted it.
@@ -30,14 +29,14 @@ export default function TrialEnded(): JSX.Element {
   // A session can reach this page without a parseable end date; naming the day
   // is a nicety, so drop it rather than rendering "Invalid Date".
   const endsAt = session?.trial?.endsAt;
-  const title = isValidDate(endsAt)
-    ? `Your 14-day trial ended on ${format(endsAt, "MMMM d, yyyy")}.`
-    : DATELESS_TITLE;
+  const statusLabel = isValidDate(endsAt)
+    ? `Trial ended ${format(endsAt, "MMM do")}`
+    : "Trial ended";
 
   return (
     <AuthShell
       page="Talk to us"
-      contentClassName="max-w-[560px]"
+      singleColumn
       // The card carries its own prefill footnote instead ("2E Book a demo").
       showTerms={false}
       headerAction={
@@ -51,16 +50,43 @@ export default function TrialEnded(): JSX.Element {
       }
     >
       <DemoBookingFlow
-        title={title}
-        subtitle="Your projects, MCP servers, and toolsets are still here. Book time with our team to move to a paid plan."
+        eventLabel="Upgrade Trial — 30 min"
+        intro={
+          <div className="grid w-full grid-cols-1 items-start gap-10 md:grid-cols-2">
+            <div className="flex flex-col gap-2.5">
+              <span className="auth-mono flex items-center gap-2.5 text-[12px] text-[var(--muted)]">
+                {/* Static, unlike the showcase's live-session dot: the pulse
+                    reads as "happening now", which is the opposite of this. */}
+                <i
+                  aria-hidden="true"
+                  className="size-[7px] rounded-full bg-[var(--vermilion)]"
+                />
+                {statusLabel}
+              </span>
+              <p className="text-[40px] leading-[1.05] font-thin tracking-[-0.035em] [font-family:var(--f-display)]">
+                Book a call to upgrade.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 md:border-l md:border-[var(--edge-soft)] md:pl-10">
+              <p className="text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
+                Trials run 14 days. Book 30 minutes and we&rsquo;ll find the
+                plan that fits your organization.
+              </p>
+              <p className="auth-mono-text text-[12px] text-[var(--muted)]">
+                MCP servers, observability data, and policies retained for 30
+                days.
+              </p>
+            </div>
+          </div>
+        }
       />
-      <div className="mt-6 text-center">
-        <Link
-          to="/explore-demo"
+      <div className="text-center">
+        <a
+          href={`mailto:${SALES_EMAIL}`}
           className="auth-mono text-[12px] text-[var(--muted)] underline underline-offset-4 transition-colors hover:text-black"
         >
-          Or explore a live demo org →
-        </Link>
+          Or email {SALES_EMAIL} →
+        </a>
       </div>
     </AuthShell>
   );

--- a/client/dashboard/src/pages/demo/TrialEnded.tsx
+++ b/client/dashboard/src/pages/demo/TrialEnded.tsx
@@ -9,6 +9,8 @@ import { format } from "date-fns";
 
 const DATELESS_TITLE = "Your 14-day trial has ended.";
 
+// The gate an organization lands on once its enterprise trial has ended and the
+// sweep has demoted it.
 export default function TrialEnded(): JSX.Element {
   const client = useSdkClient();
   const { session } = useSessionData();
@@ -34,7 +36,7 @@ export default function TrialEnded(): JSX.Element {
 
   return (
     <AuthShell
-      page="Trial ended"
+      page="Talk to us"
       contentClassName="max-w-[560px]"
       // The card carries its own prefill footnote instead ("2E Book a demo").
       showTerms={false}

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -24,14 +24,18 @@ vi.mock("@calcom/embed-react", () => ({
     config,
   }: {
     calLink: string;
-    config?: { name?: string; email?: string; company?: string };
+    config?: Record<string, string | undefined>;
   }) => (
     <div
       data-testid="cal-embed"
       data-cal-link={calLink}
       data-cal-name={config?.name ?? ""}
       data-cal-email={config?.email ?? ""}
-      data-cal-company={config?.company ?? ""}
+      // Keyed by the booking question's identifier on the Cal event, which is
+      // what the embed actually matches on.
+      data-cal-company={config?.["Company-Name"] ?? ""}
+      data-cal-source={config?.source ?? ""}
+      data-cal-notes={config?.notes ?? ""}
     />
   ),
   getCalApi: () => Promise.resolve(calUiMock),
@@ -71,6 +75,24 @@ describe("DemoBookingFlow", () => {
     expect(embed.getAttribute("data-cal-name")).toBe("Jane Smith");
     expect(embed.getAttribute("data-cal-email")).toBe("jane@acme.com");
     expect(embed.getAttribute("data-cal-company")).toBe("Acme Inc");
+  });
+
+  it("leaves the form defaults blank when the caller sets none", () => {
+    render(<DemoBookingFlow />);
+    const embed = screen.getByTestId("cal-embed");
+    expect(embed.getAttribute("data-cal-source")).toBe("");
+    expect(embed.getAttribute("data-cal-notes")).toBe("");
+  });
+
+  it("passes the caller's form defaults through to the embed", () => {
+    render(
+      <DemoBookingFlow
+        formDefaults={{ source: "Trial", notes: "Upgrade trial account" }}
+      />,
+    );
+    const embed = screen.getByTestId("cal-embed");
+    expect(embed.getAttribute("data-cal-source")).toBe("Trial");
+    expect(embed.getAttribute("data-cal-notes")).toBe("Upgrade trial account");
   });
 
   it("renders the embed even before the session resolves", () => {

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.test.tsx
@@ -84,6 +84,22 @@ describe("DemoBookingFlow", () => {
     expect(embed.getAttribute("data-cal-notes")).toBe("");
   });
 
+  it("keeps session identity when a caller tries to override it", () => {
+    render(
+      <DemoBookingFlow
+        formDefaults={{
+          email: "spoof@example.test",
+          name: "Someone Else",
+          "Company-Name": "Other Co",
+        }}
+      />,
+    );
+    const embed = screen.getByTestId("cal-embed");
+    expect(embed.getAttribute("data-cal-email")).toBe("jane@acme.com");
+    expect(embed.getAttribute("data-cal-name")).toBe("Jane Smith");
+    expect(embed.getAttribute("data-cal-company")).toBe("Acme Inc");
+  });
+
   it("passes the caller's form defaults through to the embed", () => {
     render(
       <DemoBookingFlow

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -69,14 +69,25 @@ const DEFAULT_INTRO = (
   </div>
 );
 
+/**
+ * Values to prefill on the booking form, keyed by the question's identifier on
+ * the Cal event. The form carries more questions than any one caller fills:
+ * `source` ("How'd you hear about us?"), `notes` ("Additional notes"), `title`,
+ * `attendeePhoneNumber`. Name, email and `Company-Name` come from the session
+ * and are always sent. Anything omitted is left for the user to answer.
+ */
+export type BookingFormDefaults = Record<string, string | undefined>;
+
 export function DemoBookingFlow({
   intro = DEFAULT_INTRO,
   eventLabel = "AI transformation — 30 min",
+  formDefaults,
 }: {
   /** Rendered above the booking card. Pass `null` to omit it entirely. */
   intro?: React.ReactNode;
   /** Names the meeting in the card header, which the embed itself hides. */
   eventLabel?: string;
+  formDefaults?: BookingFormDefaults;
 } = {}): JSX.Element {
   const { session } = useSessionData();
   const telemetry = useTelemetry();
@@ -142,8 +153,13 @@ export function DemoBookingFlow({
               theme: "light",
               name,
               email,
-              // Must match the booking question's identifier on the Cal event.
+              // Keys must match the booking questions' identifiers on the Cal
+              // event. Empty entries are dropped rather than sent, so an unset
+              // default leaves the field open instead of blanking it.
               "Company-Name": companyName,
+              ...Object.fromEntries(
+                Object.entries(formDefaults ?? {}).filter(([, v]) => v),
+              ),
             }}
             style={{ width: "100%", height: "100%", overflow: "auto" }}
           />

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -142,9 +142,8 @@ export function DemoBookingFlow({
               theme: "light",
               name,
               email,
-              // Prefill key must match the booking question's identifier on the
-              // Cal event (see CAL_DEMO_LINK).
-              company: companyName,
+              // Must match the booking question's identifier on the Cal event.
+              "Company-Name": companyName,
             }}
             style={{ width: "100%", height: "100%", overflow: "auto" }}
           />

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -56,12 +56,27 @@ function useCalBranding() {
   }, []);
 }
 
+// Sits above the card on the cold-signup gate. The expired-trial gate passes
+// its own header instead.
+const DEFAULT_INTRO = (
+  <div className="text-center">
+    <p className="text-[16px] tracking-[0.0025em]">
+      Looks like your company is new to Speakeasy.
+    </p>
+    <p className="mt-1.5 text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
+      Book time with our team to activate your account and get started.
+    </p>
+  </div>
+);
+
 export function DemoBookingFlow({
-  title = "Looks like your company is new to Speakeasy.",
-  subtitle = "Book time with our team to activate your account and get started.",
+  intro = DEFAULT_INTRO,
+  eventLabel = "AI transformation — 30 min",
 }: {
-  title?: string;
-  subtitle?: string;
+  /** Rendered above the booking card. Pass `null` to omit it entirely. */
+  intro?: React.ReactNode;
+  /** Names the meeting in the card header, which the embed itself hides. */
+  eventLabel?: string;
 } = {}): JSX.Element {
   const { session } = useSessionData();
   const telemetry = useTelemetry();
@@ -105,20 +120,13 @@ export function DemoBookingFlow({
 
   return (
     <div className="flex w-full flex-col items-center gap-6">
-      <div className="text-center">
-        <p className="text-[16px] tracking-[0.0025em]">{title}</p>
-        <p className="mt-1.5 text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
-          {subtitle}
-        </p>
-      </div>
+      {intro}
 
       <div className="w-full overflow-hidden border border-[var(--edge)] bg-[var(--card)]">
         {/* The embed runs with `hideEventTypeDetails`, so this header is what
             names the meeting — as in the design frame. */}
         <div className="flex h-11 items-center justify-between border-b border-[var(--edge-soft)] px-[18px]">
-          <span className="auth-mono text-[12px]">
-            AI transformation — 30 min
-          </span>
+          <span className="auth-mono text-[12px]">{eventLabel}</span>
           <span className="auth-mono-text text-[12px] text-[var(--muted)]">
             Google Meet
           </span>

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -149,17 +149,21 @@ export function DemoBookingFlow({
           <Cal
             calLink={CAL_DEMO_LINK}
             config={{
+              // Caller defaults go first so the identity below wins: the type
+              // is an open record and cannot stop a caller passing `email`,
+              // but attendee details are this component's to set.
+              // Empty entries are dropped rather than sent, so an unset
+              // default leaves the field open instead of blanking it.
+              ...Object.fromEntries(
+                Object.entries(formDefaults ?? {}).filter(([, v]) => v),
+              ),
               layout: "month_view",
               theme: "light",
               name,
               email,
-              // Keys must match the booking questions' identifiers on the Cal
-              // event. Empty entries are dropped rather than sent, so an unset
-              // default leaves the field open instead of blanking it.
+              // Key must match the booking question's identifier on the Cal
+              // event.
               "Company-Name": companyName,
-              ...Object.fromEntries(
-                Object.entries(formDefaults ?? {}).filter(([, v]) => v),
-              ),
             }}
             style={{ width: "100%", height: "100%", overflow: "auto" }}
           />

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -56,7 +56,13 @@ function useCalBranding() {
   }, []);
 }
 
-export function DemoBookingFlow(): JSX.Element {
+export function DemoBookingFlow({
+  title = "Looks like your company is new to Speakeasy.",
+  subtitle = "Book time with our team to activate your account and get started.",
+}: {
+  title?: string;
+  subtitle?: string;
+} = {}): JSX.Element {
   const { session } = useSessionData();
   const telemetry = useTelemetry();
 
@@ -100,11 +106,9 @@ export function DemoBookingFlow(): JSX.Element {
   return (
     <div className="flex w-full flex-col items-center gap-6">
       <div className="text-center">
-        <p className="text-[16px] tracking-[0.0025em]">
-          Looks like your company is new to Speakeasy.
-        </p>
+        <p className="text-[16px] tracking-[0.0025em]">{title}</p>
         <p className="mt-1.5 text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
-          Book time with our team to activate your account and get started.
+          {subtitle}
         </p>
       </div>
 

--- a/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
+++ b/client/dashboard/src/pages/demo/components/DemoBookingFlow.tsx
@@ -63,7 +63,7 @@ const DEFAULT_INTRO = (
     <p className="text-[16px] tracking-[0.0025em]">
       Looks like your company is new to Speakeasy.
     </p>
-    <p className="mt-1.5 text-[14px] tracking-[0.0025em] text-[var(--muted-strong)]">
+    <p className="mt-1.5 text-sm tracking-[0.0025em] text-(--muted-strong)">
       Book time with our team to activate your account and get started.
     </p>
   </div>
@@ -122,12 +122,12 @@ export function DemoBookingFlow({
     <div className="flex w-full flex-col items-center gap-6">
       {intro}
 
-      <div className="w-full overflow-hidden border border-[var(--edge)] bg-[var(--card)]">
+      <div className="w-full overflow-hidden border border-(--edge) bg-(--card)">
         {/* The embed runs with `hideEventTypeDetails`, so this header is what
             names the meeting — as in the design frame. */}
-        <div className="flex h-11 items-center justify-between border-b border-[var(--edge-soft)] px-[18px]">
-          <span className="auth-mono text-[12px]">{eventLabel}</span>
-          <span className="auth-mono-text text-[12px] text-[var(--muted)]">
+        <div className="flex h-11 items-center justify-between border-b border-(--edge-soft) px-[18px]">
+          <span className="auth-mono text-xs">{eventLabel}</span>
+          <span className="auth-mono-text text-xs text-(--muted)">
             Google Meet
           </span>
         </div>
@@ -152,7 +152,7 @@ export function DemoBookingFlow({
       </div>
 
       {prefill && (
-        <p className="auth-mono-text text-center text-[11px] tracking-[0.02em] text-[var(--muted)]">
+        <p className="auth-mono-text text-center text-[11px] tracking-[0.02em] text-(--muted)">
           Details prefilled from your account: {prefill}
         </p>
       )}

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
@@ -9,7 +9,13 @@ beforeAll(() => {
   process.env.TZ = "UTC";
 });
 afterAll(() => {
-  process.env.TZ = originalTZ;
+  // Assigning undefined would leave the literal string "undefined" behind for
+  // whatever else shares this worker.
+  if (originalTZ === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = originalTZ;
+  }
 });
 
 const NOW = new Date("2026-08-10T12:00:00.000Z");

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
@@ -35,6 +35,8 @@ describe("getGateCopy", () => {
     expect(copy.status).toBe("Trial ended Aug 9th, 2026");
     expect(copy.dotClassName).toContain("vermilion");
     expect(copy.detail).toContain("still here when you upgrade");
+    expect(copy.source).toBe("Trial: Expired");
+    expect(copy.notes).toBe("Upgrade expired trial");
   });
 
   it("treats the end instant itself as ended", () => {
@@ -57,6 +59,8 @@ describe("getGateCopy", () => {
     expect(copy.status).toBe("Trial · 8 days left");
     expect(copy.dotClassName).toContain("moss");
     expect(copy.body).toContain("before your trial ends");
+    expect(copy.source).toBe("Trial: Active");
+    expect(copy.notes).toBe("Upgrade trial");
   });
 
   it("says day, not days, on the final day", () => {

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getGateCopy } from "./upgrade-gate-copy";
+
+// The status line formats in local time, so a noon-UTC end date renders as the
+// next day from UTC+12 onwards. Pin the zone or these assertions depend on
+// where the machine running them happens to be.
+const originalTZ = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "UTC";
+});
+afterAll(() => {
+  process.env.TZ = originalTZ;
+});
 
 const NOW = new Date("2026-08-10T12:00:00.000Z");
 

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { getGateCopy } from "./upgrade-gate-copy";
+
+const NOW = new Date("2026-08-10T12:00:00.000Z");
+
+const trial = (startedAt: string, endsAt: string) => ({
+  startedAt: new Date(startedAt),
+  endsAt: new Date(endsAt),
+});
+
+describe("getGateCopy", () => {
+  it("names the end date once the trial has ended", () => {
+    const copy = getGateCopy(
+      trial("2026-07-26T12:00:00.000Z", "2026-08-09T12:00:00.000Z"),
+      NOW,
+    );
+
+    expect(copy.status).toBe("Trial ended Aug 9th, 2026");
+    expect(copy.dotClassName).toContain("vermilion");
+    expect(copy.detail).toContain("still here when you upgrade");
+  });
+
+  it("treats the end instant itself as ended", () => {
+    // The gate redirects on `now >= endsAt`, so the copy has to agree at the
+    // exact boundary or the page contradicts the redirect that sent them.
+    const copy = getGateCopy(
+      trial("2026-07-27T12:00:00.000Z", NOW.toISOString()),
+      NOW,
+    );
+
+    expect(copy.status).toBe("Trial ended Aug 10th, 2026");
+  });
+
+  it("counts down while the trial is running", () => {
+    const copy = getGateCopy(
+      trial("2026-08-04T12:00:00.000Z", "2026-08-18T12:00:00.000Z"),
+      NOW,
+    );
+
+    expect(copy.status).toBe("Trial · 8 days left");
+    expect(copy.dotClassName).toContain("moss");
+    expect(copy.body).toContain("before your trial ends");
+  });
+
+  it("says day, not days, on the final day", () => {
+    const copy = getGateCopy(
+      trial("2026-07-28T12:00:00.000Z", "2026-08-11T12:00:00.000Z"),
+      NOW,
+    );
+
+    expect(copy.status).toBe("Trial · 1 day left");
+  });
+
+  it("falls back to the running-trial wording with no trial", () => {
+    const copy = getGateCopy(null, NOW);
+
+    expect(copy.status).toBe("Trial in progress");
+    expect(copy.dotClassName).toContain("moss");
+  });
+
+  it("falls back rather than rendering an unparseable date", () => {
+    const copy = getGateCopy(
+      { startedAt: new Date("nope"), endsAt: new Date("nope") },
+      NOW,
+    );
+
+    expect(copy.status).toBe("Trial in progress");
+  });
+});

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
@@ -1,0 +1,55 @@
+import {
+  getTrialLifecycleFromDates,
+  getTrialStatusFromDates,
+  isValidDate,
+} from "@/lib/trial-status";
+import { format } from "date-fns";
+
+const SHARED_BODY =
+  "Book 30 minutes and we'll find the plan that fits your organization.";
+
+export type GateCopy = {
+  /** Colour of the status dot. Static — the pulse is for live sessions. */
+  dotClassName: string;
+  status: string;
+  body: string;
+  detail: string;
+};
+
+// The upgrade page serves two audiences: an org walled after its trial ran out,
+// and an org still inside its trial that wants to upgrade early. Only the
+// header copy differs; the booking card below is the same either way. A trial
+// that has ended is the exception, so the running trial is the default — a
+// session with no readable trial gets that wording rather than a third variant.
+export function getGateCopy(
+  trial: { startedAt: Date; endsAt: Date } | null | undefined,
+  now: Date,
+): GateCopy {
+  const endsAt = trial?.endsAt;
+
+  if (getTrialLifecycleFromDates(trial, now) === "expired") {
+    return {
+      dotClassName: "bg-[var(--vermilion)]",
+      // Belt and braces: "expired" already implies a parseable end date, so the
+      // dateless form is unreachable unless that changes.
+      status: isValidDate(endsAt)
+        ? `Trial ended ${format(endsAt, "MMM do, yyyy")}`
+        : "Trial ended",
+      body: `Trials run 14 days. ${SHARED_BODY}`,
+      detail:
+        "Your MCP servers, observability data, and policies are still here when you upgrade.",
+    };
+  }
+
+  const remainingDays = getTrialStatusFromDates(trial, now)?.remainingDays;
+  return {
+    dotClassName: "bg-[var(--moss)]",
+    status:
+      remainingDays === undefined
+        ? "Trial in progress"
+        : `Trial · ${remainingDays} day${remainingDays === 1 ? "" : "s"} left`,
+    body: `Upgrade before your trial ends and nothing pauses. ${SHARED_BODY}`,
+    detail:
+      "Your MCP servers, observability data, and policies carry over unchanged.",
+  };
+}

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
@@ -29,7 +29,7 @@ export function getGateCopy(
 
   if (getTrialLifecycleFromDates(trial, now) === "expired") {
     return {
-      dotClassName: "bg-[var(--vermilion)]",
+      dotClassName: "bg-(--vermilion)",
       // Belt and braces: "expired" already implies a parseable end date, so the
       // dateless form is unreachable unless that changes.
       status: isValidDate(endsAt)
@@ -43,7 +43,7 @@ export function getGateCopy(
 
   const remainingDays = getTrialStatusFromDates(trial, now)?.remainingDays;
   return {
-    dotClassName: "bg-[var(--moss)]",
+    dotClassName: "bg-(--moss)",
     status:
       remainingDays === undefined
         ? "Trial in progress"

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
@@ -6,10 +6,10 @@ import {
 import { format } from "date-fns";
 
 const SHARED_BODY =
-  "Book 30 minutes and we'll find the plan that fits your organization.";
+  "Book 30 minutes with us and we'll find the plan that fits your organization.";
 
 export type GateCopy = {
-  /** Colour of the status dot. Static — the pulse is for live sessions. */
+  /** Color of the status dot. Static — the pulse is for live sessions. */
   dotClassName: string;
   status: string;
   body: string;

--- a/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
+++ b/client/dashboard/src/pages/demo/upgrade-gate-copy.ts
@@ -14,6 +14,10 @@ export type GateCopy = {
   status: string;
   body: string;
   detail: string;
+  /** Prefills the booking form's "How'd you hear about us?" question. */
+  source: string;
+  /** Prefills the booking form's "Additional notes" question. */
+  notes: string;
 };
 
 // The upgrade page serves two audiences: an org walled after its trial ran out,
@@ -38,6 +42,8 @@ export function getGateCopy(
       body: `Trials run 14 days. ${SHARED_BODY}`,
       detail:
         "Your MCP servers, observability data, and policies are still here when you upgrade.",
+      source: "Trial: Expired",
+      notes: "Upgrade expired trial",
     };
   }
 
@@ -51,5 +57,7 @@ export function getGateCopy(
     body: `Upgrade before your trial ends and nothing pauses. ${SHARED_BODY}`,
     detail:
       "Your MCP servers, observability data, and policies carry over unchanged.",
+    source: "Trial: Active",
+    notes: "Upgrade trial",
   };
 }

--- a/client/dashboard/src/pages/login/components/auth-shell.tsx
+++ b/client/dashboard/src/pages/login/components/auth-shell.tsx
@@ -95,12 +95,12 @@ export function AuthShell({
   children: React.ReactNode;
 }): JSX.Element {
   return (
-    <main className="auth-brand flex min-h-screen flex-col bg-[var(--surface)] text-black">
+    <main className="auth-brand flex min-h-screen flex-col bg-(--surface) text-black">
       <style>{BRAND_STYLES}</style>
 
       <BrandGradientLine className="h-[4px]" />
 
-      <header className="flex h-16 flex-none items-center justify-between border-b border-[var(--edge)] bg-[var(--card)] px-6 md:px-10">
+      <header className="flex h-16 flex-none items-center justify-between border-b border-(--edge) bg-(--card) px-6 md:px-10">
         <span className="auth-mono flex items-center gap-3 text-[13px]">
           <img src={speakeasyIcon} alt="" className="h-[22px] w-[22px]" />
           Speakeasy AI Control Plane
@@ -108,12 +108,12 @@ export function AuthShell({
         {/* leading-none on both sides so the label and the action sit on the
             same optical line — a button inherits its own line box otherwise. */}
         <span className="flex items-center gap-4">
-          <span className="auth-mono text-[13px] leading-none text-[var(--muted)]">
+          <span className="auth-mono text-[13px] leading-none text-(--muted)">
             {page}
           </span>
           {headerAction && (
             <>
-              <span aria-hidden="true" className="h-3 w-px bg-[var(--edge)]" />
+              <span aria-hidden="true" className="h-3 w-px bg-(--edge)" />
               {headerAction}
             </>
           )}
@@ -132,7 +132,7 @@ export function AuthShell({
             positioned terms footer; without it that space is dead. */}
         <section
           className={cn(
-            "relative flex flex-1 flex-col items-center justify-center border-[var(--edge-soft)] bg-[var(--card)] px-8",
+            "relative flex flex-1 flex-col items-center justify-center border-(--edge-soft) bg-(--card) px-8",
             singleColumn ? "pt-14" : "pt-16 xl:border-l",
             showTerms ? "pb-28" : singleColumn ? "pb-10" : "pb-12",
           )}
@@ -149,8 +149,8 @@ export function AuthShell({
           </div>
           {showTerms && (
             <TermsFooter
-              className="absolute right-12 bottom-7 left-12 text-[var(--muted-strong)]"
-              linkClassName="text-[var(--muted-strong)] hover:text-black"
+              className="absolute right-12 bottom-7 left-12 text-(--muted-strong)"
+              linkClassName="text-(--muted-strong) hover:text-black"
             />
           )}
         </section>

--- a/client/dashboard/src/pages/login/components/auth-shell.tsx
+++ b/client/dashboard/src/pages/login/components/auth-shell.tsx
@@ -105,11 +105,18 @@ export function AuthShell({
           <img src={speakeasyIcon} alt="" className="h-[22px] w-[22px]" />
           Speakeasy AI Control Plane
         </span>
-        <span className="flex items-center gap-6">
-          <span className="auth-mono text-[13px] text-[var(--muted)]">
+        {/* leading-none on both sides so the label and the action sit on the
+            same optical line — a button inherits its own line box otherwise. */}
+        <span className="flex items-center gap-4">
+          <span className="auth-mono text-[13px] leading-none text-[var(--muted)]">
             {page}
           </span>
-          {headerAction}
+          {headerAction && (
+            <>
+              <span aria-hidden="true" className="h-3 w-px bg-[var(--edge)]" />
+              {headerAction}
+            </>
+          )}
         </span>
       </header>
 

--- a/client/dashboard/src/pages/login/components/auth-shell.tsx
+++ b/client/dashboard/src/pages/login/components/auth-shell.tsx
@@ -78,6 +78,7 @@ export function AuthShell({
   headerAction,
   contentClassName,
   showTerms = true,
+  singleColumn = false,
   children,
 }: {
   page: string;
@@ -86,6 +87,11 @@ export function AuthShell({
   /** Overrides the right-pane column width (default max-w-[380px]). */
   contentClassName?: string;
   showTerms?: boolean;
+  /**
+   * Drops the session showcase and the brand lockup for one centered column.
+   * For pages that carry their own headline and need the full width.
+   */
+  singleColumn?: boolean;
   children: React.ReactNode;
 }): JSX.Element {
   return (
@@ -107,24 +113,31 @@ export function AuthShell({
         </span>
       </header>
 
-      <div className="grid flex-1 xl:grid-cols-2">
-        <AgentSessionShowcase />
+      <div
+        className={cn(
+          "flex-1",
+          singleColumn ? "flex flex-col" : "grid xl:grid-cols-2",
+        )}
+      >
+        {!singleColumn && <AgentSessionShowcase />}
 
         {/* The deep bottom padding only exists to clear the absolutely
             positioned terms footer; without it that space is dead. */}
         <section
           className={cn(
-            "relative flex flex-col items-center justify-center border-[var(--edge-soft)] bg-[var(--card)] px-8 pt-16 xl:border-l",
-            showTerms ? "pb-28" : "pb-12",
+            "relative flex flex-1 flex-col items-center justify-center border-[var(--edge-soft)] bg-[var(--card)] px-8",
+            singleColumn ? "pt-14" : "pt-16 xl:border-l",
+            showTerms ? "pb-28" : singleColumn ? "pb-10" : "pb-12",
           )}
         >
           <div
             className={cn(
-              "flex w-full max-w-[380px] flex-col items-center gap-6",
+              "flex w-full flex-col items-center gap-6",
+              singleColumn ? "max-w-[900px]" : "max-w-[380px]",
               contentClassName,
             )}
           >
-            <BrandLockup />
+            {!singleColumn && <BrandLockup />}
             {children}
           </div>
           {showTerms && (

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -34,6 +34,7 @@ import Integrations from "./pages/integrations/Integrations";
 import Login from "./pages/login/Login";
 import Register from "./pages/login/Register";
 import ExploreDemo from "./pages/demo/ExploreDemo";
+import TrialEnded from "./pages/demo/TrialEnded";
 import SignUp from "./pages/login/SignUp";
 import { LogsRoot } from "./pages/logs/Logs";
 import { BuiltInMCPDetailPage } from "./pages/mcp/BuiltInMCPDetailPage";
@@ -206,6 +207,15 @@ const ROUTE_STRUCTURE = {
     title: "Explore demo",
     url: "/explore-demo",
     component: ExploreDemo,
+    unauthenticated: true,
+  },
+  // Not actually unauthenticated — the flag registers the route outside the
+  // main app layout, which is what a full-page gate screen needs. The gate in
+  // AuthProvider redirects demoted trials here.
+  talkToUs: {
+    title: "Talk to us",
+    url: "/talk-to-us",
+    component: TrialEnded,
     unauthenticated: true,
   },
   signUp: {

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -34,7 +34,7 @@ import Integrations from "./pages/integrations/Integrations";
 import Login from "./pages/login/Login";
 import Register from "./pages/login/Register";
 import ExploreDemo from "./pages/demo/ExploreDemo";
-import TrialEnded from "./pages/demo/TrialEnded";
+import TalkToUs from "./pages/demo/TalkToUs";
 import SignUp from "./pages/login/SignUp";
 import { LogsRoot } from "./pages/logs/Logs";
 import { BuiltInMCPDetailPage } from "./pages/mcp/BuiltInMCPDetailPage";
@@ -215,7 +215,7 @@ const ROUTE_STRUCTURE = {
   talkToUs: {
     title: "Talk to us",
     url: "/talk-to-us",
-    component: TrialEnded,
+    component: TalkToUs,
     unauthenticated: true,
   },
   signUp: {

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -34,7 +34,6 @@ import Integrations from "./pages/integrations/Integrations";
 import Login from "./pages/login/Login";
 import Register from "./pages/login/Register";
 import ExploreDemo from "./pages/demo/ExploreDemo";
-import TalkToUs from "./pages/demo/TalkToUs";
 import SignUp from "./pages/login/SignUp";
 import { LogsRoot } from "./pages/logs/Logs";
 import { BuiltInMCPDetailPage } from "./pages/mcp/BuiltInMCPDetailPage";
@@ -207,15 +206,6 @@ const ROUTE_STRUCTURE = {
     title: "Explore demo",
     url: "/explore-demo",
     component: ExploreDemo,
-    unauthenticated: true,
-  },
-  // Not actually unauthenticated — the flag registers the route outside the
-  // main app layout, which is what a full-page gate screen needs. The gate in
-  // AuthProvider redirects demoted trials here.
-  talkToUs: {
-    title: "Talk to us",
-    url: "/talk-to-us",
-    component: TalkToUs,
     unauthenticated: true,
   },
   signUp: {

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -756,10 +756,10 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	trial := loadActiveTrial(
+	trial := loadTrial(
 		ctx,
 		authCtx.ActiveOrganizationID,
-		trialsRepo.New(s.db).GetActiveTrial,
+		trialsRepo.New(s.db).GetSessionTrial,
 		s.logger,
 	)
 
@@ -888,10 +888,14 @@ func (s *Service) Info(ctx context.Context, payload *gen.InfoPayload) (res *gen.
 	}, nil
 }
 
-func loadActiveTrial(
+// loadTrial returns the organization's trial unless it converted, including
+// trials that have ended or been demoted so the dashboard can tell an expired
+// trial apart from an organization that never trialed. A lookup failure is
+// logged and reported as no trial rather than failing the whole session.
+func loadTrial(
 	ctx context.Context,
 	organizationID string,
-	getTrial func(context.Context, string) (trialsRepo.GetActiveTrialRow, error),
+	getTrial func(context.Context, string) (trialsRepo.GetSessionTrialRow, error),
 	logger *slog.Logger,
 ) *gen.Trial {
 	trial, err := getTrial(ctx, organizationID)
@@ -901,7 +905,7 @@ func loadActiveTrial(
 	case err != nil:
 		logger.ErrorContext(
 			ctx,
-			"error loading active trial; continuing without trial status",
+			"error loading trial; continuing without trial status",
 			attr.SlogError(err),
 			attr.SlogOrganizationID(organizationID),
 		)

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -128,30 +128,41 @@ func TestService_Info(t *testing.T) {
 
 	// An expired trial has to reach the dashboard so it can tell the user their
 	// trial ended instead of falling back to the generic never-trialed gate.
+	// Demotion is reported whether or not the clock ran out first: the query
+	// filters on conversion alone, so an organization demoted by hand mid-trial
+	// still resolves.
 	for _, test := range []struct {
 		name      string
+		endsAt    time.Time
 		demotedAt *time.Time
 	}{
 		{
 			name:      "expired",
+			endsAt:    time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC),
 			demotedAt: nil,
 		},
 		{
 			name:      "demoted",
+			endsAt:    time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC),
 			demotedAt: timestampPtr(time.Date(2026, time.August, 4, 13, 0, 0, 0, time.UTC)),
+		},
+		{
+			name:      "demoted before the trial ran out",
+			endsAt:    time.Date(2100, time.August, 15, 12, 0, 0, 0, time.UTC),
+			demotedAt: timestampPtr(time.Date(2026, time.August, 2, 12, 0, 0, 0, time.UTC)),
 		},
 	} {
 		t.Run("returns "+test.name+" trial", func(t *testing.T) {
 			t.Parallel()
 
 			ctx, instance, organizationID := setupInfoRequest(t)
-			insertTrial(t, ctx, instance, organizationID, time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC), time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC), nil, test.demotedAt)
+			insertTrial(t, ctx, instance, organizationID, time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC), test.endsAt, nil, test.demotedAt)
 
 			result, err := instance.service.Info(ctx, &gen.InfoPayload{})
 			require.NoError(t, err)
 			require.Equal(t, &gen.Trial{
 				StartedAt: "2026-08-01T12:00:00Z",
-				EndsAt:    "2026-08-04T12:00:00Z",
+				EndsAt:    test.endsAt.Format(time.RFC3339),
 			}, result.Trial)
 		})
 	}

--- a/server/internal/auth/info_test.go
+++ b/server/internal/auth/info_test.go
@@ -126,38 +126,56 @@ func TestService_Info(t *testing.T) {
 		require.Nil(t, result.Trial)
 	})
 
+	// An expired trial has to reach the dashboard so it can tell the user their
+	// trial ended instead of falling back to the generic never-trialed gate.
 	for _, test := range []struct {
-		name        string
-		endsAt      time.Time
-		convertedAt *time.Time
-		demotedAt   *time.Time
+		name      string
+		demotedAt *time.Time
 	}{
 		{
-			name:        "converted",
-			endsAt:      time.Date(2100, time.August, 15, 12, 0, 0, 0, time.UTC),
-			convertedAt: timestampPtr(time.Date(2100, time.August, 2, 12, 0, 0, 0, time.UTC)),
+			name:      "expired",
+			demotedAt: nil,
 		},
 		{
 			name:      "demoted",
-			endsAt:    time.Date(2100, time.August, 15, 12, 0, 0, 0, time.UTC),
-			demotedAt: timestampPtr(time.Date(2100, time.August, 2, 12, 0, 0, 0, time.UTC)),
-		},
-		{
-			name:   "expired",
-			endsAt: time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC),
+			demotedAt: timestampPtr(time.Date(2026, time.August, 4, 13, 0, 0, 0, time.UTC)),
 		},
 	} {
-		t.Run("does not return "+test.name+" trial", func(t *testing.T) {
+		t.Run("returns "+test.name+" trial", func(t *testing.T) {
 			t.Parallel()
 
 			ctx, instance, organizationID := setupInfoRequest(t)
-			insertTrial(t, ctx, instance, organizationID, time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC), test.endsAt, test.convertedAt, test.demotedAt)
+			insertTrial(t, ctx, instance, organizationID, time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC), time.Date(2026, time.August, 4, 12, 0, 0, 0, time.UTC), nil, test.demotedAt)
 
 			result, err := instance.service.Info(ctx, &gen.InfoPayload{})
 			require.NoError(t, err)
-			require.Nil(t, result.Trial)
+			require.Equal(t, &gen.Trial{
+				StartedAt: "2026-08-01T12:00:00Z",
+				EndsAt:    "2026-08-04T12:00:00Z",
+			}, result.Trial)
 		})
 	}
+
+	// A converted trial stays hidden so a paying customer never sees trial UI.
+	t.Run("does not return converted trial", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, instance, organizationID := setupInfoRequest(t)
+		insertTrial(
+			t,
+			ctx,
+			instance,
+			organizationID,
+			time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC),
+			time.Date(2100, time.August, 15, 12, 0, 0, 0, time.UTC),
+			timestampPtr(time.Date(2026, time.August, 2, 12, 0, 0, 0, time.UTC)),
+			nil,
+		)
+
+		result, err := instance.service.Info(ctx, &gen.InfoPayload{})
+		require.NoError(t, err)
+		require.Nil(t, result.Trial)
+	})
 
 	t.Run("successful info request for regular user", func(t *testing.T) {
 		t.Parallel()

--- a/server/internal/auth/trial_test.go
+++ b/server/internal/auth/trial_test.go
@@ -10,17 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadActiveTrialReturnsNilAfterLookupError(t *testing.T) {
+func TestLoadTrialReturnsNilAfterLookupError(t *testing.T) {
 	t.Parallel()
 
 	lookupErr := errors.New("trial lookup unavailable")
 	logger := testenv.NewLogger(t)
 
-	trial := loadActiveTrial(
+	trial := loadTrial(
 		t.Context(),
 		"<ORG_ID>",
-		func(context.Context, string) (trialsRepo.GetActiveTrialRow, error) {
-			return trialsRepo.GetActiveTrialRow{}, lookupErr
+		func(context.Context, string) (trialsRepo.GetSessionTrialRow, error) {
+			return trialsRepo.GetSessionTrialRow{}, lookupErr
 		},
 		logger,
 	)

--- a/server/internal/trials/queries.sql
+++ b/server/internal/trials/queries.sql
@@ -17,6 +17,16 @@ WHERE organization_id = @organization_id
   AND demoted_at IS NULL
   AND ends_at > now();
 
+-- name: GetSessionTrial :one
+-- Backs the trial status the dashboard renders for a session. Ended and demoted
+-- rows are deliberately kept so the dashboard can tell the user their trial
+-- ended, while converted rows are dropped so a paying customer never sees
+-- trial UI.
+SELECT organization_id, created_at, ends_at
+FROM trials
+WHERE organization_id = @organization_id
+  AND converted_at IS NULL;
+
 -- name: InsertTrialFixture :exec
 -- Test-only fixture for exercising active trial lifecycle states.
 INSERT INTO trials (organization_id, tier, created_at, ends_at, converted_at, demoted_at)

--- a/server/internal/trials/repo/queries.sql.go
+++ b/server/internal/trials/repo/queries.sql.go
@@ -84,6 +84,30 @@ func (q *Queries) GetActiveTrial(ctx context.Context, organizationID string) (Ge
 	return i, err
 }
 
+const getSessionTrial = `-- name: GetSessionTrial :one
+SELECT organization_id, created_at, ends_at
+FROM trials
+WHERE organization_id = $1
+  AND converted_at IS NULL
+`
+
+type GetSessionTrialRow struct {
+	OrganizationID string
+	CreatedAt      pgtype.Timestamptz
+	EndsAt         pgtype.Timestamptz
+}
+
+// Backs the trial status the dashboard renders for a session. Ended and demoted
+// rows are deliberately kept so the dashboard can tell the user their trial
+// ended, while converted rows are dropped so a paying customer never sees
+// trial UI.
+func (q *Queries) GetSessionTrial(ctx context.Context, organizationID string) (GetSessionTrialRow, error) {
+	row := q.db.QueryRow(ctx, getSessionTrial, organizationID)
+	var i GetSessionTrialRow
+	err := row.Scan(&i.OrganizationID, &i.CreatedAt, &i.EndsAt)
+	return i, err
+}
+
 const getTrial = `-- name: GetTrial :one
 SELECT organization_id, tier, ends_at, converted_at, demoted_at, created_at, updated_at
 FROM trials


### PR DESCRIPTION
Closes AGE-3103.

## Summary

When the hourly sweep demotes an enterprise trial that ran out, the organization drops off the whitelist and the dashboard gate takes over. Until now that gate showed the generic book-a-demo screen — the same thing a company that has never heard of Gram sees — with nothing to say the trial ended or how to keep going.

It could not have said otherwise: `auth.Info` resolved the trial through `GetActiveTrial`, which filters out ended and demoted rows, so by the time a user was walled the session reported no trial at all. The dashboard had no way to tell "your trial ended" from "we've never met".

This PR closes both halves:

- **The session now reports an ended trial.** A new `GetSessionTrial` keeps ended and demoted rows and filters only converted ones, so a paying customer still never sees trial messaging. No schema change, no migration, no API type change, no SDK regen. `GetActiveTrial` stays — `openrouter.go` still wants active-only semantics for the trial credit ceiling.
- **A dedicated page at `/talk-to-us`**, built to the design handoff: one centered column, a header naming the day the trial ended, confirmation that MCP servers, observability data and policies are still there, and the existing Cal booking embed. It is a real route behind `LoginCheck`, so a reload keeps the user on it.

The same page also serves the opposite direction — anyone still inside a trial can reach it from the sidebar countdown to upgrade early, and reads copy written for that case. The countdown's "Talk to sales" now points here instead of the marketing site, since this page pre-fills the booking form from the session and the marketing page cannot.

## Screenshot

The expired state. A running trial gets the same layout with a moss dot, a "Trial · N days left" status, upgrade-early copy, and "Back to dashboard" in place of "Log out".

<img width="2880" height="1800" alt="trial-ended" src="https://github.com/user-attachments/assets/9400b341-7687-46e7-89c4-b0718ae82dc6" />

## Files a reviewer may not expect

- `components/trial-status-card.tsx` — the sidebar countdown's "Talk to sales" moves from the marketing site to the in-app page, so it stays in the same tab. Its test suite needed a `MemoryRouter` for `Link`.
- `pages/login/components/auth-shell.tsx` — gains a `singleColumn` mode for full-width gate screens, and a hairline rule between the header's page label and its action. The label was 13px and the action 12px in its own button line box, so they sat on different optical lines.
- `pages/demo/BookDemo.tsx`, `pages/demo/SwitchOrg.tsx` — header-action sizing only, so the three gate screens stay consistent. No behaviour change.

## Notable decisions

- **Multi-org users still hit the org switcher first.** Their other organizations may be fine, so the switcher runs before the trial check. An expired trial in a multi-org account therefore does not reach this page — worth confirming that is the behaviour we want.
- **No wall between expiry and the sweep.** The organization is still whitelisted in that window; the sidebar card covers it. Keeping the card visible after expiry is AGE-3145.
- **Not whitelisted but the trial is still running** falls through to the existing book-a-demo gate. The condition reads exactly as its name.
- **No trial on the session redirects home**, so a converted customer is never told to upgrade before a trial that already ended.

## Test plan

- [x] `pnpm -F dashboard type-check`, `pnpm lint`, `pnpm -F dashboard build`
- [x] Dashboard suite: 187 files, 1614 tests
- [x] `mise lint:server`; `mise run test:server ./internal/auth/... ./internal/trials/...` (221 tests)
- [x] New coverage: `getGateCopy` across both copy states, the exact-expiry boundary and singular "1 day left"; `getTrialLifecycle`; `TestService_Info` for expired, demoted, demoted-before-the-clock-ran-out, and converted-stays-hidden
- [x] Verified locally against an organization forced into the demoted state
- [ ] Reviewer: confirm the multi-org behaviour above

## Known gaps

- No test covers the `AuthProvider` gate branch itself. There is no existing `AuthProvider` test harness, and the branch is three lines over a helper with 35 unit tests behind it — flagging rather than building the harness here.
- Copy is computed at render with no boundary timer, so a tab left open across the trial end keeps showing the running-trial wording until reload. `TrialStatusCard` solves this for the sidebar; the gate page does not.

## Out of scope

Sweep — AGE-3029. Emails — AGE-3042. Countdown card — AGE-3077. Entitlement revocation — AGE-3142. Sidebar card after expiry — AGE-3145.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated upgrade gate at `/talk-to-us` for ended enterprise trials and for users upgrading early, replacing the generic Book Demo screen and clarifying the path to upgrade. The session now includes ended/demoted trial data so the dashboard can detect expiry, render the right copy, and route correctly. Addresses AGE-3103.

- New Features
  - Backend: `GetSessionTrial` and `loadTrial` return a trial unless converted; no schema or SDK changes.
  - Routing: expired, non‑whitelisted orgs redirect to `/talk-to-us` behind `LoginCheck`; gate exempts `/explore-demo` and `/talk-to-us`; the org switcher wins for multi‑org users; cold orgs keep Book Demo.
  - Page: single-column gate with booking embed; header shows end date when expired or countdown when active; `DemoBookingFlow` now accepts `intro`, `eventLabel`, and `formDefaults`, prefills Cal questions (including `Company-Name`), and ignores caller overrides of session identity; converted/no‑trial sessions bounce home; footer adds “Explore demo” and a sales mailto; sidebar “Talk to sales” links to `/talk-to-us`.
  - Telemetry: captures `upgrade_gate_viewed` with `trial_lifecycle`.

- Refactors
  - Centralized trial helpers: `getTrialLifecycle`, `getTrialLifecycleFromDates`, `getTrialStatusFromDates`, and shared date validation.
  - `AuthShell` adds `singleColumn`, separates header label/action with a divider, and aligns 13px sizing/leading; copy selection moved to `upgrade-gate-copy` with tests (including pinned timezone); normalized auth screen classes to canonical Tailwind utilities.

<sup>Written for commit bc2646622769d14a8bfe3d230149fce6255d0d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->






