### PR TITLE
fix(assistants): recycle GKE runtimes onto the configured image on drift

### DIFF
--- a/.changeset/gke-runtime-image-recycle.md
+++ b/.changeset/gke-runtime-image-recycle.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Assistant runtimes on the GKE backend now roll onto the configured runtime image automatically. Previously a claimed sandbox kept its admission-time image forever unless the assistant went idle long enough for the inactivity janitor, so regularly used assistants never picked up deployed runner changes — and even a fresh claim could adopt a warm-pool pod pre-warmed on an older image. The deploy-time image recycle sweep now covers GKE runtimes (idle-gated claim re-adoption), turn admission recycles a stale claim lazily and drains stale warm-pool pods with bounded retries, and persisted runtime metadata records the pod's actual image instead of the configured one.

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -52,20 +52,13 @@ type RuntimeBackend interface {
 	// machines with, in the "<repo>:<tag>" form. Stable for the lifetime
 	// of the process — the tag is stamped at build time.
 	ImageRef() string
-	// ReusesIdleRuntimes reports whether a stopped runtime's resources are
-	// kept for warm restart on the next admission (true) or torn down so the
-	// next admission always provisions a fresh one (false). It selects how a
-	// deploy rolls the fleet onto a new image: reusing backends (Fly) keep the
-	// machine and need an in-place RecycleImage; non-reusing backends (GKE)
-	// drop the idle runtime so re-admission adopts a fresh warm-pool pod
-	// already running the new image — no in-place swap exists or is needed.
-	ReusesIdleRuntimes() bool
 	Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error)
-	// RecycleImage rolls the runtime's existing machine onto the configured
-	// runtime image when it is running a stale one, without launching
-	// anything new: missing apps/machines are skipped, not created. Gated on
+	// RecycleImage rolls the runtime onto the configured runtime image when
+	// it is running a stale one, without launching anything new: missing
+	// apps/machines/claims are skipped, not created. Fly updates the machine
+	// in place; GKE deletes the claim and re-claims a warm-pool pod. Gated on
 	// the runner's idle clock so an in-flight turn is never interrupted — a
-	// busy machine is skipped and the next admission's Ensure picks the
+	// busy runtime is skipped and the next admission's Ensure picks the
 	// upgrade up lazily.
 	RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error)
 	// RunTurn delivers a turn to the runner backing `runtime`. The call

--- a/server/internal/assistants/runtime_backend.go
+++ b/server/internal/assistants/runtime_backend.go
@@ -55,11 +55,9 @@ type RuntimeBackend interface {
 	Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error)
 	// RecycleImage rolls the runtime onto the configured runtime image when
 	// it is running a stale one, without launching anything new: missing
-	// apps/machines/claims are skipped, not created. Fly updates the machine
-	// in place; GKE deletes the claim and re-claims a warm-pool pod. Gated on
-	// the runner's idle clock so an in-flight turn is never interrupted — a
-	// busy runtime is skipped and the next admission's Ensure picks the
-	// upgrade up lazily.
+	// apps/machines/claims are skipped, not created. Gated on the runner's
+	// idle clock so an in-flight turn is never interrupted — a busy runtime
+	// is skipped and the next admission's Ensure picks the upgrade up lazily.
 	RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error)
 	// RunTurn delivers a turn to the runner backing `runtime`. The call
 	// lands on /threads/{thread_id}/turn so the runner can dispatch to the

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -221,12 +221,6 @@ func (f *FlyRuntimeBackend) ImageRef() string {
 	return f.desiredImageRef()
 }
 
-// ReusesIdleRuntimes is true: Stop pauses the machine but keeps the app and
-// allocated IP, so a later admit resumes the same incarnation. Fly has no warm
-// pool, so a new image is rolled onto that preserved machine in place via
-// RecycleImage rather than by discarding it.
-func (f *FlyRuntimeBackend) ReusesIdleRuntimes() bool { return true }
-
 // Ensure does not auto-recreate the app on ensureExisting errors. Health and
 // configure timeouts must bubble so Temporal retries drive convergence.
 // Destructive app recreation churns Fly's allocated IPs and creates DNS-stale

--- a/server/internal/assistants/runtime_fly.go
+++ b/server/internal/assistants/runtime_fly.go
@@ -98,6 +98,14 @@ func (r runnerStateResponse) minThreadIdle() *uint64 {
 	return &minIdle
 }
 
