### PR TITLE
mig: add Platform MCP onboarding state

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4404,6 +4404,9 @@ CREATE TABLE IF NOT EXISTS plugin_servers (
   CONSTRAINT plugin_servers_backend_exclusivity_check CHECK ((toolset_id IS NULL) != (mcp_server_id IS NULL))
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS plugin_servers_plugin_id_id_key
+  ON plugin_servers (plugin_id, id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS plugin_servers_plugin_id_display_name_key
   ON plugin_servers (plugin_id, display_name)
   WHERE deleted IS FALSE;
@@ -6363,6 +6366,7 @@ CREATE TABLE IF NOT EXISTS platform_mcp_onboarding_milestones (
       'authorization_succeeded',
       'authorization_failed',
       'connection_ready',
+      'catalog_explored',
       'first_read_succeeded',
       'first_write_succeeded',
       'read_only_cohort'
@@ -6389,6 +6393,7 @@ WHERE connection_id IS NOT NULL
     'authorization_succeeded',
     'authorization_failed',
     'connection_ready',
+    'catalog_explored',
     'first_read_succeeded',
     'first_write_succeeded',
     'read_only_cohort'
@@ -6637,3 +6642,146 @@ ON platform_mcp_readiness (organization_id, project_id);
 
 CREATE INDEX IF NOT EXISTS platform_mcp_readiness_organization_connection_idx
 ON platform_mcp_readiness (organization_id, connection_id);
+
+CREATE TABLE IF NOT EXISTS platform_mcp_onboarding_workflows (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  initiating_subject_urn TEXT NOT NULL,
+  source_surface TEXT NOT NULL,
+  client_family TEXT NOT NULL,
+  agent_configuration_copied_at timestamptz,
+  connection_id uuid,
+  connection_generation uuid,
+  selected_project_id uuid,
+  selected_registration_id uuid,
+  status TEXT NOT NULL DEFAULT 'active',
+  correlation_id uuid NOT NULL DEFAULT generate_uuidv7(),
+  expires_at timestamptz NOT NULL,
+  closed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT platform_mcp_onboarding_workflows_pkey PRIMARY KEY (id),
+  CONSTRAINT platform_mcp_onboarding_workflows_initiating_subject_urn_check CHECK (initiating_subject_urn <> ''),
+  CONSTRAINT platform_mcp_onboarding_workflows_source_surface_check CHECK (source_surface <> ''),
+  CONSTRAINT platform_mcp_onboarding_workflows_client_family_check CHECK (client_family <> ''),
+  CONSTRAINT platform_mcp_onboarding_workflows_status_check CHECK (status <> ''),
+  CONSTRAINT platform_mcp_onboarding_workflows_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_onboarding_workflows_organization_connection_fkey FOREIGN KEY (organization_id, connection_id) REFERENCES platform_mcp_connections (organization_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_onboarding_workflows_organization_project_fkey FOREIGN KEY (organization_id, selected_project_id) REFERENCES projects (organization_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_onboarding_workflows_project_registration_fkey FOREIGN KEY (selected_project_id, selected_registration_id) REFERENCES platform_mcp_catalog_registrations (project_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_onboarding_workflows_selected_target_check CHECK ((selected_project_id IS NULL) = (selected_registration_id IS NULL)),
+  CONSTRAINT platform_mcp_onboarding_workflows_connection_generation_check CHECK ((connection_id IS NULL) = (connection_generation IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_onboarding_workflows_organization_id_id_key ON platform_mcp_onboarding_workflows (organization_id, id);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_onboarding_workflows_active_subject_key ON platform_mcp_onboarding_workflows (organization_id, initiating_subject_urn) WHERE status = 'active';
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_onboarding_workflows_correlation_id_key ON platform_mcp_onboarding_workflows (correlation_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_onboarding_workflows_organization_updated_at_idx ON platform_mcp_onboarding_workflows (organization_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS platform_mcp_onboarding_workflows_expires_at_idx ON platform_mcp_onboarding_workflows (expires_at) WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS platform_mcp_distributions (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid NOT NULL,
+  registration_id uuid NOT NULL,
+  default_plugin_id uuid NOT NULL,
+  plugin_server_id uuid,
+  state TEXT NOT NULL,
+  version BIGINT NOT NULL,
+  attachment_was_created boolean NOT NULL,
+  publication_state TEXT NOT NULL DEFAULT 'pending',
+  publication_updated_at timestamptz,
+  connection_id uuid NOT NULL,
+  connection_generation uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT platform_mcp_distributions_pkey PRIMARY KEY (id),
+  CONSTRAINT platform_mcp_distributions_state_check CHECK (state <> ''),
+  CONSTRAINT platform_mcp_distributions_version_check CHECK (version > 0),
+  CONSTRAINT platform_mcp_distributions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_distributions_organization_project_fkey FOREIGN KEY (organization_id, project_id) REFERENCES projects (organization_id, id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_distributions_project_registration_fkey FOREIGN KEY (project_id, registration_id) REFERENCES platform_mcp_catalog_registrations (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_distributions_project_default_plugin_fkey FOREIGN KEY (project_id, default_plugin_id) REFERENCES plugins (project_id, id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_distributions_default_plugin_plugin_server_fkey FOREIGN KEY (default_plugin_id, plugin_server_id) REFERENCES plugin_servers (plugin_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_distributions_organization_connection_fkey FOREIGN KEY (organization_id, connection_id) REFERENCES platform_mcp_connections (organization_id, id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_identity_key ON platform_mcp_distributions (organization_id, project_id, registration_id, default_plugin_id);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_distributions_project_registration_id_key ON platform_mcp_distributions (project_id, registration_id, id);
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_default_plugin_idx ON platform_mcp_distributions (project_id, default_plugin_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_organization_connection_idx ON platform_mcp_distributions (organization_id, connection_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_distributions_project_plugin_server_idx ON platform_mcp_distributions (project_id, plugin_server_id) WHERE plugin_server_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS platform_mcp_selected_use_evidence (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  project_id uuid NOT NULL,
+  registration_id uuid NOT NULL,
+  distribution_id uuid NOT NULL,
+  distribution_version BIGINT NOT NULL,
+  workflow_id uuid,
+  tool_name TEXT NOT NULL,
+  tool_category TEXT NOT NULL,
+  request_reference TEXT,
+  succeeded_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT platform_mcp_selected_use_evidence_pkey PRIMARY KEY (id),
+  CONSTRAINT platform_mcp_selected_use_evidence_tool_name_check CHECK (tool_name <> ''),
+  CONSTRAINT platform_mcp_selected_use_evidence_tool_category_check CHECK (tool_category <> ''),
+  CONSTRAINT platform_mcp_selected_use_evidence_distribution_version_check CHECK (distribution_version > 0),
+  CONSTRAINT platform_mcp_selected_use_evidence_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_selected_use_evidence_organization_project_fkey FOREIGN KEY (organization_id, project_id) REFERENCES projects (organization_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_selected_use_evidence_project_registration_fkey FOREIGN KEY (project_id, registration_id) REFERENCES platform_mcp_catalog_registrations (project_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_selected_use_evidence_project_registration_distribution_fkey FOREIGN KEY (project_id, registration_id, distribution_id) REFERENCES platform_mcp_distributions (project_id, registration_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_selected_use_evidence_organization_workflow_fkey FOREIGN KEY (organization_id, workflow_id) REFERENCES platform_mcp_onboarding_workflows (organization_id, id) ON DELETE NO ACTION
+);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_selected_use_evidence_distribution_version_key ON platform_mcp_selected_use_evidence (distribution_id, distribution_version);
+CREATE INDEX IF NOT EXISTS platform_mcp_selected_use_evidence_project_registration_idx ON platform_mcp_selected_use_evidence (project_id, registration_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_selected_use_evidence_project_registration_distribution_idx ON platform_mcp_selected_use_evidence (project_id, registration_id, distribution_id);
+CREATE INDEX IF NOT EXISTS platform_mcp_selected_use_evidence_organization_project_succeeded_at_idx ON platform_mcp_selected_use_evidence (organization_id, project_id, succeeded_at DESC);
+CREATE INDEX IF NOT EXISTS platform_mcp_selected_use_evidence_workflow_id_idx ON platform_mcp_selected_use_evidence (workflow_id) WHERE workflow_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS platform_mcp_feedback (
+  id uuid NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  subject_urn TEXT NOT NULL,
+  connection_id uuid,
+  connection_generation uuid,
+  project_id uuid,
+  workflow_id uuid,
+  request_reference TEXT,
+  category TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  input_hash TEXT NOT NULL,
+  rating INT,
+  success boolean,
+  tool_name TEXT,
+  failure_category TEXT,
+  note TEXT,
+  delivery_state TEXT NOT NULL DEFAULT 'queued',
+  delivery_attempts INT NOT NULL DEFAULT 0,
+  last_delivery_attempt_at timestamptz,
+  delivered_at timestamptz,
+  dead_lettered_at timestamptz,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT platform_mcp_feedback_pkey PRIMARY KEY (id),
+  CONSTRAINT platform_mcp_feedback_subject_urn_check CHECK (subject_urn <> ''),
+  CONSTRAINT platform_mcp_feedback_category_check CHECK (category <> ''),
+  CONSTRAINT platform_mcp_feedback_idempotency_key_check CHECK (idempotency_key <> '' AND CHAR_LENGTH(idempotency_key) <= 128),
+  CONSTRAINT platform_mcp_feedback_input_hash_check CHECK (input_hash <> ''),
+  CONSTRAINT platform_mcp_feedback_delivery_state_check CHECK (delivery_state <> ''),
+  CONSTRAINT platform_mcp_feedback_rating_check CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
+  CONSTRAINT platform_mcp_feedback_note_check CHECK (note IS NULL OR CHAR_LENGTH(note) <= 500),
+  CONSTRAINT platform_mcp_feedback_delivery_attempts_check CHECK (delivery_attempts >= 0),
+  CONSTRAINT platform_mcp_feedback_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT platform_mcp_feedback_organization_connection_fkey FOREIGN KEY (organization_id, connection_id) REFERENCES platform_mcp_connections (organization_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_feedback_organization_project_fkey FOREIGN KEY (organization_id, project_id) REFERENCES projects (organization_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_feedback_organization_workflow_fkey FOREIGN KEY (organization_id, workflow_id) REFERENCES platform_mcp_onboarding_workflows (organization_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_feedback_connection_generation_check CHECK ((connection_id IS NULL) = (connection_generation IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS platform_mcp_feedback_organization_subject_idempotency_key_idx ON platform_mcp_feedback (organization_id, subject_urn, idempotency_key);
+CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_created_at_idx ON platform_mcp_feedback (organization_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_subject_created_at_idx ON platform_mcp_feedback (organization_id, subject_urn, created_at DESC);
+CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_connection_created_at_idx ON platform_mcp_feedback (organization_id, connection_id, created_at DESC) WHERE connection_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS platform_mcp_feedback_organization_workflow_created_at_idx ON platform_mcp_feedback (organization_id, workflow_id, created_at DESC) WHERE workflow_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS platform_mcp_feedback_expires_at_idx ON platform_mcp_feedback (expires_at);

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -1577,6 +1577,51 @@ type PlatformMcpConnection struct {
 	UpdatedAt        pgtype.Timestamptz
 }
 
+type PlatformMcpDistribution struct {
+	ID                   uuid.UUID
+	OrganizationID       string
+	ProjectID            uuid.UUID
+	RegistrationID       uuid.UUID
+	DefaultPluginID      uuid.UUID
+	PluginServerID       uuid.NullUUID
+	State                string
+	Version              int64
+	AttachmentWasCreated bool
+	PublicationState     string
+	PublicationUpdatedAt pgtype.Timestamptz
+	ConnectionID         uuid.UUID
+	ConnectionGeneration uuid.UUID
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
+}
+
+type PlatformMcpFeedback struct {
+	ID                    uuid.UUID
+	OrganizationID        string
+	SubjectUrn            string
+	ConnectionID          uuid.NullUUID
+	ConnectionGeneration  uuid.NullUUID
+	ProjectID             uuid.NullUUID
+	WorkflowID            uuid.NullUUID
+	RequestReference      pgtype.Text
+	Category              string
+	IdempotencyKey        string
+	InputHash             string
+	Rating                pgtype.Int4
+	Success               pgtype.Bool
+	ToolName              pgtype.Text
+	FailureCategory       pgtype.Text
+	Note                  pgtype.Text
+	DeliveryState         string
+	DeliveryAttempts      int32
+	LastDeliveryAttemptAt pgtype.Timestamptz
+	DeliveredAt           pgtype.Timestamptz
+	DeadLetteredAt        pgtype.Timestamptz
+	ExpiresAt             pgtype.Timestamptz
+	CreatedAt             pgtype.Timestamptz
+	UpdatedAt             pgtype.Timestamptz
+}
+
 type PlatformMcpOauthClient struct {
 	ID                    uuid.UUID
 	ClientID              string
@@ -1601,6 +1646,25 @@ type PlatformMcpOnboardingMilestone struct {
 	AttemptID            uuid.NullUUID
 	ProductDay           pgtype.Date
 	CreatedAt            pgtype.Timestamptz
+}
+
+type PlatformMcpOnboardingWorkflow struct {
+	ID                         uuid.UUID
+	OrganizationID             string
+	InitiatingSubjectUrn       string
+	SourceSurface              string
+	ClientFamily               string
+	AgentConfigurationCopiedAt pgtype.Timestamptz
+	ConnectionID               uuid.NullUUID
+	ConnectionGeneration       uuid.NullUUID
+	SelectedProjectID          uuid.NullUUID
+	SelectedRegistrationID     uuid.NullUUID
+	Status                     string
+	CorrelationID              uuid.UUID
+	ExpiresAt                  pgtype.Timestamptz
+	ClosedAt                   pgtype.Timestamptz
+	CreatedAt                  pgtype.Timestamptz
+	UpdatedAt                  pgtype.Timestamptz
 }
 
 type PlatformMcpOperationReceipt struct {
@@ -1634,6 +1698,21 @@ type PlatformMcpReadiness struct {
 	ExpiresAt                        pgtype.Timestamptz
 	CreatedAt                        pgtype.Timestamptz
 	UpdatedAt                        pgtype.Timestamptz
+}
+
+type PlatformMcpSelectedUseEvidence struct {
+	ID                  uuid.UUID
+	OrganizationID      string
+	ProjectID           uuid.UUID
+	RegistrationID      uuid.UUID
+	DistributionID      uuid.UUID
+	DistributionVersion int64
+	WorkflowID          uuid.NullUUID
+	ToolName            string
+	ToolCategory        string
+	RequestReference    pgtype.Text
+	SucceededAt         pgtype.Timestamptz
+	CreatedAt           pgtype.Timestamptz
 }
 
 type PlatformMcpSession struct {

--- a/server/migrations/20260813005834_platform-mcp-onboarding-state.sql
+++ b/server/migrations/20260813005834_platform-mcp-onboarding-state.sql
@@ -1,0 +1,175 @@
+-- atlas:txmode none
+
+-- Drop index "platform_mcp_onboarding_milestones_connection_generation_key" from table: "platform_mcp_onboarding_milestones"
+DROP INDEX CONCURRENTLY "platform_mcp_onboarding_milestones_connection_generation_key";
+-- Modify "platform_mcp_onboarding_milestones" table
+ALTER TABLE "platform_mcp_onboarding_milestones" DROP CONSTRAINT "platform_mcp_onboarding_milestones_connection_generation_check", ADD CONSTRAINT "platform_mcp_onboarding_milestones_connection_generation_check" CHECK ((milestone <> ALL (ARRAY['authorization_succeeded'::text, 'authorization_failed'::text, 'connection_ready'::text, 'catalog_explored'::text, 'first_read_succeeded'::text, 'first_write_succeeded'::text, 'read_only_cohort'::text])) OR ((connection_id IS NOT NULL) AND (connection_generation IS NOT NULL))) NOT VALID;
+ALTER TABLE "platform_mcp_onboarding_milestones" VALIDATE CONSTRAINT "platform_mcp_onboarding_milestones_connection_generation_check";
+-- Create index "platform_mcp_onboarding_milestones_connection_generation_key" to table: "platform_mcp_onboarding_milestones"
+CREATE UNIQUE INDEX CONCURRENTLY "platform_mcp_onboarding_milestones_connection_generation_key" ON "platform_mcp_onboarding_milestones" ("milestone", "connection_id", "connection_generation") WHERE ((connection_id IS NOT NULL) AND (connection_generation IS NOT NULL) AND (milestone = ANY (ARRAY['authorization_succeeded'::text, 'authorization_failed'::text, 'connection_ready'::text, 'catalog_explored'::text, 'first_read_succeeded'::text, 'first_write_succeeded'::text, 'read_only_cohort'::text])));
+-- Create index "plugin_servers_plugin_id_id_key" to table: "plugin_servers"
+CREATE UNIQUE INDEX CONCURRENTLY "plugin_servers_plugin_id_id_key" ON "plugin_servers" ("plugin_id", "id");
+-- Create "platform_mcp_distributions" table
+CREATE TABLE "platform_mcp_distributions" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NOT NULL,
+  "registration_id" uuid NOT NULL,
+  "default_plugin_id" uuid NOT NULL,
+  "plugin_server_id" uuid NULL,
+  "state" text NOT NULL,
+  "version" bigint NOT NULL,
+  "attachment_was_created" boolean NOT NULL,
+  "publication_state" text NOT NULL DEFAULT 'pending',
+  "publication_updated_at" timestamptz NULL,
+  "connection_id" uuid NOT NULL,
+  "connection_generation" uuid NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "platform_mcp_distributions_default_plugin_plugin_server_fkey" FOREIGN KEY ("default_plugin_id", "plugin_server_id") REFERENCES "plugin_servers" ("plugin_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_distributions_organization_connection_fkey" FOREIGN KEY ("organization_id", "connection_id") REFERENCES "platform_mcp_connections" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_distributions_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_distributions_organization_project_fkey" FOREIGN KEY ("organization_id", "project_id") REFERENCES "projects" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_distributions_project_default_plugin_fkey" FOREIGN KEY ("project_id", "default_plugin_id") REFERENCES "plugins" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_distributions_project_registration_fkey" FOREIGN KEY ("project_id", "registration_id") REFERENCES "platform_mcp_catalog_registrations" ("project_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_distributions_state_check" CHECK (state <> ''::text),
+  CONSTRAINT "platform_mcp_distributions_version_check" CHECK (version > 0)
+);
+-- Create index "platform_mcp_distributions_identity_key" to table: "platform_mcp_distributions"
+CREATE UNIQUE INDEX "platform_mcp_distributions_identity_key" ON "platform_mcp_distributions" ("organization_id", "project_id", "registration_id", "default_plugin_id");
+-- Create index "platform_mcp_distributions_organization_connection_idx" to table: "platform_mcp_distributions"
+CREATE INDEX "platform_mcp_distributions_organization_connection_idx" ON "platform_mcp_distributions" ("organization_id", "connection_id");
+-- Create index "platform_mcp_distributions_project_default_plugin_idx" to table: "platform_mcp_distributions"
+CREATE INDEX "platform_mcp_distributions_project_default_plugin_idx" ON "platform_mcp_distributions" ("project_id", "default_plugin_id");
+-- Create index "platform_mcp_distributions_project_plugin_server_idx" to table: "platform_mcp_distributions"
+CREATE INDEX "platform_mcp_distributions_project_plugin_server_idx" ON "platform_mcp_distributions" ("project_id", "plugin_server_id") WHERE (plugin_server_id IS NOT NULL);
+-- Create index "platform_mcp_distributions_project_registration_id_key" to table: "platform_mcp_distributions"
+CREATE UNIQUE INDEX "platform_mcp_distributions_project_registration_id_key" ON "platform_mcp_distributions" ("project_id", "registration_id", "id");
+-- Create "platform_mcp_onboarding_workflows" table
+CREATE TABLE "platform_mcp_onboarding_workflows" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "initiating_subject_urn" text NOT NULL,
+  "source_surface" text NOT NULL,
+  "client_family" text NOT NULL,
+  "agent_configuration_copied_at" timestamptz NULL,
+  "connection_id" uuid NULL,
+  "connection_generation" uuid NULL,
+  "selected_project_id" uuid NULL,
+  "selected_registration_id" uuid NULL,
+  "status" text NOT NULL DEFAULT 'active',
+  "correlation_id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "expires_at" timestamptz NOT NULL,
+  "closed_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "platform_mcp_onboarding_workflows_organization_connection_fkey" FOREIGN KEY ("organization_id", "connection_id") REFERENCES "platform_mcp_connections" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_onboarding_workflows_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_onboarding_workflows_organization_project_fkey" FOREIGN KEY ("organization_id", "selected_project_id") REFERENCES "projects" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_onboarding_workflows_project_registration_fkey" FOREIGN KEY ("selected_project_id", "selected_registration_id") REFERENCES "platform_mcp_catalog_registrations" ("project_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_onboarding_workflows_client_family_check" CHECK (client_family <> ''::text),
+  CONSTRAINT "platform_mcp_onboarding_workflows_connection_generation_check" CHECK ((connection_id IS NULL) = (connection_generation IS NULL)),
+  CONSTRAINT "platform_mcp_onboarding_workflows_initiating_subject_urn_check" CHECK (initiating_subject_urn <> ''::text),
+  CONSTRAINT "platform_mcp_onboarding_workflows_selected_target_check" CHECK ((selected_project_id IS NULL) = (selected_registration_id IS NULL)),
+  CONSTRAINT "platform_mcp_onboarding_workflows_source_surface_check" CHECK (source_surface <> ''::text),
+  CONSTRAINT "platform_mcp_onboarding_workflows_status_check" CHECK (status <> ''::text)
+);
+-- Create index "platform_mcp_onboarding_workflows_active_subject_key" to table: "platform_mcp_onboarding_workflows"
+CREATE UNIQUE INDEX "platform_mcp_onboarding_workflows_active_subject_key" ON "platform_mcp_onboarding_workflows" ("organization_id", "initiating_subject_urn") WHERE (status = 'active'::text);
+-- Create index "platform_mcp_onboarding_workflows_correlation_id_key" to table: "platform_mcp_onboarding_workflows"
+CREATE UNIQUE INDEX "platform_mcp_onboarding_workflows_correlation_id_key" ON "platform_mcp_onboarding_workflows" ("correlation_id");
+-- Create index "platform_mcp_onboarding_workflows_expires_at_idx" to table: "platform_mcp_onboarding_workflows"
+CREATE INDEX "platform_mcp_onboarding_workflows_expires_at_idx" ON "platform_mcp_onboarding_workflows" ("expires_at") WHERE (status = 'active'::text);
+-- Create index "platform_mcp_onboarding_workflows_organization_id_id_key" to table: "platform_mcp_onboarding_workflows"
+CREATE UNIQUE INDEX "platform_mcp_onboarding_workflows_organization_id_id_key" ON "platform_mcp_onboarding_workflows" ("organization_id", "id");
+-- Create index "platform_mcp_onboarding_workflows_organization_updated_at_idx" to table: "platform_mcp_onboarding_workflows"
+CREATE INDEX "platform_mcp_onboarding_workflows_organization_updated_at_idx" ON "platform_mcp_onboarding_workflows" ("organization_id", "updated_at" DESC);
+-- Create "platform_mcp_feedback" table
+CREATE TABLE "platform_mcp_feedback" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "subject_urn" text NOT NULL,
+  "connection_id" uuid NULL,
+  "connection_generation" uuid NULL,
+  "project_id" uuid NULL,
+  "workflow_id" uuid NULL,
+  "request_reference" text NULL,
+  "category" text NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "input_hash" text NOT NULL,
+  "rating" integer NULL,
+  "success" boolean NULL,
+  "tool_name" text NULL,
+  "failure_category" text NULL,
+  "note" text NULL,
+  "delivery_state" text NOT NULL DEFAULT 'queued',
+  "delivery_attempts" integer NOT NULL DEFAULT 0,
+  "last_delivery_attempt_at" timestamptz NULL,
+  "delivered_at" timestamptz NULL,
+  "dead_lettered_at" timestamptz NULL,
+  "expires_at" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "platform_mcp_feedback_organization_connection_fkey" FOREIGN KEY ("organization_id", "connection_id") REFERENCES "platform_mcp_connections" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_feedback_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_feedback_organization_project_fkey" FOREIGN KEY ("organization_id", "project_id") REFERENCES "projects" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_feedback_organization_workflow_fkey" FOREIGN KEY ("organization_id", "workflow_id") REFERENCES "platform_mcp_onboarding_workflows" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_feedback_category_check" CHECK (category <> ''::text),
+  CONSTRAINT "platform_mcp_feedback_connection_generation_check" CHECK ((connection_id IS NULL) = (connection_generation IS NULL)),
+  CONSTRAINT "platform_mcp_feedback_delivery_attempts_check" CHECK (delivery_attempts >= 0),
+  CONSTRAINT "platform_mcp_feedback_delivery_state_check" CHECK (delivery_state <> ''::text),
+  CONSTRAINT "platform_mcp_feedback_idempotency_key_check" CHECK ((idempotency_key <> ''::text) AND (char_length(idempotency_key) <= 128)),
+  CONSTRAINT "platform_mcp_feedback_input_hash_check" CHECK (input_hash <> ''::text),
+  CONSTRAINT "platform_mcp_feedback_note_check" CHECK ((note IS NULL) OR (char_length(note) <= 500)),
+  CONSTRAINT "platform_mcp_feedback_rating_check" CHECK ((rating IS NULL) OR ((rating >= 1) AND (rating <= 5))),
+  CONSTRAINT "platform_mcp_feedback_subject_urn_check" CHECK (subject_urn <> ''::text)
+);
+-- Create index "platform_mcp_feedback_expires_at_idx" to table: "platform_mcp_feedback"
+CREATE INDEX "platform_mcp_feedback_expires_at_idx" ON "platform_mcp_feedback" ("expires_at");
+-- Create index "platform_mcp_feedback_organization_connection_created_at_idx" to table: "platform_mcp_feedback"
+CREATE INDEX "platform_mcp_feedback_organization_connection_created_at_idx" ON "platform_mcp_feedback" ("organization_id", "connection_id", "created_at" DESC) WHERE (connection_id IS NOT NULL);
+-- Create index "platform_mcp_feedback_organization_created_at_idx" to table: "platform_mcp_feedback"
+CREATE INDEX "platform_mcp_feedback_organization_created_at_idx" ON "platform_mcp_feedback" ("organization_id", "created_at" DESC);
+-- Create index "platform_mcp_feedback_organization_subject_created_at_idx" to table: "platform_mcp_feedback"
+CREATE INDEX "platform_mcp_feedback_organization_subject_created_at_idx" ON "platform_mcp_feedback" ("organization_id", "subject_urn", "created_at" DESC);
+-- Create index "platform_mcp_feedback_organization_subject_idempotency_key_idx" to table: "platform_mcp_feedback"
+CREATE UNIQUE INDEX "platform_mcp_feedback_organization_subject_idempotency_key_idx" ON "platform_mcp_feedback" ("organization_id", "subject_urn", "idempotency_key");
+-- Create index "platform_mcp_feedback_organization_workflow_created_at_idx" to table: "platform_mcp_feedback"
+CREATE INDEX "platform_mcp_feedback_organization_workflow_created_at_idx" ON "platform_mcp_feedback" ("organization_id", "workflow_id", "created_at" DESC) WHERE (workflow_id IS NOT NULL);
+-- Create "platform_mcp_selected_use_evidence" table
+CREATE TABLE "platform_mcp_selected_use_evidence" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "project_id" uuid NOT NULL,
+  "registration_id" uuid NOT NULL,
+  "distribution_id" uuid NOT NULL,
+  "distribution_version" bigint NOT NULL,
+  "workflow_id" uuid NULL,
+  "tool_name" text NOT NULL,
+  "tool_category" text NOT NULL,
+  "request_reference" text NULL,
+  "succeeded_at" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "platform_mcp_selected_use_evidence_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "platform_mcp_selected_use_evidence_organization_project_fkey" FOREIGN KEY ("organization_id", "project_id") REFERENCES "projects" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_selected_use_evidence_organization_workflow_fkey" FOREIGN KEY ("organization_id", "workflow_id") REFERENCES "platform_mcp_onboarding_workflows" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_selected_use_evidence_project_registration_distrib" FOREIGN KEY ("project_id", "registration_id", "distribution_id") REFERENCES "platform_mcp_distributions" ("project_id", "registration_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_selected_use_evidence_project_registration_fkey" FOREIGN KEY ("project_id", "registration_id") REFERENCES "platform_mcp_catalog_registrations" ("project_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT "platform_mcp_selected_use_evidence_distribution_version_check" CHECK (distribution_version > 0),
+  CONSTRAINT "platform_mcp_selected_use_evidence_tool_category_check" CHECK (tool_category <> ''::text),
+  CONSTRAINT "platform_mcp_selected_use_evidence_tool_name_check" CHECK (tool_name <> ''::text)
+);
+-- Create index "platform_mcp_selected_use_evidence_distribution_version_key" to table: "platform_mcp_selected_use_evidence"
+CREATE UNIQUE INDEX "platform_mcp_selected_use_evidence_distribution_version_key" ON "platform_mcp_selected_use_evidence" ("distribution_id", "distribution_version");
+-- Create index "platform_mcp_selected_use_evidence_organization_project_succeed" to table: "platform_mcp_selected_use_evidence"
+CREATE INDEX "platform_mcp_selected_use_evidence_organization_project_succeed" ON "platform_mcp_selected_use_evidence" ("organization_id", "project_id", "succeeded_at" DESC);
+-- Create index "platform_mcp_selected_use_evidence_project_registration_distrib" to table: "platform_mcp_selected_use_evidence"
+CREATE INDEX "platform_mcp_selected_use_evidence_project_registration_distrib" ON "platform_mcp_selected_use_evidence" ("project_id", "registration_id", "distribution_id");
+-- Create index "platform_mcp_selected_use_evidence_project_registration_idx" to table: "platform_mcp_selected_use_evidence"
+CREATE INDEX "platform_mcp_selected_use_evidence_project_registration_idx" ON "platform_mcp_selected_use_evidence" ("project_id", "registration_id");
+-- Create index "platform_mcp_selected_use_evidence_workflow_id_idx" to table: "platform_mcp_selected_use_evidence"
+CREATE INDEX "platform_mcp_selected_use_evidence_workflow_id_idx" ON "platform_mcp_selected_use_evidence" ("workflow_id") WHERE (workflow_id IS NOT NULL);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:uxzjWCwECvBuEzT27UXBKC/dsZzP/LKDoaVf9rwUCaI=
+h1:I7Bn8Gzyv7sg9x46hXitDfdgGoJd666Ds4uqD07EOfM=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -334,3 +334,4 @@ h1:uxzjWCwECvBuEzT27UXBKC/dsZzP/LKDoaVf9rwUCaI=
 20260812140226_jwks-index-external-key-tenant.sql h1:uuAVtFJtvI9Fh8P1g0lZCvFFIlUUoUraHM+HvBKT1dY=
 20260812151548_openrouter-api-key-encrypted.sql h1:D24ETMrCq2AY9UZCCd8kL9D9heB6vPaPMxghWFz5/uM=
 20260812212223_chat_messages_add_tool_call_summaries.sql h1:bE7ZnZJ4qr4gPc3jbbPEUFefIZOasiHkJarje0QWEdc=
+20260813005834_platform-mcp-onboarding-state.sql h1:3hmXHcqDm0af3dyPBEC0v+YFVkZdkVwlMQd6VwXF9jM=


### PR DESCRIPTION
## Why
The Platform MCP onboarding-to-first-value slice needs durable, organization- and workflow-bound lifecycle state before its runtime, dashboard, distribution, and selected-use behavior can land.

## What changed
- Adds the Platform MCP onboarding, registration, readiness, distribution, and selected-use persistence schema.
- Regenerates the database model artifacts and Atlas checksum from the schema change.

## Review notes
- This PR is deliberately migration-only. The dependent runtime/dashboard vertical slice is stacked in the child PR and must not be merged first.
- The migration is additive and uses `CREATE INDEX CONCURRENTLY` with the required transaction mode annotation.

## Testing
- Migration ordering checks passed through `mise run lint:migrations`.
- Atlas snapshot lint could not complete because the configured local database is not clean (`agent_executions` exists).
- Remote CI checks are pending.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable Platform MCP onboarding lifecycle state and related schema to enable a resumable onboarding-to-first-value flow. Tightens plugin server/distribution integrity; no runtime behavior changes.

- Adds tables: `platform_mcp_onboarding_workflows`, `platform_mcp_distributions`, `platform_mcp_selected_use_evidence`, `platform_mcp_feedback`.
- Onboarding milestones: adds `catalog_explored`, tightens the `connection_generation` check, and recreates the partial unique index concurrently.
- Onboarding workflows: enforces one active workflow per subject per org, unique `correlation_id`, and indexes on `expires_at` and `(organization_id, updated_at)`; optional project/registration and connection links are validated for paired presence.
- Distribution integrity: adds composite FK from `(default_plugin_id, plugin_server_id)` to `plugin_servers (plugin_id, id)` backed by `plugin_servers_plugin_id_id_key`; ensures distribution identity uniqueness and adds lookup indexes.
- Selected-use evidence: unique per `(distribution_id, distribution_version)` with optional workflow linkage and lookup indexes.
- Feedback: idempotent per `(organization_id, subject_urn, idempotency_key)` with bounded rating/note, delivery-state fields, and expiration/lookup indexes.
- Regenerates `server/internal/database/models.go` and updates `server/migrations/atlas.sum`; migration uses CREATE INDEX CONCURRENTLY and `-- atlas:txmode none`.

<sup>Written for commit 4f3d4c0ae827e14bd7958192eb04a7aba05b805d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

