### PR TITLE
feat: send Clear-Site-Data on logout

### DIFF
--- a/.changeset/logout-clear-site-data.md
+++ b/.changeset/logout-clear-site-data.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Logging out now returns `Clear-Site-Data: "cookies", "storage"`, so the browser drops the session cookie across the origin's registrable domain and empties localStorage, sessionStorage, IndexedDB and Cache Storage. Previously teardown relied entirely on an expiring `Set-Cookie` plus a best-effort localStorage sweep, both of which leave data behind when a cookie attribute drifts or a page navigates away mid-logout. The theme preference and project favorites still survive a logout: the dashboard reads them before the request goes out and writes them back once the response lands.

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -1,6 +1,11 @@
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
 import { isProjectOverviewQueryKey } from "@/components/project/projectOverviewQuery";
-import { clearStorageForLogout } from "@/lib/logout-storage";
+import {
+  capturePreservedStorage,
+  clearStorageForLogout,
+  restorePreservedStorage,
+  type PreservedStorage,
+} from "@/lib/logout-storage";
 import { getApiBaseURL } from "@/lib/utils";
 import { datadogRum } from "@datadog/browser-rum";
 import { Gram } from "@gram/client";
@@ -19,6 +24,8 @@ import {
   useSlugs,
 } from "./Sdk";
 
