### PR TITLE
fix(skills): stop the Skills list from scanning raw telemetry for cost (DNO-811)

### DIFF
--- a/.changeset/skill-insights-skip-cost-scan.md
+++ b/.changeset/skill-insights-skip-cost-scan.md
@@ -1,0 +1,13 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Speed up the Skills list, where activation counts took ~1 minute to load. The
+`skillEfficacy.queryInsights` endpoint computed attributed session cost by
+scanning raw `telemetry_logs` for the whole project window on every request,
+even though the list only shows activations, efficacy, and estimated savings.
+A new optional `include_costs` flag (default true, so existing SDK/API
+consumers are unchanged) lets callers skip that scan; the skills list now opts
+out. Regression-signal and suggestion-trend queries, which only compare
+efficacy scores, also skip the cost scan.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -37880,6 +37880,13 @@ paths:
             description: Include per-version daily trends.
             type: boolean
         - allowEmptyValue: true
+          description: Compute attributed session cost from raw telemetry. Defaults to true. Set false for the skills list, which never displays cost, to skip the expensive telemetry scan.
+          in: query
+          name: include_costs
+          schema:
+            description: Compute attributed session cost from raw telemetry. Defaults to true. Set false for the skills list, which never displays cost, to skip the expensive telemetry scan.
+            type: boolean
+        - allowEmptyValue: true
           description: Include a newest-first page of scored sessions. Intended for one skill detail view.
           in: query
           name: include_scored_sessions

