### PR TITLE
feat(dashboard): link blocks to risk events

### DIFF
--- a/.changeset/link-risk-event-log.md
+++ b/.changeset/link-risk-event-log.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Link durable block pages to the owning project's risk event log.

--- a/client/dashboard/src/pages/blocks/BlockDetail.test.tsx
+++ b/client/dashboard/src/pages/blocks/BlockDetail.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +14,24 @@ const mocks = vi.hoisted(() => ({
   useSubmitMutation: vi.fn(),
   mutateAsync: vi.fn(),
   refetch: vi.fn(),
+  switchScopes: vi.fn(),
+  toastError: vi.fn(),
+  session: {
+    session: "sess-1",
+    activeOrganizationId: "org-1",
+    organizations: [
+      {
+        id: "org-1",
+        slug: "organization-one",
+        projects: [{ id: "proj-1", slug: "project-one" }],
+      },
+      {
+        id: "org-2",
+        slug: "organization-two",
+        projects: [{ id: "proj-2", slug: "project-two" }],
+      },
+    ],
+  },
 }));
 
 // Only useParams is exercised by BlockPage; keep the rest of react-router real.
@@ -30,7 +49,29 @@ vi.mock("@gram/client/react-query/riskSubmitBlockFeedback.js", () => ({
 
 // A signed-in session so BlockPage renders the body rather than redirecting.
 vi.mock("@/contexts/Auth", () => ({
-  useSession: () => ({ session: { id: "sess-1" } }),
+  useSession: () => mocks.session,
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({ auth: { switchScopes: mocks.switchScopes } }),
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: ({
+    orgSlug,
+    projectSlug,
+  }: {
+    orgSlug?: string;
+    projectSlug?: string;
+  }) => ({
+    riskEvents: {
+      href: () => `/${orgSlug}/projects/${projectSlug}/risk-events`,
+    },
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mocks.toastError },
 }));
 
 vi.mock("@/lib/utils", async (importOriginal) => ({
@@ -104,6 +145,14 @@ function mockLoadedBlock(block: Record<string, unknown>) {
   });
 }
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BlockPage />
+    </MemoryRouter>,
+  );
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -113,7 +162,7 @@ describe("BlockPage", () => {
   it("shows the policy/tool header and the server-provided reason verbatim", () => {
     mockLoadedBlock(sampleBlock);
 
-    render(<BlockPage />);
+    renderPage();
 
     expect(screen.getByText(/Blocked by policy/)).toBeTruthy();
     expect(screen.getByText(/tool Bash/)).toBeTruthy();
@@ -131,7 +180,7 @@ describe("BlockPage", () => {
       reason: `Speakeasy blocked this tool call: spend rule "Intern hard limit" — budget resets Aug 31, 2026 00:00 UTC`,
     });
 
-    render(<BlockPage />);
+    renderPage();
 
     expect(screen.getByText(/Blocked by a Speakeasy spend rule/)).toBeTruthy();
     expect(screen.queryByText(/Blocked by policy/)).toBeNull();
@@ -141,7 +190,7 @@ describe("BlockPage", () => {
     mockLoadedBlock(sampleBlock);
     mocks.mutateAsync.mockResolvedValue({});
 
-    render(<BlockPage />);
+    renderPage();
 
     fireEvent.click(screen.getByRole("button", { name: "Helpful" }));
 
@@ -161,7 +210,7 @@ describe("BlockPage", () => {
   it("confirms recorded feedback once a vote is present", () => {
     mockLoadedBlock({ ...sampleBlock, feedback: "down" });
 
-    render(<BlockPage />);
+    renderPage();
 
     expect(screen.getByText("Thanks for the feedback.")).toBeTruthy();
   });
@@ -178,8 +227,55 @@ describe("BlockPage", () => {
       isPending: false,
     });
 
-    render(<BlockPage />);
+    renderPage();
 
     expect(screen.getByText(/couldn't load this block/)).toBeTruthy();
+  });
+
+  it("links to the risk event log for the block's project", () => {
+    mockLoadedBlock(sampleBlock);
+
+    renderPage();
+
+    expect(
+      screen
+        .getByRole("link", { name: "View risk event log" })
+        .getAttribute("href"),
+    ).toBe("/organization-one/projects/project-one/risk-events");
+  });
+
+  it("switches organization before opening another organization's risk events", async () => {
+    mockLoadedBlock({ ...sampleBlock, projectId: "proj-2" });
+    mocks.switchScopes.mockResolvedValue({});
+    const assign = vi
+      .spyOn(window.location, "assign")
+      .mockImplementation(() => {});
+
+    renderPage();
+    fireEvent.click(screen.getByRole("link", { name: "View risk event log" }));
+
+    await waitFor(() => {
+      expect(mocks.switchScopes).toHaveBeenCalledWith({
+        organizationId: "org-2",
+      });
+      expect(assign).toHaveBeenCalledWith(
+        "/organization-two/projects/project-two/risk-events",
+      );
+    });
+    assign.mockRestore();
+  });
+
+  it("reports a failed organization switch", async () => {
+    mockLoadedBlock({ ...sampleBlock, projectId: "proj-2" });
+    mocks.switchScopes.mockRejectedValue(new Error("unavailable"));
+
+    renderPage();
+    fireEvent.click(screen.getByRole("link", { name: "View risk event log" }));
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Unable to switch organizations. Please try again.",
+      );
+    });
   });
 });

--- a/client/dashboard/src/pages/blocks/BlockDetail.tsx
+++ b/client/dashboard/src/pages/blocks/BlockDetail.tsx
@@ -1,15 +1,18 @@
 import { FullScreenPage } from "@/components/full-screen-page";
 import { Text } from "@/components/ui/Text";
 import { useSession } from "@/contexts/Auth";
+import { useSdkClient } from "@/contexts/Sdk";
 import { buildLoginRedirectURL } from "@/lib/utils";
+import { useRoutes } from "@/routes";
 import { useRiskGetBlock } from "@gram/client/react-query/riskGetBlock.js";
 import { useRiskSubmitBlockFeedbackMutation } from "@gram/client/react-query/riskSubmitBlockFeedback.js";
 import { Button } from "@/components/ui/Button";
 import { Icon } from "@/components/ui/Icon";
 import { Stack } from "@/components/ui/Stack";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { useEffect } from "react";
-import { useParams } from "react-router";
+import { type MouseEvent, useEffect, useState } from "react";
+import { Link, useParams } from "react-router";
+import { toast } from "sonner";
 
 type Sentiment = "up" | "down";
 
@@ -48,6 +51,8 @@ export function BlockPage(): JSX.Element {
 }
 
 function BlockBody({ id }: { id: string | undefined }) {
+  const session = useSession();
+  const client = useSdkClient();
   const {
     data: block,
     isLoading,
@@ -61,6 +66,18 @@ function BlockBody({ id }: { id: string | undefined }) {
 
   const { mutateAsync: submitFeedback, isPending: isSubmitting } =
     useRiskSubmitBlockFeedbackMutation();
+  const [isSwitchingOrganization, setIsSwitchingOrganization] = useState(false);
+
+  const organization = session.organizations.find((candidate) =>
+    candidate.projects.some((project) => project.id === block?.projectId),
+  );
+  const project = organization?.projects.find(
+    (candidate) => candidate.id === block?.projectId,
+  );
+  const routes = useRoutes({
+    orgSlug: organization?.slug,
+    projectSlug: project?.slug,
+  });
 
   if (!id) {
     return <Text muted>This block link is missing its identifier.</Text>;
@@ -91,6 +108,26 @@ function BlockBody({ id }: { id: string | undefined }) {
     await refetch();
   };
 
+  const onRiskEventsClick = async (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!organization || organization.id === session.activeOrganizationId) {
+      return;
+    }
+
+    event.preventDefault();
+    if (isSwitchingOrganization) {
+      return;
+    }
+
+    setIsSwitchingOrganization(true);
+    try {
+      await client.auth.switchScopes({ organizationId: organization.id });
+      window.location.assign(routes.riskEvents.href());
+    } catch {
+      setIsSwitchingOrganization(false);
+      toast.error("Unable to switch organizations. Please try again.");
+    }
+  };
+
   return (
     <Stack gap={6} align="center" className="w-full">
       <Stack gap={3} align="center">
@@ -115,6 +152,17 @@ function BlockBody({ id }: { id: string | undefined }) {
             {block.reason}
           </Text>
         </div>
+      ) : null}
+
+      {organization && project ? (
+        <Link
+          to={routes.riskEvents.href()}
+          onClick={(event) => void onRiskEventsClick(event)}
+          aria-disabled={isSwitchingOrganization}
+          className="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4 transition-colors"
+        >
+          View risk event log
+        </Link>
       ) : null}
 
       <Stack gap={2} align="center">


### PR DESCRIPTION
## Summary
- link durable block pages to the owning project's risk event log
- switch organization scope before navigation when the block belongs to another workspace
- handle scope-switch failures and prevent duplicate requests

Closes [DNO-816](https://linear.app/speakeasy/issue/DNO-816/feat-link-risk-event-back-to-the-risk-event-log)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "View risk event log" link to durable block pages to let users jump back to the owning project's risk events. Automatically switches to the correct organization before navigation and handles failures cleanly. Addresses DNO-816.

- New Features
  - Link to the owning project's risk event log on the block page.
  - Switch organization scope before navigation when the block belongs to another workspace.
  - Prevent duplicate scope-switch attempts and show an error toast on failure.
  - Tests cover link URL, successful org switch + redirect, and failure handling.

<sup>Written for commit de2b1497189181be4b2bf1eac6a311982f086de1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

