### PR TITLE
fix(billing): raise Polar refresh timeouts to tolerate slow meter queries

### DIFF
--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -84,8 +84,10 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 
 	var a *Activities
 	orgIDs := input.OrgIDs
+	didLookupOrgs := false
 	// Initial call to workflow - no orgs yet, need to fetch them
 	if len(orgIDs) == 0 {
+		didLookupOrgs = true
 		err := workflow.ExecuteActivity(ctx, a.GetAllOrganizations).Get(ctx, &orgIDs)
 		if err != nil {
 			logger.Error("Failed to get all organizations", "error", err)
@@ -128,8 +130,13 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 	// when it retries, and the in-loop guard below only runs after a batch
 	// completes — so check the budget once before the first batch too, or a
 	// slow lookup could start a batch that cannot finish within the run
-	// timeout.
-	if startIndex < len(orgIDs) && shouldContinueRefreshBillingUsageAsNew(ctx) {
+	// timeout. Only runs that performed the lookup are checked: a continued
+	// run starts with orgs in hand and near-zero elapsed time, so letting it
+	// continue as new here would repeat the same start index forever if the
+	// run timeout were ever configured at or below the worst-case window.
+	// Skipping the check instead guarantees every continued run processes at
+	// least one batch before the in-loop guard can trigger.
+	if didLookupOrgs && startIndex < len(orgIDs) && shouldContinueRefreshBillingUsageAsNew(ctx) {
 		return continueAsNew(startIndex)
 	}
 

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -124,6 +124,15 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 		return workflow.NewContinueAsNewError(ctx, RefreshBillingUsageWorkflow, nextInput)
 	}
 
+	// The initial organization lookup can burn several minutes of the run
+	// when it retries, and the in-loop guard below only runs after a batch
+	// completes — so check the budget once before the first batch too, or a
+	// slow lookup could start a batch that cannot finish within the run
+	// timeout.
+	if startIndex < len(orgIDs) && shouldContinueRefreshBillingUsageAsNew(ctx) {
+		return continueAsNew(startIndex)
+	}
+
 	for i := startIndex; i < len(orgIDs); i += refreshBillingUsageBatchSize {
 		end := min(i+refreshBillingUsageBatchSize, len(orgIDs))
 		batch := orgIDs[i:end]

--- a/server/internal/background/refresh_billing_usage.go
+++ b/server/internal/background/refresh_billing_usage.go
@@ -14,19 +14,28 @@ import (
 
 // safely wait for polar rate limits
 const (
-	refreshBillingUsageBatchSize                   = 5
-	billingUsagePauseEveryBatches                  = 2
-	refreshBillingUsageActivityStartToCloseTimeout = 60 * time.Second
+	refreshBillingUsageBatchSize  = 5
+	billingUsagePauseEveryBatches = 2
+	// Polar serializes /quantities meter queries per-meter on their side, so
+	// during degraded periods a batch of refreshes can take well over a
+	// minute. Sized to match the Polar HTTP client timeout.
+	refreshBillingUsageActivityStartToCloseTimeout = 2 * time.Minute
 	// The snapshot activity gets its own, wider deadline: a first-run backfill
 	// issues up to 12 cycles × 5 orgs of serial ClickHouse aggregate queries
 	// per attempt — far more work than the Polar refresh.
 	snapshotBillingCycleUsageStartToCloseTimeout = 5 * time.Minute
-	refreshBillingUsageActivityMaximumAttempts   = 3
+	// The PostHog forward only reads durable snapshots and posts events, so
+	// it keeps a short deadline of its own; letting it ride the wider Polar
+	// refresh deadline would inflate the batch worst-case window enough to
+	// force a continue-as-new after nearly every batch, which skips the
+	// deterministic pauses that protect Polar's rate limits.
+	forwardTokenUsageToPostHogStartToCloseTimeout = 60 * time.Second
+	refreshBillingUsageActivityMaximumAttempts    = 3
 	// Reserve more than the worst-case retry path for one batch: the Polar
-	// refresh (3 attempts × 60s), the cycle snapshot (3 attempts × 5m), and
+	// refresh (3 attempts × 2m), the cycle snapshot (3 attempts × 5m), and
 	// the PostHog usage forward (3 attempts × 60s), each with 10s/15s retry
 	// backoffs and Temporal jitter.
-	refreshBillingUsageBatchWorstCaseRetryWindow = 24 * time.Minute
+	refreshBillingUsageBatchWorstCaseRetryWindow = 27 * time.Minute
 	refreshBillingUsageWorkflowRunTimeout        = 30 * time.Minute
 	refreshBillingUsagesWaitInterval             = 10 * time.Second
 )
@@ -140,7 +149,8 @@ func RefreshBillingUsageWorkflow(ctx workflow.Context, input RefreshBillingUsage
 		// pricing analysis (AGE-2289). Reads only the durable snapshots, so
 		// it is cheap and safe even when the snapshot batch above partially
 		// failed — stale rows just re-forward the last known usage.
-		if err := workflow.ExecuteActivity(ctx, a.ForwardTokenUsageToPostHog, batch).Get(ctx, nil); err != nil {
+		forwardCtx := workflow.WithStartToCloseTimeout(ctx, forwardTokenUsageToPostHogStartToCloseTimeout)
+		if err := workflow.ExecuteActivity(forwardCtx, a.ForwardTokenUsageToPostHog, batch).Get(ctx, nil); err != nil {
 			logger.Error("Failed to forward token usage batch to posthog", "error", err, "batch_start", i)
 			failedBatchCount++
 			failedOrgCount += len(batch)

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -216,6 +216,61 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewBeforeFirstBatchWhenBudgetExh
 	require.Zero(t, nextInput.StartIndex, "the continued run must resume from the batch that never started")
 }
 
+func TestRefreshBillingUsageWorkflow_ContinuedRunAlwaysMakesProgress(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	// A run timeout at or below the batch worst-case window makes the budget
+	// check report "no room" from the very start of every run. A continued
+	// run (orgs already loaded) must still process at least one batch under
+	// that configuration, or back-to-back continue-as-new calls with an
+	// unchanged start index would livelock the workflow with zero progress.
+	env.SetWorkflowRunTimeout(refreshBillingUsageBatchWorstCaseRetryWindow - time.Minute)
+
+	orgIDs := make([]string, 2*refreshBillingUsageBatchSize)
+	for i := range orgIDs {
+		orgIDs[i] = "org_" + strconv.Itoa(i)
+	}
+
+	refreshCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []string) error {
+			refreshCallCount++
+			return nil
+		},
+		activity.RegisterOptions{Name: "RefreshBillingUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []string) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []string) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
+	)
+
+	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           orgIDs,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	var continueAsNewErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueAsNewErr)
+	require.GreaterOrEqual(t, refreshCallCount, 1, "a continued run must process at least one batch before continuing as new")
+
+	var nextInput RefreshBillingUsageInput
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextInput))
+	require.Positive(t, nextInput.StartIndex, "the continued run must advance the start index")
+}
+
 func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/activity"
@@ -12,6 +13,65 @@ import (
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 )
+
+func TestRefreshBillingUsageWorkflow_ActivityStartToCloseTimeouts(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	orgIDs := []string{"org_1"}
+
+	// The test environment stamps Deadline from the real clock, so the
+	// difference carries sub-second scheduling skew; round it away.
+	startToClose := func(ctx context.Context) time.Duration {
+		info := activity.GetInfo(ctx)
+		return info.Deadline.Sub(info.StartedTime).Round(time.Minute)
+	}
+
+	var refreshTimeout time.Duration
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, _ []string) error {
+			refreshTimeout = startToClose(ctx)
+			return nil
+		},
+		activity.RegisterOptions{Name: "RefreshBillingUsage"},
+	)
+
+	var snapshotTimeout time.Duration
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, _ []string) error {
+			snapshotTimeout = startToClose(ctx)
+			return nil
+		},
+		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+
+	var forwardTimeout time.Duration
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, _ []string) error {
+			forwardTimeout = startToClose(ctx)
+			return nil
+		},
+		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
+	)
+
+	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           orgIDs,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 2*time.Minute, refreshTimeout,
+		"Polar refresh needs headroom for slow serialized /quantities meter queries")
+	require.Equal(t, 5*time.Minute, snapshotTimeout,
+		"snapshot keeps its wider first-run backfill deadline")
+	require.Equal(t, time.Minute, forwardTimeout,
+		"posthog forward keeps a short deadline so the batch worst-case window stays inside the run timeout")
+}
 
 func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) {
 	t.Parallel()

--- a/server/internal/background/refresh_billing_usage_test.go
+++ b/server/internal/background/refresh_billing_usage_test.go
@@ -151,6 +151,71 @@ func TestRefreshBillingUsageWorkflow_ContinuesAsNewNearRunTimeout(t *testing.T) 
 	require.Zero(t, nextInput.FailedOrgCount)
 }
 
