### PR TITLE
feat: add brand mesh to assistant cards

### DIFF
--- a/client/dashboard/src/components/brand-mesh.tsx
+++ b/client/dashboard/src/components/brand-mesh.tsx
@@ -25,6 +25,18 @@ const MESH_VARIATIONS = [
   { angle: 75, focalPoint: "20% 100%" },
 ] as const;
 
+const SEEDED_BRAND_COLORS = [
+  "var(--color-brand-red-200)",
+  "var(--color-brand-red-400)",
+  "var(--color-brand-red-600)",
+  "var(--color-brand-green-200)",
+  "var(--color-brand-green-400)",
+  "var(--color-brand-green-600)",
+  "var(--color-brand-blue-200)",
+  "var(--color-brand-blue-400)",
+  "var(--color-brand-blue-600)",
+] as const;
+
 function hashSeed(seed: string): number {
   let hash = 2166136261;
   for (let index = 0; index < seed.length; index++) {
@@ -34,12 +46,28 @@ function hashSeed(seed: string): number {
   return hash >>> 0;
 }
 
-function meshVariation(seed: string | undefined) {
-  if (!seed) return MESH_VARIATIONS[0];
-  return (
-    MESH_VARIATIONS[hashSeed(seed) % MESH_VARIATIONS.length] ??
-    MESH_VARIATIONS[0]
-  );
+function meshTreatment(seed: string | undefined) {
+  if (!seed) {
+    const variation = MESH_VARIATIONS[0];
+    return {
+      variation,
+      gradient: `linear-gradient(${variation.angle}deg, ${RAINBOW_EDGE_STOPS})`,
+    };
+  }
+
+  const hash = hashSeed(seed);
+  const color =
+    SEEDED_BRAND_COLORS[hash % SEEDED_BRAND_COLORS.length] ??
+    SEEDED_BRAND_COLORS[0];
+  const variation =
+    MESH_VARIATIONS[
+      Math.floor(hash / SEEDED_BRAND_COLORS.length) % MESH_VARIATIONS.length
+    ] ?? MESH_VARIATIONS[0];
+
+  return {
+    variation,
+    gradient: `linear-gradient(${variation.angle}deg, ${color} 0%, ${color} 48%, transparent 78%)`,
+  };
 }
 
 /**
@@ -55,11 +83,11 @@ const GRAIN_TEXTURE_URL =
  * `bg-gradient-to-br from-card to-background`); the layers sit at -z-10 so
  * content stays above them, and clip themselves so the host doesn't need
  * `overflow-hidden` (which would clip popovers like the composer's slash
- * menu).
+ * menu). Passing a seed replaces the rainbow with one stable brand color and
+ * edge composition, allowing repeated cards to keep distinct identities.
  */
 export function BrandMeshLayers({ seed }: { seed?: string }): ReactElement {
-  const variation = meshVariation(seed);
-  const gradient = `linear-gradient(${variation.angle}deg, ${RAINBOW_EDGE_STOPS})`;
+  const { variation, gradient } = meshTreatment(seed);
   const mask = `radial-gradient(85% 120% at ${variation.focalPoint}, #000 0%, rgba(0,0,0,0.6) 40%, transparent 72%)`;
 
   return (

--- a/client/dashboard/src/components/brand-mesh.tsx
+++ b/client/dashboard/src/components/brand-mesh.tsx
@@ -27,13 +27,13 @@ const MESH_VARIATIONS = [
 
 const SEEDED_BRAND_COLORS = [
   "var(--color-brand-red-200)",
-  "var(--color-brand-red-400)",
-  "var(--color-brand-red-600)",
   "var(--color-brand-green-200)",
-  "var(--color-brand-green-400)",
-  "var(--color-brand-green-600)",
   "var(--color-brand-blue-200)",
+  "var(--color-brand-red-400)",
+  "var(--color-brand-green-400)",
   "var(--color-brand-blue-400)",
+  "var(--color-brand-red-600)",
+  "var(--color-brand-green-600)",
   "var(--color-brand-blue-600)",
 ] as const;
 

--- a/client/dashboard/src/components/brand-mesh.tsx
+++ b/client/dashboard/src/components/brand-mesh.tsx
@@ -1,5 +1,9 @@
 import type { ReactElement } from "react";
 
+/** Base host treatment shared by every brand-mesh surface. */
+export const BRAND_MESH_SURFACE_CLASS =
+  "from-card to-background relative isolate bg-gradient-to-br";
+
 /**
  * Brand-rainbow mesh treatment shared by the project home assistant card and
  * the /chat landing: the full tech-color rainbow (--gradient-brand-primary in

--- a/client/dashboard/src/components/brand-mesh.tsx
+++ b/client/dashboard/src/components/brand-mesh.tsx
@@ -7,16 +7,40 @@ export const BRAND_MESH_SURFACE_CLASS =
 /**
  * Brand-rainbow mesh treatment shared by the project home assistant card and
  * the /chat landing: the full tech-color rainbow (--gradient-brand-primary in
- * base.css) run along a diagonal, then masked so it only breathes in from the
- * top-right corner — an accent on the surface's edge, not a background. The
- * host surface itself stays a neutral theme-following gradient.
+ * base.css) run along a diagonal, then masked so it only breathes in from an
+ * edge — an accent on the surface, not a background. The host surface itself
+ * stays a neutral theme-following gradient.
  */
-const RAINBOW_EDGE_GRADIENT =
-  "linear-gradient(230deg, #99c2ff 0%, #2874d7 7%, #00143d 14%, #002414 21%, #59824f 28%, #d3dd92 35%, #fb8841 42%, #c83228 49%, #330f1f 56%, rgba(51,15,31,0) 70%)";
+const RAINBOW_EDGE_STOPS =
+  "#99c2ff 0%, #2874d7 7%, #00143d 14%, #002414 21%, #59824f 28%, #d3dd92 35%, #fb8841 42%, #c83228 49%, #330f1f 56%, rgba(51,15,31,0) 70%";
 
-/** Confines the rainbow to the top-right corner, dissolving inward. */
-const RAINBOW_EDGE_MASK =
-  "radial-gradient(85% 120% at 100% 0%, #000 0%, rgba(0,0,0,0.6) 40%, transparent 72%)";
+const MESH_VARIATIONS = [
+  { angle: 230, focalPoint: "100% 0%" },
+  { angle: 130, focalPoint: "0% 0%" },
+  { angle: 310, focalPoint: "100% 100%" },
+  { angle: 50, focalPoint: "0% 100%" },
+  { angle: 255, focalPoint: "100% 35%" },
+  { angle: 105, focalPoint: "0% 35%" },
+  { angle: 285, focalPoint: "80% 100%" },
+  { angle: 75, focalPoint: "20% 100%" },
+] as const;
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < seed.length; index++) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function meshVariation(seed: string | undefined) {
+  if (!seed) return MESH_VARIATIONS[0];
+  return (
+    MESH_VARIATIONS[hashSeed(seed) % MESH_VARIATIONS.length] ??
+    MESH_VARIATIONS[0]
+  );
+}
 
 /**
  * Film grain laid over the mesh — an inline SVG turbulence tile, so no
@@ -33,16 +57,20 @@ const GRAIN_TEXTURE_URL =
  * `overflow-hidden` (which would clip popovers like the composer's slash
  * menu).
  */
-export function BrandMeshLayers(): ReactElement {
+export function BrandMeshLayers({ seed }: { seed?: string }): ReactElement {
+  const variation = meshVariation(seed);
+  const gradient = `linear-gradient(${variation.angle}deg, ${RAINBOW_EDGE_STOPS})`;
+  const mask = `radial-gradient(85% 120% at ${variation.focalPoint}, #000 0%, rgba(0,0,0,0.6) 40%, transparent 72%)`;
+
   return (
     <>
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 -z-10 overflow-hidden opacity-60 saturate-[0.65]"
         style={{
-          background: RAINBOW_EDGE_GRADIENT,
-          maskImage: RAINBOW_EDGE_MASK,
-          WebkitMaskImage: RAINBOW_EDGE_MASK,
+          background: gradient,
+          maskImage: mask,
+          WebkitMaskImage: mask,
         }}
       />
       <div

--- a/client/dashboard/src/components/brand-mesh.tsx
+++ b/client/dashboard/src/components/brand-mesh.tsx
@@ -56,13 +56,11 @@ function meshTreatment(seed: string | undefined) {
   }
 
   const hash = hashSeed(seed);
-  const color =
-    SEEDED_BRAND_COLORS[hash % SEEDED_BRAND_COLORS.length] ??
-    SEEDED_BRAND_COLORS[0];
+  const color = SEEDED_BRAND_COLORS[hash % SEEDED_BRAND_COLORS.length]!;
   const variation =
     MESH_VARIATIONS[
       Math.floor(hash / SEEDED_BRAND_COLORS.length) % MESH_VARIATIONS.length
-    ] ?? MESH_VARIATIONS[0];
+    ]!;
 
   return {
     variation,

--- a/client/dashboard/src/components/ui/Card/index.tsx
+++ b/client/dashboard/src/components/ui/Card/index.tsx
@@ -235,6 +235,8 @@ type CardEntityProps = {
   children: ReactNode;
   /** Content centered in a bordered box on the icon rail. */
   icon?: ReactNode;
+  /** Additional styling for the icon rail surface. */
+  iconRailClassName?: string;
   /** Extra content layered on the icon rail (e.g. an "Added" badge). */
   overlay?: ReactNode;
   className?: string;
@@ -249,6 +251,7 @@ type CardEntityProps = {
 const CardEntity: FC<CardEntityProps> = ({
   children,
   icon,
+  iconRailClassName,
   className,
   overlay,
   onClick,
@@ -273,7 +276,12 @@ const CardEntity: FC<CardEntityProps> = ({
       className,
     )}
   >
-    <div className="relative w-40 shrink-0 overflow-hidden border-r bg-surface-secondary-default">
+    <div
+      className={cn(
+        "relative w-40 shrink-0 overflow-hidden border-r bg-surface-secondary-default",
+        iconRailClassName,
+      )}
+    >
       {icon && (
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="border bg-card p-3">{icon}</div>

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -317,7 +317,7 @@ function AssistantCard({ assistant }: { assistant: Assistant }) {
         <Card.Entity
           icon={<AssistantIcon />}
           iconRailClassName={BRAND_MESH_SURFACE_CLASS}
-          overlay={<BrandMeshLayers />}
+          overlay={<BrandMeshLayers seed={assistant.id} />}
         >
           {/* Header row: name + actions */}
           <div className="mb-3 flex items-start justify-between gap-2">

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -316,9 +316,9 @@ function AssistantCard({ assistant }: { assistant: Assistant }) {
       >
         <Card.Entity
           icon={<AssistantIcon />}
-          className={BRAND_MESH_SURFACE_CLASS}
+          iconRailClassName={BRAND_MESH_SURFACE_CLASS}
+          overlay={<BrandMeshLayers />}
         >
-          <BrandMeshLayers />
           {/* Header row: name + actions */}
           <div className="mb-3 flex items-start justify-between gap-2">
             <Text

--- a/client/dashboard/src/pages/assistants/Assistants.tsx
+++ b/client/dashboard/src/pages/assistants/Assistants.tsx
@@ -3,6 +3,10 @@ import { RequireScope } from "@/components/require-scope";
 import { AssistantActivitySparkline } from "@/components/assistants/activity-sparkline";
 import { AssistantOwner } from "@/components/assistants/assistant-owner";
 import { AssistantStatusToggle } from "@/components/assistants/status-toggle";
+import {
+  BRAND_MESH_SURFACE_CLASS,
+  BrandMeshLayers,
+} from "@/components/brand-mesh";
 import { CardContextMenu } from "@/components/card-context-menu";
 import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
@@ -310,7 +314,11 @@ function AssistantCard({ assistant }: { assistant: Assistant }) {
         params={[assistant.id]}
         className="focus-visible:ring-ring block h-full no-underline hover:no-underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
-        <Card.Entity icon={<AssistantIcon />}>
+        <Card.Entity
+          icon={<AssistantIcon />}
+          className={BRAND_MESH_SURFACE_CLASS}
+        >
+          <BrandMeshLayers />
           {/* Header row: name + actions */}
           <div className="mb-3 flex items-start justify-between gap-2">
             <Text

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -35,7 +35,10 @@ import {
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useSession } from "@/contexts/Auth";
 import { resolveChatOwner } from "@/lib/chat-owner";
-import { BrandMeshLayers } from "@/components/brand-mesh";
+import {
+  BRAND_MESH_SURFACE_CLASS,
+  BrandMeshLayers,
+} from "@/components/brand-mesh";
 import { getIdentityTint } from "@/components/gradient-colors";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar";
 import {
@@ -78,7 +81,7 @@ export function ChatHome(): ReactElement {
     // grain. Scrolling lives on an inner wrapper so the mesh (and the back
     // affordance) stay pinned to the viewport instead of scrolling away with
     // the content.
-    <div className="from-card to-background relative isolate flex h-full flex-col bg-gradient-to-br">
+    <div className={cn(BRAND_MESH_SURFACE_CLASS, "flex h-full flex-col")}>
       <BrandMeshLayers />
       <div className="absolute top-4 left-4 z-10">
         <Link

--- a/client/dashboard/src/pages/home/Home.tsx
+++ b/client/dashboard/src/pages/home/Home.tsx
@@ -2,7 +2,11 @@ import { useHideInsightsDock } from "@/components/insights-context";
 import { Page } from "@/components/page-layout";
 import { ProjectDashboard } from "@/components/project/ProjectDashboard";
 import { RequireScope } from "@/components/require-scope";
-import { BrandMeshLayers } from "@/components/brand-mesh";
+import {
+  BRAND_MESH_SURFACE_CLASS,
+  BrandMeshLayers,
+} from "@/components/brand-mesh";
+import { cn } from "@/lib/utils";
 import { ChatLanding } from "@/pages/chat/Chat";
 import { useRBAC } from "@/hooks/useRBAC";
 import { useRoutes } from "@/routes";
@@ -42,7 +46,12 @@ export default function Home(): JSX.Element {
             {/* `z-10` lifts the card's stacking context above the dashboard
                 below, so the slash menu overlays it instead of the other way
                 round. */}
-            <div className="border-border from-card to-background relative isolate z-10 border bg-gradient-to-br p-8">
+            <div
+              className={cn(
+                BRAND_MESH_SURFACE_CLASS,
+                "border-border z-10 border p-8",
+              )}
+            >
               <BrandMeshLayers />
               <ChatLanding compact />
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- Apply the project assistant's textured treatment to the left icon rail of cards on `/assistants`
- Give each assistant one stable brand color derived from its ID, selected from interleaved red, green, and blue brand ramps
- Keep project home and `/chat` on the full rainbow treatment
- Keep assistant card content on the neutral card surface for clear visual separation
- Add an icon-rail styling hook to `Card.Entity`
- Centralize the shared brand-mesh host classes

## Testing

- `pnpm -F dashboard type-check`
- `pnpm -F dashboard lint`
- Verified four deterministic single-color cards, red/green/blue coverage, neutral content panels, and light/dark contrast in the browser

## Demo

![Assistant cards with one brand color per left icon rail](https://cursor.com/artifacts/c/art-117eb186-7c55-4eb4-9a03-34e8d71b7f8b)

<a href="https://cursor.com/agents/bc-6662a2f8-a273-4373-b289-ef8d1ebee81b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassistant_card_single_brand_colors_final.mp4"><img src="https://cursor.com/artifacts/c/art-39753fa6-9a6a-4e90-8df6-6d64d6aaeaf7" alt="assistant_card_single_brand_colors_final.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6662a2f8-a273-4373-b289-ef8d1ebee81b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6662a2f8-a273-4373-b289-ef8d1ebee81b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the brand mesh to assistant cards and unify mesh surfaces across Home and Chat. On `/assistants`, each card’s icon rail shows a stable single brand color per assistant; content stays on a neutral surface.

- **New Features**
  - Assistant cards render a single-color mesh on the icon rail via `BrandMeshLayers` (seeded by `assistant.id`) and `BRAND_MESH_SURFACE_CLASS`.
  - Seeding drives hue across red/green/blue ramps and edge composition (angle and focal point) for subtle variation.

- **Refactors**
  - Introduced `BRAND_MESH_SURFACE_CLASS` and applied it to Home and Chat containers for consistent rendering.
  - Extended `Card.Entity` with `iconRailClassName` and `overlay` to support rail meshes.
  - Removed unreachable mesh fallback code.

<sup>Written for commit 685ca6a69ee46db6c60052cd9f3eb32f643caad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

