### PR TITLE
chore: payg adjustment estimator follow ups from review

### DIFF
--- a/.changeset/payg-adjustment-followups.md
+++ b/.changeset/payg-adjustment-followups.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Two refinements to the PAYG rate adjustment in the TUM contract price estimator: a cheaper-than-committed PAYG outcome is only attributed to the adjustment when it is a discount — under an uplift the modelling-error warning ("check the platform fee against the baseline") is kept, since an uplift only raises PAYG above list rates; and adjustments at or past -100% are now ignored (list rates) at every layer instead of pricing PAYG as free.

--- a/client/dashboard/src/components/billing/contract-price-estimator.tsx
+++ b/client/dashboard/src/components/billing/contract-price-estimator.tsx
@@ -17,9 +17,11 @@ import {
   BASELINE_RATE_PER_MILLION,
   derivedAnnualPlatformFee,
   effectiveRatePerMillion,
+  formatSignedPct,
   formatTokensCompact,
   formatUSD,
   overageLines,
+  paygDeltaMessage,
   paygLines,
   sumLines,
   type TierLine,
@@ -135,29 +137,6 @@ function ModelCard({
       {children}
     </div>
   );
-}
-
-// "+10%" / "-15%": the sign is the information — an unsigned "10%" wouldn't
-// say which way the rates moved.
-function formatSignedPct(pct: number): string {
-  return `${pct > 0 ? "+" : ""}${pct.toLocaleString("en-US", { maximumFractionDigits: 2 })}%`;
-}
-
-// Reads the annual gap between the two models. PAYG undercutting the
-// committed contract is a modelling error at list rates — but the expected
-// outcome of a big enough negotiated discount — so the two cases have to read
-// differently, or a deliberate discount gets reported as a pricing bug.
-function paygDeltaMessage(delta: number, rateAdjustPct: number): string {
-  if (delta > 0) {
-    return `Pay-as-you-go costs ${formatUSD(delta)}/yr more than the committed contract at this volume — the number to point at in a "should we commit?" conversation.`;
-  }
-  if (delta < 0 && rateAdjustPct !== 0) {
-    return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here at the adjusted rates (${formatSignedPct(rateAdjustPct)} vs list).`;
-  }
-  if (delta < 0) {
-    return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here, which the model isn't meant to allow — check the platform fee against the baseline.`;
-  }
-  return "Both models price identically at this volume.";
 }
 
 // How hard the account team should be looking at this contract. Steady

--- a/client/dashboard/src/components/billing/contract-pricing.test.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.test.ts
@@ -122,6 +122,13 @@ describe("paygDeltaMessage", () => {
     expect(paygDeltaMessage(-5000, 10)).toMatch(/check the platform fee/);
   });
 
+  it("keeps the modelling-error warning for out-of-window swings", () => {
+    // paygLines ignores swings at or past -100% and prices at list rates,
+    // so the message must not credit an adjustment that was never applied.
+    expect(paygDeltaMessage(-5000, -100)).toMatch(/check the platform fee/);
+    expect(paygDeltaMessage(-5000, -150)).toMatch(/check the platform fee/);
+  });
+
   it("reports an exact tie as identical pricing", () => {
     expect(paygDeltaMessage(0, 0)).toMatch(/identically/);
   });

--- a/client/dashboard/src/components/billing/contract-pricing.test.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.test.ts
@@ -6,6 +6,7 @@ import {
   effectiveRatePerMillion,
   formatTokensCompact,
   overageLines,
+  paygDeltaMessage,
   paygLines,
   sumLines,
   type VolumeBasisOption,
@@ -90,12 +91,39 @@ describe("pay-as-you-go rate adjustment", () => {
     expect(paygLines(80 * B, 0)).toEqual(paygLines(80 * B));
   });
 
-  it("floors rates at zero rather than pricing negative past -100%", () => {
-    // A -150% swing is nonsense input; free is the least-wrong reading.
-    for (const line of paygLines(80 * B, -150)) {
-      expect(line.ratePerMillion).toBe(0);
-      expect(line.cost).toBe(0);
-    }
+  it("ignores swings at or past -100% and prices at list rates", () => {
+    // -100% would zero every rate and anything past it would go negative.
+    // Both are invalid input, and the pure function applies the same
+    // fallback as the estimator's input field — list rates — so no layer
+    // ever prices PAYG as free.
+    expect(paygLines(80 * B, -100)).toEqual(paygLines(80 * B));
+    expect(paygLines(80 * B, -150)).toEqual(paygLines(80 * B));
+  });
+});
+
+describe("paygDeltaMessage", () => {
+  it("frames a dearer PAYG as the case for committing", () => {
+    expect(paygDeltaMessage(5000, 0)).toMatch(/costs \$5,000\/yr more/);
+  });
+
+  it("flags a cheaper PAYG at list rates as a modelling error", () => {
+    expect(paygDeltaMessage(-5000, 0)).toMatch(/check the platform fee/);
+  });
+
+  it("attributes a cheaper PAYG under a discount to the discount", () => {
+    const message = paygDeltaMessage(-5000, -15);
+    expect(message).toMatch(/adjusted rates \(-15% vs list\)/);
+    expect(message).not.toMatch(/check the platform fee/);
+  });
+
+  it("keeps the modelling-error warning under an uplift", () => {
+    // An uplift only raises PAYG above list, so PAYG still undercutting the
+    // committed model is a stronger anomaly signal, not a discount story.
+    expect(paygDeltaMessage(-5000, 10)).toMatch(/check the platform fee/);
+  });
+
+  it("reports an exact tie as identical pricing", () => {
+    expect(paygDeltaMessage(0, 0)).toMatch(/identically/);
   });
 });
 

--- a/client/dashboard/src/components/billing/contract-pricing.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.ts
@@ -120,13 +120,15 @@ export function overageLines(
 // `rateAdjustPct` scales every band rate by a percentage (+10 → +10% uplift,
 // -15 → 15% discount): PAYG deals are negotiated as a swing off the list
 // rates, not as four hand-edited band rates. Band boundaries are absolute
-// volumes and don't move. Floored at -100% — beyond that a rate would go
-// negative, which prices as free, not as a rebate.
+// volumes and don't move. A swing at or past -100% would zero or negate
+// every rate, so it's treated as invalid and ignored — list rates — the
+// same fallback the estimator's input applies, so no layer ever prices
+// PAYG as free.
 export function paygLines(
   monthlyTokens: number,
   rateAdjustPct = 0,
 ): TierLine[] {
-  const rateMultiplier = Math.max(0, 1 + rateAdjustPct / 100);
+  const rateMultiplier = rateAdjustPct > -100 ? 1 + rateAdjustPct / 100 : 1;
   return graduatedLines(
     monthlyTokens,
     PAYG_TIERS.map((t) => ({
@@ -276,6 +278,31 @@ export function formatUSD(value: number): string {
   return Math.abs(value) >= 1000
     ? usdWhole.format(value)
     : usdCents.format(value);
+}
+
+// "+10%" / "-15%": the sign is the information — an unsigned "10%" wouldn't
+// say which way the rates moved.
+export function formatSignedPct(pct: number): string {
+  return `${pct > 0 ? "+" : ""}${pct.toLocaleString("en-US", { maximumFractionDigits: 2 })}%`;
+}
+
+// Reads the annual gap between the two models for the estimator's summary
+// line. PAYG undercutting the committed contract is a modelling error at
+// list rates — and a fortiori under an uplift, which only raises PAYG above
+// list — but it's the expected outcome of a big enough negotiated discount.
+// So only a discount claims the gap; everything else falls through to the
+// check-the-fee warning.
+export function paygDeltaMessage(delta: number, rateAdjustPct: number): string {
+  if (delta > 0) {
+    return `Pay-as-you-go costs ${formatUSD(delta)}/yr more than the committed contract at this volume — the number to point at in a "should we commit?" conversation.`;
+  }
+  if (delta < 0 && rateAdjustPct < 0) {
+    return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here at the adjusted rates (${formatSignedPct(rateAdjustPct)} vs list).`;
+  }
+  if (delta < 0) {
+    return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here, which the model isn't meant to allow — check the platform fee against the baseline.`;
+  }
+  return "Both models price identically at this volume.";
 }
 
 // Token counts at contract scale are billions — the raw digits are unreadable

--- a/client/dashboard/src/components/billing/contract-pricing.ts
+++ b/client/dashboard/src/components/billing/contract-pricing.ts
@@ -117,18 +117,28 @@ export function overageLines(
 // The full pay-as-you-go bill for one month — every token is charged, from
 // the first one, with no baseline to subtract.
 //
+// The window of valid negotiated swings on the PAYG list rates. At -100% a
+// swing would zero every rate and past it rates would go negative, so both
+// are invalid input, and EVERY function in this module taking a swing must
+// ignore them (list rates) via this one predicate — the same fallback the
+// estimator's input applies — so no layer prices PAYG as free and no message
+// describes an adjustment that wasn't applied.
+function isValidRateAdjust(rateAdjustPct: number): boolean {
+  return rateAdjustPct > -100;
+}
+
 // `rateAdjustPct` scales every band rate by a percentage (+10 → +10% uplift,
 // -15 → 15% discount): PAYG deals are negotiated as a swing off the list
 // rates, not as four hand-edited band rates. Band boundaries are absolute
-// volumes and don't move. A swing at or past -100% would zero or negate
-// every rate, so it's treated as invalid and ignored — list rates — the
-// same fallback the estimator's input applies, so no layer ever prices
-// PAYG as free.
+// volumes and don't move. Out-of-window swings are ignored — see
+// isValidRateAdjust.
 export function paygLines(
   monthlyTokens: number,
   rateAdjustPct = 0,
 ): TierLine[] {
-  const rateMultiplier = rateAdjustPct > -100 ? 1 + rateAdjustPct / 100 : 1;
+  const rateMultiplier = isValidRateAdjust(rateAdjustPct)
+    ? 1 + rateAdjustPct / 100
+    : 1;
   return graduatedLines(
     monthlyTokens,
     PAYG_TIERS.map((t) => ({
@@ -290,13 +300,14 @@ export function formatSignedPct(pct: number): string {
 // line. PAYG undercutting the committed contract is a modelling error at
 // list rates — and a fortiori under an uplift, which only raises PAYG above
 // list — but it's the expected outcome of a big enough negotiated discount.
-// So only a discount claims the gap; everything else falls through to the
-// check-the-fee warning.
+// So only a discount claims the gap — a valid one: an out-of-window swing
+// was priced at list rates by paygLines, so it can't be what made PAYG
+// cheaper. Everything else falls through to the check-the-fee warning.
 export function paygDeltaMessage(delta: number, rateAdjustPct: number): string {
   if (delta > 0) {
     return `Pay-as-you-go costs ${formatUSD(delta)}/yr more than the committed contract at this volume — the number to point at in a "should we commit?" conversation.`;
   }
-  if (delta < 0 && rateAdjustPct < 0) {
+  if (delta < 0 && rateAdjustPct < 0 && isValidRateAdjust(rateAdjustPct)) {
     return `Pay-as-you-go is ${formatUSD(-delta)}/yr cheaper here at the adjusted rates (${formatSignedPct(rateAdjustPct)} vs list).`;
   }
   if (delta < 0) {


### PR DESCRIPTION
Follow-up to #5145, addressing the two cubic review comments there.

## What

1. **Uplift no longer suppresses the modelling-error warning.** The "cheaper at adjusted rates" delta message now requires a *discount* (`rateAdjustPct < 0`). Under an uplift, PAYG still undercutting the committed model is a stronger anomaly signal — an uplift only raises PAYG above list — so it falls through to the "check the platform fee against the baseline" warning.
2. **≤ −100% adjustments unified on the list-rate fallback.** The pure `paygLines` previously floored rates at zero (a free PAYG bill) while the estimator input already fell back to list rates for out-of-range entries. Both layers now agree: at or past −100% the swing is invalid and ignored, so nothing ever prices PAYG as free.

Also moves `paygDeltaMessage` / `formatSignedPct` into `contract-pricing.ts` so the branch logic is unit-testable (5 new tests; 31 total pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8edBG1tMBsaDSGPgi4pt9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PAYG adjustment estimator edge cases: only valid discounts claim a cheaper-than-committed outcome, uplifts keep the modelling-error warning, and swings at or below −100% now fall back to list rates across pricing and messaging to prevent free or misattributed PAYG.

- **Bug Fixes**
  - A cheaper PAYG under an uplift now shows the modelling-error warning; the “cheaper at adjusted rates” message only appears for valid discounts (`rateAdjustPct < 0` and > −100%).
  - Swings ≤ −100% are treated as invalid and ignored; all helpers use list rates, so PAYG is never priced as free and messages don’t credit an unapplied adjustment.

- **Refactors**
  - Centralized rate-adjust validity in `isValidRateAdjust`; moved `paygDeltaMessage` and `formatSignedPct` into `contract-pricing.ts` with new unit tests.

<sup>Written for commit b8fbf51331596d4f4aa80a47bbe64fbb98a0befa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

