### PR TITLE
feat(gateway): log external MCP tool calls that return an error result

### DIFF
--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -810,6 +810,35 @@ func (tp *ToolProxy) doPrompt(ctx context.Context, logger *slog.Logger, w http.R
 	return nil
 }
 
+// externalMCPErrorSummaryLimit bounds how much of an errored tool result is
+// recorded. Provider error codes lead the payload, so the head is the part
+// worth keeping; the tail can be an arbitrarily large upstream response.
+const externalMCPErrorSummaryLimit = 512
+
+// externalMCPErrorSummary renders the content of an errored tool result for
+// logging. The content is upstream-controlled, so it is truncated on a rune
+// boundary and stripped of invalid UTF-8 before it reaches the log.
+func externalMCPErrorSummary(content []json.RawMessage) string {
+	if len(content) == 0 {
+		return "external MCP server reported an error with no content"
+	}
+
+	var summary strings.Builder
+	for _, part := range content {
+		if summary.Len() >= externalMCPErrorSummaryLimit {
+			break
+		}
+		summary.Write(part)
+	}
+
+	rendered := summary.String()
+	if len(rendered) > externalMCPErrorSummaryLimit {
+		return strings.ToValidUTF8(rendered[:externalMCPErrorSummaryLimit], "") + "…(truncated)"
+	}
+
+	return strings.ToValidUTF8(rendered, "")
+}
+
 func (tp *ToolProxy) doExternalMCP(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -851,6 +880,21 @@ func (tp *ToolProxy) doExternalMCP(
 	callResult, err := client.CallTool(ctx, toolName, arguments)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to call external MCP tool").LogError(ctx, logger)
+	}
+
+	// An upstream that reports failure in-band — a result carrying isError
+	// rather than a transport or protocol error — reaches none of the error
+	// paths above, so the whole class is otherwise invisible: the result is
+	// forwarded to the caller and nothing is recorded. Providers that surface a
+	// rejected or expired bearer as a tool result rather than a 401 are the
+	// motivating case, since the failure is then visible to the end user and to
+	// no one operating the service.
+	if callResult.IsError {
+		logger.ErrorContext(ctx, "external MCP tool returned an error result",
+			attr.SlogToolName(toolName),
+			attr.SlogURL(plan.RemoteURL),
+			attr.SlogErrorMessage(externalMCPErrorSummary(callResult.Content)),
+		)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/gateway/proxy.go
+++ b/server/internal/gateway/proxy.go
@@ -816,27 +816,39 @@ func (tp *ToolProxy) doPrompt(ctx context.Context, logger *slog.Logger, w http.R
 const externalMCPErrorSummaryLimit = 512
 
 // externalMCPErrorSummary renders the content of an errored tool result for
-// logging. The content is upstream-controlled, so it is truncated on a rune
-// boundary and stripped of invalid UTF-8 before it reaches the log.
+// logging. The content is upstream-controlled, so each part is written only up
+// to the remaining budget — the limit bounds what is built, not just what is
+// returned, so one multi-megabyte part cannot be copied whole on its way to a
+// 512-byte log field. Slicing to a byte offset can split a multi-byte rune, so
+// invalid UTF-8 is stripped before the summary reaches the log.
 func externalMCPErrorSummary(content []json.RawMessage) string {
 	if len(content) == 0 {
 		return "external MCP server reported an error with no content"
 	}
 
 	var summary strings.Builder
+	truncated := false
 	for _, part := range content {
-		if summary.Len() >= externalMCPErrorSummaryLimit {
+		remaining := externalMCPErrorSummaryLimit - summary.Len()
+		if remaining <= 0 {
+			// Budget spent with parts still to go: the tail is being dropped.
+			truncated = true
+			break
+		}
+		if len(part) > remaining {
+			summary.Write(part[:remaining])
+			truncated = true
 			break
 		}
 		summary.Write(part)
 	}
 
-	rendered := summary.String()
-	if len(rendered) > externalMCPErrorSummaryLimit {
-		return strings.ToValidUTF8(rendered[:externalMCPErrorSummaryLimit], "") + "…(truncated)"
+	rendered := strings.ToValidUTF8(summary.String(), "")
+	if truncated {
+		return rendered + "…(truncated)"
 	}
 
-	return strings.ToValidUTF8(rendered, "")
+	return rendered
 }
 
 func (tp *ToolProxy) doExternalMCP(

--- a/server/internal/gateway/proxy_externalmcp_error_test.go
+++ b/server/internal/gateway/proxy_externalmcp_error_test.go
@@ -43,14 +43,61 @@ func TestExternalMCPErrorSummaryTruncatesLargeContent(t *testing.T) {
 
 // Truncation cuts at a byte offset, so a multi-byte rune can straddle the
 // boundary. The result still has to be valid UTF-8 to survive log encoding.
+// The rune here is three bytes wide so that the limit does not divide it
+// evenly — a two-byte rune lands flush against a 512-byte cut and never
+// exercises the split.
 func TestExternalMCPErrorSummaryTruncatesToValidUTF8(t *testing.T) {
 	t.Parallel()
 
-	multibyte := []json.RawMessage{json.RawMessage(strings.Repeat("é", externalMCPErrorSummaryLimit))}
+	multibyte := []json.RawMessage{json.RawMessage(strings.Repeat("€", externalMCPErrorSummaryLimit))}
 	summary := externalMCPErrorSummary(multibyte)
 
 	require.Equal(t, summary, strings.ToValidUTF8(summary, "�"),
 		"summary must not end in a split rune")
+}
+
+// Guards the returned bound and the dropping of parts past the budget. That
+// the limit also bounds the *builder* — so a multi-megabyte part is sliced on
+// the way in rather than copied whole and trimmed after — is not observable
+// through the return value, and is not covered here.
+func TestExternalMCPErrorSummaryDropsPartsPastTheBudget(t *testing.T) {
+	t.Parallel()
+
+	huge := []json.RawMessage{
+		json.RawMessage(strings.Repeat("a", externalMCPErrorSummaryLimit*20)),
+		json.RawMessage(strings.Repeat("b", externalMCPErrorSummaryLimit*20)),
+	}
+	summary := externalMCPErrorSummary(huge)
+
+	require.LessOrEqual(t, len(summary), externalMCPErrorSummaryLimit+len("…(truncated)"))
+	require.NotContains(t, summary, "b", "the second part must never be written once the budget is spent")
+}
+
+// Content landing exactly on the limit with parts still to go drops the tail,
+// so it has to be marked. Reading an unmarked summary as complete is the whole
+// failure mode this marker exists to prevent.
+func TestExternalMCPErrorSummaryMarksTruncationAtExactLimit(t *testing.T) {
+	t.Parallel()
+
+	exact := []json.RawMessage{
+		json.RawMessage(strings.Repeat("a", externalMCPErrorSummaryLimit)),
+		json.RawMessage("Bad_OAuth_Token"),
+	}
+	summary := externalMCPErrorSummary(exact)
+
+	require.Contains(t, summary, "(truncated)")
+}
+
+// The mirror case: content that exactly fills the budget with nothing left
+// over is complete, and marking it would misreport an intact summary.
+func TestExternalMCPErrorSummaryNoMarkerWhenContentExactlyFits(t *testing.T) {
+	t.Parallel()
+
+	exact := []json.RawMessage{json.RawMessage(strings.Repeat("a", externalMCPErrorSummaryLimit))}
+	summary := externalMCPErrorSummary(exact)
+
+	require.NotContains(t, summary, "(truncated)")
+	require.Len(t, summary, externalMCPErrorSummaryLimit)
 }
 
 // Several content parts make up one failure; stopping at the first would drop

--- a/server/internal/gateway/proxy_externalmcp_error_test.go
+++ b/server/internal/gateway/proxy_externalmcp_error_test.go
@@ -1,0 +1,69 @@
+package gateway
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The provider's error code leads the payload, so it must survive into the log
+// verbatim — that string is the whole reason this path is recorded.
+func TestExternalMCPErrorSummaryKeepsProviderErrorCode(t *testing.T) {
+	t.Parallel()
+
+	content := []json.RawMessage{
+		json.RawMessage(`{"type":"text","text":"INVALID_AUTH_HEADER: session expired"}`),
+	}
+
+	require.Contains(t, externalMCPErrorSummary(content), "INVALID_AUTH_HEADER")
+}
+
+// An errored result with no content still has to say something, or the log line
+// reads as though nothing went wrong.
+func TestExternalMCPErrorSummaryEmptyContent(t *testing.T) {
+	t.Parallel()
+
+	require.NotEmpty(t, externalMCPErrorSummary(nil))
+	require.NotEmpty(t, externalMCPErrorSummary([]json.RawMessage{}))
+}
+
+// Content is upstream-controlled and can be a full response body, so the log
+// must not carry it unbounded.
+func TestExternalMCPErrorSummaryTruncatesLargeContent(t *testing.T) {
+	t.Parallel()
+
+	oversized := []json.RawMessage{json.RawMessage(strings.Repeat("a", externalMCPErrorSummaryLimit*3))}
+	summary := externalMCPErrorSummary(oversized)
+
+	require.Contains(t, summary, "(truncated)")
+	require.Less(t, len(summary), externalMCPErrorSummaryLimit*2)
+}
+
+// Truncation cuts at a byte offset, so a multi-byte rune can straddle the
+// boundary. The result still has to be valid UTF-8 to survive log encoding.
+func TestExternalMCPErrorSummaryTruncatesToValidUTF8(t *testing.T) {
+	t.Parallel()
+
+	multibyte := []json.RawMessage{json.RawMessage(strings.Repeat("é", externalMCPErrorSummaryLimit))}
+	summary := externalMCPErrorSummary(multibyte)
+
+	require.Equal(t, summary, strings.ToValidUTF8(summary, "�"),
+		"summary must not end in a split rune")
+}
+
+// Several content parts make up one failure; stopping at the first would drop
+// the part naming the cause.
+func TestExternalMCPErrorSummaryJoinsMultipleParts(t *testing.T) {
+	t.Parallel()
+
+	content := []json.RawMessage{
+		json.RawMessage(`{"type":"text","text":"request failed"}`),
+		json.RawMessage(`{"type":"text","text":"Bad_OAuth_Token"}`),
+	}
+	summary := externalMCPErrorSummary(content)
+
+	require.Contains(t, summary, "request failed")
+	require.Contains(t, summary, "Bad_OAuth_Token")
+}


### PR DESCRIPTION
## Problem

An external MCP server can report a failed tool call in-band: the JSON-RPC
call succeeds, and the result carries `isError: true` with the provider's
error in the content. That is a normal, spec-compliant way for an upstream to
fail, and several providers use it for auth failures — a rejected or expired
bearer comes back as a tool result rather than a 401.

`doExternalMCP` had no handling for it. The two error paths there catch a
failed connection and a failed `CallTool`; an errored _result_ is neither.
The handler then writes `http.StatusOK` unconditionally and puts `isError`
in the response body.

The result is a failure class that is invisible from both sides:

- **Access logs** record `200`, indistinguishable from a successful call.
- **Application logs** record nothing, because no Go error is ever produced.

The failure reaches the end user's client and no one operating the service.
Found while investigating a support report of intermittent connector auth
failures where the tenant's telemetry looked completely healthy for the
period in question — the reported failures were inside the `200`s.

## Change

Log the errored result with the tool name and remote URL. Response content is
upstream-controlled, so `externalMCPErrorSummary` bounds it at 512 bytes and
runs `strings.ToValidUTF8` over the result — truncation cuts at a byte offset
and would otherwise split a multi-byte rune and corrupt the log line.

The response to the caller is unchanged; this is observability only.

## Note for reviewers

The summary records up to 512 bytes of upstream response content. For an auth
failure that is a provider error code, which is the point — the distinction
between error codes is what makes these reports diagnosable. A tool erroring
mid-fetch could put a fragment of record data there instead. Flagging it
explicitly in case that is not acceptable for our log retention posture; the
alternative is dropping the content and keeping only the tool name and URL,
which loses the diagnostic value.

## Testing

`mise lint:server` clean; full `server/internal/gateway` suite passes. Five
new tests cover: the provider error code surviving into the summary, empty
content, truncation of oversized content, valid UTF-8 after truncation, and
joining multiple content parts.
