### PR TITLE
feat: keep expired trial card visible in sidebar

### DIFF
--- a/client/dashboard/src/components/trial-status-card.test.tsx
+++ b/client/dashboard/src/components/trial-status-card.test.tsx
@@ -69,6 +69,9 @@ describe("TrialStatusCard", () => {
     render(<TrialStatusCard />);
 
     expect(screen.getByText("1 day left")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Talk to sales about upgrading" }),
+    ).toBeTruthy();
   });
 
   it("renders nothing without a trial", () => {
@@ -79,12 +82,22 @@ describe("TrialStatusCard", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders nothing once the trial has expired", () => {
+  it("renders the ended state once the trial has expired", () => {
     vi.setSystemTime(new Date("2026-08-19T00:00:00.000Z"));
 
-    const { container } = render(<TrialStatusCard />);
+    render(<TrialStatusCard />);
 
-    expect(container.firstChild).toBeNull();
+    expect(screen.getByText("Your trial has ended")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Talk to sales about upgrading" }),
+    ).toBeTruthy();
+    const progressBar = screen.getByRole("progressbar", {
+      name: "Trial ended",
+    });
+    expect(progressBar.getAttribute("aria-valuenow")).toBe("100");
+    expect(progressBar.firstElementChild?.getAttribute("style")).toBe(
+      "width: 100%;",
+    );
   });
 
   it.each([
@@ -113,10 +126,10 @@ describe("TrialStatusCard", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("removes the card when the trial expires without a parent rerender", async () => {
+  it("shows the ended state when the trial expires without a parent rerender", async () => {
     vi.setSystemTime(new Date("2026-08-18T23:59:59.999Z"));
 
-    const { container } = render(<TrialStatusCard />);
+    render(<TrialStatusCard />);
 
     expect(screen.getByText("1 day left")).toBeTruthy();
 
@@ -124,7 +137,13 @@ describe("TrialStatusCard", () => {
       await vi.advanceTimersByTimeAsync(1);
     });
 
-    expect(container.firstChild).toBeNull();
+    expect(screen.getByText("Your trial has ended")).toBeTruthy();
+    expect(
+      screen.getByRole("progressbar", { name: "Trial ended" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Talk to sales about upgrading" }),
+    ).toBeTruthy();
   });
 
   it("updates the displayed day at a day boundary without a parent rerender", async () => {

--- a/client/dashboard/src/components/trial-status-card.tsx
+++ b/client/dashboard/src/components/trial-status-card.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@/components/ui/Icon";
 import { Text } from "@/components/ui/Text";
 import { useSession } from "@/contexts/Auth";
 import {
+  getTrialLifecycleFromDates,
   getTrialStatusFromDates,
   isValidDate,
   MILLISECONDS_PER_DAY,
@@ -43,6 +44,7 @@ export function TrialStatusCard(): React.ReactNode {
   const { trial } = useSession();
   const [now, setNow] = useState(() => new Date());
   const status = getTrialStatusFromDates(trial, now);
+  const lifecycle = getTrialLifecycleFromDates(trial, now);
   const startedAt = isValidDate(trial?.startedAt)
     ? trial.startedAt.getTime()
     : undefined;
@@ -85,18 +87,32 @@ export function TrialStatusCard(): React.ReactNode {
     return () => window.clearTimeout(timer);
   }, [dayNumber, endsAt, nowTime, remainingDays, startedAt]);
 
-  if (status === null) {
+  if (status === null && lifecycle !== "expired") {
     return null;
   }
 
-  const daysLeft = status.remainingDays;
-  const daysLeftLabel = `${daysLeft} day${daysLeft === 1 ? "" : "s"} left`;
-  const progressValue = Number((status.progress * 100).toFixed(2));
-  const progressLabel = `Day ${status.dayNumber} of ${status.totalDays}`;
-  const progressColorClass = getTrialProgressColorClass(
-    status.dayNumber,
-    status.totalDays,
-  );
+  const daysLeft = status?.remainingDays;
+  const daysLeftLabel =
+    daysLeft === undefined
+      ? undefined
+      : `${daysLeft} day${daysLeft === 1 ? "" : "s"} left`;
+  let progressValue = 100;
+  let progressLabel = "Trial ended";
+  let progressColorClass = RED_PROGRESS_CLASS;
+
+  if (status !== null) {
+    progressValue = Number((status.progress * 100).toFixed(2));
+    progressLabel = `Day ${status.dayNumber} of ${status.totalDays}`;
+    progressColorClass = getTrialProgressColorClass(
+      status.dayNumber,
+      status.totalDays,
+    );
+  }
+
+  let salesLinkLabel = "Talk to sales";
+  if (status === null || status.remainingDays <= 1) {
+    salesLinkLabel = "Talk to sales about upgrading";
+  }
 
   return (
     <div className="border-border border bg-card p-3 group-data-[collapsible=icon]:hidden">
@@ -105,12 +121,16 @@ export function TrialStatusCard(): React.ReactNode {
           <Text mono small className="uppercase">
             Trial
           </Text>
-          <Text mono small className="text-muted">
-            Day {status.dayNumber}/{status.totalDays}
-          </Text>
+          {status !== null && (
+            <Text mono small className="text-muted">
+              Day {status.dayNumber}/{status.totalDays}
+            </Text>
+          )}
         </div>
         <div className="flex flex-col gap-1">
-          <Text className="text-base">{daysLeftLabel}</Text>
+          <Text className="text-base">
+            {status === null ? "Your trial has ended" : daysLeftLabel}
+          </Text>
           <div
             role="progressbar"
             aria-label={progressLabel}
@@ -130,7 +150,7 @@ export function TrialStatusCard(): React.ReactNode {
           to={SALES_PATH}
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
-          Talk to sales
+          {salesLinkLabel}
           <Icon name="arrow-right" className="size-3" aria-hidden="true" />
         </Link>
       </div>


### PR DESCRIPTION
## Summary

This keeps the sidebar trial card visible during the gap between a trial ending and the hourly cleanup sweep, so users see an explicit ended state and upgrade CTA instead of the card disappearing silently.


- Keep the sidebar trial card visible after an unconverted trial expires.
- Replace the day-left copy with `Your trial has ended` while retaining a completed progress bar.
- Use `Talk to sales about upgrading` on the final day and after expiry.

## Validation

- `pnpm -F dashboard test` — 1,617 tests passed.
- `pnpm -F dashboard type-check` — passed.
- `pnpm -F dashboard lint:format` — passed.
- `pnpm -F dashboard lint:oxlint` — passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the sidebar trial card visible after a trial ends and show a clear ended state with a completed progress bar and stronger CTA. This removes the gap where the card disappeared at expiry and aligns with Linear AGE-3145.

- **New Features**
  - Keep the card rendered when the trial lifecycle is expired, even if `getTrialStatusFromDates` returns `null`.
  - Show “Your trial has ended”; set progress to 100% with aria-label “Trial ended”; hide the day counter when expired.
  - Change CTA to “Talk to sales about upgrading” on the final day and after expiry.

- **Dependencies**
  - Relies on AGE-3103 to return the trial row after expiry; suppression for converted orgs will follow when AGE-3131 provides `converted_at`.

<sup>Written for commit 43b024a1de5a1e210a1d61f7aff743a7cc51c734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
