### PR TITLE
feat(admin): internal tracker for customer PAYG pricing and inference spend

### DIFF
--- a/.changeset/admin-pricing-inference-tracker.md
+++ b/.changeset/admin-pricing-inference-tracker.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add an internal admin pricing tracker: `GET /admin/organizations.pricingTracker` returns, per organization, the pay-as-you-go price at the current rate card (derived from observed tokens under management) alongside Gram-hosted inference spend over a trailing window, so staff can watch customer pricing exposure when adjusting spend limits. Inference spend is summed from Gram-server-run completion surfaces (playground, elements, risk analysis, assistants, and other platform-run completions) and is reported as zero when the admin service is started without a ClickHouse connection.

--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"github.com/sourcegraph/conc/pool"
@@ -170,6 +171,12 @@ func newAdminCommand() *cli.Command {
 		},
 	}
 
+	// ClickHouse powers the pricing tracker's inference-spend and
+	// tokens-under-management reads. It is best-effort: if the connection
+	// can't be established the admin server still starts and the tracker
+	// reports those figures as zero.
+	flags = append(flags, clickHouseFlags()...)
+
 	return &cli.Command{
 		Name:  "admin",
 		Usage: "Start the Gram admin server",
@@ -247,6 +254,17 @@ func newAdminCommand() *cli.Command {
 				return fmt.Errorf("failed to create admin OIDC client: %w", err)
 			}
 
+			// Best-effort ClickHouse connection for the pricing tracker. A
+			// failure here must not stop the admin server from serving the
+			// rest of its endpoints, so log and continue with a nil client.
+			var chConn clickhouse.Conn
+			if chDB, chShutdown, chErr := newClickhouseClient(ctx, logger, c); chErr != nil {
+				logger.WarnContext(ctx, "clickhouse unavailable; pricing tracker inference spend disabled", attr.SlogError(chErr))
+			} else {
+				chConn = chDB
+				shutdownFuncs = append(shutdownFuncs, chShutdown)
+			}
+
 			mux := goahttp.NewMuxer()
 			mux.Use(func(h http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -273,7 +291,7 @@ func newAdminCommand() *cli.Command {
 			mux.Use(middleware.AdminCookieAttributes(adminCrossOriginCookies, adminCookieDomain))
 			mux.Use(admin.SessionMiddleware)
 
-			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins))
+			admin.Attach(mux, admin.NewService(logger, tracerProvider, db, redisClient, adminOIDCClient, adminEncryption, adminAllowedOrigins, chConn))
 
 			srv := &http.Server{
 				Addr:              c.String("address"),

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -127,6 +127,45 @@ var AdminListOrganizationsResult = Type("AdminListOrganizationsResult", func() {
 	Attribute("next_cursor", String, "Cursor for the next page; empty when exhausted.")
 })
 
+var AdminPricingTrackerRow = Type("AdminPricingTrackerRow", func() {
+	Description("One organization's pricing exposure: PAYG price at the current rate card and Gram-hosted inference spend over the tracker window.")
+	Required(
+		"organization_id",
+		"name",
+		"slug",
+		"account_type",
+		"monthly_tum_tokens",
+		"payg_monthly_price",
+		"payg_effective_rate_per_million",
+		"inference_spend",
+	)
+
+	Attribute("organization_id", String, "The ID of the organization.")
+	Attribute("name", String, "The name of the organization (customer name).")
+	Attribute("slug", String, "The slug of the organization.")
+	Attribute("account_type", String, "Gram account type (e.g. free, pro, enterprise).")
+	Attribute("monthly_tum_tokens", Int64, "Observed tokens under management over the window, used as the PAYG pricing input.")
+	Attribute("payg_monthly_price", Float64, "Pay-as-you-go price in USD for the window's volume at the current rate card.")
+	Attribute("payg_effective_rate_per_million", Float64, "Blended PAYG rate in USD per million tokens at the window's volume.")
+	Attribute("inference_spend", Float64, "Gram-hosted inference spend in USD over the window (playground, elements, risk analysis, assistants, and other platform-run completions).")
+})
+
+var AdminListPricingTrackerResult = Type("AdminListPricingTrackerResult", func() {
+	Description("Internal pricing tracker: per-customer PAYG price and inference spend over a trailing window.")
+	Required("rows", "window_start", "window_end", "inference_spend_available")
+
+	Attribute("rows", ArrayOf(AdminPricingTrackerRow), "One row per organization, ordered by inference spend descending.")
+	Attribute("window_start", String, func() {
+		Description("Inclusive start of the tracker window.")
+		Format(FormatDateTime)
+	})
+	Attribute("window_end", String, func() {
+		Description("Exclusive end of the tracker window.")
+		Format(FormatDateTime)
+	})
+	Attribute("inference_spend_available", Boolean, "False when the analytics store is not wired into the admin service, in which case inference spend and TUM-derived PAYG figures are reported as zero.")
+})
+
 var _ = Service("admin", func() {
 	Description("Operations supporting admin tasks, protected by Google workspace auth.")
 	Security(security.AdminAuth)
@@ -351,5 +390,32 @@ var _ = Service("admin", func() {
 
 		shared.CursorPagination()
 		Meta("openapi:operationId", "adminListOrganizations")
+	})
+
+	Method("listPricingTracker", func() {
+		Description("Internal tracker of customer pricing exposure: per organization, the PAYG price at the current rate card (off observed tokens under management) and the Gram-hosted inference spend, both over a trailing window.")
+
+		Payload(func() {
+			security.AdminAuthPayload()
+
+			Attribute("account_type", String, "Filter to a single gram_account_type (e.g. enterprise). When omitted, paying tiers (pro and enterprise) are included.")
+			Attribute("include_free", Boolean, "Include free-tier organizations. Defaults to false so the tracker stays focused on paying customers.")
+			Attribute("window_days", Int, "Length of the trailing window in days. Defaults to 30, max 90.")
+			Attribute("limit", Int, "Maximum number of rows to return (default 100, max 500).")
+		})
+
+		Result(AdminListPricingTrackerResult)
+
+		HTTP(func() {
+			GET("/admin/organizations.pricingTracker")
+
+			Param("account_type")
+			Param("include_free")
+			Param("window_days")
+			Param("limit")
+			Response(StatusOK)
+		})
+
+		Meta("openapi:operationId", "adminListPricingTracker")
 	})
 })

--- a/server/gen/admin/client.go
+++ b/server/gen/admin/client.go
@@ -24,10 +24,11 @@ type Client struct {
 	ListOrganizationMembersEndpoint  goa.Endpoint
 	ListOrganizationProjectsEndpoint goa.Endpoint
 	ListOrganizationsEndpoint        goa.Endpoint
+	ListPricingTrackerEndpoint       goa.Endpoint
 }
 
 // NewClient initializes a "admin" service client given the endpoints.
-func NewClient(login, callback, logout, getProject, updateOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations goa.Endpoint) *Client {
+func NewClient(login, callback, logout, getProject, updateOrganization, getOrganization, listOrganizationMembers, listOrganizationProjects, listOrganizations, listPricingTracker goa.Endpoint) *Client {
 	return &Client{
 		LoginEndpoint:                    login,
 		CallbackEndpoint:                 callback,
@@ -38,6 +39,7 @@ func NewClient(login, callback, logout, getProject, updateOrganization, getOrgan
 		ListOrganizationMembersEndpoint:  listOrganizationMembers,
 		ListOrganizationProjectsEndpoint: listOrganizationProjects,
 		ListOrganizationsEndpoint:        listOrganizations,
+		ListPricingTrackerEndpoint:       listPricingTracker,
 	}
 }
 
@@ -237,4 +239,27 @@ func (c *Client) ListOrganizations(ctx context.Context, p *ListOrganizationsPayl
 		return
 	}
 	return ires.(*AdminListOrganizationsResult), nil
+}
+
+// ListPricingTracker calls the "listPricingTracker" endpoint of the "admin"
+// service.
+// ListPricingTracker may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): unauthorized access
+//   - "forbidden" (type *goa.ServiceError): permission denied
+//   - "bad_request" (type *goa.ServiceError): request is invalid
+//   - "not_found" (type *goa.ServiceError): resource not found
+//   - "conflict" (type *goa.ServiceError): resource already exists
+//   - "unsupported_media" (type *goa.ServiceError): unsupported media type
+//   - "invalid" (type *goa.ServiceError): request contains one or more invalidation fields
+//   - "invariant_violation" (type *goa.ServiceError): an unexpected error occurred
+//   - "unexpected" (type *goa.ServiceError): an unexpected error occurred
+//   - "gateway_error" (type *goa.ServiceError): an unexpected error occurred
+//   - error: internal error
+func (c *Client) ListPricingTracker(ctx context.Context, p *ListPricingTrackerPayload) (res *AdminListPricingTrackerResult, err error) {
+	var ires any
+	ires, err = c.ListPricingTrackerEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*AdminListPricingTrackerResult), nil
 }

--- a/server/gen/admin/endpoints.go
+++ b/server/gen/admin/endpoints.go
@@ -25,6 +25,7 @@ type Endpoints struct {
 	ListOrganizationMembers  goa.Endpoint
 	ListOrganizationProjects goa.Endpoint
 	ListOrganizations        goa.Endpoint
+	ListPricingTracker       goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "admin" service with endpoints.
@@ -41,6 +42,7 @@ func NewEndpoints(s Service) *Endpoints {
 		ListOrganizationMembers:  NewListOrganizationMembersEndpoint(s, a.APIKeyAuth),
 		ListOrganizationProjects: NewListOrganizationProjectsEndpoint(s, a.APIKeyAuth),
 		ListOrganizations:        NewListOrganizationsEndpoint(s, a.APIKeyAuth),
+		ListPricingTracker:       NewListPricingTrackerEndpoint(s, a.APIKeyAuth),
 	}
 }
 
@@ -55,6 +57,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.ListOrganizationMembers = m(e.ListOrganizationMembers)
 	e.ListOrganizationProjects = m(e.ListOrganizationProjects)
 	e.ListOrganizations = m(e.ListOrganizations)
+	e.ListPricingTracker = m(e.ListPricingTracker)
 }
 
 // NewLoginEndpoint returns an endpoint function that calls the method "login"
@@ -219,5 +222,28 @@ func NewListOrganizationsEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFun
 			return nil, err
 		}
 		return s.ListOrganizations(ctx, p)
+	}
+}
+
+// NewListPricingTrackerEndpoint returns an endpoint function that calls the
+// method "listPricingTracker" of service "admin".
+func NewListPricingTrackerEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		p := req.(*ListPricingTrackerPayload)
+		var err error
+		sc := security.APIKeyScheme{
+			Name:           "admin_auth",
+			Scopes:         []string{},
+			RequiredScopes: []string{},
+		}
+		var key string
+		if p.AdminSessionToken != nil {
+			key = *p.AdminSessionToken
+		}
+		ctx, err = authAPIKeyFn(ctx, key, &sc)
+		if err != nil {
+			return nil, err
+		}
+		return s.ListPricingTracker(ctx, p)
 	}
 }

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -36,6 +36,10 @@ type Service interface {
 	ListOrganizationProjects(context.Context, *ListOrganizationProjectsPayload) (res *AdminListOrganizationProjectsResult, err error)
 	// Lists organizations for admin operations with optional search and filters.
 	ListOrganizations(context.Context, *ListOrganizationsPayload) (res *AdminListOrganizationsResult, err error)
+	// Internal tracker of customer pricing exposure: per organization, the PAYG
+	// price at the current rate card (off observed tokens under management) and
+	// the Gram-hosted inference spend, both over a trailing window.
+	ListPricingTracker(context.Context, *ListPricingTrackerPayload) (res *AdminListPricingTrackerResult, err error)
 }
 
 // Auther defines the authorization functions to be implemented by the service.
@@ -58,7 +62,7 @@ const ServiceName = "admin"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [9]string{"login", "callback", "logout", "getProject", "updateOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations"}
+var MethodNames = [10]string{"login", "callback", "logout", "getProject", "updateOrganization", "getOrganization", "listOrganizationMembers", "listOrganizationProjects", "listOrganizations", "listPricingTracker"}
 
 // AdminListOrganizationMembersResult is the result type of the admin service
 // listOrganizationMembers method.
@@ -81,6 +85,20 @@ type AdminListOrganizationsResult struct {
 	Organizations []*AdminOrganization
 	// Cursor for the next page; empty when exhausted.
 	NextCursor *string
+}
+
+// AdminListPricingTrackerResult is the result type of the admin service
+// listPricingTracker method.
+type AdminListPricingTrackerResult struct {
+	// One row per organization, ordered by inference spend descending.
+	Rows []*AdminPricingTrackerRow
+	// Inclusive start of the tracker window.
+	WindowStart string
+	// Exclusive end of the tracker window.
+	WindowEnd string
+	// False when the analytics store is not wired into the admin service, in which
+	// case inference spend and TUM-derived PAYG figures are reported as zero.
+	InferenceSpendAvailable bool
 }
 
 // AdminOrganization is the result type of the admin service updateOrganization
@@ -124,6 +142,29 @@ type AdminOrganizationMember struct {
 	LastLogin *string
 	CreatedAt string
 	UpdatedAt string
+}
+
+// One organization's pricing exposure: PAYG price at the current rate card and
+// Gram-hosted inference spend over the tracker window.
+type AdminPricingTrackerRow struct {
+	// The ID of the organization.
+	OrganizationID string
+	// The name of the organization (customer name).
+	Name string
+	// The slug of the organization.
+	Slug string
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType string
+	// Observed tokens under management over the window, used as the PAYG pricing
+	// input.
+	MonthlyTumTokens int64
+	// Pay-as-you-go price in USD for the window's volume at the current rate card.
+	PaygMonthlyPrice float64
+	// Blended PAYG rate in USD per million tokens at the window's volume.
+	PaygEffectiveRatePerMillion float64
+	// Gram-hosted inference spend in USD over the window (playground, elements,
+	// risk analysis, assistants, and other platform-run completions).
+	InferenceSpend float64
 }
 
 // Project summary surfaced to admin operators.