+// turnInFlight reports whether any thread has a turn in flight: the runner
+// clears a thread's idle clock synchronously on /turn enqueue, so a min idle
+// of zero means a turn is running right now.
+func (r runnerStateResponse) turnInFlight() bool {
+	idle := r.minThreadIdle()
+	return idle != nil && *idle == 0
+}
+
 type flyRuntimeAPIClient interface {
 	AllocateIPAddress(ctx context.Context, appName string, addrType string, region string, orgID string, network string) (*fly.IPAddress, error)
 	AllocateSharedIPAddress(ctx context.Context, appName string) (net.IP, error)
@@ -594,14 +602,11 @@ func (f *FlyRuntimeBackend) maybeRecycleImage(
 	target := flyRuntimeTarget{URL: appURL, IP: appIP, MachineID: machine.ID}
 	if machine.State == fly.MachineStateStarted {
 		state, stateErr := f.runtimeState(ctx, target)
-		// A turn in flight reads as min(idle_seconds) == 0 across the
-		// runner's threads (the runner clears a thread's idle clock
-		// synchronously on /turn enqueue). Skip recycling so we don't reboot
-		// mid-turn; a later admission with idle threads picks the upgrade
-		// up. Probe errors fall through to recycle — the runner is
-		// unreachable on the stale image anyway and waitForRuntimeHealth
-		// would just fail next.
-		if idle := state.minThreadIdle(); stateErr == nil && idle != nil && *idle == 0 {
+		// Skip recycling so we don't reboot mid-turn; a later admission with
+		// idle threads picks the upgrade up. Probe errors fall through to
+		// recycle — the runner is unreachable on the stale image anyway and
+		// waitForRuntimeHealth would just fail next.
+		if stateErr == nil && state.turnInFlight() {
 			f.logger.InfoContext(ctx,
 				"assistant fly runtime image recycle skipped: turn in flight",
 				attr.SlogFlyAppName(appName),

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -190,10 +190,6 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 		return RuntimeBackendEnsureResult{}, err
 	}
 
-	if err := g.runner.health(ctx, g.endpoint(metadata), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
-		return RuntimeBackendEnsureResult{}, err
-	}
-
 	payload, err := json.Marshal(metadata)
 	if err != nil {
 		return RuntimeBackendEnsureResult{}, fmt.Errorf("encode gke runtime metadata: %w", err)
@@ -202,11 +198,13 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 }
 
 // ensureCurrentImageSandbox gets or creates the SandboxClaim, waits for its
-// sandbox, and recycles the claim (bounded by gkeImageDrainAttempts) while the
-// adopted pod runs a stale runtime image. A pre-existing claim is only
-// recycled when the runner has no turn in flight; a fresh claim's pod carries
-// no turns, so drift there always recycles. coldStart reports whether this
-// call created the claim that was ultimately kept.
+// sandbox, recycles the claim (bounded by gkeImageDrainAttempts) while the
+// adopted pod runs a stale runtime image, and waits for the kept pod's runner
+// to answer /healthz — so the owned-claim cleanup below covers a pod that
+// comes Ready but never turns healthy. A pre-existing claim is only recycled
+// when the runner has no turn in flight; a fresh claim's pod carries no
+// turns, so drift there always recycles. coldStart reports whether this call
+// created the claim that was ultimately kept.
 func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runtime assistantRuntimeRecord) (metadata gkeRuntimeMetadata, coldStart bool, err error) {
 	name := g.claimName(runtime)
 	desired := g.desiredImageRef()
@@ -250,29 +248,30 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 				return gkeRuntimeMetadata{}, false, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
 			}
 		}
+		coldStart = created
 
 		metadata, err = g.waitForSandbox(ctx, name)
 		if err != nil {
-			return gkeRuntimeMetadata{}, created, err
+			return gkeRuntimeMetadata{}, coldStart, err
 		}
 
 		// An empty image means the pod record was partial — recycling on
 		// missing data would churn healthy runtimes, so treat it as current.
 		if metadata.Image == "" || metadata.Image == desired {
-			return metadata, created, nil
+			break
 		}
-		if attempt >= gkeImageDrainAttempts {
+		if attempt > gkeImageDrainAttempts {
 			g.logger.WarnContext(ctx, "assistant gke runtime kept on stale image: drain attempts exhausted",
 				attr.SlogAssistantID(runtime.AssistantID.String()),
 				attr.SlogAssistantImageDesired(desired),
 				attr.SlogAssistantImageActual(metadata.Image),
 			)
-			return metadata, created, nil
+			break
 		}
 		if !created && g.runnerBusy(ctx, metadata) {
 			// Pre-existing claim with a turn in flight: don't tear it down
 			// mid-turn. A later admission with idle threads recycles it.
-			return metadata, created, nil
+			break
 		}
 
 		g.logger.InfoContext(ctx, "assistant gke runtime recycling: image upgrade",
@@ -281,10 +280,15 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 			attr.SlogAssistantImageActual(metadata.Image),
 		)
 		if delErr := g.claims().Delete(ctx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
-			return gkeRuntimeMetadata{}, created, fmt.Errorf("delete drifted sandbox claim %s: %w", name, delErr)
+			return gkeRuntimeMetadata{}, coldStart, fmt.Errorf("delete drifted sandbox claim %s: %w", name, delErr)
 		}
 		ownsClaim = false
 	}
+
+	if err = g.runner.health(ctx, g.endpoint(metadata), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
+		return gkeRuntimeMetadata{}, coldStart, err
+	}
+	return metadata, coldStart, nil
 }
 
 // runnerBusy reports whether any thread on the runner has a turn in flight
@@ -545,9 +549,6 @@ func (g *GKERuntimeBackend) RecycleImage(ctx context.Context, runtime assistantR
 
 	fresh, _, err := g.ensureCurrentImageSandbox(ctx, runtime)
 	if err != nil {
-		return RuntimeBackendRecycleResult{}, err
-	}
-	if err := g.runner.health(ctx, g.endpoint(fresh), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
 		return RuntimeBackendRecycleResult{}, err
 	}
 	payload, err := json.Marshal(fresh)

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -38,6 +38,15 @@ const (
 	gkeRuntimeReapCallTimeout = 30 * time.Second
 	gkeRuntimeTurnTimeout     = 30 * time.Minute
 
+	// gkeImageDrainAttempts bounds how many claim recycles one ensure pass
+	// performs when adopted pods keep coming up on a stale runtime image. The
+	// warm pool hands claims whatever image its pods were pre-warmed with, so
+	// a pod can lag the SandboxTemplate right after a template bump; each
+	// recycle consumes (and thereby deletes) one stale pod, so the pool
+	// converges. Past the bound the stale pod is kept — availability over
+	// freshness — and a later admission retries.
+	gkeImageDrainAttempts = 3
+
 	gkeSandboxReadyConditionType = "Ready"
 
 	// gkeClaimUIDLabel is injected by the SandboxClaim controller onto the pod,
@@ -151,14 +160,6 @@ func (g *GKERuntimeBackend) ServerURL() *url.URL { return g.config.ServerURL }
 
 func (g *GKERuntimeBackend) ImageRef() string { return g.desiredImageRef() }
 
-// ReusesIdleRuntimes is false: Stop deletes the SandboxClaim, so the next
-// admission recreates the claim and adopts a fresh pre-warmed pod from the
-// pool — already running whatever image the SandboxTemplate now points at. A
-// new image therefore rolls in by terminating idle runtimes (the deploy sweep
-// and the warm-TTL expiry both do this) rather than the in-place RecycleImage
-// Fly relies on.
-func (g *GKERuntimeBackend) ReusesIdleRuntimes() bool { return false }
-
 func (g *GKERuntimeBackend) desiredImageRef() string {
 	return runtimeImageRef(g.config.OCIImage, g.config.ImageTag)
 }
@@ -184,48 +185,10 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 		span.End()
 	}()
 
-	name := g.claimName(runtime)
-	coldStart := false
-	if _, getErr := g.claims().Get(ctx, name, metav1.GetOptions{}); getErr != nil {
-		if !k8serrors.IsNotFound(getErr) {
-			return RuntimeBackendEnsureResult{}, fmt.Errorf("get sandbox claim %s: %w", name, getErr)
-		}
-		_, createErr := g.claims().Create(ctx, g.buildClaim(name, runtime), metav1.CreateOptions{})
-		switch {
-		case createErr == nil:
-			coldStart = true
-			// We created this claim. If readiness below fails, delete it so the
-			// next admission recreates a fresh claim rather than re-attaching to
-			// an unhealthy one with no persisted metadata. Only this branch owns
-			// the claim: a pre-existing claim, or one a racing Ensure created
-			// (AlreadyExists), is left alone — another turn may be using it. Use
-			// WithoutCancel so cleanup still runs when the failure was a timeout.
-			defer func() {
-				if err == nil {
-					return
-				}
-				delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gkeRuntimeReapCallTimeout)
-				defer cancel()
-				if delErr := g.claims().Delete(delCtx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
-					g.logger.WarnContext(ctx, "delete sandbox claim after failed ensure",
-						attr.SlogAssistantID(runtime.AssistantID.String()),
-						attr.SlogError(delErr),
-					)
-				}
-			}()
-		case k8serrors.IsAlreadyExists(createErr):
-			// A racing Ensure created the claim between our Get and Create. Attach
-			// to it like a pre-existing claim; the other turn owns its lifecycle.
-		default:
-			return RuntimeBackendEnsureResult{}, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
-		}
-	}
-
-	metadata, err := g.waitForSandbox(ctx, name)
+	metadata, coldStart, err := g.ensureCurrentImageSandbox(ctx, runtime)
 	if err != nil {
 		return RuntimeBackendEnsureResult{}, err
 	}
-	metadata.Image = g.desiredImageRef()
 
 	if err := g.runner.health(ctx, g.endpoint(metadata), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
 		return RuntimeBackendEnsureResult{}, err
@@ -236,6 +199,106 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 		return RuntimeBackendEnsureResult{}, fmt.Errorf("encode gke runtime metadata: %w", err)
 	}
 	return RuntimeBackendEnsureResult{ColdStart: coldStart, BackendMetadataJSON: payload}, nil
+}
+
+// ensureCurrentImageSandbox gets or creates the SandboxClaim, waits for its
+// sandbox, and recycles the claim (bounded by gkeImageDrainAttempts) while the
+// adopted pod runs a stale runtime image. A pre-existing claim is only
+// recycled when the runner has no turn in flight; a fresh claim's pod carries
+// no turns, so drift there always recycles. coldStart reports whether this
+// call created the claim that was ultimately kept.
+func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runtime assistantRuntimeRecord) (metadata gkeRuntimeMetadata, coldStart bool, err error) {
+	name := g.claimName(runtime)
+	desired := g.desiredImageRef()
+	// ownsClaim tracks whether this call created the currently live claim. If
+	// ensure fails on an owned claim, delete it so the next admission
+	// recreates a fresh claim rather than re-attaching to an unhealthy one
+	// with no persisted metadata. A pre-existing claim, or one a racing
+	// Ensure created (AlreadyExists), is left alone — another turn may be
+	// using it. WithoutCancel so cleanup still runs when the failure was a
+	// timeout.
+	ownsClaim := false
+	defer func() {
+		if err == nil || !ownsClaim {
+			return
+		}
+		delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gkeRuntimeReapCallTimeout)
+		defer cancel()
+		if delErr := g.claims().Delete(delCtx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
+			g.logger.WarnContext(ctx, "delete sandbox claim after failed ensure",
+				attr.SlogAssistantID(runtime.AssistantID.String()),
+				attr.SlogError(delErr),
+			)
+		}
+	}()
+
+	for attempt := 1; ; attempt++ {
+		created := false
+		if _, getErr := g.claims().Get(ctx, name, metav1.GetOptions{}); getErr != nil {
+			if !k8serrors.IsNotFound(getErr) {
+				return gkeRuntimeMetadata{}, false, fmt.Errorf("get sandbox claim %s: %w", name, getErr)
+			}
+			switch _, createErr := g.claims().Create(ctx, g.buildClaim(name, runtime), metav1.CreateOptions{}); {
+			case createErr == nil:
+				created = true
+				ownsClaim = true
+			case k8serrors.IsAlreadyExists(createErr):
+				// A racing Ensure created the claim between our Get and Create.
+				// Attach to it like a pre-existing claim; the other turn owns
+				// its lifecycle.
+			default:
+				return gkeRuntimeMetadata{}, false, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
+			}
+		}
+
+		metadata, err = g.waitForSandbox(ctx, name)
+		if err != nil {
+			return gkeRuntimeMetadata{}, created, err
+		}
+
+		// An empty image means the pod record was partial — recycling on
+		// missing data would churn healthy runtimes, so treat it as current.
+		if metadata.Image == "" || metadata.Image == desired {
+			return metadata, created, nil
+		}
+		if attempt >= gkeImageDrainAttempts {
+			g.logger.WarnContext(ctx, "assistant gke runtime kept on stale image: drain attempts exhausted",
+				attr.SlogAssistantID(runtime.AssistantID.String()),
+				attr.SlogAssistantImageDesired(desired),
+				attr.SlogAssistantImageActual(metadata.Image),
+			)
+			return metadata, created, nil
+		}
+		if !created && g.runnerBusy(ctx, metadata) {
+			// Pre-existing claim with a turn in flight: don't tear it down
+			// mid-turn. A later admission with idle threads recycles it.
+			return metadata, created, nil
+		}
+
+		g.logger.InfoContext(ctx, "assistant gke runtime recycling: image upgrade",
+			attr.SlogAssistantID(runtime.AssistantID.String()),
+			attr.SlogAssistantImageDesired(desired),
+			attr.SlogAssistantImageActual(metadata.Image),
+		)
+		if delErr := g.claims().Delete(ctx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
+			return gkeRuntimeMetadata{}, created, fmt.Errorf("delete drifted sandbox claim %s: %w", name, delErr)
+		}
+		ownsClaim = false
+	}
+}
+
+// runnerBusy reports whether any thread on the runner has a turn in flight
+// (min idle == 0; the runner clears a thread's idle clock synchronously on
+// /turn enqueue). Probe errors report not-busy: an unreachable runner on a
+// stale image would fail the health wait anyway, so recycling it loses
+// nothing.
+func (g *GKERuntimeBackend) runnerBusy(ctx context.Context, metadata gkeRuntimeMetadata) bool {
+	state, err := g.runner.state(ctx, g.endpoint(metadata))
+	if err != nil {
+		return false
+	}
+	idle := state.minThreadIdle()
+	return idle != nil && *idle == 0
 }
 
 func (g *GKERuntimeBackend) buildClaim(name string, runtime assistantRuntimeRecord) *unstructured.Unstructured {
@@ -282,7 +345,7 @@ func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string
 				return gkeRuntimeMetadata{}, fmt.Errorf("get sandbox %s: %w", sandboxName, err)
 			}
 			if err == nil && sandboxReady(sandbox) {
-				podIP, err := g.resolvePodIP(ctx, string(claim.GetUID()))
+				podIP, image, err := g.resolveRunnerPod(ctx, string(claim.GetUID()))
 				if err != nil {
 					return gkeRuntimeMetadata{}, err
 				}
@@ -292,7 +355,7 @@ func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string
 						ClaimName:   claimName,
 						SandboxName: sandboxName,
 						PodIP:       podIP,
-						Image:       "",
+						Image:       image,
 					}, nil
 				}
 			}
