### PR TITLE
fix(admin): accept same-host admin writes without an allowlist

### DIFF
--- a/server/cmd/gram/admin.go
+++ b/server/cmd/gram/admin.go
@@ -262,6 +262,10 @@ func newAdminCommand() *cli.Command {
 			adminCookieDomain := c.String("admin-cookie-domain")
 			adminCrossOriginCookies := c.Bool("admin-cross-origin-cookies")
 
+			if len(adminAllowedOrigins) == 0 {
+				logger.WarnContext(ctx, "no admin allowed origins configured, so only same-host writes are accepted")
+			}
+
 			mux.Use(middleware.AdminCORS(adminAllowedOrigins))
 			mux.Use(middleware.AdminOriginCheck(adminAllowedOrigins))
 			mux.Use(func(h http.Handler) http.Handler {

--- a/server/internal/middleware/admin_security.go
+++ b/server/internal/middleware/admin_security.go
@@ -45,11 +45,9 @@ func AdminCORS(allowedOrigins []string) func(http.Handler) http.Handler {
 // arrived on. CSRF defence for cookie-based admin auth when SameSite=None is
 // required for cross-origin web UIs.
 //
-// The allowlist covers the split deployment, where the admin web UI is served
-// from a different origin than the admin API. The same-host rule covers the
-// single-origin deployment, where the UI and the API share one ingress: a
-// browser sends Origin on every unsafe method, including a same-origin one,
-// so an empty allowlist would otherwise reject every write.
+// The same-host rule keeps a single-origin deployment working: a browser sends
+// Origin on a same-origin unsafe method too, so an empty allowlist would
+// otherwise reject every write.
 func AdminOriginCheck(allowedOrigins []string) func(http.Handler) http.Handler {
 	set := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
@@ -91,15 +89,12 @@ func AdminOriginCheck(allowedOrigins []string) func(http.Handler) http.Handler {
 
 // sameHost reports whether origin names the host the request arrived on.
 //
-// Only the host is compared. Behind a TLS-terminating ingress the server sees
-// a plain HTTP request, so the scheme it observes says nothing about the
-// scheme the browser used.
-//
-// X-Forwarded-Host wins when present, because an ingress that rewrites Host to
-// an internal service name leaves the public host only in that header. A
-// browser cannot forge either header across sites: it sets Host itself, and a
-// cross-site request that carries X-Forwarded-Host needs a preflight, which
-// AdminCORS answers for allowlisted origins only.
+// The scheme is not compared: a TLS-terminating ingress leaves the server
+// seeing plain HTTP. X-Forwarded-Host wins over Host because such an ingress
+// can rewrite Host to an internal service name. Neither header is forgeable
+// across sites: the browser sets Host, and X-Forwarded-Host makes the request
+// non-simple, so it needs a preflight that AdminCORS answers only for an
+// allowlisted origin.
 func sameHost(r *http.Request, origin string) bool {
 	if origin == "" {
 		return false
@@ -114,8 +109,7 @@ func sameHost(r *http.Request, origin string) bool {
 	if host == "" {
 		host = r.Host
 	}
-	// A comma separated chain means several proxies appended to the header.
-	// The first entry is the host the browser asked for.
+	// Several proxies append to the header; the browser's host comes first.
 	host, _, _ = strings.Cut(host, ",")
 
 	return strings.EqualFold(strings.TrimSpace(host), u.Host)

--- a/server/internal/middleware/admin_security.go
+++ b/server/internal/middleware/admin_security.go
@@ -41,8 +41,15 @@ func AdminCORS(allowedOrigins []string) func(http.Handler) http.Handler {
 }
 
 // AdminOriginCheck rejects any unsafe HTTP method whose Origin (or Referer if
-// Origin is absent) is not in the allowlist. CSRF defence for cookie-based
-// admin auth when SameSite=None is required for cross-origin web UIs.
+// Origin is absent) is neither in the allowlist nor the host the request
+// arrived on. CSRF defence for cookie-based admin auth when SameSite=None is
+// required for cross-origin web UIs.
+//
+// The allowlist covers the split deployment, where the admin web UI is served
+// from a different origin than the admin API. The same-host rule covers the
+// single-origin deployment, where the UI and the API share one ingress: a
+// browser sends Origin on every unsafe method, including a same-origin one,
+// so an empty allowlist would otherwise reject every write.
 func AdminOriginCheck(allowedOrigins []string) func(http.Handler) http.Handler {
 	set := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
@@ -67,14 +74,51 @@ func AdminOriginCheck(allowedOrigins []string) func(http.Handler) http.Handler {
 				}
 			}
 
-			if _, ok := set[origin]; !ok {
-				http.Error(w, "forbidden: origin not allowed", http.StatusForbidden)
+			if _, ok := set[origin]; ok {
+				next.ServeHTTP(w, r)
 				return
 			}
 
-			next.ServeHTTP(w, r)
+			if sameHost(r, origin) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			http.Error(w, "forbidden: origin not allowed", http.StatusForbidden)
 		})
 	}
+}
+
+// sameHost reports whether origin names the host the request arrived on.
+//
+// Only the host is compared. Behind a TLS-terminating ingress the server sees
+// a plain HTTP request, so the scheme it observes says nothing about the
+// scheme the browser used.
+//
+// X-Forwarded-Host wins when present, because an ingress that rewrites Host to
+// an internal service name leaves the public host only in that header. A
+// browser cannot forge either header across sites: it sets Host itself, and a
+// cross-site request that carries X-Forwarded-Host needs a preflight, which
+// AdminCORS answers for allowlisted origins only.
+func sameHost(r *http.Request, origin string) bool {
+	if origin == "" {
+		return false
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	// A comma separated chain means several proxies appended to the header.
+	// The first entry is the host the browser asked for.
+	host, _, _ = strings.Cut(host, ",")
+
+	return strings.EqualFold(strings.TrimSpace(host), u.Host)
 }
 
 // AdminCookieAttributes rewrites Set-Cookie response headers for the admin

--- a/server/internal/middleware/admin_security_test.go
+++ b/server/internal/middleware/admin_security_test.go
@@ -151,6 +151,129 @@ func TestAdminOriginCheck_RejectsMissingOriginAndReferer(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, rec.Code)
 }
 
+func TestAdminOriginCheck_AllowsSameHostWithEmptyAllowlist(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://gram-admin.speakeasy.com/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://gram-admin.speakeasy.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAdminOriginCheck_RejectsForeignOriginWithEmptyAllowlist(t *testing.T) {
+	t.Parallel()
+
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://gram-admin.speakeasy.com/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// A TLS terminating ingress hands the server a plain HTTP request, so the
+// scheme the server sees never matches the scheme the browser sent.
+func TestAdminOriginCheck_AllowsSameHostBehindTLSTermination(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://gram-admin.speakeasy.com/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://gram-admin.speakeasy.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+}
+
+func TestAdminOriginCheck_PrefersForwardedHost(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://gram-admin.svc.cluster.local/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://gram-admin.speakeasy.com")
+	req.Header.Set("X-Forwarded-Host", "gram-admin.speakeasy.com, gram-admin.svc.cluster.local")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+}
+
+func TestAdminOriginCheck_RejectsForeignOriginWithForwardedHost(t *testing.T) {
+	t.Parallel()
+
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://gram-admin.svc.cluster.local/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.Header.Set("X-Forwarded-Host", "gram-admin.speakeasy.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestAdminOriginCheck_MatchesHostCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "https://gram-admin.speakeasy.com/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://GRAM-ADMIN.speakeasy.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+}
+
+func TestAdminOriginCheck_RejectsSameHostOnAnotherPort(t *testing.T) {
+	t.Parallel()
+
+	handler := AdminOriginCheck(nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	// The port is part of the origin, so the dev server on another port is a
+	// separate origin and it still needs the allowlist.
+	req := httptest.NewRequest(http.MethodPost, "https://localhost:8083/admin/organization.update", nil)
+	req.Header.Set("Origin", "https://localhost:5174")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
 func TestAdminCookieAttributes_RewritesAdminCookies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Every admin write returns 403 when `GRAM_ADMIN_ALLOWED_ORIGINS` is unset.

## The problem

`AdminOriginCheck` is CSRF defence for the cookie-authenticated admin API. It rejects an unsafe method whose `Origin` is not in the allowlist. The `--admin-allowed-origins` flag declares no default, so an unset `GRAM_ADMIN_ALLOWED_ORIGINS` leaves the allowlist empty.

A browser sends `Origin` on every unsafe method, including a same-origin one. With an empty allowlist, no origin matches, so every POST, PUT, and DELETE gets a 403. A single-origin deployment, where the admin UI and the admin API sit behind one ingress, cannot write at all until an operator sets the variable.

## The change

Accept a request whose `Origin` names the host the request arrived on. The allowlist still covers the split deployment, where the UI and the API sit on different origins.

Two details:

- **Host only, never the scheme.** Behind a TLS-terminating ingress the server sees a plain HTTP request, so the scheme it observes says nothing about the scheme the browser used.
- **`X-Forwarded-Host` wins over `Host`.** An ingress that rewrites `Host` to an internal service name leaves the public host only in that header. A comma-separated chain means several proxies appended to it, so the first entry is used.

A browser cannot forge either header across sites: it sets `Host` itself, and a cross-site request that carries `X-Forwarded-Host` needs a preflight, which `AdminCORS` answers for allowlisted origins only.

The server now warns at startup when the allowlist is empty, so an operator sees that only same-host writes are accepted.

## Tests

Seven cases in `admin_security_test.go`: same host allowed with an empty allowlist, foreign origin rejected, HTTPS origin allowed behind TLS termination, `X-Forwarded-Host` preferred, foreign origin rejected when `X-Forwarded-Host` is set, case-insensitive host match, and a different port on the same host rejected.

`mise run test:server -run 'TestAdminOriginCheck' ./internal/middleware/...` passes. `mise run lint:server` reports no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 403s on admin writes when `GRAM_ADMIN_ALLOWED_ORIGINS` is unset by accepting same-host writes based on the request host; cross-origin admin UIs still require the allowlist.

- Compares only the host and prefers `X-Forwarded-Host` over `Host` to handle ingress rewrites and TLS termination (case-insensitive host match; ports must match).
- Keep allowlist checks for split UI/API deployments; operators must set `GRAM_ADMIN_ALLOWED_ORIGINS` or `--admin-allowed-origins` when the admin UI and API are on different origins.
- Emits a startup warning when no admin allowed origins are configured.

<sup>Written for commit e4fe2f7660a404280f7574ffe1e64a9de7b95b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/5151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