@@ -238,6 +279,22 @@ type ListOrganizationsPayload struct {
 	// Pagination cursor: id of the last item from the previous page.
 	Cursor *string
 	// Page size (default 50, max 100).
+	Limit *int
+}
+
+// ListPricingTrackerPayload is the payload type of the admin service
+// listPricingTracker method.
+type ListPricingTrackerPayload struct {
+	AdminSessionToken *string
+	// Filter to a single gram_account_type (e.g. enterprise). When omitted, paying
+	// tiers (pro and enterprise) are included.
+	AccountType *string
+	// Include free-tier organizations. Defaults to false so the tracker stays
+	// focused on paying customers.
+	IncludeFree *bool
+	// Length of the trailing window in days. Defaults to 30, max 90.
+	WindowDays *int
+	// Maximum number of rows to return (default 100, max 500).
 	Limit *int
 }
 

--- a/server/gen/http/admin/client/cli.go
+++ b/server/gen/http/admin/client/cli.go
@@ -261,3 +261,64 @@ func BuildListOrganizationsPayload(adminListOrganizationsQ string, adminListOrga
 
 	return v, nil
 }
+
+// BuildListPricingTrackerPayload builds the payload for the admin
+// listPricingTracker endpoint from CLI flags.
+func BuildListPricingTrackerPayload(adminListPricingTrackerAccountType string, adminListPricingTrackerIncludeFree string, adminListPricingTrackerWindowDays string, adminListPricingTrackerLimit string, adminListPricingTrackerAdminSessionToken string) (*admin.ListPricingTrackerPayload, error) {
+	var err error
+	var accountType *string
+	{
+		if adminListPricingTrackerAccountType != "" {
+			accountType = &adminListPricingTrackerAccountType
+		}
+	}
+	var includeFree *bool
+	{
+		if adminListPricingTrackerIncludeFree != "" {
+			var val bool
+			val, err = strconv.ParseBool(adminListPricingTrackerIncludeFree)
+			includeFree = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for includeFree, must be BOOL")
+			}
+		}
+	}
+	var windowDays *int
+	{
+		if adminListPricingTrackerWindowDays != "" {
+			var v int64
+			v, err = strconv.ParseInt(adminListPricingTrackerWindowDays, 10, strconv.IntSize)
+			val := int(v)
+			windowDays = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for windowDays, must be INT")
+			}
+		}
+	}
+	var limit *int
+	{
+		if adminListPricingTrackerLimit != "" {
+			var v int64
+			v, err = strconv.ParseInt(adminListPricingTrackerLimit, 10, strconv.IntSize)
+			val := int(v)
+			limit = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for limit, must be INT")
+			}
+		}
+	}
+	var adminSessionToken *string
+	{
+		if adminListPricingTrackerAdminSessionToken != "" {
+			adminSessionToken = &adminListPricingTrackerAdminSessionToken
+		}
+	}
+	v := &admin.ListPricingTrackerPayload{}
+	v.AccountType = accountType
+	v.IncludeFree = includeFree
+	v.WindowDays = windowDays
+	v.Limit = limit
+	v.AdminSessionToken = adminSessionToken
+
+	return v, nil
+}

