### PR TITLE
feat(dashboard): humanize activity trail and restyle org home

### DIFF
--- a/client/dashboard/src/components/project/ActivityTimelineCard.tsx
+++ b/client/dashboard/src/components/project/ActivityTimelineCard.tsx
@@ -1,10 +1,12 @@
 import { ChevronRight } from "lucide-react";
 import { Link } from "react-router";
+import { Link as TextLink } from "@/components/ui/Link";
 import { Card } from "@/components/ui/Card";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { ActionIconTile } from "@/components/auditlogs/feed";
 import { subjectHref } from "@/components/auditlogs/subject-href";
 import { useSlugs } from "@/contexts/Sdk";
+import { formatSubjectLabel, renderVerb } from "@/lib/audit-log-format";
 import { format, formatDistanceToNow, isToday, isYesterday } from "date-fns";
 import type { AuditLog } from "@gram/client/models/components/auditlog.js";
 
@@ -53,7 +55,13 @@ export function ActivityTimelineCard({
                 {group.logs.map((log) => {
                   const actor =
                     log.actorDisplayName ?? log.actorSlug ?? "Unknown";
-                  const actionLabel = getActionLabel(log);
+                  const actionLabel = renderVerb(log);
+                  const subjectLabel = log.subjectDisplayName
+                    ? formatSubjectLabel(
+                        log.subjectDisplayName,
+                        log.subjectType,
+                      )
+                    : null;
                   const href = orgSlug ? subjectHref(log, orgSlug) : null;
                   return (
                     <li
@@ -71,15 +79,25 @@ export function ActivityTimelineCard({
                             <>
                               {" "}
                               {href ? (
-                                <Link
-                                  to={href}
-                                  className="font-medium hover:underline"
+                                <TextLink
+                                  asChild
+                                  size="sm"
+                                  underline={false}
+                                  className="font-medium"
                                 >
-                                  {log.subjectDisplayName}
-                                </Link>
+                                  <Link
+                                    to={href}
+                                    title={log.subjectDisplayName}
+                                  >
+                                    {subjectLabel}
+                                  </Link>
+                                </TextLink>
                               ) : (
-                                <span className="font-medium">
-                                  {log.subjectDisplayName}
+                                <span
+                                  className="font-medium"
+                                  title={log.subjectDisplayName}
+                                >
+                                  {subjectLabel}
                                 </span>
                               )}
                             </>
@@ -105,95 +123,16 @@ export function ActivityTimelineCard({
 
 // --- Helpers ---
 
-const ACTION_LABELS: Record<string, string> = {
-  "deployments:create": "deployed",
-  "deployments:evolve": "evolved deployment",
-  "deployments:redeploy": "redeployed",
-  "api_key:create": "created API key",
-  "api_key:revoke": "revoked API key",
-  "access_role:create": "created role",
-  "access_role:update": "updated role",
-  "access_role:delete": "deleted role",
-  "access_member:update_role": "updated member role",
-  "organization_invitation:create": "sent invite to",
-  "organization_invitation:revoke": "revoked invite for",
-  "organization_invitation:update_role": "changed invite role for",
-  "project:create": "created project",
-  "project:update": "updated project",
-  "project:delete": "deleted project",
-  "toolset:create": "added",
-  "toolset:update": "updated MCP server",
-  "toolset:delete": "deleted MCP server",
-  "toolset:attach_external_oauth": "connected OAuth",
-  "toolset:detach_external_oauth": "disconnected OAuth",
-  "toolset:attach_oauth_proxy": "attached OAuth proxy",
-  "toolset:update_oauth_proxy": "updated OAuth proxy",
-  "toolset:detach_oauth_proxy": "detached OAuth proxy",
-  "environment:create": "created environment",
-  "environment:update": "updated environment",
-  "environment:delete": "deleted environment",
-  "custom_domains:create": "added custom domain",
-  "custom_domains:delete": "removed custom domain",
-  "template:create": "created template",
-  "template:update": "updated template",
-  "template:delete": "deleted template",
-  "asset:create": "created asset",
-  "variation:update_global": "updated variation",
-  "variation:delete_global": "deleted variation",
-  "plugin:create": "created plugin",
-  "plugin:update": "updated plugin",
-  "plugin:delete": "deleted plugin",
-  "plugin:server_add": "added server to plugin",
-  "plugin:server_update": "updated plugin server",
-  "plugin:server_remove": "removed server from plugin",
-  "plugin:assignments_set": "updated plugin access",
-  "plugin:publish": "published plugins",
-  "chat_session:access": "accessed chat session",
-};
-
-function recordString(value: unknown, key: string): string | undefined {
-  if (value == null || typeof value !== "object") return undefined;
-  const field = (value as Record<string, unknown>)[key];
-  return typeof field === "string" && field !== "" ? field : undefined;
-}
-
-function formatRoleSlug(roleSlug: string) {
-  return roleSlug.replace(/[-_]/g, " ");
-}
-
-function getInviteActionLabel(log: AuditLog): string | undefined {
-  if (log.action === "organization_invitation:create") {
-    const role = recordString(log.metadata, "role_slug");
-    return role ? `sent ${formatRoleSlug(role)} invite to` : undefined;
-  }
-
-  if (log.action === "organization_invitation:update_role") {
-    const before =
-      recordString(log.beforeSnapshot, "RoleSlug") ??
-      recordString(log.beforeSnapshot, "role_slug");
-    const after =
-      recordString(log.afterSnapshot, "RoleSlug") ??
-      recordString(log.afterSnapshot, "role_slug");
-    if (before && after && before !== after) {
-      return `changed invite role from ${formatRoleSlug(before)} to ${formatRoleSlug(after)} for`;
-    }
-    if (after) {
-      return `changed invite role to ${formatRoleSlug(after)} for`;
-    }
-  }
-
-  return undefined;
-}
-
-function getActionLabel(log: AuditLog): string {
-  return getInviteActionLabel(log) ?? ACTION_LABELS[log.action] ?? log.action;
-}
-
 type LogGroup = { label: string; logs: AuditLog[] };
 
 function groupLogsByDate(logs: AuditLog[]): LogGroup[] {
   const map = new Map<string, AuditLog[]>();
-  for (const log of logs) {
+  // Newest first, matching the org audit log feed — the API is not guaranteed
+  // to hand these back in display order.
+  const ordered = [...logs].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+  );
+  for (const log of ordered) {
     const label = isToday(log.createdAt)
       ? "Today"
       : isYesterday(log.createdAt)

--- a/client/dashboard/src/components/ui/Card/index.tsx
+++ b/client/dashboard/src/components/ui/Card/index.tsx
@@ -302,6 +302,8 @@ type CardDashboardProps = {
   tooltip?: string;
   /** Body classes, e.g. `p-0` for content that should reach the card edges. */
   bodyClassName?: string;
+  /** Root classes, e.g. `h-auto` for a panel that should not stretch. */
+  className?: string;
 };
 
 /**
@@ -315,9 +317,15 @@ function CardDashboard({
   children,
   tooltip,
   bodyClassName,
+  className,
 }: CardDashboardProps): JSX.Element {
   return (
-    <div className="bg-card text-card-foreground relative flex h-full w-full flex-col border">
+    <div
+      className={cn(
+        "bg-card text-card-foreground relative flex h-full w-full flex-col border",
+        className,
+      )}
+    >
       <div className="flex w-full flex-row items-center justify-between gap-4 border-b px-6 py-4">
         <div className="flex items-center gap-1.5">
           <h3 className="text-eyebrow">{title}</h3>

--- a/client/dashboard/src/components/ui/Card/index.tsx
+++ b/client/dashboard/src/components/ui/Card/index.tsx
@@ -300,6 +300,8 @@ type CardDashboardProps = {
   action?: ReactNode;
   children: ReactNode;
   tooltip?: string;
+  /** Body classes, e.g. `p-0` for content that should reach the card edges. */
+  bodyClassName?: string;
 };
 
 /**
@@ -312,6 +314,7 @@ function CardDashboard({
   action,
   children,
   tooltip,
+  bodyClassName,
 }: CardDashboardProps): JSX.Element {
   return (
     <div className="bg-card text-card-foreground relative flex h-full w-full flex-col border">
@@ -332,7 +335,7 @@ function CardDashboard({
         </div>
         {action}
       </div>
-      <div className="px-6 py-5">{children}</div>
+      <div className={cn("px-6 py-5", bodyClassName)}>{children}</div>
     </div>
   );
 }

--- a/client/dashboard/src/components/ui/Tooltip/index.tsx
+++ b/client/dashboard/src/components/ui/Tooltip/index.tsx
@@ -74,7 +74,9 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         className={cn(
           "z-50 animate-in border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-          "max-w-sm text-pretty",
+          // `break-words` so an unbreakable token (a content hash, a URL)
+          // wraps inside max-w-sm instead of stretching the box past it.
+          "max-w-sm text-pretty break-words",
           inverted && "bg-background [&_svg]:fill-background dark:border-1",
           className,
         )}

--- a/client/dashboard/src/lib/audit-actions.test.ts
+++ b/client/dashboard/src/lib/audit-actions.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   AUDIT_ACTIONS,
@@ -7,8 +7,24 @@ import {
   staticActionPhrase,
 } from "./audit-actions";
 
-// vitest runs from client/dashboard.
-const AUDIT_PKG = join(process.cwd(), "../../server/internal/audit");
+// Walk up from the working directory to the repo root, so the guard resolves
+// whether vitest is invoked from client/dashboard or from the repo root.
+function findAuditPkg(): string {
+  let dir = process.cwd();
+  for (;;) {
+    const candidate = join(dir, "server/internal/audit");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(
+        `could not locate server/internal/audit above ${process.cwd()}`,
+      );
+    }
+    dir = parent;
+  }
+}
+
+const AUDIT_PKG = findAuditPkg();
 
 /** Every `Foo Action = "resource:verb"` constant declared in the Go package. */
 function goAuditActions(): string[] {

--- a/client/dashboard/src/lib/audit-actions.test.ts
+++ b/client/dashboard/src/lib/audit-actions.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  AUDIT_ACTIONS,
+  isAuditAction,
+  staticActionPhrase,
+} from "./audit-actions";
+
+// vitest runs from client/dashboard.
+const AUDIT_PKG = join(process.cwd(), "../../server/internal/audit");
+
+/** Every `Foo Action = "resource:verb"` constant declared in the Go package. */
+function goAuditActions(): string[] {
+  const actions = new Set<string>();
+  for (const file of readdirSync(AUDIT_PKG)) {
+    if (!file.endsWith(".go") || file.endsWith("_test.go")) continue;
+    const source = readFileSync(join(AUDIT_PKG, file), "utf8");
+    for (const match of source.matchAll(/\bAction\s*=\s*"([^"]+)"/g)) {
+      const action = match[1];
+      if (action) actions.add(action);
+    }
+  }
+  return [...actions].sort();
+}
+
+describe("AUDIT_ACTIONS", () => {
+  // Guards the exhaustive switch in staticActionPhrase: it only proves every
+  // action has a phrase if this list matches what the server can emit.
+  it("matches the Action constants declared in server/internal/audit", () => {
+    expect([...AUDIT_ACTIONS].sort()).toEqual(goAuditActions());
+  });
+
+  it("gives every action a past-tense phrase", () => {
+    for (const action of AUDIT_ACTIONS) {
+      const phrase = staticActionPhrase(action);
+      expect(phrase, action).not.toContain(":");
+      expect(phrase, action).not.toBe("");
+    }
+  });
+
+  it("rejects actions it doesn't know", () => {
+    expect(isAuditAction("risk_policy:delete")).toBe(true);
+    expect(isAuditAction("not_a_resource:not_a_verb")).toBe(false);
+  });
+});

--- a/client/dashboard/src/lib/audit-actions.ts
+++ b/client/dashboard/src/lib/audit-actions.ts
@@ -1,0 +1,586 @@
+import { assertNever } from "@/lib/utils";
+
+/**
+ * Every audit action the server can record, mirroring the `Action` constants in
+ * `server/internal/audit/*.go`. Listing them here (rather than treating
+ * `log.action` as an opaque string) is what lets `staticActionPhrase` be an
+ * exhaustive switch: adding a Go action without a phrase here fails type-check
+ * the moment the string lands in this list.
+ */
+export const AUDIT_ACTIONS = [
+  "access_challenge:resolve",
+  "access_member:update_role",
+  "access_role:create",
+  "access_role:delete",
+  "access_role:update",
+  "ai_integration:delete",
+  "ai_integration:retry_schedule",
+  "ai_integration:update_schedule",
+  "ai_integration:upsert",
+  "api_key:create",
+  "api_key:revoke",
+  "asset:create",
+  "assistant:tool_call",
+  "aws_iam_credential:create",
+  "aws_iam_credential:delete",
+  "aws_iam_credential:update",
+  "aws_kms_key:create",
+  "aws_kms_key:delete",
+  "aws_kms_key:update",
+  "billing_metadata:update",
+  "chat_analysis_settings:upsert",
+  "chat_session:access",
+  "custom_domains:create",
+  "custom_domains:delete",
+  "custom_domains:update",
+  "deployments:create",
+  "deployments:evolve",
+  "deployments:redeploy",
+  "device_integration:delete",
+  "device_integration:retry_schedule",
+  "device_integration:update_schedule",
+  "device_integration:upsert",
+  "environment:create",
+  "environment:delete",
+  "environment:update",
+  "gcp_iam_credential:create",
+  "gcp_iam_credential:delete",
+  "gcp_iam_credential:update",
+  "gcp_kms_key:create",
+  "gcp_kms_key:delete",
+  "gcp_kms_key:update",
+  "litellm_instance:create",
+  "litellm_instance:revoke",
+  "litellm_instance:rotate_key",
+  "mcp-endpoint:create",
+  "mcp-endpoint:delete",
+  "mcp-endpoint:update",
+  "mcp-server:create",
+  "mcp-server:delete",
+  "mcp-server:update",
+  "mcp-server:update-tool-metadata",
+  "mcp_collection:attach_server",
+  "mcp_collection:create",
+  "mcp_collection:delete",
+  "mcp_collection:detach_server",
+  "mcp_collection:update",
+  "mcp_metadata:update",
+  "model_provider_key:delete",
+  "model_provider_key:upsert",
+  "organization:device_agent_configuration_updated",
+  "organization:enterprise_trial_armed",
+  "organization:enterprise_trial_demoted",
+  "organization:hooks_fail_open_disabled",
+  "organization:hooks_fail_open_enabled",
+  "organization:webhooks_disabled",
+  "organization:webhooks_enabled",
+  "organization_invitation:create",
+  "organization_invitation:revoke",
+  "organization_invitation:update_role",
+  "otel_forwarding:delete",
+  "otel_forwarding:upsert",
+  "platform-mcp-registration:create",
+  "platform-mcp-registration:handoff_issue",
+  "platform-mcp-registration:handoff_redeem",
+  "plugin:assignments_set",
+  "plugin:create",
+  "plugin:delete",
+  "plugin:publish",
+  "plugin:server_add",
+  "plugin:server_remove",
+  "plugin:server_update",
+  "plugin:update",
+  "project:create",
+  "project:delete",
+  "project:update",
+  "remote-mcp-server-header:create",
+  "remote-mcp-server-header:delete",
+  "remote-mcp-server-header:update",
+  "remote-mcp:create",
+  "remote-mcp:delete",
+  "remote-mcp:update",
+  "remote-session-client:attach-user-session-issuer",
+  "remote-session-client:create",
+  "remote-session-client:delete",
+  "remote-session-client:detach-mcp-server",
+  "remote-session-client:detach-user-session-issuer",
+  "remote-session-client:revoke-sessions",
+  "remote-session-client:update",
+  "remote-session-issuer:create",
+  "remote-session-issuer:delete",
+  "remote-session-issuer:migrate",
+  "remote-session-issuer:update",
+  "remote-session:delete",
+  "remote-session:refresh",
+  "risk_exclusion:create",
+  "risk_exclusion:delete",
+  "risk_exclusion:update",
+  "risk_policy:bypass_request_approve",
+  "risk_policy:bypass_request_create",
+  "risk_policy:bypass_request_deny",
+  "risk_policy:bypass_request_revoke",
+  "risk_policy:challenge_acknowledge",
+  "risk_policy:create",
+  "risk_policy:delete",
+  "risk_policy:eval_review_delete",
+  "risk_policy:eval_review_save",
+  "risk_policy:trigger",
+  "risk_policy:update",
+  "risk_result:dismiss",
+  "risk_result:restore",
+  "risk_result:unmask",
+  "skill:add_version",
+  "skill:archive",
+  "skill:create",
+  "skill:distribute",
+  "skill:restore_version",
+  "skill:share_link_create",
+  "skill:share_link_revoke",
+  "skill:suggestion_approve",
+  "skill:suggestion_dismiss",
+  "skill:undistribute",
+  "skill:update",
+  "skill:update_distribution",
+  "skill_efficacy_settings:upsert",
+  "spend_rule:archive",
+  "spend_rule:create",
+  "spend_rule:update",
+  "template:create",
+  "template:delete",
+  "template:update",
+  "toolset:attach_external_oauth",
+  "toolset:attach_oauth_proxy",
+  "toolset:create",
+  "toolset:delete",
+  "toolset:detach_external_oauth",
+  "toolset:detach_oauth_proxy",
+  "toolset:update",
+  "toolset:update_oauth_proxy",
+  "trigger-instance:create",
+  "trigger-instance:delete",
+  "trigger-instance:pause",
+  "trigger-instance:resume",
+  "trigger-instance:update",
+  "tunneled-mcp:create",
+  "tunneled-mcp:delete",
+  "tunneled-mcp:rotate-key",
+  "tunneled-mcp:update",
+  "unproxied-mcp:create",
+  "unproxied-mcp:delete",
+  "user-session-client:revoke",
+  "user-session-consent:revoke",
+  "user-session-issuer-cimd-client:add",
+  "user-session-issuer-cimd-client:remove",
+  "user-session-issuer:create",
+  "user-session-issuer:delete",
+  "user-session-issuer:update",
+  "user-session:revoke",
+  "variation:delete_global",
+  "variation:update_global",
+  "wake:cancelled",
+  "wake:fired",
+  "wake:scheduled",
+] as const;
+
+export type AuditAction = (typeof AUDIT_ACTIONS)[number];
+
+const AUDIT_ACTION_SET: ReadonlySet<string> = new Set(AUDIT_ACTIONS);
+
+export function isAuditAction(action: string): action is AuditAction {
+  return AUDIT_ACTION_SET.has(action);
+}
+
+/**
+ * Past-tense phrase for an action, written to read as a sentence with the actor
+ * in front and the subject display name behind it:
+ *
+ *   "adam@example.com" + "deleted risk policy" + "Shadow MCP Server Policy"
+ *
+ * Phrases that dangle a preposition ("... invite for") expect a subject name;
+ * the rest read fine either way.
+ */
+export function staticActionPhrase(action: AuditAction): string {
+  switch (action) {
+    case "access_challenge:resolve":
+      return "resolved access challenge";
+    case "access_member:update_role":
+      return "changed member role for";
+    case "access_role:create":
+      return "created access role";
+    case "access_role:update":
+      return "updated access role";
+    case "access_role:delete":
+      return "deleted access role";
+
+    case "ai_integration:upsert":
+      return "configured AI integration";
+    case "ai_integration:delete":
+      return "removed AI integration";
+    case "ai_integration:update_schedule":
+      return "updated AI integration schedule";
+    case "ai_integration:retry_schedule":
+      return "retried AI integration sync";
+
+    case "api_key:create":
+      return "created API key";
+    case "api_key:revoke":
+      return "revoked API key";
+
+    case "asset:create":
+      return "uploaded asset";
+    case "assistant:tool_call":
+      return "ran assistant tool";
+
+    case "aws_iam_credential:create":
+      return "added AWS IAM credential";
+    case "aws_iam_credential:update":
+      return "updated AWS IAM credential";
+    case "aws_iam_credential:delete":
+      return "removed AWS IAM credential";
+    case "aws_kms_key:create":
+      return "added AWS KMS key";
+    case "aws_kms_key:update":
+      return "updated AWS KMS key";
+    case "aws_kms_key:delete":
+      return "removed AWS KMS key";
+    case "gcp_iam_credential:create":
+      return "added GCP IAM credential";
+    case "gcp_iam_credential:update":
+      return "updated GCP IAM credential";
+    case "gcp_iam_credential:delete":
+      return "removed GCP IAM credential";
+    case "gcp_kms_key:create":
+      return "added GCP KMS key";
+    case "gcp_kms_key:update":
+      return "updated GCP KMS key";
+    case "gcp_kms_key:delete":
+      return "removed GCP KMS key";
+
+    case "billing_metadata:update":
+      return "updated billing metadata";
+    case "chat_analysis_settings:upsert":
+      return "updated chat analysis settings";
+    case "chat_session:access":
+      return "opened chat session";
+
+    case "custom_domains:create":
+      return "added custom domain";
+    case "custom_domains:update":
+      return "updated custom domain";
+    case "custom_domains:delete":
+      return "removed custom domain";
+
+    case "deployments:create":
+      return "created deployment";
+    case "deployments:evolve":
+      return "updated deployment";
+    case "deployments:redeploy":
+      return "redeployed deployment";
+
+    case "device_integration:upsert":
+      return "configured device integration";
+    case "device_integration:delete":
+      return "removed device integration";
+    case "device_integration:update_schedule":
+      return "updated device integration schedule";
+    case "device_integration:retry_schedule":
+      return "retried device integration sync";
+
+    case "environment:create":
+      return "created environment";
+    case "environment:update":
+      return "updated environment";
+    case "environment:delete":
+      return "deleted environment";
+
+    case "litellm_instance:create":
+      return "created LiteLLM instance";
+    case "litellm_instance:rotate_key":
+      return "rotated LiteLLM instance key";
+    case "litellm_instance:revoke":
+      return "revoked LiteLLM instance";
+
+    case "mcp-endpoint:create":
+      return "created MCP endpoint";
+    case "mcp-endpoint:update":
+      return "updated MCP endpoint";
+    case "mcp-endpoint:delete":
+      return "deleted MCP endpoint";
+
+    case "mcp-server:create":
+      return "created MCP server";
+    case "mcp-server:update":
+      return "updated MCP server";
+    case "mcp-server:delete":
+      return "deleted MCP server";
+    case "mcp-server:update-tool-metadata":
+      return "updated tool metadata on MCP server";
+
+    case "mcp_collection:create":
+      return "created collection";
+    case "mcp_collection:update":
+      return "updated collection";
+    case "mcp_collection:delete":
+      return "deleted collection";
+    case "mcp_collection:attach_server":
+      return "added a server to collection";
+    case "mcp_collection:detach_server":
+      return "removed a server from collection";
+
+    case "mcp_metadata:update":
+      return "updated MCP metadata for";
+
+    case "model_provider_key:upsert":
+      return "updated model provider key";
+    case "model_provider_key:delete":
+      return "removed model provider key";
+
+    case "organization:webhooks_enabled":
+      return "enabled webhook delivery";
+    case "organization:webhooks_disabled":
+      return "disabled webhook delivery";
+    case "organization:hooks_fail_open_enabled":
+      return "enabled fail-open for hooks";
+    case "organization:hooks_fail_open_disabled":
+      return "disabled fail-open for hooks";
+    case "organization:device_agent_configuration_updated":
+      return "updated device agent configuration";
+    case "organization:enterprise_trial_armed":
+      return "started enterprise trial";
+    case "organization:enterprise_trial_demoted":
+      return "ended enterprise trial";
+
+    case "organization_invitation:create":
+      return "invited";
+    case "organization_invitation:revoke":
+      return "revoked invite for";
+    case "organization_invitation:update_role":
+      return "changed invite role for";
+
+    case "otel_forwarding:upsert":
+      return "updated OpenTelemetry forwarding configuration";
+    case "otel_forwarding:delete":
+      return "removed OpenTelemetry forwarding configuration";
+
+    case "platform-mcp-registration:create":
+      return "registered platform MCP server";
+    case "platform-mcp-registration:handoff_issue":
+      return "issued a registration handoff for";
+    case "platform-mcp-registration:handoff_redeem":
+      return "redeemed a registration handoff for";
+
+    case "plugin:create":
+      return "created plugin";
+    case "plugin:update":
+      return "updated plugin";
+    case "plugin:delete":
+      return "deleted plugin";
+    case "plugin:server_add":
+      return "added a server to plugin";
+    case "plugin:server_update":
+      return "updated a server on plugin";
+    case "plugin:server_remove":
+      return "removed a server from plugin";
+    case "plugin:assignments_set":
+      return "updated plugin access";
+    case "plugin:publish":
+      return "published plugins";
+
+    case "project:create":
+      return "created project";
+    case "project:update":
+      return "updated project";
+    case "project:delete":
+      return "deleted project";
+
+    case "remote-mcp:create":
+      return "added remote MCP server";
+    case "remote-mcp:update":
+      return "updated remote MCP server";
+    case "remote-mcp:delete":
+      return "removed remote MCP server";
+    case "remote-mcp-server-header:create":
+      return "added a header to remote MCP server";
+    case "remote-mcp-server-header:update":
+      return "updated a header on remote MCP server";
+    case "remote-mcp-server-header:delete":
+      return "removed a header from remote MCP server";
+
+    case "remote-session:refresh":
+      return "refreshed remote session";
+    case "remote-session:delete":
+      return "deleted remote session";
+    case "remote-session-client:create":
+      return "created remote session client";
+    case "remote-session-client:update":
+      return "updated remote session client";
+    case "remote-session-client:delete":
+      return "deleted remote session client";
+    case "remote-session-client:attach-user-session-issuer":
+      return "attached a user session issuer to";
+    case "remote-session-client:detach-user-session-issuer":
+      return "detached a user session issuer from";
+    case "remote-session-client:detach-mcp-server":
+      return "detached an MCP server from";
+    case "remote-session-client:revoke-sessions":
+      return "revoked sessions for";
+    case "remote-session-issuer:create":
+      return "created remote session issuer";
+    case "remote-session-issuer:update":
+      return "updated remote session issuer";
+    case "remote-session-issuer:delete":
+      return "deleted remote session issuer";
+    case "remote-session-issuer:migrate":
+      return "migrated remote session issuer";
+
+    case "risk_exclusion:create":
+      return "created risk exclusion";
+    case "risk_exclusion:update":
+      return "updated risk exclusion";
+    case "risk_exclusion:delete":
+      return "deleted risk exclusion";
+
+    case "risk_policy:create":
+      return "created risk policy";
+    case "risk_policy:update":
+      return "updated risk policy";
+    case "risk_policy:delete":
+      return "deleted risk policy";
+    case "risk_policy:trigger":
+      return "triggered risk policy";
+    case "risk_policy:bypass_request_create":
+      return "requested a bypass for";
+    case "risk_policy:bypass_request_approve":
+      return "approved a bypass for";
+    case "risk_policy:bypass_request_deny":
+      return "denied a bypass for";
+    case "risk_policy:bypass_request_revoke":
+      return "revoked a bypass for";
+    case "risk_policy:challenge_acknowledge":
+      return "acknowledged a challenge for";
+    case "risk_policy:eval_review_save":
+      return "saved an evaluation review for";
+    case "risk_policy:eval_review_delete":
+      return "deleted an evaluation review for";
+
+    case "risk_result:dismiss":
+      return "dismissed risk finding";
+    case "risk_result:restore":
+      return "restored risk finding";
+    case "risk_result:unmask":
+      return "unmasked risk finding";
+
+    case "skill:create":
+      return "created skill";
+    case "skill:update":
+      return "updated skill";
+    case "skill:archive":
+      return "archived skill";
+    case "skill:add_version":
+      return "added a version to skill";
+    case "skill:restore_version":
+      return "restored a version of skill";
+    case "skill:distribute":
+      return "distributed skill";
+    case "skill:undistribute":
+      return "stopped distributing skill";
+    case "skill:update_distribution":
+      return "updated distribution for skill";
+    case "skill:share_link_create":
+      return "created a share link for";
+    case "skill:share_link_revoke":
+      return "revoked a share link for";
+    case "skill:suggestion_approve":
+      return "approved a suggestion for";
+    case "skill:suggestion_dismiss":
+      return "dismissed a suggestion for";
+    case "skill_efficacy_settings:upsert":
+      return "updated skill efficacy settings";
+
+    case "spend_rule:create":
+      return "created spend rule";
+    case "spend_rule:update":
+      return "updated spend rule";
+    case "spend_rule:archive":
+      return "archived spend rule";
+
+    case "template:create":
+      return "created template";
+    case "template:update":
+      return "updated template";
+    case "template:delete":
+      return "deleted template";
+
+    case "toolset:create":
+      return "created MCP server";
+    case "toolset:update":
+      return "updated MCP server";
+    case "toolset:delete":
+      return "deleted MCP server";
+    case "toolset:attach_external_oauth":
+      return "connected an external OAuth server to";
+    case "toolset:detach_external_oauth":
+      return "disconnected an external OAuth server from";
+    case "toolset:attach_oauth_proxy":
+      return "attached an OAuth proxy to";
+    case "toolset:update_oauth_proxy":
+      return "updated the OAuth proxy on";
+    case "toolset:detach_oauth_proxy":
+      return "detached an OAuth proxy from";
+
+    case "trigger-instance:create":
+      return "created trigger";
+    case "trigger-instance:update":
+      return "updated trigger";
+    case "trigger-instance:delete":
+      return "deleted trigger";
+    case "trigger-instance:pause":
+      return "paused trigger";
+    case "trigger-instance:resume":
+      return "resumed trigger";
+    case "wake:scheduled":
+      return "scheduled a wake for";
+    case "wake:fired":
+      return "ran a scheduled wake for";
+    case "wake:cancelled":
+      return "cancelled a wake for";
+
+    case "tunneled-mcp:create":
+      return "added tunneled MCP server";
+    case "tunneled-mcp:update":
+      return "updated tunneled MCP server";
+    case "tunneled-mcp:delete":
+      return "removed tunneled MCP server";
+    case "tunneled-mcp:rotate-key":
+      return "rotated the key for tunneled MCP server";
+    case "unproxied-mcp:create":
+      return "added unproxied MCP server";
+    case "unproxied-mcp:delete":
+      return "removed unproxied MCP server";
+
+    case "user-session:revoke":
+      return "revoked user session";
+    case "user-session-client:revoke":
+      return "revoked user session client";
+    case "user-session-consent:revoke":
+      return "revoked consent for";
+    case "user-session-issuer:create":
+      return "created user session issuer";
+    case "user-session-issuer:update":
+      return "updated user session issuer";
+    case "user-session-issuer:delete":
+      return "deleted user session issuer";
+    case "user-session-issuer-cimd-client:add":
+      return "added a CIMD client to";
+    case "user-session-issuer-cimd-client:remove":
+      return "removed a CIMD client from";
+
+    case "variation:update_global":
+      return "updated a global variation for";
+    case "variation:delete_global":
+      return "deleted a global variation for";
+
+    default:
+      return assertNever(action);
+  }
+}

--- a/client/dashboard/src/lib/audit-log-format.test.ts
+++ b/client/dashboard/src/lib/audit-log-format.test.ts
@@ -1,0 +1,110 @@
+import type { AuditLog } from "@gram/client/models/components/auditlog.js";
+import { describe, expect, it } from "vitest";
+import {
+  formatAuditActionLabel,
+  formatSubjectLabel,
+  renderVerb,
+} from "./audit-log-format";
+
+function log(partial: Partial<AuditLog> & { action: string }): AuditLog {
+  return {
+    id: "1",
+    actorId: "actor",
+    actorType: "user",
+    subjectId: "subject",
+    subjectType: "thing",
+    createdAt: new Date(),
+    ...partial,
+  } as AuditLog;
+}
+
+describe("renderVerb", () => {
+  it("humanizes known actions in past tense", () => {
+    expect(renderVerb(log({ action: "risk_policy:delete" }))).toBe(
+      "deleted risk policy",
+    );
+    expect(renderVerb(log({ action: "chat_session:access" }))).toBe(
+      "opened chat session",
+    );
+    expect(renderVerb(log({ action: "skill:add_version" }))).toBe(
+      "added a version to skill",
+    );
+  });
+
+  it("falls back to a past-tense phrase for unknown actions", () => {
+    expect(renderVerb(log({ action: "widget:delete" }))).toBe("deleted widget");
+    expect(renderVerb(log({ action: "widget:force_sync" }))).toBe(
+      "forced sync widget",
+    );
+    expect(renderVerb(log({ action: "widget:upsert" }))).toBe("updated widget");
+  });
+
+  it("describes what changed when the action alone is ambiguous", () => {
+    expect(
+      renderVerb(
+        log({
+          action: "toolset:update",
+          beforeSnapshot: { Name: "old" },
+          afterSnapshot: { Name: "new" },
+        }),
+      ),
+    ).toBe("renamed MCP server");
+
+    expect(
+      renderVerb(
+        log({
+          action: "organization_invitation:create",
+          metadata: { role_slug: "org_admin" },
+        }),
+      ),
+    ).toBe("sent org admin invite to");
+  });
+});
+
+describe("formatAuditActionLabel", () => {
+  it("sentence-cases the phrase and drops the dangling preposition", () => {
+    expect(formatAuditActionLabel("risk_policy:delete")).toBe(
+      "Deleted risk policy",
+    );
+    expect(formatAuditActionLabel("organization_invitation:revoke")).toBe(
+      "Revoked invite",
+    );
+    expect(formatAuditActionLabel("variation:update_global")).toBe(
+      "Updated a global variation",
+    );
+    expect(formatAuditActionLabel("widget:delete")).toBe("Deleted widget");
+  });
+});
+
+describe("formatSubjectLabel", () => {
+  it("names the kind of a content-addressed upload", () => {
+    expect(
+      formatSubjectLabel(
+        "functions-247f32b0fdbe3a8ac45116625705947fa4ad4c84d5cd956564a4f76e3f9b5abe.zip",
+        "asset",
+      ),
+    ).toBe("Functions bundle · 247f32b0");
+    expect(
+      formatSubjectLabel(
+        "openapi-aad67780a4bb1c9e0e2f4d1cb2a1b0c3d4e5f60718293a4b5c6d7e8f9abb08210fe9.yaml",
+        "asset",
+      ),
+    ).toBe("OpenAPI document · aad67780");
+  });
+
+  it("labels bare UUIDs with their subject type", () => {
+    expect(
+      formatSubjectLabel("01900000-0000-7000-8000-000000000000", "deployment"),
+    ).toBe("Deployment 01900000");
+    expect(
+      formatSubjectLabel("01900000-0000-7000-8000-000000000000", "mcp_server"),
+    ).toBe("MCP server 01900000");
+  });
+
+  it("leaves human names alone", () => {
+    expect(formatSubjectLabel("Shadow MCP Server Policy", "risk_policy")).toBe(
+      "Shadow MCP Server Policy",
+    );
+    expect(formatSubjectLabel("ci-deploy", "api_key")).toBe("ci-deploy");
+  });
+});

--- a/client/dashboard/src/lib/audit-log-format.test.ts
+++ b/client/dashboard/src/lib/audit-log-format.test.ts
@@ -108,3 +108,11 @@ describe("formatSubjectLabel", () => {
     expect(formatSubjectLabel("ci-deploy", "api_key")).toBe("ci-deploy");
   });
 });
+
+describe("past-tense fallback inflection", () => {
+  it("inflects consonant-y verbs to -ied", () => {
+    expect(renderVerb(log({ action: "widget:retry" }))).toBe("retried widget");
+    expect(renderVerb(log({ action: "widget:deny" }))).toBe("denied widget");
+    expect(renderVerb(log({ action: "widget:relay" }))).toBe("relayed widget");
+  });
+});

--- a/client/dashboard/src/lib/audit-log-format.ts
+++ b/client/dashboard/src/lib/audit-log-format.ts
@@ -188,6 +188,9 @@ function pastTense(verb: string): string {
   if (irregular) return irregular;
   if (verb.endsWith("ed")) return verb;
   if (verb.endsWith("e")) return `${verb}d`;
+  // Consonant + y inflects to -ied ("retry" -> "retried"); a vowel before it
+  // does not ("relay" -> "relayed").
+  if (/[^aeiou]y$/.test(verb)) return `${verb.slice(0, -1)}ied`;
   return `${verb}ed`;
 }
 

--- a/client/dashboard/src/lib/audit-log-format.ts
+++ b/client/dashboard/src/lib/audit-log-format.ts
@@ -1,4 +1,5 @@
 import type { AuditLog } from "@gram/client/models/components/auditlog.js";
+import { isAuditAction, staticActionPhrase } from "@/lib/audit-actions";
 
 export function getActorLabel(log: AuditLog): string {
   return log.actorDisplayName || log.actorSlug || "Someone";
@@ -127,7 +128,9 @@ function describeToolsetUpdate(log: AuditLog): string {
     return `${enabled ? "enabled" : "disabled"} MCP for server`;
   }
   if (changed.has("Name") && changed.size <= 2) {
-    return `renamed MCP server to ${String(after["Name"])}`;
+    // The new name is the subject display name rendered right after this
+    // phrase, so naming it here would print it twice.
+    return "renamed MCP server";
   }
   if (changed.has("ToolSelectionMode") && changed.size <= 2) {
     return `changed tool selection mode to ${String(after["ToolSelectionMode"])}`;
@@ -139,97 +142,145 @@ function describeToolsetUpdate(log: AuditLog): string {
   return "updated MCP server";
 }
 
-export function renderVerb(log: AuditLog): string {
-  switch (log.action) {
-    case "project:create":
-      return "created project";
-    case "project:update":
-      return "updated project";
-    case "project:delete":
-      return "deleted project";
-    case "environment:create":
-      return "created environment";
-    case "environment:update":
-      return "updated environment";
-    case "environment:delete":
-      return "deleted environment";
-    case "template:create":
-      return "created template";
-    case "template:update":
-      return "updated template";
-    case "template:delete":
-      return "deleted template";
-    case "toolset:create":
-      return "created MCP server";
-    case "toolset:update":
-      return describeToolsetUpdate(log);
-    case "toolset:delete":
-      return "deleted MCP server";
-    case "toolset:attach_external_oauth":
-      return "attached an external OAuth server to MCP server";
-    case "toolset:detach_external_oauth":
-      return "detached an external OAuth server from MCP server";
-    case "toolset:attach_oauth_proxy":
-      return "attached an OAuth proxy to MCP server";
-    case "toolset:detach_oauth_proxy":
-      return "detached an OAuth proxy from MCP server";
-    case "api_key:create":
-      return "created API key";
-    case "api_key:revoke":
-      return "revoked API key";
-    case "variation:update_global":
-      return "updated a global variation for";
-    case "variation:delete_global":
-      return "deleted a global variation for";
-    case "deployments:create":
-      return "created deployment";
-    case "deployments:evolve":
-      return "created deployment";
-    case "deployments:redeploy":
-      return "redeployed deployment";
-    case "custom_domains:create":
-      return "added custom domain";
-    case "custom_domains:delete":
-      return "deleted custom domain";
-    case "mcp_metadata:update":
-      return "updated MCP metadata for";
-    case "otel_forwarding:upsert":
-      return describeOtelForwardingUpsert(log);
-    case "otel_forwarding:delete":
-      return "removed OpenTelemetry forwarding configuration";
-    case "asset:create":
-      return "uploaded asset";
-    case "plugin:create":
-      return "created plugin";
-    case "plugin:update":
-      return "updated plugin";
-    case "plugin:delete":
-      return "deleted plugin";
-    case "plugin:server_add":
-      return "added server to plugin";
-    case "plugin:server_update":
-      return "updated server on plugin";
-    case "plugin:server_remove":
-      return "removed server from plugin";
-    case "plugin:assignments_set":
-      return "updated plugin access assignments";
-    case "plugin:publish":
-      return "published plugins";
-    case "chat_session:access":
-      return "accessed chat session";
-    case "organization:webhooks_enabled":
-      return "enabled webhooks delivery";
-    case "organization:webhooks_disabled":
-      return "disabled webhooks delivery";
-    case "organization_invitation:create":
-      return "invited";
-    case "organization_invitation:revoke":
-      return "revoked invite for";
-    case "organization_invitation:update_role":
-      return "changed invite role for";
-    default: {
-      const [resource = "activity", verb = "updated"] = log.action.split(":");
-      return `${verb.replace(/_/g, " ")} ${getResourceLabel(resource)}`;
+function recordString(value: unknown, key: string): string | undefined {
+  if (value == null || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "string" && field !== "" ? field : undefined;
+}
+
+function formatRoleSlug(roleSlug: string): string {
+  return roleSlug.replace(/[-_]/g, " ");
+}
+
+function describeInvitation(log: AuditLog): string | undefined {
+  if (log.action === "organization_invitation:create") {
+    const role = recordString(log.metadata, "role_slug");
+    return role ? `sent ${formatRoleSlug(role)} invite to` : undefined;
+  }
+
+  if (log.action === "organization_invitation:update_role") {
+    const before =
+      recordString(log.beforeSnapshot, "RoleSlug") ??
+      recordString(log.beforeSnapshot, "role_slug");
+    const after =
+      recordString(log.afterSnapshot, "RoleSlug") ??
+      recordString(log.afterSnapshot, "role_slug");
+    if (before && after && before !== after) {
+      return `changed invite role from ${formatRoleSlug(before)} to ${formatRoleSlug(after)} for`;
+    }
+    if (after) {
+      return `changed invite role to ${formatRoleSlug(after)} for`;
     }
   }
+
+  return undefined;
+}
+
+const IRREGULAR_PAST_TENSE: Record<string, string> = {
+  set: "set",
+  send: "sent",
+  run: "ran",
+  upsert: "updated",
+};
+
+function pastTense(verb: string): string {
+  const irregular = IRREGULAR_PAST_TENSE[verb];
+  if (irregular) return irregular;
+  if (verb.endsWith("ed")) return verb;
+  if (verb.endsWith("e")) return `${verb}d`;
+  return `${verb}ed`;
+}
+
+/**
+ * Last-resort phrasing for an action the client doesn't know about yet — a
+ * server deploy that adds an action ships before the dashboard does. Still past
+ * tense ("risk_policy:delete" -> "deleted risk policy") so a stale client reads
+ * like the rest of the trail instead of leaking the raw action key.
+ */
+function describeUnknownAction(action: string): string {
+  const [resource = "activity", verb = "update"] = action.split(":");
+  const words = verb.replace(/[-_]/g, " ").split(" ");
+  const [head = "update", ...rest] = words;
+  return [pastTense(head), ...rest, getResourceLabel(resource)]
+    .filter(Boolean)
+    .join(" ");
+}
+
+const ASSET_KIND_LABELS: Record<string, string> = {
+  functions: "Functions bundle",
+  openapi: "OpenAPI document",
+  image: "Image",
+};
+
+const SUBJECT_TYPE_LABELS: Record<string, string> = {
+  mcp_server: "MCP server",
+  mcp_collection: "Collection",
+  otel_forwarding_config: "OpenTelemetry forwarding",
+  api_key: "API key",
+  chat_session: "Chat session",
+};
+
+function subjectTypeLabel(subjectType: string): string {
+  const known = SUBJECT_TYPE_LABELS[subjectType];
+  if (known) return known;
+  const words = subjectType.replace(/_/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+const HASHED_FILENAME = /^([a-z0-9]+)-([0-9a-f]{16,})(\.[a-z0-9]+)?$/i;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Display text for a subject whose stored name is content-addressed — upload
+ * filenames like `functions-<64 hex>.zip` and bare UUIDs carry no meaning at a
+ * glance. Names the kind and keeps a short prefix for identity; callers keep
+ * the raw value for the tooltip.
+ */
+export function formatSubjectLabel(raw: string, subjectType: string): string {
+  const hashed = HASHED_FILENAME.exec(raw);
+  if (hashed) {
+    const [, prefix = "", hash = ""] = hashed;
+    const kind =
+      ASSET_KIND_LABELS[prefix.toLowerCase()] ??
+      `${prefix.charAt(0).toUpperCase()}${prefix.slice(1)} file`;
+    return `${kind} \u00b7 ${hash.slice(0, 8)}`;
+  }
+
+  if (UUID.test(raw)) {
+    return `${subjectTypeLabel(subjectType)} ${raw.slice(0, 8)}`;
+  }
+
+  return raw;
+}
+
+/**
+ * Human label for an action on its own — filter chips, facet dropdowns — where
+ * there is no actor or subject around it. Same phrases as the feed rows, minus
+ * the dangling preposition a subject name would have filled in
+ * ("revoked invite for" -> "Revoked invite").
+ */
+export function formatAuditActionLabel(action: string): string {
+  const phrase = isAuditAction(action)
+    ? staticActionPhrase(action)
+    : describeUnknownAction(action);
+  const trimmed = phrase.replace(/\s+(for|to|from|on)$/, "");
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+export function renderVerb(log: AuditLog): string {
+  // Actions whose wording depends on what actually changed come first; the rest
+  // resolve to a fixed phrase from the exhaustive table.
+  switch (log.action) {
+    case "toolset:update":
+      return describeToolsetUpdate(log);
+    case "otel_forwarding:upsert":
+      return describeOtelForwardingUpsert(log);
+    case "organization_invitation:create":
+    case "organization_invitation:update_role":
+      return describeInvitation(log) ?? staticActionPhrase(log.action);
+  }
+
+  return isAuditAction(log.action)
+    ? staticActionPhrase(log.action)
+    : describeUnknownAction(log.action);
 }

--- a/client/dashboard/src/pages/access/ChallengesTab.tsx
+++ b/client/dashboard/src/pages/access/ChallengesTab.tsx
@@ -137,7 +137,7 @@ function FilterPill({
   );
 }
 
-export function ChallengesEmptyState({
+function ChallengesEmptyState({
   outcomeFilter,
 }: {
   outcomeFilter: OutcomeFilter;

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -31,8 +31,11 @@ import React, {
   type ReactNode,
 } from "react";
 import { Link } from "react-router";
+import { Link as TextLink } from "@/components/ui/Link";
 import {
   formatAuditAction,
+  formatAuditActionLabel,
+  formatSubjectLabel,
   getActorLabel,
   renderVerb,
 } from "@/lib/audit-log-format";
@@ -123,14 +126,21 @@ function truncateMiddle(value: string, start = 18, end = 16) {
 }
 
 const SUBJECT_MONO_CLASS = "font-mono text-xs text-muted-foreground";
+// Same mono treatment minus the colour, so the design-system link palette wins.
+const SUBJECT_LINK_CLASS = "font-mono text-xs";
 
 // A subject rendered as a link to its detail page. Centralizes the mono styling
 // and hover affordance so every linked subject looks identical.
 function SubjectLink({ to, children }: { to: string; children: ReactNode }) {
   return (
-    <Link to={to} className={cn(SUBJECT_MONO_CLASS, "hover:underline")}>
-      {children}
-    </Link>
+    <TextLink
+      asChild
+      size="xs"
+      underline={false}
+      className={SUBJECT_LINK_CLASS}
+    >
+      <Link to={to}>{children}</Link>
+    </TextLink>
   );
 }
 
@@ -161,7 +171,11 @@ function renderSubject(log: AuditLog, orgSlug: string) {
 
   const href = subjectHref(log, orgSlug);
   if (href) {
-    return <SubjectLink to={href}>{subjectLinkText(log)}</SubjectLink>;
+    return (
+      <SubjectLink to={href}>
+        {formatSubjectLabel(subjectLinkText(log), log.subjectType)}
+      </SubjectLink>
+    );
   }
 
   if (log.subjectType === "asset") {
@@ -174,7 +188,7 @@ function renderSubject(log: AuditLog, orgSlug: string) {
             "inline-block max-w-[34ch] truncate align-bottom",
           )}
         >
-          {truncateMiddle(subjectLabel)}
+          {truncateMiddle(formatSubjectLabel(subjectLabel, log.subjectType))}
         </span>
       </SimpleTooltip>
     );
@@ -194,7 +208,11 @@ function renderSubject(log: AuditLog, orgSlug: string) {
     return null;
   }
 
-  return <span className={monoClass}>{getSubjectLabel(log)}</span>;
+  return (
+    <span className={monoClass}>
+      {formatSubjectLabel(getSubjectLabel(log), log.subjectType)}
+    </span>
+  );
 }
 
 function hasDiff(log: AuditLog): boolean {
@@ -227,7 +245,6 @@ function AuditLogRow({
 
   const actorLabel = getActorLabel(log);
   const verbText = renderVerb(log);
-  const subjectLink = subjectHref(log, orgSlug);
 
   const rowContent = (
     <div className="group flex items-center gap-3 px-4 py-2.5">
@@ -252,18 +269,9 @@ function AuditLogRow({
           </button>
         )}
       </div>
-      <span className="text-muted-foreground shrink-0 font-mono text-xs">
+      <span className="text-muted-foreground w-[5.5rem] shrink-0 text-right font-mono text-xs tabular-nums">
         {formatTimeOnly(log.createdAt, timestampMode)}
       </span>
-      {subjectLink && (
-        <Link
-          to={subjectLink}
-          aria-label={`Open ${getSubjectLabel(log)}`}
-          className="text-muted-foreground hover:text-foreground focus-visible:text-foreground shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-        >
-          <Icon name="arrow-right" className="size-4" />
-        </Link>
-      )}
     </div>
   );
 
@@ -448,7 +456,7 @@ function OrgAuditLogsInner() {
     () =>
       (facetsData?.actions ?? []).map((option) => ({
         ...option,
-        displayName: formatAuditAction(option.value),
+        displayName: formatAuditActionLabel(option.value),
       })),
     [facetsData?.actions],
   );

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -82,7 +82,15 @@ const SUBJECT_LINK_CLASS = "font-mono text-xs";
 
 // A subject rendered as a link to its detail page. Centralizes the mono styling
 // and hover affordance so every linked subject looks identical.
-function SubjectLink({ to, children }: { to: string; children: ReactNode }) {
+function SubjectLink({
+  to,
+  title,
+  children,
+}: {
+  to: string;
+  title?: string;
+  children: ReactNode;
+}) {
   return (
     <TextLink
       asChild
@@ -90,7 +98,9 @@ function SubjectLink({ to, children }: { to: string; children: ReactNode }) {
       underline={false}
       className={SUBJECT_LINK_CLASS}
     >
-      <Link to={to}>{children}</Link>
+      <Link to={to} title={title}>
+        {children}
+      </Link>
     </TextLink>
   );
 }
@@ -118,9 +128,12 @@ function renderSubject(log: AuditLog, orgSlug: string) {
 
   const href = subjectHref(log, orgSlug);
   if (href) {
+    // The humanized label drops most of the identifier, so keep the raw value
+    // reachable on hover the way the asset subject below does.
+    const raw = subjectLinkText(log);
     return (
-      <SubjectLink to={href}>
-        {formatSubjectLabel(subjectLinkText(log), log.subjectType)}
+      <SubjectLink to={href} title={raw}>
+        {formatSubjectLabel(raw, log.subjectType)}
       </SubjectLink>
     );
   }

--- a/client/dashboard/src/pages/org/OrgAuditLogs.tsx
+++ b/client/dashboard/src/pages/org/OrgAuditLogs.tsx
@@ -62,60 +62,11 @@ function getSubjectLabel(log: AuditLog) {
   return log.subjectDisplayName || log.subjectSlug || log.subjectId;
 }
 
-function recordString(value: unknown, key: string): string | undefined {
-  if (value == null || typeof value !== "object") return undefined;
-  const field = (value as Record<string, unknown>)[key];
-  return typeof field === "string" && field !== "" ? field : undefined;
-}
-
-function formatRoleSlug(roleSlug: string) {
-  return roleSlug.replace(/[-_]/g, " ");
-}
-
-function inviteCreatedRole(log: AuditLog): string | undefined {
-  return recordString(log.metadata, "role_slug");
-}
-
-function inviteRoleBefore(log: AuditLog): string | undefined {
-  return (
-    recordString(log.beforeSnapshot, "RoleSlug") ??
-    recordString(log.beforeSnapshot, "role_slug")
-  );
-}
-
-function inviteRoleAfter(log: AuditLog): string | undefined {
-  return (
-    recordString(log.afterSnapshot, "RoleSlug") ??
-    recordString(log.afterSnapshot, "role_slug")
-  );
-}
-
+// renderVerb already names the role ("sent org admin invite to", "changed invite
+// role from x to y for"), so the subject is just the invitee. Repeating it here
+// rendered as "... invite to someone@example.com as org admin".
 function inviteSubjectText(log: AuditLog) {
-  const subject = getSubjectLabel(log);
-
-  if (log.action === "organization_invitation:create") {
-    const role = inviteCreatedRole(log);
-    return role ? `${subject} as ${formatRoleSlug(role)}` : subject;
-  }
-
-  if (log.action === "organization_invitation:update_role") {
-    const before = inviteRoleBefore(log);
-    const after = inviteRoleAfter(log);
-    let roleText = "";
-    if (before && after && before !== after) {
-      roleText = ` from ${formatRoleSlug(before)} to ${formatRoleSlug(after)}`;
-    } else if (after) {
-      roleText = ` to ${formatRoleSlug(after)}`;
-    }
-
-    return `${subject}${roleText}`;
-  }
-
-  return subject;
-}
-
-function renderInviteSubject(log: AuditLog, monoClass: string) {
-  return <span className={monoClass}>{inviteSubjectText(log)}</span>;
+  return getSubjectLabel(log);
 }
 
 function truncateMiddle(value: string, start = 18, end = 16) {
@@ -164,10 +115,6 @@ function subjectLinkText(log: AuditLog): string {
 
 function renderSubject(log: AuditLog, orgSlug: string) {
   const monoClass = SUBJECT_MONO_CLASS;
-
-  if (log.subjectType === "organization_invitation") {
-    return renderInviteSubject(log, monoClass);
-  }
 
   const href = subjectHref(log, orgSlug);
   if (href) {

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -37,10 +37,6 @@ vi.mock("@/components/ui/ContextMenu", () => ({
 vi.mock("@/components/auditlogs/feed", () => ({
   ActionIconTile: () => null,
 }));
-vi.mock("@/pages/access/ChallengesTab", () => ({
-  ChallengesEmptyState: () => null,
-}));
-
 vi.mock("@/contexts/Auth", () => ({
   useOrganization: () => ({
     id: "org-1",
@@ -124,13 +120,18 @@ vi.mock("@/components/ui/Icon", () => ({
   Icon: () => null,
 }));
 
+import { TooltipProvider } from "@/components/ui/Tooltip";
 import OrgHome from "./OrgHome";
 
 afterEach(cleanup);
 
 describe("OrgHome", () => {
   it("does not wrap project list rows in a full-height element", () => {
-    render(<OrgHome />);
+    render(
+      <TooltipProvider>
+        <OrgHome />
+      </TooltipProvider>,
+    );
 
     const projectName = screen.getByText("Project One");
     expect(projectName.closest(".h-full")).toBeNull();

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -68,7 +68,11 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
-import { getActorLabel, renderVerb } from "@/lib/audit-log-format";
+import {
+  formatSubjectLabel,
+  getActorLabel,
+  renderVerb,
+} from "@/lib/audit-log-format";
 
 import { ActionIconTile } from "@/components/auditlogs/feed";
 
@@ -304,6 +308,9 @@ function OrgHomeInner() {
                 padding so they do not collide with its border. */}
             <Card.Dashboard
               title="Projects"
+              // Not h-full: a single project row would otherwise stretch to
+              // whatever height the activity rail sets.
+              className="h-auto"
               // Grid keeps the card's side padding but drops the top, so the
               // first divider sits the same distance below the header as it
               // does in list mode, where the body is flush.
@@ -973,6 +980,17 @@ function RecentActivityCompact({ logs }: { logs: AuditLog[] }) {
                   <span className="text-muted-foreground">
                     {renderVerb(log)}
                   </span>
+                  {log.subjectDisplayName && (
+                    <>
+                      {" "}
+                      <span className="text-foreground font-medium">
+                        {formatSubjectLabel(
+                          log.subjectDisplayName,
+                          log.subjectType,
+                        )}
+                      </span>
+                    </>
+                  )}
                 </Text>
                 <Text
                   muted

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -9,7 +9,7 @@ import { CardContextMenu } from "@/components/card-context-menu";
 import { TableRowContextMenu } from "@/components/table-row-context-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar";
 import { Button } from "@/components/ui/Button";
-import { Heading } from "@/components/ui/Heading";
+import { Card } from "@/components/ui/Card";
 import type { Action } from "@/components/ui/MoreActions";
 import { SearchBar } from "@/components/ui/SearchBar";
 import {
@@ -26,7 +26,6 @@ import { useRBAC } from "@/hooks/useRBAC";
 import { dateTimeFormatters } from "@/lib/dates";
 import { getPreferredProject } from "@/lib/preferredProject";
 import { cn } from "@/lib/utils";
-import { ChallengesEmptyState } from "@/pages/access/ChallengesTab";
 import {
   getInitials,
   isDisplayableBucket,
@@ -295,98 +294,103 @@ function OrgHomeInner() {
           )}
         </div>
 
-        <div className="grid grid-cols-1 gap-8 xl:grid-cols-[1fr_320px]">
+        {/* `items-start` so each column is only as tall as its content — the
+            default stretch left the Projects card padded with dead space
+            whenever the rail was taller, which is the common case for orgs
+            with one or two projects. */}
+        <div className="grid grid-cols-1 items-start gap-8 xl:grid-cols-[1fr_420px] 2xl:grid-cols-[1fr_500px]">
           <main className="flex min-w-0 flex-col gap-3">
-            <Heading variant="h4" className="text-display-sm font-thin">
-              Projects
-            </Heading>
-
-            {filteredProjects.length === 0 && isSearching ? (
-              <div className="border-border bg-card flex flex-col items-center gap-3 border border-dashed py-12 text-center">
-                <Text muted>No projects matching &ldquo;{search}&rdquo;</Text>
-                <RequireScope scope="org:admin" level="component">
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      setNewProjectName(search);
-                      setCreateDialogOpen(true);
-                    }}
-                  >
-                    <Plus className="size-4" />
-                    Create &ldquo;{search}&rdquo;
-                  </Button>
-                </RequireScope>
-              </div>
-            ) : (
-              <>
-                {favoriteProjects.length > 0 && (
-                  <>
-                    <section className="flex flex-col gap-2">
-                      <div className="flex items-center gap-2">
-                        <Star className="text-foreground size-3.5 fill-current" />
-                        <Text small className="text-foreground font-medium">
-                          Your favorites
-                        </Text>
-                      </div>
-                      {renderProjectContainer(
-                        favoriteProjects.map(renderProjectItem),
+            {/* List rows run edge to edge; grid cards need the card's own
+                padding so they do not collide with its border. */}
+            <Card.Dashboard
+              title="Projects"
+              // Grid keeps the card's side padding but drops the top, so the
+              // first divider sits the same distance below the header as it
+              // does in list mode, where the body is flush.
+              bodyClassName={viewMode === "grid" ? "px-6 pt-0 pb-5" : "p-0"}
+            >
+              {filteredProjects.length === 0 && isSearching ? (
+                <div className="border-border bg-card flex flex-col items-center gap-3 border border-dashed py-12 text-center">
+                  <Text muted>No projects matching &ldquo;{search}&rdquo;</Text>
+                  <RequireScope scope="org:admin" level="component">
+                    <Button
+                      size="sm"
+                      onClick={() => {
+                        setNewProjectName(search);
+                        setCreateDialogOpen(true);
+                      }}
+                    >
+                      <Plus className="size-4" />
+                      Create &ldquo;{search}&rdquo;
+                    </Button>
+                  </RequireScope>
+                </div>
+              ) : (
+                <>
+                  {favoriteProjects.length > 0 && (
+                    <>
+                      <section className="flex flex-col">
+                        <SectionDivider
+                          label="Favorites"
+                          inset={viewMode === "list"}
+                        />
+                        {renderProjectContainer(
+                          favoriteProjects.map(renderProjectItem),
+                        )}
+                      </section>
+                      {visibleOtherProjects.length > 0 && (
+                        <SectionDivider
+                          label="All projects"
+                          inset={viewMode === "list"}
+                        />
                       )}
-                    </section>
-                    {visibleOtherProjects.length > 0 && (
-                      <div
-                        className="flex items-center gap-3"
-                        aria-hidden="true"
-                      >
-                        <div className="bg-border h-px flex-1" />
-                        <Text muted small className="text-muted-foreground/80">
-                          All projects
-                        </Text>
-                        <div className="bg-border h-px flex-1" />
+                    </>
+                  )}
+
+                  {renderProjectContainer(
+                    visibleOtherProjects.map(renderProjectItem),
+                  )}
+                  {hasMore && (
+                    <button
+                      type="button"
+                      onClick={() => setExpanded((prev) => !prev)}
+                      className={cn(
+                        "text-muted-foreground hover:text-foreground border-border hover:bg-muted/40 flex w-full items-center justify-center gap-1.5 border-dashed py-3 text-sm font-medium transition-colors",
+                        viewMode === "list" ? "border-t" : "mt-4 border",
+                      )}
+                    >
+                      {expanded ? (
+                        <>
+                          Show less
+                          <ChevronUp className="size-4" />
+                        </>
+                      ) : (
+                        <>
+                          Show all {otherProjects.length} projects
+                          <ChevronDown className="size-4" />
+                        </>
+                      )}
+                    </button>
+                  )}
+
+                  {otherProjects.length === 0 &&
+                    favoriteProjects.length === 0 && (
+                      <div className="border-border bg-card flex flex-col items-center gap-3 border border-dashed py-12 text-center">
+                        <Text muted>No projects yet</Text>
+                        <RequireScope scope="org:admin" level="component">
+                          <Button
+                            size="sm"
+                            onClick={() => setCreateDialogOpen(true)}
+                          >
+                            <Plus className="size-4" />
+                            Create your first project
+                          </Button>
+                        </RequireScope>
                       </div>
                     )}
-                  </>
-                )}
-
-                {renderProjectContainer(
-                  visibleOtherProjects.map(renderProjectItem),
-                )}
-                {hasMore && (
-                  <button
-                    type="button"
-                    onClick={() => setExpanded((prev) => !prev)}
-                    className="text-muted-foreground hover:text-foreground border-border hover:bg-muted/40 flex items-center justify-center gap-1.5 border border-dashed py-3 text-sm font-medium transition-colors"
-                  >
-                    {expanded ? (
-                      <>
-                        Show less
-                        <ChevronUp className="size-4" />
-                      </>
-                    ) : (
-                      <>
-                        Show all {otherProjects.length} projects
-                        <ChevronDown className="size-4" />
-                      </>
-                    )}
-                  </button>
-                )}
-
-                {otherProjects.length === 0 &&
-                  favoriteProjects.length === 0 && (
-                    <div className="border-border bg-card flex flex-col items-center gap-3 border border-dashed py-12 text-center">
-                      <Text muted>No projects yet</Text>
-                      <RequireScope scope="org:admin" level="component">
-                        <Button
-                          size="sm"
-                          onClick={() => setCreateDialogOpen(true)}
-                        >
-                          <Plus className="size-4" />
-                          Create your first project
-                        </Button>
-                      </RequireScope>
-                    </div>
-                  )}
-              </>
-            )}
+                </>
+              )}
+            </Card.Dashboard>
           </main>
 
           <aside className="flex flex-col gap-8 xl:sticky xl:top-4 xl:self-start">
@@ -460,18 +464,41 @@ function AddNewMenu({
 }
 
 function ProjectList({ children }: { children: React.ReactNode }) {
+  // No border of its own — the Projects card already draws one, and nesting
+  // two reads as a box in a box.
   return (
-    <div className="border-border bg-card divide-border divide-y overflow-hidden border">
+    <div className="border-border divide-border divide-y overflow-hidden">
       {children}
+    </div>
+  );
+}
+
+/**
+ * Short stub, label, then a rule out to the card edge — separates the project
+ * groups so favorites and "All projects" read as the same kind of break.
+ * `inset` lines the stub up with the row padding in list mode, where the rows
+ * themselves run edge to edge.
+ */
+function SectionDivider({ label, inset }: { label: string; inset: boolean }) {
+  return (
+    <div
+      className={cn("flex items-center gap-3 pt-5 pb-2", inset && "px-4")}
+      aria-hidden="true"
+    >
+      <div className="bg-border h-px w-6 shrink-0" />
+      <Text muted small className="text-muted-foreground/80 shrink-0">
+        {label}
+      </Text>
+      <div className="bg-border h-px flex-1" />
     </div>
   );
 }
 
 function ProjectGrid({ children }: { children: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-      {children}
-    </div>
+    // Two across at most: the main column gives up width to the activity rail
+    // from xl, and a third card there truncates every name and slug.
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">{children}</div>
   );
 }
 
@@ -549,49 +576,61 @@ function ProjectRow({
 
   return (
     <TableRowContextMenu actions={actions}>
-      <div className="group hover:bg-muted/40 relative flex items-center gap-4 px-4 py-3 transition-colors">
-        {/* Decorative content: pointer-events-none routes clicks through to the
-            Link overlay below, while the actions region opts back in. */}
-        <ProjectAvatar
-          project={project}
-          className="pointer-events-none h-9 w-9 shrink-0"
-        />
+      {/* Below `md` the row stacks: identity and summary first, then the
+          facepile and actions on their own line — side by side there is not
+          enough width for the summary without it running under the faces. */}
+      <div
+        className={cn(
+          "group hover:bg-muted/40 relative flex flex-col gap-3 px-4 py-4 transition-colors md:flex-row md:items-center md:gap-4",
+          isFavorite && "bg-muted/30",
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-4">
+          {/* Decorative content: pointer-events-none routes clicks through to
+              the Link overlay below, while the actions region opts back in. */}
+          <ProjectAvatar
+            project={project}
+            className="pointer-events-none h-9 w-9 shrink-0"
+          />
 
-        <div className="pointer-events-none flex min-w-0 flex-1 items-center gap-6">
-          <div className="w-44 min-w-0 shrink-0">
-            <Text
-              variant="subheading"
-              as="div"
-              className="text-foreground truncate text-sm font-medium"
-            >
-              {project.name}
-            </Text>
-            <Text small muted className="truncate font-mono text-xs">
-              {project.slug}
-            </Text>
-          </div>
+          <div className="pointer-events-none flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-center sm:gap-6">
+            <div className="min-w-0 sm:w-44 sm:shrink-0">
+              <Text
+                variant="subheading"
+                as="div"
+                className="text-foreground truncate text-sm font-medium"
+              >
+                {project.name}
+              </Text>
+              <Text small muted className="truncate font-mono text-xs">
+                {project.slug}
+              </Text>
+            </div>
 
-          <div className="hidden min-w-0 flex-1 sm:block">
-            <RecentActionBlock log={latestLog} />
+            <div className="min-w-0 flex-1">
+              <RecentActionBlock log={latestLog} />
+            </div>
           </div>
         </div>
 
-        <div
-          className="relative z-10 hidden md:flex"
-          onClick={(e) => {
-            // Keep clicks on the facepile from triggering the row's Link overlay.
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          <MemberFacepile members={facepile} maxFaces={5} />
-        </div>
+        <div className="flex items-center justify-between gap-3 pl-13 md:justify-end md:pl-0">
+          <div
+            className="relative z-10 flex"
+            onClick={(e) => {
+              // Keep clicks on the facepile from triggering the row's Link overlay.
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <MemberFacepile members={facepile} maxFaces={5} />
+          </div>
 
-        <ProjectRowActions
-          actions={actions}
-          isFavorite={isFavorite}
-          onToggleFavorite={onToggleFavorite}
-        />
+          <ProjectRowActions
+            actions={actions}
+            isFavorite={isFavorite}
+            onToggleFavorite={onToggleFavorite}
+          />
+        </div>
 
         {/* Anchor overlay sits on top of pointer-events-none children, so the
             entire row is one navigation target — interactive controls above
@@ -626,7 +665,12 @@ function ProjectCard({
     <CardContextMenu actions={actions}>
       {/* The card div keeps `relative`, so the Link overlay below still fills
           the card rather than the context-menu wrapper. */}
-      <div className="group border-border bg-card hover:border-foreground/20 relative flex h-full flex-col gap-4 border p-4 transition-all hover:shadow-sm">
+      <div
+        className={cn(
+          "group border-border bg-card hover:border-foreground relative flex h-full flex-col gap-3 border p-4 transition-colors",
+          isFavorite && "bg-muted/30",
+        )}
+      >
         <div className="pointer-events-none flex items-start gap-3">
           <ProjectAvatar project={project} className="h-10 w-10 shrink-0" />
           <div className="min-w-0 flex-1">
@@ -643,19 +687,19 @@ function ProjectCard({
           </div>
         </div>
 
-        <div className="pointer-events-none min-h-[42px] flex-1">
+        <div className="pointer-events-none min-w-0 flex-1">
           <RecentActionBlock log={latestLog} />
         </div>
 
         <div className="flex items-center justify-between gap-2">
           <div
-            className="relative z-10"
+            className="relative z-10 min-w-0"
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
             }}
           >
-            <MemberFacepile members={facepile} maxFaces={5} />
+            <MemberFacepile members={facepile} maxFaces={3} />
           </div>
           <ProjectRowActions
             actions={actions}
@@ -831,7 +875,7 @@ function RecentActionBlock({ log }: { log: AuditLog | undefined }) {
       </Text>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="text-muted-foreground inline-flex w-fit cursor-default text-xs">
+          <span className="text-muted-foreground inline-flex max-w-full min-w-0 cursor-default text-xs">
             <span className="truncate">
               {dateTimeFormatters.humanize(log.createdAt, {
                 includeTime: false,
@@ -898,28 +942,27 @@ function RecentActivityCompact({ logs }: { logs: AuditLog[] }) {
   const preview = logs.slice(0, AUDIT_PREVIEW_LIMIT);
 
   return (
-    <section className="flex flex-col gap-3">
-      <div className="flex items-baseline justify-between">
-        <Heading variant="h4" className="text-display-xs font-thin">
-          Recent activity
-        </Heading>
+    <Card.Dashboard
+      bodyClassName={preview.length === 0 ? undefined : "p-0"}
+      title="Recent activity"
+      tooltip="Recent administrative activity across this organization — project, MCP server, access and key changes. Most recent first."
+      action={
         <orgRoutes.auditLogs.Link className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-xs no-underline">
           View all
           <ChevronRight className="size-3" />
         </orgRoutes.auditLogs.Link>
-      </div>
+      }
+    >
       {preview.length === 0 ? (
-        <div className="border-border bg-card border border-dashed px-4 py-6 text-center">
-          <Text muted small>
-            Activity will appear here as your team makes changes.
-          </Text>
-        </div>
+        <Text muted small>
+          Activity will appear here as your team makes changes.
+        </Text>
       ) : (
-        <ol className="border-border bg-card divide-border divide-y overflow-hidden border">
+        <ol className="divide-border divide-y">
           {preview.map((log) => (
             <li
               key={log.id}
-              className="flex items-start gap-3 px-3 py-3 text-xs"
+              className="flex items-start gap-3 px-6 py-3 text-xs"
             >
               <ActionIconTile action={log.action} />
               <div className="flex min-w-0 flex-1 flex-col gap-1">
@@ -946,7 +989,7 @@ function RecentActivityCompact({ logs }: { logs: AuditLog[] }) {
           ))}
         </ol>
       )}
-    </section>
+    </Card.Dashboard>
   );
 }
 
@@ -969,20 +1012,25 @@ function RecentChallengesCompact() {
   if (isLoading) return null;
 
   return (
-    <section className="flex flex-col gap-3">
-      <div className="flex items-baseline justify-between">
-        <Heading variant="h4" className="text-display-xs font-thin">
-          Recent challenges
-        </Heading>
+    <Card.Dashboard
+      bodyClassName={buckets.length === 0 ? undefined : "p-0"}
+      title="Recent challenges"
+      tooltip="Authorization checks your team was denied recently, grouped by principal and scope."
+      action={
         <orgRoutes.access.challenges.Link className="text-muted-foreground hover:text-foreground flex items-center gap-0.5 text-xs no-underline">
           View all
           <ChevronRight className="size-3" />
         </orgRoutes.access.challenges.Link>
-      </div>
+      }
+    >
       {buckets.length === 0 ? (
-        <ChallengesEmptyState outcomeFilter="deny" />
+        // Compact copy rather than the full-page ChallengesEmptyState — inside
+        // a rail card its illustration and framing box read as a second card.
+        <Text muted small>
+          No denied access attempts. Authorization checks are all passing.
+        </Text>
       ) : (
-        <ol className="border-border bg-card divide-border divide-y overflow-hidden border">
+        <ol className="divide-border divide-y">
           {buckets.map((bucket) => (
             <li key={bucket.id}>
               <CompactChallengeRow bucket={bucket} />
@@ -990,7 +1038,7 @@ function RecentChallengesCompact() {
           ))}
         </ol>
       )}
-    </section>
+    </Card.Dashboard>
   );
 }
 
@@ -1012,33 +1060,30 @@ function CompactChallengeRow({ bucket }: { bucket: ChallengeBucket }) {
   const count = Number(bucket.challengeCount);
 
   return (
-    <orgRoutes.access.challenges.Link className="hover:bg-muted/40 flex items-start gap-2 px-3 py-3 text-xs no-underline transition-colors hover:no-underline">
-      <div className="bg-muted text-muted-foreground flex size-6 shrink-0 items-center justify-center rounded-full">
+    <orgRoutes.access.challenges.Link className="hover:bg-muted/40 flex items-start gap-3 px-6 py-3 text-xs no-underline transition-colors hover:no-underline">
+      {/* Sized to match the ActionIconTile in Recent activity below, so the two
+          rail cards line up row for row. */}
+      <div className="bg-muted text-muted-foreground flex size-8 shrink-0 items-center justify-center rounded-full">
         {isApiKey || !bucket.userEmail ? (
-          <KeyRound className="size-3" />
+          <KeyRound className="size-4" />
         ) : (
-          <Avatar className="size-6">
+          <Avatar className="size-8">
             {bucket.photoUrl ? (
               <AvatarImage src={bucket.photoUrl} alt={label} />
             ) : null}
-            <AvatarFallback className="bg-muted text-muted-foreground text-[10px] font-medium">
+            <AvatarFallback className="bg-muted text-muted-foreground text-[11px] font-medium">
               {getInitials(bucket.userEmail)}
             </AvatarFallback>
           </Avatar>
         )}
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <div className="flex items-center gap-1.5">
-          <span className="bg-destructive/10 text-destructive shrink-0 px-1 py-0.5 font-mono text-[10px] font-medium uppercase">
+        <Text small className="truncate leading-snug">
+          <span className="text-destructive mr-1.5 font-mono text-[10px] font-medium uppercase">
             deny
           </span>
-          <Text
-            small
-            className="text-foreground truncate text-xs leading-snug font-medium"
-          >
-            {label}
-          </Text>
-        </div>
+          <span className="text-foreground font-medium">{label}</span>
+        </Text>
         <Text muted small className="truncate text-[11px]">
           <span className="font-mono">{bucket.scope}</span>
           <span className="mx-1 opacity-60">·</span>

--- a/client/dashboard/src/pages/org/OrgHome.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.tsx
@@ -488,15 +488,19 @@ function ProjectList({ children }: { children: React.ReactNode }) {
  */
 function SectionDivider({ label, inset }: { label: string; inset: boolean }) {
   return (
-    <div
-      className={cn("flex items-center gap-3 pt-5 pb-2", inset && "px-4")}
-      aria-hidden="true"
-    >
-      <div className="bg-border h-px w-6 shrink-0" />
-      <Text muted small className="text-muted-foreground/80 shrink-0">
+    <div className={cn("flex items-center gap-3 pt-5 pb-2", inset && "px-4")}>
+      <div aria-hidden="true" className="bg-border h-px w-6 shrink-0" />
+      {/* A real heading, not decoration: it is the only thing distinguishing
+          the favourites group from the rest of the list for screen readers. */}
+      <Text
+        as="h3"
+        muted
+        small
+        className="text-muted-foreground/80 shrink-0 font-normal"
+      >
         {label}
       </Text>
-      <div className="bg-border h-px flex-1" />
+      <div aria-hidden="true" className="bg-border h-px flex-1" />
     </div>
   );
 }
@@ -983,7 +987,10 @@ function RecentActivityCompact({ logs }: { logs: AuditLog[] }) {
                   {log.subjectDisplayName && (
                     <>
                       {" "}
-                      <span className="text-foreground font-medium">
+                      <span
+                        className="text-foreground font-medium"
+                        title={log.subjectDisplayName}
+                      >
                         {formatSubjectLabel(
                           log.subjectDisplayName,
                           log.subjectType,


### PR DESCRIPTION
## What

The activity trail (project home timeline, org home rail, org audit logs) printed raw action keys — `risk_policy:delete` on one surface, present-tense `delete risk policy` on another — because two separate label tables had drifted, and neither knew most of the ~170 actions the server can emit.

- **One humanizer.** `lib/audit-actions.ts` lists every `Action` constant declared in `server/internal/audit/*.go` as a union, with an exhaustive switch (`assertNever` default) mapping each to a past-tense phrase: "deleted risk policy", "opened chat session", "added a version to skill". `ActivityTimelineCard`'s duplicate table is gone; both surfaces call `renderVerb`.
- **Unknown actions degrade gracefully.** A server deploy can add an action before the dashboard ships, so `renderVerb` guards with `isAuditAction()` and falls back to a past-tense phrasing (`widget:force_sync` → "forced sync widget") rather than leaking the key or throwing.
- **Readable subjects.** Content-addressed names render as `Functions bundle · 247f32b0` / `Deployment 01900000`, with the raw value kept in the tooltip and in the searchable text.
- **Filter chips** use the same phrases, sentence-cased and minus the dangling preposition ("Revoked invite").

Plus the display fixes that fell out of reviewing it in the browser:

- audit rows: trailing arrow removed (subjects are links in their own right), timestamps flush right with `tabular-nums`, subjects use the design-system `Link`
- tooltip content gets `break-words` so a 64-char hash wraps inside `max-w-sm` instead of stretching the box
- project-home timeline sorts newest-first, matching the org feed
- org home: wider right rail; Projects / Recent challenges / Recent activity all use the `Card.Dashboard` idiom; project rows stack below `md` instead of running under the facepile; grid capped at two columns; favourites grouped under a shared section divider

## Why it holds

`assertNever` only means something if the union is complete, and `action` is a plain `String` in the Goa design — so `audit-actions.test.ts` greps the `Action` constants out of the Go package and asserts set equality with the TS list. A new server-side action fails the suite instead of silently missing a phrase.

## Testing

- `pnpm -F dashboard type-check`
- `pnpm -F dashboard exec vitest run src/lib` — 169 passing, including the Go↔TS action sync check
- Both surfaces and both project view modes exercised against a local stack with seeded audit rows, challenges, and members

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies and humanizes audit activity across the dashboard, and restyles Org Home for clearer projects and activity. Improves readability, accessibility, and layout while handling unknown actions safely.

- New Features
  - Added a single audit action humanizer in `lib/audit-actions.ts` with an exhaustive mapping and tests that stay in lockstep with server `Action` constants; both org audit logs and project timelines use `renderVerb`.
  - Unknown actions degrade gracefully to past-tense phrases (e.g., `widget:force_sync` → "forced sync widget"); filter chips use the same phrases via `formatAuditActionLabel`, sentence-cased.
  - Smarter subject labels for content-addressed names and UUIDs with `formatSubjectLabel`; raw values are preserved in tooltips on both text and linked subjects.
  - Org Home restyled: wider right rail; Projects, Recent activity, and Recent challenges use `Card.Dashboard`; favorites grouped with a titled divider that screen readers announce; grid capped at two columns; rows stack on small screens; facepile/actions layout refined.
  - `Card.Dashboard` supports `bodyClassName` for edge-to-edge content and `className` for root-level sizing.

- Bug Fixes
  - Project-home timeline now sorts newest-first to match the org feed.
  - Tooltips wrap long strings with `break-words` to avoid overflow.
  - Audit rows: removed trailing arrow; subjects use the design-system `Link` with raw value on hover; timestamps are right-aligned with tabular numbers.

<sup>Written for commit de42fce951b649cf12ab2ccdf345111ea9ab5bd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

