### PR TITLE
fix(skills): replace prompt injection card with expandable warning banner

### DIFF
--- a/client/dashboard/src/pages/skills/SkillDetail.test.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.test.tsx
@@ -345,7 +345,7 @@ describe("SkillDetail", () => {
     }
   });
 
-  it("shows current-version prompt injection flags without raw content", () => {
+  it("shows a prompt injection warning banner without raw content", () => {
     testState.promptInjectionFindings = [
       {
         ruleId: "prompt_injection",
@@ -357,13 +357,21 @@ describe("SkillDetail", () => {
 
     render(<SkillDetail />);
 
-    expect(screen.getByText("Prompt injection flags")).toBeTruthy();
+    expect(screen.getByText("Prompt injection flagged")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Show findings"));
+
     expect(screen.getByText("prompt_injection")).toBeTruthy();
     expect(
       screen.getByText("Attempts to override trusted instructions."),
     ).toBeTruthy();
-    expect(screen.getByText("98%")).toBeTruthy();
+    expect(screen.getByText("98% confidence")).toBeTruthy();
     expect(screen.queryByText("raw manifest must not render")).toBeNull();
+  });
+
+  it("renders no prompt injection banner without findings", () => {
+    render(<SkillDetail />);
+    expect(screen.queryByText("Prompt injection flagged")).toBeNull();
   });
 
   it("lists validation errors for an invalid historical version", () => {

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -1,5 +1,11 @@
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
+import { StatusBanner } from "@/components/status-banner";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/Collapsible";
 import {
   RouteNotFoundState,
   SecondaryRouteAction,
@@ -25,6 +31,7 @@ import { useSkill } from "@gram/client/react-query/skill.js";
 import { useSkillVersionsInfinite } from "@gram/client/react-query/skillVersions.js";
 import { Badge } from "@/components/ui/Badge";
 import { type Column, Table } from "@/components/ui/Table";
+import { AlertTriangle, ChevronRight } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import {
@@ -72,30 +79,6 @@ const SKILL_SECTION_IDS: readonly string[] = [
   SKILL_VERSIONS_SECTION_ID,
   SKILL_TIMELINE_SECTION_ID,
   SKILL_DANGER_SECTION_ID,
-];
-
-const promptInjectionFindingColumns: Column<SkillPromptInjectionFinding>[] = [
-  {
-    key: "rule",
-    header: "Rule",
-    width: "220px",
-    render: (finding) => (
-      <span className="font-mono text-sm">{finding.ruleId}</span>
-    ),
-  },
-  {
-    key: "description",
-    header: "Description",
-    render: (finding) => <Text small>{finding.description}</Text>,
-  },
-  {
-    key: "confidence",
-    header: "Confidence",
-    width: "120px",
-    render: (finding) => (
-      <Text small>{Math.round(finding.confidence * 100)}%</Text>
-    ),
-  },
 ];
 
 function versionAnchorLabel(
@@ -245,6 +228,10 @@ function SkillDetailSections({
     <>
       <SkillPluginBanner skill={skill} />
 
+      <PromptInjectionBanner
+        findings={skillQueryData.promptInjectionFindings}
+      />
+
       <SettingsSection>
         <SettingsSection.Header>
           <SettingsSection.Title>Skill details</SettingsSection.Title>
@@ -317,33 +304,6 @@ function SkillDetailSections({
           skillId={skillId}
           latestVersion={latestVersion}
         />
-      )}
-
-      {skillQueryData.promptInjectionFindings.length > 0 && (
-        <SettingsSection>
-          <SettingsSection.Header>
-            <SettingsSection.Title>
-              Prompt injection flags
-            </SettingsSection.Title>
-            <SettingsSection.Description>
-              Findings detected in the current skill version.
-            </SettingsSection.Description>
-          </SettingsSection.Header>
-          <SettingsSection.Panel>
-            <SettingsSection.Body>
-              <div className="overflow-x-auto">
-                <Table
-                  columns={promptInjectionFindingColumns}
-                  data={skillQueryData.promptInjectionFindings}
-                  rowKey={(finding) =>
-                    `${finding.ruleId}:${finding.description}:${finding.confidence}`
-                  }
-                  className="min-w-[640px]"
-                />
-              </div>
-            </SettingsSection.Body>
-          </SettingsSection.Panel>
-        </SettingsSection>
       )}
 
       <SkillInsightsSection
@@ -651,6 +611,58 @@ function VersionHistory({
         onClose={() => setRestoreTarget(null)}
       />
     </>
+  );
+}
+
+function PromptInjectionBanner({
+  findings,
+}: {
+  findings: SkillPromptInjectionFinding[];
+}): JSX.Element | null {
+  const [expanded, setExpanded] = useState(false);
+  if (findings.length === 0) return null;
+  const summary =
+    findings.length === 1
+      ? "A prompt injection finding was detected in the current skill version."
+      : `${findings.length} prompt injection findings were detected in the current skill version.`;
+  return (
+    <StatusBanner tone="warning">
+      <Collapsible open={expanded} onOpenChange={setExpanded}>
+        <div className="flex flex-col gap-3 p-6">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="text-warning-foreground h-4 w-4 shrink-0" />
+            <Text className="text-warning-foreground text-base font-semibold">
+              Prompt injection flagged
+            </Text>
+          </div>
+          <Text variant="small" className="text-muted-foreground/90">
+            {summary}
+          </Text>
+          <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex w-fit items-center gap-1 text-sm transition-colors [&[data-state=open]>svg]:rotate-90">
+            <ChevronRight className="h-4 w-4 transition-transform" />
+            {expanded ? "Hide findings" : "Show findings"}
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <ul className="divide-border divide-y">
+              {findings.map((finding) => (
+                <li
+                  key={`${finding.ruleId}:${finding.description}:${finding.confidence}`}
+                  className="space-y-1 py-3 first:pt-0 last:pb-0"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-3">
+                    <span className="font-mono text-sm">{finding.ruleId}</span>
+                    <Text small muted>
+                      {Math.round(finding.confidence * 100)}% confidence
+                    </Text>
+                  </div>
+                  <Text small>{finding.description}</Text>
+                </li>
+              ))}
+            </ul>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+    </StatusBanner>
   );
 }
 

--- a/client/dashboard/src/pages/skills/SkillDetail.tsx
+++ b/client/dashboard/src/pages/skills/SkillDetail.tsx
@@ -31,7 +31,7 @@ import { useSkill } from "@gram/client/react-query/skill.js";
 import { useSkillVersionsInfinite } from "@gram/client/react-query/skillVersions.js";
 import { Badge } from "@/components/ui/Badge";
 import { type Column, Table } from "@/components/ui/Table";
-import { AlertTriangle, ChevronRight } from "lucide-react";
+import { ChevronRight, CircleAlert } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import {
@@ -226,11 +226,11 @@ function SkillDetailSections({
 
   return (
     <>
-      <SkillPluginBanner skill={skill} />
-
       <PromptInjectionBanner
         findings={skillQueryData.promptInjectionFindings}
       />
+
+      <SkillPluginBanner skill={skill} />
 
       <SettingsSection>
         <SettingsSection.Header>
@@ -626,12 +626,12 @@ function PromptInjectionBanner({
       ? "A prompt injection finding was detected in the current skill version."
       : `${findings.length} prompt injection findings were detected in the current skill version.`;
   return (
-    <StatusBanner tone="warning">
+    <StatusBanner tone="destructive">
       <Collapsible open={expanded} onOpenChange={setExpanded}>
         <div className="flex flex-col gap-3 p-6">
           <div className="flex items-center gap-2">
-            <AlertTriangle className="text-warning-foreground h-4 w-4 shrink-0" />
-            <Text className="text-warning-foreground text-base font-semibold">
+            <CircleAlert className="text-destructive h-4 w-4 shrink-0" />
+            <Text className="text-destructive text-base font-semibold">
               Prompt injection flagged
             </Text>
           </div>


### PR DESCRIPTION
The prompt injection findings on the skill detail page rendered as a full settings card with a table nested inside the card panel — a card-within-card look that also gave the findings the same visual weight as regular metadata sections.

This replaces the card with a warning `StatusBanner` above the Skill details section:

- No findings → nothing renders.
- Findings present → warning banner with a one-line summary and a "Show findings" toggle that expands to list each finding's rule, confidence, and description.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the prompt injection findings card on Skill detail with an expandable warning banner. The banner appears first and uses a destructive tone to surface risk without clutter.

- **Refactors**
  - Banner appears first, only renders when findings exist, and uses a destructive tone.
  - Toggle expands to list each finding’s rule ID, description, and “<n>% confidence”.
  - Copy: title “Prompt injection flagged” with a one-line summary of the count.
  - Updated tests for banner rendering, toggle behavior, and empty state.

<sup>Written for commit 3e0e38d9f2811af8d83cf548ec9deb7d7e1387eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

