### PR TITLE
fix: scope assistant dock continue chat to viewer's dashboard sessions

### DIFF
--- a/.changeset/chat-list-user-id-filter.md
+++ b/.changeset/chat-list-user-id-filter.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+chat.list accepts a `user_id` filter so callers with project-wide chat visibility can narrow results to a specific Gram user. The Project Assistant dock uses it, together with the dashboard source-kind filter, so "Continue chat" only offers sessions the viewer started from the dashboard.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -9463,6 +9463,13 @@ paths:
             description: Filter by external user ID
             type: string
         - allowEmptyValue: true
+          description: Filter by Gram user ID
+          in: query
+          name: user_id
+          schema:
+            description: Filter by Gram user ID
+            type: string
+        - allowEmptyValue: true
           description: Filter by agent source. Comma-separated list of exact source values (e.g. 'claude-code,Codex,playground') matched against each session's inferred source; empty for no filter. Use chat.listSources to discover the available values.
           in: query
           name: source

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -789,30 +789,26 @@ export function InsightsProvider({
   );
 
   // Derive "Continue chat" from the server: if the viewer's most recent
-  // dashboard conversation with the assistant was active within
+  // dashboard-initiated session with the assistant was active within
   // CONTINUE_WINDOW_MS, the resting pill offers to reopen it. Reading the
   // backend (rather than client state) means it survives reloads for free.
-  // sourceKind narrows to dashboard-initiated sessions — an admin's chat:read
-  // visibility would otherwise surface other members' and other sources'
-  // (Slack, cron, …) sessions here. Ownership is checked client-side below:
-  // the listing has no owner filter for admins, so fetch a few and pick the
-  // newest chat the viewer started.
+  // sourceKind and userId keep out other members' sessions and other sources
+  // (Slack, cron, …), which an admin's chat:read visibility would otherwise
+  // surface here. limit:1 — we only need the newest.
   const { user } = useSession();
   const { data: recentChatsData } = useListChats(
     {
       assistantId: managedAssistantId || undefined,
       sourceKind: "dashboard",
+      userId: user.id,
       sortBy: SortBy.LastMessageTimestamp,
       sortOrder: SortOrder.Desc,
-      limit: 5,
+      limit: 1,
     },
     undefined,
     { enabled: Boolean(managedAssistantId), throwOnError: false },
   );
-  const recentChat = recentChatsData?.chats?.find(
-    (chat) =>
-      chat.userId === user.id || emailsMatch(chat.externalUserId, user.email),
-  );
+  const recentChat = recentChatsData?.chats?.[0];
   const continueMode =
     recentChat !== undefined &&
     Date.now() - recentChat.lastMessageTimestamp.getTime() < CONTINUE_WINDOW_MS;

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -788,21 +788,31 @@ export function InsightsProvider({
     [skillsQuery.data?.pages],
   );
 
-  // Derive "Continue chat" from the server: if the assistant's most recent
-  // conversation was active within CONTINUE_WINDOW_MS, the resting pill offers
-  // to reopen it. Reading the backend (rather than client state) means it
-  // survives reloads for free. limit:1 — we only need the newest.
+  // Derive "Continue chat" from the server: if the viewer's most recent
+  // dashboard conversation with the assistant was active within
+  // CONTINUE_WINDOW_MS, the resting pill offers to reopen it. Reading the
+  // backend (rather than client state) means it survives reloads for free.
+  // sourceKind narrows to dashboard-initiated sessions — an admin's chat:read
+  // visibility would otherwise surface other members' and other sources'
+  // (Slack, cron, …) sessions here. Ownership is checked client-side below:
+  // the listing has no owner filter for admins, so fetch a few and pick the
+  // newest chat the viewer started.
+  const { user } = useSession();
   const { data: recentChatsData } = useListChats(
     {
       assistantId: managedAssistantId || undefined,
+      sourceKind: "dashboard",
       sortBy: SortBy.LastMessageTimestamp,
       sortOrder: SortOrder.Desc,
-      limit: 1,
+      limit: 5,
     },
     undefined,
     { enabled: Boolean(managedAssistantId), throwOnError: false },
   );
-  const recentChat = recentChatsData?.chats?.[0];
+  const recentChat = recentChatsData?.chats?.find(
+    (chat) =>
+      chat.userId === user.id || emailsMatch(chat.externalUserId, user.email),
+  );
   const continueMode =
     recentChat !== undefined &&
     Date.now() - recentChat.lastMessageTimestamp.getTime() < CONTINUE_WINDOW_MS;
@@ -846,7 +856,6 @@ export function InsightsProvider({
   // their chat:read grant, so hide the composer for those rather than let a
   // send 404. Chats started from the dashboard stash the caller's email in
   // externalUserId instead of userId (see resolveCreator above).
-  const { user } = useSession();
   const isOwnChat = useCallback(
     ({
       userId,

--- a/client/dashboard/src/sdk/src/funcs/chatList.ts
+++ b/client/dashboard/src/sdk/src/funcs/chatList.ts
@@ -123,6 +123,7 @@ async function $do(
     "source": payload?.source,
     "source_kind": payload?.source_kind,
     "to": payload?.to,
+    "user_id": payload?.user_id,
   });
 
   const headers = new Headers(compactMap({

--- a/client/dashboard/src/sdk/src/models/operations/listchats.ts
+++ b/client/dashboard/src/sdk/src/models/operations/listchats.ts
@@ -93,6 +93,10 @@ export type ListChatsRequest = {
    */
   externalUserId?: string | undefined;
   /**
+   * Filter by Gram user ID
+   */
+  userId?: string | undefined;
+  /**
    * Filter by agent source. Comma-separated list of exact source values (e.g. 'claude-code,Codex,playground') matched against each session's inferred source; empty for no filter. Use chat.listSources to discover the available values.
    */
   source?: string | undefined;
@@ -281,6 +285,7 @@ export const SortOrder$outboundSchema: z.ZodMiniEnum<typeof SortOrder> = z.enum(
 export type ListChatsRequest$Outbound = {
   search?: string | undefined;
   external_user_id?: string | undefined;
+  user_id?: string | undefined;
   source?: string | undefined;
   assistant_id?: string | undefined;
   source_kind?: string | undefined;
@@ -308,6 +313,7 @@ export const ListChatsRequest$outboundSchema: z.ZodMiniType<
   z.object({
     search: z.optional(z.string()),
     externalUserId: z.optional(z.string()),
+    userId: z.optional(z.string()),
     source: z.optional(z.string()),
     assistantId: z.optional(z.string()),
     sourceKind: z.optional(z.string()),
@@ -329,6 +335,7 @@ export const ListChatsRequest$outboundSchema: z.ZodMiniType<
   z.transform((v) => {
     return remap$(v, {
       externalUserId: "external_user_id",
+      userId: "user_id",
       assistantId: "assistant_id",
       sourceKind: "source_kind",
       excludeSourceKind: "exclude_source_kind",

--- a/client/dashboard/src/sdk/src/react-query/listChats.core.ts
+++ b/client/dashboard/src/sdk/src/react-query/listChats.core.ts
@@ -54,6 +54,7 @@ export function buildListChatsQuery(
     queryKey: queryKeyListChats({
       search: request?.search,
       externalUserId: request?.externalUserId,
+      userId: request?.userId,
       source: request?.source,
       assistantId: request?.assistantId,
       sourceKind: request?.sourceKind,
@@ -98,6 +99,7 @@ export function queryKeyListChats(
   parameters: {
     search?: string | undefined;
     externalUserId?: string | undefined;
+    userId?: string | undefined;
     source?: string | undefined;
     assistantId?: string | undefined;
     sourceKind?: string | undefined;

--- a/client/dashboard/src/sdk/src/react-query/listChats.ts
+++ b/client/dashboard/src/sdk/src/react-query/listChats.ts
@@ -112,6 +112,7 @@ export function setListChatsData(
     parameters: {
       search?: string | undefined;
       externalUserId?: string | undefined;
+      userId?: string | undefined;
       source?: string | undefined;
       assistantId?: string | undefined;
       sourceKind?: string | undefined;
@@ -144,6 +145,7 @@ export function invalidateListChats(
     [parameters: {
       search?: string | undefined;
       externalUserId?: string | undefined;
+      userId?: string | undefined;
       source?: string | undefined;
       assistantId?: string | undefined;
       sourceKind?: string | undefined;

--- a/server/design/chat/design.go
+++ b/server/design/chat/design.go
@@ -23,6 +23,7 @@ var _ = Service("chat", func() {
 			security.ChatSessionsTokenPayload()
 			Attribute("search", String, "Search query (searches chat ID, user ID, user name, and title)")
 			Attribute("external_user_id", String, "Filter by external user ID")
+			Attribute("user_id", String, "Filter by Gram user ID")
 			Attribute("source", String, "Filter by agent source. Comma-separated list of exact source values (e.g. 'claude-code,Codex,playground') matched against each session's inferred source; empty for no filter. Use chat.listSources to discover the available values.")
 			Attribute("assistant_id", String, "Filter to chats produced by this assistant", func() {
 				Format(FormatUUID)
@@ -72,6 +73,7 @@ var _ = Service("chat", func() {
 			GET("/rpc/chat.list")
 			Param("search")
 			Param("external_user_id")
+			Param("user_id")
 			Param("source")
 			Param("assistant_id")
 			Param("source_kind")

--- a/server/gen/chat/service.go
+++ b/server/gen/chat/service.go
@@ -417,6 +417,8 @@ type ListChatsPayload struct {
 	Search *string
 	// Filter by external user ID
 	ExternalUserID *string
+	// Filter by Gram user ID
+	UserID *string
 	// Filter by agent source. Comma-separated list of exact source values (e.g.
 	// 'claude-code,Codex,playground') matched against each session's inferred
 	// source; empty for no filter. Use chat.listSources to discover the available

--- a/server/gen/http/chat/client/cli.go
+++ b/server/gen/http/chat/client/cli.go
@@ -19,7 +19,7 @@ import (
 
 // BuildListChatsPayload builds the payload for the chat listChats endpoint
 // from CLI flags.
-func BuildListChatsPayload(chatListChatsSearch string, chatListChatsExternalUserID string, chatListChatsSource string, chatListChatsAssistantID string, chatListChatsSourceKind string, chatListChatsExcludeSourceKind string, chatListChatsHasRisk string, chatListChatsAccountType string, chatListChatsPinned string, chatListChatsMinRiskScore string, chatListChatsFrom string, chatListChatsTo string, chatListChatsLimit string, chatListChatsOffset string, chatListChatsSortBy string, chatListChatsSortOrder string, chatListChatsSessionToken string, chatListChatsProjectSlugInput string, chatListChatsChatSessionsToken string) (*chat.ListChatsPayload, error) {
+func BuildListChatsPayload(chatListChatsSearch string, chatListChatsExternalUserID string, chatListChatsUserID string, chatListChatsSource string, chatListChatsAssistantID string, chatListChatsSourceKind string, chatListChatsExcludeSourceKind string, chatListChatsHasRisk string, chatListChatsAccountType string, chatListChatsPinned string, chatListChatsMinRiskScore string, chatListChatsFrom string, chatListChatsTo string, chatListChatsLimit string, chatListChatsOffset string, chatListChatsSortBy string, chatListChatsSortOrder string, chatListChatsSessionToken string, chatListChatsProjectSlugInput string, chatListChatsChatSessionsToken string) (*chat.ListChatsPayload, error) {
 	var err error
 	var search *string
 	{
@@ -31,6 +31,12 @@ func BuildListChatsPayload(chatListChatsSearch string, chatListChatsExternalUser
 	{
 		if chatListChatsExternalUserID != "" {
 			externalUserID = &chatListChatsExternalUserID
+		}
+	}
+	var userID *string
+	{
+		if chatListChatsUserID != "" {
+			userID = &chatListChatsUserID
 		}
 	}
 	var source *string
@@ -217,6 +223,7 @@ func BuildListChatsPayload(chatListChatsSearch string, chatListChatsExternalUser
 	v := &chat.ListChatsPayload{}
 	v.Search = search
 	v.ExternalUserID = externalUserID
+	v.UserID = userID
 	v.Source = source
 	v.AssistantID = assistantID
 	v.SourceKind = sourceKind

--- a/server/gen/http/chat/client/encode_decode.go
+++ b/server/gen/http/chat/client/encode_decode.go
@@ -61,6 +61,9 @@ func EncodeListChatsRequest(encoder func(*http.Request) goahttp.Encoder) func(*h
 		if p.ExternalUserID != nil {
 			values.Add("external_user_id", *p.ExternalUserID)
 		}
+		if p.UserID != nil {
+			values.Add("user_id", *p.UserID)
+		}
 		if p.Source != nil {
 			values.Add("source", *p.Source)
 		}

--- a/server/gen/http/chat/server/encode_decode.go
+++ b/server/gen/http/chat/server/encode_decode.go
@@ -41,6 +41,7 @@ func DecodeListChatsRequest(mux goahttp.Muxer, decoder func(*http.Request) goaht
 		var (
 			search            *string
 			externalUserID    *string
+			userID            *string
 			source            *string
 			assistantID       *string
 			sourceKind        *string
@@ -68,6 +69,10 @@ func DecodeListChatsRequest(mux goahttp.Muxer, decoder func(*http.Request) goaht
 		externalUserIDRaw := qp.Get("external_user_id")
 		if externalUserIDRaw != "" {
 			externalUserID = &externalUserIDRaw
+		}
+		userIDRaw := qp.Get("user_id")
+		if userIDRaw != "" {
+			userID = &userIDRaw
 		}
 		sourceRaw := qp.Get("source")
 		if sourceRaw != "" {
@@ -209,7 +214,7 @@ func DecodeListChatsRequest(mux goahttp.Muxer, decoder func(*http.Request) goaht
 		if err != nil {
 			return payload, err
 		}
-		payload = NewListChatsPayload(search, externalUserID, source, assistantID, sourceKind, excludeSourceKind, hasRisk, accountType, pinned, minRiskScore, from, to, limit, offset, sortBy, sortOrder, sessionToken, projectSlugInput, chatSessionsToken)
+		payload = NewListChatsPayload(search, externalUserID, userID, source, assistantID, sourceKind, excludeSourceKind, hasRisk, accountType, pinned, minRiskScore, from, to, limit, offset, sortBy, sortOrder, sessionToken, projectSlugInput, chatSessionsToken)
 		if payload.SessionToken != nil {
 			if strings.Contains(*payload.SessionToken, " ") {
 				// Remove authorization scheme prefix (e.g. "Bearer")

--- a/server/gen/http/chat/server/types.go
+++ b/server/gen/http/chat/server/types.go
@@ -3823,10 +3823,11 @@ func NewListSourcesGatewayErrorResponseBody(res *goa.ServiceError) *ListSourcesG
 }
 
 // NewListChatsPayload builds a chat service listChats endpoint payload.
-func NewListChatsPayload(search *string, externalUserID *string, source *string, assistantID *string, sourceKind *string, excludeSourceKind *string, hasRisk *string, accountType *string, pinned *string, minRiskScore *int, from *string, to *string, limit int, offset int, sortBy string, sortOrder string, sessionToken *string, projectSlugInput *string, chatSessionsToken *string) *chat.ListChatsPayload {
+func NewListChatsPayload(search *string, externalUserID *string, userID *string, source *string, assistantID *string, sourceKind *string, excludeSourceKind *string, hasRisk *string, accountType *string, pinned *string, minRiskScore *int, from *string, to *string, limit int, offset int, sortBy string, sortOrder string, sessionToken *string, projectSlugInput *string, chatSessionsToken *string) *chat.ListChatsPayload {
 	v := &chat.ListChatsPayload{}
 	v.Search = search
 	v.ExternalUserID = externalUserID
+	v.UserID = userID
 	v.Source = source
 	v.AssistantID = assistantID
 	v.SourceKind = sourceKind

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -618,6 +618,7 @@ func ParseEndpoint(
 		chatListChatsFlags                 = flag.NewFlagSet("list-chats", flag.ExitOnError)
 		chatListChatsSearchFlag            = chatListChatsFlags.String("search", "", "")
 		chatListChatsExternalUserIDFlag    = chatListChatsFlags.String("external-user-id", "", "")
+		chatListChatsUserIDFlag            = chatListChatsFlags.String("user-id", "", "")
 		chatListChatsSourceFlag            = chatListChatsFlags.String("source", "", "")
 		chatListChatsAssistantIDFlag       = chatListChatsFlags.String("assistant-id", "", "")
 		chatListChatsSourceKindFlag        = chatListChatsFlags.String("source-kind", "", "")
@@ -6247,7 +6248,7 @@ func ParseEndpoint(
 			switch epn {
 			case "list-chats":
 				endpoint = c.ListChats()
-				data, err = chatc.BuildListChatsPayload(*chatListChatsSearchFlag, *chatListChatsExternalUserIDFlag, *chatListChatsSourceFlag, *chatListChatsAssistantIDFlag, *chatListChatsSourceKindFlag, *chatListChatsExcludeSourceKindFlag, *chatListChatsHasRiskFlag, *chatListChatsAccountTypeFlag, *chatListChatsPinnedFlag, *chatListChatsMinRiskScoreFlag, *chatListChatsFromFlag, *chatListChatsToFlag, *chatListChatsLimitFlag, *chatListChatsOffsetFlag, *chatListChatsSortByFlag, *chatListChatsSortOrderFlag, *chatListChatsSessionTokenFlag, *chatListChatsProjectSlugInputFlag, *chatListChatsChatSessionsTokenFlag)
+				data, err = chatc.BuildListChatsPayload(*chatListChatsSearchFlag, *chatListChatsExternalUserIDFlag, *chatListChatsUserIDFlag, *chatListChatsSourceFlag, *chatListChatsAssistantIDFlag, *chatListChatsSourceKindFlag, *chatListChatsExcludeSourceKindFlag, *chatListChatsHasRiskFlag, *chatListChatsAccountTypeFlag, *chatListChatsPinnedFlag, *chatListChatsMinRiskScoreFlag, *chatListChatsFromFlag, *chatListChatsToFlag, *chatListChatsLimitFlag, *chatListChatsOffsetFlag, *chatListChatsSortByFlag, *chatListChatsSortOrderFlag, *chatListChatsSessionTokenFlag, *chatListChatsProjectSlugInputFlag, *chatListChatsChatSessionsTokenFlag)
 			case "get-work-units-trend":
 				endpoint = c.GetWorkUnitsTrend()
 				data, err = chatc.BuildGetWorkUnitsTrendPayload(*chatGetWorkUnitsTrendFromFlag, *chatGetWorkUnitsTrendToFlag, *chatGetWorkUnitsTrendSessionTokenFlag, *chatGetWorkUnitsTrendProjectSlugInputFlag)
@@ -9794,6 +9795,7 @@ func chatListChatsUsage() {
 	fmt.Fprintf(os.Stderr, "%s [flags] chat list-chats", os.Args[0])
 	fmt.Fprint(os.Stderr, " -search STRING")
 	fmt.Fprint(os.Stderr, " -external-user-id STRING")
+	fmt.Fprint(os.Stderr, " -user-id STRING")
 	fmt.Fprint(os.Stderr, " -source STRING")
 	fmt.Fprint(os.Stderr, " -assistant-id STRING")
 	fmt.Fprint(os.Stderr, " -source-kind STRING")
@@ -9820,6 +9822,7 @@ func chatListChatsUsage() {
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -search STRING: `)
 	fmt.Fprintln(os.Stderr, `    -external-user-id STRING: `)
+	fmt.Fprintln(os.Stderr, `    -user-id STRING: `)
 	fmt.Fprintln(os.Stderr, `    -source STRING: `)
 	fmt.Fprintln(os.Stderr, `    -assistant-id STRING: `)
 	fmt.Fprintln(os.Stderr, `    -source-kind STRING: `)
@@ -9840,7 +9843,7 @@ func chatListChatsUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "chat list-chats --search \"abc123\" --external-user-id \"abc123\" --source \"abc123\" --assistant-id \"550e8400-e29b-41d4-a716-446655440000\" --source-kind \"abc123\" --exclude-source-kind \"abc123\" --has-risk \"true\" --account-type \"team\" --pinned \"true\" --min-risk-score 1 --from \"1970-01-01T00:00:01Z\" --to \"1970-01-01T00:00:01Z\" --limit 2 --offset 1 --sort-by \"num_messages\" --sort-order \"desc\" --session-token \"abc123\" --project-slug-input \"abc123\" --chat-sessions-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "chat list-chats --search \"abc123\" --external-user-id \"abc123\" --user-id \"abc123\" --source \"abc123\" --assistant-id \"550e8400-e29b-41d4-a716-446655440000\" --source-kind \"abc123\" --exclude-source-kind \"abc123\" --has-risk \"true\" --account-type \"team\" --pinned \"true\" --min-risk-score 1 --from \"1970-01-01T00:00:01Z\" --to \"1970-01-01T00:00:01Z\" --limit 2 --offset 1 --sort-by \"num_messages\" --sort-order \"desc\" --session-token \"abc123\" --project-slug-input \"abc123\" --chat-sessions-token \"abc123\"")
 }
 
 func chatGetWorkUnitsTrendUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -10128,6 +10128,13 @@ paths:
                     description: Filter by external user ID
                     type: string
                 - allowEmptyValue: true
+                  description: Filter by Gram user ID
+                  in: query
+                  name: user_id
+                  schema:
+                    description: Filter by Gram user ID
+                    type: string
+                - allowEmptyValue: true
                   description: Filter by agent source. Comma-separated list of exact source values (e.g. 'claude-code,Codex,playground') matched against each session's inferred source; empty for no filter. Use chat.listSources to discover the available values.
                   in: query
                   name: source

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -267,7 +267,7 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 	// managed-assistant runtime see all project sessions (optionally narrowed by
 	// an explicit external user id); everyone else is restricted to their own
 	// sessions.
-	externalUserID, userID, err := s.chatVisibilityScope(ctx, authCtx, payload.ExternalUserID)
+	externalUserID, userID, err := s.chatVisibilityScope(ctx, authCtx, payload.ExternalUserID, payload.UserID)
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +575,7 @@ func (s *Service) ListSources(ctx context.Context, payload *gen.ListSourcesPaylo
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	externalUserID, userID, err := s.chatVisibilityScope(ctx, authCtx, nil)
+	externalUserID, userID, err := s.chatVisibilityScope(ctx, authCtx, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -626,11 +626,12 @@ func parseSourceFilter(source string) []string {
 // chatVisibilityScope resolves the (external_user_id, user_id) scoping shared by
 // the chat listing endpoints. Callers holding an unrestricted chat:read grant
 // (only admins do) and the managed-assistant runtime see all project sessions
-// (optionally narrowed by an explicit external user id); everyone else is
-// restricted to their own sessions. Both empty means "all chats in the project".
-// Visibility is never a hard gate on the route — when the chat:read check can't
-// be made we fall back to own-sessions rather than failing.
-func (s *Service) chatVisibilityScope(ctx context.Context, authCtx *contextvalues.AuthContext, payloadExternalUserID *string) (string, string, error) {
+// (optionally narrowed by the payload's external user id and user id filters);
+// everyone else is restricted to their own sessions. Both empty means "all
+// chats in the project". Visibility is never a hard gate on the route — when
+// the chat:read check can't be made we fall back to own-sessions rather than
+// failing.
+func (s *Service) chatVisibilityScope(ctx context.Context, authCtx *contextvalues.AuthContext, payloadExternalUserID, payloadUserID *string) (string, string, error) {
 	// An assistant principal is set only on the assistant runtime path and only
 	// the managed-assistant platform toolset surfaces chat tools, so treat it as
 	// admin-equivalent for project-wide visibility.
@@ -673,7 +674,7 @@ func (s *Service) chatVisibilityScope(ctx context.Context, authCtx *contextvalue
 	case authCtx.ExternalUserID != "":
 		return authCtx.ExternalUserID, "", nil
 	case canReadAllSessions, isAssistantCall:
-		return conv.PtrValOr(payloadExternalUserID, ""), "", nil
+		return conv.PtrValOr(payloadExternalUserID, ""), conv.PtrValOr(payloadUserID, ""), nil
 	default:
 		if authCtx.UserID == "" {
 			return "", "", oops.C(oops.CodeUnauthorized)

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -265,8 +265,8 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 
 	// Visibility scoping: callers holding an unrestricted chat:read grant and the
 	// managed-assistant runtime see all project sessions (optionally narrowed by
-	// an explicit external user id); everyone else is restricted to their own
-	// sessions.
+	// the external user id and user id filters); everyone else is restricted to
+	// their own sessions.
 	externalUserID, userID, err := s.chatVisibilityScope(ctx, authCtx, payload.ExternalUserID, payload.UserID)
 	if err != nil {
 		return nil, err

--- a/server/internal/chat/list_chats_test.go
+++ b/server/internal/chat/list_chats_test.go
@@ -413,6 +413,52 @@ func TestListChats_OrgAdmin_FilterByExternalUserID(t *testing.T) {
 	require.Equal(t, "ext-123", conv.PtrValOr(result.Chats[0].ExternalUserID, ""))
 }
 
+// TestListChats_OrgAdmin_FilterByUserID verifies that an org admin can narrow
+// results to a specific Gram user via the payload filter.
+func TestListChats_OrgAdmin_FilterByUserID(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := grantOrgAdminWithChatRead(t, initSessionCtx(t, ti))
+
+	seedChat(t, ctx, ti, "user-aaa", "", "chat for user-aaa")
+	seedChat(t, ctx, ti, "user-bbb", "", "chat for user-bbb")
+	seedChat(t, ctx, ti, "", "ext-ccc", "chat for ext-ccc")
+
+	userID := "user-aaa"
+	payload := defaultPayload()
+	payload.UserID = &userID
+
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, "user-aaa", conv.PtrValOr(result.Chats[0].UserID, ""))
+}
+
+// TestListChats_RegularUser_PayloadUserIDIsIgnored verifies that a caller
+// without project-wide visibility stays scoped to their own chats even when
+// naming another user in the payload filter.
+func TestListChats_RegularUser_PayloadUserIDIsIgnored(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	ctx := authztest.WithExactGrants(t, initSessionCtx(t, ti))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	seedChat(t, ctx, ti, authCtx.UserID, "", "own chat")
+	seedChat(t, ctx, ti, "other-user-id", "", "other users chat")
+
+	otherUser := "other-user-id"
+	payload := defaultPayload()
+	payload.UserID = &otherUser
+
+	result, err := ti.service.ListChats(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Total)
+	require.Len(t, result.Chats, 1)
+	require.Equal(t, authCtx.UserID, conv.PtrValOr(result.Chats[0].UserID, ""))
+}
+
 // TestListChats_Filter_Search verifies that the search filter matches chats by title substring.
 func TestListChats_Filter_Search(t *testing.T) {
 	t.Parallel()

--- a/server/internal/platformtools/chats/tool_list_chats.go
+++ b/server/internal/platformtools/chats/tool_list_chats.go
@@ -95,6 +95,7 @@ func (s *ListChats) Call(ctx context.Context, _ toolconfig.ToolCallEnv, payload 
 		ChatSessionsToken: nil,
 		Search:            input.Search,
 		ExternalUserID:    input.ExternalUserID,
+		UserID:            nil,
 		Source:            input.Source,
 		AssistantID:       input.AssistantID,
 		SourceKind:        nil,


### PR DESCRIPTION
## What

The Project Assistant dock's "Continue chat" pill could offer to resume a session the viewer never started. For admins (who hold a `chat:read` grant) the chat listing returns every session in the project, so the newest chat from any member or any source (Slack, cron, wake) drove the pill.

- `chat.list` gains an optional `user_id` filter. Callers with project-wide chat visibility (unrestricted `chat:read`, the managed-assistant runtime) can narrow results to a specific Gram user; everyone else stays scoped to their own sessions as before, with the payload value ignored.
- The dock's lookup now passes `userId` (the viewer) and `sourceKind: "dashboard"`, so the pill only ever offers the viewer's own most recent dashboard-initiated session — filtering happens server-side, so it holds regardless of how many other members are using the assistant concurrently.

## Why

"Continue chat" should only appear for a session the current user initiated from the dashboard; resuming someone else's session (or an externally-triggered one) lands the viewer in a conversation they cannot send into.
