### PR TITLE
feat(dashboard): voice dictation on one shared assistant composer

### DIFF
--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -1663,6 +1663,15 @@ function ComposerDraftReporter({
   useEffect(() => {
     onChange(hasDraft);
   }, [hasDraft, onChange]);
+  // Retract the report when the composer goes away — the dock swaps it out for
+  // the "Continue chat" button whenever a recent conversation appears, and a
+  // last report of `true` would otherwise pin the dock open with nothing in it.
+  useEffect(
+    () => () => {
+      onChange(false);
+    },
+    [onChange],
+  );
   return null;
 }
 

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -426,6 +426,8 @@ function InsightsDock({
   const inputRef = useRef<HTMLInputElement>(null);
   /** Wraps the shared composer; also the focus target for Cmd+/. */
   const composerHostRef = useRef<HTMLDivElement>(null);
+  /** Whether the shared composer holds a draft (see ComposerDraftReporter). */
+  const [sharedDraft, setSharedDraft] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const collapseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Stamped only by grace-timer collapses (blur/outside click), never by
@@ -501,7 +503,11 @@ function InsightsDock({
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [expanded, scheduleCollapse]);
 
-  const composerExpanded = !open && (expanded || value.trim().length > 0);
+  // `value` only backs the fallback input; the shared composer keeps its draft
+  // on the runtime, so it reports emptiness up through `sharedDraft`. Both feed
+  // the same rule: a non-empty draft holds the dock open even without focus.
+  const hasDraft = value.trim().length > 0 || sharedDraft;
+  const composerExpanded = !open && (expanded || hasDraft);
 
   const shortcutAria = isMacPlatform() ? "Meta+/" : "Control+/";
 
@@ -535,6 +541,7 @@ function InsightsDock({
       className="gram-chat-dock min-w-0 flex-1"
       tabIndex={open ? -1 : undefined}
     >
+      <ComposerDraftReporter onChange={setSharedDraft} />
       <ChatComposer />
     </div>
   ) : (
@@ -1615,10 +1622,10 @@ function ExpandToPageButton({
 }
 
 /**
- * Opens the chat panel when the docked composer sends. The dock's composer now
- * sends through the runtime itself, so there is no submit handler to hook —
- * the message landing on the thread IS the signal. Disabled on chat routes and
- * while the panel is already open, where the panel must not steal the view.
+ * Opens the chat panel when the docked composer sends. The dock's composer
+ * submits through the runtime itself, so there is no submit handler to hook.
+ * Disabled on chat routes and while the panel is already open, where the panel
+ * must not steal the view.
  */
 function OpenPanelOnSend({
   enabled,
@@ -1627,13 +1634,35 @@ function OpenPanelOnSend({
   enabled: boolean;
   onSend: () => void;
 }): null {
-  const messageCount = useAuiState(({ thread }) => thread.messages.length);
-  const seenRef = useRef(messageCount);
+  // A run starting, not the message count growing: loading an existing
+  // conversation into the shared runtime also grows that count, which would
+  // pop the panel open on its own.
+  const isRunning = useAuiState(({ thread }) => thread.isRunning);
+  const wasRunningRef = useRef(isRunning);
   useEffect(() => {
-    const grew = messageCount > seenRef.current;
-    seenRef.current = messageCount;
-    if (grew && enabled) onSend();
-  }, [messageCount, enabled, onSend]);
+    const justStarted = isRunning && !wasRunningRef.current;
+    wasRunningRef.current = isRunning;
+    if (justStarted && enabled) onSend();
+  }, [isRunning, enabled, onSend]);
+  return null;
+}
+
+/**
+ * Reports whether the shared composer holds a draft. The docked pill stays
+ * expanded while the user has text in it — with the legacy input that was
+ * local state, but the shared composer keeps its draft on the runtime, so the
+ * dock has to be told. Without this a typed draft is hidden the moment focus
+ * leaves the composer.
+ */
+function ComposerDraftReporter({
+  onChange,
+}: {
+  onChange: (hasDraft: boolean) => void;
+}): null {
+  const hasDraft = useAuiState(({ composer }) => composer.text.trim() !== "");
+  useEffect(() => {
+    onChange(hasDraft);
+  }, [hasDraft, onChange]);
   return null;
 }
 

--- a/client/dashboard/src/components/insights-dock.tsx
+++ b/client/dashboard/src/components/insights-dock.tsx
@@ -12,7 +12,9 @@ import type { ElementsConfig, ElementsTransportFactory } from "@/elements";
 import {
   ActiveChatTitle,
   Chat,
+  ChatComposer,
   ChatHistory,
+  focusChatComposer,
   GramElementsProvider,
   useThreadId,
 } from "@/elements";
@@ -32,6 +34,7 @@ import { motion } from "motion/react";
 import {
   getRouteSuggestions,
   INSIGHTS_SUGGESTION_ICONS,
+  SLASH_COMMANDS,
   type InsightsSuggestion,
 } from "@/lib/insights-suggestions";
 import { useConfig as useMoonshineConfig } from "@/components/ui/hooks/useConfig";
@@ -140,27 +143,78 @@ const DOCK_PANEL_COMPOSER_CSS = `
   .aui-composer-action-wrapper-inner {
     display: flex;
   }
-  .aui-composer-action-wrapper-inner > :not(.aui-composer-skill-context-picker) {
+  /* The pill shows no composition tools at all — attachments, tool mentions
+     and skill context all belong to the surfaces with room for them. */
+  .aui-composer-action-wrapper-inner > * {
     display: none;
   }
-  .aui-composer-skill-context-picker-label { display: none; }
   .aui-composer-skill-context-badges { padding: 0.5rem 3rem 0 0.75rem; }
-  .aui-composer-send, .aui-composer-cancel {
-    width: 1.5rem;
-    height: 1.5rem;
-    min-width: 1.5rem;
+  /* Mic sits in the same cluster as send, so it has to shrink with it —
+     Elements sizes both at 34px, which is right for the full page only. */
+  .aui-composer-send, .aui-composer-cancel, .aui-composer-dictate {
+    width: 1.75rem;
+    height: 1.75rem;
+    min-width: 1.75rem;
     cursor: pointer;
   }
-  .aui-composer-send-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-    stroke-width: 2.5;
+  .aui-composer-send-icon, .aui-composer-dictate-icon {
+    width: 1rem;
+    height: 1rem;
+    stroke-width: 1.75;
   }
+  .aui-composer-action-send-group { gap: 0.375rem; }
+  .aui-composer-dictation-wave { height: 1.75rem; margin-right: 0.375rem; }
   /* Filled square reads heavier than the stroked arrow — smaller icon keeps
      visible padding inside the same-size circle. */
   .aui-composer-cancel-icon {
     width: 0.625rem;
     height: 0.625rem;
+  }
+`;
+
+// The docked pill already IS the input surface: it draws the border, the card
+// background and the shadow. The shared composer rendered inside it must
+// therefore contribute no chrome of its own, or the two nest into a
+// box-in-a-box. Scoped to the dock host so the panel and page composers keep
+// their own frame.
+const DOCK_INLINE_COMPOSER_CSS = `
+  :host-context(.gram-chat-dock) .aui-composer-wrapper {
+    position: static;
+    padding: 0;
+    background: transparent;
+  }
+  :host-context(.gram-chat-dock) .aui-composer-root {
+    min-height: 0;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+  :host-context(.gram-chat-dock) .aui-composer-input {
+    padding: 0.375rem 5.5rem 0.375rem 0;
+    min-height: 0;
+    margin-bottom: 0;
+  }
+  :host-context(.gram-chat-dock) .aui-composer-action-wrapper {
+    position: absolute;
+    right: 0;
+    bottom: 50%;
+    transform: translateY(50%);
+    margin: 0;
+  }
+  /* The pill has one line: the composer's own "Listening…" label sits where
+     the draft text would be. */
+  /* The pill is one line wide: keep only the newest half of the level trail
+     (the bars nearest the mic) so it can't crowd out the draft row. */
+  :host-context(.gram-chat-dock) .aui-composer-dictation-bar:nth-child(-n + 16) {
+    display: none;
+  }
+  :host-context(.gram-chat-dock) .aui-composer-listening {
+    padding: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.875rem;
   }
 `;
 
@@ -179,28 +233,97 @@ const CHAT_MARKDOWN_CSS = `
   .aui-md-ul, .aui-md-ol { margin-top: 0.75rem; margin-bottom: 0.75rem; }
 `;
 
-// The docked composer above is intentionally compact. On the full-page chat
-// (ChatSurface wraps it in `.gram-chat-fullpage`) the composer should breathe,
-// so give it a roomier min-height + padding. Scoped via :host-context so the
-// docked panel keeps its tight pill.
-const CHAT_FULLPAGE_COMPOSER_CSS = `
-  :host-context(.gram-chat-fullpage) .aui-composer-root { min-height: 3.25rem; }
-  :host-context(.gram-chat-fullpage) .aui-composer-input {
-    min-height: 3.25rem;
-    padding-top: 0.875rem;
-    padding-bottom: 0.875rem;
-    font-size: 0.9375rem;
+// The docked composer above is intentionally compact. The surfaces that own
+// the page — the full-page chat (`.gram-chat-fullpage`) and the /chat landing
+// (`.gram-chat-landing`) — give the same composer room to breathe: taller
+// input, real padding, and the toolbar the dock hides. Scoped via
+// :host-context so the docked pill keeps its tight single-line form.
+const roomyComposerCss = (scope: string) => `
+  :host-context(.${scope}) .aui-composer-root {
+    min-height: 6.5rem;
+    padding: 0.75rem 0.375rem 0;
   }
-  :host-context(.gram-chat-fullpage) .aui-composer-action-wrapper {
+  :host-context(.${scope}) .aui-composer-input {
+    min-height: 2.75rem;
+    padding: 0 1.125rem 0.5rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+  :host-context(.${scope}) .aui-composer-action-wrapper {
     position: static;
-    margin: 0.5rem 0.25rem;
+    margin: 0 0.5rem 0.625rem;
     transform: none;
   }
-  :host-context(.gram-chat-fullpage) .aui-composer-skill-context-picker-label {
+  :host-context(.${scope}) .aui-composer-action-wrapper-inner > * {
+    display: inline-flex;
+  }
+  :host-context(.${scope}) .aui-composer-skill-context-picker-label {
     display: inline;
   }
+  :host-context(.${scope}) .aui-composer-send,
+  :host-context(.${scope}) .aui-composer-cancel,
+  :host-context(.${scope}) .aui-composer-dictate {
+    width: 2.125rem;
+    height: 2.125rem;
+    min-width: 2.125rem;
+  }
+  :host-context(.${scope}) .aui-composer-send-icon,
+  :host-context(.${scope}) .aui-composer-dictate-icon {
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+  :host-context(.${scope}) .aui-composer-dictation-wave { height: 2.125rem; }
+`;
+
+const CHAT_FULLPAGE_COMPOSER_CSS = `
+  ${roomyComposerCss("gram-chat-fullpage")}
   :host-context(.gram-chat-fullpage) .aui-composer-wrapper {
-    padding-bottom: 1.25rem;
+    padding-bottom: 1.5rem;
+  }
+`;
+
+// The /chat landing renders the same composer standalone (no thread), so it
+// also has to undo the wrapper's sticky-bottom band, which has nothing to
+// stick to here.
+const CHAT_LANDING_COMPOSER_CSS = `
+  ${roomyComposerCss("gram-chat-landing")}
+  :host-context(.gram-chat-landing) .aui-composer-wrapper {
+    position: static;
+    padding: 0;
+  }
+  /* Cycling example prompts. The text arrives as a custom property set on the
+     host element — custom properties inherit through the shadow boundary, so
+     the landing can crossfade through examples without re-rendering the chat
+     tree (a changing \`composer.placeholder\` in the Elements config would).
+     The native placeholder is hidden because it cannot be transitioned. */
+  :host-context(.gram-chat-landing) .aui-composer-input::placeholder {
+    color: transparent;
+  }
+  :host-context(.gram-chat-landing) .aui-composer-root[data-empty="true"]::before {
+    content: var(--gram-composer-placeholder, "Ask anything");
+    position: absolute;
+    /* Must land exactly where the caret does: absolute offsets are measured
+       from the root's padding box, so this is the root's own padding plus the
+       input's — 0.375rem + 1.125rem across, 0.75rem down — with the input's
+       line-height so the first line sits on the same baseline. */
+    left: 1.5rem;
+    top: 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    color: var(--muted-foreground);
+    opacity: var(--gram-composer-placeholder-opacity, 1);
+    transition: opacity 300ms ease;
+    pointer-events: none;
+  }
+  /* Focus means the user is about to type — the rotating example would sit
+     under their caret, so it clears out of the way. */
+  :host-context(.gram-chat-landing) .aui-composer-root:focus-within::before {
+    content: none;
+  }
+  /* The composer paints its own "Listening…" while dictating — don't stack the
+     cycling example prompt behind it. */
+  :host-context(.gram-chat-landing) .aui-composer-root[data-dictating="true"]::before {
+    content: none;
   }
 `;
 
@@ -251,6 +374,11 @@ interface InsightsDockProps {
   onOpenHistory: () => void;
   /** Chat panel content, rendered inside the card when `open`. */
   panel: React.ReactNode;
+  /** True once the shared Elements runtime is mounted. The pill then renders
+   *  the same AUI composer every other surface uses (dictation, attachments,
+   *  tool mentions); until then it falls back to a plain input so the dock is
+   *  never a dead control. */
+  runtimeReady: boolean;
 }
 
 /** Width of the dock card across its states: chat panel open, composer
@@ -287,6 +415,7 @@ function InsightsDock({
   onDismiss,
   onOpenHistory,
   panel,
+  runtimeReady,
 }: InsightsDockProps): ReactElement {
   const [value, setValue] = useState("");
   // Expansion is sticky state, not a focus mirror: it must survive the input
@@ -295,6 +424,8 @@ function InsightsDock({
   // a route change can cancel (or, for slow clicks, undo).
   const [expanded, setExpanded] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  /** Wraps the shared composer; also the focus target for Cmd+/. */
+  const composerHostRef = useRef<HTMLDivElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
   const collapseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Stamped only by grace-timer collapses (blur/outside click), never by
@@ -328,10 +459,16 @@ function InsightsDock({
   useEffect(() => cancelCollapse, [cancelCollapse]);
 
   // Keyboard shortcut path: the provider bumps focusKey when Cmd+/ fires.
+  // The AUI composer's input lives in a shadow root, so it can't be reached
+  // with a plain ref.
   useEffect(() => {
     if (focusKey === 0) return;
+    if (runtimeReady) {
+      focusChatComposer(composerHostRef.current);
+      return;
+    }
     inputRef.current?.focus();
-  }, [focusKey]);
+  }, [focusKey, runtimeReady]);
 
   // Navigation keeps the dock expanded: cancel any pending collapse, and undo
   // one that just fired (slow click — the grace timer can win the race
@@ -390,6 +527,16 @@ function InsightsDock({
     >
       Continue chat
     </button>
+  ) : runtimeReady ? (
+    // The shared composer, sending straight through the runtime — no prompt
+    // hand-off, so the dock gets dictation and every other composer feature.
+    <div
+      ref={composerHostRef}
+      className="gram-chat-dock min-w-0 flex-1"
+      tabIndex={open ? -1 : undefined}
+    >
+      <ChatComposer />
+    </div>
   ) : (
     <input
       ref={inputRef}
@@ -412,7 +559,7 @@ function InsightsDock({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-center px-4 pt-14 pb-8",
+        "pointer-events-none absolute inset-x-0 bottom-0 z-30 flex justify-center px-4 pt-14 pb-12",
       )}
     >
       {/* Frosted veil under the dock: blurs the page content directly behind
@@ -442,7 +589,12 @@ function InsightsDock({
         // and even then through the grace timer, so a navigation click keeps
         // the dock expanded for the next page's suggestions.
         onFocus={(e) => {
-          if (e.target === inputRef.current) {
+          // Focus inside the shadow-rooted composer retargets to its host, so
+          // match on containment rather than identity for that path.
+          const fromComposer =
+            e.target === inputRef.current ||
+            (composerHostRef.current?.contains(e.target as Node) ?? false);
+          if (fromComposer) {
             cancelCollapse();
             setExpanded(true);
           }
@@ -582,9 +734,11 @@ function InsightsDock({
                     </button>
                   )}
                   {/* Greyed shortcut hint on the resting pill; hidden once the
-                      composer is engaged (focused or typing) and in continue
-                      mode (a button, not a focusable input). */}
-                  {!composerExpanded && !continueMode && (
+                      composer is engaged (focused or typing), in continue mode
+                      (a button, not a focusable input), and alongside the
+                      shared composer — whose own action cluster (mic, send,
+                      mentions) already crowds that corner. */}
+                  {!composerExpanded && !continueMode && !runtimeReady && (
                     <InsightsShortcutKeys className="opacity-60" />
                   )}
                   <button
@@ -875,8 +1029,17 @@ export function InsightsProvider({
   // `onChatRoute` takes over before `isExpanded` flips (no unmount gap).
   // Everything runtime-dependent — the dock panel's chat view, the provider
   // mount, and (via context) the chat pages — gates on this single flag.
-  const runtimeMounted =
-    assistantReady && (onChatRoute || (isExpanded && !hideTrigger));
+  // Mounted wherever a composer can appear — every surface now renders the
+  // same AUI composer, and that needs the runtime present, not just when the
+  // chat panel happens to be open. MCP discovery is a react-query on a
+  // module-level client, so the extra mounts reuse one cached result.
+  // Mounted as soon as the assistant resolves, not only where chat is visible:
+  // every entry point (dock pill, /chat landing, project home widget, full
+  // page) now renders the same AUI composer, and that needs the runtime in the
+  // tree. Pages that hide the dock still embed the landing widget, so gating on
+  // dock visibility left those surfaces on the legacy input. MCP discovery is a
+  // react-query on a module-level client, so the extra mounts share one result.
+  const runtimeMounted = assistantReady;
 
   // Read inside the transport wrapper via ref so override churn doesn't
   // re-create the transport identity on every parent re-render.
@@ -999,6 +1162,13 @@ export function InsightsProvider({
       // dock has no attach affordance and the feature is not implemented.
       composer: {
         placeholder: "Ask anything",
+        // Typing `/` offers the same canned prompts the landing widget used to
+        // own, now that every surface shares one composer.
+        slashCommands: SLASH_COMMANDS.map((command) => ({
+          title: command.title,
+          label: command.label,
+          prompt: command.prompt,
+        })),
         attachments: false,
         skillContext: {
           skills: composerSkills,
@@ -1016,8 +1186,10 @@ export function InsightsProvider({
         radius: "sharp",
         customCss:
           DOCK_PANEL_COMPOSER_CSS +
+          DOCK_INLINE_COMPOSER_CSS +
           CHAT_MARKDOWN_CSS +
           CHAT_FULLPAGE_COMPOSER_CSS +
+          CHAT_LANDING_COMPOSER_CSS +
           CHAT_LINK_CSS,
       },
     }),
@@ -1379,6 +1551,7 @@ export function InsightsProvider({
           onDismiss={handleDockDismiss}
           onOpenHistory={handleOpenHistory}
           panel={panelContent}
+          runtimeReady={runtimeMounted}
         />
       )}
     </div>
@@ -1402,6 +1575,11 @@ export function InsightsProvider({
           <PendingPromptBridge
             pending={pendingPrompt}
             onConsume={consumePendingPrompt}
+          />
+          <StopDictationOnNavigate />
+          <OpenPanelOnSend
+            enabled={!isExpanded && !onChatRoute && !hideTrigger}
+            onSend={() => setIsExpanded(true)}
           />
           {dockSurface}
         </GramElementsProvider>
@@ -1434,6 +1612,49 @@ function ExpandToPageButton({
       <Maximize2 className="size-4" />
     </button>
   );
+}
+
+/**
+ * Opens the chat panel when the docked composer sends. The dock's composer now
+ * sends through the runtime itself, so there is no submit handler to hook —
+ * the message landing on the thread IS the signal. Disabled on chat routes and
+ * while the panel is already open, where the panel must not steal the view.
+ */
+function OpenPanelOnSend({
+  enabled,
+  onSend,
+}: {
+  enabled: boolean;
+  onSend: () => void;
+}): null {
+  const messageCount = useAuiState(({ thread }) => thread.messages.length);
+  const seenRef = useRef(messageCount);
+  useEffect(() => {
+    const grew = messageCount > seenRef.current;
+    seenRef.current = messageCount;
+    if (grew && enabled) onSend();
+  }, [messageCount, enabled, onSend]);
+  return null;
+}
+
+/**
+ * Ends any live dictation when the route changes. The composer is shared and
+ * outlives navigation, so without this the mic keeps listening (and recording)
+ * on a page the user has already left.
+ */
+function StopDictationOnNavigate(): null {
+  const { pathname } = useLocation();
+  const aui = useAui();
+  const isDictating = useAuiState(({ composer }) => composer.dictation != null);
+  const dictatingRef = useRef(isDictating);
+  dictatingRef.current = isDictating;
+  useEffect(() => {
+    return () => {
+      if (dictatingRef.current) aui.composer().stopDictation();
+    };
+    // Cleanup runs on every pathname change, which is exactly the signal.
+  }, [pathname, aui]);
+  return null;
 }
 
 /**

--- a/client/dashboard/src/elements/components/ChatComposer/index.tsx
+++ b/client/dashboard/src/elements/components/ChatComposer/index.tsx
@@ -6,40 +6,12 @@ import { useAui } from "@assistant-ui/react";
 import { Composer } from "../assistant-ui/thread";
 import { ErrorBoundary } from "../assistant-ui/error-boundary";
 import { ShadowRoot } from "@/elements/components/ShadowRoot";
-
-/** Marks the shadow host so hosts can reach the input inside it (see
- *  `focusChatComposer`). */
-const COMPOSER_HOST_CLASS = "gram-elements-composer-host";
+import { COMPOSER_HOST_CLASS } from "@/elements/lib/composerFocus";
 
 interface ChatComposerProps {
   className?: string;
 }
 
-/**
- * Focus the composer's input from outside the shadow root — e.g. the dock's
- * Cmd+/ shortcut. `root` is any ancestor element of the ChatComposer; shadow
- * DOM is queried explicitly because `querySelector` does not cross it.
- */
-export function focusChatComposer(root: HTMLElement | null): void {
-  root
-    ?.querySelector<HTMLElement>(`.${COMPOSER_HOST_CLASS}`)
-    ?.shadowRoot?.querySelector<HTMLTextAreaElement>("textarea")
-    ?.focus();
-}
-
-/**
- * The chat composer on its own, without a message thread.
- *
- * Entry points that start a conversation (the /chat landing, the docked pill)
- * used to hand-roll a textarea and inject the text into the runtime after the
- * fact, which left them without dictation, attachments, tool mentions, or
- * skill context. This renders the SAME composer the thread uses, bound to the
- * surrounding runtime, so those surfaces gain every composer feature — present
- * and future — for free.
- *
- * Requires an ElementsProvider ancestor (for the runtime); its own ShadowRoot
- * carries the Elements stylesheet, exactly as `Chat` does.
- */
 /**
  * Drops the draft when a standalone composer goes away. Composer state lives
  * on the shared runtime, so without this a half-typed message follows the user
@@ -57,6 +29,18 @@ function ClearDraftOnUnmount(): null {
   return null;
 }
 
+/**
+ * The chat composer on its own, without a message thread.
+ *
+ * Entry points that start a conversation (the /chat landing, the docked pill)
+ * used to hand-roll a textarea and inject the text into the runtime after the
+ * fact, which left them without dictation, attachments, tool mentions, or
+ * skill context. This renders the SAME composer the thread uses, bound to the
+ * surrounding runtime, so those surfaces gain every composer feature.
+ *
+ * Requires an ElementsProvider ancestor (for the runtime); its own ShadowRoot
+ * carries the Elements stylesheet, exactly as `Chat` does.
+ */
 export const ChatComposer = ({
   className,
 }: ChatComposerProps): React.JSX.Element => (

--- a/client/dashboard/src/elements/components/ChatComposer/index.tsx
+++ b/client/dashboard/src/elements/components/ChatComposer/index.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import * as React from "react";
+import { useEffect } from "react";
+import { useAui } from "@assistant-ui/react";
+import { Composer } from "../assistant-ui/thread";
+import { ErrorBoundary } from "../assistant-ui/error-boundary";
+import { ShadowRoot } from "@/elements/components/ShadowRoot";
+
+/** Marks the shadow host so hosts can reach the input inside it (see
+ *  `focusChatComposer`). */
+const COMPOSER_HOST_CLASS = "gram-elements-composer-host";
+
+interface ChatComposerProps {
+  className?: string;
+}
+
+/**
+ * Focus the composer's input from outside the shadow root — e.g. the dock's
+ * Cmd+/ shortcut. `root` is any ancestor element of the ChatComposer; shadow
+ * DOM is queried explicitly because `querySelector` does not cross it.
+ */
+export function focusChatComposer(root: HTMLElement | null): void {
+  root
+    ?.querySelector<HTMLElement>(`.${COMPOSER_HOST_CLASS}`)
+    ?.shadowRoot?.querySelector<HTMLTextAreaElement>("textarea")
+    ?.focus();
+}
+
+/**
+ * The chat composer on its own, without a message thread.
+ *
+ * Entry points that start a conversation (the /chat landing, the docked pill)
+ * used to hand-roll a textarea and inject the text into the runtime after the
+ * fact, which left them without dictation, attachments, tool mentions, or
+ * skill context. This renders the SAME composer the thread uses, bound to the
+ * surrounding runtime, so those surfaces gain every composer feature — present
+ * and future — for free.
+ *
+ * Requires an ElementsProvider ancestor (for the runtime); its own ShadowRoot
+ * carries the Elements stylesheet, exactly as `Chat` does.
+ */
+/**
+ * Drops the draft when a standalone composer goes away. Composer state lives
+ * on the shared runtime, so without this a half-typed message follows the user
+ * from one entry point to the next (chat home -> project home) as if they had
+ * typed it there.
+ */
+function ClearDraftOnUnmount(): null {
+  const aui = useAui();
+  useEffect(
+    () => () => {
+      aui.composer().setText("");
+    },
+    [aui],
+  );
+  return null;
+}
+
+export const ChatComposer = ({
+  className,
+}: ChatComposerProps): React.JSX.Element => (
+  <ErrorBoundary>
+    <ShadowRoot
+      hostClassName={COMPOSER_HOST_CLASS}
+      hostStyle={{ width: "100%" }}
+    >
+      <div className={className}>
+        <ClearDraftOnUnmount />
+        <Composer showThreadAffordances={false} autoFocus={false} />
+      </div>
+    </ShadowRoot>
+  </ErrorBoundary>
+);

--- a/client/dashboard/src/elements/components/assistant-ui/thread.tsx
+++ b/client/dashboard/src/elements/components/assistant-ui/thread.tsx
@@ -8,6 +8,7 @@ import {
   CircleIcon,
   CopyIcon,
   DownloadIcon,
+  Mic,
   PencilIcon,
   Search,
   Settings2,
@@ -78,6 +79,7 @@ import { useReplayContext } from "@/elements/contexts/ReplayContext";
 import { useThreadMeta } from "@/elements/contexts/ThreadMetaContext";
 import { useAuth } from "@/elements/hooks/useAuth";
 import { useDensity } from "@/elements/hooks/useDensity";
+import { useDictationLevels } from "@/elements/hooks/useDictationLevels";
 import { useElements } from "@/elements/hooks/useElements";
 import { isLocalThreadId } from "@/elements/hooks/useGramThreadListAdapter";
 import { useRadius } from "@/elements/hooks/useRadius";
@@ -85,6 +87,7 @@ import { useRecordCassette } from "@/elements/hooks/useRecordCassette";
 import { useThemeProps } from "@/elements/hooks/useThemeProps";
 import { useToolMentions } from "@/elements/hooks/useToolMentions";
 import { getApiUrl } from "@/elements/lib/api";
+import { dictationAdapter } from "@/elements/lib/dictation";
 import { EASE_OUT_QUINT } from "@/elements/lib/easing";
 import { groupAssistantMessageParts } from "@/elements/lib/messagePartGrouping";
 import {
@@ -92,7 +95,11 @@ import {
   trailingAnnotationLine,
 } from "@/elements/lib/toolCallAnnotation";
 import { MODELS } from "@/elements/lib/models";
-import type { ComposerSkill, SkillContextConfig } from "@/elements/types";
+import type {
+  ComposerSkill,
+  ComposerSlashCommand,
+  SkillContextConfig,
+} from "@/elements/types";
 import {
   type MentionableTool,
   toolSetToMentionableTools,
@@ -585,9 +592,21 @@ const ComposerFeedback: FC = () => {
 
 interface ComposerProps {
   showFeedback?: boolean;
+  /** Standalone hosts (entry-point composers with no message list above them)
+   *  pass false: there is no viewport to scroll back down to, and the composer
+   *  must not claim the run state of a conversation it doesn't own. */
+  showThreadAffordances?: boolean;
+  /** Grab focus on mount. True inside a thread, where typing is the only thing
+   *  to do; false on landing pages, where stealing focus hijacks the scroll
+   *  position and the keyboard from the rest of the page. */
+  autoFocus?: boolean;
 }
 
-const Composer: FC<ComposerProps> = ({ showFeedback = false }) => {
+export const Composer: FC<ComposerProps> = ({
+  showFeedback = false,
+  showThreadAffordances = true,
+  autoFocus = true,
+}) => {
   const { config, mcpTools } = useElements();
   const { isResolved, setUnresolved } = useChatResolution();
   const r = useRadius();
@@ -595,6 +614,8 @@ const Composer: FC<ComposerProps> = ({ showFeedback = false }) => {
   const replayCtx = useReplayContext();
 
   const isReplay = replayCtx?.isReplay ?? false;
+  const isDictating = useAuiState(({ composer }) => composer.dictation != null);
+  const isComposerEmpty = useAuiState(({ composer }) => composer.text === "");
   const composerConfig = config.composer ?? {
     placeholder: "Send a message...",
     attachments: true,
@@ -609,6 +630,37 @@ const Composer: FC<ComposerProps> = ({ showFeedback = false }) => {
       composerConfig.toolMentions.enabled !== false);
 
   const composerRootRef = useRef<HTMLFormElement>(null);
+
+  // Slash commands: typing `/` turns the draft into a command query. Picking
+  // one REPLACES the draft and sends, so the raw "/…" text is never submitted.
+  const aui = useAui();
+  const composerText = useAuiState(({ composer }) => composer.text);
+  const slashCommands = composerConfig.slashCommands ?? [];
+  const slashQuery = composerText.startsWith("/")
+    ? composerText.slice(1).trim().toLowerCase()
+    : null;
+  const slashMatches = useMemo(() => {
+    if (slashQuery === null) return [];
+    if (!slashQuery) return slashCommands;
+    return slashCommands.filter(
+      (command) =>
+        command.title.toLowerCase().includes(slashQuery) ||
+        (command.label?.toLowerCase().includes(slashQuery) ?? false),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- slashCommands is a config array, compared by content below
+  }, [slashQuery, slashCommands]);
+  const [activeSlashIndex, setActiveSlashIndex] = useState(0);
+  const slashOpen = slashMatches.length > 0;
+
+  useEffect(() => {
+    setActiveSlashIndex(0);
+  }, [slashQuery]);
+
+  const runSlashCommand = (command: ComposerSlashCommand) => {
+    const composer = aui.composer();
+    composer.setText(command.prompt);
+    composer.send();
+  };
 
   if (components.Composer) {
     return <components.Composer />;
@@ -626,10 +678,12 @@ const Composer: FC<ComposerProps> = ({ showFeedback = false }) => {
       {/* Floating overlay above the opaque composer: keeps the message list
           scrolling all the way down to the composer instead of being cut off
           by a band of background behind the feedback pill. */}
-      <div className="aui-composer-overlay pointer-events-none absolute inset-x-0 bottom-full z-20 flex justify-center pb-3">
-        {showFeedback && <ComposerFeedback />}
-        <ThreadScrollToBottom />
-      </div>
+      {showThreadAffordances && (
+        <div className="aui-composer-overlay pointer-events-none absolute inset-x-0 bottom-full z-20 flex justify-center pb-3">
+          {showFeedback && <ComposerFeedback />}
+          <ThreadScrollToBottom />
+        </div>
+      )}
       {showFeedback && isResolved ? (
         <m.div
           className="aui-composer-resolved flex min-h-[118px] flex-col items-center justify-center gap-2 border-t border-input px-1"
@@ -652,33 +706,171 @@ const Composer: FC<ComposerProps> = ({ showFeedback = false }) => {
       ) : (
         <ComposerPrimitive.Root
           ref={composerRootRef}
+          // Capture: the menu owns Up/Down/Enter while it is open, before the
+          // textarea inserts a newline or the composer sends the raw query.
+          onKeyDownCapture={(event) => {
+            if (!slashOpen) return;
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setActiveSlashIndex((i) => (i + 1) % slashMatches.length);
+            } else if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setActiveSlashIndex(
+                (i) => (i - 1 + slashMatches.length) % slashMatches.length,
+              );
+            } else if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              event.stopPropagation();
+              const command = slashMatches[activeSlashIndex];
+              if (command) runSlashCommand(command);
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              aui.composer().setText("");
+            }
+          }}
+          // Lets compact hosts (the docked pill) restyle the composer while
+          // dictation is live — there is no room there for both the transcript
+          // and the level trail.
+          data-dictating={isDictating ? "true" : undefined}
+          // Hosts that paint their own placeholder (the landing surfaces cycle
+          // through example prompts) need to know when the draft is empty.
+          data-empty={isComposerEmpty ? "true" : undefined}
           className={cn(
-            "aui-composer-root group/input-group relative flex min-h-[118px] w-full flex-col border border-input bg-background px-1 pt-2 shadow-xs transition-[color,box-shadow] outline-none has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-1 has-[textarea:focus-visible]:ring-ring/5 dark:bg-background",
+            "aui-composer-root group/input-group relative flex min-h-[118px] w-full flex-col border border-black/8 bg-background px-1.5 pt-3 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_28px_-16px_rgba(0,0,0,0.18)] transition-[color,border-color,box-shadow] outline-none has-[textarea:focus-visible]:border-black/15 dark:border-white/10 dark:bg-background dark:has-[textarea:focus-visible]:border-white/20",
             r("xl"),
             isReplay && "pointer-events-none opacity-50",
           )}
         >
           {composerConfig.attachments && <ComposerAttachments />}
 
+          {slashOpen && (
+            <ComposerSlashCommandMenu
+              commands={slashMatches}
+              activeIndex={activeSlashIndex}
+              onHover={setActiveSlashIndex}
+              onSelect={runSlashCommand}
+            />
+          )}
+
           {toolMentionsEnabled && <ComposerToolMentions tools={mcpTools} />}
 
           <ComposerSkillContextBadges />
 
+          {/* Speech lands in the input as the recognizer finalizes it, which
+              reads as text writing itself. Hide the draft while the session is
+              live and show a single "Listening…" label instead; the text is
+              revealed intact the moment dictation stops. */}
+          {isDictating && (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "aui-composer-listening pointer-events-none absolute px-4 pt-0.5 text-muted-foreground",
+                d("text-base"),
+              )}
+            >
+              Listening…
+            </span>
+          )}
           <ComposerPrimitive.Input
             placeholder={composerConfig.placeholder}
             className={cn(
-              "aui-composer-input mb-1 max-h-32 w-full resize-none bg-transparent px-3.5 pt-1.5 pb-3 text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-0",
+              "aui-composer-input mb-1 max-h-32 w-full resize-none bg-transparent px-4 pt-0.5 pb-3 text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-0",
               d("h-input"),
               d("text-base"),
+              isDictating && "invisible",
             )}
             rows={1}
-            autoFocus={!isReplay}
+            autoFocus={autoFocus && !isReplay}
             disabled={isReplay}
             aria-label="Message input"
           />
-          <ComposerAction />
+          <ComposerAction showRunState={showThreadAffordances} />
         </ComposerPrimitive.Root>
       )}
+    </div>
+  );
+};
+
+/**
+ * Live feedback while dictating: finalized speech lands in the input, interim
+ * words only exist in the transcript primitive until the recognizer commits.
+ */
+const DICTATION_BAR_COUNT = 28;
+
+/**
+ * The scrolling level trail shown left of the mic while dictating: newest
+ * sample sits next to the button, so speech visibly flows into it.
+ */
+const ComposerDictationWave: FC = () => {
+  // The recognizer's interim transcript is the speech signal — see
+  // useDictationLevels for why this doesn't tap the microphone directly.
+  const transcript = useAuiState(
+    ({ composer }) => composer.dictation?.transcript,
+  );
+  const levels = useDictationLevels(transcript, DICTATION_BAR_COUNT);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="aui-composer-dictation-wave mr-1 flex h-[34px] items-center gap-[3px]"
+    >
+      {levels.map((level, index) => (
+        <span
+          key={index}
+          className="aui-composer-dictation-bar w-[2px] shrink-0 rounded-full bg-muted-foreground/60"
+          // Floor of 2px keeps the row reading as a dotted line while silent,
+          // exactly like the reference. No CSS transition: the value already
+          // updates every frame, and a transition would only damp the peaks.
+          style={{ height: `${(2 + level * 16).toFixed(1)}px` }}
+        />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Command list shown above the composer while the draft is a `/` query.
+ * Selection is owned by the composer so Enter and click resolve to the same
+ * row; rows use onMouseDown-prevent so clicking one doesn't blur the input
+ * (which would clear the query before the click lands).
+ */
+const ComposerSlashCommandMenu: FC<{
+  commands: ComposerSlashCommand[];
+  activeIndex: number;
+  onHover: (index: number) => void;
+  onSelect: (command: ComposerSlashCommand) => void;
+}> = ({ commands, activeIndex, onHover, onSelect }) => {
+  const r = useRadius();
+  return (
+    <div
+      role="listbox"
+      className={cn(
+        "aui-composer-slash-menu absolute bottom-full left-0 z-50 mb-2 max-h-64 w-full overflow-y-auto border border-input bg-background shadow-md",
+        r("lg"),
+      )}
+    >
+      {commands.map((command, index) => (
+        <button
+          key={command.title}
+          type="button"
+          role="option"
+          aria-selected={index === activeIndex}
+          onMouseDown={(event) => event.preventDefault()}
+          onMouseEnter={() => onHover(index)}
+          onClick={() => onSelect(command)}
+          className={cn(
+            "aui-composer-slash-item flex w-full items-baseline gap-2 px-3 py-2 text-left text-sm",
+            index === activeIndex && "bg-muted",
+          )}
+        >
+          <span className="truncate text-foreground">{command.title}</span>
+          {command.label && (
+            <span className="truncate text-xs text-muted-foreground">
+              {command.label}
+            </span>
+          )}
+        </button>
+      ))}
     </div>
   );
 };
@@ -1106,7 +1298,13 @@ const ComposerSkillContextPicker: FC = () => {
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
 
-  if (!skillContext) {
+  // Nothing to attach → no affordance. An "Add context" button that opens an
+  // empty list is worse than no button, and the project may simply have no
+  // skills yet. Still shown while loading, so it doesn't flicker in.
+  if (
+    !skillContext ||
+    (skillContext.skills.length === 0 && !skillContext.loading)
+  ) {
     return null;
   }
 
@@ -1272,13 +1470,66 @@ function SkillContextPickerResults({
   );
 }
 
-const ComposerAction: FC = () => {
+/**
+ * Push-to-talk mic. Rendered only when the browser exposes the Web Speech API —
+ * without an adapter the primitive's click handler is null, so the button would
+ * look live but do nothing.
+ */
+const ComposerDictate: FC = () => {
+  const r = useRadius();
+  // `composer.dictation` holds the live session and is undefined otherwise.
+  const isDictating = useAuiState(({ composer }) => composer.dictation != null);
+
+  if (isDictating) {
+    return (
+      <>
+        <ComposerDictationWave />
+        <ComposerPrimitive.StopDictation asChild>
+          <TooltipIconButton
+            tooltip="Stop dictation"
+            side="bottom"
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={cn(
+              "aui-composer-dictate size-[34px] bg-blue-600 p-1 text-white hover:bg-blue-600/85 hover:text-white",
+              r("full"),
+            )}
+            aria-label="Stop dictation"
+          >
+            <Mic className="aui-composer-dictate-icon size-5 stroke-[1.5px]" />
+          </TooltipIconButton>
+        </ComposerPrimitive.StopDictation>
+      </>
+    );
+  }
+
+  return (
+    <ComposerPrimitive.Dictate asChild>
+      <TooltipIconButton
+        tooltip="Dictate message"
+        side="bottom"
+        type="button"
+        variant="ghost"
+        size="icon"
+        className={cn("aui-composer-dictate size-[34px] p-1", r("full"))}
+        aria-label="Dictate message"
+      >
+        <Mic className="aui-composer-dictate-icon size-5 stroke-[1.5px]" />
+      </TooltipIconButton>
+    </ComposerPrimitive.Dictate>
+  );
+};
+
+const ComposerAction: FC<{ showRunState?: boolean }> = ({
+  showRunState = true,
+}) => {
   const { config } = useElements();
   const r = useRadius();
   const composerConfig = config.composer ?? { attachments: true };
   return (
-    <div className="aui-composer-action-wrapper relative mx-1 mt-2 mb-2 flex items-center justify-between">
-      <div className="aui-composer-action-wrapper-inner flex items-center text-muted-foreground">
+    <div className="aui-composer-action-wrapper relative mx-1.5 mt-1 mb-2 flex items-center justify-between">
+      <div className="aui-composer-action-wrapper-inner flex items-center gap-0.5 text-muted-foreground">
         {composerConfig.attachments ? (
           <ComposerAddAttachment />
         ) : (
@@ -1289,45 +1540,76 @@ const ComposerAction: FC = () => {
 
         <ComposerSkillContextPicker />
 
+        {CASSETTE_RECORDING_ENABLED && <ComposerCassetteRecorder />}
+      </div>
+
+      {/* Claude's ordering: composition tools on the left, model + voice +
+          send on the right, closest to where the eye lands after typing. */}
+      <div className="aui-composer-action-send-group flex items-center gap-1.5">
         {config.model?.showModelPicker && !config.languageModel && (
           <ComposerModelPicker />
         )}
 
-        {CASSETTE_RECORDING_ENABLED && <ComposerCassetteRecorder />}
+        {dictationAdapter && <ComposerDictate />}
+
+        {/* A standalone entry-point composer (chat home, project home, the
+            docked pill) shares the runtime with whatever conversation is
+            already streaming, but it does not OWN that run: showing its stop
+            button there offers to cancel a turn the user cannot even see. It
+            always shows send, and starts a fresh thread instead. */}
+        {!showRunState && (
+          <ComposerPrimitive.Send asChild>
+            <TooltipIconButton
+              tooltip="Send message"
+              side="bottom"
+              type="submit"
+              variant="default"
+              size="icon"
+              className={cn("aui-composer-send size-[34px] p-1", r("full"))}
+              aria-label="Send message"
+            >
+              <ArrowUpIcon className="aui-composer-send-icon size-5" />
+            </TooltipIconButton>
+          </ComposerPrimitive.Send>
+        )}
+
+        {showRunState && (
+          <ThreadPrimitive.If running={false}>
+            <ComposerPrimitive.Send asChild>
+              <TooltipIconButton
+                tooltip="Send message"
+                side="bottom"
+                type="submit"
+                variant="default"
+                size="icon"
+                className={cn("aui-composer-send size-[34px] p-1", r("full"))}
+                aria-label="Send message"
+              >
+                <ArrowUpIcon className="aui-composer-send-icon size-5" />
+              </TooltipIconButton>
+            </ComposerPrimitive.Send>
+          </ThreadPrimitive.If>
+        )}
+
+        {showRunState && (
+          <ThreadPrimitive.If running>
+            <ComposerPrimitive.Cancel asChild>
+              <Button
+                type="button"
+                variant="default"
+                size="icon"
+                className={cn(
+                  "aui-composer-cancel size-[34px] border border-muted-foreground/60 hover:bg-primary/75 dark:border-muted-foreground/90",
+                  r("full"),
+                )}
+                aria-label="Stop generating"
+              >
+                <Square className="aui-composer-cancel-icon size-3.5 fill-white dark:fill-black" />
+              </Button>
+            </ComposerPrimitive.Cancel>
+          </ThreadPrimitive.If>
+        )}
       </div>
-
-      <ThreadPrimitive.If running={false}>
-        <ComposerPrimitive.Send asChild>
-          <TooltipIconButton
-            tooltip="Send message"
-            side="bottom"
-            type="submit"
-            variant="default"
-            size="icon"
-            className={cn("aui-composer-send size-[34px] p-1", r("full"))}
-            aria-label="Send message"
-          >
-            <ArrowUpIcon className="aui-composer-send-icon size-5" />
-          </TooltipIconButton>
-        </ComposerPrimitive.Send>
-      </ThreadPrimitive.If>
-
-      <ThreadPrimitive.If running>
-        <ComposerPrimitive.Cancel asChild>
-          <Button
-            type="button"
-            variant="default"
-            size="icon"
-            className={cn(
-              "aui-composer-cancel size-[34px] border border-muted-foreground/60 hover:bg-primary/75 dark:border-muted-foreground/90",
-              r("full"),
-            )}
-            aria-label="Stop generating"
-          >
-            <Square className="aui-composer-cancel-icon size-3.5 fill-white dark:fill-black" />
-          </Button>
-        </ComposerPrimitive.Cancel>
-      </ThreadPrimitive.If>
     </div>
   );
 };

--- a/client/dashboard/src/elements/contexts/ElementsProvider.tsx
+++ b/client/dashboard/src/elements/contexts/ElementsProvider.tsx
@@ -19,6 +19,7 @@ import {
   type ApprovalHelpers,
 } from "@/elements/lib/tools";
 import { compactForModel } from "@/elements/lib/contextCompaction";
+import { dictationAdapter } from "@/elements/lib/dictation";
 import { describeStreamError } from "@/elements/lib/streamErrorMessage";
 import { cn } from "@/lib/utils";
 import { recommended } from "@/elements/plugins";
@@ -761,6 +762,7 @@ const ElementsProviderWithHistory = ({
     return useChatRuntime({
       transport,
       sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+      adapters: { dictation: dictationAdapter },
     });
   }, [transport]);
 
@@ -851,6 +853,7 @@ const ElementsProviderWithoutHistory = ({
   const runtime = useChatRuntime({
     transport,
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    adapters: { dictation: dictationAdapter },
   });
 
   // Populate runtimeRef so transport can access thread context

--- a/client/dashboard/src/elements/hooks/useDictationLevels.ts
+++ b/client/dashboard/src/elements/hooks/useDictationLevels.ts
@@ -35,17 +35,20 @@ export function useDictationLevels(
   useEffect(() => {
     let frame: number | undefined;
     let level = 0;
+    let phase = 0;
 
     const tick = () => {
+      phase += 1;
       if (transcriptRef.current !== lastSeenRef.current) {
         lastSeenRef.current = transcriptRef.current;
         level = SPEECH_LEVEL;
       } else {
         level = Math.max(IDLE_LEVEL, level * DECAY);
       }
-      // Jitter so neighbouring bars differ; a flat ramp reads as a progress
-      // bar rather than a voice trace.
-      const jittered = level * (0.55 + 0.45 * Math.abs(Math.sin(level * 37)));
+      // Jitter on the frame counter, not the level: keyed off `level` alone the
+      // idle floor is a constant, so the trail froze into a flat line a second
+      // into any silence while the mic was still listening.
+      const jittered = level * (0.55 + 0.45 * Math.abs(Math.sin(phase * 0.37)));
       historyRef.current = [...historyRef.current.slice(1), jittered];
       setLevels(historyRef.current);
       frame = requestAnimationFrame(tick);

--- a/client/dashboard/src/elements/hooks/useDictationLevels.ts
+++ b/client/dashboard/src/elements/hooks/useDictationLevels.ts
@@ -24,10 +24,9 @@ export function useDictationLevels(
   transcript: string | undefined,
   sampleCount: number,
 ): number[] {
-  const [levels, setLevels] = useState<number[]>(() =>
-    new Array<number>(sampleCount).fill(0),
-  );
-  const historyRef = useRef<number[]>(new Array<number>(sampleCount).fill(0));
+  const emptyTrail = () => Array.from<number>({ length: sampleCount }).fill(0);
+  const [levels, setLevels] = useState<number[]>(emptyTrail);
+  const historyRef = useRef<number[]>(emptyTrail());
   // Read inside the animation frame so a transcript change doesn't restart it.
   const transcriptRef = useRef(transcript);
   const lastSeenRef = useRef(transcript);

--- a/client/dashboard/src/elements/hooks/useDictationLevels.ts
+++ b/client/dashboard/src/elements/hooks/useDictationLevels.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react";
+
+/** How fast an un-fed bar level decays each frame (~250ms to silence). */
+const DECAY = 0.88;
+/** Level injected when the recognizer reports new speech. */
+const SPEECH_LEVEL = 1;
+/** Idle shimmer so the trail never looks frozen while the mic is open. */
+const IDLE_LEVEL = 0.12;
+
+/**
+ * Rolling levels for the dictation waveform, newest value last.
+ *
+ * Deliberately does NOT open its own microphone stream. An analyser-driven
+ * version reads true amplitude, but the second `getUserMedia` capture competes
+ * with the Web Speech recognizer for the device — on macOS Chrome that makes
+ * the recognizer drop most of an utterance and finalize only the last word.
+ * Speech activity comes from the recognizer's own transcript updates instead:
+ * the bars rise while words are arriving and decay when speech pauses.
+ *
+ * @param transcript the live interim transcript; any change counts as speech
+ * @param sampleCount number of bars to keep in the trail
+ */
+export function useDictationLevels(
+  transcript: string | undefined,
+  sampleCount: number,
+): number[] {
+  const [levels, setLevels] = useState<number[]>(() =>
+    new Array<number>(sampleCount).fill(0),
+  );
+  const historyRef = useRef<number[]>(new Array<number>(sampleCount).fill(0));
+  // Read inside the animation frame so a transcript change doesn't restart it.
+  const transcriptRef = useRef(transcript);
+  const lastSeenRef = useRef(transcript);
+  transcriptRef.current = transcript;
+
+  useEffect(() => {
+    let frame: number | undefined;
+    let level = 0;
+
+    const tick = () => {
+      if (transcriptRef.current !== lastSeenRef.current) {
+        lastSeenRef.current = transcriptRef.current;
+        level = SPEECH_LEVEL;
+      } else {
+        level = Math.max(IDLE_LEVEL, level * DECAY);
+      }
+      // Jitter so neighbouring bars differ; a flat ramp reads as a progress
+      // bar rather than a voice trace.
+      const jittered = level * (0.55 + 0.45 * Math.abs(Math.sin(level * 37)));
+      historyRef.current = [...historyRef.current.slice(1), jittered];
+      setLevels(historyRef.current);
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+
+    return () => {
+      if (frame !== undefined) cancelAnimationFrame(frame);
+    };
+  }, [sampleCount]);
+
+  return levels;
+}

--- a/client/dashboard/src/elements/index.ts
+++ b/client/dashboard/src/elements/index.ts
@@ -13,6 +13,10 @@ export type { MarkdownLinkValue } from "./contexts/MarkdownLinkContext";
 
 // Core Components
 export { Chat } from "@/elements/components/Chat";
+export {
+  ChatComposer,
+  focusChatComposer,
+} from "@/elements/components/ChatComposer";
 export { ChatHistory } from "@/elements/components/ChatHistory";
 export { ActiveChatTitle } from "@/elements/components/ActiveChatTitle";
 export { ShareButton } from "@/elements/components/ShareButton";

--- a/client/dashboard/src/elements/index.ts
+++ b/client/dashboard/src/elements/index.ts
@@ -13,10 +13,8 @@ export type { MarkdownLinkValue } from "./contexts/MarkdownLinkContext";
 
 // Core Components
 export { Chat } from "@/elements/components/Chat";
-export {
-  ChatComposer,
-  focusChatComposer,
-} from "@/elements/components/ChatComposer";
+export { ChatComposer } from "@/elements/components/ChatComposer";
+export { focusChatComposer } from "@/elements/lib/composerFocus";
 export { ChatHistory } from "@/elements/components/ChatHistory";
 export { ActiveChatTitle } from "@/elements/components/ActiveChatTitle";
 export { ShareButton } from "@/elements/components/ShareButton";

--- a/client/dashboard/src/elements/lib/composerFocus.ts
+++ b/client/dashboard/src/elements/lib/composerFocus.ts
@@ -1,0 +1,20 @@
+/**
+ * Marks the shadow host that `ChatComposer` renders, so hosts can reach the
+ * input inside it.
+ *
+ * Lives here rather than beside the component because a module that exports
+ * both components and helpers breaks React Fast Refresh.
+ */
+export const COMPOSER_HOST_CLASS = "gram-elements-composer-host";
+
+/**
+ * Focus the composer's input from outside the shadow root — e.g. the dock's
+ * Cmd+/ shortcut. `root` is any ancestor element of the ChatComposer; shadow
+ * DOM is queried explicitly because `querySelector` does not cross it.
+ */
+export function focusChatComposer(root: HTMLElement | null): void {
+  root
+    ?.querySelector<HTMLElement>(`.${COMPOSER_HOST_CLASS}`)
+    ?.shadowRoot?.querySelector<HTMLTextAreaElement>("textarea")
+    ?.focus();
+}

--- a/client/dashboard/src/elements/lib/dictation.ts
+++ b/client/dashboard/src/elements/lib/dictation.ts
@@ -1,0 +1,187 @@
+import type { DictationAdapter } from "@assistant-ui/react";
+
+const getSpeechRecognition = ():
+  | (new () => SpeechRecognitionLike)
+  | undefined =>
+  typeof window === "undefined"
+    ? undefined
+    : (window.SpeechRecognition ?? window.webkitSpeechRecognition);
+
+/** The slice of the Web Speech API this adapter uses. */
+interface SpeechRecognitionLike extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+interface SpeechAlternativeLike {
+  transcript: string;
+}
+interface SpeechResultLike {
+  isFinal: boolean;
+  0?: SpeechAlternativeLike;
+}
+interface SpeechResultEventLike extends Event {
+  resultIndex: number;
+  results: ArrayLike<SpeechResultLike>;
+}
+
+/**
+ * Dictation over the Web Speech API that reports the WHOLE utterance on every
+ * update, rather than per-segment deltas.
+ *
+ * assistant-ui's bundled `WebSpeechDictationAdapter` emits each segment once
+ * and relies on the composer to concatenate them. In Chrome that accumulation
+ * doesn't survive: an interim arriving after a finalized segment resets the
+ * composer's base text, so the draft ends up holding only the trailing
+ * fragment — dictate a sentence, send it, and the message is its last word.
+ *
+ * Emitting cumulative text sidesteps the whole question of who accumulates.
+ * Everything spoken so far is sent as one interim result, so the draft is
+ * correct after every event; a single final at the end commits it. Any text
+ * the user typed before starting is preserved by the composer, which snapshots
+ * it as the base and appends what we emit.
+ */
+interface DictationOptions {
+  language?: string;
+  continuous?: boolean;
+  interimResults?: boolean;
+}
+
+class CumulativeWebSpeechDictationAdapter implements DictationAdapter {
+  // Plain field + assignment rather than a parameter property: the dashboard
+  // compiles with `erasableSyntaxOnly`, which bans TS-only constructor sugar.
+  private readonly options: DictationOptions;
+
+  constructor(options: DictationOptions = {}) {
+    this.options = options;
+  }
+
+  static isSupported(): boolean {
+    return getSpeechRecognition() !== undefined;
+  }
+
+  listen(): DictationAdapter.Session {
+    const Recognition = getSpeechRecognition();
+    if (!Recognition) {
+      throw new Error("SpeechRecognition is not supported in this browser.");
+    }
+
+    const recognition = new Recognition();
+    recognition.lang = this.options.language ?? "en-US";
+    recognition.continuous = this.options.continuous ?? true;
+    recognition.interimResults = this.options.interimResults ?? true;
+
+    const speechStartCallbacks = new Set<() => void>();
+    const speechEndCallbacks = new Set<(r: DictationAdapter.Result) => void>();
+    const speechCallbacks = new Set<(r: DictationAdapter.Result) => void>();
+
+    /** Finalized segments, keyed by index so a revised segment replaces rather
+     *  than duplicates — Chrome re-emits a segment when it corrects it. */
+    const finals = new Map<number, string>();
+    let interim = "";
+
+    const cumulative = () => {
+      const finalized = [...finals.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([, text]) => text)
+        .join("");
+      return (finalized + interim).trim();
+    };
+
+    const session: DictationAdapter.Session = {
+      status: { type: "starting" },
+      stop: async () => {
+        recognition.stop();
+        return new Promise<void>((resolve) => {
+          const check = () => {
+            if (session.status.type === "ended") resolve();
+            else setTimeout(check, 50);
+          };
+          check();
+        });
+      },
+      cancel: () => recognition.abort(),
+      onSpeechStart: (callback) => {
+        speechStartCallbacks.add(callback);
+        return () => speechStartCallbacks.delete(callback);
+      },
+      onSpeechEnd: (callback) => {
+        speechEndCallbacks.add(callback);
+        return () => speechEndCallbacks.delete(callback);
+      },
+      onSpeech: (callback) => {
+        speechCallbacks.add(callback);
+        return () => speechCallbacks.delete(callback);
+      },
+    };
+
+    recognition.addEventListener("start", () => {
+      session.status = { type: "running" };
+    });
+    recognition.addEventListener("speechstart", () => {
+      for (const cb of speechStartCallbacks) cb();
+    });
+
+    recognition.addEventListener("result", (event) => {
+      const speechEvent = event as SpeechResultEventLike;
+      interim = "";
+      for (
+        let i = speechEvent.resultIndex;
+        i < speechEvent.results.length;
+        i++
+      ) {
+        const result = speechEvent.results[i];
+        if (!result) continue;
+        const transcript = result[0]?.transcript ?? "";
+        if (result.isFinal) finals.set(i, transcript);
+        else interim += transcript;
+      }
+      // Always interim: the composer treats a final as "append this delta",
+      // which would duplicate everything we have already reported.
+      for (const cb of speechCallbacks)
+        cb({ transcript: cumulative(), isFinal: false });
+    });
+
+    recognition.addEventListener("end", () => {
+      if (session.status.type !== "ended") {
+        session.status = { type: "ended", reason: "stopped" };
+      }
+      const transcript = cumulative();
+      if (transcript) {
+        for (const cb of speechEndCallbacks) cb({ transcript });
+      }
+    });
+
+    recognition.addEventListener("error", (event) => {
+      const { error } = event as Event & { error?: string };
+      session.status = {
+        type: "ended",
+        reason: error === "aborted" ? "cancelled" : "error",
+      };
+      if (error && error !== "aborted" && error !== "no-speech") {
+        console.error("Dictation error:", error);
+      }
+    });
+
+    recognition.start();
+    return session;
+  }
+}
+
+/**
+ * Push-to-talk dictation, or `undefined` where the browser has no Web Speech
+ * API (Firefox) so the composer can hide the mic instead of offering a button
+ * that throws.
+ */
+export const dictationAdapter =
+  CumulativeWebSpeechDictationAdapter.isSupported()
+    ? new CumulativeWebSpeechDictationAdapter({
+        language: "en-US",
+        continuous: true,
+        interimResults: true,
+      })
+    : undefined;

--- a/client/dashboard/src/elements/lib/dictation.ts
+++ b/client/dashboard/src/elements/lib/dictation.ts
@@ -107,15 +107,21 @@ class CumulativeWebSpeechDictationAdapter implements DictationAdapter {
       cancel: () => recognition.abort(),
       onSpeechStart: (callback) => {
         speechStartCallbacks.add(callback);
-        return () => speechStartCallbacks.delete(callback);
+        return () => {
+          speechStartCallbacks.delete(callback);
+        };
       },
       onSpeechEnd: (callback) => {
         speechEndCallbacks.add(callback);
-        return () => speechEndCallbacks.delete(callback);
+        return () => {
+          speechEndCallbacks.delete(callback);
+        };
       },
       onSpeech: (callback) => {
         speechCallbacks.add(callback);
-        return () => speechCallbacks.delete(callback);
+        return () => {
+          speechCallbacks.delete(callback);
+        };
       },
     };
 

--- a/client/dashboard/src/elements/lib/dictation.ts
+++ b/client/dashboard/src/elements/lib/dictation.ts
@@ -1,5 +1,8 @@
 import type { DictationAdapter } from "@assistant-ui/react";
 
+/** How long `stop()` waits for the recognizer's `end` event before giving up. */
+const STOP_TIMEOUT_MS = 2000;
+
 const getSpeechRecognition = ():
   | (new () => SpeechRecognitionLike)
   | undefined =>
@@ -96,10 +99,18 @@ class CumulativeWebSpeechDictationAdapter implements DictationAdapter {
       status: { type: "starting" },
       stop: async () => {
         recognition.stop();
+        // Resolve on the recognizer's `end` event, but never wait forever for
+        // it: a stale or already-aborted session may never fire one, and the
+        // caller (composer teardown, navigating away) would hang on a poll
+        // loop that outlives the page.
         return new Promise<void>((resolve) => {
+          const deadline = Date.now() + STOP_TIMEOUT_MS;
           const check = () => {
-            if (session.status.type === "ended") resolve();
-            else setTimeout(check, 50);
+            if (session.status.type === "ended" || Date.now() >= deadline) {
+              resolve();
+              return;
+            }
+            setTimeout(check, 50);
           };
           check();
         });

--- a/client/dashboard/src/elements/types/index.ts
+++ b/client/dashboard/src/elements/types/index.ts
@@ -1058,6 +1058,21 @@ export interface ComposerConfig {
    * Selected skill IDs are supplied to the caller's transport for the next turn.
    */
   skillContext?: SkillContextConfig;
+
+  /**
+   * Canned prompts offered when the draft starts with `/`. Picking one replaces
+   * the draft and sends it, so these are shortcuts rather than editable text.
+   */
+  slashCommands?: ComposerSlashCommand[];
+}
+
+export interface ComposerSlashCommand {
+  /** Command name shown first in the row (also matched against the query). */
+  title: string;
+  /** Short description shown beside the title. */
+  label?: string;
+  /** The prompt actually sent when the command is picked. */
+  prompt: string;
 }
 
 /**

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -3,13 +3,14 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent,
   type ReactElement,
 } from "react";
 import { Link, Outlet, useNavigate, useParams } from "react-router";
 import { AnimatePresence, motion } from "motion/react";
 import { useAui, useAuiState } from "@assistant-ui/react";
-import { ActiveChatTitle, Chat } from "@/elements";
+import { ActiveChatTitle, Chat, ChatComposer } from "@/elements";
 import {
   ChevronLeft,
   Home,
@@ -160,7 +161,8 @@ export function ChatLanding({
   const { user } = useSession();
   const navigate = useNavigate();
   const routes = useRoutes();
-  const { sendPrompt, assistantNeedsAdmin } = useInsightsState();
+  const { sendPrompt, assistantNeedsAdmin, assistantReady } =
+    useInsightsState();
   const [value, setValue] = useState("");
   const [inputFocused, setInputFocused] = useState(false);
   const [activeCommand, setActiveCommand] = useState(0);
@@ -259,6 +261,34 @@ export function ChatLanding({
           <p className="border-border bg-card text-muted-foreground border px-4 py-3 text-sm">
             Ask an admin to enable the Project Assistant for this project.
           </p>
+        ) : assistantReady ? (
+          // The real AUI composer, bound to the shared runtime: sending happens
+          // in the runtime itself, so this entry point has dictation,
+          // attachments, tool mentions and skill context like every other one.
+          // Navigation to the conversation view is driven by the first message
+          // landing in the thread, not by this component sending.
+          // `gram-chat-landing` is read from inside the Elements shadow root
+          // via :host-context, so it must sit on an ancestor of the host — not
+          // on anything ChatComposer renders inside it.
+          <div
+            className="gram-chat-landing border-border bg-card border"
+            // Cycling example prompts ride in as custom properties: they
+            // inherit into the Elements shadow root, so the placeholder can
+            // crossfade without re-rendering the composer (see
+            // CHAT_LANDING_COMPOSER_CSS).
+            style={
+              {
+                "--gram-composer-placeholder": JSON.stringify(placeholder),
+                "--gram-composer-placeholder-opacity": placeholderVisible
+                  ? 1
+                  : 0,
+              } as CSSProperties
+            }
+          >
+            <ChatComposer />
+            <StartFreshThread />
+            <NavigateOnFirstMessage />
+          </div>
         ) : (
           <form
             onSubmit={(e) => {
@@ -337,6 +367,56 @@ export function ChatLanding({
       )}
     </div>
   );
+}
+
+/**
+ * Drops into the full-page conversation as soon as the shared composer puts a
+ * message on the thread. The landing composer sends through the runtime
+ * directly, so there is no submit handler to navigate from — the first message
+ * appearing IS the signal. `/chat/new` then syncs to `/chat/:id` once the
+ * server mints the id.
+ */
+/**
+ * The landing widgets always start a NEW conversation: they share one runtime
+ * with the dock, and the dock is the only surface that deliberately continues
+ * an existing chat. Without this, opening /chat (or project home) after a dock
+ * conversation would drop the next message into that thread.
+ */
+function StartFreshThread(): null {
+  const aui = useAui();
+  // Running counts as "in use" too: coming back to /chat while the dock's turn
+  // is still streaming must still hand the user an empty thread, otherwise the
+  // composer inherits that run (its send button becomes a stop button for a
+  // conversation that isn't on screen).
+  // Unconditional, exactly once, as soon as the thread list has loaded.
+  // Reacting to "the thread has messages" instead would fire on the user's OWN
+  // send — switching the just-sent message out from under them and leaving an
+  // empty /chat/new. Thread ids are minted lazily (deferThreadIdMinting), so a
+  // visit that sends nothing costs no server chat.
+  const listLoading = useAuiState(({ threads }) => threads.isLoading);
+  const switchedRef = useRef(false);
+  useEffect(() => {
+    if (switchedRef.current || listLoading) return;
+    switchedRef.current = true;
+    aui.threads().switchToNewThread();
+  }, [aui, listLoading]);
+  return null;
+}
+
+function NavigateOnFirstMessage(): null {
+  const navigate = useNavigate();
+  const routes = useRoutes();
+  const messageCount = useAuiState(({ thread }) => thread.messages.length);
+  // Latch the count at mount: the shared runtime often already holds a live
+  // conversation (started in the dock), and navigating on "has messages" would
+  // bounce straight back into it every time the user opened /chat.
+  const seenRef = useRef(messageCount);
+  useEffect(() => {
+    const grew = messageCount > seenRef.current;
+    seenRef.current = messageCount;
+    if (grew) void navigate(routes.chat.conversation.href("new"));
+  }, [messageCount, navigate, routes]);
+  return null;
 }
 
 /**

--- a/client/dashboard/src/pages/chat/Chat.tsx
+++ b/client/dashboard/src/pages/chat/Chat.tsx
@@ -287,6 +287,7 @@ export function ChatLanding({
           >
             <ChatComposer />
             <StartFreshThread />
+            <SeedComposerDraft value={value} onSeeded={() => setValue("")} />
             <NavigateOnFirstMessage />
           </div>
         ) : (
@@ -370,12 +371,31 @@ export function ChatLanding({
 }
 
 /**
- * Drops into the full-page conversation as soon as the shared composer puts a
- * message on the thread. The landing composer sends through the runtime
- * directly, so there is no submit handler to navigate from — the first message
- * appearing IS the signal. `/chat/new` then syncs to `/chat/:id` once the
- * server mints the id.
+ * Carries a draft typed into the fallback input over to the shared composer.
+ *
+ * The fallback renders only until the assistant runtime is ready; the two
+ * controls keep their drafts in different places, so without this a message
+ * typed during that window vanishes when the composer swaps in. Runs after
+ * StartFreshThread so the text lands on the new thread, not the old one.
  */
+function SeedComposerDraft({
+  value,
+  onSeeded,
+}: {
+  value: string;
+  onSeeded: () => void;
+}): null {
+  const aui = useAui();
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !value.trim()) return;
+    seededRef.current = true;
+    aui.composer().setText(value);
+    onSeeded();
+  }, [aui, value, onSeeded]);
+  return null;
+}
+
 /**
  * The landing widgets always start a NEW conversation: they share one runtime
  * with the dock, and the dock is the only surface that deliberately continues
@@ -384,15 +404,11 @@ export function ChatLanding({
  */
 function StartFreshThread(): null {
   const aui = useAui();
-  // Running counts as "in use" too: coming back to /chat while the dock's turn
-  // is still streaming must still hand the user an empty thread, otherwise the
-  // composer inherits that run (its send button becomes a stop button for a
-  // conversation that isn't on screen).
-  // Unconditional, exactly once, as soon as the thread list has loaded.
-  // Reacting to "the thread has messages" instead would fire on the user's OWN
-  // send — switching the just-sent message out from under them and leaving an
-  // empty /chat/new. Thread ids are minted lazily (deferThreadIdMinting), so a
-  // visit that sends nothing costs no server chat.
+  // Switch unconditionally, exactly once, as soon as the thread list has
+  // loaded. Reacting to "the thread has messages" instead would fire on the
+  // user's OWN send — switching the just-sent message out from under them and
+  // leaving an empty /chat/new. Thread ids are minted lazily
+  // (deferThreadIdMinting), so a visit that sends nothing costs no server chat.
   const listLoading = useAuiState(({ threads }) => threads.isLoading);
   const switchedRef = useRef(false);
   useEffect(() => {
@@ -403,19 +419,26 @@ function StartFreshThread(): null {
   return null;
 }
 
+/**
+ * Drops into the full-page conversation when the landing composer sends. The
+ * composer submits through the runtime directly, so there is no submit handler
+ * to navigate from — the turn starting is the signal. `/chat/new` then syncs
+ * to `/chat/:id` once the server mints the id.
+ */
 function NavigateOnFirstMessage(): null {
   const navigate = useNavigate();
   const routes = useRoutes();
-  const messageCount = useAuiState(({ thread }) => thread.messages.length);
-  // Latch the count at mount: the shared runtime often already holds a live
-  // conversation (started in the dock), and navigating on "has messages" would
-  // bounce straight back into it every time the user opened /chat.
-  const seenRef = useRef(messageCount);
+  // A run starting is the signal. Watching the message count instead would
+  // also fire when an existing conversation hydrates into the shared runtime
+  // (history loading grows the count), bouncing the user into a chat they
+  // never opened; `isRunning` only goes true for an actual stream.
+  const isRunning = useAuiState(({ thread }) => thread.isRunning);
+  const wasRunningRef = useRef(isRunning);
   useEffect(() => {
-    const grew = messageCount > seenRef.current;
-    seenRef.current = messageCount;
-    if (grew) void navigate(routes.chat.conversation.href("new"));
-  }, [messageCount, navigate, routes]);
+    const justStarted = isRunning && !wasRunningRef.current;
+    wasRunningRef.current = isRunning;
+    if (justStarted) void navigate(routes.chat.conversation.href("new"));
+  }, [isRunning, navigate, routes]);
   return null;
 }
 


### PR DESCRIPTION
## What

Adds push-to-talk voice dictation to the Project Assistant, and gets there by
collapsing four composers into one.

Chat home, the project home widget and the docked pill each hand-rolled a
`<textarea>` that injected a prompt into the shared runtime after the fact.
Only the full-page chat used the real assistant-ui composer. That is why those
surfaces had no attachments, tool mentions or skill context — and why a mic
button could not simply be added to them. They now all render `<ChatComposer>`,
the same composer the thread uses, bound to the shared runtime.

## Changes

- **`elements/lib/dictation.ts`** — `CumulativeWebSpeechDictationAdapter`.
- **`elements/components/ChatComposer/`** — the composer without a thread, for
  entry points. Carries its own shadow root, clears its draft on unmount, and
  never claims the run state of a conversation it does not own.
- **`thread.tsx`** — mic + level trail + "Listening…" state; action row split
  into composition tools (left) and model/mic/send (right); slash-command menu;
  `showThreadAffordances` / `showRunState` / `autoFocus` for standalone hosts.
- **`insights-dock.tsx`** — the Elements runtime now mounts wherever a composer
  can appear rather than only on chat routes; scoped CSS for the three sizes
  (`.gram-chat-dock`, `.gram-chat-landing`, `.gram-chat-fullpage`).
- **`pages/chat/Chat.tsx`** — chat home uses the shared composer, starts a fresh
  thread on arrival, and navigates to the conversation once a message lands.
- **`elements/types`** — `composer.slashCommands`.

## Why a custom dictation adapter

assistant-ui ships `WebSpeechDictationAdapter`, which emits each speech segment
once as a delta and relies on the composer to concatenate them. In Chrome that
accumulation does not survive: an interim result arriving after a finalized
segment resets the composer's base text, so the draft holds only the trailing
fragment. Dictate a sentence, hit send, and the message is its last word.

The adapter here owns the transcript instead — every event reports the whole
utterance so far, so the draft is correct after each update no matter what the
composer does in between. Segments are keyed by index so Chrome's revisions
replace rather than duplicate, and text typed before starting is preserved.

Traced from a real dictation session, then verified against a stubbed
`SpeechRecognition` reproducing Chrome's event shape (cumulative `results`, a
segment flipping interim -> final in place).

## Notes for reviewers

- The waveform is driven by transcript activity, not microphone amplitude. An
  analyser-based version reads true levels but its second `getUserMedia` capture
  competes with the recognizer.
- Firefox has no Web Speech API, so `dictationAdapter` is `undefined` there and
  the mic button is absent rather than dead.
- The runtime now mounts on every page with a dock. MCP discovery is a
  react-query on a module-level client, so the extra mounts share one result.
- Overlaps with the in-flight attachments branch in `ComposerAction` and the
  `adapters` object in `ElementsProvider` (merge as
  `{ dictation, attachments }`).

## Testing

- Dictation exercised live and via a stubbed recognizer; full-sentence capture
  confirmed for the interim-after-final pattern that caused the truncation.
- Send from chat home, project home, dock and full page; navigation mid-stream;
  draft clearing between surfaces.
- `pnpm -F dashboard type-check`, `hk fix`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add push-to-talk voice dictation to the Project Assistant by switching all entry points to a single shared `ChatComposer` bound to the runtime. The dock pill, chat landing, project home, and full-page chat now share the same composer and gain dictation, attachments, tool mentions, skill context, and slash commands.

- New Features
  - Push-to-talk mic using a cumulative Web Speech dictation adapter; fixes Chrome truncation of dictated text; dictation stops on route change.
  - Slash commands: type `/` to pick canned prompts; selection replaces the draft and sends.
  - Listening UI with mic button and a scrolling level trail that stays animated while idle; mic hidden where the Web Speech API isn’t available.
  - Panel/route behavior: dock panel opens and chat landing navigates on run start; standalone composers always start a new thread; dock stays expanded while the shared composer holds a draft.
  - Dock uses the shared composer once the runtime is ready (fallback input until then); drafts typed before readiness are carried into the composer.

- Refactors
  - Replaced hand-rolled textareas with a shared `ChatComposer` (`@assistant-ui/react`) across dock, chat landing, and full chat; composer clears drafts on unmount and supports Cmd+/ via `focusChatComposer`.
  - Mounted the Elements runtime wherever a composer can appear; added a dictation adapter and a transcript-driven waveform (no extra `getUserMedia`); bounded dictation `stop()` to avoid hanging sessions.
  - Styling updates: compact dock pill vs. roomier page/landing composers; landing uses a crossfading placeholder via CSS custom properties.
  - Skill context picker hides when no skills are available.
  - Developer hygiene: unsubscribe callbacks return void, `Array.from` for dictation levels, restored navigation JSDoc; dock draft reporter retracts on unmount so the pill doesn’t remain expanded when swapped out.

<sup>Written for commit 14596863dbc1f06cb4f3c1bfb3788e4a8990db9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

