### PR TITLE
fix: make skill and environment resources clickable on challenges page

### DIFF
--- a/.changeset/clickable-skill-env-challenge-resources.md
+++ b/.changeset/clickable-skill-env-challenge-resources.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Make skill and environment resources clickable on the access challenges page. Skill rows now link to the project's Skills page and environment rows link to the project's Environments page, instead of rendering a bare resource id.

--- a/client/dashboard/src/pages/access/ResourceLink.test.tsx
+++ b/client/dashboard/src/pages/access/ResourceLink.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router";
+import { ResourceLink } from "./ResourceLink";
+
+const projectMap = new Map<string, { slug: string; name: string }>([
+  ["proj-1", { slug: "default", name: "Default" }],
+]);
+const emptyToolsetMap = new Map<
+  string,
+  { slug: string; name: string; projectId: string }
+>();
+const emptyMcpServerMap = new Map<
+  string,
+  { slug?: string; name?: string; projectId: string }
+>();
+
+function makeBucket(overrides: Partial<ChallengeBucket> = {}): ChallengeBucket {
+  return {
+    id: "bucket-1",
+    challengeCount: 1,
+    challengeIds: ["ch-1"],
+    evaluatedGrantCount: 1,
+    firstSeen: new Date("2026-05-01T00:00:00Z"),
+    lastSeen: new Date("2026-05-01T00:00:00Z"),
+    matchedGrantCount: 0,
+    operation: "require",
+    organizationId: "org-1",
+    outcome: "deny",
+    principalType: "user",
+    principalUrn: "user:u1",
+    reason: "scope_unsatisfied",
+    roleSlugs: [],
+    scope: "skill:read",
+    ...overrides,
+  };
+}
+
+function renderLink(bucket: ChallengeBucket) {
+  return render(
+    <MemoryRouter>
+      <ResourceLink
+        challenge={bucket}
+        orgSlug="acme"
+        projectMap={projectMap}
+        toolsetMap={emptyToolsetMap}
+        mcpServerMap={emptyMcpServerMap}
+      />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("ResourceLink", () => {
+  it("links skill resources to the project's skills page", () => {
+    renderLink(
+      makeBucket({
+        scope: "skill:read",
+        resourceKind: "skill",
+        resourceId: "proj-1",
+        projectId: "proj-1",
+      }),
+    );
+    const link = screen.getByRole("link", { name: /Default/ });
+    expect(link.getAttribute("href")).toBe("/acme/projects/default/skills");
+  });
+
+  it("links environment resources to the project's environments page", () => {
+    renderLink(
+      makeBucket({
+        scope: "environment:write",
+        resourceKind: "environment",
+        // A specific environment id, not a project id — resolved via the
+        // bucket's projectId.
+        resourceId: "env-abc",
+        projectId: "proj-1",
+      }),
+    );
+    const link = screen.getByRole("link", { name: /Default/ });
+    expect(link.getAttribute("href")).toBe(
+      "/acme/projects/default/environments",
+    );
+  });
+
+  it("falls back to an id chip when the project cannot be resolved", () => {
+    renderLink(
+      makeBucket({
+        scope: "environment:write",
+        resourceKind: "environment",
+        resourceId: "env-orphan",
+        projectId: "unknown-project",
+      }),
+    );
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByTitle("env-orphan").textContent).toContain("env-orph");
+  });
+});

--- a/client/dashboard/src/pages/access/ResourceLink.tsx
+++ b/client/dashboard/src/pages/access/ResourceLink.tsx
@@ -88,11 +88,9 @@ export function ResourceLink({
     }
   } else if (resourceKind === "skill") {
     IconEl = Terminal;
-    // Skill scopes are project-scoped: the resource id is the project id. Fall
-    // back to the bucket's projectId if that lookup misses.
-    const proj =
-      projectMap.get(resourceId) ??
-      (projectId ? projectMap.get(projectId) : undefined);
+    // Skill scopes are project-scoped: the resource id is the project id, so a
+    // direct project lookup is enough (same as the "project" branch above).
+    const proj = projectMap.get(resourceId);
     if (proj) {
       label = proj.name;
       to = `/${orgSlug}/projects/${proj.slug}/skills`;

--- a/client/dashboard/src/pages/access/ResourceLink.tsx
+++ b/client/dashboard/src/pages/access/ResourceLink.tsx
@@ -1,6 +1,13 @@
 import { Text } from "@/components/ui/Text";
 import type { ChallengeBucket } from "@gram/client/models/components/challengebucket.js";
-import { Building2, ChevronRight, FolderOpen, Plug } from "lucide-react";
+import {
+  Blocks,
+  Building2,
+  ChevronRight,
+  FolderOpen,
+  Plug,
+  Terminal,
+} from "lucide-react";
 import { Link } from "react-router";
 
 // Fallback for resource ids we cannot resolve to a display name (deleted
@@ -33,7 +40,7 @@ export function ResourceLink({
     { slug?: string; name?: string; projectId: string }
   >;
 }): JSX.Element {
-  const { resourceKind, resourceId } = challenge;
+  const { resourceKind, resourceId, projectId } = challenge;
 
   if (!resourceKind || !resourceId) {
     return (
@@ -78,6 +85,30 @@ export function ResourceLink({
           : null;
     } else {
       label = resourceId;
+    }
+  } else if (resourceKind === "skill") {
+    IconEl = Terminal;
+    // Skill scopes are project-scoped: the resource id is the project id. Fall
+    // back to the bucket's projectId if that lookup misses.
+    const proj =
+      projectMap.get(resourceId) ??
+      (projectId ? projectMap.get(projectId) : undefined);
+    if (proj) {
+      label = proj.name;
+      to = `/${orgSlug}/projects/${proj.slug}/skills`;
+    }
+  } else if (resourceKind === "environment") {
+    IconEl = Blocks;
+    // Environment checks carry either the project id or a specific environment
+    // id as the resource id, always with the project id on the bucket. There is
+    // no org-wide environment lookup to resolve an environment id to a slug, so
+    // link to the project's environments list.
+    const proj =
+      projectMap.get(resourceId) ??
+      (projectId ? projectMap.get(projectId) : undefined);
+    if (proj) {
+      label = proj.name;
+      to = `/${orgSlug}/projects/${proj.slug}/environments`;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

On the access **Challenges** page, the Resource column only rendered clickable links for `org`, `project`, and `mcp` resource kinds. Rows for `skill:*` and `environment:*` scopes fell through to a plain truncated UUID chip. This extends `ResourceLink` so those resources are clickable too.

- **Skill** challenges are project-scoped (the check's `resource_id` is the project id). The resource now links to the project's Skills page (`/{org}/projects/{project}/skills`) with a terminal icon, labeled by project name.
- **Environment** challenges carry either the project id or a specific environment id as `resource_id`, always alongside the bucket's `projectId`. Since there's no org-wide environment lookup to resolve an environment id → slug, the resource links to the project's Environments page (`/{org}/projects/{project}/environments`) with a blocks icon, labeled by project name.
- When the project can't be resolved (e.g. deleted), both kinds fall back to the existing truncated id chip, matching the current behavior for unresolvable `mcp` resources.

## Why

Resolves DNO-817. Skill and environment resources were the only user-visible scope families on the challenges table without a clickable target.

## Testing

- Added `ResourceLink.test.tsx` covering skill → skills page link, environment → environments page link (resolved via the bucket `projectId`), and the id-chip fallback when the project is unknown.
- `pnpm -F dashboard test` (1639 passed), `pnpm -F dashboard type-check`, and `pnpm -F dashboard lint` all pass.

The change is a small, well-tested link-mapping addition; a live screenshot would require a full dev stack seeded with `skill`/`environment` denial challenges in ClickHouse, so verification is via the unit tests that assert the rendered link hrefs.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-817](https://linear.app/speakeasy/issue/DNO-817/bug-make-skill-and-environment-resources-clickable-on-challenges-page)

<div><a href="https://cursor.com/agents/bc-3d63b2a8-f2ff-4a80-a8c6-245ef5f04852?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d63b2a8-f2ff-4a80-a8c6-245ef5f04852&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `skill` and `environment` resources clickable on the Challenges page. Links go to each project's Skills or Environments pages to satisfy DNO-817.

- **Bug Fixes**
  - Skill: resolve project via `resourceId` (project id), link to `/{org}/projects/{project}/skills` with a Terminal icon; label uses project name.
  - Environment: resolve project via `resourceId` or bucket `projectId`, link to `/{org}/projects/{project}/environments` with a Blocks icon; label uses project name.
  - Fallback to truncated id chip when the project cannot be resolved.
  - Added unit tests for skill link, environment link, and fallback.

<sup>Written for commit f717e53b89d96742e4ba972d4f0c0bfd4ce5ff20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

