### PR TITLE
feat(dashboard): PAYG rate adjustment input in TUM price estimator

### DIFF
--- a/.changeset/payg-rate-adjustment-estimator.md
+++ b/.changeset/payg-rate-adjustment-estimator.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Add a PAYG rate adjustment (%) input to the platform-admin TUM contract price estimator on the billing page. A positive percentage uplifts every pay-as-you-go band rate and a negative one discounts them, so an admin can price a negotiated swing off the list rates without retyping the bands. The adjustment is reflected in the PAYG card's tier table, blended rate, and the committed-vs-PAYG comparison, and a discount-driven "PAYG is cheaper" outcome is attributed to the adjustment instead of being flagged as a pricing-model error.

--- a/client/dashboard/src/components/billing/contract-price-estimator.tsx
+++ b/client/dashboard/src/components/billing/contract-price-estimator.tsx
@@ -137,6 +137,29 @@ function ModelCard({
   );
 }
 
+// "+10%" / "-15%": the sign is the information — an unsigned "10%" wouldn't
+// say which way the rates moved.
+function formatSignedPct(pct: number): string {
+  return `${pct > 0 ? "+" : ""}${pct.toLocaleString("en-US", { maximumFractionDigits: 2 })}%`;
+}
+
+// Reads the annual gap between the two models. PAYG undercutting the
+// committed contract is a modelling error at list rates — but the expected
+// outcome of a big enough negotiated discount — so the two cases have to read
+// differently, or a deliberate discount gets reported as a pricing bug.
+function paygDeltaMessage(delta: number, rateAdjustPct: number): string {
+  if (delta > 0) {
+    return `Pay-as-you-go costs ${formatUSD(delta)}/yr more than the committed contract at this volume — the number to point at in a "should we commit?" conversation.`;
+  }
+  if (delta < 0 && rateAdjustPct !== 0) {
+    return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here at the adjusted rates (${formatSignedPct(rateAdjustPct)} vs list).`;
+  }
+  if (delta < 0) {
+    return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here, which the model isn't meant to allow — check the platform fee against the baseline.`;
+  }
+  return "Both models price identically at this volume.";
+}
+
 // How hard the account team should be looking at this contract. Steady
 // accounts run overage at a fraction of their base; once overage rivals the
 // base contract the customer is better off upsizing the baseline than paying
