### PR TITLE
feat(risk): score watchdog signals from matched policy scores

### DIFF
--- a/.changeset/watchdog-policy-scores.md
+++ b/.changeset/watchdog-policy-scores.md
@@ -1,0 +1,6 @@
+---
+"server": minor
+"dashboard": patch
+---
+
+Score Watchdog signals from the matched risk policy's configured score, and simplify the signal drawer to a single Create-exclusion action.

--- a/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
+++ b/client/dashboard/src/pages/security/watchdog/SignalDrawer.tsx
@@ -10,23 +10,16 @@ import {
 } from "@/components/ui/Sheet";
 import { Separator } from "@/components/ui/Separator";
 import { Text } from "@/components/ui/Text";
-import { useSdkClient } from "@/contexts/Sdk";
 import type { RiskResult } from "@gram/client/models/components/riskresult.js";
 import type { RiskSignal } from "@gram/client/models/components/risksignal.js";
 import { useRiskListResults } from "@gram/client/react-query/riskListResults.js";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
-import { Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 import { ExclusionEditor, type ExclusionSheetState } from "../exclusion-sheet";
 import { MaskedMatch, RevealAllProvider, RevealAllToggle } from "../risk-ui";
 import { getRuleTitleFallback, scoreToRating } from "../risk-utils";
 import { useDismissFinding } from "../useDismissFinding";
-import {
-  collectFindingsForRules,
-  SIGNAL_DISMISS_CAP,
-} from "./collect-findings";
 import { SCORE_TEXT_COLOR } from "./signals-helpers";
 import { SignalTrend } from "./SignalsList";
 
@@ -153,83 +146,18 @@ function EvidenceRow({
   );
 }
 
-/** Header description line: the confirmation question while the
- * false-positive decision is pending, the rule description otherwise. */
-function signalDescription(signal: RiskSignal, confirming: boolean): string {
-  if (confirming) return "False positive?";
-  return signal.description || "Findings clustered on this detection rule.";
-}
-
-/**
- * Inline confirmation shown in place of the drawer's action buttons after
- * "Mark false positive" is clicked — the rest of the signal detail stays
- * visible behind it.
- */
-function FalsePositiveConfirm({
-  count,
-  onConfirm,
-  onCancel,
-}: {
-  /** Findings actually collected for dismissal (may have hit the cap). */
-  count: number;
-  onConfirm: () => void;
-  onCancel: () => void;
-}): JSX.Element {
-  return (
-    <div className="space-y-6">
-      {/* Pulled up against the sheet header so the divider reads as the
-          header's bottom edge rather than part of the confirmation block. */}
-      <Separator className="-mt-2" />
-      <div className="flex items-start gap-3">
-        <Icon
-          name="circle-alert"
-          className="text-destructive mt-0.5 size-5 shrink-0"
-        />
-        <Text className="text-base">
-          {count === 0
-            ? "No findings to mark in the selected window."
-            : `This will mark ${count.toLocaleString()} ${
-                count === 1 ? "finding" : "findings"
-              } as false positive; they won't be displayed in the watchdog view again.`}
-          {count >= SIGNAL_DISMISS_CAP &&
-            ` Only the first ${SIGNAL_DISMISS_CAP.toLocaleString()} findings can be marked at once; run this again if more remain.`}
-        </Text>
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="primary"
-          className="w-28"
-          disabled={count === 0}
-          onClick={onConfirm}
-        >
-          <Button.Text>OK</Button.Text>
-        </Button>
-        <Button variant="tertiary" className="w-28" onClick={onCancel}>
-          <Button.Text>Cancel</Button.Text>
-        </Button>
-      </div>
-      <Separator />
-    </div>
-  );
-}
-
 /**
  * Slide-over detail for one signal: stats, top affected users, redacted
- * evidence, and the two signal-level actions — create an exclusion rule for
- * the whole rule cluster, or mark every finding in the window false positive.
+ * evidence, and the signal-level action — create an exclusion rule for the
+ * whole rule cluster.
  */
 export function SignalDrawer({
   signal,
-  from,
-  to,
   onClose,
 }: {
   signal: RiskSignal | null;
-  from: Date;
-  to: Date;
   onClose: () => void;
 }): JSX.Element {
-  const client = useSdkClient();
   const { dismiss, isOptimisticallyDismissed } = useDismissFinding();
   const [exclusionState, setExclusionState] =
     useState<ExclusionSheetState | null>(null);
@@ -237,10 +165,6 @@ export function SignalDrawer({
   // slides back in from the left — but never on the drawer's first open,
   // where the Sheet's own slide already animates the content.
   const [returningFromEditor, setReturningFromEditor] = useState(false);
-  const [pendingDismissAll, setPendingDismissAll] = useState<
-    RiskResult[] | null
-  >(null);
-  const [collecting, setCollecting] = useState(false);
 
   const closeEditor = () => {
     setExclusionState(null);
@@ -255,8 +179,7 @@ export function SignalDrawer({
   // Deliberately unwindowed: signals count findings by scan time while the
   // list endpoint filters by message event time, so a windowed evidence query
   // can come back empty for a signal that clearly has findings (scans of
-  // older messages). Latest evidence for the rule is what the drawer wants
-  // anyway; only the bulk false-positive action stays window-scoped.
+  // older messages). Latest evidence for the rule is what the drawer wants.
   const evidenceQuery = useRiskListResults({ ruleId, limit: 25 }, undefined, {
     enabled: signal !== null,
     throwOnError: false,
@@ -279,27 +202,6 @@ export function SignalDrawer({
     setExclusionState({ mode: "create", results: evidence });
   };
 
-  const collectAllFindings = async () => {
-    if (!signal) return;
-    setCollecting(true);
-    try {
-      setPendingDismissAll(
-        await collectFindingsForRules(client, [signal.ruleId], { from, to }),
-      );
-    } catch {
-      toast.error("Failed to load the signal's findings.");
-    } finally {
-      setCollecting(false);
-    }
-  };
-
-  const confirmDismissAll = () => {
-    if (!pendingDismissAll) return;
-    dismiss(pendingDismissAll);
-    setPendingDismissAll(null);
-    onClose();
-  };
-
   return (
     <>
       <Sheet
@@ -308,7 +210,6 @@ export function SignalDrawer({
           if (!open) {
             setExclusionState(null);
             setReturningFromEditor(false);
-            setPendingDismissAll(null);
             onClose();
           }
         }}
@@ -382,58 +283,18 @@ export function SignalDrawer({
                   </div>
                   <SheetTitle>{getRuleTitleFallback(signal.ruleId)}</SheetTitle>
                   <SheetDescription>
-                    {signalDescription(signal, pendingDismissAll !== null)}
+                    {signal.description ||
+                      "Findings clustered on this detection rule."}
                   </SheetDescription>
                 </SheetHeader>
                 <div className="flex flex-1 flex-col gap-6 px-4 pb-6">
-                  {/* Clicking "Mark false positive" swaps the action buttons
-                    for an inline confirmation — the rest of the signal
-                    detail stays visible; no modal, no view change. */}
-                  {pendingDismissAll ? (
-                    <FalsePositiveConfirm
-                      count={pendingDismissAll.length}
-                      onConfirm={confirmDismissAll}
-                      onCancel={() => setPendingDismissAll(null)}
-                    />
-                  ) : (
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Button variant="primary" onClick={openSignalExclusion}>
-                        <Button.Text>Create exclusion rule</Button.Text>
-                      </Button>
-                      {/* Deliberately the only filled action: exclusion is the
-                        recommended path, false positive stays low-emphasis. */}
-                      <Button
-                        variant="tertiary"
-                        disabled={collecting}
-                        onClick={() => void collectAllFindings()}
-                      >
-                        {collecting && (
-                          <Button.LeftIcon>
-                            <Loader2 className="size-4 animate-spin" />
-                          </Button.LeftIcon>
-                        )}
-                        <Button.Text>Mark false positive</Button.Text>
-                      </Button>
-                    </div>
-                  )}
-                  {/* While the confirmation is up, everything below it sits
-                    under a dark scrim and is inert — the decision is the
-                    only actionable thing in the drawer. */}
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button variant="primary" onClick={openSignalExclusion}>
+                      <Button.Text>Create exclusion rule</Button.Text>
+                    </Button>
+                  </div>
                   <div className="relative flex-1">
-                    {pendingDismissAll !== null && (
-                      // Negative insets cancel the body's px-4/pb-6 padding and
-                      // the gap under the divider so the scrim bleeds to the
-                      // drawer's edges with no light border around it.
-                      <div className="bg-foreground/50 absolute -inset-x-4 -top-6 -bottom-6 z-10" />
-                    )}
-                    <div
-                      className={cn(
-                        "space-y-6",
-                        pendingDismissAll !== null &&
-                          "pointer-events-none select-none",
-                      )}
-                      aria-hidden={pendingDismissAll !== null}
-                    >
+                    <div className="space-y-6">
                       <Text small muted>
                         First seen {signal.firstSeen.toLocaleString()} · last{" "}
                         {signal.lastSeen.toLocaleString()}

--- a/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
+++ b/client/dashboard/src/pages/security/watchdog/Watchdog.tsx
@@ -402,8 +402,6 @@ function WatchdogContent(): JSX.Element {
               must live under a slot to render at all. */}
           <SignalDrawer
             signal={selectedSignal}
-            from={window.from}
-            to={window.to}
             onClose={() => setUrlParam("signal", null)}
           />
           <DismissFindingsDialog

--- a/server/internal/risk/chrepo/signals.go
+++ b/server/internal/risk/chrepo/signals.go
@@ -61,9 +61,13 @@ const (
 // stay empty/zero for rows written before the chat_source and team
 // attribution columns existed.
 type RiskSignalAggregate struct {
-	RuleID            string
-	Category          string
-	Sources           []string
+	RuleID   string
+	Category string
+	Sources  []string
+	// PolicyIDs are the distinct non-empty risk_policy_id values stamped on
+	// the rule's findings across the doubled window. The handler resolves
+	// them to configured policy scores; empty for pre-policy rows.
+	PolicyIDs         []string
 	Description       string
 	Apps              []string
 	FindingsCur       uint64
@@ -91,6 +95,7 @@ func (q *Queries) ListRiskSignalAggregates(ctx context.Context, p RiskSignalWind
 		squirrel.Expr("rule_id"),
 		squirrel.Alias(squirrel.Expr("any(category)"), "g_category"),
 		squirrel.Alias(squirrel.Expr("groupUniqArray(source)"), "g_sources"),
+		squirrel.Alias(squirrel.Expr("groupUniqArrayIf(risk_policy_id, risk_policy_id != '')"), "g_policy_ids"),
 		squirrel.Alias(squirrel.Expr("any(description)"), "g_description"),
 		squirrel.Alias(squirrel.Expr("groupUniqArrayIf(chat_source, chat_source != '' AND created_at >= ?)", p.From), "g_apps"),
 		squirrel.Alias(squirrel.Expr("uniqExactIf(id, created_at >= ?)", p.From), "findings_cur"),
@@ -126,6 +131,7 @@ func (q *Queries) ListRiskSignalAggregates(ctx context.Context, p RiskSignalWind
 			&row.RuleID,
 			&row.Category,
 			&row.Sources,
+			&row.PolicyIDs,
 			&row.Description,
 			&row.Apps,
 			&row.FindingsCur,

--- a/server/internal/risk/chrepo/signals.go
+++ b/server/internal/risk/chrepo/signals.go
@@ -64,10 +64,14 @@ type RiskSignalAggregate struct {
 	RuleID   string
 	Category string
 	Sources  []string
-	// PolicyIDs are the distinct non-empty risk_policy_id values stamped on
-	// the rule's findings across the doubled window. The handler resolves
-	// them to configured policy scores; empty for pre-policy rows.
-	PolicyIDs         []string
+	// PolicyIDsCur and PolicyIDsPrev are the distinct non-empty
+	// risk_policy_id values stamped on the rule's findings, split per
+	// window. The split matters: each window's score must resolve only from
+	// policies that matched that window's findings, or a policy added today
+	// would retroactively rescore the previous-window baseline (and vice
+	// versa). Empty for pre-policy rows.
+	PolicyIDsCur      []string
+	PolicyIDsPrev     []string
 	Description       string
 	Apps              []string
 	FindingsCur       uint64
@@ -95,7 +99,8 @@ func (q *Queries) ListRiskSignalAggregates(ctx context.Context, p RiskSignalWind
 		squirrel.Expr("rule_id"),
 		squirrel.Alias(squirrel.Expr("any(category)"), "g_category"),
 		squirrel.Alias(squirrel.Expr("groupUniqArray(source)"), "g_sources"),
-		squirrel.Alias(squirrel.Expr("groupUniqArrayIf(risk_policy_id, risk_policy_id != '')"), "g_policy_ids"),
+		squirrel.Alias(squirrel.Expr("groupUniqArrayIf(risk_policy_id, risk_policy_id != '' AND created_at >= ?)", p.From), "g_policy_ids_cur"),
+		squirrel.Alias(squirrel.Expr("groupUniqArrayIf(risk_policy_id, risk_policy_id != '' AND created_at < ?)", p.From), "g_policy_ids_prev"),
 		squirrel.Alias(squirrel.Expr("any(description)"), "g_description"),
 		squirrel.Alias(squirrel.Expr("groupUniqArrayIf(chat_source, chat_source != '' AND created_at >= ?)", p.From), "g_apps"),
 		squirrel.Alias(squirrel.Expr("uniqExactIf(id, created_at >= ?)", p.From), "findings_cur"),
@@ -131,7 +136,8 @@ func (q *Queries) ListRiskSignalAggregates(ctx context.Context, p RiskSignalWind
 			&row.RuleID,
 			&row.Category,
 			&row.Sources,
-			&row.PolicyIDs,
+			&row.PolicyIDsCur,
+			&row.PolicyIDsPrev,
 			&row.Description,
 			&row.Apps,
 			&row.FindingsCur,

--- a/server/internal/risk/signals.go
+++ b/server/internal/risk/signals.go
@@ -2,16 +2,16 @@ package risk
 
 import (
 	"math"
-	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 )
 
-// Signal scoring: deterministic heuristics that place each rule-level signal
-// on the same 0.1-10 severity scale the rest of the risk surfaces use (CVSS
-//-style bands, see severityForScore). The base weight comes from the rule's
-// category; confidence, volume, user spread, recency, and growth nudge it up
-// or down. All weights live here so product tuning is a one-file change.
+// Signal scoring: a signal's score IS the matched policy's configured 0.1-10
+// score — the operator's own severity definition, on the same CVSS-style
+// bands the rest of the risk surfaces use (see severityForScore). Category
+// weights only cover findings with no policy attribution. A richer
+// evidence-weighted formula was prototyped and parked for review; see
+// docs/risk_scores/formula.md in the internal docs repo.
 
 // signalCategoryBaseWeight is the category's starting severity on the 10
 // scale before per-signal adjustments.
@@ -35,45 +35,19 @@ var signalCategoryBaseWeight = map[categories.Category]float64{
 // (pre-classifier rows or future categories).
 const signalDefaultBaseWeight = 5.0
 
-// signalScoreInputs are the aggregate facts one score is computed from.
-type signalScoreInputs struct {
-	category      string
-	avgConfidence float64
-	findings      uint64
-	users         uint64
-	// lastSeen and windowEnd drive the recency bonus; zero lastSeen skips it.
-	lastSeen  time.Time
-	windowEnd time.Time
-	// previousFindings drives the growth bonus; zero skips it.
-	previousFindings uint64
-}
-
-// signalScore maps aggregate facts to a 0.1-10 severity score:
-// base weight scaled by detector confidence (a 0-confidence signal keeps 70%
-// of its base), plus bounded bonuses for volume (log-scaled), user spread
-// (sqrt-scaled), last-24h activity, and >=50% window-over-window growth.
-// Clamped to [0.5, 9.9] so a heuristic score never claims the extremes, and
-// rounded to one decimal to match the CVSS-style display format.
-func signalScore(in signalScoreInputs) float64 {
-	base, ok := signalCategoryBaseWeight[categories.Category(in.category)]
+// signalScore is the matched policy's configured 0.1-10 score, verbatim.
+// policyScore <= 0 means no policy attribution (pre-policy rows), which
+// falls back to the rule category's fixed weight. Rounded to one decimal to
+// match the CVSS-style display format.
+func signalScore(policyScore float64, category string) float64 {
+	if policyScore > 0 {
+		return roundScore(policyScore)
+	}
+	base, ok := signalCategoryBaseWeight[categories.Category(category)]
 	if !ok {
 		base = signalDefaultBaseWeight
 	}
-
-	confidence := math.Max(0, math.Min(1, in.avgConfidence))
-	score := base * (0.7 + 0.3*confidence)
-
-	score += math.Min(1.2, 0.5*math.Log10(1+float64(in.findings)))
-	score += math.Min(1.5, 0.3*math.Sqrt(float64(in.users)))
-
-	if !in.lastSeen.IsZero() && !in.windowEnd.IsZero() && in.windowEnd.Sub(in.lastSeen) <= 24*time.Hour {
-		score += 0.6
-	}
-	if in.previousFindings > 0 && float64(in.findings) >= 1.5*float64(in.previousFindings) {
-		score += 0.5
-	}
-
-	return roundScore(math.Max(0.5, math.Min(9.9, score)))
+	return roundScore(base)
 }
 
 // severityForScore mirrors the dashboard's CVSS-style bands

--- a/server/internal/risk/signals_ch.go
+++ b/server/internal/risk/signals_ch.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 
 	gen "github.com/speakeasy-api/gram/server/gen/risk"
@@ -159,22 +160,22 @@ func (s *Service) GetRiskSignals(ctx context.Context, payload *gen.GetRiskSignal
 
 	topUsersByRule := signalTopUsersByRule(userRows)
 
+	// Policy scores are configuration, not findings — the one deliberate
+	// Postgres read on this path. The operator's configured policy score is
+	// the base severity for every signal the policy matched; category
+	// defaults only cover findings with no policy attribution.
+	policyScores, err := s.riskPolicyScores(ctx, *authCtx.ProjectID)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "load risk policy scores").LogError(ctx, s.logger)
+	}
+
 	// Previous-window scores first: the aggregates include rules active only
 	// in the previous window (findings_cur = 0) purely as input to this
-	// comparison. Each previous-window score is the same formula minus the
-	// recency and growth bonuses, which describe the current window only.
+	// comparison.
 	prevScores := make([]float64, 0, len(aggregates))
 	for _, agg := range aggregates {
 		if agg.FindingsPrev > 0 {
-			prevScores = append(prevScores, signalScore(signalScoreInputs{
-				category:         agg.Category,
-				avgConfidence:    agg.AvgConfidencePrev,
-				findings:         agg.FindingsPrev,
-				users:            agg.UsersPrev,
-				lastSeen:         time.Time{},
-				windowEnd:        time.Time{},
-				previousFindings: 0,
-			}))
+			prevScores = append(prevScores, signalScore(maxPolicyScore(agg.PolicyIDs, policyScores), agg.Category))
 		}
 	}
 
@@ -188,15 +189,7 @@ func (s *Service) GetRiskSignals(ctx context.Context, payload *gen.GetRiskSignal
 	signals := make([]*gen.RiskSignal, 0, len(aggregates))
 	scores := make([]float64, 0, len(aggregates))
 	for _, agg := range aggregates {
-		score := signalScore(signalScoreInputs{
-			category:         agg.Category,
-			avgConfidence:    agg.AvgConfidence,
-			findings:         agg.FindingsCur,
-			users:            agg.UsersCur,
-			lastSeen:         agg.LastSeen,
-			windowEnd:        to,
-			previousFindings: agg.FindingsPrev,
-		})
+		score := signalScore(maxPolicyScore(agg.PolicyIDs, policyScores), agg.Category)
 		scores = append(scores, score)
 
 		topUsers := topUsersByRule[agg.RuleID]
@@ -418,4 +411,34 @@ func signalExposure(aggregates []chrepo.RiskSignalAggregate) []*gen.RiskExposure
 		return cmp.Compare(a.Category, b.Category)
 	})
 	return out
+}
+
+// riskPolicyScores maps every non-deleted policy id in the project to its
+// configured 0.1-10 score. Includes disabled policies on purpose: findings
+// written while a policy was enabled keep that policy's severity after it is
+// switched off.
+func (s *Service) riskPolicyScores(ctx context.Context, projectID uuid.UUID) (map[string]float64, error) {
+	policies, err := s.repo.ListRiskPolicies(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("list risk policies: %w", err)
+	}
+	scores := make(map[string]float64, len(policies))
+	for _, p := range policies {
+		scores[p.ID.String()] = p.Score
+	}
+	return scores, nil
+}
+
+// maxPolicyScore resolves a signal's base severity from the policies that
+// matched its findings: the highest configured score wins when several
+// policies contributed. Zero when no id resolves, which sends signalScore to
+// the category fallback.
+func maxPolicyScore(policyIDs []string, scores map[string]float64) float64 {
+	var best float64
+	for _, id := range policyIDs {
+		if s, ok := scores[id]; ok && s > best {
+			best = s
+		}
+	}
+	return best
 }

--- a/server/internal/risk/signals_ch.go
+++ b/server/internal/risk/signals_ch.go
@@ -175,7 +175,7 @@ func (s *Service) GetRiskSignals(ctx context.Context, payload *gen.GetRiskSignal
 	prevScores := make([]float64, 0, len(aggregates))
 	for _, agg := range aggregates {
 		if agg.FindingsPrev > 0 {
-			prevScores = append(prevScores, signalScore(maxPolicyScore(agg.PolicyIDs, policyScores), agg.Category))
+			prevScores = append(prevScores, signalScore(maxPolicyScore(agg.PolicyIDsPrev, policyScores), agg.Category))
 		}
 	}
 
@@ -189,7 +189,7 @@ func (s *Service) GetRiskSignals(ctx context.Context, payload *gen.GetRiskSignal
 	signals := make([]*gen.RiskSignal, 0, len(aggregates))
 	scores := make([]float64, 0, len(aggregates))
 	for _, agg := range aggregates {
-		score := signalScore(maxPolicyScore(agg.PolicyIDs, policyScores), agg.Category)
+		score := signalScore(maxPolicyScore(agg.PolicyIDsCur, policyScores), agg.Category)
 		scores = append(scores, score)
 
 		topUsers := topUsersByRule[agg.RuleID]

--- a/server/internal/risk/signals_internal_test.go
+++ b/server/internal/risk/signals_internal_test.go
@@ -2,7 +2,6 @@ package risk
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -10,81 +9,20 @@ import (
 func TestSignalScore_GoldenValues(t *testing.T) {
 	t.Parallel()
 
-	windowEnd := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	// A matched policy's configured score is the signal score, verbatim.
+	require.InDelta(t, 2.0, signalScore(2.0, "secrets"), 0.001)
+	require.InDelta(t, 9.6, signalScore(9.6, "pii"), 0.001)
 
-	// Full-confidence secrets signal, active in the last 24h, tripled
-	// window-over-window: base 8.5 + volume 0.30 + spread 0.42 + recency 0.6 +
-	// growth 0.5 clamps at the 9.9 ceiling.
-	require.InDelta(t, 9.9, signalScore(signalScoreInputs{
-		category:         "secrets",
-		avgConfidence:    1,
-		findings:         3,
-		users:            2,
-		lastSeen:         windowEnd.Add(-2 * time.Hour),
-		windowEnd:        windowEnd,
-		previousFindings: 1,
-	}), 0.001)
+	// No policy attribution falls back to the category weight, verbatim.
+	require.InDelta(t, 8.5, signalScore(0, "secrets"), 0.001)
+	require.InDelta(t, 5.5, signalScore(0, "pii"), 0.001)
+	require.InDelta(t, 4.5, signalScore(0, "off_policy"), 0.001)
 
-	// Quiet single-user PII signal with no recency or growth bonus:
-	// 5.5 + 0.5*log10(4) + 0.3*sqrt(1) = 6.101 -> 6.1.
-	require.InDelta(t, 6.1, signalScore(signalScoreInputs{
-		category:         "pii",
-		avgConfidence:    1,
-		findings:         3,
-		users:            1,
-		lastSeen:         windowEnd.Add(-30 * time.Hour),
-		windowEnd:        windowEnd,
-		previousFindings: 0,
-	}), 0.001)
+	// Unknown categories fall back to the default weight.
+	require.InDelta(t, 5.0, signalScore(0, "not_a_category"), 0.001)
 
-	// Zero confidence keeps 70% of the base weight: 4.5*0.7 = 3.15, plus
-	// volume 0.5*log10(2) = 0.151 -> 3.3.
-	require.InDelta(t, 3.3, signalScore(signalScoreInputs{
-		category:         "off_policy",
-		avgConfidence:    0,
-		findings:         1,
-		users:            0,
-		lastSeen:         time.Time{},
-		windowEnd:        windowEnd,
-		previousFindings: 0,
-	}), 0.001)
-
-	// Unknown categories fall back to the default base weight (5.0).
-	require.InDelta(t, 5.0*(0.7+0.3*0.5)+0.5*0.30103+0.3, signalScore(signalScoreInputs{
-		category:         "not_a_category",
-		avgConfidence:    0.5,
-		findings:         1,
-		users:            1,
-		lastSeen:         time.Time{},
-		windowEnd:        windowEnd,
-		previousFindings: 0,
-	}), 0.05)
-}
-
-func TestSignalScore_FloorAndCeiling(t *testing.T) {
-	t.Parallel()
-
-	// The floor holds even for an implausibly weak signal.
-	require.GreaterOrEqual(t, signalScore(signalScoreInputs{
-		category:         "off_policy",
-		avgConfidence:    0,
-		findings:         0,
-		users:            0,
-		lastSeen:         time.Time{},
-		windowEnd:        time.Time{},
-		previousFindings: 0,
-	}), 0.5)
-
-	// The ceiling holds for a maxed-out signal.
-	require.LessOrEqual(t, signalScore(signalScoreInputs{
-		category:         "secrets",
-		avgConfidence:    1,
-		findings:         100000,
-		users:            10000,
-		lastSeen:         time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
-		windowEnd:        time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
-		previousFindings: 1,
-	}), 9.9)
+	// Scores are normalized to one decimal.
+	require.InDelta(t, 7.3, signalScore(7.25001, "secrets"), 0.001)
 }
 
 func TestSeverityForScore_BandsMatchDashboard(t *testing.T) {

--- a/server/internal/risk/signals_test.go
+++ b/server/internal/risk/signals_test.go
@@ -286,9 +286,13 @@ func TestGetRiskSignals_PolicyScoreDrivesBase(t *testing.T) {
 	attributed := chOverviewFinding(t, projectID, orgID, chat, msg(), from.Add(36*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com")
 	attributed.RiskPolicyID = policy.ID
 	bare := chOverviewFinding(t, projectID, orgID, chat, msg(), from.Add(37*time.Hour), "gitleaks", "secret.aws_access_key", "alice@example.com")
+	// Previous-window finding for the SAME rule, without policy attribution:
+	// the policy that matched only the current window must not leak into the
+	// previous-window baseline.
+	prevBare := chOverviewFinding(t, projectID, orgID, chat, msg(), from.Add(-24*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com")
 
 	chQueries := chrepo.New(ti.chConn)
-	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{attributed, bare}))
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{attributed, bare, prevBare}))
 	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
 
 	result, err := ti.service.GetRiskSignals(ctx, &gen.GetRiskSignalsPayload{
@@ -312,4 +316,10 @@ func TestGetRiskSignals_PolicyScoreDrivesBase(t *testing.T) {
 	fallback := byRule["secret.aws_access_key"]
 	require.NotNil(t, fallback)
 	require.InDelta(t, 8.5, fallback.RiskScore, 0.001)
+
+	// The previous-window baseline scores its unattributed finding at the
+	// category weight (8.5) — not the 2.0 policy that only matched the
+	// current window: 0.5*8.5 + 0.3*8.5 + 0.2*1.2*log10(2) = 6.87 -> 6.9.
+	// A window-union policy leak would drag this down to 1.7.
+	require.InDelta(t, 6.9, result.PreviousOrgRiskScore, 0.001)
 }

--- a/server/internal/risk/signals_test.go
+++ b/server/internal/risk/signals_test.go
@@ -120,8 +120,9 @@ func TestGetRiskSignals_ClickHouse(t *testing.T) {
 	require.Equal(t, int64(1), secrets.PreviousFindings)
 	require.Equal(t, int64(2), secrets.Users)
 	require.Equal(t, int64(1), secrets.Teams)
-	require.Equal(t, "critical", secrets.Severity)
-	require.InDelta(t, 9.9, secrets.RiskScore, 0.001)
+	// Unattributed rows score at the category weight verbatim: secrets 8.5.
+	require.Equal(t, "high", secrets.Severity)
+	require.InDelta(t, 8.5, secrets.RiskScore, 0.001)
 	require.Equal(t, from.Add(36*time.Hour).Format(time.RFC3339), secrets.FirstSeen)
 	require.Equal(t, to.Add(-2*time.Hour).Format(time.RFC3339), secrets.LastSeen)
 	// Sparkline covers the window and sums to the deduplicated finding count;
@@ -155,7 +156,7 @@ func TestGetRiskSignals_ClickHouse(t *testing.T) {
 	require.Equal(t, int64(3), pii.TopUsers[0].Findings)
 
 	require.Equal(t, int64(2), result.OpenSignals)
-	require.Equal(t, int64(1), result.CriticalSignals)
+	require.Equal(t, int64(0), result.CriticalSignals)
 	require.Equal(t, int64(2), result.UsersExposed)
 	require.Equal(t, int64(1), result.PreviousUsersExposed)
 	require.Equal(t, int64(1), result.Findings24h)
@@ -254,4 +255,61 @@ func TestGetRiskSignals_InvalidWindow(t *testing.T) {
 		To:   new(now.Format(time.RFC3339)),
 	})
 	require.Error(t, err)
+}
+
+// TestGetRiskSignals_PolicyScoreDrivesBase asserts a matched policy's
+// configured score replaces the category base weight in the signal score,
+// while rules without policy attribution keep the category default.
+func TestGetRiskSignals_PolicyScoreDrivesBase(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+	ti.flags.SetFlag(feature.FlagRiskWatchdog, authCtx.ActiveOrganizationID, true)
+	projectID := *authCtx.ProjectID
+	orgID := authCtx.ActiveOrganizationID
+
+	// A deliberately low configured score — far from the secrets category
+	// weight (8.5) — so the score's base source is unambiguous below.
+	policy, err := ti.service.CreateRiskPolicy(ctx, &gen.CreateRiskPolicyPayload{Name: new("Watchdog Scored"), Score: 2})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	from := now.AddDate(0, 0, -30).Truncate(24 * time.Hour)
+	to := from.AddDate(0, 0, 7)
+	chat := uuid.Must(uuid.NewV7())
+	msg := func() uuid.UUID { return uuid.Must(uuid.NewV7()) }
+
+	attributed := chOverviewFinding(t, projectID, orgID, chat, msg(), from.Add(36*time.Hour), "gitleaks", "secret.github_pat", "alice@example.com")
+	attributed.RiskPolicyID = policy.ID
+	bare := chOverviewFinding(t, projectID, orgID, chat, msg(), from.Add(37*time.Hour), "gitleaks", "secret.aws_access_key", "alice@example.com")
+
+	chQueries := chrepo.New(ti.chConn)
+	require.NoError(t, chQueries.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{attributed, bare}))
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	result, err := ti.service.GetRiskSignals(ctx, &gen.GetRiskSignalsPayload{
+		From: new(from.Format(time.RFC3339)),
+		To:   new(to.Format(time.RFC3339)),
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Signals, 2)
+
+	byRule := map[string]*gen.RiskSignal{}
+	for _, s := range result.Signals {
+		byRule[s.RuleID] = s
+	}
+
+	// Policy-scored rule: the configured score, verbatim.
+	scored := byRule["secret.github_pat"]
+	require.NotNil(t, scored)
+	require.InDelta(t, 2.0, scored.RiskScore, 0.001)
+
+	// The unattributed rule keeps the secrets category weight, verbatim.
+	fallback := byRule["secret.aws_access_key"]
+	require.NotNil(t, fallback)
+	require.InDelta(t, 8.5, fallback.RiskScore, 0.001)
 }


### PR DESCRIPTION
## What

Two follow-ups to the Watchdog page (#5097/#5104/#5124):

### Policy-driven signal scores

A signal's risk score is now the **matched risk policy's configured score** (0.1–10), verbatim — the operator's own severity definition instead of heuristics:

- The ClickHouse signal aggregate collects each rule's distinct `risk_policy_id` values; the handler resolves them against the project's policy config (one small Postgres read — config, not findings) and takes the highest score when several policies matched.
- Findings with no policy attribution (pre-policy rows) fall back to the fixed category weight table, verbatim.
- The prior evidence-weighted formula (confidence scaling, volume/spread/recency/growth bonuses) is retired; its design rationale is parked internally for later review.
- Severity bands and the org-level max/top-3/volume blend are unchanged.

### Drawer simplification

The signal drawer's "Mark false positive" signal-level action is removed along with its inline confirmation flow — "Create exclusion rule" is the drawer's single signal-level action. The bulk-selection false-positive path and the per-evidence-row actions are untouched.

## Testing

- Golden tests rewritten for the plain scheme (policy score verbatim; category fallback verbatim; 1-decimal normalization).
- New handler test: a policy scored 2.0 produces a 2.0 signal while an unattributed secrets rule reads 8.5, against real ClickHouse + Postgres.
- Full `internal/risk` suite (491 tests) and dashboard type-check/lint/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Score Watchdog signals using the matched risk policy’s configured score (0.1–10), with per-window attribution to keep previous-window baselines accurate, and simplify the Signal drawer to a single Create-exclusion action.

- **New Features**
  - Signal scoring: matched policy’s score verbatim (highest wins). Attribution is split per window (current vs previous) to prevent score leakage; no-policy findings fall back to fixed category weights. Severity bands and org-level scoring are unchanged.
  - Backend: ClickHouse aggregates distinct `risk_policy_id` values per window; the service resolves policy scores from Postgres config.
  - UI: Removed “Mark false positive” from the Signal drawer; the only signal-level action is “Create exclusion rule.” Bulk and per-evidence false-positive flows are unchanged.
  - Tests updated for policy-driven scoring (with per-window attribution), category fallback, and 1-decimal normalization.

<sup>Written for commit 942b59c598d58fa38b815d037bfbefbcb93c9a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