--- a/client/dashboard/src/pages/skills/SkillsList.tsx
+++ b/client/dashboard/src/pages/skills/SkillsList.tsx
@@ -179,7 +179,15 @@ export default function SkillsList(): JSX.Element {
     ? metricSkills
     : (pageQuery.data?.result.skills ?? EMPTY_SKILLS);
   const insightsQuery = useSkillEfficacyInsights(
-    metricSort ? {} : { skillIds: insightSkills.map((skill) => skill.id) },
+    // The list only shows activations, efficacy, and estimated savings; it never
+    // displays attributed session cost. Skipping it avoids a full-project
+    // telemetry scan that made this table take ~1 minute to load.
+    metricSort
+      ? { includeCosts: false }
+      : {
+          skillIds: insightSkills.map((skill) => skill.id),
+          includeCosts: false,
+        },
     undefined,
     {
       throwOnError: false,

--- a/client/dashboard/src/sdk/src/funcs/skillEfficacyQueryInsights.ts
+++ b/client/dashboard/src/sdk/src/funcs/skillEfficacyQueryInsights.ts
@@ -123,6 +123,7 @@ async function $do(
   const query = encodeFormQuery({
     "cursor": payload?.cursor,
     "from": payload?.from,
+    "include_costs": payload?.include_costs,
     "include_scored_sessions": payload?.include_scored_sessions,
     "include_versions": payload?.include_versions,
     "limit": payload?.limit,

--- a/client/dashboard/src/sdk/src/models/operations/queryskillefficacyinsights.ts
+++ b/client/dashboard/src/sdk/src/models/operations/queryskillefficacyinsights.ts
@@ -35,6 +35,10 @@ export type QuerySkillEfficacyInsightsRequest = {
    */
   includeVersions?: boolean | undefined;
   /**
+   * Compute attributed session cost from raw telemetry. Defaults to true. Set false for the skills list, which never displays cost, to skip the expensive telemetry scan.
+   */
+  includeCosts?: boolean | undefined;
+  /**
    * Include a newest-first page of scored sessions. Intended for one skill detail view.
    */
   includeScoredSessions?: boolean | undefined;
@@ -99,6 +103,7 @@ export type QuerySkillEfficacyInsightsRequest$Outbound = {
   from?: string | undefined;
   to?: string | undefined;
   include_versions?: boolean | undefined;
+  include_costs?: boolean | undefined;
   include_scored_sessions?: boolean | undefined;
   cursor?: string | undefined;
   limit: number;
@@ -116,6 +121,7 @@ export const QuerySkillEfficacyInsightsRequest$outboundSchema: z.ZodMiniType<
     from: z.optional(z.pipe(z.date(), z.transform(v => v.toISOString()))),
     to: z.optional(z.pipe(z.date(), z.transform(v => v.toISOString()))),
     includeVersions: z.optional(z.boolean()),
+    includeCosts: z.optional(z.boolean()),
     includeScoredSessions: z.optional(z.boolean()),
     cursor: z.optional(z.string()),
     limit: z._default(z.int(), 20),
@@ -126,6 +132,7 @@ export const QuerySkillEfficacyInsightsRequest$outboundSchema: z.ZodMiniType<
     return remap$(v, {
       skillIds: "skill_ids",
       includeVersions: "include_versions",
+      includeCosts: "include_costs",
       includeScoredSessions: "include_scored_sessions",
       gramSession: "Gram-Session",
       gramProject: "Gram-Project",

--- a/client/dashboard/src/sdk/src/react-query/skillEfficacyInsights.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/skillEfficacyInsights.core.ts
@@ -85,6 +85,7 @@ export function buildSkillEfficacyInsightsQuery(
       from: request?.from,
       to: request?.to,
       includeVersions: request?.includeVersions,
+      includeCosts: request?.includeCosts,
       includeScoredSessions: request?.includeScoredSessions,
       cursor: request?.cursor,
       limit: request?.limit,
@@ -132,6 +133,7 @@ export function buildSkillEfficacyInsightsInfiniteQuery(
       from: request?.from,
       to: request?.to,
       includeVersions: request?.includeVersions,
+      includeCosts: request?.includeCosts,
       includeScoredSessions: request?.includeScoredSessions,
       cursor: request?.cursor,
       limit: request?.limit,
@@ -178,6 +180,7 @@ export function queryKeySkillEfficacyInsights(
     from?: Date | undefined;
     to?: Date | undefined;
     includeVersions?: boolean | undefined;
+    includeCosts?: boolean | undefined;
     includeScoredSessions?: boolean | undefined;
     cursor?: string | undefined;
     limit?: number | undefined;
@@ -194,6 +197,7 @@ export function queryKeySkillEfficacyInsightsInfinite(
     from?: Date | undefined;
     to?: Date | undefined;
     includeVersions?: boolean | undefined;
+    includeCosts?: boolean | undefined;
     includeScoredSessions?: boolean | undefined;
     cursor?: string | undefined;
     limit?: number | undefined;

--- a/client/dashboard/src/sdk/src/react-query/skillEfficacyInsights.ts
+++ b/client/dashboard/src/sdk/src/react-query/skillEfficacyInsights.ts
@@ -225,6 +225,7 @@ export function setSkillEfficacyInsightsData(
       from?: Date | undefined;
       to?: Date | undefined;
       includeVersions?: boolean | undefined;
+      includeCosts?: boolean | undefined;
       includeScoredSessions?: boolean | undefined;
       cursor?: string | undefined;
       limit?: number | undefined;
@@ -247,6 +248,7 @@ export function invalidateSkillEfficacyInsights(
       from?: Date | undefined;
       to?: Date | undefined;
       includeVersions?: boolean | undefined;
+      includeCosts?: boolean | undefined;
       includeScoredSessions?: boolean | undefined;
       cursor?: string | undefined;
       limit?: number | undefined;

--- a/server/design/skillefficacy/design.go
+++ b/server/design/skillefficacy/design.go
@@ -184,6 +184,7 @@ var _ = Service("skillEfficacy", func() {
 			Attribute("from", String, "RFC3339 window start; defaults to 30 days before to.", func() { Format(FormatDateTime) })
 			Attribute("to", String, "RFC3339 window end; defaults to now.", func() { Format(FormatDateTime) })
 			Attribute("include_versions", Boolean, "Include per-version daily trends.")
+			Attribute("include_costs", Boolean, "Compute attributed session cost from raw telemetry. Defaults to true. Set false for the skills list, which never displays cost, to skip the expensive telemetry scan.")
 			Attribute("include_scored_sessions", Boolean, "Include a newest-first page of scored sessions. Intended for one skill detail view.")
 			Attribute("cursor", String, "Cursor for the next page of scored sessions.")
 			Attribute("limit", Int, "The number of scored sessions to return per page.", func() {
@@ -201,6 +202,7 @@ var _ = Service("skillEfficacy", func() {
 			Param("from")
 			Param("to")
 			Param("include_versions")
+			Param("include_costs")
 			Param("include_scored_sessions")
 			Param("cursor")
 			Param("limit")

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -2369,6 +2369,7 @@ func ParseEndpoint(
 		skillEfficacyQueryInsightsFromFlag                  = skillEfficacyQueryInsightsFlags.String("from", "", "")
 		skillEfficacyQueryInsightsToFlag                    = skillEfficacyQueryInsightsFlags.String("to", "", "")
 		skillEfficacyQueryInsightsIncludeVersionsFlag       = skillEfficacyQueryInsightsFlags.String("include-versions", "", "")
+		skillEfficacyQueryInsightsIncludeCostsFlag          = skillEfficacyQueryInsightsFlags.String("include-costs", "", "")
 		skillEfficacyQueryInsightsIncludeScoredSessionsFlag = skillEfficacyQueryInsightsFlags.String("include-scored-sessions", "", "")
 		skillEfficacyQueryInsightsCursorFlag                = skillEfficacyQueryInsightsFlags.String("cursor", "", "")
 		skillEfficacyQueryInsightsLimitFlag                 = skillEfficacyQueryInsightsFlags.String("limit", "20", "")
@@ -7346,7 +7347,7 @@ func ParseEndpoint(
 				data, err = skillefficacyc.BuildUpsertSettingsPayload(*skillEfficacyUpsertSettingsBodyFlag, *skillEfficacyUpsertSettingsApikeyTokenFlag, *skillEfficacyUpsertSettingsSessionTokenFlag)
 			case "query-insights":
 				endpoint = c.QueryInsights()
-				data, err = skillefficacyc.BuildQueryInsightsPayload(*skillEfficacyQueryInsightsSkillIdsFlag, *skillEfficacyQueryInsightsFromFlag, *skillEfficacyQueryInsightsToFlag, *skillEfficacyQueryInsightsIncludeVersionsFlag, *skillEfficacyQueryInsightsIncludeScoredSessionsFlag, *skillEfficacyQueryInsightsCursorFlag, *skillEfficacyQueryInsightsLimitFlag, *skillEfficacyQueryInsightsSessionTokenFlag, *skillEfficacyQueryInsightsProjectSlugInputFlag)
+				data, err = skillefficacyc.BuildQueryInsightsPayload(*skillEfficacyQueryInsightsSkillIdsFlag, *skillEfficacyQueryInsightsFromFlag, *skillEfficacyQueryInsightsToFlag, *skillEfficacyQueryInsightsIncludeVersionsFlag, *skillEfficacyQueryInsightsIncludeCostsFlag, *skillEfficacyQueryInsightsIncludeScoredSessionsFlag, *skillEfficacyQueryInsightsCursorFlag, *skillEfficacyQueryInsightsLimitFlag, *skillEfficacyQueryInsightsSessionTokenFlag, *skillEfficacyQueryInsightsProjectSlugInputFlag)
 			}
 		case "skills":
 			c := skillsc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -17592,6 +17593,7 @@ func skillEfficacyQueryInsightsUsage() {
 	fmt.Fprint(os.Stderr, " -from STRING")
 	fmt.Fprint(os.Stderr, " -to STRING")
 	fmt.Fprint(os.Stderr, " -include-versions BOOL")
+	fmt.Fprint(os.Stderr, " -include-costs BOOL")
 	fmt.Fprint(os.Stderr, " -include-scored-sessions BOOL")
 	fmt.Fprint(os.Stderr, " -cursor STRING")
 	fmt.Fprint(os.Stderr, " -limit INT")
@@ -17608,6 +17610,7 @@ func skillEfficacyQueryInsightsUsage() {
 	fmt.Fprintln(os.Stderr, `    -from STRING: `)
 	fmt.Fprintln(os.Stderr, `    -to STRING: `)
 	fmt.Fprintln(os.Stderr, `    -include-versions BOOL: `)
+	fmt.Fprintln(os.Stderr, `    -include-costs BOOL: `)
 	fmt.Fprintln(os.Stderr, `    -include-scored-sessions BOOL: `)
 	fmt.Fprintln(os.Stderr, `    -cursor STRING: `)
 	fmt.Fprintln(os.Stderr, `    -limit INT: `)
@@ -17616,7 +17619,7 @@ func skillEfficacyQueryInsightsUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skill-efficacy query-insights --skill-ids '[\n      \"abc123\"\n   ]' --from \"1970-01-01T00:00:01Z\" --to \"1970-01-01T00:00:01Z\" --include-versions false --include-scored-sessions false --cursor \"abc123\" --limit 2 --session-token \"abc123\" --project-slug-input \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "skill-efficacy query-insights --skill-ids '[\n      \"abc123\"\n   ]' --from \"1970-01-01T00:00:01Z\" --to \"1970-01-01T00:00:01Z\" --include-versions false --include-costs false --include-scored-sessions false --cursor \"abc123\" --limit 2 --session-token \"abc123\" --project-slug-input \"abc123\"")
 }
 
 // skillsUsage displays the usage of the skills command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -38267,6 +38267,13 @@ paths:
                     description: Include per-version daily trends.
                     type: boolean
                 - allowEmptyValue: true
+                  description: Compute attributed session cost from raw telemetry. Defaults to true. Set false for the skills list, which never displays cost, to skip the expensive telemetry scan.
+                  in: query
+                  name: include_costs
+                  schema:
+                    description: Compute attributed session cost from raw telemetry. Defaults to true. Set false for the skills list, which never displays cost, to skip the expensive telemetry scan.
+                    type: boolean
+                - allowEmptyValue: true
                   description: Include a newest-first page of scored sessions. Intended for one skill detail view.
                   in: query
                   name: include_scored_sessions

--- a/server/gen/http/skill_efficacy/client/cli.go
+++ b/server/gen/http/skill_efficacy/client/cli.go
@@ -96,7 +96,7 @@ func BuildUpsertSettingsPayload(skillEfficacyUpsertSettingsBody string, skillEff
 
 // BuildQueryInsightsPayload builds the payload for the skillEfficacy
 // queryInsights endpoint from CLI flags.
-func BuildQueryInsightsPayload(skillEfficacyQueryInsightsSkillIds string, skillEfficacyQueryInsightsFrom string, skillEfficacyQueryInsightsTo string, skillEfficacyQueryInsightsIncludeVersions string, skillEfficacyQueryInsightsIncludeScoredSessions string, skillEfficacyQueryInsightsCursor string, skillEfficacyQueryInsightsLimit string, skillEfficacyQueryInsightsSessionToken string, skillEfficacyQueryInsightsProjectSlugInput string) (*skillefficacy.QueryInsightsPayload, error) {
+func BuildQueryInsightsPayload(skillEfficacyQueryInsightsSkillIds string, skillEfficacyQueryInsightsFrom string, skillEfficacyQueryInsightsTo string, skillEfficacyQueryInsightsIncludeVersions string, skillEfficacyQueryInsightsIncludeCosts string, skillEfficacyQueryInsightsIncludeScoredSessions string, skillEfficacyQueryInsightsCursor string, skillEfficacyQueryInsightsLimit string, skillEfficacyQueryInsightsSessionToken string, skillEfficacyQueryInsightsProjectSlugInput string) (*skillefficacy.QueryInsightsPayload, error) {
 	var err error
 	var skillIds []string
 	{
@@ -135,6 +135,17 @@ func BuildQueryInsightsPayload(skillEfficacyQueryInsightsSkillIds string, skillE
 			includeVersions = &val
 			if err != nil {
 				return nil, fmt.Errorf("invalid value for includeVersions, must be BOOL")
+			}
+		}
+	}
+	var includeCosts *bool
+	{
+		if skillEfficacyQueryInsightsIncludeCosts != "" {
+			var val bool
+			val, err = strconv.ParseBool(skillEfficacyQueryInsightsIncludeCosts)
+			includeCosts = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for includeCosts, must be BOOL")
 			}
 		}
 	}
@@ -192,6 +203,7 @@ func BuildQueryInsightsPayload(skillEfficacyQueryInsightsSkillIds string, skillE
 	v.From = from
 	v.To = to
 	v.IncludeVersions = includeVersions
+	v.IncludeCosts = includeCosts
 	v.IncludeScoredSessions = includeScoredSessions
 	v.Cursor = cursor
 	v.Limit = limit

--- a/server/gen/http/skill_efficacy/client/encode_decode.go
+++ b/server/gen/http/skill_efficacy/client/encode_decode.go
@@ -535,6 +535,9 @@ func EncodeQueryInsightsRequest(encoder func(*http.Request) goahttp.Encoder) fun
 		if p.IncludeVersions != nil {
 			values.Add("include_versions", fmt.Sprintf("%v", *p.IncludeVersions))
 		}
+		if p.IncludeCosts != nil {
+			values.Add("include_costs", fmt.Sprintf("%v", *p.IncludeCosts))
+		}
 		if p.IncludeScoredSessions != nil {
 			values.Add("include_scored_sessions", fmt.Sprintf("%v", *p.IncludeScoredSessions))
 		}

--- a/server/gen/http/skill_efficacy/server/encode_decode.go
+++ b/server/gen/http/skill_efficacy/server/encode_decode.go
@@ -472,6 +472,7 @@ func DecodeQueryInsightsRequest(mux goahttp.Muxer, decoder func(*http.Request) g
 			from                  *string
 			to                    *string
 			includeVersions       *bool
+			includeCosts          *bool
 			includeScoredSessions *bool
 			cursor                *string
 			limit                 int
@@ -503,6 +504,16 @@ func DecodeQueryInsightsRequest(mux goahttp.Muxer, decoder func(*http.Request) g
 					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("include_versions", includeVersionsRaw, "boolean"))
 				}
 				includeVersions = &v
+			}
+		}
+		{
+			includeCostsRaw := qp.Get("include_costs")
+			if includeCostsRaw != "" {
+				v, err2 := strconv.ParseBool(includeCostsRaw)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("include_costs", includeCostsRaw, "boolean"))
+				}
+				includeCosts = &v
 			}
 		}
 		{
@@ -548,7 +559,7 @@ func DecodeQueryInsightsRequest(mux goahttp.Muxer, decoder func(*http.Request) g
 		if err != nil {
 			return payload, err
 		}
-		payload = NewQueryInsightsPayload(skillIds, from, to, includeVersions, includeScoredSessions, cursor, limit, sessionToken, projectSlugInput)
+		payload = NewQueryInsightsPayload(skillIds, from, to, includeVersions, includeCosts, includeScoredSessions, cursor, limit, sessionToken, projectSlugInput)
 		if payload.SessionToken != nil {
 			if strings.Contains(*payload.SessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/skill_efficacy/server/types.go
+++ b/server/gen/http/skill_efficacy/server/types.go
@@ -1242,12 +1242,13 @@ func NewUpsertSettingsPayload(body *UpsertSettingsRequestBody, apikeyToken *stri
 
 // NewQueryInsightsPayload builds a skillEfficacy service queryInsights
 // endpoint payload.
-func NewQueryInsightsPayload(skillIds []string, from *string, to *string, includeVersions *bool, includeScoredSessions *bool, cursor *string, limit int, sessionToken *string, projectSlugInput *string) *skillefficacy.QueryInsightsPayload {
+func NewQueryInsightsPayload(skillIds []string, from *string, to *string, includeVersions *bool, includeCosts *bool, includeScoredSessions *bool, cursor *string, limit int, sessionToken *string, projectSlugInput *string) *skillefficacy.QueryInsightsPayload {
 	v := &skillefficacy.QueryInsightsPayload{}
 	v.SkillIds = skillIds
 	v.From = from
 	v.To = to
 	v.IncludeVersions = includeVersions
+	v.IncludeCosts = includeCosts
 	v.IncludeScoredSessions = includeScoredSessions
 	v.Cursor = cursor
 	v.Limit = limit

--- a/server/gen/skill_efficacy/service.go
+++ b/server/gen/skill_efficacy/service.go
@@ -69,6 +69,10 @@ type QueryInsightsPayload struct {
 	To *string
 	// Include per-version daily trends.
 	IncludeVersions *bool
+	// Compute attributed session cost from raw telemetry. Defaults to true. Set
+	// false for the skills list, which never displays cost, to skip the expensive
+	// telemetry scan.
+	IncludeCosts *bool
 	// Include a newest-first page of scored sessions. Intended for one skill
 	// detail view.
 	IncludeScoredSessions *bool

--- a/server/internal/platformtools/skills/insights.go
+++ b/server/internal/platformtools/skills/insights.go
@@ -208,6 +208,8 @@ func (t *Insights) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload i
 		From:            from,
 		To:              to,
 		IntervalSeconds: int64(insightInterval.Seconds()),
+		// This tool ranks and displays attributed session cost.
+		IncludeCosts: true,
 	})
 	if err != nil {
 		return fmt.Errorf("query skill insights: %w", err)

--- a/server/internal/skillefficacy/impl.go
+++ b/server/internal/skillefficacy/impl.go
@@ -146,6 +146,10 @@ func (s *Service) QueryInsights(ctx context.Context, payload *gen.QueryInsightsP
 			responseSkillIDs = append(responseSkillIDs, skill.Skill.ID.String())
 		}
 	}
+	// Costs come from an expensive raw-telemetry scan; only compute them when the
+	// caller asks. Defaults to true so existing SDK/API consumers are unchanged;
+	// the skills list opts out because it never displays session cost.
+	includeCosts := payload.IncludeCosts == nil || *payload.IncludeCosts
 	var rows []telemetryrepo.SkillInsightBucket
 	if len(responseSkillIDs) > 0 {
 		rows, err = s.insights.QuerySkillInsights(ctx, telemetryrepo.QuerySkillInsightsParams{
@@ -156,6 +160,7 @@ func (s *Service) QueryInsights(ctx context.Context, payload *gen.QueryInsightsP
 			From:            from,
 			To:              to,
 			IntervalSeconds: int64((24 * time.Hour).Seconds()),
+			IncludeCosts:    includeCosts,
 		})
 		if err != nil {
 			return nil, oops.E(oops.CodeUnexpected, err, "query skill efficacy insights").LogError(ctx, logger)
@@ -236,6 +241,8 @@ func (s *Service) attachRegressionSignals(ctx context.Context, logger *slog.Logg
 		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: authCtx.ProjectID.String(), SkillIDs: regressionSkillIDs,
 		SkillVersionIDs: versionIDs, From: windowEnd.Add(-config.TrendWindow), To: windowEnd,
 		IntervalSeconds: int64(config.TrendWindow.Seconds()),
+		// Regression signals only compare efficacy scores, never cost.
+		IncludeCosts: false,
 	})
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "query skill efficacy regression signal").LogError(ctx, logger)

--- a/server/internal/skillefficacy/insights_test.go
+++ b/server/internal/skillefficacy/insights_test.go
@@ -81,6 +81,33 @@ func TestQueryInsightsAggregatesVersionsAndReturnsScoredSessions(t *testing.T) {
 	require.Nil(t, result.NextCursor)
 }
 
+func TestQueryInsightsIncludeCostsControlsMainQuery(t *testing.T) {
+	skillID := uuid.NewString()
+	reader := &insightsReaderStub{rows: []telemetryrepo.SkillInsightBucket{{SkillID: skillID, SkillVersionID: uuid.NewString(), ActivationCount: 4}}}
+	ctx, ti := newTestServiceWithInsights(t, reader)
+	setSkillsFeature(t, ctx, ti, true)
+	ctx = withProjectGrants(t, ctx, authz.ScopeSkillRead)
+
+	// The skill has no persisted versions, so no regression base resolves and
+	// the main insights query is the only ClickHouse call.
+	_, err := ti.service.QueryInsights(ctx, &gen.QueryInsightsPayload{
+		SessionToken: nil, ProjectSlugInput: nil, SkillIds: []string{skillID}, From: nil, To: nil,
+		IncludeVersions: nil, IncludeCosts: nil, IncludeScoredSessions: nil, Cursor: nil, Limit: 20,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, reader.queryCalls)
+	require.True(t, reader.queryParams.IncludeCosts, "costs default to on for unspecified payloads")
+
+	exclude := false
+	_, err = ti.service.QueryInsights(ctx, &gen.QueryInsightsPayload{
+		SessionToken: nil, ProjectSlugInput: nil, SkillIds: []string{skillID}, From: nil, To: nil,
+		IncludeVersions: nil, IncludeCosts: &exclude, IncludeScoredSessions: nil, Cursor: nil, Limit: 20,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, reader.queryCalls)
+	require.False(t, reader.queryParams.IncludeCosts, "the skills list opts out of the telemetry cost scan")
+}
+
 func TestQueryInsightsPaginatesScoredSessions(t *testing.T) {
 	skillID := uuid.NewString()
 	from := time.Now().UTC().Truncate(time.Second).Add(-48 * time.Hour)
@@ -269,6 +296,10 @@ func TestQueryInsightsRegressionSignalUsesSuggestionPolicyAndEffectiveVersions(t
 	require.True(t, signal.Regression)
 	require.Equal(t, current.ID.String(), signal.CurrentVersionID)
 	require.Equal(t, predecessor.ID.String(), *signal.PredecessorVersionID)
+	// The regression query only compares efficacy scores, so it never triggers
+	// the expensive telemetry cost scan. It runs after the main query, so the
+	// last recorded params belong to it.
+	require.False(t, reader.queryParams.IncludeCosts)
 	require.InDelta(t, 0.6, signal.CurrentAverageScore, 0.000001)
 	require.InDelta(t, 0.8, signal.PredecessorAverageScore, 0.000001)
 	require.EqualValues(t, 10, signal.CurrentScoredSessions)

--- a/server/internal/skills/suggest/engine.go
+++ b/server/internal/skills/suggest/engine.go
@@ -177,6 +177,8 @@ func (e *Engine) run(ctx context.Context, in RunInput, force bool) (Result, erro
 		From:            now.Add(-e.config.TrendWindow),
 		To:              now,
 		IntervalSeconds: int64(e.config.TrendWindow.Seconds()),
+		// The suggestion engine only evaluates efficacy trends, never cost.
+		IncludeCosts: false,
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("query suggestion skill insights: %w", err)

--- a/server/internal/telemetry/repo/skill_efficacy_scores.go
+++ b/server/internal/telemetry/repo/skill_efficacy_scores.go
@@ -45,6 +45,12 @@ type QuerySkillInsightsParams struct {
 	From            time.Time
 	To              time.Time
 	IntervalSeconds int64
+	// IncludeCosts computes attributed session cost by scanning raw
+	// telemetry_logs for the whole project window (the expensive part of this
+	// query). Leave it false for callers that only need activations, efficacy,
+	// or savings (the skills list, regression signals, suggestion trends): the
+	// telemetry scan is skipped and TotalSessionCost is reported as 0.
+	IncludeCosts bool
 }
 
 type ListSkillEfficacyScoreSessionsParams struct {
@@ -228,23 +234,31 @@ func (q *Queries) QuerySkillInsights(ctx context.Context, arg QuerySkillInsights
 		return nil, fmt.Errorf("query skill insights: invalid scope, window, or interval")
 	}
 
-	sessions := sq.Select(
-		"toString(gram_project_id) AS project_id",
-		"chat_id AS session_id",
-		"if("+skillVersionAssistantUsagePredicate+", 'assistant', 'dev') AS surface",
-		"countIf("+skillVersionUsageMeasureFilter+") > 0 AS has_usage",
-		skillVersionCostExpr+" AS total_cost",
-	).
-		From("telemetry_logs").
-		Where(squirrel.Eq{"gram_project_id": []string{arg.ProjectID}}).
-		Where("time_unix_nano >= ?", arg.From.UnixNano()).
-		Where("time_unix_nano <= ?", arg.To.UnixNano()).
-		Where(skillVersionSourceRowPredicate).
-		Where("chat_id != ''").
-		GroupBy("gram_project_id", "chat_id", "surface")
-	sessionSQL, sessionArgs, err := sessions.ToSql()
-	if err != nil {
-		return nil, fmt.Errorf("building skill insight sessions query: %w", err)
+	// The sessions CTE scans raw telemetry_logs for the whole project window to
+	// attribute per-session cost. It is by far the most expensive part of this
+	// query, so it is only built when the caller asks for costs.
+	var sessionSQL string
+	var sessionArgs []any
+	var err error
+	if arg.IncludeCosts {
+		sessions := sq.Select(
+			"toString(gram_project_id) AS project_id",
+			"chat_id AS session_id",
+			"if("+skillVersionAssistantUsagePredicate+", 'assistant', 'dev') AS surface",
+			"countIf("+skillVersionUsageMeasureFilter+") > 0 AS has_usage",
+			skillVersionCostExpr+" AS total_cost",
+		).
+			From("telemetry_logs").
+			Where(squirrel.Eq{"gram_project_id": []string{arg.ProjectID}}).
+			Where("time_unix_nano >= ?", arg.From.UnixNano()).
+			Where("time_unix_nano <= ?", arg.To.UnixNano()).
+			Where(skillVersionSourceRowPredicate).
+			Where("chat_id != ''").
+			GroupBy("gram_project_id", "chat_id", "surface")
+		sessionSQL, sessionArgs, err = sessions.ToSql()
+		if err != nil {
+			return nil, fmt.Errorf("building skill insight sessions query: %w", err)
+		}
 	}
 
 	mappings := sq.Select(
@@ -307,6 +321,13 @@ func (q *Queries) QuerySkillInsights(ctx context.Context, arg QuerySkillInsights
 		return nil, fmt.Errorf("building skill insight scores query: %w", err)
 	}
 
+	// When costs are skipped there is no sessions CTE to join, so cost is a
+	// constant zero rather than a sum over the session usage rows.
+	totalSessionCostExpr := "sum(if(s.has_usage, s.total_cost, 0)) AS total_session_cost"
+	if !arg.IncludeCosts {
+		totalSessionCostExpr = "toFloat64(0) AS total_session_cost"
+	}
+
 	outer := sq.Select(
 		"m.skill_id AS skill_id",
 		"m.skill_version_id AS skill_version_id",
@@ -315,7 +336,7 @@ func (q *Queries) QuerySkillInsights(ctx context.Context, arg QuerySkillInsights
 		Columns(
 			"sum(m.activation_count) AS activation_count",
 			"count() AS activated_sessions",
-			"sum(if(s.has_usage, s.total_cost, 0)) AS total_session_cost",
+			totalSessionCostExpr,
 			"sum(ifNull(e.score_count, 0)) AS scored_sessions",
 			"sum(ifNull(e.score_sum, 0)) AS score_sum",
 			"sum(ifNull(e.turns_sum, 0)) AS estimated_turns_saved_sum",
@@ -330,12 +351,27 @@ func (q *Queries) QuerySkillInsights(ctx context.Context, arg QuerySkillInsights
 			"sum(ifNull(e.partially_followed_count, 0)) AS partially_followed_count",
 			"sum(ifNull(e.harmful_count, 0)) AS harmful_count",
 		).
-		From("mappings m").
-		LeftJoin("sessions s ON s.project_id = m.project_id AND s.session_id = m.session_id AND s.surface = m.surface").
+		From("mappings m")
+	if arg.IncludeCosts {
+		outer = outer.LeftJoin("sessions s ON s.project_id = m.project_id AND s.session_id = m.session_id AND s.surface = m.surface")
+	}
+	outer = outer.
 		LeftJoin("scores e ON e.project_id = m.project_id AND e.session_id = m.session_id AND e.surface = m.surface AND e.skill_id = m.skill_id AND e.skill_version_id = m.skill_version_id").
 		GroupBy("m.skill_id", "m.skill_version_id", "bucket_time_unix_nano").
-		OrderBy("bucket_time_unix_nano ASC", "m.skill_id ASC", "m.skill_version_id ASC").
-		Prefix("WITH sessions AS ("+sessionSQL+"), mappings AS ("+mappingSQL+"), score_events AS ("+scoreEventSQL+"), scores AS ("+scoreSQL+")", append(append(append(sessionArgs, mappingArgs...), scoreEventArgs...), scoreArgs...)...)
+		OrderBy("bucket_time_unix_nano ASC", "m.skill_id ASC", "m.skill_version_id ASC")
+
+	// CTE order in the WITH clause must match the argument order below.
+	cteParts := make([]string, 0, 4)
+	cteArgs := make([]any, 0, len(sessionArgs)+len(mappingArgs)+len(scoreEventArgs)+len(scoreArgs))
+	if arg.IncludeCosts {
+		cteParts = append(cteParts, "sessions AS ("+sessionSQL+")")
+		cteArgs = append(cteArgs, sessionArgs...)
+	}
+	cteParts = append(cteParts, "mappings AS ("+mappingSQL+")", "score_events AS ("+scoreEventSQL+")", "scores AS ("+scoreSQL+")")
+	cteArgs = append(cteArgs, mappingArgs...)
+	cteArgs = append(cteArgs, scoreEventArgs...)
+	cteArgs = append(cteArgs, scoreArgs...)
+	outer = outer.Prefix("WITH "+strings.Join(cteParts, ", "), cteArgs...)
 	query, args, err := outer.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building skill insights query: %w", err)

--- a/server/internal/telemetry/repo/skill_efficacy_scores_test.go
+++ b/server/internal/telemetry/repo/skill_efficacy_scores_test.go
@@ -183,6 +183,7 @@ func TestQuerySkillInsightsAggregatesMappingsAndScoresWithoutUsage(t *testing.T)
 		From:            observedAt.Add(-time.Hour),
 		To:              observedAt.Add(time.Hour),
 		IntervalSeconds: int64((24 * time.Hour).Seconds()),
+		IncludeCosts:    true,
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
@@ -200,6 +201,69 @@ func TestQuerySkillInsightsAggregatesMappingsAndScoresWithoutUsage(t *testing.T)
 	require.EqualValues(t, 1, rows[0].ROIConfidenceHigh)
 	require.EqualValues(t, 1, rows[0].IgnoredCount)
 	require.EqualValues(t, 1, rows[0].PartiallyFollowedCount)
+}
+
+// TestQuerySkillInsightsIncludeCostsTogglesTelemetryScan proves that attributed
+// session cost is computed only when IncludeCosts is set. With it off (the
+// skills-list path) activations still resolve but the raw telemetry_logs scan is
+// skipped, so cost is zero even though a matching usage row exists.
+func TestQuerySkillInsightsIncludeCostsTogglesTelemetryScan(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	queries := repo.New(conn)
+
+	orgID := uuid.NewString()
+	projectID := uuid.New()
+	observedAt := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	sessionID := uuid.NewString()
+	skillID := uuid.New()
+	skillVersionID := uuid.New()
+
+	// An assistant completion usage row carries the session's attributed cost.
+	logID, err := uuid.NewV7()
+	require.NoError(t, err)
+	require.NoError(t, conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, logID.String(), observedAt.UnixNano(), observedAt.UnixNano(), "INFO", "assistant.completion",
+		nil, nil, `{"gen_ai.conversation.id":"`+sessionID+`","gen_ai.usage.cost":0.42}`, "{}",
+		projectID.String(), "assistants:chat:completion", "gram-server"))
+
+	require.NoError(t, queries.InsertSkillSessionVersions(ctx, []repo.SkillSessionVersion{{
+		ID: uuid.New(), CreatedAt: observedAt, SeenAt: observedAt, OrganizationID: orgID, ProjectID: projectID,
+		SessionID: sessionID, SkillID: skillID, SkillVersionID: skillVersionID,
+		CanonicalSHA256: "0000000000000000000000000000000000000000000000000000000000000000", Surface: "assistant",
+	}}))
+	testenv.FlushClickHouseAsyncInserts(t, conn)
+
+	base := repo.QuerySkillInsightsParams{
+		OrganizationID: orgID, ProjectID: projectID.String(), SkillIDs: []string{skillID.String()}, SkillVersionIDs: nil,
+		From: observedAt.Add(-time.Hour), To: observedAt.Add(time.Hour), IntervalSeconds: int64((24 * time.Hour).Seconds()),
+	}
+
+	withCosts := base
+	withCosts.IncludeCosts = true
+	rows, err := queries.QuerySkillInsights(ctx, withCosts)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 1, rows[0].ActivationCount)
+	require.EqualValues(t, 1, rows[0].ActivatedSessions)
+	require.InDelta(t, 0.42, rows[0].TotalSessionCost, 1e-9)
+
+	withoutCosts := base
+	withoutCosts.IncludeCosts = false
+	rows, err = queries.QuerySkillInsights(ctx, withoutCosts)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.EqualValues(t, 1, rows[0].ActivationCount)
+	require.EqualValues(t, 1, rows[0].ActivatedSessions)
+	require.Zero(t, rows[0].TotalSessionCost)
 }
 
 func TestQuerySkillInsightsDeduplicatesPhysicalScoresByEventID(t *testing.T) {
@@ -239,6 +303,7 @@ func TestQuerySkillInsightsDeduplicatesPhysicalScoresByEventID(t *testing.T) {
 	rows, err := queries.QuerySkillInsights(ctx, repo.QuerySkillInsightsParams{
 		OrganizationID: orgID, ProjectID: projectID.String(), SkillIDs: []string{score.SkillID.String()}, SkillVersionIDs: nil,
 		From: observedAt.Add(-time.Hour), To: observedAt.Add(time.Hour), IntervalSeconds: int64((24 * time.Hour).Seconds()),
+		IncludeCosts: true,
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the Skills list (table view), the **Activations (30d)** column took ~1 minute to load (DNO-811). The counts weren't broken, just extremely slow.

## Root cause

The activation/efficacy/savings metrics come from `skillEfficacy.queryInsights`, whose ClickHouse query (`QuerySkillInsights`) always builds a `sessions` CTE that scans **raw `telemetry_logs` for the entire project over the whole window** (30 days) with per-row JSON attribute extraction. That scan exists only to compute **attributed session cost** (`session_cost_usd`).

The Skills **list** never displays session cost — it only shows activations, efficacy, and estimated savings. So every list load (and every metric-sort load, plus the regression-signal and suggestion-trend queries) paid for a full raw-telemetry scan whose result was thrown away. Per the `clickhouse` skill, a default list view that scans raw `telemetry_logs` on every page load is a known performance-bug pattern.

## Fix

Add an optional `include_costs` flag to `skillEfficacy.queryInsights` (**defaults to `true`**, so existing SDK/API/CLI consumers are unchanged). When `false`, `QuerySkillInsights` skips the `sessions` CTE and its raw-telemetry scan entirely and reports `session_cost_usd = 0`.

Callers:
- **Skills list** (`SkillsList.tsx`) passes `includeCosts: false` (normal and metric-sort paths).
- **Regression signals** and **suggestion trends** always pass `IncludeCosts: false` — they only compare efficacy scores.
- **Skill detail page** and the **`platform_skill_insights`** tool keep costs (default `true` / explicit `true`).

The list's insights query now reads only `skill_session_versions` (activations) and `skill_efficacy_scores` (efficacy/savings) — both properly indexed analytics tables — removing the full raw-log scan from the hot path.

## Testing

- `internal/telemetry/repo`: new `TestQuerySkillInsightsIncludeCostsTogglesTelemetryScan` inserts a telemetry usage row and asserts cost is `0.42` with `IncludeCosts: true` and `0` with `IncludeCosts: false`, while activation counts resolve in both. Existing insight tests updated to keep exercising the cost path.
- `internal/skillefficacy`: new `TestQueryInsightsIncludeCostsControlsMainQuery` (default on / explicit off) and an added assertion that the regression query runs with `IncludeCosts: false`.
- `go build`, `mise run lint:server`, `pnpm -F dashboard type-check`, and the suggest-engine / platformtools skill suites all pass.
- Goa server code and the TypeScript SDK / OpenAPI outputs were regenerated.

Note: the ~1 minute latency was driven by production-scale telemetry volume, which isn't reproducible in the local dev DB, so this is validated structurally (the raw-telemetry scan is gated) and via the automated tests above rather than a before/after timing GIF.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-811](https://linear.app/speakeasy/issue/DNO-811/skill-activation-counts-take-1-minute-to-load)

<div><a href="https://cursor.com/agents/bc-7e58ec7c-e709-4b60-a81f-51ebefbd4523?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e58ec7c-e709-4b60-a81f-51ebefbd4523&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops scanning raw telemetry for session cost when it isn’t needed. Skills list now loads quickly instead of ~1 minute, reducing ClickHouse load. Addresses DNO-811.

- New Features
  - Added optional `include_costs` to `skillEfficacy.queryInsights` (default true) to toggle cost computation from raw `telemetry_logs`.
  - Exposed in OpenAPI/SDK/CLI as `include_costs` / `includeCosts` / `--include-costs`.

- Bug Fixes
  - Skills list calls insights with `includeCosts: false` (including metric-sort), avoiding the raw `telemetry_logs` scan; it now reads only `skill_session_versions` and `skill_efficacy_scores`.
  - Regression signals and suggestion trends pass `includeCosts: false`; they only compare efficacy.
  - Skill detail page and `platform_skill_insights` keep costs enabled.
  - Tests cover the toggle: costs are computed when on, zero when off; activations unaffected.

<sup>Written for commit d0d401a9651e3875d71918bba5ff99eee58fbaa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