@@ -188,6 +211,7 @@ export function ContractPriceEstimator({
   const [basisOverride, setBasisOverride] = useState<VolumeBasis | null>(null);
   const [customVolume, setCustomVolume] = useState("");
   const [feeOverride, setFeeOverride] = useState("");
+  const [paygAdjustment, setPaygAdjustment] = useState("");
 
   // Deliberately not memoized on `cycles`. Whether the projection is even
   // offered depends on how much of the cycle has elapsed, so a `now` captured
@@ -230,6 +254,17 @@ export function ContractPriceEstimator({
       ? parsedFee
       : derivedFee;
 
+  // Negotiated swing on the PAYG list rates. Bounded below at -100% — past
+  // that a rate would go negative — and an invalid or out-of-range entry
+  // falls back to list rates rather than blanking the card mid-keystroke.
+  const parsedAdjust = Number(paygAdjustment);
+  const paygRateAdjustPct =
+    paygAdjustment.trim() !== "" &&
+    Number.isFinite(parsedAdjust) &&
+    parsedAdjust > -100
+      ? parsedAdjust
+      : 0;
+
   const committed = useMemo(() => {
     if (
       monthlyTokens == null ||
@@ -258,7 +293,7 @@ export function ContractPriceEstimator({
 
   const payg = useMemo(() => {
     if (monthlyTokens == null) return null;
-    const lines = paygLines(monthlyTokens);
+    const lines = paygLines(monthlyTokens, paygRateAdjustPct);
     const monthly = sumLines(lines);
     const annual = monthly * 12;
     return {
@@ -267,7 +302,7 @@ export function ContractPriceEstimator({
       annual,
       rate: effectiveRatePerMillion(annual, monthlyTokens),
     };
-  }, [monthlyTokens]);
+  }, [monthlyTokens, paygRateAdjustPct]);
 
   const signal =
     committed?.share != null ? overageSignal(committed.share) : null;
@@ -353,6 +388,26 @@ export function ContractPriceEstimator({
             How is the fee defaulted?
           </span>
         </SimpleTooltip>
+
+        <Stack gap={2}>
+          <Label htmlFor="contract-payg-adjustment">
+            PAYG rate adjustment (%)
+          </Label>
+          <Input
+            id="contract-payg-adjustment"
+            type="number"
+            min={-100}
+            placeholder="e.g. 10 or -15"
+            value={paygAdjustment}
+            onChange={setPaygAdjustment}
+          />
+        </Stack>
+
+        <SimpleTooltip tooltip="Scales every pay-as-you-go band rate by this percentage — positive for an uplift, negative for a discount. Band boundaries don't move, and the committed model is unaffected. Estimate only.">
+          <span className="text-muted-foreground pb-2.5 text-xs">
+            How does the adjustment apply?
+          </span>
+        </SimpleTooltip>
       </div>
 
       {/* What the selected basis actually measures. Load-bearing for the
@@ -416,7 +471,11 @@ export function ContractPriceEstimator({
 
             <ModelCard
               title="Pay As You Go"
-              subtitle="No commitment — every token billed by volume tier"
+              subtitle={
+                paygRateAdjustPct === 0
+                  ? "No commitment — every token billed by volume tier"
+                  : `No commitment — volume-tier rates ${formatSignedPct(paygRateAdjustPct)} vs list`
+              }
             >
               {payg && (
                 <>
@@ -449,11 +508,7 @@ export function ContractPriceEstimator({
 
           {delta != null && (
             <Text muted small>
-              {delta > 0
-                ? `Pay-as-you-go costs ${formatUSD(delta)}/yr more than the committed contract at this volume — the number to point at in a "should we commit?" conversation.`
-                : delta < 0
-                  ? `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here, which the model isn't meant to allow — check the platform fee against the baseline.`
-                  : "Both models price identically at this volume."}
+              {paygDeltaMessage(delta, paygRateAdjustPct)}
             </Text>
           )}
         </>

--- a/client/dashboard/src/components/billing/contract-pricing.test.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.test.ts
@@ -67,6 +67,38 @@ describe("pay-as-you-go pricing", () => {
   });
 });
 
+describe("pay-as-you-go rate adjustment", () => {
+  it("scales every band rate up by an uplift percentage", () => {
+    const adjusted = paygLines(80 * B, 10);
+    const list = paygLines(80 * B);
+    // The uplift moves rates, never band boundaries — same slices, dearer.
+    expect(adjusted.map((l) => l.tokens)).toEqual(list.map((l) => l.tokens));
+    adjusted.forEach((line, i) => {
+      expect(line.ratePerMillion).toBeCloseTo(
+        (list[i]?.ratePerMillion ?? 0) * 1.1,
+        9,
+      );
+    });
+    expect(sumLines(adjusted)).toBeCloseTo(22850 * 1.1, 6);
+  });
+
+  it("scales every band rate down by a discount percentage", () => {
+    expect(sumLines(paygLines(80 * B, -15))).toBeCloseTo(22850 * 0.85, 6);
+  });
+
+  it("leaves list rates untouched at zero adjustment", () => {
+    expect(paygLines(80 * B, 0)).toEqual(paygLines(80 * B));
+  });
+
+  it("floors rates at zero rather than pricing negative past -100%", () => {
+    // A -150% swing is nonsense input; free is the least-wrong reading.
+    for (const line of paygLines(80 * B, -150)) {
+      expect(line.ratePerMillion).toBe(0);
+      expect(line.cost).toBe(0);
+    }
+  });
+});
+
 describe("committed-contract overage pricing", () => {
   it("charges the first-tier rate between 1x and 2x baseline", () => {
     const lines = overageLines(15 * B, 10 * B);

--- a/client/dashboard/src/components/billing/contract-pricing.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.ts
@@ -124,7 +124,7 @@ export function overageLines(
 // negative, which prices as free, not as a rebate.
 export function paygLines(
   monthlyTokens: number,
-  rateAdjustPct: number = 0,
+  rateAdjustPct = 0,
 ): TierLine[] {
   const rateMultiplier = Math.max(0, 1 + rateAdjustPct / 100);
   return graduatedLines(

--- a/client/dashboard/src/components/billing/contract-pricing.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.ts
@@ -116,13 +116,23 @@ export function overageLines(
 
 // The full pay-as-you-go bill for one month — every token is charged, from
 // the first one, with no baseline to subtract.
-export function paygLines(monthlyTokens: number): TierLine[] {
+//
+// `rateAdjustPct` scales every band rate by a percentage (+10 → +10% uplift,
+// -15 → 15% discount): PAYG deals are negotiated as a swing off the list
+// rates, not as four hand-edited band rates. Band boundaries are absolute
+// volumes and don't move. Floored at -100% — beyond that a rate would go
+// negative, which prices as free, not as a rebate.
+export function paygLines(
+  monthlyTokens: number,
+  rateAdjustPct: number = 0,
+): TierLine[] {
+  const rateMultiplier = Math.max(0, 1 + rateAdjustPct / 100);
   return graduatedLines(
     monthlyTokens,
     PAYG_TIERS.map((t) => ({
       label: t.label,
       upper: t.upToTokens,
-      ratePerMillion: t.ratePerMillion,
+      ratePerMillion: t.ratePerMillion * rateMultiplier,
     })),
     0,
   );


### PR DESCRIPTION
## What

Adds a **PAYG rate adjustment (%)** input to the platform-admin TUM contract price estimator on `/billing` (enterprise orgs, admin-only section). Entering a positive percentage uplifts every pay-as-you-go band rate; a negative one discounts them — e.g. `10` prices PAYG at +10% over list, `-15` at a 15% discount.

## How

- `paygLines()` in `contract-pricing.ts` takes an optional `rateAdjustPct` that scales each band's $/M rate by `1 + pct/100` (floored at zero so past −100% prices as free, not negative). Band boundaries are absolute volumes and don't move.
- The estimator gains the input next to the platform-fee override, with a tooltip. Invalid or ≤ −100 entries fall back to list rates rather than blanking the card.
- The adjustment flows through the PAYG tier table rates, blended $/M, annual/monthly totals, and the committed-vs-PAYG delta. The PAYG card subtitle shows the active swing (e.g. "volume-tier rates +10% vs list").
- The "PAYG is cheaper, which the model isn't meant to allow" warning now only fires at list rates; with an adjustment active, a cheaper PAYG is attributed to the discount instead. (The nested ternary this lived in is hoisted to a named helper per the frontend skill.)

## Testing

- 4 new unit tests in `contract-pricing.test.ts` (uplift scales all bands, discount, zero adjustment is identity, ≤ −100% floors at zero); all 26 pass.
- `tum-admin-section.test.tsx`, oxfmt, and oxlint clean on touched files; tsc shows only the known local TS7 false-positive baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8edBG1tMBsaDSGPgi4pt9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PAYG rate adjustment (%) input to the platform-admin TUM price estimator on /billing so admins can apply an uplift/discount to PAYG list rates. All PAYG outputs update accordingly, and the delta message now accounts for discount-driven cases.

- **New Features**
  - Number input for PAYG rate adjustment with tooltip; PAYG card subtitle shows the swing (e.g. "volume-tier rates +10% vs list").
  - `paygLines(monthlyTokens, rateAdjustPct)` scales each band's $/M by max(0, 1 + pct/100); band boundaries stay fixed. Rates floor at zero; UI ignores invalid or ≤ -100% entries and uses list rates.
  - Adjustment flows through the tier table, blended $/M, monthly/annual totals, and the committed-vs-PAYG delta.
  - Delta message attributes a cheaper PAYG to the applied discount instead of flagging a list-rate model error.

<sup>Written for commit 6487f042e0b4dd65d5c58a788aefed8054dbe187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