--- a/server/gen/http/admin/client/client.go
+++ b/server/gen/http/admin/client/client.go
@@ -51,6 +51,10 @@ type Client struct {
 	// listOrganizations endpoint.
 	ListOrganizationsDoer goahttp.Doer
 
+	// ListPricingTracker Doer is the HTTP client used to make requests to the
+	// listPricingTracker endpoint.
+	ListPricingTrackerDoer goahttp.Doer
+
 	// RestoreResponseBody controls whether the response bodies are reset after
 	// decoding so they can be read again.
 	RestoreResponseBody bool
@@ -80,6 +84,7 @@ func NewClient(
 		ListOrganizationMembersDoer:  doer,
 		ListOrganizationProjectsDoer: doer,
 		ListOrganizationsDoer:        doer,
+		ListPricingTrackerDoer:       doer,
 		RestoreResponseBody:          restoreBody,
 		scheme:                       scheme,
 		host:                         host,
@@ -299,6 +304,30 @@ func (c *Client) ListOrganizations() goa.Endpoint {
 		resp, err := c.ListOrganizationsDoer.Do(req)
 		if err != nil {
 			return nil, goahttp.ErrRequestError("admin", "listOrganizations", err)
+		}
+		return decodeResponse(resp)
+	}
+}
+
+// ListPricingTracker returns an endpoint that makes HTTP requests to the admin
+// service listPricingTracker server.
+func (c *Client) ListPricingTracker() goa.Endpoint {
+	var (
+		encodeRequest  = EncodeListPricingTrackerRequest(c.encoder)
+		decodeResponse = DecodeListPricingTrackerResponse(c.decoder, c.RestoreResponseBody)
+	)
+	return func(ctx context.Context, v any) (any, error) {
+		req, err := c.BuildListPricingTrackerRequest(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		err = encodeRequest(req, v)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.ListPricingTrackerDoer.Do(req)
+		if err != nil {
+			return nil, goahttp.ErrRequestError("admin", "listPricingTracker", err)
 		}
 		return decodeResponse(resp)
 	}

--- a/server/gen/http/admin/client/encode_decode.go
+++ b/server/gen/http/admin/client/encode_decode.go
@@ -2166,6 +2166,250 @@ func DecodeListOrganizationsResponse(decoder func(*http.Response) goahttp.Decode
 	}
 }
 
+// BuildListPricingTrackerRequest instantiates a HTTP request object with
+// method and path set to call the "admin" service "listPricingTracker" endpoint
+func (c *Client) BuildListPricingTrackerRequest(ctx context.Context, v any) (*http.Request, error) {
+	u := &url.URL{Scheme: c.scheme, Host: c.host, Path: ListPricingTrackerAdminPath()}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, goahttp.ErrInvalidURL("admin", "listPricingTracker", u.String(), err)
+	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+
+	return req, nil
+}
+
+// EncodeListPricingTrackerRequest returns an encoder for requests sent to the
+// admin listPricingTracker server.
+func EncodeListPricingTrackerRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
+		p, ok := v.(*admin.ListPricingTrackerPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("admin", "listPricingTracker", "*admin.ListPricingTrackerPayload", v)
+		}
+		if p.AdminSessionToken != nil {
+			head := *p.AdminSessionToken
+			req.Header.Set("Authorization", head)
+		}
+		values := req.URL.Query()
+		if p.AccountType != nil {
+			values.Add("account_type", *p.AccountType)
+		}
+		if p.IncludeFree != nil {
+			values.Add("include_free", fmt.Sprintf("%v", *p.IncludeFree))
+		}
+		if p.WindowDays != nil {
+			values.Add("window_days", fmt.Sprintf("%v", *p.WindowDays))
+		}
+		if p.Limit != nil {
+			values.Add("limit", fmt.Sprintf("%v", *p.Limit))
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+
+// DecodeListPricingTrackerResponse returns a decoder for responses returned by
+// the admin listPricingTracker endpoint. restoreBody controls whether the
+// response body should be restored after having been read.
+// DecodeListPricingTrackerResponse may return the following errors:
+//   - "unauthorized" (type *goa.ServiceError): http.StatusUnauthorized
+//   - "forbidden" (type *goa.ServiceError): http.StatusForbidden
+//   - "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//   - "not_found" (type *goa.ServiceError): http.StatusNotFound
+//   - "conflict" (type *goa.ServiceError): http.StatusConflict
+//   - "unsupported_media" (type *goa.ServiceError): http.StatusUnsupportedMediaType
+//   - "invalid" (type *goa.ServiceError): http.StatusUnprocessableEntity
+//   - "invariant_violation" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "unexpected" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "gateway_error" (type *goa.ServiceError): http.StatusBadGateway
+//   - error: internal error
+func DecodeListPricingTrackerResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
+		if restoreBody {
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = io.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				body ListPricingTrackerResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			res := NewListPricingTrackerAdminListPricingTrackerResultOK(&body)
+			return res, nil
+		case http.StatusUnauthorized:
+			var (
+				body ListPricingTrackerUnauthorizedResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerUnauthorizedResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerUnauthorized(&body)
+		case http.StatusForbidden:
+			var (
+				body ListPricingTrackerForbiddenResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerForbiddenResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerForbidden(&body)
+		case http.StatusBadRequest:
+			var (
+				body ListPricingTrackerBadRequestResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerBadRequestResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerBadRequest(&body)
+		case http.StatusNotFound:
+			var (
+				body ListPricingTrackerNotFoundResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerNotFoundResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerNotFound(&body)
+		case http.StatusConflict:
+			var (
+				body ListPricingTrackerConflictResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerConflictResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerConflict(&body)
+		case http.StatusUnsupportedMediaType:
+			var (
+				body ListPricingTrackerUnsupportedMediaResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerUnsupportedMediaResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerUnsupportedMedia(&body)
+		case http.StatusUnprocessableEntity:
+			var (
+				body ListPricingTrackerInvalidResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerInvalidResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerInvalid(&body)
+		case http.StatusInternalServerError:
+			en := resp.Header.Get("goa-error")
+			switch en {
+			case "invariant_violation":
+				var (
+					body ListPricingTrackerInvariantViolationResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+				}
+				err = ValidateListPricingTrackerInvariantViolationResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+				}
+				return nil, NewListPricingTrackerInvariantViolation(&body)
+			case "unexpected":
+				var (
+					body ListPricingTrackerUnexpectedResponseBody
+					err  error
+				)
+				err = decoder(resp).Decode(&body)
+				if err != nil {
+					return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+				}
+				err = ValidateListPricingTrackerUnexpectedResponseBody(&body)
+				if err != nil {
+					return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+				}
+				return nil, NewListPricingTrackerUnexpected(&body)
+			default:
+				body, _ := io.ReadAll(resp.Body)
+				return nil, goahttp.ErrInvalidResponse("admin", "listPricingTracker", resp.StatusCode, string(body))
+			}
+		case http.StatusBadGateway:
+			var (
+				body ListPricingTrackerGatewayErrorResponseBody
+				err  error
+			)
+			err = decoder(resp).Decode(&body)
+			if err != nil {
+				return nil, goahttp.ErrDecodingError("admin", "listPricingTracker", err)
+			}
+			err = ValidateListPricingTrackerGatewayErrorResponseBody(&body)
+			if err != nil {
+				return nil, goahttp.ErrValidationError("admin", "listPricingTracker", err)
+			}
+			return nil, NewListPricingTrackerGatewayError(&body)
+		default:
+			body, _ := io.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("admin", "listPricingTracker", resp.StatusCode, string(body))
+		}
+	}
+}
+
 // unmarshalAdminOrganizationMemberResponseBodyToAdminAdminOrganizationMember
 // builds a value of type *admin.AdminOrganizationMember from a value of type
 // *AdminOrganizationMemberResponseBody.
@@ -2213,6 +2457,24 @@ func unmarshalAdminOrganizationResponseBodyToAdminAdminOrganization(v *AdminOrga
 		MemberCount:        *v.MemberCount,
 		CreatedAt:          *v.CreatedAt,
 		UpdatedAt:          *v.UpdatedAt,
+	}
+
+	return res
+}
+
+// unmarshalAdminPricingTrackerRowResponseBodyToAdminAdminPricingTrackerRow
+// builds a value of type *admin.AdminPricingTrackerRow from a value of type
+// *AdminPricingTrackerRowResponseBody.
+func unmarshalAdminPricingTrackerRowResponseBodyToAdminAdminPricingTrackerRow(v *AdminPricingTrackerRowResponseBody) *admin.AdminPricingTrackerRow {
+	res := &admin.AdminPricingTrackerRow{
+		OrganizationID:              *v.OrganizationID,
+		Name:                        *v.Name,
+		Slug:                        *v.Slug,
+		AccountType:                 *v.AccountType,
+		MonthlyTumTokens:            *v.MonthlyTumTokens,
+		PaygMonthlyPrice:            *v.PaygMonthlyPrice,
+		PaygEffectiveRatePerMillion: *v.PaygEffectiveRatePerMillion,
+		InferenceSpend:              *v.InferenceSpend,
 	}
 
 	return res

--- a/server/gen/http/admin/client/paths.go
+++ b/server/gen/http/admin/client/paths.go
@@ -51,3 +51,8 @@ func ListOrganizationProjectsAdminPath() string {
 func ListOrganizationsAdminPath() string {
 	return "/admin/organizations.list"
 }
+
+// ListPricingTrackerAdminPath returns the URL path to the admin service listPricingTracker HTTP endpoint.
+func ListPricingTrackerAdminPath() string {
+	return "/admin/organizations.pricingTracker"
+}

--- a/server/gen/http/admin/client/types.go
+++ b/server/gen/http/admin/client/types.go
@@ -135,6 +135,20 @@ type ListOrganizationsResponseBody struct {
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
 }
 
+// ListPricingTrackerResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body.
+type ListPricingTrackerResponseBody struct {
+	// One row per organization, ordered by inference spend descending.
+	Rows []*AdminPricingTrackerRowResponseBody `form:"rows,omitempty" json:"rows,omitempty" xml:"rows,omitempty"`
+	// Inclusive start of the tracker window.
+	WindowStart *string `form:"window_start,omitempty" json:"window_start,omitempty" xml:"window_start,omitempty"`
+	// Exclusive end of the tracker window.
+	WindowEnd *string `form:"window_end,omitempty" json:"window_end,omitempty" xml:"window_end,omitempty"`
+	// False when the analytics store is not wired into the admin service, in which
+	// case inference spend and TUM-derived PAYG figures are reported as zero.
+	InferenceSpendAvailable *bool `form:"inference_spend_available,omitempty" json:"inference_spend_available,omitempty" xml:"inference_spend_available,omitempty"`
+}
+
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
 // endpoint HTTP response body for the "unauthorized" error.
 type LoginUnauthorizedResponseBody struct {
@@ -1784,6 +1798,190 @@ type ListOrganizationsGatewayErrorResponseBody struct {
 	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
 }
 
+// ListPricingTrackerUnauthorizedResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "unauthorized" error.
+type ListPricingTrackerUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerForbiddenResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "forbidden" error.
+type ListPricingTrackerForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerBadRequestResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "bad_request" error.
+type ListPricingTrackerBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerNotFoundResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "not_found" error.
+type ListPricingTrackerNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerConflictResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "conflict" error.
+type ListPricingTrackerConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerUnsupportedMediaResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "unsupported_media" error.
+type ListPricingTrackerUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerInvalidResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "invalid" error.
+type ListPricingTrackerInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerInvariantViolationResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "invariant_violation" error.
+type ListPricingTrackerInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerUnexpectedResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "unexpected" error.
+type ListPricingTrackerUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
+// ListPricingTrackerGatewayErrorResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "gateway_error" error.
+type ListPricingTrackerGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message *string `form:"message,omitempty" json:"message,omitempty" xml:"message,omitempty"`
+	// Is the error temporary?
+	Temporary *bool `form:"temporary,omitempty" json:"temporary,omitempty" xml:"temporary,omitempty"`
+	// Is the error a timeout?
+	Timeout *bool `form:"timeout,omitempty" json:"timeout,omitempty" xml:"timeout,omitempty"`
+	// Is the error a server-side fault?
+	Fault *bool `form:"fault,omitempty" json:"fault,omitempty" xml:"fault,omitempty"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -1840,6 +2038,29 @@ type AdminOrganizationResponseBody struct {
 	CreatedAt *string `form:"created_at,omitempty" json:"created_at,omitempty" xml:"created_at,omitempty"`
 	// The last update date of the organization.
 	UpdatedAt *string `form:"updated_at,omitempty" json:"updated_at,omitempty" xml:"updated_at,omitempty"`
+}
+
+// AdminPricingTrackerRowResponseBody is used to define fields on response body
+// types.
+type AdminPricingTrackerRowResponseBody struct {
+	// The ID of the organization.
+	OrganizationID *string `form:"organization_id,omitempty" json:"organization_id,omitempty" xml:"organization_id,omitempty"`
+	// The name of the organization (customer name).
+	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// The slug of the organization.
+	Slug *string `form:"slug,omitempty" json:"slug,omitempty" xml:"slug,omitempty"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType *string `form:"account_type,omitempty" json:"account_type,omitempty" xml:"account_type,omitempty"`
+	// Observed tokens under management over the window, used as the PAYG pricing
+	// input.
+	MonthlyTumTokens *int64 `form:"monthly_tum_tokens,omitempty" json:"monthly_tum_tokens,omitempty" xml:"monthly_tum_tokens,omitempty"`
+	// Pay-as-you-go price in USD for the window's volume at the current rate card.
+	PaygMonthlyPrice *float64 `form:"payg_monthly_price,omitempty" json:"payg_monthly_price,omitempty" xml:"payg_monthly_price,omitempty"`
+	// Blended PAYG rate in USD per million tokens at the window's volume.
+	PaygEffectiveRatePerMillion *float64 `form:"payg_effective_rate_per_million,omitempty" json:"payg_effective_rate_per_million,omitempty" xml:"payg_effective_rate_per_million,omitempty"`
+	// Gram-hosted inference spend in USD over the window (playground, elements,
+	// risk analysis, assistants, and other platform-run completions).
+	InferenceSpend *float64 `form:"inference_spend,omitempty" json:"inference_spend,omitempty" xml:"inference_spend,omitempty"`
 }
 
 // NewUpdateOrganizationRequestBody builds the HTTP request body from the
@@ -3325,6 +3546,176 @@ func NewListOrganizationsGatewayError(body *ListOrganizationsGatewayErrorRespons
 	return v
 }
 
+// NewListPricingTrackerAdminListPricingTrackerResultOK builds a "admin"
+// service "listPricingTracker" endpoint result from a HTTP "OK" response.
+func NewListPricingTrackerAdminListPricingTrackerResultOK(body *ListPricingTrackerResponseBody) *admin.AdminListPricingTrackerResult {
+	v := &admin.AdminListPricingTrackerResult{
+		WindowStart:             *body.WindowStart,
+		WindowEnd:               *body.WindowEnd,
+		InferenceSpendAvailable: *body.InferenceSpendAvailable,
+	}
+	v.Rows = make([]*admin.AdminPricingTrackerRow, len(body.Rows))
+	for i, val := range body.Rows {
+		if val == nil {
+			v.Rows[i] = nil
+			continue
+		}
+		v.Rows[i] = unmarshalAdminPricingTrackerRowResponseBodyToAdminAdminPricingTrackerRow(val)
+	}
+
+	return v
+}
+
+// NewListPricingTrackerUnauthorized builds a admin service listPricingTracker
+// endpoint unauthorized error.
+func NewListPricingTrackerUnauthorized(body *ListPricingTrackerUnauthorizedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerForbidden builds a admin service listPricingTracker
+// endpoint forbidden error.
+func NewListPricingTrackerForbidden(body *ListPricingTrackerForbiddenResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerBadRequest builds a admin service listPricingTracker
+// endpoint bad_request error.
+func NewListPricingTrackerBadRequest(body *ListPricingTrackerBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerNotFound builds a admin service listPricingTracker
+// endpoint not_found error.
+func NewListPricingTrackerNotFound(body *ListPricingTrackerNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerConflict builds a admin service listPricingTracker
+// endpoint conflict error.
+func NewListPricingTrackerConflict(body *ListPricingTrackerConflictResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerUnsupportedMedia builds a admin service
+// listPricingTracker endpoint unsupported_media error.
+func NewListPricingTrackerUnsupportedMedia(body *ListPricingTrackerUnsupportedMediaResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerInvalid builds a admin service listPricingTracker
+// endpoint invalid error.
+func NewListPricingTrackerInvalid(body *ListPricingTrackerInvalidResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerInvariantViolation builds a admin service
+// listPricingTracker endpoint invariant_violation error.
+func NewListPricingTrackerInvariantViolation(body *ListPricingTrackerInvariantViolationResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerUnexpected builds a admin service listPricingTracker
+// endpoint unexpected error.
+func NewListPricingTrackerUnexpected(body *ListPricingTrackerUnexpectedResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
+// NewListPricingTrackerGatewayError builds a admin service listPricingTracker
+// endpoint gateway_error error.
+func NewListPricingTrackerGatewayError(body *ListPricingTrackerGatewayErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
+		Name:      *body.Name,
+		ID:        *body.ID,
+		Message:   *body.Message,
+		Temporary: *body.Temporary,
+		Timeout:   *body.Timeout,
+		Fault:     *body.Fault,
+	}
+
+	return v
+}
+
 // ValidateGetProjectResponseBody runs the validations defined on
 // GetProjectResponseBody
 func ValidateGetProjectResponseBody(body *GetProjectResponseBody) (err error) {
@@ -3507,6 +3898,37 @@ func ValidateListOrganizationsResponseBody(body *ListOrganizationsResponseBody) 
 				err = goa.MergeErrors(err, err2)
 			}
 		}
+	}
+	return
+}
+
+// ValidateListPricingTrackerResponseBody runs the validations defined on
+// ListPricingTrackerResponseBody
+func ValidateListPricingTrackerResponseBody(body *ListPricingTrackerResponseBody) (err error) {
+	if body.Rows == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("rows", "body"))
+	}
+	if body.WindowStart == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("window_start", "body"))
+	}
+	if body.WindowEnd == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("window_end", "body"))
+	}
+	if body.InferenceSpendAvailable == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("inference_spend_available", "body"))
+	}
+	for _, e := range body.Rows {
+		if e != nil {
+			if err2 := ValidateAdminPricingTrackerRowResponseBody(e); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
+		}
+	}
+	if body.WindowStart != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.window_start", *body.WindowStart, goa.FormatDateTime))
+	}
+	if body.WindowEnd != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.window_end", *body.WindowEnd, goa.FormatDateTime))
 	}
 	return
 }
@@ -5675,6 +6097,246 @@ func ValidateListOrganizationsGatewayErrorResponseBody(body *ListOrganizationsGa
 	return
 }
 
+// ValidateListPricingTrackerUnauthorizedResponseBody runs the validations
+// defined on listPricingTracker_unauthorized_response_body
+func ValidateListPricingTrackerUnauthorizedResponseBody(body *ListPricingTrackerUnauthorizedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerForbiddenResponseBody runs the validations defined
+// on listPricingTracker_forbidden_response_body
+func ValidateListPricingTrackerForbiddenResponseBody(body *ListPricingTrackerForbiddenResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerBadRequestResponseBody runs the validations
+// defined on listPricingTracker_bad_request_response_body
+func ValidateListPricingTrackerBadRequestResponseBody(body *ListPricingTrackerBadRequestResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerNotFoundResponseBody runs the validations defined
+// on listPricingTracker_not_found_response_body
+func ValidateListPricingTrackerNotFoundResponseBody(body *ListPricingTrackerNotFoundResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerConflictResponseBody runs the validations defined
+// on listPricingTracker_conflict_response_body
+func ValidateListPricingTrackerConflictResponseBody(body *ListPricingTrackerConflictResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerUnsupportedMediaResponseBody runs the validations
+// defined on listPricingTracker_unsupported_media_response_body
+func ValidateListPricingTrackerUnsupportedMediaResponseBody(body *ListPricingTrackerUnsupportedMediaResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerInvalidResponseBody runs the validations defined
+// on listPricingTracker_invalid_response_body
+func ValidateListPricingTrackerInvalidResponseBody(body *ListPricingTrackerInvalidResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerInvariantViolationResponseBody runs the
+// validations defined on listPricingTracker_invariant_violation_response_body
+func ValidateListPricingTrackerInvariantViolationResponseBody(body *ListPricingTrackerInvariantViolationResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerUnexpectedResponseBody runs the validations
+// defined on listPricingTracker_unexpected_response_body
+func ValidateListPricingTrackerUnexpectedResponseBody(body *ListPricingTrackerUnexpectedResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
+// ValidateListPricingTrackerGatewayErrorResponseBody runs the validations
+// defined on listPricingTracker_gateway_error_response_body
+func ValidateListPricingTrackerGatewayErrorResponseBody(body *ListPricingTrackerGatewayErrorResponseBody) (err error) {
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.ID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
+	}
+	if body.Message == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
+	}
+	if body.Temporary == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("temporary", "body"))
+	}
+	if body.Timeout == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("timeout", "body"))
+	}
+	if body.Fault == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("fault", "body"))
+	}
+	return
+}
+
 // ValidateAdminOrganizationMemberResponseBody runs the validations defined on
 // AdminOrganizationMemberResponseBody
 func ValidateAdminOrganizationMemberResponseBody(body *AdminOrganizationMemberResponseBody) (err error) {
@@ -5773,6 +6435,36 @@ func ValidateAdminOrganizationResponseBody(body *AdminOrganizationResponseBody) 
 	}
 	if body.UpdatedAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.updated_at", *body.UpdatedAt, goa.FormatDateTime))
+	}
+	return
+}
+
+// ValidateAdminPricingTrackerRowResponseBody runs the validations defined on
+// AdminPricingTrackerRowResponseBody
+func ValidateAdminPricingTrackerRowResponseBody(body *AdminPricingTrackerRowResponseBody) (err error) {
+	if body.OrganizationID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("organization_id", "body"))
+	}
+	if body.Name == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
+	}
+	if body.Slug == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("slug", "body"))
+	}
+	if body.AccountType == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("account_type", "body"))
+	}
+	if body.MonthlyTumTokens == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("monthly_tum_tokens", "body"))
+	}
+	if body.PaygMonthlyPrice == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("payg_monthly_price", "body"))
+	}
+	if body.PaygEffectiveRatePerMillion == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("payg_effective_rate_per_million", "body"))
+	}
+	if body.InferenceSpend == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("inference_spend", "body"))
 	}
 	return
 }

--- a/server/gen/http/admin/server/encode_decode.go
+++ b/server/gen/http/admin/server/encode_decode.go
@@ -1888,6 +1888,244 @@ func EncodeListOrganizationsError(encoder func(context.Context, http.ResponseWri
 	}
 }
 