+func TestRefreshBillingUsageWorkflow_ContinuesAsNewBeforeFirstBatchWhenBudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	// A run timeout smaller than the batch worst-case window means there is
+	// never room for a first batch: the workflow must continue as new right
+	// after loading organizations instead of starting a batch it cannot
+	// finish within the run timeout.
+	env.SetWorkflowRunTimeout(refreshBillingUsageBatchWorstCaseRetryWindow - time.Minute)
+
+	orgIDs := make([]string, 2*refreshBillingUsageBatchSize)
+	for i := range orgIDs {
+		orgIDs[i] = "org_" + strconv.Itoa(i)
+	}
+
+	getAllCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context) ([]string, error) {
+			getAllCallCount++
+			return orgIDs, nil
+		},
+		activity.RegisterOptions{Name: "GetAllOrganizations"},
+	)
+
+	refreshCallCount := 0
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []string) error {
+			refreshCallCount++
+			return nil
+		},
+		activity.RegisterOptions{Name: "RefreshBillingUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []string) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "SnapshotBillingCycleUsage"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ []string) error {
+			return nil
+		},
+		activity.RegisterOptions{Name: "ForwardTokenUsageToPostHog"},
+	)
+
+	env.ExecuteWorkflow(RefreshBillingUsageWorkflow, RefreshBillingUsageInput{
+		OrgIDs:           nil,
+		StartIndex:       0,
+		FailedBatchCount: 0,
+		FailedOrgCount:   0,
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	var continueAsNewErr *workflow.ContinueAsNewError
+	require.ErrorAs(t, env.GetWorkflowError(), &continueAsNewErr)
+	require.Equal(t, 1, getAllCallCount)
+	require.Zero(t, refreshCallCount, "no batch may start without a full worst-case retry window remaining")
+
+	var nextInput RefreshBillingUsageInput
+	require.NoError(t, converter.GetDefaultDataConverter().FromPayloads(continueAsNewErr.Input, &nextInput))
+	require.Equal(t, orgIDs, nextInput.OrgIDs)
+	require.Zero(t, nextInput.StartIndex, "the continued run must resume from the batch that never started")
+}
+
 func TestRefreshBillingUsageWorkflow_FailingBatchDoesNotAbortRun(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/thirdparty/polar/client.go
+++ b/server/internal/thirdparty/polar/client.go
@@ -90,7 +90,9 @@ var _ billing.Repository = (*Client)(nil)
 
 func NewClient(guardianPolicy *guardian.Policy, polarClient *polargo.Polar, bearerToken string, logger *slog.Logger, tracerProvider trace.TracerProvider, redisClient *redis.Client, catalog *Catalog, webhookSecret string) *Client {
 	client := guardianPolicy.PooledClient()
-	client.Timeout = 30 * time.Second
+	// Polar serializes /quantities meter queries per-meter on their side, so
+	// during degraded periods individual calls can take well over a minute.
+	client.Timeout = 2 * time.Minute
 
 	return &Client{
 		logger:             logger.With(attr.SlogComponent("polar_usage")),

--- a/server/internal/thirdparty/polar/client_test.go
+++ b/server/internal/thirdparty/polar/client_test.go
@@ -2,12 +2,43 @@ package polar
 
 import (
 	"testing"
+	"time"
 
 	polarComponents "github.com/polarsource/polar-go/models/components"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
+
+func TestNewClient_HTTPTimeoutAccommodatesSlowMeterQueries(t *testing.T) {
+	t.Parallel()
+
+	tracerProvider := testenv.NewTracerProvider(t)
+
+	client := NewClient(
+		guardian.NewDefaultPolicy(tracerProvider),
+		nil,
+		"test-token",
+		testenv.NewLogger(t),
+		tracerProvider,
+		nil,
+		&Catalog{
+			ProductIDBase:       "prod_base",
+			ProductIDPro:        "prod_pro",
+			ProductIDsTopUp:     nil,
+			ProductIDAssistants: "",
+			MeterIDToolCalls:    "meter_tool_calls",
+			MeterIDServers:      "meter_servers",
+			MeterIDCredits:      "meter_credits",
+		},
+		"",
+	)
+
+	require.Equal(t, 2*time.Minute, client.httpClient.Timeout,
+		"Polar /quantities meter queries are serialized per-meter on Polar's side and can exceed a minute during degraded periods")
+}
 
 func TestCatalog_IsTopUpProductID(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

Raises the two timeouts that govern the hourly billing usage refresh against Polar, both to 2 minutes:

- **Polar HTTP client timeout**: 30s → 2m (`polar/client.go`). Applies to all Polar API calls made through this client.
- **`RefreshBillingUsage` activity StartToClose**: 60s → 2m (`background/refresh_billing_usage.go`).

Two knock-on adjustments to keep the workflow's timing invariants sound:

- The PostHog usage forward gets its own 60s StartToClose (its current effective deadline) instead of riding the shared activity options. Letting it inherit 2m would push the batch worst-case retry window to ~28.5m against a 30m run timeout, forcing a continue-as-new after nearly every batch — which resets the batch counter and skips the deterministic pauses that protect Polar's rate limits.
- `refreshBillingUsageBatchWorstCaseRetryWindow`: 24m → 27m, following the documented formula (3×2m refresh + 3×5m snapshot + 3×60s forward + backoffs and jitter).

## Why

The `[Temporal] Activity failure burst` warn monitor fired on `refreshbillingusage` (prod, ~5.7 failures/30m). Every failure is the same shape: the tool-calls meter `GET /v1/meters/{id}/quantities` (30-day, `interval=day`) exceeding the 30s HTTP client timeout — `net/http: request canceled (Client.Timeout exceeded while awaiting headers)`. Polar serializes `/quantities` work per-meter server-side, so during degraded periods calls queue and blow the 30s budget, failing whole 5-org batches through all 3 retry attempts. Log history shows a ~1 failure/hour baseline with bursts (Aug 7, 9, 10) matching Polar slow episodes, predating any recent deploys.

## Validation

- New test `TestRefreshBillingUsageWorkflow_ActivityStartToCloseTimeouts` asserts the effective StartToClose seen by each of the three batch activities (2m refresh / 5m snapshot / 60s forward) via `activity.GetInfo` deadlines, written red-first against the old values.
- New test `TestNewClient_HTTPTimeoutAccommodatesSlowMeterQueries` asserts the constructed Polar client's HTTP timeout, also written red-first.
- `go test ./server/internal/background/... ./server/internal/thirdparty/polar/`, `mise run build:server`, and `mise run lint:server` all pass.

Note: the HTTP client timeout is shared by user-facing Polar calls (checkout, tier lookups). Those normally return in well under a second; the raised ceiling only changes behavior when Polar is already hanging, where the previous 30s cap applied anyway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Polar API and billing refresh timeouts to 2 minutes to tolerate slow `/quantities` queries, reducing `Temporal` activity failures. Also guard the workflow budget before the first batch only when this run looked up orgs, so we don’t start unfinishable work or livelock continued runs.

- **Bug Fixes**
  - Raise timeouts to 2m for the Polar HTTP client (`server/internal/thirdparty/polar/client.go`) and `RefreshBillingUsage` activity (`server/internal/background/refresh_billing_usage.go`).
  - Keep `ForwardTokenUsageToPostHog` StartToClose at 60s via its own context.
  - Update `refreshBillingUsageBatchWorstCaseRetryWindow`: 24m → 27m to match new ceilings.
  - Guard continue-as-new budget before the first batch only if this run performed the org lookup, ensuring continued runs always make progress.
  - Add tests for activity deadlines, the Polar HTTP client timeout, the pre-batch budget guard, and continued-run progress.

<sup>Written for commit 9ef5f1b73489c5dbbe1d96db06c999bde1dc2b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