+const LOGOUT_PATH = "/rpc/auth.logout";
+
 export const SdkProvider = ({
   children,
 }: {
@@ -33,6 +40,12 @@ export const SdkProvider = ({
 
   // Memoize the httpClient and gram instances
   const gram = useMemo(() => {
+    // Values held across the logout round-trip. The logout response tells the
+    // browser to wipe storage for the origin, which happens before the response
+    // hook below runs, so anything meant to outlive the session has to be read
+    // off localStorage before the request is sent.
+    let preservedAcrossLogout: PreservedStorage = [];
+
     const httpClient = new HTTPClient({
       fetcher: (request) => {
         const newRequest = new Request(request, {
@@ -54,13 +67,19 @@ export const SdkProvider = ({
       },
     });
 
+    httpClient.addHook("beforeRequest", (request) => {
+      if (new URL(request.url).pathname === LOGOUT_PATH) {
+        preservedAcrossLogout = capturePreservedStorage();
+      }
+    });
+
     httpClient.addHook("response", (res, request) => {
       if (!res.ok) {
         return;
       }
 
       const u = new URL(request.url);
-      if (u.pathname !== "/rpc/auth.logout") {
+      if (u.pathname !== LOGOUT_PATH) {
         return;
       }
 
@@ -68,7 +87,13 @@ export const SdkProvider = ({
       datadogRum.clearUser();
       telemetry.reset();
       document.cookie = "gram_admin_override=; path=/; max-age=0;";
+      // Still clear explicitly: Clear-Site-Data is a no-op in browsers that
+      // don't implement it (Safari) and on non-trustworthy origins. Where it
+      // did apply this finds storage already empty, and the restore then puts
+      // the preserved entries back either way.
       clearStorageForLogout();
+      restorePreservedStorage(preservedAcrossLogout);
+      preservedAcrossLogout = [];
     });
 
     const gram = new Gram({

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -3,7 +3,6 @@ import { isProjectOverviewQueryKey } from "@/components/project/projectOverviewQ
 import {
   capturePreservedStorage,
   clearStorageForLogout,
-  restorePreservedStorage,
   type PreservedStorage,
 } from "@/lib/logout-storage";
 import { getApiBaseURL } from "@/lib/utils";
@@ -43,8 +42,10 @@ export const SdkProvider = ({
     // Values held across the logout round-trip. The logout response tells the
     // browser to wipe storage for the origin, which happens before the response
     // hook below runs, so anything meant to outlive the session has to be read
-    // off localStorage before the request is sent.
-    let preservedAcrossLogout: PreservedStorage = [];
+    // off localStorage before the request is sent. Keyed by request so
+    // overlapping logouts — a double-clicked menu item — each restore their own
+    // snapshot rather than racing over one slot.
+    const preservedAcrossLogout = new WeakMap<Request, PreservedStorage>();
 
     const httpClient = new HTTPClient({
       fetcher: (request) => {
@@ -69,7 +70,7 @@ export const SdkProvider = ({
 
     httpClient.addHook("beforeRequest", (request) => {
       if (new URL(request.url).pathname === LOGOUT_PATH) {
-        preservedAcrossLogout = capturePreservedStorage();
+        preservedAcrossLogout.set(request, capturePreservedStorage());
       }
     });
 
@@ -89,11 +90,10 @@ export const SdkProvider = ({
       document.cookie = "gram_admin_override=; path=/; max-age=0;";
       // Still clear explicitly: Clear-Site-Data is a no-op on origins the
       // browser does not treat as trustworthy, and on engines that don't
-      // implement it. Where it did apply, this finds storage already empty and
-      // the restore puts the preserved entries back either way.
-      clearStorageForLogout();
-      restorePreservedStorage(preservedAcrossLogout);
-      preservedAcrossLogout = [];
+      // implement it. Where it did apply, storage is already empty and the
+      // pre-request snapshot holds the only copy of the preserved entries.
+      clearStorageForLogout(preservedAcrossLogout.get(request));
+      preservedAcrossLogout.delete(request);
     });
 
     const gram = new Gram({

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -87,10 +87,10 @@ export const SdkProvider = ({
       datadogRum.clearUser();
       telemetry.reset();
       document.cookie = "gram_admin_override=; path=/; max-age=0;";
-      // Still clear explicitly: Clear-Site-Data is a no-op in browsers that
-      // don't implement it (Safari) and on non-trustworthy origins. Where it
-      // did apply this finds storage already empty, and the restore then puts
-      // the preserved entries back either way.
+      // Still clear explicitly: Clear-Site-Data is a no-op on origins the
+      // browser does not treat as trustworthy, and on engines that don't
+      // implement it. Where it did apply, this finds storage already empty and
+      // the restore puts the preserved entries back either way.
       clearStorageForLogout();
       restorePreservedStorage(preservedAcrossLogout);
       preservedAcrossLogout = [];

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -132,6 +132,28 @@ describe("clearStorageForLogout", () => {
     expect(window.localStorage.getItem("preferredProject")).toBeNull();
   });
 
+  // The logout response hook clears a store the browser may already have
+  // emptied, so the entries it keeps have to come from the snapshot rather than
+  // from a re-read of storage.
+  it("keeps entries from a supplied snapshot when storage is already empty", () => {
+    const preserved = [
+      [PREFERRED_THEME_STORAGE_KEY, "dark"],
+      ["gram:org-favorites:<ORG_ID>", '["<PROJECT_ID>"]'],
+    ] as const;
+    window.localStorage.setItem("preferredProject", "project-slug");
+    window.localStorage.clear();
+
+    clearStorageForLogout(preserved);
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(window.localStorage.getItem("gram:org-favorites:<ORG_ID>")).toBe(
+      '["<PROJECT_ID>"]',
+    );
+    expect(window.localStorage.getItem("preferredProject")).toBeNull();
+  });
+
   it("captures nothing but the preserved keys", () => {
     window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
     window.localStorage.setItem("pylon_user_email", "user@example.com");

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { PREFERRED_THEME_STORAGE_KEY } from "./local-storage-keys";
 import {
+  capturePreservedStorage,
   clearLegacyUserStorage,
   clearStorageForLogout,
+  restorePreservedStorage,
 } from "./logout-storage";
 
 function createStorage(): Storage {
@@ -104,5 +106,47 @@ describe("clearStorageForLogout", () => {
 
     expect(() => clearStorageForLogout()).not.toThrow();
     expect(() => clearLegacyUserStorage()).not.toThrow();
+  });
+
+  // The logout response carries Clear-Site-Data, so the browser empties
+  // localStorage before any response handler runs. Capture/restore is what
+  // survives that wipe.
+  it("restores captured entries into storage the browser already emptied", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(
+      "gram:org-favorites:<ORG_ID>",
+      '["<PROJECT_ID>"]',
+    );
+    window.localStorage.setItem("preferredProject", "project-slug");
+
+    const preserved = capturePreservedStorage();
+    window.localStorage.clear();
+    restorePreservedStorage(preserved);
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(window.localStorage.getItem("gram:org-favorites:<ORG_ID>")).toBe(
+      '["<PROJECT_ID>"]',
+    );
+    expect(window.localStorage.getItem("preferredProject")).toBeNull();
+  });
+
+  it("captures nothing but the preserved keys", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem("pylon_user_email", "user@example.com");
+
+    expect(capturePreservedStorage()).toEqual([
+      [PREFERRED_THEME_STORAGE_KEY, "dark"],
+    ]);
+  });
+
+  it("degrades to a no-op when storage is blocked around a logout", () => {
+    blockStorageAccess();
+
+    expect(capturePreservedStorage()).toEqual([]);
+    expect(() =>
+      restorePreservedStorage([[PREFERRED_THEME_STORAGE_KEY, "dark"]]),
+    ).not.toThrow();
   });
 });

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -54,12 +54,27 @@ export function clearLegacyUserStorage(): void {
   }
 }
 
-export function clearStorageForLogout(): void {
-  if (typeof window === "undefined") return;
+/** localStorage entries that outlive a logout, as key/value pairs. */
+export type PreservedStorage = ReadonlyArray<readonly [string, string]>;
+
+/**
+ * Reads the localStorage entries that survive logout.
+ *
+ * Callers that clear storage themselves get this for free through
+ * `clearStorageForLogout`. It is exported for the logout request itself: that
+ * response carries `Clear-Site-Data: "cookies", "storage"`, so the browser
+ * empties localStorage while the response is in flight and there is nothing
+ * left to preserve by the time any response handler runs. Capturing before the
+ * request goes out and calling `restorePreservedStorage` afterwards is what
+ * keeps the theme and favorites across a logout.
+ */
+export function capturePreservedStorage(): PreservedStorage {
+  if (typeof window === "undefined") return [];
+
+  const preserved: Array<readonly [string, string]> = [];
 
   try {
     const local = window.localStorage;
-    const preserved = new Map<string, string>();
 
     for (let i = 0; i < local.length; i++) {
       const key = local.key(i);
@@ -67,18 +82,41 @@ export function clearStorageForLogout(): void {
 
       const value = local.getItem(key);
       if (value !== null) {
-        preserved.set(key, value);
+        preserved.push([key, value]);
       }
     }
+  } catch {
+    // Storage blocked — nothing persisted, nothing to preserve.
+  }
 
-    local.clear();
+  return preserved;
+}
 
+export function restorePreservedStorage(preserved: PreservedStorage): void {
+  if (typeof window === "undefined" || preserved.length === 0) return;
+
+  try {
+    const local = window.localStorage;
     for (const [key, value] of preserved) {
       local.setItem(key, value);
     }
   } catch {
+    // Storage blocked — nothing to restore into.
+  }
+}
+
+export function clearStorageForLogout(): void {
+  if (typeof window === "undefined") return;
+
+  const preserved = capturePreservedStorage();
+
+  try {
+    window.localStorage.clear();
+  } catch {
     // Storage blocked — nothing persisted, nothing to clear.
   }
+
+  restorePreservedStorage(preserved);
 
   try {
     window.sessionStorage.clear();

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -60,13 +60,12 @@ export type PreservedStorage = ReadonlyArray<readonly [string, string]>;
 /**
  * Reads the localStorage entries that survive logout.
  *
- * Callers that clear storage themselves get this for free through
- * `clearStorageForLogout`. It is exported for the logout request itself: that
- * response carries `Clear-Site-Data: "cookies", "storage"`, so the browser
- * empties localStorage while the response is in flight and there is nothing
- * left to preserve by the time any response handler runs. Capturing before the
- * request goes out and calling `restorePreservedStorage` afterwards is what
- * keeps the theme and favorites across a logout.
+ * Exported for the logout request itself: that response carries
+ * `Clear-Site-Data: "cookies", "storage"`, and every engine finishes emptying
+ * localStorage before the response reaches the page, so there is nothing left
+ * to preserve by the time a response handler runs. Capturing before the request
+ * goes out and handing the result to `clearStorageForLogout` is what keeps the
+ * theme and favorites across a logout.
  */
 export function capturePreservedStorage(): PreservedStorage {
   if (typeof window === "undefined") return [];
@@ -105,10 +104,18 @@ export function restorePreservedStorage(preserved: PreservedStorage): void {
   }
 }
 
-export function clearStorageForLogout(): void {
+/**
+ * Empties storage, keeping the entries that outlive a logout.
+ *
+ * Pass `preserved` when the store may already have been emptied — after a
+ * `Clear-Site-Data` response, a snapshot taken before the request is the only
+ * remaining copy of those entries. Callers clearing an intact store omit it and
+ * the entries are read from storage directly.
+ */
+export function clearStorageForLogout(
+  preserved: PreservedStorage = capturePreservedStorage(),
+): void {
   if (typeof window === "undefined") return;
-
-  const preserved = capturePreservedStorage();
 
   try {
     window.localStorage.clear();

--- a/server/internal/auth/impl.go
+++ b/server/internal/auth/impl.go
@@ -187,6 +187,10 @@ func Attach(mux goahttp.Muxer, service *Service) {
 	// context so validateAuthNonce() can verify it.
 	server.Callback = callbackNonceBindingMiddleware(server.Callback)
 
+	// Wrap Logout handler: have the browser drop the origin's cookies and
+	// client-side storage once the session has been invalidated server-side.
+	server.Logout = middleware.ClearSiteDataOnLogout(server.Logout)
+
 	srv.Mount(mux, server)
 }
 

--- a/server/internal/middleware/clear_site_data.go
+++ b/server/internal/middleware/clear_site_data.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const clearSiteDataHeader = "Clear-Site-Data"
+const clearSiteDataLogout = `"cookies", "storage"`
+
+func ClearSiteDataOnLogout(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&clearSiteDataWriter{ResponseWriter: w, wroteHeader: false}, r)
+	})
+}
+
+type clearSiteDataWriter struct {
+	http.ResponseWriter
+
+	wroteHeader bool
+}
+
+func (w *clearSiteDataWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		if code >= 200 && code < 300 {
+			w.Header().Set(clearSiteDataHeader, clearSiteDataLogout)
+		}
+	}
+
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *clearSiteDataWriter) Write(b []byte) (int, error) {
+	// A body write with no preceding WriteHeader makes net/http send 200.
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		w.Header().Set(clearSiteDataHeader, clearSiteDataLogout)
+	}
+
+	n, err := w.ResponseWriter.Write(b)
+	if err != nil {
+		return n, fmt.Errorf("write logout response: %w", err)
+	}
+
+	return n, nil
+}
+
+// Flush must be forwarded explicitly: embedding the http.ResponseWriter
+// interface hides the underlying writer's Flush from type asserts, which
+// silently disables streaming for every handler behind this middleware.
+func (w *clearSiteDataWriter) Flush() {
+	// A successful flush commits the headers with an implicit 200, so the
+	// directive has to be in the map before it runs. An unsupported or failed
+	// flush commits nothing, and leaving the directive behind would attach it
+	// to whatever status is written later — including an error status.
+	pending := !w.wroteHeader
+	if pending {
+		w.Header().Set(clearSiteDataHeader, clearSiteDataLogout)
+	}
+
+	// ResponseController finds flush support through FlushError and Unwrap
+	// chains that a direct http.Flusher assert would miss.
+	if err := http.NewResponseController(w.ResponseWriter).Flush(); err != nil {
+		if pending {
+			w.Header().Del(clearSiteDataHeader)
+		}
+		return
+	}
+
+	w.wroteHeader = true
+}
+
+// Unwrap lets http.ResponseController reach controls of the underlying
+// writer that this wrapper does not forward.
+func (w *clearSiteDataWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/server/internal/middleware/clear_site_data.go
+++ b/server/internal/middleware/clear_site_data.go
@@ -21,6 +21,13 @@ type clearSiteDataWriter struct {
 }
 
 func (w *clearSiteDataWriter) WriteHeader(code int) {
+	// 1xx other than 101 is informational: net/http sends it and leaves the
+	// final status open, so the directive stays pending for the next call.
+	if code >= 100 && code < 200 && code != 101 {
+		w.ResponseWriter.WriteHeader(code)
+		return
+	}
+
 	if !w.wroteHeader {
 		w.wroteHeader = true
 		if code >= 200 && code < 300 {

--- a/server/internal/middleware/clear_site_data_test.go
+++ b/server/internal/middleware/clear_site_data_test.go
@@ -110,6 +110,40 @@ func TestClearSiteDataOnLogout_IgnoresStatusAfterCommit(t *testing.T) {
 	require.Empty(t, rec.Header().Get("Clear-Site-Data"))
 }
 
+// net/http keeps the final status open after an informational response, so a
+// 103 must not consume the writer's one shot at setting the directive.
+func TestClearSiteDataOnLogout_SetsDirectiveAfterEarlyHints(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusEarlyHints)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	// Only the header is asserted: httptest.ResponseRecorder records the first
+	// WriteHeader it sees, so rec.Code reports the 103 that a real server would
+	// have sent as an informational response ahead of the final status.
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+}
+
+// 101 is terminal, not informational: nothing follows it, and a protocol switch
+// is not a logout.
+func TestClearSiteDataOnLogout_OmitsDirectiveOnSwitchingProtocols(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Empty(t, rec.Header().Get("Clear-Site-Data"))
+}
+
 func TestClearSiteDataOnLogout_SetsDirectiveBeforeFlush(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/middleware/clear_site_data_test.go
+++ b/server/internal/middleware/clear_site_data_test.go
@@ -1,0 +1,144 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// noFlushWriter is a ResponseWriter with no flush support of any kind, so
+// http.ResponseController.Flush on it fails with ErrNotSupported.
+type noFlushWriter struct {
+	header http.Header
+	code   int
+}
+
+func (w *noFlushWriter) Header() http.Header         { return w.header }
+func (w *noFlushWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *noFlushWriter) WriteHeader(code int)        { w.code = code }
+
+func TestClearSiteDataOnLogout_SetsDirectiveOnOK(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+}
+
+// Any success status carries the directive, not just 200 — a bodiless logout
+// answers 204.
+func TestClearSiteDataOnLogout_SetsDirectiveOnNoContent(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+}
+
+// A handler that writes a body without calling WriteHeader still sends a 200,
+// so the directive has to be attached on that path too.
+func TestClearSiteDataOnLogout_SetsDirectiveOnImplicitOK(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(`{"session_cookie":""}`))
+		require.NoError(t, err)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
+}
+
+// A logout that never invalidated anything must leave the caller's state alone:
+// an unauthenticated request would otherwise wipe cookies and storage for a
+// session that is still live in another tab.
+func TestClearSiteDataOnLogout_OmitsDirectiveOnUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Empty(t, rec.Header().Get("Clear-Site-Data"))
+}
+
+func TestClearSiteDataOnLogout_OmitsDirectiveOnRedirect(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusFound)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Empty(t, rec.Header().Get("Clear-Site-Data"))
+}
+
+// The status recorded first wins: net/http drops a second WriteHeader, so a
+// late error status cannot retract a directive already on the wire, and must
+// not add one either.
+func TestClearSiteDataOnLogout_IgnoresStatusAfterCommit(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
+
+	require.Empty(t, rec.Header().Get("Clear-Site-Data"))
+}
+
+func TestClearSiteDataOnLogout_SetsDirectiveBeforeFlush(t *testing.T) {
+	t.Parallel()
+
+	inner := &flushRecorder{ResponseRecorder: httptest.NewRecorder(), flushed: false}
+	w := &clearSiteDataWriter{ResponseWriter: inner, wroteHeader: false}
+
+	w.Flush()
+
+	require.True(t, inner.flushed)
+	require.Equal(t, `"cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
+
+	// The flush committed the headers, so a later error status must not be
+	// able to un-commit them — but it must not gain a directive either.
+	w.WriteHeader(http.StatusInternalServerError)
+	require.Equal(t, `"cookies", "storage"`, w.Header().Get("Clear-Site-Data"))
+}
+
+// A flush the underlying writer cannot serve commits nothing, so the directive
+// must go back to pending rather than ride along with a later error status.
+func TestClearSiteDataOnLogout_RetractsDirectiveOnFailedFlush(t *testing.T) {
+	t.Parallel()
+
+	inner := &noFlushWriter{header: http.Header{}, code: 0}
+	w := &clearSiteDataWriter{ResponseWriter: inner, wroteHeader: false}
+
+	w.Flush()
+	require.Empty(t, w.Header().Get("Clear-Site-Data"))
+
+	w.WriteHeader(http.StatusInternalServerError)
+	require.Empty(t, w.Header().Get("Clear-Site-Data"))
+	require.Equal(t, http.StatusInternalServerError, inner.code)
+}

--- a/server/internal/middleware/clear_site_data_test.go
+++ b/server/internal/middleware/clear_site_data_test.go
@@ -53,13 +53,14 @@ func TestClearSiteDataOnLogout_SetsDirectiveOnImplicitOK(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
+	var writeErr error
 	handler := ClearSiteDataOnLogout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write([]byte(`{"session_cookie":""}`))
-		require.NoError(t, err)
+		_, writeErr = w.Write([]byte(`{"session_cookie":""}`))
 	}))
 
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/rpc/auth.logout", nil))
 
+	require.NoError(t, writeErr)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, `"cookies", "storage"`, rec.Header().Get("Clear-Site-Data"))
 }

--- a/server/internal/middleware/response_writer_flush_test.go
+++ b/server/internal/middleware/response_writer_flush_test.go
@@ -29,8 +29,9 @@ func TestResponseWriterWrappersForwardFlush(t *testing.T) {
 
 	inner := &flushRecorder{ResponseRecorder: httptest.NewRecorder(), flushed: false}
 	wrappers := map[string]http.ResponseWriter{
-		"logging.responseWriter":             newResponseWriter(inner),
-		"admin_security.adminCookieRewriter": &adminCookieRewriter{ResponseWriter: inner, domain: "example.com", wroteHeader: false},
+		"logging.responseWriter":              newResponseWriter(inner),
+		"admin_security.adminCookieRewriter":  &adminCookieRewriter{ResponseWriter: inner, domain: "example.com", wroteHeader: false},
+		"clear_site_data.clearSiteDataWriter": &clearSiteDataWriter{ResponseWriter: inner, wroteHeader: false},
 	}
 
 	for name, w := range wrappers {


### PR DESCRIPTION
A successful `POST /rpc/auth.logout` now responds with `Clear-Site-Data: "cookies", "storage"`, so the browser — not the client — is responsible for tearing down session state.

## Why

Logout relied on two things that can silently do nothing:

- the expiring `Set-Cookie`, which the browser ignores unless name, domain and path all match the cookie that was written; and
- `clearStorageForLogout()`, which never runs if the page navigates away while the request is in flight.

The directive covers both, and reaches storage the dashboard cannot clear from script (IndexedDB, Cache Storage) plus cookies on sibling subdomains.

## Server

`middleware.ClearSiteDataOnLogout` wraps the generated Goa `Logout` handler in `auth.Attach`, alongside the existing `Login`/`Callback` wrappers. The header is attached at header-commit time and only on 2xx — a logout that fails authorization must not wipe a session that is still live. All three commit paths are covered (`WriteHeader`, an implicit-200 body `Write`, a successful `Flush`); a failed or unsupported flush retracts the directive so it cannot ride along with a later error status.

`"cache"` is deliberately excluded: browsers drop the origin's entire HTTP cache for it, so every subsequent login would re-download the dashboard bundle.

## Dashboard

`Clear-Site-Data: "storage"` empties localStorage before any response hook runs, which would take the theme preference and project favorites with it. `clearStorageForLogout`'s preserve-and-restore logic is split into `capturePreservedStorage` / `restorePreservedStorage`; `SdkProvider` captures in a `beforeRequest` hook on the logout path and writes back in the existing response hook. `clearStorageForLogout` still runs there, for origins the browser does not treat as trustworthy and engines without support; the restore is idempotent either way.

The restore depends on the browser finishing its wipe before the response is delivered to the page, which the spec does not require. Verified with a local HTTPS harness that reproduces the exact sequence: in **Firefox 152**, **Chromium** and **WebKit**, localStorage was already empty when the response handler began (so the wipe had completed), the probe cookie was gone, and the preserved entries were still present 2s afterwards. Preferences survive a logout on all three engines.

Snapshots are keyed per request (`WeakMap<Request, …>`) rather than held in one slot, because two logouts can be in flight at once — a double-clicked menu item. The same harness confirms this is not theoretical: with a single shared slot, the first response to land empties it and the second restores nothing, losing the theme and favorites on all three engines. With the per-request map both restore correctly.

## Scope

Only `/rpc/auth.logout`. The admin service's logout was considered and left alone: its response origin sits on a registrable domain shared with other Speakeasy properties, so `"cookies"` there would sign the admin out of unrelated sites. The middleware is generic if we want to revisit that.

## Notes for reviewers

- Browsers honor the header on trustworthy origins only — https in deployed environments, `localhost` in dev. In production the dashboard is served from the server's origin, so the directive lands on the right one.
- `"cookies"` clears cookies for the whole registrable domain (`getgram.ai`), not just the responding host. That is intended for logout.
- Tests: 7 new cases in `server/internal/middleware/clear_site_data_test.go` (status gating, implicit-200, flush retraction), the new writer added to the package's `TestResponseWriterWrappersForwardFlush` invariant, and 3 new cases in `logout-storage.test.ts` covering capture/restore across a wiped store.