@@ -325,24 +388,33 @@ func sandboxReady(sandbox *unstructured.Unstructured) bool {
 	return false
 }
 
-// resolvePodIP finds the runner pod for a claim (by the controller-injected
-// claim-uid label) and returns its IP once the pod is Running. An empty string
-// means the pod is not scheduled/running yet, so the caller keeps polling.
-func (g *GKERuntimeBackend) resolvePodIP(ctx context.Context, claimUID string) (string, error) {
+// resolveRunnerPod finds the runner pod for a claim (by the controller-injected
+// claim-uid label) and returns its IP and container image once the pod is
+// Running. An empty IP means the pod is not scheduled/running yet, so the
+// caller keeps polling.
+func (g *GKERuntimeBackend) resolveRunnerPod(ctx context.Context, claimUID string) (podIP string, image string, err error) {
 	pods, err := g.config.Dynamic.Resource(gkePodGVR).Namespace(g.config.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: gkeClaimUIDLabel + "=" + claimUID,
 	})
 	if err != nil {
-		return "", fmt.Errorf("list runner pods for claim %s: %w", claimUID, err)
+		return "", "", fmt.Errorf("list runner pods for claim %s: %w", claimUID, err)
 	}
 	for i := range pods.Items {
 		phase, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "phase")
 		ip, _, _ := unstructured.NestedString(pods.Items[i].Object, "status", "podIP")
-		if phase == "Running" && ip != "" {
-			return ip, nil
+		if phase != "Running" || ip == "" {
+			continue
 		}
+		img := ""
+		containers, _, _ := unstructured.NestedSlice(pods.Items[i].Object, "spec", "containers")
+		if len(containers) > 0 {
+			if container, ok := containers[0].(map[string]any); ok {
+				img, _, _ = unstructured.NestedString(container, "image")
+			}
+		}
+		return ip, img, nil
 	}
-	return "", nil
+	return "", "", nil
 }
 
 func (g *GKERuntimeBackend) endpoint(metadata gkeRuntimeMetadata) string {
@@ -424,16 +496,65 @@ func (g *GKERuntimeBackend) deleteClaim(ctx context.Context, runtime assistantRu
 	return nil
 }
 
-// RecycleImage is a no-op on GKE. There is no in-place image swap: a claimed
-// sandbox's pod ownership has moved off the warm pool, so a SandboxTemplate /
-// warm-pool image bump never disturbs an in-flight turn — the running sandbox
-// finishes on its current image and new admissions draw new-image pods. Old
-// idle sandboxes roll over via warm-TTL expiry and the janitor.
+// RecycleImage rolls a claimed sandbox onto the configured runtime image by
+// deleting the claim and re-claiming from the warm pool — GKE has no in-place
+// image swap, but a recycle only costs claim churn: the pool hands the new
+// claim a pre-warmed pod. Gated on the runner's idle clock so an in-flight
+// turn is never interrupted; a missing claim or pod is a skip, not an error.
 func (g *GKERuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
 	if err := validateRuntimeBackend(g, runtime.Backend); err != nil {
 		return RuntimeBackendRecycleResult{}, err
 	}
-	return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+	metadata, err := decodeGKERuntimeMetadata(runtime.BackendMetadataJSON)
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	name := metadata.ClaimName
+	if name == "" {
+		name = g.claimName(runtime)
+	}
+
+	claim, err := g.claims().Get(ctx, name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+	}
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, fmt.Errorf("get sandbox claim %s: %w", name, err)
+	}
+
+	podIP, image, err := g.resolveRunnerPod(ctx, string(claim.GetUID()))
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	if podIP == "" || image == "" || image == g.desiredImageRef() {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+	}
+	metadata.PodIP = podIP
+	if g.runnerBusy(ctx, metadata) {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
+	}
+
+	g.logger.InfoContext(ctx, "assistant gke runtime recycling: image upgrade",
+		attr.SlogAssistantID(runtime.AssistantID.String()),
+		attr.SlogAssistantImageDesired(g.desiredImageRef()),
+		attr.SlogAssistantImageActual(image),
+	)
+	if err := g.claims().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return RuntimeBackendRecycleResult{}, fmt.Errorf("delete drifted sandbox claim %s: %w", name, err)
+	}
+
+	fresh, _, err := g.ensureCurrentImageSandbox(ctx, runtime)
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	if err := g.runner.health(ctx, g.endpoint(fresh), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
+		return RuntimeBackendRecycleResult{}, err
+	}
+	payload, err := json.Marshal(fresh)
+	if err != nil {
+		return RuntimeBackendRecycleResult{}, fmt.Errorf("encode gke runtime metadata: %w", err)
+	}
+	return RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: payload}, nil
 }
 
 func decodeGKERuntimeMetadata(raw []byte) (gkeRuntimeMetadata, error) {

--- a/server/internal/assistants/runtime_gke.go
+++ b/server/internal/assistants/runtime_gke.go
@@ -208,16 +208,18 @@ func (g *GKERuntimeBackend) Ensure(ctx context.Context, runtime assistantRuntime
 func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runtime assistantRuntimeRecord) (metadata gkeRuntimeMetadata, coldStart bool, err error) {
 	name := g.claimName(runtime)
 	desired := g.desiredImageRef()
-	// ownsClaim tracks whether this call created the currently live claim. If
-	// ensure fails on an owned claim, delete it so the next admission
-	// recreates a fresh claim rather than re-attaching to an unhealthy one
-	// with no persisted metadata. A pre-existing claim, or one a racing
-	// Ensure created (AlreadyExists), is left alone — another turn may be
-	// using it. WithoutCancel so cleanup still runs when the failure was a
-	// timeout.
-	ownsClaim := false
+	// The ready budget spans the whole drain loop: a re-claim adopts a warm
+	// pod in seconds, so recycles must not each restart the full cold-start
+	// allowance on the turn-admission path.
+	deadline := time.Now().Add(gkeRuntimeReadyTimeout)
+	// If ensure fails on a claim this call created (coldStart), delete it so
+	// the next admission recreates a fresh claim rather than re-attaching to
+	// an unhealthy one with no persisted metadata. A pre-existing claim, or
+	// one a racing Ensure created (AlreadyExists), is left alone — another
+	// turn may be using it. WithoutCancel so cleanup still runs when the
+	// failure was a timeout.
 	defer func() {
-		if err == nil || !ownsClaim {
+		if err == nil || !coldStart {
 			return
 		}
 		delCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gkeRuntimeReapCallTimeout)
@@ -230,16 +232,15 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 		}
 	}()
 
-	for attempt := 1; ; attempt++ {
-		created := false
+	for recycles := 0; ; recycles++ {
+		coldStart = false
 		if _, getErr := g.claims().Get(ctx, name, metav1.GetOptions{}); getErr != nil {
 			if !k8serrors.IsNotFound(getErr) {
 				return gkeRuntimeMetadata{}, false, fmt.Errorf("get sandbox claim %s: %w", name, getErr)
 			}
 			switch _, createErr := g.claims().Create(ctx, g.buildClaim(name, runtime), metav1.CreateOptions{}); {
 			case createErr == nil:
-				created = true
-				ownsClaim = true
+				coldStart = true
 			case k8serrors.IsAlreadyExists(createErr):
 				// A racing Ensure created the claim between our Get and Create.
 				// Attach to it like a pre-existing claim; the other turn owns
@@ -248,9 +249,8 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 				return gkeRuntimeMetadata{}, false, fmt.Errorf("create sandbox claim %s: %w", name, createErr)
 			}
 		}
-		coldStart = created
 
-		metadata, err = g.waitForSandbox(ctx, name)
+		metadata, err = g.waitForSandbox(ctx, name, deadline)
 		if err != nil {
 			return gkeRuntimeMetadata{}, coldStart, err
 		}
@@ -260,7 +260,7 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 		if metadata.Image == "" || metadata.Image == desired {
 			break
 		}
-		if attempt > gkeImageDrainAttempts {
+		if recycles == gkeImageDrainAttempts {
 			g.logger.WarnContext(ctx, "assistant gke runtime kept on stale image: drain attempts exhausted",
 				attr.SlogAssistantID(runtime.AssistantID.String()),
 				attr.SlogAssistantImageDesired(desired),
@@ -268,7 +268,7 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 			)
 			break
 		}
-		if !created && g.runnerBusy(ctx, metadata) {
+		if !coldStart && g.runnerBusy(ctx, metadata) {
 			// Pre-existing claim with a turn in flight: don't tear it down
 			// mid-turn. A later admission with idle threads recycles it.
 			break
@@ -282,7 +282,9 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 		if delErr := g.claims().Delete(ctx, name, metav1.DeleteOptions{}); delErr != nil && !k8serrors.IsNotFound(delErr) {
 			return gkeRuntimeMetadata{}, coldStart, fmt.Errorf("delete drifted sandbox claim %s: %w", name, delErr)
 		}
-		ownsClaim = false
+		if err = g.waitClaimDeleted(ctx, name, deadline); err != nil {
+			return gkeRuntimeMetadata{}, coldStart, err
+		}
 	}
 
 	if err = g.runner.health(ctx, g.endpoint(metadata), gkeRuntimeHealthTimeout, 500*time.Millisecond); err != nil {
@@ -291,18 +293,39 @@ func (g *GKERuntimeBackend) ensureCurrentImageSandbox(ctx context.Context, runti
 	return metadata, coldStart, nil
 }
 
-// runnerBusy reports whether any thread on the runner has a turn in flight
-// (min idle == 0; the runner clears a thread's idle clock synchronously on
-// /turn enqueue). Probe errors report not-busy: an unreachable runner on a
-// stale image would fail the health wait anyway, so recycling it loses
-// nothing.
+// waitClaimDeleted polls until the claim object is gone. The claim delete
+// cascades asynchronously (finalizers), so an immediate re-Get can return the
+// terminating claim, re-adopt its dying pod, and burn every drain attempt on
+// the same stale image.
+func (g *GKERuntimeBackend) waitClaimDeleted(ctx context.Context, name string, deadline time.Time) error {
+	for {
+		_, err := g.claims().Get(ctx, name, metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("get sandbox claim %s: %w", name, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: sandbox claim %s still terminating after delete", ErrRuntimeUnhealthy, name)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for sandbox claim %s deletion: %w", name, ctx.Err())
+		case <-time.After(gkeRuntimePollInterval):
+		}
+	}
+}
+
+// runnerBusy reports whether the runner has a turn in flight. Probe errors
+// report not-busy: an unreachable runner on a stale image would fail the
+// health wait anyway, so recycling it loses nothing.
 func (g *GKERuntimeBackend) runnerBusy(ctx context.Context, metadata gkeRuntimeMetadata) bool {
 	state, err := g.runner.state(ctx, g.endpoint(metadata))
 	if err != nil {
 		return false
 	}
-	idle := state.minThreadIdle()
-	return idle != nil && *idle == 0
+	return state.turnInFlight()
 }
 
 func (g *GKERuntimeBackend) buildClaim(name string, runtime assistantRuntimeRecord) *unstructured.Unstructured {
@@ -334,8 +357,7 @@ func (g *GKERuntimeBackend) buildClaim(name string, runtime assistantRuntimeReco
 
 // waitForSandbox polls the claim until it names an assigned Sandbox, then polls
 // that Sandbox until it reports Ready and its runner pod has an IP.
-func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string) (gkeRuntimeMetadata, error) {
-	deadline := time.Now().Add(gkeRuntimeReadyTimeout)
+func (g *GKERuntimeBackend) waitForSandbox(ctx context.Context, claimName string, deadline time.Time) (gkeRuntimeMetadata, error) {
 	sandboxes := g.config.Dynamic.Resource(gkeSandboxGVR).Namespace(g.config.Namespace)
 	for {
 		claim, err := g.claims().Get(ctx, claimName, metav1.GetOptions{})
@@ -513,10 +535,7 @@ func (g *GKERuntimeBackend) RecycleImage(ctx context.Context, runtime assistantR
 	if err != nil {
 		return RuntimeBackendRecycleResult{}, err
 	}
-	name := metadata.ClaimName
-	if name == "" {
-		name = g.claimName(runtime)
-	}
+	name := firstNonEmpty(metadata.ClaimName, g.claimName(runtime))
 
 	claim, err := g.claims().Get(ctx, name, metav1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
@@ -533,29 +552,18 @@ func (g *GKERuntimeBackend) RecycleImage(ctx context.Context, runtime assistantR
 	if podIP == "" || image == "" || image == g.desiredImageRef() {
 		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
 	}
-	metadata.PodIP = podIP
-	if g.runnerBusy(ctx, metadata) {
-		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
-	}
 
-	g.logger.InfoContext(ctx, "assistant gke runtime recycling: image upgrade",
-		attr.SlogAssistantID(runtime.AssistantID.String()),
-		attr.SlogAssistantImageDesired(g.desiredImageRef()),
-		attr.SlogAssistantImageActual(image),
-	)
-	if err := g.claims().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		return RuntimeBackendRecycleResult{}, fmt.Errorf("delete drifted sandbox claim %s: %w", name, err)
-	}
-
-	fresh, _, err := g.ensureCurrentImageSandbox(ctx, runtime)
+	// Drift confirmed: the ensure drain loop performs the busy-gated claim
+	// delete and warm-pool re-claim. ColdStart reports whether the claim was
+	// replaced — false means the busy gate kept the stale pod.
+	result, err := g.Ensure(ctx, runtime)
 	if err != nil {
 		return RuntimeBackendRecycleResult{}, err
 	}
-	payload, err := json.Marshal(fresh)
-	if err != nil {
-		return RuntimeBackendRecycleResult{}, fmt.Errorf("encode gke runtime metadata: %w", err)
+	if !result.ColdStart {
+		return RuntimeBackendRecycleResult{Recycled: false, BackendMetadataJSON: nil}, nil
 	}
-	return RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: payload}, nil
+	return RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: result.BackendMetadataJSON}, nil
 }
 
 func decodeGKERuntimeMetadata(raw []byte) (gkeRuntimeMetadata, error) {

--- a/server/internal/assistants/runtime_gke_test.go
+++ b/server/internal/assistants/runtime_gke_test.go
@@ -18,8 +18,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -225,6 +227,194 @@ func TestGKEEnsureWaitsForReadySandbox(t *testing.T) {
 	require.Equal(t, claimName, meta.ClaimName)
 	require.Equal(t, "sb-1", meta.SandboxName)
 	require.Equal(t, host, meta.PodIP)
+}
+
+// seedClaimedSandbox seeds a claim (with uid), its Ready sandbox, and a
+// Running runner pod labeled with the claim uid, exercising the same
+// controller-written fields the backend reads in production.
+func seedClaimedSandbox(t *testing.T, dyn dynamic.Interface, claimName, claimUID, sandboxName, podIP, image string) {
+	t.Helper()
+	seedUnstructured(t, dyn, gkeSandboxClaimGVR, &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
+		"kind":       "SandboxClaim",
+		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test", "uid": claimUID},
+		"status":     map[string]any{"sandbox": map[string]any{"Name": sandboxName}},
+	}})
+	seedUnstructured(t, dyn, gkeSandboxGVR, &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxGVR.Group + "/" + gkeSandboxGVR.Version,
+		"kind":       "Sandbox",
+		"metadata":   map[string]any{"name": sandboxName, "namespace": "gram-test"},
+		"status": map[string]any{
+			"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+		},
+	}})
+	seedUnstructured(t, dyn, gkePodGVR, &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      sandboxName + "-pod",
+			"namespace": "gram-test",
+			"labels":    map[string]any{gkeClaimUIDLabel: claimUID},
+		},
+		"spec":   map[string]any{"containers": []any{map[string]any{"name": "runner", "image": image}}},
+		"status": map[string]any{"phase": "Running", "podIP": podIP},
+	}})
+}
+
+// adoptOnClaimCreate simulates the SandboxClaim controller in the fake
+// cluster: every claim create is stamped with the given uid and assigned the
+// given sandbox, mirroring warm-pool adoption. The matching sandbox and pod
+// must be seeded separately.
+func adoptOnClaimCreate(dyn *dynamicfake.FakeDynamicClient, claimUID, sandboxName string) {
+	dyn.PrependReactor("create", "sandboxclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		obj, ok := action.(k8stesting.CreateAction).GetObject().(*unstructured.Unstructured)
+		if !ok {
+			return false, nil, nil
+		}
+		obj.SetUID(types.UID(claimUID))
+		_ = unstructured.SetNestedField(obj.Object, sandboxName, "status", "sandbox", "Name")
+		return false, nil, nil
+	})
+}
+
+func TestGKEEnsureRecyclesClaimOnStaleImage(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/state" {
+			_ = json.NewEncoder(w).Encode(runnerStateResponse{
+				AssistantID:   assistantID.String(),
+				UptimeSeconds: 100,
+				Threads:       []runnerThreadState{{ThreadID: "t1", ChatID: "c1", IdleSeconds: 30}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	dyn := newGKEFakeDynamic()
+	backend := newTestGKEBackend(t, dyn, doer, port)
+	claimName := "gram-asst-" + assistantID.String()
+	seedClaimedSandbox(t, dyn, claimName, "claim-uid-1", "sb-stale", host, "registry.example.com/gram-assistant-runtime:old")
+
+	// The re-created claim adopts a warm pod already on the desired image.
+	adoptOnClaimCreate(dyn, "claim-uid-2", "sb-fresh")
+	seedClaimedSandbox(t, dyn, "unused-seed-claim", "claim-uid-2", "sb-fresh", host, backend.desiredImageRef())
+
+	result, err := backend.Ensure(t.Context(), assistantRuntimeRecord{
+		ID:                  uuid.New(),
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendGKE,
+		BackendMetadataJSON: nil,
+		State:               runtimeStateStarting,
+		WarmUntil:           pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+	require.True(t, result.ColdStart, "recycled claim is a fresh pod")
+	var meta gkeRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &meta))
+	require.Equal(t, "sb-fresh", meta.SandboxName)
+	require.Equal(t, backend.desiredImageRef(), meta.Image)
+}
+
+func TestGKEEnsureKeepsStaleImageClaimWhileTurnInFlight(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/state" {
+			_ = json.NewEncoder(w).Encode(runnerStateResponse{
+				AssistantID:   assistantID.String(),
+				UptimeSeconds: 100,
+				Threads:       []runnerThreadState{{ThreadID: "t1", ChatID: "c1", IdleSeconds: 0}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	dyn := newGKEFakeDynamic()
+	backend := newTestGKEBackend(t, dyn, doer, port)
+	claimName := "gram-asst-" + assistantID.String()
+	seedClaimedSandbox(t, dyn, claimName, "claim-uid-1", "sb-stale", host, "registry.example.com/gram-assistant-runtime:old")
+
+	result, err := backend.Ensure(t.Context(), assistantRuntimeRecord{
+		ID:                  uuid.New(),
+		AssistantThreadID:   uuid.Nil,
+		AssistantID:         assistantID,
+		ProjectID:           uuid.New(),
+		Backend:             runtimeBackendGKE,
+		BackendMetadataJSON: nil,
+		State:               runtimeStateStarting,
+		WarmUntil:           pgtype.Timestamptz{},
+	})
+	require.NoError(t, err)
+	require.False(t, result.ColdStart)
+	var meta gkeRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &meta))
+	require.Equal(t, "sb-stale", meta.SandboxName, "busy runner is never recycled mid-turn")
+}
+
+func TestGKERecycleImageReplacesStaleClaim(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/state" {
+			_ = json.NewEncoder(w).Encode(runnerStateResponse{
+				AssistantID:   assistantID.String(),
+				UptimeSeconds: 100,
+				Threads:       nil,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	dyn := newGKEFakeDynamic()
+	backend := newTestGKEBackend(t, dyn, doer, port)
+	record := gkeRecord(t, backend, assistantID, host)
+	claimName := "gram-asst-" + assistantID.String()
+	seedClaimedSandbox(t, dyn, claimName, "claim-uid-1", "sb-stale", host, "registry.example.com/gram-assistant-runtime:old")
+
+	adoptOnClaimCreate(dyn, "claim-uid-2", "sb-fresh")
+	seedClaimedSandbox(t, dyn, "unused-seed-claim", "claim-uid-2", "sb-fresh", host, backend.desiredImageRef())
+
+	result, err := backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.True(t, result.Recycled)
+	var meta gkeRuntimeMetadata
+	require.NoError(t, json.Unmarshal(result.BackendMetadataJSON, &meta))
+	require.Equal(t, "sb-fresh", meta.SandboxName)
+	require.Equal(t, backend.desiredImageRef(), meta.Image)
+}
+
+func TestGKERecycleImageSkipsCurrentImageAndMissingClaim(t *testing.T) {
+	t.Parallel()
+
+	assistantID := uuid.New()
+	doer, host, port := testRunner(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	dyn := newGKEFakeDynamic()
+	backend := newTestGKEBackend(t, dyn, doer, port)
+	record := gkeRecord(t, backend, assistantID, host)
+
+	// Missing claim: resource gone is a skip, not an error.
+	result, err := backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
+
+	// Pod already on the configured image: nothing to roll.
+	claimName := "gram-asst-" + assistantID.String()
+	seedClaimedSandbox(t, dyn, claimName, "claim-uid-1", "sb-1", host, backend.desiredImageRef())
+	result, err = backend.RecycleImage(t.Context(), record)
+	require.NoError(t, err)
+	require.False(t, result.Recycled)
 }
 
 func TestGKEReapDeletesClaimIdempotently(t *testing.T) {

--- a/server/internal/assistants/runtime_gke_test.go
+++ b/server/internal/assistants/runtime_gke_test.go
@@ -229,17 +229,10 @@ func TestGKEEnsureWaitsForReadySandbox(t *testing.T) {
 	require.Equal(t, host, meta.PodIP)
 }
 
-// seedClaimedSandbox seeds a claim (with uid), its Ready sandbox, and a
-// Running runner pod labeled with the claim uid, exercising the same
-// controller-written fields the backend reads in production.
-func seedClaimedSandbox(t *testing.T, dyn dynamic.Interface, claimName, claimUID, sandboxName, podIP, image string) {
+// seedSandboxWithPod seeds a Ready sandbox and a Running runner pod labeled
+// with the claim uid — the controller-written state a claim adoption ends in.
+func seedSandboxWithPod(t *testing.T, dyn dynamic.Interface, claimUID, sandboxName, podIP, image string) {
 	t.Helper()
-	seedUnstructured(t, dyn, gkeSandboxClaimGVR, &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
-		"kind":       "SandboxClaim",
-		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test", "uid": claimUID},
-		"status":     map[string]any{"sandbox": map[string]any{"Name": sandboxName}},
-	}})
 	seedUnstructured(t, dyn, gkeSandboxGVR, &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": gkeSandboxGVR.Group + "/" + gkeSandboxGVR.Version,
 		"kind":       "Sandbox",
@@ -259,6 +252,20 @@ func seedClaimedSandbox(t *testing.T, dyn dynamic.Interface, claimName, claimUID
 		"spec":   map[string]any{"containers": []any{map[string]any{"name": "runner", "image": image}}},
 		"status": map[string]any{"phase": "Running", "podIP": podIP},
 	}})
+}
+
+// seedClaimedSandbox seeds a claim (with uid) plus its Ready sandbox and
+// Running runner pod, exercising the same controller-written fields the
+// backend reads in production.
+func seedClaimedSandbox(t *testing.T, dyn dynamic.Interface, claimName, claimUID, sandboxName, podIP, image string) {
+	t.Helper()
+	seedUnstructured(t, dyn, gkeSandboxClaimGVR, &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gkeSandboxClaimGVR.Group + "/" + gkeSandboxClaimGVR.Version,
+		"kind":       "SandboxClaim",
+		"metadata":   map[string]any{"name": claimName, "namespace": "gram-test", "uid": claimUID},
+		"status":     map[string]any{"sandbox": map[string]any{"Name": sandboxName}},
+	}})
+	seedSandboxWithPod(t, dyn, claimUID, sandboxName, podIP, image)
 }
 
 // adoptOnClaimCreate simulates the SandboxClaim controller in the fake
@@ -281,17 +288,7 @@ func TestGKEEnsureRecyclesClaimOnStaleImage(t *testing.T) {
 	t.Parallel()
 
 	assistantID := uuid.New()
-	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/state" {
-			_ = json.NewEncoder(w).Encode(runnerStateResponse{
-				AssistantID:   assistantID.String(),
-				UptimeSeconds: 100,
-				Threads:       []runnerThreadState{{ThreadID: "t1", ChatID: "c1", IdleSeconds: 30}},
-			})
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+	doer, host, port := testRunner(t, healthyRunnerHandler(30))
 
 	dyn := newGKEFakeDynamic()
 	backend := newTestGKEBackend(t, dyn, doer, port)
@@ -300,7 +297,7 @@ func TestGKEEnsureRecyclesClaimOnStaleImage(t *testing.T) {
 
 	// The re-created claim adopts a warm pod already on the desired image.
 	adoptOnClaimCreate(dyn, "claim-uid-2", "sb-fresh")
-	seedClaimedSandbox(t, dyn, "unused-seed-claim", "claim-uid-2", "sb-fresh", host, backend.desiredImageRef())
+	seedSandboxWithPod(t, dyn, "claim-uid-2", "sb-fresh", host, backend.desiredImageRef())
 
 	result, err := backend.Ensure(t.Context(), assistantRuntimeRecord{
 		ID:                  uuid.New(),
@@ -324,17 +321,7 @@ func TestGKEEnsureKeepsStaleImageClaimWhileTurnInFlight(t *testing.T) {
 	t.Parallel()
 
 	assistantID := uuid.New()
-	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/state" {
-			_ = json.NewEncoder(w).Encode(runnerStateResponse{
-				AssistantID:   assistantID.String(),
-				UptimeSeconds: 100,
-				Threads:       []runnerThreadState{{ThreadID: "t1", ChatID: "c1", IdleSeconds: 0}},
-			})
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+	doer, host, port := testRunner(t, healthyRunnerHandler(0))
 
 	dyn := newGKEFakeDynamic()
 	backend := newTestGKEBackend(t, dyn, doer, port)
@@ -362,17 +349,7 @@ func TestGKERecycleImageReplacesStaleClaim(t *testing.T) {
 	t.Parallel()
 
 	assistantID := uuid.New()
-	doer, host, port := testRunner(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/state" {
-			_ = json.NewEncoder(w).Encode(runnerStateResponse{
-				AssistantID:   assistantID.String(),
-				UptimeSeconds: 100,
-				Threads:       nil,
-			})
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+	doer, host, port := testRunner(t, healthyRunnerHandler(30))
 
 	dyn := newGKEFakeDynamic()
 	backend := newTestGKEBackend(t, dyn, doer, port)
@@ -381,7 +358,7 @@ func TestGKERecycleImageReplacesStaleClaim(t *testing.T) {
 	seedClaimedSandbox(t, dyn, claimName, "claim-uid-1", "sb-stale", host, "registry.example.com/gram-assistant-runtime:old")
 
 	adoptOnClaimCreate(dyn, "claim-uid-2", "sb-fresh")
-	seedClaimedSandbox(t, dyn, "unused-seed-claim", "claim-uid-2", "sb-fresh", host, backend.desiredImageRef())
+	seedSandboxWithPod(t, dyn, "claim-uid-2", "sb-fresh", host, backend.desiredImageRef())
 
 	result, err := backend.RecycleImage(t.Context(), record)
 	require.NoError(t, err)

--- a/server/internal/assistants/runtime_local.go
+++ b/server/internal/assistants/runtime_local.go
@@ -199,10 +199,6 @@ func (l *LocalRuntimeBackend) ServerURL() *url.URL { return l.config.ServerURL }
 
 func (l *LocalRuntimeBackend) ImageRef() string { return l.desiredImageRef() }
 
-// ReusesIdleRuntimes is true: Stop leaves the container and its workspace
-// volume in place, and the next admission restarts the same container.
-func (l *LocalRuntimeBackend) ReusesIdleRuntimes() bool { return true }
-
 func (l *LocalRuntimeBackend) desiredImageRef() string {
 	return runtimeImageRef(l.config.OCIImage, l.config.ImageTag)
 }

--- a/server/internal/assistants/runtime_local.go
+++ b/server/internal/assistants/runtime_local.go
@@ -297,8 +297,7 @@ func (l *LocalRuntimeBackend) runnerBusy(ctx context.Context, info localContaine
 	if err != nil {
 		return true
 	}
-	idle := state.minThreadIdle()
-	return idle != nil && *idle == 0
+	return state.turnInFlight()
 }
 
 // startContainer converges the named container onto a running, healthy state

--- a/server/internal/assistants/runtime_router.go
+++ b/server/internal/assistants/runtime_router.go
@@ -51,11 +51,6 @@ func (r *runtimeRouter) SupportsBackend(backend string) bool {
 func (r *runtimeRouter) ServerURL() *url.URL { return r.backends[r.target].ServerURL() }
 func (r *runtimeRouter) ImageRef() string    { return r.backends[r.target].ImageRef() }
 
-// ReusesIdleRuntimes resolves against the target: it drives how a deploy rolls
-// new runtimes onto the configured image, which only concerns the backend that
-// admits them. The deploy sweep skips non-target rows for the same reason.
-func (r *runtimeRouter) ReusesIdleRuntimes() bool { return r.backends[r.target].ReusesIdleRuntimes() }
-
 func (r *runtimeRouter) Ensure(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
 	b, err := r.route(runtime.Backend)
 	if err != nil {

--- a/server/internal/assistants/runtime_router_test.go
+++ b/server/internal/assistants/runtime_router_test.go
@@ -26,10 +26,9 @@ func testRuntimeRecord(backend string) assistantRuntimeRecord {
 // stubRuntimeBackend records which calls land on it so router dispatch can be
 // asserted by backend identity.
 type stubRuntimeBackend struct {
-	name       string
-	serverURL  *url.URL
-	imageRef   string
-	reusesIdle bool
+	name      string
+	serverURL *url.URL
+	imageRef  string
 
 	ensureRecords           []assistantRuntimeRecord
 	runTurnCount            int
@@ -42,7 +41,6 @@ func (s *stubRuntimeBackend) Backend() string               { return s.name }
 func (s *stubRuntimeBackend) SupportsBackend(b string) bool { return b == s.name }
 func (s *stubRuntimeBackend) ServerURL() *url.URL           { return s.serverURL }
 func (s *stubRuntimeBackend) ImageRef() string              { return s.imageRef }
-func (s *stubRuntimeBackend) ReusesIdleRuntimes() bool      { return s.reusesIdle }
 
 func (s *stubRuntimeBackend) Ensure(_ context.Context, r assistantRuntimeRecord) (RuntimeBackendEnsureResult, error) {
 	s.ensureRecords = append(s.ensureRecords, r)
@@ -81,8 +79,8 @@ var _ RuntimeBackend = (*stubRuntimeBackend)(nil)
 
 func newTestRouter(t *testing.T, target string) (*runtimeRouter, *stubRuntimeBackend, *stubRuntimeBackend) {
 	t.Helper()
-	fly := &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: &url.URL{Scheme: "https", Host: "fly.example.com"}, imageRef: "fly:img", reusesIdle: true, ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
-	gke := &stubRuntimeBackend{name: runtimeBackendGKE, serverURL: &url.URL{Scheme: "https", Host: "gke.example.com"}, imageRef: "gke:img", reusesIdle: false, ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
+	fly := &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: &url.URL{Scheme: "https", Host: "fly.example.com"}, imageRef: "fly:img", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
+	gke := &stubRuntimeBackend{name: runtimeBackendGKE, serverURL: &url.URL{Scheme: "https", Host: "gke.example.com"}, imageRef: "gke:img", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0}
 	router, err := newRuntimeRouter(target, map[string]RuntimeBackend{
 		runtimeBackendFlyIO: fly,
 		runtimeBackendGKE:   gke,
@@ -113,13 +111,9 @@ func TestRuntimeRouterTargetSurface(t *testing.T) {
 	require.Equal(t, runtimeBackendGKE, router.Backend())
 	require.Equal(t, gke.serverURL, router.ServerURL())
 	require.Equal(t, gke.imageRef, router.ImageRef())
-	require.False(t, router.ReusesIdleRuntimes(), "gke target resolves to the gke backend's non-reuse")
 	require.True(t, router.SupportsBackend(runtimeBackendFlyIO))
 	require.True(t, router.SupportsBackend(runtimeBackendGKE))
 	require.False(t, router.SupportsBackend("bogus"))
-
-	flyTarget, _, _ := newTestRouter(t, runtimeBackendFlyIO)
-	require.True(t, flyTarget.ReusesIdleRuntimes(), "fly target resolves to the fly backend's warm reuse")
 }
 
 func TestRuntimeRouterUnknownBackendErrors(t *testing.T) {
@@ -134,7 +128,7 @@ func TestNewRuntimeRouterRequiresTargetConfigured(t *testing.T) {
 	t.Parallel()
 
 	_, err := newRuntimeRouter(runtimeBackendGKE, map[string]RuntimeBackend{
-		runtimeBackendFlyIO: &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: nil, imageRef: "", reusesIdle: true, ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0},
+		runtimeBackendFlyIO: &stubRuntimeBackend{name: runtimeBackendFlyIO, serverURL: nil, imageRef: "", ensureRecords: nil, runTurnCount: 0, stopCount: 0, reapCount: 0},
 	})
 	require.ErrorContains(t, err, `target backend "gke" is not configured`)
 

--- a/server/internal/assistants/runtime_telemetry.go
+++ b/server/internal/assistants/runtime_telemetry.go
@@ -115,10 +115,6 @@ func (t *telemetryRuntimeBackend) ImageRef() string {
 	return t.inner.ImageRef()
 }
 
-func (t *telemetryRuntimeBackend) ReusesIdleRuntimes() bool {
-	return t.inner.ReusesIdleRuntimes()
-}
-
 func (t *telemetryRuntimeBackend) RecycleImage(ctx context.Context, runtime assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {
 	result, err := t.inner.RecycleImage(ctx, runtime)
 	if err != nil {

--- a/server/internal/assistants/service.go
+++ b/server/internal/assistants/service.go
@@ -1675,18 +1675,12 @@ type RecycleAssistantRuntimeImagesParams struct {
 // the currently configured runtime image, so deploys absorb the image-pull +
 // reboot cost while runtimes are idle instead of the next turn paying it.
 // Busy or failed rows are not chased — the per-admission path catches them
-// lazily.
-//
-// This is the in-place roll for backends that reuse idle runtimes (Fly). A
-// non-reuse backend (GKE) has no in-place swap and rolls onto a new image by
-// terminating idle runtimes instead (the warm-TTL expiry stops them, which
-// deletes the claim, and the next /turn re-admits onto a fresh warm-pool pod
-// already running the new image), so this sweep is a no-op for it.
+// lazily. The roll mechanism is the backend's RecycleImage: Fly updates the
+// machine in place; GKE deletes the claim and re-claims a warm-pool pod. An
+// active-but-regularly-used runtime never goes idle long enough for the
+// inactivity janitor to reap it, so without this sweep it would stay on its
+// admission-time image across deploys indefinitely.
 func (s *ServiceCore) RecycleActiveRuntimeImages(ctx context.Context, params RecycleAssistantRuntimeImagesParams) (RecycleAssistantRuntimeImagesResult, error) {
-	if !s.runtime.ReusesIdleRuntimes() {
-		return RecycleAssistantRuntimeImagesResult{Recycled: 0, Skipped: 0, Errors: 0}, nil
-	}
-
 	queries := assistantrepo.New(s.db)
 	rows, err := queries.ListActiveAssistantRuntimes(ctx, runtimeStateActive)
 	if err != nil {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1899,36 +1899,39 @@ func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) 
 // A non-reuse backend (GKE) has no in-place image swap: it rolls onto a new
 // image by terminating idle runtimes (warm-TTL expiry), so the in-place recycle
 // sweep is a no-op for it — it touches no rows and tears nothing down.
-func TestServiceCoreRecycleActiveRuntimeImagesNoOpsForNonReuseBackend(t *testing.T) {
+func TestServiceCoreRecycleActiveRuntimeImagesSweepsGKERows(t *testing.T) {
 	t.Parallel()
 
-	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_gke_noop")
+	conn, err := assistantsInfra.CloneTestDatabase(t, "recycle_runtime_images_gke")
 	require.NoError(t, err)
 
-	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-gke-noop")
+	projectID, assistantID, threadID := insertReapableProject(t, conn, "recycle-gke")
 	runtimeID := insertActiveV2RuntimeRow(t, conn, projectID, assistantID, threadID, runtimeBackendGKE, runtimeStateActive, `{"claim_name":"gram-asst-idle"}`)
 
+	recycledMetadata := []byte(`{"claim_name":"gram-asst-idle","pod_ip":"10.52.0.9","image":"registry.example.com/gram-assistant-runtime:new"}`)
 	stopCalls := &atomic.Int64{}
 	recycleCalls := &atomic.Int64{}
 	backend := testRuntimeBackend{
-		backend:      runtimeBackendGKE,
-		statusResult: RuntimeBackendStatus{Configured: true, IdleSeconds: nil},
-		stopCalls:    stopCalls,
-		recycleCalls: recycleCalls,
+		backend:       runtimeBackendGKE,
+		statusResult:  RuntimeBackendStatus{Configured: true, IdleSeconds: nil},
+		stopCalls:     stopCalls,
+		recycleCalls:  recycleCalls,
+		recycleResult: RuntimeBackendRecycleResult{Recycled: true, BackendMetadataJSON: recycledMetadata},
 	}
 	core := NewServiceCore(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn, nil, nil, backend, nil, nil, nil, telemetry.NewStub(testenv.NewLogger(t)), nil, newTestAuditLogger())
 
 	result, err := core.RecycleActiveRuntimeImages(t.Context(), RecycleAssistantRuntimeImagesParams{OnRowProcessed: nil})
 	require.NoError(t, err)
-	require.Equal(t, 0, result.Recycled)
+	require.Equal(t, 1, result.Recycled)
 	require.Equal(t, 0, result.Skipped)
 	require.Equal(t, 0, result.Errors)
-	require.EqualValues(t, 0, stopCalls.Load(), "the in-place sweep must not tear down GKE runtimes")
-	require.EqualValues(t, 0, recycleCalls.Load(), "GKE has no in-place recycle")
+	require.EqualValues(t, 1, recycleCalls.Load(), "the deploy sweep rolls GKE rows via RecycleImage")
+	require.EqualValues(t, 0, stopCalls.Load(), "recycling must not tear the runtime row down")
 
 	runtime, err := assistantsrepo.New(conn).GetAssistantRuntime(t.Context(), assistantsrepo.GetAssistantRuntimeParams{ID: runtimeID, ProjectID: projectID})
 	require.NoError(t, err)
-	require.Equal(t, runtimeStateActive, runtime.State, "GKE rows roll via terminate-on-idle, not the sweep")
+	require.Equal(t, runtimeStateActive, runtime.State)
+	require.JSONEq(t, string(recycledMetadata), string(runtime.BackendMetadataJson), "post-recycle pod identity is persisted")
 }
 
 func TestServiceCoreReapInactiveAssistantRuntimesCollectsOnlyInactive(t *testing.T) {
@@ -2364,12 +2367,6 @@ func (t testRuntimeBackend) Ensure(context.Context, assistantRuntimeRecord) (Run
 
 func (t testRuntimeBackend) ImageRef() string {
 	return t.imageRef
-}
-
-func (t testRuntimeBackend) ReusesIdleRuntimes() bool {
-	// Mirror production: GKE tears idle runtimes down (no warm reuse), every
-	// other backend preserves them for warm restart.
-	return t.backend != runtimeBackendGKE
 }
 
 func (t testRuntimeBackend) RecycleImage(ctx context.Context, record assistantRuntimeRecord) (RuntimeBackendRecycleResult, error) {

--- a/server/internal/assistants/service_test.go
+++ b/server/internal/assistants/service_test.go
@@ -1896,9 +1896,9 @@ func TestServiceCoreRecycleActiveRuntimeImagesCountsBackendErrors(t *testing.T) 
 	require.JSONEq(t, `{"app_name":"gram-asst-flaky","machine_id":"m-1"}`, string(runtime.BackendMetadataJson))
 }
 
-// A non-reuse backend (GKE) has no in-place image swap: it rolls onto a new
-// image by terminating idle runtimes (warm-TTL expiry), so the in-place recycle
-// sweep is a no-op for it — it touches no rows and tears nothing down.
+// The deploy sweep covers GKE rows like any other backend: RecycleImage rolls
+// the claim onto the configured image and the returned pod identity is
+// persisted on the runtime row.
 func TestServiceCoreRecycleActiveRuntimeImagesSweepsGKERows(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A claimed GKE sandbox keeps its admission-time runner image forever. Nothing compared the running pod's image against the configured one:

- The deploy-time image recycle sweep early-returned for non-reusing backends, and GKE's `RecycleImage` was a no-op — the assumption was that GKE runtimes roll via warm-TTL expiry and the janitor.
- That assumption fails for regularly used assistants: they never go idle long enough for the inactivity janitor (7d), so the claim survives every deploy. Observed in prod: a sandbox pod 13 days behind the current runner image.
- `Ensure` stamped `metadata.Image` with the *desired* image unconditionally, so persisted metadata and telemetry claimed the runtime was current when it wasn't.
- The warm pool is a second drift layer: pods pre-warmed before a SandboxTemplate bump keep the old image, so even deleting a claim by hand can re-adopt a stale pod (also observed in prod).

## Fix

Ports the Fly image-drift semantics to GKE, where a "recycle" is claim churn against the warm pool rather than an in-place machine update:

- **`GKERuntimeBackend.RecycleImage`**: reads the claim's pod image; on drift and an idle runner (`/state` min-thread-idle gate, same as Fly), deletes the claim and re-claims from the warm pool, returning the new pod identity for persistence. Missing claim/pod or current image are skips, not errors.
- **`Ensure` drift drain**: after adoption, compares the pod image against the configured one and recycles the claim with bounded retries (3). Each retry consumes-and-deletes one stale warm pod, so the pool converges onto the new image. A pre-existing claim with a turn in flight is never torn down; drain exhaustion keeps the stale pod (availability over freshness) and a later admission retries.
- **Sweep ungated**: `RecycleActiveRuntimeImages` no longer early-returns for non-reusing backends, so the worker-startup sweep rolls idle GKE runtimes at deploy time. The now-unused `ReusesIdleRuntimes` interface method is removed.
- **Honest metadata**: `gkeRuntimeMetadata.Image` now records the pod's actual image instead of the configured one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically roll GKE assistant runtimes onto the configured runner image when drift is detected, so active assistants no longer get stuck on stale images. The deploy-time sweep now also updates GKE claims, runtime metadata records the pod’s actual image, and `Ensure` cleans up unhealthy owned claims.

- **Bug Fixes**
  - `GKERuntimeBackend.RecycleImage`: cheap drift check, then delegates to `Ensure` to delete the claim and re-claim from the warm pool when idle; returns the new pod identity.
  - `Ensure`: detects image drift and recycles with bounded retries; waits for claim deletion and uses one ready budget; deletes a just-created claim if the runner never turns healthy; never interrupts an in-flight turn.
  - Deploy sweep (`RecycleActiveRuntimeImages`) now runs for all backends, including GKE.
  - Persisted metadata stores the pod’s actual image.
  - Shared turn-in-flight detection across backends; removed the `ReusesIdleRuntimes` gate and related routing/telemetry code.

<sup>Written for commit 0eaf8d6e412f615f309e9d51f017b9ed573b26a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