+// EncodeListPricingTrackerResponse returns an encoder for responses returned
+// by the admin listPricingTracker endpoint.
+func EncodeListPricingTrackerResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(*admin.AdminListPricingTrackerResult)
+		enc := encoder(ctx, w)
+		body := NewListPricingTrackerResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+
+// DecodeListPricingTrackerRequest returns a decoder for requests sent to the
+// admin listPricingTracker endpoint.
+func DecodeListPricingTrackerRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*admin.ListPricingTrackerPayload, error) {
+	return func(r *http.Request) (*admin.ListPricingTrackerPayload, error) {
+		var payload *admin.ListPricingTrackerPayload
+		var (
+			accountType       *string
+			includeFree       *bool
+			windowDays        *int
+			limit             *int
+			adminSessionToken *string
+			err               error
+		)
+		qp := r.URL.Query()
+		accountTypeRaw := qp.Get("account_type")
+		if accountTypeRaw != "" {
+			accountType = &accountTypeRaw
+		}
+		{
+			includeFreeRaw := qp.Get("include_free")
+			if includeFreeRaw != "" {
+				v, err2 := strconv.ParseBool(includeFreeRaw)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("include_free", includeFreeRaw, "boolean"))
+				}
+				includeFree = &v
+			}
+		}
+		{
+			windowDaysRaw := qp.Get("window_days")
+			if windowDaysRaw != "" {
+				v, err2 := strconv.ParseInt(windowDaysRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("window_days", windowDaysRaw, "integer"))
+				}
+				pv := int(v)
+				windowDays = &pv
+			}
+		}
+		{
+			limitRaw := qp.Get("limit")
+			if limitRaw != "" {
+				v, err2 := strconv.ParseInt(limitRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("limit", limitRaw, "integer"))
+				}
+				pv := int(v)
+				limit = &pv
+			}
+		}
+		adminSessionTokenRaw := r.Header.Get("Authorization")
+		if adminSessionTokenRaw != "" {
+			adminSessionToken = &adminSessionTokenRaw
+		}
+		if err != nil {
+			return payload, err
+		}
+		payload = NewListPricingTrackerPayload(accountType, includeFree, windowDays, limit, adminSessionToken)
+		if payload.AdminSessionToken != nil {
+			if strings.Contains(*payload.AdminSessionToken, " ") {
+				// Remove authorization scheme prefix (e.g. "Bearer")
+				cred := strings.SplitN(*payload.AdminSessionToken, " ", 2)[1]
+				payload.AdminSessionToken = &cred
+			}
+		}
+
+		return payload, nil
+	}
+}
+
+// EncodeListPricingTrackerError returns an encoder for errors returned by the
+// listPricingTracker admin endpoint.
+func EncodeListPricingTrackerError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		var en goa.GoaErrorNamer
+		if !errors.As(v, &en) {
+			return encodeError(ctx, w, v)
+		}
+		switch en.GoaErrorName() {
+		case "unauthorized":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerUnauthorizedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnauthorized)
+			return enc.Encode(body)
+		case "forbidden":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerForbiddenResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusForbidden)
+			return enc.Encode(body)
+		case "bad_request":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		case "not_found":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerNotFoundResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusNotFound)
+			return enc.Encode(body)
+		case "conflict":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerConflictResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusConflict)
+			return enc.Encode(body)
+		case "unsupported_media":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerUnsupportedMediaResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return enc.Encode(body)
+		case "invalid":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerInvalidResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return enc.Encode(body)
+		case "invariant_violation":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerInvariantViolationResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "unexpected":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerUnexpectedResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "gateway_error":
+			var res *goa.ServiceError
+			errors.As(v, &res)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/json")
+			enc := encoder(ctx, w)
+			var body any
+			if formatter != nil {
+				body = formatter(ctx, res)
+			} else {
+				body = NewListPricingTrackerGatewayErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", res.GoaErrorName())
+			w.WriteHeader(http.StatusBadGateway)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+
 // marshalAdminAdminOrganizationMemberToAdminOrganizationMemberResponseBody
 // builds a value of type *AdminOrganizationMemberResponseBody from a value of
 // type *admin.AdminOrganizationMember.
@@ -1935,6 +2173,24 @@ func marshalAdminAdminOrganizationToAdminOrganizationResponseBody(v *admin.Admin
 		MemberCount:        v.MemberCount,
 		CreatedAt:          v.CreatedAt,
 		UpdatedAt:          v.UpdatedAt,
+	}
+
+	return res
+}
+
+// marshalAdminAdminPricingTrackerRowToAdminPricingTrackerRowResponseBody
+// builds a value of type *AdminPricingTrackerRowResponseBody from a value of
+// type *admin.AdminPricingTrackerRow.
+func marshalAdminAdminPricingTrackerRowToAdminPricingTrackerRowResponseBody(v *admin.AdminPricingTrackerRow) *AdminPricingTrackerRowResponseBody {
+	res := &AdminPricingTrackerRowResponseBody{
+		OrganizationID:              v.OrganizationID,
+		Name:                        v.Name,
+		Slug:                        v.Slug,
+		AccountType:                 v.AccountType,
+		MonthlyTumTokens:            v.MonthlyTumTokens,
+		PaygMonthlyPrice:            v.PaygMonthlyPrice,
+		PaygEffectiveRatePerMillion: v.PaygEffectiveRatePerMillion,
+		InferenceSpend:              v.InferenceSpend,
 	}
 
 	return res

--- a/server/gen/http/admin/server/paths.go
+++ b/server/gen/http/admin/server/paths.go
@@ -51,3 +51,8 @@ func ListOrganizationProjectsAdminPath() string {
 func ListOrganizationsAdminPath() string {
 	return "/admin/organizations.list"
 }
+
+// ListPricingTrackerAdminPath returns the URL path to the admin service listPricingTracker HTTP endpoint.
+func ListPricingTrackerAdminPath() string {
+	return "/admin/organizations.pricingTracker"
+}

--- a/server/gen/http/admin/server/server.go
+++ b/server/gen/http/admin/server/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	ListOrganizationMembers  http.Handler
 	ListOrganizationProjects http.Handler
 	ListOrganizations        http.Handler
+	ListPricingTracker       http.Handler
 }
 
 // MountPoint holds information about the mounted endpoints.
@@ -66,6 +67,7 @@ func New(
 			{"ListOrganizationMembers", "GET", "/admin/organization.members"},
 			{"ListOrganizationProjects", "GET", "/admin/organization.projects"},
 			{"ListOrganizations", "GET", "/admin/organizations.list"},
+			{"ListPricingTracker", "GET", "/admin/organizations.pricingTracker"},
 		},
 		Login:                    NewLoginHandler(e.Login, mux, decoder, encoder, errhandler, formatter),
 		Callback:                 NewCallbackHandler(e.Callback, mux, decoder, encoder, errhandler, formatter),
@@ -76,6 +78,7 @@ func New(
 		ListOrganizationMembers:  NewListOrganizationMembersHandler(e.ListOrganizationMembers, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizationProjects: NewListOrganizationProjectsHandler(e.ListOrganizationProjects, mux, decoder, encoder, errhandler, formatter),
 		ListOrganizations:        NewListOrganizationsHandler(e.ListOrganizations, mux, decoder, encoder, errhandler, formatter),
+		ListPricingTracker:       NewListPricingTrackerHandler(e.ListPricingTracker, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 
@@ -93,6 +96,7 @@ func (s *Server) Use(m func(http.Handler) http.Handler) {
 	s.ListOrganizationMembers = m(s.ListOrganizationMembers)
 	s.ListOrganizationProjects = m(s.ListOrganizationProjects)
 	s.ListOrganizations = m(s.ListOrganizations)
+	s.ListPricingTracker = m(s.ListPricingTracker)
 }
 
 // MethodNames returns the methods served.
@@ -109,6 +113,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountListOrganizationMembersHandler(mux, h.ListOrganizationMembers)
 	MountListOrganizationProjectsHandler(mux, h.ListOrganizationProjects)
 	MountListOrganizationsHandler(mux, h.ListOrganizations)
+	MountListPricingTrackerHandler(mux, h.ListPricingTracker)
 }
 
 // Mount configures the mux to serve the admin endpoints.
@@ -572,6 +577,59 @@ func NewListOrganizationsHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
 		ctx = context.WithValue(ctx, goa.MethodKey, "listOrganizations")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
+		payload, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		res, err := endpoint(ctx, payload)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			if errhandler != nil {
+				errhandler(ctx, w, err)
+			}
+		}
+	})
+}
+
+// MountListPricingTrackerHandler configures the mux to serve the "admin"
+// service "listPricingTracker" endpoint.
+func MountListPricingTrackerHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("GET", "/admin/organizations.pricingTracker", f)
+}
+
+// NewListPricingTrackerHandler creates a HTTP handler which loads the HTTP
+// request and calls the "admin" service "listPricingTracker" endpoint.
+func NewListPricingTrackerHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeListPricingTrackerRequest(mux, decoder)
+		encodeResponse = EncodeListPricingTrackerResponse(encoder)
+		encodeError    = EncodeListPricingTrackerError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "listPricingTracker")
 		ctx = context.WithValue(ctx, goa.ServiceKey, "admin")
 		payload, err := decodeRequest(r)
 		if err != nil {

--- a/server/gen/http/admin/server/types.go
+++ b/server/gen/http/admin/server/types.go
@@ -135,6 +135,20 @@ type ListOrganizationsResponseBody struct {
 	NextCursor *string `form:"next_cursor,omitempty" json:"next_cursor,omitempty" xml:"next_cursor,omitempty"`
 }
 
+// ListPricingTrackerResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body.
+type ListPricingTrackerResponseBody struct {
+	// One row per organization, ordered by inference spend descending.
+	Rows []*AdminPricingTrackerRowResponseBody `form:"rows" json:"rows" xml:"rows"`
+	// Inclusive start of the tracker window.
+	WindowStart string `form:"window_start" json:"window_start" xml:"window_start"`
+	// Exclusive end of the tracker window.
+	WindowEnd string `form:"window_end" json:"window_end" xml:"window_end"`
+	// False when the analytics store is not wired into the admin service, in which
+	// case inference spend and TUM-derived PAYG figures are reported as zero.
+	InferenceSpendAvailable bool `form:"inference_spend_available" json:"inference_spend_available" xml:"inference_spend_available"`
+}
+
 // LoginUnauthorizedResponseBody is the type of the "admin" service "login"
 // endpoint HTTP response body for the "unauthorized" error.
 type LoginUnauthorizedResponseBody struct {
@@ -1784,6 +1798,190 @@ type ListOrganizationsGatewayErrorResponseBody struct {
 	Fault bool `form:"fault" json:"fault" xml:"fault"`
 }
 
+// ListPricingTrackerUnauthorizedResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "unauthorized" error.
+type ListPricingTrackerUnauthorizedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerForbiddenResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "forbidden" error.
+type ListPricingTrackerForbiddenResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerBadRequestResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "bad_request" error.
+type ListPricingTrackerBadRequestResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerNotFoundResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "not_found" error.
+type ListPricingTrackerNotFoundResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerConflictResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "conflict" error.
+type ListPricingTrackerConflictResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerUnsupportedMediaResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "unsupported_media" error.
+type ListPricingTrackerUnsupportedMediaResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerInvalidResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "invalid" error.
+type ListPricingTrackerInvalidResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerInvariantViolationResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "invariant_violation" error.
+type ListPricingTrackerInvariantViolationResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerUnexpectedResponseBody is the type of the "admin" service
+// "listPricingTracker" endpoint HTTP response body for the "unexpected" error.
+type ListPricingTrackerUnexpectedResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
+// ListPricingTrackerGatewayErrorResponseBody is the type of the "admin"
+// service "listPricingTracker" endpoint HTTP response body for the
+// "gateway_error" error.
+type ListPricingTrackerGatewayErrorResponseBody struct {
+	// Name is the name of this class of errors.
+	Name string `form:"name" json:"name" xml:"name"`
+	// ID is a unique identifier for this particular occurrence of the problem.
+	ID string `form:"id" json:"id" xml:"id"`
+	// Message is a human-readable explanation specific to this occurrence of the
+	// problem.
+	Message string `form:"message" json:"message" xml:"message"`
+	// Is the error temporary?
+	Temporary bool `form:"temporary" json:"temporary" xml:"temporary"`
+	// Is the error a timeout?
+	Timeout bool `form:"timeout" json:"timeout" xml:"timeout"`
+	// Is the error a server-side fault?
+	Fault bool `form:"fault" json:"fault" xml:"fault"`
+}
+
 // AdminOrganizationMemberResponseBody is used to define fields on response
 // body types.
 type AdminOrganizationMemberResponseBody struct {
@@ -1840,6 +2038,29 @@ type AdminOrganizationResponseBody struct {
 	CreatedAt string `form:"created_at" json:"created_at" xml:"created_at"`
 	// The last update date of the organization.
 	UpdatedAt string `form:"updated_at" json:"updated_at" xml:"updated_at"`
+}
+
+// AdminPricingTrackerRowResponseBody is used to define fields on response body
+// types.
+type AdminPricingTrackerRowResponseBody struct {
+	// The ID of the organization.
+	OrganizationID string `form:"organization_id" json:"organization_id" xml:"organization_id"`
+	// The name of the organization (customer name).
+	Name string `form:"name" json:"name" xml:"name"`
+	// The slug of the organization.
+	Slug string `form:"slug" json:"slug" xml:"slug"`
+	// Gram account type (e.g. free, pro, enterprise).
+	AccountType string `form:"account_type" json:"account_type" xml:"account_type"`
+	// Observed tokens under management over the window, used as the PAYG pricing
+	// input.
+	MonthlyTumTokens int64 `form:"monthly_tum_tokens" json:"monthly_tum_tokens" xml:"monthly_tum_tokens"`
+	// Pay-as-you-go price in USD for the window's volume at the current rate card.
+	PaygMonthlyPrice float64 `form:"payg_monthly_price" json:"payg_monthly_price" xml:"payg_monthly_price"`
+	// Blended PAYG rate in USD per million tokens at the window's volume.
+	PaygEffectiveRatePerMillion float64 `form:"payg_effective_rate_per_million" json:"payg_effective_rate_per_million" xml:"payg_effective_rate_per_million"`
+	// Gram-hosted inference spend in USD over the window (playground, elements,
+	// risk analysis, assistants, and other platform-run completions).
+	InferenceSpend float64 `form:"inference_spend" json:"inference_spend" xml:"inference_spend"`
 }
 
 // NewGetProjectResponseBody builds the HTTP response body from the result of
@@ -1959,6 +2180,29 @@ func NewListOrganizationsResponseBody(res *admin.AdminListOrganizationsResult) *
 		}
 	} else {
 		body.Organizations = []*AdminOrganizationResponseBody{}
+	}
+	return body
+}
+
+// NewListPricingTrackerResponseBody builds the HTTP response body from the
+// result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerResponseBody(res *admin.AdminListPricingTrackerResult) *ListPricingTrackerResponseBody {
+	body := &ListPricingTrackerResponseBody{
+		WindowStart:             res.WindowStart,
+		WindowEnd:               res.WindowEnd,
+		InferenceSpendAvailable: res.InferenceSpendAvailable,
+	}
+	if res.Rows != nil {
+		body.Rows = make([]*AdminPricingTrackerRowResponseBody, len(res.Rows))
+		for i, val := range res.Rows {
+			if val == nil {
+				body.Rows[i] = nil
+				continue
+			}
+			body.Rows[i] = marshalAdminAdminPricingTrackerRowToAdminPricingTrackerRowResponseBody(val)
+		}
+	} else {
+		body.Rows = []*AdminPricingTrackerRowResponseBody{}
 	}
 	return body
 }
@@ -3248,6 +3492,148 @@ func NewListOrganizationsGatewayErrorResponseBody(res *goa.ServiceError) *ListOr
 	return body
 }
 
+// NewListPricingTrackerUnauthorizedResponseBody builds the HTTP response body
+// from the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerUnauthorizedResponseBody(res *goa.ServiceError) *ListPricingTrackerUnauthorizedResponseBody {
+	body := &ListPricingTrackerUnauthorizedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerForbiddenResponseBody builds the HTTP response body
+// from the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerForbiddenResponseBody(res *goa.ServiceError) *ListPricingTrackerForbiddenResponseBody {
+	body := &ListPricingTrackerForbiddenResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerBadRequestResponseBody builds the HTTP response body
+// from the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerBadRequestResponseBody(res *goa.ServiceError) *ListPricingTrackerBadRequestResponseBody {
+	body := &ListPricingTrackerBadRequestResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerNotFoundResponseBody builds the HTTP response body from
+// the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerNotFoundResponseBody(res *goa.ServiceError) *ListPricingTrackerNotFoundResponseBody {
+	body := &ListPricingTrackerNotFoundResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerConflictResponseBody builds the HTTP response body from
+// the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerConflictResponseBody(res *goa.ServiceError) *ListPricingTrackerConflictResponseBody {
+	body := &ListPricingTrackerConflictResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerUnsupportedMediaResponseBody builds the HTTP response
+// body from the result of the "listPricingTracker" endpoint of the "admin"
+// service.
+func NewListPricingTrackerUnsupportedMediaResponseBody(res *goa.ServiceError) *ListPricingTrackerUnsupportedMediaResponseBody {
+	body := &ListPricingTrackerUnsupportedMediaResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerInvalidResponseBody builds the HTTP response body from
+// the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerInvalidResponseBody(res *goa.ServiceError) *ListPricingTrackerInvalidResponseBody {
+	body := &ListPricingTrackerInvalidResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerInvariantViolationResponseBody builds the HTTP response
+// body from the result of the "listPricingTracker" endpoint of the "admin"
+// service.
+func NewListPricingTrackerInvariantViolationResponseBody(res *goa.ServiceError) *ListPricingTrackerInvariantViolationResponseBody {
+	body := &ListPricingTrackerInvariantViolationResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerUnexpectedResponseBody builds the HTTP response body
+// from the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerUnexpectedResponseBody(res *goa.ServiceError) *ListPricingTrackerUnexpectedResponseBody {
+	body := &ListPricingTrackerUnexpectedResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
+// NewListPricingTrackerGatewayErrorResponseBody builds the HTTP response body
+// from the result of the "listPricingTracker" endpoint of the "admin" service.
+func NewListPricingTrackerGatewayErrorResponseBody(res *goa.ServiceError) *ListPricingTrackerGatewayErrorResponseBody {
+	body := &ListPricingTrackerGatewayErrorResponseBody{
+		Name:      res.Name,
+		ID:        res.ID,
+		Message:   res.Message,
+		Temporary: res.Temporary,
+		Timeout:   res.Timeout,
+		Fault:     res.Fault,
+	}
+	return body
+}
+
 // NewLoginPayload builds a admin service login endpoint payload.
 func NewLoginPayload(returnTo *string, prompt *string) *admin.LoginPayload {
 	v := &admin.LoginPayload{}
@@ -3337,6 +3723,19 @@ func NewListOrganizationsPayload(q *string, accountType *string, includeDisabled
 	v.AccountType = accountType
 	v.IncludeDisabled = includeDisabled
 	v.Cursor = cursor
+	v.Limit = limit
+	v.AdminSessionToken = adminSessionToken
+
+	return v
+}
+
+// NewListPricingTrackerPayload builds a admin service listPricingTracker
+// endpoint payload.
+func NewListPricingTrackerPayload(accountType *string, includeFree *bool, windowDays *int, limit *int, adminSessionToken *string) *admin.ListPricingTrackerPayload {
+	v := &admin.ListPricingTrackerPayload{}
+	v.AccountType = accountType
+	v.IncludeFree = includeFree
+	v.WindowDays = windowDays
 	v.Limit = limit
 	v.AdminSessionToken = adminSessionToken
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -95,7 +95,7 @@ func UsageCommands() []string {
 		"external receive-work-os-webhook",
 		"about openapi",
 		"access (list-roles|get-role|create-role|update-role|delete-role|list-scopes|list-members|list-grants|update-member-roles|list-shadow-mcp-inventory|get-shadow-mcp-inventory-server|update-shadow-mcp-inventory-server-name|list-shadow-mcp-inventory-users|upsert-shadow-mcp-inventory-policy-bypass|delete-shadow-mcp-inventory-policy-bypass|block-shadow-mcp-inventory-server|unblock-shadow-mcp-inventory-server|resolve-shadow-mcp-inventory-request|request-access|list-challenges|list-challenge-buckets|resolve-challenge)",
-		"admin (login|callback|logout|get-project|update-organization|get-organization|list-organization-members|list-organization-projects|list-organizations)",
+		"admin (login|callback|logout|get-project|update-organization|get-organization|list-organization-members|list-organization-projects|list-organizations|list-pricing-tracker)",
 		"agent (get-plugins|list-synced-users|get-configuration|update-configuration)",
 		"ai-integrations (get-config|upsert-config|delete-config|list-schedules|set-schedule-enabled|retry-schedule)",
 		"assets (serve-image|upload-image|upload-functions|upload-open-ap-iv3|fetch-open-ap-iv3-from-url|serve-open-ap-iv3|serve-function|list-assets|upload-chat-attachment|serve-chat-attachment|create-signed-chat-attachment-url|serve-chat-attachment-signed)",
@@ -359,6 +359,13 @@ func ParseEndpoint(
 		adminListOrganizationsCursorFlag            = adminListOrganizationsFlags.String("cursor", "", "")
 		adminListOrganizationsLimitFlag             = adminListOrganizationsFlags.String("limit", "", "")
 		adminListOrganizationsAdminSessionTokenFlag = adminListOrganizationsFlags.String("admin-session-token", "", "")
+
+		adminListPricingTrackerFlags                 = flag.NewFlagSet("list-pricing-tracker", flag.ExitOnError)
+		adminListPricingTrackerAccountTypeFlag       = adminListPricingTrackerFlags.String("account-type", "", "")
+		adminListPricingTrackerIncludeFreeFlag       = adminListPricingTrackerFlags.String("include-free", "", "")
+		adminListPricingTrackerWindowDaysFlag        = adminListPricingTrackerFlags.String("window-days", "", "")
+		adminListPricingTrackerLimitFlag             = adminListPricingTrackerFlags.String("limit", "", "")
+		adminListPricingTrackerAdminSessionTokenFlag = adminListPricingTrackerFlags.String("admin-session-token", "", "")
 
 		agentFlags = flag.NewFlagSet("agent", flag.ContinueOnError)
 
@@ -3266,6 +3273,7 @@ func ParseEndpoint(
 	adminListOrganizationMembersFlags.Usage = adminListOrganizationMembersUsage
 	adminListOrganizationProjectsFlags.Usage = adminListOrganizationProjectsUsage
 	adminListOrganizationsFlags.Usage = adminListOrganizationsUsage
+	adminListPricingTrackerFlags.Usage = adminListPricingTrackerUsage
 
 	agentFlags.Usage = agentUsage
 	agentGetPluginsFlags.Usage = agentGetPluginsUsage
@@ -4178,6 +4186,9 @@ func ParseEndpoint(
 
 			case "list-organizations":
 				epf = adminListOrganizationsFlags
+
+			case "list-pricing-tracker":
+				epf = adminListPricingTrackerFlags
 
 			}
 
@@ -6072,6 +6083,9 @@ func ParseEndpoint(
 			case "list-organizations":
 				endpoint = c.ListOrganizations()
 				data, err = adminc.BuildListOrganizationsPayload(*adminListOrganizationsQFlag, *adminListOrganizationsAccountTypeFlag, *adminListOrganizationsIncludeDisabledFlag, *adminListOrganizationsCursorFlag, *adminListOrganizationsLimitFlag, *adminListOrganizationsAdminSessionTokenFlag)
+			case "list-pricing-tracker":
+				endpoint = c.ListPricingTracker()
+				data, err = adminc.BuildListPricingTrackerPayload(*adminListPricingTrackerAccountTypeFlag, *adminListPricingTrackerIncludeFreeFlag, *adminListPricingTrackerWindowDaysFlag, *adminListPricingTrackerLimitFlag, *adminListPricingTrackerAdminSessionTokenFlag)
 			}
 		case "agent":
 			c := agentc.NewClient(scheme, host, doer, enc, dec, restore)
@@ -8451,6 +8465,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    list-organization-members: Lists members of an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organization-projects: Lists projects belonging to an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for admin operations with optional search and filters.`)
+	fmt.Fprintln(os.Stderr, `    list-pricing-tracker: Internal tracker of customer pricing exposure: per organization, the PAYG price at the current rate card (off observed tokens under management) and the Gram-hosted inference spend, both over a trailing window.`)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Additional help:")
 	fmt.Fprintf(os.Stderr, "    %s admin COMMAND --help\n", os.Args[0])
@@ -8645,6 +8660,32 @@ func adminListOrganizationsUsage() {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
 	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-organizations --q \"abc123\" --account-type \"abc123\" --include-disabled false --cursor \"abc123\" --limit 1 --admin-session-token \"abc123\"")
+}
+
+func adminListPricingTrackerUsage() {
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] admin list-pricing-tracker", os.Args[0])
+	fmt.Fprint(os.Stderr, " -account-type STRING")
+	fmt.Fprint(os.Stderr, " -include-free BOOL")
+	fmt.Fprint(os.Stderr, " -window-days INT")
+	fmt.Fprint(os.Stderr, " -limit INT")
+	fmt.Fprint(os.Stderr, " -admin-session-token STRING")
+	fmt.Fprintln(os.Stderr)
+
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `Internal tracker of customer pricing exposure: per organization, the PAYG price at the current rate card (off observed tokens under management) and the Gram-hosted inference spend, both over a trailing window.`)
+
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -account-type STRING: `)
+	fmt.Fprintln(os.Stderr, `    -include-free BOOL: `)
+	fmt.Fprintln(os.Stderr, `    -window-days INT: `)
+	fmt.Fprintln(os.Stderr, `    -limit INT: `)
+	fmt.Fprintln(os.Stderr, `    -admin-session-token STRING: `)
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "admin list-pricing-tracker --account-type \"abc123\" --include-free false --window-days 1 --limit 1 --admin-session-token \"abc123\"")
 }
 
 // agentUsage displays the usage of the agent command and its subcommands.

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -705,6 +705,107 @@ paths:
                 outputs:
                     nextCursor: $.next_cursor
                 type: cursor
+    /admin/organizations.pricingTracker:
+        get:
+            tags:
+                - admin
+            summary: listPricingTracker admin
+            description: 'Internal tracker of customer pricing exposure: per organization, the PAYG price at the current rate card (off observed tokens under management) and the Gram-hosted inference spend, both over a trailing window.'
+            operationId: adminListPricingTracker
+            parameters:
+                - name: account_type
+                  in: query
+                  description: Filter to a single gram_account_type (e.g. enterprise). When omitted, paying tiers (pro and enterprise) are included.
+                  allowEmptyValue: true
+                  schema:
+                    type: string
+                    description: Filter to a single gram_account_type (e.g. enterprise). When omitted, paying tiers (pro and enterprise) are included.
+                - name: include_free
+                  in: query
+                  description: Include free-tier organizations. Defaults to false so the tracker stays focused on paying customers.
+                  allowEmptyValue: true
+                  schema:
+                    type: boolean
+                    description: Include free-tier organizations. Defaults to false so the tracker stays focused on paying customers.
+                - name: window_days
+                  in: query
+                  description: Length of the trailing window in days. Defaults to 30, max 90.
+                  allowEmptyValue: true
+                  schema:
+                    type: integer
+                    description: Length of the trailing window in days. Defaults to 30, max 90.
+                    format: int64
+                - name: limit
+                  in: query
+                  description: Maximum number of rows to return (default 100, max 500).
+                  allowEmptyValue: true
+                  schema:
+                    type: integer
+                    description: Maximum number of rows to return (default 100, max 500).
+                    format: int64
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AdminListPricingTrackerResult'
+                "400":
+                    description: 'bad_request: request is invalid'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "401":
+                    description: 'unauthorized: unauthorized access'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "403":
+                    description: 'forbidden: permission denied'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "404":
+                    description: 'not_found: resource not found'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "409":
+                    description: 'conflict: resource already exists'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "415":
+                    description: 'unsupported_media: unsupported media type'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "422":
+                    description: 'invalid: request contains one or more invalidation fields'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "500":
+                    description: 'unexpected: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "502":
+                    description: 'gateway_error: an unexpected error occurred'
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+            security:
+                - admin_auth_header_Authorization: []
     /admin/project.get:
         get:
             tags:
@@ -53452,6 +53553,31 @@ components:
                     description: The page of organizations.
             required:
                 - organizations
+        AdminListPricingTrackerResult:
+            type: object
+            properties:
+                inference_spend_available:
+                    type: boolean
+                    description: False when the analytics store is not wired into the admin service, in which case inference spend and TUM-derived PAYG figures are reported as zero.
+                rows:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AdminPricingTrackerRow'
+                    description: One row per organization, ordered by inference spend descending.
+                window_end:
+                    type: string
+                    description: Exclusive end of the tracker window.
+                    format: date-time
+                window_start:
+                    type: string
+                    description: Inclusive start of the tracker window.
+                    format: date-time
+            description: 'Internal pricing tracker: per-customer PAYG price and inference spend over a trailing window.'
+            required:
+                - rows
+                - window_start
+                - window_end
+                - inference_spend_available
         AdminOrganization:
             type: object
             properties:
@@ -53536,6 +53662,47 @@ components:
                 - display_name
                 - created_at
                 - updated_at
+        AdminPricingTrackerRow:
+            type: object
+            properties:
+                account_type:
+                    type: string
+                    description: Gram account type (e.g. free, pro, enterprise).
+                inference_spend:
+                    type: number
+                    description: Gram-hosted inference spend in USD over the window (playground, elements, risk analysis, assistants, and other platform-run completions).
+                    format: double
+                monthly_tum_tokens:
+                    type: integer
+                    description: Observed tokens under management over the window, used as the PAYG pricing input.
+                    format: int64
+                name:
+                    type: string
+                    description: The name of the organization (customer name).
+                organization_id:
+                    type: string
+                    description: The ID of the organization.
+                payg_effective_rate_per_million:
+                    type: number
+                    description: Blended PAYG rate in USD per million tokens at the window's volume.
+                    format: double
+                payg_monthly_price:
+                    type: number
+                    description: Pay-as-you-go price in USD for the window's volume at the current rate card.
+                    format: double
+                slug:
+                    type: string
+                    description: The slug of the organization.
+            description: 'One organization''s pricing exposure: PAYG price at the current rate card and Gram-hosted inference spend over the tracker window.'
+            required:
+                - organization_id
+                - name
+                - slug
+                - account_type
+                - monthly_tum_tokens
+                - payg_monthly_price
+                - payg_effective_rate_per_million
+                - inference_spend
         AdminProject:
             type: object
             properties:

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,16 +18,21 @@ import (
 	goahttp "goa.design/goa/v3/http"
 	"goa.design/goa/v3/security"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
+
 	gen "github.com/speakeasy-api/gram/server/gen/admin"
 	srv "github.com/speakeasy-api/gram/server/gen/http/admin/server"
 	"github.com/speakeasy-api/gram/server/internal/admin/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/cache"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/pricing"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
 type Service struct {
@@ -38,6 +44,11 @@ type Service struct {
 	oidc           *OIDCClient
 	sessions       *SessionStore
 	allowedOrigins []string
+	// telemetry is the ClickHouse analytics repo used by the pricing tracker.
+	// It is nil when the admin service was started without a ClickHouse
+	// connection; the pricing tracker then reports inference spend and
+	// TUM-derived figures as zero rather than failing.
+	telemetry *telemetryrepo.Queries
 }
 
 var _ gen.Service = (*Service)(nil)
@@ -51,6 +62,7 @@ func NewService(
 	oidcClient *OIDCClient,
 	encryptionClient *encryption.Client,
 	allowedOrigins []string,
+	chConn clickhouse.Conn,
 ) *Service {
 	logger = logger.With(attr.SlogComponent("admin"))
 
@@ -63,6 +75,11 @@ func NewService(
 		encryptionClient,
 	)
 
+	var telemetry *telemetryrepo.Queries
+	if chConn != nil {
+		telemetry = telemetryrepo.New(chConn)
+	}
+
 	return &Service{
 		tracer:         tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/admin"),
 		logger:         logger,
@@ -71,6 +88,7 @@ func NewService(
 		sessions:       sessionStore,
 		verifier:       NewVerifier(logger, sessionStore, oidcClient),
 		allowedOrigins: allowedOrigins,
+		telemetry:      telemetry,
 		loginStates: cache.NewTypedObjectCache[LoginState](
 			logger.With(attr.SlogCacheNamespace("admin_login_state")),
 			cache.NewRedisCacheAdapter(redisClient),
@@ -347,6 +365,167 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 	return &gen.AdminListOrganizationsResult{
 		Organizations: orgs,
 		NextCursor:    nextCursor,
+	}, nil
+}
+
+const (
+	pricingTrackerDefaultLimit  = 100
+	pricingTrackerMaxLimit      = 500
+	pricingTrackerDefaultWindow = 30
+	pricingTrackerMaxWindow     = 90
+	// pricingMonthDays normalizes window volume to a nominal 30-day month so
+	// the PAYG rate card (which is keyed on absolute monthly token volume) is
+	// quoted consistently regardless of the requested window length.
+	pricingMonthDays = 30.0
+)
+
+// orgPricingAgg accumulates the projects belonging to one organization while
+// the tracker rolls per-project analytics up to the owning customer.
+type orgPricingAgg struct {
+	id          string
+	name        string
+	slug        string
+	accountType string
+	projectIDs  []string
+}
+
+// ListPricingTracker returns, per organization, the PAYG price at the current
+// rate card (derived from observed tokens under management) alongside the
+// Gram-hosted inference spend over a trailing window — the internal tracker
+// used to watch customer pricing exposure when adjusting spend limits.
+func (s *Service) ListPricingTracker(ctx context.Context, payload *gen.ListPricingTrackerPayload) (*gen.AdminListPricingTrackerResult, error) {
+	windowDays := pricingTrackerDefaultWindow
+	if payload.WindowDays != nil {
+		windowDays = *payload.WindowDays
+		if windowDays < 1 {
+			windowDays = pricingTrackerDefaultWindow
+		}
+		if windowDays > pricingTrackerMaxWindow {
+			windowDays = pricingTrackerMaxWindow
+		}
+	}
+
+	limit := pricingTrackerDefaultLimit
+	if payload.Limit != nil {
+		limit = *payload.Limit
+		if limit < 1 {
+			limit = pricingTrackerDefaultLimit
+		}
+		if limit > pricingTrackerMaxLimit {
+			limit = pricingTrackerMaxLimit
+		}
+	}
+
+	windowEnd := time.Now().UTC()
+	windowStart := windowEnd.AddDate(0, 0, -windowDays)
+
+	rows, err := repo.New(s.db).AdminListProjectsWithOrganization(ctx, repo.AdminListProjectsWithOrganizationParams{
+		AccountType: conv.PtrToPGText(payload.AccountType),
+		IncludeFree: conv.PtrValOr(payload.IncludeFree, false),
+	})
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "list projects for pricing tracker").LogError(ctx, s.logger)
+	}
+
+	orgs := make(map[string]*orgPricingAgg)
+	order := make([]string, 0)
+	allProjectIDs := make([]string, 0, len(rows))
+	for _, r := range rows {
+		agg, ok := orgs[r.OrganizationID]
+		if !ok {
+			agg = &orgPricingAgg{
+				id:          r.OrganizationID,
+				name:        r.OrganizationName,
+				slug:        r.OrganizationSlug,
+				accountType: r.AccountType,
+				projectIDs:  nil,
+			}
+			orgs[r.OrganizationID] = agg
+			order = append(order, r.OrganizationID)
+		}
+		pid := r.ProjectID.String()
+		agg.projectIDs = append(agg.projectIDs, pid)
+		allProjectIDs = append(allProjectIDs, pid)
+	}
+
+	tumByProject := make(map[string]int64)
+	spendByProject := make(map[string]float64)
+	inferenceAvailable := s.telemetry != nil
+	if inferenceAvailable && len(allProjectIDs) > 0 {
+		tokenBuckets, err := s.telemetry.GetTumTokensByProject(ctx, telemetryrepo.GetTokensUnderManagementParams{
+			ProjectIDs:          allProjectIDs,
+			StartUnixNano:       windowStart.UnixNano(),
+			EndUnixNano:         windowEnd.UnixNano(),
+			ExcludedHookSources: billing.GramHostedHookSourceStrings(),
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "compute tokens under management for pricing tracker").LogError(ctx, s.logger)
+		}
+		for _, b := range tokenBuckets {
+			tumByProject[b.ProjectID] = b.Tokens
+		}
+
+		spendBuckets, err := s.telemetry.GetInferenceSpendByProject(ctx, telemetryrepo.InferenceSpendByProjectParams{
+			ProjectIDs:          allProjectIDs,
+			StartUnixNano:       windowStart.UnixNano(),
+			EndUnixNano:         windowEnd.UnixNano(),
+			IncludedHookSources: billing.GramHostedInferenceSources(),
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "compute inference spend for pricing tracker").LogError(ctx, s.logger)
+		}
+		for _, b := range spendBuckets {
+			spendByProject[b.ProjectID] = b.Cost
+		}
+	}
+
+	result := make([]*gen.AdminPricingTrackerRow, 0, len(order))
+	for _, oid := range order {
+		agg := orgs[oid]
+		var windowTokens int64
+		var spend float64
+		for _, pid := range agg.projectIDs {
+			windowTokens += tumByProject[pid]
+			spend += spendByProject[pid]
+		}
+
+		// Normalize observed volume to a nominal month so the rate card reads
+		// consistently across window lengths.
+		monthlyTokens := int64(float64(windowTokens) * pricingMonthDays / float64(windowDays))
+
+		result = append(result, &gen.AdminPricingTrackerRow{
+			OrganizationID:              agg.id,
+			Name:                        agg.name,
+			Slug:                        agg.slug,
+			AccountType:                 agg.accountType,
+			MonthlyTumTokens:            monthlyTokens,
+			PaygMonthlyPrice:            pricing.PaygMonthlyPrice(monthlyTokens),
+			PaygEffectiveRatePerMillion: pricing.PaygEffectiveRatePerMillion(monthlyTokens),
+			InferenceSpend:              spend,
+		})
+	}
+
+	// Highest inference spend first — that is the exposure the tracker exists
+	// to surface. Ties break on volume then name for a stable ordering.
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].InferenceSpend != result[j].InferenceSpend {
+			return result[i].InferenceSpend > result[j].InferenceSpend
+		}
+		if result[i].MonthlyTumTokens != result[j].MonthlyTumTokens {
+			return result[i].MonthlyTumTokens > result[j].MonthlyTumTokens
+		}
+		return result[i].Name < result[j].Name
+	})
+
+	if len(result) > limit {
+		result = result[:limit]
+	}
+
+	return &gen.AdminListPricingTrackerResult{
+		Rows:                    result,
+		WindowStart:             windowStart.Format(time.RFC3339),
+		WindowEnd:               windowEnd.Format(time.RFC3339),
+		InferenceSpendAvailable: inferenceAvailable,
 	}, nil
 }
 

--- a/server/internal/admin/pricingtracker_test.go
+++ b/server/internal/admin/pricingtracker_test.go
@@ -1,0 +1,220 @@
+package admin
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/admin"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+)
+
+func seedProject(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID, projectID, name, slug string) {
+	t.Helper()
+
+	err := testrepo.New(conn).CreateProjectFixture(ctx, testrepo.CreateProjectFixtureParams{
+		ID:             uuid.MustParse(projectID),
+		Name:           name,
+		Slug:           slug,
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+}
+
+// seedTumRow plants an observed-traffic attribute_metrics_summaries row so the
+// tracker's tokens-under-management read has volume to price. The TUM measure
+// is input + output + cache-creation tokens.
+func seedTumRow(t *testing.T, ctx context.Context, ch clickhouse.Conn, projectID string, bucket time.Time, hookSource string, input, output, cacheCreation int64) {
+	t.Helper()
+
+	err := ch.Exec(ctx, `
+		INSERT INTO attribute_metrics_summaries (
+			gram_project_id, time_bucket,
+			department_name, job_title, employee_type, division_name, cost_center_name, user_email,
+			model, hook_source, roles, groups,
+			total_chats, total_input_tokens, total_output_tokens, total_tokens,
+			cache_read_input_tokens, cache_creation_input_tokens, total_cost, total_tool_calls,
+			account_type, provider, billing_mode,
+			query_source, skill_name, agent_name, mcp_server_name, mcp_tool_name
+		)
+		SELECT
+			toUUID(?), toDateTime(?, 'UTC'),
+			'', '', '', '', '', '',
+			'model', ?, [], [],
+			uniqExactIfState('chat', toUInt8(0)),
+			sumIfState(toInt64(?), toUInt8(1)),
+			sumIfState(toInt64(?), toUInt8(1)),
+			sumIfState(toInt64(0), toUInt8(0)),
+			sumIfState(toInt64(0), toUInt8(0)),
+			sumIfState(toInt64(?), toUInt8(1)),
+			sumIfState(toFloat64(0), toUInt8(0)),
+			countIfState(toUInt8(0)),
+			'', '', '',
+			'', '', '', '', ''
+		FROM numbers(1)`,
+		projectID, bucket.Unix(), hookSource, input, output, cacheCreation,
+	)
+	require.NoError(t, err)
+}
+
+// seedInferenceLog plants a raw telemetry_logs completion row carrying a
+// gen_ai.usage.cost under the given hook source, the shape Gram-hosted
+// inference spend is summed from.
+func seedInferenceLog(t *testing.T, ctx context.Context, ch clickhouse.Conn, projectID string, ts time.Time, hookSource string, cost float64) {
+	t.Helper()
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attrs := `{"gram.hook.source":"` + hookSource + `","gen_ai.usage.cost":` + strconv.FormatFloat(cost, 'f', -1, 64) + `}`
+
+	err = ch.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), ts.UnixNano(), ts.UnixNano(), "INFO", "chat completion",
+		nil, nil, attrs, "{}",
+		projectID, "completions:usage", "gram-server")
+	require.NoError(t, err)
+}
+
+func rowByOrg(t *testing.T, rows []*gen.AdminPricingTrackerRow, orgID string) *gen.AdminPricingTrackerRow {
+	t.Helper()
+	for _, r := range rows {
+		if r.OrganizationID == orgID {
+			return r
+		}
+	}
+	t.Fatalf("no pricing tracker row for org %q", orgID)
+	return nil
+}
+
+func TestListPricingTracker_RollsUpSpendAndPrice(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, ch := newTestAdminServiceWithClickhouse(t)
+
+	bucket := time.Now().UTC().Add(-24 * time.Hour)
+
+	// Enterprise org with two projects: TUM and inference spend must roll up
+	// across both projects onto the org.
+	orgA := "org_pt_ent_" + uuid.NewString()[:8]
+	seedOrg(t, ctx, conn, orgFixture{id: orgA, name: "Enterprise Co", slug: "ent-" + uuid.NewString()[:8], accountType: "enterprise", whitelisted: true})
+	projA1 := uuid.NewString()
+	projA2 := uuid.NewString()
+	seedProject(t, ctx, conn, orgA, projA1, "A1", "a1-"+uuid.NewString()[:8])
+	seedProject(t, ctx, conn, orgA, projA2, "A2", "a2-"+uuid.NewString()[:8])
+	// 600k + 400k = 1,000,000 monthly tokens → PAYG first band $0.35/M = $0.35.
+	seedTumRow(t, ctx, ch, projA1, bucket, "claude-code", 600_000, 0, 0)
+	seedTumRow(t, ctx, ch, projA2, bucket, "cursor", 400_000, 0, 0)
+	// Inference spend: 1.00 (playground) + 0.75 (risk-analysis) = 1.75.
+	seedInferenceLog(t, ctx, ch, projA1, bucket, "playground", 1.00)
+	seedInferenceLog(t, ctx, ch, projA2, bucket, "risk-analysis", 0.75)
+	// Observed agent traffic cost must NOT count as inference spend.
+	seedInferenceLog(t, ctx, ch, projA1, bucket, "claude-code", 99.0)
+
+	// Pro org, single project, smaller footprint.
+	orgB := "org_pt_pro_" + uuid.NewString()[:8]
+	seedOrg(t, ctx, conn, orgFixture{id: orgB, name: "Pro Co", slug: "pro-" + uuid.NewString()[:8], accountType: "pro", whitelisted: true})
+	projB := uuid.NewString()
+	seedProject(t, ctx, conn, orgB, projB, "B", "b-"+uuid.NewString()[:8])
+	seedTumRow(t, ctx, ch, projB, bucket, "claude-code", 500_000, 0, 0)
+	seedInferenceLog(t, ctx, ch, projB, bucket, "elements", 0.50)
+
+	// Free org: excluded by default.
+	orgFree := "org_pt_free_" + uuid.NewString()[:8]
+	seedOrg(t, ctx, conn, orgFixture{id: orgFree, name: "Free Co", slug: "free-" + uuid.NewString()[:8], accountType: "free", whitelisted: true})
+	projFree := uuid.NewString()
+	seedProject(t, ctx, conn, orgFree, projFree, "F", "f-"+uuid.NewString()[:8])
+	seedInferenceLog(t, ctx, ch, projFree, bucket, "playground", 5.0)
+
+	res, err := svc.ListPricingTracker(ctx, &gen.ListPricingTrackerPayload{})
+	require.NoError(t, err)
+	require.True(t, res.InferenceSpendAvailable)
+	require.NotEmpty(t, res.WindowStart)
+	require.NotEmpty(t, res.WindowEnd)
+
+	// Free org excluded; only the two paying orgs seeded here appear.
+	rowA := rowByOrg(t, res.Rows, orgA)
+	rowB := rowByOrg(t, res.Rows, orgB)
+	for _, r := range res.Rows {
+		require.NotEqual(t, orgFree, r.OrganizationID, "free org should be excluded by default")
+	}
+
+	require.Equal(t, "enterprise", rowA.AccountType)
+	require.Equal(t, int64(1_000_000), rowA.MonthlyTumTokens)
+	require.InDelta(t, 0.35, rowA.PaygMonthlyPrice, 1e-6)
+	require.InDelta(t, 0.35, rowA.PaygEffectiveRatePerMillion, 1e-6)
+	require.InDelta(t, 1.75, rowA.InferenceSpend, 1e-6, "observed claude-code cost must be excluded")
+
+	require.Equal(t, "pro", rowB.AccountType)
+	require.Equal(t, int64(500_000), rowB.MonthlyTumTokens)
+	require.InDelta(t, 0.50, rowB.InferenceSpend, 1e-6)
+
+	// Highest inference spend sorts first.
+	require.Equal(t, orgA, res.Rows[0].OrganizationID)
+}
+
+func TestListPricingTracker_IncludeFreeAndAccountTypeFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn, ch := newTestAdminServiceWithClickhouse(t)
+
+	bucket := time.Now().UTC().Add(-24 * time.Hour)
+
+	orgEnt := "org_ptf_ent_" + uuid.NewString()[:8]
+	seedOrg(t, ctx, conn, orgFixture{id: orgEnt, name: "Ent", slug: "e-" + uuid.NewString()[:8], accountType: "enterprise", whitelisted: true})
+	projEnt := uuid.NewString()
+	seedProject(t, ctx, conn, orgEnt, projEnt, "E", "e-"+uuid.NewString()[:8])
+	seedInferenceLog(t, ctx, ch, projEnt, bucket, "playground", 1.0)
+
+	orgFree := "org_ptf_free_" + uuid.NewString()[:8]
+	seedOrg(t, ctx, conn, orgFixture{id: orgFree, name: "Free", slug: "f-" + uuid.NewString()[:8], accountType: "free", whitelisted: true})
+	projFree := uuid.NewString()
+	seedProject(t, ctx, conn, orgFree, projFree, "F", "f-"+uuid.NewString()[:8])
+	seedInferenceLog(t, ctx, ch, projFree, bucket, "playground", 2.0)
+
+	// include_free surfaces the free org.
+	includeFree := true
+	res, err := svc.ListPricingTracker(ctx, &gen.ListPricingTrackerPayload{IncludeFree: &includeFree})
+	require.NoError(t, err)
+	_ = rowByOrg(t, res.Rows, orgFree)
+	_ = rowByOrg(t, res.Rows, orgEnt)
+
+	// account_type filter narrows to a single tier.
+	entType := "enterprise"
+	res, err = svc.ListPricingTracker(ctx, &gen.ListPricingTrackerPayload{AccountType: &entType})
+	require.NoError(t, err)
+	_ = rowByOrg(t, res.Rows, orgEnt)
+	for _, r := range res.Rows {
+		require.Equal(t, "enterprise", r.AccountType)
+	}
+}
+
+func TestListPricingTracker_WithoutClickhouse(t *testing.T) {
+	t.Parallel()
+
+	ctx, svc, conn := newTestAdminService(t)
+
+	orgEnt := "org_ptn_ent_" + uuid.NewString()[:8]
+	seedOrg(t, ctx, conn, orgFixture{id: orgEnt, name: "Ent", slug: "en-" + uuid.NewString()[:8], accountType: "enterprise", whitelisted: true})
+	projEnt := uuid.NewString()
+	seedProject(t, ctx, conn, orgEnt, projEnt, "E", "en-"+uuid.NewString()[:8])
+
+	res, err := svc.ListPricingTracker(ctx, &gen.ListPricingTrackerPayload{})
+	require.NoError(t, err)
+	require.False(t, res.InferenceSpendAvailable)
+
+	row := rowByOrg(t, res.Rows, orgEnt)
+	require.Equal(t, int64(0), row.MonthlyTumTokens)
+	require.InDelta(t, 0.0, row.PaygMonthlyPrice, 1e-9)
+	require.InDelta(t, 0.0, row.InferenceSpend, 1e-9)
+}

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -88,6 +88,26 @@ SET
     updated_at = clock_timestamp()
 WHERE id = @id;
 
+-- name: AdminListProjectsWithOrganization :many
+-- Powers the internal pricing tracker: every active project joined to its
+-- (non-disabled) organization, so per-project analytics can be rolled up to
+-- the owning customer. Optionally scoped by account type; when include_free is
+-- false, free-tier organizations are dropped so the tracker stays focused on
+-- paying customers.
+SELECT
+    p.id AS project_id,
+    om.id AS organization_id,
+    om.name AS organization_name,
+    om.slug AS organization_slug,
+    om.gram_account_type AS account_type
+FROM projects p
+JOIN organization_metadata om ON om.id = p.organization_id
+WHERE p.deleted IS FALSE
+  AND om.disabled_at IS NULL
+  AND (sqlc.narg('account_type')::text IS NULL OR om.gram_account_type = sqlc.narg('account_type')::text)
+  AND (sqlc.arg('include_free')::boolean OR om.gram_account_type <> 'free')
+ORDER BY om.id ASC;
+
 -- name: AdminListProjectsForOrganization :many
 SELECT id, slug, name, created_at, updated_at
 FROM projects

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -378,6 +378,66 @@ func (q *Queries) AdminListProjectsForOrganization(ctx context.Context, organiza
 	return items, nil
 }
 
+const adminListProjectsWithOrganization = `-- name: AdminListProjectsWithOrganization :many
+SELECT
+    p.id AS project_id,
+    om.id AS organization_id,
+    om.name AS organization_name,
+    om.slug AS organization_slug,
+    om.gram_account_type AS account_type
+FROM projects p
+JOIN organization_metadata om ON om.id = p.organization_id
+WHERE p.deleted IS FALSE
+  AND om.disabled_at IS NULL
+  AND ($1::text IS NULL OR om.gram_account_type = $1::text)
+  AND ($2::boolean OR om.gram_account_type <> 'free')
+ORDER BY om.id ASC
+`
+
+type AdminListProjectsWithOrganizationParams struct {
+	AccountType pgtype.Text
+	IncludeFree bool
+}
+
+type AdminListProjectsWithOrganizationRow struct {
+	ProjectID        uuid.UUID
+	OrganizationID   string
+	OrganizationName string
+	OrganizationSlug string
+	AccountType      string
+}
+
+// Powers the internal pricing tracker: every active project joined to its
+// (non-disabled) organization, so per-project analytics can be rolled up to
+// the owning customer. Optionally scoped by account type; when include_free is
+// false, free-tier organizations are dropped so the tracker stays focused on
+// paying customers.
+func (q *Queries) AdminListProjectsWithOrganization(ctx context.Context, arg AdminListProjectsWithOrganizationParams) ([]AdminListProjectsWithOrganizationRow, error) {
+	rows, err := q.db.Query(ctx, adminListProjectsWithOrganization, arg.AccountType, arg.IncludeFree)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AdminListProjectsWithOrganizationRow
+	for rows.Next() {
+		var i AdminListProjectsWithOrganizationRow
+		if err := rows.Scan(
+			&i.ProjectID,
+			&i.OrganizationID,
+			&i.OrganizationName,
+			&i.OrganizationSlug,
+			&i.AccountType,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const adminUpdateOrganization = `-- name: AdminUpdateOrganization :exec
 UPDATE organization_metadata
 SET

--- a/server/internal/admin/setup_test.go
+++ b/server/internal/admin/setup_test.go
@@ -6,16 +6,18 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 var infra *testenv.Environment
 
 func TestMain(m *testing.M) {
-	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true})
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, ClickHouse: true})
 	if err != nil {
 		log.Fatalf("Failed to launch test infrastructure: %v", err)
 	}
@@ -50,4 +52,29 @@ func newTestAdminService(t *testing.T) (context.Context, *Service, *pgxpool.Pool
 	}
 
 	return ctx, svc, conn
+}
+
+// newTestAdminServiceWithClickhouse builds a Service wired to the shared test
+// ClickHouse instance so the pricing tracker can read inference spend and
+// tokens under management. Tests scope their reads to freshly generated
+// project ids, so the shared analytics store is safe across parallel tests.
+func newTestAdminServiceWithClickhouse(t *testing.T) (context.Context, *Service, *pgxpool.Pool, clickhouse.Conn) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	logger := testenv.NewLogger(t)
+	conn, err := infra.CloneTestDatabase(t, "admintestdb")
+	require.NoError(t, err)
+
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	svc := &Service{
+		logger:    logger,
+		db:        conn,
+		telemetry: telemetryrepo.New(chConn),
+	}
+
+	return ctx, svc, conn, chConn
 }

--- a/server/internal/billing/tracking.go
+++ b/server/internal/billing/tracking.go
@@ -95,6 +95,18 @@ func ModelUsageSourceStrings() []string {
 	return out
 }
 
+// GramHostedInferenceSources lists every TAGGED hook_source value that
+// Gram-server-run completions carry: the registered customer-facing surfaces
+// (playground, elements, gram, slack, risk-analysis) plus the internal-only
+// tags (assistants, skill-efficacy, skill-suggestions, chat-analysis). This is
+// the "inference spend" INCLUSION list — the completions Gram itself pays for
+// while reacting to or serving a customer. It deliberately omits the empty
+// string: as an inclusion filter over raw telemetry an untagged row is
+// ambiguous, so only explicitly Gram-tagged spend is summed.
+func GramHostedInferenceSources() []string {
+	return append(ModelUsageSourceStrings(), string(ModelUsageSourceAssistants), string(ModelUsageSourceSkillEfficacy), string(ModelUsageSourceSkillSuggestions), string(ModelUsageSourceChatAnalysis))
+}
+
 // GramHostedHookSourceStrings lists every hook_source value Gram-server-run
 // completions are tagged with: the registered surfaces, the internal assistants
 // and skill-efficacy tags, and the empty string for rows recorded before Gram
@@ -104,7 +116,7 @@ func ModelUsageSourceStrings() []string {
 // traffic, and everything Gram itself spends (reactive scanning inference
 // and user-initiated hosted chat alike) is out of scope.
 func GramHostedHookSourceStrings() []string {
-	return append(ModelUsageSourceStrings(), string(ModelUsageSourceAssistants), string(ModelUsageSourceSkillEfficacy), string(ModelUsageSourceSkillSuggestions), string(ModelUsageSourceChatAnalysis), "")
+	return append(GramHostedInferenceSources(), "")
 }
 
 type ModelUsageEvent struct {

--- a/server/internal/pricing/payg.go
+++ b/server/internal/pricing/payg.go
@@ -1,0 +1,68 @@
+// Package pricing holds the server-side port of Gram's pay-as-you-go (PAYG)
+// rate card. The canonical model lives in the dashboard's contract-pricing.ts
+// and is used there for the platform-admin contract estimator; this package
+// mirrors the PAYG bands so backend internal tooling (the admin pricing
+// tracker) can quote the same monthly PAYG figure off observed token volume
+// without a round-trip to the browser.
+//
+// Nothing here is billed from — these are sales-side approximations off
+// observed tokens under management, kept in a pure, unit-testable module.
+package pricing
+
+const tokensPerMillion = 1_000_000
+
+// paygTier is one graduated pay-as-you-go band, keyed on an absolute monthly
+// token ceiling. Rates are expressed in US dollars per million tokens.
+type paygTier struct {
+	upToTokens     float64
+	ratePerMillion float64
+}
+
+// paygTiers are the pay-as-you-go bands, keyed on absolute monthly volume. The
+// floor rate ($0.24) deliberately sits above both the committed baseline rate
+// and the lowest contract overage rate, so PAYG is never the cheaper option at
+// equivalent volume — it prices flexibility, not discount. Keep these in sync
+// with PAYG_TIERS in client/dashboard/src/components/billing/contract-pricing.ts.
+var paygTiers = []paygTier{
+	{upToTokens: 10e9, ratePerMillion: 0.35},
+	{upToTokens: 30e9, ratePerMillion: 0.30},
+	{upToTokens: 75e9, ratePerMillion: 0.27},
+	{upToTokens: 1e18, ratePerMillion: 0.24}, // effectively unbounded top band
+}
+
+// PaygMonthlyPrice returns the full pay-as-you-go bill, in US dollars, for one
+// month at monthlyTokens of observed volume. Every token is charged from the
+// first one against the graduated bands (no baseline to subtract): the bill is
+// the sum of each band's slice, matching graduatedLines in contract-pricing.ts.
+// Zero or negative volume prices at $0.
+func PaygMonthlyPrice(monthlyTokens int64) float64 {
+	if monthlyTokens <= 0 {
+		return 0
+	}
+	tokens := float64(monthlyTokens)
+	var cost float64
+	var lower float64
+	for _, band := range paygTiers {
+		upper := band.upToTokens
+		inBand := min(tokens, upper) - lower
+		if inBand > 0 {
+			cost += (inBand / tokensPerMillion) * band.ratePerMillion
+		}
+		if tokens <= upper {
+			break
+		}
+		lower = upper
+	}
+	return cost
+}
+
+// PaygEffectiveRatePerMillion returns the blended dollars-per-million-tokens
+// that the monthly PAYG bill works out to at the given volume — the single
+// number that makes rate cards comparable across volumes. Returns 0 when there
+// is no volume to rate.
+func PaygEffectiveRatePerMillion(monthlyTokens int64) float64 {
+	if monthlyTokens <= 0 {
+		return 0
+	}
+	return PaygMonthlyPrice(monthlyTokens) / (float64(monthlyTokens) / tokensPerMillion)
+}

--- a/server/internal/pricing/payg_test.go
+++ b/server/internal/pricing/payg_test.go
@@ -1,0 +1,69 @@
+package pricing
+
+import (
+	"math"
+	"testing"
+)
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-6
+}
+
+func TestPaygMonthlyPrice_ZeroAndNegative(t *testing.T) {
+	t.Parallel()
+
+	if got := PaygMonthlyPrice(0); got != 0 {
+		t.Fatalf("PaygMonthlyPrice(0) = %v, want 0", got)
+	}
+	if got := PaygMonthlyPrice(-5); got != 0 {
+		t.Fatalf("PaygMonthlyPrice(-5) = %v, want 0", got)
+	}
+}
+
+func TestPaygMonthlyPrice_FirstBand(t *testing.T) {
+	t.Parallel()
+
+	// 1M tokens entirely within the first band: 1M / 1M * $0.35 = $0.35.
+	if got := PaygMonthlyPrice(1_000_000); !approxEqual(got, 0.35) {
+		t.Fatalf("PaygMonthlyPrice(1M) = %v, want 0.35", got)
+	}
+
+	// 1B tokens in the first band: 1000M * $0.35 = $350.
+	if got := PaygMonthlyPrice(1_000_000_000); !approxEqual(got, 350) {
+		t.Fatalf("PaygMonthlyPrice(1B) = %v, want 350", got)
+	}
+}
+
+func TestPaygMonthlyPrice_GraduatedAcrossBands(t *testing.T) {
+	t.Parallel()
+
+	// 20B tokens: first 10B @ $0.35/M + next 10B @ $0.30/M.
+	// = 10_000 * 0.35 + 10_000 * 0.30 = 3500 + 3000 = 6500.
+	if got := PaygMonthlyPrice(20_000_000_000); !approxEqual(got, 6500) {
+		t.Fatalf("PaygMonthlyPrice(20B) = %v, want 6500", got)
+	}
+
+	// 100B tokens: 10B@0.35 + 20B@0.30 + 45B@0.27 + 25B@0.24
+	// = 3500 + 6000 + 12150 + 6000 = 27650.
+	if got := PaygMonthlyPrice(100_000_000_000); !approxEqual(got, 27650) {
+		t.Fatalf("PaygMonthlyPrice(100B) = %v, want 27650", got)
+	}
+}
+
+func TestPaygEffectiveRatePerMillion(t *testing.T) {
+	t.Parallel()
+
+	if got := PaygEffectiveRatePerMillion(0); got != 0 {
+		t.Fatalf("PaygEffectiveRatePerMillion(0) = %v, want 0", got)
+	}
+
+	// Fully within the first band → blended rate equals the band rate.
+	if got := PaygEffectiveRatePerMillion(5_000_000_000); !approxEqual(got, 0.35) {
+		t.Fatalf("PaygEffectiveRatePerMillion(5B) = %v, want 0.35", got)
+	}
+
+	// 20B → 6500 / 20000M = 0.325 blended.
+	if got := PaygEffectiveRatePerMillion(20_000_000_000); !approxEqual(got, 0.325) {
+		t.Fatalf("PaygEffectiveRatePerMillion(20B) = %v, want 0.325", got)
+	}
+}

--- a/server/internal/telemetry/repo/pricing_tracker.go
+++ b/server/internal/telemetry/repo/pricing_tracker.go
@@ -1,0 +1,139 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/squirrel"
+)
+
+// ProjectTokenBucket is one project's tokens-under-management total over a
+// window. Used by the internal pricing tracker to roll observed volume up to
+// the owning organization before quoting a PAYG rate.
+type ProjectTokenBucket struct {
+	ProjectID string `ch:"project_id"`
+	Tokens    int64  `ch:"tokens"`
+}
+
+// GetTumTokensByProject sums the tokens-under-management measure per project
+// over the window, scoped identically to the billed totals (measure derived
+// from billing.TumComponents via tumMeasureExpr; population scoped by
+// ExcludedHookSources). Unlike GetTumWindowTotal it groups by project so a
+// caller aggregating several projects into one organization needs only a
+// single ClickHouse round trip. Projects with no usage are omitted.
+//
+//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) GetTumTokensByProject(ctx context.Context, arg GetTokensUnderManagementParams) ([]ProjectTokenBucket, error) {
+	if len(arg.ProjectIDs) == 0 {
+		return nil, nil
+	}
+
+	sb := tumObservedBase(sq.Select(
+		"toString(gram_project_id) AS project_id",
+		tumMeasureExpr+" AS tokens",
+	), arg).
+		GroupBy("project_id")
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building tum tokens by project query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var buckets []ProjectTokenBucket
+	for rows.Next() {
+		var bucket ProjectTokenBucket
+		if err := rows.ScanStruct(&bucket); err != nil {
+			return nil, fmt.Errorf("scanning tum tokens by project row: %w", err)
+		}
+		buckets = append(buckets, bucket)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return buckets, nil
+}
+
+// InferenceSpendByProjectParams scopes an inference-spend rollup to a set of
+// projects, a time window, and the Gram-hosted completion surfaces.
+type InferenceSpendByProjectParams struct {
+	ProjectIDs    []string
+	StartUnixNano int64
+	EndUnixNano   int64
+	// IncludedHookSources restricts the sum to Gram-server-run completion
+	// surfaces (billing.GramHostedInferenceSources) — playground, elements,
+	// risk-analysis, assistants, and so on. Inference spend is the dollars Gram
+	// itself pays upstream serving or reacting to a customer, the mirror image
+	// of the tokens-under-management exclusion list. Empty means no source
+	// filter (all rows counted), which callers should avoid for this measure.
+	IncludedHookSources []string
+}
+
+// ProjectCostBucket is one project's Gram-hosted inference spend, in US
+// dollars, over a window.
+type ProjectCostBucket struct {
+	ProjectID string  `ch:"project_id"`
+	Cost      float64 `ch:"total_cost"`
+}
+
+// GetInferenceSpendByProject sums the per-completion cost
+// (gen_ai.usage.cost) that Gram-server-run completions recorded, per project,
+// over the window. It reads raw telemetry_logs rather than
+// attribute_metrics_summaries because that aggregate admits only observed
+// agent traffic by construction — the Gram-hosted completion surfaces this
+// measure sums never reach it. The read is scoped by gram_project_id (the
+// table's primary sort key) and the time partition, so it prunes efficiently.
+// Projects with no spend are omitted.
+//
+//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) GetInferenceSpendByProject(ctx context.Context, arg InferenceSpendByProjectParams) ([]ProjectCostBucket, error) {
+	if len(arg.ProjectIDs) == 0 {
+		return nil, nil
+	}
+
+	sb := sq.Select(
+		"toString(gram_project_id) AS project_id",
+		"sumIf(toFloat64OrZero(toString(attributes.gen_ai.usage.cost)), toString(attributes.gen_ai.usage.cost) != '') AS total_cost",
+	).
+		From("telemetry_logs").
+		Where(squirrel.Eq{"gram_project_id": arg.ProjectIDs}).
+		Where("time_unix_nano >= ?", arg.StartUnixNano).
+		Where("time_unix_nano < ?", arg.EndUnixNano)
+
+	if len(arg.IncludedHookSources) > 0 {
+		sb = sb.Where(squirrel.Eq{"hook_source": arg.IncludedHookSources})
+	}
+
+	sb = sb.GroupBy("project_id")
+
+	query, args, err := sb.ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("building inference spend by project query: %w", err)
+	}
+
+	rows, err := q.conn.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var buckets []ProjectCostBucket
+	for rows.Next() {
+		var bucket ProjectCostBucket
+		if err := rows.ScanStruct(&bucket); err != nil {
+			return nil, fmt.Errorf("scanning inference spend by project row: %w", err)
+		}
+		buckets = append(buckets, bucket)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return buckets, nil
+}

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -186,6 +186,12 @@ INSERT INTO organization_metadata (
 INSERT INTO organization_user_relationships (organization_id, user_id)
 VALUES (@organization_id, sqlc.narg('user_id')::text);
 
+-- name: CreateProjectFixture :exec
+-- Test-only fixture that seeds a project with an explicit id so callers can
+-- correlate it with analytics rows keyed on gram_project_id.
+INSERT INTO projects (id, name, slug, organization_id)
+VALUES (@id, @name, @slug, @organization_id);
+
 -- name: ForceSoftDeleteUserSessionIssuer :exec
 -- Test-only fixture for defensive paths that handle a dangling soft-delete FK.
 UPDATE user_session_issuers

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -203,6 +203,30 @@ func (q *Queries) CreateOrganizationUserRelationshipFixture(ctx context.Context,
 	return err
 }
 
+const createProjectFixture = `-- name: CreateProjectFixture :exec
+INSERT INTO projects (id, name, slug, organization_id)
+VALUES ($1, $2, $3, $4)
+`
+
+type CreateProjectFixtureParams struct {
+	ID             uuid.UUID
+	Name           string
+	Slug           string
+	OrganizationID string
+}
+
+// Test-only fixture that seeds a project with an explicit id so callers can
+// correlate it with analytics rows keyed on gram_project_id.
+func (q *Queries) CreateProjectFixture(ctx context.Context, arg CreateProjectFixtureParams) error {
+	_, err := q.db.Exec(ctx, createProjectFixture,
+		arg.ID,
+		arg.Name,
+		arg.Slug,
+		arg.OrganizationID,
+	)
+	return err
+}
+
 const deferDeviceIntegrationSyncsFixture = `-- name: DeferDeviceIntegrationSyncsFixture :exec
 UPDATE device_integration_syncs s
 SET next_poll_after = clock_timestamp() + interval '1 hour'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Resolves [DNO-823](https://linear.app/speakeasy/issue/DNO-823/feat-add-internal-tracker-for-customer-pricing-and-inference-spend). Staff need an internal tracker to watch customer pricing exposure when adjusting spend limits, showing per customer:

1. Customer name
2. PAYG price at the current rate card
3. Gram-hosted inference spend

Per the discussion, the tracker lives on the internal admin service (backing `admin.speakeasy.com`), which naturally handles cross-organization data.

## What changed

New admin endpoint `GET /admin/organizations.pricingTracker` returns one row per organization with:

- **Customer name / slug / account type**
- **PAYG monthly price** and **blended effective rate ($/Mtok)** at the current rate card, derived from observed tokens under management (TUM) over a trailing window (default 30d, max 90d), normalized to a nominal 30-day month.
- **Inference spend** — the dollars Gram itself pays upstream for platform-run completions (playground, elements, risk analysis, assistants, etc.), summed from raw `telemetry_logs`.

Rows are ordered by inference spend descending. Filters: `account_type`, `include_free` (defaults to paying tiers only), `window_days`, `limit`.

### Implementation notes

- `server/internal/pricing/` — Go port of the PAYG graduated rate card from `contract-pricing.ts`, kept as a pure, unit-tested module. Sales-side approximation only; nothing is billed from it.
- `server/internal/billing/tracking.go` — split `GramHostedInferenceSources()` (inclusion list for inference spend over raw telemetry) out from `GramHostedHookSourceStrings()` (TUM exclusion list, which additionally excludes the untagged empty string).
- `server/internal/telemetry/repo/pricing_tracker.go` — single-round-trip ClickHouse rollups grouped by `gram_project_id`: TUM from `attribute_metrics_summaries`, inference spend from `telemetry_logs`.
- `server/cmd/gram/admin.go` — wires ClickHouse into the admin binary best-effort: on connection failure the service still starts, logs a warning, and reports inference spend / TUM-derived figures as zero (`inference_spend_available: false`), so deployment isn't blocked on ClickHouse reachability.
- The endpoint is excluded from the public SDK via the existing `/admin` overlay.

## Testing

- Unit tests for the PAYG rate card (`payg_test.go`) and billing helpers.
- Integration tests (`pricingtracker_test.go`) against Postgres + ClickHouse via `testenv`, covering: per-org rollup across multiple projects, PAYG computation and sort order, exclusion of observed agent traffic (e.g. claude-code) from inference spend, `include_free` / `account_type` filters, and the ClickHouse-absent fallback.

```
ok  server/internal/pricing
ok  server/internal/billing
--- PASS: TestListPricingTracker_WithoutClickhouse
--- PASS: TestListPricingTracker_IncludeFreeAndAccountTypeFilter
--- PASS: TestListPricingTracker_RollsUpSpendAndPrice
ok  server/internal/admin
```

`mise run lint:server` and `mise build:server` both pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-823](https://linear.app/speakeasy/issue/DNO-823/feat-add-internal-tracker-for-customer-pricing-and-inference-spend)

<div><a href="https://cursor.com/agents/bc-1a073c8f-5a7e-4345-852f-3f9ca5f48351?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a073c8f-5a7e-4345-852f-3f9ca5f48351&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal admin endpoint to track per-customer PAYG pricing and Gram-hosted inference spend so staff can monitor pricing exposure when adjusting limits (DNO-823). Uses ClickHouse for analytics with a graceful fallback that reports zeros when unavailable.

- New Features
  - Endpoint `GET /admin/organizations.pricingTracker` returns, per org: name/slug/account type, monthly TUM tokens, PAYG monthly price, blended effective $/Mtok, and inference spend; sorted by spend descending.
  - Filters: `account_type`, `include_free` (default: paid tiers only), `window_days` (default 30, max 90), `limit`.
  - PAYG pricing computed via `server/internal/pricing` (Go port of the graduated rate card); inference spend includes only Gram-hosted sources via `server/internal/billing`.
  - Admin binary wires ClickHouse best‑effort; if not connected, sets `inference_spend_available: false` and returns zeros.

<sup>Written for commit 53d7b0e69e1943d61a5b63c3273acbcc4e866641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

